### PR TITLE
fix(api): classify auxiliary generation outcomes

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -87,6 +87,7 @@ export interface ApiTestMocks {
     readonly timeout: AbortSignalTimeoutMock;
   };
   readonly axiom: {
+    readonly useRealTelemetry: Mock<() => boolean>;
     readonly clientError: Mock<(error: Error) => void>;
     readonly clients: AxiomSdkClientMock[];
     readonly flush: AsyncMock;
@@ -321,6 +322,7 @@ type AxiomJSTransportMock = Readonly<Record<string, never>>;
 
 const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   const axiom = {
+    useRealTelemetry: vi.fn<() => boolean>(),
     clientError: vi.fn<(error: Error) => void>(),
     clients: [],
     flush: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -1171,16 +1173,22 @@ vi.mock("../signals/external/axiom", async () => {
       });
     },
     getDatasetName: (name: string) => {
-      return name;
+      return apiTestMocks.axiom.useRealTelemetry()
+        ? actual.getDatasetName(name)
+        : name;
     },
     ingestToAxiom: (
       dataset: string,
       events: readonly Record<string, unknown>[],
     ) => {
-      return apiTestMocks.axiom.ingest(dataset, events);
+      return apiTestMocks.axiom.useRealTelemetry()
+        ? actual.ingestToAxiom(dataset, events)
+        : apiTestMocks.axiom.ingest(dataset, events);
     },
-    flushAxiom: (options?: unknown) => {
-      return apiTestMocks.axiom.flush(options);
+    flushAxiom: (options?: Parameters<typeof actual.flushAxiom>[0]) => {
+      return apiTestMocks.axiom.useRealTelemetry()
+        ? actual.flushAxiom(options)
+        : apiTestMocks.axiom.flush(options);
     },
   };
 });
