### PR TITLE
test(runner): cover dns readiness log evidence exclusions

### DIFF
--- a/crates/runner/src/dns/log.rs
+++ b/crates/runner/src/dns/log.rs
@@ -486,7 +486,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn readiness_log_inspection_uses_attempt_offset_and_fixed_hostname() {
+    async fn readiness_log_inspection_observes_current_attempt_query_and_result() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("network.jsonl");
         let old_row = readiness_log_row(DNS_READINESS_HOSTNAME, "query");
@@ -514,6 +514,75 @@ mod tests {
 
         assert!(observation.query_observed);
         assert!(observation.result_observed);
+        assert_eq!(observation.status, DnsReadinessLogScanStatus::Complete);
+    }
+
+    #[tokio::test]
+    async fn readiness_log_inspection_ignores_previous_attempt_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let old_rows = [
+            readiness_log_row(DNS_READINESS_HOSTNAME, "query"),
+            readiness_log_row(DNS_READINESS_HOSTNAME, "config"),
+        ]
+        .join("\n");
+        tokio::fs::write(&path, format!("{old_rows}\n"))
+            .await
+            .unwrap();
+        let start_offset = tokio::fs::metadata(&path).await.unwrap().len();
+        let mut file = tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .await
+            .unwrap();
+        file.write_all(b"{}\n").await.unwrap();
+        file.flush().await.unwrap();
+
+        let observation = inspect_readiness_log_segment(&path, start_offset).await;
+
+        assert!(!observation.query_observed);
+        assert!(!observation.result_observed);
+        assert_eq!(observation.status, DnsReadinessLogScanStatus::Complete);
+    }
+
+    #[tokio::test]
+    async fn readiness_log_inspection_ignores_unrelated_hostname_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let rows = [
+            readiness_log_row("unrelated.example", "query"),
+            readiness_log_row("unrelated.example", "config"),
+        ]
+        .join("\n");
+        tokio::fs::write(&path, format!("{rows}\n")).await.unwrap();
+
+        let observation = inspect_readiness_log_segment(&path, 0).await;
+
+        assert!(!observation.query_observed);
+        assert!(!observation.result_observed);
+        assert_eq!(observation.status, DnsReadinessLogScanStatus::Complete);
+    }
+
+    #[tokio::test]
+    async fn readiness_log_inspection_ignores_non_dns_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let rows = ["query", "config"].map(|event| {
+            serde_json::json!({
+                "type": "http",
+                "host": DNS_READINESS_HOSTNAME,
+                "dns_event": event,
+            })
+            .to_string()
+        });
+        tokio::fs::write(&path, format!("{}\n", rows.join("\n")))
+            .await
+            .unwrap();
+
+        let observation = inspect_readiness_log_segment(&path, 0).await;
+
+        assert!(!observation.query_observed);
+        assert!(!observation.result_observed);
         assert_eq!(observation.status, DnsReadinessLogScanStatus::Complete);
     }
 


### PR DESCRIPTION
The readiness-log positive fixture could pass even if earlier-attempt, unrelated-host, or non-DNS rows contributed evidence. Add three independent real-file exclusion cases that require both observation flags to remain false with a `Complete` scan, and rename the positive test to describe what it asserts. Existing positive and edge-case coverage is retained; changes are confined to the test module.

Closes #32587.

Validation passed:

- `cargo fmt --manifest-path crates/runner/Cargo.toml -- --check`
- `cargo --config 'profile.local.package.runner.debug=0' test --locked --manifest-path crates/Cargo.toml --profile local -p runner --bin runner dns::log::tests` — 32 passed.
- `cargo --config 'profile.local.package.runner.debug=0' clippy --locked --manifest-path crates/Cargo.toml --profile local -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo --config 'profile.local.package.runner.debug=0' doc --locked --manifest-path crates/Cargo.toml --profile local -p runner --all-features --no-deps`

Temporarily removing the hostname filter, removing the type filter, and ignoring the valid attempt offset each caused exactly its corresponding new test to fail while the other six inspection tests passed. All mutations were restored before the final 32-test run, and the production source was verified byte-for-byte against the base.

Local builds used one Cargo job, a private temporary directory, and the command-only runner debug override above. A temporary 4 GiB swap file was needed in the 3.8 GiB runtime and was removed after validation. Broader workspace and live sandbox checks remain with the PR pipeline.
