### PR TITLE
ci: start each preview runner on one selected metal host

### DIFF
--- a/.github/scripts/reconcile-and-start-runner-groups.sh
+++ b/.github/scripts/reconcile-and-start-runner-groups.sh
@@ -40,6 +40,13 @@ for name in "${required_env[@]}"; do
   require_env "$name"
 done
 
+# Match the Crates Runner behavior lane's selection without replicating each
+# CI namespace's idle and prewarmed pools across every metal host.
+SELECTED_CONTEXT=$(AWS_METAL_RUNNER_HOSTS="$METAL_HOSTS" \
+  "${SCRIPT_DIR}/runner-host-architecture-groups.sh" select-context "$JOB_REF")
+SELECTED_HOST=$(jq -r '.host' <<<"$SELECTED_CONTEXT")
+echo "Selected runner service host: ${SELECTED_HOST}"
+
 work_dir=$(mktemp -d "${RUNNER_TEMP:-/tmp}/runner-reconcile-start.XXXXXX")
 trap 'rm -rf "$work_dir"' EXIT
 check_output="${work_dir}/check.out"
@@ -234,6 +241,7 @@ stop_started_hosts() {
   local HOST_INDEX=0
   for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
     HOST_INDEX=$((HOST_INDEX + 1))
+    [ "$HOST" = "$SELECTED_HOST" ] || continue
     local RUNNER_SERVICE_SUFFIX="${RUNNER_SERVICE_REF}-${HOST_INDEX}"
     local REMOTE="${METAL_USER}@${HOST}"
     echo "::warning::Requesting stop for partially started runner service ${RUNNER_SERVICE_SUFFIX} on ${HOST}"
@@ -267,6 +275,8 @@ export -f read_host_capacity start_on_host
 HOST_INDEX=0
 for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
   HOST_INDEX=$((HOST_INDEX + 1))
+  # Retain the original inventory index so reruns replace the existing service.
+  [ "$HOST" = "$SELECTED_HOST" ] || continue
   HOSTS+=("$HOST")
   RUNNER_START_RECORDING=1
   setsid bash -c 'start_on_host "$@"' start_on_host "$HOST" "$HOST_INDEX" >"${LOG_DIR}/${HOST}.log" 2>&1 &

--- a/.github/scripts/reconcile-and-start-runner-groups.sh
+++ b/.github/scripts/reconcile-and-start-runner-groups.sh
@@ -45,6 +45,7 @@ done
 SELECTED_CONTEXT=$(AWS_METAL_RUNNER_HOSTS="$METAL_HOSTS" \
   "${SCRIPT_DIR}/runner-host-architecture-groups.sh" select-context "$JOB_REF")
 SELECTED_HOST=$(jq -r '.host' <<<"$SELECTED_CONTEXT")
+export SELECTED_HOST
 echo "Selected runner service host: ${SELECTED_HOST}"
 
 work_dir=$(mktemp -d "${RUNNER_TEMP:-/tmp}/runner-reconcile-start.XXXXXX")
@@ -103,7 +104,7 @@ read_host_capacity() {
   ssh "$REMOTE" "sudo ${BIN_DIR}/runner service wait-running --name ${RUNNER_SERVICE_SUFFIX} --timeout-secs 120"
 }
 
-start_on_host() {
+reconcile_service_on_host() {
   set -euo pipefail
 
   local HOST=$1
@@ -112,6 +113,16 @@ start_on_host() {
   local RUNNER_DIRNAME="${RUNNER_DIR##*/}"
   local REMOTE="${METAL_USER}@${HOST}"
   local MC
+
+  # Retire the current service namespace on every host, including staging:
+  # its service names stay stable while image directories and selection change.
+  # shellcheck disable=SC2029
+  timeout 180s ssh "$REMOTE" "sudo ${BIN_DIR}/runner service stop --name '${RUNNER_SERVICE_SUFFIX}' --force --cleanup partial-start"
+  if [ "$HOST" != "$SELECTED_HOST" ]; then
+    echo "Retired unselected runner service ${RUNNER_SERVICE_SUFFIX} on ${HOST}"
+    return
+  fi
+
   echo "=== Starting runner service ${RUNNER_SERVICE_SUFFIX} on ${HOST} ==="
 
   local ROOTFS_HASH SNAPSHOT_HASH
@@ -143,8 +154,6 @@ start_on_host() {
     --api-url ${RUNNER_API_URL} \
     --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
-  # shellcheck disable=SC2029
-  timeout 180s ssh "$REMOTE" "sudo ${BIN_DIR}/runner service stop --name '${RUNNER_SERVICE_SUFFIX}' --force --cleanup partial-start"
   # shellcheck disable=SC2029
   ssh "$REMOTE" "sudo rm -f ${RUNNER_DIR}/status.json"
 
@@ -271,15 +280,14 @@ cleanup_runner_start() {
 trap cleanup_runner_start EXIT
 trap 'request_runner_start_exit 130' INT
 trap 'request_runner_start_exit 143' TERM
-export -f read_host_capacity start_on_host
+export -f read_host_capacity reconcile_service_on_host
 HOST_INDEX=0
 for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
   HOST_INDEX=$((HOST_INDEX + 1))
   # Retain the original inventory index so reruns replace the existing service.
-  [ "$HOST" = "$SELECTED_HOST" ] || continue
   HOSTS+=("$HOST")
   RUNNER_START_RECORDING=1
-  setsid bash -c 'start_on_host "$@"' start_on_host "$HOST" "$HOST_INDEX" >"${LOG_DIR}/${HOST}.log" 2>&1 &
+  setsid bash -c 'reconcile_service_on_host "$@"' reconcile_service_on_host "$HOST" "$HOST_INDEX" >"${LOG_DIR}/${HOST}.log" 2>&1 &
   PIDS+=($!)
   PGIDS+=($!)
   RUNNER_START_RECORDING=0
@@ -291,7 +299,7 @@ for i in "${!PIDS[@]}"; do
   if ! wait "${PIDS[$i]}"; then
     check_runner_start_exit
     FAILED=1
-    echo "::error::Runner start failed on ${HOSTS[$i]}"
+    echo "::error::Runner service reconciliation failed on ${HOSTS[$i]}"
   fi
   check_runner_start_exit
   echo "=== ${HOSTS[$i]} ==="

--- a/.github/scripts/tests/reconcile-and-start-runner-groups-test.sh
+++ b/.github/scripts/tests/reconcile-and-start-runner-groups-test.sh
@@ -58,6 +58,10 @@ case "$*" in
     if [ "${MOCK_FAILURE:-none}" = readiness ]; then
       exit 1
     fi
+    if [ "${MOCK_FAILURE:-none}" = cancel ]; then
+      kill -TERM "$MOCK_DEPLOY_PID"
+      exit 0
+    fi
     echo 35
     ;;
   "sudo ${BIN_DIR}/runner doctor "*) ;;
@@ -65,6 +69,12 @@ case "$*" in
 esac
 SH
 chmod +x "${tmp_dir}/bin/ssh"
+
+cat >"${tmp_dir}/run-deployment" <<'SH'
+#!/usr/bin/env bash
+export MOCK_DEPLOY_PID=$$
+exec bash "$@"
+SH
 
 run_case() {
   local case_name=$1 job_ref=$2 selected_host=$3 selected_index=$4 failure=$5
@@ -109,10 +119,13 @@ run_case() {
     MOCK_REMOTE_ROOT="$case_dir" \
     MOCK_SERVICE_LOG="${case_dir}/service.log" \
     MOCK_FAILURE="$failure" \
-    bash "$script" >"${case_dir}/output" 2>&1 || status=$?
+    bash "${tmp_dir}/run-deployment" "$script" >"${case_dir}/output" 2>&1 || status=$?
 
   if [ "$failure" != none ]; then
     [ "$status" -ne 0 ] || fail "${case_name}: ${failure} failure must fail deployment"
+    if [ "$failure" = cancel ]; then
+      [ "$status" -eq 143 ] || fail "${case_name}: cancellation must preserve the signal exit code"
+    fi
     [ ! -f "${case_dir}/${selected_host}/${service_ref}-${selected_index}" ] ||
       fail "${case_name}: failed start left the selected service running"
   else
@@ -138,6 +151,8 @@ run_case() {
     [ "$(cat "${case_dir}/${host}/pr-999-${host_index}")" = unrelated-service ] ||
       fail "${case_name}: deployment changed another PR's service"
     [ "$host" = "$selected_host" ] && continue
+    # Cancellation can interrupt retirement, but must roll back the new service.
+    [ "$failure" = cancel ] && continue
     if [ "$failure" = retire ] && [ "$host" = x86-2 ]; then
       [ -f "${case_dir}/${host}/${service_ref}-${host_index}" ] ||
         fail "${case_name}: fixture did not retain the failed retirement"
@@ -154,6 +169,7 @@ run_case x86 pr-1 x86-1 2 none
 run_case arm pr-2 arm-1 1 none
 run_case failed-start pr-9 x86-2 3 readiness
 run_case failed-retirement pr-1 x86-1 2 retire
+run_case cancelled-start pr-9 x86-2 3 cancel
 # A new staging image ref can select another host while service names stay fixed.
 run_case staging staging-000000000000 arm-1 1 none
 run_case staging staging-222222222222 x86-1 2 none

--- a/.github/scripts/tests/reconcile-and-start-runner-groups-test.sh
+++ b/.github/scripts/tests/reconcile-and-start-runner-groups-test.sh
@@ -38,20 +38,24 @@ if [ "$*" = "bash -s -- $BIN_DIR" ]; then
 fi
 
 printf '%s\t%s\n' "$host" "$*" >>"$MOCK_SERVICE_LOG"
+service_name=$(printf '%s\n' "$*" | sed -n "s/.*--name ['\"]*\\([a-z0-9-]*\\).*/\\1/p")
 case "$*" in
   "test -x ${BIN_DIR}/runner") ;;
   "sudo ${BIN_DIR}/runner config "*)
     printf '%s\n' "$*" >"${MOCK_REMOTE_ROOT}/${host}/config"
     ;;
   "sudo ${BIN_DIR}/runner service stop "*)
-    rm -f "${MOCK_REMOTE_ROOT}/${host}/service"
+    if [ "${MOCK_FAILURE:-none}" = retire ] && [ "$host" = x86-2 ]; then
+      exit 1
+    fi
+    rm -f "${MOCK_REMOTE_ROOT}/${host}/${service_name}"
     ;;
   "sudo rm -f ${RUNNER_DIR}/status.json") ;;
   "sudo ${BIN_DIR}/runner service start "*)
-    printf '%s\n' "$*" >"${MOCK_REMOTE_ROOT}/${host}/service"
+    printf '%s\n' "$*" >"${MOCK_REMOTE_ROOT}/${host}/${service_name}"
     ;;
   "sudo ${BIN_DIR}/runner service wait-running "*)
-    if [ "${MOCK_FAIL_READINESS:-false}" = true ]; then
+    if [ "${MOCK_FAILURE:-none}" = readiness ]; then
       exit 1
     fi
     echo 35
@@ -63,21 +67,30 @@ SH
 chmod +x "${tmp_dir}/bin/ssh"
 
 run_case() {
-  local case_name=$1 job_ref=$2 selected_host=$3 selected_index=$4 fail_readiness=$5
+  local case_name=$1 job_ref=$2 selected_host=$3 selected_index=$4 failure=$5
   local case_dir="${tmp_dir}/${case_name}"
-  mkdir -p "$case_dir"
-  local host
-  for host in arm-1 x86-1 x86-2; do
-    mkdir -p "${case_dir}/${host}"
-    printf 'existing-service\n' >"${case_dir}/${host}/service"
-  done
+  local service_ref=$job_ref current_event=pull_request
+  if [[ "$job_ref" == staging-* ]]; then
+    service_ref=staging
+    current_event=push
+  fi
+  local host host_index=0
+  if [ ! -d "$case_dir" ]; then
+    for host in arm-1 x86-1 x86-2; do
+      host_index=$((host_index + 1))
+      mkdir -p "${case_dir}/${host}"
+      printf 'existing-service\n' >"${case_dir}/${host}/${service_ref}-${host_index}"
+      printf 'unrelated-service\n' >"${case_dir}/${host}/pr-999-${host_index}"
+    done
+  fi
+  : >"${case_dir}/service.log"
 
   local status=0
   env \
     PATH="${tmp_dir}/bin:$PATH" \
     AWS_METAL_RUNNER_HOSTS=arm-1,x86-1,x86-2 \
     BIN_DIR="/var/lib/vm0-runner/bin/${job_ref}" \
-    CURRENT_EVENT=pull_request \
+    CURRENT_EVENT="$current_event" \
     CURRENT_RUN_ID=123 \
     DEFAULT_BRANCH=main \
     JOB_REF="$job_ref" \
@@ -88,48 +101,61 @@ run_case() {
     ROOTFS_HASH_MAP='{"arm-1":"rootfs-arm","x86-1":"rootfs-x86-1","x86-2":"rootfs-x86-2"}' \
     RUNNER_API_URL=https://api.example.test \
     RUNNER_DIR="/var/lib/vm0-runner/runners/${job_ref}" \
-    RUNNER_GROUP="vm0/development-${job_ref}" \
-    RUNNER_SERVICE_REF="$job_ref" \
+    RUNNER_GROUP="vm0/development-${service_ref}" \
+    RUNNER_SERVICE_REF="$service_ref" \
     RUNNER_SHA_MAP='{"aarch64-unknown-linux-musl":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","x86_64-unknown-linux-musl":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}' \
     SNAPSHOT_HASH_MAP='{"arm-1":"snapshot-arm","x86-1":"snapshot-x86-1","x86-2":"snapshot-x86-2"}' \
     VERCEL_BYPASS=test-bypass \
     MOCK_REMOTE_ROOT="$case_dir" \
     MOCK_SERVICE_LOG="${case_dir}/service.log" \
-    MOCK_FAIL_READINESS="$fail_readiness" \
+    MOCK_FAILURE="$failure" \
     bash "$script" >"${case_dir}/output" 2>&1 || status=$?
 
-  if [ "$fail_readiness" = true ]; then
-    [ "$status" -ne 0 ] || fail "${case_name}: failed readiness must fail deployment"
-    [ ! -f "${case_dir}/${selected_host}/service" ] ||
+  if [ "$failure" != none ]; then
+    [ "$status" -ne 0 ] || fail "${case_name}: ${failure} failure must fail deployment"
+    [ ! -f "${case_dir}/${selected_host}/${service_ref}-${selected_index}" ] ||
       fail "${case_name}: failed start left the selected service running"
   else
     if [ "$status" -ne 0 ]; then
       cat "${case_dir}/output" >&2
       fail "${case_name}: deployment failed"
     fi
-    grep -Fq -- "--name ${job_ref}-${selected_index}" "${case_dir}/${selected_host}/service" ||
+    grep -Fq -- "--name ${service_ref}-${selected_index}" "${case_dir}/${selected_host}/${service_ref}-${selected_index}" ||
       fail "${case_name}: selected service lost its original inventory index"
     grep -Fq -- "--hostname ${selected_host}" "${case_dir}/${selected_host}/config" ||
       fail "${case_name}: config does not use the selected host"
   fi
 
-  [ "$(cut -f1 "${case_dir}/service.log" | sort -u)" = "$selected_host" ] ||
-    fail "${case_name}: service operations reached an unselected host"
+  [ "$(awk '!/runner service stop / {print $1}' "${case_dir}/service.log" | sort -u)" = "$selected_host" ] ||
+    fail "${case_name}: start or readiness operations reached an unselected host"
   [ "$(grep -c 'runner service start ' "${case_dir}/service.log")" -eq 1 ] ||
     fail "${case_name}: deployment must start exactly one service"
-  grep -Fq -- "service wait-running --name ${job_ref}-${selected_index}" "${case_dir}/service.log" ||
+  grep -Fq -- "service wait-running --name ${service_ref}-${selected_index}" "${case_dir}/service.log" ||
     fail "${case_name}: readiness must use the selected service identity"
+  host_index=0
   for host in arm-1 x86-1 x86-2; do
+    host_index=$((host_index + 1))
+    [ "$(cat "${case_dir}/${host}/pr-999-${host_index}")" = unrelated-service ] ||
+      fail "${case_name}: deployment changed another PR's service"
     [ "$host" = "$selected_host" ] && continue
-    [ "$(cat "${case_dir}/${host}/service")" = existing-service ] ||
-      fail "${case_name}: deployment changed an unselected service"
+    if [ "$failure" = retire ] && [ "$host" = x86-2 ]; then
+      [ -f "${case_dir}/${host}/${service_ref}-${host_index}" ] ||
+        fail "${case_name}: fixture did not retain the failed retirement"
+    else
+      [ ! -f "${case_dir}/${host}/${service_ref}-${host_index}" ] ||
+        fail "${case_name}: unselected replica still serves the current namespace"
+    fi
   done
 }
 
 # These image refs select the same hosts as the existing Crates behavior lane.
-run_case x86 pr-1 x86-1 2 false
-run_case x86-rerun pr-1 x86-1 2 false
-run_case arm pr-2 arm-1 1 false
-run_case failed-start pr-9 x86-2 3 true
+run_case x86 pr-1 x86-1 2 none
+run_case x86 pr-1 x86-1 2 none
+run_case arm pr-2 arm-1 1 none
+run_case failed-start pr-9 x86-2 3 readiness
+run_case failed-retirement pr-1 x86-1 2 retire
+# A new staging image ref can select another host while service names stay fixed.
+run_case staging staging-000000000000 arm-1 1 none
+run_case staging staging-222222222222 x86-1 2 none
 
 echo "reconcile-and-start-runner-groups-test: ok"

--- a/.github/scripts/tests/reconcile-and-start-runner-groups-test.sh
+++ b/.github/scripts/tests/reconcile-and-start-runner-groups-test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+script="${repo_root}/.github/scripts/reconcile-and-start-runner-groups.sh"
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+mkdir -p "${tmp_dir}/bin"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+cat >"${tmp_dir}/bin/ssh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "-n" ]; then
+  shift
+fi
+host=${1#*@}
+shift
+case "$host" in
+  arm-1) arch=aarch64; target=aarch64-unknown-linux-musl ;;
+  x86-1|x86-2) arch=x86_64; target=x86_64-unknown-linux-musl ;;
+  *) echo "unexpected SSH host: $host" >&2; exit 1 ;;
+esac
+
+if [ "$*" = "uname -m" ]; then
+  echo "$arch"
+  exit 0
+fi
+if [ "$*" = "bash -s -- $BIN_DIR" ]; then
+  cat >/dev/null
+  jq -r --arg target "$target" '.[$target]' <<<"$RUNNER_SHA_MAP"
+  exit 0
+fi
+
+printf '%s\t%s\n' "$host" "$*" >>"$MOCK_SERVICE_LOG"
+case "$*" in
+  "test -x ${BIN_DIR}/runner") ;;
+  "sudo ${BIN_DIR}/runner config "*)
+    printf '%s\n' "$*" >"${MOCK_REMOTE_ROOT}/${host}/config"
+    ;;
+  "sudo ${BIN_DIR}/runner service stop "*)
+    rm -f "${MOCK_REMOTE_ROOT}/${host}/service"
+    ;;
+  "sudo rm -f ${RUNNER_DIR}/status.json") ;;
+  "sudo ${BIN_DIR}/runner service start "*)
+    printf '%s\n' "$*" >"${MOCK_REMOTE_ROOT}/${host}/service"
+    ;;
+  "sudo ${BIN_DIR}/runner service wait-running "*)
+    if [ "${MOCK_FAIL_READINESS:-false}" = true ]; then
+      exit 1
+    fi
+    echo 35
+    ;;
+  "sudo ${BIN_DIR}/runner doctor "*) ;;
+  *) echo "unexpected SSH command: $*" >&2; exit 1 ;;
+esac
+SH
+chmod +x "${tmp_dir}/bin/ssh"
+
+run_case() {
+  local case_name=$1 job_ref=$2 selected_host=$3 selected_index=$4 fail_readiness=$5
+  local case_dir="${tmp_dir}/${case_name}"
+  mkdir -p "$case_dir"
+  local host
+  for host in arm-1 x86-1 x86-2; do
+    mkdir -p "${case_dir}/${host}"
+    printf 'existing-service\n' >"${case_dir}/${host}/service"
+  done
+
+  local status=0
+  env \
+    PATH="${tmp_dir}/bin:$PATH" \
+    AWS_METAL_RUNNER_HOSTS=arm-1,x86-1,x86-2 \
+    BIN_DIR="/var/lib/vm0-runner/bin/${job_ref}" \
+    CURRENT_EVENT=pull_request \
+    CURRENT_RUN_ID=123 \
+    DEFAULT_BRANCH=main \
+    JOB_REF="$job_ref" \
+    METAL_HOSTS=arm-1,x86-1,x86-2 \
+    METAL_USER=ci \
+    OFFICIAL_RUNNER_SECRET=test-secret \
+    REPO=vm0-ai/vm0 \
+    ROOTFS_HASH_MAP='{"arm-1":"rootfs-arm","x86-1":"rootfs-x86-1","x86-2":"rootfs-x86-2"}' \
+    RUNNER_API_URL=https://api.example.test \
+    RUNNER_DIR="/var/lib/vm0-runner/runners/${job_ref}" \
+    RUNNER_GROUP="vm0/development-${job_ref}" \
+    RUNNER_SERVICE_REF="$job_ref" \
+    RUNNER_SHA_MAP='{"aarch64-unknown-linux-musl":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","x86_64-unknown-linux-musl":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}' \
+    SNAPSHOT_HASH_MAP='{"arm-1":"snapshot-arm","x86-1":"snapshot-x86-1","x86-2":"snapshot-x86-2"}' \
+    VERCEL_BYPASS=test-bypass \
+    MOCK_REMOTE_ROOT="$case_dir" \
+    MOCK_SERVICE_LOG="${case_dir}/service.log" \
+    MOCK_FAIL_READINESS="$fail_readiness" \
+    bash "$script" >"${case_dir}/output" 2>&1 || status=$?
+
+  if [ "$fail_readiness" = true ]; then
+    [ "$status" -ne 0 ] || fail "${case_name}: failed readiness must fail deployment"
+    [ ! -f "${case_dir}/${selected_host}/service" ] ||
+      fail "${case_name}: failed start left the selected service running"
+  else
+    if [ "$status" -ne 0 ]; then
+      cat "${case_dir}/output" >&2
+      fail "${case_name}: deployment failed"
+    fi
+    grep -Fq -- "--name ${job_ref}-${selected_index}" "${case_dir}/${selected_host}/service" ||
+      fail "${case_name}: selected service lost its original inventory index"
+    grep -Fq -- "--hostname ${selected_host}" "${case_dir}/${selected_host}/config" ||
+      fail "${case_name}: config does not use the selected host"
+  fi
+
+  [ "$(cut -f1 "${case_dir}/service.log" | sort -u)" = "$selected_host" ] ||
+    fail "${case_name}: service operations reached an unselected host"
+  [ "$(grep -c 'runner service start ' "${case_dir}/service.log")" -eq 1 ] ||
+    fail "${case_name}: deployment must start exactly one service"
+  grep -Fq -- "service wait-running --name ${job_ref}-${selected_index}" "${case_dir}/service.log" ||
+    fail "${case_name}: readiness must use the selected service identity"
+  for host in arm-1 x86-1 x86-2; do
+    [ "$host" = "$selected_host" ] && continue
+    [ "$(cat "${case_dir}/${host}/service")" = existing-service ] ||
+      fail "${case_name}: deployment changed an unselected service"
+  done
+}
+
+# These image refs select the same hosts as the existing Crates behavior lane.
+run_case x86 pr-1 x86-1 2 false
+run_case x86-rerun pr-1 x86-1 2 false
+run_case arm pr-2 arm-1 1 false
+run_case failed-start pr-9 x86-2 3 true
+
+echo "reconcile-and-start-runner-groups-test: ok"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -301,6 +301,7 @@ jobs:
             .github/scripts/tests/runner-attribution-ansible-test.sh \
             .github/scripts/tests/runner-promotion-ansible-test.sh \
             .github/scripts/tests/reconcile-runner-binary-groups-test.sh \
