### PR TITLE
fix(ui): enforce safe viewport bounds for dialogs

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -82,6 +82,9 @@ safe boundary.
 The popup does not accept `className`, `style`, or `render`. Use
 `contentClassName` for the inner layout and `DialogBody` for a scrolling body
 below a fixed header. `contentClassName` remains subject to the style policy.
+The shared inner container protects vertical scrolling even when caller layout
+classes include `overflow-hidden`. Short panels must keep their footer actions
+reachable by scrolling; clipping the popup to its safe boundary is not enough.
 Use `showCloseButton` instead of CSS selectors that hide the close control.
 Business code must import the shared dialog rather than Base UI's dialog
 primitives; ESLint enforces this boundary. Preserve Base UI's focus, nested

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -60,6 +60,28 @@ Commands run from `turbo`. An invalid Git reference, unreadable baseline, or mal
 
 ## Enforcement and feedback
 
+### Dialog viewport ownership
+
+`DialogContent` owns the Base UI viewport and popup. Windowed dialogs are
+centered inside the four safe-area insets plus a 24 px gutter. Fullscreen
+dialogs paint to the viewport edges while their content and close control stay
+inside the safe-area insets. The environment values come from the existing
+`--sat`, `--sar`, `--sab`, `--sal`, and `--okou-viewport-height` properties;
+the shared primitive also works with native `env()` insets outside Platform.
+
+Callers select a preferred `size`, `height`, and `mode`. The numeric size
+variants preserve existing desktop widths; `size="preview"` requests a
+1440 by 1000 px preview. Every variant is capped by the available viewport.
+Increasing a preferred size must never increase the safe boundary.
+
+The popup does not accept `className`, `style`, or `render`. Use
+`contentClassName` for the inner layout and `DialogBody` for a scrolling body
+below a fixed header. `contentClassName` remains subject to the style policy.
+Use `showCloseButton` instead of CSS selectors that hide the close control.
+Business code must import the shared dialog rather than Base UI's dialog
+primitives; ESLint enforces this boundary. Preserve Base UI's focus, nested
+portal, outside-press, and animation-completion ownership when changing it.
+
 Run the complete check from `turbo`:
 
 ```bash

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -69,10 +69,15 @@ inside the safe-area insets. The environment values come from the existing
 `--sat`, `--sar`, `--sab`, `--sal`, and `--okou-viewport-height` properties;
 the shared primitive also works with native `env()` insets outside Platform.
 
-Callers select a preferred `size`, `height`, and `mode`. The numeric size
-variants preserve existing desktop widths; `size="preview"` requests a
-1440 by 1000 px preview. Every variant is capped by the available viewport.
-Increasing a preferred size must never increase the safe boundary.
+Callers select `maxWidth`, `smMaxWidth`, `height`, and `mode`. The popup fills
+the available safe width and is capped by `maxWidth` (default `lg`);
+`smMaxWidth` changes that upper bound only from the shared `sm` breakpoint.
+Width caps never set a fixed width or determine height. Preserve existing
+breakpoints and units when migrating: `sm:max-w-[480px]` becomes
+`smMaxWidth={480}`, and `max-w-[25rem]` becomes `maxWidth="25rem"`.
+The artifact preview uses `maxWidth={1440} height={1000}`. Every variant is
+capped by the available viewport, so increasing a cap cannot increase the
+safe boundary.
 
 The popup does not accept `className`, `style`, or `render`. Use
 `contentClassName` for the inner layout and `DialogBody` for a scrolling body

--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -128,6 +128,10 @@ test("artifact dialogs keep their panel and fullscreen controls inside safe area
   await imagePreview.click();
   const dialog = page.getByTestId("attachment-lightbox");
   await expect(dialog).toBeVisible();
+  const zoom = dialog.getByTestId("artifact-dialog-image-zoom-level");
+  await expect(zoom).toHaveText("100%");
+  await dialog.getByRole("button", { name: "Zoom in", exact: true }).click();
+  await expect(zoom).toHaveText("115%");
 
   for (const scenario of [
     { width: 402, height: 874, top: 62, right: 0, bottom: 34, left: 0 },
@@ -191,6 +195,7 @@ test("artifact dialogs keep their panel and fullscreen controls inside safe area
       exact: true,
     });
     await expect(exitFullscreen).toBeVisible();
+    await expect(zoom).toHaveText("115%");
     for (const control of [
       exitFullscreen,
       dialog.getByRole("button", { name: "Close", exact: true }),
@@ -212,6 +217,7 @@ test("artifact dialogs keep their panel and fullscreen controls inside safe area
     await expect(
       dialog.getByRole("button", { name: "Enter fullscreen", exact: true }),
     ).toBeVisible();
+    await expect(zoom).toHaveText("115%");
   }
 
   // Native outside-press ownership must distinguish a drag from a deliberate click.
@@ -224,6 +230,68 @@ test("artifact dialogs keep their panel and fullscreen controls inside safe area
   await expect(dialog).toBeVisible();
   await page.mouse.click(5, 5);
   await expect(dialog).toBeHidden();
+});
+
+test("short dialogs keep nested avatar and agent footer actions reachable by scrolling", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 640 });
+  await page.goto(new URL("/agents", appUrl).href);
+  await page.evaluate(() => {
+    document.documentElement.style.setProperty("--sat", "59px");
+    document.documentElement.style.setProperty("--sab", "34px");
+  });
+  await page.getByRole("button", { name: "New agent", exact: true }).click();
+  const agent = page.getByRole("dialog", {
+    name: "Create a new agent",
+    exact: true,
+  });
+  await agent
+    .getByRole("textbox", { name: "Name", exact: true })
+    .fill("Safe area draft");
+  await agent
+    .getByRole("button", { name: "Customize avatar", exact: true })
+    .click();
+  const avatar = page.getByRole("dialog", {
+    name: /^(Edit avatar|Give your agent a face)$/,
+  });
+  await expect(avatar).toBeVisible();
+  const avatarBox = await avatar.boundingBox();
+  if (!avatarBox) throw new Error("Expected the avatar dialog bounds");
+  // Use native scrolling before clicking: click's automatic scrollIntoView can
+  // otherwise reach an action even when overflow-hidden prevents user scrolling.
+  await page.mouse.move(avatarBox.x + 8, avatarBox.y + avatarBox.height / 2);
+  await page.mouse.wheel(0, 1000);
+  const useAvatar = avatar.getByRole("button", {
+    name: "Use this avatar",
+    exact: true,
+  });
+  await expect(useAvatar).toBeInViewport({ ratio: 1 });
+  await useAvatar.click();
+  await expect(avatar).toBeHidden();
+  await expect(
+    agent.getByRole("textbox", { name: "Name", exact: true }),
+  ).toHaveValue("Safe area draft");
+
+  await page.setViewportSize({ width: 874, height: 402 });
+  await page.evaluate(() => {
+    const style = document.documentElement.style;
+    style.setProperty("--sat", "0px");
+    style.setProperty("--sab", "21px");
+    style.setProperty("--sal", "62px");
+    style.setProperty("--sar", "62px");
+  });
+  const agentBox = await agent.boundingBox();
+  if (!agentBox) throw new Error("Expected the agent dialog bounds");
+  await page.mouse.move(agentBox.x + 8, agentBox.y + agentBox.height / 2);
+  await page.mouse.wheel(0, 1000);
+  await expect(
+    agent.getByRole("button", { name: "Create", exact: true }),
+  ).toBeInViewport({ ratio: 1 });
+  const cancel = agent.getByRole("button", { name: "Cancel", exact: true });
+  await expect(cancel).toBeInViewport({ ratio: 1 });
+  await cancel.click();
+  await expect(agent).toBeHidden();
 });
 
 test("chat page displays tagline after onboarding", async ({ page }) => {

--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1,11 +1,84 @@
+import { randomUUID } from "node:crypto";
+import type { Page } from "@playwright/test";
 import { resolveApiBackendUrl } from "../api-backend-url";
 import { expect, test } from "../fixtures";
 import { omitAppApiPrefetch } from "../lib/app-api-prefetch";
-import { refreshClerkSessionToken } from "../lib/auth";
 import { deriveAppUrl } from "../playwright.config";
 
 const appUrl = deriveAppUrl(resolveApiBackendUrl());
 const MOBILE_VIEWPORT = { width: 402, height: 874 } as const;
+
+async function dialogImageFixture(page: Page) {
+  const buffer = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAFklEQVR4nGMIqFhAEmIY1TCqYfhqAAATWWgQLeF+owAAAABJRU5ErkJggg==",
+    "base64",
+  );
+  const metadata = {
+    id: randomUUID(),
+    filename: "dialog-safe-area.png",
+    contentType: "image/png",
+    size: buffer.length,
+    url: new URL("/__e2e__/dialog-safe-area.png", appUrl).href,
+  };
+  // Geometry coverage owns its image transport; it does not test R2 uploads.
+  await page.route(metadata.url, async (route) => {
+    await route.fulfill({ contentType: "image/png", body: buffer });
+  });
+  await page.route(
+    (url) =>
+      url.origin === new URL(resolveApiBackendUrl()).origin &&
+      ["/api/uploads/prepare", "/api/uploads/complete"].includes(url.pathname),
+    async (route) => {
+      const request = route.request();
+      const body = request.postDataJSON();
+      const prepare = new URL(request.url()).pathname.endsWith("/prepare");
+      if (
+        request.method() !== "POST" ||
+        (prepare
+          ? body.filename !== metadata.filename
+          : body.id !== metadata.id)
+      ) {
+        await route.fallback();
+        return;
+      }
+      await route.fulfill({
+        json: prepare
+          ? { ...metadata, uploadUrl: metadata.url, uploadHeaders: {} }
+          : metadata,
+      });
+    },
+  );
+  return { name: metadata.filename, mimeType: metadata.contentType, buffer };
+}
+
+test("dialog width caps preserve the sm breakpoint and shrink on narrow screens", async ({
+  page,
+}) => {
+  await page.goto(new URL("/agents", appUrl).href);
+  await page.getByRole("button", { name: "New agent", exact: true }).click();
+  const dialog = page.getByRole("dialog", {
+    name: "Create a new agent",
+    exact: true,
+  });
+  await expect(dialog).toBeVisible();
+
+  for (const scenario of [
+    { viewport: 639, expectedWidth: 512 },
+    { viewport: 640, expectedWidth: 480 },
+    { viewport: 1280, expectedWidth: 480 },
+    { viewport: 390, expectedWidth: 342 },
+  ]) {
+    await page.setViewportSize({ width: scenario.viewport, height: 900 });
+    await expect
+      .poll(async () => {
+        const box = await dialog.boundingBox();
+        return box ? Math.round(box.width) : null;
+      })
+      .toBe(scenario.expectedWidth);
+  }
+  await dialog.getByRole("button", { name: "Close", exact: true }).click();
+  await expect(dialog).toBeHidden();
+});
 
 test("artifact dialogs keep their panel and fullscreen controls inside safe areas", async ({
   page,
@@ -16,7 +89,7 @@ test("artifact dialogs keep their panel and fullscreen controls inside safe area
     timeout: 20_000,
   });
 
-  // Own a fresh thread so uploading this fixture cannot replace another test's draft.
+  // The lane's disposable account owns this thread and is cleaned up by global teardown.
   const [created] = await Promise.all([
     page.waitForResponse(
       (response) =>
@@ -35,124 +108,112 @@ test("artifact dialogs keep their panel and fullscreen controls inside safe area
   ) {
     throw new Error("Expected the created dialog-test thread id");
   }
-  try {
-    await expect(page).toHaveURL(new URL(`/chats/${thread.id}`, appUrl).href);
-    await page.locator('input[type="file"][multiple]').setInputFiles({
-      name: "dialog-safe-area.png",
-      mimeType: "image/png",
-      buffer: Buffer.from(
-        "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAFklEQVR4nGMIqFhAEmIY1TCqYfhqAAATWWgQLeF+owAAAABJRU5ErkJggg==",
-        "base64",
-      ),
-    });
-    await page
-      .getByRole("button", {
-        name: "Open image preview for dialog-safe-area.png",
-        exact: true,
-      })
-      .click();
-    const dialog = page.getByTestId("attachment-lightbox");
-    await expect(dialog).toBeVisible();
+  await expect(page).toHaveURL(new URL(`/chats/${thread.id}`, appUrl).href);
+  // Wait for the destination composer before attaching the owned fixture.
+  const threadPage = page.getByRole("region", {
+    name: "Chat thread",
+    exact: true,
+  });
+  await expect(
+    threadPage.getByRole("textbox", { name: "Message", exact: true }),
+  ).toBeEditable();
+  await threadPage
+    .locator('input[type="file"][multiple]')
+    .setInputFiles(await dialogImageFixture(page));
+  const imagePreview = threadPage.getByRole("button", {
+    name: "Open image preview for dialog-safe-area.png",
+    exact: true,
+  });
+  await expect(imagePreview).toBeEnabled({ timeout: 30_000 });
+  await imagePreview.click();
+  const dialog = page.getByTestId("attachment-lightbox");
+  await expect(dialog).toBeVisible();
 
-    for (const scenario of [
-      { width: 402, height: 874, top: 62, right: 0, bottom: 34, left: 0 },
-      { width: 874, height: 402, top: 0, right: 62, bottom: 21, left: 62 },
-      { width: 390, height: 640, top: 59, right: 0, bottom: 34, left: 0 },
-      { width: 1920, height: 1200, top: 0, right: 0, bottom: 0, left: 0 },
+  for (const scenario of [
+    { width: 402, height: 874, top: 62, right: 0, bottom: 34, left: 0 },
+    { width: 874, height: 402, top: 0, right: 62, bottom: 21, left: 62 },
+    { width: 390, height: 640, top: 59, right: 0, bottom: 34, left: 0 },
+    { width: 1920, height: 1200, top: 0, right: 0, bottom: 0, left: 0 },
+  ]) {
+    await page.setViewportSize({
+      width: scenario.width,
+      height: scenario.height,
+    });
+    await page.evaluate((insets) => {
+      const style = document.documentElement.style;
+      style.setProperty("--sat", `${insets.top}px`);
+      style.setProperty("--sar", `${insets.right}px`);
+      style.setProperty("--sab", `${insets.bottom}px`);
+      style.setProperty("--sal", `${insets.left}px`);
+    }, scenario);
+    await expect
+      .poll(async () => {
+        const box = await dialog.boundingBox();
+        return (
+          box !== null &&
+          box.x >= scenario.left + 23 &&
+          box.y >= scenario.top + 23 &&
+          box.x + box.width <= scenario.width - scenario.right - 23 &&
+          box.y + box.height <= scenario.height - scenario.bottom - 23
+        );
+      })
+      .toBe(true);
+    const box = await dialog.boundingBox();
+    if (!box) throw new Error("Expected the windowed preview bounds");
+    expect(box.x + box.width / 2).toBeCloseTo(
+      (scenario.width + scenario.left - scenario.right) / 2,
+      0,
+    );
+    expect(box.y + box.height / 2).toBeCloseTo(
+      (scenario.height + scenario.top - scenario.bottom) / 2,
+      0,
+    );
+    if (scenario.width === 1920) {
+      expect(box.width).toBeCloseTo(1440, 0);
+      expect(box.height).toBeCloseTo(1000, 0);
+    }
+
+    await dialog
+      .getByRole("button", { name: "Enter fullscreen", exact: true })
+      .click();
+    const exitFullscreen = dialog.getByRole("button", {
+      name: "Exit fullscreen",
+      exact: true,
+    });
+    await expect(exitFullscreen).toBeVisible();
+    for (const control of [
+      exitFullscreen,
+      dialog.getByRole("button", { name: "Close", exact: true }),
     ]) {
-      await page.setViewportSize({
-        width: scenario.width,
-        height: scenario.height,
-      });
-      await page.evaluate((insets) => {
-        const style = document.documentElement.style;
-        style.setProperty("--sat", `${insets.top}px`);
-        style.setProperty("--sar", `${insets.right}px`);
-        style.setProperty("--sab", `${insets.bottom}px`);
-        style.setProperty("--sal", `${insets.left}px`);
-      }, scenario);
       await expect
         .poll(async () => {
-          const box = await dialog.boundingBox();
+          const rect = await control.boundingBox();
           return (
-            box !== null &&
-            box.x >= scenario.left + 23 &&
-            box.y >= scenario.top + 23 &&
-            box.x + box.width <= scenario.width - scenario.right - 23 &&
-            box.y + box.height <= scenario.height - scenario.bottom - 23
+            rect !== null &&
+            rect.x >= scenario.left &&
+            rect.y >= scenario.top &&
+            rect.x + rect.width <= scenario.width - scenario.right &&
+            rect.y + rect.height <= scenario.height - scenario.bottom
           );
         })
         .toBe(true);
-      const box = await dialog.boundingBox();
-      if (!box) throw new Error("Expected the windowed preview bounds");
-      expect(box.x + box.width / 2).toBeCloseTo(
-        (scenario.width + scenario.left - scenario.right) / 2,
-        0,
-      );
-      expect(box.y + box.height / 2).toBeCloseTo(
-        (scenario.height + scenario.top - scenario.bottom) / 2,
-        0,
-      );
-      if (scenario.width === 1920) {
-        expect(box.width).toBeCloseTo(1440, 0);
-        expect(box.height).toBeCloseTo(1000, 0);
-      }
-
-      await dialog
-        .getByRole("button", { name: "Enter fullscreen", exact: true })
-        .click();
-      const exitFullscreen = dialog.getByRole("button", {
-        name: "Exit fullscreen",
-        exact: true,
-      });
-      await expect(exitFullscreen).toBeVisible();
-      for (const control of [
-        exitFullscreen,
-        dialog.getByRole("button", { name: "Close", exact: true }),
-      ]) {
-        await expect
-          .poll(async () => {
-            const rect = await control.boundingBox();
-            return (
-              rect !== null &&
-              rect.x >= scenario.left &&
-              rect.y >= scenario.top &&
-              rect.x + rect.width <= scenario.width - scenario.right &&
-              rect.y + rect.height <= scenario.height - scenario.bottom
-            );
-          })
-          .toBe(true);
-      }
-      await exitFullscreen.click();
-      await expect(
-        dialog.getByRole("button", { name: "Enter fullscreen", exact: true }),
-      ).toBeVisible();
     }
-
-    // Native outside-press ownership must distinguish a drag from a deliberate click.
-    const panel = await dialog.boundingBox();
-    if (!panel)
-      throw new Error("Expected the preview before testing dismissal");
-    await page.mouse.move(
-      panel.x + panel.width / 2,
-      panel.y + panel.height / 2,
-    );
-    await page.mouse.down();
-    await page.mouse.move(5, 5);
-    await page.mouse.up();
-    await expect(dialog).toBeVisible();
-    await page.mouse.click(5, 5);
-    await expect(dialog).toBeHidden();
-  } finally {
-    const token = await refreshClerkSessionToken(page);
-    const deleted = await page.request.delete(
-      new URL(`/api/chat-threads/${thread.id}`, resolveApiBackendUrl()).href,
-      {
-        headers: { Authorization: `Bearer ${token}` },
-      },
-    );
-    expect(deleted.status()).toBe(204);
+    await exitFullscreen.click();
+    await expect(
+      dialog.getByRole("button", { name: "Enter fullscreen", exact: true }),
+    ).toBeVisible();
   }
+
+  // Native outside-press ownership must distinguish a drag from a deliberate click.
+  const panel = await dialog.boundingBox();
+  if (!panel) throw new Error("Expected the preview before testing dismissal");
+  await page.mouse.move(panel.x + panel.width / 2, panel.y + panel.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(5, 5);
+  await page.mouse.up();
+  await expect(dialog).toBeVisible();
+  await page.mouse.click(5, 5);
+  await expect(dialog).toBeHidden();
 });
 
 test("chat page displays tagline after onboarding", async ({ page }) => {

--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -154,7 +154,17 @@ test("artifact dialogs keep their panel and fullscreen controls inside safe area
           box.x >= scenario.left + 23 &&
           box.y >= scenario.top + 23 &&
           box.x + box.width <= scenario.width - scenario.right - 23 &&
-          box.y + box.height <= scenario.height - scenario.bottom - 23
+          box.y + box.height <= scenario.height - scenario.bottom - 23 &&
+          Math.abs(
+            box.x +
+              box.width / 2 -
+              (scenario.width + scenario.left - scenario.right) / 2,
+          ) < 0.5 &&
+          Math.abs(
+            box.y +
+              box.height / 2 -
+              (scenario.height + scenario.top - scenario.bottom) / 2,
+          ) < 0.5
         );
       })
       .toBe(true);

--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1,10 +1,159 @@
 import { resolveApiBackendUrl } from "../api-backend-url";
 import { expect, test } from "../fixtures";
 import { omitAppApiPrefetch } from "../lib/app-api-prefetch";
+import { refreshClerkSessionToken } from "../lib/auth";
 import { deriveAppUrl } from "../playwright.config";
 
 const appUrl = deriveAppUrl(resolveApiBackendUrl());
 const MOBILE_VIEWPORT = { width: 402, height: 874 } as const;
+
+test("artifact dialogs keep their panel and fullscreen controls inside safe areas", async ({
+  page,
+}) => {
+  await page.goto(appUrl);
+  await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+  await expect(page.getByTestId("chat-tagline")).toBeVisible({
+    timeout: 20_000,
+  });
+
+  // Own a fresh thread so uploading this fixture cannot replace another test's draft.
+  const [created] = await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        new URL(response.url()).pathname === "/api/chat-threads",
+    ),
+    page.getByRole("button", { name: "New chat", exact: true }).last().click(),
+  ]);
+  expect(created.status()).toBe(201);
+  const thread: unknown = await created.json();
+  if (
+    typeof thread !== "object" ||
+    thread === null ||
+    !("id" in thread) ||
+    typeof thread.id !== "string"
+  ) {
+    throw new Error("Expected the created dialog-test thread id");
+  }
+  try {
+    await expect(page).toHaveURL(new URL(`/chats/${thread.id}`, appUrl).href);
+    await page.locator('input[type="file"][multiple]').setInputFiles({
+      name: "dialog-safe-area.png",
+      mimeType: "image/png",
+      buffer: Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAFklEQVR4nGMIqFhAEmIY1TCqYfhqAAATWWgQLeF+owAAAABJRU5ErkJggg==",
+        "base64",
+      ),
+    });
+    await page
+      .getByRole("button", {
+        name: "Open image preview for dialog-safe-area.png",
+        exact: true,
+      })
+      .click();
+    const dialog = page.getByTestId("attachment-lightbox");
+    await expect(dialog).toBeVisible();
+
+    for (const scenario of [
+      { width: 402, height: 874, top: 62, right: 0, bottom: 34, left: 0 },
+      { width: 874, height: 402, top: 0, right: 62, bottom: 21, left: 62 },
+      { width: 390, height: 640, top: 59, right: 0, bottom: 34, left: 0 },
+      { width: 1920, height: 1200, top: 0, right: 0, bottom: 0, left: 0 },
+    ]) {
+      await page.setViewportSize({
+        width: scenario.width,
+        height: scenario.height,
+      });
+      await page.evaluate((insets) => {
+        const style = document.documentElement.style;
+        style.setProperty("--sat", `${insets.top}px`);
+        style.setProperty("--sar", `${insets.right}px`);
+        style.setProperty("--sab", `${insets.bottom}px`);
+        style.setProperty("--sal", `${insets.left}px`);
+      }, scenario);
+      await expect
+        .poll(async () => {
+          const box = await dialog.boundingBox();
+          return (
+            box !== null &&
+            box.x >= scenario.left + 23 &&
+            box.y >= scenario.top + 23 &&
+            box.x + box.width <= scenario.width - scenario.right - 23 &&
+            box.y + box.height <= scenario.height - scenario.bottom - 23
+          );
+        })
+        .toBe(true);
+      const box = await dialog.boundingBox();
+      if (!box) throw new Error("Expected the windowed preview bounds");
+      expect(box.x + box.width / 2).toBeCloseTo(
+        (scenario.width + scenario.left - scenario.right) / 2,
+        0,
+      );
+      expect(box.y + box.height / 2).toBeCloseTo(
+        (scenario.height + scenario.top - scenario.bottom) / 2,
+        0,
+      );
+      if (scenario.width === 1920) {
+        expect(box.width).toBeCloseTo(1440, 0);
+        expect(box.height).toBeCloseTo(1000, 0);
+      }
+
+      await dialog
+        .getByRole("button", { name: "Enter fullscreen", exact: true })
+        .click();
+      const exitFullscreen = dialog.getByRole("button", {
+        name: "Exit fullscreen",
+        exact: true,
+      });
+      await expect(exitFullscreen).toBeVisible();
+      for (const control of [
+        exitFullscreen,
+        dialog.getByRole("button", { name: "Close", exact: true }),
+      ]) {
+        await expect
+          .poll(async () => {
+            const rect = await control.boundingBox();
+            return (
+              rect !== null &&
+              rect.x >= scenario.left &&
+              rect.y >= scenario.top &&
+              rect.x + rect.width <= scenario.width - scenario.right &&
+              rect.y + rect.height <= scenario.height - scenario.bottom
+            );
+          })
+          .toBe(true);
+      }
+      await exitFullscreen.click();
+      await expect(
+        dialog.getByRole("button", { name: "Enter fullscreen", exact: true }),
+      ).toBeVisible();
+    }
+
+    // Native outside-press ownership must distinguish a drag from a deliberate click.
+    const panel = await dialog.boundingBox();
+    if (!panel)
+      throw new Error("Expected the preview before testing dismissal");
+    await page.mouse.move(
+      panel.x + panel.width / 2,
+      panel.y + panel.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(5, 5);
+    await page.mouse.up();
+    await expect(dialog).toBeVisible();
+    await page.mouse.click(5, 5);
+    await expect(dialog).toBeHidden();
+  } finally {
+    const token = await refreshClerkSessionToken(page);
+    const deleted = await page.request.delete(
+      new URL(`/api/chat-threads/${thread.id}`, resolveApiBackendUrl()).href,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+    expect(deleted.status()).toBe(204);
+  }
+});
 
 test("chat page displays tagline after onboarding", async ({ page }) => {
   await page.goto(appUrl);

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -372,6 +372,17 @@ export default [
         {
           paths: [
             {
+              name: "@base-ui/react/dialog",
+              message:
+                "Use DialogContent from @okouai/ui. The shared dialog owns safe-area bounds, sizing, scrolling, and native focus behavior.",
+            },
+            {
+              name: "@base-ui/react",
+              importNames: ["Dialog"],
+              message:
+                "Use DialogContent from @okouai/ui so dialogs retain their safe-area boundary.",
+            },
+            {
               name: "ably",
               allowTypeImports: true,
               message:
@@ -381,6 +392,13 @@ export default [
               name: "@clerk/clerk-js",
               message:
                 "Use src/lib/clerk-runtime.ts so Clerk loads the official browser runtime without bundled wallet adapters.",
+            },
+          ],
+          patterns: [
+            {
+              group: ["@base-ui/react/dialog/*"],
+              message:
+                "Use the shared DialogContent instead of constructing a dialog viewport in business code.",
             },
           ],
         },

--- a/turbo/apps/platform/src/signals/okou-page/attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/okou-page/attachment-chips.ts
@@ -193,7 +193,6 @@ export const lightboxDialogFullscreen$ = computed((get) => {
 });
 
 export const toggleLightboxDialogFullscreen$ = command(({ get, set }) => {
-  set(attachmentLightboxImageCanvasSignals.reset$);
   set(
     internalLightboxDialogFullscreen$,
     !get(internalLightboxDialogFullscreen$),

--- a/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
@@ -561,7 +561,8 @@ function CreateTeammateDialogContent({
       closeLabel={t(($) => {
         return $.actions.close;
       })}
-      className="sm:max-w-[480px] p-0 gap-0 overflow-hidden"
+      size={480}
+      contentClassName="p-0 gap-0 overflow-hidden"
     >
       <DialogHeader className="sr-only">
         <DialogTitle>

--- a/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
@@ -561,7 +561,7 @@ function CreateTeammateDialogContent({
       closeLabel={t(($) => {
         return $.actions.close;
       })}
-      size={480}
+      smMaxWidth={480}
       contentClassName="p-0 gap-0 overflow-hidden"
     >
       <DialogHeader className="sr-only">

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-add-account-dialog.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-add-account-dialog.tsx
@@ -36,7 +36,7 @@ function AuthV2AddAccountDialogContent({
       }}
     >
       <DialogContent
-        size={400}
+        maxWidth="25rem"
         surface="transparent"
         contentClassName="okou-app gap-0 overflow-y-auto p-0"
         closeLabel={t(($) => {

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-add-account-dialog.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-add-account-dialog.tsx
@@ -36,7 +36,9 @@ function AuthV2AddAccountDialogContent({
       }}
     >
       <DialogContent
-        className="okou-app max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-[25rem] gap-0 overflow-y-auto border-0 bg-transparent p-0 shadow-none [&_[data-slot=dialog-close]]:right-4 [&_[data-slot=dialog-close]]:top-4 [&_[data-slot=dialog-close]]:z-10"
+        size={400}
+        surface="transparent"
+        contentClassName="okou-app gap-0 overflow-y-auto p-0"
         closeLabel={t(($) => {
           return $.settings.shared.close;
         })}

--- a/turbo/apps/platform/src/views/components/connector-connection-progress.tsx
+++ b/turbo/apps/platform/src/views/components/connector-connection-progress.tsx
@@ -27,7 +27,7 @@ export function ConnectorConnectionProgress() {
       }}
     >
       <DialogContent
-        className="max-w-md"
+        maxWidth="md"
         aria-describedby={undefined}
         closeLabel={t(($) => {
           return $.connectors.actions.close;

--- a/turbo/apps/platform/src/views/components/force-upgrade-dialog.tsx
+++ b/turbo/apps/platform/src/views/components/force-upgrade-dialog.tsx
@@ -35,7 +35,7 @@ export function ForceUpgradeDialog({
         eventDetails.cancel();
       }}
     >
-      <DialogContent className="max-w-md [&_[aria-label='Close']]:hidden">
+      <DialogContent size="md" showCloseButton={false}>
         <DialogHeader>
           <DialogTitle>
             {t(($) => {

--- a/turbo/apps/platform/src/views/components/force-upgrade-dialog.tsx
+++ b/turbo/apps/platform/src/views/components/force-upgrade-dialog.tsx
@@ -35,7 +35,7 @@ export function ForceUpgradeDialog({
         eventDetails.cancel();
       }}
     >
-      <DialogContent size="md" showCloseButton={false}>
+      <DialogContent maxWidth="md" showCloseButton={false}>
         <DialogHeader>
           <DialogTitle>
             {t(($) => {

--- a/turbo/apps/platform/src/views/components/shortcut-help-dialog.tsx
+++ b/turbo/apps/platform/src/views/components/shortcut-help-dialog.tsx
@@ -37,7 +37,7 @@ export function ShortcutHelpDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="max-w-sm"
+        size="sm"
         closeLabel={t(($) => {
           return $.appShell.shortcutHelp.close;
         })}

--- a/turbo/apps/platform/src/views/components/shortcut-help-dialog.tsx
+++ b/turbo/apps/platform/src/views/components/shortcut-help-dialog.tsx
@@ -37,7 +37,7 @@ export function ShortcutHelpDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        size="sm"
+        maxWidth="sm"
         closeLabel={t(($) => {
           return $.appShell.shortcutHelp.close;
         })}

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-composer.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-composer.test.tsx
@@ -139,7 +139,11 @@ test("A deliberate backdrop click closes an image preview", async () => {
     screen.findByRole("dialog", { name: "photo.png preview" }),
   ).resolves.toBeVisible();
 
-  fireEvent.click(screen.getByTestId("attachment-lightbox-backdrop"));
+  const viewport = document.querySelector('[data-slot="dialog-viewport"]');
+  if (!viewport) {
+    throw new Error("Expected the image preview viewport");
+  }
+  click(viewport);
 
   await waitFor(() => {
     expect(
@@ -161,11 +165,14 @@ test("Dragging from an image preview onto its backdrop keeps it open", async () 
     name: "photo.png preview",
   });
   const panel = screen.getByTestId("attachment-lightbox-panel");
-  const backdrop = screen.getByTestId("attachment-lightbox-backdrop");
+  const backdrop = document.querySelector('[data-slot="dialog-viewport"]');
+  if (!backdrop) {
+    throw new Error("Expected the image preview viewport");
+  }
 
   fireEvent.mouseDown(panel, { button: 0 });
   fireEvent.mouseUp(backdrop, { button: 0 });
-  fireEvent.click(dialog);
+  fireEvent.click(backdrop);
 
   expect(dialog).toBeVisible();
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-message-previews.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-message-previews.test.tsx
@@ -193,12 +193,30 @@ test("Image navigation stays within the current message", async () => {
   expect(getNamedButton("Next image artifact")).toBeVisible();
 
   click(await findNamedButton("Zoom in"));
+  await waitFor(() => {
+    expect(
+      screen.getByTestId("artifact-dialog-image-zoom-level"),
+    ).toHaveTextContent("115%");
+  });
+  click(getNamedButton("Enter fullscreen"));
+  await findNamedButton("Exit fullscreen");
+  expect(
+    screen.getByTestId("artifact-dialog-image-zoom-level"),
+  ).toHaveTextContent("115%");
+  click(getNamedButton("Exit fullscreen"));
+  await findNamedButton("Enter fullscreen");
+  expect(
+    screen.getByTestId("artifact-dialog-image-zoom-level"),
+  ).toHaveTextContent("115%");
   fireEvent.keyDown(document, { key: "ArrowRight" });
   await waitFor(() => {
     expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
       "alt",
       "gallery-second.png",
     );
+    expect(
+      screen.getByTestId("artifact-dialog-image-zoom-level"),
+    ).toHaveTextContent("100%");
   });
   click(getNamedButton("Previous image artifact"));
   await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connectors.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connectors.test.tsx
@@ -650,13 +650,11 @@ test.each([null, "Close", "Escape", "backdrop"] as const)(
       } else if (dismissal === "Escape") {
         await user.keyboard("{Escape}");
       } else {
-        const overlay = catalog.parentElement?.querySelector(
-          '[data-slot="dialog-overlay"]',
-        );
-        if (!(overlay instanceof HTMLElement)) {
-          throw new Error("Expected the connector directory backdrop");
+        const viewport = catalog.closest('[data-slot="dialog-viewport"]');
+        if (!(viewport instanceof HTMLElement)) {
+          throw new Error("Expected the connector directory viewport");
         }
-        await user.click(overlay);
+        await user.click(viewport);
       }
     }
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-artifact-drive.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-artifact-drive.test.tsx
@@ -590,6 +590,8 @@ test.each([
   "Reuse the artifact preview for Drive OAuth ($state, dismissal: $dismiss)",
   async ({ state, dismiss }) => {
     useWideScreen();
+    // Native outside-press needs complete pointer sequences to detect drags.
+    const user = userEvent.setup();
     const popup = installAuthorizationPopup();
     const syncing = context.mocks.deferred<void>();
     const sync = context.mocks.deferred<void>();
@@ -604,17 +606,17 @@ test.each([
       path: `/chats/${NAVIGATION_ARTIFACT_THREAD_ID}`,
       host: "app.okou.ai",
     });
-    click(await findNamedLink("Drive preview"));
+    await user.click(await findNamedLink("Drive preview"));
     const preview = await screen.findByRole("dialog", {
       name: "drive-report.pdf preview",
     });
-    click(buttonNamed("Download options", preview));
+    await user.click(buttonNamed("Download options", preview));
     await waitFor(() => {
       expect(
         roleItemNamed("menuitem", "Connect Google Drive"),
       ).not.toHaveAttribute("aria-disabled", "true");
     });
-    click(roleItemNamed("menuitem", "Connect Google Drive"));
+    await user.click(roleItemNamed("menuitem", "Connect Google Drive"));
     await expect(
       within(preview).findByRole("status"),
     ).resolves.toHaveTextContent(
@@ -627,13 +629,16 @@ test.each([
     });
 
     if (dismiss) {
-      const user = userEvent.setup();
       if (dismiss === "Close") {
         await user.click(buttonNamed("Close", preview));
       } else if (dismiss === "Escape") {
         await user.keyboard("{Escape}");
       } else {
-        await user.click(screen.getByTestId("attachment-lightbox-backdrop"));
+        const viewport = preview.closest('[data-slot="dialog-viewport"]');
+        if (!(viewport instanceof HTMLElement)) {
+          throw new Error("Expected the artifact preview viewport");
+        }
+        await user.click(viewport);
       }
     }
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
@@ -216,11 +216,7 @@ test("A carried image keeps its label and opens a lightbox over the dialog", asy
     screen.findByTestId("attachment-lightbox-image"),
   ).resolves.toHaveAttribute("src", url);
   expect(dialog).toBeVisible();
-  click(screen.getByTestId("attachment-lightbox-backdrop"));
-  await waitFor(() => {
-    expect(screen.queryByTestId("attachment-lightbox")).toBeNull();
-  });
-  expect(dialog).toBeVisible();
+  await closeRelatedArtifactPreview(dialog);
 });
 
 async function openRelatedArtifactOverSidebar(filename: string, body?: string) {
@@ -260,7 +256,13 @@ async function openRelatedArtifactOverSidebar(filename: string, body?: string) {
 }
 
 async function closeRelatedArtifactPreview(dialog: HTMLElement) {
-  click(screen.getByTestId("attachment-lightbox-backdrop"));
+  const viewport = screen
+    .getByTestId("attachment-lightbox")
+    .closest('[data-slot="dialog-viewport"]');
+  if (!viewport) {
+    throw new Error("Expected the active artifact preview viewport");
+  }
+  click(viewport);
   await waitFor(() => {
     expect(screen.queryByTestId("attachment-lightbox")).toBeNull();
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connector-connection-progress.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connector-connection-progress.test.tsx
@@ -100,13 +100,11 @@ async function dismissProgress(
   } else if (method === "Escape") {
     await user.keyboard("{Escape}");
   } else {
-    const overlay = dialog.parentElement?.querySelector(
-      '[data-slot="dialog-overlay"]',
-    );
-    if (!(overlay instanceof HTMLElement)) {
-      throw new Error("Expected the connection dialog backdrop");
+    const viewport = dialog.closest('[data-slot="dialog-viewport"]');
+    if (!(viewport instanceof HTMLElement)) {
+      throw new Error("Expected the connection dialog viewport");
     }
-    await user.click(overlay);
+    await user.click(viewport);
   }
   await waitFor(() => {
     expect(screen.queryByRole("dialog")).toBeNull();

--- a/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
@@ -1318,7 +1318,8 @@ function ArtifactPreviewDialogContent({
         initialFocus={dialogElement}
         showCloseButton={false}
         overlayClassName="okou-pwa-fixed-cover bg-gray-900/45 dark:bg-gray-900/45"
-        size="preview"
+        maxWidth={1440}
+        height={1000}
         surface="canvas"
         mode={fullscreen ? "fullscreen" : "windowed"}
         contentClassName="flex flex-col gap-0 overflow-hidden bg-background p-0"

--- a/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
@@ -635,7 +635,6 @@ function ArtifactDialogImageStage({
   resourceUrl: string | null;
 }) {
   const { t } = useTranslation();
-  const fullscreen = useGet(lightboxDialogFullscreen$);
   // Marks live on the draft rather than in the file, so the viewer has to draw
   // them too — otherwise reopening an annotated image shows a clean picture.
   const annotation = preview.annotationTarget?.annotations ?? null;
@@ -656,7 +655,7 @@ function ArtifactDialogImageStage({
             </div>
           ) : (
             <ZoomableArtifactImageCanvas
-              key={`${fullscreen ? "fullscreen" : "windowed"}:${resourceUrl}`}
+              key={resourceUrl}
               src={resourceUrl}
               alt={filename}
               signals={attachmentLightboxImageCanvasSignals}

--- a/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { Button, Dialog, DialogContent, cn } from "@okouai/ui";
+import { Button, Dialog, DialogBody, DialogContent } from "@okouai/ui";
 import {
   useGet,
   useLastLoadable,
@@ -1318,10 +1318,10 @@ function ArtifactPreviewDialogContent({
         initialFocus={dialogElement}
         showCloseButton={false}
         overlayClassName="okou-pwa-fixed-cover bg-gray-900/45 dark:bg-gray-900/45"
-        className={cn(
-          "fixed inset-0 left-0 top-0 flex max-h-none w-auto max-w-none translate-x-0 translate-y-0 items-center justify-center gap-0 overflow-hidden rounded-none border-0 bg-transparent shadow-none",
-          fullscreen ? "p-0" : "p-6",
-        )}
+        size="preview"
+        surface="canvas"
+        mode={fullscreen ? "fullscreen" : "windowed"}
+        contentClassName="flex flex-col gap-0 overflow-hidden bg-background p-0"
         aria-label={t(
           ($) => {
             return $.artifacts.preview.dialogLabel;
@@ -1340,27 +1340,9 @@ function ArtifactPreviewDialogContent({
               : undefined
           }
         />
-        {/*
-          The popup spans the viewport, so the area around the panel is the
-          backdrop the user sees. Dismissal lives on this dedicated sibling
-          rather than on the popup: a press that starts in the panel and ends
-          outside it — panning a zoomed image past the edge, dragging a text
-          selection out of a document — fires its click at the common ancestor
-          of both endpoints, which is the popup, so this element never sees it.
-        */}
-        <div
-          className="absolute inset-0"
-          onClick={closeWithAnimation}
-          data-testid="attachment-lightbox-backdrop"
-        />
         <div
           ref={registerConnectionDialog}
-          className={cn(
-            "relative flex min-h-0 flex-col overflow-hidden bg-background text-foreground shadow-[0_24px_70px_rgba(0,0,0,0.30)]",
-            fullscreen
-              ? "okou-fixed-viewport-shell w-dvw rounded-none"
-              : "h-[min(1000px,calc(100dvh-3rem))] w-[min(1440px,calc(100vw-3rem))] rounded-xl",
-          )}
+          className="relative flex min-h-0 flex-1 flex-col overflow-hidden text-foreground"
           data-testid="attachment-lightbox-panel"
         >
           <div className="flex h-14 shrink-0 items-center gap-2 border-b border-border/70 pl-4 pr-3">
@@ -1380,7 +1362,7 @@ function ArtifactPreviewDialogContent({
               />
             )}
           </div>
-          <div className="min-h-0 flex-1 bg-background">
+          <DialogBody className="overflow-hidden bg-background">
             {connectionProgressActive ? (
               <div className="flex h-full items-center justify-center p-6">
                 <ConnectorConnectionStatus />
@@ -1392,7 +1374,7 @@ function ArtifactPreviewDialogContent({
                 preview={preview}
               />
             )}
-          </div>
+          </DialogBody>
         </div>
       </DialogContent>
     </Dialog>

--- a/turbo/apps/platform/src/views/okou-page/avatar-maker.tsx
+++ b/turbo/apps/platform/src/views/okou-page/avatar-maker.tsx
@@ -412,7 +412,7 @@ function AvatarMakerDialogBody({
       closeLabel={t(($) => {
         return $.actions.close;
       })}
-      className="w-[calc(100vw-2rem)] sm:max-w-lg p-0 gap-0 overflow-hidden"
+      contentClassName="p-0 gap-0 overflow-hidden"
     >
       <DialogHeader className="sr-only">
         <DialogTitle>{title}</DialogTitle>

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -6247,7 +6247,7 @@ function TemplatePickerDialog({
         closeLabel={t(($) => {
           return $.artifacts.actions.close;
         })}
-        size="6xl"
+        maxWidth="6xl"
         height={760}
         contentClassName={dialogContentClassName}
         aria-describedby={undefined}
@@ -7063,7 +7063,7 @@ function AddConnectorsDialog({
     >
       <DialogContent
         ref={registerConnectionDialog}
-        size="2xl"
+        maxWidth="2xl"
         contentClassName="okou-app flex flex-col"
         aria-describedby={undefined}
       >
@@ -8398,7 +8398,7 @@ function ComputerUseDownloadDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent size="md" contentClassName="gap-0 overflow-hidden p-0">
+      <DialogContent maxWidth="md" contentClassName="gap-0 overflow-hidden p-0">
         <div className="flex h-44 items-center justify-center border-b border-border bg-gray-50">
           <img
             src={computerUseIllustrationImg}

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -5962,7 +5962,7 @@ function TemplatePickerDialog({
   const isPreviewing = Boolean(previewItem ?? importedPreviewItem);
   const dialogContentClassName = cn(
     "gap-0 overflow-hidden p-0 focus:outline-none focus-visible:outline-none focus-visible:ring-0",
-    "flex h-[min(82vh,760px)] max-w-6xl flex-col [&>button]:right-4 [&>button]:top-4",
+    "flex flex-col",
   );
   // A persona pill filters the grid, ideation-gallery style.
   // resolveWorkflowCatalog() keeps that logic out of this component to stay
@@ -6247,7 +6247,9 @@ function TemplatePickerDialog({
         closeLabel={t(($) => {
           return $.artifacts.actions.close;
         })}
-        className={dialogContentClassName}
+        size="6xl"
+        height={760}
+        contentClassName={dialogContentClassName}
         aria-describedby={undefined}
         onKeyDown={handleDialogKeyDown}
         onKeyDownCapture={
@@ -7061,7 +7063,8 @@ function AddConnectorsDialog({
     >
       <DialogContent
         ref={registerConnectionDialog}
-        className="okou-app max-w-2xl flex max-h-[80vh] flex-col"
+        size="2xl"
+        contentClassName="okou-app flex flex-col"
         aria-describedby={undefined}
       >
         <DialogHeader className="shrink-0">
@@ -8395,7 +8398,7 @@ function ComputerUseDownloadDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md gap-0 overflow-hidden p-0">
+      <DialogContent size="md" contentClassName="gap-0 overflow-hidden p-0">
         <div className="flex h-44 items-center justify-center border-b border-border bg-gray-50">
           <img
             src={computerUseIllustrationImg}

--- a/turbo/apps/platform/src/views/okou-page/chat-forward-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-forward-dialog.tsx
@@ -270,7 +270,10 @@ export function ChatForwardDialog({
         }
       }}
     >
-      <DialogContent className="okou-app w-[calc(100vw-2rem)] grid-cols-[minmax(0,1fr)] gap-0 overflow-hidden p-0 sm:max-w-xl">
+      <DialogContent
+        size="xl"
+        contentClassName="okou-app grid-cols-[minmax(0,1fr)] gap-0 overflow-hidden p-0"
+      >
         <DialogHeader className="min-w-0 px-5 pb-3 pt-5">
           <div className="flex min-w-0 items-center gap-2 pr-8">
             {target ? (

--- a/turbo/apps/platform/src/views/okou-page/chat-forward-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-forward-dialog.tsx
@@ -271,7 +271,7 @@ export function ChatForwardDialog({
       }}
     >
       <DialogContent
-        size="xl"
+        smMaxWidth="xl"
         contentClassName="okou-app grid-cols-[minmax(0,1fr)] gap-0 overflow-hidden p-0"
       >
         <DialogHeader className="min-w-0 px-5 pb-3 pt-5">

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -2164,11 +2164,11 @@ function HeaderWorkflowAutomationEditDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className={
+        size={
           automation.kind === "event" &&
           automation.eventType === "gmail-new-message"
-            ? "max-w-2xl"
-            : ""
+            ? "2xl"
+            : "lg"
         }
       >
         <DialogHeader>
@@ -7480,7 +7480,8 @@ function RelatedArtifactsDialog({
       </TooltipProvider>
       <DialogContent
         aria-describedby={undefined}
-        className="!flex max-h-[min(720px,calc(100dvh-2rem))] w-[calc(100vw-2rem)] !flex-col !overflow-hidden gap-0 p-0 sm:max-w-xl"
+        size="xl"
+        contentClassName="flex flex-col overflow-hidden gap-0 p-0"
         data-testid="chat-run-related-artifacts-dialog"
       >
         <DialogHeader className="shrink-0 px-5 pb-4 pt-5 pr-12">

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -2164,7 +2164,7 @@ function HeaderWorkflowAutomationEditDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        size={
+        maxWidth={
           automation.kind === "event" &&
           automation.eventType === "gmail-new-message"
             ? "2xl"
@@ -7480,7 +7480,7 @@ function RelatedArtifactsDialog({
       </TooltipProvider>
       <DialogContent
         aria-describedby={undefined}
-        size="xl"
+        smMaxWidth="xl"
         contentClassName="flex flex-col overflow-hidden gap-0 p-0"
         data-testid="chat-run-related-artifacts-dialog"
       >

--- a/turbo/apps/platform/src/views/okou-page/components/delete-agent-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/delete-agent-dialog.tsx
@@ -370,7 +370,7 @@ export function AgentDeleteDialog({
                 closeLabel={t(($) => {
                   return $.actions.close;
                 })}
-                size="3xl"
+                maxWidth="3xl"
                 contentClassName="gap-0 overflow-hidden p-0"
               >
                 {canReconcile ? (

--- a/turbo/apps/platform/src/views/okou-page/components/delete-agent-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/delete-agent-dialog.tsx
@@ -370,7 +370,8 @@ export function AgentDeleteDialog({
                 closeLabel={t(($) => {
                   return $.actions.close;
                 })}
-                className="max-w-3xl gap-0 overflow-hidden p-0"
+                size="3xl"
+                contentClassName="gap-0 overflow-hidden p-0"
               >
                 {canReconcile ? (
                   <AgentDeleteReconcileView

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/model-provider-connections-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/model-provider-connections-section.tsx
@@ -222,7 +222,7 @@ function DeleteConnectionDialog() {
         }
       }}
     >
-      <DialogContent className="max-w-md">
+      <DialogContent size="md">
         <DialogHeader>
           <DialogTitle>
             {t(($) => {
@@ -462,7 +462,7 @@ function ConnectionDialog() {
         }
       }}
     >
-      <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
+      <DialogContent size="3xl" contentClassName="overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {draft.editingId

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/model-provider-connections-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/model-provider-connections-section.tsx
@@ -222,7 +222,7 @@ function DeleteConnectionDialog() {
         }
       }}
     >
-      <DialogContent size="md">
+      <DialogContent maxWidth="md">
         <DialogHeader>
           <DialogTitle>
             {t(($) => {
@@ -462,7 +462,7 @@ function ConnectionDialog() {
         }
       }}
     >
-      <DialogContent size="3xl" contentClassName="overflow-y-auto">
+      <DialogContent maxWidth="3xl" contentClassName="overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {draft.editingId

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
@@ -278,7 +278,7 @@ function DowngradeConfirmDialogContent({
         handleClose();
       }}
     >
-      <DialogContent className="sm:max-w-[440px]">
+      <DialogContent size={440}>
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -503,7 +503,7 @@ function RestorePlanConfirmDialogContent({
         return !v && close();
       }}
     >
-      <DialogContent className="sm:max-w-[440px]">
+      <DialogContent size={440}>
         <DialogHeader>
           <DialogTitle>
             {i18n.t(
@@ -1435,7 +1435,7 @@ function ConcurrencyConfirmDialogContent({
     dialog.canReduce;
 
   return (
-    <DialogContent className="sm:max-w-[480px]">
+    <DialogContent size={480}>
       <DialogHeader>
         <DialogTitle>{copy.title}</DialogTitle>
         {copy.description ? (
@@ -1498,7 +1498,7 @@ function ConcurrencyPurchaseReviewDialogContent({
   const loading = checkoutLoadable.state === "loading";
 
   return (
-    <DialogContent className="sm:max-w-[420px]">
+    <DialogContent size={420}>
       <DialogHeader>
         <DialogTitle>
           {i18n.t(($) => {
@@ -1620,7 +1620,7 @@ function ConcurrencyPurchaseDialog({
         return !v && close();
       }}
     >
-      <DialogContent className="sm:max-w-[420px]">
+      <DialogContent size={420}>
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -1943,7 +1943,9 @@ function StandaloneBillingPricingDialog({
     >
       <DialogContent
         aria-describedby={undefined}
-        className="okou-app flex h-[min(43rem,calc(100dvh-4rem))] w-[calc(100vw-2rem)] max-w-[860px] flex-col gap-0 overflow-hidden p-0"
+        size={860}
+        height={688}
+        contentClassName="okou-app flex flex-col gap-0 overflow-hidden p-0"
       >
         <DialogTitle className="sr-only">
           {i18n.t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
@@ -278,7 +278,7 @@ function DowngradeConfirmDialogContent({
         handleClose();
       }}
     >
-      <DialogContent size={440}>
+      <DialogContent smMaxWidth={440}>
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -503,7 +503,7 @@ function RestorePlanConfirmDialogContent({
         return !v && close();
       }}
     >
-      <DialogContent size={440}>
+      <DialogContent smMaxWidth={440}>
         <DialogHeader>
           <DialogTitle>
             {i18n.t(
@@ -1435,7 +1435,7 @@ function ConcurrencyConfirmDialogContent({
     dialog.canReduce;
 
   return (
-    <DialogContent size={480}>
+    <DialogContent smMaxWidth={480}>
       <DialogHeader>
         <DialogTitle>{copy.title}</DialogTitle>
         {copy.description ? (
@@ -1498,7 +1498,7 @@ function ConcurrencyPurchaseReviewDialogContent({
   const loading = checkoutLoadable.state === "loading";
 
   return (
-    <DialogContent size={420}>
+    <DialogContent smMaxWidth={420}>
       <DialogHeader>
         <DialogTitle>
           {i18n.t(($) => {
@@ -1620,7 +1620,7 @@ function ConcurrencyPurchaseDialog({
         return !v && close();
       }}
     >
-      <DialogContent size={420}>
+      <DialogContent smMaxWidth={420}>
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -1943,7 +1943,7 @@ function StandaloneBillingPricingDialog({
     >
       <DialogContent
         aria-describedby={undefined}
-        size={860}
+        maxWidth={860}
         height={688}
         contentClassName="okou-app flex flex-col gap-0 overflow-hidden p-0"
       >

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx
@@ -829,7 +829,8 @@ function InvitePurchaseConfirmationDialogContent() {
       }}
     >
       <DialogContent
-        className="max-w-[26.5rem] gap-0"
+        size={424}
+        contentClassName="gap-0"
         closeLabel={t(($) => {
           return $.settings.shared.close;
         })}

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx
@@ -829,7 +829,7 @@ function InvitePurchaseConfirmationDialogContent() {
       }}
     >
       <DialogContent
-        size={424}
+        maxWidth="26.5rem"
         contentClassName="gap-0"
         closeLabel={t(($) => {
           return $.settings.shared.close;

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-model-policies-section.tsx
@@ -1576,7 +1576,7 @@ function ModelPolicyRouteDialog({
       }}
     >
       <DialogContent
-        className="max-w-3xl"
+        size="3xl"
         closeLabel={t(($) => {
           return $.settings.shared.close;
         })}

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-model-policies-section.tsx
@@ -1576,7 +1576,7 @@ function ModelPolicyRouteDialog({
       }}
     >
       <DialogContent
-        size="3xl"
+        maxWidth="3xl"
         closeLabel={t(($) => {
           return $.settings.shared.close;
         })}

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/purchase-confirm-dialog-shell.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/purchase-confirm-dialog-shell.tsx
@@ -61,7 +61,7 @@ export function PurchaseConfirmDialogShell({
         }
       }}
     >
-      <DialogContent className="sm:max-w-[420px]">
+      <DialogContent size={420}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/purchase-confirm-dialog-shell.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/purchase-confirm-dialog-shell.tsx
@@ -61,7 +61,7 @@ export function PurchaseConfirmDialogShell({
         }
       }}
     >
-      <DialogContent size={420}>
+      <DialogContent smMaxWidth={420}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1148,7 +1148,9 @@ function PricingStepDialog({
       <DialogContent
         aria-describedby={undefined}
         showCloseButton={false}
-        className="flex h-[min(43rem,calc(100dvh-4rem))] w-[calc(100vw-2rem)] max-w-[860px] flex-col gap-0 overflow-hidden p-0"
+        size={860}
+        height={688}
+        contentClassName="flex flex-col gap-0 overflow-hidden p-0"
       >
         {/* The close button is an item in this row rather than a box pinned to
             the frame, so the title, the step counter and the close glyph share

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1148,7 +1148,7 @@ function PricingStepDialog({
       <DialogContent
         aria-describedby={undefined}
         showCloseButton={false}
-        size={860}
+        maxWidth={860}
         height={688}
         contentClassName="flex flex-col gap-0 overflow-hidden p-0"
       >

--- a/turbo/apps/platform/src/views/okou-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/add-connection-dialog.tsx
@@ -1566,7 +1566,7 @@ export function ConnectModal({
         }
       }}
     >
-      <DialogContent size="md" aria-describedby={undefined}>
+      <DialogContent maxWidth="md" aria-describedby={undefined}>
         <DialogHeader>
           <div className="flex items-center gap-3">
             <div className="flex h-5 w-5 shrink-0 items-center justify-center">

--- a/turbo/apps/platform/src/views/okou-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/add-connection-dialog.tsx
@@ -1566,7 +1566,7 @@ export function ConnectModal({
         }
       }}
     >
-      <DialogContent className="max-w-md" aria-describedby={undefined}>
+      <DialogContent size="md" aria-describedby={undefined}>
         <DialogHeader>
           <div className="flex items-center gap-3">
             <div className="flex h-5 w-5 shrink-0 items-center justify-center">

--- a/turbo/apps/platform/src/views/okou-page/components/settings/built-in-model-cooldown-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/built-in-model-cooldown-diagnostics-block.tsx
@@ -144,7 +144,7 @@ function CooldownCancellationDialogBody({
   const { t } = useTranslation();
 
   return (
-    <DialogContent className="max-w-md" showCloseButton={!cancelling}>
+    <DialogContent size="md" showCloseButton={!cancelling}>
       <DialogHeader>
         <DialogTitle>
           {t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/components/settings/built-in-model-cooldown-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/built-in-model-cooldown-diagnostics-block.tsx
@@ -144,7 +144,7 @@ function CooldownCancellationDialogBody({
   const { t } = useTranslation();
 
   return (
-    <DialogContent size="md" showCloseButton={!cancelling}>
+    <DialogContent maxWidth="md" showCloseButton={!cancelling}>
       <DialogHeader>
         <DialogTitle>
           {t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-access-management-dialog.tsx
@@ -344,7 +344,7 @@ function ConnectorAccessDialog({
       }}
     >
       <DialogContent
-        size={720}
+        maxWidth={720}
         height={720}
         contentClassName="flex flex-col overflow-hidden"
       >

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-access-management-dialog.tsx
@@ -343,7 +343,11 @@ function ConnectorAccessDialog({
         return !open && onClose();
       }}
     >
-      <DialogContent className="!flex h-[min(720px,calc(100dvh-2rem))] w-[calc(100vw-2rem)] max-w-[720px] !flex-col !overflow-hidden">
+      <DialogContent
+        size={720}
+        height={720}
+        contentClassName="flex flex-col overflow-hidden"
+      >
         <DialogHeader className="shrink-0 gap-2">
           <div className="flex items-center gap-3">
             <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted">

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -501,7 +501,7 @@ function DeleteAccountConfirmation({
         return !open && clear();
       }}
     >
-      <DialogContent size="md">
+      <DialogContent maxWidth="md">
         <DialogHeader>
           <DialogTitle className="line-clamp-2 break-words pr-8 leading-snug">
             {t(
@@ -604,6 +604,37 @@ function enrichedDefaultConnection(
   );
 }
 
+function ConnectorAccountManagerHeader({
+  connectorLabel,
+  icon,
+}: Pick<ConnectorAccountManagerDialogProps, "connectorLabel" | "icon">) {
+  const { t } = useTranslation();
+  return (
+    <DialogHeader className="shrink-0 gap-2">
+      <div className="flex items-center gap-3">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted">
+          {icon}
+        </span>
+        <div className="min-w-0">
+          <DialogTitle className="text-base">
+            {t(
+              ($) => {
+                return $.connectors.accounts.managerTitle;
+              },
+              { connector: connectorLabel },
+            )}
+          </DialogTitle>
+          <DialogDescription>
+            {t(($) => {
+              return $.connectors.accounts.managerDescription;
+            })}
+          </DialogDescription>
+        </div>
+      </div>
+    </DialogHeader>
+  );
+}
+
 export function ConnectorAccountManagerDialog({
   target,
   connectorLabel,
@@ -649,29 +680,14 @@ export function ConnectorAccountManagerDialog({
         return !open && leave(onClose);
       }}
     >
-      <DialogContent size="xl" contentClassName="flex flex-col overflow-hidden">
-        <DialogHeader className="shrink-0 gap-2">
-          <div className="flex items-center gap-3">
-            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted">
-              {icon}
-            </span>
-            <div className="min-w-0">
-              <DialogTitle className="text-base">
-                {t(
-                  ($) => {
-                    return $.connectors.accounts.managerTitle;
-                  },
-                  { connector: connectorLabel },
-                )}
-              </DialogTitle>
-              <DialogDescription>
-                {t(($) => {
-                  return $.connectors.accounts.managerDescription;
-                })}
-              </DialogDescription>
-            </div>
-          </div>
-        </DialogHeader>
+      <DialogContent
+        maxWidth="xl"
+        contentClassName="flex flex-col overflow-hidden"
+      >
+        <ConnectorAccountManagerHeader
+          connectorLabel={connectorLabel}
+          icon={icon}
+        />
         {showSearch ? (
           <div className="shrink-0">
             <ConnectorAccountSearch value={search} />

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -501,7 +501,7 @@ function DeleteAccountConfirmation({
         return !open && clear();
       }}
     >
-      <DialogContent className="max-w-md">
+      <DialogContent size="md">
         <DialogHeader>
           <DialogTitle className="line-clamp-2 break-words pr-8 leading-snug">
             {t(
@@ -649,7 +649,7 @@ export function ConnectorAccountManagerDialog({
         return !open && leave(onClose);
       }}
     >
-      <DialogContent className="!flex w-full max-w-xl !flex-col !overflow-hidden">
+      <DialogContent size="xl" contentClassName="flex flex-col overflow-hidden">
         <DialogHeader className="shrink-0 gap-2">
           <div className="flex items-center gap-3">
             <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted">

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-name-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-name-dialog.tsx
@@ -67,7 +67,7 @@ export function ConnectorAccountNameDialog() {
         return !open && close();
       }}
     >
-      <DialogContent className="max-w-md">
+      <DialogContent size="md">
         <form className="flex flex-col gap-5" onSubmit={submit}>
           <DialogHeader>
             <DialogTitle className="line-clamp-2 break-words pr-8 leading-snug">

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-name-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-name-dialog.tsx
@@ -67,7 +67,7 @@ export function ConnectorAccountNameDialog() {
         return !open && close();
       }}
     >
-      <DialogContent size="md">
+      <DialogContent maxWidth="md">
         <form className="flex flex-col gap-5" onSubmit={submit}>
           <DialogHeader>
             <DialogTitle className="line-clamp-2 break-words pr-8 leading-snug">

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-connect-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-connect-dialog.tsx
@@ -431,7 +431,7 @@ export function CustomConnectorConnectDialog({
       }}
     >
       <DialogContent
-        size="md"
+        maxWidth="md"
         aria-describedby={undefined}
         closeLabel={t(($) => {
           return $.connectors.actions.close;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-connect-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-connect-dialog.tsx
@@ -431,7 +431,7 @@ export function CustomConnectorConnectDialog({
       }}
     >
       <DialogContent
-        className="max-w-md"
+        size="md"
         aria-describedby={undefined}
         closeLabel={t(($) => {
           return $.connectors.actions.close;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-create-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-create-dialog.tsx
@@ -1415,7 +1415,8 @@ export function CustomConnectorCreateDialog({
         }}
       >
         <DialogContent
-          className="max-w-2xl max-h-[90vh] overflow-y-auto"
+          size="2xl"
+          contentClassName="overflow-y-auto"
           aria-describedby={undefined}
           closeLabel={t(($) => {
             return $.connectors.actions.close;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-create-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-create-dialog.tsx
@@ -1415,7 +1415,7 @@ export function CustomConnectorCreateDialog({
         }}
       >
         <DialogContent
-          size="2xl"
+          maxWidth="2xl"
           contentClassName="overflow-y-auto"
           aria-describedby={undefined}
           closeLabel={t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-delete-confirm.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-delete-confirm.tsx
@@ -46,7 +46,7 @@ export function CustomConnectorDeleteConfirm({
         return !open && closeDialog();
       }}
     >
-      <DialogContent className="max-w-md" aria-describedby={undefined}>
+      <DialogContent size="md" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>
             {t(

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-delete-confirm.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-delete-confirm.tsx
@@ -46,7 +46,7 @@ export function CustomConnectorDeleteConfirm({
         return !open && closeDialog();
       }}
     >
-      <DialogContent size="md" aria-describedby={undefined}>
+      <DialogContent maxWidth="md" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>
             {t(

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-update-confirm.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-update-confirm.tsx
@@ -26,7 +26,7 @@ export function CustomConnectorUpdateConfirm({
       }}
     >
       <DialogContent
-        size="md"
+        maxWidth="md"
         aria-describedby={undefined}
         closeLabel={t(($) => {
           return $.connectors.actions.close;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-update-confirm.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-update-confirm.tsx
@@ -26,7 +26,7 @@ export function CustomConnectorUpdateConfirm({
       }}
     >
       <DialogContent
-        className="max-w-md"
+        size="md"
         aria-describedby={undefined}
         closeLabel={t(($) => {
           return $.connectors.actions.close;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/device-auth-dialog-shell.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/device-auth-dialog-shell.tsx
@@ -39,7 +39,7 @@ export function DeviceAuthDialogShell({
       }}
     >
       <DialogContent
-        className="max-w-md"
+        size="md"
         aria-describedby={undefined}
         closeLabel={t(($) => {
           return $.settings.shared.close;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/device-auth-dialog-shell.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/device-auth-dialog-shell.tsx
@@ -39,7 +39,7 @@ export function DeviceAuthDialogShell({
       }}
     >
       <DialogContent
-        size="md"
+        maxWidth="md"
         aria-describedby={undefined}
         closeLabel={t(($) => {
           return $.settings.shared.close;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/permissions-dialog.tsx
@@ -1674,7 +1674,7 @@ export function PermissionsDialog(props: PermissionsDrawerProps) {
       }}
     >
       <DialogContent
-        size={760}
+        maxWidth={760}
         height={720}
         contentClassName="flex flex-col overflow-hidden"
       >

--- a/turbo/apps/platform/src/views/okou-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/permissions-dialog.tsx
@@ -1673,7 +1673,11 @@ export function PermissionsDialog(props: PermissionsDrawerProps) {
         return !open && handleClose();
       }}
     >
-      <DialogContent className="!flex h-[min(720px,calc(100dvh-2rem))] w-[calc(100vw-2rem)] max-w-[760px] !flex-col !overflow-hidden">
+      <DialogContent
+        size={760}
+        height={720}
+        contentClassName="flex flex-col overflow-hidden"
+      >
         <PermissionsContent
           props={props}
           surface="dialog"

--- a/turbo/apps/platform/src/views/okou-page/components/settings/scope-review-modal.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/scope-review-modal.tsx
@@ -138,7 +138,7 @@ export function ScopeReviewModal({
         return !open && onClose();
       }}
     >
-      <DialogContent className="max-w-md" aria-describedby={undefined}>
+      <DialogContent size="md" aria-describedby={undefined}>
         <DialogHeader>
           <div className="flex items-center gap-3">
             <div className="flex h-5 w-5 shrink-0 items-center justify-center">

--- a/turbo/apps/platform/src/views/okou-page/components/settings/scope-review-modal.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/scope-review-modal.tsx
@@ -138,7 +138,7 @@ export function ScopeReviewModal({
         return !open && onClose();
       }}
     >
-      <DialogContent size="md" aria-describedby={undefined}>
+      <DialogContent maxWidth="md" aria-describedby={undefined}>
         <DialogHeader>
           <div className="flex items-center gap-3">
             <div className="flex h-5 w-5 shrink-0 items-center justify-center">

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/credit-balance-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/credit-balance-section.tsx
@@ -502,7 +502,7 @@ function UsagePackMemberBalancesDialog({
         closeLabel={t(($) => {
           return $.settings.shared.close;
         })}
-        size="3xl"
+        maxWidth="3xl"
         contentClassName="okou-app flex flex-col gap-0 overflow-hidden p-0"
       >
         <DialogHeader className="shrink-0 border-b border-border/70 px-6 pb-4 pt-6">

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/credit-balance-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/credit-balance-section.tsx
@@ -502,7 +502,8 @@ function UsagePackMemberBalancesDialog({
         closeLabel={t(($) => {
           return $.settings.shared.close;
         })}
-        className="okou-app flex max-h-[85vh] max-w-3xl flex-col gap-0 overflow-hidden p-0"
+        size="3xl"
+        contentClassName="okou-app flex flex-col gap-0 overflow-hidden p-0"
       >
         <DialogHeader className="shrink-0 border-b border-border/70 px-6 pb-4 pt-6">
           <DialogTitle>

--- a/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
@@ -340,7 +340,7 @@ function SettingsDialog({
         closeLabel={t(($) => {
           return $.settings.shared.close;
         })}
-        size={1200}
+        maxWidth={1200}
         height="fill"
         contentClassName="okou-app flex flex-col p-0 gap-0 overflow-hidden bg-card"
       >

--- a/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
@@ -340,7 +340,9 @@ function SettingsDialog({
         closeLabel={t(($) => {
           return $.settings.shared.close;
         })}
-        className="okou-app flex flex-col w-[calc(100vw-2rem)] max-w-[1200px] h-[92dvh] sm:h-[85vh] p-0 gap-0 overflow-hidden okou-border rounded-xl bg-card"
+        size={1200}
+        height="fill"
+        contentClassName="okou-app flex flex-col p-0 gap-0 overflow-hidden bg-card"
       >
         <DialogTitle className="sr-only">
           {t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/connector-directory-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connector-directory-dialog.tsx
@@ -1000,7 +1000,9 @@ export function ConnectorDirectoryDialog({
       }}
     >
       <DialogContent
-        className="flex h-[min(600px,85vh)] max-w-2xl flex-col gap-0 p-0"
+        maxWidth="2xl"
+        height={600}
+        contentClassName="flex flex-col gap-0 p-0"
         aria-describedby={undefined}
         onKeyDown={handleKeyDown}
       >

--- a/turbo/apps/platform/src/views/okou-page/directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-connect-page.tsx
@@ -352,7 +352,7 @@ function ManualGrantDialog({
   }
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md" aria-describedby={undefined}>
+      <DialogContent size="md" aria-describedby={undefined}>
         <DialogHeader>
           <div className="flex items-center gap-3">
             <ConnectorIcon icon={icon} size={20} />

--- a/turbo/apps/platform/src/views/okou-page/directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-connect-page.tsx
@@ -352,7 +352,7 @@ function ManualGrantDialog({
   }
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent size="md" aria-describedby={undefined}>
+      <DialogContent maxWidth="md" aria-describedby={undefined}>
         <DialogHeader>
           <div className="flex items-center gap-3">
             <ConnectorIcon icon={icon} size={20} />

--- a/turbo/apps/platform/src/views/okou-page/feishu-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/feishu-card.tsx
@@ -1975,7 +1975,9 @@ function FeishuSetupDialog({
       }}
     >
       <DialogContent
-        className="!flex h-[min(800px,calc(100dvh-2rem))] w-[calc(100vw-2rem)] max-w-2xl !flex-col !overflow-hidden"
+        size="2xl"
+        height={800}
+        contentClassName="flex flex-col overflow-hidden"
         closeLabel={t(($) => {
           return $.connectors.actions.close;
         })}

--- a/turbo/apps/platform/src/views/okou-page/feishu-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/feishu-card.tsx
@@ -1975,7 +1975,7 @@ function FeishuSetupDialog({
       }}
     >
       <DialogContent
-        size="2xl"
+        maxWidth="2xl"
         height={800}
         contentClassName="flex flex-col overflow-hidden"
         closeLabel={t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/replace-composer-draft-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/replace-composer-draft-dialog.tsx
@@ -25,7 +25,7 @@ export function ReplaceComposerDraftDialog({
   const pageSignal = useGet(pageSignal$);
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="okou-app sm:max-w-sm">
+      <DialogContent size="sm" contentClassName="okou-app">
         <DialogHeader>
           <DialogTitle>
             {t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/replace-composer-draft-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/replace-composer-draft-dialog.tsx
@@ -25,7 +25,7 @@ export function ReplaceComposerDraftDialog({
   const pageSignal = useGet(pageSignal$);
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent size="sm" contentClassName="okou-app">
+      <DialogContent smMaxWidth="sm" contentClassName="okou-app">
         <DialogHeader>
           <DialogTitle>
             {t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-dialogs.tsx
@@ -1334,7 +1334,9 @@ export function ThreeColumnSearchDialog({
       closeLabel={t(($) => {
         return $.actions.close;
       })}
-      className="okou-app w-[calc(100vw-2rem)] gap-0 sm:max-w-[820px] [&_[data-slot=dialog-close]]:hidden"
+      size={820}
+      showCloseButton={false}
+      contentClassName="okou-app gap-0"
       commandClassName="gap-0"
       commandProps={{
         shouldFilter: false,
@@ -1468,7 +1470,8 @@ export function PinAgentDialog({
       closeLabel={t(($) => {
         return $.actions.close;
       })}
-      className="okou-app sm:max-w-xl w-[calc(100vw-2rem)] gap-0"
+      size="xl"
+      contentClassName="okou-app gap-0"
       commandClassName="gap-0"
       commandProps={{
         shouldFilter: false,

--- a/turbo/apps/platform/src/views/okou-page/sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-dialogs.tsx
@@ -1334,7 +1334,7 @@ export function ThreeColumnSearchDialog({
       closeLabel={t(($) => {
         return $.actions.close;
       })}
-      size={820}
+      smMaxWidth={820}
       showCloseButton={false}
       contentClassName="okou-app gap-0"
       commandClassName="gap-0"
@@ -1470,7 +1470,7 @@ export function PinAgentDialog({
       closeLabel={t(($) => {
         return $.actions.close;
       })}
-      size="xl"
+      smMaxWidth="xl"
       contentClassName="okou-app gap-0"
       commandClassName="gap-0"
       commandProps={{

--- a/turbo/apps/platform/src/views/okou-page/telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/telegram-settings-page.tsx
@@ -1006,7 +1006,7 @@ function AddTelegramBotDialogFrame({
           })}
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[640px]">
+      <DialogContent size={640}>
         <DialogHeader>
           <DialogTitle>
             {t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/telegram-settings-page.tsx
@@ -1006,7 +1006,7 @@ function AddTelegramBotDialogFrame({
           })}
         </Button>
       </DialogTrigger>
-      <DialogContent size={640}>
+      <DialogContent smMaxWidth={640}>
         <DialogHeader>
           <DialogTitle>
             {t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/website-template-preview-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/website-template-preview-dialog.tsx
@@ -1,9 +1,12 @@
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from "@okouai/ui/components/ui/dialog";
+import { Button } from "@okouai/ui/components/ui/button";
+import { X } from "lucide-react";
 import { useGet, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import { r2ImageTransformUrl } from "@okouai/core/r2-image-transform";
@@ -47,9 +50,12 @@ function WebsiteTemplatePreviewDialog({
         closeLabel={t(($) => {
           return $.artifacts.actions.close;
         })}
-        className="flex h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-[1120px] flex-col gap-0 overflow-hidden p-0 [&>button]:top-[7px] sm:h-[min(760px,calc(100dvh-4rem))]"
+        size={1120}
+        height={760}
+        showCloseButton={false}
+        contentClassName="flex flex-col gap-0 overflow-hidden p-0"
       >
-        <DialogHeader className="shrink-0 border-b border-border px-5 py-4 pr-14 text-left sm:pr-16">
+        <DialogHeader className="relative shrink-0 border-b border-border px-5 py-4 pr-14 text-left sm:pr-16">
           <DialogTitle className="flex min-w-0 max-w-full items-center justify-start gap-1.5 text-left text-base leading-none">
             <button
               type="button"
@@ -67,6 +73,21 @@ function WebsiteTemplatePreviewDialog({
               {item.title}
             </span>
           </DialogTitle>
+          <DialogClose
+            render={
+              <Button
+                variant="ghost"
+                size="icon"
+                iconSize="lg"
+                className="absolute right-4 top-[7px] opacity-70 hover:opacity-100"
+                aria-label={t(($) => {
+                  return $.artifacts.actions.close;
+                })}
+              />
+            }
+          >
+            <X />
+          </DialogClose>
         </DialogHeader>
         <div className="min-h-0 flex-1 bg-muted/20 p-3 sm:p-5">
           <div className="relative h-full overflow-hidden rounded-lg border border-border bg-background">

--- a/turbo/apps/platform/src/views/okou-page/website-template-preview-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/website-template-preview-dialog.tsx
@@ -50,7 +50,7 @@ function WebsiteTemplatePreviewDialog({
         closeLabel={t(($) => {
           return $.artifacts.actions.close;
         })}
-        size={1120}
+        maxWidth={1120}
         height={760}
         showCloseButton={false}
         contentClassName="flex flex-col gap-0 overflow-hidden p-0"

--- a/turbo/apps/platform/src/views/okou-page/workflow-automations-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/workflow-automations-page.tsx
@@ -1052,7 +1052,7 @@ export function CreateWorkflowAutomationDialog() {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent
-        size="xl"
+        smMaxWidth="xl"
         contentClassName="okou-app flex flex-col overflow-hidden gap-0 p-0"
       >
         <DialogHeader className="shrink-0 px-5 pb-3 pt-5">

--- a/turbo/apps/platform/src/views/okou-page/workflow-automations-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/workflow-automations-page.tsx
@@ -1051,7 +1051,10 @@ export function CreateWorkflowAutomationDialog() {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="okou-app !flex max-h-[min(720px,calc(100dvh-2rem))] w-[calc(100vw-2rem)] !flex-col !overflow-hidden gap-0 p-0 sm:max-w-xl">
+      <DialogContent
+        size="xl"
+        contentClassName="okou-app flex flex-col overflow-hidden gap-0 p-0"
+      >
         <DialogHeader className="shrink-0 px-5 pb-3 pt-5">
           <DialogTitle className="text-base font-semibold">
             {creatingAutomationInChat

--- a/turbo/apps/platform/src/views/onboarding/onboarding-shell.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-shell.tsx
@@ -140,7 +140,10 @@ export function OnboardingDialog({
         }
       }}
     >
-      <DialogContent className="flex max-h-[calc(100dvh-32px)] w-[calc(100%-32px)] max-w-4xl flex-col gap-0 overflow-hidden border-border bg-background p-5 sm:p-6">
+      <DialogContent
+        size="4xl"
+        contentClassName="flex flex-col gap-0 overflow-hidden border-border bg-background p-5 sm:p-6"
+      >
         <header className="shrink-0 pr-9">
           <div className="min-w-0">
             <DialogTitle className="text-lg font-semibold leading-6">

--- a/turbo/apps/platform/src/views/onboarding/onboarding-shell.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-shell.tsx
@@ -141,7 +141,7 @@ export function OnboardingDialog({
       }}
     >
       <DialogContent
-        size="4xl"
+        maxWidth="4xl"
         contentClassName="flex flex-col gap-0 overflow-hidden border-border bg-background p-5 sm:p-6"
       >
         <header className="shrink-0 pr-9">

--- a/turbo/apps/platform/src/views/pwa-install/install-banner.tsx
+++ b/turbo/apps/platform/src/views/pwa-install/install-banner.tsx
@@ -88,7 +88,7 @@ export function IosInstallModal() {
         }
       }}
     >
-      <DialogContent size="sm">
+      <DialogContent maxWidth="sm">
         <DialogHeader>
           <DialogTitle>
             {t(($) => {

--- a/turbo/apps/platform/src/views/pwa-install/install-banner.tsx
+++ b/turbo/apps/platform/src/views/pwa-install/install-banner.tsx
@@ -88,7 +88,7 @@ export function IosInstallModal() {
         }
       }}
     >
-      <DialogContent className="max-w-sm">
+      <DialogContent size="sm">
         <DialogHeader>
           <DialogTitle>
             {t(($) => {

--- a/turbo/apps/platform/src/views/workflows-page/official-workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/official-workflows-page.tsx
@@ -303,7 +303,7 @@ function InstallDialog({
         }
       }}
     >
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-[680px]">
+      <DialogContent size={680} contentClassName="overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {i18n.t(

--- a/turbo/apps/platform/src/views/workflows-page/official-workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/official-workflows-page.tsx
@@ -303,7 +303,7 @@ function InstallDialog({
         }
       }}
     >
-      <DialogContent size={680} contentClassName="overflow-y-auto">
+      <DialogContent smMaxWidth={680} contentClassName="overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {i18n.t(

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -1681,7 +1681,7 @@ function OfficialWorkflowReconfigureDialog({
         }
       }}
     >
-      <DialogContent size={680} contentClassName="overflow-y-auto">
+      <DialogContent smMaxWidth={680} contentClassName="overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -2383,7 +2383,7 @@ function WorkflowCopyDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent size={560}>
+      <DialogContent smMaxWidth={560}>
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -4547,7 +4547,7 @@ function AutomationCreateMenu({
           </span>
         </button>
       </DialogTrigger>
-      <DialogContent size={880}>
+      <DialogContent smMaxWidth={880}>
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -6669,7 +6669,7 @@ function CreateGmailNewMessageAutomationDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent size="2xl">
+      <DialogContent maxWidth="2xl">
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -8092,7 +8092,7 @@ function CreateWebhookAutomationDialog({
         onOpenChange(nextOpen);
       }}
     >
-      <DialogContent size="2xl">
+      <DialogContent maxWidth="2xl">
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -8250,7 +8250,7 @@ function RevealWebhookSecretDialog({
 
   return (
     <Dialog open onOpenChange={onOpenChange}>
-      <DialogContent size="2xl">
+      <DialogContent maxWidth="2xl">
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -9249,7 +9249,7 @@ function EditWorkflowAutomationDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        size={
+        maxWidth={
           automation.kind === "event" &&
           (automation.eventType === "gmail-new-message" ||
             automation.eventType === "github-workflow-run-completed" ||

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -1681,7 +1681,7 @@ function OfficialWorkflowReconfigureDialog({
         }
       }}
     >
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-[680px]">
+      <DialogContent size={680} contentClassName="overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -2383,7 +2383,7 @@ function WorkflowCopyDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[560px]">
+      <DialogContent size={560}>
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -4547,7 +4547,7 @@ function AutomationCreateMenu({
           </span>
         </button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[880px]">
+      <DialogContent size={880}>
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -6669,7 +6669,7 @@ function CreateGmailNewMessageAutomationDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent size="2xl">
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -7685,7 +7685,7 @@ function CreateGithubWorkflowRunCompletedAutomationDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto">
+      <DialogContent contentClassName="overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -7826,7 +7826,7 @@ function CreateGithubWebhookAutomationDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto">
+      <DialogContent contentClassName="overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{copy.title}</DialogTitle>
           <DialogDescription>{copy.description}</DialogDescription>
@@ -8092,7 +8092,7 @@ function CreateWebhookAutomationDialog({
         onOpenChange(nextOpen);
       }}
     >
-      <DialogContent className="max-w-2xl">
+      <DialogContent size="2xl">
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -8250,7 +8250,7 @@ function RevealWebhookSecretDialog({
 
   return (
     <Dialog open onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent size="2xl">
         <DialogHeader>
           <DialogTitle>
             {i18n.t(($) => {
@@ -9249,13 +9249,13 @@ function EditWorkflowAutomationDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className={
+        size={
           automation.kind === "event" &&
           (automation.eventType === "gmail-new-message" ||
             automation.eventType === "github-workflow-run-completed" ||
             isGithubWebhookWorkflowAutomation(automation))
-            ? "max-w-2xl"
-            : ""
+            ? "2xl"
+            : "lg"
         }
       >
         <DialogHeader>

--- a/turbo/apps/platform/src/views/workflows-page/workflow-webhook-upgrade-dialog.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-webhook-upgrade-dialog.tsx
@@ -44,7 +44,7 @@ export function WorkflowWebhookUpgradeDialog() {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent size="md">
+      <DialogContent smMaxWidth="md">
         <DialogHeader>
           <div className="mb-1 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-50 text-amber-700">
             <Lock size={19} />

--- a/turbo/apps/platform/src/views/workflows-page/workflow-webhook-upgrade-dialog.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-webhook-upgrade-dialog.tsx
@@ -44,7 +44,7 @@ export function WorkflowWebhookUpgradeDialog() {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent size="md">
         <DialogHeader>
           <div className="mb-1 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-50 text-amber-700">
             <Lock size={19} />

--- a/turbo/eslint.style.config.mjs
+++ b/turbo/eslint.style.config.mjs
@@ -76,6 +76,7 @@ export default [
       "better-tailwindcss/no-unknown-classes": [
         "error",
         {
+          attributes: ["class", "className", "contentClassName"],
           ignore: baseline.legacyClassTokens.map(exactRegex),
         },
       ],

--- a/turbo/packages/ui/src/components/ui/__tests__/dialog.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/dialog.test.tsx
@@ -19,7 +19,8 @@ describe("Dialog", () => {
         <Dialog>
           <DialogTrigger>Open preview</DialogTrigger>
           <DialogContent
-            size="preview"
+            maxWidth={1440}
+            height={1000}
             mode={fullscreen ? "fullscreen" : "windowed"}
           >
             <DialogTitle>Image preview</DialogTitle>

--- a/turbo/packages/ui/src/components/ui/__tests__/dialog.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/dialog.test.tsx
@@ -1,8 +1,82 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { describe, expect, it } from "vitest";
-import { Dialog, DialogContent, DialogTitle } from "../dialog";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "../dialog";
 
 describe("Dialog", () => {
+  it("preserves the preview and nested focus ownership across fullscreen changes", async () => {
+    const user = userEvent.setup();
+    function Preview() {
+      const [fullscreen, setFullscreen] = useState(false);
+      return (
+        <Dialog>
+          <DialogTrigger>Open preview</DialogTrigger>
+          <DialogContent
+            size="preview"
+            mode={fullscreen ? "fullscreen" : "windowed"}
+          >
+            <DialogTitle>Image preview</DialogTitle>
+            <button
+              onClick={() => {
+                setFullscreen(!fullscreen);
+              }}
+            >
+              {fullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+            </button>
+            <DialogBody>
+              <input aria-label="Annotation" />
+              <Dialog>
+                <DialogTrigger>Open details</DialogTrigger>
+                <DialogContent>
+                  <DialogTitle>Image details</DialogTitle>
+                  <input aria-label="Description" />
+                </DialogContent>
+              </Dialog>
+            </DialogBody>
+          </DialogContent>
+        </Dialog>
+      );
+    }
+    render(<Preview />);
+    const trigger = screen.getByRole("button", { name: "Open preview" });
+    await user.click(trigger);
+    const preview = screen.getByRole("dialog", { name: "Image preview" });
+    await user.type(
+      screen.getByRole("textbox", { name: "Annotation" }),
+      "Keep this draft",
+    );
+    await user.click(screen.getByRole("button", { name: "Enter fullscreen" }));
+    expect(screen.getByRole("dialog", { name: "Image preview" })).toBe(preview);
+    expect(screen.getByRole("textbox", { name: "Annotation" })).toHaveValue(
+      "Keep this draft",
+    );
+
+    const detailsTrigger = screen.getByRole("button", { name: "Open details" });
+    await user.click(detailsTrigger);
+    expect(screen.getByRole("dialog", { name: "Image details" })).toBeVisible();
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(detailsTrigger).toHaveFocus();
+    });
+    expect(screen.queryByRole("dialog", { name: "Image details" })).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Exit fullscreen" }));
+    expect(screen.getByRole("textbox", { name: "Annotation" })).toHaveValue(
+      "Keep this draft",
+    );
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+    expect(screen.queryByRole("dialog", { name: "Image preview" })).toBeNull();
+  });
+
   it("applies Base UI animations that run on initial mount", () => {
     render(
       <Dialog open>

--- a/turbo/packages/ui/src/components/ui/command.tsx
+++ b/turbo/packages/ui/src/components/ui/command.tsx
@@ -53,7 +53,10 @@ interface CommandDialogProps extends Omit<
   readonly children?: React.ReactNode;
   readonly closeLabel?: string | undefined;
   readonly contentClassName?: string | undefined;
-  readonly size?: React.ComponentProps<typeof DialogContent>["size"];
+  readonly maxWidth?: React.ComponentProps<typeof DialogContent>["maxWidth"];
+  readonly smMaxWidth?: React.ComponentProps<
+    typeof DialogContent
+  >["smMaxWidth"];
   readonly showCloseButton?: boolean;
   readonly commandClassName?: string | undefined;
   readonly commandProps?:
@@ -65,7 +68,8 @@ function CommandDialog({
   children,
   contentClassName,
   closeLabel,
-  size,
+  maxWidth,
+  smMaxWidth,
   showCloseButton,
   commandClassName,
   commandProps,
@@ -75,7 +79,8 @@ function CommandDialog({
     <Dialog {...props}>
       <DialogContent
         closeLabel={closeLabel}
-        size={size}
+        maxWidth={maxWidth}
+        smMaxWidth={smMaxWidth}
         showCloseButton={showCloseButton}
         contentClassName={cn("overflow-hidden p-0", contentClassName)}
       >

--- a/turbo/packages/ui/src/components/ui/command.tsx
+++ b/turbo/packages/ui/src/components/ui/command.tsx
@@ -51,8 +51,10 @@ interface CommandDialogProps extends Omit<
   "children"
 > {
   readonly children?: React.ReactNode;
-  readonly className?: string | undefined;
   readonly closeLabel?: string | undefined;
+  readonly contentClassName?: string | undefined;
+  readonly size?: React.ComponentProps<typeof DialogContent>["size"];
+  readonly showCloseButton?: boolean;
   readonly commandClassName?: string | undefined;
   readonly commandProps?:
     | React.ComponentPropsWithoutRef<typeof Command>
@@ -61,8 +63,10 @@ interface CommandDialogProps extends Omit<
 
 function CommandDialog({
   children,
-  className,
+  contentClassName,
   closeLabel,
+  size,
+  showCloseButton,
   commandClassName,
   commandProps,
   ...props
@@ -71,7 +75,9 @@ function CommandDialog({
     <Dialog {...props}>
       <DialogContent
         closeLabel={closeLabel}
-        className={cn("overflow-hidden p-0", className)}
+        size={size}
+        showCloseButton={showCloseButton}
+        contentClassName={cn("overflow-hidden p-0", contentClassName)}
       >
         <Command
           {...commandProps}

--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -117,6 +117,7 @@ const dialogMaxWidthClasses = {
 const dialogHeightClasses = {
   content: "h-auto",
   fill: "h-full",
+  600: "h-[600px]",
   688: "h-[688px]",
   720: "h-[720px]",
   760: "h-[760px]",

--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -85,8 +85,56 @@ const DialogOverlay = React.forwardRef<
 });
 DialogOverlay.displayName = "DialogOverlay";
 
-interface DialogContentProps extends DialogPrimitive.Popup.Props {
+// Preferred sizes are clamped by the viewport, including for future callers.
+// Numeric variants preserve the existing dialogs' desktop dimensions.
+const dialogSizeClasses = {
+  sm: "w-96",
+  md: "w-md",
+  lg: "w-lg",
+  xl: "w-xl",
+  "2xl": "w-2xl",
+  "3xl": "w-3xl",
+  "4xl": "w-4xl",
+  "6xl": "w-6xl",
+  400: "w-[400px]",
+  420: "w-[420px]",
+  424: "w-[424px]",
+  440: "w-[440px]",
+  480: "w-[480px]",
+  560: "w-[560px]",
+  640: "w-[640px]",
+  680: "w-[680px]",
+  720: "w-[720px]",
+  760: "w-[760px]",
+  820: "w-[820px]",
+  860: "w-[860px]",
+  880: "w-[880px]",
+  1120: "w-[1120px]",
+  1200: "w-[1200px]",
+  preview: "w-[1440px]",
+} as const;
+
+const dialogHeightClasses = {
+  content: "h-auto",
+  fill: "h-full",
+  688: "h-[688px]",
+  720: "h-[720px]",
+  760: "h-[760px]",
+  800: "h-[800px]",
+  1000: "h-[1000px]",
+} as const;
+
+interface DialogContentProps extends Omit<
+  DialogPrimitive.Popup.Props,
+  "className" | "style" | "render"
+> {
   readonly closeLabel?: string;
+  /** Styles the inner content, never the viewport or popup boundary. */
+  readonly contentClassName?: string;
+  readonly size?: keyof typeof dialogSizeClasses;
+  readonly height?: keyof typeof dialogHeightClasses;
+  readonly mode?: "windowed" | "fullscreen";
+  readonly surface?: "card" | "canvas" | "transparent";
   readonly overlayClassName?: string;
   readonly showCloseButton?: boolean;
 }
@@ -95,8 +143,12 @@ const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
   (
     {
       children,
-      className,
+      contentClassName,
       closeLabel = "Close",
+      size = "lg",
+      height = size === "preview" ? 1000 : "content",
+      mode = "windowed",
+      surface = "card",
       overlayClassName,
       showCloseButton = true,
       ...props
@@ -106,37 +158,92 @@ const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
     return (
       <DialogPortal>
         <DialogOverlay className={overlayClassName} forceRender />
-        <DialogPrimitive.Popup
-          ref={ref}
-          data-slot="dialog-content"
+        <DialogPrimitive.Viewport
+          data-slot="dialog-viewport"
           className={cn(
-            dialogPopupAnimationClassName,
-            "fixed left-[50%] top-[50%] grid max-h-[90vh] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-xl border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-6 shadow-lg outline-none dialog-scrollable",
-            className,
+            "fixed inset-x-0 top-0 flex h-[var(--okou-viewport-height,100dvh)] items-center justify-center overflow-hidden",
+            mode === "windowed" && [
+              "pt-[calc(var(--sat,env(safe-area-inset-top,0px))+1.5rem)]",
+              "pr-[calc(var(--sar,env(safe-area-inset-right,0px))+1.5rem)]",
+              "pb-[calc(var(--sab,env(safe-area-inset-bottom,0px))+1.5rem)]",
+              "pl-[calc(var(--sal,env(safe-area-inset-left,0px))+1.5rem)]",
+            ],
           )}
-          {...props}
         >
-          {children}
-          {showCloseButton ? (
-            <DialogPrimitive.Close
-              data-slot="dialog-close"
-              render={
-                <button
-                  type="button"
-                  className="icon-button absolute right-4 top-4 opacity-70 hover:opacity-100"
-                  aria-label={closeLabel}
-                />
-              }
-            >
-              <X size={20} className="text-foreground" />
-            </DialogPrimitive.Close>
-          ) : null}
-        </DialogPrimitive.Popup>
+          <DialogPrimitive.Popup
+            {...props}
+            ref={ref}
+            data-slot="dialog-content"
+            data-mode={mode}
+            // Keep geometry owned here even when props arrive through a spread.
+            style={undefined}
+            render={undefined}
+            className={cn(
+              dialogPopupAnimationClassName,
+              "relative flex min-h-0 min-w-0 max-h-full max-w-full flex-col overflow-hidden outline-none contain-layout",
+              surface === "card" && "bg-card",
+              surface === "canvas" && "bg-background",
+              mode === "windowed"
+                ? [
+                    dialogSizeClasses[size],
+                    dialogHeightClasses[height],
+                    "rounded-xl",
+                    surface === "card" &&
+                      "border-[0.7px] border-[hsl(var(--gray-400))] shadow-lg",
+                    surface === "canvas" &&
+                      "shadow-[0_24px_70px_rgba(0,0,0,0.30)]",
+                  ]
+                : [
+                    "h-full w-full rounded-none",
+                    "pt-[var(--sat,env(safe-area-inset-top,0px))]",
+                    "pr-[var(--sar,env(safe-area-inset-right,0px))]",
+                    "pb-[var(--sab,env(safe-area-inset-bottom,0px))]",
+                    "pl-[var(--sal,env(safe-area-inset-left,0px))]",
+                  ],
+            )}
+          >
+            <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+              <div
+                data-slot="dialog-inner"
+                className={cn(
+                  "grid min-h-0 min-w-0 flex-1 gap-4 overflow-y-auto p-6 dialog-scrollable",
+                  contentClassName,
+                )}
+              >
+                {children}
+              </div>
+              {showCloseButton ? (
+                <DialogPrimitive.Close
+                  data-slot="dialog-close"
+                  render={
+                    <button
+                      type="button"
+                      className="icon-button absolute right-4 top-4 opacity-70 hover:opacity-100"
+                      aria-label={closeLabel}
+                    />
+                  }
+                >
+                  <X size={20} className="text-foreground" />
+                </DialogPrimitive.Close>
+              ) : null}
+            </div>
+          </DialogPrimitive.Popup>
+        </DialogPrimitive.Viewport>
       </DialogPortal>
     );
   },
 );
 DialogContent.displayName = "DialogContent";
+
+function DialogBody({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-body"
+      className={cn("min-h-0 min-w-0 flex-1 overflow-auto", className)}
+      {...props}
+    />
+  );
+}
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -192,11 +299,10 @@ function DialogDescription({
 
 export {
   Dialog,
-  DialogPortal,
-  DialogOverlay,
   DialogClose,
   DialogTrigger,
   DialogContent,
+  DialogBody,
   DialogHeader,
   DialogFooter,
   DialogTitle,

--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -85,33 +85,33 @@ const DialogOverlay = React.forwardRef<
 });
 DialogOverlay.displayName = "DialogOverlay";
 
-// Preferred sizes are clamped by the viewport, including for future callers.
-// Numeric variants preserve the existing dialogs' desktop dimensions.
-const dialogSizeClasses = {
-  sm: "w-96",
-  md: "w-md",
-  lg: "w-lg",
-  xl: "w-xl",
-  "2xl": "w-2xl",
-  "3xl": "w-3xl",
-  "4xl": "w-4xl",
-  "6xl": "w-6xl",
-  400: "w-[400px]",
-  420: "w-[420px]",
-  424: "w-[424px]",
-  440: "w-[440px]",
-  480: "w-[480px]",
-  560: "w-[560px]",
-  640: "w-[640px]",
-  680: "w-[680px]",
-  720: "w-[720px]",
-  760: "w-[760px]",
-  820: "w-[820px]",
-  860: "w-[860px]",
-  880: "w-[880px]",
-  1120: "w-[1120px]",
-  1200: "w-[1200px]",
-  preview: "w-[1440px]",
+// These are upper bounds, not requested widths. The popup's w-full fills only
+// the safe viewport. Keep rem units and responsive caps when migrating callers.
+const dialogMaxWidthClasses = {
+  sm: { base: "max-w-sm", sm: "sm:max-w-sm" },
+  md: { base: "max-w-md", sm: "sm:max-w-md" },
+  lg: { base: "max-w-lg", sm: "sm:max-w-lg" },
+  xl: { base: "max-w-xl", sm: "sm:max-w-xl" },
+  "2xl": { base: "max-w-2xl", sm: "sm:max-w-2xl" },
+  "3xl": { base: "max-w-3xl", sm: "sm:max-w-3xl" },
+  "4xl": { base: "max-w-4xl", sm: "sm:max-w-4xl" },
+  "6xl": { base: "max-w-6xl", sm: "sm:max-w-6xl" },
+  "25rem": { base: "max-w-[25rem]", sm: "sm:max-w-[25rem]" },
+  "26.5rem": { base: "max-w-[26.5rem]", sm: "sm:max-w-[26.5rem]" },
+  420: { base: "max-w-[420px]", sm: "sm:max-w-[420px]" },
+  440: { base: "max-w-[440px]", sm: "sm:max-w-[440px]" },
+  480: { base: "max-w-[480px]", sm: "sm:max-w-[480px]" },
+  560: { base: "max-w-[560px]", sm: "sm:max-w-[560px]" },
+  640: { base: "max-w-[640px]", sm: "sm:max-w-[640px]" },
+  680: { base: "max-w-[680px]", sm: "sm:max-w-[680px]" },
+  720: { base: "max-w-[720px]", sm: "sm:max-w-[720px]" },
+  760: { base: "max-w-[760px]", sm: "sm:max-w-[760px]" },
+  820: { base: "max-w-[820px]", sm: "sm:max-w-[820px]" },
+  860: { base: "max-w-[860px]", sm: "sm:max-w-[860px]" },
+  880: { base: "max-w-[880px]", sm: "sm:max-w-[880px]" },
+  1120: { base: "max-w-[1120px]", sm: "sm:max-w-[1120px]" },
+  1200: { base: "max-w-[1200px]", sm: "sm:max-w-[1200px]" },
+  1440: { base: "max-w-[1440px]", sm: "sm:max-w-[1440px]" },
 } as const;
 
 const dialogHeightClasses = {
@@ -131,7 +131,10 @@ interface DialogContentProps extends Omit<
   readonly closeLabel?: string;
   /** Styles the inner content, never the viewport or popup boundary. */
   readonly contentClassName?: string;
-  readonly size?: keyof typeof dialogSizeClasses;
+  /** Maximum width; the available safe viewport may be narrower. */
+  readonly maxWidth?: keyof typeof dialogMaxWidthClasses;
+  /** Maximum width from the shared sm breakpoint onward. */
+  readonly smMaxWidth?: keyof typeof dialogMaxWidthClasses;
   readonly height?: keyof typeof dialogHeightClasses;
   readonly mode?: "windowed" | "fullscreen";
   readonly surface?: "card" | "canvas" | "transparent";
@@ -145,8 +148,9 @@ const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
       children,
       contentClassName,
       closeLabel = "Close",
-      size = "lg",
-      height = size === "preview" ? 1000 : "content",
+      maxWidth = "lg",
+      smMaxWidth,
+      height = "content",
       mode = "windowed",
       surface = "card",
       overlayClassName,
@@ -180,12 +184,14 @@ const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
             render={undefined}
             className={cn(
               dialogPopupAnimationClassName,
-              "relative flex min-h-0 min-w-0 max-h-full max-w-full flex-col overflow-hidden outline-none contain-layout",
+              "relative flex min-h-0 min-w-0 w-full max-h-full max-w-full flex-col overflow-hidden outline-none contain-layout",
               surface === "card" && "bg-card",
               surface === "canvas" && "bg-background",
               mode === "windowed"
                 ? [
-                    dialogSizeClasses[size],
+                    dialogMaxWidthClasses[maxWidth].base,
+                    smMaxWidth !== undefined &&
+                      dialogMaxWidthClasses[smMaxWidth].sm,
                     dialogHeightClasses[height],
                     "rounded-xl",
                     surface === "card" &&

--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -130,7 +130,7 @@ interface DialogContentProps extends Omit<
   "className" | "style" | "render"
 > {
   readonly closeLabel?: string;
-  /** Styles the inner content, never the viewport or popup boundary. */
+  /** Styles the inner layout; viewport bounds and vertical scrolling stay owned here. */
   readonly contentClassName?: string;
   /** Maximum width; the available safe viewport may be narrower. */
   readonly maxWidth?: keyof typeof dialogMaxWidthClasses;
@@ -213,8 +213,11 @@ const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
               <div
                 data-slot="dialog-inner"
                 className={cn(
-                  "grid min-h-0 min-w-0 flex-1 gap-4 overflow-y-auto p-6 dialog-scrollable",
+                  "grid min-h-0 min-w-0 flex-1 gap-4 p-6 dialog-scrollable",
                   contentClassName,
+                  // A caller's clipping utility must not make footer actions
+                  // unreachable when the safe viewport constrains the panel.
+                  "overflow-y-auto!",
                 )}
               >
                 {children}

--- a/turbo/packages/ui/src/index.ts
+++ b/turbo/packages/ui/src/index.ts
@@ -23,11 +23,10 @@ export {
 } from "./components/ui/multi-select-combobox";
 export {
   Dialog,
-  DialogPortal,
-  DialogOverlay,
   DialogClose,
   DialogTrigger,
   DialogContent,
+  DialogBody,
   DialogHeader,
   DialogFooter,
   DialogTitle,

--- a/turbo/scripts/style-class-usage.mjs
+++ b/turbo/scripts/style-class-usage.mjs
@@ -33,13 +33,13 @@ function propertyName(node) {
 function classArguments(node) {
   if (
     ts.isJsxAttribute(node) &&
-    ["class", "className"].includes(node.name.getText())
+    ["class", "className", "contentClassName"].includes(node.name.getText())
   ) {
     return node.initializer === undefined ? [] : [node.initializer];
   }
   if (
     ts.isPropertyAssignment(node) &&
-    ["class", "className"].includes(propertyName(node.name))
+    ["class", "className", "contentClassName"].includes(propertyName(node.name))
   ) {
     return [node.initializer];
   }

--- a/turbo/scripts/style-policy.test.mjs
+++ b/turbo/scripts/style-policy.test.mjs
@@ -475,6 +475,24 @@ test("the command matches scope adapters exactly without leaking context to sibl
   }
 });
 
+test("dialog content styling remains subject to the legacy class ratchet", (t) => {
+  const file = "apps/platform/src/view.tsx";
+  const root = createCommandWorkspace(
+    t,
+    {
+      [file]:
+        'export const View = () => <DialogContent contentClassName="flex" />;',
+    },
+    emptyBaseline(["legacy"]),
+  );
+  assert.equal(runPolicy(root).status, 0);
+  writeFileSync(
+    join(root, file),
+    'const CONTENT = "legacy"; export const View = () => <DialogContent contentClassName={CONTENT} />;',
+  );
+  assertRejected(runPolicy(root), /usage grew from 0 to 1/);
+});
+
 test("the command counts local and re-exported class aliases at each consumer", (t) => {
   const file = "apps/platform/src/view.tsx";
   const root = createCommandWorkspace(

--- a/turbo/style-legacy-baseline.json
+++ b/turbo/style-legacy-baseline.json
@@ -3993,8 +3993,7 @@
     },
     "apps/platform/src/views/okou-page/attachment-chips.tsx": {
       "okou-chat-card": 4,
-      "okou-chat-frame": 1,
-      "okou-fixed-viewport-shell": 1
+      "okou-chat-frame": 1
     },
     "apps/platform/src/views/okou-page/banking-action-card.tsx": {
       "okou-chat-card": 3
@@ -4174,7 +4173,6 @@
     },
     "apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx": {
       "okou-app": 1,
-      "okou-border": 1,
       "okou-border-r": 1
     },
     "apps/platform/src/views/okou-page/components/settings/timezone-settings.tsx": {


### PR DESCRIPTION
## Summary

The larger artifact preview introduced in #32574 leaves a 24 px gutter that does not include iOS PWA safe areas. Move viewport ownership into shared `DialogContent` so windowed panels stay inside all four safe-area insets plus the gutter, and fullscreen content and controls remain inside the insets.

Expose bounded `maxWidth`, responsive `smMaxWidth`, `height`, `mode`, and `surface` options. Preserve width units and breakpoints: `max-w-[25rem]` becomes `maxWidth="25rem"`, and `sm:max-w-[480px]` becomes `smMaxWidth={480}`. The artifact preview requests a 1440 × 1000 px upper size and shrinks within the available safe viewport.

The primitive owns popup geometry and vertical scrolling. Caller `contentClassName="overflow-hidden"` cannot disable the inner scroll path and strand footer actions on short screens. `DialogBody` supports a scrolling body below a fixed header. Migrate existing dialogs and CommandDialog, restrict direct Base UI dialog imports, remove public raw portal/backdrop exports, and apply the existing style policy to `contentClassName`.

Keep the artifact preview's native focus, nested dialog, outside-press, and animation ownership. Fullscreen changes retain image zoom and pan by preserving the resource-keyed canvas and removing the fullscreen command's zoom reset. Opening or navigating to another image still resets zoom.

## Verification

- 35 targeted shared dialog, CommandDialog, attachment composer, message preview, and annotation tests passed. The image regression failed at 115% → 100% before the fix and now passes across entering/exiting fullscreen and navigating to another image.
- Complete style lint passed, including 19 style-policy tests.
- UI lint, lint on the affected Platform files, E2E TypeScript checks, and normal commit hooks passed (formatting, style policy, Knip, workspace type checks, file-size checks, and commitlint).
- Browser regressions cover responsive width caps, portrait/landscape/short-screen safe areas, fullscreen controls and zoom retention, drag-versus-click dismissal, and native wheel scrolling to nested avatar and New agent footer actions.
- All current-head CI checks passed, including the three required gates and all 14 feature Playwright tests. App/API preview build `74048cdf` includes PR head `6067077`; direct browser checks confirmed native footer scrolling, retained name draft, 115% zoom through fullscreen changes, and portrait panel bounds of 354 × 730 at (24, 86) with 62 px top / 34 px bottom insets.
- The geometry test owns its image transport fixture and does not validate R2 upload transport. Linux Chromium with injected safe-area values does not establish real-device iOS PWA or software-keyboard behavior.

## Acceptance

Use a preview/test account; no Lab switch is needed. Preview: https://pr-32706-app-okou-app-preview.vm0.workers.dev/agents (preview access parameters are delivered separately).

- Open Agents → New agent. At viewport widths of 639, 640, and 390 px, verify panel widths of 512, 480, and 342 px. A `25rem` width cap should continue following the root font size.
- At 390 × 640, open Customize avatar and scroll to Use this avatar. Apply it and confirm the parent name draft remains. At 874 × 402, scroll the New agent dialog to its Cancel/Create buttons.
- Open an image preview, zoom to 115%, and enter/exit fullscreen. Zoom should remain 115%; another image should start at 100%. Windowed panels and fullscreen controls must remain within their safe-area bounds.
- A drag from the image onto the backdrop keeps the preview open; a deliberate backdrop click closes it.
