### PR TITLE
fix(platform): make annotation arrows and strokes editable

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/image-annotation.ts
+++ b/turbo/apps/platform/src/signals/okou-page/image-annotation.ts
@@ -184,16 +184,23 @@ export const ANNOTATION_RESIZE_EDGES = [
 
 export type AnnotationResizeEdge = (typeof ANNOTATION_RESIZE_EDGES)[number];
 
+/** Which end of an arrow a drag is holding. */
+export type AnnotationArrowEnd = "from" | "to";
+
 /**
- * A mark being moved or resized. Drawing produces a new mark; this edits one
- * that already exists, so it carries the mark it started from and the pointer
- * offset at grab time — without the offset a drag snaps the mark's corner to
- * the cursor on the first move.
+ * A mark being moved, resized, or re-aimed. Drawing produces a new mark; this
+ * edits one that already exists, so it carries the mark it started from and the
+ * pointer offset at grab time — without the offset a drag snaps the mark's
+ * corner to the cursor on the first move.
+ *
+ * `endpoint` is the arrow's own mode: an arrow has no rectangle to resize, so
+ * its two ends are dragged directly and the pointer position *is* the new end.
  */
 export interface AnnotationDrag {
   readonly markId: string;
-  readonly mode: "move" | "resize";
+  readonly mode: "move" | "resize" | "endpoint";
   readonly corner?: AnnotationResizeEdge;
+  readonly endpoint?: AnnotationArrowEnd;
   readonly origin: AnnotationPoint;
   readonly startRect: {
     x: number;
@@ -209,8 +216,11 @@ const MAX_NOTE_WIDTH = 1;
 /** Clear of the mark's own outline and its ordinal pin. */
 const NOTE_GAP = 0.015;
 
-/** The box a mark occupies, used to place its note under it. */
-function markBounds(mark: ImageAnnotationMark): {
+/**
+ * The box a mark occupies, used to place its note under it and — for the shapes
+ * that have no rectangle of their own — to give a drag something to translate.
+ */
+export function markBounds(mark: ImageAnnotationMark): {
   x: number;
   y: number;
   width: number;
@@ -244,6 +254,56 @@ function markBounds(mark: ImageAnnotationMark): {
     return { x: mark.at.x, y: mark.at.y, width: 0, height: 0 };
   }
   return mark.rect;
+}
+
+/**
+ * Slides a whole mark by a normalized delta, held so its bounding box cannot
+ * leave the image — a mark dragged off the edge would survive in the draft but
+ * disappear from the flattened copy the model actually reads.
+ *
+ * An arrow and a freehand stroke have no rectangle to assign, so this is the
+ * only way either of them moves: every point shifts by the same amount, which
+ * keeps the arrow's aim and the stroke's shape while changing where it sits.
+ */
+function offsetMark(
+  mark: ImageAnnotationMark,
+  dx: number,
+  dy: number,
+): ImageAnnotationMark {
+  const bounds = markBounds(mark);
+  const shiftX = Math.min(
+    Math.max(dx, -bounds.x),
+    Math.max(0, 1 - bounds.width - bounds.x),
+  );
+  const shiftY = Math.min(
+    Math.max(dy, -bounds.y),
+    Math.max(0, 1 - bounds.height - bounds.y),
+  );
+  const shift = (point: AnnotationPoint): AnnotationPoint => {
+    return { x: point.x + shiftX, y: point.y + shiftY };
+  };
+
+  switch (mark.shape) {
+    case "arrow": {
+      return { ...mark, from: shift(mark.from), to: shift(mark.to) };
+    }
+    case "pen": {
+      return { ...mark, points: mark.points.map(shift) };
+    }
+    case "text": {
+      return { ...mark, at: shift(mark.at) };
+    }
+    default: {
+      return {
+        ...mark,
+        rect: {
+          ...mark.rect,
+          x: mark.rect.x + shiftX,
+          y: mark.rect.y + shiftY,
+        },
+      };
+    }
+  }
 }
 
 /**
@@ -321,6 +381,15 @@ interface AnnotationSelection {
 
 function createAnnotationViewportSignals() {
   const drag$ = state<AnnotationDrag | null>(null);
+  /**
+   * Whether the drag in flight has already taken its undo step.
+   *
+   * A drag reports a new geometry on every pointer move, and each one used to
+   * become its own history entry — so undoing one gesture meant pressing Cmd+Z
+   * once per frame it lasted. The first move of a drag pushes; the rest amend
+   * the present in place, which makes the whole gesture a single undo.
+   */
+  const dragPushed$ = state(false);
   const zoom$ = state(1);
   const stroke$ = state<AnnotationStroke | null>(null);
   const surface$ = state<HTMLElement | null>(null);
@@ -338,6 +407,7 @@ function createAnnotationViewportSignals() {
   });
   const setAnnotationDrag$ = command(({ set }, drag: AnnotationDrag | null) => {
     set(drag$, drag);
+    set(dragPushed$, false);
   });
   const zoomAnnotation$ = command(({ get, set }, direction: 1 | -1) => {
     const next = get(zoom$) + direction * ZOOM_STEP;
@@ -400,7 +470,7 @@ function createAnnotationViewportSignals() {
     }),
   );
   return {
-    internal: { drag$, zoom$, stroke$ },
+    internal: { drag$, dragPushed$, zoom$, stroke$ },
     signals: {
       annotationStroke$,
       annotationSurface$,
@@ -543,6 +613,28 @@ function createAnnotationHistorySignals(session: AnnotationSessionSignals) {
       });
     },
   );
+  /**
+   * Rewrites the present without recording a step.
+   *
+   * Only a gesture already represented in `past` may use this: the continuation
+   * of a drag belongs to the entry its first move pushed, not to one of its
+   * own. Anything that starts an edit must go through `pushAnnotation$`.
+   */
+  const amendAnnotation$ = command(
+    (
+      { get, set },
+      update: (current: ImageAnnotation) => ImageAnnotation,
+    ): void => {
+      const current = get(session.internal.session$);
+      if (!current) {
+        return;
+      }
+      set(session.internal.session$, {
+        ...current,
+        present: update(current.present),
+      });
+    },
+  );
   const undoAnnotation$ = command(({ get, set }) => {
     const current = get(session.internal.session$);
     const previous = current?.past.at(-1);
@@ -573,7 +665,12 @@ function createAnnotationHistorySignals(session: AnnotationSessionSignals) {
     });
     set(session.internal.selection$, null);
   });
-  return { pushAnnotation$, undoAnnotation$, redoAnnotation$ };
+  return {
+    pushAnnotation$,
+    amendAnnotation$,
+    undoAnnotation$,
+    redoAnnotation$,
+  };
 }
 
 type AnnotationHistorySignals = ReturnType<
