### PR TITLE
ci: make runner e2e junit artifact uploads non-blocking

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -581,6 +581,9 @@ run_step = runner.fetch("steps").find do |step|
   step.fetch("name", "").include?("Run runner E2E tests")
 end
 raise "missing runner E2E BATS execution" unless run_step
+if run_step.key?("continue-on-error")
+  raise "runner E2E BATS failures must remain blocking"
+end
 run_script = run_step.fetch("run")
 unless run_script.include?('mapfile -t test_files') &&
     run_script.include?('BATS_TEST_TIMEOUT=240 ./test/libs/bats/bin/bats') &&
@@ -604,10 +607,13 @@ unless runner.fetch("steps").any? do |step|
 end
 unless runner.fetch("steps").any? do |step|
     step["name"] == "Upload runner E2E JUnit XML" &&
+      step["continue-on-error"] == true &&
+      step["if"] == "${{ !cancelled() }}" &&
       step.dig("with", "name") == "e2e-runner-junit-${{ matrix.index }}" &&
+      step.dig("with", "path") == "e2e/results/runner-${{ matrix.index }}/" &&
       step.dig("with", "retention-days") == 7
   end
-  raise "every runner shard must upload its JUnit report"
+  raise "every runner shard must attempt a non-blocking JUnit upload unless cancelled"
 end
 
 cleanup_steps = account_cleanup.fetch("steps")

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2954,6 +2954,8 @@ jobs:
           report_type: test_results
       - name: Upload runner E2E JUnit XML
         if: ${{ !cancelled() }}
+        # JUnit artifacts are diagnostic; the BATS step determines test success.
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-runner-junit-${{ matrix.index }}


### PR DESCRIPTION
## Summary

- Make only `Upload runner E2E JUnit XML` best-effort, so an artifact service failure cannot turn passing Runner E2E tests into a failed job.
- Extend the existing workflow contract check to keep the JUnit upload non-blocking while preserving its cancellation condition and per-shard artifact contract, and keep BATS execution blocking.

Closes #32710

## Evidence and scope

[The reported job](https://github.com/vm0-ai/vm0/actions/runs/34249268196/job/102141508144) passed all three BATS tests and Codecov upload, then failed solely because GitHub `FinalizeArtifact` returned an intermediary HTTP 403. The same commit passed on rerun.

No changes to test selection, assertions, test/job timeouts, job-level failure policy, required CI gates, other upload steps, credentials, runtime code, or UI. The upload still runs unless cancelled and retains its existing action, per-shard name/path, and seven-day retention.

## Risk

A passing run may lack its downloadable JUnit artifact when reporting fails. Upload errors remain in step logs; BATS output, trace logging and the separate Codecov attempt are unchanged. This is explicit ownership of best-effort diagnostics, not a compatibility fallback or suppression of test failures.

## Validation

- `cd turbo && pnpm exec prettier --check ../.github/workflows/turbo.yml`
- `bash -n .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `shellcheck .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `codex-work/bin/actionlint .github/workflows/turbo.yml`
- `PATH="$PWD/codex-work/bin:$PATH" bash .github/scripts/check-workflow-shell-compatibility.sh`
- `bash .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `PATH="$PWD/codex-work/bin:$PATH" bash .github/scripts/tests/runner-lifecycle-ownership-workflow-test.sh`
- `bash .github/scripts/tests/clerk-test-resource-workflow-test.sh`
- Ran the updated workflow assertions against the old workflow via a pipe: correctly rejected the original blocking upload policy. An in-memory workflow variant tolerating BATS errors was also correctly rejected. No mutation fixtures or additional test harness were committed.
- `git diff --check`; commit hooks (file size and commitlint).

All selected local checks passed. GitHub's transient intermediary failure was not reproduced locally, and hosted CI is separate verification. No unrelated runtime suites were run for this workflow-only change.
