### PR TITLE
perf(runner): attribute guest connection startup phases

### DIFF
--- a/crates/guest-control-client/examples/connection_timing_overhead.rs
+++ b/crates/guest-control-client/examples/connection_timing_overhead.rs
@@ -1,0 +1,81 @@
+//! Alternating observed/unobserved real-socket samples; not a performance test.
+//! Run an optimized build on the target host and retain stdout for analysis.
+
+use std::io;
+use std::time::{Duration, Instant};
+
+use guest_control_client::GuestControlClient;
+use guest_control_proto::{MSG_PING, MSG_PONG, MSG_READY};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+async fn sample(observed: bool) -> io::Result<Duration> {
+    let base = std::env::temp_dir()
+        .join(format!("gct-{}", uuid::Uuid::new_v4()))
+        .display()
+        .to_string();
+    let socket = format!("{base}_{}", guest_control_proto::VSOCK_PORT);
+    let host = async {
+        let started = Instant::now();
+        let client = if observed {
+            let (result, timing) =
+                GuestControlClient::wait_for_connection_with_timing(&base, TIMEOUT).await;
+            std::hint::black_box(timing);
+            result?
+        } else {
+            GuestControlClient::wait_for_connection(&base, TIMEOUT).await?
+        };
+        Ok::<_, io::Error>((client, started.elapsed()))
+    };
+    let guest = async {
+        let mut stream = loop {
+            match UnixStream::connect(&socket).await {
+                Ok(stream) => break stream,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                    tokio::task::yield_now().await;
+                }
+                Err(error) => return Err(error),
+            }
+        };
+        let ready = guest_control_proto::encode(MSG_READY, 0, &[]).map_err(io::Error::other)?;
+        stream.write_all(&ready).await?;
+        let ping = guest_control_proto::encode(MSG_PING, 1, &[]).map_err(io::Error::other)?;
+        let mut received = vec![0; ping.len()];
+        stream.read_exact(&mut received).await?;
+        if received != ping {
+            return Err(io::Error::other("unexpected handshake PING"));
+        }
+        let pong = guest_control_proto::encode(MSG_PONG, 1, &[]).map_err(io::Error::other)?;
+        stream.write_all(&pong).await?;
+        Ok(stream)
+    };
+    let ((client, elapsed), guest) =
+        tokio::time::timeout(TIMEOUT, async { tokio::try_join!(host, guest) }).await??;
+    drop(client);
+    drop(guest);
+    Ok(elapsed)
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> io::Result<()> {
+    // Warmup is explicit and excluded from emitted samples. ABBA ordering
+    // balances slow drift; distributions are not proof of fleet-wide overhead.
+    for observed in [false, true].into_iter().cycle().take(40) {
+        sample(observed).await?;
+    }
+    let mut records = Vec::with_capacity(4000);
+    for batch in 0..1000 {
+        for observed in [false, true, true, false] {
+            records.push((batch, observed, sample(observed).await?));
+        }
+    }
+    for (batch, observed, elapsed) in records {
+        println!(
+            "{{\"batch\":{batch},\"observed\":{observed},\"duration_ns\":{}}}",
+            elapsed.as_nanos()
+        );
+    }
+    Ok(())
+}

--- a/crates/guest-control-client/src/connection/listener.rs
+++ b/crates/guest-control-client/src/connection/listener.rs
@@ -14,6 +14,7 @@ use crate::operation_tracker::NormalOperationTracker;
 use crate::{GuestControlClient, exec_operation, file};
 
 use super::request::deadline_after;
