### PR TITLE
feat(api): extend pi execution and learning to automation and goals

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -2807,10 +2807,11 @@ async function postThreadPiAutomationEvent(args: {
   readonly webhookUrl: string;
   readonly webhookSecret: string;
   readonly payload: string;
+  readonly timestamp: number;
   readonly usagePricingResolution: UsagePricingFixture["resolution"];
 }) {
   const rawBody = JSON.stringify({ event: args.payload });
-  const timestamp = Math.floor(now() / 1000);
+  const timestamp = args.timestamp;
   const response = await createAppWithRoutes({
     signal: context.signal,
     routes: webhooksWorkflowAutomationsRoutes,
@@ -2928,6 +2929,7 @@ describe("thread-bound Pi Automation and Goal execution", () => {
         await postThreadPiAutomationEvent({
           ...eventRoute,
           payload: "legacy",
+          timestamp: Math.floor(now() / 1000),
           usagePricingResolution,
         });
         if (!automation.chatThreadId) {
@@ -2995,6 +2997,7 @@ describe("thread-bound Pi Automation and Goal execution", () => {
         const event = {
           ...eventRoute,
           payload: "pi-event",
+          timestamp: Math.floor(now() / 1000),
           usagePricingResolution,
         };
         await expect(postThreadPiAutomationEvent(event)).resolves.toMatchObject(
@@ -3002,6 +3005,8 @@ describe("thread-bound Pi Automation and Goal execution", () => {
             duplicate: false,
           },
         );
+        // A retry keeps the original signed envelope across clock seconds.
+        mockNow(now() + 1000);
         await expect(postThreadPiAutomationEvent(event)).resolves.toMatchObject(
           {
             duplicate: true,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -42,6 +42,10 @@ import {
   PI_MEMORY_ROOT,
   piApiFirstTurnManifestSchema,
 } from "@okouai/api-contracts/contracts/runners";
+import { goalsContract } from "@okouai/api-contracts/contracts/goals";
+import { cronExtractPiMemoryStage1Contract } from "@okouai/api-contracts/contracts/cron";
+import { workflowAutomationsContract } from "@okouai/api-contracts/contracts/workflows";
+import { testWorkflowAutomationExecutionContract } from "@okouai/api-contracts/contracts/test-workflow-automation-execution";
 import { mailContract } from "@okouai/api-contracts/contracts/mail";
 import { triggerSourceSchema } from "@okouai/api-contracts/contracts/logs";
 import {
@@ -63,6 +67,9 @@ import { describe, expect, it, onTestFinished } from "vitest";
 import { v5 as uuidv5 } from "uuid";
 import { z } from "zod";
 import { createApp } from "../../../app-factory";
+import { createAppWithRoutes } from "../../../app-factory-core";
+import { cronExtractPiMemoryStage1RoutesForTest } from "../cron-extract-pi-memory-stage1";
+import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
 import type { AgentEvent } from "../../../lib/event-consumer/verify";
 import { env, mockEnv, mockOptionalEnv } from "../../../lib/env";
 import {
@@ -184,7 +191,7 @@ import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise } from "../../utils";
 import { openRouterModelContractError } from "./helpers/openrouter-model-contract";
 import { openRouterErrorFixtures } from "./helpers/openrouter-error-fixtures";
-import { verifyOkouToken } from "../../auth/tokens";
+import { signSandboxJwtForTests, verifyOkouToken } from "../../auth/tokens";
 import {
   createUnassociatedThreadBoundAgentRunFixture,
   createUnassociatedThreadBoundAgentRunsServiceFixture,
@@ -216,6 +223,15 @@ import {
   setChatCallbackGitHubDeliveryFixture,
   timeoutRunWithoutCallbacksFixture,
 } from "../../../test-fixtures/chat-events";
+import {
+  readGoalQueueStateFixture,
+  readGoalThreadFixture,
+} from "../../../test-fixtures/goal-queue";
+import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
+import { goalsRoutes } from "../goals";
+import { workflowAutomationsRoutes } from "../workflow-automations";
+import { webhooksWorkflowAutomationsRoutes } from "../webhooks-workflow-automations";
+import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
 import { chatEventsRoutes } from "../chat-events";
 import { chatThreadRoutes } from "../chat-threads";
 import { mailRoutes } from "../mail";
@@ -594,6 +610,7 @@ const openRouterBodySchema = z.object({
 
 async function entitledChatActor(
   options: ApiTestUserOptions = {},
+  tier: "pro" | "team" = "pro",
 ): Promise<EntitledChatActor> {
   const actor = bdd.user(options);
   chatCallbacks.acceptChatObjectStorage();
@@ -602,15 +619,15 @@ async function entitledChatActor(
   mockOptionalEnv("OPENROUTER_API_KEY", undefined);
   chatCallbacks.disableVapid();
   const runnerGroup = api.configureRunnerGroup();
-  await api.grantProEntitlement(
-    actor,
-    options.orgId === STAFF_ORG_ID
+  await api.grantProEntitlement(actor, {
+    ...(options.orgId === STAFF_ORG_ID
       ? {
           customerId: "cus_bdd_chat_events_staff",
           subscriptionId: "sub_bdd_chat_events_staff",
         }
-      : {},
-  );
+      : {}),
+    tier,
+  });
   const { providerId } = await api.ensureOrgModelProvider(actor);
   const agent = await bdd.createAgent(actor, {
     displayName: "BDD chat messages agent",
@@ -2685,7 +2702,635 @@ async function expectExactPrivatePiMemoryAdmission(args: {
   await expect(
     readmitPiMemoryStage1CandidateFixture(args.runId),
   ).resolves.toMatchObject({ outcome: "exact_retry" });
+  // Admission has no public endpoint. A mismatched captured identity must not
+  // create or replace learning, even when the run has valid native history.
+  for (const ownership of [
+    { userId: `other-${args.userId}` },
+    { orgId: `other-${args.orgId}` },
+    { chatThreadId: randomUUID() },
+  ]) {
+    await expect(
+      readmitPiMemoryStage1CandidateFixture(args.runId, ownership),
+    ).resolves.toMatchObject({
+      outcome: "skipped",
+      reason: "not_owned_chat_thread",
+    });
+  }
 }
+
+async function extractOwnedThreadPiMemory(actor: ApiTestUser, runId: string) {
+  const scope = { orgId: requireOrgId(actor), userId: actor.userId };
+  const candidate = await readPiMemoryStage1CandidateFixture(scope);
+  if (!candidate) {
+    throw new Error("Expected completed source admission");
+  }
+  await seedBuiltInModelKey("gpt-5.6-terra");
+  const requests: unknown[] = [];
+  server.use(
+    http.post(
+      "https://api.openai.com/v1/responses",
+      async ({ request }) => {
+        requests.push(await request.json());
+        return new HttpResponse(
+          piResponsesTextSse(
+            JSON.stringify({
+              raw_memory: "The owner prefers concise progress reports.",
+              rollout_summary: "Learned the owner's reporting preference.",
+              rollout_slug: "owned-reporting-preference",
+            }),
+            100,
+          ),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      },
+      { once: true },
+    ),
+  );
+  mockNow(candidate.eligibleAt.getTime() + 1000);
+  const extracted = await accept(
+    setupApp({
+      context,
+      // Scope the existing cron worker to this source; no production API
+      // exposes internal candidate extraction or its private output.
+      routes: cronExtractPiMemoryStage1RoutesForTest({
+        memoryStorageId: candidate.memoryStorageId,
+        piSessionId: candidate.piSessionId,
+      }),
+    })(cronExtractPiMemoryStage1Contract).extract({
+      headers: { authorization: `Bearer ${env("CRON_SECRET")}` },
+    }),
+    [200],
+  );
+  expect(extracted.body).toMatchObject({ claimed: 1, succeeded: 1 });
+  expect(requests).toHaveLength(1);
+  await expect(
+    readPiMemoryStage1CandidateFixture(scope),
+  ).resolves.toMatchObject({
+    sourceRunId: runId,
+    piSessionId: candidate.piSessionId,
+    sourceHistoryHash: candidate.sourceHistoryHash,
+    status: "succeeded",
+    rawMemory: "The owner prefers concise progress reports.",
+  });
+}
+
+function threadPiAutomationsClient(
+  usagePricingResolution?: UsagePricingFixture["resolution"],
+) {
+  return setupApp({
+    context,
+    routes: workflowAutomationsRoutes,
+    usagePricingResolution,
+  })(workflowAutomationsContract);
+}
+
+function threadPiGoalHeaders(actor: ApiTestUser, runId: string) {
+  const seconds = Math.floor(now() / 1000);
+  return {
+    authorization: `Bearer ${signSandboxJwtForTests({
+      scope: "okou",
+      userId: actor.userId,
+      orgId: requireOrgId(actor),
+      runId,
+      capabilities: [
+        "goal:read",
+        "goal:agent-result:write",
+        "goal:user-control:write",
+      ],
+      iat: seconds,
+      exp: seconds + 600,
+    })}`,
+  };
+}
+
+async function postThreadPiAutomationEvent(args: {
+  readonly webhookUrl: string;
+  readonly webhookSecret: string;
+  readonly payload: string;
+  readonly usagePricingResolution: UsagePricingFixture["resolution"];
+}) {
+  const rawBody = JSON.stringify({ event: args.payload });
+  const timestamp = Math.floor(now() / 1000);
+  const response = await createAppWithRoutes({
+    signal: context.signal,
+    routes: webhooksWorkflowAutomationsRoutes,
+    usagePricingResolution: args.usagePricingResolution,
+  }).request(new URL(args.webhookUrl).pathname, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "X-VM0-Timestamp": String(timestamp),
+      "X-VM0-Signature": computeHmacSignature(
+        rawBody,
+        args.webhookSecret,
+        timestamp,
+      ),
+    },
+    body: rawBody,
+  });
+  expect(response.status).toBe(200);
+  return z
+    .object({ success: z.literal(true), duplicate: z.boolean() })
+    .parse(await response.json());
+}
+
+async function lastThreadPiAutomationRun(actor: ApiTestUser, threadId: string) {
+  const page = await chat.listThreadEvents(actor, threadId);
+  const event = [...page.events].reverse().find((item) => {
+    return (
+      item.eventType === "input.prompt" &&
+      item.userMessage.parts.some((part) => {
+        return part.type === "automation";
+      })
+    );
+  });
+  if (event?.eventType !== "input.prompt" || !event.runId) {
+    throw new Error("Expected an admitted Automation run");
+  }
+  return event.runId;
+}
+
+async function expectThreadPiTerminal(
+  actor: ApiTestUser,
+  threadId: string,
+  runId: string,
+) {
+  await waitForRunStatus(actor, runId, "completed", 10_000);
+  await flushWaitUntilForTest();
+  await expect(
+    readRunLaunchSnapshotFixture(context, runId),
+  ).resolves.toMatchObject({
+    launch_snapshot: { schemaVersion: 3, framework: "pi" },
+  });
+  const page = await chat.listThreadEvents(actor, threadId);
+  expect(
+    page.events
+      .filter((event) => {
+        return (
+          event.runId === runId && isChatRunTerminalEventType(event.eventType)
+        );
+      })
+      .map((event) => {
+        return event.eventType;
+      }),
+  ).toStrictEqual(["run.completed"]);
+}
+
+describe("thread-bound Pi Automation and Goal execution", () => {
+  it.each(["schedule", "event"] as const)(
+    "rotates the %s Automation session into Pi and shares owned learning with user turns",
+    async (source) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor(
+        {},
+        source === "event" ? "team" : "pro",
+      );
+      const orgId = requireOrgId(actor);
+      const usagePricingResolution = await createGptUsagePricingResolution();
+      const workflows = createWorkflowsBddApi(context);
+      const workflowId = await workflows.createWorkflow(actor, {
+        agentId,
+        name: `pi-source-${source}`,
+      });
+      if (source === "schedule") {
+        await configureBuiltInPiModel(actor, "gpt-5.6-terra");
+      }
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId },
+        {
+          [FeatureSwitchKey.PiLoop]: false,
+        },
+      );
+      const created = await accept(
+        threadPiAutomationsClient().create({
+          headers: sessionHeaders(actor),
+          params: { workflowId },
+          body:
+            source === "schedule"
+              ? { schedule: { type: "loop", intervalSeconds: 3600 } }
+              : { kind: "event", eventType: "webhook-received" },
+        }),
+        [201],
+      );
+      const automation = created.body;
+      const eventRoute =
+        automation.kind === "event" &&
+        automation.eventType === "webhook-received" &&
+        automation.webhookUrl &&
+        automation.webhookSecret
+          ? {
+              webhookUrl: automation.webhookUrl,
+              webhookSecret: automation.webhookSecret,
+            }
+          : null;
+      let threadId: string;
+      if (eventRoute) {
+        await postThreadPiAutomationEvent({
+          ...eventRoute,
+          payload: "legacy",
+          usagePricingResolution,
+        });
+        if (!automation.chatThreadId) {
+          throw new Error("Expected the event thread");
+        }
+        threadId = automation.chatThreadId;
+      } else {
+        const started = await accept(
+          threadPiAutomationsClient().run({
+            headers: sessionHeaders(actor),
+            params: { id: automation.id },
+          }),
+          [201],
+        );
+        threadId = started.body.chatThreadId;
+      }
+      const legacyRunId = await lastThreadPiAutomationRun(actor, threadId);
+      const legacyClaim = await claimChatRun(runnerGroup, legacyRunId);
+      const legacyFramework = source === "schedule" ? "codex" : "claude-code";
+      await completeChatRunOk(legacyRunId, legacyClaim.sandboxHeaders, {
+        cliAgentType: legacyFramework,
+      });
+      await flushWaitUntilForTest();
+      const legacyBinding = await readThreadSessionBinding(context, threadId);
+      await expect(
+        readRunLaunchSnapshotFixture(context, legacyRunId),
+      ).resolves.toMatchObject({
+        launch_snapshot: { framework: legacyFramework },
+      });
+      await expect(
+        readPiMemoryStage1CandidateFixture({ orgId, userId: actor.userId }),
+      ).resolves.toBeNull();
+
+      await configureBuiltInPiModel(actor, "gpt-5.6-terra");
+      await chat.updateThreadModelSelection(actor, threadId, "gpt-5.6-terra");
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId },
+        {
+          [FeatureSwitchKey.PiLoop]: true,
+        },
+      );
+      mockEnv("PI_MEMORY_STAGE1_IDLE_DELAY_MS", 60_000);
+      mockPiResourceArchiveDownloads();
+      const checkpointObjects = mockPiCheckpointObjectStore();
+      const requests: unknown[] = [];
+      server.use(
+        http.post(
+          "https://api.openai.com/v1/responses",
+          async ({ request }) => {
+            requests.push(await request.json());
+            return new HttpResponse(
+              piResponsesTextSse(
+                `owned ${source} answer ${requests.length}`,
+                requests.length,
+              ),
+              {
+                headers: { "content-type": "text/event-stream" },
+              },
+            );
+          },
+        ),
+      );
+      if (eventRoute) {
+        const event = {
+          ...eventRoute,
+          payload: "pi-event",
+          usagePricingResolution,
+        };
+        await expect(postThreadPiAutomationEvent(event)).resolves.toMatchObject(
+          {
+            duplicate: false,
+          },
+        );
+        await expect(postThreadPiAutomationEvent(event)).resolves.toMatchObject(
+          {
+            duplicate: true,
+          },
+        );
+      } else {
+        const scheduled = await workflows.readAutomation(automation.id);
+        if (!scheduled.nextRunAt) {
+          throw new Error("Expected preserved recurrence");
+        }
+        mockNow(Date.parse(scheduled.nextRunAt) + 1000);
+        await accept(
+          setupApp({
+            context,
+            routes: testWorkflowAutomationExecutionRoutes,
+            usagePricingResolution,
+          })(testWorkflowAutomationExecutionContract).execute({
+            body: { automation_id: automation.id },
+          }),
+          [200],
+        );
+      }
+      const piRunId = await lastThreadPiAutomationRun(actor, threadId);
+      expect(piRunId).not.toBe(legacyRunId);
+      // Workflow slash input intentionally enters native AgentSession in the
+      // Sandbox. Exercise the real runner claim/checkpoint/completion protocol.
+      await flushWaitUntilForTest();
+      const piClaim = await claimChatRun(runnerGroup, piRunId);
+      expect(piClaim.claim).toMatchObject({
+        piModelConfig: { model: "gpt-5.6-terra" },
+      });
+      const sandboxUsage = {
+        idempotencyKey: randomUUID(),
+        kind: "model" as const,
+        provider: "gpt-5.6-terra",
+        category: "tokens.output",
+        quantity: 3,
+      };
+      for (const _receipt of [1, 2]) {
+        await webhooks.requestAgentUsageEvent(
+          { runId: piRunId, events: [sandboxUsage] },
+          piClaim.sandboxHeaders,
+          [200],
+          usagePricingResolution,
+        );
+      }
+      await completeSandboxFirstPiRun({
+        actor,
+        run: { runId: piRunId, threadId },
+        claim: piClaim,
+        checkpointObjects,
+        prompt: piClaim.claim.prompt,
+        answer: `owned ${source} answer`,
+        outputTokens: 3,
+        usagePricingResolution,
+      });
+      await expectThreadPiTerminal(actor, threadId, piRunId);
+      const piBinding = await readThreadSessionBinding(context, threadId);
+      expect(piBinding.agent_session_id).not.toBe(
+        legacyBinding.agent_session_id,
+      );
+      const piHistory = await readPiConversationIdentityFixture(piRunId);
+      await expectExactPrivatePiMemoryAdmission({
+        orgId,
+        userId: actor.userId,
+        runId: piRunId,
+      });
+      const runState = await runStateStore.set(
+        readAgentRunState$,
+        { orgId, userId: actor.userId, runId: piRunId },
+        context.signal,
+      );
+      expect(runState.agent_run).toMatchObject({
+        triggerSource: `automation-${source}`,
+      });
+      await expectPiApiUsage(piRunId, "gpt-5.6-terra", "", {
+        input: 0,
+        output: 3,
+        cacheRead: 0,
+        cacheCreation: 0,
+      });
+      await accept(
+        setupApp({ context, routes: testWorkflowAutomationExecutionRoutes })(
+          testWorkflowAutomationExecutionContract,
+        ).dispatchCallbacks({
+          body: { run_id: piRunId, status: "completed", dispatch_count: 2 },
+        }),
+        [200],
+      );
+      await expectThreadPiTerminal(actor, threadId, piRunId);
+      expect(requests).toHaveLength(0);
+      await extractOwnedThreadPiMemory(actor, piRunId);
+
+      mockNow(now() + 1000);
+      const user = await sendChatRun(
+        actor,
+        { agentId, threadId, prompt: "continue this Automation conversation" },
+        "vm0",
+        usagePricingResolution,
+      );
+      await expectThreadPiTerminal(actor, threadId, user.runId);
+      expect(
+        (await readThreadSessionBinding(context, threadId)).agent_session_id,
+      ).toBe(piBinding.agent_session_id);
+      const userHistory = await readPiConversationIdentityFixture(user.runId);
+      expect(userHistory.piSessionId).toBe(piHistory.piSessionId);
+      expect(userHistory.sourceHistoryHash).not.toBe(
+        piHistory.sourceHistoryHash,
+      );
+      await expect(
+        readPiMemoryStage1CandidateFixture({ orgId, userId: actor.userId }),
+      ).resolves.toMatchObject({
+        piSessionId: piHistory.piSessionId,
+        sourceRunId: user.runId,
+        sourceHistoryHash: userHistory.sourceHistoryHash,
+      });
+      expect(requests).toHaveLength(1);
+      expect(requests[0]).toMatchObject({ model: "gpt-5.6-terra" });
+      await expectPiApiUsage(user.runId, "gpt-5.6-terra", "", {
+        input: 5,
+        output: 3,
+        cacheRead: 0,
+        cacheCreation: 0,
+      });
+      clearMockNow();
+    },
+    90_000,
+  );
+
+  it.each(["bootstrap", "continuation"] as const)(
+    "uses the exact owner subscription for Goal %s and preserves Pi session, budget and pause",
+    async (entry) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const orgId = requireOrgId(actor);
+      const origin =
+        entry === "bootstrap"
+          ? await api.createRun(actor, {
+              agentId,
+              prompt: "create a goal outside chat",
+              modelProvider: "anthropic-api-key",
+            })
+          : await sendChatRun(actor, {
+              agentId,
+              prompt: "create a goal inside chat",
+              model: "claude-sonnet-5",
+            });
+      const originClaim = await claimChatRun(runnerGroup, origin.runId);
+      const legacyBinding =
+        "threadId" in origin
+          ? await readThreadSessionBinding(context, origin.threadId)
+          : null;
+      const { oauth } = await configureSubscriptionPiModel(
+        actor,
+        { accountId: "goal-owner-account" },
+        "gpt-5.6-luna",
+      );
+      if ("threadId" in origin) {
+        await chat.updateThreadModelSelection(
+          actor,
+          origin.threadId,
+          "gpt-5.6-luna",
+          { codexServiceTier: "fast" },
+        );
+      }
+      mockEnv("PI_MEMORY_STAGE1_IDLE_DELAY_MS", 60_000);
+      mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+      mockPiResourceArchiveDownloads();
+      mockPiCheckpointObjectStore();
+      const entered = [
+        createDeferredPromise<void>(context.signal),
+        createDeferredPromise<void>(context.signal),
+      ] as const;
+      const release = [
+        createDeferredPromise<void>(context.signal),
+        createDeferredPromise<void>(context.signal),
+      ] as const;
+      onTestFinished(() => {
+        for (const gate of release) {
+          if (!gate.settled()) {
+            gate.resolve(undefined);
+          }
+        }
+      });
+      const requests: {
+        readonly body: unknown;
+        readonly account: string | null;
+        readonly authorization: string | null;
+      }[] = [];
+      server.use(
+        http.post(
+          "https://chatgpt.com/backend-api/codex/responses",
+          async ({ request }) => {
+            const index = requests.length;
+            requests.push({
+              body: await readCodexRequestJson(request),
+              account: request.headers.get("chatgpt-account-id"),
+              authorization: request.headers.get("authorization"),
+            });
+            if (!entered[index] || !release[index]) {
+              return HttpResponse.json(
+                { error: "unexpected extra Goal turn" },
+                { status: 400 },
+              );
+            }
+            entered[index].resolve(undefined);
+            await release[index].promise;
+            return nativeCodexSseResponse(
+              piResponsesTextSse(`goal answer ${index}`, index),
+            );
+          },
+        ),
+      );
+      const goals = setupApp({ context, routes: goalsRoutes })(goalsContract);
+      await accept(
+        goals.create({
+          headers: threadPiGoalHeaders(actor, origin.runId),
+          body: { objective: "verify shared Pi Goal continuation" },
+        }),
+        [201],
+      );
+      if (entry === "continuation") {
+        await completeChatRunOk(origin.runId, originClaim.sandboxHeaders);
+      }
+      await entered[0].promise;
+      const goal = await readGoalThreadFixture({
+        orgId,
+        userId: actor.userId,
+        agentId,
+      });
+      if (!goal) {
+        throw new Error("Expected the owned Goal thread");
+      }
+      const [firstId] = (await readGoalQueueStateFixture(goal.threadId)).runIds;
+      if (!firstId) {
+        throw new Error("Expected the first Goal run");
+      }
+      const firstBinding = await readThreadSessionBinding(
+        context,
+        goal.threadId,
+      );
+      if (legacyBinding) {
+        expect(firstBinding.agent_session_id).not.toBe(
+          legacyBinding.agent_session_id,
+        );
+      }
+      release[0].resolve(undefined);
+      await entered[1].promise;
+      await accept(
+        goals.pauseForChatThread({
+          headers: sessionHeaders(actor),
+          params: { threadId: goal.threadId },
+        }),
+        [200],
+      );
+      const secondId = (
+        await readGoalQueueStateFixture(goal.threadId)
+      ).runIds.find((id) => {
+        return id !== firstId;
+      });
+      if (!secondId) {
+        throw new Error("Expected terminal Goal continuation");
+      }
+      mockNow(now() + 1000);
+      release[1].resolve(undefined);
+      await expectThreadPiTerminal(actor, goal.threadId, firstId);
+      await expectThreadPiTerminal(actor, goal.threadId, secondId);
+      expect(
+        (await readThreadSessionBinding(context, goal.threadId))
+          .agent_session_id,
+      ).toBe(firstBinding.agent_session_id);
+      const firstHistory = await readPiConversationIdentityFixture(firstId);
+      const secondHistory = await readPiConversationIdentityFixture(secondId);
+      expect(secondHistory.piSessionId).toBe(firstHistory.piSessionId);
+      await expect(
+        readPiMemoryStage1CandidateFixture({ orgId, userId: actor.userId }),
+      ).resolves.toMatchObject({
+        sourceRunId: secondId,
+        piSessionId: firstHistory.piSessionId,
+        sourceHistoryHash: secondHistory.sourceHistoryHash,
+      });
+      // Each turn inherits the budget captured when the Goal was created;
+      // continuation does not consume another delegation level.
+      for (const id of [firstId, secondId]) {
+        await expect(readRunAutonomyBudgetFixture(context, id)).resolves.toBe(
+          9,
+        );
+        await expectNoBuiltInModelUsage(id);
+        const state = await runStateStore.set(
+          readAgentRunState$,
+          { orgId, userId: actor.userId, runId: id },
+          context.signal,
+        );
+        expect(state.agent_run).toMatchObject({
+          triggerSource: "goal",
+        });
+      }
+      expect(requests).toHaveLength(2);
+      expect(requests).toStrictEqual(
+        requests.map(() => {
+          return expect.objectContaining({
+            account: "goal-owner-account",
+            authorization: `Bearer ${oauth.oauthTokenResponses[0]?.access_token}`,
+            body: expect.objectContaining({
+              model: "gpt-5.6-luna",
+              ...(entry === "continuation" ? { service_tier: "priority" } : {}),
+            }),
+          });
+        }),
+      );
+      const state = await accept(
+        goals.getForChatThread({
+          headers: sessionHeaders(actor),
+          params: { threadId: goal.threadId },
+        }),
+        [200],
+      );
+      expect(state.body.status).toBe("paused");
+      expect(
+        (await readGoalQueueStateFixture(goal.threadId)).runIds,
+      ).toHaveLength(2);
+      if (entry === "bootstrap") {
+        await cancelChatRun(actor, origin.runId, originClaim.sandboxHeaders);
+      }
+      await extractOwnedThreadPiMemory(actor, secondId);
+      clearMockNow();
+    },
+    90_000,
+  );
+});
 
 describe("CHAT-02: web chat send and client ids", () => {
   it("creates a web chat run with client-provided ids", async () => {
@@ -5888,6 +6533,7 @@ function warningCallsForRun(runId: string): readonly unknown[] {
 async function completeSandboxFirstPiRun(args: {
   readonly actor: ApiTestUser;
   readonly answer: string;
+  readonly outputTokens?: number;
   readonly checkpointObjects: Map<string, Buffer>;
   readonly claim: Awaited<ReturnType<typeof claimChatRun>>;
   readonly prompt: string;
@@ -5913,10 +6559,10 @@ async function completeSandboxFirstPiRun(args: {
     model: "gpt-5.6-terra",
     usage: {
       input: 0,
-      output: 0,
+      output: args.outputTokens ?? 0,
       cacheRead: 0,
       cacheWrite: 0,
-      totalTokens: 0,
+      totalTokens: args.outputTokens ?? 0,
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     },
     stopReason: "stop",
@@ -6084,6 +6730,207 @@ function piResponsesDeveloperPrompt(rawBody: string | undefined): string {
   }
   return developer.content;
 }
+
+describe("thread-bound Pi terminal failures", () => {
+  it.each([
+    { source: "automation", status: "failed" },
+    { source: "automation", status: "cancelled" },
+    { source: "goal", status: "failed" },
+    { source: "goal", status: "cancelled" },
+  ] as const)(
+    "settles $source $status once without learning or Built-in fallback",
+    async ({ source, status }) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const orgId = requireOrgId(actor);
+      const origin =
+        source === "goal"
+          ? await sendChatRun(actor, {
+              agentId,
+              prompt: "start a Goal",
+              model: "claude-sonnet-5",
+            })
+          : null;
+      const originClaim = origin
+        ? await claimChatRun(runnerGroup, origin.runId)
+        : null;
+      await configureSubscriptionPiModel(
+        actor,
+        { accountId: "terminal-owner" },
+        "gpt-5.6-luna",
+      );
+      mockPiResourceArchiveDownloads();
+      mockPiCheckpointObjectStore();
+      const entered = createDeferredPromise<void>(context.signal);
+      const release = createDeferredPromise<void>(context.signal);
+      onTestFinished(() => {
+        if (!release.settled()) {
+          release.resolve(undefined);
+        }
+      });
+      const requests: string[] = [];
+      server.use(
+        http.post(
+          "https://chatgpt.com/backend-api/codex/responses",
+          async ({ request }) => {
+            requests.push(request.url);
+            expect(request.headers.get("chatgpt-account-id")).toBe(
+              "terminal-owner",
+            );
+            entered.resolve(undefined);
+            await release.promise;
+            return HttpResponse.json(
+              {
+                error: {
+                  code: "invalid_api_key",
+                  message: "subscription rejected",
+                },
+              },
+              { status: 401 },
+            );
+          },
+        ),
+        http.post("https://api.openai.com/v1/responses", ({ request }) => {
+          requests.push(request.url);
+          return HttpResponse.json(
+            { error: "unexpected Built-in fallback" },
+            { status: 400 },
+          );
+        }),
+      );
+      const goals = setupApp({ context, routes: goalsRoutes })(goalsContract);
+      let run: { readonly runId: string; readonly threadId: string };
+      if (origin && originClaim) {
+        await chat.updateThreadModelSelection(
+          actor,
+          origin.threadId,
+          "gpt-5.6-luna",
+        );
+        await accept(
+          goals.create({
+            headers: threadPiGoalHeaders(actor, origin.runId),
+            body: { objective: "preserve terminal failure semantics" },
+          }),
+          [201],
+        );
+        await completeChatRunOk(origin.runId, originClaim.sandboxHeaders);
+        await entered.promise;
+        const [runId] = (await readGoalQueueStateFixture(origin.threadId))
+          .runIds;
+        if (!runId) {
+          throw new Error("Expected the admitted Goal run");
+        }
+        run = { runId, threadId: origin.threadId };
+        if (status === "cancelled") {
+          await cancelChatRun(actor, runId);
+        }
+        release.resolve(undefined);
+        await waitForRunStatus(actor, runId, status, 10_000);
+      } else {
+        const workflowId = await createWorkflowsBddApi(context).createWorkflow(
+          actor,
+          { agentId, name: "pi-terminal" },
+        );
+        const created = await accept(
+          threadPiAutomationsClient().create({
+            headers: sessionHeaders(actor),
+            params: { workflowId },
+            body: { schedule: { type: "loop", intervalSeconds: 3600 } },
+          }),
+          [201],
+        );
+        const started = await accept(
+          threadPiAutomationsClient().run({
+            headers: sessionHeaders(actor),
+            params: { id: created.body.id },
+          }),
+          [201],
+        );
+        const threadId = started.body.chatThreadId;
+        const runId = await lastThreadPiAutomationRun(actor, threadId);
+        run = { runId, threadId };
+        await flushWaitUntilForTest();
+        await api.heartbeatRunner(runnerGroup);
+        const claim = await claimGptPiSandbox(actor, runId, undefined);
+        const claimed = {
+          claim,
+          sandboxHeaders: { authorization: `Bearer ${claim.sandboxToken}` },
+        };
+        expect(claimed.claim.piModelConfig).toMatchObject({
+          model: "gpt-5.6-luna",
+        });
+        if (status === "cancelled") {
+          await cancelChatRun(actor, runId, claimed.sandboxHeaders);
+        } else {
+          await failChatRun(
+            runId,
+            claimed.sandboxHeaders,
+            "subscription rejected",
+          );
+        }
+        await failChatRun(
+          runId,
+          claimed.sandboxHeaders,
+          "duplicate terminal delivery",
+        );
+      }
+      await flushWaitUntilForTest();
+      await accept(
+        setupApp({ context, routes: testWorkflowAutomationExecutionRoutes })(
+          testWorkflowAutomationExecutionContract,
+        ).dispatchCallbacks({
+          body: {
+            run_id: run.runId,
+            status: "failed",
+            error:
+              status === "cancelled"
+                ? "Run cancelled"
+                : "subscription rejected",
+            dispatch_count: 2,
+          },
+        }),
+        [200],
+      );
+      await flushWaitUntilForTest();
+      await expect(
+        readRunLaunchSnapshotFixture(context, run.runId),
+      ).resolves.toMatchObject({
+        launch_snapshot: { schemaVersion: 3, framework: "pi" },
+      });
+      await expectNoBuiltInModelUsage(run.runId);
+      await expect(
+        readPiMemoryStage1CandidateFixture({ orgId, userId: actor.userId }),
+      ).resolves.toBeNull();
+      const events = (await chat.listThreadEvents(actor, run.threadId)).events;
+      expect(
+        events
+          .filter((event) => {
+            return (
+              event.runId === run.runId &&
+              isChatRunTerminalEventType(event.eventType)
+            );
+          })
+          .map((event) => {
+            return event.eventType;
+          }),
+      ).toStrictEqual([`run.${status}`]);
+      expect(requests).toHaveLength(source === "goal" ? 1 : 0);
+      if (source === "goal") {
+        const goal = await accept(
+          goals.getForChatThread({
+            headers: sessionHeaders(actor),
+            params: { threadId: run.threadId },
+          }),
+          [200],
+        );
+        expect(goal.body.status).toBe("paused");
+        expect(
+          (await readGoalQueueStateFixture(run.threadId)).runIds,
+        ).toHaveLength(1);
+      }
+    },
+    90_000,
+  );
+});
 
 describe("CHAT-02: model-first provider policies", () => {
   it("adds Codex image upload guidance for web chat Codex sends", async () => {
@@ -7283,16 +8130,10 @@ describe("CHAT-02: model-first provider policies", () => {
     }
   }, 90_000);
 
-  it("keeps webhook completion failure and non-interactive source exclusions", async () => {
+  it("keeps failed and synthetic completions out of shared Pi learning", async () => {
     const cases = [
       ["failed status", {}, true],
-      ["goal controller", { triggerSource: "goal" as const }, false],
-      [
-        "scheduled automation",
-        { triggerSource: "automation-schedule" as const },
-        false,
-      ],
-      ["webhook", { triggerSource: "webhook" as const }, false],
+      ["synthetic run", { triggerSource: "test" as const }, false],
     ] as const;
     for (const [name, inputs, fails] of cases) {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
@@ -7412,7 +8253,7 @@ describe("CHAT-02: model-first provider policies", () => {
     await cancelChatRun(actor, source.runId, sourceClaim.sandboxHeaders);
   }, 90_000);
 
-  it("admits exact Pi web histories with immutable launch policy and stale-lease fencing", async () => {
+  it("admits exact owned Pi histories with immutable launch policy and stale-lease fencing", async () => {
     const { actor, agentId } = await entitledChatActor();
     const orgId = requireOrgId(actor);
     expect(piMemoryStage1AdmissionPrerequisiteSkipReasonFixture()).toBeNull();
@@ -7431,7 +8272,7 @@ describe("CHAT-02: model-first provider policies", () => {
         generationEnabled: false,
       }),
     ).toBe("generation_disabled");
-    // A classified Web Chat source must still own a Chat Thread. The actual
+    // Every product source must still own a Chat Thread. The actual
     // threadless Phase 2 maintenance route is covered by the boundary test.
     expect(
       piMemoryStage1AdmissionPrerequisiteSkipReasonFixture({
@@ -7453,35 +8294,16 @@ describe("CHAT-02: model-first provider policies", () => {
       piMemoryStage1AdmissionPrerequisiteSkipReasonFixture({
         triggerSource: null,
       }),
-    ).toBe("source_not_interactive_chat");
+    ).toBe("invalid_source");
     expect(
       piMemoryStage1AdmissionPrerequisiteSkipReasonFixture({
         triggerSource: "unknown",
       }),
-    ).toBe("source_not_interactive_chat");
-    const expectedAdmissionBySource = {
-      web: null,
-      slack: null,
-      teams: null,
-      feishu: null,
-      email: "source_not_interactive_chat",
-      telegram: null,
-      agentphone: null,
-      github: null,
-      test: "source_not_interactive_chat",
-      agent: null,
-      webhook: "source_not_interactive_chat",
-      "automation-schedule": "source_not_interactive_chat",
-      "automation-event": "source_not_interactive_chat",
-      goal: "source_not_interactive_chat",
-    } as const satisfies Record<
-      (typeof triggerSourceSchema.options)[number],
-      "source_not_interactive_chat" | null
-    >;
+    ).toBe("invalid_source");
     for (const triggerSource of triggerSourceSchema.options) {
       expect(
         piMemoryStage1AdmissionPrerequisiteSkipReasonFixture({ triggerSource }),
-      ).toBe(expectedAdmissionBySource[triggerSource]);
+      ).toBe(triggerSource === "test" ? "synthetic_source" : null);
     }
     const usagePricingResolution = await createGptUsagePricingResolution();
     mockEnv("PI_MEMORY_STAGE1_IDLE_DELAY_MS", 60_000);

--- a/turbo/apps/api/src/signals/services/chat-run-event.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-run-event.service.ts
@@ -1,4 +1,5 @@
 import { isCodexFastModeEnabled } from "@okouai/core/model-feature-switch";
+import type { FeatureSwitchContext } from "@okouai/core";
 
 import { badRequestMessage } from "../../lib/error";
 import type { Db } from "../external/db";
@@ -24,7 +25,10 @@ export async function resolveRunChatThreadModelContext(params: {
   readonly userId: string;
   readonly threadId: string;
 }): Promise<
-  ResolvedPersistedChatThreadModel | ReturnType<typeof badRequestMessage>
+  | (ResolvedPersistedChatThreadModel & {
+      readonly featureSwitchContext: FeatureSwitchContext;
+    })
+  | ReturnType<typeof badRequestMessage>
 > {
   const featureSwitchContext = await loadUserFeatureSwitchContext(
     params.db,
@@ -42,7 +46,7 @@ export async function resolveRunChatThreadModelContext(params: {
   if (!resolved) {
     return badRequestMessage("Chat thread not found");
   }
-  return resolved;
+  return { ...resolved, featureSwitchContext };
 }
 
 async function publishRunUserMessageSignals(

--- a/turbo/apps/api/src/signals/services/chat-trigger-source.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-trigger-source.service.ts
@@ -1,42 +1,7 @@
 import type { TriggerSource } from "@okouai/api-contracts/contracts/logs";
 
-type PiMemoryInteractiveChatTriggerSource = Extract<
-  TriggerSource,
-  | "web"
-  | "agent"
-  | "slack"
-  | "feishu"
-  | "teams"
-  | "telegram"
-  | "agentphone"
-  | "github"
->;
-
-const PI_MEMORY_INTERACTIVE_CHAT_TRIGGER_SOURCES = {
-  web: true,
-  slack: true,
-  teams: true,
-  feishu: true,
-  email: false,
-  telegram: true,
-  agentphone: true,
-  github: true,
-  test: false,
-  agent: true,
-  webhook: false,
-  "automation-schedule": false,
-  "automation-event": false,
-  goal: false,
-} as const satisfies Readonly<Record<TriggerSource, boolean>>;
-
 export function isWebChatTriggerSource(
   triggerSource: TriggerSource,
 ): triggerSource is Extract<TriggerSource, "web" | "agent"> {
   return triggerSource === "web" || triggerSource === "agent";
-}
-
-export function isPiMemoryInteractiveChatTriggerSource(
-  triggerSource: TriggerSource,
-): triggerSource is PiMemoryInteractiveChatTriggerSource {
-  return PI_MEMORY_INTERACTIVE_CHAT_TRIGGER_SOURCES[triggerSource];
 }

--- a/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
@@ -1,4 +1,5 @@
 import { isCodexFastModeEnabled } from "@okouai/core/model-feature-switch";
+import type { FeatureSwitchContext } from "@okouai/core";
 import { command } from "ccstate";
 import { isBuiltInModelProviderType } from "@okouai/api-contracts/contracts/model-providers";
 
@@ -28,6 +29,7 @@ import type { InternalRunCallbackKind } from "./internal-run-callback";
 import { resolvePersistedChatThreadModel } from "./chat-thread-model.service";
 import { normalizeGoalObjectiveBrief } from "./goal-objective-brief-normalization.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
+import { shouldUsePiExecution } from "./pi-sandbox-config";
 import {
   modelProviderWriteTypeForLaunch,
   type ModelFirstPin,
@@ -89,6 +91,7 @@ type ModelContext =
       readonly builtInModelRuntimeRoute: BuiltInModelRuntimeRoute | undefined;
       readonly cliAgentType: string | null;
       readonly codexServiceTier: "fast" | undefined;
+      readonly piExecution: boolean;
     }
   | {
       readonly ok: false;
@@ -234,7 +237,7 @@ function buildQueueFirstGoalRunInput(args: {
       modelProviderCredentialScope: modelPin.modelProviderCredentialScope,
       selectedModel: modelPin.selectedModel,
     },
-    piExecution: false,
+    piExecution: args.modelContext.piExecution,
     dispatchFailedCallbacks: args.dispatchFailedCallbacks,
     timing: args.timing,
   };
@@ -242,7 +245,10 @@ function buildQueueFirstGoalRunInput(args: {
 
 async function resolveGoalThreadModelContext(
   args: ResolveGoalModelContextArgs,
-): Promise<GoalThreadModelContext> {
+): Promise<{
+  readonly threadModelContext: GoalThreadModelContext;
+  readonly featureSwitchContext: FeatureSwitchContext;
+}> {
   const featureSwitchContext = await args.timing.measure(
     "api_dispatch_pre_create_agent_goal_drain_model_context_load_initial_feature_switches",
     "nested",
@@ -255,7 +261,7 @@ async function resolveGoalThreadModelContext(
     },
     args.timingDimensions,
   );
-  return await args.timing.measure(
+  const threadModelContext = await args.timing.measure(
     "api_dispatch_pre_create_agent_goal_drain_model_context_resolve_persisted_model_policy",
     "nested",
     async () => {
@@ -271,13 +277,15 @@ async function resolveGoalThreadModelContext(
     },
     args.timingDimensions,
   );
+  return { threadModelContext, featureSwitchContext };
 }
 
 async function resolveModelContext(
   args: ResolveGoalModelContextArgs,
   signal: AbortSignal,
 ): Promise<ModelContext> {
-  const threadModelContext = await resolveGoalThreadModelContext(args);
+  const { threadModelContext, featureSwitchContext } =
+    await resolveGoalThreadModelContext(args);
   signal.throwIfAborted();
   if ("status" in threadModelContext) {
     return {
@@ -337,13 +345,22 @@ async function resolveModelContext(
     };
   }
 
+  const piExecution = shouldUsePiExecution({
+    chatThreadId: args.goal.threadId,
+    modelProviderType: effectiveModelProvider,
+    selectedModel,
+    codexServiceTier: runCodexServiceTier,
+    builtInModelRuntimeRoute: builtInModelRuntimeRoute ?? undefined,
+    featureSwitchContext,
+  });
   return {
     ok: true,
     modelPin: pin,
     effectiveModelProvider,
     builtInModelRuntimeRoute: builtInModelRuntimeRoute ?? undefined,
-    cliAgentType: providerAdmission.cliAgentType,
+    cliAgentType: piExecution ? "pi" : providerAdmission.cliAgentType,
     codexServiceTier: runCodexServiceTier,
+    piExecution,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/pi-memory-stage1-candidate.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-stage1-candidate.service.ts
@@ -2,7 +2,11 @@ import { and, eq, gt, sql } from "drizzle-orm";
 
 import { triggerSourceSchema } from "@okouai/api-contracts/contracts/logs";
 import { MEMORY_ARTIFACT_NAME } from "@okouai/core/storage-names";
+import { agents } from "@okouai/db/schema/agent";
+import { agentRuns } from "@okouai/db/schema/agent-run";
+import { agentSessions } from "@okouai/db/schema/agent-session";
 import { blobs } from "@okouai/db/schema/blob";
+import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { conversations } from "@okouai/db/schema/conversation";
 import { piMemoryStage1Candidates } from "@okouai/db/schema/pi-memory-stage1-candidate";
 import { storages } from "@okouai/db/schema/storage";
@@ -11,7 +15,6 @@ import type { Tx } from "../../lib/db-types";
 import { nowDate } from "../../lib/time";
 import { advancePiMemoryPhase2InputRevision } from "./pi-memory-phase2-job.service";
 import { newStorageS3Location } from "./storage-s3-prefix.utils";
-import { isPiMemoryInteractiveChatTriggerSource } from "./chat-trigger-source.service";
 
 export type PiMemoryStage1AdmissionSkipReason =
   | "generation_disabled"
@@ -19,7 +22,9 @@ export type PiMemoryStage1AdmissionSkipReason =
   | "missing_chat_thread"
   | "not_completed"
   | "not_pi"
-  | "source_not_interactive_chat"
+  | "not_owned_chat_thread"
+  | "invalid_source"
+  | "synthetic_source"
   | "stale_source";
 
 export type PiMemoryStage1Admission =
@@ -63,16 +68,53 @@ export function getPiMemoryStage1AdmissionPrerequisiteSkipReason(
     return "generation_disabled";
   }
   const triggerSource = triggerSourceSchema.safeParse(args.triggerSource);
-  if (
-    !triggerSource.success ||
-    !isPiMemoryInteractiveChatTriggerSource(triggerSource.data)
-  ) {
-    return "source_not_interactive_chat";
+  if (!triggerSource.success) {
+    return "invalid_source";
+  }
+  if (triggerSource.data === "test") {
+    return "synthetic_source";
   }
   if (args.chatThreadId === null) {
     return "missing_chat_thread";
   }
   return null;
+}
+
+async function ownsProductChatThread(
+  tx: Tx,
+  args: AdmitPiMemoryStage1CandidateArgs,
+): Promise<boolean> {
+  if (args.chatThreadId === null) {
+    return false;
+  }
+  const [thread] = await tx
+    .select({ id: chatThreads.id })
+    .from(agentRuns)
+    .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
+    .innerJoin(
+      chatThreads,
+      and(
+        eq(chatThreads.id, agentRuns.chatThreadId),
+        eq(chatThreads.agentId, agentSessions.agentId),
+      ),
+    )
+    .innerJoin(agents, eq(agents.id, chatThreads.agentId))
+    .where(
+      and(
+        eq(agentRuns.id, args.runId),
+        eq(agentRuns.userId, args.userId),
+        eq(agentRuns.orgId, args.orgId),
+        eq(chatThreads.id, args.chatThreadId),
+        eq(chatThreads.userId, args.userId),
+        eq(agentSessions.userId, args.userId),
+        eq(agentSessions.orgId, args.orgId),
+        eq(agents.orgId, args.orgId),
+      ),
+    )
+    .limit(1);
+  // Private maintenance has no product Agent/session/thread binding, even
+  // though its run uses the same owner and the ordinary "agent" source.
+  return thread !== undefined;
 }
 
 async function resolveMemoryStorageId(
@@ -135,6 +177,9 @@ export async function admitPiMemoryStage1Candidate(
     getPiMemoryStage1AdmissionPrerequisiteSkipReason(args);
   if (prerequisiteSkipReason !== null) {
     return { outcome: "skipped", reason: prerequisiteSkipReason };
+  }
+  if (!(await ownsProductChatThread(tx, args))) {
+    return { outcome: "skipped", reason: "not_owned_chat_thread" };
   }
 
   const [source] = await tx

--- a/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
+++ b/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
@@ -160,7 +160,7 @@ function isFastGptPiProvider(
 
 /**
  * Route canonical chat threads by model and provider policy. Trigger source is
- * intentionally absent so every queued connector shares the same admission.
+ * intentionally absent so every thread-bound launch shares the same admission.
  */
 export function shouldUsePiExecution(args: {
   readonly chatThreadId: string | undefined;

--- a/turbo/apps/api/src/signals/services/workflow-automation-launch.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-launch.service.ts
@@ -29,6 +29,7 @@ import {
 import { createQueueFirstAgentRun$ } from "./agent-runs-create.service";
 import { workflowAutomationCanFire } from "./workflow-automation-access.service";
 import { loadComputerUseHostGrantForAutoSend } from "./chat-computer-use-host.service";
+import { shouldUsePiExecution } from "./pi-sandbox-config";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
 import type { ChatAgentRunSourceAnnotation } from "./chat-user-message.service";
 import {
@@ -89,6 +90,7 @@ type ModelContext =
       readonly builtInModelRuntimeRoute: BuiltInModelRuntimeRoute | undefined;
       readonly cliAgentType: string | null;
       readonly codexServiceTier: "fast" | undefined;
+      readonly piExecution: boolean;
     }
   | { readonly ok: false; readonly failure: RunFailure };
 
@@ -339,13 +341,22 @@ async function resolveModelContext(
     };
   }
 
+  const piExecution = shouldUsePiExecution({
+    chatThreadId: args.chatThreadId,
+    modelProviderType: effectiveModelProvider,
+    selectedModel,
+    codexServiceTier: runCodexServiceTier,
+    builtInModelRuntimeRoute: builtInModelRuntimeRoute ?? undefined,
+    featureSwitchContext: threadModelContext.featureSwitchContext,
+  });
   return {
     ok: true,
     modelPin: pin,
     effectiveModelProvider,
     builtInModelRuntimeRoute: builtInModelRuntimeRoute ?? undefined,
-    cliAgentType: providerAdmission.cliAgentType,
+    cliAgentType: piExecution ? "pi" : providerAdmission.cliAgentType,
     codexServiceTier: runCodexServiceTier,
+    piExecution,
   };
 }
 
@@ -685,7 +696,7 @@ export const launchQueuedWorkflowAutomation$ = command(
           modelProviderCredentialScope: modelPin.modelProviderCredentialScope,
           selectedModel: modelPin.selectedModel,
         },
-        piExecution: false,
+        piExecution: modelContext.piExecution,
         dispatchFailedCallbacks: args.dispatchFailedCallbacks,
         timing,
       },

--- a/turbo/apps/api/src/test-fixtures/pi-memory-stage1-candidates.ts
+++ b/turbo/apps/api/src/test-fixtures/pi-memory-stage1-candidates.ts
@@ -261,7 +261,12 @@ export async function setSyntheticPiMemoryStage1SelectionFixture(args: {
   }
 }
 
-export async function readmitPiMemoryStage1CandidateFixture(runId: string) {
+export async function readmitPiMemoryStage1CandidateFixture(
+  runId: string,
+  ownership: Partial<
+    Pick<AdmitPiMemoryStage1CandidateArgs, "orgId" | "userId" | "chatThreadId">
+  > = {},
+) {
   const [run] = await db()
     .select({
       orgId: agentRuns.orgId,
@@ -302,6 +307,7 @@ export async function readmitPiMemoryStage1CandidateFixture(runId: string) {
       chatThreadId: run.chatThreadId,
       completedAt,
       idleDelayMs: 0,
+      ...ownership,
     });
   });
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -297,7 +297,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.PiLoop]: {
     maintainer: "lancy@okou.ai",
     description:
-      "Run web chat jobs with the sandbox-owned official Pi runtime, JSONL session persistence, and shared Codex-compatible memory.",
+      "Run owned chat threads with the official Pi runtime, native session persistence, and shared memory learning across interactive, Automation, and Goal turns.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },


### PR DESCRIPTION
Closes #32578. Part of #32168.

Automation and Goal queue launches currently retain the previous framework even when the owner's thread is eligible for Pi. Route both common launch boundaries through `shouldUsePiExecution`, and use the same decision to select `cliAgentType: pi` before canonical session preparation. This rotates incompatible Codex/Claude sessions and preserves compatible native Pi continuation while retaining the resolved owner, model, provider account, tier, and concrete route.

Replace Stage 1's temporary interactive-source allowlist with the completed owned Pi conversation contract: captured framework/generation, matching run/session/product-thread ownership, and exact hash-backed native history. Completed Automation and Goal turns enter the existing shared learner; private threadless maintenance and synthetic, invalid-owner, failed/cancelled, non-Pi, and historyless runs remain excluded. Update obsolete Pi source wording and the PiLoop description.

The change uses current shared model/provider policy, including the separately merged Custom Responses Fast support. Queue claims, priorities, callbacks, schedule recurrence/coalescing/Run now, Goal revision/autonomy/recovery, accounting, memory workers, cooldowns, leases, revisions, storage concurrency, persisted formats, and PiLoop/Fast keys/defaults/cohorts retain their existing contracts.

### Validation

- Real PostgreSQL, queue/session/completion, native Pi history, and external-provider mocks cover schedule/event ingress, Goal bootstrap/continuation, framework rotation, mixed-source continuation, Stage 1 extraction, owner isolation, failure/cancel/duplicate terminal settlement, provider account/tier, and exact billing.
- Existing queue, scheduler, Goal, event-ingress, callback, Stage 1 worker, Phase 2 revision, and projection suites: 267 tests passed across 10 files.
- Real Pi maintenance boundary suite: 15 tests passed through the local CLI/Guest/provider boundary, including private `agent` maintenance exclusion and terminal retry/race handling.
- Focused Chat entry-point, immutable admission, and then-current Custom Responses Fast regression selection: 18 tests passed on the rebased branch.
- API/core lint and type checks and repository-wide Knip passed. Complete commit hooks passed, including formatting, style policy, repository-wide Knip, all 15 workspace type-check tasks, file size, and commitlint.

### Acceptance boundary

This PR completes the consolidated code scope. Switch graduation and production acceptance/release belong to the controller and designated Production Release thread. Local Phase 2 boundary coverage is not production publication/accounting evidence. The previously waived fresh-thread recall check remains waived. Goal's larger historical run volume still requires the controller's bounded post-release stability, learning-load, and billing assessment.
