### PR TITLE
fix: preserve citation delimiter examples across runtimes

### DIFF
--- a/crates/guest-agent/Cargo.toml
+++ b/crates/guest-agent/Cargo.toml
@@ -21,7 +21,7 @@ pin-project-lite = "0.2"
 reqwest = { workspace = true }
 rustix = { workspace = true, features = ["process"] }
 serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["raw_value"] }
 hex.workspace = true
 sha2.workspace = true
 tempfile.workspace = true

--- a/crates/guest-agent/examples/codex_citation_probe.rs
+++ b/crates/guest-agent/examples/codex_citation_probe.rs
@@ -1,0 +1,86 @@
+//! Explicit installed-runtime acceptance driver; uses the production Guest entry point.
+//! Run with an isolated fixture home, a Codex binary, and a local synthetic provider.
+
+use std::path::PathBuf;
+
+use guest_agent::active_input::ActiveInputRuntime;
+use guest_agent::cli::execute_cli_with_active_input_for_config;
+use guest_agent::env::{GuestConfig, GuestConfigRaw};
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use guest_agent::paths::GuestPaths;
+use guest_contracts::env::{RUN_PAYLOAD_FILENAME, RUN_PAYLOAD_PRIVATE_DIR_NAME, RunPayload};
+use serde_json::{Value, json};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let home = PathBuf::from(args.next().ok_or("missing isolated home")?);
+    let binary = args.next().ok_or("missing Codex binary")?;
+    let provider_url = args.next().ok_or("missing fixture provider URL")?;
+    if !provider_url.starts_with("http://127.0.0.1:") {
+        return Err("this acceptance driver requires a local synthetic provider".into());
+    }
+    let resume = args.next().unwrap_or_default();
+    let runtime_dir = home.join(format!("probe-run-{}", uuid::Uuid::new_v4()));
+    let payload_dir = runtime_dir.join(RUN_PAYLOAD_PRIVATE_DIR_NAME);
+    std::fs::create_dir_all(&payload_dir)?;
+    let payload_path = payload_dir.join(RUN_PAYLOAD_FILENAME);
+    let payload = RunPayload {
+        prompt: "Explain the synthetic delimiter example without using tools.".to_string(),
+        codex_runtime_config: json!({
+            "providerId": "fixture", "name": "Synthetic fixture", "baseUrl": provider_url,
+            "envKey": "OPENAI_API_KEY", "wireApi": "responses", "supportsWebsockets": false
+        })
+        .to_string(),
+        ..RunPayload::default()
+    };
+    std::fs::write(&payload_path, serde_json::to_vec(&payload)?)?;
+    let mut config = GuestConfig::from_raw(GuestConfigRaw {
+        run_id: "citation-native-probe".to_string(),
+        cli_agent_type: "codex".to_string(),
+        use_mock_codex: "true".to_string(),
+        mock_codex_path: Some(binary),
+        run_payload_file: payload_path.to_string_lossy().into_owned(),
+        guest_runtime_dir: Some(runtime_dir.clone()),
+        home: Some(home.to_string_lossy().into_owned()),
+        resume_session_id: resume,
+        ..GuestConfigRaw::default()
+    })?;
+    config.codex_home_dir = home.join("codex").to_string_lossy().into_owned();
+    config.user_env.insert(
+        "OPENAI_API_KEY".to_string(),
+        "synthetic-no-provider-secret".to_string(),
+    );
+    config
+        .user_env
+        .insert("OPENAI_MODEL".to_string(), "gpt-5.4".to_string());
+    let paths = GuestPaths::from_runtime_dir(runtime_dir);
+    let http = HttpClient::for_config(&config)?;
+    let active = ActiveInputRuntime::new_disabled(&config.run_id, &config.prompt);
+    let result = execute_cli_with_active_input_for_config(
+        &SecretMasker::from_raw(""),
+        None,
+        http,
+        active.into_writer(),
+        &config,
+        &paths,
+    )
+    .await?;
+    let events: Vec<Value> = std::fs::read_to_string(paths.agent_log_file())?
+        .lines()
+        .map(serde_json::from_str)
+        .collect::<Result<_, _>>()?;
+    let visible: Vec<&str> = events
+        .iter()
+        .filter(|event| {
+            event.pointer("/item/type").and_then(Value::as_str) == Some("agent_message")
+        })
+        .filter_map(|event| event.pointer("/item/text").and_then(Value::as_str))
+        .collect();
+    println!(
+        "{}",
+        json!({"exitCode": result.exit_code, "threadId": std::fs::read_to_string(paths.session_id_file())?, "visible": visible})
+    );
+    Ok(())
+}

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -51,7 +51,7 @@ struct NotificationIngestResult {
 
 #[derive(Default)]
 struct PreparedNotificationIngest {
-    event: Option<Value>,
+    events: Vec<Value>,
     output_item_start: Option<CodexOutputItemStart>,
     emitted_thread_started: bool,
     active_input_ready: bool,
@@ -60,6 +60,7 @@ struct PreparedNotificationIngest {
 
 #[derive(Default)]
 struct CodexNotificationState {
+    citation_repair: super::codex_citation_repair::NativeCitationRepair,
     thread_started_emitted: bool,
     secondary_thread_notification_logged: bool,
     turn_usage: CodexTurnUsageTracker,
@@ -379,6 +380,12 @@ async fn run_codex_app_server(
         .await?;
         let thread_identity = thread_identity_from_response(&thread_response)?;
         validate_resumed_thread_id(&thread_identity.canonical_id, resume_thread_id.as_deref())?;
+        notification_state.citation_repair =
+            super::codex_citation_repair::NativeCitationRepair::new(
+                runtime.codex_home(),
+                &thread_identity.canonical_id,
+                resume_thread_id.is_some(),
+            );
 
         while let Some(notification) = client.pop_notification() {
             let mut sink = EventIngestSink {
@@ -629,6 +636,17 @@ async fn run_codex_app_server(
     }
     let active_input_delivery_ids = active_input_controller.finalize_receipts().await;
     let stderr_lines = masker.mask_diagnostic_lines(client.stderr_tail().to_vec());
+    for event in notification_state.citation_repair.abandon() {
+        let mut sink = EventIngestSink {
+            ingestor: &mut ingestor,
+            output_timing: &mut output_timing,
+            agent_log: &mut agent_log,
+            masker,
+            should_send_events,
+            event_tx,
+        };
+        ingest_event(event, &mut sink).await?;
+    }
     // Publish buffered event-log bytes after the child is stopped and before
     // callers observe the finished app-server execution.
     agent_log.flush().await;
@@ -1063,7 +1081,7 @@ async fn drain_queued_notifications(
     }
     for prepared in prepared_notifications {
         record_output_item_start(prepared.output_item_start.as_ref(), sink);
-        if let Some(event) = prepared.event {
+        for event in prepared.events {
             ingest_event(event, sink).await?;
         }
         notification_state.thread_started_emitted =
@@ -1100,7 +1118,7 @@ async fn ingest_run_notification(
         active_input_ready: prepared.active_input_ready,
         terminal_exit_code: prepared.terminal_exit_code,
     };
-    if let Some(event) = prepared.event {
+    for event in prepared.events {
         ingest_event(event, sink).await?;
     }
     notification_state.thread_started_emitted =
@@ -1201,7 +1219,7 @@ async fn ingest_notification(
         active_input_ready: prepared.active_input_ready,
         terminal_exit_code: prepared.terminal_exit_code,
     };
-    if let Some(event) = prepared.event {
+    for event in prepared.events {
         ingest_event(event, sink).await?;
     }
     Ok(result)
@@ -1271,6 +1289,7 @@ fn prepare_notification_ingest(
         .map_err(|error| AgentError::Execution(error.to_string()))?
     else {
         return Ok(PreparedNotificationIngest {
+            events: notification_state.citation_repair.drain(false),
             output_item_start,
             ..PreparedNotificationIngest::default()
         });
@@ -1300,7 +1319,15 @@ fn prepare_notification_ingest(
     let active_input_ready = is_turn_started_event(&event);
     let terminal_exit_code = terminal_exit_code(&event, expected_thread_id, active_turn_id);
     Ok(PreparedNotificationIngest {
-        event: Some(event),
+        events: notification_state.citation_repair.submit(
+            event,
+            notification
+                .params
+                .as_ref()
+                .and_then(|params| params.pointer("/item/phase"))
+                .and_then(Value::as_str),
+            terminal_exit_code.is_some(),
+        ),
         output_item_start,
         emitted_thread_started,
         active_input_ready,

--- a/crates/guest-agent/src/cli/codex_citation_repair.rs
+++ b/crates/guest-agent/src/cli/codex_citation_repair.rs
@@ -1,0 +1,219 @@
+//! Ordered public projection of eligible native assistant delimiter examples.
+
+use std::collections::{HashSet, VecDeque};
+use std::path::Path;
+
+use guest_contracts::session_history_identity::SessionHistorySourceRef;
+use guest_telemetry::log_warn;
+use serde_json::Value;
+
+use super::codex_citation_source::{CitationSource, MAX_TEXT, MessageIdentity};
+use super::pi_memory_citation::{CLOSE, OPEN, project_segments};
+
+#[cfg(test)]
+mod tests;
+
+const MAX_PENDING_EVENTS: usize = 128;
+const MAX_PENDING_BYTES: usize = 16 * 1024 * 1024;
+const MAX_ITEMS: usize = 4096;
+
+struct PendingEvent {
+    event: Value,
+    identity: Option<MessageIdentity>,
+    bytes: usize,
+}
+
+#[derive(Default)]
+pub(super) struct NativeCitationRepair {
+    source_ref: Option<SessionHistorySourceRef>,
+    source: Option<CitationSource>,
+    deferred_open: bool,
+    attempted_open: bool,
+    pending: VecDeque<PendingEvent>,
+    pending_bytes: usize,
+    seen: HashSet<(String, String)>,
+    diagnostic_emitted: bool,
+    disabled: bool,
+}
+
+impl NativeCitationRepair {
+    pub(super) fn new(home: &str, thread_id: &str, resumed: bool) -> Self {
+        let source_ref = SessionHistorySourceRef::Codex {
+            sessions_dir: Path::new(home)
+                .join("sessions")
+                .to_string_lossy()
+                .into_owned(),
+            thread_id: thread_id.to_string(),
+        };
+        let source = CitationSource::open(&source_ref, resumed).ok();
+        let deferred_open = !resumed && source.is_none();
+        Self {
+            source_ref: Some(source_ref),
+            source,
+            deferred_open,
+            ..Self::default()
+        }
+    }
+
+    pub(super) fn submit(
+        &mut self,
+        event: Value,
+        phase: Option<&str>,
+        terminal: bool,
+    ) -> Vec<Value> {
+        if self.source_ref.is_none() {
+            return vec![event];
+        }
+        let identity = candidate_identity(&event, phase);
+        if let Some(identity) = &identity
+            && !self.disabled
+        {
+            if !self
+                .seen
+                .insert((identity.turn.clone(), identity.item.clone()))
+            {
+                return self.drain(terminal);
+            }
+            if self.seen.len() >= MAX_ITEMS {
+                self.disabled = true;
+            }
+        }
+        if self.pending.is_empty() && (identity.is_none() || self.disabled) {
+            return vec![event];
+        }
+        let bytes = event.to_string().len();
+        if self.pending.len() >= MAX_PENDING_EVENTS
+            || self.pending_bytes.saturating_add(bytes) > MAX_PENDING_BYTES
+        {
+            self.disabled = true;
+            self.diagnostic();
+            let mut output = self.drain(true);
+            output.push(event);
+            return output;
+        }
+        self.pending_bytes = self.pending_bytes.saturating_add(bytes);
+        self.pending.push_back(PendingEvent {
+            event,
+            identity,
+            bytes,
+        });
+        self.drain(terminal)
+    }
+
+    pub(super) fn drain(&mut self, terminal: bool) -> Vec<Value> {
+        let mut output = Vec::new();
+        if self.pending.is_empty() {
+            return output;
+        }
+        if self.deferred_open && (!self.attempted_open || terminal) {
+            if let Some(source_ref) = &self.source_ref {
+                self.source = CitationSource::open(source_ref, false).ok();
+            }
+            // One bounded lookup after the first completed message, then one
+            // final attempt at the native flush barrier if still unavailable.
+            if self.source.is_some() || terminal {
+                self.deferred_open = false;
+            }
+            self.attempted_open = true;
+        }
+        while let Some(pending) = self.pending.front_mut() {
+            if let Some(identity) = &pending.identity {
+                let evidence = if self.disabled {
+                    Err(())
+                } else {
+                    match &mut self.source {
+                        Some(source) => source.find(identity),
+                        None => Ok(None),
+                    }
+                };
+                match evidence {
+                    Ok(Some(raw)) => {
+                        if let Some(text) = pending.event.pointer_mut("/item/text")
+                            && let Some(normalized) = text.as_str()
+                            && let Some(repaired) = repair_text(&raw, normalized)
+                        {
+                            *text = Value::String(repaired);
+                        } else {
+                            self.diagnostic();
+                        }
+                    }
+                    Ok(None) if !terminal && !self.disabled => break,
+                    _ => self.diagnostic(),
+                }
+            }
+            if let Some(pending) = self.pending.pop_front() {
+                self.pending_bytes -= pending.bytes;
+                output.push(pending.event);
+            }
+        }
+        output
+    }
+
+    pub(super) fn abandon(&mut self) -> Vec<Value> {
+        // Cancellation/process failure has no successful native flush barrier.
+        // Release only the original normalized events and keep terminal status.
+        self.disabled = true;
+        self.drain(true)
+    }
+
+    fn diagnostic(&mut self) {
+        if !self.diagnostic_emitted {
+            log_warn!(
+                super::LOG_TAG,
+                "Native citation literal repair unavailable; preserving native projection"
+            );
+            self.diagnostic_emitted = true;
+        }
+    }
+}
+
+fn candidate_identity(event: &Value, phase: Option<&str>) -> Option<MessageIdentity> {
+    if event.get("type")?.as_str()? != "item.completed"
+        || event.pointer("/item/type")?.as_str()? != "agent_message"
+    {
+        return None;
+    }
+    let text = event.pointer("/item/text")?.as_str()?;
+    if text.len() > MAX_TEXT || (!text.contains('`') && !text.contains('~')) {
+        return None;
+    }
+    let phase = phase.filter(|phase| matches!(*phase, "commentary" | "final_answer"))?;
+    let turn = event.get("turn_id")?.as_str()?;
+    let item = event.pointer("/item/id")?.as_str()?;
+    if turn.is_empty() || item.is_empty() || turn.len() > 128 || item.len() > 128 {
+        return None;
+    }
+    Some(MessageIdentity {
+        turn: turn.to_string(),
+        item: item.to_string(),
+        phase: phase.to_string(),
+    })
+}
+
+fn repair_text(raw: &str, normalized: &str) -> Option<String> {
+    // Native contributors and plan-mode projection remain authoritative. Never
+    // restore text in a message containing native plan controls, even if a
+    // preceding citation would also have hidden those controls from comparison.
+    if raw.contains("<proposed_plan>")
+        || raw.contains("</proposed_plan>")
+        || native_citation_projection(raw) != normalized
+    {
+        return None;
+    }
+    Some(project_segments(&[raw]).visible_segments.concat())
+}
+
+/// Pinned native literal-only behavior (OpenAI Codex 0.153.4, Apache-2.0).
+/// Unlike vm0's public defense, native leaves a stray closing marker unchanged.
+fn native_citation_projection(mut text: &str) -> String {
+    let mut visible = String::new();
+    while let Some((before, body)) = text.split_once(OPEN) {
+        visible.push_str(before);
+        let Some((_, after)) = body.split_once(CLOSE) else {
+            return visible;
+        };
+        text = after;
+    }
+    visible.push_str(text);
+    visible
+}

--- a/crates/guest-agent/src/cli/codex_citation_repair/tests.rs
+++ b/crates/guest-agent/src/cli/codex_citation_repair/tests.rs
@@ -1,0 +1,252 @@
+use std::io::Write;
+
+use serde_json::json;
+
+use super::*;
+
+const THREAD: &str = "019e9154-c304-70f0-adde-36efb1be1701";
+const TURN: &str = "019e9154-c304-70f0-adde-36efb1be1702";
+const ITEM: &str = "msg_literal_fixture";
+
+struct Harness {
+    home: tempfile::TempDir,
+    path: std::path::PathBuf,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let home = tempfile::tempdir().unwrap();
+        let parent = home.path().join("sessions/2026/09/08");
+        std::fs::create_dir_all(&parent).unwrap();
+        let path = parent.join(format!("rollout-{THREAD}.jsonl"));
+        let result = Self { home, path };
+        result.append(json!({"type": "session_meta", "payload": {"id": THREAD}}));
+        result
+    }
+
+    fn append(&self, record: Value) {
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&self.path)
+            .or_else(|_| std::fs::File::create(&self.path))
+            .unwrap();
+        writeln!(file, "{record}").unwrap();
+        file.flush().unwrap();
+    }
+
+    fn repair(&self, resumed: bool) -> NativeCitationRepair {
+        NativeCitationRepair::new(self.home.path().to_str().unwrap(), THREAD, resumed)
+    }
+}
+
+fn raw(text: &str) -> Value {
+    json!({"type":"response_item", "payload": {
+        "type":"message", "id":ITEM, "role":"assistant", "phase":"final_answer",
+        "internal_chat_message_metadata_passthrough":{"turn_id":TURN},
+        "content":[{"type":"output_text", "text":text}]
+    }})
+}
+
+fn normalized(text: &str) -> Value {
+    json!({"type":"item.completed", "thread_id":THREAD, "turn_id":TURN,
+        "item":{"type":"agent_message", "id":ITEM, "text":native_citation_projection(text)}})
+}
+
+fn terminal(status: &str) -> Value {
+    json!({"type":status, "thread_id":THREAD, "turn_id":TURN})
+}
+
+#[test]
+fn fresh_and_new_process_resume_wait_for_private_raw_before_ordered_publication() {
+    let text = format!("explanation `{OPEN}` complete suffix");
+    let safe = project_segments(&[&text]).visible_segments.concat();
+    for resumed in [false, true] {
+        let harness = Harness::new();
+        // An identically named historical item is never the resumed raw source.
+        let mut old = raw(&format!("old `{OPEN}` unrelated private history"));
+        old["payload"]["internal_chat_message_metadata_passthrough"]["turn_id"] = json!("old-turn");
+        harness.append(old);
+        let mut repair = harness.repair(resumed);
+        assert!(
+            repair
+                .submit(normalized(&text), Some("final_answer"), false)
+                .is_empty()
+        );
+        let tool = json!({"type":"item.started", "item":{"type":"command_execution", "id":"tool"}});
+        assert!(repair.submit(tool.clone(), None, false).is_empty());
+        harness.append(raw(&text));
+        let end = terminal("turn.completed");
+        let events = repair.submit(end.clone(), None, true);
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0]["item"]["text"], safe);
+        assert_eq!(events[1], tool);
+        assert_eq!(events[2], end);
+        assert!(
+            repair
+                .submit(normalized(&text), Some("final_answer"), false)
+                .is_empty()
+        );
+        assert!(repair.drain(true).is_empty());
+        assert!(
+            std::fs::read_to_string(harness.path)
+                .unwrap()
+                .contains(&text)
+        );
+    }
+}
+
+#[test]
+fn current_raw_can_arrive_before_the_normalized_notification() {
+    let harness = Harness::new();
+    let mut repair = harness.repair(false);
+    let text = format!("`{OPEN}` suffix");
+    harness.append(raw(&text));
+    let events = repair.submit(normalized(&text), Some("final_answer"), false);
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0]["item"]["text"],
+        project_segments(&[&text]).visible_segments.concat()
+    );
+}
+
+#[test]
+fn private_source_requires_exact_item_turn_role_phase_and_text_contract() {
+    let text = format!("before `{OPEN}` private raw suffix");
+    for (path, replacement) in [
+        ("/payload/id", json!("unrelated-item")),
+        ("/payload/role", json!("developer")),
+        ("/payload/phase", json!("commentary")),
+        (
+            "/payload/internal_chat_message_metadata_passthrough/turn_id",
+            json!("unrelated-turn"),
+        ),
+        ("/payload/content/0/type", json!("input_text")),
+        ("/item/text", json!("different native projection `")),
+        ("/payload/type", json!("reasoning")),
+        ("/payload/id", Value::Null),
+        ("/payload/phase", Value::Null),
+        (
+            "/payload/internal_chat_message_metadata_passthrough",
+            Value::Null,
+        ),
+    ] {
+        let harness = Harness::new();
+        let mut repair = harness.repair(true);
+        let mut record = raw(&text);
+        let mut event = normalized(&text);
+        let target = if path == "/item/text" {
+            &mut event
+        } else {
+            &mut record
+        };
+        *target.pointer_mut(path).unwrap() = replacement;
+        harness.append(record);
+        let mut events = repair.submit(event.clone(), Some("final_answer"), false);
+        events.extend(repair.submit(terminal("turn.failed"), None, true));
+        assert_eq!(events, [event, terminal("turn.failed")], "{path}");
+    }
+}
+
+#[test]
+fn plan_controls_and_private_bodies_never_enter_recovered_suffix() {
+    let private =
+        format!("{OPEN}<citation_entries>private.md:1-2|note=[secret]</citation_entries>{CLOSE}");
+    let text = format!("before `{OPEN}` suffix `{private}` after");
+    let projected = repair_text(&text, &native_citation_projection(&text)).unwrap();
+    assert!(projected.ends_with("suffix `` after"));
+    assert!(!projected.contains("private.md") && !projected.contains("secret"));
+    for plan in [
+        "<proposed_plan>private plan</proposed_plan>",
+        "<proposed_plan>unclosed private plan",
+    ] {
+        let text = format!("before `{OPEN}` {plan}");
+        assert!(repair_text(&text, &native_citation_projection(&text)).is_none());
+    }
+    for body in [
+        format!("`{OPEN}secret{CLOSE}`"),
+        format!("```\n{OPEN}secret\n```"),
+        format!("{OPEN}invalid unclosed secret"),
+    ] {
+        let visible = repair_text(&body, &native_citation_projection(&body)).unwrap();
+        assert!(!visible.contains("secret"));
+    }
+}
+
+#[test]
+fn missing_partial_oversized_and_cancelled_evidence_keep_native_events() {
+    let text = format!("before `{OPEN}` raw suffix");
+    for mode in ["missing", "partial", "oversized", "cancel"] {
+        let harness = Harness::new();
+        let mut repair = harness.repair(true);
+        let event = normalized(&text);
+        assert!(
+            repair
+                .submit(event.clone(), Some("final_answer"), false)
+                .is_empty()
+        );
+        match mode {
+            "partial" => {
+                write!(
+                    std::fs::OpenOptions::new()
+                        .append(true)
+                        .open(&harness.path)
+                        .unwrap(),
+                    "{{\"type\":"
+                )
+                .unwrap();
+            }
+            "oversized" => harness.append(raw(&"x".repeat(MAX_TEXT + 1))),
+            "cancel" => harness.append(raw(&text)),
+            _ => {}
+        }
+        let output = if mode == "cancel" {
+            repair.abandon()
+        } else {
+            repair.drain(true)
+        };
+        assert_eq!(output, [event], "{mode}");
+    }
+}
+
+#[test]
+fn pending_limit_keeps_original_output_order_and_terminal_status() {
+    let harness = Harness::new();
+    let mut repair = harness.repair(true);
+    let event = normalized(&format!("before `{OPEN}` raw suffix"));
+    let mut expected = vec![event.clone()];
+    let mut actual = repair.submit(event, Some("final_answer"), false);
+    for id in 0..=MAX_PENDING_EVENTS {
+        let tool = json!({"type":"item.started", "item":{"type":"command_execution", "id":id.to_string()}});
+        expected.push(tool.clone());
+        actual.extend(repair.submit(tool, None, false));
+    }
+    expected.push(terminal("turn.failed"));
+    actual.extend(repair.submit(terminal("turn.failed"), None, true));
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn session_identity_and_descriptor_fail_closed_without_reading_another_file() {
+    let harness = Harness::new();
+    let text = format!("before `{OPEN}` unrelated suffix");
+    std::fs::write(
+        &harness.path,
+        format!("{}\n", json!({"type":"session_meta","payload":{"id":TURN}})),
+    )
+    .unwrap();
+    harness.append(raw(&text));
+    let mut repair = harness.repair(true);
+    let event = normalized(&text);
+    repair.submit(event.clone(), Some("final_answer"), false);
+    assert_eq!(repair.drain(true).as_slice(), std::slice::from_ref(&event));
+
+    #[cfg(unix)]
+    {
+        let outside = harness.home.path().join("outside.jsonl");
+        std::fs::rename(&harness.path, &outside).unwrap();
+        std::os::unix::fs::symlink(outside, &harness.path).unwrap();
+        let mut repair = harness.repair(true);
+        repair.submit(event.clone(), Some("final_answer"), false);
+        assert_eq!(repair.drain(true), [event]);
+    }
+}

--- a/crates/guest-agent/src/cli/codex_citation_source.rs
+++ b/crates/guest-agent/src/cli/codex_citation_source.rs
@@ -1,0 +1,170 @@
+//! Private, incremental access to the one canonical native Codex rollout.
+//!
+//! The shipped 0.153.4 writer queues raw items after normalized completions and
+//! flushes them before turn completion. A missing row is not evidence of public
+//! text: the caller waits for that barrier, then retains native safe output.
+
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+
+use guest_contracts::codex_thread_id::canonical_codex_thread_id;
+use guest_contracts::session_history_identity::SessionHistorySourceRef;
+use serde::Deserialize;
+use serde_json::value::RawValue;
+
+use crate::session_history::resolve_session_history_from_source;
+
+const MAX_RECORD: usize = 4 * 1024 * 1024;
+const MAX_RUN_READ: usize = 64 * 1024 * 1024;
+pub(super) const MAX_TEXT: usize = 1024 * 1024;
+
+#[derive(Clone)]
+pub(super) struct MessageIdentity {
+    pub(super) turn: String,
+    pub(super) item: String,
+    pub(super) phase: String,
+}
+
+#[derive(Deserialize)]
+struct Record<'a> {
+    #[serde(rename = "type")]
+    kind: &'a str,
+    #[serde(borrow)]
+    payload: &'a RawValue,
+}
+
+#[derive(Deserialize)]
+struct MessageHead<'a> {
+    #[serde(rename = "type")]
+    kind: &'a str,
+    id: Option<&'a str>,
+    role: Option<&'a str>,
+    phase: Option<&'a str>,
+    #[serde(borrow)]
+    internal_chat_message_metadata_passthrough: Option<MessageMetadata<'a>>,
+}
+
+#[derive(Deserialize)]
+struct MessageMetadata<'a> {
+    turn_id: Option<&'a str>,
+}
+
+#[derive(Deserialize)]
+struct MessageText {
+    content: Vec<TextPart>,
+}
+
+#[derive(Deserialize)]
+struct TextPart {
+    #[serde(rename = "type")]
+    kind: String,
+    text: String,
+}
+
+pub(super) struct CitationSource {
+    reader: BufReader<File>,
+    line: Vec<u8>,
+    read_bytes: usize,
+}
+
+impl CitationSource {
+    pub(super) fn open(source: &SessionHistorySourceRef, resumed: bool) -> Result<Self, ()> {
+        let SessionHistorySourceRef::Codex { thread_id, .. } = source else {
+            return Err(());
+        };
+        let mut resolved = resolve_session_history_from_source(source).map_err(|_| ())?;
+        // Active native rollouts are plain JSONL. Do not decode an entire
+        // compressed archive or fall back to another session for this repair.
+        let file = resolved
+            .plain_file_mut()
+            .ok_or(())?
+            .try_clone()
+            .map_err(|_| ())?;
+        let mut result = Self {
+            reader: BufReader::new(file),
+            line: Vec::new(),
+            read_bytes: 0,
+        };
+        if !result.read_line()? {
+            return Err(());
+        }
+        let record: Record<'_> = serde_json::from_slice(&result.line).map_err(|_| ())?;
+        #[derive(Deserialize)]
+        struct SessionMeta<'a> {
+            id: &'a str,
+        }
+        let meta: SessionMeta<'_> = serde_json::from_str(record.payload.get()).map_err(|_| ())?;
+        if record.kind != "session_meta"
+            || canonical_codex_thread_id(meta.id).as_deref() != Some(thread_id)
+        {
+            return Err(());
+        }
+        result.line.clear();
+        if resumed {
+            // Establish this cursor before turn/start; never scan old history.
+            result.reader.seek(SeekFrom::End(0)).map_err(|_| ())?;
+        }
+        result.read_bytes = 0;
+        Ok(result)
+    }
+
+    fn read_line(&mut self) -> Result<bool, ()> {
+        let budget = MAX_RECORD.checked_sub(self.line.len()).ok_or(())?;
+        let read = self
+            .reader
+            .by_ref()
+            .take((budget + 1) as u64)
+            .read_until(b'\n', &mut self.line)
+            .map_err(|_| ())?;
+        self.read_bytes = self.read_bytes.checked_add(read).ok_or(())?;
+        if self.line.len() > MAX_RECORD || self.read_bytes > MAX_RUN_READ {
+            return Err(());
+        }
+        Ok(self.line.last() == Some(&b'\n'))
+    }
+
+    pub(super) fn find(&mut self, identity: &MessageIdentity) -> Result<Option<String>, ()> {
+        while self.read_line()? {
+            let result = matching_text(&self.line, identity);
+            self.line.clear();
+            if let Some(text) = result? {
+                return Ok(Some(text));
+            }
+        }
+        Ok(None)
+    }
+}
+
+fn matching_text(line: &[u8], identity: &MessageIdentity) -> Result<Option<String>, ()> {
+    let record: Record<'_> = serde_json::from_slice(line).map_err(|_| ())?;
+    if record.kind != "response_item" {
+        return Ok(None);
+    }
+    let head: MessageHead<'_> = serde_json::from_str(record.payload.get()).map_err(|_| ())?;
+    if head.kind != "message"
+        || head.id != Some(identity.item.as_str())
+        || head.role != Some("assistant")
+    {
+        return Ok(None);
+    }
+    let turn = head
+        .internal_chat_message_metadata_passthrough
+        .and_then(|metadata| metadata.turn_id);
+    if turn != Some(identity.turn.as_str()) {
+        return Ok(None);
+    }
+    if head.phase != Some(identity.phase.as_str()) {
+        return Err(());
+    }
+    // Deserialize content only after all identity/role/phase checks. Unknown
+    // fields, reasoning, tool payloads and other roles never become text.
+    let message: MessageText = serde_json::from_str(record.payload.get()).map_err(|_| ())?;
+    let mut text = String::new();
+    for part in message.content {
+        if part.kind != "output_text" || text.len().saturating_add(part.text.len()) > MAX_TEXT {
+            return Err(());
+        }
+        text.push_str(&part.text);
+    }
+    Ok(Some(text))
+}

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -26,6 +26,8 @@ mod claude;
 pub mod codex_app_server;
 mod codex_app_server_backend;
 mod codex_app_server_events;
+mod codex_citation_repair;
+mod codex_citation_source;
 mod codex_event_delivery;
 mod codex_runtime_config;
 mod codex_setup;

--- a/crates/guest-agent/src/cli/pi_memory_citation.rs
+++ b/crates/guest-agent/src/cli/pi_memory_citation.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use uuid::Uuid;
 
+mod literals;
+
 pub(super) const OPEN: &str = "<oai-mem-citation>";
 pub(super) const CLOSE: &str = "</oai-mem-citation>";
 const MAX_BODY_BYTES: usize = 64 * 1024;
@@ -64,6 +66,7 @@ fn delimiter_starts_with(delimiter: &str, pending: &[SourcedChar]) -> bool {
 }
 
 pub(super) struct CitationParser {
+    literals: literals::LiteralEscaper,
     visible_segments: Vec<String>,
     citation: PiMemoryCitation,
     diagnostics: CitationDiagnostics,
@@ -77,6 +80,7 @@ pub(super) struct CitationParser {
 impl CitationParser {
     pub(super) fn new(segment_count: usize) -> Self {
         Self {
+            literals: literals::LiteralEscaper::default(),
             visible_segments: vec![String::new(); segment_count],
             citation: PiMemoryCitation::default(),
             diagnostics: CitationDiagnostics::default(),
@@ -89,11 +93,42 @@ impl CitationParser {
     }
 
     pub(super) fn push(&mut self, chunk: &str, source: usize) {
+        // Preserve the allocation-free ordinary-text path from #32348. Code
+        // recognition adds work only when the chunk can change Markdown state.
+        if self.literals.bypass_plain_chunk(chunk) {
+            for value in chunk.chars() {
+                self.push_character(SourcedChar { value, source });
+            }
+            return;
+        }
+        let mut literals = std::mem::take(&mut self.literals);
         for value in chunk.chars() {
-            self.push_character(SourcedChar { value, source });
+            literals.push(SourcedChar { value, source }, &mut |item, escape| {
+                self.push_literal_character(item, escape);
+            });
+        }
+        self.literals = literals;
+    }
+
+    fn push_literal_character(&mut self, item: SourcedChar, escape: bool) {
+        let replacement = match (escape && !self.inside, item.value) {
+            (true, '<') => Some("&lt;"),
+            (true, '>') => Some("&gt;"),
+            _ => None,
+        };
+        if let Some(replacement) = replacement {
+            for value in replacement.chars() {
+                self.push_character(SourcedChar {
+                    value,
+                    source: item.source,
+                });
+            }
+        } else {
+            self.push_character(item);
         }
     }
 
+    #[inline(always)]
     fn push_character(&mut self, character: SourcedChar) {
         if self.inside {
             self.close_pending.push(character);
@@ -167,6 +202,8 @@ impl CitationParser {
     }
 
     pub(super) fn finish(mut self) -> CitationProjection {
+        let mut literals = std::mem::take(&mut self.literals);
+        literals.finish(&mut |item, escape| self.push_literal_character(item, escape));
         if self.inside {
             let pending = std::mem::take(&mut self.close_pending);
             for character in pending {
@@ -312,6 +349,54 @@ mod tests {
     #[derive(Deserialize)]
     struct Fixture {
         cases: Vec<FixtureCase>,
+        #[serde(rename = "literalCases")]
+        literal_cases: Vec<LiteralCase>,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct LiteralCase {
+        name: String,
+        text: String,
+        visible_text: String,
+    }
+
+    fn expand(template: &str) -> String {
+        template
+            .replace(
+                "$ESCAPED_OPEN",
+                &OPEN.replace('<', "&lt;").replace('>', "&gt;"),
+            )
+            .replace(
+                "$ESCAPED_CLOSE",
+                &CLOSE.replace('<', "&lt;").replace('>', "&gt;"),
+            )
+            .replace("$OPEN", OPEN)
+            .replace("$CLOSE", CLOSE)
+    }
+
+    #[test]
+    fn shared_literals_preserve_every_split_and_repeat_projection() {
+        for case in fixture().literal_cases {
+            let text = expand(&case.text);
+            let visible = expand(&case.visible_text);
+            for split in (0..=text.len()).filter(|&split| text.is_char_boundary(split)) {
+                let projected = project_segments(&[&text[..split], &text[split..]]);
+                assert_eq!(
+                    projected.visible_segments.concat(),
+                    visible,
+                    "{} split {split}",
+                    case.name
+                );
+            }
+            assert_eq!(
+                project_segments(&[&visible]).visible_segments.concat(),
+                visible,
+                "{} repeated",
+                case.name
+            );
+            assert!(!visible.contains(OPEN) && !visible.contains(CLOSE));
+        }
     }
 
     fn fixture() -> Fixture {

--- a/crates/guest-agent/src/cli/pi_memory_citation/literals.rs
+++ b/crates/guest-agent/src/cli/pi_memory_citation/literals.rs
@@ -1,0 +1,236 @@
+//! Bounded Markdown recognition for isolated citation delimiter examples only.
+//! Larger code bodies still go through the private-envelope scanner unchanged.
+
+use super::{CLOSE, OPEN, SourcedChar};
+
+const MAX_CANDIDATE: usize = 4096;
+
+#[derive(Default, PartialEq)]
+enum Mode {
+    #[default]
+    Text,
+    Run,
+    Inline,
+    Header,
+    Fence,
+}
+
+#[derive(Default)]
+pub(super) struct LiteralEscaper {
+    mode: Mode,
+    pending: Vec<SourcedChar>,
+    eligible: bool,
+    marker: char,
+    width: usize,
+    closing: usize,
+    fence_start: bool,
+    fence_close: bool,
+    fence_tail: bool,
+    indent: usize,
+    escaped: bool,
+    token: String,
+    token_ended: bool,
+}
+
+impl LiteralEscaper {
+    pub(super) fn bypass_plain_chunk(&mut self, chunk: &str) -> bool {
+        // Single-byte searches use str's optimized ASCII search rather than a
+        // Unicode character predicate on every ordinary byte.
+        if self.mode != Mode::Text
+            || chunk.contains('`')
+            || chunk.contains('~')
+            || chunk.contains('\\')
+            || chunk.contains('\n')
+        {
+            return false;
+        }
+        if !chunk.is_empty() {
+            self.indent = if chunk.bytes().all(|byte| byte == b' ') {
+                self.indent.saturating_add(chunk.len()).min(4)
+            } else {
+                4
+            };
+            self.escaped = false;
+        }
+        true
+    }
+
+    pub(super) fn push(&mut self, item: SourcedChar, emit: &mut impl FnMut(SourcedChar, bool)) {
+        self.consume(item, emit);
+        self.indent = match item.value {
+            '\n' => 0,
+            ' ' if self.indent < 4 => self.indent + 1,
+            _ => 4,
+        };
+    }
+
+    fn consume(&mut self, item: SourcedChar, emit: &mut impl FnMut(SourcedChar, bool)) {
+        let c = item.value;
+        match self.mode {
+            Mode::Text => {
+                if (c == '`' && !self.escaped) || (c == '~' && self.indent <= 3) {
+                    self.mode = Mode::Run;
+                    self.marker = c;
+                    self.width = 1;
+                    self.fence_start = self.indent <= 3;
+                    self.eligible = true;
+                    self.token.clear();
+                    self.token_ended = false;
+                    self.closing = 0;
+                    self.pending.push(item);
+                } else {
+                    emit(item, false);
+                }
+                self.escaped = c == '\\' && !self.escaped;
+            }
+            Mode::Run => {
+                if c == self.marker {
+                    self.width = self.width.saturating_add(1);
+                    self.retain(item, emit);
+                } else {
+                    if self.fence_start && self.width >= 3 && !(self.marker == '`' && c == '<') {
+                        self.mode = Mode::Header;
+                    } else if self.marker == '`' {
+                        self.mode = Mode::Inline;
+                    } else {
+                        self.flush(false, emit);
+                        self.mode = Mode::Text;
+                    }
+                    self.consume(item, emit);
+                }
+            }
+            Mode::Inline => {
+                if c != '`' && self.closing == self.width {
+                    self.flush(self.complete_token(), emit);
+                    self.mode = Mode::Text;
+                    self.consume(item, emit);
+                    return;
+                }
+                if c == '`' {
+                    self.closing = self.closing.saturating_add(1);
+                    if self.closing > self.width || !self.complete_token() {
+                        self.invalidate(emit);
+                    }
+                } else {
+                    if self.closing > 0 {
+                        self.invalidate(emit);
+                    }
+                    self.closing = 0;
+                    self.consume_token(c, false, emit);
+                }
+                self.retain(item, emit);
+            }
+            Mode::Header => {
+                if c == '\n' {
+                    self.mode = Mode::Fence;
+                    self.fence_close = true;
+                    self.fence_tail = false;
+                    self.closing = 0;
+                } else if !c.is_ascii_alphanumeric() && !matches!(c, ' ' | '\t' | '\r' | '_' | '-')
+                {
+                    // Only simple language labels are supported literal fence headers.
+                    self.invalidate(emit);
+                }
+                self.retain(item, emit);
+            }
+            Mode::Fence => self.consume_fence(item, emit),
+        }
+    }
+
+    fn consume_fence(&mut self, item: SourcedChar, emit: &mut impl FnMut(SourcedChar, bool)) {
+        let c = item.value;
+        if c == '\n' {
+            let closes = self.fence_close && self.closing >= self.width;
+            if !closes {
+                self.consume_token(c, true, emit);
+            }
+            self.retain(item, emit);
+            if closes {
+                self.flush(self.complete_token(), emit);
+                self.mode = Mode::Text;
+            }
+            self.fence_close = true;
+            self.fence_tail = false;
+            self.closing = 0;
+            return;
+        }
+        if self.fence_close {
+            if self.closing == 0 && c == ' ' && self.indent < 3 {
+                self.consume_token(c, true, emit);
+            } else if c == self.marker && !self.fence_tail {
+                self.closing = self.closing.saturating_add(1);
+            } else if self.closing > 0 && matches!(c, ' ' | '\t' | '\r') {
+                self.fence_tail = true;
+            } else {
+                self.fence_close = false;
+                if self.closing > 0 {
+                    self.invalidate(emit);
+                }
+                self.consume_token(c, true, emit);
+            }
+        } else {
+            self.consume_token(c, true, emit);
+        }
+        self.retain(item, emit);
+    }
+
+    fn consume_token(
+        &mut self,
+        c: char,
+        whitespace: bool,
+        emit: &mut impl FnMut(SourcedChar, bool),
+    ) {
+        if !self.eligible {
+            return;
+        }
+        if whitespace && matches!(c, ' ' | '\t' | '\r' | '\n') {
+            if !self.token.is_empty() {
+                if !self.complete_token() {
+                    self.invalidate(emit);
+                }
+                self.token_ended = true;
+            }
+            return;
+        }
+        if self.token_ended {
+            self.invalidate(emit);
+            return;
+        }
+        self.token.push(c);
+        if !OPEN.starts_with(&self.token) && !CLOSE.starts_with(&self.token) {
+            self.invalidate(emit);
+        }
+    }
+
+    fn complete_token(&self) -> bool {
+        self.eligible && (self.token == OPEN || self.token == CLOSE)
+    }
+
+    fn retain(&mut self, item: SourcedChar, emit: &mut impl FnMut(SourcedChar, bool)) {
+        if self.pending.len() >= MAX_CANDIDATE {
+            self.invalidate(emit);
+        }
+        if self.eligible {
+            self.pending.push(item);
+        } else {
+            emit(item, false);
+        }
+    }
+
+    fn invalidate(&mut self, emit: &mut impl FnMut(SourcedChar, bool)) {
+        self.flush(false, emit);
+        self.eligible = false;
+    }
+
+    fn flush(&mut self, escape: bool, emit: &mut impl FnMut(SourcedChar, bool)) {
+        for item in self.pending.drain(..) {
+            emit(item, escape);
+        }
+    }
+
+    pub(super) fn finish(&mut self, emit: &mut impl FnMut(SourcedChar, bool)) {
+        let closed = (self.mode == Mode::Inline && self.closing == self.width)
+            || (self.mode == Mode::Fence && self.fence_close && self.closing >= self.width);
+        self.flush(closed && self.complete_token(), emit);
+    }
+}

--- a/docs/citation-delimiter-literals.md
+++ b/docs/citation-delimiter-literals.md
@@ -1,0 +1,121 @@
+# Citation delimiter literal boundary
+
+Issue #32569 repairs explanatory code examples without changing the private
+citation transport established by #31959 / #31967 or the retained native memory
+and checkpoint decisions in #31067. `OPEN` and `CLOSE` below denote the existing
+parser constants; examples deliberately avoid printing control delimiters.
+
+## Literal grammar
+
+The TS and Rust scanners share `fixtures/pi-memory-citations.json`. Only an
+entire `OPEN` or `CLOSE` inside a fully closed backtick span is exempt. A fence
+may contain ASCII whitespace around one delimiter, but no other content. Fences
+use at least three backticks or tildes, at most three leading spaces, a simple
+ASCII language label, and a same-character closing run at least as wide as the
+opening run. A closing fence at EOF is supported. Candidates retain at most
+4,096 characters, including their code delimiters.
+
+Only delimiter angle brackets become `&lt;` and `&gt;`. Their source segment
+ownership is retained. Entities stay encoded on every subsequent projection;
+old readers therefore cannot reinterpret the example as transport. This is a
+deliberately narrow grammar, not a Markdown parser or renderer change.
+
+Unclosed, mismatched, oversized or larger code bodies go through the existing
+private-envelope scanner unchanged. A real envelope inside code remains
+private. A closed code span inside an already open private envelope does not
+escape that envelope's closing delimiter. Missing closers and zero parsed
+entries never authorize publication. Existing body/provenance size limits and
+the Rust allocation fix from #32348 remain in place.
+
+## Native source and publication order
+
+The audited runtime is Codex CLI 0.153.4, upstream `rust-v0.153.4` commit
+[`3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`](https://github.com/openai/codex/tree/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a).
+The generated experimental protocol exposes `experimentalRawEvents` on
+`thread/start`, but not on `thread/resume`. In the actual binary, fresh native
+`item/completed` precedes `rawResponseItem/completed`; a resumed thread in a
+new process does not emit the latter. Neither a fresh subscription assumption
+nor normalized `item.text` can repair the reported truncation.
+
+Guest uses one private source for both cases: the canonical rollout selected
+by the existing descriptor-safe session history resolver. Native
+`core/src/tasks/mod.rs` flushes the rollout before emitting turn completion;
+`core/src/rollout/recorder.rs` materializes a compressed rollout before opening
+it for append on resume. The executable probe below verifies both contracts.
+
+The resolver binds the canonical thread UUID, rejects ambiguous paths and
+symlinks, and pins the file descriptor. Guest checks `session_meta.id` and sets
+the resume cursor to EOF **before** `turn/start`, so it does not scan historical
+message bodies. Fresh resolution may be deferred until the first eligible
+message, with one final bounded attempt at turn completion. Reads are bounded
+to 4 MiB per record, 64 MiB per run, and 1 MiB of eligible text.
+
+Only an assistant `response_item` message with the exact native turn ID, item
+ID and commentary/final-answer phase is decoded as text. Its content must
+contain only `output_text` parts. Other rows, roles, reasoning and tool payloads
+are never public text sources. Raw notifications are not subscribed to or
+forwarded by this repair.
+
+Before replacement, Guest requires that the pinned native citation-only
+projection of the raw text exactly equals native normalized text. Messages
+containing proposed-plan controls are ineligible, including controls hidden
+after the erroneous opener. This preserves native contributor/other
+normalization and prevents plan restoration. Only the normalized event's text
+field is replaced; its existing native metadata/provenance is retained.
+
+An eligible normalized completion waits privately for its matching persisted
+item. Subsequent public events remain ordered behind it. Native turn completion
+is the flush barrier, not a timer. The queue is bounded by 128 events / 16 MiB;
+item deduplication is bounded by 4,096 identities. Missing, malformed, ambiguous,
+oversized or incompatible evidence retains the original native safe projection
+and emits at most one content-free diagnostic per run. Cancellation or process
+failure releases only original normalized events. This external-evidence
+failure policy is required by #32569, not a fleet compatibility fallback; a
+future runtime replacement must re-audit the contract before removing it.
+
+## Caller and compatibility audit
+
+| Boundary                           | Owning code / evidence                                                                                                                                                                    |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Native app-server                  | `codex_app_server_backend.rs` prepares all three notification ingest paths; scope validation precedes repair; all terminal/cancellation paths drain safely.                               |
+| Sandbox Pi / modern Guest          | `pi_rpc.rs` consumes the Rust parser; `events.rs` keeps the existing top-level private sidecar transport.                                                                                 |
+| API-first Pi                       | `api-turn.ts` uses the TS segment projection and retains structured provenance.                                                                                                           |
+| Old Guest / new API                | `pi-memory-citation-events.ts` retains the request-spanning legacy classifier; existing cap/retry/replay/ordering route regressions remain active.                                        |
+| New Guest / old API                | Pinned rollback wire fixture and executable baseline consumers prove sidecar stripping; escaped literals remain complete in activity, chat and callbacks.                                 |
+| Rows / Snapshot / cache            | `chat-event-row-projection.ts:chatEventFromRow` and `canonical-chat-event-read.service.ts` use the shared projector; row tests pin repeated projection and source immutability.           |
+| Share / search / archive / export  | `shared-thread.service.ts`, `chat-search.service.ts`, canonical reads and `user-export.service.ts`; archive consumer route tests exercise historical raw examples with private envelopes. |
+| Notification / callback / activity | `run-output.service.ts`, `internal-chat-run-callback.service.ts`, `run-detail.service.ts` reuse the same TS public projector.                                                             |
+| Session export / Stage 1           | `session-memory.ts` and `stage1-memory.ts` project derivative copies and leave canonical session JSONL unchanged.                                                                         |
+
+No schema, protocol field, storage identity, checkpoint writer, memory setting,
+billing, model routing or history format changes. Old frontend/new API and new
+frontend/old API keep the same response shape. Escaped bytes remain safe across
+API skew (including the documented ~102-minute incident exposure), existing
+runner/sandbox lifetimes (up to two hours), and old browser clients (~two days).
+The existing #31964 compatibility remains; this fix establishes no deletion,
+drain, rollback or production release gate.
+
+## Reproduce installed-runtime acceptance
+
+From the repository root, with dependencies installed, Codex 0.153.4 and libzstd:
+
+```sh
+cargo build --manifest-path crates/Cargo.toml --profile local -p guest-agent --example codex_citation_probe
+python3 scripts/codex-citation-native-probe.py --codex /usr/bin/codex --guest-probe crates/target/local/examples/codex_citation_probe
+```
+
+The probe serves synthetic Responses SSE locally, reproduces raw 872 versus
+native 114 characters, and verifies Guest emits the complete safely escaped
+878-character answer exactly once. It starts a new app-server process for each
+resume, including a compressed synthetic checkpoint, checks raw identity and
+native publication order, and executes current plus pre-fix public readers
+twenty times. It uses no provider credentials, user session, or public browser.
+Only temporary fixture histories are created/compressed by the probe; production
+repair code never writes history.
+
+This is deterministic installed-binary acceptance, not production or browser
+verification. It does not reconstruct already truncated historical public rows,
+test every arbitrary Markdown extension, or claim support for an untested
+future native protocol. Unsupported evidence intentionally retains native safe
+text. Targeted parser/privacy, Guest lifecycle, API consumer and compatibility
+tests complement the probe; full integration remains the PR pipeline's gate.

--- a/fixtures/pi-memory-citations.json
+++ b/fixtures/pi-memory-citations.json
@@ -41,8 +41,18 @@
       ],
       "visibleText": "abc",
       "entries": [
-        { "path": "a.md", "lineStart": 1, "lineEnd": 1, "note": "one" },
-        { "path": "b.md", "lineStart": 3, "lineEnd": 5, "note": "two" }
+        {
+          "path": "a.md",
+          "lineStart": 1,
+          "lineEnd": 1,
+          "note": "one"
+        },
+        {
+          "path": "b.md",
+          "lineStart": 3,
+          "lineEnd": 5,
+          "note": "two"
+        }
       ],
       "rolloutIds": [
         "019c6e27-e55b-73d1-87d8-4e01f1f75043",
@@ -55,7 +65,14 @@
         "<oai-mem-citation><citation_entries>x:1-2|note=[n]</citation_entries></oai-mem-citation>"
       ],
       "visibleText": "",
-      "entries": [{ "path": "x", "lineStart": 1, "lineEnd": 2, "note": "n" }],
+      "entries": [
+        {
+          "path": "x",
+          "lineStart": 1,
+          "lineEnd": 2,
+          "note": "n"
+        }
+      ],
       "rolloutIds": []
     },
     {
@@ -64,7 +81,14 @@
         "visible<oai-mem-citation><citation_entries>x:1-1|note=[n]</citation_entries>"
       ],
       "visibleText": "visible",
-      "entries": [{ "path": "x", "lineStart": 1, "lineEnd": 1, "note": "n" }],
+      "entries": [
+        {
+          "path": "x",
+          "lineStart": 1,
+          "lineEnd": 1,
+          "note": "n"
+        }
+      ],
       "rolloutIds": []
     },
     {
@@ -80,7 +104,14 @@
         "a</oai-mem-citation>b<oai-mem-citation>outer<oai-mem-citation><citation_entries>x:1-1|note=[n]</citation_entries></oai-mem-citation>c</oai-mem-citation>d"
       ],
       "visibleText": "abcd",
-      "entries": [{ "path": "x", "lineStart": 1, "lineEnd": 1, "note": "n" }],
+      "entries": [
+        {
+          "path": "x",
+          "lineStart": 1,
+          "lineEnd": 1,
+          "note": "n"
+        }
+      ],
       "rolloutIds": []
     },
     {
@@ -96,7 +127,12 @@
           "lineEnd": 6,
           "note": "trimmed"
         },
-        { "path": "good", "lineStart": 7, "lineEnd": 8, "note": "ok" }
+        {
+          "path": "good",
+          "lineStart": 7,
+          "lineEnd": 8,
+          "note": "ok"
+        }
       ],
       "rolloutIds": ["019c6e27-e55b-73d1-87d8-4e01f1f75043"]
     },
@@ -107,7 +143,12 @@
       ],
       "visibleText": "ab",
       "entries": [
-        { "path": "first", "lineStart": 1, "lineEnd": 1, "note": "kept" }
+        {
+          "path": "first",
+          "lineStart": 1,
+          "lineEnd": 1,
+          "note": "kept"
+        }
       ],
       "rolloutIds": ["019c6e27-e55b-73d1-87d8-4e01f1f75043"]
     },
@@ -117,6 +158,138 @@
       "visibleText": "ab",
       "entries": [],
       "rolloutIds": []
+    }
+  ],
+  "literalCases": [
+    {
+      "name": "inline $OPEN 1",
+      "text": "解释 `$OPEN` suffix ✓",
+      "visibleText": "解释 `$ESCAPED_OPEN` suffix ✓"
+    },
+    {
+      "name": "inline $OPEN 2",
+      "text": "解释 ``$OPEN`` suffix ✓",
+      "visibleText": "解释 ``$ESCAPED_OPEN`` suffix ✓"
+    },
+    {
+      "name": "fence $OPEN ```",
+      "text": "before\n  ```text\n \t$OPEN \n\n ```\nsuffix ✓",
+      "visibleText": "before\n  ```text\n \t$ESCAPED_OPEN \n\n ```\nsuffix ✓"
+    },
+    {
+      "name": "fence $OPEN ~~~~",
+      "text": "before\n  ~~~~text\n \t$OPEN \n\n ~~~~\nsuffix ✓",
+      "visibleText": "before\n  ~~~~text\n \t$ESCAPED_OPEN \n\n ~~~~\nsuffix ✓"
+    },
+    {
+      "name": "fence $OPEN ````",
+      "text": "before\n  ````text\n \t$OPEN \n\n ````\nsuffix ✓",
+      "visibleText": "before\n  ````text\n \t$ESCAPED_OPEN \n\n ````\nsuffix ✓"
+    },
+    {
+      "name": "inline $CLOSE 1",
+      "text": "解释 `$CLOSE` suffix ✓",
+      "visibleText": "解释 `$ESCAPED_CLOSE` suffix ✓"
+    },
+    {
+      "name": "inline $CLOSE 2",
+      "text": "解释 ``$CLOSE`` suffix ✓",
+      "visibleText": "解释 ``$ESCAPED_CLOSE`` suffix ✓"
+    },
+    {
+      "name": "fence $CLOSE ```",
+      "text": "before\n  ```text\n \t$CLOSE \n\n ```\nsuffix ✓",
+      "visibleText": "before\n  ```text\n \t$ESCAPED_CLOSE \n\n ```\nsuffix ✓"
+    },
+    {
+      "name": "fence $CLOSE ~~~~",
+      "text": "before\n  ~~~~text\n \t$CLOSE \n\n ~~~~\nsuffix ✓",
+      "visibleText": "before\n  ~~~~text\n \t$ESCAPED_CLOSE \n\n ~~~~\nsuffix ✓"
+    },
+    {
+      "name": "fence $CLOSE ````",
+      "text": "before\n  ````text\n \t$CLOSE \n\n ````\nsuffix ✓",
+      "visibleText": "before\n  ````text\n \t$ESCAPED_CLOSE \n\n ````\nsuffix ✓"
+    },
+    {
+      "name": "inline eof",
+      "text": "a `$OPEN`",
+      "visibleText": "a `$ESCAPED_OPEN`"
+    },
+    {
+      "name": "fence eof",
+      "text": "~~~\n$OPEN\n~~~",
+      "visibleText": "~~~\n$ESCAPED_OPEN\n~~~"
+    },
+    {
+      "name": "inline real body",
+      "text": "a `$OPEN private/path secret note $CLOSE` suffix",
+      "visibleText": "a `` suffix"
+    },
+    {
+      "name": "fence real body",
+      "text": "a\n```\n$OPEN private/path secret note $CLOSE\n```\nsuffix",
+      "visibleText": "a\n```\n\n```\nsuffix"
+    },
+    {
+      "name": "larger code with nested ticks",
+      "text": "a ``some `$OPEN` body`` suffix",
+      "visibleText": "a ``some `"
+    },
+    {
+      "name": "unclosed span",
+      "text": "a `$OPEN suffix",
+      "visibleText": "a `"
+    },
+    {
+      "name": "unclosed fence",
+      "text": "a\n```\n$OPEN\nsuffix",
+      "visibleText": "a\n```\n"
+    },
+    {
+      "name": "mismatched inline close",
+      "text": "a ``$OPEN` suffix",
+      "visibleText": "a ``"
+    },
+    {
+      "name": "escaped inline opener",
+      "text": "a \\`$OPEN` suffix",
+      "visibleText": "a \\`"
+    },
+    {
+      "name": "ambiguous prose",
+      "text": "a $OPEN suffix",
+      "visibleText": "a "
+    },
+    {
+      "name": "real envelope with code body",
+      "text": "a $OPEN`secret`$CLOSE suffix",
+      "visibleText": "a  suffix"
+    },
+    {
+      "name": "adjacent real envelope",
+      "text": "a `$OPEN`$OPEN private/path secret note $CLOSE suffix",
+      "visibleText": "a `$ESCAPED_OPEN` suffix"
+    },
+    {
+      "name": "two examples",
+      "text": "a `$OPEN` and `$CLOSE` suffix",
+      "visibleText": "a `$ESCAPED_OPEN` and `$ESCAPED_CLOSE` suffix"
+    },
+    {
+      "name": "escaped idempotent",
+      "text": "a `$ESCAPED_OPEN` and `$ESCAPED_CLOSE` suffix",
+      "visibleText": "a `$ESCAPED_OPEN` and `$ESCAPED_CLOSE` suffix"
+    },
+    {
+      "name": "ordinary markdown",
+      "text": "a `hello` and ```code``` suffix",
+      "visibleText": "a `hello` and ```code``` suffix"
+    },
+    {
+      "name": "wide inline delimiter at line start",
+      "text": "```$OPEN``` suffix",
+      "visibleText": "```$ESCAPED_OPEN``` suffix"
     }
   ]
 }

--- a/scripts/codex-citation-native-probe.py
+++ b/scripts/codex-citation-native-probe.py
@@ -1,0 +1,231 @@
+"""Deterministic acceptance against shipped Codex, a synthetic provider, and Guest.
+
+No provider credentials or user sessions are used. Build the Guest driver with:
+  cargo build --manifest-path crates/Cargo.toml --profile local -p guest-agent \
+    --example codex_citation_probe
+Then run this script with --codex and --guest-probe executable paths.
+"""
+
+import argparse
+import ctypes
+import ctypes.util
+import http.server
+import json
+import os
+import pathlib
+import queue
+import re
+import subprocess
+import tempfile
+import threading
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PARSER = ROOT / "crates/guest-agent/src/cli/pi_memory_citation.rs"
+OPEN = json.loads(re.search(r'const OPEN: &str = ("[^"]+")', PARSER.read_text())[1])
+CLOSE = json.loads(re.search(r'const CLOSE: &str = ("[^"]+")', PARSER.read_text())[1])
+PREFIX = "The implementation uses a reserved delimiter, shown here as inline code: ".ljust(113) + "`"
+SUFFIX = " SENTINEL_END_OF_REPLY"
+TEXT = (PREFIX + OPEN + "` marks internal transport. The explanation continues. ").ljust(872 - len(SUFFIX), "x") + SUFFIX
+SAFE = TEXT.replace(OPEN, OPEN.replace("<", "&lt;").replace(">", "&gt;"))
+ITEM = "msg_citation_literal_acceptance"
+BASELINE = "f222eab48ae3490abd952db26ef1ff51c8074af6"
+
+
+class Provider(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *_):
+        pass
+
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        item = {"type": "message", "id": ITEM, "role": "assistant", "phase": "final_answer",
+                "status": "completed", "content": [{"type": "output_text", "text": TEXT, "annotations": []}]}
+        events = [
+            {"type": "response.created", "response": {"id": "resp_fixture", "status": "in_progress"}},
+            {"type": "response.output_item.added", "output_index": 0, "item": {**item, "content": [], "status": "in_progress"}},
+            {"type": "response.output_text.delta", "output_index": 0, "content_index": 0, "item_id": ITEM, "delta": TEXT},
+            {"type": "response.output_item.done", "output_index": 0, "item": item},
+            {"type": "response.completed", "response": {"id": "resp_fixture", "status": "completed", "output": [item],
+             "usage": {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30}}},
+        ]
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.end_headers()
+        for event in events:
+            self.wfile.write(("event: " + event["type"] + "\ndata: " + json.dumps(event) + "\n\n").encode())
+            self.wfile.flush()
+
+
+def protocol_run(codex, home, url, thread_id=None):
+    env = {key: value for key, value in os.environ.items() if key in ["PATH", "HOME", "LANG"]}
+    env["CODEX_HOME"] = str(home)
+    config = '{name="Synthetic fixture",base_url=' + json.dumps(url) + ',wire_api="responses",supports_websockets=false}'
+    proc = subprocess.Popen([codex, "app-server", "--stdio", "-c", 'model_provider="fixture"',
+                             "-c", 'model="gpt-5.4"', "-c", "model_providers.fixture=" + config],
+                            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, env=env)
+    inbox = queue.Queue()
+
+    def read():
+        for line in proc.stdout:
+            inbox.put(json.loads(line))
+
+    threading.Thread(target=read, daemon=True).start()
+
+    def send(method, params, ident=None):
+        value = {"method": method, "params": params}
+        if ident is not None:
+            value["id"] = ident
+        proc.stdin.write(json.dumps(value) + "\n")
+        proc.stdin.flush()
+
+    def response(ident):
+        while True:
+            value = inbox.get(timeout=30)
+            if value.get("id") == ident:
+                assert "error" not in value, "native protocol request failed"
+                return value["result"]
+
+    try:
+        send("initialize", {"clientInfo": {"name": "citation_probe", "version": "1"},
+                            "capabilities": {"experimentalApi": True}}, 1)
+        response(1)
+        send("initialized", {})
+        params = {"cwd": str(home), "approvalPolicy": "never", "sandbox": "danger-full-access",
+                  "config": {"features.memories": True}, "baseInstructions": "Answer without tools."}
+        if thread_id:
+            params.update(threadId=thread_id, excludeTurns=True)
+            method = "thread/resume"
+        else:
+            params["experimentalRawEvents"] = True
+            method = "thread/start"
+        send(method, params, 2)
+        thread = response(2)["thread"]
+        assert not thread_id or thread["id"] == thread_id
+        send("turn/start", {"threadId": thread["id"], "input": [{"type": "text", "text": "Explain."}]}, 3)
+        turn = response(3)["turn"]["id"]
+        order = []
+        while True:
+            notification = inbox.get(timeout=30)
+            method = notification.get("method")
+            params = notification.get("params", {})
+            item = params.get("item", {})
+            if item.get("id") == ITEM and method in ["item/completed", "rawResponseItem/completed"]:
+                assert params["threadId"] == thread["id"] and params["turnId"] == turn
+                assert item["phase"] == "final_answer"
+                if method == "item/completed":
+                    assert item["type"] == "agentMessage" and item["text"] == PREFIX
+                else:
+                    assert item["role"] == "assistant" and item["content"][0]["text"] == TEXT
+                order.append(method)
+            if method == "turn/completed":
+                assert params["turn"]["status"] == "completed"
+                break
+        expected_order = ["item/completed"] if thread_id else ["item/completed", "rawResponseItem/completed"]
+        assert order == expected_order, "unexpected raw/normalized ordering"
+        # Native's terminal event is the actual flush barrier, not a timer.
+        path = pathlib.Path(thread["path"])
+        assert path.is_relative_to(home)
+        rows = [json.loads(line) for line in path.read_text().splitlines()]
+        matches = [row["payload"] for row in rows if row.get("type") == "response_item"
+                   and row["payload"].get("id") == ITEM
+                   and row["payload"].get("internal_chat_message_metadata_passthrough", {}).get("turn_id") == turn]
+        assert len(matches) == 1 and matches[0]["content"][0]["text"] == TEXT
+        return thread["id"]
+    finally:
+        proc.stdin.close()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+
+def guest_run(driver, codex, home, url, thread_id=None):
+    args = [driver, str(home), codex, url] + ([thread_id] if thread_id else [])
+    result = subprocess.run(args, capture_output=True, text=True, timeout=30, check=True)
+    response = json.loads(result.stdout.splitlines()[-1])
+    assert response["exitCode"] == 0 and response["visible"] == [SAFE], "Guest did not recover the complete explanation"
+    assert "repair unavailable" not in result.stdout + result.stderr, "happy path used fallback"
+    assert not thread_id or thread_id == response["threadId"]
+    return response["threadId"]
+
+
+def public_readers():
+    baseline = subprocess.check_output(["git", "show", BASELINE + ":turbo/packages/api-contracts/src/contracts/pi-memory-citations.ts"], cwd=ROOT, text=True)
+    # Place the temporary old module beside its dependency resolution root.
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".mts", prefix=".citation-old-", dir=ROOT / "turbo/packages/api-contracts") as old:
+        old.write(baseline)
+        old.flush()
+        program = """
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { visiblePiMemoryCitationText as current } from './packages/api-contracts/src/contracts/pi-memory-citations.ts';
+import { pathToFileURL } from 'node:url';
+async function verify() {
+  const {visiblePiMemoryCitationText: old} = await import(pathToFileURL(process.argv[1]).href);
+  const safe = JSON.parse(fs.readFileSync(0, 'utf8'));
+  let text = safe;
+  for (let n = 0; n < 20; n++) { text = old(current(text)); assert.equal(text, safe); }
+}
+verify();
+"""
+        subprocess.run(["pnpm", "exec", "tsx", "-e", program, old.name], cwd=ROOT / "turbo",
+                       input=json.dumps(SAFE), text=True, capture_output=True, check=True, timeout=30)
+
+
+def compress_synthetic_rollout(home):
+    # Simulate a restored compressed checkpoint only inside this temporary fixture.
+    paths = list(home.glob("codex/sessions/*/*/*/*.jsonl"))
+    assert len(paths) == 1
+    path = paths[0]
+    library = ctypes.util.find_library("zstd")
+    assert library, "libzstd is required for restored-checkpoint acceptance"
+    zstd = ctypes.CDLL(library)
+    zstd.ZSTD_compressBound.argtypes = [ctypes.c_size_t]
+    zstd.ZSTD_compressBound.restype = ctypes.c_size_t
+    zstd.ZSTD_compress.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int]
+    zstd.ZSTD_compress.restype = ctypes.c_size_t
+    zstd.ZSTD_isError.argtypes = [ctypes.c_size_t]
+    zstd.ZSTD_isError.restype = ctypes.c_uint
+    data = path.read_bytes()
+    output = ctypes.create_string_buffer(zstd.ZSTD_compressBound(len(data)))
+    length = zstd.ZSTD_compress(output, len(output), data, len(data), 1)
+    assert not zstd.ZSTD_isError(length)
+    path.with_suffix(".jsonl.zst").write_bytes(output.raw[:length])
+    path.unlink()
+    return path
+
+
+def main():
+    parser = argparse.ArgumentParser(__doc__)
+    parser.add_argument("--codex", required=True)
+    parser.add_argument("--guest-probe", required=True)
+    args = parser.parse_args()
+    version = subprocess.check_output([args.codex, "--version"], text=True).strip()
+    assert version == "codex-cli 0.153.4", "re-audit the native contract before changing the pinned version"
+    assert len(TEXT) == 872 and len(PREFIX) == 114
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Provider)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    url = f"http://127.0.0.1:{server.server_port}/v1"
+    try:
+        with tempfile.TemporaryDirectory(prefix="citation-native-acceptance-") as directory:
+            root = pathlib.Path(directory)
+            home = root / "protocol"
+            home.mkdir()
+            thread = protocol_run(args.codex, home, url)
+            protocol_run(args.codex, home, url, thread)
+            thread = guest_run(args.guest_probe, args.codex, root / "guest", url)
+            guest_run(args.guest_probe, args.codex, root / "guest", url, thread)
+            path = compress_synthetic_rollout(root / "guest")
+            guest_run(args.guest_probe, args.codex, root / "guest", url, thread)
+            assert path.is_file(), "native resume must materialize its active canonical rollout"
+        public_readers()
+    finally:
+        server.shutdown()
+    print(json.dumps({"runtime": version, "rawCharacters": len(TEXT), "nativeCharacters": len(PREFIX),
+                      "safeCharacters": len(SAFE), "fresh": "pass", "newProcessResume": "pass",
+                      "guestFreshResume": "pass", "compressedCheckpointResume": "pass",
+                      "oldNewPublicReaders": "pass"}))
+
+
+if __name__ == "__main__":
+    main()

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-event-archive-consumers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-event-archive-consumers.test.ts
@@ -55,10 +55,7 @@ interface ArchiveFixture {
   readonly threadId: string;
 }
 
-const escapedOpen = PI_MEMORY_CITATION_OPEN.replaceAll("<", "&lt;").replaceAll(
-  ">",
-  "&gt;",
-);
+const escapedOpen = `&lt;${PI_MEMORY_CITATION_OPEN.slice(1, -1)}&gt;`;
 
 function withHiddenCitation(visible: string): string {
   // Retained raw-backed rows contain both an isolated example and real private provenance.

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-event-archive-consumers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-event-archive-consumers.test.ts
@@ -2,6 +2,10 @@ import { randomUUID } from "node:crypto";
 import { gzipSync } from "node:zlib";
 
 import AdmZip from "adm-zip";
+import {
+  PI_MEMORY_CITATION_OPEN,
+  PI_MEMORY_CITATION_CLOSE,
+} from "@okouai/api-contracts/contracts/pi-memory-citations";
 import { sharedThreadsContract } from "@okouai/api-contracts/contracts/shared-threads";
 import { testChatEventRetentionContract } from "@okouai/api-contracts/contracts/test-chat-event-retention";
 import { testChatEventSearchProjectionContract } from "@okouai/api-contracts/contracts/test-chat-event-search-projection";
@@ -51,8 +55,14 @@ interface ArchiveFixture {
   readonly threadId: string;
 }
 
+const escapedOpen = PI_MEMORY_CITATION_OPEN.replaceAll("<", "&lt;").replaceAll(
+  ">",
+  "&gt;",
+);
+
 function withHiddenCitation(visible: string): string {
-  return `${visible}<oai-mem-citation><citation_entries>memory.md:1-1|note=[private]</citation_entries></oai-mem-citation>`;
+  // Retained raw-backed rows contain both an isolated example and real private provenance.
+  return `${visible.replace(escapedOpen, PI_MEMORY_CITATION_OPEN)}${PI_MEMORY_CITATION_OPEN}<citation_entries>memory.md:1-1|note=[private]</citation_entries>${PI_MEMORY_CITATION_CLOSE}`;
 }
 
 function searchClient() {
@@ -209,7 +219,7 @@ describe("archived chat event consumers", () => {
 
   it("exports snapshot history plus the PostgreSQL tail after archived source rows are gone", async () => {
     const fixture = await createArchiveFixture("export");
-    const archivedVisible = `archived-export-${randomUUID()}`;
+    const archivedVisible = `archived-export-${randomUUID()} \`${escapedOpen}\` suffix`;
     const archivedText = withHiddenCitation(archivedVisible);
     const archivedEventId = await store.set(
       seedRetentionOutputEvent$,
@@ -221,7 +231,7 @@ describe("archived chat event consumers", () => {
       context.signal,
     );
     await archiveAndRetain(fixture.threadId, [archivedEventId]);
-    const tailVisible = `hot-tail-${randomUUID()}`;
+    const tailVisible = `hot-tail-${randomUUID()} \`${escapedOpen}\` suffix`;
     const tailText = withHiddenCitation(tailVisible);
     await store.set(
       seedRetentionOutputEvent$,
@@ -251,7 +261,7 @@ describe("archived chat event consumers", () => {
 
   it("shares an archived selection while excluding archived revoked and invisible messages", async () => {
     const fixture = await createArchiveFixture("sharing");
-    const archivedVisible = `share-archived-${randomUUID()}`;
+    const archivedVisible = `share-archived-${randomUUID()} \`${escapedOpen}\` suffix`;
     const archivedText = withHiddenCitation(archivedVisible);
     const archivedEventId = await store.set(
       seedRetentionOutputEvent$,
@@ -366,7 +376,7 @@ describe("archived chat event consumers", () => {
 
   it("shares one hot-table snapshot when physical deletion queues behind its read", async () => {
     const fixture = await createArchiveFixture("sharing-race");
-    const hotVisible = `share-hot-race-${randomUUID()}`;
+    const hotVisible = `share-hot-race-${randomUUID()} \`${escapedOpen}\` suffix`;
     const hotText = withHiddenCitation(hotVisible);
     const hotEventId = await store.set(
       seedRetentionOutputEvent$,

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-memory-citation-old-api-rollback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-memory-citation-old-api-rollback.test.ts
@@ -132,7 +132,7 @@ describe("new Pi Guest to old API rollback privacy", () => {
       ],
     });
     expect(visible).toBe(
-      `explain \`${PI_MEMORY_CITATION_OPEN.replaceAll("<", "&lt;").replaceAll(">", "&gt;")}\` suffix `,
+      `explain \`&lt;${PI_MEMORY_CITATION_OPEN.slice(1, -1)}&gt;\` suffix `,
     );
     expect(rollback.chatProjection).toStrictEqual([{ content: visible }]);
     expect(rollback.callback).toBe(visible);

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-memory-citation-old-api-rollback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-memory-citation-old-api-rollback.test.ts
@@ -2,6 +2,11 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { z } from "zod";
 import { describe, expect, it } from "vitest";
+import {
+  PI_MEMORY_CITATION_OPEN,
+  PI_MEMORY_CITATION_CLOSE,
+  projectPiMemoryCitationText,
+} from "@okouai/api-contracts/contracts/pi-memory-citations";
 
 interface RollbackWireFixture {
   readonly baselineCommit: string;
@@ -110,6 +115,34 @@ const fixture = JSON.parse(
 ) as RollbackWireFixture;
 
 describe("new Pi Guest to old API rollback privacy", () => {
+  it("preserves escaped examples in old activity, chat and callback consumers", () => {
+    const projection = projectPiMemoryCitationText(
+      `explain \`${PI_MEMORY_CITATION_OPEN}\` suffix ${PI_MEMORY_CITATION_OPEN}<citation_entries>private.md:1-1|note=[private note]</citation_entries>${PI_MEMORY_CITATION_CLOSE}`,
+    );
+    const visible = projection.visibleText;
+    const rollback = executeRollbackBaseline({
+      ...recordOf(fixture.wirePayload),
+      events: [
+        {
+          type: "assistant",
+          sequenceNumber: 0,
+          message: { content: [{ type: "text", text: visible }] },
+        },
+        { type: "result", sequenceNumber: 1, result: visible },
+      ],
+    });
+    expect(visible).toBe(
+      `explain \`${PI_MEMORY_CITATION_OPEN.replaceAll("<", "&lt;").replaceAll(">", "&gt;")}\` suffix `,
+    );
+    expect(rollback.chatProjection).toStrictEqual([{ content: visible }]);
+    expect(rollback.callback).toBe(visible);
+    const serialized = JSON.stringify(rollback);
+    expect(serialized).not.toContain("private.md");
+    expect(serialized).not.toContain("private note");
+    expect(serialized).not.toContain(PI_MEMORY_CITATION_OPEN);
+    expect(serialized).toContain("suffix");
+  });
+
   it("strips the exact private sidecar before every baseline consumer", () => {
     expect(fixture.baselineCommit).toBe(
       "e5cbf8b3fff605d41581d511fc890a6d87a9bdbe",

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-event-rows.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-event-rows.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { CHAT_EVENT_TYPES, type ChatEventType } from "../chat-events";
 import { chatEventFromRow } from "../chat-event-row-projection";
+import {
+  PI_MEMORY_CITATION_OPEN,
+  PI_MEMORY_CITATION_CLOSE,
+} from "../pi-memory-citations";
 import { chatEventRowSchema, type ChatEventRow } from "../chat-event-rows";
 import {
   CHAT_EVENT_SCHEMA_VERSION_HEADER,
@@ -235,6 +239,22 @@ describe("canonical row projection preserves the public ChatEvent contract", () 
       eventType: "output.message",
       content: "visible",
     });
+  });
+
+  it("repeatedly projects historical literal examples without mutating rows or leaking private bodies", () => {
+    const content = `explain \`${PI_MEMORY_CITATION_OPEN}\` suffix${PI_MEMORY_CITATION_OPEN}private path and note${PI_MEMORY_CITATION_CLOSE}`;
+    const row = canonicalRow({ payload: { content } });
+    const before = JSON.stringify(row);
+    const expected = `explain \`${PI_MEMORY_CITATION_OPEN.replaceAll("<", "&lt;").replaceAll(">", "&gt;")}\` suffix`;
+    let projected = chatEventFromRow(row);
+    expect(projected.content).toBe(expected);
+    for (let i = 0; i < 3; i++) {
+      projected = chatEventFromRow(
+        canonicalRow({ payload: { content: projected.content } }),
+      );
+      expect(projected.content).toBe(expected);
+    }
+    expect(JSON.stringify(row)).toBe(before);
   });
 
   it("reads canonical usage and error payloads", () => {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-event-rows.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-event-rows.test.ts
@@ -245,7 +245,7 @@ describe("canonical row projection preserves the public ChatEvent contract", () 
     const content = `explain \`${PI_MEMORY_CITATION_OPEN}\` suffix${PI_MEMORY_CITATION_OPEN}private path and note${PI_MEMORY_CITATION_CLOSE}`;
     const row = canonicalRow({ payload: { content } });
     const before = JSON.stringify(row);
-    const expected = `explain \`${PI_MEMORY_CITATION_OPEN.replaceAll("<", "&lt;").replaceAll(">", "&gt;")}\` suffix`;
+    const expected = `explain \`&lt;${PI_MEMORY_CITATION_OPEN.slice(1, -1)}&gt;\` suffix`;
     let projected = chatEventFromRow(row);
     expect(projected.content).toBe(expected);
     for (let i = 0; i < 3; i++) {

--- a/turbo/packages/api-contracts/src/contracts/pi-memory-citation-literals.ts
+++ b/turbo/packages/api-contracts/src/contracts/pi-memory-citation-literals.ts
@@ -1,0 +1,225 @@
+/** Bounded recognition of isolated citation examples, shared with the Rust adapter. */
+export interface CitationCharacter {
+  readonly value: string;
+  readonly source: number;
+}
+
+type Emit = (item: CitationCharacter, escape: boolean) => void;
+type Mode = "text" | "run" | "inline" | "header" | "fence";
+
+export class CitationLiteralEscaper {
+  readonly #open: string;
+  readonly #close: string;
+  #mode: Mode = "text";
+  #pending: CitationCharacter[] = [];
+  #eligible = false;
+  #marker = "";
+  #width = 0;
+  #closing = 0;
+  #fenceStart = false;
+  #fenceClose = false;
+  #fenceTail = false;
+  #indent = 0;
+  #escaped = false;
+  #token = "";
+  #tokenEnded = false;
+
+  constructor(open: string, close: string) {
+    this.#open = open;
+    this.#close = close;
+  }
+
+  push(item: CitationCharacter, emit: Emit): void {
+    this.#consume(item, emit);
+    this.#indent =
+      item.value === "\n"
+        ? 0
+        : item.value === " " && this.#indent < 4
+          ? this.#indent + 1
+          : 4;
+  }
+
+  #consume(item: CitationCharacter, emit: Emit): void {
+    const c = item.value;
+    switch (this.#mode) {
+      case "text":
+        if ((c === "`" && !this.#escaped) || (c === "~" && this.#indent <= 3)) {
+          this.#mode = "run";
+          this.#marker = c;
+          this.#width = 1;
+          this.#fenceStart = this.#indent <= 3;
+          this.#eligible = true;
+          this.#token = "";
+          this.#tokenEnded = false;
+          this.#closing = 0;
+          this.#pending.push(item);
+        } else {
+          emit(item, false);
+        }
+        this.#escaped = c === "\\" && !this.#escaped;
+        return;
+      case "run":
+        if (c === this.#marker) {
+          this.#width += 1;
+          this.#retain(item, emit);
+        } else {
+          if (
+            this.#fenceStart &&
+            this.#width >= 3 &&
+            !(this.#marker === "`" && c === "<")
+          ) {
+            this.#mode = "header";
+          } else if (this.#marker === "`") {
+            this.#mode = "inline";
+          } else {
+            this.#flush(false, emit);
+            this.#mode = "text";
+          }
+          this.#consume(item, emit);
+        }
+        return;
+      case "inline":
+        this.#consumeInline(item, emit);
+        return;
+      case "header":
+        if (c === "\n") {
+          this.#mode = "fence";
+          this.#fenceClose = true;
+          this.#fenceTail = false;
+          this.#closing = 0;
+        } else if (!/^[a-zA-Z0-9 \t\r_-]$/.test(c)) {
+          // Only simple language labels are supported literal fence headers.
+          this.#invalidate(emit);
+        }
+        this.#retain(item, emit);
+        return;
+      case "fence":
+        this.#consumeFence(item, emit);
+    }
+  }
+
+  #consumeInline(item: CitationCharacter, emit: Emit): void {
+    const c = item.value;
+    if (c !== "`" && this.#closing === this.#width) {
+      this.#flush(this.#completeToken(), emit);
+      this.#mode = "text";
+      this.#consume(item, emit);
+      return;
+    }
+    if (c === "`") {
+      this.#closing += 1;
+      if (this.#closing > this.#width || !this.#completeToken()) {
+        this.#invalidate(emit);
+      }
+    } else {
+      if (this.#closing > 0) {
+        this.#invalidate(emit);
+      }
+      this.#closing = 0;
+      this.#consumeToken(c, false, emit);
+    }
+    this.#retain(item, emit);
+  }
+
+  #consumeFence(item: CitationCharacter, emit: Emit): void {
+    const c = item.value;
+    if (c === "\n") {
+      const closes = this.#fenceClose && this.#closing >= this.#width;
+      if (!closes) {
+        this.#consumeToken(c, true, emit);
+      }
+      this.#retain(item, emit);
+      if (closes) {
+        this.#flush(this.#completeToken(), emit);
+        this.#mode = "text";
+      }
+      this.#fenceClose = true;
+      this.#fenceTail = false;
+      this.#closing = 0;
+      return;
+    }
+    if (this.#fenceClose) {
+      if (this.#closing === 0 && c === " " && this.#indent < 3) {
+        this.#consumeToken(c, true, emit);
+      } else if (c === this.#marker && !this.#fenceTail) {
+        this.#closing += 1;
+      } else if (this.#closing > 0 && /^[ \t\r]$/.test(c)) {
+        this.#fenceTail = true;
+      } else {
+        this.#fenceClose = false;
+        if (this.#closing > 0) {
+          this.#invalidate(emit);
+        }
+        this.#consumeToken(c, true, emit);
+      }
+    } else {
+      this.#consumeToken(c, true, emit);
+    }
+    this.#retain(item, emit);
+  }
+
+  #consumeToken(c: string, whitespace: boolean, emit: Emit): void {
+    if (!this.#eligible) {
+      return;
+    }
+    if (whitespace && /^[ \t\r\n]$/.test(c)) {
+      if (this.#token.length > 0) {
+        if (!this.#completeToken()) {
+          this.#invalidate(emit);
+        }
+        this.#tokenEnded = true;
+      }
+      return;
+    }
+    if (this.#tokenEnded) {
+      this.#invalidate(emit);
+      return;
+    }
+    this.#token += c;
+    if (
+      !this.#open.startsWith(this.#token) &&
+      !this.#close.startsWith(this.#token)
+    ) {
+      this.#invalidate(emit);
+    }
+  }
+
+  #completeToken(): boolean {
+    return (
+      this.#eligible &&
+      (this.#token === this.#open || this.#token === this.#close)
+    );
+  }
+
+  #retain(item: CitationCharacter, emit: Emit): void {
+    if (this.#pending.length >= 4096) {
+      this.#invalidate(emit);
+    }
+    if (this.#eligible) {
+      this.#pending.push(item);
+    } else {
+      emit(item, false);
+    }
+  }
+
+  #invalidate(emit: Emit): void {
+    this.#flush(false, emit);
+    this.#eligible = false;
+  }
+
+  #flush(escape: boolean, emit: Emit): void {
+    for (const item of this.#pending) {
+      emit(item, escape);
+    }
+    this.#pending = [];
+  }
+
+  finish(emit: Emit): void {
+    const closed =
+      (this.#mode === "inline" && this.#closing === this.#width) ||
+      (this.#mode === "fence" &&
+        this.#fenceClose &&
+        this.#closing >= this.#width);
+    this.#flush(closed && this.#completeToken(), emit);
+  }
+}

--- a/turbo/packages/api-contracts/src/contracts/pi-memory-citations.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/pi-memory-citations.test.ts
@@ -36,11 +36,11 @@ function expand(template: string): string {
   return template
     .replaceAll(
       "$ESCAPED_OPEN",
-      PI_MEMORY_CITATION_OPEN.replaceAll("<", "&lt;").replaceAll(">", "&gt;"),
+      `&lt;${PI_MEMORY_CITATION_OPEN.slice(1, -1)}&gt;`,
     )
     .replaceAll(
       "$ESCAPED_CLOSE",
-      PI_MEMORY_CITATION_CLOSE.replaceAll("<", "&lt;").replaceAll(">", "&gt;"),
+      `&lt;${PI_MEMORY_CITATION_CLOSE.slice(1, -1)}&gt;`,
     )
     .replaceAll("$OPEN", PI_MEMORY_CITATION_OPEN)
     .replaceAll("$CLOSE", PI_MEMORY_CITATION_CLOSE);

--- a/turbo/packages/api-contracts/src/contracts/pi-memory-citations.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/pi-memory-citations.test.ts
@@ -13,6 +13,11 @@ import {
 } from "./pi-memory-citations";
 
 interface Fixture {
+  readonly literalCases: readonly {
+    readonly name: string;
+    readonly text: string;
+    readonly visibleText: string;
+  }[];
   readonly cases: readonly {
     readonly name: string;
     readonly chunks: readonly string[];
@@ -27,6 +32,20 @@ const fixturePath = fileURLToPath(
 );
 const fixture = JSON.parse(readFileSync(fixturePath, "utf8")) as Fixture;
 
+function expand(template: string): string {
+  return template
+    .replaceAll(
+      "$ESCAPED_OPEN",
+      PI_MEMORY_CITATION_OPEN.replaceAll("<", "&lt;").replaceAll(">", "&gt;"),
+    )
+    .replaceAll(
+      "$ESCAPED_CLOSE",
+      PI_MEMORY_CITATION_CLOSE.replaceAll("<", "&lt;").replaceAll(">", "&gt;"),
+    )
+    .replaceAll("$OPEN", PI_MEMORY_CITATION_OPEN)
+    .replaceAll("$CLOSE", PI_MEMORY_CITATION_CLOSE);
+}
+
 function parseChunks(chunks: readonly string[]) {
   const parser = new PiMemoryCitationStreamParser();
   for (const chunk of chunks) {
@@ -36,6 +55,66 @@ function parseChunks(chunks: readonly string[]) {
 }
 
 describe("Pi memory citations", () => {
+  for (const example of fixture.literalCases) {
+    it(`preserves the shared literal boundary at every split: ${example.name}`, () => {
+      const text = expand(example.text);
+      const visible = expand(example.visibleText);
+      for (let split = 0; split <= text.length; split += 1) {
+        const chunks = [text.slice(0, split), text.slice(split)];
+        expect(parseChunks(chunks).visibleText).toBe(visible);
+        expect(
+          projectPiMemoryCitationSegments(chunks).visibleSegments.join(""),
+        ).toBe(visible);
+      }
+      expect(projectPiMemoryCitationText(visible).visibleText).toBe(visible);
+      // A previous literal-only reader sees no control bytes to consume.
+      expect(visible).not.toContain(PI_MEMORY_CITATION_OPEN);
+      expect(visible).not.toContain(PI_MEMORY_CITATION_CLOSE);
+    });
+  }
+
+  it("preserves the entire 872-character incident equivalent at all 873 boundaries", () => {
+    const prefix =
+      "The implementation uses a reserved delimiter, shown here as inline code: ".padEnd(
+        113,
+        " ",
+      ) + "`";
+    const suffix = " SENTINEL_END_OF_REPLY";
+    const text =
+      (
+        prefix +
+        PI_MEMORY_CITATION_OPEN +
+        "` marks internal transport. The complete explanation continues. "
+      ).padEnd(872 - suffix.length, "x") + suffix;
+    expect(text).toHaveLength(872);
+    const visible = text.replace(
+      PI_MEMORY_CITATION_OPEN,
+      expand("$ESCAPED_OPEN"),
+    );
+    for (let split = 0; split <= text.length; split += 1) {
+      expect(
+        parseChunks([text.slice(0, split), text.slice(split)]).visibleText,
+      ).toBe(visible);
+    }
+  });
+
+  it("retains source placement while expanding only delimiter angle brackets", () => {
+    expect(
+      projectPiMemoryCitationSegments(["a `<", "oai-mem-citation", ">` tail"])
+        .visibleSegments,
+    ).toEqual(["a `&lt;", "oai-mem-citation", "&gt;` tail"]);
+  });
+
+  it("fails oversized literal candidates closed without retaining hidden body bytes", () => {
+    const text =
+      "```\n" +
+      " ".repeat(4096) +
+      PI_MEMORY_CITATION_OPEN +
+      "\n```\nprivate suffix";
+    expect(projectPiMemoryCitationText(text).visibleText).toBe(
+      "```\n" + " ".repeat(4096),
+    );
+  });
   for (const fixtureCase of fixture.cases) {
     it(`matches the shared fixture: ${fixtureCase.name}`, () => {
       const result = parseChunks(fixtureCase.chunks);

--- a/turbo/packages/api-contracts/src/contracts/pi-memory-citations.ts
+++ b/turbo/packages/api-contracts/src/contracts/pi-memory-citations.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { CitationLiteralEscaper } from "./pi-memory-citation-literals";
 
 /**
  * Adapted from OpenAI Codex rust-v0.152.1 at
@@ -256,6 +257,10 @@ function isPrefix(value: string, candidate: string): boolean {
 }
 
 class CitationScanner {
+  readonly #literals = new CitationLiteralEscaper(
+    PI_MEMORY_CITATION_OPEN,
+    PI_MEMORY_CITATION_CLOSE,
+  );
   readonly #visibleBySource = new Map<number, string[]>();
   readonly #citation: MutableCitation = { entries: [], rolloutIds: [] };
   readonly #diagnostics = emptyDiagnostics();
@@ -268,7 +273,23 @@ class CitationScanner {
 
   push(chunk: string, source = 0): void {
     for (const value of chunk) {
-      this.#pushCharacter({ value, source });
+      this.#literals.push({ value, source }, (item, escape) => {
+        this.#pushLiteralCharacter(item, escape);
+      });
+    }
+  }
+
+  #pushLiteralCharacter(item: SourcedCharacter, escape: boolean): void {
+    const replacement =
+      escape && !this.#inside
+        ? item.value === "<"
+          ? "&lt;"
+          : item.value === ">"
+            ? "&gt;"
+            : item.value
+        : item.value;
+    for (const value of replacement) {
+      this.#pushCharacter({ value, source: item.source });
     }
   }
 
@@ -366,6 +387,9 @@ class CitationScanner {
   }
 
   finish(): PiMemoryCitationProjection {
+    this.#literals.finish((item, escape) => {
+      this.#pushLiteralCharacter(item, escape);
+    });
     if (this.#inside) {
       for (const character of this.#closePending) {
         this.#appendBody(character.value);

--- a/turbo/packages/pi-agent-runtime/src/api.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/api.test.ts
@@ -1130,7 +1130,7 @@ describe("Pi API facade", () => {
   it("preserves split delimiter examples through API-first and immutable session export", () => {
     const literal = `explain \`${PI_MEMORY_CITATION_OPEN}\` suffix`;
     const hidden = `${PI_MEMORY_CITATION_OPEN}<citation_entries>private.md:1-1|note=[private note]</citation_entries>${PI_MEMORY_CITATION_CLOSE}`;
-    const expected = literal.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+    const expected = `explain \`&lt;${PI_MEMORY_CITATION_OPEN.slice(1, -1)}&gt;\` suffix`;
     const native = fauxAssistantMessage([
       { type: "text", text: literal.slice(0, 14) },
       { type: "text", text: literal.slice(14) + hidden },
@@ -1138,8 +1138,12 @@ describe("Pi API facade", () => {
     const projected = projectPiApiAssistantMessage(native);
     expect(
       projected.content
-        .filter((block) => {return block.type === "text"})
-        .map((block) => {return block.text})
+        .filter((block) => {
+          return block.type === "text";
+        })
+        .map((block) => {
+          return block.text;
+        })
         .join(""),
     ).toBe(expected);
     expect(projected.memoryCitation?.entries).toEqual([
@@ -1154,13 +1158,17 @@ describe("Pi API facade", () => {
     const exported = projectPiSessionJsonlForExport(canonical);
     const exportedText = MemoryPiSession.fromJsonl(exported)
       .buildSessionContext()
-      .messages.flatMap((message) =>
-        {return message.role === "assistant"
+      .messages.flatMap((message) => {
+        return message.role === "assistant"
           ? message.content
-              .filter((block) => {return block.type === "text"})
-              .map((block) => {return block.text})
-          : []},
-      )
+              .filter((block) => {
+                return block.type === "text";
+              })
+              .map((block) => {
+                return block.text;
+              })
+          : [];
+      })
       .join("");
     expect(exportedText).toBe(expected);
     expect(exported).not.toContain("private.md");

--- a/turbo/packages/pi-agent-runtime/src/api.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/api.test.ts
@@ -2,6 +2,10 @@ import { zstdDecompressSync } from "node:zlib";
 import { createServer, type ServerResponse } from "node:http";
 
 import { piModelConfigSchema } from "@okouai/api-contracts/contracts/runners";
+import {
+  PI_MEMORY_CITATION_OPEN,
+  PI_MEMORY_CITATION_CLOSE,
+} from "@okouai/api-contracts/contracts/pi-memory-citations";
 import { materializePiAgentModelConfig } from "./credential";
 import {
   fauxAssistantMessage,
@@ -1120,6 +1124,48 @@ describe("Pi API facade", () => {
     const exported = projectPiSessionJsonlForExport(canonical);
     expect(exported).not.toContain("<oai-mem-citation>");
     expect(exported).toContain('"errorMessage":"provider failed"');
+    expect(session.toJsonl()).toBe(canonical);
+  });
+
+  it("preserves split delimiter examples through API-first and immutable session export", () => {
+    const literal = `explain \`${PI_MEMORY_CITATION_OPEN}\` suffix`;
+    const hidden = `${PI_MEMORY_CITATION_OPEN}<citation_entries>private.md:1-1|note=[private note]</citation_entries>${PI_MEMORY_CITATION_CLOSE}`;
+    const expected = literal.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+    const native = fauxAssistantMessage([
+      { type: "text", text: literal.slice(0, 14) },
+      { type: "text", text: literal.slice(14) + hidden },
+    ]);
+    const projected = projectPiApiAssistantMessage(native);
+    expect(
+      projected.content
+        .filter((block) => {return block.type === "text"})
+        .map((block) => {return block.text})
+        .join(""),
+    ).toBe(expected);
+    expect(projected.memoryCitation?.entries).toEqual([
+      { path: "private.md", lineStart: 1, lineEnd: 1, note: "private note" },
+    ]);
+    const session = MemoryPiSession.create({
+      cwd: "/workspace",
+      id: SESSION_ID,
+    });
+    session.appendMessage(native);
+    const canonical = session.toJsonl();
+    const exported = projectPiSessionJsonlForExport(canonical);
+    const exportedText = MemoryPiSession.fromJsonl(exported)
+      .buildSessionContext()
+      .messages.flatMap((message) =>
+        {return message.role === "assistant"
+          ? message.content
+              .filter((block) => {return block.type === "text"})
+              .map((block) => {return block.text})
+          : []},
+      )
+      .join("");
+    expect(exportedText).toBe(expected);
+    expect(exported).not.toContain("private.md");
+    expect(exported).not.toContain("private note");
+    expect(projectPiSessionJsonlForExport(exported)).toBe(exported);
     expect(session.toJsonl()).toBe(canonical);
   });
 

--- a/turbo/packages/pi-agent-runtime/src/memory-recall-upstream.md
+++ b/turbo/packages/pi-agent-runtime/src/memory-recall-upstream.md
@@ -49,3 +49,8 @@ Guest output and transactionally stores private provenance in the additive
 `run_output_memory_citations` table, keyed by run and event sequence. Historical
 chat, Snapshot, browser-cache, shared-thread, search, callback, and activity
 reads apply the same text-only defense without rewriting source rows or blobs.
+
+Issue #32569 adds bounded escaping for isolated, closed code examples of the
+delimiter constants. Real envelopes inside code remain private. The native
+Codex 0.153.4 source/order evidence, literal grammar and public caller audit are
+documented in [the delimiter boundary](../../../../docs/citation-delimiter-literals.md).

--- a/turbo/packages/pi-agent-runtime/src/stage1-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/stage1-memory.test.ts
@@ -4,6 +4,10 @@ import { createServer, type ServerResponse } from "node:http";
 import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { CURRENT_SESSION_VERSION } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
+import {
+  PI_MEMORY_CITATION_OPEN,
+  PI_MEMORY_CITATION_CLOSE,
+} from "@okouai/api-contracts/contracts/pi-memory-citations";
 
 import {
   PI_MEMORY_STAGE1_RESPONSE_SCHEMA,
@@ -237,6 +241,20 @@ describe("Pi memory Stage 1 runtime", () => {
     expect(projected).toContain('"content":"visible"');
     expect(projected).not.toContain("oai-mem-citation");
     expect(projected).not.toContain("memory.md");
+  });
+
+  it("retains delimiter examples and the following answer in Stage 1 without private provenance", () => {
+    const hidden = `${PI_MEMORY_CITATION_OPEN}<citation_entries>private.md:1-1|note=[private note]</citation_entries>${PI_MEMORY_CITATION_CLOSE}`;
+    const text = `explain \`${PI_MEMORY_CITATION_OPEN}\` complete suffix${hidden}`;
+    const projected = projectPiMemoryStage1History({
+      jsonl: branchedJsonl().replace("finished", text),
+      expectedSessionId: SESSION_ID,
+    });
+    expect(projected).toContain("&lt;oai-mem-citation&gt;");
+    expect(projected).toContain("complete suffix");
+    expect(projected).not.toContain("private.md");
+    expect(projected).not.toContain("private note");
+    expect(projected).not.toContain("private reasoning");
   });
 
   it("redacts adversarial secret forms and truncates both ends deterministically", () => {


### PR DESCRIPTION
A closed code example containing a reserved citation delimiter can make Codex 0.153.4 truncate a normal 872-character explanation to 114 characters before Guest sees it. This repair recovers only the exact eligible native assistant item from the private canonical rollout, then escapes isolated closed code examples while keeping genuine citation bodies hidden. The same narrow contract applies to Pi and existing public read projections.

Closes #32569.

## Implementation

- Shared TS/Rust fixtures define isolated inline delimiters and bounded backtick/tilde fences, source-segment placement, Unicode, incomplete/real/nested/oversized envelopes, and idempotent entity escaping. No general Markdown renderer or prompt-only workaround.
- Native fresh/resume share one descriptor-bound canonical source. Resume establishes EOF before `turn/start`; messages wait for matching raw evidence, with native turn completion as the verified flush barrier. Exact thread/session, turn, item, assistant role, phase, content type and normalized projection must match. No raw notification or JSONL is forwarded. Plan controls reject recovery, existing native metadata remains authoritative, and output/terminal ordering is retained.
- Existing API-first, sandbox Pi, old Guest classifier, private sidecar, row/Snapshot/cache, sharing/search/callback/activity, export and Stage 1 boundaries retain their ownership. The caller audit and pinned upstream evidence are in `docs/citation-delimiter-literals.md`.

## Acceptance evidence

| Issue AC | Evidence |
| --- | --- |
| 1. Reproduce 872-to-114 through native -> Guest -> public projection | `scripts/codex-citation-native-probe.py` exercises installed Codex 0.153.4 against synthetic Responses SSE and the production Guest entry point; raw=872, native=114, safe=878 with the complete suffix exactly once. Current and pre-fix public readers preserve the result through 20 alternating projections. |
| 2. Fresh and restored/resumed native processes | The same probe launches a new app-server process for fresh, plain resume, and compressed-checkpoint resume. It verifies fresh normalized-before-raw event order, absent raw notifications on new-process resume, exact raw identity and persistence at the terminal barrier. Production uses the canonical source for both modes. |
| 3. Closed isolated examples and chunk boundaries | 44 TS parser regressions include all 873 incident split points, every shared delimiter/fence split, Unicode and adjacent real envelopes. Rust consumes the same fixture cases at every UTF-8 split; escaped output remains idempotent and segment ownership is preserved. |
| 4. Private citation boundaries | Existing complete/incomplete/malformed/nested/oversized cases remain active; added code-body and neighboring-envelope cases keep paths/notes/IDs private. API-first retains structured provenance. Canonical export and Stage 1 tests exclude private content without rewriting the input. |
| 5. Native privacy and lifecycle | Native filesystem/coordinator regressions exercise matching/missing/wrong item/role/phase/turn, reasoning, plan controls, invalid content, missing/partial/oversized evidence, deduplication, ordering, queue bounds, cancellation and failed terminal events. The affected Guest crate suite covers existing secondary-thread/scope, retry, active-input and cancellation paths. Raw notifications remain ignored rather than serving as a second authority. |
| 6. TS/Rust and old/new transport | Shared fixtures pass in both languages. Two existing real API BDD regressions pass for API-first private provenance and old Guest request caps/retries/replay/ordering. The pinned old API consumer harness also preserves a new escaped example while dropping the existing exact wire sidecar. The existing Rust benchmark covers 64 KiB, 1 MiB and 8 MiB plain/hidden inputs; body/field/count bounds and allocation-free ordinary-text handling are retained. |
| 7. Repeated public derivatives | Seven focused TS/consumer files passed 83 tests; the additional wide-inline fixture then passed with 44 parser tests (84 total unique tests in those files). Archive/share/export, row immutability, API-first/session export and Stage 1 have consumer assertions. Browser cache/Snapshot, search, notification, callback and activity call paths were inspected and reuse the tested shared projector; no browser verification is claimed. |
| 8. Scope and retained memory/checkpoint contract | Native memories stay enabled. No migrations, backfills, user history/memory writes, checkpoint identity changes, routing/billing edits, #31964 cleanup, or release work. Only the test probe creates/compresses temporary synthetic histories. |
| 9. Verification and merge lifecycle | Local commands below; full integration is left to PR CI. Same-thread pr-auto owns review, CI repair and protected merge. This implementation thread performs no production release. |

## Local verification

From `crates/`:

```sh
cargo test --profile local -p guest-agent
cargo test --profile local -p guest-agent --lib citation
cargo build --profile local -p guest-agent --example codex_citation_probe
cargo clippy --profile local -p guest-agent --all-targets
cargo doc --profile local -p guest-agent --no-deps
cargo fmt -p guest-agent
```

From repository root:

```sh
python3 scripts/codex-citation-native-probe.py --codex /usr/bin/codex --guest-probe crates/target/local/examples/codex_citation_probe
```

From `turbo/` (one Vitest process at a time):

```sh
pnpm exec vitest run packages/api-contracts/src/contracts/pi-memory-citations.test.ts packages/api-contracts/src/contracts/__tests__/chat-event-rows.test.ts packages/pi-agent-runtime/src/api.test.ts packages/pi-agent-runtime/src/stage1-memory.test.ts apps/api/src/signals/routes/__tests__/pi-memory-citation-old-api-rollback.test.ts apps/api/src/signals/routes/__tests__/chat-event-archive-consumers.test.ts apps/api/src/signals/services/__tests__/pi-memory-citation-events.test.ts --maxWorkers=1
pnpm -F @okouai/api-contracts exec vitest run src/contracts/pi-memory-citations.test.ts
pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t citation --maxWorkers=1
pnpm -F @okouai/api-contracts -F @okouai/pi-agent-runtime check-types
pnpm -F api check-types
pnpm -F @okouai/api-contracts lint
pnpm -F @okouai/pi-agent-runtime lint
pnpm exec knip --workspace packages/api-contracts --workspace packages/pi-agent-runtime --workspace apps/api
```

The two changed API test files also passed scoped Oxlint, type-aware Oxlint and ESLint. Changed TS/JSON/Markdown passed Prettier; `git diff --check` passed. The existing Rust benchmark was compiled with `rustc -O` against identical local dependencies for baseline/current: representative 8 MiB current runs were 38.8-46.3 ms plain and 36.3-38.3 ms hidden. These are local observations, not a production latency guarantee.

Initial local failures were resolved without changing assertions: memory pressure killed Knip during overlapping checks; PostgreSQL initially used Asia/Shanghai, making UTC timestamp queue rows appear expired. Running memory-heavy checks separately and configuring the isolated test database to UTC restored the checks. The full Guest suite passed before final bounded-queue/parser refinements; affected citation tests and installed-binary acceptance were rerun afterward.

## Fallbacks

- `NativeCitationRepair` preserves the original safe native projection when the required private evidence is absent, malformed, mismatched, unsupported, oversized, or interrupted. It emits at most one content-free diagnostic per run and never selects another message. This is the explicit #32569 fail-closed external-runtime contract, not a deployment-window compatibility branch. It remains necessary while raw evidence can be unavailable; removal requires a separately audited native contract that makes safe recovery authoritative for both fresh and resumed processes. No fleet/drain/rollback cleanup is introduced.

## Compatibility and limits

No wire or persisted schema changes. Entity-escaped transport is accepted by old readers; existing old Guest and sidecar paths remain. This covers API skew, up to two-hour runner/sandbox overlap and retained browser clients without an atomic deployment assumption. Live overlap inventory found only #32525 in neighboring Runner history restoration files, with no direct citation/parser/backend conflict and no ordering dependency.

Acceptance uses synthetic local provider traffic and installed Codex 0.153.4 (upstream `3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`), not production traffic, a live browser, every Markdown extension or a future CLI version. Existing public rows containing only a previously truncated prefix cannot be reconstructed. Unsupported phase/identity/content or resource bounds intentionally keep native safe text. No production promotion, release-please merge or release approval is included.