+            .github/scripts/tests/reconcile-and-start-runner-groups-test.sh \
             .github/scripts/tests/report-cgroup-memory-peak-test.sh \
             .github/scripts/tests/runner-lifecycle-lock-test.sh \
             .github/scripts/tests/rust-ci-memory-workflow-test.sh \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2465,6 +2465,7 @@ jobs:
 
   # Deploy runner start: start one service on the existing deterministic host
   # selection for runner-image-job-ref, matching the Crates Runner behavior lane.
+  # Retire the same service namespace on unselected hosts before reporting ready.
   # Shared image preparation and lifecycle locking still cover all hosts.
   # Waits for both deploy-runner-prepare (binaries + image) and deploy-api (preview URL)
   deploy-runner-start:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2463,7 +2463,9 @@ jobs:
           PROFILE: vm0/default
         run: .github/scripts/wait-runner-image-groups.sh
 
-  # Deploy runner start: generate config with real API preview URL and start service
+  # Deploy runner start: start one service on the existing deterministic host
+  # selection for runner-image-job-ref, matching the Crates Runner behavior lane.
+  # Shared image preparation and lifecycle locking still cover all hosts.
   # Waits for both deploy-runner-prepare (binaries + image) and deploy-api (preview URL)
   deploy-runner-start:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Closes #32643

