### PR TITLE
fix(api): cache codex reset-credit expiry metadata

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -245,6 +245,17 @@ export default [
     },
   },
   {
+    files: ["src/signals/services/codex-reset-credit-expiry.service.ts"],
+    rules: {
+      // One demand-driven aggregate per minute, not per-read diagnostics.
+      // Axiom's default transport drops debug events, so retain this bounded audit.
+      "api/no-logger-info": [
+        "error",
+        { allowedMessages: ["codex reset credit expiry outcomes"] },
+      ],
+    },
+  },
+  {
     files: ["src/signals/services/onboarding.service.ts"],
     rules: {
       "api/no-logger-info": [

--- a/turbo/apps/api/src/signals/routes/__tests__/codex-reset-credit-expiry.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/codex-reset-credit-expiry.test.ts
@@ -1,0 +1,688 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it, onTestFinished } from "vitest";
+import { http, HttpResponse } from "msw";
+import {
+  personalModelProviderAccountsByIdContract,
+  personalModelProvidersByTypeContract,
+  personalModelProvidersMainContract,
+} from "@okouai/api-contracts/contracts/personal-model-providers";
+import { modelProvidersMainContract } from "@okouai/api-contracts/contracts/model-provider-routes";
+import { codexDeviceAuthContract } from "@okouai/api-contracts/contracts/codex-device-auth";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
+import { mockNow, now } from "../../../lib/time";
+import { server } from "../../../mocks/server";
+import { createDeferredPromise } from "../../utils";
+import { meModelProvidersListRoutes } from "../me-model-providers-list";
+import { meModelProvidersUpsertRoutes } from "../me-model-providers-upsert";
+import { meModelProvidersResetSubscriptionRoutes } from "../me-model-providers-reset-subscription";
+import { meModelProviderAccountRoutes } from "../me-model-provider-accounts";
+import { codexDeviceAuthRoutes } from "../codex-device-auth";
+import { modelProvidersRoutes } from "../model-providers";
+import { createRouteMocks } from "./helpers/route-test";
+import { mockCodexDeviceAuthProvider } from "./helpers/api-bdd-auth-device";
+import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
+
+const context = testContext();
+const mocks = createRouteMocks(context);
+const headers = Object.freeze({ authorization: "Bearer clerk-session" });
+const routes = Object.freeze([
+  ...meModelProvidersListRoutes,
+  ...meModelProvidersUpsertRoutes,
+]);
+const detailsUrl =
+  "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
+
+function jwt(payload: Record<string, unknown>): string {
+  return `${Buffer.from('{"alg":"RS256","typ":"JWT"}').toString("base64url")}.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+}
+
+function credentials(accountId = randomUUID(), accessToken?: string) {
+  const token =
+    accessToken ??
+    jwt({ exp: Math.floor(now() / 1000) + 7200, jti: randomUUID() });
+  return {
+    accountId,
+    accessToken: token,
+    raw: JSON.stringify({
+      tokens: {
+        access_token: token,
+        refresh_token: `refresh-${randomUUID()}`,
+        account_id: accountId,
+        id_token: jwt({
+          email: "expiry@example.com",
+          "https://api.openai.com/auth": {
+            chatgpt_account_id: accountId,
+            chatgpt_plan_type: "plus",
+          },
+        }),
+      },
+    }),
+  };
+}
+
+function expiryResponse(expiry: string | null) {
+  return HttpResponse.json({
+    credits: [{ status: "available", expires_at: expiry }],
+  });
+}
+
+function upstream() {
+  const control = {
+    usageCalls: 0,
+    detailsCalls: 0,
+    expiry: new Date(now() + 3_600_000).toISOString(),
+    details: (_request: Request): Response | Promise<Response> => {
+      return expiryResponse(control.expiry);
+    },
+    usage: (): Response | Promise<Response> => {
+      return HttpResponse.json({
+        rate_limit_reset_credits: { available_count: control.usageCalls },
+      });
+    },
+  };
+  server.use(
+    http.get("https://chatgpt.com/backend-api/wham/usage", () => {
+      control.usageCalls += 1;
+      return control.usage();
+    }),
+    http.get(detailsUrl, ({ request }) => {
+      control.detailsCalls += 1;
+      return control.details(request);
+    }),
+  );
+  return control;
+}
+
+async function fixture(
+  options: {
+    accounts?: boolean;
+    auth?: ReturnType<typeof credentials>;
+    orgId?: string;
+    userId?: string;
+  } = {},
+) {
+  const owner = {
+    orgId: options.orgId ?? `org_expiry_${randomUUID()}`,
+    userId: options.userId ?? `user_expiry_${randomUUID()}`,
+  };
+  const auth = options.auth ?? credentials();
+  const session = () => {
+    return mocks.clerk.session(owner.userId, owner.orgId);
+  };
+  session();
+  await updateFeatureSwitchesForUser(context, owner, {
+    [FeatureSwitchKey.PersonalModelProviderAccounts]: options.accounts ?? false,
+  });
+  const client = (signal?: AbortSignal) => {
+    return setupApp({ context, routes, signal, rethrowErrors: true })(
+      personalModelProvidersMainContract,
+    );
+  };
+  const connect = async (next = auth) => {
+    session();
+    return await accept(
+      client().upsert({
+        headers,
+        body: {
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: { CODEX_AUTH_JSON: next.raw },
+        },
+      }),
+      [200, 201],
+    );
+  };
+  const connected = await connect();
+  return {
+    ...owner,
+    id: connected.body.provider.id,
+    auth,
+    connect,
+    session,
+    list: async (signal?: AbortSignal) => {
+      session();
+      const result = await accept(client(signal).list({ headers }), [200]);
+      return result.body.modelProviders;
+    },
+    consume: async () => {
+      session();
+      const idempotencyKey = randomUUID();
+      if (options.accounts) {
+        return await setupApp({
+          context,
+          routes: meModelProviderAccountRoutes,
+        })(personalModelProviderAccountsByIdContract).resetSubscriptionUsage({
+          headers,
+          params: { id: connected.body.provider.id },
+          body: { idempotencyKey },
+        });
+      }
+      return await setupApp({
+        context,
+        routes: meModelProvidersResetSubscriptionRoutes,
+      })(personalModelProvidersByTypeContract).resetSubscriptionUsage({
+        headers,
+        params: { type: "codex-oauth-token" },
+        body: { idempotencyKey },
+      });
+    },
+  };
+}
+
+function expectExpiry(
+  providers: Awaited<ReturnType<Awaited<ReturnType<typeof fixture>>["list"]>>,
+  expiry: string | null,
+  count?: number,
+) {
+  expect(providers[0]).toMatchObject({
+    subscriptionResetCreditsNextExpiresAt: expiry,
+    ...(count === undefined ? {} : { subscriptionResetCredits: count }),
+  });
+}
+
+function controller() {
+  const value = new AbortController();
+  onTestFinished(() => {
+    return value.abort();
+  });
+  return value;
+}
+
+describe("Codex expiry metadata resilience", () => {
+  it.each([false, true])(
+    "caches successful dates and nulls for five minutes, accounts=%s",
+    async (accounts) => {
+      mockNow(Date.UTC(2030, 0, 1));
+      const remote = upstream();
+      const user = await fixture({ accounts });
+      const start = now();
+      expectExpiry(await user.list(), remote.expiry, 2);
+      remote.details = () => {
+        return expiryResponse(null);
+      };
+      mockNow(start + 299_999);
+      expectExpiry(await user.list(), remote.expiry, 3);
+      expect(remote.detailsCalls).toBe(2);
+      mockNow(start + 300_000);
+      expectExpiry(await user.list(), null, 4);
+      remote.details = () => {
+        return expiryResponse(remote.expiry);
+      };
+      mockNow(start + 599_999);
+      expectExpiry(await user.list(), null, 5);
+      expect(remote.detailsCalls).toBe(3);
+      mockNow(start + 600_000);
+      expectExpiry(await user.list(), remote.expiry, 6);
+      expect(remote.detailsCalls).toBe(4);
+    },
+  );
+
+  it("omits past expiry both on a cache hit and in upstream details", async () => {
+    mockNow(Date.UTC(2030, 0, 1));
+    const remote = upstream();
+    const user = await fixture();
+    remote.expiry = new Date(now() + 1000).toISOString();
+    expectExpiry(await user.list(), remote.expiry);
+    mockNow(now() + 1000);
+    expectExpiry(await user.list(), null);
+    mockNow(now() + 300_000);
+    expectExpiry(await user.list(), null);
+    expect(remote.detailsCalls).toBe(3);
+  });
+
+  it.each([
+    ["120", 120_000],
+    ["Tue, 01 Jan 2030 00:02:00 GMT", 120_000],
+    ["Tuesday, 01-Jan-30 00:02:00 GMT", 120_000],
+    ["Tue Jan  1 00:02:00 2030", 120_000],
+    [null, 60_000],
+    ["garbage", 60_000],
+    ["Fri, 30 Feb 2030 00:02:00 GMT", 60_000],
+    ["Tue, 01 Jan 2030 99:02:00 GMT", 60_000],
+    ["-10", 60_000],
+    ["0", 60_000],
+    ["1.5", 60_000],
+    ["999999999999999999999999999", 60_000],
+    ["Tue, 01 Jan 2030 00:00:00 GMT", 60_000],
+    ["Mon, 31 Dec 2029 23:59:59 GMT", 60_000],
+  ] as const)(
+    "honors Retry-After %s without retrying usage or expiry",
+    async (retryAfter, cooldown) => {
+      mockNow(Date.UTC(2030, 0, 1));
+      const remote = upstream();
+      const user = await fixture();
+      remote.details = () => {
+        return new HttpResponse(null, {
+          status: 429,
+          headers: retryAfter === null ? {} : { "Retry-After": retryAfter },
+        });
+      };
+      const start = now();
+      expectExpiry(await user.list(), null, 2);
+      expect(remote.detailsCalls).toBe(2);
+      mockNow(start + cooldown - 1);
+      expectExpiry(await user.list(), null, 3);
+      expect(remote.detailsCalls).toBe(2);
+      remote.details = () => {
+        return expiryResponse(remote.expiry);
+      };
+      mockNow(start + cooldown);
+      expectExpiry(await user.list(), remote.expiry, 4);
+      expect(remote.detailsCalls).toBe(3);
+      expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+    },
+  );
+
+  it("coalesces readers and isolates one caller's TimeoutError cancellation", async () => {
+    const remote = upstream();
+    const user = await fixture();
+    const started = createDeferredPromise<void>(context.signal);
+    const release = createDeferredPromise<Response>(context.signal);
+    const bothUsage = createDeferredPromise<void>(context.signal);
+    let detailsSignal: AbortSignal | undefined;
+    remote.details = (request) => {
+      detailsSignal = request.signal;
+      started.resolve();
+      return release.promise;
+    };
+    remote.usage = () => {
+      if (remote.usageCalls === 3) {
+        bothUsage.resolve();
+      }
+      return HttpResponse.json({
+        rate_limit_reset_credits: { available_count: remote.usageCalls },
+      });
+    };
+    const firstController = controller();
+    const first = user.list(firstController.signal);
+    const cancelled = (async () => {
+      await expect(first).rejects.toThrow("caller deadline");
+    })();
+    await started.promise;
+    const second = user.list();
+    await bothUsage.promise;
+    firstController.abort(new DOMException("caller deadline", "TimeoutError"));
+    await cancelled;
+    expect(detailsSignal?.aborted).toBeFalsy();
+    release.resolve(expiryResponse(remote.expiry));
+    expectExpiry(await second, remote.expiry, 3);
+    expect(remote.detailsCalls).toBe(2);
+    expectExpiry(await user.list(), remote.expiry, 4);
+    expect(remote.detailsCalls).toBe(2);
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+  });
+
+  it("aborts all-waiter work and lets a new flight survive late cleanup", async () => {
+    const remote = upstream();
+    const user = await fixture();
+    const started = createDeferredPromise<void>(context.signal);
+    const aborted = createDeferredPromise<void>(context.signal);
+    const release = createDeferredPromise<Response>(context.signal);
+    remote.details = (request) => {
+      request.signal.addEventListener(
+        "abort",
+        () => {
+          return aborted.resolve();
+        },
+        {
+          once: true,
+        },
+      );
+      started.resolve();
+      return release.promise;
+    };
+    const owner = controller();
+    const cancelled = (async () => {
+      await expect(user.list(owner.signal)).rejects.toThrow("cancelled");
+    })();
+    await started.promise;
+    owner.abort(new DOMException("cancelled", "AbortError"));
+    await cancelled;
+    await aborted.promise;
+    remote.expiry = new Date(now() + 7_200_000).toISOString();
+    remote.details = () => {
+      return expiryResponse(remote.expiry);
+    };
+    expectExpiry(await user.list(), remote.expiry);
+    release.resolve(expiryResponse(new Date(now() + 1000).toISOString()));
+    expectExpiry(await user.list(), remote.expiry);
+    expect(remote.detailsCalls).toBe(3);
+  });
+
+  it("uses only the local five-second deadline for a timeout cooldown", async () => {
+    mockNow(Date.UTC(2030, 0, 1));
+    const remote = upstream();
+    const user = await fixture();
+    const started = createDeferredPromise<void>(context.signal);
+    const deadline = createDeferredPromise<void>(context.signal);
+    const release = createDeferredPromise<Response>(context.signal);
+    remote.details = () => {
+      started.resolve();
+      return release.promise;
+    };
+    context.mocks.signalTimers.delay.mockImplementation((ms) => {
+      expect(ms).toBe(5000);
+      return deadline.promise;
+    });
+    const attempt = user.list();
+    await started.promise;
+    deadline.resolve();
+    expectExpiry(await attempt, null, 2);
+    release.resolve(expiryResponse(remote.expiry));
+    mockNow(now() + 59_999);
+    expectExpiry(await user.list(), null, 3);
+    expect(remote.detailsCalls).toBe(2);
+    context.mocks.signalTimers.delay.mockReset();
+    remote.details = () => {
+      return expiryResponse(remote.expiry);
+    };
+    mockNow(now() + 1);
+    expectExpiry(await user.list(), remote.expiry, 4);
+    expect(remote.detailsCalls).toBe(3);
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+  });
+
+  it.each([401, 500, "schema", "transport"] as const)(
+    "keeps unexpected %s failures diagnosable and preserves the count",
+    async (failure) => {
+      const remote = upstream();
+      const user = await fixture();
+      remote.details = () => {
+        return failure === "schema"
+          ? HttpResponse.json({ credits: "invalid" })
+          : failure === "transport"
+            ? HttpResponse.error()
+            : new HttpResponse(null, { status: failure });
+      };
+      expectExpiry(await user.list(), null, 2);
+      expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+        expect.stringContaining("failed to read codex reset credit expiry"),
+        expect.anything(),
+      );
+    },
+  );
+
+  it.each([false, true])(
+    "invalidates on ambiguous consume failure, accounts=%s",
+    async (accounts) => {
+      const remote = upstream();
+      const user = await fixture({ accounts });
+      expectExpiry(await user.list(), remote.expiry);
+      let consumeCalls = 0;
+      server.use(
+        http.post(`${detailsUrl}/consume`, async ({ request }) => {
+          consumeCalls += 1;
+          expect(request.headers.get("chatgpt-account-id")).toBe(
+            user.auth.accountId,
+          );
+          await expect(request.json()).resolves.toStrictEqual({
+            redeem_request_id: expect.any(String),
+          });
+          return HttpResponse.error();
+        }),
+      );
+      const result = await user.consume();
+      expect(result.status).toBe(500);
+      remote.expiry = new Date(now() + 7_200_000).toISOString();
+      expectExpiry(await user.list(), remote.expiry);
+      expect(remote.detailsCalls).toBe(3);
+      expect(consumeCalls).toBe(1);
+    },
+  );
+
+  it.each(["consume", "reconnect", "replace-account"] as const)(
+    "fences an in-flight expiry across %s",
+    async (mutation) => {
+      const remote = upstream();
+      const user = await fixture({ accounts: mutation === "replace-account" });
+      const started = createDeferredPromise<void>(context.signal);
+      const release = createDeferredPromise<Response>(context.signal);
+      remote.details = () => {
+        started.resolve();
+        return release.promise;
+      };
+      const oldRead = user.list();
+      await started.promise;
+      remote.details = () => {
+        return expiryResponse(null);
+      };
+      if (mutation === "consume") {
+        server.use(
+          http.post(`${detailsUrl}/consume`, () => {
+            return HttpResponse.json({ code: "reset" });
+          }),
+        );
+        expect((await user.consume()).status).toBe(200);
+      } else {
+        await user.connect(
+          mutation === "replace-account" ? credentials() : user.auth,
+        );
+      }
+      expectExpiry(await oldRead, null);
+      const freshExpiry = new Date(now() + 7_200_000).toISOString();
+      remote.details = () => {
+        return expiryResponse(freshExpiry);
+      };
+      expectExpiry(await user.list(), freshExpiry);
+      release.resolve(expiryResponse(remote.expiry));
+      expectExpiry(await user.list(), freshExpiry);
+    },
+  );
+
+  it("rechecks invalidation after expiry settled while the main usage read is pending", async () => {
+    const remote = upstream();
+    const user = await fixture();
+    expectExpiry(await user.list(), remote.expiry);
+    const started = createDeferredPromise<void>(context.signal);
+    const release = createDeferredPromise<Response>(context.signal);
+    remote.usage = () => {
+      started.resolve();
+      return release.promise;
+    };
+    const oldRead = user.list();
+    await started.promise;
+    server.use(
+      http.post(`${detailsUrl}/consume`, () => {
+        return HttpResponse.json({ code: "reset" });
+      }),
+    );
+    expect((await user.consume()).status).toBe(200);
+    release.resolve(
+      HttpResponse.json({ rate_limit_reset_credits: { available_count: 7 } }),
+    );
+    expectExpiry(await oldRead, null, 7);
+  });
+
+  it.each(["user", "org"] as const)(
+    "isolates identical upstream credentials by %s",
+    async (dimension) => {
+      const remote = upstream();
+      const first = await fixture();
+      remote.details = () => {
+        return new HttpResponse(null, { status: 429 });
+      };
+      expectExpiry(await first.list(), null);
+      remote.details = () => {
+        return expiryResponse(remote.expiry);
+      };
+      const second = await fixture({
+        auth: first.auth,
+        ...(dimension === "user"
+          ? { orgId: first.orgId }
+          : { userId: first.userId }),
+      });
+      expectExpiry(await second.list(), remote.expiry);
+      expectExpiry(await first.list(), null);
+      expect(remote.detailsCalls).toBe(4);
+    },
+  );
+
+  it("preserves another concrete account's cooldown across connect and reconnect", async () => {
+    const remote = upstream();
+    const first = await fixture({ accounts: true });
+    remote.details = () => {
+      return new HttpResponse(null, {
+        status: 429,
+        headers: { "Retry-After": "120" },
+      });
+    };
+    expectExpiry(await first.list(), null);
+    remote.details = (request) => {
+      expect(request.headers.get("chatgpt-account-id")).not.toBe(
+        first.auth.accountId,
+      );
+      return expiryResponse(remote.expiry);
+    };
+    first.session();
+    mockCodexDeviceAuthProvider({
+      tokenScope: "personal",
+      accountId: randomUUID(),
+    });
+    const device = setupApp({ context, routes: codexDeviceAuthRoutes })(
+      codexDeviceAuthContract,
+    );
+    const connect = async (id?: string) => {
+      const started = await accept(
+        device.start({
+          headers,
+          body: {
+            scope: "personal",
+            mode: id ? "reconnect" : "add",
+            modelProviderId: id,
+          },
+        }),
+        [200],
+      );
+      const completed = await accept(
+        device.complete({
+          headers,
+          body: { sessionToken: started.body.sessionToken },
+        }),
+        [200],
+      );
+      if (completed.body.status !== "complete") {
+        throw new Error("Expected device auth completion");
+      }
+      return completed.body.provider.id;
+    };
+    const secondId = await connect();
+    await connect(secondId);
+    const before = remote.detailsCalls;
+    const listed = await first.list();
+    expect(listed).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: first.id,
+          subscriptionResetCreditsNextExpiresAt: null,
+        }),
+        expect.objectContaining({
+          id: secondId,
+          subscriptionResetCreditsNextExpiresAt: remote.expiry,
+        }),
+      ]),
+    );
+    expect(remote.detailsCalls).toBe(before + 1);
+    await expect(first.list()).resolves.toHaveLength(2);
+    expect(remote.detailsCalls).toBe(before + 1);
+  });
+
+  it("isolates org connect metadata from the personal cooldown", async () => {
+    const remote = upstream();
+    const user = await fixture();
+    remote.details = () => {
+      return new HttpResponse(null, { status: 429 });
+    };
+    expectExpiry(await user.list(), null);
+    remote.details = () => {
+      return expiryResponse(remote.expiry);
+    };
+    user.session();
+    const result = await accept(
+      setupApp({ context, routes: modelProvidersRoutes })(
+        modelProvidersMainContract,
+      ).upsert({
+        headers,
+        body: {
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: { CODEX_AUTH_JSON: user.auth.raw },
+        },
+      }),
+      [200, 201],
+    );
+    expect(result.body.provider.type).toBe("codex-oauth-token");
+    expect(remote.detailsCalls).toBe(3);
+    expectExpiry(await user.list(), null);
+    expect(remote.detailsCalls).toBe(3);
+  });
+
+  it.each(["credential", "account"] as const)(
+    "does not reuse expiry after changing %s",
+    async (dimension) => {
+      const remote = upstream();
+      const user = await fixture();
+      expectExpiry(await user.list(), remote.expiry);
+      const next = credentials(
+        dimension === "account" ? randomUUID() : user.auth.accountId,
+      );
+      await user.connect(next);
+      remote.expiry = new Date(now() + 7_200_000).toISOString();
+      expectExpiry(await user.list(), remote.expiry);
+      expect(remote.detailsCalls).toBe(4);
+    },
+  );
+
+  it("fences an old flight when current credentials rotate without reconnect", async () => {
+    mockNow(Date.UTC(2030, 0, 1));
+    const remote = upstream();
+    const user = await fixture({ accounts: true });
+    const started = createDeferredPromise<void>(context.signal);
+    const release = createDeferredPromise<Response>(context.signal);
+    remote.details = () => {
+      started.resolve();
+      return release.promise;
+    };
+    const oldRead = user.list();
+    await started.promise;
+    const freshToken = `fresh-${randomUUID()}`;
+    server.use(
+      http.post("https://auth.openai.com/oauth/token", () => {
+        return HttpResponse.json({
+          access_token: freshToken,
+          refresh_token: `rotated-${randomUUID()}`,
+          expires_in: 3600,
+        });
+      }),
+    );
+    mockNow(now() + 7_201_000);
+    const freshExpiry = new Date(now() + 3_600_000).toISOString();
+    remote.details = (request) => {
+      expect(request.headers.get("authorization")).toBe(`Bearer ${freshToken}`);
+      return expiryResponse(freshExpiry);
+    };
+    expectExpiry(await user.list(), freshExpiry);
+    expectExpiry(await oldRead, null);
+    release.resolve(expiryResponse(remote.expiry));
+    expectExpiry(await user.list(), freshExpiry);
+    expect(remote.detailsCalls).toBe(3);
+  });
+
+  it("evicts old identity entries at bounded capacity", async () => {
+    const remote = upstream();
+    const first = await fixture();
+    expectExpiry(await first.list(), remote.expiry);
+    // Each API-created owner occupies a connect binding and a legacy binding.
+    // More than 256 bindings must evict the oldest, without time manipulation.
+    for (let index = 0; index < 129; index += 1) {
+      const other = await fixture();
+      expectExpiry(await other.list(), remote.expiry);
+    }
+    const before = remote.detailsCalls;
+    remote.expiry = new Date(now() + 7_200_000).toISOString();
+    expectExpiry(await first.list(), remote.expiry);
+    expect(remote.detailsCalls).toBe(before + 1);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/codex-reset-credit-expiry.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/codex-reset-credit-expiry.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@okouai/api-contracts/contracts/personal-model-providers";
 import { modelProvidersMainContract } from "@okouai/api-contracts/contracts/model-provider-routes";
 import { codexDeviceAuthContract } from "@okouai/api-contracts/contracts/codex-device-auth";
+import { featureSwitchesContract } from "@okouai/api-contracts/contracts/feature-switches";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { accept, testContext } from "../../../__tests__/test-context";
@@ -21,6 +22,7 @@ import { meModelProvidersResetSubscriptionRoutes } from "../me-model-providers-r
 import { meModelProviderAccountRoutes } from "../me-model-provider-accounts";
 import { codexDeviceAuthRoutes } from "../codex-device-auth";
 import { modelProvidersRoutes } from "../model-providers";
+import { featureSwitchesRoutes } from "../feature-switches";
 import { createRouteMocks } from "./helpers/route-test";
 import { mockCodexDeviceAuthProvider } from "./helpers/api-bdd-auth-device";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
@@ -674,11 +676,68 @@ describe("Codex expiry metadata resilience", () => {
     const remote = upstream();
     const first = await fixture();
     expectExpiry(await first.list(), remote.expiry);
+    const userIds = Array.from({ length: 129 }, () => {
+      return `user_expiry_${randomUUID()}`;
+    });
+    const owners = new Set(userIds);
+    context.mocks.clerk.authenticateRequest.mockImplementation((request) => {
+      if (!(request instanceof Request)) {
+        throw new Error("Expected a Clerk authentication request");
+      }
+      const userId = request.headers.get("authorization")?.slice(7);
+      if (!userId || !owners.has(userId)) {
+        throw new Error("Expected a capacity-test owner token");
+      }
+      return Promise.resolve({
+        isAuthenticated: true,
+        toAuth: () => {
+          return { userId, orgId: first.orgId, orgRole: "org:admin" };
+        },
+      });
+    });
+    const app = setupApp({
+      context,
+      routes: [...routes, ...featureSwitchesRoutes],
+    });
+    const providers = app(personalModelProvidersMainContract);
+    const switches = app(featureSwitchesContract);
     // Each API-created owner occupies a connect binding and a legacy binding.
     // More than 256 bindings must evict the oldest, without time manipulation.
-    for (let index = 0; index < 129; index += 1) {
-      const other = await fixture();
-      expectExpiry(await other.list(), remote.expiry);
+    // Token-scoped Clerk responses let independent owners prepare concurrently
+    // without racing the shared session mock or creating unrelated organizations.
+    for (let index = 0; index < userIds.length; index += 8) {
+      await Promise.all(
+        userIds.slice(index, index + 8).map(async (userId) => {
+          const ownerHeaders = { authorization: `Bearer ${userId}` };
+          await accept(
+            switches.update({
+              headers: ownerHeaders,
+              body: {
+                switches: {
+                  [FeatureSwitchKey.PersonalModelProviderAccounts]: false,
+                },
+              },
+            }),
+            [200],
+          );
+          await accept(
+            providers.upsert({
+              headers: ownerHeaders,
+              body: {
+                type: "codex-oauth-token",
+                authMethod: "auth_json",
+                secrets: { CODEX_AUTH_JSON: credentials().raw },
+              },
+            }),
+            [200, 201],
+          );
+          const listed = await accept(
+            providers.list({ headers: ownerHeaders }),
+            [200],
+          );
+          expectExpiry(listed.body.modelProviders, remote.expiry);
+        }),
+      );
     }
     const before = remote.detailsCalls;
     remote.expiry = new Date(now() + 7_200_000).toISOString();

--- a/turbo/apps/api/src/signals/services/codex-auth-json-paste-handler.ts
+++ b/turbo/apps/api/src/signals/services/codex-auth-json-paste-handler.ts
@@ -12,6 +12,10 @@ import {
 } from "./codex-auth-json-parser";
 import { fetchCodexUsageMetadata } from "./codex-usage.service";
 import type { PersonalProviderAccountErrorResponse } from "./model-provider-account.service";
+import {
+  invalidateCodexResetCreditExpiry,
+  prepareCodexResetCreditExpiryRead,
+} from "./codex-reset-credit-expiry.service";
 import { logger } from "../../lib/log";
 import { settle, tapError, throwIfAbort } from "../utils";
 
@@ -165,6 +169,14 @@ export async function handleCodexAuthJsonPaste(
   const pasteResult = await settle(
     (async () => {
       const parsed = parseCodexAuthJson(args.rawAuthJson);
+      const invalidateExpiry = () => {
+        invalidateCodexResetCreditExpiry(args, { accountId: parsed.accountId });
+      };
+      invalidateExpiry();
+      const readResetCreditExpiry = prepareCodexResetCreditExpiryRead(
+        args,
+        "connect",
+      );
       const usageMetadata =
         (await tapError(
           fetchCodexUsageMetadata(
@@ -172,39 +184,45 @@ export async function handleCodexAuthJsonPaste(
               accessToken: parsed.accessToken,
               accountId: parsed.accountId,
               idToken: parsed.idToken,
+              readResetCreditExpiry,
             },
             signal,
           ),
           () => {
+            signal.throwIfAborted();
             return undefined;
           },
         )) ?? null;
 
-      const upserted = await args.upsert({
-        authMethod: "auth_json",
-        secretValues: {
-          CHATGPT_ACCESS_TOKEN: parsed.accessToken,
-          CHATGPT_REFRESH_TOKEN: parsed.refreshToken,
-          CHATGPT_ACCOUNT_ID: parsed.accountId,
-          CHATGPT_ID_TOKEN: parsed.idToken,
-        },
-        selectedModel: args.selectedModel,
-        metadata: {
-          externalAccountId: parsed.accountId,
-          accountEmail:
-            usageMetadata?.accountEmail ??
-            extractCodexAccountEmailFromIdToken(parsed.idToken),
-          tokenExpiresAt: parsed.tokenExpiresAt,
-          workspaceName: usageMetadata?.workspaceName ?? parsed.workspaceName,
-          planType: usageMetadata?.planType ?? parsed.planType,
-          ...(usageMetadata
-            ? {
-                subscriptionResetPeriod: usageMetadata.subscriptionResetPeriod,
-                subscriptionNextResetAt: usageMetadata.subscriptionNextResetAt,
-              }
-            : {}),
-        },
-      });
+      const upserted = await args
+        .upsert({
+          authMethod: "auth_json",
+          secretValues: {
+            CHATGPT_ACCESS_TOKEN: parsed.accessToken,
+            CHATGPT_REFRESH_TOKEN: parsed.refreshToken,
+            CHATGPT_ACCOUNT_ID: parsed.accountId,
+            CHATGPT_ID_TOKEN: parsed.idToken,
+          },
+          selectedModel: args.selectedModel,
+          metadata: {
+            externalAccountId: parsed.accountId,
+            accountEmail:
+              usageMetadata?.accountEmail ??
+              extractCodexAccountEmailFromIdToken(parsed.idToken),
+            tokenExpiresAt: parsed.tokenExpiresAt,
+            workspaceName: usageMetadata?.workspaceName ?? parsed.workspaceName,
+            planType: usageMetadata?.planType ?? parsed.planType,
+            ...(usageMetadata
+              ? {
+                  subscriptionResetPeriod:
+                    usageMetadata.subscriptionResetPeriod,
+                  subscriptionNextResetAt:
+                    usageMetadata.subscriptionNextResetAt,
+                }
+              : {}),
+          },
+        })
+        .finally(invalidateExpiry);
       if ("status" in upserted) {
         return upserted;
       }

--- a/turbo/apps/api/src/signals/services/codex-reset-credit-expiry.service.ts
+++ b/turbo/apps/api/src/signals/services/codex-reset-credit-expiry.service.ts
@@ -1,0 +1,388 @@
+import { createHash } from "node:crypto";
+import { delay } from "signal-timers";
+import { z } from "zod";
+
+import { logger } from "../../lib/log";
+import { singleton } from "../../lib/singleton";
+import { now } from "../../lib/time";
+import { awaitWithSignal, onRejection, settle, tapError } from "../utils";
+
+type CodexExpiryScope =
+  | { readonly scope: "org"; readonly orgId: string }
+  | {
+      readonly scope: "personal";
+      readonly orgId: string;
+      readonly userId: string;
+    };
+
+interface Credentials {
+  readonly accessToken: string;
+  readonly accountId: string;
+}
+
+interface Flight {
+  readonly controller: AbortController;
+  readonly promise: Promise<void>;
+  waiters: number;
+}
+
+interface Entry {
+  readonly scopeKey: string;
+  readonly binding: string | null;
+  credentialKey: string | undefined;
+  accountKey: string | undefined;
+  version: number;
+  expiresAt: Date | null;
+  trustedUntil: number;
+  cooldownUntil: number;
+  flight: Flight | undefined;
+}
+
+const DETAILS_URL =
+  "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
+const TTL_MS = 5 * 60_000;
+const COOLDOWN_MS = 60_000;
+const DETAILS_TIMEOUT_MS = 5000;
+// Best-effort warm-instance LRU, including in-flight entries. Eviction aborts
+// owned work and invalidates every outstanding reader; cold instances are independent.
+const MAX_ENTRIES = 256;
+const entries = singleton(() => {
+  return new Map<string, Entry>();
+});
+const L = logger("codex-reset-credit-expiry.service");
+const observation = singleton(() => {
+  return {
+    since: now(),
+    counts: {
+      cached: 0,
+      coalesced: 0,
+      cooldown: 0,
+      success: 0,
+      rate_limited: 0,
+      local_timeout: 0,
+      unexpected_failure: 0,
+    },
+  };
+});
+
+function record(outcome: keyof ReturnType<typeof observation>["counts"]): void {
+  const summary = observation();
+  summary.counts[outcome] = Math.min(
+    Number.MAX_SAFE_INTEGER,
+    summary.counts[outcome] + 1,
+  );
+  if (now() - summary.since >= COOLDOWN_MS) {
+    // Demand-driven, at most one aggregate per minute per warm instance. Never
+    // include scope keys, account IDs, credentials, or per-waiter log records.
+    L.info("codex reset credit expiry outcomes", {
+      windowMs: now() - summary.since,
+      ...summary.counts,
+    });
+    observation.reset();
+  }
+}
+
+function digest(parts: readonly unknown[]): string {
+  return createHash("sha256").update(JSON.stringify(parts)).digest("hex");
+}
+
+function scopeKey(scope: CodexExpiryScope): string {
+  return digest([
+    scope.scope,
+    scope.orgId,
+    scope.scope === "personal" ? scope.userId : null,
+  ]);
+}
+
+function invalidate(entry: Entry): void {
+  entry.version += 1;
+  entry.expiresAt = null;
+  entry.trustedUntil = 0;
+  entry.cooldownUntil = 0;
+  const flight = entry.flight;
+  entry.flight = undefined;
+  // This is owned cache invalidation, not a caller AbortError or local timeout.
+  flight?.controller.abort(new Error("Codex expiry read invalidated"));
+}
+
+export function invalidateCodexResetCreditExpiry(
+  scope: CodexExpiryScope,
+  target: { readonly binding: string | null } | { readonly accountId: string },
+): void {
+  const owner = scopeKey(scope);
+  const accountKey =
+    "accountId" in target ? digest([target.accountId]) : undefined;
+  for (const entry of entries().values()) {
+    if (entry.scopeKey !== owner) {
+      continue;
+    }
+    const matches =
+      "binding" in target
+        ? entry.binding === target.binding
+        : entry.binding === null ||
+          entry.binding === "connect" ||
+          entry.accountKey === undefined ||
+          entry.accountKey === accountKey;
+    if (matches) {
+      // Reconnect may replace the legacy slot, but must preserve another
+      // concrete account's cached value and retained Retry-After deadline.
+      invalidate(entry);
+    }
+  }
+}
+
+function httpDateTimestamp(header: string): number {
+  // HTTP-date permits IMF-fixdate and the two obsolete wire forms. Normalize
+  // before parsing so Date.parse cannot admit ISO dates or normalized bad dates.
+  const normalized = header
+    .replace(
+      /^(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday), (\d{2}-[A-Z][a-z]{2})-(\d{2}) (\d{2}:\d{2}:\d{2}) GMT$/,
+      (
+        _match: string,
+        weekday: string,
+        dayMonth: string,
+        year: string,
+        time: string,
+      ) => {
+        const currentYear = new Date(now()).getUTCFullYear();
+        let fullYear = Math.floor(currentYear / 100) * 100 + Number(year);
+        if (fullYear > currentYear + 50) {
+          fullYear -= 100;
+        } else if (fullYear < currentYear - 50) {
+          fullYear += 100;
+        }
+        return `${weekday.slice(0, 3)}, ${dayMonth.replace("-", " ")} ${fullYear} ${time} GMT`;
+      },
+    )
+    .replace(
+      /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) ([A-Z][a-z]{2}) ( \d|\d{2}) (\d{2}:\d{2}:\d{2}) (\d{4})$/,
+      "$1, $3 $2 $5 $4 GMT",
+    )
+    .replace(/, {2}(\d) /, ", 0$1 ");
+  const timestamp = Date.parse(normalized);
+  return new Date(timestamp).toUTCString() === normalized
+    ? timestamp
+    : Number.NaN;
+}
+
+function retryAfterDeadline(value: string | null): number {
+  const current = now();
+  const fallback = current + COOLDOWN_MS;
+  if (!value || value.length > 128) {
+    return fallback;
+  }
+  const header = value.trim();
+  const deadline = /^\d+$/.test(header)
+    ? current + Number(header) * 1000
+    : httpDateTimestamp(header);
+  return Number.isSafeInteger(deadline) &&
+    deadline > current &&
+    deadline <= 8_640_000_000_000_000
+    ? deadline
+    : fallback;
+}
+
+const detailsSchema = z.object({
+  credits: z
+    .array(
+      z.object({
+        status: z.string().nullable().optional(),
+        expires_at: z.string().nullable().optional(),
+      }),
+    )
+    .nullable()
+    .optional(),
+});
+
+async function fetchDetails(args: Credentials, signal: AbortSignal) {
+  const response = await fetch(DETAILS_URL, {
+    method: "GET",
+    headers: {
+      authorization: `Bearer ${args.accessToken}`,
+      "chatgpt-account-id": args.accountId,
+      originator: "codex_cli_rs",
+      "user-agent": "codex_cli_rs/0.0.0",
+    },
+    signal,
+  });
+  if (response.status === 429) {
+    return {
+      outcome: "rate_limited" as const,
+      cooldownUntil: retryAfterDeadline(response.headers.get("retry-after")),
+    };
+  }
+  if (!response.ok) {
+    throw new Error(
+      `Codex reset credit details request failed with status ${response.status}`,
+    );
+  }
+  const parsed = detailsSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new Error("Codex reset credit details response shape unrecognized");
+  }
+  let expiresAt: Date | null = null;
+  for (const credit of parsed.data.credits ?? []) {
+    if (credit.status !== "available" || !credit.expires_at) {
+      continue;
+    }
+    const candidate = new Date(credit.expires_at);
+    if (candidate.getTime() > now() && (!expiresAt || candidate < expiresAt)) {
+      expiresAt = candidate;
+    }
+  }
+  return { outcome: "success" as const, expiresAt };
+}
+
+async function load(
+  entry: Entry,
+  args: Credentials,
+  signal: AbortSignal,
+): Promise<void> {
+  const version = entry.version;
+  const controller = new AbortController();
+  const detailsSignal = AbortSignal.any([signal, controller.signal]);
+  let timedOut = false;
+  const deadline = tapError(
+    (async () => {
+      await awaitWithSignal(
+        delay(DETAILS_TIMEOUT_MS, { signal: detailsSignal }),
+        detailsSignal,
+      );
+      timedOut = true;
+      controller.abort(
+        new DOMException("Codex expiry deadline", "TimeoutError"),
+      );
+    })(),
+  );
+  const finishDeadline = async () => {
+    controller.abort(new Error("Codex expiry read settled"));
+    await deadline;
+  };
+  const result = await onRejection(
+    settle(awaitWithSignal(fetchDetails(args, detailsSignal), detailsSignal)),
+    finishDeadline,
+  );
+  await finishDeadline();
+  if (entry.version !== version) {
+    return;
+  }
+  if (result.ok) {
+    record(result.value.outcome);
+    if (result.value.outcome === "rate_limited") {
+      entry.cooldownUntil = result.value.cooldownUntil;
+    } else {
+      entry.expiresAt = result.value.expiresAt;
+      entry.trustedUntil = now() + TTL_MS;
+    }
+  } else if (timedOut) {
+    record("local_timeout");
+    entry.cooldownUntil = now() + COOLDOWN_MS;
+  } else {
+    record("unexpected_failure");
+    L.warn("failed to read codex reset credit expiry", { error: result.error });
+  }
+}
+
+/** Capture before credential resolution so invalidation also fences readers
+ * still awaiting credentials. The returned accessor rechecks at serialization,
+ * after the independent main usage GET/body may have finished much later. */
+export function prepareCodexResetCreditExpiryRead(
+  scope: CodexExpiryScope,
+  binding: string | null = null,
+) {
+  const owner = scopeKey(scope);
+  const key = digest([owner, binding]);
+  const cache = entries();
+  let entry = cache.get(key);
+  if (entry) {
+    cache.delete(key);
+  } else {
+    if (cache.size >= MAX_ENTRIES) {
+      const oldest = cache.entries().next().value;
+      if (oldest) {
+        invalidate(oldest[1]);
+        cache.delete(oldest[0]);
+      }
+    }
+    entry = {
+      scopeKey: owner,
+      binding,
+      credentialKey: undefined,
+      accountKey: undefined,
+      version: 0,
+      expiresAt: null,
+      trustedUntil: 0,
+      cooldownUntil: 0,
+      flight: undefined,
+    };
+  }
+  cache.set(key, entry);
+  return readerForEntry(cache, key, entry);
+}
+
+function readerForEntry(cache: Map<string, Entry>, key: string, entry: Entry) {
+  let version = entry.version;
+  const current = () => {
+    return cache.get(key) === entry && entry.version === version;
+  };
+  const value = () => {
+    return current() &&
+      entry.trustedUntil > now() &&
+      entry.expiresAt &&
+      entry.expiresAt.getTime() > now()
+      ? entry.expiresAt
+      : null;
+  };
+  return async (args: Credentials, signal: AbortSignal) => {
+    signal.throwIfAborted();
+    if (!current()) {
+      return value;
+    }
+    const credentialKey = digest([args.accountId, args.accessToken]);
+    if (entry.credentialKey !== credentialKey) {
+      if (entry.credentialKey !== undefined) {
+        invalidate(entry);
+        version = entry.version;
+      }
+      entry.credentialKey = credentialKey;
+      entry.accountKey = digest([args.accountId]);
+    }
+    if (entry.cooldownUntil > now()) {
+      record("cooldown");
+      return value;
+    }
+    if (entry.trustedUntil > now()) {
+      record("cached");
+      return value;
+    }
+    let flight = entry.flight;
+    if (flight) {
+      record("coalesced");
+    } else {
+      const controller = new AbortController();
+      flight = {
+        controller,
+        waiters: 0,
+        promise: load(entry, args, controller.signal).finally(() => {
+          if (entry.flight?.controller === controller) {
+            entry.flight = undefined;
+          }
+        }),
+      };
+      entry.flight = flight;
+    }
+    const ownedFlight = flight;
+    ownedFlight.waiters += 1;
+    const leave = async () => {
+      ownedFlight.waiters -= 1;
+      if (ownedFlight.waiters === 0 && entry.flight === ownedFlight) {
+        invalidate(entry);
+        await ownedFlight.promise;
+      }
+    };
+    await onRejection(awaitWithSignal(ownedFlight.promise, signal), leave);
+    await leave();
+    signal.throwIfAborted();
+    return value;
+  };
+}

--- a/turbo/apps/api/src/signals/services/codex-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/codex-usage.service.ts
@@ -1,8 +1,7 @@
 import { z } from "zod";
 
-import { logger } from "../../lib/log";
 import { now } from "../../lib/time";
-import { tapError } from "../utils";
+import type { prepareCodexResetCreditExpiryRead } from "./codex-reset-credit-expiry.service";
 import type {
   SubscriptionUsageMetadata,
   SubscriptionUsageWindowMetadata,
@@ -10,18 +9,10 @@ import type {
 import { extractCodexAccountEmailFromIdToken } from "./codex-auth-json-parser";
 
 const CHATGPT_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-const CHATGPT_RESET_CREDITS_URL =
-  "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
 const CHATGPT_RESET_CREDITS_CONSUME_URL =
   "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume";
 const CODEX_ORIGINATOR = "codex_cli_rs";
 const CODEX_USER_AGENT = "codex_cli_rs/0.0.0";
-/**
- * The usage response only carries the reset credit count, so the expiry needs a
- * second upstream read. It is decorative next to the count that the reset flow
- * actually depends on, so it gets its own short budget and degrades quietly.
- */
-const RESET_CREDIT_DETAILS_TIMEOUT_MS = 5000;
 const WEEK_SECONDS = 7 * 24 * 60 * 60;
 const DAY_SECONDS = 24 * 60 * 60;
 const HOUR_SECONDS = 60 * 60;
@@ -47,19 +38,6 @@ const rateLimitDetailsSchema = z
 const rateLimitResetCreditsSchema = z
   .object({
     available_count: z.number().int().nonnegative().nullable().optional(),
-  })
-  .passthrough();
-
-const rateLimitResetCreditSchema = z
-  .object({
-    status: z.string().nullable().optional(),
-    expires_at: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-const rateLimitResetCreditsDetailsSchema = z
-  .object({
-    credits: z.array(rateLimitResetCreditSchema).nullable().optional(),
   })
   .passthrough();
 
@@ -106,8 +84,6 @@ const codexRateLimitResetCreditConsumeResponseSchema = z
 type RateLimitWindow = z.infer<typeof rateLimitWindowSchema>;
 type CodexNamedMetadata = z.infer<typeof namedMetadataSchema>;
 type CodexUsageResponse = z.infer<typeof codexUsageResponseSchema>;
-
-const L = logger("codex-usage.service");
 
 interface CodexUsageMetadata {
   readonly accountEmail: string | null;
@@ -324,82 +300,20 @@ function subscriptionUsageFromRateLimit(
   };
 }
 
-/**
- * Soonest expiry among the credits the account can still redeem. Credits that
- * never expire and credits in a non-redeemable status carry no deadline worth
- * showing, so they drop out here rather than in the view layer.
- */
-function nextResetCreditExpiry(
-  credits: readonly z.infer<typeof rateLimitResetCreditSchema>[],
-): Date | null {
-  const expiries = credits
-    .filter((credit) => {
-      return credit.status === "available";
-    })
-    .map((credit) => {
-      return credit.expires_at ? new Date(credit.expires_at) : null;
-    })
-    .filter((expiry): expiry is Date => {
-      return expiry !== null && !Number.isNaN(expiry.getTime());
-    });
-
-  if (expiries.length === 0) {
-    return null;
-  }
-  return expiries.reduce((soonest, candidate) => {
-    return candidate < soonest ? candidate : soonest;
-  });
-}
-
-async function fetchCodexResetCreditExpiry(
-  args: {
-    readonly accessToken: string;
-    readonly accountId: string;
-  },
-  signal: AbortSignal,
-): Promise<Date | null> {
-  const response = await fetch(CHATGPT_RESET_CREDITS_URL, {
-    method: "GET",
-    headers: {
-      authorization: `Bearer ${args.accessToken}`,
-      "chatgpt-account-id": args.accountId,
-      originator: CODEX_ORIGINATOR,
-      "user-agent": CODEX_USER_AGENT,
-    },
-    signal,
-  });
-
-  if (!response.ok) {
-    throw new Error(
-      `Codex reset credit details request failed with status ${response.status}`,
-    );
-  }
-
-  const parsed = rateLimitResetCreditsDetailsSchema.safeParse(
-    await response.json(),
-  );
-  if (!parsed.success) {
-    throw new Error("Codex reset credit details response shape unrecognized");
-  }
-
-  return nextResetCreditExpiry(parsed.data.credits ?? []);
-}
-
 export async function fetchCodexUsageMetadata(
   args: {
     readonly accessToken: string;
     readonly accountId: string;
     readonly idToken?: string | null;
+    readonly readResetCreditExpiry: ReturnType<
+      typeof prepareCodexResetCreditExpiryRead
+    >;
   },
   signal: AbortSignal,
 ): Promise<CodexUsageMetadata | null> {
-  // The caller's abort still cancels both reads; only the extra detail budget
-  // is scoped here, so a slow expiry read cannot hold up the usage response.
-  const detailsSignal = AbortSignal.any([
-    signal,
-    AbortSignal.timeout(RESET_CREDIT_DETAILS_TIMEOUT_MS),
-  ]);
-  const [response, nextExpiresAt] = await Promise.all([
+  const detailsWaiter = new AbortController();
+  const detailsSignal = AbortSignal.any([signal, detailsWaiter.signal]);
+  const [response, resetCreditExpiry] = await Promise.all([
     fetch(CHATGPT_USAGE_URL, {
       method: "GET",
       headers: {
@@ -410,19 +324,10 @@ export async function fetchCodexUsageMetadata(
       },
       signal,
     }),
-    tapError(
-      fetchCodexResetCreditExpiry(
-        {
-          accessToken: args.accessToken,
-          accountId: args.accountId,
-        },
-        detailsSignal,
-      ),
-      (error) => {
-        L.warn("failed to read codex reset credit expiry", { error });
-      },
-    ),
-  ]);
+    args.readResetCreditExpiry(args, detailsSignal),
+  ]).finally(() => {
+    detailsWaiter.abort(new Error("Codex usage metadata read settled"));
+  });
 
   if (!response.ok) {
     throw new Error(
@@ -435,6 +340,7 @@ export async function fetchCodexUsageMetadata(
     throw new Error("Codex usage response shape unrecognized");
   }
 
+  signal.throwIfAborted();
   const resetWindow = chooseSubscriptionResetWindow(parsed.data.rate_limit);
   return {
     accountEmail: extractCodexAccountEmailFromIdToken(args.idToken),
@@ -445,7 +351,7 @@ export async function fetchCodexUsageMetadata(
     subscriptionUsage: subscriptionUsageFromRateLimit(parsed.data.rate_limit),
     subscriptionResetCredits:
       parsed.data.rate_limit_reset_credits?.available_count ?? null,
-    subscriptionResetCreditsNextExpiresAt: nextExpiresAt ?? null,
+    subscriptionResetCreditsNextExpiresAt: resetCreditExpiry(),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/model-provider-account.service.ts
+++ b/turbo/apps/api/src/signals/services/model-provider-account.service.ts
@@ -24,6 +24,7 @@ import {
   encryptStoredSecretValue,
 } from "./crypto.utils";
 import { extractCodexAccountEmailFromIdToken } from "./codex-auth-json-parser";
+import { invalidateCodexResetCreditExpiry } from "./codex-reset-credit-expiry.service";
 
 const MAX_PERSONAL_PROVIDER_ACCOUNTS = 10;
 const CODEX_TYPE = "codex-oauth-token";
@@ -724,6 +725,33 @@ async function applyAccountMutation(
   return { account, created: !selected };
 }
 
+function affectedCodexExpiryBindings(
+  args: Parameters<typeof selectMutationTarget>[0],
+): (string | null)[] {
+  if (args.type !== CODEX_TYPE) {
+    return [];
+  }
+  const selected = selectMutationTarget(args);
+  if (selected && "status" in selected) {
+    return [];
+  }
+  // Fence replaced/deleted rows even when reconnect changes upstream identity.
+  // Unrelated concrete accounts retain their values and Retry-After deadlines.
+  return [
+    null,
+    ...args.accounts
+      .filter((account) => {
+        return (
+          account.id === selected?.id ||
+          identityMatches(account, args.type, args.metadata)
+        );
+      })
+      .map((account) => {
+        return account.id;
+      }),
+  ];
+}
+
 export async function upsertPersonalModelProviderAccount(
   args: {
     readonly db: Db;
@@ -769,62 +797,82 @@ export async function upsertPersonalModelProviderAccount(
   }
   signal.throwIfAborted();
 
-  return await args.db.transaction(async (tx) => {
-    await lockModelProviderState(tx, {
-      orgId: args.orgId,
-      userId: args.userId,
-      type: args.type,
-    });
-    signal.throwIfAborted();
-    const [providerRow] = await tx
-      .select()
-      .from(modelProviders)
-      .where(
-        and(
-          eq(modelProviders.orgId, args.orgId),
-          eq(modelProviders.userId, args.userId),
-          eq(modelProviders.type, args.type),
-        ),
-      )
-      .limit(1);
-    const provider =
-      providerRow ??
-      (await createLogicalProvider(tx, {
+  const expiryBindings = new Set<string | null>();
+  const invalidateExpiry = () => {
+    for (const binding of expiryBindings) {
+      invalidateCodexResetCreditExpiry(
+        { scope: "personal", orgId: args.orgId, userId: args.userId },
+        { binding },
+      );
+    }
+  };
+  return await args.db
+    .transaction(async (tx) => {
+      await lockModelProviderState(tx, {
         orgId: args.orgId,
         userId: args.userId,
         type: args.type,
-        selectedModel: args.selectedModel,
-      }));
-    const accounts = await tx
-      .select()
-      .from(modelProviderAccounts)
-      .where(eq(modelProviderAccounts.modelProviderId, provider.id))
-      .orderBy(
-        asc(modelProviderAccounts.createdAt),
-        asc(modelProviderAccounts.id),
-      );
-    const metadata = accountMetadataValues({
-      type: args.type,
-      metadata: args.metadata,
-      secretValues: args.secretValues,
-    });
-    const result = await applyAccountMutation(tx, {
-      provider,
-      accounts,
-      type: args.type,
-      authMethod: args.authMethod,
-      mode: args.mode,
-      metadata,
-      encryptedSecrets,
-    });
-    if ("status" in result) {
-      return result;
-    }
-    return {
-      provider: accountResponse({ account: result.account, provider }),
-      created: result.created,
-    };
-  });
+      });
+      signal.throwIfAborted();
+      const [providerRow] = await tx
+        .select()
+        .from(modelProviders)
+        .where(
+          and(
+            eq(modelProviders.orgId, args.orgId),
+            eq(modelProviders.userId, args.userId),
+            eq(modelProviders.type, args.type),
+          ),
+        )
+        .limit(1);
+      const provider =
+        providerRow ??
+        (await createLogicalProvider(tx, {
+          orgId: args.orgId,
+          userId: args.userId,
+          type: args.type,
+          selectedModel: args.selectedModel,
+        }));
+      const accounts = await tx
+        .select()
+        .from(modelProviderAccounts)
+        .where(eq(modelProviderAccounts.modelProviderId, provider.id))
+        .orderBy(
+          asc(modelProviderAccounts.createdAt),
+          asc(modelProviderAccounts.id),
+        );
+      const metadata = accountMetadataValues({
+        type: args.type,
+        metadata: args.metadata,
+        secretValues: args.secretValues,
+      });
+      for (const binding of affectedCodexExpiryBindings({
+        accounts,
+        mode: args.mode,
+        type: args.type,
+        metadata,
+      })) {
+        expiryBindings.add(binding);
+      }
+      invalidateExpiry();
+      const result = await applyAccountMutation(tx, {
+        provider,
+        accounts,
+        type: args.type,
+        authMethod: args.authMethod,
+        mode: args.mode,
+        metadata,
+        encryptedSecrets,
+      });
+      if ("status" in result) {
+        return result;
+      }
+      return {
+        provider: accountResponse({ account: result.account, provider }),
+        created: result.created,
+      };
+    })
+    .finally(invalidateExpiry);
 }
 
 async function accountWithProvider(

--- a/turbo/apps/api/src/signals/services/model-provider-subscription-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/model-provider-subscription-usage.service.ts
@@ -8,6 +8,10 @@ import { secrets } from "@okouai/db/schema/secret";
 import { modelProviderAccountSecrets } from "@okouai/db/schema/model-provider-account";
 import { and, eq, inArray } from "drizzle-orm";
 
+import {
+  invalidateCodexResetCreditExpiry,
+  prepareCodexResetCreditExpiryRead,
+} from "./codex-reset-credit-expiry.service";
 import { logger } from "../../lib/log";
 import { type Db, type ReadonlyDb, writeDb$ } from "../external/db";
 import { notFound } from "../../lib/error";
@@ -178,6 +182,10 @@ async function refreshCodexProvider(
   },
   signal: AbortSignal,
 ): Promise<ModelProviderResponse> {
+  const readResetCreditExpiry = prepareCodexResetCreditExpiryRead(
+    { scope: "personal", orgId: args.orgId, userId: args.userId },
+    args.provider.modelProviderId ? args.provider.id : null,
+  );
   const accountMetadata = {
     sourceType: "model-provider" as const,
     sourceUserId: args.userId,
@@ -234,6 +242,7 @@ async function refreshCodexProvider(
       accessToken: accessTokenResult.value,
       accountId,
       idToken,
+      readResetCreditExpiry,
     },
     signal,
   );
@@ -336,6 +345,7 @@ export const refreshPersonalModelProviderSubscriptionUsage$ = command(
               signal,
             ),
             (error) => {
+              signal.throwIfAborted();
               L.warn(
                 "failed to refresh personal model provider subscription usage",
                 {
@@ -431,6 +441,13 @@ export const consumePersonalCodexRateLimitResetCredit$ = command(
       );
     }
 
+    const invalidateExpiry = () => {
+      invalidateCodexResetCreditExpiry(
+        { scope: "personal", orgId: args.orgId, userId: args.userId },
+        { binding: args.modelProviderAccountId ?? null },
+      );
+    };
+    invalidateExpiry();
     return await consumeCodexRateLimitResetCredit(
       {
         accessToken: accessTokenResult.value,
@@ -438,6 +455,6 @@ export const consumePersonalCodexRateLimitResetCredit$ = command(
         idempotencyKey: args.idempotencyKey,
       },
       signal,
-    );
+    ).finally(invalidateExpiry);
   },
 );


### PR DESCRIPTION
Repeated subscription refreshes can issue the optional Codex reset-credit expiry GET on every request, producing handled 429/timeout warnings while credit counts remain valid. Cache successful expiry dates and nulls for five minutes, coalesce concurrent reads, honor valid Retry-After deadlines (or a 60-second fallback), and cool down for 60 seconds after the existing five-second expiry deadline. Every main usage GET still runs and supplies its current credit count.

Closes #32115

## Ownership and invalidation

- A singleton LRU retains at most 256 provider bindings, including in-flight work. Authenticated org/personal scope, tenant/user, provider-account binding, upstream account, and hashed access-token identity isolate values and cooldowns. Capacity eviction aborts owned work; TTL checks are lazy and there is no background refresh.
- Each shared flight owns its cancellation and deadline. One waiter can cancel (including with a TimeoutError reason) while other waiters continue; the final waiter terminates owned work. Version and flight-identity checks fence credential rotation, invalidation, eviction, and late cleanup.
- Capture the expiry reader before credential resolution, and recheck trust/invalidation after the independent usage response finishes. Reconnect invalidates the affected upstream account and replaceable legacy/connecting bindings before and after persistence, preserving other concrete accounts' cooldowns. Personal account writes also fence the actual replaced/deduplicated rows on both sides of the transaction, including an upstream identity change. Consume invalidates the selected binding before and after the unchanged operation, including ambiguous failure.
- Handled 429/local deadlines no longer warn. A demand-driven aggregate distinguishes cached, coalesced, cooldown, success, rate-limited, local-timeout, and unexpected-failure outcomes, at most once per minute per warm instance. The exact message uses the existing info audit allowlist because Axiom's default transport filters debug. No identifiers or credentials enter this aggregate; unexpected expiry failures retain a warning once per actual shared attempt.

## Scope and scale

MaskDB snapshot from 2026-09-08 around 08:18 UTC, recorded in the issue: **25 `model_providers` rows; 21 `model_provider_accounts` rows (9 active, 12 inactive), referring to 9 of those provider rows**. These inventories overlap and include internal configurations; they are not 46 accounts, affected users, or an incident-population estimate.

There is **no schema migration or backfill**. This is best-effort **process-local warm-instance caching/coalescing**, not a distributed rate limiter: separate serverless instances and cold starts can independently call upstream, and eviction ends retained cooldown protection. No Redis, database cache, scheduler, request-local retry, or new infrastructure is added.

The main usage GET/count, consume method/URL/body/idempotency/outcome mapping, API schema, frontend 60-second opportunistic refresh, provider selection, auth persistence, billing, and run execution remain unchanged. Only expiry invalidation surrounds consume, paste, and affected personal account write boundaries; account mutation policy is unchanged.

## Caller and blast-radius inventory

Started after fetching latest `origin/main` at `fe57f9eb1df389c1e4d1e396e96f29f9114a4d90`. Repository-wide searches covered `fetchCodexUsageMetadata`, `consumeCodexRateLimitResetCredit`, `handleCodexAuthJsonPaste`, `upsertPersonalModelProviderAccount`, and expiry consumers:

- Personal list refresh uses both current account-ID and supported legacy bindings.
- Org/personal paste upserts share the paste handler; org/personal device auth also calls it.
- Current account-ID and legacy reset-subscription routes share the consume service.
- Personal account mutation is also used by direct secret upsert and Claude device auth; the new invalidation hook is guarded to Codex and leaves those existing policies intact.
- Frontend personal-provider preferences and account-menu display consume the unchanged optional expiry field.

Refreshed `gh pr list --limit 100` and inspected related files (39 open PRs in the latest complete file inventory); no direct overlap in the changed services or caller regression files was found. The only configuration change is one file/message-specific API logging allowlist entry.

## Fallbacks

- `codex-reset-credit-expiry.service.ts`: optional external expiry remains null when no value is trustworthy, including expiry failure, cooldown, invalidation, eviction, past date, and exhausted TTL. A successful null is cached for five minutes. This is permanent optional display metadata behavior authorized by #32115, not cross-version rollout compatibility; removal requires an explicit change to that metadata contract.
- `retryAfterDeadline`: absent, malformed, out-of-range, or non-future Retry-After uses 60 seconds. This covers observed optional upstream throttling metadata; removal requires a provider contract that guarantees a valid future deadline. No immediate retries or extended request budgets are introduced.

## Validation and boundaries

- Four focused API route integration files passed: `codex-reset-credit-expiry.test.ts`, `me-model-providers-upsert.test.ts`, `model-providers.test.ts`, and `auth-device.bdd.test.ts` (118 tests).
- Capacity eviction is exercised through 129 independent API-created users in one test-owned organization, prepared in batches of eight with token-scoped Clerk responses. Five focused repetitions passed (test time 2.81–3.83 seconds), followed by the full four-file regression run. The original test timeout and production capacity remain unchanged.
- API workspace lint (including type-aware lint), API type checks, scoped Knip, formatting, and `git diff --check` passed.
- Tests use real API routes/database, MSW for external HTTP, the existing mock clock, and owned deferred synchronization. They cover TTL/date/null/past values, Retry-After forms/bounds and recovery, isolated cancellation, late completions, consume/reconnect/credential rotation, identity isolation, bounded eviction, warning behavior, and existing count/consume regressions.
- No full local Vitest suite or dev server. Required PR and merge-group pipelines remain merge gates. No production release, deployment approval, or production consume verification is part of this PR.

No material design deviation. Implementation details: provider-binding versions fence readers that are still resolving credentials; a value accessor prevents a later usage response from returning invalidated expiry. The bounded aggregate's precise info allowlist preserves production visibility without changing global logging.
