### PR TITLE
fix(cli): guide connector search through connection setup

### DIFF
--- a/turbo/apps/cli/src/commands/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/search.test.ts
@@ -36,6 +36,7 @@ import {
 const AGENT_UUID = "550e8400-e29b-41d4-a716-446655440000";
 const ALT_AGENT_UUID = "550e8400-e29b-41d4-a716-446655440099";
 const RUN_CONNECTION_ID = "11111111-1111-4111-8111-111111111111";
+const THREAD_UUID = "22222222-2222-4222-8222-222222222222";
 
 const connectedGithub = {
   id: "1",
@@ -138,7 +139,9 @@ function stubAvailableConnectors(connectorSlugs: string[]) {
 }
 
 function findDataRows(lines: readonly string[]): string[] {
-  return lines.filter((line) => {
+  const contextIndex = lines.indexOf("Connection context:");
+  const tableLines = contextIndex === -1 ? lines : lines.slice(0, contextIndex);
+  return tableLines.filter((line) => {
     const trimmed = line.trim();
     if (!trimmed) return false;
     if (trimmed.startsWith("SLUG")) return false;
@@ -169,6 +172,7 @@ describe("okou connector search command", () => {
     vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", contextPath);
     searchCommand.setOptionValue("agent", undefined);
     searchCommand.setOptionValue("limit", undefined);
+    searchCommand.setOptionValue("callbackPrompt", undefined);
     server.use(stubCustomConnectors([]), stubAgentCustomConnectors([]));
   });
 
@@ -521,6 +525,9 @@ describe("okou connector search command", () => {
 
       const output = (mockConsoleLog.mock.calls.flat() as string[]).join("\n");
       expect(output).toContain("(not connected)");
+      expect(output).toContain(
+        "http://localhost:3000/connectors/github/connect",
+      );
     });
 
     it("renders reconnect-needed state", async () => {
@@ -611,6 +618,9 @@ describe("okou connector search command", () => {
       expect(text).toContain("ACCOUNT USED BY THIS RUN");
       expect(text).toContain("Run account B");
       expect(text).toContain("no (reconnect needed)");
+      expect(text).toContain(
+        `http://localhost:3000/connectors/github/reconnect/${RUN_CONNECTION_ID}?agentId=${AGENT_UUID}`,
+      );
       expect(text).not.toContain("default-account-a");
       expect(defaultStatusRequests).toBe(0);
     });
@@ -729,6 +739,12 @@ describe("okou connector search command", () => {
       expect(metadataUnavailableOutput).toContain(
         "no (metadata unavailable or deleted)",
       );
+      expect(metadataUnavailableOutput).toContain(
+        `[Review GitHub accounts and agent access](http://localhost:3000/connectors?agentId=${AGENT_UUID})`,
+      );
+      expect(metadataUnavailableOutput).not.toContain(
+        "/connectors/github/connect",
+      );
 
       mockConsoleLog.mockClear();
       vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", "");
@@ -736,6 +752,148 @@ describe("okou connector search command", () => {
       expect(
         (mockConsoleLog.mock.calls.flat() as string[]).join("\n"),
       ).toContain("unknown (run context unavailable)");
+    });
+  });
+
+  describe("connection guidance", () => {
+    beforeEach(() => {
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
+      vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_UUID);
+      writeRunConnectorAccountContext(contextPath, []);
+      server.use(
+        stubConnectorCatalog([
+          catalogItem({
+            connectorSlug: "google-sheets",
+            label: "Google Sheets",
+          }),
+          catalogItem({ connectorSlug: "sheetdb", label: "SheetDB" }),
+        ]),
+        stubAgent(AGENT_UUID, "maya"),
+        stubUserConnectors(AGENT_UUID, []),
+      );
+    });
+
+    it("offers connection links for supported services that are not admitted to the run", async () => {
+      await searchCommand.parseAsync(["node", "cli", "sheet"]);
+
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain(
+        `[Connect or authorize Google Sheets](http://localhost:3000/connectors/google-sheets/connect?agentId=${AGENT_UUID})`,
+      );
+      expect(output).toContain(
+        `[Connect or authorize SheetDB](http://localhost:3000/connectors/sheetdb/connect?agentId=${AGENT_UUID})`,
+      );
+      expect(output).toContain("--callback-prompt");
+      expect(output).not.toContain("callbackPrompt=");
+    });
+
+    it("preserves the task in a callback link scoped to the current chat and configured app origin", async () => {
+      vi.stubEnv("OKOU_APP_URL", "https://app.example.com");
+      const callbackPrompt =
+        "Check Google Sheets access, then review the user's Q3 budget & summarize it.";
+
+      await searchCommand.parseAsync([
+        "node",
+        "cli",
+        "google-sheets",
+        "--limit",
+        "1",
+        "--callback-prompt",
+        callbackPrompt,
+      ]);
+
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      const link = output.match(
+        /\[Connect or authorize Google Sheets\]\(([^)]+)\)/u,
+      );
+      expect(link).not.toBeNull();
+      const url = new URL(link![1]!);
+      expect(url.origin).toBe("https://app.example.com");
+      expect(url.pathname).toBe("/connectors/google-sheets/connect");
+      expect(Object.fromEntries(url.searchParams)).toEqual({
+        agentId: AGENT_UUID,
+        threadId: THREAD_UUID,
+        callbackPrompt,
+      });
+      expect(output).not.toContain("/connectors/sheetdb/");
+    });
+
+    it("rejects a callback when the search matches multiple connectors", async () => {
+      await expect(
+        searchCommand.parseAsync([
+          "node",
+          "cli",
+          "sheet",
+          "--callback-prompt",
+          "Continue reviewing the spreadsheet",
+        ]),
+      ).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+        "--callback-prompt requires a single connector match",
+      );
+      expect(mockConsoleLog.mock.calls.flat().join("\n")).not.toContain(
+        "callbackPrompt=",
+      );
+    });
+
+    it("rejects callback links for another agent", async () => {
+      server.use(
+        stubAgent(ALT_AGENT_UUID, "other-agent"),
+        stubUserConnectors(ALT_AGENT_UUID, []),
+      );
+      await expect(
+        searchCommand.parseAsync([
+          "node",
+          "cli",
+          "google-sheets",
+          "--limit",
+          "1",
+          "--agent",
+          ALT_AGENT_UUID,
+          "--callback-prompt",
+          "Continue reviewing the spreadsheet",
+        ]),
+      ).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+        "--callback-prompt can only target the current web chat thread and agent",
+      );
+      expect(mockConsoleLog.mock.calls.flat().join("\n")).not.toContain(
+        "callbackPrompt=",
+      );
+    });
+
+    it("uses connector settings for custom connector setup", async () => {
+      const connector = customConnector();
+      server.use(stubConnectorCatalog([]), stubCustomConnectors([connector]));
+
+      await searchCommand.parseAsync(["node", "cli", connector.slug]);
+
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain(
+        `[Review ${connector.displayName} accounts and agent access](http://localhost:3000/connectors?agentId=${AGENT_UUID})`,
+      );
+      expect(output).not.toContain(`/connectors/${connector.slug}/authorize`);
+    });
+
+    it("offers authorization for a connected service when inspecting an agent outside a run", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", "");
+      server.use(stubConnectors([connectedGithub]));
+
+      await searchCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--agent",
+        AGENT_UUID,
+        "--limit",
+        "1",
+      ]);
+
+      expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+        `http://localhost:3000/connectors/github/authorize?agentId=${AGENT_UUID}`,
+      );
     });
   });
 

--- a/turbo/apps/cli/src/commands/connector/search-guidance.ts
+++ b/turbo/apps/cli/src/commands/connector/search-guidance.ts
@@ -1,0 +1,145 @@
+import type { ConnectorDiscoveryAgentContext } from "./agent-context";
+import {
+  connectorActionUrl,
+  currentChatSupportsActionCallback,
+  finalizeActionUrl,
+} from "./action-url";
+import {
+  isConnectorDiscoveryAuthorized,
+  type ConnectorDiscoveryDefinition,
+  type ConnectorDiscoveryItem,
+} from "./discovery";
+import type { RunConnectorAccountLookup } from "./run-account-context";
+
+export interface ConnectorSearchAction {
+  readonly label: string;
+  readonly path: string;
+  readonly supportsCallback: boolean;
+}
+
+function accountSettingsAction(
+  connector: ConnectorDiscoveryDefinition,
+): ConnectorSearchAction {
+  return {
+    label: `Review ${connector.label} accounts and agent access`,
+    path: "/connectors",
+    supportsCallback: false,
+  };
+}
+
+function connectAction(
+  connector: ConnectorDiscoveryDefinition,
+): ConnectorSearchAction {
+  return connector.kind === "custom"
+    ? accountSettingsAction(connector)
+    : {
+        label: `Connect or authorize ${connector.label}`,
+        path: `/connectors/${connector.slug}/connect`,
+        supportsCallback: true,
+      };
+}
+
+export function runConnectorSearchAction(
+  connector: ConnectorDiscoveryDefinition,
+  lookup: RunConnectorAccountLookup,
+): ConnectorSearchAction | null {
+  switch (lookup.state) {
+    case "available":
+      if (lookup.metadata.connectionStatus !== "reconnect-required") {
+        return null;
+      }
+      return connector.kind === "custom"
+        ? accountSettingsAction(connector)
+        : {
+            label: `Reconnect ${connector.label} (${lookup.label})`,
+            path: `/connectors/${connector.slug}/reconnect/${lookup.connectionId}`,
+            supportsCallback: true,
+          };
+    case "not-admitted":
+      return connectAction(connector);
+    case "metadata-unavailable":
+    case "context-unavailable":
+      return accountSettingsAction(connector);
+  }
+}
+
+export function currentConnectorSearchAction(
+  connector: ConnectorDiscoveryItem,
+  agentContext: ConnectorDiscoveryAgentContext | null,
+): ConnectorSearchAction | null {
+  const authorized =
+    !agentContext || isConnectorDiscoveryAuthorized(connector, agentContext);
+  if (connector.kind === "custom") {
+    return connector.customConnector.connected && authorized
+      ? null
+      : accountSettingsAction(connector);
+  }
+  if (connector.catalogConnector.connectionStatus === "reconnect-required") {
+    return accountSettingsAction(connector);
+  }
+  if (!connector.catalogConnector.connected) {
+    return connectAction(connector);
+  }
+  return authorized
+    ? null
+    : {
+        label: `Authorize ${connector.label}`,
+        path: `/connectors/${connector.slug}/authorize`,
+        supportsCallback: true,
+      };
+}
+
+export function printConnectorSearchGuidance(args: {
+  readonly actions: readonly ConnectorSearchAction[];
+  readonly origin: string;
+  readonly agentId: string | undefined;
+  readonly runBound: boolean;
+  readonly callbackPrompt: string | undefined;
+}): void {
+  if (args.actions.length === 0) {
+    return;
+  }
+
+  const links = args.actions.map((action) => {
+    if (args.callbackPrompt !== undefined && !action.supportsCallback) {
+      throw new Error(
+        "This connector needs an account or access review in Connectors settings, which does not support --callback-prompt.",
+      );
+    }
+    const url = connectorActionUrl({
+      origin: args.origin,
+      path: action.path,
+      agentId: args.agentId,
+    });
+    return `[${action.label}](${finalizeActionUrl(new URL(url), args.callbackPrompt, args.agentId)})`;
+  });
+
+  console.log("");
+  console.log("Connection context:");
+  console.log(
+    "These services are supported by Okou. When a service is needed for the user's task, the connection links below let you help the user connect or authorize it now. The user completes sign-in or approval in Okou; credentials stay out of chat and private files can remain private.",
+  );
+  if (args.runBound) {
+    console.log(
+      '"Not admitted" means no account was selected for this run; it does not establish whether the user already has a connected account. Connector changes apply to future runs. The command okou connector account list <slug> --json shows existing account IDs, and okou connector account switch-request --help describes selecting one for this chat.',
+    );
+  }
+  for (const link of links) {
+    console.log(`  ${link}`);
+  }
+
+  if (args.callbackPrompt !== undefined) {
+    console.log(
+      "This link starts the next round in the current chat with the supplied prompt after the user completes the action. The current turn can end after sharing the exact link, including all query parameters; the connection is pending until the user completes it.",
+    );
+  } else if (
+    currentChatSupportsActionCallback(args.agentId) &&
+    args.actions.some((action) => {
+      return action.supportsCallback;
+    })
+  ) {
+    console.log(
+      'When only one connector or permission action is needed, okou connector search <slug> --limit 1 --callback-prompt "<original task and next step>" provides a link that continues this chat after the user completes the action. The prompt is included in the URL, so a short task description without secrets is sufficient. Ordinary links support tasks that need multiple access actions.',
+    );
+  }
+}

--- a/turbo/apps/cli/src/commands/connector/search.ts
+++ b/turbo/apps/cli/src/commands/connector/search.ts
@@ -7,6 +7,7 @@ import {
   listCustomConnectors,
 } from "../../lib/api/domains/connectors";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { getPlatformOrigin } from "../doctor/platform-url";
 import { resolveConnectorDiscoveryAgentContext } from "./agent-context";
 import { padEndAnsi, stripAnsi } from "./connected-as";
 import {
@@ -19,6 +20,12 @@ import {
   type ConnectorDiscoveryItem,
 } from "./discovery";
 import { searchConnectorCatalog } from "./public-catalog";
+import {
+  currentConnectorSearchAction,
+  printConnectorSearchGuidance,
+  runConnectorSearchAction,
+  type ConnectorSearchAction,
+} from "./search-guidance";
 import {
   isRunBoundConnectorContext,
   resolveRunConnectorAccountLookups,
@@ -97,6 +104,10 @@ function printSearchResults<T extends ConnectorDiscoveryDefinition>(args: {
   readonly renderAvailability: (connector: T) => string;
   readonly accountHeader: string;
   readonly renderAccount: (connector: T) => string;
+  readonly connectionAction: (connector: T) => ConnectorSearchAction | null;
+  readonly origin: string;
+  readonly runBound: boolean;
+  readonly callbackPrompt: string | undefined;
   readonly agentContext: Awaited<
     ReturnType<typeof resolveConnectorDiscoveryAgentContext>
   >;
@@ -107,6 +118,12 @@ function printSearchResults<T extends ConnectorDiscoveryDefinition>(args: {
     args.keyword,
     effectiveLimit,
   );
+
+  if (args.callbackPrompt !== undefined && results.length !== 1) {
+    throw new Error(
+      "--callback-prompt requires a single connector match. Narrow the search to the intended connector with --limit 1.",
+    );
+  }
 
   if (results.length === 0) {
     console.log("No matches found.");
@@ -175,15 +192,30 @@ function printSearchResults<T extends ConnectorDiscoveryDefinition>(args: {
     }
     console.log(parts.join("  "));
   }
+
+  printConnectorSearchGuidance({
+    actions: results.flatMap((result) => {
+      const action = args.connectionAction(result.connector);
+      return action ? [action] : [];
+    }),
+    origin: args.origin,
+    agentId: args.agentContext?.agentId,
+    runBound: args.runBound,
+    callbackPrompt: args.callbackPrompt,
+  });
 }
 
 export const searchCommand = new Command()
   .name("search")
   .description(
-    "Search supported connectors by slug, label, category, generation type, or tag and show availability",
+    "Search supported connectors by slug, label, category, generation type, or tag and show availability and connection links",
   )
   .argument("<keyword>", "Search keyword (case-insensitive)")
   .option("--agent <id>", "Show per-agent authorization column")
+  .option(
+    "--callback-prompt <prompt>",
+    "Continue the current web chat after one connector action (use --limit 1)",
+  )
   .option(
     "--limit <n>",
     "Maximum number of results to display (default: all matches)",
@@ -191,18 +223,22 @@ export const searchCommand = new Command()
   )
   .action(
     withErrorHandler(
-      async (keyword: string, options: { agent?: string; limit?: number }) => {
+      async (
+        keyword: string,
+        options: { agent?: string; limit?: number; callbackPrompt?: string },
+      ) => {
         const trimmed = keyword.trim();
         if (!trimmed) {
           throw new Error("Keyword cannot be empty.");
         }
 
         if (isRunBoundConnectorContext()) {
-          const [{ connectors }, customConnectors, agentContext] =
+          const [{ connectors }, customConnectors, agentContext, origin] =
             await Promise.all([
               listConnectorCatalog(),
               listCustomConnectors(),
               resolveConnectorDiscoveryAgentContext(options.agent),
+              getPlatformOrigin(),
             ]);
           const definitions = connectorDiscoveryDefinitions(
             connectors,
@@ -243,16 +279,26 @@ export const searchCommand = new Command()
             renderAccount: (connector) => {
               return renderRunAccountCell(runAccountForConnector(connector));
             },
+            connectionAction: (connector) => {
+              return runConnectorSearchAction(
+                connector,
+                runAccountForConnector(connector),
+              );
+            },
+            origin,
+            runBound: true,
+            callbackPrompt: options.callbackPrompt,
             agentContext,
           });
           return;
         }
 
-        const [{ connectors }, customConnectors, agentContext] =
+        const [{ connectors }, customConnectors, agentContext, origin] =
           await Promise.all([
             listConnectorCatalogStatus(),
             listCustomConnectors(),
             resolveConnectorDiscoveryAgentContext(options.agent),
+            getPlatformOrigin(),
           ]);
         const discoveredConnectors = connectorDiscoveryItems(
           connectors,
@@ -268,6 +314,12 @@ export const searchCommand = new Command()
           },
           accountHeader: "CONNECTED AS",
           renderAccount: renderConnectorDiscoveryConnectedAsCell,
+          connectionAction: (connector) => {
+            return currentConnectorSearchAction(connector, agentContext);
+          },
+          origin,
+          runBound: false,
+          callbackPrompt: options.callbackPrompt,
           agentContext,
         });
       },


### PR DESCRIPTION
## Summary

When a user asks to inspect their Google Sheets, `okou connector search` can find the supported service but stop at `no (not admitted)`, leaving the agent without a connection handoff. Search now includes links to the existing connection, authorization, and account-recovery flows alongside contextual guidance about what the state means and how the user can complete setup while keeping credentials and files private.

For one required access action, `okou connector search google-sheets --limit 1 --callback-prompt "Check Google Sheets access, then continue reviewing the user's spreadsheet"` produces a link that resumes the current chat after the user completes it. Callback links require one displayed connector and the current chat's agent; ordinary searches keep ordinary links for tasks requiring multiple access actions. Reconnect links retain the exact run account ID, while missing account metadata and custom connectors use the existing settings flow.

The guidance describes available capabilities, confirmation ownership, and when account changes take effect, following the requested context-over-control style. Search only discovers and prints links; the existing UI handles user sign-in and confirmation.

## Verification

- 37 command integration tests passed in `connector/__tests__/search.test.ts`, including unadmitted services, task-preserving callback URLs, multiple-match and other-agent rejection, authorization, exact-account reconnection, and custom connector settings.
- Prettier, Oxlint including type-aware checks, ESLint, CLI type checking, and Knip for the CLI workspace passed.
- Full test suites are left to PR CI. No local development server was started, and a fresh-user Google OAuth flow has not been exercised.
