### PR TITLE
fix(models): classify provider cooldown report logs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -34,6 +34,23 @@ const chat = createChatFilesBddApi(context);
 const runs = createRunsApi(context);
 const reads = createRunReadsApi(context);
 
+function cooldownReports(level: "debug" | "info" | "warn" | "error") {
+  return context.mocks.axiomLogging[level].mock.calls.filter(([, fields]) => {
+    return (
+      typeof fields === "object" &&
+      fields !== null &&
+      "type" in fields &&
+      fields.type === "built_in_model_provider_cooldown"
+    );
+  });
+}
+
+function expectNoCooldownReports(): void {
+  for (const level of ["debug", "info", "warn", "error"] as const) {
+    expect(cooldownReports(level)).toStrictEqual([]);
+  }
+}
+
 interface ClaimedBuiltInRun {
   readonly actor: ReturnType<typeof bdd.user>;
   readonly agentId: string;
@@ -415,36 +432,42 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
   it.each([
     {
       caseName: "authentication intervention",
+      logLevel: "warn",
       body: { failureKind: "authentication", retryAfterSeconds: 1 },
       source: "unspecified",
       cooldownSeconds: 30 * 60,
     },
     {
       caseName: "billing intervention",
+      logLevel: "warn",
       body: { failureKind: "billing", retryAfterSeconds: 1 },
       source: "unspecified",
       cooldownSeconds: 30 * 60,
     },
     {
       caseName: "rate limit default",
+      logLevel: "info",
       body: { failureKind: "rate_limit" },
       source: "unspecified",
       cooldownSeconds: 5 * 60,
     },
     {
       caseName: "provider unavailable default",
+      logLevel: "info",
       body: { failureKind: "provider_unavailable" },
       source: "unspecified",
       cooldownSeconds: 5 * 60,
     },
     {
       caseName: "timeout default",
+      logLevel: "info",
       body: { failureKind: "timeout" },
       source: "unspecified",
       cooldownSeconds: 5 * 60,
     },
     {
       caseName: "provider-response connection default",
+      logLevel: "info",
       body: {
         failureKind: "connection",
         connectionSource: "provider_response",
@@ -454,13 +477,14 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     },
     {
       caseName: "bounded provider retry delay",
+      logLevel: "info",
       body: { failureKind: "rate_limit", retryAfterSeconds: 120 },
       source: "unspecified",
       cooldownSeconds: 120,
     },
   ] as const)(
     "records the $caseName cooldown for only the persisted built-in model route",
-    async ({ body, source, cooldownSeconds }) => {
+    async ({ body, source, cooldownSeconds, logLevel }) => {
       const startedAt = Date.UTC(2026, 7, 21, 0, 0, 0);
       await withMockNowForTest(startedAt, async () => {
         const claimed = await createClaimedBuiltInRun();
@@ -480,24 +504,31 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         await expect(
           runs.reportRunnerModelProviderFailure(claimed.runId, body),
         ).resolves.toStrictEqual({ outcome: "recorded" });
-        expect(context.mocks.axiomLogging.error).toHaveBeenCalledWith(
-          "Built-in model provider failure report recorded",
-          expect.objectContaining({
-            type: "built_in_model_provider_cooldown",
-            context: "Runners",
-            runId: claimed.runId,
-            selectedModel: claimed.selectedModel,
-            providerType: primary.provider_type,
-            upstreamModel: primary.upstream_model,
-            failureKind: body.failureKind,
-            source,
-            reason: body.failureKind,
-            retryAfterSeconds: cooldownSeconds,
-            unavailableUntil: new Date(
-              startedAt + cooldownSeconds * 1000,
-            ).toISOString(),
-          }),
-        );
+        expect(cooldownReports(logLevel)).toStrictEqual([
+          [
+            "Built-in model provider failure report recorded",
+            expect.objectContaining({
+              type: "built_in_model_provider_cooldown",
+              context: "Runners",
+              runId: claimed.runId,
+              selectedModel: claimed.selectedModel,
+              providerType: primary.provider_type,
+              upstreamModel: primary.upstream_model,
+              failureKind: body.failureKind,
+              source,
+              reason: body.failureKind,
+              retryAfterSeconds: cooldownSeconds,
+              unavailableUntil: new Date(
+                startedAt + cooldownSeconds * 1000,
+              ).toISOString(),
+            }),
+          ],
+        ]);
+        for (const level of ["debug", "info", "warn", "error"] as const) {
+          if (level !== logLevel) {
+            expect(cooldownReports(level)).toStrictEqual([]);
+          }
+        }
         await expect(
           runs.readRun(claimed.actor, claimed.runId),
         ).resolves.toMatchObject({ status: "running" });
@@ -555,7 +586,9 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
       claimed.selectedModel,
       primary,
     );
-    context.mocks.axiomLogging.error.mockClear();
+    for (const level of ["debug", "info", "warn", "error"] as const) {
+      context.mocks.axiomLogging[level].mockClear();
+    }
     await withMockNowForTest(startedAt, async () => {
       await expect(
         runs.reportRunnerModelProviderFailure(secondClaimed.runId, {
@@ -571,6 +604,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
       });
     });
     expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+    expectNoCooldownReports();
 
     await withMockNowForTest(startedAt + 60_000, async () => {
       await expect(
@@ -586,17 +620,30 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         upstream_model: primary.upstream_model,
       });
     });
-    expect(context.mocks.axiomLogging.error).toHaveBeenCalledTimes(1);
-    expect(context.mocks.axiomLogging.error).toHaveBeenCalledWith(
-      "Built-in model provider failure report recorded",
-      expect.objectContaining({
-        type: "built_in_model_provider_cooldown",
-        failureKind: "connection",
-        source: "upstream_transport",
-        reason: "sustained_transport",
-        unavailableUntil: new Date(startedAt + 6 * 60_000).toISOString(),
-      }),
-    );
+    expect(cooldownReports("info")).toStrictEqual([
+      [
+        "Built-in model provider failure report recorded",
+        expect.objectContaining({
+          type: "built_in_model_provider_cooldown",
+          context: "Runners",
+          runId: claimed.runId,
+          selectedModel: claimed.selectedModel,
+          providerType: primary.provider_type,
+          upstreamModel: primary.upstream_model,
+          failureKind: "connection",
+          source: "upstream_transport",
+          reason: "sustained_transport",
+          retryAfterSeconds: 5 * 60,
+          unavailableUntil: new Date(startedAt + 6 * 60_000).toISOString(),
+        }),
+      ],
+    ]);
+    for (const level of ["debug", "warn", "error"] as const) {
+      expect(cooldownReports(level)).toStrictEqual([]);
+    }
+    await expect(
+      runs.readRun(claimed.actor, claimed.runId),
+    ).resolves.toMatchObject({ status: "running" });
   });
 
   it("keeps an observation-only route selectable to an in-flight resolver", async () => {
@@ -624,6 +671,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
       ).resolves.toStrictEqual({ outcome: "observed" });
     });
 
+    expectNoCooldownReports();
     // A resolver can capture time before the observation transaction commits.
     await withMockNowForTest(startedAt - 1, async () => {
       await expect(
@@ -656,7 +704,9 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         failureKind: "rate_limit",
         retryAfterSeconds: 60,
       });
-      context.mocks.axiomLogging.error.mockClear();
+      for (const level of ["debug", "info", "warn", "error"] as const) {
+        context.mocks.axiomLogging[level].mockClear();
+      }
       await expect(
         runs.reportRunnerModelProviderFailure(claimed.runId, {
           failureKind: "connection",
@@ -666,6 +716,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     });
 
     expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+    expectNoCooldownReports();
     await withMockNowForTest(startedAt + 60_000, async () => {
       await expect(
         resolveBuiltInModelRouteFixture(context, claimed.selectedModel),
@@ -731,7 +782,9 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         failureKind: "authentication",
       });
     });
-    context.mocks.axiomLogging.error.mockClear();
+    for (const level of ["debug", "info", "warn", "error"] as const) {
+      context.mocks.axiomLogging[level].mockClear();
+    }
     await withMockNowForTest(startedAt + 100_000, async () => {
       await expect(
         runs.reportRunnerModelProviderFailure(claimed.runId, {
@@ -771,6 +824,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     });
 
     expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+    expectNoCooldownReports();
     await withMockNowForTest(startedAt + 8 * 60_000, async () => {
       await expect(
         resolveBuiltInModelRouteFixture(context, claimed.selectedModel),
@@ -1080,6 +1134,26 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         ]);
       });
 
+      expect(cooldownReports("info")).toStrictEqual([
+        [
+          "Built-in model provider failure report recorded",
+          expect.objectContaining({
+            failureKind: "rate_limit",
+            unavailableUntil: new Date(startedAt + 300_000).toISOString(),
+          }),
+        ],
+        [
+          "Built-in model provider failure report recorded",
+          expect.objectContaining({
+            failureKind: "provider_unavailable",
+            unavailableUntil: new Date(startedAt + 400_000).toISOString(),
+          }),
+        ],
+      ]);
+      for (const level of ["debug", "warn", "error"] as const) {
+        expect(cooldownReports(level)).toStrictEqual([]);
+      }
+
       await withMockNowForTest(startedAt + 350_000, async () => {
         await expect(
           resolveBuiltInModelRouteFixture(context, claimed.selectedModel),
@@ -1096,6 +1170,90 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
           upstream_model: primary.upstream_model,
         });
       });
+    });
+  });
+
+  it("preserves the application error boundary when a report query fails", async () => {
+    const claimed = await createClaimedBuiltInRun();
+    const primary = await resolveBuiltInModelRouteFixture(
+      context,
+      claimed.selectedModel,
+    );
+    if (!primary) {
+      throw new Error("Expected a built-in model primary route");
+    }
+    // Give the infrastructure failure a run-owned route so its row lock cannot
+    // block or cancel another test's provider report.
+    const fixtureRoute = {
+      ...primary,
+      upstream_model: `fixture-${randomUUID()}`,
+    };
+    await setRunModelRuntimeRouteFixture({
+      runId: claimed.runId,
+      modelRuntimeProvider: fixtureRoute.provider_type,
+      modelRuntimeModel: fixtureRoute.upstream_model,
+    });
+    await setBuiltInCandidateCooldownFixture(
+      context,
+      claimed.selectedModel,
+      fixtureRoute,
+      new Date(0),
+    );
+    const held = await holdBuiltInModelRouteLockFixture({
+      route: {
+        selectedModel: claimed.selectedModel,
+        providerType: fixtureRoute.provider_type,
+        upstreamModel: fixtureRoute.upstream_model,
+      },
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      held.release();
+      await held.done;
+    });
+    const report = await runs.startRunnerModelProviderFailureWithDelayedBody(
+      claimed.runId,
+      { failureKind: "rate_limit" },
+    );
+    onTestFinished(async () => {
+      report.releaseBody();
+      held.release();
+      await report.response;
+    });
+    report.releaseBody();
+    await expect.poll(held.blockedWaiterCount).toBe(1);
+
+    // Infrastructure can fail a query; the production API cannot request that
+    // state. Fail only this fixture's waiter, keeping the request signal live.
+    await expect(held.cancelBlockedQueries()).resolves.toBe(1);
+    await expect(report.response).resolves.toStrictEqual({
+      status: 500,
+      body: { error: "Internal server error" },
+    });
+    held.release();
+    await held.done;
+
+    expect(context.signal.aborted).toBeFalsy();
+    expect(context.mocks.axiomLogging.error).toHaveBeenCalledTimes(1);
+    expect(context.mocks.axiomLogging.error).toHaveBeenCalledWith(
+      "Unhandled request error: canceling statement due to user request",
+      expect.objectContaining({
+        type: "unhandled_request_error",
+        method: "POST",
+        route: "/api/runners/runs/:runId/model-provider-failures",
+        errorCode: "57014",
+      }),
+    );
+    expect(context.mocks.sentry.captureException).toHaveBeenCalledTimes(1);
+    expectNoCooldownReports();
+    await expect(
+      runs.readRun(claimed.actor, claimed.runId),
+    ).resolves.toMatchObject({ status: "running" });
+    await expect(
+      resolveBuiltInModelRouteFixture(context, claimed.selectedModel),
+    ).resolves.toMatchObject({
+      provider_type: primary.provider_type,
+      upstream_model: primary.upstream_model,
     });
   });
 
@@ -1225,6 +1383,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
           failureKind: "billing",
         }),
       ).resolves.toStrictEqual({ outcome: "ignored" });
