### PR TITLE
fix(pi): bound bash output spooling with backpressure

### DIFF
--- a/turbo/packages/pi-agent-runtime/bash-spool-backpressure.md
+++ b/turbo/packages/pi-agent-runtime/bash-spool-backpressure.md
@@ -1,0 +1,185 @@
+# Pi Bash spool backpressure
+
+The version-pinned `@earendil-works/pi-coding-agent@0.84.1` patch fixes the
+local backend used by `createBashTool` in `src/session-runtime.ts`. The runtime
+still selects `/usr/local/bin/guest-tool-exec`; its factory and the existing
+AgentSession/Photon patch behavior are unchanged.
+
+This implements [#32637](https://github.com/vm0-ai/vm0/issues/32637). It does
+not establish the cause of the historical termination in
+[#32577](https://github.com/vm0-ai/vm0/issues/32577), which remains a separate
+investigation. No production replay, stress test, provider request, release,
+or production verification is part of this work.
+
+## Flow and lifecycle
+
+`BashOperations.onData` remains synchronous, including consumers whose callback
+returns a value that TypeScript discards. The optional `waitForDrain(signal)`
+callback lets the local backend wait for the spool using its execution signal.
+On a pending wait it pauses **both** stdout and stderr synchronously. There is
+one pending wait, with no per-chunk promise chain or auxiliary output queue.
+
+Node's internal `flushStdio()` calls `resume()` on child pipes after exit. The
+backend reasserts the shared pause during the `resume` event, before data starts
+flowing. The shared `waitForChildProcess` helper has optional cancellation and
+consumer-pause inputs. Its existing 100 ms post-exit idle grace cannot destroy
+paused unread output; a quiet inherited pipe without consumer backpressure
+retains the existing grace and does not hang.
+
+The accumulator keeps the original decoded tail, UTF-8 decoder, counters,
+truncation metadata, and update throttle. Its pre-spool raw prefix is at most
+`maxBytes`. It flushes that prefix as one bounded write and includes that write
+in the spool's `writableNeedDrain` state. Snapshot-created and finish-created
+spools use the same path. Successful finalization awaits both file finish and
+close. Repeated close is safe.
+
+Sink errors abort the command, including errors between data events. Abort,
+caller timeout, open/write failure, and premature close cannot report a
+successful partial output file. The caller's existing timeout also owns final
+flush; no default timeout is added. Cancellation decodes the accepted display
+tail without opening a new spool. It destroys the file stream and uses the
+existing process-tree termination path. A kernel filesystem write already in
+flight completes asynchronously before Node closes its descriptor; the tool
+settles without waiting for that write, and its error listener remains until
+close so late I/O errors cannot become unhandled events.
+
+Successful output preserves each pipe's byte order and the observed merged
+ingestion order. It does not establish a new chronological order across two
+independent OS pipes.
+
+## Audited callers and scope
+
+The upstream source is pinned at
+`earendil-works/pi@53fa77ccd8a279eb87e92294ef3687b03ff80112` and the installed
+runtime is the corresponding distributed JavaScript, not the TypeScript source.
+The patch updates the three affected `.js` files and their `.d.ts` declarations.
+
+- `core/tools/bash.js` is the sole installed `OutputAccumulator` consumer.
+- `core/exec.js` also uses `waitForChildProcess`; its existing call without the
+  new options remains supported and is exercised through `execCommand`.
+- `core/bash-executor.js` / `AgentSession.executeBash` consume
+  `createLocalBashOperations` synchronously. Small sanitized output and exit
+  behavior are exercised without changing that independent executor.
+- Custom operations and the independent interactive/remote executor are not
+  converted to paced spooling by this patch. The independent executor retains
+  its existing separate spool implementation. The bounded-output guarantee here
+  applies to the official local Bash tool used by vm0's factory.
+
+The existing `patchedDependencies` entry and Pi version stay unchanged. The
+lockfile changes only the coding-agent patch hash and references. `pnpm
+patch-commit` generates the patch and hash; unrelated peer-resolution churn is
+excluded from this focused change. Applying the original patch to the official
+npm tarball and comparing AgentSession JS/declarations and Photon JS confirms
+those three files are preserved byte-for-byte.
+
+## Contract fixtures and buffer bound
+
+Run from `turbo/`:
+
+```sh
+pnpm -F @okouai/pi-agent-runtime exec vitest run src/bash-spool.test.ts --maxWorkers=1
+```
+
+The test launches an isolated Node process for each case. That process imports
+the installed official `createBashTool` and uses its real local child-process
+backend, without substituting Bash operations or the accumulator. Instrumented
+Node built-ins observe the real child pipes and real file `WriteStream`. Only
+the filesystem write completion is delayed or gated; writes still reach an
+actual temporary file. Error fixtures inject an asynchronous disk error at this
+boundary, use a real missing parent directory, or destroy the real stream.
+The child-side producer respects its own pipe backpressure.
+
+Each large fixture emits 32 or 64 MiB using unique 64 KiB chunks. Both pipe hashes
+are checked against deterministic expected content, and the full output file's
+SHA-256 is checked against the observed merged ingestion hash, including size
+and successful close. This catches loss, duplication, and per-pipe reordering
+without assuming a total order between stdout and stderr.
+
+For these Linux fixtures let `B = 65,536` (maximum admitted chunk and upper bound
+on each pipe high-water mark), `H = 65,536` (configured spool high-water mark),
+and `P = 51,200` (pre-spool prefix limit). A conservative user-space bound is:
+
+| Component                                       |                                   Bound |
+| ----------------------------------------------- | --------------------------------------: |
+| Prefix and its single flush copy                |                                    `2P` |
+| Writable plus one admitted chunk                |                                 `H + B` |
+| Two readable buffers plus one overshoot each    |                                    `4B` |
+| Currently delivered chunk                       |                                     `B` |
+| Two child write buffers plus one overshoot each |                                    `4B` |
+| Total                                           | `2P + 11B = 823,296 bytes`, below 1 MiB |
+
+The fixture samples actual `writableLength`, both actual `readableLength`
+values, and the delivered chunk size. It conservatively charges the entire
+prefix/copy and child-write allowances even after those buffers are released.
+It also checks child-side write peaks, high-water marks, maximum delivered
+chunk size, and that at most one drain listener waits. The bound excludes OS
+pipe buffers and the separately bounded, unchanged decoded display tail; it is
+not an RSS prediction or an exact-RSS assertion.
+
+Observed with Node 24.20.0 and pnpm 10.33.4 in a fresh frozen install:
+
+| Output | MiB | Writable peak | Combined conservative measurement |
+| ------ | --: | ------------: | --------------------------------: |
+| stdout |  32 |        65,536 |                           495,616 |
+| stdout |  64 |        65,536 |                           495,616 |
+| stderr |  32 |        65,536 |                           495,616 |
+| stderr |  64 |        65,536 |                           495,616 |
+| mixed  |  32 |        65,536 |                           561,152 |
+| mixed  |  64 |        65,536 |                           561,152 |
+
+Each case has a 20-second internal watchdog and 30-second parent kill deadline.
+Paused/final-flush interruption and disk-error settlement, and quiet inherited
+stdio have an additional two-second deadline. The post-exit fixture deliberately holds a filesystem write
+for 250 ms **after observing child exit**, with unread data remaining, before
+releasing it. This is the tested timing boundary, not an arbitrary readiness
+sleep. File, child, signal, and drain listeners are inspected after teardown.
+The parent also requires a clean child exit and empty stderr, so unhandled
+errors/rejections cannot pass silently.
+
+The remaining fixtures cover prefix flush, threshold equality, long-line and
+line-count truncation, split UTF-8, empty/small output, live update metadata,
+finish-created/snapshot-created spools, repeated close, nonzero exit, real
+asynchronous spawn failure, abort/timeout while paused, abort at drain, and
+abort/timeout/write error during final flush.
+
+### Negative control and install verification
+
+The original npm tarball was verified against SHA-512 (base64):
+
+```text
+ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A==
+```
+
+Temporarily restoring its three original distributed runtime files makes the
+same `slow-32-stdout` contract fail: `Writable pending 33030144 exceeds 131072`.
+The patched files are restored after the negative control. This verifies the
+real producer regression, not only a manually paced accumulator.
+
+A separate directory with the repository manifests, workspace configuration,
+patches, and lockfile and **no `node_modules`** successfully runs:
+
+```sh
+pnpm install --frozen-lockfile --ignore-scripts
+```
+
+All nine installed patched JS/declaration files match the edited patch package,
+Pi remains 0.84.1, and the six large contract fixtures run from that fresh
+installation. Skipping package lifecycle scripts in this disposable install
+does not skip pnpm patch application; the main checkout also passes normal
+`pnpm install --frozen-lockfile`.
+
+Additional targeted validation:
+
+```sh
+pnpm -F @okouai/pi-agent-runtime exec vitest run src/bash-spool.test.ts src/session-runtime.test.ts src/pending-tool-cancellation.test.ts --maxWorkers=1
+pnpm -F @okouai/pi-agent-runtime run lint
+pnpm -F @okouai/pi-agent-runtime run check-types
+pnpm -F @okouai/pi-agent-runtime run build
+pnpm knip --workspace packages/pi-agent-runtime
+pnpm exec prettier --check packages/pi-agent-runtime/src/bash-spool.test.ts packages/pi-agent-runtime/src/test-fixtures/bash-spool.mjs packages/pi-agent-runtime/bash-spool-backpressure.md
+```
+
+The build includes `check-public-declarations`. An additional TypeScript probe
+checks the installed additive declarations, synchronous `onData` return-value
+compatibility, and the optional helper/drain arguments. Broader checks belong
+to PR CI; no full local Vitest suite or development server is used.

--- a/turbo/packages/pi-agent-runtime/src/bash-spool.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/bash-spool.test.ts
@@ -1,0 +1,49 @@
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const scenarios = [
+  "slow-32-stdout",
+  "slow-64-stdout",
+  "slow-32-stderr",
+  "slow-64-stderr",
+  "slow-32-mixed",
+  "slow-64-mixed",
+  "exit",
+  "quiet",
+  "abort",
+  "timeout",
+  "flush-abort",
+  "flush-timeout",
+  "open-error",
+  "write-error",
+  "premature-close",
+  "spawn-error",
+  "semantics",
+  "compatibility",
+  "accumulator",
+  "drain-abort",
+  "flush-write-error",
+];
+
+describe("installed official Pi Bash spool contract", () => {
+  it.each(scenarios)(
+    "%s",
+    async (scenario) => {
+      const { stdout, stderr } = await promisify(execFile)(
+        process.execPath,
+        [
+          fileURLToPath(
+            new URL("./test-fixtures/bash-spool.mjs", import.meta.url),
+          ),
+          scenario,
+        ],
+        { timeout: 30_000, killSignal: "SIGKILL", maxBuffer: 1024 * 1024 },
+      );
+      expect(stderr).toBe("");
+      expect(stdout).toContain(`"scenario":"${scenario}"`);
+    },
+    35_000,
+  );
+});

--- a/turbo/packages/pi-agent-runtime/src/test-fixtures/bash-spool.mjs
+++ b/turbo/packages/pi-agent-runtime/src/test-fixtures/bash-spool.mjs
@@ -1,0 +1,608 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import process from "node:process";
+import {
+  setTimeout,
+  clearTimeout,
+  setInterval,
+  clearInterval,
+} from "node:timers";
+import childProcess from "node:child_process";
+import { createHash } from "node:crypto";
+import { getEventListeners } from "node:events";
+import fs from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { syncBuiltinESMExports } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import {
+  createBashTool,
+  createLocalBashOperations,
+} from "@earendil-works/pi-coding-agent";
+
+const scenario = process.argv[2];
+const root = await mkdtemp(join(tmpdir(), "bash-spool-contract-"));
+const realCreateWriteStream = fs.createWriteStream;
+const realSpawn = childProcess.spawn;
+const controller = new globalThis.AbortController();
+const chunkSize = 64 * 1024;
+const spoolHighWaterMark = 64 * 1024;
+const prefixLimit = 50 * 1024;
+// Prefix + its flush copy, spool HWM + admitted chunk, two readable HWMs +
+// overshoots, a delivered chunk, and two child-side write HWMs + overshoots.
+const combinedBound = 2 * prefixLimit + 11 * chunkSize;
+assert.ok(combinedBound <= 1024 * 1024);
+const children = [];
+const sinks = [];
+const observedHash = createHash("sha256");
+const pipeHashes = [createHash("sha256"), createHash("sha256")];
+const pipeBytes = [0, 0];
+let peakPending = 0;
+let peakCombined = 0;
+let maxChunk = 0;
+let fullHash;
+let producerPeaks;
+let maxDrainListeners = 0;
+let peakReads = 0;
+let acceptedBytes = 0;
+let completed = false;
+let failure;
+let settleCount = 0;
+let updates = 0;
+let initialUpdate = false;
+let blockedWrite;
+const blocked = Promise.withResolvers();
+const childExited = Promise.withResolvers();
+let hold = [
+  "exit",
+  "abort",
+  "timeout",
+  "write-error",
+  "premature-close",
+  "flush-abort",
+  "flush-timeout",
+  "flush-write-error",
+  "drain-abort",
+].includes(scenario);
+let nextError = scenario.endsWith("write-error");
+const sampler = setInterval(() => {
+  return measure();
+}, 1);
+const watchdog = setTimeout(() => {
+  failure = new Error("Fixture exceeded its 20-second watchdog");
+  controller.abort();
+  releaseWrite();
+}, 20_000);
+
+function measure(delivered = 0) {
+  const pending = sinks.reduce((sum, stream) => {
+    return sum + stream.writableLength;
+  }, 0);
+  const reads = children.reduce((sum, child) => {
+    return sum + child.stdout.readableLength + child.stderr.readableLength;
+  }, 0);
+  peakPending = Math.max(peakPending, pending);
+  peakReads = Math.max(peakReads, reads);
+  // Include the fixed prefix/copy and conservative child-side queues even when
+  // already released; do not measure RSS or hide the real Writable queue.
+  peakCombined = Math.max(
+    peakCombined,
+    pending + reads + delivered + 2 * prefixLimit + 4 * chunkSize,
+  );
+  maxDrainListeners = Math.max(
+    maxDrainListeners,
+    ...sinks.map((stream) => {
+      return stream.listenerCount("drain");
+    }),
+  );
+}
+
+function releaseWrite() {
+  hold = false;
+  const write = blockedWrite;
+  blockedWrite = undefined;
+  write?.();
+}
+
+childProcess.spawn = (...args) => {
+  const child = realSpawn(...args);
+  if (!child.stdout || !child.stderr) return child;
+  children.push(child);
+  [child.stdout, child.stderr].forEach((pipe, index) => {
+    assert.ok(pipe.readableHighWaterMark <= chunkSize);
+    pipe.on("data", (data) => {
+      maxChunk = Math.max(maxChunk, data.length);
+      observedHash.update(data);
+      pipeHashes[index].update(data);
+      pipeBytes[index] += data.length;
+      acceptedBytes += data.length;
+      measure(data.length);
+    });
+  });
+  child.once("exit", () => {
+    return childExited.resolve();
+  });
+  return child;
+};
+
+fs.createWriteStream = (path, options) => {
+  if (!String(path).includes("pi-bash-"))
+    return realCreateWriteStream(path, options);
+  const stream = realCreateWriteStream(
+    scenario === "open-error" ? join(root, "missing", "output.log") : path,
+    {
+      ...options,
+      fs: {
+        open: fs.open,
+        close: fs.close,
+        write(fd, buffer, offset, length, position, callback) {
+          const perform = () => {
+            if (nextError) {
+              nextError = false;
+              callback(new Error("controlled asynchronous disk write failure"));
+            } else {
+              fs.write(fd, buffer, offset, length, position, callback);
+            }
+          };
+          if (hold) {
+            assert.equal(blockedWrite, undefined);
+            blockedWrite = perform;
+            blocked.resolve(stream);
+          } else {
+            setTimeout(perform, 1);
+          }
+        },
+      },
+    },
+  );
+  sinks.push(stream);
+  const write = stream.write.bind(stream);
+  stream.write = (...args) => {
+    const ready = write(...args);
+    measure();
+    return ready;
+  };
+  return stream;
+};
+syncBuiltinESMExports();
+
+function quote(text) {
+  return `'${text.replaceAll("'", "'\\''")}'`;
+}
+
+async function command(source) {
+  const path = join(root, "producer.mjs");
+  await writeFile(path, source);
+  return `exec ${quote(process.execPath)} ${quote(path)}`;
+}
+
+function producer(bytes, mode) {
+  return `import { once } from 'node:events';
+import { writeFileSync } from 'node:fs';
+const size = ${chunkSize};
+async function produce(pipe, tag, count) {
+  if (pipe.writableHighWaterMark > size) throw new Error('Unexpected producer HWM');
+  let peak = 0;
+  for (let i = 0; i < count; i++) {
+    const chunk = Buffer.alloc(size, tag);
+    chunk.writeUInt32LE(i, 0);
+    const ready = pipe.write(chunk);
+    peak = Math.max(peak, pipe.writableLength);
+    if (!ready) await once(pipe, 'drain');
+  }
+  return peak;
+}
+const peaks = await Promise.all([
+  produce(process.stdout, 65, ${mode === "stderr" ? 0 : bytes / chunkSize / (mode === "mixed" ? 2 : 1)}),
+  produce(process.stderr, 66, ${mode === "stdout" ? 0 : bytes / chunkSize / (mode === "mixed" ? 2 : 1)})
+]);
+writeFileSync(${JSON.stringify(join(root, "producer-peaks.json"))}, JSON.stringify(peaks));`;
+}
+
+function expectedHash(bytes, tag) {
+  const hash = createHash("sha256");
+  for (let i = 0; i < bytes / chunkSize; i++) {
+    const chunk = Buffer.alloc(chunkSize, tag);
+    chunk.writeUInt32LE(i, 0);
+    hash.update(chunk);
+  }
+  return hash.digest("hex");
+}
+
+async function hashFile(path) {
+  const hash = createHash("sha256");
+  for await (const chunk of fs.createReadStream(path)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+function execute(cmd, timeout) {
+  return createBashTool(root)
+    .execute(
+      "fixture",
+      { command: cmd, timeout },
+      controller.signal,
+      (update) => {
+        if (updates === 0) initialUpdate = update.content.length === 0;
+        updates++;
+      },
+    )
+    .then(
+      (result) => {
+        completed = true;
+        settleCount++;
+        return { result };
+      },
+      (error) => {
+        completed = true;
+        settleCount++;
+        return { error };
+      },
+    );
+}
+
+async function verifyFull(result, bytes) {
+  assert.ok(result.details.fullOutputPath);
+  const path = result.details.fullOutputPath;
+  assert.equal(fs.statSync(path).size, bytes);
+  fullHash = await hashFile(path);
+  assert.equal(fullHash, observedHash.digest("hex"));
+  assert.ok(result.details.truncation.truncated);
+  assert.ok(result.details.truncation.outputBytes <= prefixLimit);
+  assert.ok(initialUpdate);
+  assert.ok(updates > 1);
+  assert.ok(
+    sinks.every((stream) => {
+      return stream.closed && stream.writableFinished;
+    }),
+  );
+  await rm(path);
+}
+
+async function slowOutput() {
+  const [, size, mode] = scenario.split("-");
+  const bytes = Number(size) * 1024 * 1024;
+  const outcome = await execute(await command(producer(bytes, mode)));
+  assert.ifError(outcome.error);
+  await verifyFull(outcome.result, bytes);
+  for (const [index, tag] of [
+    [0, 65],
+    [1, 66],
+  ]) {
+    const expectedBytes =
+      mode === "mixed"
+        ? bytes / 2
+        : (mode === "stdout" ? index === 0 : index === 1)
+          ? bytes
+          : 0;
+    assert.equal(pipeBytes[index], expectedBytes);
+    assert.equal(
+      pipeHashes[index].digest("hex"),
+      expectedHash(expectedBytes, tag),
+    );
+  }
+  producerPeaks = JSON.parse(
+    await readFile(join(root, "producer-peaks.json"), "utf8"),
+  );
+  assert.equal(producerPeaks.length, 2);
+  assert.ok(
+    producerPeaks.every((peak) => {
+      return peak <= 2 * chunkSize;
+    }),
+  );
+  assert.ok(maxChunk <= chunkSize);
+  assert.ok(
+    peakPending <= spoolHighWaterMark + chunkSize,
+    `Writable pending ${peakPending} exceeds ${spoolHighWaterMark + chunkSize}`,
+  );
+  assert.ok(
+    peakCombined <= combinedBound,
+    `${peakCombined} exceeds ${combinedBound}`,
+  );
+  assert.equal(maxDrainListeners, 1);
+}
+
+async function exitWhilePaused() {
+  const bytes = 2 * chunkSize;
+  const task = execute(await command(producer(bytes, "stdout")));
+  await blocked.promise;
+  await childExited.promise;
+  // This delay is the behavior under test: exceed the upstream 100 ms grace
+  // while the real child has exited and the disk writer is deliberately held.
+  await delay(250);
+  assert.equal(completed, false);
+  assert.ok(acceptedBytes < bytes || children[0].stdout.readableLength > 0);
+  releaseWrite();
+  const outcome = await task;
+  assert.ifError(outcome.error);
+  await verifyFull(outcome.result, bytes);
+}
+
+async function settleWithin(promise) {
+  let deadline;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_resolve, reject) => {
+        deadline = setTimeout(() => {
+          return reject(
+            new Error("Operation did not settle within two seconds"),
+          );
+        }, 2000);
+      }),
+    ]);
+  } finally {
+    clearTimeout(deadline);
+  }
+}
+
+async function interrupted() {
+  const flushing = scenario.startsWith("flush-");
+  // Line truncation creates a sub-HWM spool, so the command exits and reaches
+  // stream.end() while the filesystem write is still held.
+  const source = flushing
+    ? 'process.stdout.write("x\\n".repeat(3000))'
+    : producer(32 * 1024 * 1024, "mixed");
+  const task = execute(
+    await command(source),
+    scenario.includes("timeout") ? 0.5 : undefined,
+  );
+  const stream = await blocked.promise;
+  if (flushing) {
+    await childExited.promise;
+    while (!stream.writableEnded && !completed) await delay(1);
+    assert.ok(stream.writableEnded);
+  }
+  if (scenario === "drain-abort") {
+    stream.once("drain", () => {
+      return controller.abort();
+    });
+    releaseWrite();
+  } else if (scenario.includes("abort")) controller.abort();
+  if (scenario.endsWith("write-error")) releaseWrite();
+  if (scenario === "premature-close") {
+    // Destroy the actual WriteStream while a real filesystem write is in flight.
+    stream.destroy();
+    releaseWrite();
+  }
+  const outcome = await settleWithin(task);
+  assert.ok(outcome.error instanceof Error);
+  const message = scenario.includes("abort")
+    ? "Command aborted"
+    : scenario.includes("timeout")
+      ? "Command timed out"
+      : scenario.endsWith("write-error")
+        ? "controlled asynchronous disk write failure"
+        : "Output file closed before";
+  assert.ok(
+    outcome.error.message.includes(message) ||
+      (scenario === "premature-close" &&
+        outcome.error.code === "ERR_STREAM_DESTROYED"),
+    outcome.error.message,
+  );
+  assert.equal(settleCount, 1);
+  assert.equal(getEventListeners(controller.signal, "abort").length, 0);
+  releaseWrite();
+  for (const sink of sinks) {
+    if (!sink.closed)
+      await new Promise((resolve) => {
+        return sink.once("close", resolve);
+      });
+    assert.equal(sink.listenerCount("drain"), 0);
+    assert.equal(sink.listenerCount("finish"), 0);
+    assert.equal(sink.listenerCount("error"), 0);
+  }
+}
+
+async function semantics() {
+  const cases = [
+    { source: "", expected: "(no output)" },
+    { source: 'process.stdout.write("hello\\n")', expected: "hello\n" },
+    {
+      source:
+        'for (const byte of Buffer.from("🙂tail")) { process.stdout.write(Buffer.from([byte])); await new Promise(r => setTimeout(r, 5)); }',
+      expected: "🙂tail",
+    },
+    {
+      source: `process.stdout.write('a'.repeat(${prefixLimit}))`,
+      expected: "a".repeat(prefixLimit),
+    },
+    {
+      source:
+        'process.stdout.write("p".repeat(16384)); await new Promise(r => setTimeout(r, 10)); process.stdout.write("q".repeat(65536)); process.stdout.write("tail")',
+      full: "p".repeat(16384) + "q".repeat(65536) + "tail",
+      truncatedBy: "bytes",
+    },
+    {
+      source: 'process.stdout.write("x\\n".repeat(3000))',
+      full: "x\n".repeat(3000),
+      truncatedBy: "lines",
+    },
+  ];
+  for (const testCase of cases) {
+    const outcome = await execute(await command(testCase.source));
+    assert.ifError(outcome.error);
+    if (testCase.expected !== undefined) {
+      assert.equal(outcome.result.content[0].text, testCase.expected);
+      assert.equal(outcome.result.details, undefined);
+    } else {
+      const full = await readFile(
+        outcome.result.details.fullOutputPath,
+        "utf8",
+      );
+      assert.equal(full, testCase.full);
+      const truncation = outcome.result.details.truncation;
+      assert.equal(truncation.truncatedBy, testCase.truncatedBy);
+      assert.equal(truncation.totalBytes, Buffer.byteLength(full));
+      assert.equal(
+        truncation.lastLinePartial,
+        testCase.truncatedBy === "bytes",
+      );
+      await rm(outcome.result.details.fullOutputPath);
+    }
+  }
+}
+
+async function accumulatorLifecycle() {
+  const dist = dirname(
+    fileURLToPath(import.meta.resolve("@earendil-works/pi-coding-agent")),
+  );
+  const { OutputAccumulator } = await import(
+    join(dist, "core/tools/output-accumulator.js")
+  );
+  for (const persist of [true, false]) {
+    const output = new OutputAccumulator({
+      maxBytes: 4,
+      tempFilePrefix: "pi-bash",
+    });
+    const raw = Buffer.from([97, 98, 99, 240]);
+    output.append(raw);
+    assert.equal(output.snapshot().fullOutputPath, undefined);
+    output.finish({ persist });
+    const snapshot = output.snapshot({ persistIfTruncated: true });
+    assert.ok(snapshot.truncation.truncated);
+    assert.equal(snapshot.truncation.totalBytes, 6);
+    await output.waitForDrain(controller.signal);
+    await output.closeTempFile(controller.signal);
+    await output.closeTempFile(controller.signal);
+    assert.deepEqual(await readFile(snapshot.fullOutputPath), raw);
+    output.destroyTempFile();
+    await rm(snapshot.fullOutputPath);
+  }
+}
+
+async function compatibility() {
+  const local = createLocalBashOperations();
+  const chunks = [];
+  const result = await local.exec("printf synchronous", root, {
+    onData: (data) => {
+      return chunks.push(data);
+    },
+  });
+  assert.equal(result.exitCode, 0);
+  assert.equal(Buffer.concat(chunks).toString(), "synchronous");
+  const dist = dirname(
+    fileURLToPath(import.meta.resolve("@earendil-works/pi-coding-agent")),
+  );
+  const { executeBashWithOperations } = await import(
+    join(dist, "core/bash-executor.js")
+  );
+  const interactive = await executeBashWithOperations(
+    "printf '\\033[31mhello\\033[0m'",
+    root,
+    local,
+  );
+  assert.equal(interactive.output, "hello");
+  assert.equal(interactive.exitCode, 0);
+  const { execCommand } = await import(join(dist, "core/exec.js"));
+  assert.deepEqual(
+    await execCommand(
+      process.execPath,
+      ["-e", 'process.stdout.write("out"); process.stderr.write("err")'],
+      root,
+    ),
+    { stdout: "out", stderr: "err", code: 0, killed: false },
+  );
+  const failed = await execute("printf failure; exit 7");
+  assert.match(
+    failed.error.message,
+    /failure[\s\S]*Command exited with code 7/,
+  );
+}
+
+async function quietDescendant() {
+  const pidFile = join(root, "descendant.pid");
+  const cmd = await command(
+    `import { spawn } from 'node:child_process'; import { writeFileSync } from 'node:fs'; const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {stdio: ['ignore', 1, 2]}); writeFileSync(${JSON.stringify(pidFile)}, String(child.pid)); child.unref();`,
+  );
+  const outcome = await settleWithin(execute(cmd));
+  const pid = Number(await readFile(pidFile, "utf8"));
+  process.kill(pid, "SIGKILL");
+  assert.ifError(outcome.error);
+  assert.equal(outcome.result.content[0].text, "(no output)");
+}
+
+function stopChildGroup(child) {
+  if (!child.pid) return;
+  try {
+    process.kill(-child.pid, "SIGKILL");
+  } catch (error) {
+    assert.equal(error.code, "ESRCH");
+  }
+}
+
+try {
+  if (scenario.startsWith("slow-")) await slowOutput();
+  else if (scenario === "exit") await exitWhilePaused();
+  else if (scenario === "semantics") await semantics();
+  else if (scenario === "accumulator") await accumulatorLifecycle();
+  else if (scenario === "compatibility") await compatibility();
+  else if (scenario === "quiet") await quietDescendant();
+  else if (scenario === "spawn-error") {
+    const shellPath = join(root, "broken-shell");
+    await writeFile(shellPath, "#!/missing-interpreter\n", { mode: 0o755 });
+    await assert.rejects(
+      createBashTool(root, { shellPath }).execute(
+        "fixture",
+        { command: "echo impossible" },
+        controller.signal,
+      ),
+      /ENOENT/,
+    );
+  } else if (scenario === "open-error") {
+    const outcome = await execute(
+      await command(producer(32 * 1024 * 1024, "mixed")),
+    );
+    assert.match(outcome.error.message, /ENOENT/);
+  } else await interrupted();
+  assert.equal(getEventListeners(controller.signal, "abort").length, 0);
+  for (const child of children) {
+    if (child.pid && child.exitCode === null && child.signalCode === null) {
+      await new Promise((resolve) => {
+        return child.once("exit", resolve);
+      });
+    }
+    assert.equal(child.listenerCount("error"), 0);
+    assert.equal(child.listenerCount("close"), 0);
+    assert.equal(child.stdout.listenerCount("resume"), 0);
+    assert.equal(child.stderr.listenerCount("resume"), 0);
+    // execCommand keeps its original collection listeners; the local Bash
+    // producer must leave only the fixture's hash observers.
+    const dataListeners =
+      scenario === "compatibility" && child.spawnfile === process.execPath
+        ? 2
+        : 1;
+    assert.equal(child.stdout.listenerCount("data"), dataListeners);
+    assert.equal(child.stderr.listenerCount("data"), dataListeners);
+  }
+  assert.ifError(failure);
+  process.stdout.write(
+    JSON.stringify({
+      scenario,
+      peakPending,
+      peakReads,
+      peakCombined,
+      combinedBound,
+      maxChunk,
+      fullHash,
+      producerPeaks,
+      maxDrainListeners,
+      settleCount,
+    }) + "\n",
+  );
+} finally {
+  clearTimeout(watchdog);
+  clearInterval(sampler);
+  controller.abort();
+  releaseWrite();
+  fs.createWriteStream = realCreateWriteStream;
+  childProcess.spawn = realSpawn;
+  syncBuiltinESMExports();
+  for (const child of children) stopChildGroup(child);
+  for (const sink of sinks) {
+    sink.destroy();
+    await rm(sink.path, { force: true });
+  }
+  await rm(root, { recursive: true, force: true });
+}