@@ -633,7 +730,19 @@ function createAnnotationContentSignals(
 function createAnnotationGeometrySignals(
   session: AnnotationSessionSignals,
   history: AnnotationHistorySignals,
+  viewport: AnnotationViewport,
 ) {
+  /** One undo step per gesture: the first move records, the rest amend. */
+  const applyDragEdit$ = command(
+    ({ get, set }, update: (current: ImageAnnotation) => ImageAnnotation) => {
+      if (get(viewport.internal.dragPushed$)) {
+        set(history.amendAnnotation$, update);
+        return;
+      }
+      set(viewport.internal.dragPushed$, true);
+      set(history.pushAnnotation$, update);
+    },
+  );
   const addAnnotationMark$ = command(({ set }, mark: ImageAnnotationMark) => {
     set(history.pushAnnotation$, (current) => {
       return {
@@ -671,7 +780,7 @@ function createAnnotationGeometrySignals(
       id: string,
       rect: { x: number; y: number; width: number; height: number },
     ) => {
-      set(history.pushAnnotation$, (current) => {
+      set(applyDragEdit$, (current) => {
         return {
           ...current,
           marks: current.marks.map((mark) => {
@@ -681,9 +790,69 @@ function createAnnotationGeometrySignals(
             if (mark.shape === "box") {
               return { ...mark, rect };
             }
-            return mark.shape === "text"
-              ? { ...mark, at: { x: rect.x, y: rect.y } }
-              : mark;
+            if (mark.shape === "text") {
+              return { ...mark, at: { x: rect.x, y: rect.y } };
+            }
+            // An arrow and a freehand stroke have no rectangle to assign, so
+            // the incoming rect is read as a destination for their bounding box
+            // and the difference is applied to every point. The drag computes
+            // each rect from the box it grabbed, so the difference against the
+            // mark's *current* bounds is exactly this move's increment — which
+            // is what keeps amended moves from compounding.
+            const bounds = markBounds(mark);
+            return offsetMark(mark, rect.x - bounds.x, rect.y - bounds.y);
+          }),
+        };
+      });
+    },
+  );
+  /**
+   * Re-aims an arrow by dragging one of its ends.
+   *
+   * The pointer position is the new end outright rather than an offset: an
+   * arrow is defined by where it starts and where it points, so a grip that
+   * lags the cursor by its grab offset would feel like the tip is slipping.
+   */
+  const moveAnnotationArrowEnd$ = command(
+    (
+      { set },
+      id: string,
+      endpoint: AnnotationArrowEnd,
+      point: AnnotationPoint,
+    ) => {
+      set(applyDragEdit$, (current) => {
+        return {
+          ...current,
+          marks: current.marks.map((mark) => {
+            if (mark.id !== id || mark.shape !== "arrow") {
+              return mark;
+            }
+            return endpoint === "from"
+              ? { ...mark, from: point }
+              : { ...mark, to: point };
+          }),
+        };
+      });
+    },
+  );
+  /**
+   * Moves the open mark by a step from the keyboard.
+   *
+   * One press is one undo step. That differs from a drag on purpose: a nudge is
+   * already the smallest edit the user can make, so collapsing a run of them
+   * would leave no way to take back just the last one.
+   */
+  const nudgeAnnotationMark$ = command(
+    ({ get, set }, dx: number, dy: number) => {
+      const id = get(session.signals.annotationOpenMarkId$);
+      if (id === null) {
+        return;
+      }
+      set(history.pushAnnotation$, (current) => {
+        return {
+          ...current,
+          marks: current.marks.map((mark) => {
+            return mark.id === id ? offsetMark(mark, dx, dy) : mark;
           }),
         };
       });
@@ -694,6 +863,8 @@ function createAnnotationGeometrySignals(
     removeAnnotationMark$,
     removeSelectedAnnotationMark$,
     moveAnnotationMarkRect$,
+    moveAnnotationArrowEnd$,
+    nudgeAnnotationMark$,
   };
 }
 
@@ -716,7 +887,7 @@ export function createImageAnnotationSignals() {
   const session = createAnnotationSessionSignals(viewport);
   const history = createAnnotationHistorySignals(session);
   const content = createAnnotationContentSignals(session, history);
-  const geometry = createAnnotationGeometrySignals(session, history);
+  const geometry = createAnnotationGeometrySignals(session, history, viewport);
   return {
     ...viewport.signals,
     ...session.signals,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-annotation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-annotation.test.tsx
@@ -7,6 +7,7 @@ import { expect, test, vi } from "vitest";
 import { click, fill, setupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
+  arrowAnnotation,
   ATTACHMENT_THREAD_ID,
   boxAnnotation,
   draftAttachment,
@@ -14,6 +15,7 @@ import {
   findNamedButton,
   mockAttachmentChat,
   mockPrivateUrlSequence,
+  penAnnotation,
   privateAttachmentUrl,
 } from "./chat-attachment-test-helpers.ts";
 import { fillComposer } from "./chat-test-helpers.ts";
@@ -367,4 +369,130 @@ test("A draft with marks but no annotated copy rebuilds it and can send", async 
   // Rebuilt from the original rather than presented as a failure.
   expect(imageReads).toBe(1);
   expect(screen.queryByLabelText(/Try again/)).toBeNull();
+});
+
+test("An arrow can be selected and re-aimed by dragging its tip", async () => {
+  const image = draftAttachment("arrow-flow.png", {
+    annotatedFileId: "draft-arrow-flow-annotated",
+    annotations: arrowAnnotation("aimable-arrow"),
+  });
+  mockAttachmentChat(context, { draft: draftForAttachment(image, "") });
+
+  await setupPage({
+    context,
+    path: `/chats/${ATTACHMENT_THREAD_ID}`,
+    featureSwitches: { [FeatureSwitchKey.ComposerImageAnnotation]: true },
+  });
+
+  const surface = await openAnnotationEditor("arrow-flow.png");
+  // The arrow used to render as decoration, so this click reached the canvas
+  // underneath and started a new stroke instead of selecting anything.
+  fireEvent.click(screen.getByTestId("annotation-mark-1"));
+
+  const tip = screen.getByTestId("annotation-handle-to");
+  expect(tip).toBeVisible();
+  expect(screen.getByTestId("annotation-handle-from")).toBeVisible();
+  // An arrow is aimed, not resized: it gets two ends rather than eight grips.
+  expect(screen.queryByTestId("annotation-handle-tl")).toBeNull();
+
+  fireEvent.pointerDown(tip, { clientX: 560, clientY: 300, pointerId: 2 });
+  fireEvent.pointerMove(surface, { clientX: 200, clientY: 450, pointerId: 2 });
+  fireEvent.pointerUp(surface, { clientX: 200, clientY: 450, pointerId: 2 });
+
+  await waitFor(() => {
+    expect(screen.getByTestId("annotation-handle-to")).toHaveStyle({
+      left: "25%",
+      top: "90%",
+    });
+  });
+});
+
+test("A freehand stroke can be selected and moved", async () => {
+  const image = draftAttachment("sketch.png", {
+    annotatedFileId: "draft-sketch-annotated",
+    annotations: penAnnotation("movable-stroke"),
+  });
+  mockAttachmentChat(context, { draft: draftForAttachment(image, "") });
+
+  await setupPage({
+    context,
+    path: `/chats/${ATTACHMENT_THREAD_ID}`,
+    featureSwitches: { [FeatureSwitchKey.ComposerImageAnnotation]: true },
+  });
+
+  const surface = await openAnnotationEditor("sketch.png");
+  fireEvent.click(screen.getByTestId("annotation-mark-1"));
+
+  // A stroke has nothing to resize, so the dashed extent is the whole of what
+  // "selected" looks like on one.
+  const outline = screen.getByTestId("annotation-pen-outline");
+  expect(outline).toBeVisible();
+  expect(outline).toHaveStyle({ left: "20%", top: "25%" });
+
+  fireEvent.pointerDown(screen.getByTestId("annotation-mark-1"), {
+    clientX: 280,
+    clientY: 200,
+    pointerId: 3,
+  });
+  fireEvent.pointerMove(surface, { clientX: 360, clientY: 250, pointerId: 3 });
+  fireEvent.pointerUp(surface, { clientX: 360, clientY: 250, pointerId: 3 });
+
+  // Compared as numbers: the offset is accumulated in floating point, so the
+  // style lands on "30.000000000000004%" and an exact string match would be
+  // asserting the arithmetic rather than the move.
+  await waitFor(() => {
+    const moved = screen.getByTestId("annotation-pen-outline");
+    expect(Number.parseFloat(moved.style.left)).toBeCloseTo(30, 6);
+    expect(Number.parseFloat(moved.style.top)).toBeCloseTo(35, 6);
+  });
+});
+
+test("Enter confirms a note and one drag is a single undo step", async () => {
+  const user = userEvent.setup();
+  const image = draftAttachment("keyboard-plan.png", {
+    annotatedFileId: "draft-keyboard-plan-annotated",
+    annotations: boxAnnotation([{ id: "keyboard-mark", ordinal: 1 }]),
+  });
+  mockAttachmentChat(context, { draft: draftForAttachment(image, "") });
+
+  await setupPage({
+    context,
+    path: `/chats/${ATTACHMENT_THREAD_ID}`,
+    featureSwitches: { [FeatureSwitchKey.ComposerImageAnnotation]: true },
+  });
+
+  const surface = await openAnnotationEditor("keyboard-plan.png");
+  fireEvent.click(screen.getByTestId("annotation-mark-1"));
+
+  const note = await screen.findByPlaceholderText(
+    "Say what should change here",
+  );
+  await fill(note, "Raise this panel");
+  // Enter had no binding at all: the only way out of the field was Escape or
+  // clicking off it.
+  await user.keyboard("{Enter}");
+  expect(screen.queryByTestId("annotation-note-popover")).toBeNull();
+  expect(
+    screen.getByTestId("annotation-note-label-keyboard-mark"),
+  ).toHaveTextContent("Raise this panel");
+
+  // Every pointer move used to push its own history entry, so undoing one
+  // gesture took one Cmd+Z per frame it lasted.
+  fireEvent.pointerDown(screen.getByTestId("annotation-mark-1"), {
+    clientX: 100,
+    clientY: 80,
+    pointerId: 4,
+  });
+  for (const clientX of [140, 180, 220, 260]) {
+    fireEvent.pointerMove(surface, { clientX, clientY: 140, pointerId: 4 });
+  }
+  fireEvent.pointerUp(surface, { clientX: 260, clientY: 140, pointerId: 4 });
+
+  const moved = screen.getByTestId("annotation-mark-1").style.left;
+  expect(moved).not.toBe("8%");
+
+  await user.keyboard("{Control>}z{/Control}");
+  await waitFor(() => {
+    expect(screen.getByTestId("annotation-mark-1")).toHaveStyle({ left: "8%" });
+  });
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-test-helpers.ts
@@ -107,6 +107,41 @@ export function boxAnnotation(
   };
 }
 
+/** One arrow, drawn top-left to bottom-right across the middle of the image. */
+export function arrowAnnotation(id: string): ImageAnnotation {
+  return {
+    marks: [
+      {
+        id,
+        ordinal: 1,
+        shape: "arrow" as const,
+        from: { x: 0.2, y: 0.2 },
+        to: { x: 0.7, y: 0.6 },
+        ink: "#5E6AD2",
+      },
+    ],
+  };
+}
+
+/** One freehand stroke, as a short diagonal run of points. */
+export function penAnnotation(id: string): ImageAnnotation {
+  return {
+    marks: [
+      {
+        id,
+        ordinal: 1,
+        shape: "pen" as const,
+        points: [
+          { x: 0.2, y: 0.25 },
+          { x: 0.35, y: 0.4 },
+          { x: 0.5, y: 0.45 },
+        ],
+        ink: "#5E6AD2",
+      },
+    ],
+  };
+}
+
 export function draftForAttachment(
   attachment: AnnotatedPersistedAttachment,
   text = "Draft message",

--- a/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
+++ b/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
@@ -21,13 +21,15 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@okouai/ui/components/ui/tooltip";
-import { cn } from "@okouai/ui";
+import { cn, Kbd, KbdGroup } from "@okouai/ui";
 import type { ImageAnnotationMark } from "@okouai/api-contracts/contracts/chat-threads";
 import {
   ANNOTATION_INKS,
   ANNOTATION_RESIZE_EDGES,
+  markBounds,
   markOrdinal,
   nextMarkOrdinal,
+  type AnnotationArrowEnd,
   type AnnotationDrag,
   type AnnotationInk,
   type AnnotationPoint,
@@ -67,6 +69,108 @@ const TOOL_SHORTCUTS: Readonly<Record<string, AnnotationTool | undefined>> = {
   d: "pen",
   t: "text",
 };
+
+/** The letter shown on each tool's tooltip, so the binding is discoverable. */
+const TOOL_KEYS: Readonly<Record<AnnotationTool, string>> = {
+  box: "B",
+  arrow: "A",
+  pen: "D",
+  text: "T",
+};
+
+/** Zoom direction per key, with `0` meaning "back to fit". */
+const ZOOM_SHORTCUTS: Readonly<Record<string, 1 | -1 | 0 | undefined>> = {
+  "=": 1,
+  "+": 1,
+  "-": -1,
+  _: -1,
+  0: 0,
+};
+
+/** One arrow key, one direction. */
+const NUDGE_KEYS: Readonly<
+  Record<string, { x: number; y: number } | undefined>
+> = {
+  ArrowUp: { x: 0, y: -1 },
+  ArrowDown: { x: 0, y: 1 },
+  ArrowLeft: { x: -1, y: 0 },
+  ArrowRight: { x: 1, y: 0 },
+};
+
+/**
+ * Nudge distance in normalized units — roughly 4px and 20px on a 1000px-wide
+ * image. The marks are stored against the image rather than the screen, so a
+ * step in pixels would move a mark further on a small image than a large one.
+ */
+const NUDGE_STEP = 0.004;
+const NUDGE_STEP_COARSE = 0.02;
+
+/** A shortcut taken with Cmd/Ctrl held, which a note being typed cannot claim. */
+type ChordAction =
+  | { kind: "undo" }
+  | { kind: "redo" }
+  | { kind: "commit" }
+  | { kind: "zoom"; direction: 1 | -1 }
+  | { kind: "zoomReset" };
+
+/** A shortcut taken on its own, which only applies when nothing has the caret. */
+type BareAction =
+  | { kind: "remove" }
+  | { kind: "nudge"; x: number; y: number }
+  | { kind: "ink"; ink: AnnotationInk }
+  | { kind: "tool"; tool: AnnotationTool };
+
+function resolveChord(event: KeyboardEvent): ChordAction | null {
+  if (!event.metaKey && !event.ctrlKey) {
+    return null;
+  }
+  if (event.key.toLowerCase() === "z") {
+    return event.shiftKey ? { kind: "redo" } : { kind: "undo" };
+  }
+  if (event.key === "Enter") {
+    return { kind: "commit" };
+  }
+  // The zoom buttons had no keys at all. These are the bindings every viewer
+  // already trains people to try, and the modifier keeps them clear of a note.
+  const zoom = ZOOM_SHORTCUTS[event.key];
+  if (zoom === undefined) {
+    return null;
+  }
+  return zoom === 0 ? { kind: "zoomReset" } : { kind: "zoom", direction: zoom };
+}
+
+function resolveBareKey(event: KeyboardEvent): BareAction | null {
+  if (event.key === "Delete" || event.key === "Backspace") {
+    return { kind: "remove" };
+  }
+  // Placing a mark by dragging is accurate to whatever the hand did; the arrow
+  // keys are how it gets from close to right. Shift covers distance, the bare
+  // key covers the last few pixels.
+  const nudge = NUDGE_KEYS[event.key];
+  if (nudge) {
+    const step = event.shiftKey ? NUDGE_STEP_COARSE : NUDGE_STEP;
+    return { kind: "nudge", x: nudge.x * step, y: nudge.y * step };
+  }
+  // The ink swatches are five buttons in a fixed order, so the digits are
+  // already their names. With a mark open this recolours it, which is exactly
+  // what pressing the swatch does.
+  const ink = ANNOTATION_INKS[Number.parseInt(event.key, 10) - 1];
+  if (ink !== undefined) {
+    return { kind: "ink", ink };
+  }
+  const tool = TOOL_SHORTCUTS[event.key.toLowerCase()];
+  return tool ? { kind: "tool", tool } : null;
+}
+
+/** A shortcut must never steal a keystroke aimed at a note being written. */
+function isTyping(): boolean {
+  const active = document.activeElement;
+  return (
+    active instanceof HTMLInputElement ||
+    active instanceof HTMLTextAreaElement ||
+    (active instanceof HTMLElement && active.isContentEditable)
+  );
+}
 
 function clamp01(value: number): number {
   return Math.min(1, Math.max(0, value));
@@ -310,7 +414,12 @@ function ToolPill({ signals }: { readonly signals: ImageAnnotationSignals }) {
                 </Button>
               }
             />
-            <TooltipContent>{toolLabel(candidate)}</TooltipContent>
+            <TooltipContent>
+              <KbdGroup>
+                {toolLabel(candidate)}
+                <Kbd>{TOOL_KEYS[candidate]}</Kbd>
+              </KbdGroup>
+            </TooltipContent>
           </Tooltip>
         );
       })}
@@ -376,6 +485,17 @@ function MarkNotePopover({
             setNote(mark.id, event.target.value);
           }}
           onKeyDown={(event) => {
+            // Enter is how a one-line field is finished everywhere else, and
+            // the note had no way to be committed from the keyboard at all —
+            // the only exit was clicking off it or pressing Escape. The text is
+            // already saved on every keystroke, so this only puts the caret
+            // away. Cmd/Ctrl+Enter is left alone: the global handler reads it
+            // as "attach the whole annotation".
+            if (event.key === "Enter" && !event.metaKey && !event.ctrlKey) {
+              event.preventDefault();
+              deselect(null);
+              return;
+            }
             // Backspace edits the text. Once the field is empty the next press
             // dismisses the note — deleting the mark from here would be a
             // surprise, so that stays on the bin button alone.
@@ -561,6 +681,10 @@ function KeyboardShortcuts({
   const removeSelected = useSet(signals.removeSelectedAnnotationMark$);
   const selectMark = useSet(signals.selectAnnotationMark$);
   const setTool = useSet(signals.setAnnotationTool$);
+  const setInk = useSet(signals.setAnnotationInk$);
+  const nudgeMark = useSet(signals.nudgeAnnotationMark$);
+  const zoomBy = useSet(signals.zoomAnnotation$);
+  const resetZoom = useSet(signals.resetAnnotationZoom$);
   const undo = useSet(signals.undoAnnotation$);
   const redo = useSet(signals.redoAnnotation$);
   const close = useSet(signals.closeAnnotationEditor$);
@@ -574,6 +698,50 @@ function KeyboardShortcuts({
   const pageSignal = useGet(pageSignal$);
   let cleanup: (() => void) | null = null;
 
+  const runChord = (action: ChordAction) => {
+    switch (action.kind) {
+      case "undo": {
+        undo();
+        return;
+      }
+      case "redo": {
+        redo();
+        return;
+      }
+      case "commit": {
+        detach(commit(pageSignal), Reason.DomCallback);
+        return;
+      }
+      case "zoom": {
+        zoomBy(action.direction);
+        return;
+      }
+      case "zoomReset": {
+        resetZoom();
+      }
+    }
+  };
+
+  const runBareKey = (action: BareAction) => {
+    switch (action.kind) {
+      case "remove": {
+        removeSelected();
+        return;
+      }
+      case "nudge": {
+        nudgeMark(action.x, action.y);
+        return;
+      }
+      case "ink": {
+        setInk(action.ink);
+        return;
+      }
+      case "tool": {
+        setTool(action.tool);
+      }
+    }
+  };
+
   return (
     <span
       ref={(node) => {
@@ -583,27 +751,10 @@ function KeyboardShortcuts({
           return;
         }
         const onKeyDown = (event: KeyboardEvent) => {
-          const active = document.activeElement;
-          const typing =
-            active instanceof HTMLInputElement ||
-            active instanceof HTMLTextAreaElement ||
-            (active instanceof HTMLElement && active.isContentEditable);
-
-          if (
-            (event.metaKey || event.ctrlKey) &&
-            event.key.toLowerCase() === "z"
-          ) {
+          const chord = resolveChord(event);
+          if (chord) {
             event.preventDefault();
-            if (event.shiftKey) {
-              redo();
-            } else {
-              undo();
-            }
-            return;
-          }
-          if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
-            event.preventDefault();
-            detach(commit(pageSignal), Reason.DomCallback);
+            runChord(chord);
             return;
           }
           if (event.key === "Escape") {
@@ -617,18 +768,13 @@ function KeyboardShortcuts({
             }
             return;
           }
-          if (typing) {
+          if (isTyping()) {
             return;
           }
-          if (event.key === "Delete" || event.key === "Backspace") {
+          const bare = resolveBareKey(event);
+          if (bare) {
             event.preventDefault();
-            removeSelected();
-            return;
-          }
-          const shortcut = TOOL_SHORTCUTS[event.key.toLowerCase()];
-          if (shortcut) {
-            event.preventDefault();
-            setTool(shortcut);
+            runBareKey(bare);
           }
         };
         document.addEventListener("keydown", onKeyDown, true);
@@ -649,6 +795,7 @@ interface StrokeHandlers {
     applyDrag: (
       drag: AnnotationDrag,
       rect: { x: number; y: number; width: number; height: number },
+      point: AnnotationPoint,
     ) => void,
   ) => void;
   onPointerUp: () => void;
@@ -732,7 +879,7 @@ function useStrokeHandlers(signals: ImageAnnotationSignals): StrokeHandlers {
         return;
       }
       if (drag) {
-        applyDrag(drag, draggedRect(drag, point));
+        applyDrag(drag, draggedRect(drag, point), point);
         return;
       }
       if (!stroke) {
@@ -767,6 +914,14 @@ function useStrokeHandlers(signals: ImageAnnotationSignals): StrokeHandlers {
 
 type ResizeCorner = AnnotationResizeEdge;
 
+/**
+ * The box a drag works against.
+ *
+ * An arrow and a freehand stroke get their bounding box rather than `null`:
+ * they cannot be resized, but a move is expressed as "put this box there", and
+ * returning nothing here is what used to make `grabMark` bail out before the
+ * drag even started — so a stroke could be clicked and then not moved.
+ */
 function rectOf(mark: ImageAnnotationMark) {
   if (mark.shape === "box") {
     return mark.rect;
@@ -774,7 +929,7 @@ function rectOf(mark: ImageAnnotationMark) {
   if (mark.shape === "text") {
     return { x: mark.at.x, y: mark.at.y, width: 0, height: 0 };
   }
-  return null;
+  return markBounds(mark);
 }
 
 function cornerCursor(corner: ResizeCorner): string {
@@ -811,6 +966,78 @@ function handleAnchor(corner: ResizeCorner): { fx: number; fy: number } {
   const fx = corner.includes("l") ? 0 : corner.includes("r") ? 1 : 0.5;
   const fy = corner.includes("t") ? 0 : corner.includes("b") ? 1 : 0.5;
   return { fx, fy };
+}
+
+/** The dot every grip is drawn as, so all three kinds read as one control. */
+const GRIP_CLASS =
+  "absolute -ml-[5px] -mt-[5px] h-2.5 w-2.5 rounded-full border border-border bg-background shadow-sm";
+
+/**
+ * The two ends of a selected arrow.
+ *
+ * An arrow is not resized by a box — it is aimed — so its grips sit on the tail
+ * and the tip and each one carries that end to the pointer. Dragging the tip is
+ * what changes the direction; dragging the shaft between them moves the whole
+ * arrow without changing where it points.
+ */
+function ArrowEndpointHandles({
+  mark,
+  onGrab,
+}: {
+  mark: ImageAnnotationMark;
+  onGrab: (
+    endpoint: AnnotationArrowEnd,
+    event: ReactPointerEvent<HTMLElement>,
+  ) => void;
+}) {
+  if (mark.shape !== "arrow") {
+    return null;
+  }
+
+  return (
+    <>
+      {(["from", "to"] as const).map((endpoint) => {
+        const point = mark[endpoint];
+        return (
+          <span
+            key={endpoint}
+            role="presentation"
+            onPointerDown={(event) => {
+              onGrab(endpoint, event);
+            }}
+            style={{ left: percent(point.x), top: percent(point.y) }}
+            className={cn(GRIP_CLASS, "cursor-grab")}
+            data-testid={`annotation-handle-${endpoint}`}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+/**
+ * What "selected" looks like on a freehand stroke.
+ *
+ * A stroke has no rectangle and no ends worth grabbing, so there is nothing for
+ * grips to sit on and no state left to show. A dashed box around its extent is
+ * the whole affordance: it says which stroke the ink swatch, the note and
+ * Delete are now aimed at. It must not take the pointer — the band around the
+ * stroke itself is what the drag is grabbed by.
+ */
+function PenSelectionOutline({ mark }: { mark: ImageAnnotationMark }) {
+  const bounds = markBounds(mark);
+  return (
+    <span
+      style={{
+        left: percent(bounds.x),
+        top: percent(bounds.y),
+        width: percent(bounds.width),
+        height: percent(bounds.height),
+      }}
+      className="pointer-events-none absolute -m-1 rounded-md border border-dashed border-muted-foreground/70 p-1"
+      data-testid="annotation-pen-outline"
+    />
+  );
 }
 
 /**
@@ -859,9 +1086,7 @@ function ResizeHandles({
               cornerCursor(corner),
               horizontal && "-mt-[5px] h-2.5 -translate-x-1/2",
               vertical && "-ml-[5px] w-2.5 -translate-y-1/2",
-              !horizontal &&
-                !vertical &&
-                "-ml-[5px] -mt-[5px] h-2.5 w-2.5 rounded-full border border-border bg-background shadow-sm",
+              !horizontal && !vertical && GRIP_CLASS,
             )}
             data-testid={`annotation-handle-${corner}`}
           />
@@ -907,6 +1132,40 @@ function NoteLayer({
   );
 }
 
+/**
+ * What the selected mark shows, which depends on what it can be reshaped into.
+ *
+ * A box has eight grips, an arrow has its two ends, and a stroke has neither —
+ * so it gets an outline instead of nothing at all, which is what "selected"
+ * used to look like on one.
+ */
+function SelectionLayer({
+  mark,
+  onGrabEndpoint,
+  onGrabHandle,
+}: {
+  readonly mark: ImageAnnotationMark | undefined;
+  readonly onGrabEndpoint: (
+    endpoint: AnnotationArrowEnd,
+    event: ReactPointerEvent<HTMLElement>,
+  ) => void;
+  readonly onGrabHandle: (
+    corner: ResizeCorner,
+    event: ReactPointerEvent<HTMLElement>,
+  ) => void;
+}) {
+  if (!mark) {
+    return null;
+  }
+  if (mark.shape === "arrow") {
+    return <ArrowEndpointHandles mark={mark} onGrab={onGrabEndpoint} />;
+  }
+  if (mark.shape === "pen") {
+    return <PenSelectionOutline mark={mark} />;
+  }
+  return <ResizeHandles mark={mark} onGrab={onGrabHandle} />;
+}
+
 /** Starts a resize from whichever grip was grabbed on the selected mark. */
 function useGrabHandle(
   signals: ImageAnnotationSignals,
@@ -940,6 +1199,38 @@ function useGrabHandle(
   };
 }
 
+/** Starts an arrow re-aim from the tail or the tip. */
+function useGrabEndpoint(
+  signals: ImageAnnotationSignals,
+  selectedMark: ImageAnnotationMark | undefined,
+): (
+  endpoint: AnnotationArrowEnd,
+  event: ReactPointerEvent<HTMLElement>,
+) => void {
+  const surface = useGet(signals.annotationSurface$);
+  const beginDrag = useSet(signals.setAnnotationDrag$);
+
+  return (endpoint, event) => {
+    event.stopPropagation();
+    const bounds = surface?.getBoundingClientRect();
+    if (!selectedMark || !bounds || bounds.width === 0) {
+      return;
+    }
+    beginDrag({
+      markId: selectedMark.id,
+      mode: "endpoint",
+      endpoint,
+      origin: {
+        x: (event.clientX - bounds.left) / bounds.width,
+        y: (event.clientY - bounds.top) / bounds.height,
+      },
+      // An endpoint drag reads the pointer directly, so it has no start box to
+      // measure against. The field is on the record for move and resize.
+      startRect: { x: 0, y: 0, width: 0, height: 0 },
+    });
+  };
+}
+
 function EditorStage({
   filename,
   signals,
@@ -959,6 +1250,7 @@ function EditorStage({
   const selectMark = useSet(signals.selectAnnotationMark$);
   const bindSurface = useSet(signals.bindAnnotationSurface$);
   const moveRect = useSet(signals.moveAnnotationMarkRect$);
+  const moveArrowEnd = useSet(signals.moveAnnotationArrowEnd$);
   const handlers = useStrokeHandlers(signals);
 
   const box = surface?.getBoundingClientRect();
@@ -977,19 +1269,25 @@ function EditorStage({
     return mark.id === openMarkId;
   });
   const grabHandle = useGrabHandle(signals, selectedMark);
+  const grabEndpoint = useGrabEndpoint(signals, selectedMark);
 
-  // A drag only ever moves or resizes a MARK now; a note follows the mark it
-  // belongs to and is never dragged (see `NoteLayer`).
+  // A drag only ever moves, resizes or re-aims a MARK now; a note follows the
+  // mark it belongs to and is never dragged (see `NoteLayer`).
   const applyDrag = (
     drag: AnnotationDrag,
     rect: { x: number; y: number; width: number; height: number },
+    point: AnnotationPoint,
   ) => {
+    if (drag.mode === "endpoint" && drag.endpoint) {
+      moveArrowEnd(drag.markId, drag.endpoint, point);
+      return;
+    }
     moveRect(drag.markId, rect);
   };
 
   const grabMark = (
     mark: ImageAnnotationMark,
-    event: ReactPointerEvent<HTMLElement>,
+    event: ReactPointerEvent<Element>,
   ) => {
     event.stopPropagation();
     selectMark(mark.id);
@@ -1052,9 +1350,11 @@ function EditorStage({
             );
           })}
           <NoteLayer marks={annotation.marks} signals={signals} />
-          {selectedMark && (
-            <ResizeHandles mark={selectedMark} onGrab={grabHandle} />
-          )}
+          <SelectionLayer
+            mark={selectedMark}
+            onGrabEndpoint={grabEndpoint}
+            onGrabHandle={grabHandle}
+          />
           {openMark && <MarkNotePopover mark={openMark} signals={signals} />}
           {preview && (
             <MarkShape

--- a/turbo/apps/platform/src/views/okou-page/image-annotation-marks.tsx
+++ b/turbo/apps/platform/src/views/okou-page/image-annotation-marks.tsx
@@ -28,17 +28,55 @@ export function markInk(mark: ImageAnnotationMark): string {
 /** Head length as a fraction of the shorter edge. */
 const ARROW_HEAD_UNITS = 0.045;
 
+/**
+ * How wide the invisible grab band around a stroke is, in on-screen pixels.
+ *
+ * A 3px line is not a target anyone can hit, so every stroke carries a second
+ * copy of its own path drawn in `transparent` at this width. It has to be the
+ * *stroke* that is hittable and not the SVG box: the box spans the whole image,
+ * and a hittable box would swallow every press meant for the canvas underneath,
+ * leaving no way to draw a second mark anywhere near the first.
+ */
+const STROKE_HIT_WIDTH = 14;
+
 function percent(value: number): string {
   return `${value * 100}%`;
+}
+
+/**
+ * The pointer surface for a stroke, or nothing when the layer is read-only.
+ *
+ * `pointerEvents: "stroke"` overrides the `pointer-events-none` on the parent
+ * `<svg>` for this one path, which is what confines hit-testing to the band
+ * around the line.
+ */
+function strokeHitProps(interaction: MarkInteraction | null) {
+  if (!interaction) {
+    return null;
+  }
+  return {
+    fill: "none",
+    stroke: "transparent",
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    vectorEffect: "non-scaling-stroke" as const,
+    className: "cursor-move",
+    style: { pointerEvents: "stroke" as const, strokeWidth: STROKE_HIT_WIDTH },
+    ...interaction,
+  };
 }
 
 function StrokeMark({
   mark,
   aspect,
+  interaction,
 }: {
   mark: ImageAnnotationMark;
   aspect: number;
+  interaction: MarkInteraction | null;
 }) {
+  const hit = strokeHitProps(interaction);
+
   if (mark.shape === "pen") {
     const points = mark.points
       .map((point) => {
@@ -67,6 +105,7 @@ function StrokeMark({
           vectorEffect="non-scaling-stroke"
           style={{ strokeWidth: 3 }}
         />
+        {hit && <polyline points={points} {...hit} />}
       </svg>
     );
   }
@@ -120,6 +159,9 @@ function StrokeMark({
         vectorEffect="non-scaling-stroke"
         style={{ strokeWidth: 3 }}
       />
+      {/* The shaft alone. Grabbing the head would put the band the arrow is
+          dragged by right on top of the two endpoint grips that re-aim it. */}
+      {hit && <path d={shaft} {...hit} />}
     </svg>
   );
 }
@@ -140,6 +182,13 @@ function boxedFill(
   };
 }
 
+/** What a mark needs in order to be picked up, shared by every shape. */
+interface MarkInteraction {
+  onClick: () => void;
+  onPointerDown?: (event: ReactPointerEvent<Element>) => void;
+  "data-testid": string;
+}
+
 /**
  * Selection is carried entirely by the resize handles. An outline on top of the
  * mark's own border reads as two strokes around one shape, which looks like a
@@ -157,27 +206,32 @@ export function MarkShape({
   ordinal: number;
   aspect?: number;
   onSelect?: () => void;
-  onGrab?: (event: ReactPointerEvent<HTMLElement>) => void;
+  onGrab?: (event: ReactPointerEvent<Element>) => void;
 }) {
   // Without a handler the mark is decoration, so it must not eat pointer events
   // from the surface underneath — that surface is where new marks get drawn.
-  const interaction = onSelect
+  const interaction: MarkInteraction | null = onSelect
     ? {
         onClick: onSelect,
         ...(onGrab ? { onPointerDown: onGrab } : {}),
-        className: "absolute cursor-move",
         "data-testid": `annotation-mark-${ordinal}`,
       }
+    : null;
+  const boxedProps = interaction
+    ? { ...interaction, className: "absolute cursor-move" }
     : { className: "pointer-events-none absolute" };
 
+  // A stroke used to drop `interaction` here and render as decoration in the
+  // editor too, so an arrow or a freehand line could be drawn and then never
+  // clicked, moved, recoloured, or given a note.
   if (mark.shape === "pen" || mark.shape === "arrow") {
-    return <StrokeMark mark={mark} aspect={aspect} />;
+    return <StrokeMark mark={mark} aspect={aspect} interaction={interaction} />;
   }
 
   if (mark.shape === "text") {
     return (
       <span
-        {...interaction}
+        {...boxedProps}
         style={{
           left: percent(mark.at.x),
           top: percent(mark.at.y),
@@ -192,7 +246,7 @@ export function MarkShape({
 
   return (
     <span
-      {...interaction}
+      {...boxedProps}
       style={{
         left: percent(mark.rect.x),
         top: percent(mark.rect.y),


### PR DESCRIPTION
## What

Three fixes to the image annotation editor, from feedback on the Mark feature.

### 1. Arrows and pen strokes were not selectable or editable

`MarkShape` returned `StrokeMark` **before** applying the interaction props, and `StrokeMark` hard-coded `pointer-events-none` on its `<svg>`. An arrow or a freehand stroke could be drawn and then never clicked, moved, recoloured, deleted from the canvas, or given a note. Two further layers backed this up:

- `rectOf` returned `null` for both shapes, so `grabMark` bailed out before `beginDrag` — the drag never started.
- `moveAnnotationMarkRect$` only handled `box` and `text`; arrow and pen fell through unchanged.

Every stroke now carries a transparent 14px hit band along its own path with `pointer-events: stroke`. That matters: the SVG box spans the whole image, so making the *box* hittable would swallow every press meant for the canvas and leave no way to draw a second mark nearby.

- A selected **arrow** gets grips on its tail and tip, so direction is changed by dragging an end. Dragging the shaft moves the whole arrow without changing where it points.
- A selected **stroke** gets a dashed extent — it has no rectangle to resize and no ends worth grabbing, so this is the whole affordance.
- Both translate every point together, clamped so a mark cannot leave the image (it would survive in the draft but vanish from the flattened copy the model reads).

### 2. One drag was one undo step per frame

`moveAnnotationMarkRect$` called `pushAnnotation$` on **every** pointer move, so undoing a one-second drag took ~60 presses of Cmd+Z. The first move of a gesture now pushes and the rest amend the present in place.

### 3. Keyboard

`Enter` had no binding in the note field at all — the only way out was Escape or clicking off it. Added, plus the gaps around it:

| Key | Action |
| --- | --- |
| `Enter` | Commit the note and dismiss the field (`Cmd/Ctrl+Enter` still attaches) |
| `←↑→↓` | Nudge the open mark; `Shift` for a coarse step |
| `Cmd/Ctrl` `+` / `-` / `0` | Zoom in / out / back to fit — the zoom buttons had no keys |
| `1`–`5` | Pick ink, same as the five swatches |
| `B` `A` `D` `T` | Existing tool bindings, now shown on each tool's tooltip |

## Not included

Making marks reachable with `Tab` (focusable shapes, `Enter` to open a note) is the remaining keyboard gap — there is currently no way to reach a mark without a pointer. That is an a11y change with its own i18n surface, so it is left for a follow-up rather than folded in here.

## Testing

- 3 new integration tests: arrow select + re-aim by tip, stroke select + move, and Enter-commits-note + one-drag-is-one-undo.
- `chat-attachment-annotation`, `chat-attachment-composer`, `chat-composer-connectors`: 32 passed.
- `check-types`, `lint`, `knip`, `format` clean on `@okouai/app`.

Behind the existing `composerImageAnnotation` feature switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
