### PR TITLE
fix(platform): collapse nonempty chat work history by default

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
@@ -643,7 +643,7 @@ function foldRunWorkGroup(
       runGroupId: unit.runGroupId,
       runIds: unit.runIds,
       anchorEventId: anchorEvent.id,
-      collapsible: stepCount > 3,
+      collapsible: stepCount > 0,
       stepCount,
       hiddenGroups: groupEventsByRole(hiddenEvents),
       hiddenGroupsAfterAnchor: groupEventsByRole(hiddenEventsAfterAnchor),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-run-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-run-history.test.tsx
@@ -3,6 +3,7 @@ import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { expect, test } from "vitest";
 
 import {
+  click,
   queryAllByRoleFast,
   setupPage,
 } from "../../../__tests__/page-helper.ts";
@@ -187,13 +188,13 @@ test("Project all workflow run outputs through one run-group history", async () 
   });
 
   await readyChat();
-  expect(screen.getByText("Earlier workflow evidence 1")).toBeVisible();
-  expect(screen.getByText("Earlier workflow result 1")).toBeVisible();
-  expect(screen.getByText("Earlier workflow evidence 2")).toBeVisible();
+  expect(screen.queryByText("Earlier workflow evidence 1")).toBeNull();
+  expect(screen.queryByText("Earlier workflow result 1")).toBeNull();
+  expect(screen.queryByText("Earlier workflow evidence 2")).toBeNull();
   const main = screen.getByText("Earlier workflow result 2");
   expect(main).toBeVisible();
   expect(queryButton("Expand grouped run history")).toBeNull();
-  expect(queryWorkHistoryToggle("collapsed")).toBeNull();
+  expect(queryWorkHistoryToggle("collapsed")).toBeVisible();
   const currentProgress = await screen.findByLabelText(
     "Checking the latest workflow run",
   );
@@ -211,6 +212,7 @@ test("Project all workflow run outputs through one run-group history", async () 
     }),
   ).toHaveLength(1);
 
+  click(await findWorkHistoryToggle("collapsed"));
   const firstEarlierEvidence = await screen.findByText(
     "Earlier workflow evidence 1",
   );
@@ -222,6 +224,9 @@ test("Project all workflow run outputs through one run-group history", async () 
     assistantGroup,
   );
   expect(screen.queryByText("Nightly launch review")).toBeNull();
+
+  click(await findWorkHistoryToggle("expanded"));
+  await expect(findWorkHistoryToggle("collapsed")).resolves.toBeVisible();
 
   events.push(
     assistantOutput({
@@ -431,21 +436,22 @@ test("Keep the prior goal result as main while the next run has no output", asyn
   const answer = await screen.findByText(
     "The current launch evidence is ready.",
   );
-  const historyMessage = screen.getByText(
-    "The earlier launch evidence is complete.",
-  );
-  expect(historyMessage).toBeVisible();
   expect(
-    historyMessage.closest("[data-chat-run-work-history-list]"),
-  ).toBeVisible();
+    screen.queryByText("The earlier launch evidence is complete."),
+  ).toBeNull();
   expect(queryButton("The earlier launch evidence is complete.")).toBeNull();
-  expect(queryWorkHistoryToggle("collapsed")).toBeNull();
+  expect(queryWorkHistoryToggle("collapsed")).toBeVisible();
   const answeringAssistant = answer.closest<HTMLElement>(
     '[data-role="assistant"]',
   );
   if (!answeringAssistant) {
     throw new Error("Expected the answer in an assistant response");
   }
+  click(await findWorkHistoryToggle("collapsed"));
+  const historyMessage = await screen.findByText(
+    "The earlier launch evidence is complete.",
+  );
+  expect(historyMessage).toBeVisible();
   expect(historyMessage.closest('[data-role="assistant"]')).toBe(
     answeringAssistant,
   );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
@@ -496,8 +496,7 @@ test("The conversation locator follows folded goal continuation work", async () 
   });
 
   await screen.findByText("All deployment regions are healthy");
-  await screen.findByText("Checked the first deployment region");
-  expect(screen.getByText("Checked the first deployment region")).toBeVisible();
+  expect(screen.queryByText("Checked the first deployment region")).toBeNull();
   expect(
     screen.queryByText("Keep checking the deployment regions"),
   ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
@@ -478,7 +478,10 @@ test("Subtract final artifacts after ordered URL deduplication", async () => {
     }),
   ]);
 
-  const firstHistory = screen.getByText("First historical output");
+  expect(screen.getByText("Final artifact summary")).toBeVisible();
+  expect(screen.queryByText("First historical output")).toBeNull();
+  click(await findWorkHistoryToggle("collapsed"));
+  const firstHistory = await screen.findByText("First historical output");
   const secondHistory = screen.getByText("Second historical output");
   const main = screen.getByText("Final artifact summary");
   await findNamedLink("Open pdf preview for repeated.pdf");
@@ -532,11 +535,11 @@ test("Keep artifacts with the same filename distinct when their URLs differ", as
   const second = relatedArtifactRow(dialog, secondUrl);
   expectDocumentOrder(first, second);
   expect(within(dialog).getAllByText("Report")).toHaveLength(2);
-  expect(screen.getByText("First report version")).toBeVisible();
-  expect(screen.getByText("Second report version")).toBeVisible();
+  expect(screen.queryByText("First report version")).toBeNull();
+  expect(screen.queryByText("Second report version")).toBeNull();
 });
 
