### PR TITLE
feat(platform): distinguish queued thread activity

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -2503,6 +2503,7 @@ describe("CHAT-01 chat thread read state", () => {
         [runningRun.threadId]: "active",
         [queuedRun.threadId]: "active",
       },
+      queuedThreadIds: [queuedRun.threadId],
     });
 
     chatCallbacks.mockChatOutputEvents([]);
@@ -2527,6 +2528,7 @@ describe("CHAT-01 chat thread read state", () => {
         [runningRun.threadId]: "unread",
         [queuedRun.threadId]: "active",
       },
+      queuedThreadIds: [],
     });
   }, 120_000);
 
@@ -2562,6 +2564,7 @@ describe("CHAT-01 chat thread read state", () => {
           [recentRun.threadId]: "unread",
           [activeRun.threadId]: "active",
         },
+        queuedThreadIds: [],
       });
     });
   }, 120_000);
@@ -2654,6 +2657,7 @@ describe("CHAT-01 chat thread read state", () => {
         [completedRun.threadId]: "unread",
         [completeGoalRun.threadId]: "unread",
       },
+      queuedThreadIds: [],
     });
 
     chatCallbacks.mockChatOutputEvents([]);
@@ -2687,6 +2691,7 @@ describe("CHAT-01 chat thread read state", () => {
         [completedRun.threadId]: "unread",
         [completeGoalRun.threadId]: "unread",
       },
+      queuedThreadIds: [],
     });
   }, 120_000);
 

--- a/turbo/apps/api/src/signals/services/chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread.service.ts
@@ -53,7 +53,10 @@ import {
   sql,
 } from "drizzle-orm";
 
-import { zodEnumDriverValueDecoder } from "../../lib/db-structured-result";
+import {
+  pgBooleanDecoder,
+  zodEnumDriverValueDecoder,
+} from "../../lib/db-structured-result";
 import { now, nowDate } from "../../lib/time";
 import { type Db, db$, type ReadonlyDb, writeDb$ } from "../external/db";
 import { inferMimetype } from "./chat-event-shared.service";
