### PR TITLE
test(platform): split inline template composer scenarios

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-workflows.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-workflows.test.tsx
@@ -195,12 +195,11 @@ function installOffsetVisualViewport(): void {
   );
 }
 
-test("Compose a message with inline templates", async () => {
+test("Send a message with multiple inline templates", async () => {
   const first = PRESENTATION_TEMPLATE_PICKER_ITEMS[0];
   const second = PRESENTATION_TEMPLATE_PICKER_ITEMS[1];
-  const replacement = PRESENTATION_TEMPLATE_PICKER_ITEMS[2];
-  if (!first || !second || !replacement) {
-    throw new Error("Expected at least three presentation templates");
+  if (!first || !second) {
+    throw new Error("Expected at least two presentation templates");
   }
   let sentTemplateTitles: string[] = [];
   mockAgent();
@@ -242,6 +241,34 @@ test("Compose a message with inline templates", async () => {
     }),
   ).toStrictEqual([first.title, second.title]);
   expect(composerInlineTemplates()).toHaveLength(0);
+});
+
+test("Replace an inline template after sending a message", async () => {
+  const first = PRESENTATION_TEMPLATE_PICKER_ITEMS[0];
+  const replacement = PRESENTATION_TEMPLATE_PICKER_ITEMS[2];
+  if (!first || !replacement) {
+    throw new Error("Expected presentation templates to insert and replace");
+  }
+  mockAgent();
+  mockChatLifecycle(context, {
+    threadId: THREAD_ID,
+    threadTitle: "My thread",
+  });
+  installWorkflows(() => {
+    return [];
+  });
+
+  await setupPage({ context, path: `/chats/${THREAD_ID}` });
+
+  const user = userEvent.setup();
+  await selectTemplate(user, first);
+  await user.click(await findComposerEditor());
+  await user.keyboard("{Enter}");
+  await waitFor(() => {
+    expect(structuredTemplateReferences()).toHaveLength(1);
+    expect(structuredTemplateReferences()[0]).toHaveTextContent(first.title);
+    expect(composerInlineTemplates()).toHaveLength(0);
+  });
 
   await selectTemplate(user, first);
   const inlineTemplate = composerInlineTemplates()[0];
@@ -261,6 +288,8 @@ test("Compose a message with inline templates", async () => {
     expect(templates).toHaveLength(1);
     expect(templates[0]).toHaveTextContent(replacement.title);
   });
+  expect(structuredTemplateReferences()).toHaveLength(1);
+  expect(structuredTemplateReferences()[0]).toHaveTextContent(first.title);
 });
 
 test("Dismiss workflow suggestions without losing the query", async () => {


### PR DESCRIPTION
The inline-template composer scenario exceeded its 5-second test budget in [Turbo run 34238219292](https://github.com/vm0-ai/vm0/actions/runs/34238219292/job/102102345968), after passing in 4,924 ms on the same SHA. It combined page startup with four template-picker openings across sending and editing.

Split that scenario into multiple-template sending and template replacement after sending. Preserve template order, rendered references, draft clearing, and replacement assertions. The replacement case still sends through the real page before editing the next draft, and now also checks that the previously sent template reference stays unchanged. Both cases retain the existing 5-second timeout.

Validation:

- Five serial runs of `chat-composer-workflows.test.tsx` with V8 coverage and `--maxWorkers=1`: 55/55 passed.
- Sending case: 2,444–3,789 ms; replacement case: 2,111–3,085 ms.
- File-scoped Prettier, Oxlint, and ESLint passed.
- Normal repository commit hooks passed: formatting, style policy, Knip, workspace type checks, file size, and commitlint.
