### PR TITLE
fix(workflows): publish created workflows with prepared files

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/workflows-creation.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflows-creation.test.ts
@@ -1,0 +1,690 @@
+import { randomUUID } from "node:crypto";
+import { Readable } from "node:stream";
+import { gunzipSync } from "node:zlib";
+
+import {
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  workflowsCollectionContract,
+  workflowsDetailContract,
+  type WorkflowCreateRequest,
+} from "@okouai/api-contracts/contracts/workflows";
+import { synthesizeWorkflowSkillMd } from "@okouai/core/skill-document";
+import { onTestFinished, vi } from "vitest";
+
+import { nowDate } from "../../../lib/time";
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
+import {
+  assertWorkflowPreparationUnlockedFixture,
+  holdWorkflowCreationThreadFixture,
+  readWorkflowPreparationFixture,
+  readWorkflowPublicationFixture,
+} from "../../../test-fixtures/workflow-creation";
+import { createDeferredPromise } from "../../utils";
+import { workflowsRoutes } from "../workflows";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
+import { createRouteMocks } from "./helpers/route-test";
+
+const context = testContext();
+const bdd = createBddApi(context);
+const mocks = createRouteMocks(context);
+const chat = createChatFilesBddApi(context);
+type OrgActor = ApiTestUser & { readonly orgId: string };
+
+function deferred<T>() {
+  const pending = createDeferredPromise<T>(context.signal);
+  return {
+    promise: pending.promise,
+    resolve: (value: T) => {
+      if (!pending.settled()) {
+        pending.resolve(value);
+      }
+    },
+  };
+}
+
+function headers(actor: ApiTestUser) {
+  mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+  return { authorization: "Bearer clerk-session" };
+}
+
+function client(signal = context.signal, rethrowErrors = false) {
+  return setupApp({ context, routes: workflowsRoutes, signal, rethrowErrors })(
+    workflowsCollectionContract,
+  );
+}
+
+function detailClient() {
+  return setupApp({ context, routes: workflowsRoutes })(
+    workflowsDetailContract,
+  );
+}
+
+async function setupCreation() {
+  const actor = bdd.user();
+  bdd.acceptAgentStorageWrites();
+  const agent = await bdd.createAgent(actor, {
+    displayName: "Atomic publication agent",
+    visibility: "public",
+  });
+  const thread = await chat.createThread(actor, {
+    agentId: agent.agentId,
+    title: "Creation thread",
+  });
+  const body: WorkflowCreateRequest = {
+    agentId: agent.agentId,
+    chatThreadId: thread.id,
+    name: `atomic-${randomUUID().slice(0, 8)}`,
+    description: "Creation publication regression",
+    instruction: "Read the attached reference and produce the report.",
+    files: [
+      { path: "references/input.txt", content: "Original attachment: 世界" },
+      { path: "script.sh", content: "echo report" },
+    ],
+  };
+  if (!actor.orgId) {
+    throw new Error("Expected an organization");
+  }
+  return { actor: { ...actor, orgId: actor.orgId }, agent, thread, body };
+}
+
+function installS3Fixture() {
+  const objects = new Map<string, Buffer>();
+  let beforeCommand: (command: unknown) => void | Promise<void> = () => {};
+  context.mocks.s3.send.mockImplementation(async (command: unknown) => {
+    await beforeCommand(command);
+    if (command instanceof PutObjectCommand) {
+      const { Key: key, Body: body } = command.input;
+      if (!key || !(typeof body === "string" || body instanceof Uint8Array)) {
+        throw new Error("Expected a volume object body and key");
+      }
+      objects.set(key, Buffer.from(body));
+      return {};
+    }
+    if (
+      command instanceof HeadObjectCommand ||
+      command instanceof GetObjectCommand
+    ) {
+      const key = command.input.Key;
+      const body = key ? objects.get(key) : undefined;
+      if (!body) {
+        throw Object.assign(new Error("Object not found"), {
+          name: "NotFound",
+          $metadata: { httpStatusCode: 404 },
+        });
+      }
+      return { ContentLength: body.length, Body: Readable.from([body]) };
+    }
+    if (command instanceof ListObjectsV2Command) {
+      const prefix = command.input.Prefix;
+      if (!prefix) {
+        throw new Error("Expected a scoped cleanup prefix");
+      }
+      return {
+        Contents: [...objects]
+          .filter(([key]) => {
+            return key.startsWith(prefix);
+          })
+          .map(([Key, body]) => {
+            return {
+              Key,
+              Size: body.length,
+              LastModified: nowDate(),
+            };
+          }),
+      };
+    }
+    if (command instanceof DeleteObjectsCommand) {
+      for (const object of command.input.Delete?.Objects ?? []) {
+        if (object.Key) {
+          objects.delete(object.Key);
+        }
+      }
+    }
+    return {};
+  });
+  return {
+    objects,
+    intercept(callback: (command: unknown) => void | Promise<void>) {
+      beforeCommand = callback;
+    },
+  };
+}
+
+async function assertAbsent(actor: OrgActor, workflowId: string, name: string) {
+  const listed = await accept(
+    client().list({ headers: headers(actor) }),
+    [200],
+  );
+  expect(
+    listed.body.map((workflow) => {
+      return workflow.name;
+    }),
+  ).not.toContain(name);
+  await accept(
+    detailClient().run({
+      headers: headers(actor),
+      params: { workflowId },
+    }),
+    [404],
+  );
+  const state = await readWorkflowPublicationFixture(actor.orgId, workflowId);
+  expect(state.workflow).toStrictEqual([]);
+  expect(state.mappings).toStrictEqual([]);
+  expect(state.versions).toStrictEqual([]);
+  expect(
+    state.storage.every((storage) => {
+      return storage.headVersionId === null;
+    }),
+  ).toBeTruthy();
+  return state;
+}
+
+async function assertReadable(
+  actor: OrgActor,
+  workflowId: string,
+  body: WorkflowCreateRequest,
+) {
+  const detail = await accept(
+    detailClient().get({ headers: headers(actor), params: { workflowId } }),
+    [200],
+  );
+  expect(detail.body).toMatchObject({
+    id: workflowId,
+    instruction: body.instruction,
+    fileContents: body.files,
+  });
+}
+
+describe("Workflow creation publication", () => {
+  it("keeps uploads outside publication locks and atomically publishes all rows after files are ready", async () => {
+    const { actor, agent, thread, body } = await setupCreation();
+    const s3 = installS3Fixture();
+    const started = deferred<string>();
+    const release = deferred<void>();
+    s3.intercept(async (command) => {
+      if (command instanceof PutObjectCommand && command.input.Key) {
+        started.resolve(command.input.Key);
+        await release.promise;
+      }
+    });
+    const creating = client().create({ headers: headers(actor), body });
+    onTestFinished(async () => {
+      release.resolve();
+      await creating;
+    });
+    const objectKey = await started.promise;
+    const prepared = await readWorkflowPreparationFixture(
+      actor.orgId,
+      objectKey,
+    );
+    await assertAbsent(actor, prepared.workflowId, body.name);
+    await assertWorkflowPreparationUnlockedFixture(
+      agent.agentId,
+      prepared.storageId,
+    );
+    release.resolve();
+    const created = await accept(creating, [201]);
+    expect(created.body).toMatchObject({
+      id: prepared.workflowId,
+      name: body.name,
+      visibility: "private",
+    });
+    await assertReadable(actor, created.body.id, body);
+    const state = await readWorkflowPublicationFixture(
+      actor.orgId,
+      created.body.id,
+    );
+    expect(
+      state.mappings.map((mapping) => {
+        return mapping.chatThreadId;
+      }),
+    ).toStrictEqual([thread.id]);
+    expect(state.versions).toHaveLength(1);
+    expect(state.storage[0]?.headVersionId).toBe(state.versions[0]?.id);
+    const transactions = [
+      ...state.workflow,
+      ...state.mappings,
+      ...state.storage,
+      ...state.versions,
+    ].map((row) => {
+      return row.transaction;
+    });
+    expect(transactions).toHaveLength(4);
+    expect(new Set(transactions).size).toBe(1);
+    const archive = [...s3.objects].find(([key]) => {
+      return key.endsWith("/archive.tar.gz");
+    })?.[1];
+    expect(archive).toBeDefined();
+    if (!archive) {
+      throw new Error("Expected the published archive");
+    }
+    expect(gunzipSync(archive).toString("utf8")).toContain(
+      synthesizeWorkflowSkillMd({
+        name: body.name,
+        description: body.description ?? null,
+        instruction: body.instruction ?? null,
+      }),
+    );
+  });
+
+  it.each([
+    "archive upload",
+    "manifest upload",
+    "archive verification",
+    "manifest verification",
+  ])(
+    "does not publish after %s fails and permits the same create after recovery",
+    async (phase) => {
+      const { actor, body } = await setupCreation();
+      const s3 = installS3Fixture();
+      const started = deferred<string>();
+      const release = deferred<void>();
+      s3.intercept(async (command) => {
+        if (command instanceof PutObjectCommand && command.input.Key) {
+          started.resolve(command.input.Key);
+          await release.promise;
+        }
+        const uploading = phase.endsWith("upload");
+        if (
+          (uploading && command instanceof PutObjectCommand) ||
+          (!uploading && command instanceof HeadObjectCommand)
+        ) {
+          const suffix = phase.startsWith("archive")
+            ? "/archive.tar.gz"
+            : "/manifest.json";
+          if (command.input.Key?.endsWith(suffix)) {
+            throw Object.assign(
+              new Error("Storage unavailable after SDK attempts"),
+              {
+                name: "ServiceUnavailable",
+                $metadata: { httpStatusCode: 503, attempts: 3 },
+              },
+            );
+          }
+        }
+      });
+      const creating = Promise.allSettled([
+        client(context.signal, true).create({ headers: headers(actor), body }),
+      ]);
+      onTestFinished(async () => {
+        release.resolve();
+        await creating;
+      });
+      const prepared = await readWorkflowPreparationFixture(
+        actor.orgId,
+        await started.promise,
+      );
+      release.resolve();
+      expect((await creating)[0]).toMatchObject({
+        status: "rejected",
+        reason: {
+          name: "ServiceUnavailable",
+          $metadata: { httpStatusCode: 503, attempts: 3 },
+        },
+      });
+      const state = await assertAbsent(actor, prepared.workflowId, body.name);
+      expect(state.storage).toStrictEqual([]);
+      expect(s3.objects.size).toBe(0);
+      s3.intercept(() => {});
+      const recovered = await accept(
+        client().create({ headers: headers(actor), body }),
+        [201],
+      );
+      await assertReadable(actor, recovered.body.id, body);
+    },
+  );
+
+  it("cleans up an aborted upload with a separate signal and leaves the name available", async () => {
+    const { actor, body } = await setupCreation();
+    const s3 = installS3Fixture();
+    const controller = new AbortController();
+    const started = deferred<string>();
+    const release = deferred<void>();
+    s3.intercept(async (command) => {
+      if (command instanceof PutObjectCommand && command.input.Key) {
+        started.resolve(command.input.Key);
+        await release.promise;
+      }
+    });
+    const creating = Promise.allSettled([
+      client(AbortSignal.any([context.signal, controller.signal]), true).create(
+        { headers: headers(actor), body },
+      ),
+    ]);
+    onTestFinished(async () => {
+      release.resolve();
+      await creating;
+    });
+    const prepared = await readWorkflowPreparationFixture(
+      actor.orgId,
+      await started.promise,
+    );
+    controller.abort();
+    release.resolve();
+    expect((await creating)[0]).toMatchObject({
+      status: "rejected",
+      reason: { name: "AbortError" },
+    });
+    expect(
+      (await assertAbsent(actor, prepared.workflowId, body.name)).storage,
+    ).toStrictEqual([]);
+    expect(s3.objects.size).toBe(0);
+    const recovered = await accept(
+      client().create({ headers: headers(actor), body }),
+      [201],
+    );
+    await assertReadable(actor, recovered.body.id, body);
+  });
+
+  it.each(["public", "private"] as const)(
+    "publishes one winner for concurrent %s creates and preserves its files",
+    async (visibility) => {
+      const { actor, body: input } = await setupCreation();
+      const body = { ...input, visibility };
+      const s3 = installS3Fixture();
+      const started = deferred<void>();
+      const release = deferred<void>();
+      const attempts: { workflowId: string; storageId: string }[] = [];
+      s3.intercept(async (command) => {
+        if (
+          command instanceof PutObjectCommand &&
+          command.input.Key?.endsWith("/archive.tar.gz")
+        ) {
+          attempts.push(
+            await readWorkflowPreparationFixture(
+              actor.orgId,
+              command.input.Key,
+            ),
+          );
+          if (attempts.length === 2) {
+            started.resolve();
+          }
+          await release.promise;
+        }
+      });
+      const requests = Promise.all([
+        client().create({ headers: headers(actor), body }),
+        client().create({ headers: headers(actor), body }),
+      ]);
+      onTestFinished(async () => {
+        release.resolve();
+        await requests;
+      });
+      await started.promise;
+      release.resolve();
+      const results = await requests;
+      expect(
+        results
+          .map((result) => {
+            return result.status;
+          })
+          .sort(),
+      ).toStrictEqual([201, 409]);
+      const winner = results.find((result) => {
+        return result.status === 201;
+      });
+      if (!winner || winner.status !== 201) {
+        throw new Error("Expected one successful creation");
+      }
+      const loser = attempts.find((attempt) => {
+        return attempt.workflowId !== winner.body.id;
+      });
+      if (!loser) {
+        throw new Error("Expected a losing creation attempt");
+      }
+      const loserState = await readWorkflowPublicationFixture(
+        actor.orgId,
+        loser.workflowId,
+      );
+      expect(loserState).toStrictEqual({
+        workflow: [],
+        mappings: [],
+        storage: [],
+        versions: [],
+      });
+      expect(s3.objects.size).toBe(2);
+      await assertReadable(actor, winner.body.id, body);
+    },
+  );
+
+  it("rolls back an interrupted publication transaction without publishing a binding or HEAD", async () => {
+    const { actor, thread, body } = await setupCreation();
+    const s3 = installS3Fixture();
+    const started = deferred<string>();
+    s3.intercept((command) => {
+      if (command instanceof PutObjectCommand && command.input.Key) {
+        started.resolve(command.input.Key);
+      }
+    });
+    const boundary = await holdWorkflowCreationThreadFixture(
+      thread.id,
+      context.signal,
+    );
+    const creating = Promise.allSettled([
+      client(context.signal, true).create({ headers: headers(actor), body }),
+    ]);
+    onTestFinished(async () => {
+      boundary.release();
+      await boundary.done;
+      await creating;
+    });
+    const prepared = await readWorkflowPreparationFixture(
+      actor.orgId,
+      await started.promise,
+    );
+    await vi.waitFor(async () => {
+      await expect(boundary.blockedPids()).resolves.toHaveLength(1);
+    });
+    await assertAbsent(actor, prepared.workflowId, body.name);
+    const [pid] = await boundary.blockedPids();
+    if (!pid) {
+      throw new Error("Expected the blocked publication backend");
+    }
+    await boundary.cancelBlockedPublication(pid);
+    expect((await creating)[0]).toMatchObject({
+      status: "rejected",
+      reason: { cause: { code: "57014" } },
+    });
+    boundary.release();
+    await boundary.done;
+    expect(
+      (await assertAbsent(actor, prepared.workflowId, body.name)).storage,
+    ).toStrictEqual([]);
+    const recovered = await accept(
+      client().create({ headers: headers(actor), body }),
+      [201],
+    );
+    await assertReadable(actor, recovered.body.id, body);
+  });
+
+  it.each(["notification failure", "post-commit cancellation"])(
+    "preserves the committed Workflow after %s",
+    async (failure) => {
+      const { actor, body } = await setupCreation();
+      const s3 = installS3Fixture();
+      const controller = new AbortController();
+      context.mocks.ably.publish.mockImplementationOnce(() => {
+        if (failure === "post-commit cancellation") {
+          controller.abort();
+        }
+        throw new Error("Notification unavailable");
+      });
+      const [response] = await Promise.allSettled([
+        client(
+          AbortSignal.any([context.signal, controller.signal]),
+          true,
+        ).create({ headers: headers(actor), body }),
+      ]);
+      expect(response).toMatchObject(
+        failure === "notification failure"
+          ? { status: "fulfilled", value: { status: 201 } }
+          : { status: "rejected", reason: { name: "AbortError" } },
+      );
+      const listed = await accept(
+        client().list({ headers: headers(actor) }),
+        [200],
+      );
+      const workflow = listed.body.find((workflow) => {
+        return workflow.name === body.name;
+      });
+      if (!workflow) {
+        throw new Error("Expected the committed Workflow");
+      }
+      await assertReadable(actor, workflow.id, body);
+      const state = await readWorkflowPublicationFixture(
+        actor.orgId,
+        workflow.id,
+      );
+      expect(state.versions).toHaveLength(1);
+      expect(state.mappings).toHaveLength(1);
+      expect(s3.objects.size).toBe(2);
+    },
+  );
+
+  it("preserves the original upload error when cleanup fails and leaves other Workflows intact", async () => {
+    const { actor, body } = await setupCreation();
+    const other = await setupCreation();
+    const s3 = installS3Fixture();
+    const sameOrg = await accept(
+      client().create({
+        headers: headers(actor),
+        body: { ...body, name: `${body.name}-existing` },
+      }),
+      [201],
+    );
+    const otherOrg = await accept(
+      client().create({ headers: headers(other.actor), body: other.body }),
+      [201],
+    );
+    const originalError = new Error("Original archive upload failure");
+    s3.intercept((command) => {
+      if (
+        command instanceof PutObjectCommand &&
+        command.input.Key?.endsWith("/archive.tar.gz")
+      ) {
+        throw originalError;
+      }
+      if (command instanceof ListObjectsV2Command) {
+        throw new Error("Cleanup storage unavailable");
+      }
+    });
+    await expect(
+      client(context.signal, true).create({ headers: headers(actor), body }),
+    ).rejects.toBe(originalError);
+    const listed = await accept(
+      client().list({ headers: headers(actor) }),
+      [200],
+    );
+    expect(
+      listed.body.map((workflow) => {
+        return workflow.name;
+      }),
+    ).not.toContain(body.name);
+    await assertReadable(actor, sameOrg.body.id, body);
+    await assertReadable(other.actor, otherOrg.body.id, other.body);
+  });
+  it.each(["agent deleted", "agent access revoked", "thread deleted"])(
+    "revalidates publication after %s during upload",
+    async (change) => {
+      const { actor, agent, thread, body } = await setupCreation();
+      const creator =
+        change === "agent access revoked"
+          ? {
+              ...bdd.user({ orgId: actor.orgId, orgRole: "org:member" }),
+              orgId: actor.orgId,
+            }
+          : actor;
+      const s3 = installS3Fixture();
+      const started = deferred<string>();
+      const release = deferred<void>();
+      s3.intercept(async (command) => {
+        if (command instanceof PutObjectCommand && command.input.Key) {
+          started.resolve(command.input.Key);
+          await release.promise;
+        }
+      });
+      const creating = client().create({ headers: headers(creator), body });
+      onTestFinished(async () => {
+        release.resolve();
+        await creating;
+      });
+      const prepared = await readWorkflowPreparationFixture(
+        actor.orgId,
+        await started.promise,
+      );
+      if (change === "agent deleted") {
+        await bdd.deleteAgent(actor, agent.agentId);
+      } else if (change === "agent access revoked") {
+        await bdd.updateAgentMetadata(actor, agent.agentId, {
+          visibility: "private",
+        });
+      } else {
+        await chat.deleteThread(actor, thread.id);
+      }
+      release.resolve();
+      const result = await creating;
+      if (change === "thread deleted") {
+        expect(result.status).toBe(201);
+        await assertReadable(actor, prepared.workflowId, body);
+        const state = await readWorkflowPublicationFixture(
+          actor.orgId,
+          prepared.workflowId,
+        );
+        expect(state.mappings).toStrictEqual([]);
+        expect(state.versions).toHaveLength(1);
+      } else {
+        expect(result.status).toBe(change === "agent deleted" ? 404 : 403);
+        const state = await assertAbsent(
+          creator,
+          prepared.workflowId,
+          body.name,
+        );
+        expect(state.storage).toStrictEqual([]);
+      }
+    },
+  );
+
+  it("does not reserve the name when the supplied files cannot be materialized", async () => {
+    const { actor, body } = await setupCreation();
+    const s3 = installS3Fixture();
+    const [failed] = await Promise.allSettled([
+      client(context.signal, true).create({
+        headers: headers(actor),
+        body: {
+          ...body,
+          files: [
+            { path: "directory", content: "file" },
+            { path: "directory/child.txt", content: "nested file" },
+          ],
+        },
+      }),
+    ]);
+    expect(failed).toMatchObject({
+      status: "rejected",
+      reason: { code: "EEXIST" },
+    });
+    const listed = await accept(
+      client().list({ headers: headers(actor) }),
+      [200],
+    );
+    expect(
+      listed.body.map((workflow) => {
+        return workflow.name;
+      }),
+    ).not.toContain(body.name);
+    expect(s3.objects.size).toBe(0);
+    const recovered = await accept(
+      client().create({ headers: headers(actor), body }),
+      [201],
+    );
+    await assertReadable(actor, recovered.body.id, body);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/workflows.ts
+++ b/turbo/apps/api/src/signals/routes/workflows.ts
@@ -5,12 +5,14 @@ import {
   workflowsCollectionContract,
   workflowsDetailContract,
   workflowVisibilityContract,
+  type WorkflowCreateRequest,
 } from "@okouai/api-contracts/contracts/workflows";
 import { SEED_SKILLS } from "@okouai/core/seed-skills";
 import { getCustomSkillStorageName } from "@okouai/core/storage-names";
 import { synthesizeWorkflowSkillMd } from "@okouai/core/skill-document";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { agents } from "@okouai/db/schema/agent";
+import { storages } from "@okouai/db/schema/storage";
 import {
   workflowUserAutomationThreads,
   workflowAutomations,
@@ -30,8 +32,8 @@ import {
 } from "../services/api-dispatch-timing.service";
 import { autonomyBudgetExhausted, conflict, notFound } from "../../lib/error";
 import { nowDate } from "../../lib/time";
+import { logger } from "../../lib/log";
 import { requireAgentPermission } from "../../lib/require-agent-permission";
-import { uploadVolumeServerSide$ } from "../services/storage-volume-upload.service";
 import {
   deleteOrphanedWorkflowVolume$,
   deleteWorkflow$,
@@ -59,7 +61,7 @@ import {
   childAutonomyBudget,
   loadOwnedRunAutonomyBudget,
 } from "../services/autonomy-budget.service";
-import { bestEffort, onRejection } from "../utils";
+import { awaitWithSignal, bestEffort, onRejection } from "../utils";
 import { reconcileGmailWatchesForUser } from "../services/gmail-automation-event.service";
 import { reconcileGoogleCalendarWatchesForUser } from "../services/google-calendar-automation-event.service";
 import { lockConnectorAccountTarget } from "../services/auth-state-lock.service";
@@ -96,6 +98,8 @@ import {
   commitPreparedVolumeServerSide,
   ensureVolumeStorage$,
   prepareVolumeServerSideWithDb$,
+  prepareVolumeServerSide$,
+  type PreparedServerSideVolume,
 } from "../services/storage-volume-publication.service";
 
 const workflowReadAuth = {
@@ -141,9 +145,10 @@ async function loadAgentForConfiguration(
   args: {
     readonly orgId: string;
     readonly agentId: string;
+    readonly lock?: boolean;
   },
 ): Promise<ConfigurableAgent | null> {
-  const [agent] = await db
+  const query = db
     .select({
       id: agents.id,
       owner: agents.owner,
@@ -154,6 +159,7 @@ async function loadAgentForConfiguration(
     .from(agents)
     .where(and(eq(agents.orgId, args.orgId), eq(agents.id, args.agentId)))
     .limit(1);
+  const [agent] = await (args.lock ? query.for("update") : query);
 
   return agent ?? null;
 }
@@ -209,6 +215,14 @@ async function publicWorkflowSlugExists(
   return existing !== undefined;
 }
 
+function workflowSlugConflict(visibility: "public" | "private", name: string) {
+  return conflict(
+    visibility === "public"
+      ? `A public workflow named "/${name}" already exists on this agent. Rename this workflow or keep it private.`
+      : `You already have a private workflow named "/${name}" on this agent. Rename the existing workflow or choose a different name.`,
+  );
+}
+
 async function requirePublicWorkflowSlugAvailable(
   db: Db,
   args: {
@@ -219,11 +233,7 @@ async function requirePublicWorkflowSlugAvailable(
   },
 ) {
   const exists = await publicWorkflowSlugExists(db, args);
-  return exists
-    ? conflict(
-        `A public workflow named "/${args.name}" already exists on this agent. Rename this workflow or keep it private.`,
-      )
-    : null;
+  return exists ? workflowSlugConflict("public", args.name) : null;
 }
 
 async function privateWorkflowSlugExists(
@@ -267,11 +277,7 @@ async function requirePrivateWorkflowSlugAvailable(
   },
 ) {
   const exists = await privateWorkflowSlugExists(db, args);
-  return exists
-    ? conflict(
-        `You already have a private workflow named "/${args.name}" on this agent. Rename the existing workflow or choose a different name.`,
-      )
-    : null;
+  return exists ? workflowSlugConflict("private", args.name) : null;
 }
 
 async function requireWorkflowSlugAvailableForVisibility(
@@ -344,6 +350,201 @@ const listWorkflowsInner$ = computed(async (get) => {
   return { status: 200 as const, body: [...workflows] };
 });
 
+interface WorkflowCreationInput {
+  readonly orgId: string;
+  readonly member: WorkflowMember;
+  readonly body: WorkflowCreateRequest;
+  readonly visibility: "public" | "private";
+}
+
+async function validateWorkflowCreation(
+  db: Db,
+  args: WorkflowCreationInput,
+  lockAgent: boolean,
+  signal: AbortSignal,
+) {
+  const agent = await loadAgentForConfiguration(db, {
+    orgId: args.orgId,
+    agentId: args.body.agentId,
+    lock: lockAgent,
+  });
+  signal.throwIfAborted();
+  if (!agent) {
+    return notFound(`Agent not found: ${args.body.agentId}`);
+  }
+  const permissionError =
+    args.visibility === "public"
+      ? requireAgentWritePermission(
+          agent,
+          args.member,
+          "create workflows on this agent",
+        )
+      : requireVisibleAgentForPrivateWorkflowCreate(agent, args.member);
+  if (permissionError) {
+    return permissionError;
+  }
+  const slugError = await requireWorkflowSlugAvailableForVisibility(db, {
+    orgId: args.orgId,
+    agentId: agent.id,
+    ownerUserId: args.member.userId,
+    name: args.body.name,
+    visibility: args.visibility,
+  });
+  signal.throwIfAborted();
+  return slugError;
+}
+
+async function createPreparedWorkflow(
+  db: Db,
+  args: WorkflowCreationInput & {
+    readonly workflowId: string;
+    readonly volume: PreparedServerSideVolume;
+  },
+  signal: AbortSignal,
+) {
+  return await db.transaction(async (tx) => {
+    const error = await validateWorkflowCreation(tx, args, true, signal);
+    if (error) {
+      return { kind: "error" as const, response: error };
+    }
+
+    // Cleanup takes this same lock before checking Workflow absence, so even
+    // an uncertain COMMIT cannot let cleanup race a late publication.
+    const [storage] = await tx
+      .select({ id: storages.id })
+      .from(storages)
+      .where(eq(storages.id, args.volume.version.storageId))
+      .for("update");
+    signal.throwIfAborted();
+    if (!storage) {
+      throw new Error(
+        `Prepared workflow storage not found: ${args.workflowId}`,
+      );
+    }
+
+    const { body, member, visibility } = args;
+    const currentTime = nowDate();
+    const [workflow] = await tx
+      .insert(workflows)
+      .values({
+        id: args.workflowId,
+        orgId: args.orgId,
+        agentId: body.agentId,
+        name: body.name,
+        visibility,
+        instruction: body.instruction ?? null,
+        ownerUserId: member.userId,
+        displayName: body.displayName ?? null,
+        description: body.description ?? null,
+        createdBy: member.userId,
+        updatedBy: member.userId,
+        createdAt: currentTime,
+        updatedAt: currentTime,
+      })
+      .onConflictDoNothing()
+      .returning({ id: workflows.id });
+    signal.throwIfAborted();
+    if (!workflow) {
+      return {
+        kind: "error" as const,
+        response: workflowSlugConflict(visibility, body.name),
+      };
+    }
+
+    const chatThreadId = body.chatThreadId
+      ? await loadMatchingWorkflowCreationThreadId(tx, {
+          userId: member.userId,
+          agentId: body.agentId,
+          chatThreadId: body.chatThreadId,
+        })
+      : null;
+    signal.throwIfAborted();
+    if (chatThreadId) {
+      await tx.insert(workflowUserAutomationThreads).values({
+        orgId: args.orgId,
+        userId: member.userId,
+        workflowId: workflow.id,
+        chatThreadId,
+        createdAt: currentTime,
+        updatedAt: currentTime,
+      });
+      signal.throwIfAborted();
+    }
+    await commitPreparedVolumeServerSide(
+      { db: tx, volume: args.volume },
+      signal,
+    );
+    return { kind: "created" as const, workflow, chatThreadId };
+  });
+}
+
+const cleanupUnpublishedWorkflow$ = command(
+  async (
+    { set },
+    args: { readonly orgId: string; readonly workflowId: string },
+  ): Promise<void> => {
+    // Cleanup gets its own bounded lifetime, including when create was aborted.
+    // Its failure (including timeout) must never replace the creation error.
+    const signal = AbortSignal.timeout(5000);
+    const [result] = await Promise.allSettled([
+      awaitWithSignal(set(deleteOrphanedWorkflowVolume$, args, signal), signal),
+    ]);
+    if (result.status === "rejected") {
+      logger("WorkflowCreate").warn(
+        "Failed to clean up unpublished workflow volume",
+        {
+          ...args,
+          error: result.reason,
+        },
+      );
+    }
+  },
+);
+
+const prepareAndCreateWorkflow$ = command(
+  async ({ set }, args: WorkflowCreationInput, signal: AbortSignal) => {
+    const workflowId = randomUUID();
+    const cleanup = { orgId: args.orgId, workflowId };
+    const result = await onRejection(
+      (async () => {
+        const volume = await set(
+          prepareVolumeServerSide$,
+          {
+            orgId: args.orgId,
+            storageName: getCustomSkillStorageName(workflowId),
+            files: [
+              {
+                path: "SKILL.md",
+                content: synthesizeWorkflowSkillMd({
+                  name: args.body.name,
+                  description: args.body.description ?? null,
+                  instruction: args.body.instruction ?? null,
+                }),
+              },
+              ...(args.body.files ?? []),
+            ],
+          },
+          signal,
+        );
+        const created = await createPreparedWorkflow(
+          set(writeDb$),
+          { ...args, workflowId, volume },
+          signal,
+        );
+        if (created.kind === "error") {
+          await set(cleanupUnpublishedWorkflow$, cleanup);
+        }
+        return created;
+      })(),
+      async () => {
+        await set(cleanupUnpublishedWorkflow$, cleanup);
+      },
+    );
+    signal.throwIfAborted();
+    return result;
+  },
+);
+
 const createWorkflowInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
@@ -353,121 +554,30 @@ const createWorkflowInner$ = command(
     if (!bodyResult.ok) {
       return bodyResult.response;
     }
-
     const body = bodyResult.data;
-    const visibility = body.visibility ?? "private";
-
     if (SEED_SKILLS.includes(body.name)) {
       return conflict(
         `Workflow name "${body.name}" conflicts with a built-in workflow`,
       );
     }
-
+    const args = {
+      orgId: auth.orgId,
+      member,
+      body,
+      visibility: body.visibility ?? "private",
+    };
     const writeDb = set(writeDb$);
-    const agent = await loadAgentForConfiguration(writeDb, {
-      orgId: auth.orgId,
-      agentId: body.agentId,
-    });
-    signal.throwIfAborted();
-    if (!agent) {
-      return notFound(`Agent not found: ${body.agentId}`);
+    const error = await validateWorkflowCreation(writeDb, args, false, signal);
+    if (error) {
+      return error;
     }
-
-    const permissionError =
-      visibility === "public"
-        ? requireAgentWritePermission(
-            agent,
-            member,
-            "create workflows on this agent",
-          )
-        : requireVisibleAgentForPrivateWorkflowCreate(agent, member);
-    if (permissionError) {
-      return permissionError;
-    }
-
-    const slugError = await requireWorkflowSlugAvailableForVisibility(writeDb, {
-      orgId: auth.orgId,
-      agentId: agent.id,
-      ownerUserId: auth.userId,
-      name: body.name,
-      visibility,
-    });
+    const inserted = await set(prepareAndCreateWorkflow$, args, signal);
+    // Publication has committed. Notification, response or cancellation failures
+    // from this point must leave the valid Workflow and its volume intact.
     signal.throwIfAborted();
-    if (slugError) {
-      return slugError;
+    if (inserted.kind === "error") {
+      return inserted.response;
     }
-
-    const currentTime = nowDate();
-    const inserted = await writeDb.transaction(async (tx) => {
-      const [workflow] = await tx
-        .insert(workflows)
-        .values({
-          orgId: auth.orgId,
-          agentId: agent.id,
-          name: body.name,
-          visibility,
-          instruction: body.instruction ?? null,
-          ownerUserId: auth.userId,
-          displayName: body.displayName ?? null,
-          description: body.description ?? null,
-          createdBy: auth.userId,
-          updatedBy: auth.userId,
-          createdAt: currentTime,
-          updatedAt: currentTime,
-        })
-        .returning({ id: workflows.id });
-
-      if (!workflow) {
-        return null;
-      }
-
-      const chatThreadId = body.chatThreadId
-        ? await loadMatchingWorkflowCreationThreadId(tx, {
-            userId: auth.userId,
-            agentId: agent.id,
-            chatThreadId: body.chatThreadId,
-          })
-        : null;
-
-      if (chatThreadId) {
-        await tx.insert(workflowUserAutomationThreads).values({
-          orgId: auth.orgId,
-          userId: auth.userId,
-          workflowId: workflow.id,
-          chatThreadId,
-          createdAt: currentTime,
-          updatedAt: currentTime,
-        });
-      }
-
-      return { workflow, chatThreadId };
-    });
-    signal.throwIfAborted();
-    if (!inserted) {
-      throw new Error("Failed to create workflow");
-    }
-
-    const skillMd = synthesizeWorkflowSkillMd({
-      name: body.name,
-      description: body.description ?? null,
-      instruction: body.instruction ?? null,
-    });
-    await set(
-      uploadVolumeServerSide$,
-      {
-        orgId: auth.orgId,
-        storageName: getCustomSkillStorageName(inserted.workflow.id),
-        files: [
-          { path: "SKILL.md", content: skillMd },
-          ...(body.files ?? []).map((file) => {
-            return { path: file.path, content: file.content };
-          }),
-        ],
-      },
-      signal,
-    );
-    signal.throwIfAborted();
-
     const visible = await loadVisibleWorkflowById(writeDb, {
       orgId: auth.orgId,
       member,
@@ -477,7 +587,6 @@ const createWorkflowInner$ = command(
     if (!visible) {
       throw new Error(`Created workflow not found: ${inserted.workflow.id}`);
     }
-
     const summary = workflowSummary({
       workflow: visible.workflow,
       agent: visible.agent,

--- a/turbo/apps/api/src/signals/services/workflow-delete.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-delete.service.ts
@@ -39,20 +39,6 @@ export const deleteOrphanedWorkflowVolume$ = command(
   ): Promise<boolean> => {
     const writeDb = set(writeDb$);
     const result = await writeDb.transaction(async (tx) => {
-      const [workflow] = await tx
-        .select({ id: workflows.id })
-        .from(workflows)
-        .where(
-          and(
-            eq(workflows.orgId, args.orgId),
-            eq(workflows.id, args.workflowId),
-          ),
-        )
-        .limit(1);
-      if (workflow) {
-        return { deleted: false as const };
-      }
-
       const [storage] = await tx
         .select({ id: storages.id, s3Prefix: storages.s3Prefix })
         .from(storages)
@@ -68,6 +54,25 @@ export const deleteOrphanedWorkflowVolume$ = command(
       if (!storage) {
         return { deleted: false as const };
       }
+
+      signal.throwIfAborted();
+      // Publication holds the storage lock before inserting the Workflow. Read
+      // its reference only after that transaction's commit/rollback is known.
+      const [workflow] = await tx
+        .select({ id: workflows.id })
+        .from(workflows)
+        .where(
+          and(
+            eq(workflows.orgId, args.orgId),
+            eq(workflows.id, args.workflowId),
+          ),
+        )
+        .limit(1);
+      if (workflow) {
+        return { deleted: false as const };
+      }
+
+      signal.throwIfAborted();
 
       await tx.delete(storages).where(eq(storages.id, storage.id));
       return {

--- a/turbo/apps/api/src/test-fixtures/workflow-creation.ts
+++ b/turbo/apps/api/src/test-fixtures/workflow-creation.ts
@@ -1,0 +1,173 @@
+import {
+  getCustomSkillStorageName,
+  VOLUME_ORG_USER_ID,
+} from "@okouai/core/storage-names";
+import { agents } from "@okouai/db/schema/agent";
+import { chatThreads } from "@okouai/db/schema/chat-thread";
+import { storages, storageVersions } from "@okouai/db/schema/storage";
+import {
+  workflows,
+  workflowUserAutomationThreads,
+} from "@okouai/db/schema/workflow";
+import { and, eq, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { db } from "../lib/db";
+import { executeRawRows } from "../lib/db-raw-rows";
+import { createDeferredPromise } from "../signals/utils";
+
+// Product APIs cannot expose unpublished identities, transaction IDs or pause a
+// database statement. These fixtures inspect only the test-owned attempt; all
+// creation, access changes and observable outcomes still use production APIs.
+export async function readWorkflowPreparationFixture(
+  orgId: string,
+  objectKey: string,
+) {
+  const s3Prefix = objectKey.split("/").slice(0, -2).join("/");
+  const [storage] = await db()
+    .select({ id: storages.id, name: storages.name })
+    .from(storages)
+    .where(
+      and(
+        eq(storages.orgId, orgId),
+        eq(storages.userId, VOLUME_ORG_USER_ID),
+        eq(storages.s3Prefix, s3Prefix),
+      ),
+    );
+  if (!storage?.name.startsWith(getCustomSkillStorageName(""))) {
+    throw new Error("Expected a prepared Workflow storage identity");
+  }
+  return {
+    storageId: storage.id,
+    workflowId: storage.name.slice(getCustomSkillStorageName("").length),
+  };
+}
+
+export async function readWorkflowPublicationFixture(
+  orgId: string,
+  workflowId: string,
+) {
+  const database = db();
+  const workflow = await database
+    .select({
+      id: workflows.id,
+      transaction: sql`${workflows}.xmin::text`.mapWith(workflows.name),
+    })
+    .from(workflows)
+    .where(and(eq(workflows.orgId, orgId), eq(workflows.id, workflowId)));
+  const mappings = await database
+    .select({
+      chatThreadId: workflowUserAutomationThreads.chatThreadId,
+      transaction: sql`${workflowUserAutomationThreads}.xmin::text`.mapWith(
+        workflowUserAutomationThreads.userId,
+      ),
+    })
+    .from(workflowUserAutomationThreads)
+    .where(
+      and(
+        eq(workflowUserAutomationThreads.orgId, orgId),
+        eq(workflowUserAutomationThreads.workflowId, workflowId),
+      ),
+    );
+  const storage = await database
+    .select({
+      id: storages.id,
+      headVersionId: storages.headVersionId,
+      transaction: sql`${storages}.xmin::text`.mapWith(storages.name),
+    })
+    .from(storages)
+    .where(
+      and(
+        eq(storages.orgId, orgId),
+        eq(storages.userId, VOLUME_ORG_USER_ID),
+        eq(storages.name, getCustomSkillStorageName(workflowId)),
+      ),
+    );
+  const versions = await database
+    .select({
+      id: storageVersions.id,
+      transaction: sql`${storageVersions}.xmin::text`.mapWith(
+        storageVersions.id,
+      ),
+    })
+    .from(storageVersions)
+    .innerJoin(storages, eq(storages.id, storageVersions.storageId))
+    .where(
+      and(
+        eq(storages.orgId, orgId),
+        eq(storages.userId, VOLUME_ORG_USER_ID),
+        eq(storages.name, getCustomSkillStorageName(workflowId)),
+      ),
+    );
+  return { workflow, mappings, storage, versions };
+}
+
+export async function assertWorkflowPreparationUnlockedFixture(
+  agentId: string,
+  storageId: string,
+): Promise<void> {
+  await db().transaction(async (tx) => {
+    await tx
+      .select({ id: agents.id })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .for("update", { noWait: true });
+    await tx
+      .select({ id: storages.id })
+      .from(storages)
+      .where(eq(storages.id, storageId))
+      .for("update", { noWait: true });
+  });
+}
+
+const pidSchema = z.object({ pid: z.int() });
+
+export async function holdWorkflowCreationThreadFixture(
+  threadId: string,
+  signal: AbortSignal,
+) {
+  const started = createDeferredPromise<number>(signal);
+  const released = createDeferredPromise<void>(signal);
+  const done = db().transaction(async (tx) => {
+    await tx
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, threadId))
+      .for("update");
+    const [row] = await executeRawRows(
+      tx,
+      sql`SELECT pg_backend_pid() AS pid`,
+      pidSchema,
+    );
+    if (!row) {
+      throw new Error("Expected the creation-thread lock backend");
+    }
+    started.resolve(row.pid);
+    await released.promise;
+  });
+  const holderPid = await started.promise;
+  return {
+    done,
+    release: () => {
+      if (!released.settled()) {
+        released.resolve();
+      }
+    },
+    blockedPids: async () => {
+      const rows = await executeRawRows(
+        db(),
+        sql`SELECT pid FROM pg_stat_activity WHERE ${holderPid} = ANY(pg_blocking_pids(pid))`,
+        pidSchema,
+      );
+      return rows.map((row) => {
+        return row.pid;
+      });
+    },
+    cancelBlockedPublication: async (pid: number) => {
+      // Limit cancellation to a backend still blocked by this exact fixture.
+      await db().execute(
+        sql`SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE pid = ${pid} AND ${holderPid} = ANY(pg_blocking_pids(pid))`,
+      );
+    },
+  };
+}


### PR DESCRIPTION
## Summary

`POST /api/workflows` currently commits the Workflow and creation-thread mapping before uploading its files. An exhausted S3 request can therefore fail creation after a visible Workflow has already occupied the name. This change prepares the complete file volume first and publishes the Workflow and its file-version association together.

- Allocate a fresh Workflow UUID, synthesize `SKILL.md`, and prepare/upload/verify every supplied file outside the publication transaction using the existing storage prepare primitive.
- In one short transaction, lock and revalidate the agent/access/name boundary, insert the Workflow and any still-valid creation-thread mapping, and commit the prepared storage version and HEAD. Existing unique constraints arbitrate name conflicts; a losing create receives the existing 409 response.
- Reuse scoped orphan-volume cleanup with an independent five-second budget. Publication and cleanup lock the same storage identity before the authoritative Workflow-reference check, so an uncertain COMMIT is not mistaken for a rollback. Cleanup preserves the original error and never deletes a Workflow. Notifications and response construction remain outside the cleanup boundary after commit.

The existing 201 payload, default-private visibility, public/private name scopes, thread ownership checks, CLI/API error handling, and storage SDK retry policy remain compatible. Copy/Remix retains its source-consistency transaction; its shared orphan-cleanup caller is covered by an existing targeted regression. No migration, backfill, historical deletion, new state machine, worker, or production release is included.

## Verification

| Contract | Evidence |
| --- | --- |
| Pending preparation publishes no Workflow, binding, version or HEAD | Deferred S3 uploads; list/run API checks; scoped real-DB fixture; agent/storage `FOR UPDATE NOWAIT` succeeds during upload |
| Archive/manifest upload and verification failures, cancellation and invalid file materialization do not reserve the name | Four storage failure variants, cancellation and materialization regression; identical healthy create succeeds afterward |
| Successful files and business rows publish together | Readable original attachments and synthesized `SKILL.md`; Workflow, mapping, version and HEAD have the same PostgreSQL transaction ID |
| Publication failure rolls back all rows | A real transaction is paused at the creation-thread lock and its blocked backend statement is cancelled; no published rows remain and retry succeeds |
| Concurrent public/private names have one winner | Deferred concurrent creates produce 201 and the existing 409; losing preparation is removed and winner files remain readable |
| Mutable boundaries and committed success stay safe | Agent deletion/access revocation and thread deletion during upload; post-commit notification failure/cancellation; cleanup failure preserves the exact original error and other Workflows in the same and another org |

Local checks:

- `workflows-creation.test.ts` and `workflows.test.ts`: **43 passed** (16 new regression cases plus 27 existing cases).
- Existing Official Copy durable-publication/rejected-upload regression: **1 passed** (selected by test name).
- API type checks; scoped Oxlint, type-aware Oxlint and ESLint; Prettier; API-workspace Knip; `git diff --check`.
- Local PostgreSQL was initially configured with `Asia/Shanghai`, causing an existing runner-job expiry assertion to fail identically on the unchanged main baseline. Setting this local test database to UTC resolved it; the 43-case run above is the subsequent passing result. No product code or test was changed for that environment issue.
- Full local Vitest and a local dev server were not run. Broader validation runs in the PR pipeline.

## Production evidence and limits

The corrected incident is a **POST creation** S3 `ServiceUnavailable` / HTTP 503, with **three total SDK attempts**, not a GET/listing failure or evidence of missing SDK retries. The exact failing S3 operation and whether that historical request left a partial Workflow remain unconfirmed.

The issue's read-only MaskDB inventory at **2026-09-08T09:34:00.265Z** counted **1,159 Workflow rows: 187 public and 972 private**. It used two complete `limit=1000` pages with a fixed creation-time upper bound and client-side counting. These were live reads, **not a transactional snapshot or affected-row count**; the historical orphan count is unknown. This PR contains no migration/backfill or historical repair.

PostgreSQL publication is atomic; S3 and PostgreSQL do not form a distributed transaction. A killed process, storage outage or bounded cleanup timeout can leave unreferenced preparation objects. A later notification, response or cancellation failure can also occur after a valid Workflow has committed; it must not remove that Workflow.

Closes #32137
