### PR TITLE
feat(connectors): roll out dropbox oauth to all users

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -274,7 +274,7 @@ describe("getAllFeatureStates", () => {
     });
     expect(states[FeatureSwitchKey.AhrefsConnector]).toBe(true);
     // Non-overridden disabled feature stays false
-    expect(states[FeatureSwitchKey.DropboxConnector]).toBe(false);
+    expect(states[FeatureSwitchKey.TestOauthConnector]).toBe(false);
   });
 
   it("should apply overrides to disable enabled features", () => {
@@ -395,7 +395,7 @@ describe("overrides", () => {
 
   it("should not affect keys without overrides", () => {
     expect(
-      isFeatureEnabled(FeatureSwitchKey.DropboxConnector, {
+      isFeatureEnabled(FeatureSwitchKey.TestOauthConnector, {
         overrides: { [FeatureSwitchKey.AhrefsConnector]: true },
       }),
     ).toBe(false);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -104,7 +104,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.DropboxConnector]: {
     maintainer: "yuma@okou.ai",
     description: "Enable the Dropbox file storage connector",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.FigmaConnector]: {
     maintainer: "yuma@okou.ai",


### PR DESCRIPTION
Dropbox OAuth is hidden by the default-off `dropboxConnector` feature switch. Enable it globally so all users can discover and connect Dropbox, with the existing user override behavior preserved.

Keep the two override-isolation assertions meaningful by using the deliberately default-off test OAuth connector instead of Dropbox.

The expanded OAuth scopes in https://github.com/vm0-ai/vm0-connectors/pull/4094 are merged and published to production: https://github.com/vm0-ai/vm0-connectors/actions/runs/34224655952.

Validation: the feature-switch test file passed all 31 tests; core lint, type checking, scoped Knip, formatting, and `git diff --check` passed. Full integration checks are delegated to PR CI.
