### PR TITLE
feat: enable chat desktop selection for all users

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -232,7 +232,7 @@ describe("getAllFeatureStates", () => {
     );
     expect(otherOrgStates[FeatureSwitchKey.PresentationTemplates]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ChatTranslation]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ChatDesktopSelection]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ChatDesktopSelection]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.VoiceInputV2]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -324,8 +324,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "bingjie@okou.ai",
     description:
       "Offer desktop passage actions for selections anywhere within one assistant reply.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.VoiceInputV2]: {
     maintainer: "ethan@okou.ai",


### PR DESCRIPTION
## Summary

Enable `chatDesktopSelection` by default for all organizations so desktop users can use passage actions for selections anywhere within a single assistant reply. Remove the staff-only organization allowlist and update the existing rollout-matrix expectation for non-staff organizations.

Existing per-user overrides and touch selection behavior remain unchanged.

## Verification

- Prettier check on both changed files: passed.
- Core package lint and TypeScript checks: passed.
- Feature-switch test file: 31 tests passed.
- Core package Knip check: passed.
- The full local Vitest suite was not run; broader validation uses the PR pipeline.