-test("Render inline media and action cards inside visible short history", async () => {
+test("Render inline media and action cards after expanding short history", async () => {
   await setupArtifactRun([
     assistantEvent({
       id: "non-artifact-history",
@@ -557,11 +560,18 @@ test("Render inline media and action cards inside visible short history", async 
   ]);
 
   expect(screen.getByText("Final result without artifacts")).toBeVisible();
-  expect(screen.getByText("Historical rich output")).toBeVisible();
+  expect(screen.queryByText("Historical rich output")).toBeNull();
+  expect(screen.queryByAltText("Inline chart")).toBeNull();
+  expect(screen.queryByTestId("plan-upgrade-card")).toBeNull();
+  expect(screen.queryByTestId("chat-run-related-artifacts-trigger")).toBeNull();
+  click(await findWorkHistoryToggle("collapsed"));
+  await expect(
+    screen.findByText("Historical rich output"),
+  ).resolves.toBeVisible();
   expect(screen.getByAltText("Inline chart")).toBeVisible();
   expect(screen.getByTestId("plan-upgrade-card")).toBeVisible();
   expect(screen.queryByTestId("chat-run-related-artifacts-trigger")).toBeNull();
-  expect(queryWorkHistoryToggle("collapsed")).toBeNull();
+  expect(queryWorkHistoryToggle("expanded")).toBeVisible();
 });
 
 test("Carry artifacts across every run in the same run group", async () => {
@@ -642,11 +652,11 @@ test("Carry artifacts across every run in the same run group", async () => {
   await readyChat();
 
   expect(screen.getByText("Latest run result")).toBeVisible();
-  expect(screen.getByText("Earlier run output")).toBeVisible();
+  expect(screen.queryByText("Earlier run output")).toBeNull();
   const dialog = await openRelatedArtifacts();
   expect(relatedArtifactRow(dialog, earlierUrl)).toHaveTextContent("Report");
   expect(queryButton("Expand grouped run history")).toBeNull();
-  expect(queryWorkHistoryToggle("collapsed")).toBeNull();
+  expect(queryWorkHistoryToggle("collapsed")).toBeVisible();
 });
 
 test("Ignore artifacts from revoked output messages", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-goal-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-goal-history.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { expect, test } from "vitest";
 
-import { queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
+import { click, queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
 import { setupPage } from "./chat-lifecycle-test-helpers.ts";
 import type { MockChatEventInput } from "./chat-event-test-helpers.ts";
 import {
@@ -12,8 +12,10 @@ import {
   context,
   creditUsage,
   expectTextOrder,
+  findWorkHistoryToggle,
   installRunChat,
   promptEvent,
+  queryWorkHistoryToggles,
   readyChat,
   RUN_PATH,
   usageEvent,
@@ -181,11 +183,12 @@ test("Review goal continuations as one work history", async () => {
   expect(screen.getByText("Review the launch readiness")).toBeVisible();
   expect(screen.getByText("The launch is ready in every region")).toBeVisible();
   expect(screen.getByLabelText("Credit usage 10")).toBeVisible();
-  expect(screen.getByText("Checked the initial launch evidence")).toBeVisible();
-  expect(screen.getByText("Validated the regional rollout")).toBeVisible();
+  expect(screen.queryByText("Checked the initial launch evidence")).toBeNull();
+  expect(screen.queryByText("Validated the regional rollout")).toBeNull();
   expect(screen.queryByText("Keep checking launch readiness")).toBeNull();
   expect(screen.queryByText("Finish checking launch readiness")).toBeNull();
 
+  click(await findWorkHistoryToggle("collapsed"));
   await expect(
     screen.findByText("Checked the initial launch evidence"),
   ).resolves.toBeVisible();
@@ -436,8 +439,8 @@ test("Keep a cancelled goal continuation beside its latest answer", async () => 
       return link.getAttribute("aria-label") === "View agent profile";
     }),
   ).toHaveLength(1);
-  expect(screen.getByText("Model changed to GPT 5.6 Luna")).toBeVisible();
-  expect(screen.getByText("Model changed to GPT 5.6 Sol")).toBeVisible();
+  expect(screen.queryByText("Model changed to GPT 5.6 Luna")).toBeNull();
+  expect(screen.queryByText("Model changed to GPT 5.6 Sol")).toBeNull();
   expect(
     screen.queryByText("Continue the deployment investigation with Luna"),
   ).toBeNull();
@@ -445,7 +448,12 @@ test("Keep a cancelled goal continuation beside its latest answer", async () => 
     screen.queryByText("Continue the deployment investigation with Sol"),
   ).toBeNull();
 
-  expect(screen.getByText("Checked the deployment logs")).toBeVisible();
+  click(await findWorkHistoryToggle("collapsed"));
+  await expect(
+    screen.findByText("Checked the deployment logs"),
+  ).resolves.toBeVisible();
+  expect(screen.getByText("Model changed to GPT 5.6 Luna")).toBeVisible();
+  expect(screen.getByText("Model changed to GPT 5.6 Sol")).toBeVisible();
   expectTextOrder(
     "Checked the deployment logs",
     "Model changed to GPT 5.6 Luna",
@@ -551,8 +559,7 @@ test("Start a fresh work history after interrupting a goal continuation", async 
     "[data-chat-run-work-history]",
   );
   expect(workHistories).toHaveLength(2);
-  expect(screen.getByText("Checked the first rollout logs")).toBeVisible();
-  expect(
-    screen.getByText("Checked the replacement rollout logs"),
-  ).toBeVisible();
+  expect(screen.queryByText("Checked the first rollout logs")).toBeNull();
+  expect(screen.queryByText("Checked the replacement rollout logs")).toBeNull();
+  expect(queryWorkHistoryToggles("collapsed")).toHaveLength(2);
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history-preview.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history-preview.test.tsx
@@ -54,33 +54,24 @@ test("Show no history messages without assistant output", async () => {
   expect(
     document.querySelector("[data-chat-run-work-history-list]"),
   ).toBeNull();
+  expect(queryButton("Expand work history")).toBeNull();
 });
 
-test.each([1, 2, 3, 4])(
-  "Show every history message without a group toggle with %s outputs",
-  async (count) => {
-    await setupRunWithOutputCount(count);
+test("Show no history toggle when the only output is the main result", async () => {
+  await setupRunWithOutputCount(1);
 
-    for (let index = 1; index < count; index += 1) {
-      const message = screen.getByText(`Step ${String(index)}`);
-      expect(message).toBeVisible();
-      expect(
-        message.closest("[data-chat-run-work-history-list]"),
-      ).toBeVisible();
-      expect(message.closest("button")).toBeNull();
-    }
-    const main = screen
-      .getByText(`Step ${String(count)}`)
-      .closest("[data-chat-run-work-main]");
-    if (!main) {
-      throw new Error("Expected the main result container");
-    }
-    expect(queryButton("Copy message", main)).toBeVisible();
-    expect(queryButton("Expand work history")).toBeNull();
-  },
-);
+  const main = screen.getByText("Step 1").closest("[data-chat-run-work-main]");
+  if (!main) {
+    throw new Error("Expected the main result container");
+  }
+  expect(queryButton("Copy message", main)).toBeVisible();
+  expect(queryButton("Expand work history")).toBeNull();
+  expect(
+    document.querySelector("[data-chat-run-work-history-list]"),
+  ).toBeNull();
+});
 
-test.each([5, 6])(
+test.each([2, 3, 4, 5, 6])(
   "Hide all collapsed history and expand every message with %s outputs",
   async (count) => {
     await setupRunWithOutputCount(count);
@@ -266,10 +257,14 @@ test("Render a card-only history output without message folding", async () => {
   });
   await readyChat();
 
+  expect(screen.getByText("The comparison is ready")).toBeVisible();
+  expect(screen.queryByTestId("plan-upgrade-card")).toBeNull();
+  click(await findWorkHistoryToggle("collapsed"));
+
   const card = await screen.findByTestId("plan-upgrade-card");
   expect(card).toBeVisible();
   expect(card.closest("[data-chat-run-work-history-list]")).toBeVisible();
-  expect(queryButton("Expand work history")).toBeNull();
+  expect(queryButton("Collapse work history")).toBeVisible();
 });
 
 test.each(["completed", "failed", "cancelled"] as const)(
@@ -320,6 +315,14 @@ test.each(["completed", "failed", "cancelled"] as const)(
     });
     await readyChat();
 
+    expect(screen.getByText("The review is ready")).toBeVisible();
+    expect(screen.queryByRole("heading", { name: "Review" })).toBeNull();
+    expect(screen.queryByAltText("Dependency chart")).toBeNull();
+    click(await findWorkHistoryToggle("collapsed"));
+    await expect(
+      screen.findByRole("heading", { name: "Review" }),
+    ).resolves.toBeVisible();
+
     const historyBody = document.querySelector<HTMLElement>(
       '[data-chat-scroll-anchor-event-id="rich-preview-0"]',
     );
@@ -336,6 +339,6 @@ test.each(["completed", "failed", "cancelled"] as const)(
     await expect(
       findLink("Open pdf preview for report.pdf"),
     ).resolves.toBeVisible();
-    expect(queryButton("Expand work history")).toBeNull();
+    expect(queryButton("Collapse work history")).toBeVisible();
   },
 );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history.test.tsx
@@ -203,10 +203,22 @@ test("Browse completed work by conversation phase", async () => {
   expect(screen.getByText("Phase one outline")).toBeVisible();
   expect(screen.getByText("Phase one final plan")).toBeVisible();
   expect(screen.getByText("Phase two final plan")).toBeVisible();
-  expect(screen.getByText("Collected requirements")).toBeVisible();
-  expect(screen.getByText("Compared rollback options")).toBeVisible();
-  expect(screen.getByText("Checked launch dependencies")).toBeVisible();
-  expect(queryWorkHistoryToggles("collapsed")).toHaveLength(0);
+  expect(screen.queryByText("Collected requirements")).toBeNull();
+  expect(screen.queryByText("Compared rollback options")).toBeNull();
+  expect(screen.queryByText("Checked launch dependencies")).toBeNull();
+  expect(queryWorkHistoryToggles("collapsed")).toHaveLength(3);
+
+  click(
+    buttonNamedIn(
+      "Expand work history",
+      assistantGroupFor(screen.getByText("Phase one outline")),
+    ),
+  );
+  await expect(
+    screen.findByText("Collected requirements"),
+  ).resolves.toBeVisible();
+  expect(screen.queryByText("Compared rollback options")).toBeNull();
+  expect(screen.queryByText("Checked launch dependencies")).toBeNull();
   expectTextOrder(
     "Plan phase one",
     "Collected requirements",
@@ -214,6 +226,27 @@ test("Browse completed work by conversation phase", async () => {
     "Include rollback steps",
     "Phase one final plan",
   );
+  click(
+    buttonNamedIn(
+      "Expand work history",
+      assistantGroupFor(screen.getByText("Phase one final plan")),
+    ),
+  );
+  await expect(
+    screen.findByText("Compared rollback options"),
+  ).resolves.toBeVisible();
+  expect(screen.queryByText("Checked launch dependencies")).toBeNull();
+
+  click(
+    buttonNamedIn(
+      "Expand work history",
+      assistantGroupFor(screen.getByText("Phase two final plan")),
+    ),
+  );
+  await expect(
+    screen.findByText("Checked launch dependencies"),
+  ).resolves.toBeVisible();
+  expect(queryWorkHistoryToggles("collapsed")).toHaveLength(0);
   expect(screen.getByLabelText("Credit usage 7")).toBeVisible();
 
   expect(screen.getByText("Plan phase two")).toBeVisible();
@@ -498,8 +531,8 @@ test.each(finalOutputDocuments)(
     const main = await find();
     expect(main).toBeVisible();
     expect(viewAgentProfileLinks()).toHaveLength(1);
-    expect(screen.getByText("Earlier output belongs in history")).toBeVisible();
-    expect(queryWorkHistoryToggles("collapsed")).toHaveLength(0);
+    expect(screen.queryByText("Earlier output belongs in history")).toBeNull();
+    expect(queryWorkHistoryToggles("collapsed")).toHaveLength(1);
     const thinking = document.querySelector<HTMLElement>(
       "[data-thinking-indicator]",
     );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-steer.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-steer.test.tsx
@@ -294,12 +294,11 @@ test("Keep separate histories, artifacts and actions on both sides of a steer in
   for (const text of oldHistory) {
     expect(screen.queryByText(text)).toBeNull();
   }
-  const nextHistory = screen.getByText("Checked the token validation path");
-  expect(nextHistory).toBeVisible();
+  expect(screen.queryByText("Checked the token validation path")).toBeNull();
   expect(
-    nextHistory.closest("[data-chat-run-work-history-list]"),
-  ).toBeVisible();
-  expect(queryButton("Expand work history", nextGroup)).toBeNull();
+    nextGroup.querySelector("[data-chat-run-work-history-list]"),
+  ).toBeNull();
+  expect(queryButton("Expand work history", nextGroup)).toBeVisible();
   expect(queryButton("Copy message", mainResult(NEXT_RESULT))).toBeVisible();
   expect(screen.getAllByTestId("chat-event-actions")).toHaveLength(2);
   expect(nextGroup).not.toContainElement(relatedArtifacts);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll.test.tsx
@@ -528,6 +528,7 @@ test("Keep a visible work message in place when its run completes", async () => 
     ).not.toBeInTheDocument();
   });
 
+  click(buttonByLabel("Expand work history"));
   await screen.findByText("Checked the first rollout stage");
   const container = chatScrollContainer();
   const geometry = installChatScrollGeometry(container);
@@ -563,9 +564,7 @@ test("Keep a visible work message in place when its run completes", async () => 
   await screen.findByText("The rollout is healthy");
   await waitFor(() => {
     expect(screen.getByText("Checked the first rollout stage")).toBeVisible();
-    expect(
-      document.querySelector("[data-chat-run-work-range]"),
-    ).not.toBeInTheDocument();
+    expect(buttonByLabel("Collapse work history")).toBeVisible();
     expect(screen.getByText("Worked for 1m")).toBeVisible();
     expect(
       anchorById(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-sharing.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-sharing.test.tsx
@@ -182,8 +182,8 @@ test("A folded multi-message answer counts as one shared selection", async () =>
   });
 
   await screen.findByText("Launch answer 3");
-  expect(screen.getByText("Launch answer 1")).toBeVisible();
-  expect(screen.getByText("Launch answer 2")).toBeVisible();
+  expect(screen.queryByText("Launch answer 1")).toBeNull();
+  expect(screen.queryByText("Launch answer 2")).toBeNull();
   await waitFor(() => {
     expect(buttonsNamed("Share messages").length).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## Summary

Work histories with one to three messages remained expanded without a toggle after per-message folding was removed. Collapse every nonempty history by default and show its expand control, while keeping the main result visible and omitting the control for empty history.

Update existing page coverage for short histories, explicit expansion, incoming output, goal continuations, artifacts, sharing, scrolling, and conversation navigation.

## Verification

- 100 targeted Platform page tests across nine files, using one worker
- `pnpm -F @okouai/app lint`
- `TSC_CHECKERS=2 pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- Prettier, style policy, and commitlint
- Browser verification not performed; no local development server started
