### PR TITLE
fix(e2e): exclude clipped chat rows from mobile safe-area measurement

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -168,7 +168,6 @@ test.describe("dark theme", () => {
 test("mobile pages assign the bottom safe area to content and controls", async ({
   page,
 }) => {
-  await page.setViewportSize(MOBILE_VIEWPORT);
   await page.goto(appUrl);
   await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
   const agentId = /\/agents\/([^/]+)\/chat/.exec(
@@ -177,6 +176,39 @@ test("mobile pages assign the bottom safe area to content and controls", async (
   if (!agentId) {
     throw new Error("Expected the home route to resolve an agent id");
   }
+
+  // Give this test its own overflowing history instead of depending on chats
+  // left by other tests sharing the account. Create through the desktop UI so
+  // the mobile drawer does not need to be reopened after every navigation.
+  const newChatButton = page
+    .getByTestId("chat-list-column")
+    .getByRole("button", { name: "New chat", exact: true })
+    .last();
+  for (let index = 0; index < 20; index++) {
+    const [response] = await Promise.all([
+      page.waitForResponse((response) => {
+        return (
+          response.request().method() === "POST" &&
+          new URL(response.url()).pathname === "/api/chat-threads"
+        );
+      }),
+      newChatButton.click(),
+    ]);
+    expect(response.status()).toBe(201);
+    const thread: unknown = await response.json();
+    if (
+      typeof thread !== "object" ||
+      thread === null ||
+      !("id" in thread) ||
+      typeof thread.id !== "string"
+    ) {
+      throw new Error("Expected the created chat thread to have an id");
+    }
+    await expect(page).toHaveURL(new URL(`/chats/${thread.id}`, appUrl).href);
+  }
+
+  await page.setViewportSize(MOBILE_VIEWPORT);
+  await page.goto(appUrl);
   const tagline = page.getByTestId("chat-tagline");
   await expect(tagline).toBeVisible({ timeout: 20_000 });
 
@@ -209,14 +241,39 @@ test("mobile pages assign the bottom safe area to content and controls", async (
 
   const drawer = page.getByRole("complementary", { name: "Sidebar" });
   await expect(drawer).toBeVisible();
+  const drawerScrollViewport = drawer.getByRole("region", {
+    name: "Chat threads",
+  });
+  await expect
+    .poll(async () => {
+      return drawerScrollViewport.evaluate((element) => {
+        return (
+          element.clientHeight > 0 &&
+          element.scrollHeight > element.clientHeight
+        );
+      });
+    })
+    .toBe(true);
+
   const drawerMetrics = await drawer.evaluate((element) => {
     if (!(element instanceof HTMLElement)) {
       throw new Error("Expected the mobile drawer to be an element");
     }
     const rect = element.getBoundingClientRect();
+    const chatViewport = element.querySelector(
+      '[data-testid="sidebar-scroll-area"]',
+    );
+    if (!(chatViewport instanceof HTMLElement)) {
+      throw new Error("Expected the drawer's chat scroll viewport");
+    }
     const controlBottoms = Array.from(
       element.querySelectorAll<HTMLElement>("a, button"),
     )
+      // Virtualized rows outside the scrollport still have nonzero bounds.
+      // Check their clipping viewport, and measure fixed controls separately.
+      .filter((control) => {
+        return !chatViewport.contains(control);
+      })
       .map((control) => {
         return control.getBoundingClientRect();
       })
@@ -233,6 +290,8 @@ test("mobile pages assign the bottom safe area to content and controls", async (
       bottom: rect.bottom,
       paddingBottom: Number.parseFloat(getComputedStyle(element).paddingBottom),
       lastControlBottom: Math.max(...controlBottoms),
+      chatViewportBottom: chatViewport.getBoundingClientRect().bottom,
+      chatViewportOverflowY: getComputedStyle(chatViewport).overflowY,
     };
   });
 
@@ -241,6 +300,10 @@ test("mobile pages assign the bottom safe area to content and controls", async (
   expect(drawerMetrics.lastControlBottom).toBeLessThanOrEqual(
     MOBILE_VIEWPORT.height - MOBILE_SAFE_BOTTOM_PX,
   );
+  expect(drawerMetrics.chatViewportBottom).toBeLessThanOrEqual(
+    MOBILE_VIEWPORT.height - MOBILE_SAFE_BOTTOM_PX,
+  );
+  expect(drawerMetrics.chatViewportOverflowY).toMatch(/^(auto|scroll)$/);
 
   await page.getByRole("button", { name: "Collapse sidebar" }).click();
   await page.goto(new URL("/connectors", appUrl).href);


### PR DESCRIPTION
The mobile safe-area E2E can fail when the shared account has a populated chat history: it treats every nonzero `getBoundingClientRect()` as visible, including virtualized chat rows clipped by the scroll viewport. The virtualizer deliberately renders eight overscan rows beyond the visible range. In the reported merge-queue run, 20 chats from the preceding desktop test made this assertion read 1078px against the 840px safe boundary. The same PR's earlier feature run passed, so the result also depended on when the history became observable.

Create 20 chats through the product UI in the mobile test itself and wait for the history to overflow. Measure the fixed controls separately from the chat rows, then verify that the chat viewport clips its contents and stays above the bottom safe area. This retains the drawer's 34px inset and the existing checks for home content, connectors, the unsaved bar, and browser sessions.

Reported failure: https://github.com/vm0-ai/vm0/actions/runs/34202699092/job/101986627979

Validation:

- `cd e2e && pnpm check-types`
- `npx --yes prettier@3.6.2 --check e2e/playwright/tests/chat.spec.ts`
- `git diff --check` and the repository file-size check
- The revised mobile E2E passed **5/5 consecutive runs** with `--grep 'mobile pages assign' --repeat-each=5 --workers=1` (2.4 minutes total).
- Browser comparison on the deployed preview for commit `98461f101fd874b6ad72c70c8c89206af76128bd`: the overflowing fixture with the old control selection fails at 970px versus 840px. The revised test uses the same test body as this worktree, with import paths adapted for a temporary Playwright config and an API-origin-only preview bypass fixture. A fresh test account was authenticated manually and onboarding completed through the preview API before this scoped check.
