### PR TITLE
test(platform): avoid stale stop control assertion

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-keyboard.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-keyboard.test.tsx
@@ -13,6 +13,7 @@ import {
   findFastControl,
   installMessageExperienceChat,
   MESSAGE_EXPERIENCE_AGENT_ID,
+  queryFastControl,
 } from "./chat-message-experience-test-helpers.ts";
 
 const COMPOSER_PLACEHOLDER = "Ask me to automate workflows, manage tasks...";
@@ -57,8 +58,8 @@ async function expectSentPrompt(prompt: string): Promise<void> {
 }
 
 async function expectAgentWorking(): Promise<void> {
-  await expect(findFastControl("button", "Stop")).resolves.toBeVisible();
   await waitFor(() => {
+    expect(queryFastControl("button", "Stop")).toBeVisible();
     expect(document.querySelector("[data-thinking-indicator]")).toBeVisible();
   });
 }


### PR DESCRIPTION
## Summary

- query the currently mounted Stop control inside the same observable wait as its visibility assertion
- keep the active-run thinking indicator and exact keyboard behavior assertions unchanged
- remove the stale DOM reference window exposed by React replacing the optimistic control

## Failure evidence

- [Main Turbo run](https://github.com/vm0-ai/vm0/actions/runs/34221470580)
- [Failed app shard](https://github.com/vm0-ai/vm0/actions/runs/34221470580/job/102045425074)
- [Passing merge-group shard on the same SHA](https://github.com/vm0-ai/vm0/actions/runs/34220891728/job/102043570887)

The failed assertion received a `button[aria-label="Stop"]` that was no longer in the document. The query and matcher previously ran across an asynchronous boundary, so a React remount could detach that exact node while preserving the same user-visible active-run state.

## Verification

- target file passed five consecutive runs on the latest pre-commit `main`: 35/35 tests
- Prettier check
- scoped Oxlint and type-aware Oxlint
- scoped ESLint
- `pnpm -F @okouai/app check-types`
