### PR TITLE
fix(runner): attribute guest dns readiness attempts

### DIFF
--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -200,6 +200,10 @@ struct FreshSandboxStartObserver<'a> {
 }
 
 impl SandboxStartObserver for FreshSandboxStartObserver<'_> {
+    fn record_dns_readiness_attempt(&mut self, attempt: sandbox::SandboxDnsReadinessAttempt) {
+        self.telemetry.record_dns_readiness_attempt(attempt);
+    }
+
     fn record_stage(&mut self, stage: SandboxStartStage, duration: Duration, success: bool) {
         let error = (!success).then_some(SANDBOX_START_STAGE_FAILED);
         self.telemetry.record(

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -382,6 +382,30 @@ impl Sandbox for ObservedStartSandbox {
                 continue;
             }
             let success = self.failed_stage != Some(stage);
+            if stage == SandboxStartStage::GuestDnsReadiness {
+                for (attempt, duration, guest_duration_ms, outcome) in [
+                    (1, 4, 0, sandbox::SandboxDnsReadinessOutcome::ProcessTimeout),
+                    (
+                        2,
+                        9,
+                        6,
+                        if success {
+                            sandbox::SandboxDnsReadinessOutcome::Success
+                        } else {
+                            sandbox::SandboxDnsReadinessOutcome::WaitFailed
+                        },
+                    ),
+                ] {
+                    observer.record_dns_readiness_attempt(sandbox::SandboxDnsReadinessAttempt {
+                        attempt,
+                        final_attempt: attempt == 2,
+                        duration: Duration::from_millis(duration),
+                        guest_duration_ms: Some(guest_duration_ms),
+                        outcome,
+                        completed_at: std::time::SystemTime::now(),
+                    });
+                }
+            }
             observer.record_stage(stage, Duration::from_millis(index as u64 + 30), success);
             if !success {
                 return Err(SandboxError::Start {
@@ -1594,6 +1618,48 @@ async fn execute_job_records_exact_reuse_speculation_timing() {
 }
 
 #[tokio::test]
+async fn execute_job_keeps_dns_attempt_failures_inside_the_successful_start() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let factory = ObservedMockSandboxFactory::new();
+    let (_outcome, telemetry) = execute_job(
+        &factory,
+        minimal_context(),
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await;
+    let attempts: Vec<_> = telemetry
+        .pending_ops_with_duration_snapshot()
+        .into_iter()
+        .filter(|(action, _, _, _)| {
+            action == "runner_fresh_sandbox_start_guest_dns_readiness_attempt"
+        })
+        .map(|(_, duration, success, error)| (duration, success, error))
+        .collect();
+    assert_eq!(
+        attempts,
+        vec![(4, false, Some("process_timeout".into())), (9, true, None)]
+    );
+    assert_action_duration(
+        &telemetry,
+        "runner_fresh_sandbox_start_guest_dns_readiness",
+        33,
+    );
+    assert_action_success(
+        &telemetry,
+        "runner_fresh_sandbox_start_guest_dns_readiness",
+        true,
+    );
+    assert_action_success(&telemetry, "runner_agent_start_process", true);
+}
+
+#[tokio::test]
 async fn execute_job_omits_inapplicable_sandbox_start_stages() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
@@ -1625,6 +1691,10 @@ async fn execute_job_omits_inapplicable_sandbox_start_stages() {
         "runner_fresh_sandbox_start_snapshot_load_resume",
     );
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_start_guest_dns_readiness");
+    assert_lacks_action(
+        &telemetry,
+        "runner_fresh_sandbox_start_guest_dns_readiness_attempt",
+    );
     assert_action_success(&telemetry, "runner_fresh_sandbox_start", true);
 }
 

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -23,6 +23,7 @@ pub(crate) use session_history::{
     SessionHistoryTransferEncodingState, session_history_prefix_extension_action_type,
 };
 
+mod dns_readiness;
 mod session_history;
 
 /// How long before we auto-flush pending ops (matching TS: 30s).
@@ -219,6 +220,8 @@ struct SandboxOp {
     runner_resource_budget_lease_count_bucket: Option<RunnerResourceBudgetLeaseCountBucket>,
     #[serde(flatten)]
     session_history: Option<SessionHistoryTelemetryFields>,
+    #[serde(flatten)]
+    dns_readiness: Option<dns_readiness::DnsReadinessTelemetryFields>,
 }
 
 #[derive(Serialize)]
@@ -702,6 +705,7 @@ fn sandbox_op_at(
         runner_resource_budget_memory_utilization_bucket: None,
         runner_resource_budget_lease_count_bucket: None,
         session_history: metadata.map(SessionHistoryTelemetryFields::from),
+        dns_readiness: None,
     }
 }
 
@@ -780,7 +784,7 @@ mod tests {
         http_client_for_api_url("http://localhost")
     }
 
-    fn http_client_for_api_url(api_url: &str) -> HttpClient {
+    pub(super) fn http_client_for_api_url(api_url: &str) -> HttpClient {
         HttpClient::new(HttpClientConfig {
             api_url: api_url.to_string(),
             vercel_bypass: None,
@@ -818,6 +822,7 @@ mod tests {
             runner_resource_budget_memory_utilization_bucket: None,
             runner_resource_budget_lease_count_bucket: None,
             session_history: None,
+            dns_readiness: None,
         };
         let json = serde_json::to_value(&op).unwrap();
         assert_eq!(
@@ -1043,6 +1048,7 @@ mod tests {
                 runner_resource_budget_memory_utilization_bucket: None,
                 runner_resource_budget_lease_count_bucket: None,
                 session_history: Some(metadata.into()),
+                dns_readiness: None,
             }],
         };
         let json = serde_json::to_value(&payload).unwrap();

--- a/crates/runner/src/telemetry/dns_readiness.rs
+++ b/crates/runner/src/telemetry/dns_readiness.rs
@@ -1,0 +1,125 @@
+use sandbox::{SandboxDnsReadinessAttempt, SandboxDnsReadinessOutcome};
+use serde::Serialize;
+
+use super::{JobTelemetry, sandbox_op_at};
+use crate::duration::duration_ms;
+
+#[derive(Clone, Serialize)]
+pub(super) struct DnsReadinessTelemetryFields {
+    dns_readiness_attempt: u16,
+    dns_readiness_final_attempt: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dns_readiness_guest_duration_ms: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dns_readiness_host_residual_ms: Option<u64>,
+    dns_readiness_timing: &'static str,
+}
+
+impl JobTelemetry {
+    pub(crate) fn record_dns_readiness_attempt(&mut self, attempt: SandboxDnsReadinessAttempt) {
+        // Subtract only a complete same-attempt pair at the telemetry's integer
+        // millisecond resolution. This residual is not pure transport latency.
+        let residual = attempt
+            .guest_duration_ms
+            .and_then(|guest| duration_ms(attempt.duration).checked_sub(u64::from(guest)));
+        let timing = match (attempt.guest_duration_ms, residual) {
+            (None, _) => "unavailable",
+            (Some(_), None) => "inconsistent",
+            (Some(_), Some(_)) => "paired",
+        };
+        let success = attempt.outcome == SandboxDnsReadinessOutcome::Success;
+        let mut operation = sandbox_op_at(
+            "runner_fresh_sandbox_start_guest_dns_readiness_attempt",
+            attempt.duration,
+            success,
+            (!success).then_some(attempt.outcome.as_str()),
+            Some(attempt.outcome.as_str()),
+            None,
+            attempt.completed_at.into(),
+        );
+        operation.dns_readiness = Some(DnsReadinessTelemetryFields {
+            dns_readiness_attempt: attempt.attempt,
+            dns_readiness_final_attempt: attempt.final_attempt,
+            dns_readiness_guest_duration_ms: attempt.guest_duration_ms,
+            dns_readiness_host_residual_ms: residual,
+            dns_readiness_timing: timing,
+        });
+        self.push_operation(operation);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, SystemTime};
+
+    use super::*;
+    use crate::ids::RunId;
+    use crate::telemetry::tests::http_client_for_api_url;
+    use crate::test_fixtures::raw_http::{RawHttpAction, RawHttpTestServer, json_response};
+
+    #[tokio::test]
+    async fn dns_readiness_flush_preserves_numeric_pairs_and_missing_measurements() {
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(json_response(
+            "200 OK",
+            r#"{"success":true}"#,
+        ))])
+        .await;
+        let mut telemetry = JobTelemetry::new(
+            http_client_for_api_url(&server.url()),
+            RunId::nil(),
+            "test-token".into(),
+            None,
+        );
+        for (duration, guest, outcome) in [
+            (10, Some(3), SandboxDnsReadinessOutcome::Success),
+            (0, Some(0), SandboxDnsReadinessOutcome::ProcessTimeout),
+            (2, Some(10), SandboxDnsReadinessOutcome::Success),
+            (4, None, SandboxDnsReadinessOutcome::Deadline),
+            (5, None, SandboxDnsReadinessOutcome::HostCancelled),
+        ] {
+            telemetry.record_dns_readiness_attempt(SandboxDnsReadinessAttempt {
+                attempt: 1,
+                final_attempt: outcome != SandboxDnsReadinessOutcome::ProcessTimeout,
+                duration: Duration::from_millis(duration),
+                guest_duration_ms: guest,
+                outcome,
+                completed_at: SystemTime::UNIX_EPOCH + Duration::from_secs(1_788_864_000),
+            });
+        }
+        telemetry.flush().await;
+        let request = server.next_request("DNS attempt telemetry").await;
+        assert!(request.starts_with("POST /api/webhooks/agent/telemetry "));
+        let (_, body) = request.split_once("\r\n\r\n").unwrap();
+        let payload: serde_json::Value = serde_json::from_str(body).unwrap();
+        let ops = payload["sandboxOperations"].as_array().unwrap();
+        assert_eq!(ops.len(), 5);
+        for op in ops {
+            assert_eq!(op["ts"], "2026-09-08T10:40:00.000Z");
+            assert_eq!(
+                op["action_type"],
+                "runner_fresh_sandbox_start_guest_dns_readiness_attempt"
+            );
+            assert_eq!(op["dns_readiness_attempt"], 1);
+        }
+        assert_eq!(ops[0]["duration_ms"], 10);
+        assert_eq!(ops[0]["dns_readiness_guest_duration_ms"], 3);
+        assert_eq!(ops[0]["dns_readiness_host_residual_ms"], 7);
+        assert_eq!(ops[0]["dns_readiness_timing"], "paired");
+        assert_eq!(ops[0]["success"], true);
+        assert_eq!(ops[1]["dns_readiness_guest_duration_ms"], 0);
+        assert_eq!(ops[1]["dns_readiness_host_residual_ms"], 0);
+        assert_eq!(ops[1]["dns_readiness_final_attempt"], false);
+        assert_eq!(ops[1]["success"], false);
+        assert_eq!(ops[1]["outcome"], "process_timeout");
+        assert_eq!(ops[2]["dns_readiness_guest_duration_ms"], 10);
+        assert_eq!(ops[2]["dns_readiness_timing"], "inconsistent");
+        assert!(ops[2].get("dns_readiness_host_residual_ms").is_none());
+        for op in &ops[3..] {
+            assert_eq!(op["dns_readiness_timing"], "unavailable");
+            assert_eq!(op["dns_readiness_final_attempt"], true);
+            assert!(op.get("dns_readiness_guest_duration_ms").is_none());
+            assert!(op.get("dns_readiness_host_residual_ms").is_none());
+        }
+        server.assert_finished().await;
+    }
+}

--- a/crates/sandbox-firecracker/src/guest_dns_readiness.rs
+++ b/crates/sandbox-firecracker/src/guest_dns_readiness.rs
@@ -1,10 +1,13 @@
 use std::fmt;
 use std::io;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use guest_control_client::{GuestControlClient, GuestDnsReadinessResult};
 use guest_control_proto::GuestDnsReadinessTermination;
-use sandbox::SandboxGuestDnsReadinessReason;
+use sandbox::{
+    SandboxDnsReadinessAttempt, SandboxDnsReadinessOutcome, SandboxGuestDnsReadinessReason,
+    SandboxStartObserver,
+};
 use tokio::time::Instant;
 
 use crate::guest_dns_probe::{DNS_READINESS_HOSTNAME, DNS_READINESS_IPV4};
@@ -59,6 +62,20 @@ impl fmt::Display for GuestDnsReadinessFailure {
 }
 
 impl GuestDnsReadinessFailure {
+    fn outcome(self) -> SandboxDnsReadinessOutcome {
+        match self {
+            Self::Deadline => SandboxDnsReadinessOutcome::Deadline,
+            Self::Transport(_) => SandboxDnsReadinessOutcome::Transport,
+            Self::TimedOut => SandboxDnsReadinessOutcome::ProcessTimeout,
+            Self::Cancelled => SandboxDnsReadinessOutcome::ProcessCancelled,
+            Self::StartFailed => SandboxDnsReadinessOutcome::StartFailed,
+            Self::WaitFailed => SandboxDnsReadinessOutcome::WaitFailed,
+            Self::ExitNonZero(_) => SandboxDnsReadinessOutcome::ExitNonZero,
+            Self::OutputTruncated => SandboxDnsReadinessOutcome::OutputTruncated,
+            Self::UnexpectedAnswer => SandboxDnsReadinessOutcome::UnexpectedAnswer,
+        }
+    }
+
     fn retryable(self) -> bool {
         matches!(
             self,
@@ -104,30 +121,87 @@ impl fmt::Display for GuestDnsReadinessError {
 
 impl std::error::Error for GuestDnsReadinessError {}
 
+// Buffer observations so observer work cannot delay a retry or alter its budget
+// decision. Drop also preserves the completed prefix on host cancellation, but
+// never owns guest cancellation, connection fencing or process cleanup.
+struct AttemptObservations<'a> {
+    observer: &'a mut dyn SandboxStartObserver,
+    records: Vec<SandboxDnsReadinessAttempt>,
+    current_started: Instant,
+    in_flight: bool,
+}
+
+impl AttemptObservations<'_> {
+    fn finish(
+        &mut self,
+        guest_duration_ms: Option<u32>,
+        outcome: SandboxDnsReadinessOutcome,
+        final_attempt: bool,
+    ) {
+        self.records.push(SandboxDnsReadinessAttempt {
+            attempt: self.records.len() as u16 + 1,
+            final_attempt,
+            duration: self.current_started.elapsed(),
+            guest_duration_ms,
+            outcome,
+            completed_at: SystemTime::now(),
+        });
+        self.in_flight = false;
+    }
+}
+
+impl Drop for AttemptObservations<'_> {
+    fn drop(&mut self) {
+        if self.in_flight {
+            self.finish(None, SandboxDnsReadinessOutcome::HostCancelled, true);
+        }
+        for record in &self.records {
+            self.observer.record_dns_readiness_attempt(*record);
+        }
+    }
+}
+
 pub(crate) async fn wait_for_guest_dns_readiness(
     guest: &GuestControlClient,
+    observer: &mut dyn SandboxStartObserver,
 ) -> Result<(), GuestDnsReadinessError> {
-    wait_for_guest_dns_readiness_with_policy(guest, PRODUCTION_POLICY).await
+    wait_for_guest_dns_readiness_with_policy(guest, PRODUCTION_POLICY, observer).await
 }
 
 async fn wait_for_guest_dns_readiness_with_policy(
     guest: &GuestControlClient,
     policy: ReadinessPolicy,
+    observer: &mut dyn SandboxStartObserver,
 ) -> Result<(), GuestDnsReadinessError> {
     let started = Instant::now();
     let deadline = started + policy.total_timeout;
     let mut attempts = 0;
+    let mut observations = AttemptObservations {
+        observer,
+        records: Vec::with_capacity(usize::from(policy.max_attempts)),
+        current_started: started,
+        in_flight: false,
+    };
 
     loop {
         attempts += 1;
-        let failure = match probe_guest_dns_once(guest, policy.attempt_timeout).await {
-            Ok(()) => return Ok(()),
+        observations.current_started = Instant::now();
+        observations.in_flight = true;
+        let (result, guest_duration_ms) = probe_guest_dns_once(guest, policy.attempt_timeout).await;
+        let failure = match result {
+            Ok(()) => {
+                observations.finish(guest_duration_ms, SandboxDnsReadinessOutcome::Success, true);
+                return Ok(());
+            }
             Err(failure) => failure,
         };
 
         let complete_retry_fits =
             deadline.saturating_duration_since(Instant::now()) >= policy.attempt_timeout;
-        if !failure.retryable() || attempts >= policy.max_attempts || !complete_retry_fits {
+        let final_attempt =
+            !failure.retryable() || attempts >= policy.max_attempts || !complete_retry_fits;
+        observations.finish(guest_duration_ms, failure.outcome(), final_attempt);
+        if final_attempt {
             return Err(GuestDnsReadinessError {
                 attempts,
                 elapsed: started.elapsed(),
@@ -137,19 +211,22 @@ async fn wait_for_guest_dns_readiness_with_policy(
     }
 }
 
-pub(crate) async fn probe_guest_dns_once(
+async fn probe_guest_dns_once(
     guest: &GuestControlClient,
     wait_timeout: Duration,
-) -> Result<(), GuestDnsReadinessFailure> {
+) -> (Result<(), GuestDnsReadinessFailure>, Option<u32>) {
     match guest
         .guest_dns_readiness(DNS_READINESS_HOSTNAME, PROCESS_TIMEOUT_MS, wait_timeout)
         .await
     {
-        Ok(result) => validate_result(result),
-        Err(error) if error.kind() == io::ErrorKind::TimedOut => {
-            Err(GuestDnsReadinessFailure::Deadline)
+        Ok(result) => {
+            let duration_ms = result.duration_ms;
+            (validate_result(result), Some(duration_ms))
         }
-        Err(error) => Err(GuestDnsReadinessFailure::Transport(error.kind())),
+        Err(error) if error.kind() == io::ErrorKind::TimedOut => {
+            (Err(GuestDnsReadinessFailure::Deadline), None)
+        }
+        Err(error) => (Err(GuestDnsReadinessFailure::Transport(error.kind())), None),
     }
 }
 
@@ -201,6 +278,8 @@ fn validate_result(result: GuestDnsReadinessResult) -> Result<(), GuestDnsReadin
 
 #[cfg(test)]
 mod tests {
+    mod attribution;
+
     use std::sync::Arc;
 
     use guest_control_proto::{
@@ -212,6 +291,21 @@ mod tests {
     use tokio::net::UnixStream;
 
     use super::*;
+
+    #[derive(Default)]
+    struct RecordingObserver {
+        attempts: Vec<SandboxDnsReadinessAttempt>,
+    }
+
+    impl SandboxStartObserver for RecordingObserver {
+        fn record_stage(&mut self, _: sandbox::SandboxStartStage, _: Duration, _: bool) {
+            panic!("attempt observations must not synthesize a parent stage");
+        }
+
+        fn record_dns_readiness_attempt(&mut self, attempt: SandboxDnsReadinessAttempt) {
+            self.attempts.push(attempt);
+        }
+    }
 
     const TEST_POLICY: ReadinessPolicy = ReadinessPolicy {
         total_timeout: Duration::from_secs(1),
@@ -315,7 +409,12 @@ mod tests {
     async fn guest_dns_readiness_uses_fixed_guest_resolver_request() {
         let (host, mut guest) = setup_host_and_guest().await;
         let task = tokio::spawn(async move {
-            wait_for_guest_dns_readiness_with_policy(&host, TEST_POLICY).await
+            wait_for_guest_dns_readiness_with_policy(
+                &host,
+                TEST_POLICY,
+                &mut RecordingObserver::default(),
+            )
+            .await
         });
         let request = read_message(&mut guest).await;
         assert_readiness_request(&request);
@@ -335,7 +434,12 @@ mod tests {
     async fn guest_dns_readiness_recovers_after_transient_failure() {
         let (host, mut guest) = setup_host_and_guest().await;
         let task = tokio::spawn(async move {
-            wait_for_guest_dns_readiness_with_policy(&host, TEST_POLICY).await
+            wait_for_guest_dns_readiness_with_policy(
+                &host,
+                TEST_POLICY,
+                &mut RecordingObserver::default(),
+            )
+            .await
         });
         let first = read_message(&mut guest).await;
         send_result(
@@ -363,7 +467,12 @@ mod tests {
     async fn guest_dns_readiness_retries_late_guest_process_timeout() {
         let (host, mut guest) = setup_host_and_guest().await;
         let task = tokio::spawn(async move {
-            wait_for_guest_dns_readiness_with_policy(&host, PRODUCTION_POLICY).await
+            wait_for_guest_dns_readiness_with_policy(
+                &host,
+                PRODUCTION_POLICY,
+                &mut RecordingObserver::default(),
+            )
+            .await
         });
         let first = read_message(&mut guest).await;
 
@@ -399,10 +508,14 @@ mod tests {
             attempt_timeout: Duration::from_millis(300),
             max_attempts: 3,
         };
-        let task =
-            tokio::spawn(
-                async move { wait_for_guest_dns_readiness_with_policy(&host, policy).await },
-            );
+        let task = tokio::spawn(async move {
+            wait_for_guest_dns_readiness_with_policy(
+                &host,
+                policy,
+                &mut RecordingObserver::default(),
+            )
+            .await
+        });
         let first = read_message(&mut guest).await;
 
         tokio::time::pause();
@@ -426,7 +539,12 @@ mod tests {
     async fn guest_dns_readiness_stops_at_attempt_limit() {
         let (host, mut guest) = setup_host_and_guest().await;
         let task = tokio::spawn(async move {
-            wait_for_guest_dns_readiness_with_policy(&host, TEST_POLICY).await
+            wait_for_guest_dns_readiness_with_policy(
+                &host,
+                TEST_POLICY,
+                &mut RecordingObserver::default(),
+            )
+            .await
         });
         for _ in 0..TEST_POLICY.max_attempts {
             let request = read_message(&mut guest).await;
@@ -457,8 +575,14 @@ mod tests {
             attempt_timeout: Duration::from_millis(50),
             max_attempts: 3,
         };
-        let readiness =
-            async move { wait_for_guest_dns_readiness_with_policy(&host, policy).await };
+        let readiness = async move {
+            wait_for_guest_dns_readiness_with_policy(
+                &host,
+                policy,
+                &mut RecordingObserver::default(),
+            )
+            .await
+        };
         let task = tokio::spawn(readiness);
         let request = read_message(&mut guest).await;
         assert_readiness_request(&request);
@@ -509,7 +633,12 @@ mod tests {
     async fn guest_dns_readiness_rejects_truncated_output() {
         let (host, mut guest) = setup_host_and_guest().await;
         let task = tokio::spawn(async move {
-            wait_for_guest_dns_readiness_with_policy(&host, TEST_POLICY).await
+            wait_for_guest_dns_readiness_with_policy(
+                &host,
+                TEST_POLICY,
+                &mut RecordingObserver::default(),
+            )
+            .await
         });
         let request = read_message(&mut guest).await;
         send_result(
@@ -533,7 +662,12 @@ mod tests {
     async fn guest_dns_readiness_rejects_malformed_dedicated_result() {
         let (host, mut guest) = setup_host_and_guest().await;
         let task = tokio::spawn(async move {
-            wait_for_guest_dns_readiness_with_policy(&host, TEST_POLICY).await
+            wait_for_guest_dns_readiness_with_policy(
+                &host,
+                TEST_POLICY,
+                &mut RecordingObserver::default(),
+            )
+            .await
         });
         let request = read_message(&mut guest).await;
         guest

--- a/crates/sandbox-firecracker/src/guest_dns_readiness/tests/attribution.rs
+++ b/crates/sandbox-firecracker/src/guest_dns_readiness/tests/attribution.rs
@@ -1,0 +1,211 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use super::*;
+
+#[tokio::test]
+async fn guest_dns_readiness_observes_terminal_results_and_attempt_exhaustion() {
+    use GuestDnsReadinessTermination as Termination;
+    use SandboxDnsReadinessOutcome as Outcome;
+
+    for (termination, answer, truncated, outcome, attempts) in [
+        (
+            Termination::Exited { exit_code: 0 },
+            "192.0.2.1 STREAM\n",
+            false,
+            Outcome::Success,
+            1,
+        ),
+        (Termination::StartFailed, "", false, Outcome::StartFailed, 1),
+        (Termination::WaitFailed, "", false, Outcome::WaitFailed, 1),
+        (
+            Termination::Cancelled,
+            "",
+            false,
+            Outcome::ProcessCancelled,
+            1,
+        ),
+        (
+            Termination::Exited { exit_code: 1 },
+            "",
+            false,
+            Outcome::ExitNonZero,
+            1,
+        ),
+        (
+            Termination::Exited { exit_code: 0 },
+            "203.0.113.1 STREAM\n",
+            false,
+            Outcome::UnexpectedAnswer,
+            3,
+        ),
+        (
+            Termination::Exited { exit_code: 0 },
+            "192.0.2.1 STREAM\n",
+            true,
+            Outcome::OutputTruncated,
+            1,
+        ),
+    ] {
+        let (host, mut guest) = setup_host_and_guest().await;
+        let mut observer = RecordingObserver::default();
+        let started = Instant::now();
+        let (result, ()) = tokio::join!(
+            wait_for_guest_dns_readiness_with_policy(&host, TEST_POLICY, &mut observer),
+            async {
+                for _ in 0..attempts {
+                    let request = read_message(&mut guest).await;
+                    assert_readiness_request(&request);
+                    send_result(
+                        &mut guest,
+                        &request,
+                        termination,
+                        answer.as_bytes(),
+                        truncated,
+                    )
+                    .await;
+                }
+            },
+        );
+        assert_eq!(result.is_ok(), outcome == Outcome::Success);
+        assert_eq!(observer.attempts.len(), attempts);
+        for (index, record) in observer.attempts.iter().enumerate() {
+            assert_eq!(record.attempt, index as u16 + 1);
+            assert_eq!(record.final_attempt, index + 1 == attempts);
+            assert_eq!(record.outcome, outcome);
+            assert_eq!(record.guest_duration_ms, Some(1));
+        }
+        let child_total: Duration = observer.attempts.iter().map(|record| record.duration).sum();
+        assert!(child_total <= started.elapsed());
+        assert!(host.try_fence_normal_operations().is_ok());
+    }
+}
+
+#[tokio::test]
+async fn guest_dns_readiness_replays_failed_and_successful_attempts_only_after_retry_finishes() {
+    struct DeferredObserver {
+        ready: Arc<AtomicBool>,
+        inner: RecordingObserver,
+    }
+    impl SandboxStartObserver for DeferredObserver {
+        fn record_stage(&mut self, _: sandbox::SandboxStartStage, _: Duration, _: bool) {
+            panic!("attempt observations must not synthesize a parent stage");
+        }
+
+        fn record_dns_readiness_attempt(&mut self, attempt: SandboxDnsReadinessAttempt) {
+            assert!(
+                self.ready.load(Ordering::Acquire),
+                "observer ran between retries"
+            );
+            self.inner.record_dns_readiness_attempt(attempt);
+        }
+    }
+
+    let (host, mut guest) = setup_host_and_guest().await;
+    let ready = Arc::new(AtomicBool::new(false));
+    let mut observer = DeferredObserver {
+        ready: Arc::clone(&ready),
+        inner: RecordingObserver::default(),
+    };
+    let (result, ()) = tokio::join!(
+        wait_for_guest_dns_readiness_with_policy(&host, TEST_POLICY, &mut observer),
+        async {
+            let first = read_message(&mut guest).await;
+            send_result(
+                &mut guest,
+                &first,
+                GuestDnsReadinessTermination::Exited { exit_code: 2 },
+                b"",
+                false,
+            )
+            .await;
+            let second = read_message(&mut guest).await;
+            ready.store(true, Ordering::Release);
+            send_result(
+                &mut guest,
+                &second,
+                GuestDnsReadinessTermination::Exited { exit_code: 0 },
+                b"192.0.2.1 DGRAM\n",
+                false,
+            )
+            .await;
+        },
+    );
+    result.unwrap();
+    let records = observer.inner.attempts;
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0].outcome, SandboxDnsReadinessOutcome::ExitNonZero);
+    assert!(!records[0].final_attempt);
+    assert_eq!(records[1].outcome, SandboxDnsReadinessOutcome::Success);
+    assert!(records[1].final_attempt);
+    assert_eq!(records[1].attempt, 2);
+    assert!(
+        records
+            .iter()
+            .all(|record| record.guest_duration_ms == Some(1))
+    );
+}
+
+#[tokio::test]
+async fn guest_dns_readiness_cancellation_retains_prefix_without_reopening_connection() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let mut observer = RecordingObserver::default();
+    let mut readiness = Box::pin(wait_for_guest_dns_readiness_with_policy(
+        &host,
+        TEST_POLICY,
+        &mut observer,
+    ));
+    tokio::select! {
+        result = &mut readiness => panic!("readiness finished before cancellation: {result:?}"),
+        () = async {
+            let first = read_message(&mut guest).await;
+            send_result(&mut guest, &first, GuestDnsReadinessTermination::TimedOut, b"", false).await;
+            let second = read_message(&mut guest).await;
+            assert_readiness_request(&second);
+        } => {}
+    }
+    drop(readiness);
+    assert_eq!(observer.attempts.len(), 2);
+    assert_eq!(
+        observer.attempts[0].outcome,
+        SandboxDnsReadinessOutcome::ProcessTimeout
+    );
+    assert_eq!(observer.attempts[0].guest_duration_ms, Some(1));
+    assert!(!observer.attempts[0].final_attempt);
+    assert_eq!(
+        observer.attempts[1].outcome,
+        SandboxDnsReadinessOutcome::HostCancelled
+    );
+    assert_eq!(observer.attempts[1].guest_duration_ms, None);
+    assert_eq!(observer.attempts[1].attempt, 2);
+    assert!(observer.attempts[1].final_attempt);
+    assert!(host.try_fence_normal_operations().is_err());
+}
+
+#[tokio::test]
+async fn guest_dns_readiness_deadline_has_no_guest_measurement_and_retains_fencing() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let mut observer = RecordingObserver::default();
+    let policy = ReadinessPolicy {
+        total_timeout: Duration::from_millis(50),
+        attempt_timeout: Duration::from_millis(50),
+        max_attempts: 3,
+    };
+    tokio::time::pause();
+    let (result, request) = tokio::join!(
+        wait_for_guest_dns_readiness_with_policy(&host, policy, &mut observer),
+        read_message(&mut guest),
+    );
+    assert_readiness_request(&request);
+    assert_eq!(
+        result.unwrap_err().last_failure,
+        GuestDnsReadinessFailure::Deadline
+    );
+    assert_eq!(observer.attempts.len(), 1);
+    assert_eq!(
+        observer.attempts[0].outcome,
+        SandboxDnsReadinessOutcome::Deadline
+    );
+    assert_eq!(observer.attempts[0].guest_duration_ms, None);
+    assert!(observer.attempts[0].final_attempt);
+    assert!(host.try_fence_normal_operations().is_err());
+}

--- a/crates/sandbox-firecracker/src/sandbox.rs
+++ b/crates/sandbox-firecracker/src/sandbox.rs
@@ -191,6 +191,20 @@ impl<'a> SandboxStartTiming<'a> {
     }
 }
 
+impl SandboxStartObserver for SandboxStartTiming<'_> {
+    fn record_stage(&mut self, stage: SandboxStartStage, duration: Duration, success: bool) {
+        if let Some(observer) = self.observer.as_deref_mut() {
+            observer.record_stage(stage, duration, success);
+        }
+    }
+
+    fn record_dns_readiness_attempt(&mut self, attempt: sandbox::SandboxDnsReadinessAttempt) {
+        if let Some(observer) = self.observer.as_deref_mut() {
+            observer.record_dns_readiness_attempt(attempt);
+        }
+    }
+}
+
 struct SandboxFinalExecParkTiming<'a> {
     observer: Option<&'a mut dyn SandboxFinalExecParkObserver>,
 }
@@ -1540,7 +1554,7 @@ impl FirecrackerSandbox {
 
         if let Some(dns_port) = self.factory_config.dns_port {
             let dns_started = Instant::now();
-            match wait_for_guest_dns_readiness(&guest_control_client).await {
+            match wait_for_guest_dns_readiness(&guest_control_client, &mut timing).await {
                 Ok(()) => {
                     timing.record(SandboxStartStage::GuestDnsReadiness, dns_started, true);
                 }

--- a/crates/sandbox/src/dns_readiness.rs
+++ b/crates/sandbox/src/dns_readiness.rs
@@ -1,0 +1,70 @@
+use std::time::{Duration, SystemTime};
+
+/// Bounded result of one guest DNS readiness attempt, not the whole start.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SandboxDnsReadinessOutcome {
+    /// The guest resolver returned the required answer.
+    Success,
+    /// The host request reached its deadline without a complete result.
+    Deadline,
+    /// The guest control request failed without a valid result.
+    Transport,
+    /// The guest killed the resolver after its process deadline.
+    ProcessTimeout,
+    /// The guest cancelled the resolver.
+    ProcessCancelled,
+    /// The guest could not start the resolver.
+    StartFailed,
+    /// The guest could not wait for the resolver.
+    WaitFailed,
+    /// The resolver exited unsuccessfully.
+    ExitNonZero,
+    /// Resolver output exceeded its bounds or could not be fully collected.
+    OutputTruncated,
+    /// The resolver did not return the required answer.
+    UnexpectedAnswer,
+    /// The host future was dropped; elapsed time is an incomplete interval.
+    HostCancelled,
+}
+
+impl SandboxDnsReadinessOutcome {
+    /// Stable low-cardinality telemetry classification.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Deadline => "deadline",
+            Self::Transport => "transport",
+            Self::ProcessTimeout => "process_timeout",
+            Self::ProcessCancelled => "process_cancelled",
+            Self::StartFailed => "start_failed",
+            Self::WaitFailed => "wait_failed",
+            Self::ExitNonZero => "exit_nonzero",
+            Self::OutputTruncated => "output_truncated",
+            Self::UnexpectedAnswer => "unexpected_answer",
+            Self::HostCancelled => "host_cancelled",
+        }
+    }
+}
+
+/// One attempt nested inside the authoritative guest DNS readiness start stage.
+///
+/// Host and guest elapsed durations are measured locally in their respective
+/// processes. Guest time includes resolver setup, execution and cleanup, not
+/// just DNS network latency. Completion wall time is only for event placement;
+/// it must never be subtracted from a guest timestamp to derive elapsed time.
+#[derive(Clone, Copy, Debug)]
+pub struct SandboxDnsReadinessAttempt {
+    /// One-based ordinal within this readiness invocation, bounded to three.
+    /// A replacement sandbox starts its own sequence at one.
+    pub attempt: u16,
+    /// Whether this invocation ends after this attempt, including cancellation.
+    pub final_attempt: bool,
+    /// Host request/response and validation interval; incomplete on host cancellation.
+    pub duration: Duration,
+    /// Existing guest-reported helper lifecycle duration, absent without a valid result.
+    pub guest_duration_ms: Option<u32>,
+    /// Bounded validation or operation outcome.
+    pub outcome: SandboxDnsReadinessOutcome,
+    /// Host completion time, captured before any buffered observer replay.
+    pub completed_at: SystemTime,
+}

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -19,6 +19,7 @@
 
 mod config;
 mod control;
+mod dns_readiness;
 mod error;
 mod factory;
 mod guest_rpc;
@@ -35,6 +36,7 @@ pub use config::{
 pub use control::{
     RemoteExecResult, RemoteKillResult, SandboxControl, SandboxControlError, SandboxControlTarget,
 };
+pub use dns_readiness::{SandboxDnsReadinessAttempt, SandboxDnsReadinessOutcome};
 pub use error::{
     Result, SandboxError, SandboxGuestDnsReadinessReason, SandboxIdleTransition,
     SandboxInitializationPhase, SandboxInvalidStateContext, SandboxOperation,

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -367,6 +367,14 @@ pub trait SandboxStartObserver: Send {
     /// start. A provider invokes this callback at most once per applicable
     /// stage.
     fn record_stage(&mut self, stage: SandboxStartStage, duration: Duration, success: bool);
+
+    /// Records a child attempt inside the guest DNS readiness stage.
+    ///
+    /// Providers may buffer these callbacks until the invocation ends to avoid
+    /// observer work between retries. Children overlap their parent, and must
+    /// not be added to it. Cancellation may report an incomplete child without
+    /// a completed parent; this callback never owns cancellation or cleanup.
+    fn record_dns_readiness_attempt(&mut self, _attempt: crate::SandboxDnsReadinessAttempt) {}
 }
 
 /// Fixed low-cardinality stages of the final reuse preparation and park path.

--- a/docs/runner-dns-readiness-attribution.md
+++ b/docs/runner-dns-readiness-attribution.md
@@ -1,0 +1,94 @@
+# Guest DNS readiness attribution
+
+The authoritative readiness interval is
+`runner_fresh_sandbox_start_guest_dns_readiness`. It includes all attempts inside
+one sandbox start and observation overhead, and retains its existing success and
+failure semantics. Failure diagnostics and sandbox destruction happen afterward.
+Readiness still completes before real Agent process spawn.
+
+## Attempt records
+
+`runner_fresh_sandbox_start_guest_dns_readiness_attempt` is a child event, emitted
+at most three times per readiness invocation. Each event contains its own timing
+pair; never join separate operations by timestamp to manufacture a pair.
+
+| Field                             | Meaning                                                                    |
+| --------------------------------- | -------------------------------------------------------------------------- |
+| `duration_ms`                     | Host request/response and validation elapsed time, in integer milliseconds |
+| `dns_readiness_attempt`           | One-based attempt ordinal, from 1 to 3 within this invocation              |
+| `dns_readiness_final_attempt`     | This invocation ends after this attempt, including cancellation            |
+| `dns_readiness_guest_duration_ms` | Optional existing guest-reported helper lifecycle duration                 |
+| `dns_readiness_host_residual_ms`  | Optional host duration minus guest duration from this same attempt         |
+| `dns_readiness_timing`            | `paired`, `unavailable`, or `inconsistent`                                 |
+| `outcome`                         | Bounded attempt result, not the outcome of the whole start                 |
+
+Outcome values are `success`, `deadline`, `transport`, `process_timeout`,
+`process_cancelled`, `start_failed`, `wait_failed`, `exit_nonzero`,
+`output_truncated`, `unexpected_answer`, and `host_cancelled`. Unsuccessful
+attempts also use that same bounded classification in `error`; arbitrary resolver
+diagnostics, output, hostnames, exit codes and additional identities are not sent.
+
+The guest timer starts before resolver process setup and ends after process and
+descendant cleanup and output collection. It does **not** measure only DNS wire
+latency. Earlier guest worker dispatch and response encoding/writing lie outside
+this timer. The host residual includes those costs plus host request processing,
+queueing and transport; it is **not** pure network latency either.
+
+Both durations use process-local monotonic clocks. Subtraction uses their integer
+millisecond durations, not timestamps from different clocks. Values have
+millisecond quantization; a zero residual does not establish zero overhead.
+
+`paired` means a valid result supplied a guest duration no greater than the host
+duration. Only those rows have a residual. `inconsistent` retains the returned
+guest duration but omits the invalid residual. `unavailable` omits both guest and
+residual measurements, as on a request deadline, invalid/absent result or host
+cancellation. Missing measurements must not be replaced with zero. Actual zero
+durations and `false` final-attempt values are preserved by the API.
+
+## Retry, cancellation and nesting
+
+Attempts remain sequential, with the existing three-attempt limit, 1.1-second
+child timeout, 2.1-second request allowance and seven-second overall retry budget.
+The retry classification and requirement that a complete attempt fits the
+remaining budget are unchanged. Measurements use a preallocated buffer bounded
+to three entries and are replayed when the invocation ends, so callbacks do not run
+between retry decisions. Event timestamps are captured at attempt completion,
+before that replay; wall time is only used to place events.
+
+Dropping an in-progress readiness future preserves completed attempts and adds
+an incomplete `host_cancelled` attempt. Its host duration ends at cancellation;
+it does not include later guest cleanup. The existing parent can be absent on
+cancellation. No completed parent is synthesized, and recording does not own or
+change connection fencing, cancellation or process cleanup.
+
+The Runner may separately destroy and replace a DNS-unready sandbox under its
+existing policy. Each replacement start has a new readiness invocation and its
+ordinal restarts at one, even for the same run. This is not a fourth DNS attempt.
+An attempt's `success: false` followed by success must not be counted as a failed
+run. Parent/child durations nest: do not add attempts to their parent, or add
+independently ranked percentiles.
+
+## Rollout and analysis
+
+These are optional fields on the existing telemetry webhook. The guest protocol,
+API route, authentication and persisted state are unchanged. The new API accepts
+old operations without these fields. An older API accepts the operation but
+strips unknown optional measurements. That overlap loses attribution coverage,
+not run correctness; require a containing API revision for analysis.
+
+For a fixed observation window and exact API/Runner revision pair, report:
+
+- Applicable starts and completed readiness parents, including failed starts;
+- Attempt rows, observed invocations (attempt 1), final-attempt counts and outcome
+  distributions, distinguishing inner retries from sandbox replacement;
+- Coverage and unavailable/inconsistent/cancelled rows, without filling gaps;
+- Parent and per-attempt host/guest/residual p50/p90/p95/p99 from raw observations,
+  restricting residual percentiles to valid pairs;
+- True cold, workspace, and blank/reuse paths separately, plus instrumentation
+  and resource overhead for controlled comparisons.
+
+Missing events or successful-start-only cohorts cannot establish failure rates.
+Local measurements do not establish production coverage or a removable latency
+budget. Issue #32445 retains the fixed-revision production report and subsequent
+optimization/no-change decision after rollout; this instrumentation alone does
+not complete parent #24203.

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -1991,6 +1991,124 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
 });
 
 describe("WHCB-05: sandbox agent webhook boundaries", () => {
+  it("preserves same-attempt DNS timing, zero values, and legacy operations", async () => {
+    const { runId, headers } = await createEventWebhookRun(
+      "DNS attempt attribution",
+    );
+    const timestamp = nowDate().toISOString();
+    const operations = [
+      {
+        ts: timestamp,
+        action_type: "runner_fresh_sandbox_start_guest_dns_readiness",
+        duration_ms: 10,
+        success: true,
+      },
+      {
+        ts: timestamp,
+        action_type: "runner_fresh_sandbox_start_guest_dns_readiness_attempt",
+        duration_ms: 0,
+        success: false,
+        outcome: "process_timeout",
+        dns_readiness_attempt: 1,
+        dns_readiness_final_attempt: false,
+        dns_readiness_guest_duration_ms: 0,
+        dns_readiness_host_residual_ms: 0,
+        dns_readiness_timing: "paired",
+      },
+      {
+        ts: timestamp,
+        action_type: "runner_fresh_sandbox_start_guest_dns_readiness_attempt",
+        duration_ms: 10,
+        success: true,
+        outcome: "success",
+        dns_readiness_attempt: 2,
+        dns_readiness_final_attempt: true,
+        dns_readiness_guest_duration_ms: 7,
+        dns_readiness_host_residual_ms: 3,
+        dns_readiness_timing: "paired",
+      },
+      {
+        ts: timestamp,
+        action_type: "runner_fresh_sandbox_start_guest_dns_readiness_attempt",
+        duration_ms: 4,
+        success: false,
+        outcome: "host_cancelled",
+        dns_readiness_attempt: 1,
+        dns_readiness_final_attempt: true,
+        dns_readiness_timing: "unavailable",
+      },
+      {
+        ts: timestamp,
+        action_type: "runner_fresh_sandbox_start_guest_dns_readiness_attempt",
+        duration_ms: 2,
+        success: true,
+        outcome: "success",
+        dns_readiness_attempt: 1,
+        dns_readiness_final_attempt: true,
+        dns_readiness_guest_duration_ms: 10,
+        dns_readiness_timing: "inconsistent",
+      },
+    ] as const;
+    context.mocks.axiom.sdkIngest.mockClear();
+    await api.requestAgentTelemetry(
+      { runId, sandboxOperations: [...operations] },
+      headers,
+      [200],
+    );
+    await flushWaitUntilForTest();
+    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledTimes(
+      operations.length,
+    );
+    for (const { ts, action_type: actionType, ...fields } of operations) {
+      expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
+        "vm0-sandbox-op-log-dev",
+        [
+          {
+            _time: ts,
+            op_type: actionType,
+            source: "sandbox",
+            sandbox_type: "runner",
+            run_id: runId,
+            ...fields,
+          },
+        ],
+      );
+    }
+  });
+
+  it("rejects unbounded DNS attempt dimensions at the telemetry boundary", async () => {
+    const runId = randomUUID();
+    const headers = api.sandboxWebhookHeaders({ runId });
+    for (const invalid of [
+      { dns_readiness_attempt: 0 },
+      { dns_readiness_attempt: 4 },
+      { dns_readiness_guest_duration_ms: -1 },
+      { dns_readiness_host_residual_ms: -1 },
+      { dns_readiness_timing: "arbitrary-diagnostic" },
+      { dns_readiness_final_attempt: "false" },
+    ]) {
+      const response = await api.requestAgentTelemetryUnchecked(
+        {
+          runId,
+          sandboxOperations: [
+            {
+              ts: nowDate().toISOString(),
+              action_type:
+                "runner_fresh_sandbox_start_guest_dns_readiness_attempt",
+              duration_ms: 1,
+              success: true,
+              ...invalid,
+            },
+          ],
+        },
+        headers,
+        [400],
+      );
+      expectApiError(response.body);
+      expect(response.body.error.code).toBe("BAD_REQUEST");
+    }
+  });
+
   it("returns 500 with structured diagnostics when telemetry ingest times out", async () => {
     const { runId, headers } = await createEventWebhookRun(
       "required Axiom telemetry deadline",

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -51,6 +51,11 @@ interface SandboxOperationDimensionInput {
   readonly error?: string;
   readonly outcome?: string;
   readonly reason?: string;
+  readonly dns_readiness_attempt?: number;
+  readonly dns_readiness_final_attempt?: boolean;
+  readonly dns_readiness_guest_duration_ms?: number;
+  readonly dns_readiness_host_residual_ms?: number;
+  readonly dns_readiness_timing?: string;
   readonly runner_startup_path?: RunnerStartupPath;
   readonly sandbox_reuse_result?: SandboxReuseResult;
   readonly runner_pre_spawn_concurrency_bucket?: RunnerPreSpawnConcurrencyBucket;
@@ -99,10 +104,32 @@ function runnerResourceBudgetDimensions(
   };
 }
 
+function dnsReadinessDimensions(
+  op: SandboxOperationDimensionInput,
+): Record<string, string | number | boolean> {
+  return {
+    ...(op.dns_readiness_attempt !== undefined
+      ? { dns_readiness_attempt: op.dns_readiness_attempt }
+      : {}),
+    ...(op.dns_readiness_final_attempt !== undefined
+      ? { dns_readiness_final_attempt: op.dns_readiness_final_attempt }
+      : {}),
+    ...(op.dns_readiness_guest_duration_ms !== undefined
+      ? { dns_readiness_guest_duration_ms: op.dns_readiness_guest_duration_ms }
+      : {}),
+    ...(op.dns_readiness_host_residual_ms !== undefined
+      ? { dns_readiness_host_residual_ms: op.dns_readiness_host_residual_ms }
+      : {}),
+    ...(op.dns_readiness_timing
+      ? { dns_readiness_timing: op.dns_readiness_timing }
+      : {}),
+  };
+}
+
 function sandboxOperationDimensions(
   op: SandboxOperationDimensionInput,
   runner: SandboxRunnerDimensionInput,
-): Record<string, string> {
+): Record<string, string | number | boolean> {
   return {
     source: "sandbox",
     ...(runner.runnerHostname
@@ -112,6 +139,7 @@ function sandboxOperationDimensions(
     ...(op.error ? { error: op.error } : {}),
     ...(op.outcome ? { outcome: op.outcome } : {}),
     ...(op.reason ? { reason: op.reason } : {}),
+    ...dnsReadinessDimensions(op),
     ...(op.runner_startup_path
       ? { runner_startup_path: op.runner_startup_path }
       : {}),

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -988,6 +988,18 @@ const sandboxOperationSchema = z.object({
   error: z.string().optional(),
   outcome: z.string().max(64).optional(),
   reason: z.string().max(64).optional(),
+  dns_readiness_attempt: z.number().int().min(1).max(3).optional(),
+  dns_readiness_final_attempt: z.boolean().optional(),
+  dns_readiness_guest_duration_ms: z
+    .number()
+    .int()
+    .min(0)
+    .max(4_294_967_295)
+    .optional(),
+  dns_readiness_host_residual_ms: z.number().int().nonnegative().optional(),
+  dns_readiness_timing: z
+    .enum(["paired", "unavailable", "inconsistent"])
+    .optional(),
   runner_startup_path: runnerStartupPathSchema.optional(),
   sandbox_reuse_result: sandboxReuseResultSchema.optional(),
   runner_pre_spawn_concurrency_bucket:


### PR DESCRIPTION
## Summary

Relates to #32445; parent context: #24203. This PR supplies the bounded instrumentation and local validation slice. It intentionally does not close either issue: the containing API/Runner production report and subsequent optimization/no-change decision remain open.

- Preserve each DNS readiness attempt's host elapsed time, existing guest helper duration, bounded outcome, ordinal, and final-attempt state through the existing start observer.
- Buffer at most three observations until the invocation ends, keeping observer work out of retries. On host cancellation, retain the completed prefix and an incomplete attempt without changing guest cancellation, connection fencing or cleanup.
- Emit one fixed child action through the existing telemetry webhook. Forward optional numeric/boolean dimensions, preserving zero and false, and compute host-minus-guest only for valid same-attempt pairs.
- Keep the existing readiness parent authoritative and document timer boundaries, retry/replacement scopes, missing measurements and rollout coverage.

## Scope and compatibility

No resolver, controlled answer, timeout, attempt limit, retry classification, firewall/proxy ordering, guest protocol, persistence, billing, UI or Agent-spawn behavior changes. Guest time includes helper setup/execution/cleanup, not DNS wire time. Host residual is not pure network latency. Parent and children must not be summed.

The new API accepts existing operations without the new fields. The actual base API schema was executed against a new payload: it accepts the operation but strips the optional measurements. Require a containing API revision for attribution. No dual-reader or compatibility fallback branch is introduced.

## Validation

- Rust fmt, affected all-target/all-feature Clippy with warnings denied, and Rustdoc with warnings denied.
- Full runner and affected sandbox tests: 3,553 runner tests plus guest inventory; 43 sandbox tests; 868 Firecracker tests plus prewarm integration. Existing opt-in tests remain unchanged; no new skips. Earlier full guest-control-server and guest-control-tests suites passed as well.
- Socket/executor/HTTP boundary coverage includes success, prior retry failure, attempt exhaustion, termination failures, unexpected/truncated output, request deadline, cancellation prefix/fencing, invalid/missing timing, exact external ingestion and zero/false preservation.
- API-contracts lint/type checks and 721 tests; API lint and all type-check partitions; scoped Knip; 66 webhook BDD tests; changed-file Prettier.
- Rust API generation produced no diff. Actual previous API contract/new payload overlap check passed.
- An intermediate concurrent local test run hit existing 5s test deadlines; the final isolated unchanged 66-test run passed in 35.98s. No timeout increase or test bypass was used.

## local-11 validation

Same host, exact same guest binaries/rootfs/snapshot, local queue + mock Claude, one job at a time (2 vCPU / 4096 MiB), no chat-thread reuse key and no blank pool. Four ten-job B/C/B/C batches: baseline 20/20 success, candidate 20/20 success, candidate 20/20 complete paired ordinal-1 attempts. Six preliminary smoke runs are excluded.

| Integer milliseconds, nearest rank | n | p50 | p90 | p95 | p99 |
| --- | ---: | ---: | ---: | ---: | ---: |
| Baseline readiness parent | 20 | 31 | 35 | 44 | 289 |
| Candidate readiness parent / host attempt | 20 | 31 | 33 | 39 | 40 |
| Candidate guest helper | 20 | 29 | 32 | 38 | 39 |
| Candidate same-attempt residual | 20 | 1 | 2 | 2 | 2 |

Parent-minus-attempt rounded to 0ms in all candidate samples; this does not establish zero overhead. Each new serialized row was 525 bytes including existing resource dimensions. Small tails, a time gap between batches, shared host load and page-cache accounting prohibit a causal speedup claim. Host fault paths remain integration-test coverage, not injected faults on the shared host.

Candidate binary SHA256: `8d891679a2fdc84386c28f17bf631357d79e966feb560e9aa7e80f52c38ef4e2`; baseline: `fb01ebe8a87b35712b53b402fda7cbae5600b39d8c44cea4b268b7d045bdda32`. Rootfs `d63c4b72fb68dc2904234e78063d973166db1a39569cc5a7f99850be1fe6cf0e`, snapshot `400f10eea0b844596f76eebfdf34197dc555fabe6dcbe95afa6a37d4c92f9cc8`.

## Risks and remaining gate

One additional operation per attempt, at most three per readiness invocation, adds bounded CPU/memory/payload cost. Millisecond quantization limits small residual measurements. Cancellation or telemetry transport loss can leave incomplete coverage; missing values must not become zero or a failure-rate denominator. Mixed-version API rollout strips new measurements without changing readiness.

No production deployment or production performance improvement is claimed. Other #24203 slices remain outside this PR.