+use super::timing::GuestConnectionTiming;
 use super::{ConnectionState, READ_BUF_SIZE, Shared, reader_loop};
 
 struct ListenerSocketGuard {
@@ -43,6 +44,28 @@ impl GuestControlClient {
     /// Returns [`io::ErrorKind::InvalidInput`] if `timeout` cannot be
     /// represented as a Tokio deadline.
     pub async fn wait_for_connection(vsock_path: &str, timeout: Duration) -> io::Result<Self> {
+        Self::wait_for_connection_inner(vsock_path, timeout, None).await
+    }
+
+    /// Observe one connection attempt without changing its deadline or handshake.
+    ///
+    /// Timing accompanies ordinary errors as well as successful connections.
+    /// Cancellation drops the attempt and its timing; it still unlinks the listener.
+    pub async fn wait_for_connection_with_timing(
+        vsock_path: &str,
+        timeout: Duration,
+    ) -> (io::Result<Self>, GuestConnectionTiming) {
+        let mut timing = GuestConnectionTiming::new();
+        let result = Self::wait_for_connection_inner(vsock_path, timeout, Some(&mut timing)).await;
+        timing.completed = std::time::Instant::now();
+        (result, timing)
+    }
+
+    async fn wait_for_connection_inner(
+        vsock_path: &str,
+        timeout: Duration,
+        mut timing: Option<&mut GuestConnectionTiming>,
+    ) -> io::Result<Self> {
         let deadline = deadline_after(timeout, "guest connection timeout overflowed")?;
         let listener_path = format!("{vsock_path}_{}", guest_control_proto::VSOCK_PORT);
 
@@ -50,11 +73,19 @@ impl GuestControlClient {
         let _ = std::fs::remove_file(&listener_path);
 
         let listener = UnixListener::bind(&listener_path)?;
+        if let Some(timing) = timing.as_deref_mut() {
+            timing.listener_bound = Some(std::time::Instant::now());
+        }
         let mut listener_socket = ListenerSocketGuard {
             path: Some(listener_path.clone()),
         };
 
         let accept_result = time::timeout_at(deadline, listener.accept()).await;
+        if matches!(&accept_result, Ok(Ok(_)))
+            && let Some(timing) = timing.as_deref_mut()
+        {
+            timing.accepted = Some(std::time::Instant::now());
+        }
 
         // Stop accepting and unlink the listener socket before the accepted
         // stream is handed off. The guard still covers cancellation before
@@ -69,7 +100,10 @@ impl GuestControlClient {
             )
         })??;
 
-        Self::from_stream(stream, deadline).await
+        match timing {
+            Some(timing) => Self::from_stream_with_timing(stream, deadline, Some(timing)).await,
+            None => Self::from_stream(stream, deadline).await,
+        }
     }
 
     /// Build a `GuestControlClient` from an already-connected stream.
@@ -77,8 +111,16 @@ impl GuestControlClient {
     /// Performs the handshake on the unsplit stream, then splits it and
     /// spawns the background reader task.
     pub(crate) async fn from_stream(stream: UnixStream, deadline: Instant) -> io::Result<Self> {
+        Self::from_stream_with_timing(stream, deadline, None).await
+    }
+
+    async fn from_stream_with_timing(
+        stream: UnixStream,
+        deadline: Instant,
+        timing: Option<&mut GuestConnectionTiming>,
+    ) -> io::Result<Self> {
         // Handshake on the unsplit stream (reader task not running yet).
-        let (stream, handshake_decoder) = Self::handshake(stream, deadline).await?;
+        let (stream, handshake_decoder) = Self::handshake(stream, deadline, timing).await?;
 
         // Grab the raw fd BEFORE splitting — used by Drop to shutdown the
         // socket and unblock any pending reads (both our reader_loop and the
@@ -126,6 +168,7 @@ impl GuestControlClient {
     async fn handshake(
         mut stream: UnixStream,
         deadline: Instant,
+        mut timing: Option<&mut GuestConnectionTiming>,
     ) -> io::Result<(UnixStream, Decoder)> {
         let mut decoder = Decoder::new();
         let mut buf = Box::new([0u8; READ_BUF_SIZE]);
@@ -136,17 +179,28 @@ impl GuestControlClient {
         })
         .await?;
 
+        if let Some(timing) = timing.as_deref_mut() {
+            timing.ready = Some(std::time::Instant::now());
+        }
+
         // Send ping with a fixed seq. Shared.seq starts at 2 to avoid collision.
         let ping_seq: u32 = 1;
         let ping = guest_control_proto::encode(MSG_PING, ping_seq, &[])
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
         stream.write_all(&ping).await?;
+        if let Some(timing) = timing.as_deref_mut() {
+            timing.ping_written = Some(std::time::Instant::now());
+        }
 
         // Wait for pong with matching seq
         Self::read_until_handshake(&mut stream, &mut decoder, &mut buf, deadline, |m| {
             m.msg_type == MSG_PONG && m.seq == ping_seq
         })
         .await?;
+
+        if let Some(timing) = timing {
+            timing.pong_received = Some(std::time::Instant::now());
+        }
 
         Ok((stream, decoder))
     }

--- a/crates/guest-control-client/src/connection/mod.rs
+++ b/crates/guest-control-client/src/connection/mod.rs
@@ -1,6 +1,9 @@
 mod frame;
 mod listener;
 mod request;
+mod timing;
+
+pub use timing::GuestConnectionTiming;
 
 use std::collections::HashMap;
 use std::io;

--- a/crates/guest-control-client/src/connection/timing.rs
+++ b/crates/guest-control-client/src/connection/timing.rs
@@ -1,0 +1,39 @@
+use std::time::Instant;
+
+/// Host monotonic milestones from one guest connection attempt.
+///
+/// Missing milestones were not reached, not zero-duration work. The record is
+/// returned with ordinary I/O errors, but not if the owning future is dropped.
+/// These observations include host scheduling and are not guest execution times.
+#[derive(Clone, Copy, Debug)]
+pub struct GuestConnectionTiming {
+    /// First poll of the timed connection operation, before listener setup.
+    pub started: Instant,
+    /// The listener socket was bound successfully.
+    pub listener_bound: Option<Instant>,
+    /// A guest stream was accepted, before listener unlinking.
+    pub accepted: Option<Instant>,
+    /// The READY message was decoded.
+    pub ready: Option<Instant>,
+    /// The complete PING frame was written.
+    pub ping_written: Option<Instant>,
+    /// A PONG with the expected sequence was decoded.
+    pub pong_received: Option<Instant>,
+    /// The operation completed, including client setup or its original error.
+    pub completed: Instant,
+}
+
+impl GuestConnectionTiming {
+    pub(super) fn new() -> Self {
+        let started = Instant::now();
+        Self {
+            started,
+            listener_bound: None,
+            accepted: None,
+            ready: None,
+            ping_written: None,
+            pong_received: None,
+            completed: started,
+        }
+    }
+}

--- a/crates/guest-control-client/src/lib.rs
+++ b/crates/guest-control-client/src/lib.rs
@@ -96,6 +96,7 @@ use connection::{
 use connection::{request_on_shared, write_request_frame_with_builder};
 use operation_tracker::NormalOperationFenceRejection as TrackerNormalOperationFenceRejection;
 
+pub use connection::GuestConnectionTiming;
 pub use exec_operation::{
     CodexSessionCleanupRequest, ExecCaptureRequest, ExecControlAck, ExecControlGuestStatus,
     ExecControlHandle, ExecControlOutcome, ExecOperationHandle, ExecOperationRequest,

--- a/crates/guest-control-client/src/tests/connection.rs
+++ b/crates/guest-control-client/src/tests/connection.rs
@@ -1,4 +1,5 @@
 use std::io;
+mod timing;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/guest-control-client/src/tests/connection/timing.rs
+++ b/crates/guest-control-client/src/tests/connection/timing.rs
@@ -1,0 +1,174 @@
+use std::io;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use guest_control_proto::{MSG_PING, MSG_PONG, MSG_READY, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK};
+use tokio::io::AsyncWriteExt;
+use tokio::net::UnixStream;
+
+use super::super::support::MockGuest;
+use super::unique_vsock_paths;
+use crate::GuestControlClient;
+
+async fn wait_for_listener(path: &Path) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !path.exists() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn timed_connection_preserves_milestones_and_decoder_handoff() {
+    let (base, listener) = unique_vsock_paths("timing");
+    let task = tokio::spawn(async move {
+        GuestControlClient::wait_for_connection_with_timing(&base, Duration::from_secs(30)).await
+    });
+    wait_for_listener(&listener).await;
+    let connect_released = Instant::now();
+    let mut guest = MockGuest::new(UnixStream::connect(&listener).await.unwrap());
+    let ready_released = Instant::now();
+    guest.send_empty_response(MSG_READY, 0).await;
+    let ping = guest.expect_message(MSG_PING).await;
+    assert_eq!(ping.seq, 1);
+    assert!(!listener.exists());
+
+    guest.send_empty_response(MSG_PONG, 99).await;
+    tokio::task::yield_now().await;
+    assert!(
+        !task.is_finished(),
+        "an unrelated PONG cannot finish the handshake"
+    );
+
+    // A partial next frame must stay in the handshake decoder until the
+    // background reader receives its remainder after the real request.
+    let ack = guest_control_proto::encode(MSG_SHUTDOWN_ACK, 2, &[]).unwrap();
+    let (prefix, suffix) = ack.split_at(3);
+    let mut bytes = guest_control_proto::encode(MSG_PONG, ping.seq, &[]).unwrap();
+    bytes.extend_from_slice(prefix);
+    let pong_released = Instant::now();
+    guest.stream_mut().write_all(&bytes).await.unwrap();
+    let (result, timing) = task.await.unwrap();
+    let host = result.unwrap();
+
+    let bound = timing.listener_bound.unwrap();
+    let accepted = timing.accepted.unwrap();
+    let ready = timing.ready.unwrap();
+    let written = timing.ping_written.unwrap();
+    let pong = timing.pong_received.unwrap();
+    assert!(timing.started <= bound);
+    assert!(bound <= connect_released);
+    assert!(connect_released <= accepted);
+    assert!(accepted <= ready);
+    assert!(ready_released <= ready);
+    assert!(ready <= written && written <= pong);
+    assert!(pong_released <= pong && pong <= timing.completed);
+
+    let shutdown = tokio::spawn(async move { host.shutdown(Duration::from_secs(5)).await });
+    let request = guest.expect_message(MSG_SHUTDOWN).await;
+    assert_eq!(request.seq, 2);
+    guest.stream_mut().write_all(suffix).await.unwrap();
+    shutdown.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn timed_connection_retains_eof_phase_without_later_milestones() {
+    for after_ready in [false, true] {
+        let (base, listener) = unique_vsock_paths("timing-eof");
+        let task = tokio::spawn(async move {
+            GuestControlClient::wait_for_connection_with_timing(&base, Duration::from_secs(30))
+                .await
+        });
+        wait_for_listener(&listener).await;
+        let mut guest = MockGuest::new(UnixStream::connect(&listener).await.unwrap());
+        if after_ready {
+            guest.send_empty_response(MSG_READY, 0).await;
+            guest.expect_message(MSG_PING).await;
+        }
+        drop(guest);
+        let (result, timing) = task.await.unwrap();
+        assert_eq!(result.err().unwrap().kind(), io::ErrorKind::ConnectionReset);
+        assert!(timing.listener_bound.is_some());
+        assert!(timing.accepted.is_some());
+        assert_eq!(timing.ready.is_some(), after_ready);
+        assert_eq!(timing.ping_written.is_some(), after_ready);
+        assert!(timing.pong_received.is_none());
+        assert!(timing.completed >= timing.accepted.unwrap());
+        assert!(!listener.exists());
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn timed_connection_keeps_one_deadline_for_accept_and_handshake() {
+    for connect in [false, true] {
+        let (base, listener) = unique_vsock_paths("timing-deadline");
+        let timeout = Duration::from_secs(10);
+        let started = tokio::time::Instant::now();
+        let task = tokio::spawn(async move {
+            GuestControlClient::wait_for_connection_with_timing(&base, timeout).await
+        });
+        tokio::task::yield_now().await;
+        assert!(listener.exists());
+        let mut guest = None;
+        if connect {
+            tokio::time::advance(Duration::from_secs(4)).await;
+            let mut connected = MockGuest::new(UnixStream::connect(&listener).await.unwrap());
+            connected.send_empty_response(MSG_READY, 0).await;
+            connected.expect_message(MSG_PING).await;
+            guest = Some(connected);
+        }
+        let (result, timing) = task.await.unwrap();
+        assert_eq!(result.err().unwrap().kind(), io::ErrorKind::TimedOut);
+        assert_eq!(started.elapsed(), timeout);
+        // Production milestones use the host clock, not the paused Tokio clock.
+        assert!(timing.completed >= timing.started);
+        assert!(timing.listener_bound.is_some());
+        assert_eq!(timing.accepted.is_some(), connect);
+        assert_eq!(timing.ping_written.is_some(), connect);
+        assert!(timing.pong_received.is_none());
+        assert!(!listener.exists());
+        drop(guest);
+    }
+}
+
+#[tokio::test]
+async fn timed_connection_abort_unlinks_listener_and_closes_accepted_stream() {
+    for connect in [false, true] {
+        let (base, listener) = unique_vsock_paths("timing-abort");
+        let task = tokio::spawn(async move {
+            GuestControlClient::wait_for_connection_with_timing(&base, Duration::from_secs(30))
+                .await
+        });
+        wait_for_listener(&listener).await;
+        let mut guest = None;
+        if connect {
+            let mut connected = MockGuest::new(UnixStream::connect(&listener).await.unwrap());
+            connected.send_empty_response(MSG_READY, 0).await;
+            connected.expect_message(MSG_PING).await;
+            guest = Some(connected);
+        }
+        task.abort();
+        assert!(task.await.err().unwrap().is_cancelled());
+        assert!(!listener.exists());
+        if let Some(mut guest) = guest {
+            guest.expect_eof().await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn timed_connection_setup_failure_does_not_claim_listener_completion() {
+    let (base, listener) = unique_vsock_paths("timing-overflow");
+    let (result, timing) =
+        GuestControlClient::wait_for_connection_with_timing(&base, Duration::MAX).await;
+    assert_eq!(result.err().unwrap().kind(), io::ErrorKind::InvalidInput);
+    assert!(timing.listener_bound.is_none());
+    assert!(timing.accepted.is_none());
+    assert!(timing.ready.is_none());
+    assert!(timing.ping_written.is_none());
+    assert!(timing.pong_received.is_none());
+    assert!(timing.completed >= timing.started);
+    assert!(!listener.exists());
+}

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -27,6 +27,60 @@ struct Timing {
     exec_ms: Option<u128>,
 }
 
+#[derive(Default)]
+struct BenchmarkStartObserver {
+    stages: Vec<(sandbox::SandboxStartStage, Duration, bool)>,
+    connection: Vec<(
+        sandbox::SandboxGuestConnectionPhase,
+        Duration,
+        Duration,
+        bool,
+    )>,
+}
+
+impl sandbox::SandboxStartObserver for BenchmarkStartObserver {
+    fn record_stage(
+        &mut self,
+        stage: sandbox::SandboxStartStage,
+        duration: Duration,
+        success: bool,
+    ) {
+        self.stages.push((stage, duration, success));
+    }
+
+    fn record_guest_connection_phase(
+        &mut self,
+        phase: sandbox::SandboxGuestConnectionPhase,
+        duration: Duration,
+        remaining: Duration,
+        success: bool,
+    ) {
+        self.connection.push((phase, duration, remaining, success));
+    }
+}
+
+impl BenchmarkStartObserver {
+    fn report(self) {
+        for (stage, duration, success) in self.stages {
+            info!(
+                ?stage,
+                duration_ms = duration.as_secs_f64() * 1000.0,
+                success,
+                "benchmark sandbox start stage"
+            );
+        }
+        for (phase, duration, remaining, success) in self.connection {
+            info!(
+                ?phase,
+                duration_ms = duration.as_secs_f64() * 1000.0,
+                remaining_ms = remaining.as_secs_f64() * 1000.0,
+                success,
+                "benchmark guest connection phase"
+            );
+        }
+    }
+}
+
 const DEFAULT_BENCHMARK_TIMEZONE: &str = "UTC";
 
 /// Reject malformed entries so typos fail loud before benchmark startup.
@@ -434,9 +488,11 @@ async fn run_in_sandbox(
 ) -> (RunnerResult<ExecResult>, Timing) {
     let mut timing = Timing::default();
 
+    let mut observer = BenchmarkStartObserver::default();
     let t_boot = Instant::now();
-    let start_result = sandbox.start().await;
+    let start_result = sandbox.start_with_observer(&mut observer).await;
     timing.boot_ms = Some(t_boot.elapsed().as_millis());
+    observer.report();
     if let Err(e) = start_result {
         return (Err(e.into()), timing);
     }

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -8,9 +8,9 @@ use guest_contracts::cli_agent_session_id::is_valid_cli_agent_session_id;
 use guest_contracts::codex_thread_id::canonical_codex_thread_id;
 use sandbox::{
     Sandbox, SandboxConfig, SandboxCreateObserver, SandboxCreateStage, SandboxError,
-    SandboxFactory, SandboxGuestDnsReadinessReason, SandboxId, SandboxNbdCowCreateOutcome,
-    SandboxNbdCowCreateStage, SandboxNbdNetlinkConnectStage, SandboxStartObserver,
-    SandboxStartStage,
+    SandboxFactory, SandboxGuestConnectionPhase, SandboxGuestDnsReadinessReason, SandboxId,
+    SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage, SandboxNbdNetlinkConnectStage,
+    SandboxStartObserver, SandboxStartStage,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -212,6 +212,59 @@ impl SandboxStartObserver for FreshSandboxStartObserver<'_> {
             success,
             error,
         );
+    }
+
+    fn record_guest_connection_phase(
+        &mut self,
+        phase: SandboxGuestConnectionPhase,
+        duration: Duration,
+        remaining: Duration,
+        success: bool,
+    ) {
+        let (full_action, remaining_action) = guest_connection_phase_actions(phase);
+        let error = (!success).then_some(SANDBOX_START_STAGE_FAILED);
+        self.telemetry.record(full_action, duration, success, error);
+        self.telemetry
+            .record(remaining_action, remaining, success, error);
+    }
+}
+
+fn guest_connection_phase_actions(
+    phase: SandboxGuestConnectionPhase,
+) -> (&'static str, &'static str) {
+    match phase {
+        SandboxGuestConnectionPhase::TaskSchedule => (
+            "runner_fresh_sandbox_start_guest_connection_task_schedule_full",
+            "runner_fresh_sandbox_start_guest_connection_task_schedule_remaining",
+        ),
+        SandboxGuestConnectionPhase::ListenerSetup => (
+            "runner_fresh_sandbox_start_guest_connection_listener_setup_full",
+            "runner_fresh_sandbox_start_guest_connection_listener_setup_remaining",
+        ),
+        SandboxGuestConnectionPhase::Accept => (
+            "runner_fresh_sandbox_start_guest_connection_accept_full",
+            "runner_fresh_sandbox_start_guest_connection_accept_remaining",
+        ),
+        SandboxGuestConnectionPhase::Ready => (
+            "runner_fresh_sandbox_start_guest_connection_ready_full",
+            "runner_fresh_sandbox_start_guest_connection_ready_remaining",
+        ),
+        SandboxGuestConnectionPhase::Ping => (
+            "runner_fresh_sandbox_start_guest_connection_ping_full",
+            "runner_fresh_sandbox_start_guest_connection_ping_remaining",
+        ),
+        SandboxGuestConnectionPhase::Pong => (
+            "runner_fresh_sandbox_start_guest_connection_pong_full",
+            "runner_fresh_sandbox_start_guest_connection_pong_remaining",
+        ),
+        SandboxGuestConnectionPhase::ClientSetup => (
+            "runner_fresh_sandbox_start_guest_connection_client_setup_full",
+            "runner_fresh_sandbox_start_guest_connection_client_setup_remaining",
+        ),
+        SandboxGuestConnectionPhase::TaskHandoff => (
+            "runner_fresh_sandbox_start_guest_connection_task_handoff_full",
+            "runner_fresh_sandbox_start_guest_connection_task_handoff_remaining",
+        ),
     }
 }
 

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -6,11 +6,11 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use sandbox::{
     CopyFileOptions, ExecRequest, ExecResult, ProcessExit, Sandbox, SandboxConfig,
-    SandboxCreateObserver, SandboxCreateStage, SandboxError, SandboxFactory, SandboxId,
-    SandboxInitializationPhase, SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage,
-    SandboxNbdNetlinkConnectStage, SandboxOperation, SandboxOperationReason,
-    SandboxOperationTimeoutStage, SandboxStartObserver, SandboxStartStage, StartProcessRequest,
-    WriteFileEntry,
+    SandboxCreateObserver, SandboxCreateStage, SandboxError, SandboxFactory,
+    SandboxGuestConnectionPhase, SandboxId, SandboxInitializationPhase, SandboxNbdCowCreateOutcome,
+    SandboxNbdCowCreateStage, SandboxNbdNetlinkConnectStage, SandboxOperation,
+    SandboxOperationReason, SandboxOperationTimeoutStage, SandboxStartObserver, SandboxStartStage,
+    StartProcessRequest, WriteFileEntry,
 };
 use sandbox_mock::{MockSandbox, MockSandboxFactory, MockSandboxOverrides};
 
@@ -407,6 +407,19 @@ impl Sandbox for ObservedStartSandbox {
                 }
             }
             observer.record_stage(stage, Duration::from_millis(index as u64 + 30), success);
+            if stage == SandboxStartStage::GuestConnectionWait && !self.omit_optional_stages {
+                for (index, phase) in SandboxGuestConnectionPhase::ALL.into_iter().enumerate() {
+                    if !success && phase == SandboxGuestConnectionPhase::ClientSetup {
+                        continue;
+                    }
+                    observer.record_guest_connection_phase(
+                        phase,
+                        Duration::from_millis(index as u64 + 1),
+                        Duration::from_millis(u64::from(index >= 5)),
+                        success || phase != SandboxGuestConnectionPhase::Pong,
+                    );
+                }
+            }
             if !success {
                 return Err(SandboxError::Start {
                     message: "observed mock start failure".to_string(),
@@ -729,6 +742,17 @@ const FRESH_SANDBOX_START_STAGE_ACTIONS: &[&str] = &[
     "runner_fresh_sandbox_start_guest_connection_wait",
     "runner_fresh_sandbox_start_guest_dns_readiness",
     "runner_fresh_sandbox_start_runtime_finalize",
+];
+
+const GUEST_CONNECTION_PHASE_NAMES: [&str; 8] = [
+    "task_schedule",
+    "listener_setup",
+    "accept",
+    "ready",
+    "ping",
+    "pong",
+    "client_setup",
+    "task_handoff",
 ];
 
 const RUNNER_PRE_SPAWN_PHASE_CASES: &[(RunnerPreSpawnPhase, &str, u64)] = &[
@@ -1413,6 +1437,16 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
         assert_action_success(&telemetry, action, true);
         assert_action_duration(&telemetry, action, index as u64 + 30);
     }
+    for (index, phase) in GUEST_CONNECTION_PHASE_NAMES.into_iter().enumerate() {
+        for (kind, duration) in [
+            ("full", index as u64 + 1),
+            ("remaining", u64::from(index >= 5)),
+        ] {
+            let action = format!("runner_fresh_sandbox_start_guest_connection_{phase}_{kind}");
+            assert_action_once_with_duration(&telemetry, &action, duration);
+            assert_action_success(&telemetry, &action, true);
+        }
+    }
     let operations = telemetry.pending_ops_with_duration_snapshot();
     for action in FRESH_SANDBOX_FACTORY_NBD_COW_OUTCOME_ACTIONS {
         let matching: Vec<_> = operations
@@ -1696,6 +1730,14 @@ async fn execute_job_omits_inapplicable_sandbox_start_stages() {
         "runner_fresh_sandbox_start_guest_dns_readiness_attempt",
     );
     assert_action_success(&telemetry, "runner_fresh_sandbox_start", true);
+    for phase in GUEST_CONNECTION_PHASE_NAMES {
+        for kind in ["full", "remaining"] {
+            assert_lacks_action(
+                &telemetry,
+                &format!("runner_fresh_sandbox_start_guest_connection_{phase}_{kind}"),
+            );
+        }
+    }
 }
 
 #[tokio::test]
@@ -1742,6 +1784,23 @@ async fn execute_job_records_failed_sandbox_start_stage_timing() {
         "runner_fresh_sandbox_start_guest_connection_wait",
         32,
     );
+    for kind in ["full", "remaining"] {
+        assert_action_outcome(
+            &telemetry,
+            &format!("runner_fresh_sandbox_start_guest_connection_pong_{kind}"),
+            false,
+            Some("sandbox_start_stage_failed"),
+        );
+        assert_lacks_action(
+            &telemetry,
+            &format!("runner_fresh_sandbox_start_guest_connection_client_setup_{kind}"),
+        );
+        assert_action_success(
+            &telemetry,
+            &format!("runner_fresh_sandbox_start_guest_connection_task_handoff_{kind}"),
+            true,
+        );
+    }
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_start_guest_dns_readiness");
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_start_runtime_finalize");
     assert_action_outcome(

--- a/crates/sandbox-firecracker/src/sandbox.rs
+++ b/crates/sandbox-firecracker/src/sandbox.rs
@@ -73,6 +73,7 @@ use crate::process_log::{
 use crate::runtime_dirs::{prepare_private_runtime_vsock_dir, set_private_runtime_socket_mode};
 use crate::snapshot_mount_namespace::{BindMount, SnapshotMountMode, build_command};
 
+mod guest_connection_timing;
 mod snapshot_restore;
 mod state;
 
@@ -1441,11 +1442,26 @@ impl FirecrackerSandbox {
                     message: format!("bind guest RPC transport: {error}"),
                 })?;
 
-        // Start the vsock listener BEFORE launching Firecracker.
-        // The UDS must be bound before the guest tries to connect.
+        // Submit the vsock listener before launching Firecracker. The task
+        // overlaps backend startup; submission is not a listener-bind barrier.
         let vsock_path = self.sock_paths.vsock().display().to_string();
+        let observe_connection = timing.observer.is_some();
+        let connection_submitted = Instant::now();
         let mut vsock_task = tokio::spawn(async move {
-            GuestControlClient::wait_for_connection(&vsock_path, VSOCK_CONNECT_TIMEOUT).await
+            if observe_connection {
+                let (result, timing) = GuestControlClient::wait_for_connection_with_timing(
+                    &vsock_path,
+                    VSOCK_CONNECT_TIMEOUT,
+                )
+                .await;
+                (result, Some(timing))
+            } else {
+                (
+                    GuestControlClient::wait_for_connection(&vsock_path, VSOCK_CONNECT_TIMEOUT)
+                        .await,
+                    None,
+                )
+            }
         });
 
         let launch_result = if self.factory_config.snapshot.is_some() {
@@ -1505,13 +1521,16 @@ impl FirecrackerSandbox {
         // The listener overlaps backend startup. Measure only the remaining
         // critical-path wait after launch and optional snapshot restore.
         let guest_connection_started = Instant::now();
+        let mut connection_timing = None;
         let (guest_connection_result, abort_vsock_on_failure) = tokio::select! {
             result = &mut vsock_task => {
                 let result = match result {
-                    Ok(Ok(guest)) => Ok(guest),
-                    Ok(Err(error)) => Err(SandboxError::Start {
-                        message: format!("vsock connection: {error}"),
-                    }),
+                    Ok((result, observed_timing)) => {
+                        connection_timing = observed_timing;
+                        result.map_err(|error| SandboxError::Start {
+                            message: format!("vsock connection: {error}"),
+                        })
+                    },
                     Err(error) => Err(SandboxError::Start {
                         message: format!("vsock task: {error}"),
                     }),
@@ -1527,21 +1546,26 @@ impl FirecrackerSandbox {
                 )
             }
         };
+        let connection_observed = Instant::now();
+        timing.record(
+            SandboxStartStage::GuestConnectionWait,
+            guest_connection_started,
+            guest_connection_result.is_ok(),
+        );
+        if let Some(connection_timing) = connection_timing
+            && let Some(observer) = timing.observer.as_deref_mut()
+        {
+            guest_connection_timing::record_guest_connection_timing(
+                observer,
+                connection_timing,
+                connection_submitted,
+                guest_connection_started,
+                connection_observed,
+            );
+        }
         let guest_control_client = match guest_connection_result {
-            Ok(guest) => {
-                timing.record(
-                    SandboxStartStage::GuestConnectionWait,
-                    guest_connection_started,
-                    true,
-                );
-                guest
-            }
+            Ok(guest) => guest,
             Err(error) => {
-                timing.record(
-                    SandboxStartStage::GuestConnectionWait,
-                    guest_connection_started,
-                    false,
-                );
                 if abort_vsock_on_failure {
                     abort_and_join(vsock_task).await;
                 }

--- a/crates/sandbox-firecracker/src/sandbox/guest_connection_timing.rs
+++ b/crates/sandbox-firecracker/src/sandbox/guest_connection_timing.rs
@@ -1,0 +1,52 @@
+use std::time::Instant;
+
+use guest_control_client::GuestConnectionTiming;
+use sandbox::{SandboxGuestConnectionPhase, SandboxStartObserver};
+
+/// Convert one completed task's monotonic timeline without changing ownership.
+pub(super) fn record_guest_connection_timing(
+    observer: &mut dyn SandboxStartObserver,
+    timing: GuestConnectionTiming,
+    submitted: Instant,
+    remaining_started: Instant,
+    observed: Instant,
+) {
+    let mut started = submitted;
+    let phases = [
+        (
+            SandboxGuestConnectionPhase::TaskSchedule,
+            Some(timing.started),
+        ),
+        (
+            SandboxGuestConnectionPhase::ListenerSetup,
+            timing.listener_bound,
+        ),
+        (SandboxGuestConnectionPhase::Accept, timing.accepted),
+        (SandboxGuestConnectionPhase::Ready, timing.ready),
+        (SandboxGuestConnectionPhase::Ping, timing.ping_written),
+        (SandboxGuestConnectionPhase::Pong, timing.pong_received),
+        (
+            SandboxGuestConnectionPhase::ClientSetup,
+            Some(timing.completed),
+        ),
+    ];
+    for (phase, completed) in phases {
+        let ended = completed.unwrap_or(timing.completed);
+        observer.record_guest_connection_phase(
+            phase,
+            ended.duration_since(started),
+            ended.saturating_duration_since(started.max(remaining_started)),
+            completed.is_some(),
+        );
+        started = ended;
+        if completed.is_none() {
+            break;
+        }
+    }
+    observer.record_guest_connection_phase(
+        SandboxGuestConnectionPhase::TaskHandoff,
+        observed.duration_since(timing.completed),
+        observed.saturating_duration_since(timing.completed.max(remaining_started)),
+        true,
+    );
+}

--- a/crates/sandbox-firecracker/src/sandbox/tests.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests.rs
@@ -15,6 +15,7 @@ use tracing::Level;
 use tracing_subscriber::prelude::*;
 use tracing_test_support::{CapturedEvent, CapturedEvents};
 
+mod guest_connection_timing;
 mod guest_rpc;
 mod private_write_diagnostics;
 mod process_write;

--- a/crates/sandbox-firecracker/src/sandbox/tests/guest_connection_timing.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests/guest_connection_timing.rs
@@ -1,0 +1,180 @@
+use std::time::{Duration, Instant};
+
+use guest_control_client::GuestControlClient;
+use guest_control_proto::{MSG_PONG, MSG_READY};
+use sandbox::{SandboxGuestConnectionPhase, SandboxStartObserver, SandboxStartStage};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+
+use super::super::guest_connection_timing::record_guest_connection_timing;
+
+#[derive(Default)]
+struct Observer {
+    phases: Vec<(SandboxGuestConnectionPhase, Duration, Duration, bool)>,
+}
+
+impl SandboxStartObserver for Observer {
+    fn record_stage(&mut self, _: SandboxStartStage, _: Duration, _: bool) {}
+
+    fn record_guest_connection_phase(
+        &mut self,
+        phase: SandboxGuestConnectionPhase,
+        duration: Duration,
+        remaining: Duration,
+        success: bool,
+    ) {
+        self.phases.push((phase, duration, remaining, success));
+    }
+}
+
+#[tokio::test]
+async fn real_connection_timeline_partitions_full_and_remaining_waits() {
+    // Each timeline is produced by the public client against a real socket;
+    // no hand-constructed milestone record or scheduling-duration assertion.
+    for remaining_point in 0..3 {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("guest").display().to_string();
+        let socket = format!("{base}_{}", guest_control_proto::VSOCK_PORT);
+        let submitted = Instant::now();
+        let task = tokio::spawn(async move {
+            GuestControlClient::wait_for_connection_with_timing(&base, Duration::from_secs(30))
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while !std::path::Path::new(&socket).exists() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        let before_connect = Instant::now();
+        let mut guest = UnixStream::connect(&socket).await.unwrap();
+        guest
+            .write_all(&guest_control_proto::encode(MSG_READY, 0, &[]).unwrap())
+            .await
+            .unwrap();
+        let ping = guest_control_proto::encode(guest_control_proto::MSG_PING, 1, &[]).unwrap();
+        let mut received = vec![0; ping.len()];
+        guest.read_exact(&mut received).await.unwrap();
+        assert_eq!(received, ping);
+        let before_pong = Instant::now();
+        guest
+            .write_all(&guest_control_proto::encode(MSG_PONG, 1, &[]).unwrap())
+            .await
+            .unwrap();
+        let (result, timing) = task.await.unwrap();
+        let client = result.unwrap();
+        let remaining_started = match remaining_point {
+            0 => before_connect,
+            1 => before_pong,
+            _ => Instant::now(),
+        };
+        let observed = Instant::now();
+        let mut observer = Observer::default();
+        record_guest_connection_timing(
+            &mut observer,
+            timing,
+            submitted,
+            remaining_started,
+            observed,
+        );
+        assert_eq!(observer.phases.len(), 8);
+        assert_eq!(
+            observer
+                .phases
+                .iter()
+                .map(|record| record.0)
+                .collect::<Vec<_>>(),
+            SandboxGuestConnectionPhase::ALL
+        );
+        assert!(
+            observer
+                .phases
+                .iter()
+                .all(|(_, full, remaining, success)| *success && remaining <= full)
+        );
+        assert_eq!(
+            observer
+                .phases
+                .iter()
+                .map(|record| record.1)
+                .sum::<Duration>(),
+            observed.duration_since(submitted)
+        );
+        assert_eq!(
+            observer
+                .phases
+                .iter()
+                .map(|record| record.2)
+                .sum::<Duration>(),
+            observed.duration_since(remaining_started)
+        );
+        if remaining_point == 2 {
+            for (phase, _, remaining, _) in &observer.phases {
+                if *phase != SandboxGuestConnectionPhase::TaskHandoff {
+                    assert_eq!(
+                        *remaining,
+                        Duration::ZERO,
+                        "{phase:?} completed before the parent wait"
+                    );
+                }
+            }
+        }
+        drop(client);
+        let mut eof = [0];
+        assert_eq!(guest.read(&mut eof).await.unwrap(), 0);
+    }
+}
+
+#[tokio::test]
+async fn real_connection_eof_records_failed_phase_and_successful_error_handoff() {
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().join("guest").display().to_string();
+    let socket = format!("{base}_{}", guest_control_proto::VSOCK_PORT);
+    let submitted = Instant::now();
+    let task = tokio::spawn(async move {
+        GuestControlClient::wait_for_connection_with_timing(&base, Duration::from_secs(30)).await
+    });
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !std::path::Path::new(&socket).exists() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    let guest = UnixStream::connect(&socket).await.unwrap();
+    drop(guest);
+    let (result, timing) = task.await.unwrap();
+    assert_eq!(
+        result.err().unwrap().kind(),
+        std::io::ErrorKind::ConnectionReset
+    );
+    let observed = Instant::now();
+    let mut observer = Observer::default();
+    record_guest_connection_timing(&mut observer, timing, submitted, submitted, observed);
+    let phases: Vec<_> = observer
+        .phases
+        .iter()
+        .map(|record| (record.0, record.3))
+        .collect();
+    assert_eq!(
+        phases,
+        vec![
+            (SandboxGuestConnectionPhase::TaskSchedule, true),
+            (SandboxGuestConnectionPhase::ListenerSetup, true),
+            (SandboxGuestConnectionPhase::Accept, true),
+            (SandboxGuestConnectionPhase::Ready, false),
+            (SandboxGuestConnectionPhase::TaskHandoff, true),
+        ]
+    );
+    assert!(observer.phases.iter().all(|record| record.1 == record.2));
+    assert_eq!(
+        observer
+            .phases
+            .iter()
+            .map(|record| record.2)
+            .sum::<Duration>(),
+        observed.duration_since(submitted)
+    );
+    assert!(!std::path::Path::new(&socket).exists());
+}

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -52,8 +52,8 @@ pub use sandbox::{
     GuestMemorySnapshot, Sandbox, SandboxFinalExecParkHandoff, SandboxFinalExecParkHandoffOutcome,
     SandboxFinalExecParkHandoffPoint, SandboxFinalExecParkObserver, SandboxFinalExecParkOutcome,
     SandboxFinalExecParkStage, SandboxFinalExecParkSubstage, SandboxFinalExecParkSubstageOutcome,
-    SandboxParkNonReusableReason, SandboxParkOutcome, SandboxStartObserver, SandboxStartStage,
-    SevereMemoryRetentionDiagnostics,
+    SandboxGuestConnectionPhase, SandboxParkNonReusableReason, SandboxParkOutcome,
+    SandboxStartObserver, SandboxStartStage, SevereMemoryRetentionDiagnostics,
 };
 pub use snapshot::{
     PendingSnapshotPublish, SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider,

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -375,6 +375,57 @@ pub trait SandboxStartObserver: Send {
     /// not be added to it. Cancellation may report an incomplete child without
     /// a completed parent; this callback never owns cancellation or cleanup.
     fn record_dns_readiness_attempt(&mut self, _attempt: crate::SandboxDnsReadinessAttempt) {}
+
+    /// Records optional guest-connection detail, separately from critical-path stages.
+    ///
+    /// `duration` covers the full host-observed phase, including work overlapping
+    /// backend startup. `remaining` is its intersection with this same start's
+    /// residual guest-connection wait. Never add full durations to start stages.
+    /// A phase is emitted at most once; missing detail after cancellation, panic,
+    /// or an earlier startup failure is not a zero-duration observation.
+    fn record_guest_connection_phase(
+        &mut self,
+        _phase: SandboxGuestConnectionPhase,
+        _duration: Duration,
+        _remaining: Duration,
+        _success: bool,
+    ) {
+    }
+}
+
+/// Fixed host-side guest connection phases, not guest-internal execution times.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SandboxGuestConnectionPhase {
+    /// Task submission through the connection operation's first poll.
+    TaskSchedule,
+    /// Deadline/path preparation, stale socket removal and listener bind.
+    ListenerSetup,
+    /// Bound listener through successful accept, or the accept error.
+    Accept,
+    /// Accept through READY decode, including listener unlinking and decoder setup.
+    Ready,
+    /// READY decode through complete PING frame write.
+    Ping,
+    /// PING write through decode of the matching PONG.
+    Pong,
+    /// PONG decode through client initialization and reader task submission.
+    ClientSetup,
+    /// Connection operation completion through the startup caller's observation.
+    TaskHandoff,
+}
+
+impl SandboxGuestConnectionPhase {
+    /// Stable phase order; errors may produce only a completed prefix and failed phase.
+    pub const ALL: [Self; 8] = [
+        Self::TaskSchedule,
+        Self::ListenerSetup,
+        Self::Accept,
+        Self::Ready,
+        Self::Ping,
+        Self::Pong,
+        Self::ClientSetup,
+        Self::TaskHandoff,
+    ];
 }
 
 /// Fixed low-cardinality stages of the final reuse preparation and park path.

--- a/docs/guest-connection-timing.md
+++ b/docs/guest-connection-timing.md
@@ -1,0 +1,239 @@
+# Guest connection timing
+
+Issue [#32444](https://github.com/vm0-ai/vm0/issues/32444) attributes host-observed
+guest control connection work. It does not change the handshake or establish
+that its duration is removable.
+
+## Boundaries
+
+The connection task is submitted before backend launch and snapshot restore.
+Submission is not proof that the listener has bound. All milestones use the
+same host `std::time::Instant` clock, not guest timestamps or Tokio virtual time.
+
+| Phase            | Full interval                                                           |
+| ---------------- | ----------------------------------------------------------------------- |
+| `task_schedule`  | Task submission to the connection operation's first poll                |
+| `listener_setup` | First poll to successful listener bind                                  |
+| `accept`         | Listener bind to accepted stream                                        |
+| `ready`          | Accept to decoded READY, including listener unlinking and decoder setup |
+| `ping`           | READY to complete PING write                                            |
+| `pong`           | PING write to decoded PONG with the expected sequence                   |
+| `client_setup`   | PONG to client initialization and reader task submission                |
+| `task_handoff`   | Connection operation completion to startup caller observation           |
+
+These are host observations: accept includes time before the guest connects;
+READY/PONG include host scheduling and decoding, not just network transit.
+Handoff can contain backend work after an already completed connection.
+They do not identify guest retry counts, kernel/vsock causes or guest scheduling.
+
+The five `SandboxStartStage` intervals remain the non-overlapping startup
+critical path. In particular,
+`runner_fresh_sandbox_start_guest_connection_wait` still starts after backend
+launch and optional snapshot restore and ends when the caller observes its
+connection result or process exit. Its duration is recorded before detail
+callbacks run.
+
+For each detail interval `[phase_start, phase_end]`, `remaining` is its
+intersection with that same invocation's residual wait interval. Completed
+connection phases have zero remaining duration when they finish before the
+residual wait begins. The final handoff interval accounts for caller observation.
+The residual phase sum covers the parent interval up to its small final timer
+observation gap; it is not a second duration to add to that parent.
+
+## Telemetry and coverage
+
+Runner emits at most eight pairs of fixed action names per returned connection
+attempt:
+
+```text
+runner_fresh_sandbox_start_guest_connection_<phase>_full
+runner_fresh_sandbox_start_guest_connection_<phase>_remaining
+```
+
+No new action dimensions, socket paths, addresses, sandbox/session identities or
+arbitrary errors are added. Records use the existing collector and flush policy.
+The API schema and runner/guest wire protocol are unchanged. Existing observer
+implementations can omit this optional detail through the default callback.
+
+Ordinary I/O errors return the completed milestone prefix, the failed phase
+ending at operation completion, and a successful task-handoff observation.
+Handoff success means the result was returned, not that connection succeeded.
+The original error and existing failed parent event remain authoritative.
+Aborted or panicked tasks cannot return detail; backend/snapshot failures and
+caller cancellation can also leave it absent. Missing detail is not zero or
+success. Do not derive fleet failure rates from complete successful records.
+
+Operation event timestamps are buffer-insertion times, not the individual
+milestone timestamps. Do not reconstruct overlap from those timestamps. Full
+and remaining durations are already computed from the actual shared timeline.
+The existing operation format truncates durations to milliseconds; sub-millisecond
+phases can legitimately be zero. Benchmark output retains fractional milliseconds.
+
+Keep exact API/Runner revisions, host, startup/reuse path and retries separate.
+Exclude same-run blank-pool hits from true-cold cohorts. A new sandbox can resume
+a base VM snapshot; true cold does not necessarily mean fresh OS boot or cold
+host page cache. Report event coverage, duplicates, failed/missing records and
+ambiguous repeated attempts; do not pair repeated groups by timestamp proximity.
+Use fixed query windows/caps and account for late ingestion. Compute distributions
+from same-invocation intervals, never by subtracting independent percentiles.
+
+## Reproduction
+
+`runner benchmark` now records startup and guest-connection detail through the
+same provider observer. It buffers observations and reports them after startup
+timing is captured. Its required command, readiness, exit and cleanup semantics
+are unchanged.
+
+```bash
+runner benchmark --config /path/to/isolated/runner.yaml --profile vm0/default true
+```
+
+This utility warms snapshot memory and disables custom DNS readiness; it does
+not measure the full production `api_to_spawn` path. Run baseline/candidate
+batches with identical guest artifacts, resource limits and cache policy. Retain
+source and binary hashes, rootfs/snapshot identity, host load, success/failure
+coverage and serial/concurrent p50/p90/p95/p99 separately. On shared test hosts,
+use independent mutable directories and normal artifact locks or a private mount
+namespace. Never stop unrelated services, run shared GC or flush host caches.
+
+For a same-source collection-overhead comparison:
+
+```bash
+cd crates
+cargo run --profile ci -p guest-control-client --example connection_timing_overhead
+```
+
+The example performs real Unix-socket READY/PING/PONG exchanges, excludes 40
+warmup calls, then emits 2,000 observed and 2,000 unobserved samples in ABBA order.
+It buffers output until sampling ends. Keep raw samples and analyze per-batch
+as well as overall distributions. This isolates client timestamp collection
+with a current-thread runtime; it does not measure Firecracker, production
+telemetry serialization/transport or fleet-wide scheduling overhead.
+
+Retain attribution only after integration coverage and the authorized same-host
+experiment pass. A later behavior change requires an identified avoidable owner
+and its own correctness/tail/resource validation. A no-change decision is valid;
+the historical parent wait is not a performance-gain forecast.
+
+## Controlled local-11 experiment (2026-09-08)
+
+The formal VM window was 15:17:02–15:21:03 UTC on
+`local-11.gcp.vm3.ai` (x86_64, Linux 6.17.0-1018-gcp, 32 GiB RAM).
+Both Runners used baseline `6cc4252ee186826c4fdfef9f385e23585fd4c797`
+and the same nine guest binaries built from that revision. The candidate adds
+this PR's host instrumentation. Optimized `ci`/x86_64-musl binary SHA-256:
+
+The measured candidate is pre-rebase commit
+`967d185c3a620ab05b01ebf3e73e2ad4943761d4`. The PR was subsequently rebased
+onto `7558632c0eea9bded6c831fdba33a76c369677aa`, preserving main's independent
+DNS-attempt observer alongside the connection callback. The fixed-revision
+experiment below was not rerun after that rebase; it is not a measurement of
+the final rebased binary.
+
+- Baseline: `fb01ebe8a87b35712b53b402fda7cbae5600b39d8c44cea4b268b7d045bdda32`.
+- Candidate: `81b2434de57b5f5b285b0574e846eee8a1a2dcc09f011ba71587c67f4951febc`.
+- Overhead example (consuming the record with `black_box`): `1365a41cf8571d85adfbb32c971099e9c1130a92c62bc903945409025b1da529`.
+
+The fixed profile was 2 vCPU, 4096 MiB RAM, 12288 MiB rootfs and 16384 MiB
+workspace. Firecracker v1.15.1 and kernel 6.1.155 used the same image:
+
+- Rootfs identity: `2055bdb3f6d74f810902b6626fa28846202135f4ff602444450c1cac8b005428`.
+- Snapshot identity: `91ff3b50efa39f3f280f5f21f0e15eadf3084c4a5ec6e6340a073ff5658d91c3`.
+
+A private mount namespace isolated the runner home while retaining host-global
+NBD claims and network/socket coordination. No existing service was stopped,
+no shared GC ran, and no host caches were flushed. Two existing services and
+three pre-existing Firecracker processes remained after testing; the experiment's
+live-runner registry and sandbox workspace directories were empty. Images and
+raw logs were retained under `/tmp/issue-32444-vm7-20260908` for reproduction.
+Host load was 0.64/0.35/0.27 at preparation and 0.00/0.00/0.15 at postflight;
+other workloads were not controlled or sampled continuously.
+
+### Coverage and startup comparison
+
+Each invocation ran `runner benchmark ... true` with no API server configured.
+Two successful VM warmups were excluded. Serial ABBA ordering produced 20
+samples per binary. Twenty pairs of concurrent benchmark processes produced
+another 20 per binary, rotating lanes/order. CA/proxy preparation can serialize
+these processes: this is not a synchronized two-guest handshake stress test.
+All 80 formal invocations succeeded; all 40 candidate invocations had exactly
+one parent and eight successful phase records, with no duplicate/missing phases.
+Three setup failures (new-home ownership, permissions, missing runners directory)
+occurred before formal sampling and are not silently counted as successful starts.
+
+All values below use nearest-rank p50 / p90 / p95 / p99. Each VM cell has n=20;
+p99 is the maximum of this small cohort, not a fleet-tail estimate.
+
+| Cohort     | Binary    | Startup ms         | Benchmark total ms        |
+| ---------- | --------- | ------------------ | ------------------------- |
+| serial     | baseline  | 74 / 76 / 77 / 79  | 3009 / 3054 / 3067 / 3106 |
+| serial     | candidate | 72 / 76 / 77 / 77  | 2969 / 3016 / 3025 / 3078 |
+| concurrent | baseline  | 73 / 77 / 79 / 100 | 4710 / 4962 / 4973 / 4987 |
+| concurrent | candidate | 74 / 79 / 82 / 86  | 3081 / 4978 / 4994 / 4999 |
+
+The benchmark total includes proxy preparation, which explains the concurrent
+bimodality; do not interpret its median difference as instrumentation savings.
+Startup distributions do not show a consistent cross-cohort increase, but do
+not bound a small regression or production tails.
+
+### Connection attribution
+
+Full and remaining milliseconds, p50 / p90 / p95 / p99:
+
+| serial phase  | Full ms                         | Remaining ms                      |
+| ------------- | ------------------------------- | --------------------------------- |
+| TaskSchedule  | 0.024 / 0.032 / 0.034 / 0.065   | 0 / 0 / 0 / 0                     |
+| ListenerSetup | 0.039 / 0.052 / 0.06 / 0.063    | 0 / 0 / 0 / 0                     |
+| Accept        | 66.32 / 69.453 / 69.54 / 70.452 | 44.995 / 46.871 / 47.398 / 48.244 |
+| Ready         | 2.52 / 2.863 / 3.11 / 3.122     | 2.52 / 2.863 / 3.11 / 3.122       |
+| Ping          | 0.007 / 0.011 / 0.012 / 0.012   | 0.007 / 0.011 / 0.012 / 0.012     |
+| Pong          | 3.98 / 4.368 / 4.665 / 5.314    | 3.98 / 4.368 / 4.665 / 5.314      |
+| ClientSetup   | 0.022 / 0.026 / 0.037 / 0.042   | 0.022 / 0.026 / 0.037 / 0.042     |
+| TaskHandoff   | 0.05 / 0.067 / 0.073 / 0.082    | 0.05 / 0.067 / 0.073 / 0.082      |
+
+Residual parent: 51.562 / 53.25 / 54.562 / 56.49 ms. Maximum same-invocation parent-minus-phase
+sum gap: 0.000475 ms (final timer observation).
+
+| concurrent phase | Full ms                           | Remaining ms                      |
+| ---------------- | --------------------------------- | --------------------------------- |
+| TaskSchedule     | 0.02 / 0.031 / 0.033 / 0.068      | 0 / 0 / 0 / 0                     |
+| ListenerSetup    | 0.035 / 0.042 / 0.043 / 0.047     | 0 / 0 / 0 / 0                     |
+| Accept           | 66.872 / 70.762 / 75.707 / 80.202 | 44.827 / 47.424 / 48.496 / 59.445 |
+| Ready            | 2.545 / 3.072 / 3.43 / 3.506      | 2.545 / 3.072 / 3.43 / 3.506      |
+| Ping             | 0.007 / 0.009 / 0.01 / 0.014      | 0.007 / 0.009 / 0.01 / 0.014      |
+| Pong             | 3.953 / 4.381 / 4.419 / 4.566     | 3.953 / 4.381 / 4.419 / 4.566     |
+| ClientSetup      | 0.02 / 0.025 / 0.025 / 0.03       | 0.02 / 0.025 / 0.025 / 0.03       |
+| TaskHandoff      | 0.052 / 0.072 / 0.087 / 0.095     | 0.052 / 0.072 / 0.087 / 0.095     |
+
+Residual parent: 50.952 / 54.83 / 56.672 / 65.849 ms. Maximum same-invocation parent-minus-phase
+sum gap: 0.000449 ms (final timer observation).
+
+Accept is the largest residual phase in these measurements. Task scheduling
+and listener setup completed before the parent wait in all 40 samples. The
+roughly 21 ms difference between full and remaining accept in an individual
+sample is overlapped work, not an additional startup cost. Host observations
+still do not identify a guest retry, kernel delay or removable owner.
+
+### Collection overhead and decision
+
+The final real-socket run excluded 40 warmups and retained 2,000 samples per
+mode in 1,000 ABBA batches. Microseconds, p50 / p90 / p95 / p99:
+
+| Mode       | Duration µs                      |
+| ---------- | -------------------------------- |
+| Unobserved | 42.416 / 50.826 / 55.54 / 70.748 |
+| Observed   | 42.557 / 50.657 / 55.342 / 75.65 |
+
+Within-batch mean observed-minus-unobserved differences had mean
+0.382 µs and p50 / p90 / p95 / p99
+-0.013 / 5.703 / 9.831 / 66.828 µs. Negative values reflect noise,
+not a speedup. This measures client collection. The VM comparison also exercises
+the provider callback and CLI reporting; neither directly measures production
+`JobTelemetry` recording, batch serialization or HTTP ingestion cost.
+
+Decision: retain attribution for further evaluation, with **no handshake,
+listener-order, retry or deadline change**. Accept dominates this local residual,
+but its internal cause and avoidability remain unknown. Before closing #32444,
+finish the production-collector recording/batch overhead check; this PR uses a
+non-closing issue link. Production rollout/soak and the parent's historical
+latency cohorts are not validated by this isolated experiment.


### PR DESCRIPTION
## Summary

- Return fixed host-monotonic connection milestones from an optional guest-control client entry point, using the existing listener/handshake implementation.
- Preserve the five startup critical-path stages and separately report eight bounded full/remaining phase pairs through the sandbox observer and Runner telemetry.
- Expose fractional phase timings from `runner benchmark`; add real-socket integration coverage, an optimized collection-overhead example, and reproducible local-11 attribution results.

Relates to #32444. Parent context: #24203 (not closed).

## Behavior and boundaries

No new guest frame, listener, retry, deadline, readiness bypass, API schema or persisted contract. Keep matching PONG, decoder handoff, listener unlinking, task abort/join and the existing startup process-exit selection. Ordinary errors retain the completed prefix and failed phase; aborted/panicked tasks omit detail rather than inventing zero-duration success.

At most 16 fixed telemetry actions per returned attempt, with no new identity/path/error dimensions. Full durations overlap backend work; remaining durations intersect the original residual wait and must not be added to it. Parent timing is recorded before detail callbacks.

## Validation

Passed:

```bash
cd crates
cargo fmt --all -- --check
cargo clippy --profile local -p guest-control-client -p sandbox -p sandbox-firecracker -p sandbox-mock -p guest-control-tests -p runner --all-targets --all-features -- -D warnings
RUSTDOCFLAGS='-D warnings' cargo doc --profile local -p guest-control-client -p sandbox -p sandbox-firecracker -p sandbox-mock -p guest-control-tests -p runner --all-features --no-deps
cargo test --profile local -p guest-control-client -p sandbox -p sandbox-firecracker -p sandbox-mock -p guest-control-tests -p runner --all-targets --all-features -- --test-threads=4
cargo clippy --profile local -p guest-control-client --example connection_timing_overhead -- -D warnings
```

Documentation Prettier passed. The client/Firecracker tests cover gated real-socket milestones, incorrect PONG, partial next-frame decoder handoff, shared deadline, EOF, abort cleanup, and full/residual partition including early completion. Full Runner job tests cover emitted, failed and omitted phase detail.

Both fixed x86_64-musl `ci` Runner builds passed. The first candidate cross-build reused baseline workspace rlibs in a shared target directory; after successful `scripts/prepare.sh`, scoped generated-package invalidation fixed the build. The reproduction script includes this invalidation; no source/dependency/CI workaround was added.

## Controlled host results and remaining gate

On authorized `local-11.gcp.vm3.ai`, both binaries used identical baseline guest binaries, rootfs/snapshot and 2-vCPU/4096-MiB resources. A private runner-home mount preserved host-global device/network coordination. No existing service was stopped, no shared GC or cache flush ran.

- 80/80 formal VM invocations passed: 20 per binary serial, 20 per binary in paired concurrent benchmark processes; two successful warmups excluded.
- 40/40 candidate invocations had all eight phases and one residual parent, without duplicate/missing phases.
- Startup p50/p90: serial baseline 74/76 ms, candidate 72/76 ms; paired-process baseline 73/77 ms, candidate 74/79 ms. Small samples do not establish fleet non-regression.
- Candidate residual parent p90: serial 53.250 ms, paired-process 54.830 ms. Accept remaining p90: 46.871/47.424 ms. These are separately ranked distributions, not additive or removable-time estimates.
- 2,000 observed + 2,000 unobserved real-socket exchanges passed. Paired-batch mean difference: +0.382 microseconds; noise/tails and exact artifacts are documented.

Decision: retain attribution for further evaluation; make **no handshake, listener-order, retry or deadline change** based on these host observations. Concurrent proxy preparation can serialize benchmark processes, so this is not synchronized guest-handshake stress. `runner benchmark` warms snapshot pages and omits custom DNS readiness; it does not measure production `api_to_spawn`.

The client benchmark and CLI observer comparison do **not** directly measure production `JobTelemetry` recording, batching/serialization or HTTP ingestion overhead. Keep #32444 open for that remaining gate; this PR intentionally has no closing keyword. No production deployment or parent completion is claimed. See `docs/guest-connection-timing.md` for boundaries, hashes, full p50/p90/p95/p99 tables, coverage and reproduction.

## Rebase verification

Rebased onto `main` at `7558632c0eea9bded6c831fdba33a76c369677aa`; submitted head: `0ac77d24d5de147f061a7048083bca47cef1abb0`. Preserved main's independent DNS-attempt observer alongside the new connection callback.

On the rebased head, scoped formatting, Clippy (`-D warnings`), Rustdoc (`-D warnings`), and the six-crate all-target/all-feature test command above passed again. Runner: 3,600 passed and 27 pre-existing ignored; Firecracker: 870 passed (the separate privileged host-fairness test remains ignored). Other selected crate suites passed. Documentation Prettier and the post-rebase database migration also passed.

The local-11 measurements above are from pre-rebase candidate `967d185c3a620ab05b01ebf3e73e2ad4943761d4` and the fixed binary hashes in the documentation. They were **not rerun on the rebased binary**. CI state and production-collector overhead are separate gates; no production deployment or merge is claimed.
