### PR TITLE
chore(api): refresh sidebar touch preview marker

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createProductionApp } from "./production-bootstrap";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed to deploy the public artifact base URL on 2026-09-03)
+// (no-op API release marker refreshed for sidebar touch preview QA on 2026-09-08)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Purpose

Provision an isolated App/API Preview to investigate a mobile sidebar interaction: after manually scrolling the thread list, a tap can scroll the list back to the already-open thread without changing the main thread or closing the sidebar.

The only change is a comment in the API deployment entry point. Runtime behavior is unchanged. This PR is a browser QA fixture and must not be merged as a product change.

## Preview verification

- PR head: `eb38d6197a52873de6c2a732b0d243151d4d9bd3`.
- Deployed merge commit: `ca8b04f2a22ec86b17404c26474cf50f019e6beb`; its complete Git tree matches the PR head.
- App: https://pr-32682-app-okou-app-preview.vm0.workers.dev
- API: https://pr-32682-api.vm6.ai
- App/API deployment jobs and all three required CI gates passed.
- Fixture: a unique Clerk test account, 120 API-created threads, two pinned threads, current thread `Sidebar QA 040`. Onboarding was bypassed. `stableChatThreadNavigation` was enabled and `_realAgentInPreview` remained disabled. No agent runs were started.
- Chromium 152 with a 402 x 874 mobile viewport and native touch input: scrolling to the top and tapping a thread row navigated to the correct thread. Both 80 ms and 420 ms row presses worked.
- A controlled reproduction occurs when a touch lands on the list's left gutter and lasts about 420 ms. The pointer-focus guard has expired when the viewport receives focus. The application writes `scrollTop = 2952` before the subsequent container click, reveals the current thread, and leaves the route unchanged and sidebar open. Three repeated 420 ms trials reproduced it; three 250 ms trials did not.
- A supplemental WebKit 26.0 check also opened the correct thread after wheel scrolling and a native tap. This used Linux WebKit with a narrow viewport, `hasTouch=true`, and `isMobile=false` to support wheel input; it is not a physical iPhone/PWA test.

## Attribution limits

The controlled result establishes a focus-driven scroll path, not the exact touch target or timing in the original recording. The 350 ms guard and current-thread focus handler predate #32520. That PR removed the animation-frame wait before scrolling and changed list readiness/virtual-window propagation, but did not change row click binding. A before/after deployment comparison has not established that #32520 introduced the reported incident.

- [Before/after screenshots](https://a.okou.io/kachg5il3j.png)
- [Sanitized event evidence](https://a.okou.io/frdzlrs2tg.json)

## Local checks

`git diff --check` passed; exactly one comment changed. No local development server or full local Vitest run was used.
