### PR TITLE
fix: reject implausible voice input output

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
@@ -746,6 +746,131 @@ describe("POST /api/voice-io/transcribe/segment", () => {
     },
   );
 
+  it.each([
+    {
+      label: "keeps output below the conservative evidence floor",
+      transcript: "x".repeat(199),
+      polishedText: "x".repeat(199),
+      durationSeconds: 1,
+      status: 200,
+    },
+    {
+      label: "keeps output at the maximum plausible speech rate",
+      transcript: "x".repeat(200),
+      polishedText: "x".repeat(200),
+      durationSeconds: 8,
+      status: 200,
+    },
+    {
+      label: "drops an implausibly long segment transcript",
+      transcript: "x".repeat(200),
+      polishedText: "x".repeat(200),
+      durationSeconds: 1,
+      status: 204,
+    },
+    {
+      label: "rejects implausible polish while preserving a short transcript",
+      transcript: "Recorded speech.",
+      polishedText: "x".repeat(200),
+      durationSeconds: 1,
+      status: 502,
+    },
+  ])(
+    "$label",
+    async ({ transcript, polishedText, durationSeconds, status }) => {
+      mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+      await enabledActor();
+      server.use(
+        http.post(OPENROUTER_URL, () => {
+          return HttpResponse.json({
+            choices: [
+              {
+                finish_reason: "stop",
+                message: {
+                  content: JSON.stringify({
+                    transcript,
+                    polishedText,
+                    language: "en",
+                  }),
+                },
+              },
+            ],
+          });
+        }),
+      );
+      const response = await client().segment({
+        headers: { authorization: "Bearer clerk-session" },
+        body: segmentForm(
+          [audioFile(1, durationSeconds)],
+          "",
+          true,
+          durationSeconds,
+        ),
+      });
+      expect(response.status).toBe(status);
+    },
+  );
+
+  it("does not return context-derived polish without transcribed speech", async () => {
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    await enabledActor();
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: {
+                content: JSON.stringify({
+                  transcript: "[NO_SPEECH]",
+                  polishedText: "Use LaunchPad for this release.",
+                  language: "und",
+                }),
+              },
+            },
+          ],
+        });
+      }),
+    );
+    const response = await client().segment({
+      headers: { authorization: "Bearer clerk-session" },
+      body: segmentForm([audioFile(1)], "", true, 1),
+    });
+    expect(response.status).toBe(204);
+  });
+
+  it("rejects implausible final output without discarding saved speech", async () => {
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    await enabledActor();
+    const invented = "x".repeat(200);
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: {
+                content: JSON.stringify({
+                  transcript: invented,
+                  polishedText: `Earlier speech. ${invented}`,
+                  language: "en",
+                }),
+              },
+            },
+          ],
+        });
+      }),
+    );
+    const response = await accept(
+      client().segment({
+        headers: { authorization: "Bearer clerk-session" },
+        body: segmentForm([audioFile(1)], "Earlier speech.", true, 61),
+      }),
+      [502],
+    );
+    expect(response.body.error.code).toBe("VOICE_TRANSCRIPTION_FAILED");
+  });
+
   it("counts one free-tier recording only after finalization, including a failed final attempt", async () => {
     mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
     const actor = await enabledActor();

--- a/turbo/apps/api/src/signals/routes/voice-io-transcribe.ts
+++ b/turbo/apps/api/src/signals/routes/voice-io-transcribe.ts
@@ -183,9 +183,11 @@ async function validateVoiceDraftDuration(
       "Voice segment must contain new audio beyond its overlap",
     );
   }
-  // Validate precise WAV duration above; only usage counters use whole seconds.
+  // Preserve the precise uploaded duration for response grounding checks; only
+  // usage counters round the unique, non-overlapping recording time.
   return {
-    durationSeconds: Math.ceil(
+    audioDurationSeconds: durationSeconds,
+    usageDurationSeconds: Math.ceil(
       durationSeconds - segment.overlapDurationSeconds,
     ),
   };
@@ -244,13 +246,13 @@ const voiceIoTranscribeHandler$ = command(
     if ("status" in duration) {
       return duration;
     }
-    const { durationSeconds } = duration;
+    const { audioDurationSeconds, usageDurationSeconds } = duration;
 
     const policy = await set(
       sttDailyPolicy$,
       auth.orgId,
       auth.userId,
-      durationSeconds,
+      usageDurationSeconds,
       signal,
     );
     if ("status" in policy) {
@@ -260,6 +262,7 @@ const voiceIoTranscribeHandler$ = command(
     const input = {
       files,
       model,
+      audioDurationSeconds,
       debug: isFeatureEnabled(FeatureSwitchKey.OkouDebug, featureContext),
       ...(reference === undefined ? {} : { lastAssistantMessage: reference }),
       ...(editorContext === undefined ? {} : { editorContext }),

--- a/turbo/apps/api/src/signals/services/voice-io-transcribe.service.ts
+++ b/turbo/apps/api/src/signals/services/voice-io-transcribe.service.ts
@@ -32,11 +32,17 @@ import {
 } from "../external/voice-input-transcription";
 import { settle } from "../utils";
 
+// Character rate is noisy for short clips, so only context-sized output can
+// trigger the conservative upper bound for human speech.
+const VOICE_TRANSCRIPT_MAX_CHARACTERS_PER_SECOND = 25;
+const VOICE_TRANSCRIPT_MINIMUM_SUSPICIOUS_CHARACTERS = 200;
+
 type VoiceDraftTranscriptionInput = VoiceIoTranscribeContext &
   VoiceIoTranscribeSegmentOptions & {
     readonly files: readonly File[];
     readonly model: VoiceInputModel;
     readonly debug: boolean;
+    readonly audioDurationSeconds: number;
   };
 
 function voicePolishModel(
@@ -121,6 +127,54 @@ function normalizeVoiceTranscript(
       ? { polishedText: "" }
       : {}),
   };
+}
+
+function exceedsPlausibleSpeechRate(
+  text: string,
+  durationSeconds: number,
+): boolean {
+  const characters = text.trim().length;
+  return (
+    durationSeconds > 0 &&
+    characters >= VOICE_TRANSCRIPT_MINIMUM_SUSPICIOUS_CHARACTERS &&
+    characters / durationSeconds > VOICE_TRANSCRIPT_MAX_CHARACTERS_PER_SECOND
+  );
+}
+
+function rejectUnusableVoiceOutput(
+  input: VoiceDraftTranscriptionInput,
+  result: VoiceIoTranscribeSegmentResponse,
+) {
+  const hasSavedSpeech = Boolean(input.previousTranscript.trim());
+  const hasTranscribedSpeech = Boolean(result.transcript.trim());
+  if (input.final && !hasSavedSpeech && !hasTranscribedSpeech) {
+    return { status: 204 as const, body: undefined };
+  }
+  if (
+    exceedsPlausibleSpeechRate(result.transcript, input.audioDurationSeconds)
+  ) {
+    return input.final && !hasSavedSpeech
+      ? { status: 204 as const, body: undefined }
+      : providerError(
+          new Error("Voice transcription exceeded a plausible speech rate"),
+        );
+  }
+  if (
+    input.final &&
+    result.polishedText !== undefined &&
+    exceedsPlausibleSpeechRate(result.polishedText, input.totalDurationSeconds)
+  ) {
+    return providerError(
+      new Error("Voice polish exceeded a plausible speech rate"),
+    );
+  }
+  if (
+    input.final &&
+    (hasSavedSpeech || hasTranscribedSpeech) &&
+    !result.polishedText?.trim()
+  ) {
+    return providerError(new Error("Voice polish discarded recorded speech"));
+  }
 }
 
 async function transcribeIncrementalVoice(
@@ -239,12 +293,9 @@ export const transcribeVoiceSegment$ = command(
     if (!generated.ok) {
       return providerError(generated.error);
     }
-    if (
-      input.final &&
-      (input.previousTranscript.trim() || generated.value.transcript.trim()) &&
-      !generated.value.polishedText?.trim()
-    ) {
-      return providerError(new Error("Voice polish discarded recorded speech"));
+    const rejected = rejectUnusableVoiceOutput(input, generated.value);
+    if (rejected) {
+      return rejected;
     }
     if (input.debug) {
       set(


### PR DESCRIPTION
## Summary

- reject model-generated segment transcripts that are at least 200 characters and exceed 25 characters per uploaded audio second
- apply the same conservative bound to final polished text using the complete recording duration, without comparing accumulated text to only the final segment
- return an empty completion only when a final recording has no saved or transcribed speech source; keep suspicious in-progress or previously transcribed recordings retryable
- add no client dependency or bundle payload

## Context

A silent or non-speech recording can be sent alongside editor and assistant reference context. If a multimodal model invents context-derived text instead of returning `[NO_SPEECH]`, that text can otherwise be delivered as user input. The minimum-length floor avoids classifying ordinary short responses by their burst character rate, while the duration bound rejects context-sized output that the audio cannot physically contain.

The guard follows the layered approach documented by DoNotType, where prompt-only no-speech handling did not reliably stop context-grounded hallucinations: https://github.com/bojieli/DoNotType/blob/67fb439bed421c112d7172f514c2f12f1cb4d0f4/Sources/DoNotTypeCore/HallucinationGuard.swift

## Compatibility

- the request and response schemas are unchanged
- existing clients continue to receive the endpoint's established `204` no-content and `502` retryable failure outcomes

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/voice-io-transcribe.test.ts --maxWorkers=1 --silent=passed-only` — 44 passed
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm exec prettier --check apps/api/src/signals/services/voice-io-transcribe.service.ts apps/api/src/signals/routes/voice-io-transcribe.ts apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts`
- `pnpm exec commitlint --from HEAD~1 --to HEAD`
