### PR TITLE
fix(app): stabilize pwa manifest identity

### DIFF
--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -1193,6 +1193,7 @@ assert.equal(
 assert.equal(manifest.name, "Okou");
 assert.equal(manifest.short_name, "Okou");
 assert.equal(manifest.description, okouDescription);
+assert.equal(manifest.id, "/?source=pwa");
 assert.equal(manifest.icons.length, 3);
 
 let observedR2Key = null;

--- a/turbo/apps/platform/public/manifest.webmanifest
+++ b/turbo/apps/platform/public/manifest.webmanifest
@@ -2,6 +2,7 @@
   "name": "Okou",
   "short_name": "Okou",
   "description": "An AI teammate that connects to 3,000+ tools: get the right data, run agentic workflows, and deliver finished work with team-wide context.",
+  "id": "/?source=pwa",
   "start_url": "/?source=pwa",
   "scope": "/",
   "display": "standalone",


### PR DESCRIPTION
## Summary

- pin the Okou web app manifest ID to the existing `/?source=pwa` fallback identity
- verify the standalone App Worker preserves and serves the stable manifest ID

## Compatibility

The explicit ID matches Chrome's identity for existing `app.okou.ai` installations whose manifest previously omitted `id`. This PR does not migrate or remove legacy `app.vm0.ai` installations and does not change legacy-domain routing.

## Verification

- `bash .github/scripts/tests/okou-app-worker-test.sh`
- `node turbo/apps/platform/scripts/check-static-assets.mjs`
- `node --check .github/scripts/tests/okou-app-worker-test.mjs`
- `jq -e '.id == .start_url and .id == "/?source=pwa"' turbo/apps/platform/public/manifest.webmanifest`
- `npx --yes --package=prettier@3.6.2 prettier --check .github/scripts/tests/okou-app-worker-test.mjs turbo/apps/platform/public/manifest.webmanifest`
- `git diff --check`
