### PR TITLE
feat(platform): add image reference library state

### DIFF
--- a/turbo/apps/platform/src/shared-database/protocol.ts
+++ b/turbo/apps/platform/src/shared-database/protocol.ts
@@ -95,6 +95,7 @@ const userRealtimeTopicSchema = z.union([
   z.literal("customConnectorListChanged"),
   z.literal("feishu:changed"),
   z.literal("github:changed"),
+  z.literal("imageReferencesChanged"),
   z.literal("presentationTemplatesChanged"),
   z.literal("slack:changed"),
   z.literal("teams:changed"),
@@ -113,7 +114,9 @@ function isSharedDatabaseAppRealtimeSubscription(
 ): boolean {
   return (
     (scope === "user" && userRealtimeTopicSchema.safeParse(topic).success) ||
-    (scope === "org" && topic === "presentationTemplatesChanged")
+    (scope === "org" &&
+      (topic === "imageReferencesChanged" ||
+        topic === "presentationTemplatesChanged"))
   );
 }
 

--- a/turbo/apps/platform/src/signals/authenticated-daemons.ts
+++ b/turbo/apps/platform/src/signals/authenticated-daemons.ts
@@ -13,6 +13,7 @@ import {
 import { i18n } from "../i18n/index.ts";
 import { setupBillingRealtime$ } from "./okou-page/billing.ts";
 import { subscribePresentationTemplatesChanged$ } from "./okou-page/presentation-template-library.ts";
+import { subscribeImageReferencesChanged$ } from "./okou-page/image-reference-library.ts";
 import { subscribeCustomConnectorListChanged$ } from "./okou-page/settings/custom-connectors.ts";
 import {
   bridgeConnected$,
@@ -30,6 +31,7 @@ const runAppRealtimeDaemons$ = command(
       set(subscribePermissionUpdate$, signal),
       set(setupBillingRealtime$, signal),
       set(subscribePresentationTemplatesChanged$, signal),
+      set(subscribeImageReferencesChanged$, signal),
       set(setupUserPreferenceRealtime$, signal),
       set(subscribeCustomConnectorListChanged$, signal),
     ]);

--- a/turbo/apps/platform/src/signals/okou-page/chat-composer.ts
+++ b/turbo/apps/platform/src/signals/okou-page/chat-composer.ts
@@ -17,6 +17,7 @@ import { readableAttachmentResourceUrl } from "../../views/okou-page/attachment-
 import { createAvatarTemplatePickerSignals } from "./avatar-template-picker.ts";
 import { createExplainerVideoPickerSignals } from "./explainer-video-picker.ts";
 import { createImportedPresentationTemplateSignals } from "./presentation-template-library.ts";
+import { createImageReferenceLibrarySignals } from "./image-reference-library.ts";
 import { createModelPickerMenuSignals } from "./model-picker-menu.ts";
 import type { VideoRunOptionsPatch } from "./video-run-options.ts";
 
@@ -959,6 +960,7 @@ export function createComposerUiSignals() {
   const detail = createTemplateDetailStateSignals();
   const importedPresentationTemplates =
     createImportedPresentationTemplateSignals();
+  const imageReference = createImageReferenceLibrarySignals();
   const resources = createTemplatePreviewResourceSignals(list, cards, detail);
   const applySelection$ =
     createApplyPresentationTemplateDetailSelectionSignal(detail);
@@ -983,6 +985,7 @@ export function createComposerUiSignals() {
       ...cards.signals,
       ...detail.signals,
       ...importedPresentationTemplates,
+      imageReference,
       ...resources,
       loadPresentationTemplateHtmlPreview,
       openPresentationTemplateDetailPreview$,

--- a/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
@@ -1,4 +1,3 @@
-import { fetchResource } from "../../lib/resource-fetch.ts";
 import {
   command,
   computed,
@@ -7,14 +6,7 @@ import {
   type Computed,
   type State,
 } from "ccstate";
-import { delay } from "signal-timers";
-import {
-  onRejection,
-  resetSignal,
-  setLoop,
-  settle,
-  tapError,
-} from "../utils.ts";
+import { resetSignal, settle, tapError } from "../utils.ts";
 import {
   createImageLoadSignals,
   type ImageLoadSignals,
@@ -22,14 +14,12 @@ import {
 import { apiClient$ } from "../api-client.ts";
 import { rootSignal$ } from "../root-signal.ts";
 import { accept } from "../../lib/accept.ts";
-import { IN_VITEST } from "../../env.ts";
 import type {
   GenerationTemplateRequest,
   PersistedAttachment,
   UserMessageDocument,
   ImageAnnotation,
 } from "@okouai/api-contracts/contracts/chat-threads";
-import { uploadsContract } from "@okouai/api-contracts/contracts/uploads";
 import { webFilesContract } from "@okouai/api-contracts/contracts/web-files";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import type { EditorDocumentSnapshot } from "./user-message-document-codec.ts";
@@ -39,23 +29,17 @@ import { logger } from "../log.ts";
 import { pageAttachmentResourceUrlResolver$ } from "../attachment-resource-url.ts";
 import { publicAttachmentUrl } from "../../views/okou-page/attachment-url.ts";
 import { isAnnotationMeaningful } from "./image-annotation.ts";
+import {
+  inferUploadContentType,
+  uploadFileToStorage$,
+  type UploadedFileInfo,
+} from "./file-upload.ts";
 
 // ---------------------------------------------------------------------------
 // Attachment types
 // ---------------------------------------------------------------------------
 
-interface FileInfo {
-  id: string;
-  url: string;
-  contentType: string;
-}
-
-function uploadFileInfo(
-  file: Pick<FileInfo, "id" | "url">,
-  contentType: string,
-): FileInfo {
-  return { id: file.id, url: file.url, contentType };
-}
+type FileInfo = UploadedFileInfo;
 
 type AttachmentUploadState =
   | {
@@ -68,290 +52,6 @@ type AttachmentUploadState =
     };
 
 const log = logger("chat-draft");
-
-const MULTIPART_UPLOAD_THRESHOLD_BYTES = 5 * 1024 * 1024;
-const MAX_PART_UPLOAD_ATTEMPTS = 5;
-const PART_UPLOAD_RETRY_BASE_DELAY_MS = 250;
-const MULTIPART_ABORT_TIMEOUT_MS = 5000;
-interface MultipartUploadReference {
-  id: string;
-  filename: string;
-  uploadId: string;
-}
-
-const abortMultipartUpload$ = command(
-  async (
-    { get },
-    upload: MultipartUploadReference,
-    signal: AbortSignal,
-  ): Promise<void> => {
-    const client = get(apiClient$)(uploadsContract);
-    await tapError(
-      accept(
-        client.abortMultipart({
-          body: upload,
-          fetchOptions: {
-            keepalive: true,
-            signal,
-          },
-        }),
-        [200],
-        signal,
-        { showErrorToast: false },
-      ),
-    );
-  },
-);
-
-function uploadContentTypeByExtension(ext: string): string | undefined {
-  const contentTypeByExtension: Record<string, string | undefined> = {
-    aac: "audio/aac",
-    "7z": "application/x-7z-compressed",
-    ai: "application/postscript",
-    avif: "image/avif",
-    bmp: "image/bmp",
-    bz2: "application/x-bzip2",
-    csv: "text/csv",
-    db: "application/vnd.sqlite3",
-    doc: "application/msword",
-    docm: "application/vnd.ms-word.document.macroenabled.12",
-    docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    dotm: "application/vnd.ms-word.template.macroenabled.12",
-    dotx: "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
-    epub: "application/epub+zip",
-    flac: "audio/flac",
-    gif: "image/gif",
-    gz: "application/gzip",
-    har: "application/json",
-    heic: "image/heic",
-    heif: "image/heif",
-    htm: "text/html",
-    html: "text/html",
-    jpeg: "image/jpeg",
-    jpg: "image/jpeg",
-    json: "application/json",
-    key: "application/vnd.apple.keynote",
-    m4a: "audio/mp4",
-    md: "text/markdown",
-    mov: "video/quicktime",
-    mp3: "audio/mpeg",
-    mp4: "video/mp4",
-    mpga: "audio/mpga",
-    odp: "application/vnd.oasis.opendocument.presentation",
-    ods: "application/vnd.oasis.opendocument.spreadsheet",
-    odt: "application/vnd.oasis.opendocument.text",
-    oga: "audio/ogg",
-    ogg: "audio/ogg",
-    opus: "audio/opus",
-    numbers: "application/vnd.apple.numbers",
-    pages: "application/vnd.apple.pages",
-    parquet: "application/vnd.apache.parquet",
-    pdf: "application/pdf",
-    png: "image/png",
-    potm: "application/vnd.ms-powerpoint.template.macroenabled.12",
-    potx: "application/vnd.openxmlformats-officedocument.presentationml.template",
-    ppsm: "application/vnd.ms-powerpoint.slideshow.macroenabled.12",
-    ppsx: "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
-    ppt: "application/vnd.ms-powerpoint",
-    pptm: "application/vnd.ms-powerpoint.presentation.macroenabled.12",
-    pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-    psd: "image/vnd.adobe.photoshop",
-    rar: "application/vnd.rar",
-    rtf: "application/rtf",
-    sqlite: "application/vnd.sqlite3",
-    sqlite3: "application/vnd.sqlite3",
-    svg: "image/svg+xml",
-    tar: "application/x-tar",
-    tgz: "application/gzip",
-    tif: "image/tiff",
-    tiff: "image/tiff",
-    txt: "text/plain",
-    tsv: "text/tab-separated-values",
-    wav: "audio/wav",
-    wave: "audio/wave",
-    webm: "video/webm",
-    webp: "image/webp",
-    xls: "application/vnd.ms-excel",
-    xlsb: "application/vnd.ms-excel.sheet.binary.macroenabled.12",
-    xlsm: "application/vnd.ms-excel.sheet.macroenabled.12",
-    xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    xltm: "application/vnd.ms-excel.template.macroenabled.12",
-    xltx: "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
-    xml: "application/xml",
-    xz: "application/x-xz",
-    yaml: "application/yaml",
-    yml: "application/yaml",
-    zip: "application/zip",
-  };
-  return contentTypeByExtension[ext];
-}
-
-function inferUploadContentType(file: File): string {
-  const explicitType = file.type.split(";")[0]?.trim().toLowerCase();
-  if (explicitType && explicitType !== "application/octet-stream") {
-    return explicitType;
-  }
-  const ext = file.name.split(".").pop()?.toLowerCase();
-  return ext
-    ? (uploadContentTypeByExtension(ext) ?? "application/octet-stream")
-    : "application/octet-stream";
-}
-
-async function uploadPartWithRetry(
-  uploadUrl: string,
-  body: Blob,
-  contentType: string,
-  signal: AbortSignal,
-): Promise<void> {
-  let attempt = 0;
-  await setLoop(
-    async (loopSignal) => {
-      attempt += 1;
-      const result = await settle(
-        fetchResource(
-          uploadUrl,
-          {
-            method: "PUT",
-            body,
-            headers: { "content-type": contentType },
-          },
-          loopSignal,
-        ),
-        loopSignal,
-      );
-      if (result.ok) {
-        if (result.value.ok) {
-          return true;
-        }
-        if (attempt === MAX_PART_UPLOAD_ATTEMPTS) {
-          throw new Error(
-            `storage returned ${result.value.status} ${result.value.statusText}`,
-          );
-        }
-      } else if (attempt === MAX_PART_UPLOAD_ATTEMPTS) {
-        throw result.error;
-      }
-      await delay(
-        IN_VITEST ? 0 : PART_UPLOAD_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
-        { signal: loopSignal },
-      );
-      return false;
-    },
-    0,
-    signal,
-    { retryTransientErrors: false },
-  );
-  signal.throwIfAborted();
-}
-
-/**
- * Presigns, transfers and finalizes one file, returning its canonical info.
- *
- * Extracted from the draft attachment closure so the send path can push a
- * flattened annotated copy through exactly the same route rather than growing
- * a second, subtly different uploader. The file body never travels through the
- * app runtime in either case.
- */
-const uploadFileToStorage$ = command(
-  async ({ get, set }, file: File, signal: AbortSignal): Promise<FileInfo> => {
-    const createClient = get(apiClient$);
-    const client = createClient(uploadsContract);
-    const contentType = inferUploadContentType(file);
-
-    // Step 1: ask the server to sign either one PUT URL or retryable R2
-    // multipart URLs. The file body never travels through the app runtime.
-    const prepared = await accept(
-      client.prepare({
-        body: {
-          filename: file.name,
-          contentType,
-          size: file.size,
-          ...(file.size >= MULTIPART_UPLOAD_THRESHOLD_BYTES
-            ? { multipart: true as const }
-            : {}),
-        },
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
-    signal.throwIfAborted();
-
-    if ("multipart" in prepared.body) {
-      const multipart = prepared.body.multipart;
-      let completionStarted = false;
-      return await onRejection(
-        (async () => {
-          signal.throwIfAborted();
-          for (const part of multipart.parts) {
-            const start = (part.partNumber - 1) * multipart.partSize;
-            const end = Math.min(start + multipart.partSize, file.size);
-            await uploadPartWithRetry(
-              part.uploadUrl,
-              file.slice(start, end, prepared.body.contentType),
-              prepared.body.contentType,
-              signal,
-            );
-          }
-
-          signal.throwIfAborted();
-          completionStarted = true;
-          const completed = await accept(
-            client.completeMultipart({
-              body: {
-                id: prepared.body.id,
-                filename: prepared.body.filename,
-                uploadId: multipart.uploadId,
-                partCount: multipart.parts.length,
-              },
-              fetchOptions: { signal },
-            }),
-            [200],
-          );
-          signal.throwIfAborted();
-          return uploadFileInfo(completed.body, prepared.body.contentType);
-        })(),
-        async () => {
-          // Aborting after completion starts can remove the upload while R2
-          // is still finalizing it, so only clean up pre-completion failures.
-          if (completionStarted) {
-            return;
-          }
-          const cleanupSignal = AbortSignal.timeout(MULTIPART_ABORT_TIMEOUT_MS);
-          await set(
-            abortMultipartUpload$,
-            {
-              id: prepared.body.id,
-              filename: prepared.body.filename,
-              uploadId: multipart.uploadId,
-            },
-            cleanupSignal,
-          );
-        },
-      );
-    }
-
-    signal.throwIfAborted();
-    const putRes = await fetchResource(
-      prepared.body.uploadUrl,
-      {
-        method: "PUT",
-        body: file,
-        headers: {
-          "content-type": prepared.body.contentType,
-          ...prepared.body.uploadHeaders,
-        },
-      },
-      signal,
-    );
-    signal.throwIfAborted();
-
-    if (!putRes.ok) {
-      throw new Error(`storage returned ${putRes.status} ${putRes.statusText}`);
-    }
-
-    return uploadFileInfo(prepared.body, prepared.body.contentType);
-  },
-);
 
 export type AttachmentAnnotationUploadStatus =
   | "idle"

--- a/turbo/apps/platform/src/signals/okou-page/file-upload.ts
+++ b/turbo/apps/platform/src/signals/okou-page/file-upload.ts
@@ -337,7 +337,7 @@ export const uploadFileToStorage$ = command(
   },
 );
 
-export interface UploadedPrivateArtifact {
+interface UploadedPrivateArtifact {
   readonly id: string;
 }
 

--- a/turbo/apps/platform/src/signals/okou-page/file-upload.ts
+++ b/turbo/apps/platform/src/signals/okou-page/file-upload.ts
@@ -1,3 +1,8 @@
+import {
+  IMAGE_REFERENCE_CONTENT_TYPES,
+  imageReferencesContract,
+  type ImageReferenceContentType,
+} from "@okouai/api-contracts/contracts/image-references";
 import { uploadsContract } from "@okouai/api-contracts/contracts/uploads";
 import { command } from "ccstate";
 import { delay } from "signal-timers";
@@ -197,21 +202,15 @@ async function uploadPartWithRetry(
   signal.throwIfAborted();
 }
 
-type UploadPurpose = "image-reference" | undefined;
-
 const uploadFile$ = command(
   async (
     { get, set },
     file: File,
-    purpose: UploadPurpose,
     signal: AbortSignal,
   ): Promise<UploadedFileInfo> => {
     const client = get(apiClient$)(uploadsContract);
     const contentType = inferUploadContentType(file);
 
-    // The browser transfers bytes directly to storage. The narrow
-    // image-reference purpose selects a private-artifact allocation without
-    // changing ordinary composer attachment uploads.
     const prepared = await accept(
       client.prepare({
         body: {
@@ -221,7 +220,6 @@ const uploadFile$ = command(
           ...(file.size >= MULTIPART_UPLOAD_THRESHOLD_BYTES
             ? { multipart: true as const }
             : {}),
-          ...(purpose === undefined ? {} : { purpose }),
         },
         fetchOptions: { signal },
       }),
@@ -261,18 +259,7 @@ const uploadFile$ = command(
             [200],
           );
           signal.throwIfAborted();
-          if (purpose === undefined) {
-            return uploadedFileInfo(completed.body, prepared.body.contentType);
-          }
-          const finalized = await accept(
-            client.complete({
-              body: { id: completed.body.id },
-              fetchOptions: { signal },
-            }),
-            [200],
-          );
-          signal.throwIfAborted();
-          return uploadedFileInfo(finalized.body, finalized.body.contentType);
+          return uploadedFileInfo(completed.body, prepared.body.contentType);
         })(),
         async () => {
           // Once completion begins, aborting can race a successful R2 finalize.
@@ -314,41 +301,82 @@ const uploadFile$ = command(
         `storage returned ${putResponse.status} ${putResponse.statusText}`,
       );
     }
-    if (purpose === undefined) {
-      return uploadedFileInfo(prepared.body, prepared.body.contentType);
-    }
-
-    const finalized = await accept(
-      client.complete({
-        body: { id: prepared.body.id },
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
-    signal.throwIfAborted();
-    return uploadedFileInfo(finalized.body, finalized.body.contentType);
+    return uploadedFileInfo(prepared.body, prepared.body.contentType);
   },
 );
 
 /** Upload an ordinary composer attachment without changing its existing flow. */
 export const uploadFileToStorage$ = command(
   async ({ set }, file: File, signal: AbortSignal) => {
-    return await set(uploadFile$, file, undefined, signal);
+    return await set(uploadFile$, file, signal);
   },
 );
 
-interface UploadedPrivateArtifact {
-  readonly id: string;
+function isImageReferenceContentType(
+  value: string,
+): value is ImageReferenceContentType {
+  const accepted: readonly string[] = IMAGE_REFERENCE_CONTENT_TYPES;
+  return accepted.includes(value);
 }
 
-/** Upload and finalize one owner-authenticated private artifact. */
-export const uploadPrivateArtifactToStorage$ = command(
+interface UploadedImageReferenceSource {
+  readonly sourceFileId: string;
+}
+
+/** Upload and finalize one image-reference source through its domain API. */
+export const uploadImageReferenceSource$ = command(
   async (
-    { set },
+    { get },
     file: File,
     signal: AbortSignal,
-  ): Promise<UploadedPrivateArtifact> => {
-    const uploaded = await set(uploadFile$, file, "image-reference", signal);
-    return { id: uploaded.id };
+  ): Promise<UploadedImageReferenceSource> => {
+    const contentType = inferUploadContentType(file);
+    if (!isImageReferenceContentType(contentType)) {
+      throw new Error("Image must be a PNG, JPEG, or WebP file");
+    }
+
+    const imageClient = get(apiClient$)(imageReferencesContract);
+    const prepared = await accept(
+      imageClient.prepareUpload({
+        body: {
+          filename: file.name,
+          contentType,
+          size: file.size,
+        },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+
+    const putResponse = await fetchResource(
+      prepared.body.uploadUrl,
+      {
+        method: "PUT",
+        body: file,
+        headers: {
+          "content-type": contentType,
+          ...prepared.body.uploadHeaders,
+        },
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    if (!putResponse.ok) {
+      throw new Error(
+        `storage returned ${putResponse.status} ${putResponse.statusText}`,
+      );
+    }
+
+    const uploadsClient = get(apiClient$)(uploadsContract);
+    await accept(
+      uploadsClient.complete({
+        body: { id: prepared.body.sourceFileId },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    return { sourceFileId: prepared.body.sourceFileId };
   },
 );

--- a/turbo/apps/platform/src/signals/okou-page/file-upload.ts
+++ b/turbo/apps/platform/src/signals/okou-page/file-upload.ts
@@ -1,0 +1,354 @@
+import { uploadsContract } from "@okouai/api-contracts/contracts/uploads";
+import { command } from "ccstate";
+import { delay } from "signal-timers";
+
+import { IN_VITEST } from "../../env.ts";
+import { accept } from "../../lib/accept.ts";
+import { fetchResource } from "../../lib/resource-fetch.ts";
+import { apiClient$ } from "../api-client.ts";
+import { onRejection, setLoop, settle, tapError } from "../utils.ts";
+
+export interface UploadedFileInfo {
+  readonly id: string;
+  readonly url: string;
+  readonly contentType: string;
+}
+
+function uploadedFileInfo(
+  file: Pick<UploadedFileInfo, "id" | "url">,
+  contentType: string,
+): UploadedFileInfo {
+  return { id: file.id, url: file.url, contentType };
+}
+
+const MULTIPART_UPLOAD_THRESHOLD_BYTES = 5 * 1024 * 1024;
+const MAX_PART_UPLOAD_ATTEMPTS = 5;
+const PART_UPLOAD_RETRY_BASE_DELAY_MS = 250;
+const MULTIPART_ABORT_TIMEOUT_MS = 5000;
+
+interface MultipartUploadReference {
+  readonly id: string;
+  readonly filename: string;
+  readonly uploadId: string;
+}
+
+const abortMultipartUpload$ = command(
+  async (
+    { get },
+    upload: MultipartUploadReference,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const client = get(apiClient$)(uploadsContract);
+    await tapError(
+      accept(
+        client.abortMultipart({
+          body: upload,
+          fetchOptions: {
+            keepalive: true,
+            signal,
+          },
+        }),
+        [200],
+        signal,
+        { showErrorToast: false },
+      ),
+    );
+  },
+);
+
+function uploadContentTypeByExtension(ext: string): string | undefined {
+  const contentTypeByExtension: Record<string, string | undefined> = {
+    aac: "audio/aac",
+    "7z": "application/x-7z-compressed",
+    ai: "application/postscript",
+    avif: "image/avif",
+    bmp: "image/bmp",
+    bz2: "application/x-bzip2",
+    csv: "text/csv",
+    db: "application/vnd.sqlite3",
+    doc: "application/msword",
+    docm: "application/vnd.ms-word.document.macroenabled.12",
+    docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    dotm: "application/vnd.ms-word.template.macroenabled.12",
+    dotx: "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+    epub: "application/epub+zip",
+    flac: "audio/flac",
+    gif: "image/gif",
+    gz: "application/gzip",
+    har: "application/json",
+    heic: "image/heic",
+    heif: "image/heif",
+    htm: "text/html",
+    html: "text/html",
+    jpeg: "image/jpeg",
+    jpg: "image/jpeg",
+    json: "application/json",
+    key: "application/vnd.apple.keynote",
+    m4a: "audio/mp4",
+    md: "text/markdown",
+    mov: "video/quicktime",
+    mp3: "audio/mpeg",
+    mp4: "video/mp4",
+    mpga: "audio/mpga",
+    odp: "application/vnd.oasis.opendocument.presentation",
+    ods: "application/vnd.oasis.opendocument.spreadsheet",
+    odt: "application/vnd.oasis.opendocument.text",
+    oga: "audio/ogg",
+    ogg: "audio/ogg",
+    opus: "audio/opus",
+    numbers: "application/vnd.apple.numbers",
+    pages: "application/vnd.apple.pages",
+    parquet: "application/vnd.apache.parquet",
+    pdf: "application/pdf",
+    png: "image/png",
+    potm: "application/vnd.ms-powerpoint.template.macroenabled.12",
+    potx: "application/vnd.openxmlformats-officedocument.presentationml.template",
+    ppsm: "application/vnd.ms-powerpoint.slideshow.macroenabled.12",
+    ppsx: "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+    ppt: "application/vnd.ms-powerpoint",
+    pptm: "application/vnd.ms-powerpoint.presentation.macroenabled.12",
+    pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    psd: "image/vnd.adobe.photoshop",
+    rar: "application/vnd.rar",
+    rtf: "application/rtf",
+    sqlite: "application/vnd.sqlite3",
+    sqlite3: "application/vnd.sqlite3",
+    svg: "image/svg+xml",
+    tar: "application/x-tar",
+    tgz: "application/gzip",
+    tif: "image/tiff",
+    tiff: "image/tiff",
+    txt: "text/plain",
+    tsv: "text/tab-separated-values",
+    wav: "audio/wav",
+    wave: "audio/wave",
+    webm: "video/webm",
+    webp: "image/webp",
+    xls: "application/vnd.ms-excel",
+    xlsb: "application/vnd.ms-excel.sheet.binary.macroenabled.12",
+    xlsm: "application/vnd.ms-excel.sheet.macroenabled.12",
+    xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    xltm: "application/vnd.ms-excel.template.macroenabled.12",
+    xltx: "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+    xml: "application/xml",
+    xz: "application/x-xz",
+    yaml: "application/yaml",
+    yml: "application/yaml",
+    zip: "application/zip",
+  };
+  return contentTypeByExtension[ext];
+}
+
+export function inferUploadContentType(file: File): string {
+  const explicitType = file.type.split(";")[0]?.trim().toLowerCase();
+  if (explicitType && explicitType !== "application/octet-stream") {
+    return explicitType;
+  }
+  const ext = file.name.split(".").pop()?.toLowerCase();
+  return ext
+    ? (uploadContentTypeByExtension(ext) ?? "application/octet-stream")
+    : "application/octet-stream";
+}
+
+async function uploadPartWithRetry(
+  uploadUrl: string,
+  body: Blob,
+  contentType: string,
+  signal: AbortSignal,
+): Promise<void> {
+  let attempt = 0;
+  await setLoop(
+    async (loopSignal) => {
+      attempt += 1;
+      const result = await settle(
+        fetchResource(
+          uploadUrl,
+          {
+            method: "PUT",
+            body,
+            headers: { "content-type": contentType },
+          },
+          loopSignal,
+        ),
+        loopSignal,
+      );
+      if (result.ok) {
+        if (result.value.ok) {
+          return true;
+        }
+        if (attempt === MAX_PART_UPLOAD_ATTEMPTS) {
+          throw new Error(
+            `storage returned ${result.value.status} ${result.value.statusText}`,
+          );
+        }
+      } else if (attempt === MAX_PART_UPLOAD_ATTEMPTS) {
+        throw result.error;
+      }
+      await delay(
+        IN_VITEST ? 0 : PART_UPLOAD_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+        { signal: loopSignal },
+      );
+      return false;
+    },
+    0,
+    signal,
+    { retryTransientErrors: false },
+  );
+  signal.throwIfAborted();
+}
+
+type UploadPurpose = "image-reference" | undefined;
+
+const uploadFile$ = command(
+  async (
+    { get, set },
+    file: File,
+    purpose: UploadPurpose,
+    signal: AbortSignal,
+  ): Promise<UploadedFileInfo> => {
+    const client = get(apiClient$)(uploadsContract);
+    const contentType = inferUploadContentType(file);
+
+    // The browser transfers bytes directly to storage. The narrow
+    // image-reference purpose selects a private-artifact allocation without
+    // changing ordinary composer attachment uploads.
+    const prepared = await accept(
+      client.prepare({
+        body: {
+          filename: file.name,
+          contentType,
+          size: file.size,
+          ...(file.size >= MULTIPART_UPLOAD_THRESHOLD_BYTES
+            ? { multipart: true as const }
+            : {}),
+          ...(purpose === undefined ? {} : { purpose }),
+        },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+
+    if ("multipart" in prepared.body) {
+      const multipart = prepared.body.multipart;
+      let completionStarted = false;
+      return await onRejection(
+        (async () => {
+          signal.throwIfAborted();
+          for (const part of multipart.parts) {
+            const start = (part.partNumber - 1) * multipart.partSize;
+            const end = Math.min(start + multipart.partSize, file.size);
+            await uploadPartWithRetry(
+              part.uploadUrl,
+              file.slice(start, end, prepared.body.contentType),
+              prepared.body.contentType,
+              signal,
+            );
+          }
+
+          signal.throwIfAborted();
+          completionStarted = true;
+          const completed = await accept(
+            client.completeMultipart({
+              body: {
+                id: prepared.body.id,
+                filename: prepared.body.filename,
+                uploadId: multipart.uploadId,
+                partCount: multipart.parts.length,
+              },
+              fetchOptions: { signal },
+            }),
+            [200],
+          );
+          signal.throwIfAborted();
+          if (purpose === undefined) {
+            return uploadedFileInfo(completed.body, prepared.body.contentType);
+          }
+          const finalized = await accept(
+            client.complete({
+              body: { id: completed.body.id },
+              fetchOptions: { signal },
+            }),
+            [200],
+          );
+          signal.throwIfAborted();
+          return uploadedFileInfo(finalized.body, finalized.body.contentType);
+        })(),
+        async () => {
+          // Once completion begins, aborting can race a successful R2 finalize.
+          // Pre-completion failures still release the multipart upload eagerly;
+          // pending private-artifact rows follow the backend's orphan cleanup.
+          if (completionStarted) {
+            return;
+          }
+          const cleanupSignal = AbortSignal.timeout(MULTIPART_ABORT_TIMEOUT_MS);
+          await set(
+            abortMultipartUpload$,
+            {
+              id: prepared.body.id,
+              filename: prepared.body.filename,
+              uploadId: multipart.uploadId,
+            },
+            cleanupSignal,
+          );
+        },
+      );
+    }
+
+    const putResponse = await fetchResource(
+      prepared.body.uploadUrl,
+      {
+        method: "PUT",
+        body: file,
+        headers: {
+          "content-type": prepared.body.contentType,
+          ...prepared.body.uploadHeaders,
+        },
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (!putResponse.ok) {
+      throw new Error(
+        `storage returned ${putResponse.status} ${putResponse.statusText}`,
+      );
+    }
+    if (purpose === undefined) {
+      return uploadedFileInfo(prepared.body, prepared.body.contentType);
+    }
+
+    const finalized = await accept(
+      client.complete({
+        body: { id: prepared.body.id },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    return uploadedFileInfo(finalized.body, finalized.body.contentType);
+  },
+);
+
+/** Upload an ordinary composer attachment without changing its existing flow. */
+export const uploadFileToStorage$ = command(
+  async ({ set }, file: File, signal: AbortSignal) => {
+    return await set(uploadFile$, file, undefined, signal);
+  },
+);
+
+export interface UploadedPrivateArtifact {
+  readonly id: string;
+}
+
+/** Upload and finalize one owner-authenticated private artifact. */
+export const uploadPrivateArtifactToStorage$ = command(
+  async (
+    { set },
+    file: File,
+    signal: AbortSignal,
+  ): Promise<UploadedPrivateArtifact> => {
+    const uploaded = await set(uploadFile$, file, "image-reference", signal);
+    return { id: uploaded.id };
+  },
+);

--- a/turbo/apps/platform/src/signals/okou-page/image-reference-library.ts
+++ b/turbo/apps/platform/src/signals/okou-page/image-reference-library.ts
@@ -1,10 +1,10 @@
 import {
   IMAGE_REFERENCE_PREVIEW_URL_TTL_SECONDS,
-  MAX_IMAGE_REFERENCE_PREVIEW_ASSETS,
+  MAX_IMAGE_REFERENCE_PREVIEW_URLS,
   imageReferencesContract,
   type CreateImageReferenceBody,
   type ImageReference,
-  type ImageReferencePreviewAsset,
+  type ImageReferencePreviewUrl,
   type ImageReferenceVisibility,
   type UpdateImageReferenceBody,
 } from "@okouai/api-contracts/contracts/image-references";
@@ -36,7 +36,7 @@ import {
   setLoop,
   withCleanup,
 } from "../utils.ts";
-import { uploadPrivateArtifactToStorage$ } from "./file-upload.ts";
+import { uploadImageReferenceSource$ } from "./file-upload.ts";
 
 export type { ImageReference, ImageReferenceVisibility };
 
@@ -249,8 +249,7 @@ export const subscribeImageReferencesChanged$ = command(
 );
 
 interface ImageReferenceCache {
-  readonly previewAssetIdByReferenceId: Map<string, string>;
-  readonly previewUrlByAssetId: Map<string, ImageReferencePreviewAsset>;
+  readonly previewByReferenceId: Map<string, ImageReferencePreviewUrl>;
   readonly imageBuffersByReferenceId: Map<string, ImageReferenceImageBuffers>;
   readonly detailByReferenceId: Map<
     string,
@@ -259,8 +258,7 @@ interface ImageReferenceCache {
 }
 
 function clearImageReferenceCache(cache: ImageReferenceCache): void {
-  cache.previewAssetIdByReferenceId.clear();
-  cache.previewUrlByAssetId.clear();
+  cache.previewByReferenceId.clear();
   cache.imageBuffersByReferenceId.clear();
   cache.detailByReferenceId.clear();
 }
@@ -269,27 +267,23 @@ function evictImageReferenceCache(
   cache: ImageReferenceCache,
   referenceId: string,
 ): void {
-  const previewAssetId = cache.previewAssetIdByReferenceId.get(referenceId);
-  cache.previewAssetIdByReferenceId.delete(referenceId);
+  cache.previewByReferenceId.delete(referenceId);
   cache.imageBuffersByReferenceId.delete(referenceId);
   cache.detailByReferenceId.delete(referenceId);
-  if (previewAssetId !== undefined) {
-    cache.previewUrlByAssetId.delete(previewAssetId);
-  }
 }
 
-function mergeImageReferencePreviewAsset(
+function mergeImageReferencePreviewUrl(
   cache: ImageReferenceCache,
-  asset: ImageReferencePreviewAsset,
+  preview: ImageReferencePreviewUrl,
 ): boolean {
-  const existing = cache.previewUrlByAssetId.get(asset.previewAssetId);
+  const existing = cache.previewByReferenceId.get(preview.referenceId);
   if (
     existing !== undefined &&
-    Date.parse(existing.expiresAt) >= Date.parse(asset.expiresAt)
+    Date.parse(existing.expiresAt) >= Date.parse(preview.expiresAt)
   ) {
     return false;
   }
-  cache.previewUrlByAssetId.set(asset.previewAssetId, asset);
+  cache.previewByReferenceId.set(preview.referenceId, preview);
   return true;
 }
 
@@ -302,30 +296,23 @@ function synchronizeImageReferenceCache(
       return reference.id;
     }),
   );
-  for (const referenceId of cache.previewAssetIdByReferenceId.keys()) {
+  for (const referenceId of cache.previewByReferenceId.keys()) {
     if (!referenceIds.has(referenceId)) {
       evictImageReferenceCache(cache, referenceId);
     }
   }
 
   return references.map((reference) => {
-    const previousAssetId = cache.previewAssetIdByReferenceId.get(reference.id);
-    if (
-      previousAssetId !== undefined &&
-      previousAssetId !== reference.previewAsset.previewAssetId
-    ) {
-      cache.previewUrlByAssetId.delete(previousAssetId);
-    }
-    cache.previewAssetIdByReferenceId.set(
-      reference.id,
-      reference.previewAsset.previewAssetId,
-    );
-    mergeImageReferencePreviewAsset(cache, reference.previewAsset);
+    mergeImageReferencePreviewUrl(cache, {
+      referenceId: reference.id,
+      url: reference.previewUrl,
+      expiresAt: reference.previewUrlExpiresAt,
+    });
+    const preview = cache.previewByReferenceId.get(reference.id);
     return {
       ...reference,
-      previewAsset:
-        cache.previewUrlByAssetId.get(reference.previewAsset.previewAssetId) ??
-        reference.previewAsset,
+      previewUrl: preview?.url ?? reference.previewUrl,
+      previewUrlExpiresAt: preview?.expiresAt ?? reference.previewUrlExpiresAt,
     };
   });
 }
@@ -442,28 +429,28 @@ function imageReferenceCreator(
   };
 }
 
-async function resolveImageReferencePreviewAssets(
+async function resolveImageReferencePreviewUrls(
   createClient: ApiClientFactory,
-  previewAssetIds: readonly string[],
+  referenceIds: readonly string[],
   signal: AbortSignal,
-): Promise<readonly ImageReferencePreviewAsset[]> {
-  const uniqueIds = [...new Set(previewAssetIds)];
+): Promise<readonly ImageReferencePreviewUrl[]> {
+  const uniqueIds = [...new Set(referenceIds)];
   const batches: string[][] = [];
   for (
     let index = 0;
     index < uniqueIds.length;
-    index += MAX_IMAGE_REFERENCE_PREVIEW_ASSETS
+    index += MAX_IMAGE_REFERENCE_PREVIEW_URLS
   ) {
     batches.push(
-      uniqueIds.slice(index, index + MAX_IMAGE_REFERENCE_PREVIEW_ASSETS),
+      uniqueIds.slice(index, index + MAX_IMAGE_REFERENCE_PREVIEW_URLS),
     );
   }
   const client = createClient(imageReferencesContract);
   const responses = await Promise.all(
-    batches.map(async (previewAssetIdsBatch) => {
+    batches.map(async (referenceIdsBatch) => {
       return await accept(
         client.resolvePreviewUrls({
-          body: { previewAssetIds: previewAssetIdsBatch },
+          body: { referenceIds: referenceIdsBatch },
           fetchOptions: { signal },
         }),
         [200],
@@ -471,23 +458,23 @@ async function resolveImageReferencePreviewAssets(
     }),
   );
   return responses.flatMap((response) => {
-    return response.body.assets;
+    return response.body.previews;
   });
 }
 
-function expiringPreviewAssetIds(
+function expiringPreviewReferenceIds(
   cache: ImageReferenceCache,
   requestedAt: number,
 ): readonly string[] {
-  return [...cache.previewUrlByAssetId.values()]
-    .filter((asset) => {
+  return [...cache.previewByReferenceId.values()]
+    .filter((preview) => {
       return (
-        Date.parse(asset.expiresAt) - requestedAt <=
+        Date.parse(preview.expiresAt) - requestedAt <=
         IMAGE_REFERENCE_PREVIEW_URL_SAFETY_MS
       );
     })
-    .map((asset) => {
-      return asset.previewAssetId;
+    .map((preview) => {
+      return preview.referenceId;
     });
 }
 
@@ -496,9 +483,11 @@ function previewRefreshDelayMs(
   catalogLoadedAtMs: number,
 ): number {
   const requestedAt = now();
-  const expirations = [...cache.previewUrlByAssetId.values()].map((asset) => {
-    return Date.parse(asset.expiresAt);
-  });
+  const expirations = [...cache.previewByReferenceId.values()].map(
+    (preview) => {
+      return Date.parse(preview.expiresAt);
+    },
+  );
   if (expirations.length === 0) {
     return Math.max(
       0,
@@ -515,12 +504,6 @@ function previewRefreshDelayMs(
   );
 }
 
-function referencedPreviewAssetIds(
-  cache: ImageReferenceCache,
-): ReadonlySet<string> {
-  return new Set(cache.previewAssetIdByReferenceId.values());
-}
-
 function createPreviewRefreshSignals(
   catalog$: Computed<Promise<ImageReferenceCatalog>>,
   cache: ImageReferenceCache,
@@ -530,7 +513,7 @@ function createPreviewRefreshSignals(
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
       await get(imageReferencesAvailable$);
       signal.throwIfAborted();
-      if (cache.previewUrlByAssetId.size === 0) {
+      if (cache.previewByReferenceId.size === 0) {
         const catalog = await get(catalog$);
         signal.throwIfAborted();
         if (
@@ -542,36 +525,35 @@ function createPreviewRefreshSignals(
         return;
       }
 
-      const previewAssetIds = expiringPreviewAssetIds(cache, now());
-      if (previewAssetIds.length === 0) {
+      const referenceIds = expiringPreviewReferenceIds(cache, now());
+      if (referenceIds.length === 0) {
         return;
       }
-      const assets = await resolveImageReferencePreviewAssets(
+      const previews = await resolveImageReferencePreviewUrls(
         get(apiClient$),
-        previewAssetIds,
+        referenceIds,
         signal,
       );
       signal.throwIfAborted();
       const resolvedIds = new Set(
-        assets.map((asset) => {
-          return asset.previewAssetId;
+        previews.map((preview) => {
+          return preview.referenceId;
         }),
       );
       if (
-        previewAssetIds.some((previewAssetId) => {
-          return !resolvedIds.has(previewAssetId);
+        referenceIds.some((referenceId) => {
+          return !resolvedIds.has(referenceId);
         })
       ) {
         await set(refreshAndLoadImageReferences$, signal);
         return;
       }
-      const referencedIds = referencedPreviewAssetIds(cache);
-      const updated = assets
-        .filter((asset) => {
-          return referencedIds.has(asset.previewAssetId);
+      const updated = previews
+        .filter((preview) => {
+          return cache.previewByReferenceId.has(preview.referenceId);
         })
-        .map((asset) => {
-          return mergeImageReferencePreviewAsset(cache, asset);
+        .map((preview) => {
+          return mergeImageReferencePreviewUrl(cache, preview);
         })
         .includes(true);
       if (updated) {
@@ -599,7 +581,7 @@ function createPreviewRefreshSignals(
           setLoop(
             async (loopSignal) => {
               const catalogLoadedAtMs =
-                cache.previewUrlByAssetId.size === 0
+                cache.previewByReferenceId.size === 0
                   ? (await get(catalog$)).loadedAtMs
                   : now();
               loopSignal.throwIfAborted();
@@ -685,7 +667,7 @@ function createMutationSignals(
       await get(imageReferencesAvailable$);
       signal.throwIfAborted();
       const uploaded = await set(
-        uploadPrivateArtifactToStorage$,
+        uploadImageReferenceSource$,
         input.file,
         signal,
       );
@@ -693,7 +675,7 @@ function createMutationSignals(
       return await set(
         create$,
         {
-          sourceFileId: uploaded.id,
+          sourceFileId: uploaded.sourceFileId,
           title: input.title,
           visibility: input.visibility,
         },
@@ -792,8 +774,7 @@ function createMutationSignals(
 /** Composer-owned reusable image-reference catalog and mutation state. */
 export function createImageReferenceLibrarySignals(): ImageReferenceLibrarySignals {
   const cache: ImageReferenceCache = {
-    previewAssetIdByReferenceId: new Map(),
-    previewUrlByAssetId: new Map(),
+    previewByReferenceId: new Map(),
     imageBuffersByReferenceId: new Map(),
     detailByReferenceId: new Map(),
   };
@@ -850,9 +831,7 @@ export function createImageReferenceLibrarySignals(): ImageReferenceLibrarySigna
         let imageBuffers = cache.imageBuffersByReferenceId.get(reference.id);
         if (!imageBuffers) {
           const desiredUrl$ = computed(async (read) => {
-            return (
-              (await read(resolve(reference.id)))?.previewAsset.url ?? null
-            );
+            return (await read(resolve(reference.id)))?.previewUrl ?? null;
           });
           imageBuffers = {
             card: createImageReferenceImageSignals(desiredUrl$),

--- a/turbo/apps/platform/src/signals/okou-page/image-reference-library.ts
+++ b/turbo/apps/platform/src/signals/okou-page/image-reference-library.ts
@@ -1,0 +1,901 @@
+import {
+  IMAGE_REFERENCE_PREVIEW_URL_TTL_SECONDS,
+  MAX_IMAGE_REFERENCE_PREVIEW_ASSETS,
+  imageReferencesContract,
+  type CreateImageReferenceBody,
+  type ImageReference,
+  type ImageReferencePreviewAsset,
+  type ImageReferenceVisibility,
+  type UpdateImageReferenceBody,
+} from "@okouai/api-contracts/contracts/image-references";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import {
+  command,
+  computed,
+  state,
+  type Command,
+  type Computed,
+  type State,
+} from "ccstate";
+import { delay } from "signal-timers";
+
+import { accept } from "../../lib/accept.ts";
+import { now } from "../../lib/time.ts";
+import { apiClient$, type ApiClientFactory } from "../api-client.ts";
+import { authenticatedIdentity$ } from "../auth.ts";
+import {
+  featureSwitch$,
+  initialFeatureSwitchHydration$,
+} from "../external/feature-switch.ts";
+import { orgMembers$, type OrgMember } from "../external/org-members.ts";
+import { setAblyLoop$ } from "../realtime.ts";
+import { rootSignal$ } from "../root-signal.ts";
+import {
+  createDeferredPromise,
+  onRef,
+  setLoop,
+  withCleanup,
+} from "../utils.ts";
+import { uploadPrivateArtifactToStorage$ } from "./file-upload.ts";
+
+export type {
+  ImageReference,
+  ImageReferencePreviewAsset,
+  ImageReferenceVisibility,
+};
+
+const IMAGE_REFERENCE_PREVIEW_URL_SAFETY_MS = 45 * 1000;
+const IMAGE_REFERENCE_CATALOG_REVALIDATE_AGE_MS =
+  (IMAGE_REFERENCE_PREVIEW_URL_TTL_SECONDS * 1000 * 2) / 3;
+
+interface ImageReferenceCatalog {
+  readonly references: readonly ImageReference[];
+  readonly loadedAtMs: number;
+}
+
+export interface ImageReferenceCreator {
+  readonly userId: string;
+  readonly displayName: string;
+  readonly email: string;
+  readonly imageUrl: string;
+}
+
+export type ImageReferenceImageSlot = "a" | "b";
+
+export interface ImageReferenceLoadedImage {
+  readonly desiredUrl: string;
+  readonly sourceUrl: string;
+  readonly slot: ImageReferenceImageSlot;
+}
+
+export interface ImageReferenceImageState {
+  readonly active: ImageReferenceLoadedImage | null;
+  readonly failed: readonly ImageReferenceLoadedImage[];
+}
+
+export interface ImageReferenceImageSignals {
+  readonly desiredUrl$: Computed<Promise<string | null>>;
+  readonly state$: Computed<ImageReferenceImageState>;
+  readonly commitLoadedImage$: Command<
+    Promise<void>,
+    [ImageReferenceLoadedImage, AbortSignal]
+  >;
+  readonly failImageLoad$: Command<
+    Promise<void>,
+    [ImageReferenceLoadedImage, AbortSignal]
+  >;
+}
+
+export interface ImageReferenceImageBuffers {
+  readonly card: ImageReferenceImageSignals;
+  readonly detail: ImageReferenceImageSignals;
+}
+
+export interface ImageReferencePickerItem {
+  readonly reference: ImageReference;
+  readonly creator: ImageReferenceCreator | null;
+  readonly imageBuffers: ImageReferenceImageBuffers;
+}
+
+export interface UploadImageReferenceInput {
+  readonly file: File;
+  readonly title: string;
+  readonly visibility: ImageReferenceVisibility;
+}
+
+export type ImageReferenceLookup = (
+  referenceId: string,
+) => Computed<Promise<ImageReference | null>>;
+
+export interface ImageReferenceLibrarySignals {
+  readonly enabled$: Computed<boolean>;
+  readonly references$: Computed<Promise<readonly ImageReference[]>>;
+  readonly ownReferences$: Computed<Promise<readonly ImageReference[]>>;
+  readonly organizationReferences$: Computed<
+    Promise<readonly ImageReference[]>
+  >;
+  readonly pickerItems$: Computed<Promise<readonly ImageReferencePickerItem[]>>;
+  readonly resolve: ImageReferenceLookup;
+  readonly refresh$: Command<Promise<void>, [AbortSignal]>;
+  readonly create$: Command<
+    Promise<ImageReference>,
+    [CreateImageReferenceBody, AbortSignal]
+  >;
+  readonly uploadAndCreate$: Command<
+    Promise<ImageReference>,
+    [UploadImageReferenceInput, AbortSignal]
+  >;
+  readonly update$: Command<
+    Promise<ImageReference | null>,
+    [string, UpdateImageReferenceBody, AbortSignal]
+  >;
+  readonly rename$: Command<
+    Promise<ImageReference>,
+    [string, string, AbortSignal]
+  >;
+  readonly setVisibility$: Command<
+    Promise<ImageReference>,
+    [string, ImageReferenceVisibility, AbortSignal]
+  >;
+  readonly adminUnshare$: Command<Promise<void>, [string, AbortSignal]>;
+  readonly delete$: Command<Promise<void>, [string, AbortSignal]>;
+  readonly refreshPreviewUrlsIfExpiring$: Command<Promise<void>, [AbortSignal]>;
+  readonly lifecycleRef$: Command<
+    (() => void) | undefined,
+    [HTMLElement | null]
+  >;
+}
+
+const imageReferencesVersion$ = state(0);
+const imageReferencesRealtimeReady$ = computed((get) => {
+  return createDeferredPromise<void>(get(rootSignal$));
+});
+
+export const imageReferencesEnabled$ = computed((get): boolean => {
+  return get(featureSwitch$)[FeatureSwitchKey.ReferenceImages] === true;
+});
+
+const imageReferencesAvailable$ = computed(async (get): Promise<void> => {
+  await get(initialFeatureSwitchHydration$);
+  if (!get(imageReferencesEnabled$)) {
+    throw new Error("Image references are unavailable");
+  }
+});
+
+const imageReferenceCatalog$ = computed(
+  async (get): Promise<ImageReferenceCatalog> => {
+    await get(initialFeatureSwitchHydration$);
+    if (!get(imageReferencesEnabled$)) {
+      return { references: [], loadedAtMs: now() };
+    }
+
+    // Both invalidation scopes attach before the baseline request. This closes
+    // the fetch/subscribe gap while remaining compatible with servers that
+    // publish only the older user-scoped event.
+    await get(imageReferencesRealtimeReady$).promise;
+    get(imageReferencesVersion$);
+    const client = get(apiClient$)(imageReferencesContract);
+    const result = await accept(client.list(), [200]);
+    return { references: result.body, loadedAtMs: now() };
+  },
+);
+
+const refreshImageReferencesVersion$ = command(({ get, set }) => {
+  set(imageReferencesVersion$, get(imageReferencesVersion$) + 1);
+});
+
+const refreshAndLoadImageReferences$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    set(refreshImageReferencesVersion$);
+    await get(imageReferenceCatalog$);
+    signal.throwIfAborted();
+  },
+);
+
+const refreshImageReferencesFromRealtime$ = command(
+  async ({ set }, signal: AbortSignal): Promise<boolean> => {
+    await set(refreshAndLoadImageReferences$, signal);
+    return false;
+  },
+);
+
+/** Subscribe once for the authenticated app lifetime. */
+export const subscribeImageReferencesChanged$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    await get(initialFeatureSwitchHydration$);
+    signal.throwIfAborted();
+    const ready = get(imageReferencesRealtimeReady$);
+    if (!get(imageReferencesEnabled$)) {
+      if (!ready.settled()) {
+        ready.resolve();
+      }
+      return;
+    }
+
+    const subscribedScopes = new Set<"user" | "org">();
+    const markSubscribed = (scope: "user" | "org") => {
+      subscribedScopes.add(scope);
+      if (subscribedScopes.size === 2 && !ready.settled()) {
+        ready.resolve();
+      }
+    };
+    await Promise.all([
+      set(
+        setAblyLoop$,
+        {
+          topic: "imageReferencesChanged",
+          loopCommand$: refreshImageReferencesFromRealtime$,
+          options: {
+            onSubscribed: () => {
+              markSubscribed("user");
+            },
+          },
+        },
+        signal,
+      ),
+      set(
+        setAblyLoop$,
+        {
+          scope: "org",
+          topic: "imageReferencesChanged",
+          loopCommand$: refreshImageReferencesFromRealtime$,
+          options: {
+            runOnForegroundCatchUp: false,
+            onSubscribed: () => {
+              markSubscribed("org");
+            },
+          },
+        },
+        signal,
+      ),
+    ]);
+  },
+);
+
+interface ImageReferenceCache {
+  readonly previewAssetIdByReferenceId: Map<string, string>;
+  readonly previewUrlByAssetId: Map<string, ImageReferencePreviewAsset>;
+  readonly imageBuffersByReferenceId: Map<string, ImageReferenceImageBuffers>;
+  readonly detailByReferenceId: Map<
+    string,
+    Computed<Promise<ImageReference | null>>
+  >;
+}
+
+function clearImageReferenceCache(cache: ImageReferenceCache): void {
+  cache.previewAssetIdByReferenceId.clear();
+  cache.previewUrlByAssetId.clear();
+  cache.imageBuffersByReferenceId.clear();
+  cache.detailByReferenceId.clear();
+}
+
+function evictImageReferenceCache(
+  cache: ImageReferenceCache,
+  referenceId: string,
+): void {
+  const previewAssetId = cache.previewAssetIdByReferenceId.get(referenceId);
+  cache.previewAssetIdByReferenceId.delete(referenceId);
+  cache.imageBuffersByReferenceId.delete(referenceId);
+  cache.detailByReferenceId.delete(referenceId);
+  if (previewAssetId !== undefined) {
+    cache.previewUrlByAssetId.delete(previewAssetId);
+  }
+}
+
+function mergeImageReferencePreviewAsset(
+  cache: ImageReferenceCache,
+  asset: ImageReferencePreviewAsset,
+): boolean {
+  const existing = cache.previewUrlByAssetId.get(asset.previewAssetId);
+  if (
+    existing !== undefined &&
+    Date.parse(existing.expiresAt) >= Date.parse(asset.expiresAt)
+  ) {
+    return false;
+  }
+  cache.previewUrlByAssetId.set(asset.previewAssetId, asset);
+  return true;
+}
+
+function synchronizeImageReferenceCache(
+  cache: ImageReferenceCache,
+  references: readonly ImageReference[],
+): readonly ImageReference[] {
+  const referenceIds = new Set(
+    references.map((reference) => {
+      return reference.id;
+    }),
+  );
+  for (const referenceId of cache.previewAssetIdByReferenceId.keys()) {
+    if (!referenceIds.has(referenceId)) {
+      evictImageReferenceCache(cache, referenceId);
+    }
+  }
+
+  return references.map((reference) => {
+    const previousAssetId = cache.previewAssetIdByReferenceId.get(reference.id);
+    if (
+      previousAssetId !== undefined &&
+      previousAssetId !== reference.previewAsset.previewAssetId
+    ) {
+      cache.previewUrlByAssetId.delete(previousAssetId);
+    }
+    cache.previewAssetIdByReferenceId.set(
+      reference.id,
+      reference.previewAsset.previewAssetId,
+    );
+    mergeImageReferencePreviewAsset(cache, reference.previewAsset);
+    return {
+      ...reference,
+      previewAsset:
+        cache.previewUrlByAssetId.get(reference.previewAsset.previewAssetId) ??
+        reference.previewAsset,
+    };
+  });
+}
+
+function createCachedImageReferenceCatalog$(
+  cache: ImageReferenceCache,
+  previewUrlsVersion$: State<number>,
+  deletedReferenceIds$: State<ReadonlySet<string>>,
+) {
+  return computed(async (get): Promise<ImageReferenceCatalog> => {
+    get(previewUrlsVersion$);
+    const deletedReferenceIds = get(deletedReferenceIds$);
+    const catalog = await get(imageReferenceCatalog$);
+    const retained = catalog.references.filter((reference) => {
+      return !deletedReferenceIds.has(reference.id);
+    });
+    return {
+      ...catalog,
+      references: synchronizeImageReferenceCache(cache, retained),
+    };
+  });
+}
+
+function sameLoadedImage(
+  left: ImageReferenceLoadedImage | null,
+  right: ImageReferenceLoadedImage,
+): boolean {
+  return (
+    left?.desiredUrl === right.desiredUrl &&
+    left.sourceUrl === right.sourceUrl &&
+    left.slot === right.slot
+  );
+}
+
+function createImageReferenceImageSignals(
+  desiredUrl$: Computed<Promise<string | null>>,
+): ImageReferenceImageSignals {
+  const internalState$ = state<ImageReferenceImageState>({
+    active: null,
+    failed: [],
+  });
+  const state$ = computed((get): ImageReferenceImageState => {
+    return get(internalState$);
+  });
+  const commitLoadedImage$ = command(
+    async (
+      { get, set },
+      loadedImage: ImageReferenceLoadedImage,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      const currentDesiredUrl = await get(desiredUrl$);
+      signal.throwIfAborted();
+      if (currentDesiredUrl !== loadedImage.desiredUrl) {
+        return;
+      }
+      const current = get(internalState$);
+      if (sameLoadedImage(current.active, loadedImage)) {
+        if (current.failed.length > 0) {
+          set(internalState$, { active: loadedImage, failed: [] });
+        }
+        return;
+      }
+      set(internalState$, { active: loadedImage, failed: [] });
+    },
+  );
+  const failImageLoad$ = command(
+    async (
+      { get, set },
+      failedImage: ImageReferenceLoadedImage,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      const currentDesiredUrl = await get(desiredUrl$);
+      signal.throwIfAborted();
+      if (currentDesiredUrl !== failedImage.desiredUrl) {
+        return;
+      }
+      const current = get(internalState$);
+      if (
+        current.failed.some((candidate) => {
+          return sameLoadedImage(candidate, failedImage);
+        })
+      ) {
+        return;
+      }
+      set(internalState$, {
+        ...current,
+        failed: [...current.failed, failedImage],
+      });
+    },
+  );
+  return { desiredUrl$, state$, commitLoadedImage$, failImageLoad$ };
+}
+
+function imageReferenceCreator(
+  reference: ImageReference,
+  members: readonly OrgMember[],
+): ImageReferenceCreator | null {
+  const member = members.find((candidate) => {
+    return candidate.userId === reference.ownerUserId;
+  });
+  if (!member) {
+    return null;
+  }
+  const displayName = [member.firstName, member.lastName]
+    .filter((part): part is string => {
+      return Boolean(part);
+    })
+    .join(" ");
+  return {
+    userId: member.userId,
+    displayName: displayName || member.email,
+    email: member.email,
+    imageUrl: member.imageUrl,
+  };
+}
+
+async function resolveImageReferencePreviewAssets(
+  createClient: ApiClientFactory,
+  previewAssetIds: readonly string[],
+  signal: AbortSignal,
+): Promise<readonly ImageReferencePreviewAsset[]> {
+  const uniqueIds = [...new Set(previewAssetIds)];
+  const batches: string[][] = [];
+  for (
+    let index = 0;
+    index < uniqueIds.length;
+    index += MAX_IMAGE_REFERENCE_PREVIEW_ASSETS
+  ) {
+    batches.push(
+      uniqueIds.slice(index, index + MAX_IMAGE_REFERENCE_PREVIEW_ASSETS),
+    );
+  }
+  const client = createClient(imageReferencesContract);
+  const responses = await Promise.all(
+    batches.map(async (previewAssetIdsBatch) => {
+      return await accept(
+        client.resolvePreviewUrls({
+          body: { previewAssetIds: previewAssetIdsBatch },
+          fetchOptions: { signal },
+        }),
+        [200],
+      );
+    }),
+  );
+  return responses.flatMap((response) => {
+    return response.body.assets;
+  });
+}
+
+function expiringPreviewAssetIds(
+  cache: ImageReferenceCache,
+  requestedAt: number,
+): readonly string[] {
+  return [...cache.previewUrlByAssetId.values()]
+    .filter((asset) => {
+      return (
+        Date.parse(asset.expiresAt) - requestedAt <=
+        IMAGE_REFERENCE_PREVIEW_URL_SAFETY_MS
+      );
+    })
+    .map((asset) => {
+      return asset.previewAssetId;
+    });
+}
+
+function previewRefreshDelayMs(
+  cache: ImageReferenceCache,
+  catalogLoadedAtMs: number,
+): number {
+  const requestedAt = now();
+  const expirations = [...cache.previewUrlByAssetId.values()].map((asset) => {
+    return Date.parse(asset.expiresAt);
+  });
+  if (expirations.length === 0) {
+    return Math.max(
+      0,
+      catalogLoadedAtMs +
+        IMAGE_REFERENCE_CATALOG_REVALIDATE_AGE_MS -
+        requestedAt,
+    );
+  }
+  return Math.max(
+    0,
+    Math.min(...expirations) -
+      IMAGE_REFERENCE_PREVIEW_URL_SAFETY_MS -
+      requestedAt,
+  );
+}
+
+function referencedPreviewAssetIds(
+  cache: ImageReferenceCache,
+): ReadonlySet<string> {
+  return new Set(cache.previewAssetIdByReferenceId.values());
+}
+
+function createPreviewRefreshSignals(
+  catalog$: Computed<Promise<ImageReferenceCatalog>>,
+  cache: ImageReferenceCache,
+  previewUrlsVersion$: State<number>,
+) {
+  const refreshPreviewUrlsIfExpiring$ = command(
+    async ({ get, set }, signal: AbortSignal): Promise<void> => {
+      await get(imageReferencesAvailable$);
+      signal.throwIfAborted();
+      if (cache.previewUrlByAssetId.size === 0) {
+        const catalog = await get(catalog$);
+        signal.throwIfAborted();
+        if (
+          now() - catalog.loadedAtMs >=
+          IMAGE_REFERENCE_CATALOG_REVALIDATE_AGE_MS
+        ) {
+          await set(refreshAndLoadImageReferences$, signal);
+        }
+        return;
+      }
+
+      const previewAssetIds = expiringPreviewAssetIds(cache, now());
+      if (previewAssetIds.length === 0) {
+        return;
+      }
+      const assets = await resolveImageReferencePreviewAssets(
+        get(apiClient$),
+        previewAssetIds,
+        signal,
+      );
+      signal.throwIfAborted();
+      const resolvedIds = new Set(
+        assets.map((asset) => {
+          return asset.previewAssetId;
+        }),
+      );
+      if (
+        previewAssetIds.some((previewAssetId) => {
+          return !resolvedIds.has(previewAssetId);
+        })
+      ) {
+        await set(refreshAndLoadImageReferences$, signal);
+        return;
+      }
+      const referencedIds = referencedPreviewAssetIds(cache);
+      const updated = assets
+        .filter((asset) => {
+          return referencedIds.has(asset.previewAssetId);
+        })
+        .map((asset) => {
+          return mergeImageReferencePreviewAsset(cache, asset);
+        })
+        .includes(true);
+      if (updated) {
+        set(previewUrlsVersion$, (version) => {
+          return version + 1;
+        });
+      }
+    },
+  );
+
+  const lifecycleRef$ = onRef(
+    command(
+      async (
+        { get, set },
+        _element: HTMLElement,
+        signal: AbortSignal,
+      ): Promise<void> => {
+        await get(initialFeatureSwitchHydration$);
+        signal.throwIfAborted();
+        if (!get(imageReferencesEnabled$)) {
+          clearImageReferenceCache(cache);
+          return;
+        }
+        await withCleanup(
+          setLoop(
+            async (loopSignal) => {
+              const catalogLoadedAtMs =
+                cache.previewUrlByAssetId.size === 0
+                  ? (await get(catalog$)).loadedAtMs
+                  : now();
+              loopSignal.throwIfAborted();
+              await delay(previewRefreshDelayMs(cache, catalogLoadedAtMs), {
+                signal: loopSignal,
+              });
+              await set(refreshPreviewUrlsIfExpiring$, loopSignal);
+              return false;
+            },
+            0,
+            signal,
+            { retryTransientErrors: false },
+          ),
+          () => {
+            clearImageReferenceCache(cache);
+          },
+        );
+      },
+    ),
+  );
+  return { refreshPreviewUrlsIfExpiring$, lifecycleRef$ };
+}
+
+function createDeleteImageReference$(
+  deletedReferenceIds$: State<ReadonlySet<string>>,
+  cache: ImageReferenceCache,
+) {
+  return command(
+    async (
+      { get, set },
+      referenceId: string,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      await get(imageReferencesAvailable$);
+      signal.throwIfAborted();
+      const client = get(apiClient$)(imageReferencesContract);
+      await accept(
+        client.delete({
+          params: { referenceId },
+          fetchOptions: { signal },
+        }),
+        [204],
+      );
+      signal.throwIfAborted();
+      evictImageReferenceCache(cache, referenceId);
+      set(deletedReferenceIds$, (deletedIds) => {
+        return new Set([...deletedIds, referenceId]);
+      });
+      await set(refreshAndLoadImageReferences$, signal);
+    },
+  );
+}
+
+function createMutationSignals(
+  deletedReferenceIds$: State<ReadonlySet<string>>,
+  cache: ImageReferenceCache,
+) {
+  const create$ = command(
+    async (
+      { get, set },
+      body: CreateImageReferenceBody,
+      signal: AbortSignal,
+    ): Promise<ImageReference> => {
+      await get(imageReferencesAvailable$);
+      signal.throwIfAborted();
+      const client = get(apiClient$)(imageReferencesContract);
+      const result = await accept(
+        client.create({ body, fetchOptions: { signal } }),
+        [201],
+      );
+      signal.throwIfAborted();
+      await set(refreshAndLoadImageReferences$, signal);
+      return result.body;
+    },
+  );
+
+  const uploadAndCreate$ = command(
+    async (
+      { get, set },
+      input: UploadImageReferenceInput,
+      signal: AbortSignal,
+    ): Promise<ImageReference> => {
+      await get(imageReferencesAvailable$);
+      signal.throwIfAborted();
+      const uploaded = await set(
+        uploadPrivateArtifactToStorage$,
+        input.file,
+        signal,
+      );
+      signal.throwIfAborted();
+      return await set(
+        create$,
+        {
+          sourceFileId: uploaded.id,
+          title: input.title,
+          visibility: input.visibility,
+        },
+        signal,
+      );
+    },
+  );
+
+  const update$ = command(
+    async (
+      { get, set },
+      referenceId: string,
+      body: UpdateImageReferenceBody,
+      signal: AbortSignal,
+    ): Promise<ImageReference | null> => {
+      await get(imageReferencesAvailable$);
+      signal.throwIfAborted();
+      const client = get(apiClient$)(imageReferencesContract);
+      const result = await accept(
+        client.update({
+          params: { referenceId },
+          body,
+          fetchOptions: { signal },
+        }),
+        [200, 204],
+      );
+      signal.throwIfAborted();
+      if (result.status === 204) {
+        evictImageReferenceCache(cache, referenceId);
+        set(deletedReferenceIds$, (deletedIds) => {
+          return new Set([...deletedIds, referenceId]);
+        });
+        await set(refreshAndLoadImageReferences$, signal);
+        return null;
+      }
+      await set(refreshAndLoadImageReferences$, signal);
+      return result.body;
+    },
+  );
+
+  const rename$ = command(
+    async (
+      { set },
+      referenceId: string,
+      title: string,
+      signal: AbortSignal,
+    ): Promise<ImageReference> => {
+      const reference = await set(update$, referenceId, { title }, signal);
+      if (!reference) {
+        throw new Error("Image reference became unavailable while renaming");
+      }
+      return reference;
+    },
+  );
+
+  const setVisibility$ = command(
+    async (
+      { set },
+      referenceId: string,
+      visibility: ImageReferenceVisibility,
+      signal: AbortSignal,
+    ): Promise<ImageReference> => {
+      const reference = await set(update$, referenceId, { visibility }, signal);
+      if (!reference) {
+        throw new Error(
+          "Image reference became unavailable while changing visibility",
+        );
+      }
+      return reference;
+    },
+  );
+
+  const adminUnshare$ = command(
+    async (
+      { set },
+      referenceId: string,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      await set(update$, referenceId, { visibility: "private" }, signal);
+    },
+  );
+
+  const delete$ = createDeleteImageReference$(deletedReferenceIds$, cache);
+
+  return {
+    create$,
+    uploadAndCreate$,
+    update$,
+    rename$,
+    setVisibility$,
+    adminUnshare$,
+    delete$,
+  };
+}
+
+/** Composer-owned reusable image-reference catalog and mutation state. */
+export function createImageReferenceLibrarySignals(): ImageReferenceLibrarySignals {
+  const cache: ImageReferenceCache = {
+    previewAssetIdByReferenceId: new Map(),
+    previewUrlByAssetId: new Map(),
+    imageBuffersByReferenceId: new Map(),
+    detailByReferenceId: new Map(),
+  };
+  const internalPreviewUrlsVersion$ = state(0);
+  const deletedReferenceIds$ = state<ReadonlySet<string>>(new Set());
+  const catalog$ = createCachedImageReferenceCatalog$(
+    cache,
+    internalPreviewUrlsVersion$,
+    deletedReferenceIds$,
+  );
+  const references$ = computed(async (get) => {
+    return (await get(catalog$)).references;
+  });
+  const ownReferences$ = computed(async (get) => {
+    const [references, identity] = await Promise.all([
+      get(references$),
+      get(authenticatedIdentity$),
+    ]);
+    return references.filter((reference) => {
+      return reference.ownerUserId === identity.userId;
+    });
+  });
+  const organizationReferences$ = computed(async (get) => {
+    const [references, identity] = await Promise.all([
+      get(references$),
+      get(authenticatedIdentity$),
+    ]);
+    return references.filter((reference) => {
+      return reference.ownerUserId !== identity.userId;
+    });
+  });
+
+  const resolve: ImageReferenceLookup = (referenceId) => {
+    const existing = cache.detailByReferenceId.get(referenceId);
+    if (existing) {
+      return existing;
+    }
+    const detail$ = computed(async (get): Promise<ImageReference | null> => {
+      return (
+        (await get(references$)).find((reference) => {
+          return reference.id === referenceId;
+        }) ?? null
+      );
+    });
+    cache.detailByReferenceId.set(referenceId, detail$);
+    return detail$;
+  };
+
+  const pickerItems$ = computed(
+    async (get): Promise<readonly ImageReferencePickerItem[]> => {
+      const references = await get(references$);
+      const members = references.length > 0 ? await get(orgMembers$) : [];
+      return references.map((reference) => {
+        let imageBuffers = cache.imageBuffersByReferenceId.get(reference.id);
+        if (!imageBuffers) {
+          const desiredUrl$ = computed(async (read) => {
+            return (
+              (await read(resolve(reference.id)))?.previewAsset.url ?? null
+            );
+          });
+          imageBuffers = {
+            card: createImageReferenceImageSignals(desiredUrl$),
+            detail: createImageReferenceImageSignals(desiredUrl$),
+          };
+          cache.imageBuffersByReferenceId.set(reference.id, imageBuffers);
+        }
+        return {
+          reference,
+          creator: imageReferenceCreator(reference, members),
+          imageBuffers,
+        };
+      });
+    },
+  );
+
+  const previewRefresh = createPreviewRefreshSignals(
+    catalog$,
+    cache,
+    internalPreviewUrlsVersion$,
+  );
+  const mutations = createMutationSignals(deletedReferenceIds$, cache);
+  const refresh$ = command(
+    async ({ get, set }, signal: AbortSignal): Promise<void> => {
+      await get(imageReferencesAvailable$);
+      signal.throwIfAborted();
+      await set(refreshAndLoadImageReferences$, signal);
+    },
+  );
+
+  return {
+    enabled$: imageReferencesEnabled$,
+    references$,
+    ownReferences$,
+    organizationReferences$,
+    pickerItems$,
+    resolve,
+    refresh$,
+    ...mutations,
+    ...previewRefresh,
+  };
+}

--- a/turbo/apps/platform/src/signals/okou-page/image-reference-library.ts
+++ b/turbo/apps/platform/src/signals/okou-page/image-reference-library.ts
@@ -38,11 +38,7 @@ import {
 } from "../utils.ts";
 import { uploadPrivateArtifactToStorage$ } from "./file-upload.ts";
 
-export type {
-  ImageReference,
-  ImageReferencePreviewAsset,
-  ImageReferenceVisibility,
-};
+export type { ImageReference, ImageReferenceVisibility };
 
 const IMAGE_REFERENCE_PREVIEW_URL_SAFETY_MS = 45 * 1000;
 const IMAGE_REFERENCE_CATALOG_REVALIDATE_AGE_MS =
@@ -53,27 +49,27 @@ interface ImageReferenceCatalog {
   readonly loadedAtMs: number;
 }
 
-export interface ImageReferenceCreator {
+interface ImageReferenceCreator {
   readonly userId: string;
   readonly displayName: string;
   readonly email: string;
   readonly imageUrl: string;
 }
 
-export type ImageReferenceImageSlot = "a" | "b";
+type ImageReferenceImageSlot = "a" | "b";
 
-export interface ImageReferenceLoadedImage {
+interface ImageReferenceLoadedImage {
   readonly desiredUrl: string;
   readonly sourceUrl: string;
   readonly slot: ImageReferenceImageSlot;
 }
 
-export interface ImageReferenceImageState {
+interface ImageReferenceImageState {
   readonly active: ImageReferenceLoadedImage | null;
   readonly failed: readonly ImageReferenceLoadedImage[];
 }
 
-export interface ImageReferenceImageSignals {
+interface ImageReferenceImageSignals {
   readonly desiredUrl$: Computed<Promise<string | null>>;
   readonly state$: Computed<ImageReferenceImageState>;
   readonly commitLoadedImage$: Command<
@@ -86,7 +82,7 @@ export interface ImageReferenceImageSignals {
   >;
 }
 
-export interface ImageReferenceImageBuffers {
+interface ImageReferenceImageBuffers {
   readonly card: ImageReferenceImageSignals;
   readonly detail: ImageReferenceImageSignals;
 }
@@ -151,7 +147,7 @@ const imageReferencesRealtimeReady$ = computed((get) => {
   return createDeferredPromise<void>(get(rootSignal$));
 });
 
-export const imageReferencesEnabled$ = computed((get): boolean => {
+const imageReferencesEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.ReferenceImages] === true;
 });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/image-reference-library.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/image-reference-library.test.tsx
@@ -3,7 +3,7 @@ import {
   imageReferencesContract,
   type CreateImageReferenceBody,
   type ImageReference,
-  type ImageReferencePreviewAsset,
+  type ImageReferencePreviewUrl,
   type UpdateImageReferenceBody,
 } from "@okouai/api-contracts/contracts/image-references";
 import { uploadsContract } from "@okouai/api-contracts/contracts/uploads";
@@ -17,7 +17,6 @@ import { setMockOrgMembers } from "../../../mocks/handlers/api-org-members.ts";
 import { agentChatComposerSignals$ } from "../../../signals/okou-page/agent-composer-signals.ts";
 import type { ImageReferenceLibrarySignals } from "../../../signals/okou-page/image-reference-library.ts";
 import { mockNow, now } from "../../../lib/time.ts";
-import { createChildAbortController } from "../../../signals/utils.ts";
 import {
   AGENT_ID,
   context,
@@ -64,14 +63,11 @@ function createReference(options: {
     contentType: "image/png",
     width: 1280,
     height: 720,
-    previewAsset: {
-      previewAssetId: `image-reference:${id}:source`,
-      url:
-        options.previewUrl ??
-        `https://preview.example.test/references/${id}/initial.png`,
-      expiresAt:
-        options.expiresAt ?? new Date(now() + 15 * 60 * 1000).toISOString(),
-    },
+    previewUrl:
+      options.previewUrl ??
+      `https://preview.example.test/references/${id}/initial.png`,
+    previewUrlExpiresAt:
+      options.expiresAt ?? new Date(now() + 15 * 60 * 1000).toISOString(),
     canManage: options.canManage ?? ownerUserId === USER_ID,
     canModerate: options.canModerate ?? false,
     createdAt: "2026-09-08T12:00:00.000Z",
@@ -96,7 +92,7 @@ interface ImageReferenceLibraryControl {
     readonly release: () => void;
   };
   replace(references: readonly ImageReference[]): void;
-  renew(asset: ImageReferencePreviewAsset): void;
+  renew(preview: ImageReferencePreviewUrl): void;
   moderateNextUpdate(): void;
 }
 
@@ -112,7 +108,7 @@ function installImageReferenceLibrary(
   const updates: ImageReferenceLibraryControl["requests"]["updates"] = [];
   const deletes: string[] = [];
   const previewResolutions: string[][] = [];
-  const renewedAssets = new Map<string, ImageReferencePreviewAsset>();
+  const renewedPreviews = new Map<string, ImageReferencePreviewUrl>();
   let nextListGate: {
     readonly started: ReturnType<typeof context.mocks.deferred<void>>;
     readonly release: ReturnType<typeof context.mocks.deferred<void>>;
@@ -141,18 +137,26 @@ function installImageReferenceLibrary(
   context.mocks.api(
     imageReferencesContract.resolvePreviewUrls,
     ({ body, respond }) => {
-      previewResolutions.push([...body.previewAssetIds]);
-      const assets = body.previewAssetIds.flatMap((previewAssetId) => {
-        const renewed = renewedAssets.get(previewAssetId);
+      previewResolutions.push([...body.referenceIds]);
+      const previews = body.referenceIds.flatMap((referenceId) => {
+        const renewed = renewedPreviews.get(referenceId);
         if (renewed) {
           return [renewed];
         }
         const reference = references.find((candidate) => {
-          return candidate.previewAsset.previewAssetId === previewAssetId;
+          return candidate.id === referenceId;
         });
-        return reference ? [reference.previewAsset] : [];
+        return reference
+          ? [
+              {
+                referenceId,
+                url: reference.previewUrl,
+                expiresAt: reference.previewUrlExpiresAt,
+              },
+            ]
+          : [];
       });
-      return respond(200, { assets });
+      return respond(200, { previews });
     },
   );
   context.mocks.api(imageReferencesContract.create, ({ body, respond }) => {
@@ -231,8 +235,8 @@ function installImageReferenceLibrary(
     replace(nextReferences) {
       references = [...nextReferences];
     },
-    renew(asset) {
-      renewedAssets.set(asset.previewAssetId, asset);
+    renew(preview) {
+      renewedPreviews.set(preview.referenceId, preview);
     },
     moderateNextUpdate() {
       moderateNextUpdate = true;
@@ -451,7 +455,7 @@ test("create, rename, share, moderate, and delete through API boundaries", async
   ).resolves.toBeNull();
 });
 
-test("renew preview URLs by asset identity while retaining the loaded image", async () => {
+test("renew preview URLs by reference identity while retaining the loaded image", async () => {
   mockNow(new Date("2026-09-08T15:50:00.000Z"), context.signal);
   const initial = createReference({
     index: 6,
@@ -465,8 +469,8 @@ test("renew preview URLs by asset identity while retaining the loaded image", as
     throw new Error("Expected an image reference picker item");
   }
   const loaded = {
-    desiredUrl: initial.previewAsset.url,
-    sourceUrl: initial.previewAsset.url,
+    desiredUrl: initial.previewUrl,
+    sourceUrl: initial.previewUrl,
     slot: "a" as const,
   };
   await context.store.set(
@@ -476,7 +480,7 @@ test("renew preview URLs by asset identity while retaining the loaded image", as
   );
 
   const renewed = {
-    ...initial.previewAsset,
+    referenceId: initial.id,
     url: "https://preview.example.test/renewed.png",
     expiresAt: "2026-09-08T16:15:00.000Z",
   };
@@ -493,9 +497,7 @@ test("renew preview URLs by asset identity while retaining the loaded image", as
   expect(context.store.get(item.imageBuffers.card.state$).active).toStrictEqual(
     loaded,
   );
-  expect(control.requests.previewResolutions).toStrictEqual([
-    [initial.previewAsset.previewAssetId],
-  ]);
+  expect(control.requests.previewResolutions).toStrictEqual([[initial.id]]);
   const refreshedItem = (await context.store.get(library.pickerItems$))[0];
   expect(refreshedItem?.imageBuffers).toBe(item.imageBuffers);
 });
@@ -518,8 +520,8 @@ test("apply user and organization invalidations and evict inaccessible state", a
     throw new Error("Expected an owner picker item");
   }
   const loaded = {
-    desiredUrl: own.previewAsset.url,
-    sourceUrl: own.previewAsset.url,
+    desiredUrl: own.previewUrl,
+    sourceUrl: own.previewUrl,
     slot: "a" as const,
   };
   await context.store.set(
@@ -551,25 +553,24 @@ test("apply user and organization invalidations and evict inaccessible state", a
   ).toStrictEqual(loaded);
 });
 
-test("upload a private artifact and create a row without composer or thread side effects", async () => {
+test("upload an image-reference source and create a row without composer or thread side effects", async () => {
   const { chat, control, library } = await setupImageReferencePage([]);
   let completed = 0;
-  context.mocks.api(uploadsContract.prepare, ({ body, respond }) => {
-    expect(body).toMatchObject({
-      filename: "canonical.png",
-      contentType: "image/png",
-      purpose: "image-reference",
-    });
-    return respond(200, {
-      id: sourceFileId(2),
-      filename: body.filename,
-      contentType: body.contentType,
-      size: body.size,
-      url: `https://files.example.test/${sourceFileId(2)}`,
-      uploadUrl: "https://uploads.example.test/canonical.png",
-      uploadHeaders: { "x-upload-token": "private" },
-    });
-  });
+  context.mocks.api(
+    imageReferencesContract.prepareUpload,
+    ({ body, respond }) => {
+      expect(body).toStrictEqual({
+        filename: "canonical.png",
+        contentType: "image/png",
+        size: 9,
+      });
+      return respond(200, {
+        sourceFileId: sourceFileId(2),
+        uploadUrl: "https://uploads.example.test/canonical.png",
+        uploadHeaders: { "x-upload-token": "private" },
+      });
+    },
+  );
   context.mocks.http.put(
     "https://uploads.example.test/canonical.png",
     ({ request }) => {
@@ -622,110 +623,21 @@ test("upload a private artifact and create a row without composer or thread side
   expect(chat.runPrompts).toStrictEqual([]);
 });
 
-test("cancel multipart upload cleanup and retry without sending chat", async () => {
-  const { chat, control, library } = await setupImageReferencePage([]);
-  const firstPutStarted = context.mocks.deferred<void>();
-  const cancelledPut = context.mocks.deferred<void>();
-  let prepareCount = 0;
-  let abortCount = 0;
-  let completeCount = 0;
-  context.mocks.api(uploadsContract.prepare, ({ body, respond }) => {
-    prepareCount += 1;
-    if (prepareCount === 1) {
-      return respond(200, {
-        id: sourceFileId(3),
-        filename: body.filename,
-        contentType: body.contentType,
-        size: body.size,
-        url: `https://files.example.test/${sourceFileId(3)}`,
-        multipart: {
-          uploadId: "multipart-cancelled",
-          partSize: body.size,
-          parts: [
-            {
-              partNumber: 1,
-              uploadUrl: "https://uploads.example.test/cancelled-part",
-            },
-          ],
-        },
-      });
-    }
-    return respond(200, {
-      id: sourceFileId(4),
-      filename: body.filename,
-      contentType: body.contentType,
-      size: body.size,
-      url: `https://files.example.test/${sourceFileId(4)}`,
-      uploadUrl: "https://uploads.example.test/retry.png",
-      uploadHeaders: {},
-    });
-  });
-  context.mocks.http.put(
-    "https://uploads.example.test/cancelled-part",
-    async ({ request }) => {
-      firstPutStarted.resolve();
-      request.signal.addEventListener(
-        "abort",
-        () => {
-          cancelledPut.reject(request.signal.reason);
-        },
-        { once: true },
-      );
-      await cancelledPut.promise;
-      return new HttpResponse(null, { status: 500 });
-    },
-  );
-  context.mocks.http.put("https://uploads.example.test/retry.png", () => {
-    return new HttpResponse(null, { status: 200 });
-  });
-  context.mocks.api(uploadsContract.abortMultipart, ({ respond }) => {
-    abortCount += 1;
-    return respond(200, { id: sourceFileId(3) });
-  });
-  context.mocks.api(uploadsContract.complete, ({ body, respond }) => {
-    completeCount += 1;
-    return respond(200, {
-      id: body.id,
-      filename: "retry.png",
-      contentType: "image/png",
-      size: 5,
-      url: `https://files.example.test/${body.id}`,
-    });
-  });
+test("reject unsupported source formats before preparing an upload", async () => {
+  const { control, library } = await setupImageReferencePage([]);
 
-  const largeFile = new File(["first"], "cancelled.png", {
-    type: "image/png",
-  });
-  Object.defineProperty(largeFile, "size", {
-    configurable: true,
-    value: 6 * 1024 * 1024,
-  });
-  const operation = createChildAbortController(context.signal);
-  const cancelled = context.store.set(
-    library.uploadAndCreate$,
-    { file: largeFile, title: "Cancelled", visibility: "private" },
-    operation.signal,
-  );
-  await firstPutStarted.promise;
-  operation.abort(new DOMException("Upload cancelled", "AbortError"));
-  await expect(cancelled).rejects.toMatchObject({ name: "AbortError" });
-  await waitFor(() => {
-    expect(abortCount).toBe(1);
-  });
+  await expect(
+    context.store.set(
+      library.uploadAndCreate$,
+      {
+        file: new File(["document"], "reference.pdf", {
+          type: "application/pdf",
+        }),
+        title: "Unsupported",
+        visibility: "private",
+      },
+      context.signal,
+    ),
+  ).rejects.toThrow("Image must be a PNG, JPEG, or WebP file");
   expect(control.requests.creates).toStrictEqual([]);
-
-  await context.store.set(
-    library.uploadAndCreate$,
-    {
-      file: new File(["retry"], "retry.png", { type: "image/png" }),
-      title: "Retried",
-      visibility: "private",
-    },
-    context.signal,
-  );
-  expect(completeCount).toBe(1);
-  expect(control.requests.creates).toHaveLength(1);
-  expect(chat.sentMessages).toStrictEqual([]);
-  expect(chat.threadCreates).toStrictEqual([]);
-  expect(chat.runPrompts).toStrictEqual([]);
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/image-reference-library.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/image-reference-library.test.tsx
@@ -1,0 +1,726 @@
+import { screen, waitFor } from "@testing-library/react";
+import {
+  imageReferencesContract,
+  type CreateImageReferenceBody,
+  type ImageReference,
+  type ImageReferencePreviewAsset,
+  type UpdateImageReferenceBody,
+} from "@okouai/api-contracts/contracts/image-references";
+import { uploadsContract } from "@okouai/api-contracts/contracts/uploads";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse } from "msw";
+import { expect, test } from "vitest";
+
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { setMockOrgMembers } from "../../../mocks/handlers/api-org-members.ts";
+import { agentChatComposerSignals$ } from "../../../signals/okou-page/agent-composer-signals.ts";
+import type { ImageReferenceLibrarySignals } from "../../../signals/okou-page/image-reference-library.ts";
+import { mockNow, now } from "../../../lib/time.ts";
+import { createChildAbortController } from "../../../signals/utils.ts";
+import {
+  AGENT_ID,
+  context,
+  mockTemplateChat,
+} from "./chat-composer-template-gallery-test-helpers.ts";
+
+const USER_ID = "test-user-123";
+const ORG_ID = "org_default";
+const OTHER_USER_ID = "test-user-456";
+const REFERENCE_TOPIC = "imageReferencesChanged";
+
+function referenceId(index: number): string {
+  return `10000000-0000-4000-a000-${index.toString().padStart(12, "0")}`;
+}
+
+function sourceFileId(index: number): string {
+  return `20000000-0000-4000-a000-${index.toString().padStart(12, "0")}`;
+}
+
+function createReference(options: {
+  readonly index: number;
+  readonly title: string;
+  readonly ownerUserId?: string;
+  readonly visibility?: "private" | "public";
+  readonly canManage?: boolean;
+  readonly canModerate?: boolean;
+  readonly previewUrl?: string;
+  readonly expiresAt?: string;
+  readonly updatedAt?: string;
+}): ImageReference {
+  const id = referenceId(options.index);
+  const ownerUserId = options.ownerUserId ?? USER_ID;
+  return {
+    id,
+    title: options.title,
+    visibility: options.visibility ?? "private",
+    ownerUserId,
+    sourceFilename: `${options.title}.png`,
+    contentType: "image/png",
+    width: 1280,
+    height: 720,
+    previewAsset: {
+      previewAssetId: `image-reference:${id}:source`,
+      url:
+        options.previewUrl ??
+        `https://preview.example.test/references/${id}/initial.png`,
+      expiresAt:
+        options.expiresAt ?? new Date(now() + 15 * 60 * 1000).toISOString(),
+    },
+    canManage: options.canManage ?? ownerUserId === USER_ID,
+    canModerate: options.canModerate ?? false,
+    createdAt: "2026-09-08T12:00:00.000Z",
+    updatedAt: options.updatedAt ?? "2026-09-08T12:00:00.000Z",
+  };
+}
+
+interface ImageReferenceLibraryControl {
+  readonly requests: {
+    readonly creates: CreateImageReferenceBody[];
+    readonly updates: {
+      readonly referenceId: string;
+      readonly body: UpdateImageReferenceBody;
+    }[];
+    readonly deletes: string[];
+    readonly previewResolutions: string[][];
+    readonly listCount: number;
+  };
+  readonly subscriptionsWereReady: () => boolean;
+  deferNextList(): {
+    readonly started: Promise<void>;
+    readonly release: () => void;
+  };
+  replace(references: readonly ImageReference[]): void;
+  renew(asset: ImageReferencePreviewAsset): void;
+  moderateNextUpdate(): void;
+}
+
+function installImageReferenceLibrary(
+  initialReferences: readonly ImageReference[],
+): ImageReferenceLibraryControl {
+  let references = [...initialReferences];
+  let listCount = 0;
+  let subscriptionsWereReady = false;
+  let nextCreateIndex = 900;
+  let moderateNextUpdate = false;
+  const creates: CreateImageReferenceBody[] = [];
+  const updates: ImageReferenceLibraryControl["requests"]["updates"] = [];
+  const deletes: string[] = [];
+  const previewResolutions: string[][] = [];
+  const renewedAssets = new Map<string, ImageReferencePreviewAsset>();
+  let nextListGate: {
+    readonly started: ReturnType<typeof context.mocks.deferred<void>>;
+    readonly release: ReturnType<typeof context.mocks.deferred<void>>;
+  } | null = null;
+
+  context.mocks.api(imageReferencesContract.list, async ({ respond }) => {
+    listCount += 1;
+    subscriptionsWereReady ||=
+      context.mocks.ably.hasSubscriptionOnChannel(
+        `user:${USER_ID}`,
+        REFERENCE_TOPIC,
+      ) &&
+      context.mocks.ably.hasSubscriptionOnChannel(
+        `org:${ORG_ID}`,
+        REFERENCE_TOPIC,
+      );
+    const snapshot = [...references];
+    const gate = nextListGate;
+    nextListGate = null;
+    if (gate) {
+      gate.started.resolve();
+      await gate.release.promise;
+    }
+    return respond(200, snapshot);
+  });
+  context.mocks.api(
+    imageReferencesContract.resolvePreviewUrls,
+    ({ body, respond }) => {
+      previewResolutions.push([...body.previewAssetIds]);
+      const assets = body.previewAssetIds.flatMap((previewAssetId) => {
+        const renewed = renewedAssets.get(previewAssetId);
+        if (renewed) {
+          return [renewed];
+        }
+        const reference = references.find((candidate) => {
+          return candidate.previewAsset.previewAssetId === previewAssetId;
+        });
+        return reference ? [reference.previewAsset] : [];
+      });
+      return respond(200, { assets });
+    },
+  );
+  context.mocks.api(imageReferencesContract.create, ({ body, respond }) => {
+    creates.push(body);
+    nextCreateIndex += 1;
+    const created = createReference({
+      index: nextCreateIndex,
+      title: body.title,
+      visibility: body.visibility,
+    });
+    references = [created, ...references];
+    return respond(201, created);
+  });
+  context.mocks.api(
+    imageReferencesContract.update,
+    ({ params, body, respond }) => {
+      updates.push({ referenceId: params.referenceId, body });
+      const previous = references.find((candidate) => {
+        return candidate.id === params.referenceId;
+      });
+      if (!previous) {
+        return respond(404, {
+          error: { code: "NOT_FOUND", message: "Image reference not found" },
+        });
+      }
+      if (moderateNextUpdate) {
+        moderateNextUpdate = false;
+        references = references.filter((candidate) => {
+          return candidate.id !== params.referenceId;
+        });
+        return respond(204);
+      }
+      const updated = {
+        ...previous,
+        ...body,
+        updatedAt: "2026-09-08T12:01:00.000Z",
+      };
+      references = references.map((candidate) => {
+        return candidate.id === updated.id ? updated : candidate;
+      });
+      return respond(200, updated);
+    },
+  );
+  context.mocks.api(imageReferencesContract.delete, ({ params, respond }) => {
+    deletes.push(params.referenceId);
+    references = references.filter((candidate) => {
+      return candidate.id !== params.referenceId;
+    });
+    return respond(204);
+  });
+
+  return {
+    requests: {
+      creates,
+      updates,
+      deletes,
+      previewResolutions,
+      get listCount() {
+        return listCount;
+      },
+    },
+    subscriptionsWereReady: () => {
+      return subscriptionsWereReady;
+    },
+    deferNextList() {
+      const started = context.mocks.deferred<void>();
+      const release = context.mocks.deferred<void>();
+      nextListGate = { started, release };
+      return {
+        started: started.promise,
+        release: () => {
+          release.resolve();
+        },
+      };
+    },
+    replace(nextReferences) {
+      references = [...nextReferences];
+    },
+    renew(asset) {
+      renewedAssets.set(asset.previewAssetId, asset);
+    },
+    moderateNextUpdate() {
+      moderateNextUpdate = true;
+    },
+  };
+}
+
+function imageReferenceLibrary(): ImageReferenceLibrarySignals {
+  return context.store.get(agentChatComposerSignals$).template.imageReference;
+}
+
+async function setupImageReferencePage(
+  references: readonly ImageReference[],
+): Promise<{
+  readonly chat: ReturnType<typeof mockTemplateChat>;
+  readonly control: ImageReferenceLibraryControl;
+  readonly library: ImageReferenceLibrarySignals;
+}> {
+  const chat = mockTemplateChat();
+  const control = installImageReferenceLibrary(references);
+  setMockOrgMembers({
+    members: [
+      {
+        userId: USER_ID,
+        email: "owner@example.test",
+        firstName: "Olivia",
+        lastName: "Owner",
+        imageUrl: "https://images.example.test/owner.png",
+        role: "admin",
+        joinedAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        userId: OTHER_USER_ID,
+        email: "creator@example.test",
+        firstName: "Casey",
+        lastName: "Creator",
+        imageUrl: "https://images.example.test/creator.png",
+        role: "member",
+        joinedAt: "2026-01-02T00:00:00.000Z",
+      },
+    ],
+  });
+  await setupPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+    featureSwitches: { [FeatureSwitchKey.ReferenceImages]: true },
+  });
+  return { chat, control, library: imageReferenceLibrary() };
+}
+
+async function waitForTitles(
+  signal: ImageReferenceLibrarySignals["references$"],
+  expected: readonly string[],
+): Promise<void> {
+  await waitFor(async () => {
+    expect(
+      (await context.store.get(signal)).map((reference) => {
+        return reference.title;
+      }),
+    ).toStrictEqual(expected);
+  });
+}
+
+function triggerReferenceEvent(scope: "user" | "org"): void {
+  context.mocks.ably.triggerOnChannel(
+    `${scope}:${scope === "user" ? USER_ID : ORG_ID}`,
+    REFERENCE_TOPIC,
+    {},
+  );
+}
+
+test("load owner and organization catalogs only after both realtime subscriptions", async () => {
+  const own = createReference({ index: 1, title: "My watercolor" });
+  const shared = createReference({
+    index: 2,
+    title: "Studio collage",
+    ownerUserId: OTHER_USER_ID,
+    visibility: "public",
+  });
+  const { control, library } = await setupImageReferencePage([own, shared]);
+
+  const ownReferences = await context.store.get(library.ownReferences$);
+  expect(
+    ownReferences.map(({ title }) => {
+      return title;
+    }),
+  ).toStrictEqual(["My watercolor"]);
+  const organizationReferences = await context.store.get(
+    library.organizationReferences$,
+  );
+  expect(
+    organizationReferences.map(({ title }) => {
+      return title;
+    }),
+  ).toStrictEqual(["Studio collage"]);
+  const pickerItems = await context.store.get(library.pickerItems$);
+  expect(
+    pickerItems.map(({ reference }) => {
+      return reference.title;
+    }),
+  ).toStrictEqual(["My watercolor", "Studio collage"]);
+  expect(pickerItems[1]?.creator).toMatchObject({
+    userId: OTHER_USER_ID,
+    displayName: "Casey Creator",
+  });
+  expect(control.requests.listCount).toBeGreaterThan(0);
+  expect(control.subscriptionsWereReady()).toBeTruthy();
+});
+
+test("catch an invalidation that arrives during the baseline request", async () => {
+  mockTemplateChat();
+  const baseline = createReference({ index: 10, title: "Baseline" });
+  const added = createReference({ index: 11, title: "Arrived during fetch" });
+  const control = installImageReferenceLibrary([baseline]);
+  const gate = control.deferNextList();
+  const page = setupPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+    featureSwitches: { [FeatureSwitchKey.ReferenceImages]: true },
+  });
+
+  await gate.started;
+  control.replace([added, baseline]);
+  triggerReferenceEvent("user");
+  gate.release();
+  await page;
+  const library = imageReferenceLibrary();
+  await waitForTitles(library.ownReferences$, [
+    "Arrived during fetch",
+    "Baseline",
+  ]);
+  expect(control.requests.listCount).toBeGreaterThanOrEqual(2);
+});
+
+test("keep the disabled switch on the existing no-library path", async () => {
+  mockTemplateChat();
+  const control = installImageReferenceLibrary([
+    createReference({ index: 3, title: "Hidden" }),
+  ]);
+  await setupPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+    featureSwitches: { [FeatureSwitchKey.ReferenceImages]: false },
+  });
+
+  const library = imageReferenceLibrary();
+  expect(context.store.get(library.enabled$)).toBeFalsy();
+  await expect(context.store.get(library.references$)).resolves.toStrictEqual(
+    [],
+  );
+  expect(control.requests.listCount).toBe(0);
+  expect(
+    context.mocks.ably.hasSubscriptionOnChannel(
+      `user:${USER_ID}`,
+      REFERENCE_TOPIC,
+    ),
+  ).toBeFalsy();
+});
+
+test("create, rename, share, moderate, and delete through API boundaries", async () => {
+  const owned = createReference({ index: 4, title: "Owned" });
+  const shared = createReference({
+    index: 5,
+    title: "Shared",
+    ownerUserId: OTHER_USER_ID,
+    visibility: "public",
+    canManage: false,
+    canModerate: true,
+  });
+  const { control, library } = await setupImageReferencePage([owned, shared]);
+
+  const created = await context.store.set(
+    library.create$,
+    {
+      sourceFileId: sourceFileId(1),
+      title: "New reference",
+      visibility: "private",
+    },
+    context.signal,
+  );
+  await context.store.set(
+    library.rename$,
+    created.id,
+    "Renamed reference",
+    context.signal,
+  );
+  await context.store.set(
+    library.setVisibility$,
+    created.id,
+    "public",
+    context.signal,
+  );
+  control.moderateNextUpdate();
+  await context.store.set(library.adminUnshare$, shared.id, context.signal);
+  await context.store.set(library.delete$, owned.id, context.signal);
+
+  await waitForTitles(library.ownReferences$, ["Renamed reference"]);
+  await expect(
+    context.store.get(library.organizationReferences$),
+  ).resolves.toStrictEqual([]);
+  expect(control.requests.creates).toStrictEqual([
+    {
+      sourceFileId: sourceFileId(1),
+      title: "New reference",
+      visibility: "private",
+    },
+  ]);
+  expect(control.requests.updates).toStrictEqual([
+    { referenceId: created.id, body: { title: "Renamed reference" } },
+    { referenceId: created.id, body: { visibility: "public" } },
+    { referenceId: shared.id, body: { visibility: "private" } },
+  ]);
+  expect(control.requests.deletes).toStrictEqual([owned.id]);
+  await expect(
+    context.store.get(library.resolve(shared.id)),
+  ).resolves.toBeNull();
+});
+
+test("renew preview URLs by asset identity while retaining the loaded image", async () => {
+  mockNow(new Date("2026-09-08T15:50:00.000Z"), context.signal);
+  const initial = createReference({
+    index: 6,
+    title: "Buffered preview",
+    previewUrl: "https://preview.example.test/old.png",
+    expiresAt: "2026-09-08T16:00:00.000Z",
+  });
+  const { control, library } = await setupImageReferencePage([initial]);
+  const [item] = await context.store.get(library.pickerItems$);
+  if (!item) {
+    throw new Error("Expected an image reference picker item");
+  }
+  const loaded = {
+    desiredUrl: initial.previewAsset.url,
+    sourceUrl: initial.previewAsset.url,
+    slot: "a" as const,
+  };
+  await context.store.set(
+    item.imageBuffers.card.commitLoadedImage$,
+    loaded,
+    context.signal,
+  );
+
+  const renewed = {
+    ...initial.previewAsset,
+    url: "https://preview.example.test/renewed.png",
+    expiresAt: "2026-09-08T16:15:00.000Z",
+  };
+  control.renew(renewed);
+  mockNow(new Date("2026-09-08T15:59:30.000Z"), context.signal);
+  await context.store.set(
+    library.refreshPreviewUrlsIfExpiring$,
+    context.signal,
+  );
+
+  await expect(
+    context.store.get(item.imageBuffers.card.desiredUrl$),
+  ).resolves.toBe(renewed.url);
+  expect(context.store.get(item.imageBuffers.card.state$).active).toStrictEqual(
+    loaded,
+  );
+  expect(control.requests.previewResolutions).toStrictEqual([
+    [initial.previewAsset.previewAssetId],
+  ]);
+  const refreshedItem = (await context.store.get(library.pickerItems$))[0];
+  expect(refreshedItem?.imageBuffers).toBe(item.imageBuffers);
+});
+
+test("apply user and organization invalidations and evict inaccessible state", async () => {
+  const own = createReference({ index: 7, title: "Owned baseline" });
+  const shared = createReference({
+    index: 8,
+    title: "Organization baseline",
+    ownerUserId: OTHER_USER_ID,
+    visibility: "public",
+  });
+  const { control, library } = await setupImageReferencePage([own, shared]);
+  const sharedResolution$ = library.resolve(shared.id);
+  await expect(context.store.get(sharedResolution$)).resolves.toMatchObject({
+    id: shared.id,
+  });
+  const ownPickerItem = (await context.store.get(library.pickerItems$))[0];
+  if (!ownPickerItem) {
+    throw new Error("Expected an owner picker item");
+  }
+  const loaded = {
+    desiredUrl: own.previewAsset.url,
+    sourceUrl: own.previewAsset.url,
+    slot: "a" as const,
+  };
+  await context.store.set(
+    ownPickerItem.imageBuffers.card.commitLoadedImage$,
+    loaded,
+    context.signal,
+  );
+
+  const added = createReference({ index: 9, title: "Second owned" });
+  control.replace([added, own, shared]);
+  triggerReferenceEvent("user");
+  await waitForTitles(library.ownReferences$, [
+    "Second owned",
+    "Owned baseline",
+  ]);
+
+  control.replace([added, own]);
+  triggerReferenceEvent("org");
+  await waitForTitles(library.organizationReferences$, []);
+  await expect(context.store.get(sharedResolution$)).resolves.toBeNull();
+  const retained = (await context.store.get(library.pickerItems$)).find(
+    ({ reference }) => {
+      return reference.id === own.id;
+    },
+  );
+  expect(retained?.imageBuffers).toBe(ownPickerItem.imageBuffers);
+  expect(
+    retained && context.store.get(retained.imageBuffers.card.state$).active,
+  ).toStrictEqual(loaded);
+});
+
+test("upload a private artifact and create a row without composer or thread side effects", async () => {
+  const { chat, control, library } = await setupImageReferencePage([]);
+  let completed = 0;
+  context.mocks.api(uploadsContract.prepare, ({ body, respond }) => {
+    expect(body).toMatchObject({
+      filename: "canonical.png",
+      contentType: "image/png",
+      purpose: "image-reference",
+    });
+    return respond(200, {
+      id: sourceFileId(2),
+      filename: body.filename,
+      contentType: body.contentType,
+      size: body.size,
+      url: `https://files.example.test/${sourceFileId(2)}`,
+      uploadUrl: "https://uploads.example.test/canonical.png",
+      uploadHeaders: { "x-upload-token": "private" },
+    });
+  });
+  context.mocks.http.put(
+    "https://uploads.example.test/canonical.png",
+    ({ request }) => {
+      expect(request.headers.get("x-upload-token")).toBe("private");
+      return new HttpResponse(null, { status: 200 });
+    },
+  );
+  context.mocks.api(uploadsContract.complete, ({ body, respond }) => {
+    completed += 1;
+    return respond(200, {
+      id: body.id,
+      filename: "canonical.png",
+      contentType: "image/png",
+      size: 9,
+      url: `https://files.example.test/${body.id}`,
+    });
+  });
+  const composer = await screen.findByRole("textbox", { name: "Message" });
+  await userEvent.type(composer, "Keep this draft");
+
+  await context.store.set(
+    library.uploadAndCreate$,
+    {
+      file: new File(["canonical"], "canonical.png", { type: "image/png" }),
+      title: "Canonical image",
+      visibility: "private",
+    },
+    context.signal,
+  );
+
+  expect(completed).toBe(1);
+  expect(control.requests.creates).toStrictEqual([
+    {
+      sourceFileId: sourceFileId(2),
+      title: "Canonical image",
+      visibility: "private",
+    },
+  ]);
+  expect(
+    context.store.get(agentChatComposerSignals$).draft.attachments$,
+  ).toBeDefined();
+  expect(
+    context.store.get(
+      context.store.get(agentChatComposerSignals$).draft.attachments$,
+    ),
+  ).toStrictEqual([]);
+  expect(composer).toHaveTextContent("Keep this draft");
+  expect(chat.sentMessages).toStrictEqual([]);
+  expect(chat.threadCreates).toStrictEqual([]);
+  expect(chat.runPrompts).toStrictEqual([]);
+});
+
+test("cancel multipart upload cleanup and retry without sending chat", async () => {
+  const { chat, control, library } = await setupImageReferencePage([]);
+  const firstPutStarted = context.mocks.deferred<void>();
+  const cancelledPut = context.mocks.deferred<void>();
+  let prepareCount = 0;
+  let abortCount = 0;
+  let completeCount = 0;
+  context.mocks.api(uploadsContract.prepare, ({ body, respond }) => {
+    prepareCount += 1;
+    if (prepareCount === 1) {
+      return respond(200, {
+        id: sourceFileId(3),
+        filename: body.filename,
+        contentType: body.contentType,
+        size: body.size,
+        url: `https://files.example.test/${sourceFileId(3)}`,
+        multipart: {
+          uploadId: "multipart-cancelled",
+          partSize: body.size,
+          parts: [
+            {
+              partNumber: 1,
+              uploadUrl: "https://uploads.example.test/cancelled-part",
+            },
+          ],
+        },
+      });
+    }
+    return respond(200, {
+      id: sourceFileId(4),
+      filename: body.filename,
+      contentType: body.contentType,
+      size: body.size,
+      url: `https://files.example.test/${sourceFileId(4)}`,
+      uploadUrl: "https://uploads.example.test/retry.png",
+      uploadHeaders: {},
+    });
+  });
+  context.mocks.http.put(
+    "https://uploads.example.test/cancelled-part",
+    async ({ request }) => {
+      firstPutStarted.resolve();
+      request.signal.addEventListener(
+        "abort",
+        () => {
+          cancelledPut.reject(request.signal.reason);
+        },
+        { once: true },
+      );
+      await cancelledPut.promise;
+      return new HttpResponse(null, { status: 500 });
+    },
+  );
+  context.mocks.http.put("https://uploads.example.test/retry.png", () => {
+    return new HttpResponse(null, { status: 200 });
+  });
+  context.mocks.api(uploadsContract.abortMultipart, ({ respond }) => {
+    abortCount += 1;
+    return respond(200, { id: sourceFileId(3) });
+  });
+  context.mocks.api(uploadsContract.complete, ({ body, respond }) => {
+    completeCount += 1;
+    return respond(200, {
+      id: body.id,
+      filename: "retry.png",
+      contentType: "image/png",
+      size: 5,
+      url: `https://files.example.test/${body.id}`,
+    });
+  });
+
+  const largeFile = new File(["first"], "cancelled.png", {
+    type: "image/png",
+  });
+  Object.defineProperty(largeFile, "size", {
+    configurable: true,
+    value: 6 * 1024 * 1024,
+  });
+  const operation = createChildAbortController(context.signal);
+  const cancelled = context.store.set(
+    library.uploadAndCreate$,
+    { file: largeFile, title: "Cancelled", visibility: "private" },
+    operation.signal,
+  );
+  await firstPutStarted.promise;
+  operation.abort(new DOMException("Upload cancelled", "AbortError"));
+  await expect(cancelled).rejects.toMatchObject({ name: "AbortError" });
+  await waitFor(() => {
+    expect(abortCount).toBe(1);
+  });
+  expect(control.requests.creates).toStrictEqual([]);
+
+  await context.store.set(
+    library.uploadAndCreate$,
+    {
+      file: new File(["retry"], "retry.png", { type: "image/png" }),
+      title: "Retried",
+      visibility: "private",
+    },
+    context.signal,
+  );
+  expect(completeCount).toBe(1);
+  expect(control.requests.creates).toHaveLength(1);
+  expect(chat.sentMessages).toStrictEqual([]);
+  expect(chat.threadCreates).toStrictEqual([]);
+  expect(chat.runPrompts).toStrictEqual([]);
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/image-reference-library.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/image-reference-library.test.tsx
@@ -55,6 +55,11 @@ function createReference(options: {
     title: options.title,
     visibility: options.visibility ?? "private",
     ownerUserId,
+    creator: {
+      userId: ownerUserId,
+      displayName: null,
+      imageUrl: null,
+    },
     sourceFilename: `${options.title}.png`,
     contentType: "image/png",
     width: 1280,

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -6808,12 +6808,22 @@ function ComposerImportedTemplateUrlRefreshLifecycle({
   const setImportedTemplateUrlRefreshLifecycleRef = useSet(
     signals.template.importedPresentationTemplateUrlRefreshLifecycleRef$,
   );
+  const setImageReferenceLifecycleRef = useSet(
+    signals.template.imageReference.lifecycleRef$,
+  );
   return (
-    <span
-      ref={setImportedTemplateUrlRefreshLifecycleRef}
-      aria-hidden="true"
-      className="pointer-events-none absolute size-px overflow-hidden opacity-0"
-    />
+    <>
+      <span
+        ref={setImportedTemplateUrlRefreshLifecycleRef}
+        aria-hidden="true"
+        className="pointer-events-none absolute size-px overflow-hidden opacity-0"
+      />
+      <span
+        ref={setImageReferenceLifecycleRef}
+        aria-hidden="true"
+        className="pointer-events-none absolute size-px overflow-hidden opacity-0"
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
## Stack

Review in order: [#32712](https://github.com/vm0-ai/vm0/pull/32712) → [#32713](https://github.com/vm0-ai/vm0/pull/32713) → [#32714](https://github.com/vm0-ai/vm0/pull/32714) → [#32709](https://github.com/vm0-ai/vm0/pull/32709) → [#32715](https://github.com/vm0-ai/vm0/pull/32715).

- **PR 4 of 5**
- Base: `feat/image-reference-chat-runtime`
- Head: `feat/image-reference-platform-library`
- Part of #32442

## Behavior

- adds a composer-owned image-reference catalog with derived owner and organization views
- subscribes to user and organization realtime invalidation before the baseline request
- resolves organization creator labels from existing member state
- keeps one bounded `referenceId → preview URL` cache, renews URLs before expiry, and preserves already-loaded images while the URL rotates
- evicts deleted or newly inaccessible references from catalog, detail, image, and preview state
- adds create, rename, visibility, admin-unshare, delete, and refresh commands through the image-reference contracts
- uploads sources through the dedicated image-reference prepare endpoint, then finalizes the private artifact through the existing completion endpoint
- keeps generic composer uploads free of image-reference branching and preserves their existing single/multipart behavior
- wires lifecycle ownership and realtime only; there is no visible picker entry point in this PR

## Compatibility

`ReferenceImages` remains disabled by default. When disabled, Platform does not load the catalog or subscribe to its realtime topic. Existing attachment upload request shapes remain unchanged.

## Verification

- Platform production/test/build-config type checks: passed on the final stack
- changed Platform ESLint, Oxlint, and type-aware Oxlint: passed
- style lint: passed
- focused preview-renewal, dedicated-upload, and unsupported-format tests: 3 passed
- `git diff --check`: passed
- repository-wide tests are delegated to the fresh PR CI run

No full local Vitest suite or dev server was run.

## Automation

- Draft PR only
- `pr-auto` was not invoked or attached
- no review requested and no merge attempted
