### PR TITLE
fix(desktop): recover native permission probes through their lifecycle owner

### DIFF
--- a/turbo/apps/desktop/NATIVE-PERMISSION-LIFECYCLE.md
+++ b/turbo/apps/desktop/NATIVE-PERMISSION-LIFECYCLE.md
@@ -1,0 +1,95 @@
+# Native permission query lifecycle
+
+`ComputerUseNativeRuntimeClient` retains the correlated settlement owner until
+status, result shape and permission fields are validated. Terminal protocol,
+transport, timeout and process failures invalidate the backend, settle its
+pending request and release queued callers with failures. A poisoned backend
+cannot spawn another helper. Duplicate/unowned frames are ignored; output from
+a retired process cannot make a new generation ready.
+
+`ComputerUseRuntimeController.refreshNativePermissions` owns read-only refresh
+recovery. A current, running Okou generation may recover only from the typed
+`permissions.state` deadline: either the outer request timer or Swift's existing
+`target_app_unresponsive` deadline response for that specific command. Other
+native failures, malformed responses, actual permission denial and permission
+requests do not retry. Startup and passive reads do not enable recovery.
+
+Concurrent refreshes share their first read and one recovery episode. The
+permission-provider lease is released before the existing replacement queue
+waits for command completion, generation retirement and proven process exit.
+The replacement gets exactly one new permission probe. The driver retains
+snapshot and executor ownership: a claimed command fails/reports in its old
+generation and never moves to the replacement. Fresh commands must observe
+again. Failed retirement remains owned and blocks replacement.
+
+The current lifecycle intent and opaque auth-session authority invalidate late
+work. Stop, sign-out, workspace/session changes, driver selection, Quit,
+update and caller cancellation revoke recovery. A cancellation or shorter
+budget from any joined waiter cancels the shared episode; it cannot publish
+readiness for another waiter. New work under a new intent cannot share an old
+result. Explicit selection can perform its own authorized replacement after
+superseding the obsolete recovery.
+
+## Bounds
+
+- A helper request retains its 60-second backstop. Swift's semaphore policy is
+  unchanged at 10 seconds.
+- A refresh starts with a total monotonic cap of the existing 60-second attempt
+  plus the existing 30-second transition bound: at most 90 seconds by default.
+  The transition includes command drain, old-process cleanup and the one fresh
+  probe; it does not give the probe another unconditional 60 seconds.
+- Heartbeat passes its existing 10-second deadline and cancellation signal.
+  Startup and explicit transitions keep their existing 30-second bounds.
+  Claimed commands keep their own total execution and reporting budgets and
+  never use automatic permission recovery.
+- A shorter caller deadline wins. It is checked in continuations as well as
+  timers, so delayed timer delivery cannot mint a fresh budget after resumption.
+- Native disposal retains the existing three one-second EOF/TERM/KILL exit
+  waits. Failure cleanup can remain owned for those three seconds after the
+  caller-facing deadline (93 seconds for the default refresh plus cleanup).
+  An unproven exit is a failure, never permission to overlap processes. Old
+  command leases retain their independent, existing reporting lifetime.
+- No timer guarantees progress while the parent process or OS is suspended.
+
+## Diagnostics and evidence limits
+
+Existing helper error reporting receives at most 12 phase entries per process:
+spawn request, observed spawn, dispatch, response processing, timeout, protocol,
+write and close. Elapsed values and timer overshoot clamp to 120 seconds. The
+record contains request/process sequences, parent-observed helper age and known
+exit state. Arbitrary serve-mode stderr is discarded; only a byte count capped
+at 4096 is retained. No payload, typed text, app/screen contents, JSONL response
+body, token or user identity is added. History belongs to its process, and query
+listeners/timers are removed when their owner finishes.
+
+A bounded recovery breadcrumb records generation, outcome and elapsed time.
+Existing timeout, protocol, shutdown and unexpected-exit errors remain
+reportable. There is no broad Sentry suppression or new monitoring service.
+
+Swift receipt/completion markers and OS suspend/resume markers are absent and
+therefore unknown. A response-processing timestamp is the parent's observation,
+not a helper execution timestamp. Timer overshoot proves delayed timer delivery,
+not macOS sleep or a blocked permission API. The production incident establishes
+one outer timeout only; the two regressions do not establish its unique cause.
+
+## Regression boundaries
+
+The exported native backend tests cover correlated malformed status/result,
+invalid permission fields, malformed JSON, non-object frames, duplicate and
+unowned frames, queue settlement, teardown and diagnostic bounds/privacy.
+Driver/runtime integration covers shared recovery, two failures, unproven exit,
+Stop/auth/workspace/switch/Quit/update/cancellation, late old-process results,
+caller deadlines, claimed-command completion and old snapshot rejection.
+
+The parent-stall fixture runs the actual backend, driver, permissions, runtime
+and host composition in an independent Node process. Filesystem notifications
+synchronize a warmed helper and an independent coordinator. The helper proves
+its JSONL write completed before the 400 ms attempt deadline; the coordinator
+holds only that parent until the deadline has elapsed. Vitest itself never
+stalls. The assertion requires fresh-generation readiness, not acceptance of
+the stale buffered reply. This and the correlated settlement regressions fail
+on unmodified pre-fix source.
+
+Linux fixtures and CI do not establish signed-Mac/TCC, real permission dialogs,
+real applications, or sleep/wake acceptance. No Swift, SDK or Electron version,
+public API, database, default driver, UI layout or release behavior changes.

--- a/turbo/apps/desktop/NATIVE-PERMISSION-LIFECYCLE.md
+++ b/turbo/apps/desktop/NATIVE-PERMISSION-LIFECYCLE.md
@@ -30,6 +30,12 @@ readiness for another waiter. New work under a new intent cannot share an old
 result. Explicit selection can perform its own authorized replacement after
 superseding the obsolete recovery.
 
+Graceful driver replacement and drain-and-stop cancel the probe's result while
+the existing host owner drains healthy claimed actions through completion
+reporting. They do not force-stop a healthy helper merely because a read was
+concurrent. Revoked authority, explicit query cancellation and expired budgets
+still withdraw readiness and force retirement; failed helpers remain poisoned.
+
 ## Bounds
 
 - A helper request retains its 60-second backstop. Swift's semaphore policy is

--- a/turbo/apps/desktop/src/computer-use-driver.ts
+++ b/turbo/apps/desktop/src/computer-use-driver.ts
@@ -36,6 +36,7 @@ interface DriverGeneration {
   leases: number;
   disposal: Promise<void> | null;
   permissionsReady: boolean;
+  permissionRead: Promise<ComputerUsePermissionState> | null;
 }
 
 export interface ComputerUseCommandSession {
@@ -156,6 +157,7 @@ export class ComputerUseDriverController {
         leases: 0,
         disposal: null,
         permissionsReady: false,
+        permissionRead: null,
       };
       this.onChange();
     }
@@ -187,7 +189,9 @@ export class ComputerUseDriverController {
         ...context.backend,
         getPermissions: () => this.readPermissions(context),
       });
