### PR TITLE
fix(api): prevent duplicate pi phase two charges

### DIFF
--- a/crates/guest-agent/src/maintenance_usage.rs
+++ b/crates/guest-agent/src/maintenance_usage.rs
@@ -1,4 +1,4 @@
-//! Content-free accounting from the private maintenance child, including failure.
+//! Content-free compatibility journal from the private maintenance child.
 
 use crate::{constants, error::AgentError, run_context::GuestRuntime};
 use api_contracts::generated::types::webhooks::agent::pi_memory_phase2::usage::Request;
@@ -11,7 +11,8 @@ fn invalid_usage() -> AgentError {
 }
 
 /// Forward the child's bounded private usage journal before terminal reporting.
-/// The API binds it to the immutable callback and deduplicates each attempt.
+/// The API validates its immutable private binding and acknowledges it; the
+/// runner proxy is the sole model-usage ledger writer, including on failure.
 pub async fn report_for_runtime(runtime: &GuestRuntime) -> Result<(), AgentError> {
     if !matches!(runtime.config.framework, crate::env::Framework::Pi)
         || runtime.config.pi_launch_config.is_empty()

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -11,7 +11,6 @@ import {
   type SandboxReuseResult,
 } from "@okouai/api-contracts/contracts/webhooks";
 import { agentRuns } from "@okouai/db/schema/agent-run";
-import { agentRunCallbacks } from "@okouai/db/schema/agent-run-callback";
 import { usageEvent } from "@okouai/db/schema/usage-event";
 import { and, eq, inArray, isNotNull } from "drizzle-orm";
 import { isBuiltInModelProviderType } from "@okouai/api-contracts/contracts/model-providers";
@@ -36,8 +35,7 @@ import {
   unauthorizedRunMismatch,
 } from "./agent-webhook-auth";
 import { usageUnderbillingFields } from "../usage-underbilling";
-import { piMemoryPhase2MaintenanceCallbackPayloadSchema } from "../services/pi-memory-phase2-maintenance.service";
-import { recordPiMemoryPhase2Usage } from "../services/pi-memory-phase2-usage.service";
+import { loadPiMemoryPhase2UsageBinding } from "../services/pi-memory-phase2-usage.service";
 
 const SANDBOX_TELEMETRY_SYSTEM_DATASET = "sandbox-telemetry-system";
 const SANDBOX_TELEMETRY_METRICS_DATASET = "sandbox-telemetry-metrics";
@@ -235,36 +233,24 @@ const maintenanceUsage$ = command(async ({ get, set }, signal: AbortSignal) => {
     return unauthorizedRunMismatch;
   }
   const db = set(writeDb$);
-  const [callback] = await db
-    .select({ payload: agentRunCallbacks.payload })
-    .from(agentRunCallbacks)
-    .where(
-      and(
-        eq(agentRunCallbacks.runId, auth.runId),
-        eq(agentRunCallbacks.internalKind, "pi-memory:phase2"),
-      ),
-    )
-    .limit(1);
+  const binding = await loadPiMemoryPhase2UsageBinding(db, auth);
   signal.throwIfAborted();
-  const binding = piMemoryPhase2MaintenanceCallbackPayloadSchema.safeParse(
-    callback?.payload,
-  );
   if (
-    !binding.success ||
-    binding.data.orgId !== auth.orgId ||
-    binding.data.userId !== auth.userId ||
-    binding.data.memoryStorageId !== body.memoryStorageId ||
-    binding.data.leaseToken !== body.leaseToken ||
-    binding.data.claimedRevision !== body.claimedRevision ||
-    binding.data.claimedBaseVersionId !== body.claimedBaseVersionId ||
-    binding.data.selectionDigest !== body.selectionDigest
+    !binding ||
+    binding.memoryStorageId !== body.memoryStorageId ||
+    binding.leaseToken !== body.leaseToken ||
+    binding.claimedRevision !== body.claimedRevision ||
+    binding.claimedBaseVersionId !== body.claimedBaseVersionId ||
+    binding.selectionDigest !== body.selectionDigest
   ) {
     return notFound("Pi memory maintenance usage binding not found");
   }
-  for (const attempt of body.attempts) {
-    await recordPiMemoryPhase2Usage(db, { ...binding.data, ...attempt });
-    signal.throwIfAborted();
-  }
+  // Existing Guest/commit-pinned CLI contexts still submit this journal. ACK
+  // their validated private binding, but only usageEvent$ charges the provider
+  // work. The proxy survives a killed child and also covers missing journals.
+  // Retire the journal reporters/endpoint under #32168 only after the last old
+  // producer's contexts drain: up to two hours queued, two hours executing,
+  // and bounded finalization. New API + old Guest/CLI keeps the same response.
   return { status: 200 as const, body: { success: true } };
 });
 const usageEvent$ = command(async ({ get, set }, signal: AbortSignal) => {

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-maintenance.boundary.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-maintenance.boundary.test.ts
@@ -13,10 +13,7 @@ import { promisify } from "node:util";
 import { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 
-import {
-  CANCELLATION_RECOVERY_STALE_AFTER_MS,
-  executionContextSchema,
-} from "@okouai/api-contracts/contracts/runners";
+import { executionContextSchema } from "@okouai/api-contracts/contracts/runners";
 import { testCronCleanupSandboxesStateContract } from "@okouai/api-contracts/contracts/test-cron-cleanup-sandboxes-state";
 import { agents } from "@okouai/db/schema/agent";
 import { agentRuns } from "@okouai/db/schema/agent-run";
@@ -55,6 +52,7 @@ import {
   PI_MEMORY_PHASE2_LEASE_DURATION_MS,
 } from "../pi-memory-phase2-job.service";
 import { executePiMemoryPhase2Work$ } from "../pi-memory-phase2-worker.service";
+import { PI_MEMORY_PHASE2_USAGE_DRAIN_MS } from "../pi-memory-phase2-usage.service";
 import {
   piMemoryPhase2MaintenanceCallbackPayloadSchema,
   handlePiMemoryPhase2MaintenanceCallback,
@@ -491,7 +489,8 @@ async function launch(fault: Fault, noDiff = false, cleanupMode?: CleanupMode) {
   if (result.outcome !== "dispatched") {
     throw new Error("Maintenance dispatch failed");
   }
-  cleanup.runId = result.runId;
+  const runId = result.runId;
+  cleanup.runId = runId;
   const [maintenanceRunIdentity] = await db()
     .select({
       sessionId: agentRuns.sessionId,
@@ -627,6 +626,34 @@ async function launch(fault: Fault, noDiff = false, cleanupMode?: CleanupMode) {
       process.kill(pid, "SIGKILL");
       response.destroy();
       return;
+    }
+    // This harness runs the real CLI/Guest but has no runner proxy. Model the
+    // proxy's HTTP ingress from the same provider response that fills the
+    // child's journal, so the full boundary catches cross-writer double billing.
+    if (fault !== "provider" || providerCount === 0) {
+      const proxyUsage = await app.request("/api/webhooks/agent/usage-event", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          runId,
+          events: [
+            { category: "tokens.input", quantity: 8 },
+            { category: "tokens.output", quantity: 5 },
+            { category: "tokens.cache_read", quantity: 2 },
+          ].map((entry) => {
+            return {
+              ...entry,
+              idempotencyKey: randomUUID(),
+              kind: "model",
+              provider: "gpt-5.6-terra",
+            };
+          }),
+        }),
+      });
+      expect(proxyUsage.status).toBe(200);
     }
     sse(response, providerCount++, fault === "provider");
     return;
@@ -930,7 +957,7 @@ async function assertUsageReplay(
         .every((entry) => {
           return (
             entry.quantity === quantity &&
-            entry.runId === null &&
+            entry.runId === run.runId &&
             entry.provider === "gpt-5.6-terra"
           );
         }),
@@ -1014,7 +1041,7 @@ describe("private maintenance across CLI, Guest, generic checkpoint and real Pos
       expect(run.usage.length).toBeGreaterThan(0);
       expect(
         run.usage.every((entry) => {
-          return entry.runId === null;
+          return entry.runId === run.runId;
         }),
       ).toBeTruthy();
       await expect(
@@ -1186,7 +1213,7 @@ describe("private maintenance across CLI, Guest, generic checkpoint and real Pos
           .where(
             eq(piMemoryPhase2Jobs.memoryStorageId, run.scope.memoryStorageId),
           );
-        mockNow(completedAt.getTime() + CANCELLATION_RECOVERY_STALE_AFTER_MS);
+        mockNow(completedAt.getTime() + PI_MEMORY_PHASE2_USAGE_DRAIN_MS);
         const cleanupResult = await cleanupMaintenanceRun(run.runId, run.scope);
         expect(cleanupResult.threadlessRuns).toStrictEqual({
           discovered: 1,
@@ -1270,7 +1297,7 @@ describe("private maintenance across CLI, Guest, generic checkpoint and real Pos
         if (!completedAt) {
           throw new Error("Cleanup no-diff run did not complete");
         }
-        mockNow(completedAt.getTime() + CANCELLATION_RECOVERY_STALE_AFTER_MS);
+        mockNow(completedAt.getTime() + PI_MEMORY_PHASE2_USAGE_DRAIN_MS);
         const cleanupResult = await cleanupMaintenanceRun(run.runId, run.scope);
         expect(cleanupResult.threadlessRuns).toStrictEqual({
           discovered: 1,
@@ -1321,7 +1348,7 @@ describe("private maintenance across CLI, Guest, generic checkpoint and real Pos
       );
       expect(
         run.usage.every((entry) => {
-          return entry.runId === null;
+          return entry.runId === run.runId;
         }),
       ).toBeTruthy();
       const [storage] = await db()

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-usage.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-usage.service.test.ts
@@ -1,77 +1,402 @@
 import { randomUUID } from "node:crypto";
 
+import {
+  webhookPiMemoryPhase2UsageContract,
+  webhookUsageEventContract,
+} from "@okouai/api-contracts/contracts/webhooks";
+import { testCronCleanupSandboxesStateContract } from "@okouai/api-contracts/contracts/test-cron-cleanup-sandboxes-state";
+import { agentRuns } from "@okouai/db/schema/agent-run";
+import { agentRunCallbacks } from "@okouai/db/schema/agent-run-callback";
+import { agentSessions } from "@okouai/db/schema/agent-session";
+import { chatThreads } from "@okouai/db/schema/chat-thread";
+import { piMemoryPhase2Jobs } from "@okouai/db/schema/pi-memory-phase2-job";
+import { runnerJobQueue } from "@okouai/db/schema/runner-job-queue";
 import { usageEvent } from "@okouai/db/schema/usage-event";
-import { and, eq } from "drizzle-orm";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
 import { onTestFinished, describe, expect, it } from "vitest";
 
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
 import { db } from "../../../lib/db";
+import { mockOptionalEnv } from "../../../lib/env";
+import { nowDate, withMockNowForTest } from "../../../lib/time";
 import {
-  PI_MEMORY_PHASE2_MODEL,
-  recordPiMemoryPhase2Usage,
-} from "../pi-memory-phase2-usage.service";
+  seedOrgMetadata,
+  createUsagePricingFixture,
+} from "../../../test-fixtures/system-config-seeds";
+import { generateSandboxToken } from "../../auth/tokens";
+import { seedBuiltInModelKey } from "../../routes/__tests__/helpers/runtime-state";
+import { testCronCleanupSandboxesStateRoutes } from "../../routes/test-cron-cleanup-sandboxes-state";
+import { webhooksAgentHealthUsageTelemetryRoutes } from "../../routes/webhooks-agent-health-usage-telemetry";
+import { piMemoryPhase2MaintenanceCallbackPayloadSchema } from "../pi-memory-phase2-maintenance.service";
+import { executePiMemoryPhase2Work$ } from "../pi-memory-phase2-worker.service";
+import {
+  createPhase2TestScope,
+  insertPendingPhase2Job,
+  insertPhase2Candidates,
+} from "./pi-memory-phase2-job.test-fixture";
 
-describe("Pi memory Phase 2 usage", () => {
-  it("persists one owner-scoped runless ledger set idempotently", async () => {
-    const memoryStorageId = randomUUID();
-    const orgId = `phase2-usage-org-${randomUUID()}`;
-    const userId = `phase2-usage-user-${randomUUID()}`;
-    const args = {
-      memoryStorageId,
-      claimedRevision: 7,
-      selectionDigest: "a".repeat(64),
-      orgId,
-      userId,
-      responseId: "phase2-response-31291",
-      usage: {
-        input: 101,
-        output: 29,
-        cacheRead: 17,
-        cacheWrite: 11,
-        reasoning: 13,
-      },
-    } as const;
-    onTestFinished(async () => {
-      await db()
-        .delete(usageEvent)
-        .where(and(eq(usageEvent.orgId, orgId), eq(usageEvent.userId, userId)));
-    });
+// Private maintenance has no public launch/control/ledger API. Seed only its
+// infrastructure-owned cron input and terminal faults; the real dispatcher
+// persists the binding, and both real HTTP ingress paths own all usage writes.
+const context = testContext();
 
-    await recordPiMemoryPhase2Usage(db(), args);
-    await recordPiMemoryPhase2Usage(db(), args);
-
-    const rows = await db()
-      .select({
-        runId: usageEvent.runId,
-        orgId: usageEvent.orgId,
-        userId: usageEvent.userId,
-        provider: usageEvent.provider,
-        category: usageEvent.category,
-        quantity: usageEvent.quantity,
-      })
-      .from(usageEvent)
-      .where(and(eq(usageEvent.orgId, orgId), eq(usageEvent.userId, userId)));
-    expect(rows).toHaveLength(4);
-    expect(rows).toStrictEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ category: "tokens.input", quantity: 101 }),
-        expect.objectContaining({ category: "tokens.output", quantity: 29 }),
-        expect.objectContaining({
-          category: "tokens.cache_read",
-          quantity: 17,
-        }),
-        expect.objectContaining({
-          category: "tokens.cache_creation",
-          quantity: 11,
-        }),
-      ]),
-    );
-    for (const row of rows) {
-      expect(row).toMatchObject({
-        runId: null,
-        orgId,
-        userId,
-        provider: PI_MEMORY_PHASE2_MODEL,
-      });
-    }
+async function dispatchMaintenance() {
+  const scope = await createPhase2TestScope("usage", { emptyBase: true });
+  await seedOrgMetadata({ orgId: scope.orgId, tier: "pro", credits: 100_000 });
+  await seedBuiltInModelKey(context, "gpt-5.6-terra");
+  await insertPhase2Candidates(scope, [
+    {
+      piSessionId: randomUUID(),
+      rawMemory: "private candidate",
+      rolloutSummary: "private evidence",
+    },
+  ]);
+  const currentTime = nowDate();
+  await insertPendingPhase2Job(scope, { updatedAt: currentTime });
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+  const result = await createStore().set(
+    executePiMemoryPhase2Work$,
+    { scope, currentTime },
+    context.signal,
+  );
+  if (result.outcome !== "dispatched") {
+    throw new Error(`Maintenance dispatch failed: ${result.outcome}`);
+  }
+  const runId = result.runId;
+  const [run] = await db()
+    .select()
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId));
+  if (!run) {
+    throw new Error("Missing private run");
+  }
+  onTestFinished(async () => {
+    await db().delete(usageEvent).where(eq(usageEvent.orgId, scope.orgId));
+    await db().delete(agentSessions).where(eq(agentSessions.id, run.sessionId));
   });
+  const [callback] = await db()
+    .select()
+    .from(agentRunCallbacks)
+    .where(eq(agentRunCallbacks.runId, runId));
+  const binding = piMemoryPhase2MaintenanceCallbackPayloadSchema.parse(
+    callback?.payload,
+  );
+  return { scope, run, runId, binding };
+}
+
+function usageReports({
+  runId,
+  binding,
+}: Awaited<ReturnType<typeof dispatchMaintenance>>) {
+  const attempts = [1, 2].map((index) => {
+    return {
+      responseId: `response-${index}`,
+      usage: {
+        input: 3,
+        output: 2093,
+        cacheRead: 43_845,
+        cacheWrite: 24_236,
+        reasoning: 100,
+      },
+    };
+  });
+  const journal = {
+    schemaVersion: 1 as const,
+    runId,
+    memoryStorageId: binding.memoryStorageId,
+    leaseToken: binding.leaseToken,
+    claimedRevision: binding.claimedRevision,
+    claimedBaseVersionId: binding.claimedBaseVersionId,
+    selectionDigest: binding.selectionDigest,
+    attempts,
+  };
+  // One proxy flush aggregates the same two provider responses in the journal.
+  const events = [
+    { category: "tokens.input", quantity: 6 },
+    { category: "tokens.output", quantity: 4186 },
+    { category: "tokens.cache_read", quantity: 87_690 },
+    { category: "tokens.cache_creation", quantity: 48_472 },
+  ].map((entry) => {
+    return {
+      ...entry,
+      idempotencyKey: randomUUID(),
+      kind: "model" as const,
+      provider: "gpt-5.6-terra",
+    };
+  });
+  return { journal, events };
+}
+
+async function launchMaintenance() {
+  const maintenance = await dispatchMaintenance();
+  const { scope, run, runId, binding } = maintenance;
+  const { journal, events } = usageReports(maintenance);
+  const headers = {
+    authorization: `Bearer ${generateSandboxToken(scope.userId, runId, scope.orgId)}`,
+  };
+  const client = setupApp({
+    context,
+    routes: webhooksAgentHealthUsageTelemetryRoutes,
+  });
+  const pricing = await createUsagePricingFixture({
+    configured: events.map((event) => {
+      return {
+        kind: event.kind,
+        provider: event.provider,
+        category: event.category,
+        unitPrice: 1,
+        unitSize: 1000,
+      };
+    }),
+  });
+  onTestFinished(pricing.cleanup);
+  return {
+    scope,
+    run,
+    runId,
+    binding,
+    headers,
+    journal,
+    events,
+    async proxy() {
+      return await accept(
+        client(webhookUsageEventContract).send({
+          headers,
+          body: { runId, events },
+        }),
+        [200],
+      );
+    },
+    async reportJournal(body = journal) {
+      return await client(webhookPiMemoryPhase2UsageContract).send({
+        headers,
+        body,
+      });
+    },
+    async ledger() {
+      return await db()
+        .select()
+        .from(usageEvent)
+        .where(eq(usageEvent.orgId, scope.orgId));
+    },
+    async cleanup() {
+      return await accept(
+        setupApp({
+          context,
+          routes: testCronCleanupSandboxesStateRoutes,
+          usagePricingResolution: pricing.resolution,
+        })(testCronCleanupSandboxesStateContract).cleanup({
+          body: {
+            chatThreadIds: [],
+            runIds: [runId],
+            orgIds: [scope.orgId],
+            exportJobIds: [],
+          },
+        }),
+        [200],
+      );
+    },
+  };
+}
+
+function canonicalLedger(run: Awaited<ReturnType<typeof launchMaintenance>>) {
+  return expect.arrayContaining(
+    run.events.map((event) => {
+      return expect.objectContaining({
+        ...event,
+        runId: run.runId,
+        orgId: run.scope.orgId,
+        userId: run.scope.userId,
+      });
+    }),
+  );
+}
+
+describe("Pi memory Phase 2 cross-writer billing", () => {
+  it.each(["proxy-first", "journal-first", "concurrent"] as const)(
+    "charges one provider vector with aggregated batches and retries: %s",
+    async (order) => {
+      const run = await launchMaintenance();
+      if (order === "concurrent") {
+        await Promise.all([run.proxy(), accept(run.reportJournal(), [200])]);
+      } else if (order === "proxy-first") {
+        await run.proxy();
+        await accept(run.reportJournal(), [200]);
+      } else {
+        await accept(run.reportJournal(), [200]);
+        await run.proxy();
+      }
+      await run.proxy();
+      await accept(run.reportJournal(), [200]);
+      await expect(run.ledger()).resolves.toHaveLength(4);
+      await expect(run.ledger()).resolves.toStrictEqual(canonicalLedger(run));
+    },
+  );
+
+  it.each(["completed", "failed", "cancelled", "timeout"])(
+    "keeps the proxy owner without a journal through %s and delayed cleanup",
+    async (status) => {
+      const run = await launchMaintenance();
+      const completedAt = nowDate();
+      // A persisted V1 context can pin a CLI without journal support. Terminal
+      // states and the lost/delayed proxy flush are infrastructure-only inputs.
+      await db()
+        .update(agentRuns)
+        .set({
+          status,
+          completedAt,
+          launchSnapshot: {
+            schemaVersion: 1,
+            framework: "pi",
+            runnerProfile: "vm0/test",
+          },
+        })
+        .where(eq(agentRuns.id, run.runId));
+      await db()
+        .update(agentRunCallbacks)
+        .set({ status: "delivered" })
+        .where(eq(agentRunCallbacks.runId, run.runId));
+      await db()
+        .delete(runnerJobQueue)
+        .where(eq(runnerJobQueue.runId, run.runId));
+      await db()
+        .update(piMemoryPhase2Jobs)
+        .set({ leaseExpiresAt: new Date(completedAt.getTime() - 1) })
+        .where(
+          eq(piMemoryPhase2Jobs.memoryStorageId, run.scope.memoryStorageId),
+        );
+      await withMockNowForTest(
+        new Date(completedAt.getTime() + 10 * 60_000),
+        async () => {
+          const cleanup = await run.cleanup();
+          expect(cleanup.body.threadlessRuns.deleted).toBe(0);
+          await run.proxy();
+          await run.proxy();
+          await expect(run.ledger()).resolves.toHaveLength(4);
+          await expect(run.ledger()).resolves.toStrictEqual(
+            canonicalLedger(run),
+          );
+        },
+      );
+      // The ordinary terminal lifecycle settles pending charges before cleanup.
+      expect(
+        (await run.ledger()).every((entry) => {
+          return entry.status === "pending";
+        }),
+      ).toBeTruthy();
+      await withMockNowForTest(
+        new Date(completedAt.getTime() + 3 * 60 * 60_000),
+        async () => {
+          expect((await run.cleanup()).body.threadlessRuns.deleted).toBe(1);
+        },
+      );
+      const ledger = await run.ledger();
+      expect(ledger).toHaveLength(4);
+      expect(
+        ledger.every((entry) => {
+          return (
+            entry.status === "processed" &&
+            entry.billingError === null &&
+            (entry.creditsCharged ?? 0) > 0
+          );
+        }),
+      ).toBeTruthy();
+      expect(
+        ledger.every((entry) => {
+          return entry.runId === null;
+        }),
+      ).toBeTruthy();
+      // Cleanup only unlinks the private run; billable quantities and keys survive.
+      expect(ledger).toStrictEqual(
+        expect.arrayContaining(
+          run.events.map((event) => {
+            return expect.objectContaining(event);
+          }),
+        ),
+      );
+    },
+  );
+
+  it("rejects mismatched journal bindings without exempting proxy usage", async () => {
+    const run = await launchMaintenance();
+    await accept(
+      run.reportJournal({ ...run.journal, leaseToken: randomUUID() }),
+      [404],
+    );
+    await run.proxy();
+    await expect(run.ledger()).resolves.toHaveLength(4);
+    await expect(run.ledger()).resolves.toStrictEqual(canonicalLedger(run));
+  });
+
+  it.each([
+    "missing-callback",
+    "mismatched-owner",
+    "non-pi",
+    "owned-thread",
+    "api-first",
+  ])(
+    "cannot turn %s into a private journal billing exemption",
+    async (fault) => {
+      const run = await launchMaintenance();
+      if (fault === "missing-callback") {
+        await db()
+          .delete(agentRunCallbacks)
+          .where(eq(agentRunCallbacks.runId, run.runId));
+      } else if (fault === "mismatched-owner") {
+        await db()
+          .update(agentRunCallbacks)
+          .set({ payload: { ...run.binding, userId: randomUUID() } })
+          .where(eq(agentRunCallbacks.runId, run.runId));
+      } else if (fault === "owned-thread") {
+        const threadId = randomUUID();
+        await db().insert(chatThreads).values({
+          id: threadId,
+          userId: run.scope.userId,
+        });
+        onTestFinished(async () => {
+          await db().delete(chatThreads).where(eq(chatThreads.id, threadId));
+        });
+        await db()
+          .update(agentRuns)
+          .set({ chatThreadId: threadId })
+          .where(eq(agentRuns.id, run.runId));
+      } else if (fault === "api-first") {
+        await db()
+          .update(agentRuns)
+          .set({ modelProvider: null, triggerSource: "api" })
+          .where(eq(agentRuns.id, run.runId));
+      } else {
+        await db()
+          .update(agentRuns)
+          .set({
+            launchSnapshot: {
+              schemaVersion: 1,
+              framework: "codex",
+              runnerProfile: "vm0/test",
+            },
+          })
+          .where(eq(agentRuns.id, run.runId));
+      }
+      await accept(run.reportJournal(), [404]);
+      await run.proxy();
+      await expect(run.ledger()).resolves.toHaveLength(4);
+      await expect(run.ledger()).resolves.toStrictEqual(canonicalLedger(run));
+    },
+  );
+
+  it.each(["openai-api-key", "codex-oauth-token"])(
+    "preserves %s exclusions even with a spoofed maintenance callback",
+    async (modelProvider) => {
+      const run = await launchMaintenance();
+      await db()
+        .update(agentRuns)
+        .set({ modelProvider })
+        .where(eq(agentRuns.id, run.runId));
+      await accept(run.reportJournal(), [404]);
+      await run.proxy();
+      await expect(run.ledger()).resolves.toStrictEqual([]);
+    },
+  );
 });

--- a/turbo/apps/api/src/signals/services/pi-memory-phase2-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-phase2-usage.service.ts
@@ -1,155 +1,70 @@
-import { MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS } from "@okouai/api-contracts/contracts/model-price-tiers";
-import { usageEvent } from "@okouai/db/schema/usage-event";
-import type { PiMemoryPhase2ProviderUsage } from "@okouai/pi-agent-runtime/api";
-import { inArray } from "drizzle-orm";
-import { v5 as uuidv5 } from "uuid";
+import {
+  AGENT_EXECUTION_TIMEOUT_SECONDS,
+  CANCELLATION_RECOVERY_STALE_AFTER_MS,
+} from "@okouai/api-contracts/contracts/runners";
+import { agentRuns } from "@okouai/db/schema/agent-run";
+import { agentRunCallbacks } from "@okouai/db/schema/agent-run-callback";
+import { and, eq, isNull } from "drizzle-orm";
 
 import type { Db } from "../external/db";
+import { piMemoryPhase2MaintenanceCallbackPayloadSchema } from "./pi-memory-phase2-maintenance.service";
 
-const PI_MEMORY_PHASE2_USAGE_NAMESPACE = "cae7f79f-7180-46db-aaed-84228c63d0d8";
 export const PI_MEMORY_PHASE2_MODEL = "gpt-5.6-terra";
 
-type UsageCategoryBase =
-  | "tokens.input"
-  | "tokens.output"
-  | "tokens.cache_read"
-  | "tokens.cache_creation";
-type UsageCategory = UsageCategoryBase | `${UsageCategoryBase}.long_context`;
+// A terminal callback can precede the runner's final proxy flush. Keep the
+// private binding for a full runner lifetime plus finalization, including
+// retained webhook retries, instead of the ordinary two-minute quiet window.
+export const PI_MEMORY_PHASE2_USAGE_DRAIN_MS =
+  AGENT_EXECUTION_TIMEOUT_SECONDS * 1000 + CANCELLATION_RECOVERY_STALE_AFTER_MS;
 
-interface UsageEntry {
-  readonly category: UsageCategory;
-  readonly quantity: number;
-}
-
-interface RecordPiMemoryPhase2UsageArgs {
-  readonly memoryStorageId: string;
-  readonly claimedRevision: number;
-  readonly selectionDigest: string;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly responseId: string;
-  readonly usage: PiMemoryPhase2ProviderUsage;
-}
-
-function quantity(value: number, field: string): number {
-  if (!Number.isSafeInteger(value) || value < 0) {
-    throw new Error(`Pi memory Phase 2 ${field} usage is invalid`);
-  }
-  return value;
-}
-
-function usageEntries(usage: PiMemoryPhase2ProviderUsage): UsageEntry[] {
-  const input = quantity(usage.input, "input");
-  const output = quantity(usage.output, "output");
-  const cacheRead = quantity(usage.cacheRead, "cache-read");
-  const cacheCreation = quantity(usage.cacheWrite, "cache-creation");
-  quantity(usage.reasoning, "reasoning");
-  const minimum =
-    MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS[PI_MEMORY_PHASE2_MODEL];
-  if (minimum === undefined) {
-    throw new Error("Pi memory Phase 2 pricing threshold is missing");
-  }
-  const longContext = input + cacheRead + cacheCreation >= minimum;
-  const category = (base: UsageCategoryBase): UsageCategory => {
-    return longContext ? `${base}.long_context` : base;
-  };
-  return [
-    { category: category("tokens.input"), quantity: input },
-    { category: category("tokens.output"), quantity: output },
-    { category: category("tokens.cache_read"), quantity: cacheRead },
-    {
-      category: category("tokens.cache_creation"),
-      quantity: cacheCreation,
-    },
-  ].filter((entry) => {
-    return entry.quantity > 0;
-  });
-}
-
-function idempotencyKey(
-  args: RecordPiMemoryPhase2UsageArgs,
-  category: UsageCategory,
-): string {
-  return uuidv5(
-    JSON.stringify([
-      args.memoryStorageId,
-      args.claimedRevision,
-      args.selectionDigest,
-      args.responseId,
-      category,
-    ]),
-    PI_MEMORY_PHASE2_USAGE_NAMESPACE,
+/**
+ * Proxy accounting owns every sandbox Phase 2 attempt, including persisted
+ * contexts whose pinned CLI cannot write a journal. Never elect an owner from
+ * arrival order or a mutable job lease: failed/revoked attempts still cost.
+ */
+export async function loadPiMemoryPhase2UsageBinding(
+  db: Pick<Db, "select">,
+  scope: {
+    readonly runId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+) {
+  const [context] = await db
+    .select({
+      launchSnapshot: agentRuns.launchSnapshot,
+      payload: agentRunCallbacks.payload,
+    })
+    .from(agentRuns)
+    .innerJoin(
+      agentRunCallbacks,
+      and(
+        eq(agentRunCallbacks.runId, agentRuns.id),
+        eq(agentRunCallbacks.internalKind, "pi-memory:phase2"),
+      ),
+    )
+    .where(
+      and(
+        eq(agentRuns.id, scope.runId),
+        eq(agentRuns.orgId, scope.orgId),
+        eq(agentRuns.userId, scope.userId),
+        eq(agentRuns.triggerSource, "agent"),
+        isNull(agentRuns.chatThreadId),
+        eq(agentRuns.modelProvider, "built-in"),
+        eq(agentRuns.selectedModel, PI_MEMORY_PHASE2_MODEL),
+      ),
+    )
+    .limit(1);
+  const binding = piMemoryPhase2MaintenanceCallbackPayloadSchema.safeParse(
+    context?.payload,
   );
-}
-
-/** Persist one terminal Phase 2 provider attempt outside foreground runs. */
-export async function recordPiMemoryPhase2Usage(
-  db: Db,
-  args: RecordPiMemoryPhase2UsageArgs,
-): Promise<void> {
-  const expected = usageEntries(args.usage).map((entry) => {
-    return {
-      runId: null,
-      idempotencyKey: idempotencyKey(args, entry.category),
-      orgId: args.orgId,
-      userId: args.userId,
-      kind: "model",
-      provider: PI_MEMORY_PHASE2_MODEL,
-      category: entry.category,
-      quantity: entry.quantity,
-    } as const;
-  });
-  if (expected.length === 0) {
-    return;
+  if (
+    context?.launchSnapshot?.framework !== "pi" ||
+    !binding.success ||
+    binding.data.orgId !== scope.orgId ||
+    binding.data.userId !== scope.userId
+  ) {
+    return undefined;
   }
-  await db.transaction(async (tx) => {
-    await tx
-      .insert(usageEvent)
-      .values(expected)
-      .onConflictDoNothing({ target: [usageEvent.idempotencyKey] });
-    const stored = await tx
-      .select({
-        idempotencyKey: usageEvent.idempotencyKey,
-        runId: usageEvent.runId,
-        orgId: usageEvent.orgId,
-        userId: usageEvent.userId,
-        kind: usageEvent.kind,
-        provider: usageEvent.provider,
-        category: usageEvent.category,
-        quantity: usageEvent.quantity,
-      })
-      .from(usageEvent)
-      .where(
-        inArray(
-          usageEvent.idempotencyKey,
-          expected.map((row) => {
-            return row.idempotencyKey;
-          }),
-        ),
-      );
-    const remaining = new Map(
-      expected.map((row) => {
-        return [row.idempotencyKey, row] as const;
-      }),
-    );
-    for (const row of stored) {
-      const wanted = remaining.get(row.idempotencyKey);
-      if (
-        !wanted ||
-        row.runId !== null ||
-        row.orgId !== wanted.orgId ||
-        row.userId !== wanted.userId ||
-        row.kind !== wanted.kind ||
-        row.provider !== wanted.provider ||
-        row.category !== wanted.category ||
-        row.quantity !== wanted.quantity
-      ) {
-        throw new Error("Pi memory Phase 2 usage identity collision");
-      }
-      remaining.delete(row.idempotencyKey);
-    }
-    if (remaining.size > 0) {
-      throw new Error("Pi memory Phase 2 usage persistence is incomplete");
-    }
-  });
+  return binding.data;
 }

--- a/turbo/apps/api/src/signals/services/threadless-run-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/threadless-run-cleanup.service.ts
@@ -13,6 +13,7 @@ import {
   eq,
   exists,
   gte,
+  gt,
   inArray,
   isNotNull,
   isNull,
@@ -35,6 +36,11 @@ import {
   activePiMemoryPhase2MaintenanceRunCondition,
   lockPiMemoryPhase2MaintenanceCleanupProtection,
 } from "./pi-memory-phase2-maintenance.service";
+import {
+  loadPiMemoryPhase2UsageBinding,
+  PI_MEMORY_PHASE2_USAGE_DRAIN_MS,
+  PI_MEMORY_PHASE2_MODEL,
+} from "./pi-memory-phase2-usage.service";
 
 const L = logger("ThreadlessRunCleanup");
 
@@ -112,6 +118,9 @@ async function loadThreadlessRunCandidates(
   currentTime: Date,
 ): Promise<readonly ThreadlessRunCandidate[]> {
   const forwardCutoff = new Date(THREADLESS_RUN_FORWARD_CUTOFF_ISO);
+  const usageQuietBefore = new Date(
+    currentTime.getTime() - PI_MEMORY_PHASE2_USAGE_DRAIN_MS,
+  );
   return await db
     .select({
       runId: agentRuns.id,
@@ -143,6 +152,32 @@ async function loadThreadlessRunCandidates(
                 userId: agentRuns.userId,
                 currentTime,
               }),
+            ),
+        ),
+        // Do not let retained private billing contexts occupy the bounded
+        // sweep and starve ordinary threadless cleanup. Revalidate under lock.
+        notExists(
+          db
+            .select({ id: agentRunCallbacks.id })
+            .from(agentRunCallbacks)
+            .where(
+              and(
+                eq(agentRunCallbacks.runId, agentRuns.id),
+                eq(agentRunCallbacks.internalKind, "pi-memory:phase2"),
+                eq(
+                  sql`${agentRunCallbacks.payload}->>'orgId'`,
+                  agentRuns.orgId,
+                ),
+                eq(
+                  sql`${agentRunCallbacks.payload}->>'userId'`,
+                  agentRuns.userId,
+                ),
+                eq(agentRuns.triggerSource, "agent"),
+                eq(agentRuns.modelProvider, "built-in"),
+                eq(agentRuns.selectedModel, PI_MEMORY_PHASE2_MODEL),
+                eq(sql`${agentRuns.launchSnapshot}->>'framework'`, "pi"),
+                gt(agentRuns.completedAt, usageQuietBefore),
+              ),
             ),
         ),
         runIds === null ? undefined : inArray(agentRuns.id, runIds),
@@ -278,6 +313,14 @@ async function deleteIfStillEligible(
         orgId: candidate.orgId,
         userId: candidate.userId,
       })
+    ) {
+      return false;
+    }
+
+    if (
+      current.completedAt.getTime() >
+        nowDate().getTime() - PI_MEMORY_PHASE2_USAGE_DRAIN_MS &&
+      (await loadPiMemoryPhase2UsageBinding(tx, candidate))
     ) {
       return false;
     }


### PR DESCRIPTION
## Summary

Private Pi Phase 2 maintenance charged each provider response through both the proxy and the child's journal. Their UUIDv5 namespaces and aggregation boundaries differ, so each writer's retry deduplication still allowed two bills. This change makes the existing proxy the sole model-usage ledger writer and turns the journal endpoint into a validated compatibility ACK.

Closes #32626. Acceptance repair for #32168; source admission and learner implementation remain with #32578.

## Accounting authority and failure coverage

The issue permits a different canonical writer when necessary to preserve failure accounting. The proxy is necessary here: the child records its journal only after receiving a provider response, Guest forwards it during completion, and the existing Guest contract explicitly permits missing journals from commit-pinned CLIs. Electing the journal writer by arrival order or CLI capability would leave already-incurred usage uncovered when a child is killed or an old CLI omits the journal. The runner proxy reports independently of that child.

- Validate the persisted run owner, built-in Terra model, immutable Pi launch snapshot, private `agent` trigger without a Chat Thread, and server-created `pi-memory:phase2` callback. Validate the journal's storage/lease/revision/base/selection against that immutable binding; never use the mutable current job lease or a caller-supplied ownership flag.
- Keep generic proxy ingestion, idempotency keys, category/tier selection, aggregation and credit rounding unchanged. Journal retries acknowledge the same binding without creating another identity namespace. Foreground/API-first billing and BYOK/subscription exclusions retain their existing behavior.
- Retain a terminal private run and its binding for the two-hour execution budget plus two-minute finalization window, measured from terminal settlement. Exclude these retained contexts before the bounded cleanup selection, then revalidate under the run lock. Existing pending-usage/callback/job gates still apply. Delayed proxy rows settle through the normal lifecycle and survive run deletion with `runId` set to null.

This chooses the existing proxy's billing granularity rather than the journal's per-response rounding. Run attribution stays on the private threadless run until cleanup; it never attaches maintenance costs to a foreground thread. Existing proxy process-loss/retry-exhaustion limitations remain; this repair does not introduce durable proxy delivery or claim to recover provider work that no reporter observed.

## Fallbacks

`webhooks-agent-health-usage-telemetry.ts:maintenanceUsage$` keeps the existing journal request and success response supported as an ACK-only compatibility surface for current and commit-pinned Guest/CLI producers. New API plus either journal-producing or missing-journal CLI uses the same proxy owner; no schema migration, new capability field, arrival-time election or dual-write transition is required. Tests exercise a persisted V1 launch with no journal, successful/failed/cancelled/timed-out runs, and a flush arriving after the ordinary cleanup window.

Retire the journal producer and endpoint together under #32168 only after the last old producer's contexts drain: up to two hours in the queue, two hours executing, and bounded finalization. Keep the ACK while current producers still submit it. The 122-minute per-run retention separately protects late proxy delivery after a terminal transition.

Old API instances retain the original double writer until replaced; rollback to that API restores the defect. Production acceptance must observe a fresh natural maintenance run after old API instances stop serving. Historical rows/balances are untouched, and release execution and production verification remain with the controller's designated Production Release thread.

## Validation

- Regression proved against the pre-fix production code: the same two responses, represented as one aggregated proxy flush and two journal attempts, produce **12 rows instead of 4** in proxy-first, journal-first and concurrent ordering. The fixed path produces exactly the four canonical proxy rows, including duplicate delivery of both reporters.
- Focused API coverage: 15 cross-writer/compatibility tests; 50 cleanup tests; 20 private worker and Stage 1 tests; 2 usage-webhook tests.
- Real CLI/Guest/Postgres maintenance boundary: 15 tests covering publication, terminal failures, abrupt child death, revoked leases, no-diff, callback faults, journal replay and cleanup. The harness forwards proxy usage from the same provider response that populates the real child's journal.
- API lint, type checks and Knip; scoped Prettier; Guest documentation/format checks; `git diff --check`.

No full local Vitest run, dev server, production canary, historical ledger repair, routing/firewall change or Actions definition change.