@@ -1289,6 +1297,8 @@ export function resetApiTestMocks(): void {
   apiTestMocks.ably.requestToken.mockResolvedValue({
     token: "test-ably-token",
   });
+  apiTestMocks.axiom.useRealTelemetry.mockReset();
+  apiTestMocks.axiom.useRealTelemetry.mockReturnValue(false);
   apiTestMocks.axiom.clientError.mockReset();
   apiTestMocks.axiom.clients.splice(0);
   apiTestMocks.axiom.flush.mockReset();

--- a/turbo/apps/api/src/signals/external/openrouter-failure.ts
+++ b/turbo/apps/api/src/signals/external/openrouter-failure.ts
@@ -1,0 +1,122 @@
+import { singleton } from "../../lib/singleton";
+
+/** Origin evidence only; annotating preserves the error identity for shared callers. */
+export type OpenRouterFailureReason =
+  | "rate_limited"
+  | "upstream_timeout"
+  | "network"
+  | "provider_unavailable"
+  | "invalid_request"
+  | "auth"
+  | "invalid_output"
+  | "unknown";
+
+const failureReasons = singleton(() => {
+  return new WeakMap<object, OpenRouterFailureReason>();
+});
+
+export function openRouterFailureReason(
+  error: unknown,
+): OpenRouterFailureReason {
+  return typeof error === "object" && error !== null
+    ? (failureReasons().get(error) ?? "unknown")
+    : "unknown";
+}
+
+export function recordOpenRouterFailure(
+  error: unknown,
+  reason: OpenRouterFailureReason,
+): void {
+  if (typeof error === "object" && error !== null) {
+    failureReasons().set(error, reason);
+  }
+}
+
+function property(value: unknown, key: string): unknown {
+  return typeof value === "object" && value !== null && key in value
+    ? value[key as keyof typeof value]
+    : undefined;
+}
+
+export function recordOpenRouterRequestFailure(
+  error: Error,
+  status: number,
+  origin: "http" | "completion",
+  value: unknown,
+): void {
+  const detail = property(value, "error") ?? value;
+  const code = property(error, "errorCode") ?? property(detail, "code");
+  const errorType = property(property(detail, "metadata"), "error_type");
+  const httpStatus = origin === "http" ? status : undefined;
+  let reason: OpenRouterFailureReason = "unknown";
+  if (
+    [401, 403].some((candidate) => {
+      return candidate === httpStatus || candidate === code;
+    })
+  ) {
+    reason = "auth";
+  } else if (
+    [
+      400,
+      402,
+      404,
+      413,
+      422,
+      "invalid_request_error",
+      "invalid_argument",
+      "invalid_parameter",
+      "unsupported_parameter",
+      "unsupported_value",
+      "INVALID_ARGUMENT",
+    ].some((candidate) => {
+      return candidate === httpStatus || candidate === code;
+    }) ||
+    errorType === "invalid_request_error"
+  ) {
+    reason = "invalid_request";
+  } else if (
+    code === "rate_limit_exceeded" ||
+    code === 429 ||
+    errorType === "rate_limit_exceeded" ||
+    httpStatus === 429
+  ) {
+    reason = "rate_limited";
+  } else if (httpStatus === 408 || httpStatus === 504) {
+    reason = "upstream_timeout";
+  } else if (httpStatus === 502 || httpStatus === 503) {
+    reason = "provider_unavailable";
+  }
+  recordOpenRouterFailure(error, reason);
+}
+
+/** Call only at fetch/body I/O, never around feature code or output interpretation. */
+export function recordOpenRouterTransportFailure(error: unknown): void {
+  const code =
+    property(property(error, "cause"), "code") ?? property(error, "code");
+  if (
+    typeof code === "string" &&
+    [
+      "UND_ERR_CONNECT_TIMEOUT",
+      "UND_ERR_HEADERS_TIMEOUT",
+      "UND_ERR_BODY_TIMEOUT",
+      "ETIMEDOUT",
+    ].includes(code)
+  ) {
+    recordOpenRouterFailure(error, "upstream_timeout");
+  } else if (
+    (typeof code === "string" &&
+      [
+        "ECONNRESET",
+        "ECONNREFUSED",
+        "EAI_AGAIN",
+        "ENOTFOUND",
+        "ENETUNREACH",
+        "UND_ERR_SOCKET",
+      ].includes(code)) ||
+    (code === undefined &&
+      error instanceof TypeError &&
+      (error.message === "fetch failed" || error.message === "Failed to fetch"))
+  ) {
+    recordOpenRouterFailure(error, "network");
+  }
+}

--- a/turbo/apps/api/src/signals/external/openrouter.ts
+++ b/turbo/apps/api/src/signals/external/openrouter.ts
@@ -1,5 +1,15 @@
 import { optionalEnv } from "../../lib/env";
-import { readBoundedResponseText, safeJsonParse } from "../utils";
+import {
+  onRejection,
+  readBoundedResponseText,
+  safeJsonParse,
+  safeSync,
+} from "../utils";
+import {
+  recordOpenRouterFailure,
+  recordOpenRouterRequestFailure,
+  recordOpenRouterTransportFailure,
+} from "./openrouter-failure";
 
 const OPENROUTER_CHAT_COMPLETIONS_URL =
   "https://openrouter.ai/api/v1/chat/completions";
@@ -149,6 +159,7 @@ function openRouterRequestError(args: {
   readonly message: string;
   readonly status: number;
   readonly value: unknown;
+  readonly origin: "http" | "completion";
 }): OpenRouterRequestError {
   const error = objectProperty(args.value, "error") ?? args.value;
   const metadata = objectProperty(error, "metadata");
@@ -180,13 +191,20 @@ function openRouterRequestError(args: {
     safeErrorCode(provider) ??
     safeErrorCode(error);
   const errorParam = safeErrorParam(provider) ?? safeErrorParam(error);
-  return new OpenRouterRequestError({
+  const requestError = new OpenRouterRequestError({
     message: args.message,
     status: args.status,
     ...(errorType === undefined ? {} : { errorType }),
     ...(errorCode === undefined ? {} : { errorCode }),
     ...(errorParam === undefined ? {} : { errorParam }),
   });
+  recordOpenRouterRequestFailure(
+    requestError,
+    args.status,
+    args.origin,
+    args.value,
+  );
+  return requestError;
 }
 
 async function ensureOpenRouterResponseOk(response: Response): Promise<void> {
@@ -202,6 +220,7 @@ async function ensureOpenRouterResponseOk(response: Response): Promise<void> {
   throw openRouterRequestError({
     message: "OpenRouter request failed",
     status: response.status,
+    origin: "http",
     value: errorValue,
   });
 }
@@ -215,6 +234,7 @@ function parseOpenRouterGeneration(
       throw openRouterRequestError({
         message: "OpenRouter request failed",
         status: 502,
+        origin: "completion",
         value: data,
       });
     }
@@ -224,6 +244,7 @@ function parseOpenRouterGeneration(
     throw openRouterRequestError({
       message: "OpenRouter completion failed",
       status: 502,
+      origin: "completion",
       value: choice.error ?? data.error,
     });
   }
@@ -306,28 +327,47 @@ export async function generateTextWithUsage(
     return null;
   }
 
-  const response = await fetch(OPENROUTER_CHAT_COMPLETIONS_URL, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      model,
-      messages,
-      ...(maxTokens === undefined ? {} : { max_tokens: maxTokens }),
-      ...(options?.reasoning === undefined
-        ? {}
-        : { reasoning: options.reasoning }),
-      temperature: options?.temperature ?? 0.3,
+  const response = await onRejection(
+    fetch(OPENROUTER_CHAT_COMPLETIONS_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(maxTokens === undefined ? {} : { max_tokens: maxTokens }),
+        ...(options?.reasoning === undefined
+          ? {}
+          : { reasoning: options.reasoning }),
+        temperature: options?.temperature ?? 0.3,
+      }),
+      signal,
     }),
-    signal,
+    recordOpenRouterTransportFailure,
+  );
+  await onRejection(
+    ensureOpenRouterResponseOk(response),
+    recordOpenRouterTransportFailure,
+  );
+  const body = await onRejection(
+    response.text(),
+    recordOpenRouterTransportFailure,
+  );
+  const parsed = safeSync(() => {
+    // Preserve the shared helper's payload-free parsing and throw contract.
+    const data = safeJsonParse(body);
+    if (typeof data !== "object" || data === null) {
+      throw new Error("OpenRouter returned invalid JSON");
+    }
+    return parseOpenRouterGeneration(data as OpenRouterResponse);
   });
-  await ensureOpenRouterResponseOk(response);
-  // JSON parser errors can quote the upstream body. Keep failures payload-free.
-  const data = safeJsonParse(await response.text());
-  if (typeof data !== "object" || data === null) {
-    throw new Error("OpenRouter returned invalid JSON");
+  if ("error" in parsed) {
+    if (!(parsed.error instanceof OpenRouterRequestError)) {
+      recordOpenRouterFailure(parsed.error, "invalid_output");
+    }
+    throw parsed.error;
   }
-  return parseOpenRouterGeneration(data as OpenRouterResponse);
+  return parsed.ok;
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/auxiliary-generation.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auxiliary-generation.test.ts
@@ -1,16 +1,20 @@
 import { randomUUID } from "node:crypto";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it, onTestFinished, beforeEach } from "vitest";
+import { goalsContract } from "@okouai/api-contracts/contracts/goals";
 import { testRuntimeStateContract } from "@okouai/api-contracts/contracts/test-runtime-state";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
-import { mockNow } from "../../../lib/time";
+import { mockNow, now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { createDeferredPromise } from "../../utils";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { testRuntimeStateRoutes } from "../test-runtime-state";
+import { goalsRoutes } from "../goals";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { createRouteMocks } from "./helpers/route-test";
 import { createBddApi } from "./helpers/api-bdd";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
@@ -25,6 +29,7 @@ import {
 const context = testContext();
 beforeEach(() => {
   context.mocks.axiom.useRealTelemetry.mockReturnValue(true);
+  mockOptionalEnv("OPENROUTER_API_KEY", undefined);
 });
 const endpoint = "https://openrouter.ai/api/v1/chat/completions";
 const secret = "private-provider-payload";
@@ -59,9 +64,12 @@ function brokenBody(error: Error) {
   );
 }
 
-function summaryRequest(signal: AbortSignal = context.signal) {
-  // Existing test entry point reaches the same generation + database boundary
-  // as callbacks, without creating unrelated agent execution for every case.
+function summaryCancellationRequest(signal: AbortSignal) {
+  // Infrastructure-only exception: a public callback acknowledges before its
+  // background work finishes and cannot inject an independently owned task
+  // AbortSignal. The existing runtime harness lets cancellation reach the real
+  // summary boundary; every case aborts before persistence. Normal output and
+  // fallback cases below use the production Goal API and readback instead.
   return setupApp({
     context,
     routes: testRuntimeStateRoutes,
@@ -76,6 +84,77 @@ function summaryRequest(signal: AbortSignal = context.signal) {
       result_text: secret,
     },
   });
+}
+
+async function prepareGoal() {
+  const bdd = createBddApi(context);
+  const runs = createRunsApi(context);
+  const chat = createChatFilesBddApi(context);
+  const actor = bdd.user();
+  if (!actor.orgId) {
+    throw new Error("Goal outcome tests require an organization");
+  }
+  const orgId = actor.orgId;
+  bdd.acceptAgentStorageWrites();
+  runs.acceptStorageDownloads();
+  runs.acceptTelemetryIngest();
+  runs.configureRunnerGroup();
+  await runs.grantProEntitlement(actor);
+  await runs.ensureOrgModelProvider(actor);
+  const agent = await bdd.createAgent(actor, { displayName: "Outcome goal" });
+  const sent = await accept(
+    chat.requestSendEvent(
+      actor,
+      {
+        agentId: agent.agentId,
+        prompt: "Prepare an observable goal",
+        model: "claude-sonnet-5",
+      },
+      [201],
+    ),
+    [201],
+  );
+  const runId = sent.body.runId;
+  if (runId === null) {
+    throw new Error("Expected a thread-linked run");
+  }
+  await flushWaitUntilForTest();
+  const client = setupApp({ context, routes: goalsRoutes })(goalsContract);
+  return {
+    create: async () => {
+      const seconds = Math.floor(now() / 1000);
+      const token = signSandboxJwtForTests({
+        scope: "okou",
+        userId: actor.userId,
+        orgId,
+        runId,
+        capabilities: ["goal:user-control:write"],
+        iat: seconds,
+        exp: seconds + 600,
+      });
+      return await accept(
+        client.create({
+          headers: { authorization: `Bearer ${token}` },
+          body: { objective: secret },
+        }),
+        [201],
+      );
+    },
+    read: async () => {
+      createRouteMocks(context).clerk.session(
+        actor.userId,
+        orgId,
+        actor.orgRole,
+      );
+      return await accept(
+        client.getForChatThread({
+          headers: { authorization: "Bearer clerk-session" },
+          params: { threadId: sent.body.threadId },
+        }),
+        [200],
+      );
+    },
+  };
 }
 
 const cases = Object.freeze([
@@ -292,28 +371,47 @@ describe("auxiliary generation outcomes", () => {
   it.each(cases)(
     "records one bounded outcome for $name",
     async ({ response, outcome, reason }) => {
+      const goal = await prepareGoal();
       mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
       server.use(http.post(endpoint, response));
-      const result = await accept(summaryRequest(), [200]);
+      const result = await goal.create();
       await flushWaitUntilForTest();
-      expect(result.body).toStrictEqual({ ok: true });
+      expect(result.body).toStrictEqual({
+        objective: secret,
+        objectiveBrief: outcome === "success" ? "A usable summary" : secret,
+        status: "active",
+      });
+      const persisted = await goal.read();
+      expect(persisted.body).toStrictEqual(result.body);
       expect(auxiliaryResults(context)).toStrictEqual([
-        expect.objectContaining({ feature: "run_summary", outcome, reason }),
+        expect.objectContaining({
+          feature: "goal_objective_brief",
+          outcome,
+          reason,
+        }),
       ]);
       expect(auxiliaryWarnings(context)).toHaveLength(
         outcome === "error" ? 1 : 0,
       );
       expect(JSON.stringify(auxiliaryWarnings(context))).not.toContain(secret);
-      expect(context.mocks.axiomLogging.warn.mock.calls).toHaveLength(
-        outcome === "error" ? 1 : 0,
+      expect(
+        context.mocks.axiomLogging.warn.mock.calls.map(([message]) => {
+          return message;
+        }),
+      ).toStrictEqual(
+        outcome === "error" ? ["Auxiliary generation failed"] : [],
       );
       expect(context.mocks.axiomLogging.error.mock.calls).toStrictEqual([]);
     },
   );
 
   it("records missing optional generation configuration as a skip", async () => {
+    const goal = await prepareGoal();
     mockOptionalEnv("OPENROUTER_API_KEY", undefined);
-    await accept(summaryRequest(), [200]);
+    const created = await goal.create();
+    const persisted = await goal.read();
+    expect(persisted.body).toStrictEqual(created.body);
+    expect(created.body.objectiveBrief).toBe(secret);
     await flushWaitUntilForTest();
     expect(auxiliaryResults(context)).toStrictEqual([
       expect.objectContaining({ outcome: "skipped", reason: "not_applicable" }),
@@ -328,6 +426,7 @@ describe("auxiliary generation outcomes", () => {
     "async-flush",
     "abort-ingest",
   ])("keeps generation successful with %s telemetry", async (mode) => {
+    const goal = await prepareGoal();
     mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
     server.use(
       http.post(endpoint, () => {
@@ -353,9 +452,15 @@ describe("auxiliary generation outcomes", () => {
         new Error("flush unavailable"),
       );
     }
-    const result = await accept(summaryRequest(), [200]);
+    const result = await goal.create();
     await expect(flushWaitUntilForTest()).resolves.toBeUndefined();
-    expect(result.body).toStrictEqual({ ok: true });
+    expect(result.body).toStrictEqual({
+      objective: secret,
+      objectiveBrief: "A usable summary",
+      status: "active",
+    });
+    const persisted = await goal.read();
+    expect(persisted.body).toStrictEqual(result.body);
     expect(auxiliaryWarnings(context)).toStrictEqual([]);
     if (mode === "missing") {
       expect(auxiliaryResults(context)).toStrictEqual([]);
@@ -387,7 +492,7 @@ describe("auxiliary generation outcomes", () => {
           return completion();
         }),
       );
-      const request = summaryRequest(controller.signal);
+      const request = summaryCancellationRequest(controller.signal);
       const outcome = (async () => {
         await expect(request).rejects.toBe(reason);
       })();
@@ -429,7 +534,7 @@ describe("auxiliary generation outcomes", () => {
         );
       }),
     );
-    const request = summaryRequest(controller.signal);
+    const request = summaryCancellationRequest(controller.signal);
     const rejected = (async () => {
       await expect(request).rejects.toMatchObject({ name: "AbortError" });
     })();
@@ -539,6 +644,7 @@ describe("auxiliary generation outcomes", () => {
   });
 
   it("measures interpretation and bounds duration when the clock moves backwards", async () => {
+    const goal = await prepareGoal();
     mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
     mockNow(1000);
     server.use(
@@ -547,7 +653,7 @@ describe("auxiliary generation outcomes", () => {
         return completion();
       }),
     );
-    await accept(summaryRequest(), [200]);
+    await goal.create();
     await flushWaitUntilForTest();
     expect(auxiliaryResults(context)).toStrictEqual([
       expect.objectContaining({ outcome: "success", duration_ms: 0 }),

--- a/turbo/apps/api/src/signals/routes/__tests__/auxiliary-generation.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auxiliary-generation.test.ts
@@ -1,0 +1,556 @@
+import { randomUUID } from "node:crypto";
+import { HttpResponse, http } from "msw";
+import { describe, expect, it, onTestFinished, beforeEach } from "vitest";
+import { testRuntimeStateContract } from "@okouai/api-contracts/contracts/test-runtime-state";
+
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
+import { mockNow } from "../../../lib/time";
+import { server } from "../../../mocks/server";
+import { createDeferredPromise } from "../../utils";
+import { flushWaitUntilForTest } from "../../context/wait-until";
+import { testRuntimeStateRoutes } from "../test-runtime-state";
+import { createBddApi } from "./helpers/api-bdd";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
+import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
+import {
+  auxiliaryResults,
+  auxiliaryWarnings,
+} from "./helpers/auxiliary-generation";
+
+// Exercise the real ingest/configuration/flush lifecycle, mocking only its SDK.
+
+const context = testContext();
+beforeEach(() => {
+  context.mocks.axiom.useRealTelemetry.mockReturnValue(true);
+});
+const endpoint = "https://openrouter.ai/api/v1/chat/completions";
+const secret = "private-provider-payload";
+
+function completion(
+  content: unknown = "A usable summary",
+  finishReason = "stop",
+) {
+  return HttpResponse.json({
+    choices: [{ finish_reason: finishReason, message: { content } }],
+  });
+}
+
+function responseFailure(code?: string) {
+  return HttpResponse.json({
+    choices: [
+      {
+        finish_reason: "error",
+        error: { metadata: { error_type: code }, message: secret },
+      },
+    ],
+  });
+}
+
+function brokenBody(error: Error) {
+  return new HttpResponse(
+    new ReadableStream({
+      start(controller) {
+        controller.error(error);
+      },
+    }),
+  );
+}
+
+function summaryRequest(signal: AbortSignal = context.signal) {
+  // Existing test entry point reaches the same generation + database boundary
+  // as callbacks, without creating unrelated agent execution for every case.
+  return setupApp({
+    context,
+    routes: testRuntimeStateRoutes,
+    signal,
+    rethrowErrors: true,
+  })(testRuntimeStateContract).action({
+    body: {
+      action: "save-run-summary",
+      run_id: randomUUID(),
+      trigger_source: "web",
+      prompt: secret,
+      result_text: secret,
+    },
+  });
+}
+
+const cases = Object.freeze([
+  {
+    name: "rate limit wrapped in synthetic 502",
+    response: () => {
+      return responseFailure("rate_limit_exceeded");
+    },
+    outcome: "degraded",
+    reason: "rate_limited",
+  },
+  {
+    name: "response error code",
+    response: () => {
+      return HttpResponse.json({
+        error: { code: "rate_limit_exceeded", message: secret },
+      });
+    },
+    outcome: "degraded",
+    reason: "rate_limited",
+  },
+  {
+    name: "typed response rate limit",
+    response: () => {
+      return HttpResponse.json({ error: { code: 429, message: secret } });
+    },
+    outcome: "degraded",
+    reason: "rate_limited",
+  },
+  {
+    name: "wrapped invalid parameter overrides transient HTTP",
+    response: () => {
+      return HttpResponse.json(
+        {
+          error: {
+            metadata: {
+              raw: JSON.stringify({
+                error: { status: "INVALID_ARGUMENT", message: secret },
+              }),
+            },
+          },
+        },
+        { status: 503 },
+      );
+    },
+    outcome: "error",
+    reason: "invalid_request",
+  },
+  {
+    name: "TLS configuration failure",
+    response: () => {
+      return brokenBody(
+        new TypeError("fetch failed", {
+          cause: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" },
+        }),
+      );
+    },
+    outcome: "error",
+    reason: "unknown",
+  },
+  {
+    name: "HTTP rate limit",
+    response: () => {
+      return new HttpResponse(secret, { status: 429 });
+    },
+    outcome: "degraded",
+    reason: "rate_limited",
+  },
+  {
+    name: "HTTP bad gateway",
+    response: () => {
+      return new HttpResponse(secret, { status: 502 });
+    },
+    outcome: "degraded",
+    reason: "provider_unavailable",
+  },
+  {
+    name: "HTTP unavailable",
+    response: () => {
+      return new HttpResponse(secret, { status: 503 });
+    },
+    outcome: "degraded",
+    reason: "provider_unavailable",
+  },
+  {
+    name: "HTTP gateway timeout",
+    response: () => {
+      return new HttpResponse(secret, { status: 504 });
+    },
+    outcome: "degraded",
+    reason: "upstream_timeout",
+  },
+  {
+    name: "transport failure",
+    response: () => {
+      return HttpResponse.error();
+    },
+    outcome: "degraded",
+    reason: "network",
+  },
+  {
+    name: "typed transport timeout",
+    response: () => {
+      return brokenBody(
+        new TypeError("terminated", {
+          cause: { code: "UND_ERR_BODY_TIMEOUT" },
+        }),
+      );
+    },
+    outcome: "degraded",
+    reason: "upstream_timeout",
+  },
+  {
+    name: "unproven TimeoutError",
+    response: () => {
+      return brokenBody(new DOMException(secret, "TimeoutError"));
+    },
+    outcome: "error",
+    reason: "unknown",
+  },
+  {
+    name: "unrelated TypeError",
+    response: () => {
+      return brokenBody(
+        new TypeError(`${secret}\n at /src/signals/${secret}.ts:1:2`),
+      );
+    },
+    outcome: "error",
+    reason: "unknown",
+  },
+  {
+    name: "broken credentials",
+    response: () => {
+      return new HttpResponse(secret, { status: 401 });
+    },
+    outcome: "error",
+    reason: "auth",
+  },
+  {
+    name: "invalid request",
+    response: () => {
+      return new HttpResponse(secret, { status: 400 });
+    },
+    outcome: "error",
+    reason: "invalid_request",
+  },
+  {
+    name: "unknown synthetic 502",
+    response: () => {
+      return responseFailure("private_identifier");
+    },
+    outcome: "error",
+    reason: "unknown",
+  },
+  {
+    name: "malformed JSON",
+    response: () => {
+      return new HttpResponse(secret);
+    },
+    outcome: "error",
+    reason: "invalid_output",
+  },
+  {
+    name: "missing choices",
+    response: () => {
+      return HttpResponse.json({});
+    },
+    outcome: "error",
+    reason: "invalid_output",
+  },
+  {
+    name: "incompatible content",
+    response: () => {
+      return completion({ text: secret });
+    },
+    outcome: "error",
+    reason: "invalid_output",
+  },
+  {
+    name: "length terminal outcome",
+    response: () => {
+      return completion(secret, "length");
+    },
+    outcome: "error",
+    reason: "invalid_output",
+  },
+  {
+    name: "tool terminal outcome",
+    response: () => {
+      return completion(secret, "tool_calls");
+    },
+    outcome: "error",
+    reason: "invalid_output",
+  },
+  {
+    name: "empty interpreted output",
+    response: () => {
+      return completion("---");
+    },
+    outcome: "error",
+    reason: "invalid_output",
+  },
+  {
+    name: "success",
+    response: () => {
+      return completion();
+    },
+    outcome: "success",
+    reason: "none",
+  },
+]);
+
+describe("auxiliary generation outcomes", () => {
+  it.each(cases)(
+    "records one bounded outcome for $name",
+    async ({ response, outcome, reason }) => {
+      mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
+      server.use(http.post(endpoint, response));
+      const result = await accept(summaryRequest(), [200]);
+      await flushWaitUntilForTest();
+      expect(result.body).toStrictEqual({ ok: true });
+      expect(auxiliaryResults(context)).toStrictEqual([
+        expect.objectContaining({ feature: "run_summary", outcome, reason }),
+      ]);
+      expect(auxiliaryWarnings(context)).toHaveLength(
+        outcome === "error" ? 1 : 0,
+      );
+      expect(JSON.stringify(auxiliaryWarnings(context))).not.toContain(secret);
+      expect(context.mocks.axiomLogging.warn.mock.calls).toHaveLength(
+        outcome === "error" ? 1 : 0,
+      );
+      expect(context.mocks.axiomLogging.error.mock.calls).toStrictEqual([]);
+    },
+  );
+
+  it("records missing optional generation configuration as a skip", async () => {
+    mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+    await accept(summaryRequest(), [200]);
+    await flushWaitUntilForTest();
+    expect(auxiliaryResults(context)).toStrictEqual([
+      expect.objectContaining({ outcome: "skipped", reason: "not_applicable" }),
+    ]);
+    expect(context.mocks.axiomLogging.warn.mock.calls).toStrictEqual([]);
+  });
+
+  it.each([
+    "missing",
+    "sync-ingest",
+    "sync-flush",
+    "async-flush",
+    "abort-ingest",
+  ])("keeps generation successful with %s telemetry", async (mode) => {
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
+    server.use(
+      http.post(endpoint, () => {
+        return completion();
+      }),
+    );
+    if (mode === "missing") {
+      mockOptionalEnv("AXIOM_TOKEN_TELEMETRY", undefined);
+    } else if (mode === "sync-ingest" || mode === "abort-ingest") {
+      context.mocks.axiom.sdkIngest.mockImplementation((_dataset, events) => {
+        if (JSON.stringify(events).includes("auxiliary_generation_result")) {
+          throw mode === "abort-ingest"
+            ? new DOMException("telemetry abort", "AbortError")
+            : new Error("ingest unavailable");
+        }
+      });
+    } else if (mode === "sync-flush") {
+      context.mocks.axiom.flush.mockImplementation(() => {
+        throw new Error("flush unavailable");
+      });
+    } else {
+      context.mocks.axiom.flush.mockRejectedValue(
+        new Error("flush unavailable"),
+      );
+    }
+    const result = await accept(summaryRequest(), [200]);
+    await expect(flushWaitUntilForTest()).resolves.toBeUndefined();
+    expect(result.body).toStrictEqual({ ok: true });
+    expect(auxiliaryWarnings(context)).toStrictEqual([]);
+    if (mode === "missing") {
+      expect(auxiliaryResults(context)).toStrictEqual([]);
+    }
+  });
+
+  it.each([
+    new DOMException("Caller cancelled", "AbortError"),
+    new DOMException("Caller deadline", "TimeoutError"),
+  ])(
+    "propagates caller cancellation and records it once ($name)",
+    async (reason) => {
+      const controller = new AbortController();
+      onTestFinished(() => {
+        return controller.abort();
+      });
+      const entered = createDeferredPromise<void>(context.signal);
+      const release = createDeferredPromise<void>(context.signal);
+      onTestFinished(() => {
+        if (!release.settled()) {
+          release.resolve(undefined);
+        }
+      });
+      mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
+      server.use(
+        http.post(endpoint, async () => {
+          entered.resolve(undefined);
+          await release.promise;
+          return completion();
+        }),
+      );
+      const request = summaryRequest(controller.signal);
+      const outcome = (async () => {
+        await expect(request).rejects.toBe(reason);
+      })();
+      await entered.promise;
+      controller.abort(reason);
+      release.resolve(undefined);
+      await outcome;
+      await flushWaitUntilForTest();
+      expect(auxiliaryResults(context)).toStrictEqual([
+        expect.objectContaining({
+          outcome: "cancelled",
+          reason: "caller_cancelled",
+        }),
+      ]);
+      expect(context.mocks.axiomLogging.warn.mock.calls).toStrictEqual([]);
+    },
+  );
+
+  it("diagnoses an unrelated body error even when the caller aborts before its rejection settles", async () => {
+    const controller = new AbortController();
+    onTestFinished(() => {
+      controller.abort();
+    });
+    const bodyReady = createDeferredPromise<
+      ReadableStreamDefaultController<Uint8Array>
+    >(context.signal);
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
+    server.use(
+      http.post(endpoint, () => {
+        return new HttpResponse(
+          new ReadableStream<Uint8Array>(
+            {
+              pull(body) {
+                bodyReady.resolve(body);
+              },
+            },
+            { highWaterMark: 0 },
+          ),
+        );
+      }),
+    );
+    const request = summaryRequest(controller.signal);
+    const rejected = (async () => {
+      await expect(request).rejects.toMatchObject({ name: "AbortError" });
+    })();
+    const body = await bodyReady.promise;
+    body.error(new TypeError("Unrelated programming failure"));
+    controller.abort();
+    await rejected;
+    await flushWaitUntilForTest();
+    expect(auxiliaryResults(context)).toStrictEqual([
+      expect.objectContaining({ outcome: "error", reason: "unknown" }),
+    ]);
+    expect(auxiliaryWarnings(context)).toHaveLength(1);
+  });
+
+  it("flushes a background title that finishes after the response through the request lifetime", async () => {
+    const bdd = createBddApi(context);
+    const runs = createRunsApi(context);
+    const chat = createChatFilesBddApi(context);
+    const callbacks = createChatCallbacksApi(context);
+    const actor = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    runs.configureRunnerGroup();
+    await runs.grantProEntitlement(actor);
+    await runs.ensureOrgModelProvider(actor);
+    const agent = await bdd.createAgent(actor, { displayName: "Late title" });
+    const titleEntered = createDeferredPromise<void>(context.signal);
+    const releaseTitle = createDeferredPromise<void>(context.signal);
+    const flushEntered = createDeferredPromise<void>(context.signal);
+    const releaseFlush = createDeferredPromise<void>(context.signal);
+    onTestFinished(() => {
+      if (!releaseTitle.settled()) {
+        releaseTitle.resolve(undefined);
+      }
+      if (!releaseFlush.settled()) {
+        releaseFlush.resolve(undefined);
+      }
+    });
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
+    callbacks.mockOpenRouterCompletions(async (body) => {
+      if (
+        body.messages[0]?.content.includes(
+          "Generate a short, descriptive title",
+        )
+      ) {
+        titleEntered.resolve(undefined);
+        await releaseTitle.promise;
+        return "Late generated title";
+      }
+      return "Thinking";
+    });
+    const beforeSendFlushes = context.mocks.axiom.flush.mock.calls.length;
+    const response = await chat.requestSendEvent(
+      actor,
+      {
+        agentId: agent.agentId,
+        prompt: "Generate a title",
+        model: "claude-sonnet-5",
+      },
+      [201],
+    );
+    await titleEntered.promise;
+    if (response.status !== 201) {
+      throw new Error("Expected an accepted chat event");
+    }
+    expect(auxiliaryResults(context)).toStrictEqual([]);
+    expect(context.mocks.axiom.flush.mock.calls.length).toBeGreaterThan(
+      beforeSendFlushes,
+    );
+    // The response has already scheduled its ordinary flush. Hold only the
+    // flush initiated by the late generation and observe the lifecycle drain.
+    context.mocks.axiom.flush.mockImplementation(async () => {
+      if (!flushEntered.settled()) {
+        flushEntered.resolve(undefined);
+      }
+      await releaseFlush.promise;
+    });
+    releaseTitle.resolve(undefined);
+    let drained = false;
+    const drain = (async () => {
+      await flushWaitUntilForTest();
+      drained = true;
+    })();
+    await flushEntered.promise;
+    expect(drained).toBeFalsy();
+    releaseFlush.resolve(undefined);
+    await drain;
+    expect(drained).toBeTruthy();
+    expect(auxiliaryResults(context)).toStrictEqual([
+      expect.objectContaining({ feature: "chat_title", outcome: "success" }),
+    ]);
+    const events = await chat.requestThreadEvents(actor, {}, [200]);
+    if (events.status !== 200) {
+      throw new Error("Expected the thread event list");
+    }
+    expect(events.body.events).toContainEqual(
+      expect.objectContaining({
+        chatThreadId: response.body.threadId,
+        kind: "renamed",
+        title: "Late generated title",
+      }),
+    );
+    if (response.status === 201 && response.body.runId) {
+      await runs.requestCancelRun(actor, response.body.runId, [200]);
+    }
+  });
+
+  it("measures interpretation and bounds duration when the clock moves backwards", async () => {
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
+    mockNow(1000);
+    server.use(
+      http.post(endpoint, () => {
+        mockNow(900);
+        return completion();
+      }),
+    );
+    await accept(summaryRequest(), [200]);
+    await flushWaitUntilForTest();
+    expect(auxiliaryResults(context)).toStrictEqual([
+      expect.objectContaining({ outcome: "success", duration_ms: 0 }),
+    ]);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1,4 +1,9 @@
 import { createHash, randomUUID } from "node:crypto";
+import { HttpResponse } from "msw";
+import {
+  auxiliaryResults,
+  auxiliaryWarnings,
+} from "./helpers/auxiliary-generation";
 import { WebPushError } from "web-push";
 import type { Capability } from "@okouai/api-contracts/contracts/capabilities";
 import { CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE } from "@okouai/api-contracts/contracts/errors";
@@ -1732,6 +1737,181 @@ describe("CHAT-02: completed chat callback", () => {
     expect(marker).not.toHaveProperty("recommendedFollowups");
   });
 
+  it("silently degrades all four callback features while delivering the generic notification", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
+    chatCallbacks.mockOpenRouterCompletions((body) => {
+      const system = body.messages[0]?.content ?? "";
+      if (
+        ![
+          "Generate a short, descriptive title",
+          "recommended follow-up messages",
+          "one short notification sentence",
+          "agent run in at most 50 words",
+        ].some((text) => {
+          return system.includes(text);
+        })
+      ) {
+        return "Thinking";
+      }
+      return HttpResponse.json({
+        choices: [
+          {
+            finish_reason: "error",
+            error: { metadata: { error_type: "rate_limit_exceeded" } },
+          },
+        ],
+      });
+    });
+    const run = await startChatRun(actor, {
+      agentId,
+      prompt: "Keep the main answer",
+    });
+    await flushWaitUntilForTest();
+    await chatCallbacks.registerPushSubscription(actor);
+    chatCallbacks.enableVapid();
+    const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
+    // Separate the eager title from the callback's three generations.
+    const beforeComplete = auxiliaryResults(context).length;
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "The main answer survives"),
+    ]);
+    await completeChatRunOk(run.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+    await flushWaitUntilForTest();
+    const events = await chat.listThreadEvents(actor, run.threadId);
+    expect(events.events).toContainEqual(
+      expect.objectContaining({ content: "The main answer survives" }),
+    );
+    expect(
+      events.events.some((event) => {
+        return event.eventType === "output.followups";
+      }),
+    ).toBeFalsy();
+    await expect(
+      readThreadTitleFromEvents(actor, run.threadId),
+    ).resolves.toBeNull();
+    expect(
+      context.mocks.webpush.sendNotification.mock.calls.map(pushPayload),
+    ).toContainEqual(
+      expect.objectContaining({ body: "Your task is complete" }),
+    );
+    const results = auxiliaryResults(context);
+    expect(results.slice(0, beforeComplete)).toStrictEqual([
+      expect.objectContaining({
+        feature: "chat_title",
+        outcome: "degraded",
+        reason: "rate_limited",
+      }),
+    ]);
+    expect(
+      results
+        .slice(beforeComplete)
+        .map(({ feature }) => {
+          return feature;
+        })
+        .sort(),
+    ).toStrictEqual([
+      "notification_summary",
+      "recommended_followups",
+      "run_summary",
+    ]);
+    expect(
+      results.every((event) => {
+        return event.outcome === "degraded" && event.reason === "rate_limited";
+      }),
+    ).toBeTruthy();
+    expect(context.mocks.axiomLogging.warn.mock.calls).toStrictEqual([]);
+    expect(context.mocks.axiomLogging.error.mock.calls).toStrictEqual([]);
+  });
+
+  it("keeps title and summary storage failures observable after successful generation", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
+    // PostgreSQL rejects NUL in text. This induces a real write failure using
+    // a provider response, without DB mocks or changing shared schema/state.
+    chatCallbacks.mockOpenRouterCompletions((body) => {
+      const system = body.messages[0]?.content ?? "";
+      if (
+        system.includes("Generate a short, descriptive title") ||
+        system.includes("agent run in at most 50 words")
+      ) {
+        return "Unstorable\u0000text";
+      }
+      if (system.includes("recommended follow-up messages")) {
+        return JSON.stringify([
+          { prompt: "Continue the analysis", kind: "talk" },
+        ]);
+      }
+      return "Task finished";
+    });
+    const run = await startChatRun(actor, {
+      agentId,
+      prompt: "Keep storage errors visible",
+    });
+    const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "The main answer survives"),
+    ]);
+    await completeChatRunOk(run.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+    await flushWaitUntilForTest();
+    await expect(
+      readThreadTitleFromEvents(actor, run.threadId),
+    ).resolves.toBeNull();
+    const warnings = context.mocks.axiomLogging.warn.mock.calls.map(
+      ([message]) => {
+        return message;
+      },
+    );
+    expect(warnings).toContain("Chat title persistence failed");
+    expect(warnings).toContain("Failed to save run summary");
+    expect(auxiliaryWarnings(context)).toStrictEqual([]);
+    expect(
+      auxiliaryResults(context).every((event) => {
+        return event.outcome === "success";
+      }),
+    ).toBeTruthy();
+  });
+
+  it("keeps push delivery errors observable after summary degradation", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const run = await startChatRun(actor, { agentId, prompt: "Notify me" });
+    await chatCallbacks.registerPushSubscription(actor);
+    chatCallbacks.enableVapid();
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
+    chatCallbacks.mockOpenRouterCompletions(() => {
+      return new HttpResponse(null, { status: 503 });
+    });
+    context.mocks.webpush.sendNotification.mockRejectedValue(
+      new Error("Push delivery failed"),
+    );
+    const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
+    chatCallbacks.mockChatOutputEvents([assistantEvent(0, "Completed answer")]);
+    await completeChatRunOk(run.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+    await flushWaitUntilForTest();
+    expect(
+      context.mocks.webpush.sendNotification.mock.calls.map(pushPayload),
+    ).toContainEqual(
+      expect.objectContaining({ body: "Your task is complete" }),
+    );
+    expect(auxiliaryWarnings(context)).toStrictEqual([]);
+    expect(context.mocks.axiomLogging.warn.mock.calls).toContainEqual([
+      "Failed to send push notification",
+      expect.objectContaining({
+        error: expect.objectContaining({ message: "Push delivery failed" }),
+      }),
+    ]);
+    const events = await chat.listThreadEvents(actor, run.threadId);
+    expect(events.events).toContainEqual(
+      expect.objectContaining({ content: "Completed answer" }),
+    );
+  });
+
   it("pins the model, reasoning effort, and token budget of every fast-path completion", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -1781,6 +1961,21 @@ describe("CHAT-02: completed chat callback", () => {
       lastEventSequence: 0,
     });
     await flushWaitUntilForTest();
+
+    expect(
+      auxiliaryResults(context)
+        .map(({ feature, outcome, reason }) => {
+          return { feature, outcome, reason };
+        })
+        .sort((a, b) => {
+          return a.feature.localeCompare(b.feature);
+        }),
+    ).toStrictEqual([
+      { feature: "chat_title", outcome: "success", reason: "none" },
+      { feature: "notification_summary", outcome: "success", reason: "none" },
+      { feature: "recommended_followups", outcome: "success", reason: "none" },
+      { feature: "run_summary", outcome: "success", reason: "none" },
+    ]);
 
     // Reasoning tokens are drawn from the same budget as the answer, so a
     // budget sized for a non-reasoning model starves the answer entirely.

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1868,6 +1868,12 @@ describe("CHAT-02: completed chat callback", () => {
     );
     expect(warnings).toContain("Chat title persistence failed");
     expect(warnings).toContain("Failed to save run summary");
+    expect(auxiliaryResults(context)).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ feature: "chat_title", outcome: "success" }),
+        expect.objectContaining({ feature: "run_summary", outcome: "success" }),
+      ]),
+    );
     expect(auxiliaryWarnings(context)).toStrictEqual([]);
     expect(
       auxiliaryResults(context).every((event) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-event-archive-consumers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-event-archive-consumers.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { gzipSync } from "node:zlib";
 
 import AdmZip from "adm-zip";
+import { HttpResponse } from "msw";
 import { sharedThreadsContract } from "@okouai/api-contracts/contracts/shared-threads";
 import { testChatEventRetentionContract } from "@okouai/api-contracts/contracts/test-chat-event-retention";
 import { testChatEventSearchProjectionContract } from "@okouai/api-contracts/contracts/test-chat-event-search-projection";
@@ -38,6 +39,7 @@ import {
 } from "./helpers/fake-chat-event-r2";
 import { createOpsLogsApi } from "./helpers/api-bdd-ops-logs";
 import { createRouteMocks } from "./helpers/route-test";
+import { auxiliaryResults } from "./helpers/auxiliary-generation";
 
 const context = testContext();
 const store = createStore();
@@ -248,6 +250,36 @@ describe("archived chat event consumers", () => {
       { role: "assistant", content: tailVisible },
     ]);
   }, 60_000);
+
+  it("preserves user-requested shared-title failures outside auxiliary degradation", async () => {
+    const fixture = await createArchiveFixture("sharing-provider-failure");
+    const eventId = await store.set(
+      seedRetentionOutputEvent$,
+      {
+        chatThreadId: fixture.threadId,
+        content: "A completed answer to share",
+      },
+      context.signal,
+    );
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-sharing-key");
+    chatCallbacks.mockOpenRouterCompletions(() => {
+      return new HttpResponse(null, { status: 503 });
+    });
+    const client = setupApp({
+      context,
+      routes: sharedThreadRoutes,
+      rethrowErrors: true,
+    })(sharedThreadsContract);
+    await expect(
+      client.create({
+        params: { threadId: fixture.threadId },
+        headers: authenticate(fixture.actor),
+        body: { eventIds: [eventId] },
+      }),
+    ).rejects.toMatchObject({ name: "OpenRouterRequestError", status: 503 });
+    await flushWaitUntilForTest();
+    expect(auxiliaryResults(context)).toStrictEqual([]);
+  });
 
   it("shares an archived selection while excluding archived revoked and invisible messages", async () => {
     const fixture = await createArchiveFixture("sharing");

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-event-archive-consumers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-event-archive-consumers.test.ts
@@ -251,16 +251,20 @@ describe("archived chat event consumers", () => {
     ]);
   }, 60_000);
 
-  it("preserves user-requested shared-title failures outside auxiliary degradation", async () => {
+  it("preserves user-requested shared-title failures for archived selections", async () => {
     const fixture = await createArchiveFixture("sharing-provider-failure");
+    // Expired, physically removed events are historical state with no public
+    // write API. Reuse this archive harness, then observe the public share API.
     const eventId = await store.set(
       seedRetentionOutputEvent$,
       {
         chatThreadId: fixture.threadId,
         content: "A completed answer to share",
+        offsetMs: -180_000,
       },
       context.signal,
     );
+    await archiveAndRetain(fixture.threadId, [eventId]);
     mockOptionalEnv("OPENROUTER_API_KEY", "test-sharing-key");
     chatCallbacks.mockOpenRouterCompletions(() => {
       return new HttpResponse(null, { status: 503 });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-translation.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-translation.test.ts
@@ -16,6 +16,8 @@ import { createBddApi } from "./helpers/api-bdd";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { createRouteMocks } from "./helpers/route-test";
 import { chatTranslationRoutes } from "../chat-translation";
+import { auxiliaryResults } from "./helpers/auxiliary-generation";
+import { flushWaitUntilForTest } from "../../context/wait-until";
 
 const context = testContext();
 const mocks = createRouteMocks(context);
@@ -120,6 +122,26 @@ describe("POST /api/chat/translate", () => {
         },
       ],
     });
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        return new HttpResponse(null, { status: 503 });
+      }),
+    );
+    const unavailable = await accept(
+      client(pricing.resolution).translate({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { text: "Hello, world", targetLanguage: "zh-CN" },
+      }),
+      [503],
+    );
+    expect(unavailable.body).toStrictEqual({
+      error: {
+        code: "PROVIDER_UNAVAILABLE",
+        message: "Translation is temporarily unavailable",
+      },
+    });
+    await flushWaitUntilForTest();
+    expect(auxiliaryResults(context)).toStrictEqual([]);
   });
 
   it("requires session auth and the chat translation switch", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/goals.test.ts
@@ -1,4 +1,9 @@
 import { HttpResponse, http } from "msw";
+import { flushWaitUntilForTest } from "../../context/wait-until";
+import {
+  auxiliaryResults,
+  auxiliaryWarnings,
+} from "./helpers/auxiliary-generation";
 import { z } from "zod";
 import type { Capability } from "@okouai/api-contracts/contracts/capabilities";
 import { chatThreadsContract } from "@okouai/api-contracts/contracts/chat-threads";
@@ -695,6 +700,31 @@ describe("agent goals", () => {
     });
   });
 
+  it("keeps the deterministic goal brief when upstream is rate limited", async () => {
+    const fixture = await seedGoalApiFixture();
+    mockOptionalEnv("OPENROUTER_API_KEY", "goal-brief-key");
+    server.use(
+      http.post("https://openrouter.ai/api/v1/chat/completions", () => {
+        return HttpResponse.json({ error: { code: "rate_limit_exceeded" } });
+      }),
+    );
+    const created = await createGoal(fixture, "ship thread goals");
+    await flushWaitUntilForTest();
+    expect(created.body).toStrictEqual({
+      objective: "ship thread goals",
+      objectiveBrief: "ship thread goals",
+      status: "active",
+    });
+    expect(
+      auxiliaryResults(context).filter(({ feature }) => {
+        return feature === "goal_objective_brief";
+      }),
+    ).toStrictEqual([
+      expect.objectContaining({ outcome: "degraded", reason: "rate_limited" }),
+    ]);
+    expect(auxiliaryWarnings(context)).toStrictEqual([]);
+  });
+
   it("pins the model, reasoning effort, and token budget of the objective brief completion", async () => {
     const fixture = await seedGoalApiFixture();
     mockOptionalEnv("OPENROUTER_API_KEY", "goal-brief-key");
@@ -731,6 +761,14 @@ describe("agent goals", () => {
       objectiveBrief: "Ship the token budget repair",
       status: "active",
     });
+    await flushWaitUntilForTest();
+    expect(
+      auxiliaryResults(context).filter(({ feature }) => {
+        return feature === "goal_objective_brief";
+      }),
+    ).toStrictEqual([
+      expect.objectContaining({ outcome: "success", reason: "none" }),
+    ]);
     // Reasoning tokens are drawn from the same budget as the answer, so a
     // budget sized for a non-reasoning model starves the answer entirely.
     expect(briefRequestBody).toMatchObject({

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
@@ -45,7 +45,10 @@ interface TruncatedOpenRouterCompletion {
   readonly finishReason: "length";
 }
 
-type OpenRouterCompletionResult = string | TruncatedOpenRouterCompletion;
+type OpenRouterCompletionResult =
+  | string
+  | TruncatedOpenRouterCompletion
+  | Response;
 
 interface StoredS3Object {
   readonly bucket: string;
@@ -326,6 +329,9 @@ export function createChatCallbacksApi(context: TestContext) {
             return contractError;
           }
           const result = await handler(body);
+          if (result instanceof Response) {
+            return result;
+          }
           return HttpResponse.json({
             choices: [
               typeof result === "string"

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/auxiliary-generation.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/auxiliary-generation.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import type { TestContext } from "../../../../__tests__/test-context";
+
+const resultSchema = z
+  .object({
+    _time: z.iso.datetime(),
+    type: z.literal("auxiliary_generation_result"),
+    source: z.literal("api"),
+    feature: z.enum([
+      "chat_title",
+      "run_summary",
+      "recommended_followups",
+      "notification_summary",
+      "goal_objective_brief",
+    ]),
+    outcome: z.enum(["success", "degraded", "cancelled", "error", "skipped"]),
+    reason: z.enum([
+      "none",
+      "rate_limited",
+      "upstream_timeout",
+      "network",
+      "provider_unavailable",
+      "caller_cancelled",
+      "invalid_request",
+      "auth",
+      "invalid_output",
+      "unknown",
+      "not_applicable",
+    ]),
+    duration_ms: z.number().finite().nonnegative().max(Number.MAX_SAFE_INTEGER),
+  })
+  .strict();
+
+export function auxiliaryResults(context: TestContext) {
+  return [
+    ...context.mocks.axiom.ingest.mock.calls,
+    ...context.mocks.axiom.sdkIngest.mock.calls,
+  ].flatMap((call) => {
+    const events = call[1];
+    if (!Array.isArray(events)) {
+      return [];
+    }
+    return events.flatMap((event: unknown) => {
+      if (
+        typeof event !== "object" ||
+        event === null ||
+        !("type" in event) ||
+        event.type !== "auxiliary_generation_result"
+      ) {
+        return [];
+      }
+      return [resultSchema.parse(event)];
+    });
+  });
+}
+
+export function auxiliaryWarnings(context: TestContext) {
+  return context.mocks.axiomLogging.warn.mock.calls.filter(([message]) => {
+    return message === "Auxiliary generation failed";
+  });
+}

--- a/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
@@ -1,0 +1,197 @@
+import { logger } from "../../lib/log";
+import { now, nowDate } from "../../lib/time";
+import { waitUntil } from "../context/wait-until";
+import { flushAxiom, getDatasetName, ingestToAxiom } from "../external/axiom";
+import {
+  isLlmConfigured,
+  OpenRouterRequestError,
+} from "../external/openrouter";
+import {
+  openRouterFailureReason,
+  type OpenRouterFailureReason,
+} from "../external/openrouter-failure";
+import { onRejection, safeSync, settle } from "../utils";
+
+type AuxiliaryFeature =
+  | "chat_title"
+  | "run_summary"
+  | "recommended_followups"
+  | "notification_summary"
+  | "goal_objective_brief";
+type Outcome = "success" | "degraded" | "cancelled" | "error" | "skipped";
+type Reason =
+  | OpenRouterFailureReason
+  | "none"
+  | "caller_cancelled"
+  | "not_applicable";
+const log = logger("api:auxiliary-generation");
+
+async function deliverResult(
+  feature: AuxiliaryFeature,
+  outcome: Outcome,
+  reason: Reason,
+  startedAt: number,
+): Promise<void> {
+  const elapsed = now() - startedAt;
+  const ingested = safeSync(() => {
+    return ingestToAxiom(getDatasetName("web-logs"), [
+      {
+        _time: nowDate().toISOString(),
+        type: "auxiliary_generation_result",
+        source: "api",
+        feature,
+        outcome,
+        reason,
+        duration_ms: Number.isFinite(elapsed)
+          ? Math.min(Number.MAX_SAFE_INTEGER, Math.max(0, elapsed))
+          : 0,
+      },
+    ]);
+  });
+  if ("ok" in ingested && ingested.ok) {
+    await flushAxiom({ client: "telemetry" });
+  }
+}
+
+function recordResult(
+  feature: AuxiliaryFeature,
+  outcome: Outcome,
+  reason: Reason,
+  startedAt: number,
+): void {
+  // A title/callback may finish after the response's flush. Register its own
+  // flush with the same request lifetime; exporter failure is never business failure.
+  waitUntil(
+    Promise.allSettled([deliverResult(feature, outcome, reason, startedAt)]),
+  );
+}
+
+function diagnosticLocations(error: unknown): readonly string[] {
+  if (!(error instanceof Error)) {
+    return [];
+  }
+  const header = `${error.name}: ${error.message}`;
+  const stack = error.stack;
+  if (!stack?.startsWith(header)) {
+    return [];
+  }
+  // Remove the complete message, including any injected newlines, before
+  // accepting bounded first-party frames from the engine-generated stack.
+  return stack
+    .slice(header.length)
+    .split("\n")
+    .flatMap((frame) => {
+      const location =
+        /^\s+at .+\/src\/((?:signals|lib)\/[a-zA-Z0-9_./-]+\.ts:\d+:\d+)\)?$/u.exec(
+          frame,
+        )?.[1];
+      return location ? [location.slice(0, 240)] : [];
+    })
+    .slice(0, 5);
+}
+
+function diagnose(
+  feature: AuxiliaryFeature,
+  reason: Reason,
+  error: unknown,
+  context: Readonly<{ runId?: string; threadId?: string }> | undefined,
+): void {
+  log.warn("Auxiliary generation failed", {
+    feature,
+    reason,
+    ...context,
+    errorKind:
+      error instanceof OpenRouterRequestError
+        ? "openrouter_request"
+        : error instanceof TypeError
+          ? "type_error"
+          : error instanceof SyntaxError
+            ? "syntax_error"
+            : "unknown",
+    ...(error instanceof OpenRouterRequestError
+      ? {
+          status: error.status,
+          errorCode: error.errorCode,
+          errorParam: error.errorParam,
+          errorType: error.errorType,
+        }
+      : {}),
+    // Keep first-party source locations, without the error message, provider
+    // payload, arbitrary file paths, or a raw stack in the diagnostic.
+    locations: diagnosticLocations(error),
+  });
+}
+
+/** Only generation and feature output interpretation belong inside this boundary. */
+export async function generateAuxiliary<T>(
+  args: {
+    readonly feature: AuxiliaryFeature;
+    readonly generate: () => Promise<T>;
+    readonly usable: (value: T) => boolean;
+    readonly diagnosticContext?: Readonly<{
+      runId?: string;
+      threadId?: string;
+    }>;
+  },
+  signal?: AbortSignal,
+): Promise<T | undefined> {
+  const startedAt = now();
+  const result = await settle(
+    onRejection(
+      (async () => {
+        signal?.throwIfAborted();
+        if (!isLlmConfigured()) {
+          recordResult(args.feature, "skipped", "not_applicable", startedAt);
+          return undefined;
+        }
+        const value = await args.generate();
+        signal?.throwIfAborted();
+        const usable = args.usable(value);
+        if (!usable) {
+          diagnose(
+            args.feature,
+            "invalid_output",
+            undefined,
+            args.diagnosticContext,
+          );
+        }
+        recordResult(
+          args.feature,
+          usable ? "success" : "error",
+          usable ? "none" : "invalid_output",
+          startedAt,
+        );
+        return value;
+      })(),
+      (error) => {
+        // A late, unrelated rejection must not be reclassified just because the
+        // caller has since aborted. Preserve the exact cancellation reason.
+        const cancelled = signal?.aborted === true && error === signal.reason;
+        const reason = cancelled
+          ? "caller_cancelled"
+          : openRouterFailureReason(error);
+        const outcome = cancelled
+          ? "cancelled"
+          : [
+                "rate_limited",
+                "upstream_timeout",
+                "network",
+                "provider_unavailable",
+              ].includes(reason)
+            ? "degraded"
+            : "error";
+        if (outcome === "error") {
+          diagnose(args.feature, reason, error, args.diagnosticContext);
+        }
+        recordResult(args.feature, outcome, reason, startedAt);
+      },
+    ),
+  );
+  if (!result.ok) {
+    if (signal?.aborted && result.error === signal.reason) {
+      throw result.error;
+    }
+    return undefined;
+  }
+  return result.value;
+}

--- a/turbo/apps/api/src/signals/services/chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-title.service.ts
@@ -33,6 +33,7 @@ import { publishThreadListChanged } from "../external/realtime";
 import type { Db } from "../external/db";
 import { nowDate } from "../../lib/time";
 import { safeJsonParse, tapError } from "../utils";
+import { generateAuxiliary } from "./auxiliary-generation.service";
 import { chatEventTextCondition } from "./chat-event-type.service";
 import { visibleChatEventCondition } from "./chat-event-shared.service";
 import {
@@ -189,11 +190,18 @@ async function generateFastPathText(
   options?: {
     readonly stripMarkdown?: boolean;
   },
+  signal?: AbortSignal,
 ): Promise<string | null> {
-  const content = await generateText(FAST_PATH_MODEL, messages, maxTokens, {
-    reasoning: { effort: "low" },
-    temperature: 0.3,
-  });
+  const content = await generateText(
+    FAST_PATH_MODEL,
+    messages,
+    maxTokens,
+    {
+      reasoning: { effort: "low" },
+      temperature: 0.3,
+    },
+    signal,
+  );
   if (content === null) {
     return null;
   }
@@ -363,9 +371,18 @@ async function generateAndPersistChatThreadTitle(args: {
       const priorRounds = args.includePriorRounds
         ? await getLatestTitleContextMessages(args.db, args.threadId)
         : [];
-      const title = await generateChatTitle({
-        currentUserMessage: args.prompt,
-        priorRounds: priorRounds.length > 0 ? priorRounds : undefined,
+      const title = await generateAuxiliary({
+        feature: "chat_title",
+        generate: () => {
+          return generateChatTitle({
+            currentUserMessage: args.prompt,
+            priorRounds: priorRounds.length > 0 ? priorRounds : undefined,
+          });
+        },
+        usable: (value) => {
+          return Boolean(value);
+        },
+        diagnosticContext: { threadId: args.threadId },
       });
       if (title) {
         await updateChatThreadTitle(
@@ -378,7 +395,7 @@ async function generateAndPersistChatThreadTitle(args: {
       }
     })(),
     (err) => {
-      log.warn("Chat title generation failed", {
+      log.warn("Chat title persistence failed", {
         threadId: args.threadId,
         err,
       });
@@ -406,23 +423,43 @@ export function scheduleChatThreadTitleGeneration(args: {
   waitUntil(generateAndPersistChatThreadTitle(args));
 }
 
-export function generateChatNotificationSummary(
-  prompt: string,
-  resultText: string,
+export async function generateChatNotificationSummary(
+  args: {
+    readonly prompt: string;
+    readonly resultText: string;
+    readonly runId: string;
+  },
+  signal?: AbortSignal,
 ): Promise<string | null> {
-  return generateFastPathText(
-    [
+  return (
+    (await generateAuxiliary(
       {
-        role: "system",
-        content:
-          "Summarize this completed task in one short notification sentence, max 90 chars. Plain text only.",
+        feature: "notification_summary",
+        diagnosticContext: { runId: args.runId },
+        usable: (value) => {
+          return Boolean(value);
+        },
+        generate: () => {
+          return generateFastPathText(
+            [
+              {
+                role: "system",
+                content:
+                  "Summarize this completed task in one short notification sentence, max 90 chars. Plain text only.",
+              },
+              {
+                role: "user",
+                content: `User request:\n${args.prompt.slice(0, TITLE_CONTEXT_CHAR_CAP)}\n\nAssistant reply:\n${args.resultText.slice(0, TITLE_CONTEXT_CHAR_CAP)}`,
+              },
+            ],
+            512,
+            undefined,
+            signal,
+          );
+        },
       },
-      {
-        role: "user",
-        content: `User request:\n${prompt.slice(0, TITLE_CONTEXT_CHAR_CAP)}\n\nAssistant reply:\n${resultText.slice(0, TITLE_CONTEXT_CHAR_CAP)}`,
-      },
-    ],
-    512,
+      signal,
+    )) ?? null
   );
 }
 
@@ -467,12 +504,8 @@ async function getLatestFollowupContextMessages(
 
 async function generateRecommendedFollowups(
   messages: readonly ChatCompletionContextMessage[],
+  signal?: AbortSignal,
 ): Promise<ChatRecommendedFollowup[]> {
-  const last = messages[messages.length - 1];
-  if (last?.role !== "assistant" || last.content.trim().length === 0) {
-    return [];
-  }
-
   const context = messages
     .map((message) => {
       return `${message.role}: ${message.content.slice(0, FOLLOWUP_CONTEXT_CHAR_CAP)}`;
@@ -492,6 +525,7 @@ async function generateRecommendedFollowups(
     ],
     1024,
     { stripMarkdown: false },
+    signal,
   );
 
   return text === null ? [] : parseRecommendedFollowups(text);
@@ -504,16 +538,32 @@ export async function loadChatThreadRecommendedFollowupContext(args: {
   return await getLatestFollowupContextMessages(args.db, args.threadId);
 }
 
-export async function generateChatThreadRecommendedFollowupsFromContext(args: {
-  readonly messages: readonly ChatCompletionContextMessage[];
-  readonly threadId?: string;
-}): Promise<ChatRecommendedFollowup[]> {
+export async function generateChatThreadRecommendedFollowupsFromContext(
+  args: {
+    readonly messages: readonly ChatCompletionContextMessage[];
+    readonly threadId?: string;
+  },
+  signal?: AbortSignal,
+): Promise<ChatRecommendedFollowup[]> {
+  const last = args.messages[args.messages.length - 1];
+  if (last?.role !== "assistant" || last.content.trim().length === 0) {
+    return [];
+  }
   return (
-    (await tapError(generateRecommendedFollowups(args.messages), (err) => {
-      log.warn("Recommended follow-up generation failed", {
-        ...(args.threadId ? { threadId: args.threadId } : {}),
-        err,
-      });
-    })) ?? []
+    (await generateAuxiliary(
+      {
+        feature: "recommended_followups",
+        generate: () => {
+          return generateRecommendedFollowups(args.messages, signal);
+        },
+        usable: (value) => {
+          return value.length > 0;
+        },
+        diagnosticContext: args.threadId
+          ? { threadId: args.threadId }
+          : undefined,
+      },
+      signal,
+    )) ?? []
   );
 }

--- a/turbo/apps/api/src/signals/services/goal-objective-brief.service.ts
+++ b/turbo/apps/api/src/signals/services/goal-objective-brief.service.ts
@@ -1,51 +1,42 @@
-import { logger } from "../../lib/log";
 import { FAST_PATH_MODEL, generateText } from "../external/openrouter";
-import { tapError } from "../utils";
+import { generateAuxiliary } from "./auxiliary-generation.service";
 import {
   capGoalObjectiveBriefText,
   compactGoalObjectiveBriefText,
   fallbackGoalObjectiveBrief,
 } from "./goal-objective-brief-normalization.service";
 
-const log = logger("api:goal-objective-brief");
 const OBJECTIVE_CONTEXT_CHAR_CAP = 4000;
 export async function generateGoalObjectiveBrief(
   objective: string,
 ): Promise<string> {
   const fallback = fallbackGoalObjectiveBrief(objective);
-  const generated = await tapError(
-    generateText(
-      FAST_PATH_MODEL,
-      [
-        {
-          role: "system",
-          content:
-            "Rewrite the goal objective into a short objective brief. Focus only on what outcome the goal is trying to achieve, not how to execute it. Keep the original language. Return one short sentence or phrase, max 140 characters, as plain text only. No markdown, no quotes.",
-        },
-        {
-          role: "user",
-          content: `Objective:\n${objective.slice(0, OBJECTIVE_CONTEXT_CHAR_CAP)}`,
-        },
-      ],
-      768,
-      { reasoning: { effort: "low" } },
-    ),
-    (error) => {
-      log.warn("Failed to generate goal objective brief", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+  const brief = await generateAuxiliary({
+    feature: "goal_objective_brief",
+    usable: (value) => {
+      return value !== null && value.length > 0;
     },
-  );
-
-  if (generated === undefined) {
-    return fallback;
-  }
-  if (generated === null) {
-    return fallback;
-  }
-
-  const brief = capGoalObjectiveBriefText(
-    compactGoalObjectiveBriefText(generated),
-  );
-  return brief.length > 0 ? brief : fallback;
+    generate: async () => {
+      const generated = await generateText(
+        FAST_PATH_MODEL,
+        [
+          {
+            role: "system",
+            content:
+              "Rewrite the goal objective into a short objective brief. Focus only on what outcome the goal is trying to achieve, not how to execute it. Keep the original language. Return one short sentence or phrase, max 140 characters, as plain text only. No markdown, no quotes.",
+          },
+          {
+            role: "user",
+            content: `Objective:\n${objective.slice(0, OBJECTIVE_CONTEXT_CHAR_CAP)}`,
+          },
+        ],
+        768,
+        { reasoning: { effort: "low" } },
+      );
+      return generated === null
+        ? null
+        : capGoalObjectiveBriefText(compactGoalObjectiveBriefText(generated));
+    },
+  });
+  return brief || fallback;
 }

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -1915,10 +1915,13 @@ async function generateRecommendedFollowupsForCompletedRun(
   signal: AbortSignal,
 ): Promise<readonly ChatRecommendedFollowup[] | undefined> {
   signal.throwIfAborted();
-  const suggestions = await generateChatThreadRecommendedFollowupsFromContext({
-    messages: args.followupContext,
-    threadId: args.threadId,
-  });
+  const suggestions = await generateChatThreadRecommendedFollowupsFromContext(
+    {
+      messages: args.followupContext,
+      threadId: args.threadId,
+    },
+    signal,
+  );
   signal.throwIfAborted();
   return suggestions.length > 0 ? suggestions : undefined;
 }
@@ -2164,18 +2167,17 @@ async function runCompletedChatCallbackSideEffects(
 
     let summary: string | null = null;
     if (args.lastResultText) {
-      summary =
-        (await tapError(
-          generateChatNotificationSummary(args.run.prompt, args.lastResultText),
-          (error) => {
-            log.warn("Failed to generate notification summary", {
-              runId: args.runId,
-              error,
-            });
-          },
-        )) ?? null;
+      summary = await generateChatNotificationSummary(
+        {
+          prompt: args.run.prompt,
+          resultText: args.lastResultText,
+          runId: args.runId,
+        },
+        signal,
+      );
     }
 
+    signal.throwIfAborted();
     await sendUserPushNotifications({
       db: args.db,
       userId: args.chatThread.userId,

--- a/turbo/apps/api/src/signals/services/run-summary.service.ts
+++ b/turbo/apps/api/src/signals/services/run-summary.service.ts
@@ -5,12 +5,9 @@ import { agentRuns } from "@okouai/db/schema/agent-run";
 import { logger } from "../../lib/log";
 import { stripMarkdown } from "../../lib/strip-markdown";
 import { writeDb$, type Db } from "../external/db";
-import {
-  FAST_PATH_MODEL,
-  generateText,
-  isLlmConfigured,
-} from "../external/openrouter";
+import { FAST_PATH_MODEL, generateText } from "../external/openrouter";
 import { tapError } from "../utils";
+import { generateAuxiliary } from "./auxiliary-generation.service";
 import { writeRunMetadata } from "./agent-run-metadata-write.service";
 
 const log = logger("run-summary");
@@ -35,12 +32,8 @@ async function generateRunSummary(
   triggerSource: string,
   prompt: string,
   resultText: string,
+  signal?: AbortSignal,
 ): Promise<string | null> {
-  if (!isLlmConfigured()) {
-    log.warn("OPENROUTER_API_KEY not configured, skipping text generation");
-    return null;
-  }
-
   const promptSnippet = truncateSnippet(prompt);
   const resultSnippet = truncateSnippet(resultText);
 
@@ -58,6 +51,7 @@ async function generateRunSummary(
     ],
     768,
     { reasoning: { effort: "low" }, temperature: 0.3 },
+    signal,
   );
   return content === null ? null : stripMarkdown(content);
 }
@@ -72,23 +66,31 @@ export async function saveRunSummary(
   },
   signal?: AbortSignal,
 ): Promise<void> {
+  const summary = await generateAuxiliary(
+    {
+      feature: "run_summary",
+      generate: () => {
+        return generateRunSummary(
+          args.triggerSource,
+          args.prompt,
+          args.resultText,
+          signal,
+        );
+      },
+      usable: (value) => {
+        return Boolean(value);
+      },
+      diagnosticContext: { runId: args.runId },
+    },
+    signal,
+  );
+  signal?.throwIfAborted();
+  if (!summary) {
+    return;
+  }
+
   await tapError(
     (async () => {
-      const summary = await generateRunSummary(
-        args.triggerSource,
-        args.prompt,
-        args.resultText,
-      );
-      signal?.throwIfAborted();
-
-      if (!summary) {
-        log.warn("Run summary generation returned null (API key missing?)", {
-          runId: args.runId,
-          triggerSource: args.triggerSource,
-        });
-        return;
-      }
-
       await writeRunMetadata(db, {
         patch: { summary },
         where: eq(agentRuns.id, args.runId),
@@ -96,7 +98,7 @@ export async function saveRunSummary(
       signal?.throwIfAborted();
     })(),
     (error) => {
-      log.warn("Failed to generate run summary", {
+      log.warn("Failed to save run summary", {
         runId: args.runId,
         error,
       });


### PR DESCRIPTION
## Summary

Expected failures of five best-effort generations now preserve their existing fallback without per-invocation inner, outer, or null-result warnings. Genuine generation/output faults emit a bounded diagnostic; title/summary persistence and push-delivery failures retain their separate diagnostics. This implements the complete approved Design, non-goals, and acceptance contract at #32116, not its superseded historical retry suggestion.

Each finished logical generation makes one recording decision for a structured `auxiliary_generation_result` event in the existing Axiom `web-logs` telemetry dataset, including successful, cancelled, and intentionally skipped invocations. This provides event-derived counts/rates and generation-plus-interpretation duration; it does not introduce an OpenTelemetry counter or another metrics backend.

Closes #32116.

## Classification and ownership

- Quiet degradation requires transport-origin evidence: actual HTTP 429/408/502/503/504, the typed `rate_limit_exceeded`/429 response code (including synthetic 502 wrappers), or a bounded network/timeout cause at fetch/body I/O. Explicit authentication/invalid-request evidence takes precedence over a transient wrapper status. Unknown synthetic 502, arbitrary TypeError/TimeoutError, TLS configuration faults, malformed output, length/tool-call outcomes, and programming errors remain diagnostic.
- OpenRouter annotations retain only a finite reason in a weak map keyed by the original error. Shared helpers still throw the same error or return their existing result/null, with unchanged usage data. The safe diagnostic fields and reasoning compatibility fix already merged in #32612 are preserved.
- Only an identical caller abort reason is classified as cancellation. Existing signals are passed narrowly through summary/follow-up/notification generation; no new signal owner, deadline, wait budget, or retry is introduced. Late unrelated failures are still diagnosed.
- The generation boundary ends before DB writes or push delivery. Existing fallback values/text remain unchanged: absent background title/summary, empty follow-ups, generic push text, and the deterministic objective brief.
- Each result schedules ingest/flush through existing request-owned `waitUntil`. Completion after the response's ordinary flush is covered by a deferred SDK-flush test. Missing telemetry configuration and synchronous/asynchronous exporter errors cannot change the business result or cancellation. One recording decision does not promise exactly-once delivery across exporter/network failures.

## Caller and overlap inventory

Full symbol/call-site searches cover `generateText`, `generateTextWithUsage`, the title fast-path helper, and all five feature entry points, including ccstate command and callback dependency wiring.

| Surface | Callers and retained boundary |
| --- | --- |
| Background chat title | `chat-events.command.ts` and `internal-chat-run-callback.service.ts` schedule the existing request-owned task; context reads and title persistence remain outside the quiet generation boundary. |
| Run summary | Web chat callbacks, Feishu organization callbacks, `saveRunSummary$`, and the existing test-runtime entry point use the same generation policy; metadata writes retain their error handler. |
| Recommended follow-ups | Completed-chat callback generates and interprets suggestions before persistence; the pre-existing non-assistant/empty-context no-op stays a no-op. |
| Notification summary | Completed-chat callback uses the existing generic notification fallback; actual push delivery remains separately observable. |
| Goal objective brief | Goal create/edit retain the same normalization, cap, and deterministic fallback. |
| User-requested shared title | `shared-thread.service.ts` still receives failures from `generateSharedThreadTitle`; a route regression proves HTTP 503 throws instead of silently creating a snapshot. |
| Other direct OpenRouter callers | Initial thinking, voice polish, paid translation, and image recognition retain policy, request parameters, public behavior, usage, and billing. Their existing route suites plus translation success/provider-failure coverage are included in verification. |

The open-PR file inventory used `gh pr list --limit 100` (47 open PRs at the implementation checkpoint). Remaining file overlap was test-only with #32614 and #32622. #32612 had already merged and was incorporated from current main. Overlap did not impose merge ordering.

## Event contract and queries

The result event has exactly these root fields: `_time` (timestamp), `type` (`auxiliary_generation_result`), `source` (`api`), `feature` (`chat_title`, `run_summary`, `recommended_followups`, `notification_summary`, `goal_objective_brief`), `outcome` (`success`, `degraded`, `cancelled`, `error`, `skipped`), `reason` (finite enum), and `duration_ms` (finite, nonnegative, capped at `Number.MAX_SAFE_INTEGER`).

Reasons are `none`, `rate_limited`, `upstream_timeout`, `network`, `provider_unavailable`, `caller_cancelled`, `invalid_request`, `auth`, `invalid_output`, `unknown`, and `not_applicable`. Events contain no prompt, output, token usage, user/org/thread/run ID, arbitrary error message, or raw stack. True-error diagnostics separately retain existing run/thread correlation where available, enumerated provider diagnostic fields, and bounded first-party source locations.

Completed invocation counts, including separate cancellation/skips:

```apl
['vm0-web-logs-prod']
| where _time >= ago(24h)
| where type == "auxiliary_generation_result"
| summarize completed = count() by feature, outcome, reason
| order by feature asc, outcome asc, reason asc
```

Rates use only `success + degraded + error`. A feature with no denominator observations produces no rate row; missing telemetry or traffic does not mean zero failures:

```apl
['vm0-web-logs-prod']
| where _time >= ago(24h)
| where type == "auxiliary_generation_result"
| where outcome in ("success", "degraded", "error")
| summarize observed = count(), succeeded = countif(outcome == "success"), degraded = countif(outcome == "degraded"), errors = countif(outcome == "error") by feature
| where observed > 0
| extend success_pct = 100.0 * succeeded / observed, degradation_pct = 100.0 * degraded / observed, error_pct = 100.0 * errors / observed
```

Duration distributions exclude persistence, push delivery, and exporter flush:

```apl
['vm0-web-logs-prod']
| where _time >= ago(24h)
| where type == "auxiliary_generation_result"
| summarize completed = count(), p50_ms = percentile(duration_ms, 50), p95_ms = percentile(duration_ms, 95) by feature, outcome
| order by feature asc, outcome asc
```

## Evidence and scale limits

The approved issue records 78 warning/error events for Beijing September 4–6, 2026, plus two September 7 samples (recommended follow-up and run summary) explicitly carrying `rate_limit_exceeded` inside a synthetic 502 wrapper. These are dated diagnostic samples, not an invocation failure rate or proof of one underlying provider incident.

The controller's MaskDB reconciliation found **12,843 unique `agent_runs` on Beijing September 7, 2026**, verified over **13 pages** (12 × 1,000 + 843). This is overall run scale including internal traffic, not auxiliary invocation count, affected-user count, or the failure-rate denominator. This PR has **no DB migration or backfill**.

## Fallbacks

- `services/auxiliary-generation.service.ts:recordResult` / `deliverResult`: missing telemetry credentials or exporter failure drops the optional result event without changing generation, cancellation, persistence, or delivery. Surface: optional observability, with no old/new protocol interaction or rollout window. This enduring boundary is expressly required by #32116; removal would require a separately approved change making telemetry mandatory, so there is no compatibility-removal follow-up.
- `services/auxiliary-generation.service.ts:deliverResult`: elapsed time is normalized to a finite number in `[0, Number.MAX_SAFE_INTEGER]`, including a backward clock. Surface: the result event's numeric contract; no rollout window. This is the approved duration-validity requirement and remains for the lifetime of this event contract.
- `services/chat-title.service.ts`, `run-summary.service.ts`, and `goal-objective-brief.service.ts`: existing title/summary omission, empty follow-ups, generic push text, and deterministic goal brief remain the approved best-effort behavior, including feature-level output interpretation. Genuine faults still produce a diagnostic and an error outcome. No business fallback value, retry, or alternate-provider path is added.
- `external/openrouter-failure.ts:openRouterFailureReason`: absent or unrecognized external evidence stays `unknown` and therefore diagnostic; this is a fail-closed classifier, not an inferred transient success.

## Verification and deviations

- **577 tests passed across 8 scoped route files**: auxiliary-generation, chat-callbacks, goals, chat-event-archive-consumers, chat-translation, image-recognition, voice-io-polish, and chat-events (448 seconds, one Vitest worker).
- Review repairs reran all **101 tests in the three modified test files** successfully (97 seconds), plus changed-test lint/format and API test type checking. After resolving the import-only conflict with main `3f8af4be1066b033675e828178be6db4cfbad3a3`, all **101 tests passed again** (102 seconds), preserving both the incoming citation-literal coverage and this PR's requested-title regression. Production implementation files did not change during either repair.
- `pnpm -F api lint`: passed, including production/test type-aware Oxlint and ESLint.
- All API typecheck phases passed sequentially with `TSC_CHECKERS=1`: dependencies, boundaries, gateways, core, bootstrap, tests, and bootstrap wiring. The initial local run exhausted memory while checks overlapped; the sequential run completed, with two test-only union narrowings corrected.
- `pnpm exec knip --workspace apps/api`, changed-file Prettier, and `git diff --check`: passed.
- Tests cover the outcome matrix, all five successful/degraded features, absent configuration, no inner/outer/null warnings, real PostgreSQL write rejection, actual push rejection, shared requested-title failure, translation success/usage/provider failure, standard/custom cancellation reasons, a deterministic late unrelated rejection, strict event fields/duration, and synchronous/asynchronous exporter failures. A deferred background-title/SDK-flush test proves request-lifetime draining after the response flush.
- A local native Node fetch probe additionally confirmed original abort-reason identity both before and during response-body consumption. No production fault was injected.
- Local PostgreSQL was configured to UTC so test queue expiry comparisons match production timestamp conventions. No repository DB configuration or schema changed.

No implementation deviations from the approved contract. Normal outcome/exporter cases use the production Goal API with persisted readback. Narrow test exceptions are documented for injecting an independently owned background-task AbortSignal through the existing runtime harness, and for historical physically removed events in the existing archive harness; neither adds a production endpoint or changes a contract. No full local Vitest suite or local dev server is used. No retry/backoff, model/provider, prompt, token/deadline budget, API schema, billing, migration, dataset, dashboard, scheduler, alert, or production behavior is added outside the approved observability policy. #32117 and #32118 remain separate.

Production release is not part of this PR's execution. Traffic-bearing production telemetry, rate queries, and true-error observability must be checked by the controller only after a separately authorized release is verified; warning disappearance alone is insufficient evidence.