--- a/turbo/patches/@earendil-works__pi-coding-agent@0.84.1.patch
+++ b/turbo/patches/@earendil-works__pi-coding-agent@0.84.1.patch
@@ -1,18 +1,18 @@
-diff --git a/dist/utils/photon.js b/dist/utils/photon.js
-index 3078895bedba898ce26c439b6123425834ca2586..2ad6a42c60d6277dd0ab49c3e972eaa42a2e3ff3 100644
---- a/dist/utils/photon.js
-+++ b/dist/utils/photon.js
-@@ -105,7 +105,8 @@ export async function loadPhoton() {
-     loadPromise = (async () => {
-         const restoreReadFileSync = patchPhotonWasmRead();
-         try {
--            photonModule = await import("@silvia-odwyer/photon-node");
-+            const imported = await import("@silvia-odwyer/photon-node");
-+            photonModule = imported.default;
-             return photonModule;
-         }
-         catch {
+diff --git a/dist/core/agent-session.d.ts b/dist/core/agent-session.d.ts
+index f37d1ccd41418199e1450f753de8d03b3205c83d..845fc54bda9210ed17c0b2b0dffab925ada761d3 100644
+--- a/dist/core/agent-session.d.ts
++++ b/dist/core/agent-session.d.ts
+@@ -341,6 +341,8 @@ export declare class AgentSession {
+     private _normalizePromptSnippet;
+     private _normalizePromptGuidelines;
+     private _rebuildSystemPrompt;
++    /** Resume unresolved tools; settlement extensions prepare once before native cancellation/input reconciliation and public settlement. */
++    continuePendingTools(options?: Pick<PromptOptions, "preflightResult">): Promise<void>;
+     private _runAgentPrompt;
+     private _handlePostAgentRun;
+     /**
 diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
+index ce8a9a2a613c08de483a6c94ef4f6341efff0457..755e681c47d609e6e4ece121dd8ae5e0dfb7f002 100644
 --- a/dist/core/agent-session.js
 +++ b/dist/core/agent-session.js
 @@ -741,6 +741,35 @@ export class AgentSession {
@@ -251,15 +251,520 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
          }
          catch {
              // Aborted during sleep - emit end event so UI can clean up
-diff --git a/dist/core/agent-session.d.ts b/dist/core/agent-session.d.ts
---- a/dist/core/agent-session.d.ts
-+++ b/dist/core/agent-session.d.ts
-@@ -341,6 +341,8 @@ export declare class AgentSession {
-     private _normalizePromptSnippet;
-     private _normalizePromptGuidelines;
-     private _rebuildSystemPrompt;
-+    /** Resume unresolved tools; settlement extensions prepare once before native cancellation/input reconciliation and public settlement. */
-+    continuePendingTools(options?: Pick<PromptOptions, "preflightResult">): Promise<void>;
-     private _runAgentPrompt;
-     private _handlePostAgentRun;
-     /**
+diff --git a/dist/core/tools/bash.d.ts b/dist/core/tools/bash.d.ts
+index 7fcbe2435afa926ae3f76fc8f915f6e66d7c7667..8d8597653722d9b499844c9f364890c09651bf76 100644
+--- a/dist/core/tools/bash.d.ts
++++ b/dist/core/tools/bash.d.ts
+@@ -29,6 +29,8 @@ export interface BashOperations {
+      */
+     exec: (command: string, cwd: string, options: {
+         onData: (data: Buffer) => void;
++        /** Local execution pauses both pipes until this optional spool wait settles. */
++        waitForDrain?: (signal: AbortSignal) => Promise<void> | undefined;
+         signal?: AbortSignal;
+         timeout?: number;
+         env?: NodeJS.ProcessEnv;
+diff --git a/dist/core/tools/bash.js b/dist/core/tools/bash.js
+index f274908793624a5870008ab738fa19ac6758165c..f8f542c27d8f244d8b043e6c1aee28a951aec8d2 100644
+--- a/dist/core/tools/bash.js
++++ b/dist/core/tools/bash.js
+@@ -42,7 +42,7 @@ export const bashToolSystemPromptContribution = {
+  */
+ export function createLocalBashOperations(options) {
+     return {
+-        exec: async (command, cwd, { onData, signal, timeout, env }) => {
++        exec: async (command, cwd, { onData, waitForDrain, signal, timeout, env }) => {
+             const timeoutMs = resolveTimeoutMs(timeout);
+             if (signal?.aborted) {
+                 throw new Error("aborted");
+@@ -54,6 +54,7 @@ export function createLocalBashOperations(options) {
+             catch {
+                 throw new Error(`Working directory does not exist: ${cwd}\nCannot execute bash commands.`);
+             }
++            if (signal?.aborted) throw new Error("aborted");
+             const commandFromStdin = shellConfig.commandTransport === "stdin";
+             const child = spawn(shellConfig.shell, commandFromStdin ? shellConfig.args : [...shellConfig.args, command], {
+                 cwd,
+@@ -68,49 +69,75 @@ export function createLocalBashOperations(options) {
+             }
+             if (child.pid)
+                 trackDetachedChildPid(child.pid);
+-            let timedOut = false;
++            const execution = new AbortController();
+             let timeoutHandle;
+-            const onAbort = () => {
+-                if (child.pid)
+-                    killProcessTree(child.pid);
++            let outputPaused = false;
++            let pendingOutput;
++            const onAbort = () => execution.abort(new Error("aborted"));
++            const stopChild = () => {
++                if (child.pid) killProcessTree(child.pid);
+             };
+-            try {
+-                // Set timeout if provided.
+-                if (timeoutMs !== undefined) {
+-                    timeoutHandle = setTimeout(() => {
+-                        timedOut = true;
+-                        if (child.pid)
+-                            killProcessTree(child.pid);
+-                    }, timeoutMs);
++            const onResume = () => {
++                // Node flushStdio() resumes child pipes after exit. Reassert the
++                // shared pause before its resume event can start flowing data.
++                if (outputPaused) {
++                    child.stdout?.pause();
++                    child.stderr?.pause();
+                 }
+-                // Stream stdout and stderr.
+-                child.stdout?.on("data", onData);
+-                child.stderr?.on("data", onData);
+-                // Handle abort signal by killing the entire process tree.
+-                if (signal) {
+-                    if (signal.aborted)
+-                        onAbort();
+-                    else
+-                        signal.addEventListener("abort", onAbort, { once: true });
++            };
++            const handleData = (data) => {
++                if (execution.signal.aborted) return;
++                try {
++                    onData(data);
++                    const drain = waitForDrain?.(execution.signal);
++                    if (drain) {
++                        outputPaused = true;
++                        child.stdout?.pause();
++                        child.stderr?.pause();
++                        // Pausing both streams synchronously admits only one wait,
++                        // not an output-sized chain of async EventEmitter callbacks.
++                        pendingOutput = drain.then(() => {
++                            outputPaused = false;
++                            if (!execution.signal.aborted) {
++                                child.stdout?.resume();
++                                child.stderr?.resume();
++                            }
++                        }, (error) => execution.abort(error));
++                    }
+                 }
+-                // Handle shell spawn errors and wait for the process to terminate without hanging
+-                // on inherited stdio handles held by detached descendants.
+-                const exitCode = await waitForChildProcess(child);
+-                if (signal?.aborted) {
+-                    throw new Error("aborted");
++                catch (error) {
++                    execution.abort(error);
+                 }
+-                if (timedOut) {
+-                    throw new Error(`timeout:${timeout}`);
++            };
++            try {
++                execution.signal.addEventListener("abort", stopChild, { once: true });
++                if (timeoutMs !== undefined) {
++                    timeoutHandle = setTimeout(() => execution.abort(new Error(`timeout:${timeout}`)), timeoutMs);
+                 }
++                child.stdout?.on("resume", onResume);
++                child.stderr?.on("resume", onResume);
++                child.stdout?.on("data", handleData);
++                child.stderr?.on("data", handleData);
++                const completion = waitForChildProcess(child, {
++                    signal: execution.signal,
++                    isOutputPaused: () => outputPaused,
++                });
++                signal?.addEventListener("abort", onAbort, { once: true });
++                if (signal?.aborted) onAbort();
++                const exitCode = await completion;
++                await pendingOutput;
++                execution.signal.throwIfAborted();
+                 return { exitCode };
+             }
+             finally {
+-                if (child.pid)
+-                    untrackDetachedChildPid(child.pid);
+-                if (timeoutHandle)
+-                    clearTimeout(timeoutHandle);
+-                if (signal)
+-                    signal.removeEventListener("abort", onAbort);
++                child.stdout?.off("resume", onResume);
++                child.stderr?.off("resume", onResume);
++                child.stdout?.off("data", handleData);
++                child.stderr?.off("data", handleData);
++                execution.signal.removeEventListener("abort", stopChild);
++                if (child.pid) untrackDetachedChildPid(child.pid);
++                if (timeoutHandle) clearTimeout(timeoutHandle);
++                signal?.removeEventListener("abort", onAbort);
+             }
+         },
+     };
+@@ -237,7 +264,14 @@ export function createBashToolDefinition(cwd, options) {
+         async execute(_toolCallId, { command, timeout }, signal, onUpdate, ctx) {
+             const resolvedCommand = commandPrefix ? `${commandPrefix}\n${command}` : command;
+             const spawnContext = resolveSpawnContext(resolvedCommand, cwd, spawnHook, exposeSessionEnvironment, ctx);
+-            const output = new OutputAccumulator({ tempFilePrefix: "pi-bash" });
++            const timeoutMs = resolveTimeoutMs(timeout);
++            const execution = new AbortController();
++            const onAbort = () => execution.abort(new Error("aborted"));
++            const output = new OutputAccumulator({
++                tempFilePrefix: "pi-bash",
++                onError: (error) => execution.abort(error),
++            });
++            let timeoutHandle;
+             let acceptingOutput = true;
+             let updateTimer;
+             let updateDirty = false;
+@@ -274,12 +308,10 @@ export function createBashToolDefinition(cwd, options) {
+                 }
+                 updateTimer ??= setTimeout(() => {
+                     updateTimer = undefined;
+-                    emitOutputUpdate();
++                    try { emitOutputUpdate(); }
++                    catch (error) { execution.abort(error); }
+                 }, delay);
+             };
+-            if (onUpdate) {
+-                onUpdate({ content: [], details: undefined });
+-            }
+             const handleData = (data) => {
+                 if (!acceptingOutput)
+                     return;
+@@ -292,7 +324,7 @@ export function createBashToolDefinition(cwd, options) {
+                 clearUpdateTimer();
+                 emitOutputUpdate();
+                 const snapshot = output.snapshot({ persistIfTruncated: true });
+-                await output.closeTempFile();
++                await output.closeTempFile(execution.signal);
+                 return snapshot;
+             };
+             const formatOutput = (snapshot, emptyText = "(no output)") => {
+@@ -318,37 +350,48 @@ export function createBashToolDefinition(cwd, options) {
+             };
+             const appendStatus = (text, status) => `${text ? `${text}\n\n` : ""}${status}`;
+             try {
+-                let exitCode;
+-                try {
+-                    const result = await ops.exec(spawnContext.command, spawnContext.cwd, {
+-                        onData: handleData,
+-                        signal,
+-                        timeout,
+-                        env: spawnContext.env,
+-                    });
+-                    exitCode = result.exitCode;
+-                }
+-                catch (err) {
+-                    const snapshot = await finishOutput();
+-                    const { text } = formatOutput(snapshot, "");
+-                    if (err instanceof Error && err.message === "aborted") {
+-                        throw new Error(appendStatus(text, "Command aborted"));
+-                    }
+-                    if (err instanceof Error && err.message.startsWith("timeout:")) {
+-                        const timeoutSecs = err.message.split(":")[1];
+-                        throw new Error(appendStatus(text, `Command timed out after ${timeoutSecs} seconds`));
+-                    }
+-                    throw err;
++                signal?.addEventListener("abort", onAbort, { once: true });
++                if (signal?.aborted) onAbort();
++                if (timeoutMs !== undefined) {
++                    // The caller's existing deadline also owns the final file flush.
++                    timeoutHandle = setTimeout(() => execution.abort(new Error(`timeout:${timeout}`)), timeoutMs);
+                 }
++                execution.signal.throwIfAborted();
++                onUpdate?.({ content: [], details: undefined });
++                const { exitCode } = await ops.exec(spawnContext.command, spawnContext.cwd, {
++                    onData: handleData,
++                    waitForDrain: (drainSignal) => output.waitForDrain(drainSignal),
++                    signal: execution.signal,
++                    timeout,
++                    env: spawnContext.env,
++                });
+                 const snapshot = await finishOutput();
++                execution.signal.throwIfAborted();
+                 const { text: outputText, details } = formatOutput(snapshot);
+                 if (exitCode !== 0 && exitCode !== null) {
+                     throw new Error(appendStatus(outputText, `Command exited with code ${exitCode}`));
+                 }
+                 return { content: [{ type: "text", text: outputText }], details };
+             }
++            catch (error) {
++                const err = execution.signal.aborted ? execution.signal.reason : error;
++                acceptingOutput = false;
++                output.finish({ persist: false });
++                const text = output.snapshot().content;
++                if (err instanceof Error && err.message === "aborted") {
++                    throw new Error(appendStatus(text, "Command aborted"));
++                }
++                if (err instanceof Error && err.message.startsWith("timeout:")) {
++                    throw new Error(appendStatus(text, `Command timed out after ${err.message.split(":")[1]} seconds`));
++                }
++                throw err;
++            }
+             finally {
++                acceptingOutput = false;
+                 clearUpdateTimer();
++                if (timeoutHandle) clearTimeout(timeoutHandle);
++                signal?.removeEventListener("abort", onAbort);
++                output.destroyTempFile();
+             }
+         },
+         renderCall(args, _theme, context) {
+diff --git a/dist/core/tools/output-accumulator.d.ts b/dist/core/tools/output-accumulator.d.ts
+index fbd581f6067c98771dc6a29272a5bab2b2653dcd..6ecae286e90e6d2008ea1c8a77526f4589fe4f80 100644
+--- a/dist/core/tools/output-accumulator.d.ts
++++ b/dist/core/tools/output-accumulator.d.ts
+@@ -3,6 +3,7 @@ export interface OutputAccumulatorOptions {
+     maxLines?: number;
+     maxBytes?: number;
+     tempFilePrefix?: string;
++    onError?: (error: Error) => void;
+ }
+ export interface OutputSnapshot {
+     content: string;
+@@ -35,13 +36,18 @@ export declare class OutputAccumulator {
+     private finished;
+     private tempFilePath;
+     private tempFileStream;
++    private tempFileError;
++    private onError;
++    private disposed;
+     constructor(options?: OutputAccumulatorOptions);
+     append(data: Buffer): void;
+-    finish(): void;
++    finish(options?: { persist?: boolean }): void;
+     snapshot(options?: {
+         persistIfTruncated?: boolean;
+     }): OutputSnapshot;
+-    closeTempFile(): Promise<void>;
++    waitForDrain(signal?: AbortSignal): Promise<void> | undefined;
++    closeTempFile(signal?: AbortSignal): Promise<void>;
++    destroyTempFile(): void;
+     getLastLineBytes(): number;
+     private appendDecodedText;
+     private trimTail;
+diff --git a/dist/core/tools/output-accumulator.js b/dist/core/tools/output-accumulator.js
+index 72416680b6307108ffeace36e45fa7076cc8b7e5..293d1f1509c95505c3c5ac2371eb3df9a55df038 100644
+--- a/dist/core/tools/output-accumulator.js
++++ b/dist/core/tools/output-accumulator.js
+@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
+ import { createWriteStream } from "node:fs";
+ import { tmpdir } from "node:os";
+ import { join } from "node:path";
++import { finished } from "node:stream/promises";
+ import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, truncateTail } from "./truncate.js";
+ function defaultTempFilePath(prefix) {
+     const id = randomBytes(8).toString("hex");
+@@ -36,7 +37,11 @@ export class OutputAccumulator {
+     finished = false;
+     tempFilePath;
+     tempFileStream;
++    tempFileError;
++    onError;
++    disposed = false;
+     constructor(options = {}) {
++        this.onError = options.onError;
+         this.maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
+         this.maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+         this.maxRollingBytes = Math.max(this.maxBytes * 2, 1);
+@@ -56,13 +61,13 @@ export class OutputAccumulator {
+             this.rawChunks.push(data);
+         }
+     }
+-    finish() {
++    finish(options = {}) {
+         if (this.finished) {
+             return;
+         }
+         this.finished = true;
+         this.appendDecodedText(this.decoder.decode());
+-        if (this.shouldUseTempFile()) {
++        if (options.persist !== false && this.shouldUseTempFile()) {
+             this.ensureTempFile();
+         }
+     }
+@@ -93,26 +98,43 @@ export class OutputAccumulator {
+             fullOutputPath: this.tempFilePath,
+         };
+     }
+-    async closeTempFile() {
+-        if (!this.tempFileStream) {
+-            return;
+-        }
++    // The producer must stop both pipes while this single wait is pending.
++    waitForDrain(signal) {
++        signal?.throwIfAborted();
++        if (this.tempFileError) throw this.tempFileError;
+         const stream = this.tempFileStream;
+-        this.tempFileStream = undefined;
+-        await new Promise((resolve, reject) => {
+-            const onError = (error) => {
+-                stream.off("finish", onFinish);
+-                reject(error);
+-            };
+-            const onFinish = () => {
++        if (!stream?.writableNeedDrain) return;
++        return new Promise((resolve, reject) => {
++            const cleanup = () => {
++                stream.off("drain", onDrain);
+                 stream.off("error", onError);
+-                resolve();
++                stream.off("close", onClose);
++                signal?.removeEventListener("abort", onAbort);
+             };
++            const onDrain = () => { cleanup(); resolve(); };
++            const onError = (error) => { cleanup(); reject(error); };
++            const onClose = () => onError(new Error("Output file closed before draining"));
++            const onAbort = () => onError(signal.reason);
++            stream.once("drain", onDrain);
+             stream.once("error", onError);
+-            stream.once("finish", onFinish);
+-            stream.end();
++            stream.once("close", onClose);
++            signal?.addEventListener("abort", onAbort, { once: true });
+         });
+     }
++    async closeTempFile(signal) {
++        signal?.throwIfAborted();
++        if (this.tempFileError) throw this.tempFileError;
++        const stream = this.tempFileStream;
++        if (!stream) return;
++        const completion = finished(stream, { cleanup: true, signal });
++        stream.end();
++        await completion;
++    }
++    destroyTempFile() {
++        this.disposed = true;
++        this.rawChunks = [];
++        this.tempFileStream?.destroy();
++    }
+     getLastLineBytes() {
+         return this.currentLineBytes;
+     }
+@@ -174,10 +196,23 @@ export class OutputAccumulator {
+             return;
+         }
+         this.tempFilePath = defaultTempFilePath(this.tempFilePrefix);
+-        this.tempFileStream = createWriteStream(this.tempFilePath);
+-        for (const chunk of this.rawChunks) {
+-            this.tempFileStream.write(chunk);
+-        }
++        const stream = createWriteStream(this.tempFilePath, { highWaterMark: 64 * 1024 });
++        this.tempFileStream = stream;
++        const onError = (error) => {
++            if (this.tempFileError || this.disposed) return;
++            this.tempFileError = error;
++            this.onError?.(error);
++        };
++        stream.on("error", onError);
++        stream.once("close", () => {
++            if (!stream.writableFinished && !this.disposed) {
++                onError(new Error("Output file closed before finishing"));
++            }
++            stream.off("error", onError);
++        });
++        // The pre-spool prefix is at most maxBytes. Flush it as one bounded
++        // write, then include it in writableNeedDrain before admitting more data.
++        if (this.rawChunks.length > 0) stream.write(Buffer.concat(this.rawChunks));
+         this.rawChunks = [];
+     }
+ }
+diff --git a/dist/utils/child-process.d.ts b/dist/utils/child-process.d.ts
+index c75b42d9d43a0ef9000277b4ef5426443eab9a3e..a554d3e4ef12363dc903f366abb0143d68d7c950 100644
+--- a/dist/utils/child-process.d.ts
++++ b/dist/utils/child-process.d.ts
+@@ -14,5 +14,5 @@ export declare function spawnProcessSync(command: string, args: string[], option
+  * us reading, while a quiet inherited handle (e.g. a Windows daemonized descendant
+  * that never lets `close` fire) still releases us after the grace elapses.
+  */
+-export declare function waitForChildProcess(child: ChildProcess): Promise<number | null>;
++export declare function waitForChildProcess(child: ChildProcess, options?: { signal?: AbortSignal; isOutputPaused?: () => boolean }): Promise<number | null>;
+ //# sourceMappingURL=child-process.d.ts.map
+\ No newline at end of file
+diff --git a/dist/utils/child-process.js b/dist/utils/child-process.js
+index 48e5724c50f719449e4ef4e20f3497eed779ae35..fcdd8fef93006ff9cc45ecf653127af203cbbb88 100644
+--- a/dist/utils/child-process.js
++++ b/dist/utils/child-process.js
+@@ -20,7 +20,7 @@ export function spawnProcessSync(command, args, options) {
+  * us reading, while a quiet inherited handle (e.g. a Windows daemonized descendant
+  * that never lets `close` fire) still releases us after the grace elapses.
+  */
+-export function waitForChildProcess(child) {
++export function waitForChildProcess(child, options = {}) {
+     return new Promise((resolve, reject) => {
+         let settled = false;
+         let exited = false;
+@@ -33,9 +33,12 @@ export function waitForChildProcess(child) {
+                 clearTimeout(postExitTimer);
+                 postExitTimer = undefined;
+             }
++            options.signal?.removeEventListener("abort", onAbort);
+             child.removeListener("error", onError);
+             child.removeListener("exit", onExit);
+             child.removeListener("close", onClose);
++            child.stdout?.removeListener("resume", onResume);
++            child.stderr?.removeListener("resume", onResume);
+             child.stdout?.removeListener("end", onStdoutEnd);
+             child.stderr?.removeListener("end", onStderrEnd);
+             child.stdout?.removeListener("data", onData);
+@@ -58,10 +61,16 @@ export function waitForChildProcess(child) {
+             }
+         };
+         const armIdleTimer = () => {
+-            if (postExitTimer)
+-                clearTimeout(postExitTimer);
++            if (postExitTimer) clearTimeout(postExitTimer);
++            postExitTimer = undefined;
++            // Paused disk consumers accrue no idle time. Resume starts a fresh
++            // grace window, including when an inherited pipe remains quiet.
++            if (options.isOutputPaused?.()) return;
+             postExitTimer = setTimeout(() => finalize(exitCode), EXIT_STDIO_GRACE_MS);
+         };
++        const onResume = () => {
++            if (exited && !settled) armIdleTimer();
++        };
+         const onData = () => {
+             // Output is still arriving after exit; defer finalizing so we don't
+             // destroy the stream mid-write and truncate the tail.
+@@ -81,8 +90,11 @@ export function waitForChildProcess(child) {
+                 return;
+             settled = true;
+             cleanup();
++            child.stdout?.destroy();
++            child.stderr?.destroy();
+             reject(err);
+         };
++        const onAbort = () => onError(options.signal.reason);
+         const onExit = (code) => {
+             exited = true;
+             exitCode = code;
+@@ -94,6 +106,10 @@ export function waitForChildProcess(child) {
+         const onClose = (code) => {
+             finalize(code);
+         };
++        if (options.isOutputPaused) {
++            child.stdout?.on("resume", onResume);
++            child.stderr?.on("resume", onResume);
++        }
+         child.stdout?.once("end", onStdoutEnd);
+         child.stderr?.once("end", onStderrEnd);
+         child.stdout?.on("data", onData);
+@@ -101,6 +117,8 @@ export function waitForChildProcess(child) {
+         child.once("error", onError);
+         child.once("exit", onExit);
+         child.once("close", onClose);
++        options.signal?.addEventListener("abort", onAbort, { once: true });
++        if (options.signal?.aborted) onAbort();
+     });
+ }
+ //# sourceMappingURL=child-process.js.map
+\ No newline at end of file
+diff --git a/dist/utils/photon.js b/dist/utils/photon.js
+index 3078895bedba898ce26c439b6123425834ca2586..d67667b307af07c5a001efd5f1f5849a8cba8e6a 100644
+--- a/dist/utils/photon.js
++++ b/dist/utils/photon.js
+@@ -105,7 +105,8 @@ export async function loadPhoton() {
+     loadPromise = (async () => {
+         const restoreReadFileSync = patchPhotonWasmRead();
+         try {
+-            photonModule = await import("@silvia-odwyer/photon-node");
++            const imported = await import("@silvia-odwyer/photon-node");
++            photonModule = imported.default;
+             return photonModule;
+         }
+         catch {

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -92,7 +92,7 @@ patchedDependencies:
     hash: e5308d9f3e3abf237b28f3b607b5f41e4535fe10f23a6c59d6c4a5fbf896be55
     path: patches/@earendil-works__pi-ai@0.84.1.patch
   '@earendil-works/pi-coding-agent@0.84.1':
-    hash: ec82bfdbfcd840a2287feaaa6f4b3533743b1723225eb3823464f6b7ffe7c913
+    hash: ff1a3e5516bfae0508b38b2021278c563cf5d2c2894934a35c17170e6068f0ac
     path: patches/@earendil-works__pi-coding-agent@0.84.1.patch
 
 importers:
@@ -391,7 +391,7 @@ importers:
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.1
-        version: 0.84.1(patch_hash=ec82bfdbfcd840a2287feaaa6f4b3533743b1723225eb3823464f6b7ffe7c913)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+        version: 0.84.1(patch_hash=ff1a3e5516bfae0508b38b2021278c563cf5d2c2894934a35c17170e6068f0ac)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1177,7 +1177,7 @@ importers:
         version: 0.84.1(patch_hash=e5308d9f3e3abf237b28f3b607b5f41e4535fe10f23a6c59d6c4a5fbf896be55)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.1
-        version: 0.84.1(patch_hash=ec82bfdbfcd840a2287feaaa6f4b3533743b1723225eb3823464f6b7ffe7c913)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+        version: 0.84.1(patch_hash=ff1a3e5516bfae0508b38b2021278c563cf5d2c2894934a35c17170e6068f0ac)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@okouai/api-contracts':
         specifier: workspace:*
         version: link:../api-contracts
@@ -10631,7 +10631,7 @@ snapshots:
     dependencies:
       '@earendil-works/pi-protocol': 0.84.2
 
-  '@earendil-works/pi-coding-agent@0.84.1(patch_hash=ec82bfdbfcd840a2287feaaa6f4b3533743b1723225eb3823464f6b7ffe7c913)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
+  '@earendil-works/pi-coding-agent@0.84.1(patch_hash=ff1a3e5516bfae0508b38b2021278c563cf5d2c2894934a35c17170e6068f0ac)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.84.1(patch_hash=c16c1735f34a3f1f5bba3dc1d7a80a78b1c9324f00b6ff1813916883f8a4ac11)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-ai': 0.84.1(patch_hash=e5308d9f3e3abf237b28f3b607b5f41e4535fe10f23a6c59d6c4a5fbf896be55)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)


### PR DESCRIPTION
## Summary

When Bash produces output faster than disk can accept it, Pi 0.84.1 queues the full output in its file Writable even though the displayed tail stays bounded. Extend the existing version-pinned pnpm patch so the official local Bash backend pauses **both** stdout and stderr while its shared spool is blocked, and resumes only after drain. Successful spools remain byte-complete; disk errors, cancellation, and the caller's timeout fail promptly, including during final flush.

Fixes #32637. Related investigation: #32577 remains open; this independently reproduced defect does **not** establish the historical incident's root cause.

The production factory still uses official `createBashTool` with `/usr/local/bin/guest-tool-exec`. Pi stays at **0.84.1**. Existing AgentSession and Photon patched files are preserved byte-for-byte. The only lockfile change is the generated coding-agent patch hash and its references.

## Implementation and scope

- Keep synchronous `BashOperations.onData` consumers compatible; add an optional cancellable drain callback to the local backend. There is one pending drain wait, with no output-sized promise chain or extra queue.
- Bound and flush the pre-spool prefix, cover snapshot/finish-created spools, and await successful file finish **and close**. Keep UTF-8 decoding, truncation counters/metadata, live updates, full-output references, and per-pipe byte ordering.
- Preserve the existing 100 ms post-exit idle behavior for quiet inherited handles while excluding deliberately paused pipes from idle finalization. Node also calls `flushStdio().resume()` after child exit; the backend reasserts its pause before the resume event can start flowing data.
- Retain the caller deadline through final flush, without adding a default command timeout. Reuse process-tree cleanup; propagate open/write/premature-close errors instead of returning successful truncated output.
- `core/exec.js` and the independent `core/bash-executor.js` callers remain compatible. The separate interactive/remote spool and custom operations that do not participate in drain handling are outside this local-tool guarantee and are not rewritten.

See [the implementation and validation notes](https://github.com/vm0-ai/vm0/blob/b9b65ff607697e3b3c2c937d997e48c312c3277a/turbo/packages/pi-agent-runtime/bash-spool-backpressure.md) for the caller audit, exact buffer derivation, fixture design, lifecycle boundaries, and commands.

## Acceptance evidence

| Issue criterion | Evidence |
| --- | --- |
| 1: actual producer feedback | Installed official `createBashTool`, real child pipes, real file WriteStream with controlled slow filesystem completion; both pipes pause synchronously and only one drain listener waits. |
| 2: bounded 32/64 MiB fixtures | stdout, stderr, and mixed cases all pass. Writable peak: **65,536 bytes**. Conservative combined measurement: **495,616** for single-pipe and **561,152** for mixed output. The derived fixed bound is **823,296 bytes**, below 1 MiB; no RSS assertions. |
| 3: negative control | Restoring integrity-verified original 0.84.1 runtime files makes the same 32 MiB real-producer regression fail: `Writable pending 33030144 exceeds 131072`. |
| 4: complete output/semantics | Full-file SHA-256 equals observed merged ingestion; independent deterministic hashes verify each pipe. Prefix/tail, threshold equality, split UTF-8, long lines, line truncation, empty/small output, metadata, and updates pass. |
| 5: exit/idle | Hold the sink for 250 ms after actual child exit with unread bytes remaining; full output survives. Quiet inherited stdio settles within a bounded deadline. |
| 6: failure lifecycle | Abort, timeout, drain/abort race, final-flush abort/timeout/write error, asynchronous spawn/open/write failure, and premature close pass. Assertions cover one settlement, producer exit, removed signal/drain/helper listeners, and no unhandled child stderr. |
| 7: compatibility/install | Synchronous local consumers, independent Bash executor, and shared `execCommand` caller pass. Fresh frozen install applies the patch; all nine distributed patched files match; additive declaration probe passes. |
| 8: targeted validation | 105 tests across the three focused files pass; package lint, type check, build/public-declaration boundary, scoped Knip, formatting and diff checks pass. |
| 9: protected merge | This implementation thread owns immediate `/pr-auto`, independent exact-head review, required CI, and the normal protected merge queue. Links will be recorded with the terminal result. |

## Validation

Using Node 24.20.0 and pnpm 10.33.4, from `turbo/`:

```sh
pnpm -F @okouai/pi-agent-runtime exec vitest run src/bash-spool.test.ts src/session-runtime.test.ts src/pending-tool-cancellation.test.ts --maxWorkers=1
pnpm -F @okouai/pi-agent-runtime run lint
pnpm -F @okouai/pi-agent-runtime run check-types
pnpm -F @okouai/pi-agent-runtime run build
pnpm knip --workspace packages/pi-agent-runtime
pnpm exec prettier --check packages/pi-agent-runtime/src/bash-spool.test.ts packages/pi-agent-runtime/src/test-fixtures/bash-spool.mjs packages/pi-agent-runtime/bash-spool-backpressure.md
git diff --check
```

A separate empty dependency installation also passes `pnpm install --frozen-lockfile --ignore-scripts`, file comparisons, and all six large producer fixtures. The main checkout passes normal frozen installation. The build reports `entries=2; declarations=10; forbidden=0`.

## Limits

These are bounded Linux filesystem/child-process fixtures, not production stress tests. A kernel write already in flight finishes asynchronously before Node closes its descriptor; cancellation settles the tool immediately, requests stream destruction, and retains the error listener until close. The existing display tail and kernel pipe buffers are outside the documented spool/in-flight byte bound. No new chronological ordering between independent stdout/stderr pipes is promised.

No full local Vitest suite, dev server, provider/model changes, production telemetry/schema changes, production replay, release, or production verification. Controller acceptance (criterion 10) and the separate #32577 investigation follow independently.
