### PR TITLE
test(platform): limit emoji picker fixture to 20 items

### DIFF
--- a/turbo/apps/platform/src/test/setup.ts
+++ b/turbo/apps/platform/src/test/setup.ts
@@ -17,22 +17,6 @@ import { server } from "../mocks/server.ts";
 import { afterAll, afterEach, beforeEach, beforeAll, vi } from "vitest";
 import { clearAllDetached } from "../signals/utils.ts";
 
-vi.mock("../data/chat-thread-emoji.json", async (importOriginal) => {
-  const { default: groups } =
-    await importOriginal<typeof import("../data/chat-thread-emoji.json")>();
-  return {
-    default: groups.map((group) => {
-      return {
-        ...group,
-        // The picker adds nine frequently used items. One item from each
-        // category plus the first three food items keeps the test grid at 20
-        // buttons while retaining grinning face and watermelon coverage.
-        emojis: group.emojis.slice(0, group.name === "Food & Drink" ? 3 : 1),
-      };
-    }),
-  };
-});
-
 for (const [name, content] of [
   ["okou-app-git-commit-sha", "0123456789abcdef0123456789abcdef01234567"],
   ["okou-app-version", "0.540.0"],

--- a/turbo/apps/platform/src/test/setup.ts
+++ b/turbo/apps/platform/src/test/setup.ts
@@ -17,6 +17,22 @@ import { server } from "../mocks/server.ts";
 import { afterAll, afterEach, beforeEach, beforeAll, vi } from "vitest";
 import { clearAllDetached } from "../signals/utils.ts";
 
+vi.mock("../data/chat-thread-emoji.json", async (importOriginal) => {
+  const { default: groups } =
+    await importOriginal<typeof import("../data/chat-thread-emoji.json")>();
+  return {
+    default: groups.map((group) => {
+      return {
+        ...group,
+        // The picker adds nine frequently used items. One item from each
+        // category plus the first three food items keeps the test grid at 20
+        // buttons while retaining grinning face and watermelon coverage.
+        emojis: group.emojis.slice(0, group.name === "Food & Drink" ? 3 : 1),
+      };
+    }),
+  };
+});
+
 for (const [name, content] of [
   ["okou-app-git-commit-sha", "0123456789abcdef0123456789abcdef01234567"],
   ["okou-app-version", "0.540.0"],

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-emoji.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-emoji.test.tsx
@@ -62,6 +62,19 @@ function emojiFeed(): HTMLElement {
   return feed;
 }
 
+async function waitForEmojiPicker(): Promise<HTMLInputElement> {
+  const searchInput = await screen.findByLabelText("Search emoji");
+  if (!(searchInput instanceof HTMLInputElement)) {
+    throw new Error("Emoji search is not an input");
+  }
+  await waitFor(() => {
+    expect(document.querySelectorAll("[data-chat-thread-emoji]")).toHaveLength(
+      20,
+    );
+  });
+  return searchInput;
+}
+
 async function openEmojiPicker(): Promise<HTMLInputElement> {
   await setupEmojiPage();
   await waitFor(() => {
@@ -70,11 +83,7 @@ async function openEmojiPicker(): Promise<HTMLInputElement> {
 
   click(buttonByLabel("Change icon"));
 
-  const searchInput = await screen.findByLabelText("Search emoji");
-  if (!(searchInput instanceof HTMLInputElement)) {
-    throw new Error("Emoji search is not an input");
-  }
-  return searchInput;
+  return waitForEmojiPicker();
 }
 
 function setCategoryLayout(feed: HTMLElement): void {
@@ -135,7 +144,7 @@ test("Change a thread icon before its save finishes", async () => {
   const changeIcon = buttonByLabel("Change icon");
 
   click(changeIcon);
-  const searchInput = await screen.findByLabelText("Search emoji");
+  const searchInput = await waitForEmojiPicker();
   click(emojiButton("grinning face"));
   await waitFor(() => {
     expect(changeIcon).toHaveTextContent("😀");
@@ -157,7 +166,7 @@ test("Restore chat focus after closing the mobile emoji picker", async () => {
   const changeIcon = buttonByLabel("Change icon");
 
   click(changeIcon);
-  const searchInput = await screen.findByLabelText("Search emoji");
+  const searchInput = await waitForEmojiPicker();
   click(changeIcon);
   await waitFor(() => {
     expect(searchInput).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-emoji.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-emoji.test.tsx
@@ -5,6 +5,7 @@ import { chatThreadRenameContract } from "@okouai/api-contracts/contracts/chat-t
 
 import {
   click,
+  fill,
   queryAllByRoleFast,
   setupPage,
 } from "../../../__tests__/page-helper.ts";
@@ -62,19 +63,6 @@ function emojiFeed(): HTMLElement {
   return feed;
 }
 
-async function waitForEmojiPicker(): Promise<HTMLInputElement> {
-  const searchInput = await screen.findByLabelText("Search emoji");
-  if (!(searchInput instanceof HTMLInputElement)) {
-    throw new Error("Emoji search is not an input");
-  }
-  await waitFor(() => {
-    expect(document.querySelectorAll("[data-chat-thread-emoji]")).toHaveLength(
-      20,
-    );
-  });
-  return searchInput;
-}
-
 async function openEmojiPicker(): Promise<HTMLInputElement> {
   await setupEmojiPage();
   await waitFor(() => {
@@ -83,7 +71,11 @@ async function openEmojiPicker(): Promise<HTMLInputElement> {
 
   click(buttonByLabel("Change icon"));
 
-  return waitForEmojiPicker();
+  const searchInput = await screen.findByLabelText("Search emoji");
+  if (!(searchInput instanceof HTMLInputElement)) {
+    throw new Error("Emoji search is not an input");
+  }
+  return searchInput;
 }
 
 function setCategoryLayout(feed: HTMLElement): void {
@@ -144,7 +136,7 @@ test("Change a thread icon before its save finishes", async () => {
   const changeIcon = buttonByLabel("Change icon");
 
   click(changeIcon);
-  const searchInput = await waitForEmojiPicker();
+  const searchInput = await screen.findByLabelText("Search emoji");
   click(emojiButton("grinning face"));
   await waitFor(() => {
     expect(changeIcon).toHaveTextContent("😀");
@@ -166,7 +158,7 @@ test("Restore chat focus after closing the mobile emoji picker", async () => {
   const changeIcon = buttonByLabel("Change icon");
 
   click(changeIcon);
-  const searchInput = await waitForEmojiPicker();
+  const searchInput = await screen.findByLabelText("Search emoji");
   click(changeIcon);
   await waitFor(() => {
     expect(searchInput).not.toBeInTheDocument();
@@ -183,7 +175,15 @@ test.each([
   "Keep one focused emoji picker when resizing from $from to $to",
   async ({ desktop }) => {
     const viewport = context.mocks.browser.matchMedia(desktop);
-    await openEmojiPicker();
+    const searchInput = await openEmojiPicker();
+
+    // "eye" has 20 matches in the production emoji data. Search through the
+    // page before remounting so this responsive contract does not repeatedly
+    // build the unrelated full emoji grid.
+    await fill(searchInput, "eye");
+    await waitFor(() => {
+      expect(queryAllByRoleFast("button", emojiFeed())).toHaveLength(20);
+    });
 
     act(() => {
       viewport.setMatches(!desktop);
@@ -196,6 +196,8 @@ test.each([
       const searchInputs = screen.getAllByLabelText("Search emoji");
       expect(searchInputs).toHaveLength(1);
       expect(searchInputs[0]).toHaveFocus();
+      expect(searchInputs[0]).toHaveValue("eye");
+      expect(queryAllByRoleFast("button", emojiFeed())).toHaveLength(20);
     });
     expect(screen.getAllByTestId("chat-thread-header-title")).toHaveLength(1);
     expect(screen.getByTestId("chat-thread-header-title")).toHaveTextContent(


### PR DESCRIPTION
## Summary
- use the real emoji search input to reduce each responsive picker remount to exactly 20 production-data results
- preserve the search query, focused input, single-picker invariant, and both mobile/desktop resize directions
- leave the full production emoji dataset and category/search coverage unchanged

## Context
The full production emoji grid made the responsive picker tests sensitive to the five-second test budget under CI runner contention. Searching for `eye` through the page yields 20 accessible emoji buttons before the breakpoint remount, removing irrelevant remount volume without replacing internal application data.

## Verification
- `vitest run --project=@okouai/app src/views/okou-page/__tests__/chat-emoji.test.tsx` repeated 5 times (50/50 passed; resize cases 1.003–1.315 seconds)
- `eslint src/views/okou-page/__tests__/chat-emoji.test.tsx --max-warnings 0`
- `prettier --check src/views/okou-page/__tests__/chat-emoji.test.tsx`
- `git diff --check`