-      return this.context === context && this.authorized(context)
+      return this.context === context &&
+        !this.permissionsPaused &&
+        this.authorized(context)
         ? result
         : null;
     } finally {
@@ -265,7 +269,20 @@ export class ComputerUseDriverController {
       : [];
   }
 
-  private async readPermissions(
+  private readPermissions(
+    context: DriverGeneration,
+  ): Promise<ComputerUsePermissionState> {
+    if (context.permissionRead) return context.permissionRead;
+    const read = this.readGenerationPermissions(context);
+    context.permissionRead = read;
+    const finish = () => {
+      if (context.permissionRead === read) context.permissionRead = null;
+    };
+    void read.then(finish, finish);
+    return read;
+  }
+
+  private async readGenerationPermissions(
     context: DriverGeneration,
   ): Promise<ComputerUsePermissionState> {
     try {
@@ -282,10 +299,12 @@ export class ComputerUseDriverController {
       this.onChange();
       return permissions;
     } catch (error) {
-      this.failure =
-        "Native driver permission check failed. Explicit recovery is required.";
       context.permissionsReady = false;
-      if (this.context === context) void this.forceRetire().catch(() => {});
+      if (this.context === context) {
+        this.failure =
+          "Native driver permission check failed. Explicit recovery is required.";
+        void this.forceRetire().catch(() => {});
+      }
       throw error;
     }
   }

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -1,3 +1,4 @@
+import type { ComputerUsePermissionQuery } from "./computer-use-permissions";
 import { createComputerUseDrain } from "./computer-use-lifecycle-deadline";
 import {
   ComputerUseCommandBudget,
@@ -71,7 +72,9 @@ interface ComputerUseHostRuntimeOptions {
   readonly sessionFetch: ComputerUseHostFetch;
   readonly hostFetch: ComputerUseHostFetch;
   readonly addClientHeaders: DesktopClientHeaderInjector;
-  readonly getPermissions: () => MaybePromise<ComputerUsePermissionState>;
+  readonly getPermissions: (
+    query?: ComputerUsePermissionQuery,
+  ) => MaybePromise<ComputerUsePermissionState>;
   readonly getSupportedCapabilities?: () => readonly string[];
   readonly acquireCommand: () => ComputerUseCommandSession;
   readonly onCommandFailure?: (args: {
@@ -396,8 +399,10 @@ export class ComputerUseHostRuntime {
     return this.state;
   }
 
-  private async runtimeBody(): Promise<Record<string, unknown>> {
-    const permissions = await this.getPermissions();
+  private async runtimeBody(
+    query?: ComputerUsePermissionQuery,
+  ): Promise<Record<string, unknown>> {
+    const permissions = await this.getPermissions(query);
     const capabilities = this.getSupportedCapabilities();
     if (capabilities.length === 0) {
       if (this.draining) throw new ComputerUseCapabilitiesPaused();
@@ -941,11 +946,12 @@ export class ComputerUseHostRuntime {
 
   private async heartbeat(): Promise<boolean> {
     const generation = this.sessionGeneration;
+    const deadline = performance.now() + HEARTBEAT_REQUEST_TIMEOUT_MS;
     const response = await this.runHostRequestWithTimeout({
       label: "heartbeat",
       timeoutMs: HEARTBEAT_REQUEST_TIMEOUT_MS,
       request: async (signal) => {
-        const body = await this.runtimeBody();
+        const body = await this.runtimeBody({ signal, deadline });
         if (!this.running || generation !== this.sessionGeneration)
           throw new Error("Computer Use heartbeat was superseded");
         return await this.hostFetch("/api/computer-use/heartbeat", {

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -1054,7 +1054,7 @@ describe("computer use native backend", () => {
     }
   });
 
-  it("recovers by respawning the helper after a request times out", async () => {
+  it("requires generation retirement after a request times out", async () => {
     const helper = await createConcurrencyHelper(20);
     const onRuntimeError = vi.fn();
     // Generous enough that a legitimate request (which must cold-start a fresh
@@ -1071,13 +1071,14 @@ describe("computer use native backend", () => {
         code: "accessibility_unavailable",
         message: expect.stringContaining("timed out running app.open"),
       });
-      // The next request runs on a freshly spawned helper, not the killed one.
-      await expect(backend.openApp("ok")).resolves.toEqual({});
+      // The old backend cannot make its process-owned snapshots/actions valid
+      // in a replacement. Fresh work belongs to a newly constructed generation.
+      await expect(backend.openApp("ok")).rejects.toThrow("closed");
 
       const starts = (await readFile(helper.startLogPath, "utf8"))
         .trim()
         .split("\n");
-      expect(starts).toHaveLength(2);
+      expect(starts).toHaveLength(1);
       expect(onRuntimeError).toHaveBeenCalledWith(
         expect.any(Error),
         expect.objectContaining({
@@ -1174,4 +1175,119 @@ describe("computer use native backend", () => {
       await rm(helper.dir, { recursive: true, force: true });
     }
   });
+});
+
+describe("native permission response settlement", () => {
+  it.each([
+    ["invalid status", 'JSON.stringify({id: request.id, status: "invalid"})'],
+    [
+      "invalid result",
+      'JSON.stringify({id: request.id, status: "succeeded", result: []})',
+    ],
+    [
+      "invalid permission fields",
+      'JSON.stringify({id: request.id, status: "succeeded", result: {accessibility: "secret"}})',
+    ],
+    ["malformed JSON", '"{private-payload"'],
+    ["non-object frame", '"null"'],
+  ])(
+    "rejects %s and releases queued work without reusing the poisoned helper",
+    async (_label, frame) => {
+      const dir = await mkdtemp(path.join(tmpdir(), "native-settlement-"));
+      const helperPath = path.join(dir, "helper.cjs");
+      await writeFile(
+        helperPath,
+        `#!${process.execPath}\nrequire('node:readline').createInterface({input:process.stdin}).on('line', line => { const request = JSON.parse(line); process.stdout.write(${frame} + '\\n'); });\n`,
+      );
+      await chmod(helperPath, 0o755);
+      const onRuntimeError = vi.fn();
+      const backend = createComputerUseNativeBackend({
+        helperPath,
+        requestTimeoutMs: 400,
+        onRuntimeError,
+      });
+      try {
+        const results = await Promise.allSettled([
+          backend.getPermissions(),
+          backend.listApps(),
+        ]);
+        expect(results.map((result) => result.status)).toEqual([
+          "rejected",
+          "rejected",
+        ]);
+        expect(onRuntimeError).toHaveBeenCalledExactlyOnceWith(
+          expect.any(Error),
+          expect.objectContaining({
+            stage: "protocol",
+            pendingRequestCount: 1,
+          }),
+        );
+        expect(JSON.stringify(onRuntimeError.mock.calls)).not.toContain(
+          "private-payload",
+        );
+        await expect(backend.getPermissions()).rejects.toThrow("closed");
+      } finally {
+        await backend.dispose();
+        await rm(dir, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+it("ignores duplicate and unowned replies, and bounds protocol diagnostics without retaining private output", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "native-frame-ownership-"));
+  const helperPath = path.join(dir, "helper.cjs");
+  await writeFile(
+    helperPath,
+    `#!${process.execPath}
+const fs = require('node:fs');
+let previous;
+require('node:readline').createInterface({input:process.stdin}).on('line', line => {
+  const request=JSON.parse(line);
+  if (request.kind === 'permissions.state') {
+    fs.writeSync(2, 'private-token-and-app-content'.repeat(1000));
+    fs.writeSync(1, JSON.stringify({id:request.id,status:'succeeded',result:[]})+'\\n');
+    return;
+  }
+  if(previous) fs.writeSync(1, JSON.stringify({id:previous,status:'failed',error:{code:'permission_denied'}})+'\\n');
+  fs.writeSync(1, JSON.stringify({id:'unowned',status:'invalid'})+'\\n');
+  fs.writeSync(1, JSON.stringify({id:request.id,status:'succeeded',result:{apps:['Fresh']}})+'\\n');
+  previous=request.id;
+});
+`,
+  );
+  await chmod(helperPath, 0o755);
+  const onRuntimeError = vi.fn();
+  const backend = createComputerUseNativeBackend({
+    helperPath,
+    onRuntimeError,
+  });
+  try {
+    for (let index = 0; index < 20; index++)
+      await expect(backend.listApps()).resolves.toEqual([{ name: "Fresh" }]);
+    await expect(backend.getPermissions()).rejects.toThrow("invalid result");
+    const context = onRuntimeError.mock.calls[0]?.[1] as {
+      phases: { elapsedMs: number }[];
+      stderrBytes: number;
+      pendingRequestCount: number;
+    };
+    expect(context.phases).toHaveLength(12);
+    expect(
+      context.phases.every(
+        (phase) => phase.elapsedMs >= 0 && phase.elapsedMs <= 120_000,
+      ),
+    ).toBe(true);
+    expect(context.stderrBytes).toBeLessThanOrEqual(4096);
+    expect(context.pendingRequestCount).toBe(1);
+    expect(JSON.stringify(onRuntimeError.mock.calls)).not.toContain(
+      "private-token",
+    );
+    expect(JSON.stringify(onRuntimeError.mock.calls)).not.toContain("Fresh");
+    await backend.dispose();
+    await expect(backend.listApps()).rejects.toThrow("closed");
+    expect(onRuntimeError).toHaveBeenCalledTimes(1);
+  } finally {
+    await backend.dispose();
+    await rm(dir, { recursive: true, force: true });
+  }
 });

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -189,6 +189,30 @@ export class ComputerUseNativeHelperError extends Error {
   }
 }
 
+/** Only a read-only native probe deadline is eligible for lifecycle recovery. */
+export class ComputerUseNativePermissionTimeoutError extends ComputerUseNativeHelperError {
+  constructor() {
+    super(
+      "accessibility_unavailable",
+      "Native Computer Use runtime timed out running permissions.state",
+    );
+  }
+}
+
+interface NativeRuntimePhase {
+  readonly phase:
+    | "spawn"
+    | "spawned"
+    | "dispatch"
+    | "response"
+    | "timeout"
+    | "protocol"
+    | "write"
+    | "close";
+  readonly elapsedMs: number;
+  readonly requestSequence?: number;
+}
+
 export interface ComputerUseNativeRuntimeErrorContext {
   readonly helperPath: string;
   readonly mode: "serve" | "oneshot";
@@ -206,6 +230,15 @@ export interface ComputerUseNativeRuntimeErrorContext {
   readonly terminationReason?: ComputerUseNativeTerminationReason;
   readonly pendingRequestCount?: number;
   readonly queuedRequestCount?: number;
+  readonly processSequence?: number;
+  readonly requestSequence?: number;
+  readonly elapsedMs?: number;
+  readonly helperUptimeMs?: number;
+  /** Timer overshoot is observed scheduling delay, not proof of OS sleep. */
+  readonly timerDelayMs?: number;
+  readonly exitKnown?: boolean;
+  readonly phases?: readonly NativeRuntimePhase[];
+  readonly stderrBytes?: number;
 }
 
 type ComputerUseNativeRuntimeErrorReporter = (
@@ -559,7 +592,10 @@ interface ComputerUseNativeRuntimeProcess {
   readonly closePromise: Promise<void>;
   readonly resolveClose: () => void;
   stdoutBuffer: string;
-  stderr: string;
+  readonly sequence: number;
+  readonly startedAt: number;
+  readonly phases: NativeRuntimePhase[];
+  stderrBytes: number;
   closed: boolean;
   terminalErrorReported: boolean;
   stopReason: ComputerUseNativeTerminationReason | null;
@@ -569,6 +605,8 @@ interface ComputerUseNativeRuntimeProcess {
 interface PendingRuntimeRequest {
   readonly kind: string;
   readonly runtime: ComputerUseNativeRuntimeProcess;
+  readonly sequence: number;
+  readonly dispatchedAt: number;
   readonly resolve: (result: Record<string, unknown>) => void;
   readonly reject: (error: Error) => void;
 }
@@ -588,15 +626,23 @@ function runtimePayload(
 // macOS funnels screen capture through a single WindowServer broker that fails
 // transiently when two captures overlap, so the helper must run one request at
 // a time. This is the backstop that keeps a wedged helper from blocking the
-// whole serialized queue forever; on timeout the helper is killed and respawned.
-const DEFAULT_RUNTIME_REQUEST_TIMEOUT_MS = 60_000;
+// whole serialized queue forever. A timeout invalidates this backend; only the
+// generation owner may construct a replacement after proving retirement.
+export const COMPUTER_USE_NATIVE_PERMISSION_TIMEOUT_MS = 60_000;
+const DEFAULT_RUNTIME_REQUEST_TIMEOUT_MS =
+  COMPUTER_USE_NATIVE_PERMISSION_TIMEOUT_MS;
 const DEFAULT_RUNTIME_SHUTDOWN_GRACE_MS = 1_000;
+
+function boundedElapsed(start: number): number {
+  return Math.min(120_000, Math.max(0, Math.round(performance.now() - start)));
+}
 
 class ComputerUseNativeRuntimeClient {
   private runtime: ComputerUseNativeRuntimeProcess | null = null;
   private readonly retiringRuntimes =
     new Set<ComputerUseNativeRuntimeProcess>();
   private requestCounter = 0;
+  private processCounter = 0;
   private state: ComputerUseNativeRuntimeClientState = "open";
   private readonly pending = new Map<string, PendingRuntimeRequest>();
   private queueTail: Promise<void> = Promise.resolve();
@@ -612,6 +658,17 @@ class ComputerUseNativeRuntimeClient {
       | undefined,
   ) {}
 
+  isAvailable(): boolean {
+    return this.state === "open";
+  }
+
+  isCleanupPending(): boolean {
+    return (
+      this.retiringRuntimes.size > 0 ||
+      (this.state === "closing" && !!this.runtime && !this.runtime.closed)
+    );
+  }
+
   request(request: ComputerUseNativeRequest): Promise<Record<string, unknown>> {
     if (this.state !== "open") {
       return Promise.reject(this.closedError());
@@ -622,14 +679,6 @@ class ComputerUseNativeRuntimeClient {
     this.queuedRequestCount += 1;
     const run = this.queueTail.then(async () => {
       this.queuedRequestCount -= 1;
-      for (const runtime of this.retiringRuntimes) {
-        if (!(await this.waitForRuntimeClose(runtime))) {
-          throw new ComputerUseNativeHelperError(
-            "accessibility_unavailable",
-            "Previous native Computer Use runtime has not exited",
-          );
-        }
-      }
       // Disposal may start while this request is waiting behind another one.
       // Re-check at dispatch time so a queued request cannot respawn a helper
       // after shutdown has begun.
@@ -650,37 +699,41 @@ class ComputerUseNativeRuntimeClient {
   ): Promise<Record<string, unknown>> {
     const runtime = this.ensureRuntime();
     const id = `desktop_${(this.requestCounter += 1).toString()}`;
+    const sequence = this.requestCounter;
+    const dispatchedAt = performance.now();
+    this.recordPhase(runtime, "dispatch", sequence);
     return new Promise<Record<string, unknown>>((resolve, reject) => {
       const timer = setTimeout(() => {
-        if (!this.pending.delete(id)) {
+        const pending = this.pending.get(id);
+        if (!pending || pending.runtime !== runtime) {
           return;
         }
-        // A wedged helper would block every queued request behind it. Replace
-        // it so the next request starts on a fresh process. Mark ownership
-        // before signaling so the later close event cannot be misclassified.
-        if (this.runtime === runtime) {
-          this.runtime = null;
-        }
-        this.retiringRuntimes.add(runtime);
+        // Mark timeout ownership before signaling. The generation owner must
+        // prove retirement before allowing a replacement process.
         runtime.stopReason = "timeout_replace";
-        runtime.terminalErrorReported = true;
-        this.signalRuntime(runtime, "SIGKILL");
-        const helperError = new ComputerUseNativeHelperError(
-          "accessibility_unavailable",
-          `Native Computer Use runtime timed out running ${request.kind}`,
-        );
+        const helperError =
+          request.kind === "permissions.state"
+            ? new ComputerUseNativePermissionTimeoutError()
+            : new ComputerUseNativeHelperError(
+                "accessibility_unavailable",
+                `Native Computer Use runtime timed out running ${request.kind}`,
+              );
+        this.recordPhase(runtime, "timeout", sequence);
         this.reportRuntimeError(helperError, {
           mode: "serve",
           requestKind: request.kind,
           stage: "timeout",
           terminationReason: "timeout_replace",
-          pendingRequestCount: this.pending.size + 1,
+          ...this.runtimeEvidence(runtime, pending),
+          timerDelayMs: boundedElapsed(dispatchedAt + this.requestTimeoutMs),
         });
-        reject(helperError);
+        this.failRuntime(runtime, helperError);
       }, this.requestTimeoutMs);
       this.pending.set(id, {
         kind: request.kind,
         runtime,
+        sequence,
+        dispatchedAt,
         resolve: (value) => {
           clearTimeout(timer);
           resolve(value);
@@ -690,26 +743,31 @@ class ComputerUseNativeRuntimeClient {
           reject(error);
         },
       });
-      runtime.child.stdin.write(
-        `${JSON.stringify({ id, kind: request.kind, payload: runtimePayload(request) })}\n`,
-        (error) => {
-          const pending = this.pending.get(id);
-          if (error && pending?.runtime === runtime) {
-            this.pending.delete(id);
-            clearTimeout(timer);
-            const helperError = new ComputerUseNativeHelperError(
-              "accessibility_unavailable",
-              `Unable to write to native Computer Use runtime: ${error.message}`,
-            );
-            this.reportRuntimeError(helperError, {
-              mode: "serve",
-              requestKind: request.kind,
-              stage: "write",
-            });
-            reject(helperError);
-          }
-        },
-      );
+      const failedWrite = (error: Error | null | undefined) => {
+        const pending = this.pending.get(id);
+        if (error && pending?.runtime === runtime) {
+          const helperError = new ComputerUseNativeHelperError(
+            "accessibility_unavailable",
+            "Unable to write to native Computer Use runtime",
+          );
+          this.recordPhase(runtime, "write", sequence);
+          this.reportRuntimeError(helperError, {
+            mode: "serve",
+            requestKind: request.kind,
+            stage: "write",
+            ...this.runtimeEvidence(runtime, pending),
+          });
+          this.failRuntime(runtime, helperError);
+        }
+      };
+      try {
+        runtime.child.stdin.write(
+          `${JSON.stringify({ id, kind: request.kind, payload: runtimePayload(request) })}\n`,
+          failedWrite,
+        );
+      } catch (error) {
+        failedWrite(runtimeErrorFromUnknown(error));
+      }
     });
   }
 
@@ -758,13 +816,18 @@ class ComputerUseNativeRuntimeClient {
       closePromise,
       resolveClose,
       stdoutBuffer: "",
-      stderr: "",
+      sequence: ++this.processCounter,
+      startedAt: performance.now(),
+      phases: [],
+      stderrBytes: 0,
       closed: false,
       terminalErrorReported: false,
       stopReason: null,
       sentSignal: null,
     };
     this.runtime = runtime;
+    this.recordPhase(runtime, "spawn");
+    child.once("spawn", () => this.recordPhase(runtime, "spawned"));
 
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => {
@@ -772,7 +835,11 @@ class ComputerUseNativeRuntimeClient {
     });
     child.stderr.setEncoding("utf8");
     child.stderr.on("data", (chunk: string) => {
-      runtime.stderr += chunk;
+      // Count, never retain arbitrary helper stderr (which can contain app data).
+      runtime.stderrBytes = Math.min(
+        4096,
+        runtime.stderrBytes + Buffer.byteLength(chunk),
+      );
     });
     // Shutdown can close the pipe while a write callback is still pending.
     // The callback below owns request errors; this listener prevents the
@@ -795,8 +862,9 @@ class ComputerUseNativeRuntimeClient {
         mode: "serve",
         requestKind: "runtime",
         stage: "spawn",
+        ...this.runtimeEvidence(runtime),
       });
-      this.rejectRuntime(runtime, helperError);
+      this.failRuntime(runtime, helperError);
     });
     child.on("close", (code, signal) => {
       this.markRuntimeClosed(runtime);
@@ -810,13 +878,11 @@ class ComputerUseNativeRuntimeClient {
         return;
       }
       runtime.terminalErrorReported = true;
-      const stderr = runtime.stderr.trim();
       const helperError = new ComputerUseNativeHelperError(
         "accessibility_unavailable",
-        stderr ||
-          (signal
-            ? `Native Computer Use runtime terminated by ${signal}`
-            : `Native Computer Use runtime exited with status ${code ?? "null"}`),
+        signal
+          ? `Native Computer Use runtime terminated by ${signal}`
+          : `Native Computer Use runtime exited with status ${code ?? "null"}`,
       );
       this.reportRuntimeError(helperError, {
         mode: "serve",
@@ -824,10 +890,10 @@ class ComputerUseNativeRuntimeClient {
         stage: "exit",
         exitCode: code,
         signal,
-        stderr,
+        ...this.runtimeEvidence(runtime),
         terminationReason: "unexpected_exit",
       });
-      this.rejectRuntime(runtime, helperError);
+      this.failRuntime(runtime, helperError);
     });
     return runtime;
   }
@@ -836,6 +902,12 @@ class ComputerUseNativeRuntimeClient {
     runtime: ComputerUseNativeRuntimeProcess,
     chunk: string,
   ): void {
+    if (
+      runtime.terminalErrorReported ||
+      runtime.closed ||
+      this.runtime !== runtime
+    )
+      return;
     runtime.stdoutBuffer += chunk;
     while (true) {
       const newlineIndex = runtime.stdoutBuffer.indexOf("\n");
@@ -855,6 +927,7 @@ class ComputerUseNativeRuntimeClient {
     line: string,
   ): void {
     let requestKind = "runtime";
+    let correlated: PendingRuntimeRequest | undefined;
     try {
       const parsed = JSON.parse(line) as unknown;
       if (!isRecord(parsed) || typeof parsed.id !== "string") {
@@ -868,9 +941,25 @@ class ComputerUseNativeRuntimeClient {
         return;
       }
       requestKind = pending.kind;
-      this.pending.delete(parsed.id);
+      correlated = pending;
+      this.recordPhase(runtime, "response", pending.sequence);
       const response = parseHelperResponse(line);
       if (response.status === "failed") {
+        if (
+          pending.kind === "permissions.state" &&
+          response.error?.code === "target_app_unresponsive"
+        ) {
+          const error = new ComputerUseNativePermissionTimeoutError();
+          this.reportRuntimeError(error, {
+            mode: "serve",
+            requestKind,
+            stage: "timeout",
+            ...this.runtimeEvidence(runtime, pending),
+          });
+          this.failRuntime(runtime, error);
+          return;
+        }
+        this.pending.delete(parsed.id);
         pending.reject(
           new ComputerUseNativeHelperError(
             responseErrorCode(response.error?.code),
@@ -879,16 +968,33 @@ class ComputerUseNativeRuntimeClient {
         );
         return;
       }
-      pending.resolve(resultRecord(response.result ?? {}, pending.kind));
+      const result = resultRecord(response.result ?? {}, pending.kind);
+      if (
+        pending.kind === "permissions.state" ||
+        pending.kind === "permissions.request_accessibility" ||
+        pending.kind === "permissions.request_screen_recording"
+      ) {
+        resultPermissions(result);
+      }
+      // Keep correlation and settlement ownership until every validation succeeds.
+      this.pending.delete(parsed.id);
+      pending.resolve(result);
     } catch (error) {
-      const helperError = runtimeErrorFromUnknown(error);
+      const helperError =
+        error instanceof ComputerUseNativeHelperError
+          ? error
+          : new ComputerUseNativeHelperError(
+              "accessibility_unavailable",
+              "Native Computer Use runtime returned malformed JSON",
+            );
+      this.recordPhase(runtime, "protocol", correlated?.sequence);
       this.reportRuntimeError(helperError, {
         mode: "serve",
         requestKind,
         stage: "protocol",
-        stderr: runtime.stderr.trim(),
+        ...this.runtimeEvidence(runtime, correlated),
       });
-      this.rejectRuntime(runtime, helperError);
+      this.failRuntime(runtime, helperError);
     }
   }
 
@@ -930,7 +1036,7 @@ class ComputerUseNativeRuntimeClient {
       requestKind: "runtime",
       stage: "shutdown",
       terminationReason: reason,
-      stderr: runtime.stderr.trim(),
+      ...this.runtimeEvidence(runtime),
     });
     throw error;
   }
@@ -1006,7 +1112,53 @@ class ComputerUseNativeRuntimeClient {
       return;
     }
     runtime.closed = true;
+    this.recordPhase(runtime, "close");
+    runtime.stdoutBuffer = "";
     runtime.resolveClose();
+  }
+
+  private recordPhase(
+    runtime: ComputerUseNativeRuntimeProcess,
+    phase: NativeRuntimePhase["phase"],
+    requestSequence?: number,
+  ): void {
+    runtime.phases.push({
+      phase,
+      elapsedMs: boundedElapsed(runtime.startedAt),
+      ...(requestSequence === undefined ? {} : { requestSequence }),
+    });
+    if (runtime.phases.length > 12) runtime.phases.shift();
+  }
+
+  private runtimeEvidence(
+    runtime: ComputerUseNativeRuntimeProcess,
+    pending?: PendingRuntimeRequest,
+  ) {
+    return {
+      processSequence: runtime.sequence,
+      requestSequence: pending?.sequence,
+      elapsedMs: pending ? boundedElapsed(pending.dispatchedAt) : undefined,
+      helperUptimeMs: boundedElapsed(runtime.startedAt),
+      exitKnown: runtime.closed,
+      stderrBytes: runtime.stderrBytes,
+      phases: [...runtime.phases],
+    };
+  }
+
+  private failRuntime(
+    runtime: ComputerUseNativeRuntimeProcess,
+    error: Error,
+  ): void {
+    // A poisoned process cannot be replaced inside an old generation. Its owner
+    // must retire all leases and snapshots before constructing a new backend.
+    this.state = "closing";
+    runtime.terminalErrorReported = true;
+    runtime.stdoutBuffer = "";
+    if (!runtime.closed) {
+      this.retiringRuntimes.add(runtime);
+      this.signalRuntime(runtime, "SIGKILL");
+    }
+    this.rejectRuntime(runtime, error);
   }
 
   private reportRuntimeError(
@@ -1079,6 +1231,11 @@ export function createComputerUseNativeBackend(
   };
 
   return {
+    isAvailable: () => runtime?.isAvailable() ?? true,
+    isCleanupPending: () => runtime?.isCleanupPending() ?? false,
+    forceStop: async () => {
+      await runtime?.dispose();
+    },
     setCommandBudget: (budget) => {
       commandBudget = budget;
     },

--- a/turbo/apps/desktop/src/computer-use-permissions.ts
+++ b/turbo/apps/desktop/src/computer-use-permissions.ts
@@ -14,6 +14,12 @@ export type ComputerUsePermissionProvider = Pick<
   | "probeAutomationPermission"
 >;
 
+export interface ComputerUsePermissionQuery {
+  readonly signal?: AbortSignal;
+  /** Absolute local monotonic deadline; never renewed by native recovery. */
+  readonly deadline?: number;
+}
+
 const DEFAULT_COMPUTER_USE_PERMISSION_STATE: ComputerUsePermissionState =
   Object.freeze({
     accessibility: false,
@@ -25,6 +31,10 @@ export function createComputerUsePermissions(
   withProvider: <T>(
     read: (provider: ComputerUsePermissionProvider) => Promise<T>,
   ) => Promise<T | null>,
+  readPermissions: (
+    query?: ComputerUsePermissionQuery,
+  ) => Promise<ComputerUsePermissionState | null> = () =>
+    withProvider((provider) => provider.getPermissions()),
 ) {
   let currentPermissionState = DEFAULT_COMPUTER_USE_PERMISSION_STATE;
   let revision = 0;
@@ -38,11 +48,11 @@ export function createComputerUsePermissions(
     return currentPermissionState;
   }
 
-  async function refreshComputerUsePermissionState(): Promise<ComputerUsePermissionState> {
+  async function refreshComputerUsePermissionState(
+    query?: ComputerUsePermissionQuery,
+  ): Promise<ComputerUsePermissionState> {
     const current = revision;
-    const permissions = await withProvider((provider) =>
-      provider.getPermissions(),
-    );
+    const permissions = await readPermissions(query);
     if (!permissions || current !== revision) return currentPermissionState;
     currentPermissionState = normalizeComputerUsePermissionState({
       ...permissions,

--- a/turbo/apps/desktop/src/computer-use-runtime-controller.ts
+++ b/turbo/apps/desktop/src/computer-use-runtime-controller.ts
@@ -32,7 +32,7 @@ export interface ComputerUsePermissionRecoveryDiagnostic {
 
 interface PermissionRefresh {
   readonly promise: Promise<ComputerUsePermissionState | null>;
-  readonly cancel: () => void;
+  readonly cancel: (mode?: "retire" | "drain") => void;
   deadline: number;
 }
 
@@ -263,11 +263,15 @@ export class ComputerUseRuntimeController {
         COMPUTER_USE_NATIVE_PERMISSION_TIMEOUT_MS +
         this.transitionTimeoutMs,
       promise: Promise.race([Promise.resolve().then(work), aborted]),
-      cancel: () => {
+      cancel: (mode = "retire") => {
         if (cancelled) return;
         cancelled = true;
         rejectCancelled(new Error("Native permission query was cancelled"));
-        if (this.permissionRefresh === refresh && intent === this.intent) {
+        if (
+          mode === "retire" &&
+          this.permissionRefresh === refresh &&
+          intent === this.intent
+        ) {
           this.driver?.withdrawAdmission();
           void this.driver?.forceRetire().catch(() => {});
         }
@@ -597,13 +601,14 @@ export class ComputerUseRuntimeController {
 
   /** Serialized native replacement; it never changes host/plugin online state on success. */
   transitionDriver(driver: ComputerUseDriver): Promise<void> {
-    this.cancelPermissionRefresh();
+    // Supersede the probe; the replacement owner still drains healthy claims.
+    this.cancelPermissionRefresh("drain");
     return this.replaceDriver(driver);
   }
 
   /** The auth owner calls this synchronously when its session proof changes. */
-  cancelPermissionRefresh(): void {
-    this.permissionRefresh?.cancel();
+  cancelPermissionRefresh(mode: "retire" | "drain" = "retire"): void {
+    this.permissionRefresh?.cancel(mode);
     this.permissionRefresh = null;
   }
 
@@ -798,6 +803,7 @@ export class ComputerUseRuntimeController {
   async drainAndStop(): Promise<void> {
     this.runningRequested = false;
     this.manualStopRequested = true;
+    this.cancelPermissionRefresh("drain");
     this.supersede();
     await this.runtime?.drainAndStop();
     await this.detachRuntime();

--- a/turbo/apps/desktop/src/computer-use-runtime-controller.ts
+++ b/turbo/apps/desktop/src/computer-use-runtime-controller.ts
@@ -4,6 +4,11 @@ import type {
 } from "./computer-use-driver";
 import type { ComputerUseNativeShutdownReason } from "./computer-use-native";
 import {
+  ComputerUseNativePermissionTimeoutError,
+  COMPUTER_USE_NATIVE_PERMISSION_TIMEOUT_MS,
+} from "./computer-use-native";
+import type { ComputerUsePermissionQuery } from "./computer-use-permissions";
+import {
   withComputerUseDeadline,
   type ComputerUseLifecycleTimers,
 } from "./computer-use-lifecycle-deadline";
@@ -19,6 +24,24 @@ import {
 
 const DEFAULT_QUIT_STOP_TIMEOUT_MS = 1_000;
 
+export interface ComputerUsePermissionRecoveryDiagnostic {
+  readonly generation: number | null;
+  readonly outcome: "recovered" | "failed" | "superseded";
+  readonly elapsedMs: number;
+}
+
+interface PermissionRefresh {
+  readonly promise: Promise<ComputerUsePermissionState | null>;
+  readonly cancel: () => void;
+  deadline: number;
+}
+
+interface PermissionRecovery {
+  readonly check: () => void;
+  readonly probe: () => Promise<ComputerUsePermissionState>;
+  readonly remaining: () => number;
+}
+
 /** The `ComputerUseHostRuntime` surface the controller drives. */
 interface ComputerUseRuntimeLike {
   start(): Promise<void>;
@@ -29,6 +52,9 @@ interface ComputerUseRuntimeLike {
 }
 
 interface ComputerUseRuntimeControllerOptions {
+  readonly onPermissionRecovery?: (
+    diagnostic: ComputerUsePermissionRecoveryDiagnostic,
+  ) => void;
   readonly prepareNative?: () => Promise<ComputerUsePermissionState>;
   readonly nativeBlockReason?: (driver: ComputerUseDriver) => string | null;
   /**
@@ -39,6 +65,7 @@ interface ComputerUseRuntimeControllerOptions {
   readonly createRuntime: () => ComputerUseRuntimeLike;
   readonly refreshPermissions: () => Promise<ComputerUsePermissionState>;
   readonly getAuthState: () => Promise<DesktopAuthState>;
+  readonly getAuthAuthority?: () => object | null;
   /** Propagates runtime online/offline transitions to the plugin manager. */
   readonly setHostRuntimeOnline: (online: boolean) => void;
   /** Zero-arg "something changed" signal; defaults to a no-op. */
@@ -91,6 +118,7 @@ export class ComputerUseRuntimeController {
   private readonly getPluginCapabilities: () => readonly string[];
   private readonly preparePlugins: () => Promise<void>;
   private pluginStartupIntent: number | null = null;
+  private permissionRefresh: PermissionRefresh | null = null;
 
   constructor(private readonly options: ComputerUseRuntimeControllerOptions) {
     this.getPluginCapabilities = options.getPluginCapabilities ?? (() => []);
@@ -124,6 +152,178 @@ export class ComputerUseRuntimeController {
 
   pluginsMayRun(): boolean {
     return this.isRuntimeOnline() || this.pluginStartupIntent === this.intent;
+  }
+
+  /** Read-only refreshes share one episode under this lifecycle's current intent.
+   * Claimed commands use their pinned driver's permission read directly.
+   */
+  async refreshNativePermissions(
+    query: ComputerUsePermissionQuery = {},
+  ): Promise<ComputerUsePermissionState | null> {
+    query.signal?.throwIfAborted();
+    const refresh = this.permissionRefresh ?? this.beginPermissionRefresh();
+    if (query.deadline !== undefined)
+      refresh.deadline = Math.min(refresh.deadline, query.deadline);
+    const cancel = () => refresh.cancel();
+    query.signal?.addEventListener("abort", cancel, { once: true });
+    try {
+      if (refresh.deadline <= performance.now())
+        throw new Error("Native permission query budget expired");
+      return await withComputerUseDeadline(
+        refresh.promise,
+        refresh.deadline - performance.now(),
+        this.lifecycleTimers,
+      );
+    } catch (error) {
+      refresh.cancel();
+      throw error;
+    } finally {
+      query.signal?.removeEventListener("abort", cancel);
+    }
+  }
+
+  private beginPermissionRefresh(): PermissionRefresh {
+    const intent = this.intent;
+    const authority = this.options.getAuthAuthority?.();
+    const generation = this.driver?.generation ?? null;
+    const selected = this.driver?.selectedDriver;
+    const eligible =
+      !!selected &&
+      selected.id === "okou" &&
+      this.runningRequested &&
+      !!this.runtime &&
+      !this.manualStopRequested &&
+      !this.quitStopStarted &&
+      !this.starting &&
+      !this.transitionCount &&
+      (this.driver?.getCapabilities().length ?? 0) > 0;
+    const startedAt = performance.now();
+    let cancelled = false;
+    let rejectCancelled!: (error: Error) => void;
+    const aborted = new Promise<never>((_resolve, reject) => {
+      rejectCancelled = reject;
+    });
+    const check = () => {
+      if (
+        cancelled ||
+        intent !== this.intent ||
+        authority !== this.options.getAuthAuthority?.() ||
+        this.quitStopStarted ||
+        refresh.deadline <= performance.now()
+      ) {
+        refresh.cancel();
+        throw new Error("Native permission query was superseded or expired");
+      }
+    };
+    const read = () =>
+      this.driver?.withPermissionProvider((provider) =>
+        provider.getPermissions(),
+      ) ?? Promise.resolve(null);
+    const work = async () => {
+      // Capture auth before probing. A later identity is never authority for an
+      // earlier refresh, even if permission grants themselves remain unchanged.
+      const auth = eligible ? await this.getAuthState() : null;
+      check();
+      try {
+        const permissions = await read();
+        check();
+        return permissions;
+      } catch (error) {
+        if (
+          !(error instanceof ComputerUseNativePermissionTimeoutError) ||
+          !eligible ||
+          !selected ||
+          auth?.status !== "signed_in" ||
+          !auth.organization
+        )
+          throw error;
+        return this.retryPermissionProbe({
+          selected,
+          auth,
+          check,
+          read,
+          remaining: () => refresh.deadline - performance.now(),
+          report: (outcome) =>
+            this.options.onPermissionRecovery?.({
+              generation,
+              outcome: cancelled ? "superseded" : outcome,
+              elapsedMs: Math.min(
+                120_000,
+                Math.max(0, Math.round(performance.now() - startedAt)),
+              ),
+            }),
+        });
+      }
+    };
+    const refresh: PermissionRefresh = {
+      // The existing attempt bound plus the existing replacement bound is the
+      // total cap (90s by default), including drain, old-process exit and retry.
+      deadline:
+        startedAt +
+        COMPUTER_USE_NATIVE_PERMISSION_TIMEOUT_MS +
+        this.transitionTimeoutMs,
+      promise: Promise.race([Promise.resolve().then(work), aborted]),
+      cancel: () => {
+        if (cancelled) return;
+        cancelled = true;
+        rejectCancelled(new Error("Native permission query was cancelled"));
+        if (this.permissionRefresh === refresh && intent === this.intent) {
+          this.driver?.withdrawAdmission();
+          void this.driver?.forceRetire().catch(() => {});
+        }
+      },
+    };
+    this.permissionRefresh = refresh;
+    const finish = () => {
+      if (this.permissionRefresh === refresh) this.permissionRefresh = null;
+    };
+    void refresh.promise.then(finish, finish);
+    return refresh;
+  }
+
+  private async retryPermissionProbe(options: {
+    readonly selected: ComputerUseDriver;
+    readonly auth: Extract<DesktopAuthState, { status: "signed_in" }>;
+    readonly check: () => void;
+    readonly read: () => Promise<ComputerUsePermissionState | null>;
+    readonly remaining: () => number;
+    readonly report: (outcome: "failed" | "recovered") => void;
+  }): Promise<ComputerUsePermissionState | null> {
+    const { selected, auth, check, read, remaining, report } = options;
+    let outcome: "failed" | "recovered" = "failed";
+    try {
+      check();
+      // The failed probe has released its lease before replacement waits for
+      // retirement and any separately claimed command's completion reporting.
+      let fresh: ComputerUsePermissionState | null = null;
+      this.driver?.resetFailure();
+      await this.replaceDriver(selected, {
+        check,
+        remaining,
+        probe: async () => {
+          const currentAuth = await this.getAuthState();
+          check();
+          if (
+            currentAuth.status !== "signed_in" ||
+            currentAuth.user.userId !== auth.user.userId ||
+            currentAuth.organization?.id !== auth.organization?.id
+          )
+            throw new Error("Native permission recovery authorization changed");
+          fresh = await read();
+          check();
+          if (!fresh)
+            throw new Error("Native permission recovery was superseded");
+          return fresh;
+        },
+      });
+      check();
+      if (!fresh || !hasRequiredComputerUsePermissions(fresh))
+        throw new Error("Native permission recovery did not restore readiness");
+      outcome = "recovered";
+      return fresh;
+    } finally {
+      report(outcome);
+    }
   }
 
   private nativeBlockReason(): string | null {
@@ -397,6 +597,20 @@ export class ComputerUseRuntimeController {
 
   /** Serialized native replacement; it never changes host/plugin online state on success. */
   transitionDriver(driver: ComputerUseDriver): Promise<void> {
+    this.cancelPermissionRefresh();
+    return this.replaceDriver(driver);
+  }
+
+  /** The auth owner calls this synchronously when its session proof changes. */
+  cancelPermissionRefresh(): void {
+    this.permissionRefresh?.cancel();
+    this.permissionRefresh = null;
+  }
+
+  private replaceDriver(
+    driver: ComputerUseDriver,
+    recovery?: PermissionRecovery,
+  ): Promise<void> {
     if (this.lastTransition?.driver === driver)
       return this.lastTransition.promise;
     if (!this.driver || this.quitStopStarted) {
@@ -414,6 +628,7 @@ export class ComputerUseRuntimeController {
     this.driver.pausePermissions();
     let expired = false;
     const checkIntent = () => {
+      recovery?.check();
       if (
         expired ||
         intent !== this.intent ||
@@ -455,15 +670,18 @@ export class ComputerUseRuntimeController {
         return;
       }
       if (runtime && !this.manualStopRequested)
-        await this.resumeSelectedDriver(resume, checkIntent);
+        await this.resumeSelectedDriver(resume, checkIntent, recovery?.probe);
     })();
     const transition = withComputerUseDeadline(
       work,
-      this.transitionTimeoutMs,
+      Math.min(
+        this.transitionTimeoutMs,
+        recovery?.remaining() ?? this.transitionTimeoutMs,
+      ),
       this.lifecycleTimers,
     ).catch((error: unknown) => {
       expired = true;
-      this.handleDriverTransitionFailure(error, intent, selection);
+      this.handleDriverTransitionFailure(error, intent, selection, !!recovery);
     });
     this.transitionCount++;
     this.phaseStartedAt = performance.now();
@@ -491,6 +709,7 @@ export class ComputerUseRuntimeController {
     error: unknown,
     intent: number,
     selection: number,
+    recovering: boolean,
   ): void {
     // A failure withdraws the host rather than advertising empty legacy capabilities.
     if (intent === this.intent && selection === this.selectionRevision) {
@@ -504,7 +723,7 @@ export class ComputerUseRuntimeController {
         throw error;
       }
       this.manualStopRequested = true;
-      this.supersede();
+      this.supersede(!recovering);
       this.detachRuntime();
       this.blockedHostState = {
         ...OFFLINE_COMPUTER_USE_HOST_STATE,
@@ -519,6 +738,7 @@ export class ComputerUseRuntimeController {
   private async resumeSelectedDriver(
     resume: (() => void) | undefined,
     checkIntent: () => void,
+    probe?: () => Promise<ComputerUsePermissionState>,
   ): Promise<void> {
     if (
       this.nativeError ||
@@ -535,11 +755,12 @@ export class ComputerUseRuntimeController {
       await this.detachRuntime();
       return;
     }
-    let permissions = await this.refreshPermissions();
+    let permissions = await (probe ? probe() : this.refreshPermissions());
     checkIntent();
     if (
       hasRequiredComputerUsePermissions(permissions) &&
-      this.options.prepareNative
+      this.options.prepareNative &&
+      !probe
     )
       permissions = await this.options.prepareNative();
     checkIntent();
@@ -646,7 +867,10 @@ export class ComputerUseRuntimeController {
     return this.quitPromise;
   }
 
-  private supersede(): void {
+  private supersede(cancelRefresh = true): void {
+    if (cancelRefresh) {
+      this.cancelPermissionRefresh();
+    }
     this.intent++;
     this.lastTransition = null;
     this.phaseStartedAt = performance.now();

--- a/turbo/apps/desktop/src/desktop-computer-use-driver.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-driver.test.ts
@@ -32,9 +32,15 @@ import {
   ComputerUseDriverController,
   type ComputerUseDriver,
 } from "./computer-use-driver";
-import { createComputerUseNativeBackend } from "./computer-use-native";
+import {
+  createComputerUseNativeBackend,
+  type ComputerUseNativeRuntimeErrorContext,
+} from "./computer-use-native";
 import { createComputerUsePermissions } from "./computer-use-permissions";
-import { ComputerUseRuntimeController } from "./computer-use-runtime-controller";
+import {
+  ComputerUseRuntimeController,
+  type ComputerUsePermissionRecoveryDiagnostic,
+} from "./computer-use-runtime-controller";
 import {
   SUPPORTED_COMPUTER_USE_CAPABILITIES,
   type ComputerUseCommand,
@@ -116,6 +122,11 @@ interface NativeRequest {
 }
 
 function nativeProcesses(events: string[]) {
+  let permissionReply: {
+    status: string;
+    result?: unknown;
+    error?: { code: string };
+  } | null = null;
   const pauses = new Map<string, ReturnType<typeof pause>>();
   const active = new Set<ChildProcess>();
   const closeReached = deferred<void>();
@@ -178,8 +189,11 @@ function nativeProcesses(events: string[]) {
               },
             ],
           };
+        const reply = request.kind.startsWith("permissions.")
+          ? permissionReply
+          : null;
         output.write(
-          `${JSON.stringify({ id: request.id, status: "succeeded", result })}\n`,
+          `${JSON.stringify({ id: request.id, ...(reply ?? { status: "succeeded", result }) })}\n`,
         );
       };
       void reply();
@@ -195,6 +209,23 @@ function nativeProcesses(events: string[]) {
     return child;
   });
   return {
+    failNextWrite: (mode: "throw" | "callback") => {
+      for (const child of active) {
+        if (!child.stdin) throw new Error("Fixture has no stdin");
+        if (mode === "throw")
+          vi.spyOn(child.stdin, "write").mockImplementationOnce(() => {
+            throw new Error("fixture write failure");
+          });
+        else
+          vi.spyOn(child.stdin, "_write").mockImplementationOnce(
+            (_chunk, _encoding, done) =>
+              done(new Error("fixture pipe failure")),
+          );
+      }
+    },
+    permissions: (reply: typeof permissionReply) => {
+      permissionReply = reply;
+    },
     pause,
     closeReached,
     holdClose: () => {
@@ -219,11 +250,14 @@ function desktop(
     commandClock?: ComputerUseCommandClock;
     transitionTimeoutMs?: number;
     nativeShutdownGraceMs?: number;
+    nativeRequestTimeoutMs?: number;
     expectedQuitError?: string;
     plugin?: DesktopMcpPluginManager;
   } = {},
 ) {
   const events: string[] = [];
+  const nativeErrors: ComputerUseNativeRuntimeErrorContext[] = [];
+  const recoveries: ComputerUsePermissionRecoveryDiagnostic[] = [];
   const native = nativeProcesses(events);
   const timers = controlledTimers();
   const config = resolveDesktopConfig(undefined, "okou");
@@ -231,6 +265,10 @@ function desktop(
     clientVersion: "1.2.3",
   });
   const authSession = new DesktopAuthSession({
+    onChange: () => {
+      controller.cancelPermissionRefresh();
+      permissions.resetComputerUsePermissionState();
+    },
     apiBaseUrl: api,
     addClientHeaders,
     tokenUrl: buildDesktopAuthTokenUrl(config.authUrl),
@@ -245,11 +283,14 @@ function desktop(
       createComputerUseNativeBackend({
         helperPath: "/test/computer-use-helper",
         shutdownGraceMs: options.nativeShutdownGraceMs ?? 100,
+        requestTimeoutMs: options.nativeRequestTimeoutMs,
+        onRuntimeError: (_error, context) => nativeErrors.push(context),
       }),
   };
   const driver = new ComputerUseDriverController(driverDefinition, "darwin");
-  const permissions = createComputerUsePermissions((read) =>
-    driver.withPermissionProvider(read),
+  const permissions = createComputerUsePermissions(
+    (read) => driver.withPermissionProvider(read),
+    (query) => controller.refreshNativePermissions(query),
   );
   const requests: {
     path: string;
@@ -291,6 +332,7 @@ function desktop(
     for (const resolve of stateWaiters.splice(0)) resolve();
   };
   const controller = new ComputerUseRuntimeController({
+    onPermissionRecovery: (diagnostic) => recoveries.push(diagnostic),
     driver,
     createRuntime: () =>
       createDesktopComputerUseHostRuntime(
@@ -321,6 +363,7 @@ function desktop(
       ),
     refreshPermissions: permissions.refreshComputerUsePermissionState,
     getAuthState: () => authSession.getAuthState(),
+    getAuthAuthority: () => authSession.getAuthority(),
     setHostRuntimeOnline: (value) => {
       online.push(value);
       options.plugin?.setHostRuntimeOnline(value);
@@ -386,6 +429,9 @@ function desktop(
     controller,
     driver,
     driverDefinition,
+    authSession,
+    nativeErrors,
+    recoveries,
     permissions,
     native,
     events,
@@ -951,3 +997,397 @@ it.each(["permissions.state", "apps.list", "app.open", "app.state"])(
     await app.driver.retire();
   },
 );
+
+describe("native permission recovery through the runtime owner", () => {
+  it("coalesces a hung read, retires before one fresh probe, and preserves the host", async () => {
+    const app = desktop({ nativeRequestTimeoutMs: 100 });
+    await app.controller.start();
+    const generation = app.driver.generation;
+    const pause = app.native.pause("permissions.state");
+    const first = app.permissions.refreshComputerUsePermissionState();
+    const second = app.permissions.refreshComputerUsePermissionState();
+    await pause.reached.promise;
+    const permissions = await Promise.all([first, second]);
+    expect(permissions).toEqual([
+      expect.objectContaining({ accessibility: true }),
+      expect.objectContaining({ accessibility: true }),
+    ]);
+    expect(app.native.created).toBe(2);
+    expect(app.driver.generation).not.toBe(generation);
+    expect(app.driver.getCapabilities()).toEqual(
+      SUPPORTED_COMPUTER_USE_CAPABILITIES,
+    );
+    expect(app.events.indexOf("dispose:1")).toBeLessThan(
+      app.events.indexOf("create:2"),
+    );
+    expect(
+      app.events.filter((event) => event === "2:permissions.state"),
+    ).toHaveLength(1);
+    expect(
+      app.requests.filter((request) => request.path.endsWith("/hosts/start")),
+    ).toHaveLength(1);
+    expect(app.recoveries).toEqual([
+      expect.objectContaining({ generation, outcome: "recovered" }),
+    ]);
+    pause.resume.resolve();
+    await app.permissions.refreshComputerUsePermissionState();
+    expect(app.native.created).toBe(2);
+  });
+
+  it("ends a second hung probe without a third generation", async () => {
+    const app = desktop({ nativeRequestTimeoutMs: 100 });
+    await app.controller.start();
+    const first = app.native.pause("permissions.state");
+    const result = app.permissions.refreshComputerUsePermissionState();
+    const rejected = expect(result).rejects.toThrow();
+    await first.reached.promise;
+    const second = app.native.pause("permissions.state");
+    await second.reached.promise;
+    await rejected;
+    await app.driver.retire();
+    expect(app.native.created).toBe(2);
+    expect(app.driver.getCapabilities()).toEqual([]);
+    expect(app.controller.getDriverState()).toMatchObject({
+      phase: "error",
+      canRetry: true,
+    });
+    expect(app.recoveries).toEqual([
+      expect.objectContaining({ outcome: "failed" }),
+    ]);
+    first.resume.resolve();
+    second.resume.resolve();
+  });
+
+  it.each([
+    [
+      "denied",
+      {
+        status: "succeeded",
+        result: { accessibility: false, screenRecording: true },
+      },
+    ],
+    [
+      "native denial",
+      { status: "failed", error: { code: "permission_denied" } },
+    ],
+    ["malformed", { status: "succeeded", result: [] }],
+  ])(
+    "does not retry %s or reinterpret persistent permission grants",
+    async (_label, reply) => {
+      const app = desktop();
+      await app.controller.start();
+      app.native.permissions(reply);
+      await Promise.allSettled([
+        app.permissions.refreshComputerUsePermissionState(),
+      ]);
+      expect(app.native.created).toBe(1);
+      expect(app.driver.getCapabilities()).toEqual([]);
+      expect(app.recoveries).toEqual([]);
+      if (_label !== "denied")
+        expect(
+          app.permissions.getComputerUsePermissionState().accessibility,
+        ).toBe(true);
+    },
+  );
+
+  it.each([
+    "stop",
+    "auth",
+    "workspace",
+    "quit",
+    "update",
+    "cancel",
+    "switch",
+  ] as const)(
+    "%s supersedes cleanup and prevents a fresh probe",
+    async (action) => {
+      const app = desktop({ nativeRequestTimeoutMs: 100 });
+      await app.controller.start();
+      app.native.holdClose();
+      const pause = app.native.pause("permissions.state");
+      const abort = new AbortController();
+      const refresh = app.permissions.refreshComputerUsePermissionState({
+        signal: abort.signal,
+      });
+      const rejected = expect(refresh).rejects.toThrow();
+      await pause.reached.promise;
+      await app.native.closeReached.promise;
+      let supersede: Promise<void> = Promise.resolve();
+      if (action === "stop") supersede = app.controller.stop();
+      if (action === "auth") {
+        app.authSession.signOut();
+        supersede = app.controller.stopForAuthChange();
+      }
+      if (action === "workspace")
+        supersede = app.authSession.selectOrganization();
+      if (action === "quit" || action === "update")
+        supersede = app.controller.stopForQuit(
+          action === "quit" ? "app_quit" : "update_relaunch",
+        );
+      if (action === "cancel") abort.abort();
+      if (action === "switch")
+        supersede = app.controller.transitionDriver({
+          ...app.driverDefinition,
+          id: "replacement",
+        });
+      const settledSupersede = Promise.allSettled([supersede]);
+      app.native.close();
+      pause.resume.resolve();
+      await rejected;
+      await settledSupersede;
+      expect(
+        app.recoveries.filter((event) => event.outcome === "recovered"),
+      ).toEqual([]);
+      if (action === "switch") {
+        expect(app.driver.selectedDriver.id).toBe("replacement");
+        expect(app.native.created).toBe(2);
+      } else {
+        expect(
+          app.events.filter((event) => event === "2:permissions.state"),
+        ).toEqual([]);
+        expect(app.driver.getCapabilities()).toEqual([]);
+      }
+    },
+  );
+
+  it("leaves cleanup owned when old helper exit cannot be proven", async () => {
+    const app = desktop({
+      nativeRequestTimeoutMs: 100,
+      nativeShutdownGraceMs: 5,
+      expectedQuitError: "did not exit after SIGKILL",
+    });
+    await app.controller.start();
+    app.native.holdClose();
+    const pause = app.native.pause("permissions.state");
+    const result = app.permissions.refreshComputerUsePermissionState();
+    const rejected = expect(result).rejects.toThrow("did not exit");
+    await pause.reached.promise;
+    await rejected;
+    expect(app.native.created).toBe(1);
+    expect(app.driver.cleanupPending).toBe(true);
+    expect(app.nativeErrors).toContainEqual(
+      expect.objectContaining({ stage: "shutdown", exitKnown: false }),
+    );
+    expect(app.driver.getCapabilities()).toEqual([]);
+    pause.resume.resolve();
+  });
+
+  it("does not recover a stopped passive probe or a permission prompt", async () => {
+    const app = desktop({ nativeRequestTimeoutMs: 100 });
+    const pause = app.native.pause("permissions.state");
+    const passive = app.permissions.refreshComputerUsePermissionState();
+    const rejected = expect(passive).rejects.toThrow("timed out");
+    await pause.reached.promise;
+    await rejected;
+    expect(app.native.created).toBe(1);
+    expect(app.recoveries).toEqual([]);
+    pause.resume.resolve();
+    await app.controller.start({ userInitiated: true });
+    const prompt = app.native.pause("permissions.request_accessibility");
+    const request = app.permissions.requestComputerUseAccessibilityPermission();
+    const promptRejected = expect(request).rejects.toThrow("timed out");
+    await prompt.reached.promise;
+    await promptRejected;
+    expect(app.native.created).toBe(2);
+    expect(app.recoveries).toEqual([]);
+    prompt.resume.resolve();
+  });
+});
+
+describe("permission recovery ownership and deadlines", () => {
+  it.each([
+    "stop",
+    "sign-out",
+    "workspace",
+    "quit",
+    "update",
+    "cancel",
+  ] as const)(
+    "%s withdraws a pending fresh probe before a late success",
+    async (action) => {
+      const app = desktop({ nativeRequestTimeoutMs: 100 });
+      await app.controller.start();
+      const first = app.native.pause("permissions.state");
+      const abort = new AbortController();
+      const refresh = app.permissions.refreshComputerUsePermissionState({
+        signal: abort.signal,
+      });
+      const rejected = expect(refresh).rejects.toThrow();
+      await first.reached.promise;
+      const fresh = app.native.pause("permissions.state");
+      await fresh.reached.promise;
+      // The original process's buffered result is not fresh-generation readiness.
+      first.resume.resolve();
+      expect(app.driver.getCapabilities()).toEqual([]);
+      let change: Promise<void> = Promise.resolve();
+      if (action === "stop") change = app.controller.stop();
+      if (action === "sign-out") {
+        app.authSession.signOut();
+        change = app.controller.stopForAuthChange();
+      }
+      if (action === "workspace") change = app.authSession.selectOrganization();
+      if (action === "quit" || action === "update")
+        change = app.controller.stopForQuit(
+          action === "quit" ? "app_quit" : "update_relaunch",
+        );
+      if (action === "cancel") abort.abort();
+      const changed = Promise.allSettled([change]);
+      fresh.resume.resolve();
+      await rejected;
+      await changed;
+      expect(app.native.created).toBe(2);
+      expect(app.driver.getCapabilities()).toEqual([]);
+      expect(
+        app.recoveries.filter((value) => value.outcome === "recovered"),
+      ).toEqual([]);
+    },
+  );
+
+  it("uses the caller deadline before retry dispatch even when its timer has not run", async () => {
+    const app = desktop({ nativeRequestTimeoutMs: 100 });
+    await app.controller.start();
+    const pause = app.native.pause("permissions.state");
+    const deadline = performance.now() + 50;
+    const refresh = app.permissions.refreshComputerUsePermissionState({
+      deadline,
+    });
+    const rejected = expect(refresh).rejects.toThrow();
+    await pause.reached.promise;
+    // Native's real 100ms timer fires; the host's controlled deadline callback
+    // stays undelivered. The monotonic deadline must still reject replacement.
+    await rejected;
+    expect(app.native.created).toBe(1);
+    expect(app.driver.getCapabilities()).toEqual([]);
+    pause.resume.resolve();
+  });
+
+  it("keeps a claimed command in its failed generation through completion reporting", async () => {
+    const app = desktop({ nativeRequestTimeoutMs: 100 });
+    await app.controller.start();
+    const generation = app.driver.generation;
+    const pause = app.native.pause("permissions.state");
+    const claim = app.claim({
+      ...action,
+      id: "claimed-before-permission-recovery",
+    });
+    app.timers.run(5_000);
+    claim.response.resolve();
+    await pause.reached.promise;
+    const refresh = app.permissions.refreshComputerUsePermissionState();
+    const completed = await claim.completed.promise;
+    expect(completed).toMatchObject({ status: "failed" });
+    expect(app.driver.getCapabilities()).toEqual([]);
+    expect(app.native.created).toBe(1);
+    expect(app.events).not.toContain("1:keyboard.type_text");
+    claim.completeResponse.resolve();
+    await refresh;
+    expect(app.driver.generation).not.toBe(generation);
+    expect(app.events).not.toContain("2:keyboard.type_text");
+    expect(app.events.indexOf("completion")).toBeLessThan(
+      app.events.indexOf("create:2"),
+    );
+    pause.resume.resolve();
+  });
+
+  it("rejects an old snapshot after automatic permission recovery", async () => {
+    const app = desktop({ nativeRequestTimeoutMs: 100 });
+    await app.controller.start();
+    const capture = app.claim({
+      id: "capture-before-recovery",
+      kind: "app.state",
+      payload: { app: "test.app" },
+    });
+    app.timers.run(5_000);
+    capture.response.resolve();
+    const completed = await capture.completed.promise;
+    const result = completed.result as { snapshotId: string };
+    const pause = app.native.pause("permissions.state");
+    const refresh = app.permissions.refreshComputerUsePermissionState();
+    await pause.reached.promise;
+    capture.completeResponse.resolve();
+    await refresh;
+    const stale = app.claim({
+      ...action,
+      id: "stale-after-recovery",
+      payload: { ...action.payload, snapshotId: result.snapshotId },
+    });
+    app.timers.run(0);
+    stale.response.resolve();
+    expect(await stale.completed.promise).toMatchObject({
+      status: "failed",
+      error: { code: "unsupported_command" },
+    });
+    expect(app.events).not.toContain("2:keyboard.type_text");
+    stale.completeResponse.resolve();
+    pause.resume.resolve();
+  });
+});
+
+it("recovers only the correlated native permission execution deadline", async () => {
+  const app = desktop();
+  await app.controller.start();
+  app.native.holdClose();
+  app.native.permissions({
+    status: "failed",
+    error: { code: "target_app_unresponsive" },
+  });
+  const refresh = app.permissions.refreshComputerUsePermissionState();
+  await app.native.closeReached.promise;
+  expect(app.driver.getCapabilities()).toEqual([]);
+  app.native.permissions(null);
+  app.native.close();
+  await expect(refresh).resolves.toMatchObject({
+    accessibility: true,
+    screenRecording: true,
+  });
+  expect(app.native.created).toBe(2);
+  expect(app.nativeErrors).toEqual([
+    expect.objectContaining({
+      stage: "timeout",
+      requestKind: "permissions.state",
+    }),
+  ]);
+  expect(app.nativeErrors[0]?.timerDelayMs).toBeUndefined();
+});
+
+it.each(["throw", "callback"] as const)(
+  "settles %s write failures and queued probes without recovery",
+  async (mode) => {
+    const app = desktop();
+    await app.controller.start();
+    app.native.failNextWrite(mode);
+    const results = await Promise.allSettled([
+      app.permissions.refreshComputerUsePermissionState(),
+      app.permissions.refreshComputerUsePermissionState(),
+    ]);
+    expect(results.map((value) => value.status)).toEqual([
+      "rejected",
+      "rejected",
+    ]);
+    app.native.close();
+    expect(app.native.created).toBe(1);
+    expect(app.driver.getCapabilities()).toEqual([]);
+    expect(app.nativeErrors).toEqual([
+      expect.objectContaining({ stage: "write", pendingRequestCount: 1 }),
+    ]);
+    expect(app.recoveries).toEqual([]);
+  },
+);
+
+it("cancels a native heartbeat probe at the existing host deadline", async () => {
+  const app = desktop();
+  await app.controller.start();
+  const pause = app.native.pause("permissions.state");
+  app.timers.run(2_000);
+  await pause.reached.promise;
+  app.timers.run(10_000);
+  await app.waitForHostState("recovering");
+  expect(app.driver.getCapabilities()).toEqual([]);
+  expect(app.native.created).toBe(1);
+  expect(app.nativeErrors.filter((error) => error.stage === "timeout")).toEqual(
+    [],
+  );
+  expect(app.recoveries).toEqual([]);
+  pause.resume.resolve();
+  await app.driver.retire();
+});

--- a/turbo/apps/desktop/src/desktop-computer-use-driver.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-driver.test.ts
@@ -533,6 +533,40 @@ const action: ComputerUseCommand = {
 };
 
 describe("production driver generation and admission wiring", () => {
+  it.each(["switch", "drain"] as const)(
+    "drains a healthy claimed action when %s cancels a concurrent permission refresh",
+    async (mode) => {
+      const app = desktop();
+      await app.controller.start();
+      const write = app.native.pause("keyboard.type_text");
+      const command = app.claim(action);
+      app.timers.run(5_000);
+      command.response.resolve();
+      await write.reached.promise;
+      const refresh = app.permissions.refreshComputerUsePermissionState();
+      const rejected = expect(refresh).rejects.toThrow();
+      const transition =
+        mode === "switch"
+          ? app.controller.transitionDriver(app.driverDefinition)
+          : app.controller.drainAndStop();
+      write.resume.resolve();
+      const completed = await command.completed.promise;
+      command.completeResponse.resolve();
+      await transition;
+      await rejected;
+      expect(completed).toMatchObject({ status: "succeeded" });
+      expect(app.events.indexOf("completion")).toBeLessThan(
+        app.events.indexOf("dispose:1"),
+      );
+      expect(app.driver.getCapabilities()).toEqual(
+        mode === "switch" ? SUPPORTED_COMPUTER_USE_CAPABILITIES : [],
+      );
+      expect(app.controller.getHostState().status).toBe(
+        mode === "switch" ? "online" : "offline",
+      );
+    },
+  );
+
   it("drains delayed claim, permission, action, capture and completion on the original generation while the host stays alive", async () => {
     const app = desktop();
     await app.controller.start();

--- a/turbo/apps/desktop/src/desktop-computer-use-permission-stall.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-permission-stall.test.ts
@@ -1,0 +1,51 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { expect, it } from "vitest";
+import { runPermissionStallFixture } from "./test/native-permission-stall";
+
+it("recovers a ready helper's buffered reply after an isolated parent stall", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "native-parent-stall-"));
+  try {
+    const { stdout } = await promisify(execFile)(
+      process.execPath,
+      [
+        "--conditions=import",
+        "--import",
+        import.meta.resolve("tsx"),
+        "-e",
+        `require('./src/test/native-permission-stall.ts').${runPermissionStallFixture.name}(process.argv[1])`,
+        directory,
+      ],
+      { timeout: 10_000 },
+    );
+    const result = JSON.parse(stdout) as {
+      outcome: { ok: boolean };
+      generation: number;
+      freshGeneration: number;
+      ready: boolean;
+      writtenAfterMs: number;
+      elapsedMs: number;
+      starts: number;
+      errors: unknown[];
+    };
+    expect(result.writtenAfterMs).toBeLessThan(400);
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(850);
+    expect(result.outcome.ok).toBe(true);
+    expect(result.ready).toBe(true);
+    expect(result.freshGeneration).toBeGreaterThan(result.generation);
+    expect(result.starts).toBe(2);
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        stage: "timeout",
+        requestKind: "permissions.state",
+        timerDelayMs: expect.any(Number),
+        pendingRequestCount: 1,
+      }),
+    ]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/turbo/apps/desktop/src/desktop-computer-use-permissions.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-permissions.ts
@@ -2,24 +2,36 @@ import type { ComputerUseDriverController } from "./computer-use-driver";
 import {
   createComputerUsePermissions,
   type ComputerUsePermissionProvider,
+  type ComputerUsePermissionQuery,
 } from "./computer-use-permissions";
-import type { ComputerUseDriverId } from "./computer-use-types";
+import type {
+  ComputerUseDriverId,
+  ComputerUsePermissionState,
+} from "./computer-use-types";
 
 export function createDesktopComputerUsePermissions(options: {
   readonly driver: ComputerUseDriverController;
   readonly requestedDriver: () => ComputerUseDriverId;
   readonly transitioning: () => boolean;
   readonly host: ComputerUsePermissionProvider;
+  readonly refreshNative: (
+    query?: ComputerUsePermissionQuery,
+  ) => Promise<ComputerUsePermissionState | null>;
 }) {
-  const permissions = createComputerUsePermissions((read) => {
-    if (
-      options.requestedDriver() === "cua" ||
-      options.driver.selectedDriver.id === "cua" ||
-      options.transitioning()
-    )
-      return read(options.host);
-    return options.driver.withPermissionProvider(read);
-  });
+  const useHostPermissions = () =>
+    options.requestedDriver() === "cua" ||
+    options.driver.selectedDriver.id === "cua" ||
+    options.transitioning();
+  const permissions = createComputerUsePermissions(
+    (read) => {
+      if (useHostPermissions()) return read(options.host);
+      return options.driver.withPermissionProvider(read);
+    },
+    (query) =>
+      useHostPermissions()
+        ? options.host.getPermissions()
+        : options.refreshNative(query),
+  );
   return {
     ...permissions,
     /** Called only inside the authorized runtime start/replacement intent. */
@@ -30,12 +42,13 @@ export function createDesktopComputerUsePermissions(options: {
       if (!result) throw new Error("Native driver readiness was superseded");
       return result;
     },
-    refreshReady: async () => {
-      if (options.driver.getCapabilities().length > 0) {
+    refreshReady: async (query?: ComputerUsePermissionQuery) => {
+      if (
+        options.driver.getCapabilities().length > 0 ||
+        options.transitioning()
+      ) {
         try {
-          const fresh = await options.driver.withPermissionProvider(
-            (provider) => provider.getPermissions(),
-          );
+          const fresh = await options.refreshNative(query);
           if (fresh) return fresh;
         } catch {
           // Driver ownership already withdrew admission and retained cleanup.

--- a/turbo/apps/desktop/src/desktop-computer-use-selection.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-selection.test.ts
@@ -150,6 +150,7 @@ require('node:readline').createInterface({input:process.stdin}).on('line', line 
   };
   const driver = new ComputerUseDriverController(okou, "darwin");
   const permissions = createDesktopComputerUsePermissions({
+    refreshNative: (query) => controller.refreshNativePermissions(query),
     driver,
     requestedDriver: () => preference.getState().selectedDriver,
     transitioning: () => controller.isTransitioning(),
@@ -187,6 +188,7 @@ require('node:readline').createInterface({input:process.stdin}).on('line', line 
     prepareNative: permissions.prepareNative,
     nativeBlockReason: (driver) => selection.blockReason(driver),
     getAuthState: () => auth.getAuthState(),
+    getAuthAuthority: () => auth.getAuthority(),
     setHostRuntimeOnline: (online) => plugin.setHostRuntimeOnline(online),
     getPluginCapabilities: () => plugin.getCapabilities(),
     preparePlugins: () => plugin.prepareForHost(),
@@ -227,6 +229,7 @@ require('node:readline').createInterface({input:process.stdin}).on('line', line 
     const current = auth.getAuthority();
     if (lastAuth !== current) {
       lastAuth = current;
+      controller.cancelPermissionRefresh();
       permissions.resetComputerUsePermissionState();
       if (
         selection.requestedDriver().id === "cua" ||

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -1,4 +1,7 @@
-import { captureDesktopNativeHelperError } from "./sentry-main";
+import {
+  captureDesktopNativeHelperError,
+  captureDesktopNativePermissionRecovery,
+} from "./sentry-main";
 import { openAsBlob, writeSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -211,6 +214,8 @@ const {
   probeComputerUseAutomationPermission,
   recordComputerUseAutomationPermissionDenied,
 } = createDesktopComputerUsePermissions({
+  refreshNative: (query) =>
+    computerUseController.refreshNativePermissions(query),
   driver: computerUseDriver,
   requestedDriver: () => driverPreferences.getState().selectedDriver,
   transitioning: () => computerUseController.isTransitioning(),
@@ -347,6 +352,7 @@ const applicationMenu = new DesktopApplicationMenu({
   quit: requestDesktopQuit,
 });
 const computerUseController = new ComputerUseRuntimeController({
+  onPermissionRecovery: captureDesktopNativePermissionRecovery,
   driver: computerUseDriver,
   createRuntime: createComputerUseHostRuntime,
   refreshPermissions: refreshComputerUsePermissionState,
@@ -360,6 +366,7 @@ const computerUseController = new ComputerUseRuntimeController({
     ]);
   },
   getAuthState: () => getAuthSession().getAuthState(),
+  getAuthAuthority: () => getAuthSession().getAuthority(),
   setHostRuntimeOnline: (online) => {
     filesystemPluginManager?.setHostRuntimeOnline(online);
     mcpPluginManager?.setHostRuntimeOnline(online);
@@ -490,6 +497,7 @@ function notifyAuthChanged(): void {
   const authority = authSession?.getAuthority() ?? null;
   if (lastSessionAuthority !== authority) {
     lastSessionAuthority = authority;
+    computerUseController.cancelPermissionRefresh();
     resetComputerUsePermissionState();
     if (
       driverSelection.requestedDriver().id === "cua" ||

--- a/turbo/apps/desktop/src/sentry-main.ts
+++ b/turbo/apps/desktop/src/sentry-main.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/electron/main";
 import type { ComputerUseNativeRuntimeErrorContext } from "./computer-use-native";
+import type { ComputerUsePermissionRecoveryDiagnostic } from "./computer-use-runtime-controller";
 
 declare const __DESKTOP_VERSION__: string;
 declare const __DESKTOP_SENTRY_DSN__: string;
@@ -74,7 +75,27 @@ export function captureDesktopNativeHelperError(
       terminationReason: context.terminationReason,
       pendingRequestCount: context.pendingRequestCount,
       queuedRequestCount: context.queuedRequestCount,
+      processSequence: context.processSequence,
+      requestSequence: context.requestSequence,
+      elapsedMs: context.elapsedMs,
+      helperUptimeMs: context.helperUptimeMs,
+      timerDelayMs: context.timerDelayMs,
+      exitKnown: context.exitKnown,
+      phases: context.phases,
+      stderrBytes: context.stderrBytes,
     });
     Sentry.captureException(error);
+  });
+}
+
+export function captureDesktopNativePermissionRecovery(
+  diagnostic: ComputerUsePermissionRecoveryDiagnostic,
+): void {
+  if (!sentryDsn) return;
+  Sentry.addBreadcrumb({
+    category: "computer-use-helper",
+    message: "Native permission recovery",
+    level: diagnostic.outcome === "failed" ? "warning" : "info",
+    data: { ...diagnostic },
   });
 }

--- a/turbo/apps/desktop/src/test/native-permission-stall.ts
+++ b/turbo/apps/desktop/src/test/native-permission-stall.ts
@@ -1,0 +1,199 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  readFileSync,
+  watch,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { ComputerUseDriverController } from "../computer-use-driver";
+import {
+  createComputerUseNativeBackend,
+  type ComputerUseNativeRuntimeErrorContext,
+} from "../computer-use-native";
+import { ComputerUseRuntimeController } from "../computer-use-runtime-controller";
+import { createDesktopComputerUsePermissions } from "../desktop-computer-use-permissions";
+import { createDesktopComputerUseHostRuntime } from "../desktop-computer-use-api";
+import { DesktopAuthSession } from "../desktop-auth-session";
+
+/** Executed in an isolated Node process; Vitest's event loop never stalls. */
+export async function runPermissionStallFixture(
+  directory: string,
+): Promise<void> {
+  const helper = path.join(directory, "helper.cjs");
+  const received = path.join(directory, "received");
+  const written = path.join(directory, "written");
+  const release = path.join(directory, "release");
+  const armed = path.join(directory, "armed");
+  const starts = path.join(directory, "starts");
+  writeFileSync(starts, "");
+  writeFileSync(
+    helper,
+    `#!${process.execPath}
+const fs = require('node:fs');
+fs.appendFileSync(${JSON.stringify(starts)}, process.pid+'\\n');
+const lines = require('node:readline').createInterface({input:process.stdin});
+lines.on('line', line => {
+  const request = JSON.parse(line);
+  const reply = () => fs.writeSync(1, JSON.stringify({id:request.id,status:'succeeded',result:{accessibility:true,screenRecording:true}})+'\\n');
+  if (fs.existsSync(${JSON.stringify(armed)}) && !fs.existsSync(${JSON.stringify(received)})) {
+    const watcher = fs.watch(${JSON.stringify(directory)}, () => {
+      if (!fs.existsSync(${JSON.stringify(release)})) return;
+      watcher.close();
+      reply();
+      fs.writeFileSync(${JSON.stringify(written)}, String(Date.now()));
+    });
+    fs.writeFileSync(${JSON.stringify(received)}, 'received');
+  } else reply();
+});
+`,
+  );
+  chmodSync(helper, 0o755);
+  const api = "https://native-permission-fixture.test";
+  const server = setupServer(
+    http.all(`${api}/*`, ({ request }) => {
+      const route = new URL(request.url).pathname;
+      if (route === "/api/auth/me")
+        return HttpResponse.json({
+          userId: "fixture",
+          email: "fixture@example.test",
+          orgId: "fixture-org",
+        });
+      if (route === "/api/org")
+        return HttpResponse.json({ id: "fixture-org", name: "Fixture" });
+      if (route.endsWith("/hosts/start"))
+        return HttpResponse.json({
+          hostId: "fixture-host",
+          hostToken: "fixture-token",
+        });
+      return HttpResponse.json({ status: "idle" });
+    }),
+  );
+  server.listen({ onUnhandledRequest: "error" });
+  const auth = new DesktopAuthSession({
+    apiBaseUrl: api,
+    addClientHeaders: () => {},
+    tokenUrl: `${api}/token`,
+    selectOrgUrl: `${api}/org`,
+    consumeUrl: () => `${api}/consume`,
+    runAuthWindow: async () => "fixture-token",
+  });
+  const errors: ComputerUseNativeRuntimeErrorContext[] = [];
+  const driver = new ComputerUseDriverController(
+    {
+      id: "okou",
+      createBackend: () =>
+        createComputerUseNativeBackend({
+          helperPath: helper,
+          requestTimeoutMs: 400,
+          onRuntimeError: (_error, context) => errors.push(context),
+        }),
+    },
+    "darwin",
+  );
+  const grants = { accessibility: true, screenRecording: true };
+  const permissions = createDesktopComputerUsePermissions({
+    driver,
+    requestedDriver: () => "okou",
+    transitioning: () => controller.isTransitioning(),
+    refreshNative: (query) => controller.refreshNativePermissions(query),
+    host: {
+      getPermissions: async () => grants,
+      requestAccessibilityPermission: async () => grants,
+      requestScreenRecordingPermission: async () => grants,
+      probeAutomationPermission: async () => ({
+        status: "unknown",
+        reason: null,
+        updatedAt: null,
+      }),
+    },
+  });
+  const controller = new ComputerUseRuntimeController({
+    driver,
+    refreshPermissions: permissions.refreshComputerUsePermissionState,
+    prepareNative: permissions.prepareNative,
+    transitionTimeoutMs: 4_000,
+    getAuthState: () => auth.getAuthState(),
+    setHostRuntimeOnline: () => {},
+    createRuntime: () =>
+      createDesktopComputerUseHostRuntime(
+        {
+          platformUrl: new URL(api),
+          installationId: "00000000-0000-4000-8000-000000000001",
+          hostName: "fixture",
+          appVersion: "test",
+          addClientHeaders: () => {},
+          hostFetch: (input, init) => fetch(input, init),
+          getPermissions: permissions.refreshReady,
+          getSupportedCapabilities: () => driver.getCapabilities(),
+          driver,
+          executePluginCommand: async () => {
+            throw new Error("No plugin in this fixture");
+          },
+        },
+        { getAuthSession: () => auth },
+      ),
+  });
+  let watcher: ReturnType<typeof watch> | undefined;
+  try {
+    await controller.start();
+    const generation = driver.generation;
+    const receipt = new Promise<void>((resolve) => {
+      watcher = watch(directory, () => {
+        if (existsSync(received)) {
+          watcher?.close();
+          resolve();
+        }
+      });
+    });
+    writeFileSync(armed, "armed");
+    const startedAt = Date.now();
+    const query = permissions.refreshComputerUsePermissionState();
+    // Observe rejection immediately so the old-source red run is also clean.
+    const result = query.then(
+      (value) => ({ ok: true, value }),
+      (error) => ({ ok: false, message: String(error) }),
+    );
+    await receipt;
+    // The independent coordinator releases the warmed helper while this parent
+    // is synchronously blocked. It exits only after that helper proves write(2)
+    // completed AND the first attempt deadline has elapsed. No polling sleeps.
+    const blocked = spawnSync(
+      process.execPath,
+      [
+        "-e",
+        `
+const fs = require('node:fs');
+let deadlinePassed = false;
+const finish = () => { if (deadlinePassed && fs.existsSync(${JSON.stringify(written)})) { watcher.close(); process.exit(0); } };
+const watcher = fs.watch(${JSON.stringify(directory)}, finish);
+setTimeout(() => {deadlinePassed=true;finish();}, Math.max(0, ${startedAt + 850} - Date.now()));
+fs.writeFileSync(${JSON.stringify(release)}, 'release');
+`,
+      ],
+      { timeout: 5_000, encoding: "utf8" },
+    );
+    if (blocked.status !== 0)
+      throw new Error(`Stall coordinator failed: ${blocked.status}`);
+    const outcome = await result;
+    process.stdout.write(
+      JSON.stringify({
+        outcome,
+        generation,
+        freshGeneration: driver.generation,
+        ready: driver.getCapabilities().length > 0,
+        writtenAfterMs: Number(readFileSync(written, "utf8")) - startedAt,
+        elapsedMs: Date.now() - startedAt,
+        starts: readFileSync(starts, "utf8").trim().split("\n").length,
+        errors,
+      }) + "\n",
+    );
+  } finally {
+    watcher?.close();
+    await controller.stopForQuit();
+    server.close();
+  }
+}


### PR DESCRIPTION
## Problem and behavior

A valid native permission reply can lose the outer timeout race when the parent event loop resumes late. Separately, correlated malformed status/result validation removed the only pending rejection owner and could leave the serialized queue permanently unsettled. Retain settlement ownership through validation, invalidate poisoned backends, and allow one generation-owned recovery for a timed-out read-only `permissions.state` refresh.

Closes #32155.

Recovery uses the existing runtime replacement queue after the failed probe releases its lease. It drains already claimed work, proves old-process exit, retires snapshots, and performs exactly one fresh permission query under the original enabling intent and current auth authority. Concurrent refreshes share the episode. Commands and permission prompts are never retried or moved between generations; Okou remains the default and CUA remains experimental with no fallback.

## Acceptance evidence

| Issue criterion | Result and boundary |
| --- | --- |
| Healthy reads and actual denial | Healthy return shapes and explicit permission behavior pass. Denied/native-denied/malformed reads and permission prompts do not retry. Persistent permission grants remain distinct from runtime availability. |
| Ready helper versus delayed parent | An isolated Node parent loads the real exported backend, driver, permission store, runtime and host composition. A warmed helper wrote valid JSONL in 72 ms under a 400 ms attempt bound; an independently synchronized coordinator held the parent beyond 850 ms. The original source fails the fresh-readiness assertion; this change retires it and succeeds with generation 2. The original buffered reply is not accepted as fresh readiness. |
| Hung probe and exhaustion | Actual request timers exercise one replacement and a second failure without a third generation. Unconfirmed EOF/TERM/KILL exit blocks replacement, retains cleanup ownership and produces a shutdown diagnostic. |
| Concurrency and supersession | Shared read/recovery tests cover Stop, sign-out, workspace/session authority changes, switching, Quit, update and cancellation during cleanup and during the fresh probe. Explicit switching may proceed with its own new intent. Obsolete results cannot revive readiness. |
| Command and snapshot ownership | Healthy commands still drain through capture and completion reporting when a concurrent refresh is cancelled by driver switching or drain-and-stop. A command already claimed before timeout fails and completes its report before replacement admission. It is never transplanted/replayed. An old snapshot is rejected before any fresh-generation action; late replies from the old process do not restore readiness. |
| Exactly-once settlement and queue release | Correlated invalid status and invalid result both time out the test on unmodified source because the promise never settles; they reject promptly after this repair. Invalid permission fields, malformed JSON/non-object frames, duplicate/unowned frames, late replies, synchronous/asynchronous write failure, process close and disposal are covered. Queued requests fail without waiting behind poisoned process cleanup. |
| Bounded private diagnostics | Existing error contexts carry a 12-entry process-phase history, request/process sequence, clamped elapsed/overshoot values and known exit state. Serve stderr bodies are discarded; the byte counter caps at 4096. Tests verify bounds and absence of private fixture output. Recovery adds one bounded breadcrumb; terminal errors remain reportable. No monitoring service or broad Sentry suppression. |
| Real composition and red-before/green-after | All relevant internal owners remain real; only native/process, clock scheduling and HTTP boundaries are controlled. The parent-stall regression runs in its own Node process, synchronizes via filesystem notifications, and does not stall Vitest. Its old-source failure is `outcome.ok === false`, after the pre-deadline helper write and delayed-parent assertions pass. |
| Static and targeted checks | Desktop lint, TypeScript and scoped Knip passed. 247 tests across 11 selected integration files passed after the tracked-review repair; required PR/merge-group results are recorded in the tracked review. No full local Vitest or dev server. Swift is unchanged; macOS/package CI provides separate native/artifact validation, not real-device acceptance. The final exact-head and merge-group results are linked in the review and completion report. |
| Delivery lifecycle | One implementation owner and one PR. Same-thread `/pr-auto` handles exact-head tracked review, required CI, conflicts and the normal protected queue through GitHub-confirmed MERGED. No production actions. |

## Budgets and diagnostics limits

The helper's per-attempt 60-second and Swift 10-second policies remain unchanged. The default refresh cap is the existing 60-second attempt plus 30-second replacement bound (90 seconds); that replacement bound includes drain, proven old-process exit and retry. A shorter caller deadline wins, including the heartbeat's existing 10 seconds. Startup and transitions retain their existing 30-second limits; claimed commands retain their existing execution/reporting budget. Native failure cleanup may remain owned for its existing three one-second exit waits after the caller deadline (93 seconds including final cleanup). Timers cannot guarantee progress while the process or OS is suspended.

See [the lifecycle contract](turbo/apps/desktop/NATIVE-PERMISSION-LIFECYCLE.md) for ownership, caps and diagnostic semantics. Helper receipt/completion and OS suspend/resume are unknown without markers. The production record proves **one outer timeout**, not a macOS sleep event, a blocked permission API, SIGPIPE, CUA failure, or the malformed-response bug as its cause.

The 2026-09-08 MaskDB inventory of **120 distinct host-registry records, 46 non-revoked**, is all-org background including internal/historical records. It is **not affected users, active devices, installations, or an incident-rate denominator**. No database/API migration or production-data change is included.

## Fallbacks

- `ComputerUseRuntimeController.refreshNativePermissions` / `retryPermissionProbe`: the explicitly approved #32155 recovery policy for an expired read-only native probe, limited to original call plus one fresh attempt under unchanged intent and authority. This is a local lifecycle repair, not cross-version compatibility or a driver fallback. It retains all shorter caller deadlines, fails visibly on exhaustion, and must be removed/revised if that product recovery contract is retired. No rollout compatibility window or follow-up migration is introduced.

## Scope and unperformed acceptance

Based on freshly fetched `fdc9511532d552ae1745185cee3e8445a187049f`; the pre-PR inventory was refreshed against newer main and returned 36 open PRs with no Computer Use file overlap. Overlap is inventory, not ordering. Rebased without conflicts onto `d341a1707e` before opening.

No Swift/helper policy, CUA SDK/Electron pin, default driver, UI layout, public API, database, process-isolation redesign, or #32650 implementation is included. No user's Mac was operated. Signed installation/TCC grants and revocation, real permission prompts, sleep/wake and real application behavior remain unperformed Mac acceptance. Linux fixtures and CI do not establish those results. No release-please merge, deployment approval, publication, signing promotion or force upgrade is authorized or performed.
