### PR TITLE
fix(guest-agent): bound masked json key collision resolution

### DIFF
--- a/crates/guest-agent/src/masker.rs
+++ b/crates/guest-agent/src/masker.rs
@@ -25,6 +25,7 @@ pub struct SecretMasker {
     diagnostic_matcher: Option<AhoCorasick>,
     url_encoded_matcher: Option<AhoCorasick>,
     diagnostic_url_encoded_matcher: Option<AhoCorasick>,
+    collision_alphabet: [char; 3],
 }
 
 impl SecretMasker {
@@ -92,6 +93,7 @@ impl SecretMasker {
             diagnostic_matcher: None,
             url_encoded_matcher: None,
             diagnostic_url_encoded_matcher: None,
+            collision_alphabet: Self::collision_alphabet(&[]),
         }
     }
 
@@ -111,7 +113,42 @@ impl SecretMasker {
             diagnostic_matcher: Self::build_matcher(&diagnostic_patterns),
             url_encoded_matcher: Self::build_matcher(&url_encoded_patterns),
             diagnostic_url_encoded_matcher: Self::build_matcher(&diagnostic_url_encoded_patterns),
+            collision_alphabet: Self::collision_alphabet(&patterns),
         }
+    }
+
+    fn collision_alphabet(patterns: &[String]) -> [char; 3] {
+        // A production pattern is at least five bytes, so it cannot fit in one
+        // four-byte scalar or start inside one. Excluding its first two scalars
+        // from our separator/digit transitions prevents it from matching at all.
+        let forbidden_pairs: HashSet<_> = patterns
+            .iter()
+            .filter_map(|pattern| {
+                let mut chars = pattern.chars();
+                let first = chars.next()?;
+                let second = chars.next()?;
+                (first.len_utf8() == 4 && second.len_utf8() == 4)
+                    .then_some((first.min(second), first.max(second)))
+            })
+            .collect();
+        let mut alphabet = ['\u{10000}'; 3];
+        let found = ('\u{10000}'..=char::MAX).any(|separator| {
+            let mut digits = ('\u{10000}'..=char::MAX).filter(|&digit| {
+                digit != separator
+                    && !forbidden_pairs.contains(&(separator.min(digit), separator.max(digit)))
+            });
+            if let (Some(zero), Some(one)) = (digits.next(), digits.next()) {
+                alphabet = [separator, zero, one];
+                true
+            } else {
+                false
+            }
+        });
+        // There are 2^20 four-byte scalars. Denying every separator two distinct
+        // neighbors needs over 2^38 pairs, beyond a successfully built matcher's
+        // 32-bit pattern-ID limit. Blocked neighbors are bounded by those pairs.
+        assert!(found, "secret patterns exhausted the collision alphabet");
+        alphabet
     }
 
     /// # Panics
@@ -347,13 +384,38 @@ impl SecretMasker {
             return masked_key;
         }
 
-        let mut suffix = 2;
-        loop {
+        // Secrets can exclude the entire decimal suffix family. Bound these
+        // probes even when rejection is unrelated to occupied keys.
+        for suffix in 2..=map.len().saturating_add(2) {
             let candidate = format!("{masked_key}#{suffix}");
             if !map.contains_key(&candidate) && self.masked_string(&candidate).is_none() {
                 return candidate;
             }
+        }
+
+        // These identifiers are distinct and intrinsically secret-free. Every
+        // rejection consumes an occupied key, so n entries need at most n + 1
+        // probes; the counter cannot overflow before finding a free key.
+        let mut suffix = 0;
+        loop {
+            let candidate = self.collision_key(suffix);
+            if !map.contains_key(&candidate) {
+                return candidate;
+            }
             suffix += 1;
+        }
+    }
+
+    fn collision_key(&self, mut suffix: usize) -> String {
+        let [separator, zero, one] = self.collision_alphabet;
+        let mut key = String::new();
+        loop {
+            key.push(separator);
+            key.push(if suffix & 1 == 0 { zero } else { one });
+            suffix >>= 1;
+            if suffix == 0 {
+                return key;
+            }
         }
     }
 }

