### PR TITLE
fix(app): reset agent instructions editor on discard

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/job-detail/instructions.ts
+++ b/turbo/apps/platform/src/signals/okou-page/job-detail/instructions.ts
@@ -38,9 +38,14 @@ export const agentInstructions$ = computed(
 // ---------------------------------------------------------------------------
 
 const editedContent$ = state<string | null>(null);
+const editorRevision$ = state(0);
 
 export const agentEditedContent$ = computed((get) => {
   return get(editedContent$);
+});
+
+export const agentInstructionsEditorRevision$ = computed((get) => {
+  return get(editorRevision$);
 });
 
 export const agentInstructionsDirty$ = computed(async (get) => {
@@ -56,6 +61,9 @@ export const setAgentEditedContent$ = command(({ set }, value: string) => {
 
 export const discardAgentEdit$ = command(({ set }) => {
   set(editedContent$, null);
+  set(editorRevision$, (previous) => {
+    return previous + 1;
+  });
 });
 
 export const buildAgentInstructions$ = command(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/agent-instructions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/agent-instructions.test.tsx
@@ -77,6 +77,50 @@ test("Markdown links load as editable instruction text", async () => {
   expect(pathname()).toBe(`/agents/${AGENT_ID}`);
 });
 
+test.each([
+  { name: "saved instructions", initialContent: "Review release notes" },
+  { name: "empty instructions", initialContent: "" },
+])("Discard restores $name and exits editing", async ({ initialContent }) => {
+  await setupInstructionsPage(initialContent);
+  const user = userEvent.setup({ delay: null });
+  const editor = await instructionsEditor();
+
+  await fill(editor, "Unsaved instructions");
+  await user.click(editor);
+  expect(editor).toHaveFocus();
+  const unsavedBar = await screen.findByTestId("unsaved-bar");
+
+  click(within(unsavedBar).getByTestId("discard-button"));
+
+  await waitFor(() => {
+    expect(screen.getByLabelText("Instructions editor").textContent).toBe(
+      initialContent,
+    );
+  });
+  const restoredEditor = await instructionsEditor();
+  expect(restoredEditor).not.toHaveFocus();
+  expect(screen.queryByTestId("unsaved-bar")).not.toBeInTheDocument();
+
+  await user.click(restoredEditor);
+  await user.keyboard("{Control>}z{/Control}");
+
+  expect(restoredEditor.textContent).toBe(initialContent);
+  expect(screen.queryByTestId("unsaved-bar")).not.toBeInTheDocument();
+
+  await fill(restoredEditor, "A fresh edit");
+  const nextUnsavedBar = await screen.findByTestId("unsaved-bar");
+
+  click(within(nextUnsavedBar).getByTestId("discard-button"));
+
+  await waitFor(() => {
+    expect(screen.getByLabelText("Instructions editor").textContent).toBe(
+      initialContent,
+    );
+  });
+  expect(screen.getByLabelText("Instructions editor")).not.toHaveFocus();
+  expect(screen.queryByTestId("unsaved-bar")).not.toBeInTheDocument();
+});
+
 test("A user can format and save agent instructions", async () => {
   const updates: string[] = [];
   await setupInstructionsPage("Review release notes", (content) => {
@@ -122,4 +166,17 @@ test("A user can format and save agent instructions", async () => {
   expect((await instructionsEditor()).querySelector("h2")).toHaveTextContent(
     "Launch risks",
   );
+
+  await fill(await instructionsEditor(), "An unsaved replacement");
+  const nextUnsavedBar = await screen.findByTestId("unsaved-bar");
+
+  click(within(nextUnsavedBar).getByTestId("discard-button"));
+
+  await waitFor(() => {
+    expect(
+      screen.getByLabelText("Instructions editor").querySelector("h2"),
+    ).toHaveTextContent("Launch risks");
+  });
+  expect(screen.getByLabelText("Instructions editor")).not.toHaveFocus();
+  expect(screen.queryByTestId("unsaved-bar")).not.toBeInTheDocument();
 });

--- a/turbo/apps/platform/src/views/okou-page/instructions-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/instructions-tab.tsx
@@ -8,6 +8,7 @@ interface InstructionsTabProps {
   loading: boolean;
   fetchError: string | null;
   editedContent: string | null;
+  editorRevision: number;
   isDirty: boolean;
   isBuilding: boolean;
   buildError: string | null;
@@ -21,6 +22,7 @@ export function InstructionsTab({
   loading,
   fetchError,
   editedContent,
+  editorRevision,
   isDirty,
   isBuilding,
   buildError,
@@ -32,10 +34,9 @@ export function InstructionsTab({
   const rawContent = instructions?.content ?? "";
   const displayContent = editedContent ?? rawContent;
 
-  // Use rawContent as key so the editor remounts when saved content changes
-  // (initial fetch or after discard). During typing, editedContent changes
-  // but rawContent stays the same, so the editor keeps its internal state.
-  const editorKey = rawContent;
+  // Discard must reset the document, undo history, and focus even though the
+  // saved content has not changed. Keep the key stable while the user types.
+  const editorKey = `${editorRevision}:${rawContent}`;
 
   return (
     <div className="mx-auto max-w-[900px]">

--- a/turbo/apps/platform/src/views/team-page/job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/job-detail-page.tsx
@@ -47,6 +47,7 @@ import {
   agentInstructions$,
   agentEditedContent$,
   agentInstructionsDirty$,
+  agentInstructionsEditorRevision$,
   setAgentEditedContent$,
   discardAgentEdit$,
   buildAgentInstructions$,
@@ -769,6 +770,7 @@ function JobInstructionsTab() {
   const instructionsLoadable = useLoadable(agentInstructions$);
   const editedLoadable = useLoadable(agentEditedContent$);
   const dirtyLoadable = useLoadable(agentInstructionsDirty$);
+  const editorRevision = useGet(agentInstructionsEditorRevision$);
   const [buildLoadable, build] = useLoadableSet(buildAgentInstructions$);
 
   const instructions =
@@ -797,6 +799,7 @@ function JobInstructionsTab() {
       loading={loading}
       fetchError={fetchError}
       editedContent={edited}
+      editorRevision={editorRevision}
       isDirty={isDirty}
       isBuilding={isBuilding}
       buildError={buildError}


### PR DESCRIPTION
## Summary

Clicking Discard on an agent's Instructions tab currently hides the unsaved-changes bar but leaves the edited text in the rich-text editor. Discard now restores the last saved instructions, clears the editor's undo history, and removes editing focus without saving the draft.

The existing discard command now advances the editor revision so its document, undo history, and focus reset together. Ordinary typing keeps the same editor instance.

## Verification

- Reproduced the bug with page-level regression tests before applying the fix.
- Regression coverage includes saved and empty instructions, repeated edit/discard cycles, undo after discard, and discarding back to the latest saved formatted content.
- Passed all 4 tests in `agent-instructions.test.tsx` with a single worker.
- Passed formatting, App lint checks, App type checking, scoped Knip, and the style policy check.
- Passed browser verification on the PR preview: saved content returns, focus and the unsaved bar clear, Undo cannot revive the discarded draft, and a second discard also restores the original content. A fresh API read confirmed that saved instructions did not change.
- All CI checks passed; the full test suite ran in CI.

Preview deployment: https://pr-32674-app-okou-app-preview.vm0.workers.dev

Browser QA used a fresh Clerk test account and its own default agent at 1440×1000 in Chromium, with no feature-switch overrides. The deployed merge commit `a7715c9dd8ee9281b3d3d10094349b5f90e54b86` includes PR head `9989cdcea724cb7e36d7a3eb085f31be4683d793`.

## Acceptance

1. Open an agent's Instructions tab and change its content.
2. Click Discard. The saved content should return, the unsaved-changes bar should disappear, and the editor should lose focus.
3. Click into the editor again and use Undo. The discarded draft should not return.
4. Edit and save, then make another edit and discard. The last saved content should remain.