- Start the Turbo CI Runner service on one metal host, using the existing `runner-host-architecture-groups.sh select-context "$JOB_REF"` selection shared with the Crates Runner behavior lane.
- Preserve the selected host's original inventory index in its service name, so reruns replace the existing service instead of creating a second identity.
- Retire unselected replicas of the same service namespace before reporting deployment success. This is required for staging, whose service names stay fixed while its image reference and selected host change. Failed retirement fails deployment and rolls back the selected service.
- Keep partial-start rollback limited to the selected host. Add SSH-boundary integration coverage for ARM/x86 selection, stable reruns, staging host changes, failed readiness/retirement, SIGTERM cancellation, and isolation from other PR services.

## Why

Each all-host Runner replica retains its own idle and prewarmed sandbox pools. During the dev-12 memory-pressure incident, historical monitoring recorded hundreds of retained VMs. This change prevents new deployments from multiplying those pools across every configured machine; it does not claim to fix a proven per-VM memory leak.

## Scope and risks

- Shared image preparation, all-host binary reconciliation, lifecycle locking, architecture coverage, and production release/rollback are unchanged.
- Runner group identity and API routing remain unchanged; no E2E tests, shards, or timeouts are removed or relaxed.
- A CI namespace now uses one Runner's capacity instead of pooling capacity across all hosts. Queueing or duration may increase under load, and selection is deterministic rather than load-aware.
- Only replicas of the namespace being deployed are retired on unselected hosts. Other PR namespaces are untouched and remain owned by existing closed-PR cleanup. This is not a machine-wide historical cleanup.
- This does not make CI independent of unselected-host availability because existing all-host image preparation and locking are retained.

