### PR TITLE
fix(platform): keep completion tail without followups

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-status-tail.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-status-tail.test.tsx
@@ -229,6 +229,43 @@ test.each(["failed", "cancelled"] as const)(
   },
 );
 
+test("Keep completion status visible while followups are unavailable", async () => {
+  const events = [
+    ...resultEvents(),
+    completedEvent({
+      id: "completed-without-followups",
+      runId: RUN_A,
+      seqId: 4,
+    }),
+  ];
+  installRunChat({ chatEvents: events });
+  await openChat();
+
+  const completionTail = document.querySelector<HTMLElement>(
+    "[data-chat-run-status-tail]",
+  );
+  expect(completionTail).toBeVisible();
+  expect(completionTail?.querySelector("p")).toBeVisible();
+  expect(completionTail?.querySelector('[role="separator"]')).toBeVisible();
+  expect(screen.queryByRole("group", { name: "Keep going" })).toBeNull();
+  await expectRetainedResult();
+
+  events.push({
+    id: "delayed-followups",
+    content: null,
+    runId: RUN_A,
+    seqId: 5,
+    createdAt: "2026-08-01T10:00:05.000Z",
+    followups: [{ prompt: "Summarize the check", kind: "talk" }],
+  });
+  publishRunUpdate();
+
+  const followups = await screen.findByRole("group", { name: "Keep going" });
+  expect(followups.closest("[data-chat-run-status-tail]")).toBeVisible();
+  expect(screen.getByText("Summarize the check")).toBeVisible();
+  await expectRetainedResult();
+});
+
 test("Retire completion and followups while retaining the result actions", async () => {
   const sendGate = context.mocks.deferred<void>();
   installRunChat({

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -4948,17 +4948,12 @@ function FinishedRunRow({
   source: RecommendedFollowupSource | null;
 }) {
   const { t } = useTranslation();
-  const runWorkFoldingEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.ChatRunWorkFolding] ?? false;
   const donePhrase =
     useLastResolved(thread.donePhrase$) ??
     t(($) => {
       return $.chat.run.done.default;
     });
   const runFinishedAt = useLastResolved(thread.latestRunFinishCreatedAt$);
-  if (runWorkFoldingEnabled && source === null) {
-    return null;
-  }
   const label =
     source && runFinishedAt
       ? t(
@@ -5148,8 +5143,6 @@ function ThinkingIndicator({
   inAssistantGroup?: boolean;
 }) {
   const featureSwitches = useGet(featureSwitch$);
-  const runWorkFoldingEnabled =
-    featureSwitches[FeatureSwitchKey.ChatRunWorkFolding] ?? false;
   const spinnerEnabled =
     featureSwitches[FeatureSwitchKey.ChatThinkingSpinner] ?? false;
   const [c1, c2, c3] = useGet(thread.blockColors$);
@@ -5185,12 +5178,7 @@ function ThinkingIndicator({
         }
       : undefined;
 
-  if (
-    mode === null ||
-    (runWorkFoldingEnabled &&
-      mode === "finished" &&
-      recommendedFollowupSource === null)
-  ) {
+  if (mode === null) {
     return null;
   }
 
@@ -7532,19 +7520,6 @@ type PagedAssistantGroupProps = {
   readonly statusTailEvents?: readonly EnrichedChatEvent[];
 };
 
-function visibleRunIndicatorMode(
-  mode: Exclude<ThinkingIndicatorMode, null> | undefined,
-  recommendedFollowupSource: RecommendedFollowupSource | null,
-): Exclude<ThinkingIndicatorMode, null> | undefined {
-  if (mode === undefined) {
-    return undefined;
-  }
-  if (mode === "finished" && recommendedFollowupSource === null) {
-    return undefined;
-  }
-  return mode;
-}
-
 type PagedAssistantHistoryItem =
   | {
       readonly kind: "assistant";
@@ -7809,10 +7784,6 @@ function PagedRunWorkAssistantContent({
   | "runIndicatorMode"
   | "statusTailEvents"
 >) {
-  const recommendedFollowupSource =
-    useLastResolved(thread.recommendedFollowupSource$, {
-      equalityFn: equalRecommendedFollowupSources,
-    }) ?? null;
   const timelineItems = buildPagedAssistantTimeline({
     group: {
       ...group,
@@ -7829,10 +7800,6 @@ function PagedRunWorkAssistantContent({
         return event.id === runWorkSection.anchorEventId;
       })
     : undefined;
-  const visibleIndicatorMode = visibleRunIndicatorMode(
-    runIndicatorMode,
-    recommendedFollowupSource,
-  );
   const mainActions =
     mainEvent !== undefined ? (
       <PagedGroupActions
@@ -7851,8 +7818,7 @@ function PagedRunWorkAssistantContent({
         thread={thread}
         mainActions={mainActions}
       />
-      {(statusTailEvents?.length ?? 0) > 0 ||
-      visibleIndicatorMode !== undefined ? (
+      {(statusTailEvents?.length ?? 0) > 0 || runIndicatorMode !== undefined ? (
         <div
           data-chat-run-status-tail
           className={CHAT_THREAD_RESPONSE_STACK_CLASS}
@@ -7867,10 +7833,10 @@ function PagedRunWorkAssistantContent({
                 />
               );
             })
-          ) : visibleIndicatorMode !== undefined ? (
+          ) : runIndicatorMode !== undefined ? (
             <ThinkingIndicator
               thread={thread}
-              mode={visibleIndicatorMode}
+              mode={runIndicatorMode}
               runGroupFolds={[]}
               inAssistantGroup
             />


### PR DESCRIPTION
## Summary
- keep a completed run's status tail visible when optional recommended followups are unavailable
- remove followup-dependent completion filtering from folded and paged chat rendering
- cover both missing and delayed followups through the production page bootstrap and realtime update path

## Root cause
Recommended followups are best-effort post-run output and may be absent after a provider failure. Run work folding treated that optional output as the condition for rendering the completed status row, so the persisted completion timestamp disappeared with it.

## Verification
- `pnpm prettier --write --ignore-unknown apps/platform/src/views/okou-page/chat-thread-page.tsx apps/platform/src/views/okou-page/__tests__/chat-run-status-tail.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-run-status-tail.test.tsx src/views/okou-page/__tests__/chat-run-history.test.tsx src/views/okou-page/__tests__/chat-run-history-preview.test.tsx --maxWorkers=1 --silent=passed-only` (50 passed)
- `pnpm knip --workspace @okouai/app`