--- a/crates/guest-agent/tests/masked_key_collisions.rs
+++ b/crates/guest-agent/tests/masked_key_collisions.rs
@@ -1,0 +1,205 @@
+use base64::Engine;
+use guest_agent::{events::prepare_event_payload_for_run_id, masker::SecretMasker};
+use serde_json::{Map, Value, json};
+use std::{error::Error, time::Duration};
+
+type TestResult = Result<(), Box<dyn Error>>;
+
+fn masker_for(secrets: &[String]) -> SecretMasker {
+    let raw = secrets
+        .iter()
+        .map(|secret| base64::engine::general_purpose::STANDARD.encode(secret))
+        .collect::<Vec<_>>()
+        .join(",");
+    SecretMasker::from_raw(&raw)
+}
+
+fn blocked_decimal_secrets() -> Vec<String> {
+    let mut secrets = vec!["token-alpha".to_string(), "token-bravo".to_string()];
+    secrets.extend((1..=9).map(|digit| format!("***#{digit}")));
+    secrets
+}
+
+async fn in_child_process(test_name: &str, check: impl FnOnce()) -> TestResult {
+    const CHILD_CASE: &str = "GUEST_AGENT_MASKED_KEY_COLLISION_CASE";
+    if std::env::var(CHILD_CASE).as_deref() == Ok(test_name) {
+        check();
+        return Ok(());
+    }
+
+    // Masking is synchronous: only a separate process can interrupt a stuck call.
+    let mut child = tokio::process::Command::new(std::env::current_exe()?)
+        .args(["--exact", test_name, "--nocapture"])
+        .env(CHILD_CASE, test_name)
+        .kill_on_drop(true)
+        .spawn()?;
+    match tokio::time::timeout(Duration::from_secs(5), child.wait()).await {
+        Ok(status) => assert!(status?.success(), "collision regression child failed"),
+        Err(_) => {
+            child.kill().await?;
+            child.wait().await?;
+            return Err("event preparation did not finish within the subprocess watchdog".into());
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn event_preparation_finishes_when_every_decimal_suffix_is_secret() -> TestResult {
+    in_child_process(
+        "event_preparation_finishes_when_every_decimal_suffix_is_secret",
+        || {
+            let masker = masker_for(&blocked_decimal_secrets());
+            let event = json!({
+                "type": "assistant",
+                "tool_input": {"token-alpha": "first value", "token-bravo": "second value"}
+            });
+            let payload = prepare_event_payload_for_run_id(event.clone(), 7, &masker, "test-run");
+
+            assert_eq!(payload["runId"], "test-run");
+            assert_eq!(payload["events"].as_array().unwrap().len(), 1);
+            assert_eq!(payload["events"][0]["type"], "assistant");
+            assert_eq!(payload["events"][0]["sequenceNumber"], 7);
+            let input = payload["events"][0]["tool_input"].as_object().unwrap();
+            assert_eq!(input.len(), 2);
+            assert_eq!(input["***"], "first value");
+            assert!(input.values().any(|value| value == "second value"));
+            for key in input.keys() {
+                assert_eq!(masker.mask_string(key), *key);
+            }
+            let mut reordered_secrets = blocked_decimal_secrets();
+            reordered_secrets.reverse();
+            let rebuilt_masker = masker_for(&reordered_secrets);
+            assert_eq!(
+                payload,
+                prepare_event_payload_for_run_id(event, 7, &rebuilt_masker, "test-run")
+            );
+            let serialized = serde_json::to_string(&payload).unwrap();
+            assert_eq!(serde_json::from_str::<Value>(&serialized).unwrap(), payload);
+        },
+    )
+    .await
+}
+
+#[tokio::test]
+async fn event_preparation_preserves_reserved_fallback_keys_and_nested_values() -> TestResult {
+    in_child_process(
+        "event_preparation_preserves_reserved_fallback_keys_and_nested_values",
+        || {
+            let mut secrets = blocked_decimal_secrets();
+            // Challenge both directions of the initially preferred Unicode transitions.
+            secrets.extend([
+                "\u{10000}\u{10001}".to_string(),
+                "\u{10002}\u{10000}".to_string(),
+                "sequenceNumber".to_string(),
+            ]);
+            secrets.extend((0..64).map(|index| format!("token-{index}")));
+            let masker = masker_for(&secrets);
+            let probe = prepare_event_payload_for_run_id(
+                json!({
+                    "type": "assistant",
+                    "tool_input": {"token-alpha": 1, "token-bravo": 2}
+                }),
+                1,
+                &masker,
+                "test-run",
+            );
+            // Reserve actual generated keys as ordinary input to the next event.
+            let mut reserved = Map::new();
+            for key in probe["events"][0]["tool_input"].as_object().unwrap().keys() {
+                assert_eq!(masker.mask_string(key), *key);
+                reserved.insert(key.clone(), json!("reserved opaque key"));
+            }
+            reserved.insert("".to_string(), json!("reserved empty key"));
+            reserved.insert("***#0".to_string(), json!("reserved numeric key"));
+            let mut input = reserved.clone();
+            for index in 0..64 {
+                input.insert(format!("token-{index}"), json!(index));
+            }
+            input.insert(
+                "nested".to_string(),
+                json!([{
+                    "token-alpha": "contains token-bravo here",
+                    "token-bravo": {"sequenceNumber": "event-controlled"}
+                }]),
+            );
+            let entry_count = input.len();
+            let event = json!({"type": "assistant", "tool_input": input});
+            let payload = prepare_event_payload_for_run_id(event.clone(), 42, &masker, "test-run");
+            let masked_input = payload["events"][0]["tool_input"].as_object().unwrap();
+
+            assert_eq!(masked_input.len(), entry_count);
+            for (key, value) in reserved {
+                assert_eq!(masked_input[&key], value);
+            }
+            let mut numbers = masked_input
+                .values()
+                .filter_map(Value::as_u64)
+                .collect::<Vec<_>>();
+            numbers.sort_unstable();
+            assert_eq!(numbers, (0..64).collect::<Vec<_>>());
+            for key in masked_input.keys() {
+                assert_eq!(masker.mask_string(key), *key);
+            }
+            let nested = masked_input["nested"][0].as_object().unwrap();
+            assert_eq!(nested.len(), 2);
+            assert!(nested.values().any(|value| value == "contains *** here"));
+            assert!(
+                nested
+                    .values()
+                    .any(|value| value == &json!({"***": "event-controlled"}))
+            );
+            for key in nested.keys() {
+                assert_eq!(masker.mask_string(key), *key);
+            }
+            assert_eq!(payload["events"][0]["sequenceNumber"], 42);
+            assert_eq!(payload["runId"], "test-run");
+            assert_eq!(
+                payload,
+                prepare_event_payload_for_run_id(event, 42, &masker, "test-run")
+            );
+        },
+    )
+    .await
+}
+
+#[tokio::test]
+async fn event_preparation_keeps_ordinary_collision_suffixes() -> TestResult {
+    in_child_process(
+        "event_preparation_keeps_ordinary_collision_suffixes",
+        || {
+            let masker = masker_for(&["token-alpha".to_string(), "token-bravo".to_string()]);
+            let payload = prepare_event_payload_for_run_id(
+                json!({
+                    "type": "assistant",
+                    "tool_input": {
+                        "***": "reserved base",
+                        "***#2": "reserved suffix",
+                        "token-alpha": {"token-bravo": "first"},
+                        "token-bravo": "second"
+                    }
+                }),
+                7,
+                &masker,
+                "test-run",
+            );
+            assert_eq!(
+                payload,
+                json!({
+                    "runId": "test-run",
+                    "events": [{
+                        "type": "assistant",
+                        "sequenceNumber": 7,
+                        "tool_input": {
+                            "***": "reserved base",
+                            "***#2": "reserved suffix",
+                            "***#3": {"***": "first"},
+                            "***#4": "second"
+                        }
+                    }]
+                })
+            );
+        },
+    )
+    .await
+}


### PR DESCRIPTION
When configured secrets include `***#1` through `***#9`, two JSON keys redacting to `***` make synchronous event preparation search decimal suffixes indefinitely. Bound decimal probes by object occupancy, then allocate deterministic secret-free identifiers when that bounded search is exhausted. Unmatched keys, every entry, nested values, and the event envelope remain intact.

The escape identifiers use a three-character Unicode alphabet derived from the configured patterns. Forbidden leading pairs cannot appear in an identifier; production patterns require at least five UTF-8 bytes, while each alphabet character occupies four. For n occupied keys, at most n+1 distinct identifiers are needed, with logarithmic identifier length. Ordinary free redacted keys and numeric suffixes retain their existing output.

Closes #32594.

## Fallbacks

- `crates/guest-agent/src/masker.rs::unique_masked_key` allocates opaque Unicode keys after bounded numeric probes fail. This is permanent collision resolution for accepted event data on the guest-event payload surface. It preserves all entries while preventing secret reintroduction; no version-skew window, migration, or removal gate applies.

## Validation

- The new public event-preparation regression catches both blocked-suffix scenarios on unchanged production code using a five-second subprocess watchdog; the ordinary suffix control passes. After the fix, all three tests pass in about 0.02 seconds.
- Coverage includes the exact reported secret set, 64 colliding entries, nested objects/arrays, reserved generated keys, secrets excluding preferred Unicode transitions, reconstructed maskers with reversed secret order, JSON round-trip, and system sequence preservation.
- Passed `cargo fmt --manifest-path crates/guest-agent/Cargo.toml -- --check` and `git diff --check`.
- Passed `cargo test --manifest-path crates/Cargo.toml --profile local -p guest-agent --no-fail-fast` and the final focused `--test masked_key_collisions` run.
- Passed `cargo clippy --manifest-path crates/Cargo.toml --profile local -p guest-agent --all-targets --all-features -- -D warnings`.
- Passed `cargo doc --manifest-path crates/Cargo.toml --profile local -p guest-agent --all-features --no-deps`.

Local Cargo checks used `CARGO_BUILD_JOBS=2` and a private, short `TMPDIR` under `codex-work/tmp/r`; the first longer TMPDIR exceeded a pre-existing Unix socket test's pathname limit, and the complete suite passed after correcting that environment setting. No dependencies, event schema, or deployment configuration changed.
