### PR TITLE
fix(platform): align connector account rename controls

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -437,13 +437,13 @@ function RenameAccountForm({ target }: { target: ConnectorAccountTarget }) {
     );
   };
   return (
-    <form className="px-1 py-4" onSubmit={submit}>
-      <label className="text-sm font-medium" htmlFor="account-rename">
-        {t(($) => {
-          return $.connectors.accounts.accountName;
-        })}
-      </label>
-      <div className="mt-2 flex gap-2">
+    <form className="space-y-4 px-5 py-4" onSubmit={submit}>
+      <div className="flex flex-col gap-1.5">
+        <label className="text-sm font-medium" htmlFor="account-rename">
+          {t(($) => {
+            return $.connectors.accounts.accountName;
+          })}
+        </label>
         <Input
           id="account-rename"
           value={draft.displayName}
@@ -452,14 +452,16 @@ function RenameAccountForm({ target }: { target: ConnectorAccountTarget }) {
           }}
           maxLength={255}
         />
-        <Button type="submit" disabled={renameLoadable.state === "loading"}>
-          {t(($) => {
-            return $.connectors.actions.save;
-          })}
-        </Button>
+      </div>
+      <div className="flex justify-end gap-2">
         <Button type="button" variant="outline" onClick={clear}>
           {t(($) => {
             return $.connectors.actions.cancel;
+          })}
+        </Button>
+        <Button type="submit" disabled={renameLoadable.state === "loading"}>
+          {t(($) => {
+            return $.connectors.actions.save;
           })}
         </Button>
       </div>


### PR DESCRIPTION
Renaming a connector account currently squeezes the name field and both actions into one row with only 4px of horizontal padding. Match the account rows' 20px padding, give the input its own full-width row, and place Cancel then Save in a separate row aligned to the right.

The change reuses the existing Input and Button components and preserves the current rename submission, cancellation, and empty-name behavior.

[Before / after design reference](https://a.okou.io/43xm94kwkj.png)

## Verification

- Prettier check passed for the changed component.
- `git diff --check` passed.
- Application runtime checks and Vitest were not run locally, per the task constraints; automated validation is delegated to the PR pipeline.