## Validation

Passed locally on the submitted changes:

```sh
turbo/node_modules/.bin/prettier --check .github/workflows/turbo.yml .github/workflows/security.yml
bash -n .github/scripts/reconcile-and-start-runner-groups.sh
bash -n .github/scripts/tests/reconcile-and-start-runner-groups-test.sh
shellcheck .github/scripts/reconcile-and-start-runner-groups.sh .github/scripts/tests/reconcile-and-start-runner-groups-test.sh
codex-work/bin/actionlint
PATH="$PWD/codex-work/bin:$PATH" bash .github/scripts/check-workflow-shell-compatibility.sh
```

The following script tests passed (with the existing local `yq` binary on PATH):

```sh
for test_script in \
  reconcile-and-start-runner-groups \
  runner-host-architecture-groups \
  reconcile-runner-binary-groups \
  wait-runner-image-groups \
  runner-lifecycle-lock \
  runner-lifecycle-ownership-workflow \
  turbo-playwright-runner-workflow \
  crates-detect-workflow \
  runner-image-workflow \
  prepare-runner-image; do
  PATH="$PWD/codex-work/bin:$PATH" bash ".github/scripts/tests/${test_script}-test.sh"
done
```

The deployment integration script also passed five consecutive runs with the signal-driven cancellation case. The test cancels at the SSH readiness boundary and uses no sleep-based synchronization.

No live services were modified manually during implementation. Remote end-to-end validation remains with this PR's CI.
