### PR TITLE
fix(api): restrict slack reads to shared conversations

### DIFF
--- a/turbo/apps/api/src/lib/slack-client.ts
+++ b/turbo/apps/api/src/lib/slack-client.ts
@@ -90,15 +90,21 @@ async function callSlackApi<T>(
   return data as T;
 }
 
-const conversationPageSchema = z.object({
+const sharedChannelPageSchema = z.object({
   channels: z.array(
     z.object({
       id: z.string(),
       name: z.string(),
       is_private: z.boolean(),
-      is_member: z.boolean(),
     }),
   ),
+  response_metadata: z
+    .object({ next_cursor: z.string().optional() })
+    .optional(),
+});
+
+const sharedConversationPageSchema = z.object({
+  channels: z.array(z.object({ id: z.string() })),
   response_metadata: z
     .object({ next_cursor: z.string().optional() })
     .optional(),
@@ -112,17 +118,21 @@ const historyPageSchema = z.object({
     .optional(),
 });
 
-export async function listSlackChannelsPage(
+// For bot tokens, Slack defines `user` as an intersection with the bot's own
+// memberships, including private conversations shared by both identities.
+export async function listSharedSlackChannelsPage(
   token: string,
+  slackUserId: string,
   query: SlackChannelListQuery,
-  signal: AbortSignal,
+  signal?: AbortSignal,
 ) {
-  return conversationPageSchema.parse(
+  return sharedChannelPageSchema.parse(
     await callSlackApi<unknown>(
       token,
-      "conversations.list",
+      "users.conversations",
       {
         ...query,
+        user: slackUserId,
         types: "public_channel,private_channel",
         exclude_archived: true,
       },
@@ -141,54 +151,28 @@ export async function readSlackHistoryPage(
   );
 }
 
-interface SlackConversation {
-  id: string;
-  name: string;
-  is_channel: boolean;
-  is_group: boolean;
-  is_im: boolean;
-  is_member: boolean;
-  is_archived: boolean;
-}
-
-interface ConversationsListResponse {
-  ok: true;
-  channels: SlackConversation[];
-  response_metadata?: { next_cursor?: string };
-}
-
-export async function listConversations(
+export async function listSharedSlackChannels(
   token: string,
-  options?: {
-    types?: string;
-    excludeArchived?: boolean;
-    limit?: number;
-  },
+  slackUserId: string,
   signal?: AbortSignal,
 ): Promise<{ id: string; name: string }[]> {
   const channels: { id: string; name: string }[] = [];
   let cursor: string | undefined;
 
   do {
-    const result = await callSlackApi<ConversationsListResponse>(
+    const result = await listSharedSlackChannelsPage(
       token,
-      "conversations.list",
-      {
-        types: options?.types ?? "public_channel,private_channel",
-        exclude_archived: options?.excludeArchived ?? true,
-        limit: options?.limit ?? 200,
-        cursor,
-      },
+      slackUserId,
+      { limit: 200, cursor },
       signal,
     );
 
-    for (const ch of result.channels ?? []) {
-      if (ch.is_member && ch.id && ch.name) {
-        channels.push({ id: ch.id, name: ch.name });
-      }
-    }
-
-    cursor = result.response_metadata?.next_cursor;
+    channels.push(
+      ...result.channels.map((channel) => {
+        return { id: channel.id, name: channel.name };
+      }),
+    );
+    cursor = result.response_metadata?.next_cursor || undefined;
   } while (cursor);
 
   channels.sort((a, b) => {
@@ -196,6 +180,44 @@ export async function listConversations(
   });
 
   return channels;
+}
+
+export async function isSlackConversationShared(
+  token: string,
+  slackUserId: string,
+  conversationId: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const types = conversationId.startsWith("D")
+    ? "im"
+    : "public_channel,private_channel";
+  let cursor: string | undefined;
+
+  do {
+    const result = sharedConversationPageSchema.parse(
+      await callSlackApi<unknown>(
+        token,
+        "users.conversations",
+        {
+          user: slackUserId,
+          types,
+          limit: 200,
+          cursor,
+        },
+        signal,
+      ),
+    );
+    if (
+      result.channels.some((channel) => {
+        return channel.id === conversationId;
+      })
+    ) {
+      return true;
+    }
+    cursor = result.response_metadata?.next_cursor || undefined;
+  } while (cursor);
+
+  return false;
 }
 
 interface SlackFileInfo {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-read.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-read.test.ts
@@ -14,17 +14,24 @@ import { signSandboxJwtForTests } from "../../auth/tokens";
 import { integrationsSlackReadRoutes } from "../integrations-slack-read";
 import type { ApiTestUser } from "./helpers/api-bdd";
 import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
-import { seedSlackOrgInstallation$ } from "./helpers/integrations-slack";
+import {
+  seedSlackOrgConnection$,
+  seedSlackOrgInstallation$,
+} from "./helpers/integrations-slack";
 import { seedOrgMembership$ } from "./helpers/org-membership";
 
 const context = testContext();
 const store = createStore();
 const connectors = createConnectorBddApi(context);
+const SLACK_USER_CONVERSATIONS_URL =
+  "https://slack.com/api/users.conversations";
+const SLACK_HISTORY_URL = "https://slack.com/api/conversations.history";
 
 async function fixture(
   options: {
     enabled?: boolean;
     installed?: boolean;
+    connected?: boolean;
     capabilities?: readonly Capability[];
   } = {},
 ) {
@@ -53,6 +60,17 @@ async function fixture(
           { orgId, botToken },
           context.signal,
         );
+  const connection =
+    installation && options.connected !== false
+      ? await store.set(
+          seedSlackOrgConnection$,
+          {
+            slackWorkspaceId: installation.slackWorkspaceId,
+            userId,
+          },
+          context.signal,
+        )
+      : null;
   const seconds = Math.floor(now() / 1000);
   const token = signSandboxJwtForTests({
     scope: "okou",
@@ -70,29 +88,38 @@ async function fixture(
     actor,
     botToken,
     installation,
+    slackUserId: connection?.slackUserId ?? null,
     headers: { authorization: `Bearer ${token}` },
   };
 }
 
+function allowSharedConversation(conversationId: string): void {
+  server.use(
+    http.get(SLACK_USER_CONVERSATIONS_URL, () => {
+      return HttpResponse.json({
+        ok: true,
+        channels: [{ id: conversationId }],
+        response_metadata: { next_cursor: "" },
+      });
+    }),
+  );
+}
+
 describe("Slack bot channel discovery and history", () => {
-  it("lists unjoined public channels and joined private channels using the current org's bot", async () => {
-    const { client, headers, botToken, installation } = await fixture();
+  it("lists only channels shared by the connected Slack user and bot", async () => {
+    const { client, headers, botToken, installation, slackUserId } =
+      await fixture();
     let requestedToken: string | null = null;
     let query: URLSearchParams | undefined;
     server.use(
-      http.get("https://slack.com/api/conversations.list", ({ request }) => {
+      http.get(SLACK_USER_CONVERSATIONS_URL, ({ request }) => {
         requestedToken = request.headers.get("authorization");
         query = new URL(request.url).searchParams;
         return HttpResponse.json({
           ok: true,
           channels: [
-            {
-              id: "C123",
-              name: "general",
-              is_private: false,
-              is_member: false,
-            },
-            { id: "C456", name: "private", is_private: true, is_member: true },
+            { id: "C123", name: "general", is_private: false },
+            { id: "C456", name: "private", is_private: true },
           ],
           response_metadata: { next_cursor: "next-page" },
         });
@@ -109,6 +136,7 @@ describe("Slack bot channel discovery and history", () => {
     expect(Object.fromEntries(query ?? [])).toStrictEqual({
       limit: "20",
       cursor: "previous-page",
+      user: slackUserId,
       types: "public_channel,private_channel",
       exclude_archived: "true",
     });
@@ -118,7 +146,7 @@ describe("Slack bot channel discovery and history", () => {
           id: "C123",
           name: "general",
           isPrivate: false,
-          isMember: false,
+          isMember: true,
           channelUrl: `https://slack.com/app_redirect?team=${installation?.slackWorkspaceId}&channel=C123`,
         },
         {
@@ -136,7 +164,7 @@ describe("Slack bot channel discovery and history", () => {
   it("preserves continuation for an empty channel page", async () => {
     const { client, headers } = await fixture();
     server.use(
-      http.get("https://slack.com/api/conversations.list", () => {
+      http.get(SLACK_USER_CONVERSATIONS_URL, () => {
         return HttpResponse.json({
           ok: true,
           channels: [],
@@ -154,10 +182,28 @@ describe("Slack bot channel discovery and history", () => {
     });
   });
 
-  it.each(["C123", "G123", "D123"])(
-    "reads one page from %s and preserves time bounds and metadata",
-    async (channel) => {
-      const { client, headers, botToken } = await fixture();
+  it("requires the current Okou user to connect a Slack identity", async () => {
+    const { client, headers } = await fixture({ connected: false });
+
+    const response = await accept(
+      client.listChannels({ headers, query: { limit: 10 } }),
+      [404],
+    );
+
+    expect(response.body.error.message).toContain(
+      "Slack account is not connected",
+    );
+  });
+
+  it.each([
+    ["C123", "public_channel,private_channel"],
+    ["G123", "public_channel,private_channel"],
+    ["D123", "im"],
+  ])(
+    "authorizes shared conversation %s before reading one history page",
+    async (channel, expectedTypes) => {
+      const { client, headers, botToken, slackUserId } = await fixture();
+      let membershipQuery: URLSearchParams | undefined;
       let received: URLSearchParams | undefined;
       let requestedToken: string | null = null;
       const messages = [
@@ -172,19 +218,24 @@ describe("Slack bot channel discovery and history", () => {
         },
       ];
       server.use(
-        http.get(
-          "https://slack.com/api/conversations.history",
-          ({ request }) => {
-            received = new URL(request.url).searchParams;
-            requestedToken = request.headers.get("authorization");
-            return HttpResponse.json({
-              ok: true,
-              messages,
-              has_more: true,
-              response_metadata: { next_cursor: "next+page=" },
-            });
-          },
-        ),
+        http.get(SLACK_USER_CONVERSATIONS_URL, ({ request }) => {
+          membershipQuery = new URL(request.url).searchParams;
+          return HttpResponse.json({
+            ok: true,
+            channels: [{ id: channel }],
+            response_metadata: { next_cursor: "" },
+          });
+        }),
+        http.get(SLACK_HISTORY_URL, ({ request }) => {
+          received = new URL(request.url).searchParams;
+          requestedToken = request.headers.get("authorization");
+          return HttpResponse.json({
+            ok: true,
+            messages,
+            has_more: true,
+            response_metadata: { next_cursor: "next+page=" },
+          });
+        }),
       );
       const response = await accept(
         client.history({
@@ -199,6 +250,11 @@ describe("Slack bot channel discovery and history", () => {
         }),
         [200],
       );
+      expect(Object.fromEntries(membershipQuery ?? [])).toStrictEqual({
+        user: slackUserId,
+        types: expectedTypes,
+        limit: "200",
+      });
       expect(Object.fromEntries(received ?? [])).toStrictEqual({
         channel,
         limit: "15",
@@ -216,8 +272,72 @@ describe("Slack bot channel discovery and history", () => {
     },
   );
 
-  it("returns an actionable channel URL when the bot has not joined", async () => {
+  it("continues shared-membership pagination before reading history", async () => {
+    const { client, headers } = await fixture();
+    const membershipCursors: (string | null)[] = [];
+    server.use(
+      http.get(SLACK_USER_CONVERSATIONS_URL, ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get("cursor");
+        membershipCursors.push(cursor);
+        return cursor
+          ? HttpResponse.json({
+              ok: true,
+              channels: [{ id: "CTARGET" }],
+              response_metadata: { next_cursor: "" },
+            })
+          : HttpResponse.json({
+              ok: true,
+              channels: [{ id: "COTHER" }],
+              response_metadata: { next_cursor: "membership-page-2" },
+            });
+      }),
+      http.get(SLACK_HISTORY_URL, () => {
+        return HttpResponse.json({ ok: true, messages: [] });
+      }),
+    );
+
+    const response = await accept(
+      client.history({ headers, query: { channel: "CTARGET", limit: 15 } }),
+      [200],
+    );
+
+    expect(response.body.messages).toStrictEqual([]);
+    expect(membershipCursors).toStrictEqual([null, "membership-page-2"]);
+  });
+
+  it("does not read a bot DM that is not shared with the connected user", async () => {
+    const { client, headers } = await fixture();
+    let historyRequested = false;
+    server.use(
+      http.get(SLACK_USER_CONVERSATIONS_URL, () => {
+        return HttpResponse.json({
+          ok: true,
+          channels: [],
+          response_metadata: { next_cursor: "" },
+        });
+      }),
+      http.get(SLACK_HISTORY_URL, () => {
+        historyRequested = true;
+        return HttpResponse.json({ ok: true, messages: [] });
+      }),
+    );
+
+    const response = await accept(
+      client.history({ headers, query: { channel: "DOTHER", limit: 15 } }),
+      [404],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      code: "NOT_FOUND",
+      message:
+        "This Slack conversation does not exist or is not shared by your connected Slack account and Okou.",
+    });
+    expect(historyRequested).toBeFalsy();
+  });
+
+  it("returns an actionable channel URL if the bot leaves after authorization", async () => {
     const { client, headers, installation } = await fixture();
+    allowSharedConversation("C123");
     server.use(
       http.get("https://slack.com/api/conversations.history", () => {
         return HttpResponse.json({ ok: false, error: "not_in_channel" });
@@ -237,6 +357,7 @@ describe("Slack bot channel discovery and history", () => {
 
   it("does not claim an inaccessible channel is known to exist", async () => {
     const { client, headers } = await fixture();
+    allowSharedConversation("C123");
     server.use(
       http.get("https://slack.com/api/conversations.history", () => {
         return HttpResponse.json({ ok: false, error: "channel_not_found" });
@@ -256,6 +377,7 @@ describe("Slack bot channel discovery and history", () => {
     "does not suggest channel invitations for inaccessible DMs (%s)",
     async (error) => {
       const { client, headers } = await fixture();
+      allowSharedConversation("D123");
       server.use(
         http.get("https://slack.com/api/conversations.history", () => {
           return HttpResponse.json({ ok: false, error });
@@ -273,14 +395,14 @@ describe("Slack bot channel discovery and history", () => {
     },
   );
 
-  it("distinguishes missing bot scopes from bot membership", async () => {
+  it("reports a missing scope while checking shared DM membership", async () => {
     const { client, headers } = await fixture();
     server.use(
-      http.get("https://slack.com/api/conversations.history", () => {
+      http.get(SLACK_USER_CONVERSATIONS_URL, () => {
         return HttpResponse.json({
           ok: false,
           error: "missing_scope",
-          needed: "im:history",
+          needed: "im:read",
         });
       }),
     );
@@ -296,6 +418,7 @@ describe("Slack bot channel discovery and history", () => {
 
   it("propagates Slack's retry duration instead of retrying in the request", async () => {
     const { client, headers } = await fixture();
+    allowSharedConversation("C123");
     server.use(
       http.get("https://slack.com/api/conversations.history", () => {
         return new HttpResponse(null, {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-status.test.ts
@@ -402,6 +402,7 @@ describe("GET /api/integrations/slack", () => {
       "groups:read",
       "groups:history",
       "im:history",
+      "im:read",
       "im:write",
       "commands",
       "users:read",

--- a/turbo/apps/api/src/signals/routes/__tests__/slack-channels.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/slack-channels.test.ts
@@ -7,7 +7,7 @@ import { createBddIntegrationApi } from "./helpers/api-bdd-integrations";
 const context = testContext();
 const integrations = createBddIntegrationApi(context);
 
-const SLACK_LIST_URL = "https://slack.com/api/conversations.list";
+const SLACK_LIST_URL = "https://slack.com/api/users.conversations";
 
 describe("GET /api/slack/channels", () => {
   it("returns 401 when the request is unauthenticated", async () => {
@@ -43,20 +43,21 @@ describe("GET /api/slack/channels", () => {
     });
   });
 
-  it("returns channels where the bot is a member", async () => {
+  it("returns channels shared by the connected user and bot", async () => {
     const actor = integrations.user();
     integrations.configureSlackAppMocks();
-    await integrations.installSlackWorkspace(actor);
+    const installation = await integrations.installSlackWorkspace(actor);
+    let query: URLSearchParams | undefined;
 
     server.use(
-      http.get(SLACK_LIST_URL, () => {
+      http.get(SLACK_LIST_URL, ({ request }) => {
+        query = new URL(request.url).searchParams;
         return HttpResponse.json({
           ok: true,
           channels: [
-            { id: "C001", name: "general", is_member: true },
-            { id: "C002", name: "random", is_member: true },
-            { id: "C003", name: "not-joined", is_member: false },
-            { id: "C004", name: "alpha", is_member: true },
+            { id: "C001", name: "general", is_private: false },
+            { id: "C002", name: "random", is_private: false },
+            { id: "C004", name: "alpha", is_private: true },
           ],
           response_metadata: { next_cursor: "" },
         });
@@ -65,12 +66,40 @@ describe("GET /api/slack/channels", () => {
 
     const response = await integrations.requestListSlackChannels(actor, [200]);
 
+    expect(Object.fromEntries(query ?? [])).toStrictEqual({
+      limit: "200",
+      user: installation.installerSlackUserId,
+      types: "public_channel,private_channel",
+      exclude_archived: "true",
+    });
     expect(response.body).toStrictEqual({
       channels: [
         { id: "C004", name: "alpha" },
         { id: "C001", name: "general" },
         { id: "C002", name: "random" },
       ],
+    });
+  });
+
+  it("returns 404 when the current user has not connected Slack", async () => {
+    const installer = integrations.user();
+    const disconnected = integrations.user({
+      orgId: installer.orgId,
+      orgRole: "org:member",
+    });
+    integrations.configureSlackAppMocks();
+    await integrations.installSlackWorkspace(installer);
+
+    const response = await integrations.requestListSlackChannels(
+      disconnected,
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "No Slack account connected for this user",
+        code: "NOT_FOUND",
+      },
     });
   });
 
@@ -87,13 +116,13 @@ describe("GET /api/slack/channels", () => {
         if (!cursor) {
           return HttpResponse.json({
             ok: true,
-            channels: [{ id: "C001", name: "page-one", is_member: true }],
+            channels: [{ id: "C001", name: "page-one", is_private: false }],
             response_metadata: { next_cursor: "cursor_page2" },
           });
         }
         return HttpResponse.json({
           ok: true,
-          channels: [{ id: "C002", name: "page-two", is_member: true }],
+          channels: [{ id: "C002", name: "page-two", is_private: false }],
           response_metadata: { next_cursor: "" },
         });
       }),
@@ -110,7 +139,7 @@ describe("GET /api/slack/channels", () => {
     expect(callCount).toBe(2);
   });
 
-  it("returns an empty array when no channels have bot membership", async () => {
+  it("returns an empty array when the user and bot share no channels", async () => {
     const actor = integrations.user();
     integrations.configureSlackAppMocks();
     await integrations.installSlackWorkspace(actor);
@@ -119,7 +148,7 @@ describe("GET /api/slack/channels", () => {
       http.get(SLACK_LIST_URL, () => {
         return HttpResponse.json({
           ok: true,
-          channels: [{ id: "C001", name: "no-bot", is_member: false }],
+          channels: [],
           response_metadata: { next_cursor: "" },
         });
       }),

--- a/turbo/apps/api/src/signals/routes/__tests__/slack-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/slack-oauth.test.ts
@@ -174,6 +174,7 @@ describe("Slack OAuth API routes", () => {
       expect(scopes).not.toContain("assistant:write");
       expect(scopes).toContain("channels:history");
       expect(scopes).toContain("im:history");
+      expect(scopes).toContain("im:read");
       expect(scopes).toContain("commands");
       expect(scopes).toContain("users:read");
       expect(scopes).toContain("files:read");

--- a/turbo/apps/api/src/signals/routes/integrations-slack-read.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-slack-read.ts
@@ -6,7 +6,8 @@ import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import {
   isSlackApiClientError,
-  listSlackChannelsPage,
+  isSlackConversationShared,
+  listSharedSlackChannelsPage,
   readSlackHistoryPage,
 } from "../../lib/slack-client";
 import { OFFICIAL_SLACK_APP_NAME } from "../../lib/slack-official-app";
@@ -14,7 +15,7 @@ import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { queryOf } from "../context/request";
 import { userFeatureSwitchContext } from "../services/feature-switches.service";
-import { slackOrgInstallation } from "../services/slack-data.service";
+import { slackUserInstallation } from "../services/slack-data.service";
 import type { RouteEntry } from "../route-entry";
 import { settle } from "../utils";
 
@@ -30,15 +31,21 @@ const readInstallation$ = computed(async (get) => {
     );
   }
   const installation = await get(
-    slackOrgInstallation({ orgId: auth.orgId, userId: auth.userId }),
+    slackUserInstallation({ orgId: auth.orgId, userId: auth.userId }),
   );
-  return (
-    installation ??
-    createErrorResponse(
+  if (installation.kind === "not-installed") {
+    return createErrorResponse(
       "NOT_FOUND",
       "No Slack installation found for this organization. Install Okou from Settings > Slack first.",
-    )
-  );
+    );
+  }
+  if (installation.kind === "not-connected") {
+    return createErrorResponse(
+      "NOT_FOUND",
+      "Your Slack account is not connected to this organization. Connect it from Settings > Slack before reading conversations.",
+    );
+  }
+  return installation;
 });
 
 function channelLink(workspaceId: string, channel: string): string {
@@ -143,7 +150,12 @@ const listChannels$ = command(async ({ get }, signal: AbortSignal) => {
   }
 
   const result = await settle(
-    listSlackChannelsPage(installation.botToken, query, signal),
+    listSharedSlackChannelsPage(
+      installation.botToken,
+      installation.slackUserId,
+      query,
+      signal,
+    ),
   );
   signal.throwIfAborted();
   if (!result.ok) {
@@ -157,7 +169,7 @@ const listChannels$ = command(async ({ get }, signal: AbortSignal) => {
           id: channel.id,
           name: channel.name,
           isPrivate: channel.is_private,
-          isMember: channel.is_member,
+          isMember: true,
           channelUrl: channelLink(installation.workspaceId, channel.id),
         };
       }),
@@ -172,6 +184,25 @@ const history$ = command(async ({ get }, signal: AbortSignal) => {
   signal.throwIfAborted();
   if ("status" in installation) {
     return installation;
+  }
+
+  const shared = await settle(
+    isSlackConversationShared(
+      installation.botToken,
+      installation.slackUserId,
+      query.channel,
+      signal,
+    ),
+  );
+  signal.throwIfAborted();
+  if (!shared.ok) {
+    return slackReadError(shared.error);
+  }
+  if (!shared.value) {
+    return createErrorResponse(
+      "NOT_FOUND",
+      "This Slack conversation does not exist or is not shared by your connected Slack account and Okou.",
+    );
   }
 
   const channelUrl = channelLink(installation.workspaceId, query.channel);

--- a/turbo/apps/api/src/signals/routes/slack-channels.ts
+++ b/turbo/apps/api/src/signals/routes/slack-channels.ts
@@ -1,9 +1,10 @@
 import { computed } from "ccstate";
 import { slackChannelsContract } from "@okouai/api-contracts/contracts/slack-channels";
 
+import { listSharedSlackChannels } from "../../lib/slack-client";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { slackChannels } from "../services/slack-data.service";
+import { slackUserInstallation } from "../services/slack-data.service";
 import type { RouteEntry } from "../route-entry";
 
 const slackInstallationNotFound = Object.freeze({
@@ -16,17 +17,34 @@ const slackInstallationNotFound = Object.freeze({
   }),
 });
 
+const slackConnectionNotFound = Object.freeze({
+  status: 404 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "No Slack account connected for this user",
+      code: "NOT_FOUND",
+    }),
+  }),
+});
+
 const getSlackChannelsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
-  const channels = await get(
-    slackChannels({ orgId: auth.orgId, userId: auth.userId }),
+  const installation = await get(
+    slackUserInstallation({ orgId: auth.orgId, userId: auth.userId }),
   );
-  if (channels === null) {
+  if (installation.kind === "not-installed") {
     return slackInstallationNotFound;
   }
+  if (installation.kind === "not-connected") {
+    return slackConnectionNotFound;
+  }
+  const channels = await listSharedSlackChannels(
+    installation.botToken,
+    installation.slackUserId,
+  );
   return {
     status: 200 as const,
-    body: { channels: [...channels] },
+    body: { channels },
   };
 });
 

--- a/turbo/apps/api/src/signals/routes/test-slack-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-state.ts
@@ -58,6 +58,7 @@ const SLACK_BOT_SCOPES = JSON.stringify([
   "groups:read",
   "groups:history",
   "im:history",
+  "im:read",
   "im:write",
   "commands",
   "users:read",

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -482,7 +482,7 @@ function buildAgentToolsPrompt(args: {
     "- Slack messages: when the task explicitly asks to send or post to Slack, use `okou slack message send --help` for channels, DMs, and thread replies.",
     ...(args.slackReadEnabled
       ? [
-          "- Slack channel discovery and history: use `okou slack channel list --help` to find channel IDs and bot membership, then `okou slack message history --help` to read channel or bot DM history.",
+          "- Slack channel discovery and history: use `okou slack channel list --help` to find channels shared by the connected user and bot, then `okou slack message history --help` to read shared channel or bot DM history.",
         ]
       : []),
     "- Feishu messages: when the task explicitly asks to send or post to Feishu, use `okou feishu message send --help` for chats, DMs, and replies.",

--- a/turbo/apps/api/src/signals/services/slack-data.service.ts
+++ b/turbo/apps/api/src/signals/services/slack-data.service.ts
@@ -8,7 +8,6 @@ import { and, eq } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { db$ } from "../external/db";
-import { listConversations } from "../../lib/slack-client";
 import { decryptPersistentSecretValue } from "./crypto.utils";
 import type { ApiOrgRole } from "../../types/auth";
 import { userFeatureSwitchContext } from "./feature-switches.service";
@@ -21,6 +20,7 @@ export const SLACK_BOT_SCOPES: readonly string[] = [
   "groups:read",
   "groups:history",
   "im:history",
+  "im:read",
   "im:write",
   "commands",
   "users:read",
@@ -259,22 +259,60 @@ export function slackOrgInstallation(args: {
   });
 }
 
-interface SlackChannel {
-  readonly id: string;
-  readonly name: string;
-}
-
-export function slackChannels(args: {
+export function slackUserInstallation(args: {
   readonly orgId: string;
-  readonly userId?: string;
-}): Computed<Promise<readonly SlackChannel[] | null>> {
+  readonly userId: string;
+}): Computed<
+  Promise<
+    | {
+        readonly kind: "connected";
+        readonly workspaceId: string;
+        readonly botToken: string;
+        readonly workspaceName: string | null;
+        readonly slackUserId: string;
+      }
+    | { readonly kind: "not-installed" }
+    | { readonly kind: "not-connected" }
+  >
+> {
   return computed(async (get) => {
-    const installation = await get(slackOrgInstallation(args));
+    const db = get(db$);
+    const [installation] = await db
+      .select()
+      .from(slackOrgInstallations)
+      .where(eq(slackOrgInstallations.orgId, args.orgId))
+      .limit(1);
     if (!installation) {
-      return null;
+      return { kind: "not-installed" } as const;
     }
 
-    const channels = await listConversations(installation.botToken);
-    return channels;
+    const [connection] = await db
+      .select({ slackUserId: slackOrgConnections.slackUserId })
+      .from(slackOrgConnections)
+      .where(
+        and(
+          eq(slackOrgConnections.userId, args.userId),
+          eq(
+            slackOrgConnections.slackWorkspaceId,
+            installation.slackWorkspaceId,
+          ),
+        ),
+      )
+      .limit(1);
+    if (!connection) {
+      return { kind: "not-connected" } as const;
+    }
+
+    const botToken = await decryptPersistentSecretValue(
+      installation.encryptedBotToken,
+      await get(userFeatureSwitchContext(args.orgId, args.userId)),
+    );
+    return {
+      kind: "connected",
+      workspaceId: installation.slackWorkspaceId,
+      botToken,
+      workspaceName: installation.slackWorkspaceName ?? null,
+      slackUserId: connection.slackUserId,
+    } as const;
   });
 }

--- a/turbo/apps/cli/src/commands/slack/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/slack/__tests__/list.test.ts
@@ -16,7 +16,7 @@ describe("okou slack channel list", () => {
     listCommand.setOptionValue("limit", "100");
   });
 
-  it("shows unjoined public channels with their invitation destination", async () => {
+  it("shows a channel shared by the connected user and Okou", async () => {
     const channelUrl = "https://slack.com/app_redirect?team=T123&channel=C123";
     server.use(
       http.get(listUrl, () => {
@@ -26,7 +26,7 @@ describe("okou slack channel list", () => {
               id: "C123",
               name: "general",
               isPrivate: false,
-              isMember: false,
+              isMember: true,
               channelUrl,
             },
           ],
@@ -37,7 +37,7 @@ describe("okou slack channel list", () => {
     await listCommand.parseAsync(["node", "okou"]);
     const text = output.mock.calls.flat().join("\n");
     expect(text).toContain("#general");
-    expect(text).toContain("invite Okou first");
+    expect(text).toContain("shared");
     expect(text).toContain(channelUrl);
     expect(text).toContain("okou slack message history");
   });

--- a/turbo/apps/cli/src/commands/slack/channel/index.ts
+++ b/turbo/apps/cli/src/commands/slack/channel/index.ts
@@ -3,5 +3,5 @@ import { listCommand } from "./list";
 
 export const slackChannelCommand = new Command()
   .name("channel")
-  .description("Discover Slack channels and bot membership")
+  .description("Discover channels shared by your Slack account and Okou")
   .addCommand(listCommand);

--- a/turbo/apps/cli/src/commands/slack/channel/list.ts
+++ b/turbo/apps/cli/src/commands/slack/channel/list.ts
@@ -6,7 +6,7 @@ import { withErrorHandler } from "../../../lib/command/with-error-handler";
 export const listCommand = new Command()
   .name("list")
   .alias("ls")
-  .description("List public channels and private channels visible to the bot")
+  .description("List channels shared by your Slack account and Okou")
   .option("--limit <count>", "Maximum channels in one page (1-200)", "100")
   .option("--cursor <cursor>", "Continue from a previous page's nextCursor")
   .option("--json", "Print the response as JSON")
@@ -19,10 +19,10 @@ Examples:
   okou slack channel list --cursor <next-cursor>
 
 Notes:
-  - Public channels include channels the bot has not joined. Private channels are visible only after the bot joins.
+  - Only channels joined by both your connected Slack account and Okou are listed.
   - Archived channels are excluded. This command does not list DMs or join channels.
+  - To make another channel readable, add Okou via the channel name > Agents & apps.
   - Use the returned channel ID with okou slack message history --channel <id>.
-  - For an unjoined channel, open its link and add Okou via the channel name > Agents & apps.
   - Requires slack:read. Each call reads one page; an empty page can still have a nextCursor.`,
   )
   .action(
@@ -45,12 +45,12 @@ Notes:
         }
         if (result.channels.length === 0) {
           console.log(
-            "No channels on this page. Private channels appear after Okou is invited.",
+            "No shared channels on this page. Make sure your Slack account is connected and Okou has joined the channel.",
           );
         }
         for (const channel of result.channels) {
           console.log(
-            `${channel.id}  #${channel.name}  ${channel.isPrivate ? "private" : "public"}  ${channel.isMember ? "joined" : "invite Okou first"}`,
+            `${channel.id}  #${channel.name}  ${channel.isPrivate ? "private" : "public"}  ${channel.isMember ? "shared" : "Okou not joined"}`,
           );
           console.log(channel.channelUrl);
         }

--- a/turbo/apps/cli/src/commands/slack/message/history.ts
+++ b/turbo/apps/cli/src/commands/slack/message/history.ts
@@ -5,7 +5,7 @@ import { withErrorHandler } from "../../../lib/command/with-error-handler";
 
 export const historyCommand = new Command()
   .name("history")
-  .description("Read one page of channel or bot direct-message history")
+  .description("Read shared channel or bot direct-message history")
   .requiredOption(
     "-c, --channel <id>",
     "Channel ID or bot DM conversation ID (D...)",
@@ -36,13 +36,14 @@ Examples:
   okou slack message history --channel C012345 --cursor <next-cursor>
 
 Notes:
-  - Requires slack:read and uses the organization's Slack bot. The bot must belong to the conversation.
-  - IM history is limited to single-user conversations with the bot, identified by a D-prefixed ID, not a user ID.
+  - Requires slack:read and uses the organization's Slack bot.
+  - Both your connected Slack account and Okou must belong to the conversation.
+  - IM history is limited to your single-user conversation with the bot, identified by a D-prefixed ID, not a user ID.
   - To find a bot DM's ID, open its details in Slack and copy the conversation ID or link.
   - Channel history contains conversation messages; thread replies are not expanded. Use --json to retain blocks, files and thread metadata.
   - Results are newest first. Each call reads one page. Keep the channel and time filters when continuing with --cursor.
   - If Slack rate limits a request, wait for the returned Retry-After duration before retrying.
-  - If the bot has not joined a channel, open the returned channel link, add Okou via Agents & apps, and retry.`,
+  - To make a channel readable, join it in Slack and add Okou via the channel name > Agents & apps.`,
   )
   .action(
     withErrorHandler(

--- a/turbo/packages/api-contracts/src/contracts/integrations-slack-read.ts
+++ b/turbo/packages/api-contracts/src/contracts/integrations-slack-read.ts
@@ -69,7 +69,7 @@ const slackHistoryResponseSchema = z.object({
   nextCursor: z.string().nullable(),
 });
 
-/** Organization bot reads, authorized by the slack:read run capability. */
+/** Reads shared by the connected Slack user and organization bot. */
 export const integrationsSlackReadContract = c.router({
   listChannels: {
     method: "GET",
@@ -85,7 +85,7 @@ export const integrationsSlackReadContract = c.router({
       429: slackReadErrorSchema,
       502: slackReadErrorSchema,
     },
-    summary: "List public channels and private channels visible to the bot",
+    summary: "List channels shared by the connected Slack user and bot",
   },
   history: {
     method: "GET",
@@ -101,7 +101,7 @@ export const integrationsSlackReadContract = c.router({
       429: slackReadErrorSchema,
       502: slackReadErrorSchema,
     },
-    summary: "Read one page of channel or bot direct-message history",
+    summary: "Read shared channel or bot direct-message history",
   },
 });
 

--- a/turbo/packages/api-contracts/src/contracts/slack-channels.ts
+++ b/turbo/packages/api-contracts/src/contracts/slack-channels.ts
@@ -11,7 +11,7 @@ const slackChannelSchema = z.object({
 
 /**
  * Slack channels contract (GET /api/slack/channels)
- * Lists Slack channels where the bot is a member.
+ * Lists Slack channels shared by the connected user and bot.
  */
 export const slackChannelsContract = c.router({
   list: {
@@ -23,7 +23,7 @@ export const slackChannelsContract = c.router({
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
-    summary: "List Slack channels where bot is a member",
+    summary: "List Slack channels shared by connected user and bot",
   },
 });
 


### PR DESCRIPTION
## Summary

- Require the requesting Okou user to have a Slack identity connected to the organization before decrypting the organization bot token.
- List channels through Slack's [`users.conversations`](https://docs.slack.dev/reference/methods/users.conversations/) bot-token contract with the connected Slack user ID, so both channel-list APIs expose only conversations shared by that user and the Okou bot.
- Authorize every direct `C`, `G`, or `D` history request against the same shared-conversation boundary before calling `conversations.history`; return a generic `404` without reading history when the conversation is absent or not shared.
- Add the minimal `im:read` bot scope needed to verify direct-message membership, and update CLI/API guidance without changing the existing response shape or Slack write behavior.

## Rollout

- Existing installations can continue checking public and private channel membership with their current `channels:read` and `groups:read` scopes.
- Direct-message membership checks fail closed until an admin reauthorizes an older installation with `im:read`; the existing scope-mismatch status exposes the reinstall URL.
- No database migration is required.

## Verification

- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/integrations-slack-read.test.ts src/signals/routes/__tests__/slack-channels.test.ts src/signals/routes/__tests__/integrations-slack-status.test.ts src/signals/routes/__tests__/slack-oauth.test.ts` — 91 passed
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t 'advertises Slack bot reads only while the feature is enabled'` — 1 passed
- `pnpm -F @okouai/cli exec vitest run src/commands/slack/__tests__/list.test.ts src/commands/slack/__tests__/history.test.ts` — 7 passed
- `TSC_CHECKERS=1 pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F @okouai/cli check-types && pnpm -F @okouai/cli lint`
- `pnpm -F @okouai/api-contracts check-types && pnpm -F @okouai/api-contracts lint`
- `pnpm knip --production --strict --include files,exports --workspace api --workspace @okouai/cli --workspace @okouai/api-contracts`
- Prettier and `git diff --check`

## Fallbacks

None. Missing identity, membership, and OAuth-scope states fail closed.