@@ -359,12 +362,13 @@ export function chatThreadUnreads(args: {
 }
 
 /**
- * Active and unread indicators for the user's agents and threads in the
- * current organization. Active threads are complete; unread threads are the
- * latest 50 terminal markers from the last seven days. Active threads are
- * computed once and reused to keep unread classification within one database
- * snapshot. Unread agent aggregates take precedence so unread actions remain
- * available while another thread for the same agent is active.
+ * Active, queued, and unread indicators for the user's agents and threads in
+ * the current organization. Active threads are complete; queued thread ids
+ * refine active threads whose work has not been admitted yet. Unread threads
+ * are the latest 50 terminal markers from the last seven days. Active threads
+ * are computed once and reused to keep unread classification within one
+ * database snapshot. Unread agent aggregates take precedence so unread
+ * actions remain available while another thread for the same agent is active.
  */
 export function chatIndicators(args: {
   readonly userId: string;
@@ -375,9 +379,12 @@ export function chatIndicators(args: {
     const unreadCutoff = new Date(now() - INDICATOR_UNREAD_LOOKBACK_MS);
     const activeThreads = db.$with("active_threads").as(
       db
-        .selectDistinct({
+        .select({
           threadId: chatThreads.id,
           agentId: chatThreads.agentId,
+          queuedOnly: sql`bool_and(${agentRuns.status} = 'queued')`
+            .mapWith(pgBooleanDecoder)
+            .as("queued_only"),
         })
         .from(agentRuns)
         .innerJoin(chatThreads, eq(chatThreads.id, agentRuns.chatThreadId))
@@ -389,7 +396,8 @@ export function chatIndicators(args: {
             inArray(agentRuns.status, [...ACTIVE_RUN_STATUSES]),
             isNotNull(agentRuns.triggerSource),
           ),
-        ),
+        )
+        .groupBy(chatThreads.id, chatThreads.agentId),
     );
     const lastRunFinish = latestRunFinishEventSubquery(db, chatThreads.id);
     const unreadThreads = db.$with("unread_threads").as(
@@ -430,6 +438,7 @@ export function chatIndicators(args: {
             threadId: activeThreads.threadId,
             agentId: activeThreads.agentId,
             indicator: sql`'active'`.mapWith(indicatorDecoder).as("indicator"),
+            queuedOnly: activeThreads.queuedOnly,
           })
           .from(activeThreads),
         db
@@ -437,6 +446,7 @@ export function chatIndicators(args: {
             threadId: unreadThreads.threadId,
             agentId: unreadThreads.agentId,
             indicator: sql`'unread'`.mapWith(indicatorDecoder).as("indicator"),
+            queuedOnly: sql`false`.mapWith(pgBooleanDecoder).as("queued_only"),
           })
           .from(unreadThreads),
       ),
@@ -448,8 +458,12 @@ export function chatIndicators(args: {
 
     const agentIndicators: Record<string, Indicator> = {};
     const threads: Record<string, Indicator> = {};
+    const queuedThreadIds: string[] = [];
     for (const row of rows) {
       threads[row.threadId] = row.indicator;
+      if (row.indicator === "active" && row.queuedOnly) {
+        queuedThreadIds.push(row.threadId);
+      }
       if (
         row.agentId !== null &&
         (row.indicator === "unread" ||
@@ -458,7 +472,7 @@ export function chatIndicators(args: {
         agentIndicators[row.agentId] = row.indicator;
       }
     }
-    return { agents: agentIndicators, threads };
+    return { agents: agentIndicators, threads, queuedThreadIds };
   });
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-indicators-from-worker.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-indicators-from-worker.ts
@@ -23,3 +23,10 @@ export const sidebarActiveThreadIds$ = computed(
     );
   },
 );
+
+export const sidebarQueuedThreadIds$ = computed(
+  async (get): Promise<ReadonlySet<string>> => {
+    const indicators = await get(chatThreadIndicatorsFromWorker$);
+    return new Set(indicators.queuedThreadIds ?? []);
+  },
+);

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-item.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-item.ts
@@ -3,7 +3,10 @@ import { pathParams$, searchParams$ } from "../route.ts";
 import { setSidebarExpanded$ } from "../okou-page/nav.ts";
 import { setPendingDeleteThreadId$ } from "../okou-page/sidebar-state.ts";
 import { threadMeta } from "./chat-thread-event-sourcing.ts";
-import { sidebarActiveThreadIds$ } from "./chat-thread-indicators-from-worker.ts";
+import {
+  sidebarActiveThreadIds$,
+  sidebarQueuedThreadIds$,
+} from "./chat-thread-indicators-from-worker.ts";
 import { pinChatThread$, unpinChatThread$ } from "./chat-event.ts";
 import {
   currentLeftThread$,
@@ -18,7 +21,11 @@ import { markChatThreadUnread$ } from "./chat-thread-mark-unread.ts";
 import { sidebarDraftThreadIds$ } from "./sidebar-draft-threads.ts";
 import { sidebarUnreadThreadIds$ } from "./sidebar-unread-threads.ts";
 
-export type SidebarChatThreadIndicatorState = "running" | "unread" | "draft";
+export type SidebarChatThreadIndicatorState =
+  | "running"
+  | "queued"
+  | "unread"
+  | "draft";
 
 export type SidebarChatThreadPaneIndicator = "main" | "sidebar";
 export type SidebarChatThreadTargetPane = "main" | "sidebar";
@@ -95,7 +102,9 @@ function createSidebarChatThreadItemSignals(
     indicatorState$: computed(
       async (get): Promise<SidebarChatThreadIndicatorState | null> => {
         if ((await get(sidebarActiveThreadIds$)).has(threadId)) {
-          return "running";
+          return (await get(sidebarQueuedThreadIds$)).has(threadId)
+            ? "queued"
+            : "running";
         }
         if (await get(unread$)) {
           return "unread";

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -2124,10 +2124,21 @@ test("Recognize and pin sidebar conversation states", async () => {
       createThread(INCIDENT_THREAD_ID, "Incident notes"),
       createThread(AUTOMATION_THREAD_ID, "Running analysis"),
       createThread(ARCHIVED_THREAD_ID, "Draft brief"),
+      createThread(RESEARCH_THREAD_ID, "Queued synthesis"),
     ],
     [],
-    [AUTOMATION_THREAD_ID],
+    [AUTOMATION_THREAD_ID, RESEARCH_THREAD_ID],
   );
+  context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+    return respond(200, {
+      agents: {},
+      threads: {
+        [AUTOMATION_THREAD_ID]: "active",
+        [RESEARCH_THREAD_ID]: "active",
+      },
+      queuedThreadIds: [RESEARCH_THREAD_ID],
+    });
+  });
   context.mocks.api(chatThreadsContract.drafts, ({ respond }) => {
     return respond(200, { draftThreadIds: [ARCHIVED_THREAD_ID] });
   });
@@ -2154,6 +2165,9 @@ test("Recognize and pin sidebar conversation states", async () => {
       within(threadRowByTitle("Running analysis")).getByLabelText("Running"),
     ).toBeInTheDocument();
     expect(
+      within(threadRowByTitle("Queued synthesis")).getByLabelText("Queued"),
+    ).toBeInTheDocument();
+    expect(
       within(threadRowByTitle("Draft brief")).getByLabelText("Draft"),
     ).toBeInTheDocument();
   });
@@ -2163,12 +2177,19 @@ test("Recognize and pin sidebar conversation states", async () => {
   expect(
     within(threadRowByTitle("Draft brief")).getByLabelText("Draft"),
   ).toHaveAttribute("role", "img");
+  expect(
+    within(threadRowByTitle("Queued synthesis")).getByLabelText("Queued"),
+  ).toHaveClass("bg-sky-300");
+  expect(
+    within(threadRowByTitle("Queued synthesis")).queryByLabelText("Running"),
+  ).not.toBeInTheDocument();
 
   // Touch rows never hover, so the state indicator has to be the menu trigger
   // itself; otherwise running, unread, and draft chats lose every row action.
   for (const [title, label] of [
     ["Incident notes", "Unread"],
     ["Running analysis", "Running"],
+    ["Queued synthesis", "Queued"],
     ["Draft brief", "Draft"],
   ] as const) {
     const row = threadRowByTitle(title);

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -131,6 +131,17 @@ function SessionStateIndicator({
   if (state === "running") {
     return <RunningIndicator />;
   }
+  if (state === "queued") {
+    return (
+      <span
+        role="img"
+        aria-label={t(($) => {
+          return $.activity.statuses.queued;
+        })}
+        className="h-2 w-2 rounded-full bg-sky-300"
+      />
+    );
+  }
   if (state === "unread") {
     return (
       <span

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
@@ -77,6 +77,29 @@ describe("google drive artifact recovery contract", () => {
   });
 });
 
+describe("chat thread indicators contract", () => {
+  it("keeps queued thread detail additive across API and Platform versions", () => {
+    const threadId = "11111111-1111-4111-8111-111111111111";
+    const legacyResponse = {
+      agents: {},
+      threads: { [threadId]: "active" as const },
+    };
+    const queuedResponse = {
+      ...legacyResponse,
+      queuedThreadIds: [threadId],
+    };
+    const previousSchema = z.object({
+      agents: z.record(z.string().uuid(), z.enum(["active", "unread"])),
+      threads: z.record(z.string().uuid(), z.enum(["active", "unread"])),
+    });
+    const currentSchema = chatThreadsContract.indicators.responses[200];
+
+    expect(currentSchema.parse(legacyResponse)).toStrictEqual(legacyResponse);
+    expect(previousSchema.parse(queuedResponse)).toStrictEqual(legacyResponse);
+    expect(currentSchema.parse(queuedResponse)).toStrictEqual(queuedResponse);
+  });
+});
+
 describe("chat message response contract", () => {
   const workflowId = "11111111-1111-4111-8111-111111111111";
 

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -312,6 +312,7 @@ export const indicatorSchema = z.enum(["active", "unread"]);
 const indicatorsSchema = z.object({
   agents: z.record(z.string().uuid(), indicatorSchema),
   threads: z.record(z.string().uuid(), indicatorSchema),
+  queuedThreadIds: z.array(z.string().uuid()).optional(),
 });
 
 const chatThreadEventIdSchema = z.string().uuid();
@@ -1185,7 +1186,7 @@ export const chatThreadsContract = c.router({
       401: apiErrorSchema,
     },
     summary:
-      "Get active and unread indicators for the caller's agents and chat threads in the current organization.",
+      "Get active, queued, and unread indicators for the caller's agents and chat threads in the current organization.",
   },
   snapshot: {
     method: "GET",


### PR DESCRIPTION
## Summary

- expose queued thread IDs as additive indicator metadata while preserving the existing `active` classification
- classify a thread as queued only when all of its active runs are still queued, so admitted `pending` or `running` work takes precedence
- render queued threads as a static light-blue dot while keeping the animated running indicator and dark-blue unread dot unchanged

## Compatibility

- older Platform builds ignore the additive response field
- newer Platform builds fall back to the existing running indicator when an older API omits the field

## Testing

- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts` (42 passed)
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx` (39 passed)
- `pnpm --filter @okouai/api-contracts test` (722 passed)
- `pnpm --filter api check-types`
- `pnpm --filter @okouai/app check-types`
- `pnpm --filter @okouai/api-contracts check-types`
- `pnpm --filter api lint`
- `pnpm --filter @okouai/app lint`
- `pnpm --filter @okouai/api-contracts lint`
- `pnpm lint:style`
- `pnpm knip`
- `pnpm format`

Closes #32656
Related to #22273

Rebase merge is the default. Please delete the feature branch after merge.

Co-Authored-By: Zero <zero@vm0.ai>
