### PR TITLE
test(guest-control): synchronize private write status with worker readiness

### DIFF
--- a/crates/guest-control-tests/tests/integration/file_write_status.rs
+++ b/crates/guest-control-tests/tests/integration/file_write_status.rs
@@ -49,7 +49,7 @@ async fn private_write_status_survives_quiesce_and_tracks_the_next_write() {
 async fn private_write_status_does_not_reopen_an_uncertain_or_quiescing_connection() {
     let h = Harness::new().await;
     let path = blocking_write_path(&h.dir, "private-diagnostic");
-    {
+    let blocked_status = {
         let write = h
             .host()
             .write_private_file(path.to_str().unwrap(), b"synthetic private content");
@@ -62,19 +62,30 @@ async fn private_write_status_does_not_reopen_an_uncertain_or_quiescing_connecti
             .quiesce_operations(QUERY_TIMEOUT)
             .await
             .unwrap_err();
-        let status = h.host().file_write_status(QUERY_TIMEOUT).await.unwrap();
+        // The child can publish its marker before the worker returns from
+        // spawning it and records WaitingForHelper. Observe that boundary
+        // through the server instead of treating the child marker as a fence.
+        let status = tokio::time::timeout(QUERY_TIMEOUT, async {
+            loop {
+                let status = h.host().file_write_status(QUERY_TIMEOUT).await.unwrap();
+                if status.stage == FileWriteStage::WaitingForHelper {
+                    break status;
+                }
+                assert_eq!(status.stage, FileWriteStage::StartingHelper);
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("worker did not reach WaitingForHelper while the helper was blocked");
         assert_ne!(status.sequence, 0);
         assert_eq!(status.stage, FileWriteStage::WaitingForHelper);
         assert_eq!(status.encode_payload().len(), 5);
         // Drop the unresolved write. Its operation token must remain fail-closed.
-    }
+        status
+    };
     assert_eq!(
-        h.host()
-            .file_write_status(QUERY_TIMEOUT)
-            .await
-            .unwrap()
-            .stage,
-        FileWriteStage::WaitingForHelper
+        h.host().file_write_status(QUERY_TIMEOUT).await.unwrap(),
+        blocked_status
     );
     assert!(h.host().try_fence_normal_operations().is_err());
     let later = h.dir.join("must-not-write");


### PR DESCRIPTION
## Summary

Closes #32648

The helper process can publish its `.started` marker before the server worker returns from spawning it and records `WaitingForHelper`. The independent diagnostic dispatcher can therefore legitimately return `StartingHelper`. The old test reproduced the reported failure at iteration 6 of a fail-fast local repetition.

- Wait through `StartingHelper` for the actual server-side `WaitingForHelper` snapshot, bounded by the existing two-second timeout.
- Fail immediately on query errors or unexpected stages; keep exact stage, nonzero sequence, five-byte payload, and fail-closed later-write assertions.
- After dropping the unresolved write, require the entire snapshot (sequence and stage) to remain unchanged.

Only one integration-test file changes. No production state machine, protocol, UI, account flow, database, dependency, or deployment changes. No fixed sleeps, larger timeouts, or skipped tests were added.

## Validation

From `crates/`:

- `cargo fmt --all -- --check`
- `cargo clippy --locked --profile local -p guest-control-tests --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --profile local -p guest-control-tests --all-features --no-deps`
- `cargo test --locked --profile local -p guest-control-tests --all-targets --all-features`: 35 integration tests passed.
- Exact failing integration test: 300 consecutive passes under normal scheduling plus 300 under single-CPU affinity (`taskset -c 0`), fail-fast on the first failure.
- Complete integration binary: 50 consecutive successful runs with default concurrency.
- Existing ignored `write_file::bench_write_file_many_small_files` benchmark: explicitly selected and passed separately.
- `git diff --check`
- Repository commit hooks: workspace-wide `cargo fmt`, all-target/all-feature Clippy, workspace all-feature rustdoc, file-size check, and commitlint passed.

`scripts/prepare.sh` completed successfully. Rust-only test change; unrelated TypeScript/Python suites were not needed. Full instrumented workspace coverage is delegated to CI.

## Risks

No production behavior changes. A permanently stuck worker still hits the existing deadline, and an unexpected stage still fails. Repetition is regression evidence, not proof of every possible OS schedule.