+      expectNoCooldownReports();
 
       await expect(
         resolveBuiltInModelRouteFixture(context, claimed.selectedModel),

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -2743,12 +2743,26 @@ const modelProviderFailureInner$ = command(
     });
     signal.throwIfAborted();
     if (transition.outcome === "recorded" && transition.cooldown) {
-      L.error("Built-in model provider failure report recorded", {
-        type: "built_in_model_provider_cooldown",
-        runId,
-        ...transition.cooldown,
-        unavailableUntil: transition.cooldown.unavailableUntil.toISOString(),
-      });
+      const logLevels = {
+        authentication: "warn",
+        billing: "warn",
+        rate_limit: "info",
+        provider_unavailable: "info",
+        timeout: "info",
+        connection: "info",
+      } as const satisfies Record<
+        typeof transition.cooldown.failureKind,
+        "info" | "warn"
+      >;
+      L[logLevels[transition.cooldown.failureKind]](
+        "Built-in model provider failure report recorded",
+        {
+          type: "built_in_model_provider_cooldown",
+          runId,
+          ...transition.cooldown,
+          unavailableUntil: transition.cooldown.unavailableUntil.toISOString(),
+        },
+      );
     }
     return { status: 200 as const, body: { outcome: transition.outcome } };
   },

--- a/turbo/apps/api/src/test-fixtures/built-in-model-runtime-route.ts
+++ b/turbo/apps/api/src/test-fixtures/built-in-model-runtime-route.ts
@@ -23,6 +23,7 @@ interface HeldBuiltInModelRouteBoundary {
   readonly release: () => void;
   readonly done: Promise<void>;
   readonly blockedWaiterCount: () => Promise<number>;
+  readonly cancelBlockedQueries: () => Promise<number>;
 }
 
 /**
@@ -121,6 +122,22 @@ export async function holdBuiltInModelRouteLockFixture(args: {
     done,
     blockedWaiterCount: async () => {
       return await blockedWaiterCount(pid);
+    },
+    // A real query failure cannot be requested through the report API. Only
+    // cancel queries waiting on this fixture's owned row lock.
+    cancelBlockedQueries: async () => {
+      const rows = await executeRawRows(
+        db(),
+        sql`
+          SELECT pg_cancel_backend(activity.pid) AS cancelled
+          FROM pg_stat_activity AS activity
+          WHERE ${pid} = ANY(pg_blocking_pids(activity.pid))
+        `,
+        z.object({ cancelled: z.boolean() }),
+      );
+      return rows.filter((row) => {
+        return row.cancelled;
+      }).length;
     },
   };
 }


### PR DESCRIPTION
## Summary

Successful built-in provider cooldown updates were reported as API errors. Classify the existing committed transition explicitly by its typed failure kind: `rate_limit`, `provider_unavailable`, `timeout`, and `connection` now log at `info`; provider `authentication` and `billing` log at `warn`.

The original `recorded && cooldown` guard, event message, type, diagnostic fields and ISO deadline remain intact. Observed, ignored and non-extending reports stay silent, while genuine non-abort processing failures retain the existing application error boundary and 500 response. Cooldown policy, route selection, run status, API contracts and production data are unchanged.

Closes #32134

## Coverage and validation

- Extend the existing endpoint table for all six failure kinds and bounded retry delay; assert the exact message and fields, expected severity and absence at every other level.
- Cover both connection activation sources, observation-only/no-extension silence, and multiple legitimate deadline extensions. Preserve existing duration, route, run-status, delayed-body/row-lock and transport-evidence assertions.
- Reuse the real PostgreSQL row-lock fixture for an isolated query failure on a UUID-owned route. Assert the unchanged 500 body, one application error/Sentry capture, a live request signal, no cooldown event, and unchanged run/unrelated-route behavior. No internal service/database mocks or sleeps.
- Passed: targeted Prettier, Oxlint (including type-aware checks), ESLint, API workspace type checks, API-scoped Knip and `git diff --check`.
- Passed: `pnpm -F api exec vitest run src/signals/routes/__tests__/test-runtime-state.test.ts src/__tests__/app-factory.test.ts --maxWorkers=1 --silent=passed-only` — **94 tests, 2 files**. Used repository-pinned pnpm 10.33.4 and local PostgreSQL with UTC sessions. The initial local run failed at claim setup because the freshly initialized database defaulted to Asia/Shanghai; configuring only that test database to UTC resolved the fixture failures without source changes.
- Full local Vitest/dev-server runs were not used; required PR and merge-group coverage remains enforced by CI.

## Scale and rollout

The controller's read-only MaskDB inventory began at `2026-09-08T09:57:56.804Z` and counted **5 stored route-identity rows** in `built_in_model_candidate_cooldown`. It read one complete `limit=1000` page containing only the three route-identity columns, ordered by composite identity, and counted client-side. This was a live, non-transactional read, not a snapshot, active-cooldown count, error/report count, affected-run count or affected-user count. Controller code baseline: `102f26387e677aad1261455c57dc0ffa1e829e67`; implementation started from `d7aae1fd1f563af6024cc28400f3d08efd1bb086` with unchanged affected code.

No schema changes, migration, backfill, feature flag or production write is needed. Refreshed inventory of 46 open PRs found no overlapping target route, service, test or row-lock fixture and no other #32134 implementation PR. This owner carries the PR through a fresh exact-head tracked review, required CI and the normal protected merge queue. Production publication remains outside this PR owner's authority.
