### PR TITLE
feat(image): resolve saved reference ids for built-in generation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -407,14 +407,13 @@ async function createImageReferenceViaApi(
 ): Promise<CreatedImageReference> {
   useImageReferenceActor(actor);
   const title = options?.title ?? "Generation reference";
-  const prepare = await app.request("/api/uploads/prepare", {
+  const prepare = await app.request("/api/image-references/uploads/prepare", {
     method: "POST",
     headers: authHeaders(),
     body: JSON.stringify({
       filename: "reference.png",
       contentType: "image/png",
       size: REFERENCE_IMAGE_BYTES.byteLength,
-      purpose: "image-reference",
     }),
   });
   expect(prepare.status).toBe(200);
@@ -422,8 +421,8 @@ async function createImageReferenceViaApi(
   if (
     typeof prepared !== "object" ||
     prepared === null ||
-    !("id" in prepared) ||
-    typeof prepared.id !== "string"
+    !("sourceFileId" in prepared) ||
+    typeof prepared.sourceFileId !== "string"
   ) {
     throw new Error("Expected a prepared reference upload");
   }
@@ -440,7 +439,7 @@ async function createImageReferenceViaApi(
         typeof metadata === "object" &&
         metadata !== null &&
         "artifact-id" in metadata &&
-        metadata["artifact-id"] === prepared.id
+        metadata["artifact-id"] === prepared.sourceFileId
       );
     });
   const uploadInput = s3CommandInput(uploadCommand);
@@ -452,7 +451,7 @@ async function createImageReferenceViaApi(
   }
   expect(bucket).toBe(PRIVATE_ARTIFACTS_BUCKET);
   storage.storedObjects.set(storedReferenceIdentity(bucket, key), {
-    id: prepared.id,
+    id: prepared.sourceFileId,
     bucket,
     key,
     contentType: "image/png",
@@ -462,7 +461,7 @@ async function createImageReferenceViaApi(
   const complete = await app.request("/api/uploads/complete", {
     method: "POST",
     headers: authHeaders(),
-    body: JSON.stringify({ id: prepared.id }),
+    body: JSON.stringify({ id: prepared.sourceFileId }),
   });
   expect(complete.status).toBe(200);
 
@@ -470,7 +469,7 @@ async function createImageReferenceViaApi(
     method: "POST",
     headers: authHeaders(),
     body: JSON.stringify({
-      sourceFileId: prepared.id,
+      sourceFileId: prepared.sourceFileId,
       title,
       visibility: options?.visibility ?? "private",
     }),

--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -1,12 +1,16 @@
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
+import { Readable } from "node:stream";
 
 import {
+  DeleteObjectsCommand,
+  GetObjectCommand,
   HeadObjectCommand,
   PutObjectCommand,
   type PutObjectCommandInput,
 } from "@aws-sdk/client-s3";
 import { billingStatusContract } from "@okouai/api-contracts/contracts/billing";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
 import { onTestFinished } from "vitest";
@@ -29,7 +33,11 @@ import { createDeferredPromise } from "../../utils";
 import { webhooksBuiltInGenerationRoutes } from "../webhooks-built-in-generations";
 import { billingStatusRoutes } from "../billing-status";
 import { builtInGenerationRoutes } from "../built-in-generation";
+import { featureSwitchesRoutes } from "../feature-switches";
 import { imageIoGenerateRoutes } from "../image-io-generate";
+import { imageReferencesRoutes } from "../image-references";
+import { uploadsCompleteRoutes } from "../uploads-complete";
+import { uploadsPrepareRoutes } from "../uploads-prepare";
 import { usageRecordRoutes } from "../usage-record";
 import {
   createUsagePricingFixture,
@@ -59,7 +67,12 @@ const context = testContext();
 const store = createStore();
 const mocks = createRouteMocks(context);
 const TEST_BUCKET = "test-user-artifacts";
+const PRIVATE_ARTIFACTS_BUCKET = "test-private-artifacts";
 const IMAGE_BYTES = Buffer.from("fake image bytes");
+const REFERENCE_IMAGE_BYTES = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Z0YQAAAAASUVORK5CYII=",
+  "base64",
+);
 const IMAGE_IO_MODEL = "gpt-image-1";
 const FAL_GPT_IMAGE_1_URL =
   "https://queue.fal.run/fal-ai/gpt-image-1/text-to-image";
@@ -176,6 +189,14 @@ const GPT_IMAGE_2_5_PRICING = GPT_IMAGE_2_5_MODELS.flatMap((provider) => {
   });
 }) satisfies readonly UsagePricingRow[];
 
+interface StoredReferenceObject {
+  readonly id: string;
+  readonly bucket: string;
+  readonly key: string;
+  readonly contentType: string;
+  readonly body: Buffer;
+}
+
 const tokenRequest = Object.freeze({
   keyName: "test-key",
   timestamp: 1_700_000_000_000,
@@ -227,10 +248,244 @@ function createImageIoTestApp(
       ...imageIoGenerateRoutes,
       ...webhooksBuiltInGenerationRoutes,
       ...billingStatusRoutes,
+      ...featureSwitchesRoutes,
+      ...uploadsPrepareRoutes,
+      ...uploadsCompleteRoutes,
+      ...imageReferencesRoutes,
       ...usageRecordRoutes,
     ],
     usagePricingResolution,
   });
+}
+
+type ImageIoTestApp = ReturnType<typeof createImageIoTestApp>;
+
+interface ImageReferenceActor {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly orgRole?: "org:admin" | "org:member";
+}
+
+interface CreatedImageReference {
+  readonly id: string;
+  readonly title: string;
+  readonly sourceKey: string;
+}
+
+function storedReferenceIdentity(bucket: string, key: string): string {
+  return `${bucket}\u0000${key}`;
+}
+
+function s3CommandInput(command: unknown): Record<string, unknown> {
+  if (
+    typeof command === "object" &&
+    command !== null &&
+    "input" in command &&
+    typeof command.input === "object" &&
+    command.input !== null
+  ) {
+    return command.input as Record<string, unknown>;
+  }
+  return {};
+}
+
+function deleteStoredReferenceObjects(
+  storedObjects: Map<string, StoredReferenceObject>,
+  bucket: string,
+  deletion: unknown,
+): void {
+  if (
+    typeof deletion !== "object" ||
+    deletion === null ||
+    !("Objects" in deletion) ||
+    !Array.isArray(deletion.Objects)
+  ) {
+    return;
+  }
+  for (const candidate of deletion.Objects) {
+    const key =
+      typeof candidate === "object" &&
+      candidate !== null &&
+      "Key" in candidate &&
+      typeof candidate.Key === "string"
+        ? candidate.Key
+        : null;
+    if (key) {
+      storedObjects.delete(storedReferenceIdentity(bucket, key));
+    }
+  }
+}
+
+function installReferenceStorageMock(): {
+  readonly events: string[];
+  readonly storedObjects: Map<string, StoredReferenceObject>;
+} {
+  const events: string[] = [];
+  const storedObjects = new Map<string, StoredReferenceObject>();
+  let sequence = 0;
+  context.mocks.s3.send.mockImplementation((command: unknown) => {
+    const input = s3CommandInput(command);
+    const bucket = typeof input.Bucket === "string" ? input.Bucket : "";
+    const key = typeof input.Key === "string" ? input.Key : "";
+    const object = storedObjects.get(storedReferenceIdentity(bucket, key));
+    if (command instanceof HeadObjectCommand) {
+      if (!object) {
+        return Promise.reject(
+          Object.assign(new Error("Missing test object"), { name: "NotFound" }),
+        );
+      }
+      return Promise.resolve({
+        ContentLength: object.body.byteLength,
+        ContentType: object.contentType,
+        LastModified: new Date("2026-01-01T00:00:00.000Z"),
+        Metadata: { "artifact-id": object.id },
+      });
+    }
+    if (command instanceof GetObjectCommand) {
+      if (!object) {
+        return Promise.reject(
+          Object.assign(new Error("Missing test object"), {
+            name: "NoSuchKey",
+          }),
+        );
+      }
+      return Promise.resolve({
+        ContentLength: object.body.byteLength,
+        ContentType: object.contentType,
+        Body: Readable.from([object.body]),
+      });
+    }
+    if (command instanceof DeleteObjectsCommand) {
+      deleteStoredReferenceObjects(storedObjects, bucket, input.Delete);
+      return Promise.resolve({});
+    }
+    return Promise.resolve({});
+  });
+  context.mocks.s3.getSignedUrl.mockImplementation(
+    (_client: unknown, command: unknown) => {
+      sequence += 1;
+      const base = new URL(apiTestS3PresignedUrl(command));
+      base.searchParams.set("sequence", sequence.toString());
+      const url = base.toString();
+      if (command instanceof GetObjectCommand) {
+        events.push("presign-get");
+      }
+      return Promise.resolve(url);
+    },
+  );
+  return { events, storedObjects };
+}
+
+function useImageReferenceActor(actor: ImageReferenceActor): void {
+  mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole ?? "org:admin");
+}
+
+async function setReferenceImagesEnabled(
+  app: ImageIoTestApp,
+  actor: ImageReferenceActor,
+  enabled: boolean,
+): Promise<void> {
+  useImageReferenceActor(actor);
+  const response = await app.request("/api/feature-switches", {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify({
+      switches: { [FeatureSwitchKey.ReferenceImages]: enabled },
+    }),
+  });
+  expect(response.status).toBe(200);
+}
+
+async function createImageReferenceViaApi(
+  app: ImageIoTestApp,
+  actor: ImageReferenceActor,
+  storage: ReturnType<typeof installReferenceStorageMock>,
+  options?: {
+    readonly visibility?: "private" | "public";
+    readonly title?: string;
+  },
+): Promise<CreatedImageReference> {
+  useImageReferenceActor(actor);
+  const title = options?.title ?? "Generation reference";
+  const prepare = await app.request("/api/uploads/prepare", {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify({
+      filename: "reference.png",
+      contentType: "image/png",
+      size: REFERENCE_IMAGE_BYTES.byteLength,
+      purpose: "image-reference",
+    }),
+  });
+  expect(prepare.status).toBe(200);
+  const prepared: unknown = await prepare.json();
+  if (
+    typeof prepared !== "object" ||
+    prepared === null ||
+    !("id" in prepared) ||
+    typeof prepared.id !== "string"
+  ) {
+    throw new Error("Expected a prepared reference upload");
+  }
+  const uploadCommand = context.mocks.s3.getSignedUrl.mock.calls
+    .map((call) => {
+      return call[1];
+    })
+    .reverse()
+    .find((command: unknown) => {
+      const input = s3CommandInput(command);
+      const metadata = input.Metadata;
+      return (
+        command instanceof PutObjectCommand &&
+        typeof metadata === "object" &&
+        metadata !== null &&
+        "artifact-id" in metadata &&
+        metadata["artifact-id"] === prepared.id
+      );
+    });
+  const uploadInput = s3CommandInput(uploadCommand);
+  const bucket =
+    typeof uploadInput.Bucket === "string" ? uploadInput.Bucket : null;
+  const key = typeof uploadInput.Key === "string" ? uploadInput.Key : null;
+  if (!bucket || !key) {
+    throw new Error("Expected a private reference upload target");
+  }
+  expect(bucket).toBe(PRIVATE_ARTIFACTS_BUCKET);
+  storage.storedObjects.set(storedReferenceIdentity(bucket, key), {
+    id: prepared.id,
+    bucket,
+    key,
+    contentType: "image/png",
+    body: REFERENCE_IMAGE_BYTES,
+  });
+
+  const complete = await app.request("/api/uploads/complete", {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify({ id: prepared.id }),
+  });
+  expect(complete.status).toBe(200);
+
+  const create = await app.request("/api/image-references", {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify({
+      sourceFileId: prepared.id,
+      title,
+      visibility: options?.visibility ?? "private",
+    }),
+  });
+  expect(create.status).toBe(201);
+  const created: unknown = await create.json();
+  if (
+    typeof created !== "object" ||
+    created === null ||
+    !("id" in created) ||
+    typeof created.id !== "string"
+  ) {
+    throw new Error("Expected a created image reference");
+  }
+  return { id: created.id, title, sourceKey: key };
 }
 
 function currentSecond(): number {
@@ -4398,6 +4653,472 @@ describe("POST /api/image-io/generate", () => {
     });
     expect(falCalls).toBe(0);
     await expect(orgCredits(fixture)).resolves.toBe(1000);
+  });
+
+  it("gates saved references and makes inaccessible ids indistinguishable", async () => {
+    const owner = await seedImageFixture({ credits: 1000 });
+    const member = {
+      userId: `user_${randomUUID()}`,
+      orgId: owner.orgId,
+      orgRole: "org:member" as const,
+    };
+    await store.set(
+      seedOrgMembership$,
+      { orgId: owner.orgId, userId: member.userId, role: "member" },
+      context.signal,
+    );
+    const storage = installReferenceStorageMock();
+    const app = createImageIoTestApp();
+    await setReferenceImagesEnabled(app, owner, true);
+    const reference = await createImageReferenceViaApi(app, owner, storage);
+
+    let falCalls = 0;
+    server.use(
+      http.post(FAL_QWEN_IMAGE_3_EDIT_URL, () => {
+        falCalls += 1;
+        return HttpResponse.json({});
+      }),
+    );
+    const generate = async (actor: ImageReferenceActor) => {
+      useImageReferenceActor(actor);
+      return await app.request("/api/image-io/generate", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          prompt: "Use an unavailable reference",
+          model: "qwen-image-3",
+          imageReferenceIds: [reference.id],
+        }),
+      });
+    };
+
+    useImageReferenceActor(owner);
+    for (const imageReferenceIds of [
+      ["not-a-uuid"],
+      [reference.id, randomUUID()],
+    ]) {
+      const invalid = await app.request("/api/image-io/generate", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          prompt: "Invalid saved reference input",
+          model: "qwen-image-3",
+          imageReferenceIds,
+        }),
+      });
+      expect(invalid.status).toBe(400);
+      expect(JSON.stringify(await invalid.json())).not.toContain(reference.id);
+    }
+
+    await setReferenceImagesEnabled(app, owner, false);
+    const disabled = await generate(owner);
+    expect(disabled.status).toBe(403);
+    await expect(disabled.json()).resolves.toStrictEqual({
+      error: {
+        message: "Reference images are not enabled",
+        code: "FORBIDDEN",
+      },
+    });
+
+    await setReferenceImagesEnabled(app, owner, true);
+    const privateNonOwner = await generate(member);
+    expect(privateNonOwner.status).toBe(404);
+    const notFoundBody = await privateNonOwner.json();
+    expect(notFoundBody).toStrictEqual({
+      error: { message: "Image reference not found", code: "NOT_FOUND" },
+    });
+    expect(JSON.stringify(notFoundBody)).not.toContain(reference.id);
+
+    useImageReferenceActor(owner);
+    const shared = await app.request(`/api/image-references/${reference.id}`, {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ visibility: "public" }),
+    });
+    expect(shared.status).toBe(200);
+    const revoked = await app.request(`/api/image-references/${reference.id}`, {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ visibility: "private" }),
+    });
+    expect(revoked.status).toBe(200);
+    const revokedMember = await generate(member);
+    expect(revokedMember.status).toBe(404);
+    await expect(revokedMember.json()).resolves.toStrictEqual(notFoundBody);
+
+    const otherOrg = await seedImageFixture({ credits: 1000 });
+    await setReferenceImagesEnabled(app, otherOrg, true);
+    const crossOrg = await generate(otherOrg);
+    expect(crossOrg.status).toBe(404);
+    await expect(crossOrg.json()).resolves.toStrictEqual(notFoundBody);
+
+    await seedOrgMetadata({ orgId: owner.orgId, tier: "free", credits: 0 });
+    const signedUrlCallsBeforeInsufficientCredits =
+      context.mocks.s3.getSignedUrl.mock.calls.length;
+    const insufficientCreditsResponse = await generate(owner);
+    expect(insufficientCreditsResponse.status).toBe(402);
+    await expect(insufficientCreditsResponse.json()).resolves.toStrictEqual({
+      error: {
+        message: "Insufficient credits. Please add credits to continue.",
+        code: "INSUFFICIENT_CREDITS",
+      },
+    });
+    expect(context.mocks.s3.getSignedUrl.mock.calls).toHaveLength(
+      signedUrlCallsBeforeInsufficientCredits,
+    );
+
+    useImageReferenceActor(owner);
+    const deleted = await app.request(`/api/image-references/${reference.id}`, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+    expect(deleted.status).toBe(204);
+    const deletedReference = await generate(owner);
+    expect(deletedReference.status).toBe(404);
+    await expect(deletedReference.json()).resolves.toStrictEqual(notFoundBody);
+    expect(falCalls).toBe(0);
+  });
+
+  it("redacts private reference values when provider URL preparation fails", async () => {
+    const fixture = await seedImageFixture({ credits: 1000 });
+    const pricingFixture = await createScopedImagePricing({
+      configured: QWEN_IMAGE_3_PRICING,
+    });
+    const storage = installReferenceStorageMock();
+    const app = createImageIoTestApp(pricingFixture.resolution);
+    await setReferenceImagesEnabled(app, fixture, true);
+    const reference = await createImageReferenceViaApi(app, fixture, storage, {
+      title: "Private error-path title",
+    });
+    const syntheticProviderUrl = `https://private.example/${reference.sourceKey}?signature=secret`;
+    context.mocks.s3.getSignedUrl.mockRejectedValueOnce(
+      new Error(
+        `${reference.id} ${reference.title} ${reference.sourceKey} ${syntheticProviderUrl}`,
+      ),
+    );
+
+    let falCalls = 0;
+    server.use(
+      http.post(FAL_QWEN_IMAGE_3_EDIT_URL, () => {
+        falCalls += 1;
+        return HttpResponse.json({});
+      }),
+    );
+    useImageReferenceActor(fixture);
+    const response = await app.request("/api/image-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        prompt: "Use the private reference",
+        model: "qwen-image-3",
+        imageReferenceIds: [reference.id],
+      }),
+    });
+    expect(response.status).toBe(503);
+    const responseBody: unknown = await response.json();
+    expect(responseBody).toStrictEqual({
+      error: {
+        message: "Image reference is temporarily unavailable",
+        code: "PROVIDER_UNAVAILABLE",
+      },
+    });
+    expect(falCalls).toBe(0);
+
+    const generationId = readPublishedGenerationId(
+      context.mocks.ably.publish.mock.calls,
+    );
+    const statusResponse = await app.request(
+      `/api/built-in-generations/${generationId}`,
+      { headers: authHeaders() },
+    );
+    expect(statusResponse.status).toBe(200);
+    const statusBody: unknown = await statusResponse.json();
+    expect(statusBody).toMatchObject({
+      generationId,
+      type: "image",
+      status: "failed",
+      error: {
+        message: "Image reference is temporarily unavailable",
+        code: "PROVIDER_UNAVAILABLE",
+      },
+    });
+    const publicAndLogSurfaces = JSON.stringify({
+      responseBody,
+      statusBody,
+      realtime: context.mocks.ably.publish.mock.calls,
+      debug: context.mocks.axiomLogging.debug.mock.calls,
+      info: context.mocks.axiomLogging.info.mock.calls,
+      warn: context.mocks.axiomLogging.warn.mock.calls,
+      error: context.mocks.axiomLogging.error.mock.calls,
+    });
+    for (const privateValue of [
+      reference.id,
+      reference.title,
+      reference.sourceKey,
+      syntheticProviderUrl,
+    ]) {
+      expect(publicAndLogSurfaces).not.toContain(privateValue);
+    }
+  });
+
+  it("appends an owner reference just in time for Fal without persisting private values", async () => {
+    const fixture = await seedImageFixture({ credits: 1000 });
+    const pricingFixture = await createScopedImagePricing({
+      configured: QWEN_IMAGE_3_PRICING,
+    });
+    const storage = installReferenceStorageMock();
+    const app = createImageIoTestApp(pricingFixture.resolution);
+    await setReferenceImagesEnabled(app, fixture, true);
+    const reference = await createImageReferenceViaApi(app, fixture, storage, {
+      visibility: "public",
+      title: "Confidential campaign style",
+    });
+    storage.events.length = 0;
+
+    const explicitUrls = [MOCKUP_IMAGE_URL, SECOND_MOCKUP_IMAGE_URL];
+    let falCalls = 0;
+    let observedBody: Record<string, unknown> | null = null;
+    let observedRequestUrl: string | null = null;
+    server.use(
+      http.post(FAL_QWEN_IMAGE_3_EDIT_URL, async ({ request }) => {
+        falCalls += 1;
+        storage.events.push("fal-submit");
+        observedRequestUrl = request.url;
+        observedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(
+          falQueueHandle("saved-reference-qwen-image-3-request"),
+        );
+      }),
+      http.get(FAL_QWEN_IMAGE_3_MEDIA_URL, () => {
+        return new HttpResponse(IMAGE_BYTES, {
+          headers: { "Content-Type": "image/png" },
+        });
+      }),
+    );
+
+    useImageReferenceActor(fixture);
+    const response = await app.request("/api/image-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        prompt: "Restyle the subject using the saved visual language",
+        model: "qwen-image-3",
+        imageUrls: explicitUrls,
+        imageReferenceIds: [reference.id],
+      }),
+    });
+    expect(response.status).toBe(202);
+    const acceptedBody: unknown = await response.json();
+    const generationId = readAcceptedGenerationId(
+      acceptedBody,
+      "image",
+      fixture.userId,
+    );
+
+    expect(falCalls).toBe(1);
+    expect(storage.events).toStrictEqual(["presign-get", "fal-submit"]);
+    const providerImageUrls = (
+      observedBody as unknown as Record<string, unknown> | null
+    )?.["image_urls"];
+    expect(Array.isArray(providerImageUrls)).toBeTruthy();
+    if (!Array.isArray(providerImageUrls)) {
+      throw new Error("Expected mixed Fal image references");
+    }
+    expect(providerImageUrls.slice(0, 2)).toStrictEqual(explicitUrls);
+    const providerReferenceUrl = String(providerImageUrls[2]);
+    const parsedProviderReferenceUrl = new URL(providerReferenceUrl);
+    expect(parsedProviderReferenceUrl.origin).toBe("https://r2.example.com");
+    expect(parsedProviderReferenceUrl.searchParams.get("object")).toBe(
+      `${PRIVATE_ARTIFACTS_BUCKET}/${reference.sourceKey}`,
+    );
+    const providerPresignCall = [...context.mocks.s3.getSignedUrl.mock.calls]
+      .reverse()
+      .find((call: unknown[]) => {
+        const input = s3CommandInput(call[1]);
+        return (
+          call[1] instanceof GetObjectCommand &&
+          input.Bucket === PRIVATE_ARTIFACTS_BUCKET &&
+          input.Key === reference.sourceKey
+        );
+      });
+    expect(s3CommandInput(providerPresignCall?.[1])).toMatchObject({
+      Bucket: PRIVATE_ARTIFACTS_BUCKET,
+      Key: reference.sourceKey,
+      ResponseCacheControl: "private, no-store",
+    });
+    expect(providerPresignCall?.[2]).toStrictEqual({ expiresIn: 60 * 60 });
+
+    expect(JSON.stringify(acceptedBody)).not.toContain(reference.id);
+    expect(JSON.stringify(acceptedBody)).not.toContain(providerReferenceUrl);
+
+    const rejected = await app.request("/api/image-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        prompt: "Too many mixed references",
+        model: "qwen-image-3",
+        imageUrls: [
+          MOCKUP_IMAGE_URL,
+          SECOND_MOCKUP_IMAGE_URL,
+          THIRD_MOCKUP_IMAGE_URL,
+        ],
+        imageReferenceIds: [reference.id],
+      }),
+    });
+    expect(rejected.status).toBe(400);
+    await expect(rejected.json()).resolves.toStrictEqual({
+      error: {
+        message:
+          "qwen-image-3 accepts at most 3 source images across image URLs and saved references",
+        code: "IMAGE_REFERENCE_INCOMPATIBLE",
+      },
+    });
+    expect(falCalls).toBe(1);
+
+    await postFalWebhook(app, observedRequestUrl, {
+      images: [
+        {
+          url: FAL_QWEN_IMAGE_3_MEDIA_URL,
+          width: 1024,
+          height: 768,
+          content_type: "image/png",
+        },
+      ],
+    });
+    await flushWaitUntilForTest();
+    const statusResponse = await app.request(
+      `/api/built-in-generations/${generationId}`,
+      { headers: authHeaders() },
+    );
+    expect(statusResponse.status).toBe(200);
+    const statusBody: unknown = await statusResponse.json();
+    expect(readGenerationResult(statusBody)).toMatchObject({
+      creditsCharged: FAL_QWEN_IMAGE_3_STANDARD_TIER_CREDITS,
+      sourceImageUrls: explicitUrls,
+    });
+    const publicSurface = JSON.stringify(statusBody);
+    for (const privateValue of [
+      reference.id,
+      reference.title,
+      reference.sourceKey,
+      providerReferenceUrl,
+    ]) {
+      expect(publicSurface).not.toContain(privateValue);
+    }
+    await expect(orgCredits(fixture)).resolves.toBe(
+      1000 - FAL_QWEN_IMAGE_3_STANDARD_TIER_CREDITS,
+    );
+  });
+
+  it("submits a shared reference through BytePlus and bills it exactly once", async () => {
+    const owner = await seedImageFixture({ credits: 1000 });
+    const member = {
+      userId: `user_${randomUUID()}`,
+      orgId: owner.orgId,
+      orgRole: "org:member" as const,
+    };
+    await store.set(
+      seedOrgMembership$,
+      { orgId: owner.orgId, userId: member.userId, role: "member" },
+      context.signal,
+    );
+    const pricingFixture = await createScopedImagePricing({
+      configured: SEEDREAM_5_PRO_IMAGE_PRICING,
+    });
+    const storage = installReferenceStorageMock();
+    const app = createImageIoTestApp(pricingFixture.resolution);
+    await setReferenceImagesEnabled(app, owner, true);
+    const reference = await createImageReferenceViaApi(app, owner, storage, {
+      visibility: "public",
+      title: "Shared private-source reference",
+    });
+    storage.events.length = 0;
+
+    let observedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.post(BYTEPLUS_IMAGE_GENERATIONS_URL, async ({ request }) => {
+        storage.events.push("byteplus-submit");
+        observedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          created: 1_700_000_000,
+          model: "dola-seedream-5-0-pro-260628",
+          data: [
+            {
+              url: BYTEPLUS_SEEDREAM_5_PRO_LOW_MEDIA_URL,
+              size: "1536x1536",
+              output_format: "jpeg",
+            },
+          ],
+        });
+      }),
+      http.get(BYTEPLUS_SEEDREAM_5_PRO_LOW_MEDIA_URL, () => {
+        return new HttpResponse(IMAGE_BYTES, {
+          headers: { "Content-Type": "image/jpeg" },
+        });
+      }),
+    );
+
+    useImageReferenceActor(member);
+    const response = await app.request("/api/image-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        prompt: "Use the organization reference after the explicit subject",
+        model: "seedream5-pro",
+        size: "1.5K",
+        outputFormat: "jpeg",
+        imageUrls: [MOCKUP_IMAGE_URL],
+        imageReferenceIds: [reference.id],
+      }),
+    });
+    expect(response.status).toBe(202);
+    const acceptedBody: unknown = await response.json();
+    const generationId = readAcceptedGenerationId(
+      acceptedBody,
+      "image",
+      member.userId,
+    );
+    await flushWaitUntilForTest();
+
+    expect(storage.events).toStrictEqual(["presign-get", "byteplus-submit"]);
+    const providerImages = observedBody?.["image"];
+    expect(Array.isArray(providerImages)).toBeTruthy();
+    if (!Array.isArray(providerImages)) {
+      throw new Error("Expected BytePlus image references");
+    }
+    expect(providerImages[0]).toBe(MOCKUP_IMAGE_URL);
+    const providerReferenceUrl = String(providerImages[1]);
+    const parsedProviderReferenceUrl = new URL(providerReferenceUrl);
+    expect(parsedProviderReferenceUrl.searchParams.get("object")).toBe(
+      `${PRIVATE_ARTIFACTS_BUCKET}/${reference.sourceKey}`,
+    );
+
+    const statusResponse = await app.request(
+      `/api/built-in-generations/${generationId}`,
+      { headers: authHeaders() },
+    );
+    expect(statusResponse.status).toBe(200);
+    const statusBody: unknown = await statusResponse.json();
+    expect(readGenerationResult(statusBody)).toMatchObject({
+      creditsCharged: 60,
+      billingCategory: "provider_cost_usd_micros",
+      billingQuantity: 48_000,
+      sourceImageUrls: [MOCKUP_IMAGE_URL],
+    });
+    const nonProviderSurfaces = JSON.stringify({
+      acceptedBody,
+      statusBody,
+      realtime: context.mocks.ably.publish.mock.calls,
+    });
+    for (const privateValue of [
+      reference.id,
+      reference.title,
+      reference.sourceKey,
+      providerReferenceUrl,
+    ]) {
+      expect(nonProviderSurfaces).not.toContain(privateValue);
+    }
+    await expect(orgCredits(owner)).resolves.toBe(940);
   });
 
   it("records a failed job when fal image generation fails", async () => {

--- a/turbo/apps/api/src/signals/routes/image-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/image-io-generate.ts
@@ -117,6 +117,17 @@ function imageReferenceAccessError(
       },
     };
   }
+  if (access.kind === "unavailable") {
+    return {
+      status: 503,
+      body: {
+        error: {
+          message: "Image reference is temporarily unavailable",
+          code: "PROVIDER_UNAVAILABLE",
+        },
+      },
+    };
+  }
   return {
     status: 404,
     body: {
@@ -127,6 +138,28 @@ function imageReferenceAccessError(
     },
   };
 }
+
+const preflightImageReference$ = command(
+  async (
+    { get, set },
+    options: ImageOptions,
+    signal: AbortSignal,
+  ): Promise<GenerationErrorResponse | null> => {
+    const referenceId = options.imageReferenceIds[0];
+    if (!referenceId) {
+      return null;
+    }
+    const auth = get(organizationAuthContext$);
+    const access = await set(
+      authorizeImageReferenceForGeneration$,
+      { orgId: auth.orgId, userId: auth.userId, referenceId },
+      signal,
+    );
+    return access.kind === "authorized"
+      ? null
+      : imageReferenceAccessError(access);
+  },
+);
 
 async function loadRunImageModelDefault(
   db: ReadonlyDb,
@@ -559,16 +592,9 @@ const postImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return options;
   }
 
-  const referenceId = options.imageReferenceIds[0];
-  if (referenceId) {
-    const access = await set(
-      authorizeImageReferenceForGeneration$,
-      { orgId: auth.orgId, userId: auth.userId, referenceId },
-      signal,
-    );
-    if (access.kind !== "authorized") {
-      return imageReferenceAccessError(access);
-    }
+  const referenceError = await set(preflightImageReference$, options, signal);
+  if (referenceError) {
+    return referenceError;
   }
 
   const hasCredits = await set(

--- a/turbo/apps/api/src/signals/routes/image-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/image-io-generate.ts
@@ -53,6 +53,11 @@ import {
   startRunBuiltInAdmission$,
   type RunBuiltInAdmission,
 } from "../services/run-built-in-admission.service";
+import {
+  authorizeImageReferenceForGeneration$,
+  resolveImageReferenceProviderUrl$,
+  type ImageReferenceGenerationAccess,
+} from "../services/image-reference-generation.service";
 import { resolveProviderReferenceUrls$ } from "../services/provider-reference-url.service";
 import { PUBLIC_BRAND } from "@okouai/core/public-brand";
 
@@ -81,6 +86,46 @@ interface ImageJobArgs {
   readonly admission: RunBuiltInAdmission | null;
   readonly options: ImageOptions;
   readonly pricing: ImagePricing;
+}
+
+type ImageReferenceSource = "owner" | "organization";
+type ImageReferenceAccessFailure = Exclude<
+  ImageReferenceGenerationAccess,
+  { readonly kind: "authorized" }
+>;
+
+type ImageProviderReferencesResolution =
+  | ReturnType<typeof badRequestMessage>
+  | ImageReferenceAccessFailure
+  | {
+      readonly kind: "resolved";
+      readonly references: ImageProviderReferences;
+      readonly imageReferenceSource: ImageReferenceSource | undefined;
+    };
+
+function imageReferenceAccessError(
+  access: ImageReferenceAccessFailure,
+): GenerationErrorResponse {
+  if (access.kind === "disabled") {
+    return {
+      status: 403,
+      body: {
+        error: {
+          message: "Reference images are not enabled",
+          code: "FORBIDDEN",
+        },
+      },
+    };
+  }
+  return {
+    status: 404,
+    body: {
+      error: {
+        message: "Image reference not found",
+        code: "NOT_FOUND",
+      },
+    },
+  };
 }
 
 async function loadRunImageModelDefault(
@@ -178,9 +223,7 @@ const resolveImageProviderReferences$ = command(
     { set },
     args: Pick<ImageJobArgs, "orgId" | "userId" | "options">,
     signal: AbortSignal,
-  ): Promise<
-    ImageProviderReferences | ReturnType<typeof badRequestMessage>
-  > => {
+  ): Promise<ImageProviderReferencesResolution> => {
     const sourceCount = args.options.sourceImageUrls.length;
     const urls = [
       ...args.options.sourceImageUrls,
@@ -194,11 +237,40 @@ const resolveImageProviderReferences$ = command(
     if ("status" in resolved) {
       return resolved;
     }
+    const referenceId = args.options.imageReferenceIds[0];
+    if (!referenceId) {
+      return {
+        kind: "resolved",
+        references: {
+          sourceImageUrls: resolved.slice(0, sourceCount),
+          maskImageUrl: args.options.maskImageUrl
+            ? resolved[sourceCount]
+            : undefined,
+        },
+        imageReferenceSource: undefined,
+      };
+    }
+
+    const savedReference = await set(
+      resolveImageReferenceProviderUrl$,
+      { orgId: args.orgId, userId: args.userId, referenceId },
+      signal,
+    );
+    if (savedReference.kind !== "resolved") {
+      return savedReference;
+    }
     return {
-      sourceImageUrls: resolved.slice(0, sourceCount),
-      maskImageUrl: args.options.maskImageUrl
-        ? resolved[sourceCount]
-        : undefined,
+      kind: "resolved",
+      references: {
+        sourceImageUrls: [
+          ...resolved.slice(0, sourceCount),
+          savedReference.url,
+        ],
+        maskImageUrl: args.options.maskImageUrl
+          ? resolved[sourceCount]
+          : undefined,
+      },
+      imageReferenceSource: savedReference.referenceSource,
     };
   },
 );
@@ -218,18 +290,39 @@ const submitImageProviderWebhookJob$ = command(
         "NOT_CONFIGURED",
       );
     }
-    const references = await set(resolveImageProviderReferences$, args, signal);
-    if ("status" in references) {
+    const resolution = await set(resolveImageProviderReferences$, args, signal);
+    if ("status" in resolution) {
       await set(
         failBuiltInGenerationJob$,
-        { generationId: args.generationId, error: references.body.error },
+        { generationId: args.generationId, error: resolution.body.error },
         signal,
       );
-      return references;
+      return resolution;
+    }
+    if (resolution.kind !== "resolved") {
+      const error = imageReferenceAccessError(resolution);
+      await set(
+        failBuiltInGenerationJob$,
+        { generationId: args.generationId, error: error.body.error },
+        signal,
+      );
+      return error;
+    }
+    if (resolution.imageReferenceSource) {
+      await set(
+        mergeBuiltInGenerationJobInternal$,
+        {
+          generationId: args.generationId,
+          internal: {
+            imageReferenceSource: resolution.imageReferenceSource,
+          },
+        },
+        signal,
+      );
     }
     const handle = await submitFalImageQueueGeneration(
       args.options,
-      references,
+      resolution.references,
       falKey,
       falBuiltInGenerationWebhookUrl({ generationId: args.generationId }),
       signal,
@@ -286,16 +379,51 @@ const executeDirectImageProviderJob$ = command(
       return;
     }
 
-    const references = await set(resolveImageProviderReferences$, args, signal);
-    const generation =
-      "status" in references
-        ? references
-        : await (isOpenAi ? generateOpenAiImage : generateBytePlusImage)(
-            args.options,
-            references,
-            apiKey,
-            signal,
-          );
+    const resolution = await set(resolveImageProviderReferences$, args, signal);
+    if ("status" in resolution) {
+      await set(
+        failBuiltInGenerationJob$,
+        { generationId: args.generationId, error: resolution.body.error },
+        signal,
+      );
+      signal.throwIfAborted();
+      await set(completeRunBuiltInAdmission$, {
+        admission: args.admission,
+        status: "failed",
+      });
+      signal.throwIfAborted();
+      return;
+    }
+    if (resolution.kind !== "resolved") {
+      const error = imageReferenceAccessError(resolution);
+      await set(
+        failBuiltInGenerationJob$,
+        { generationId: args.generationId, error: error.body.error },
+        signal,
+      );
+      signal.throwIfAborted();
+      await set(completeRunBuiltInAdmission$, {
+        admission: args.admission,
+        status: "failed",
+      });
+      signal.throwIfAborted();
+      return;
+    }
+    if (resolution.imageReferenceSource) {
+      await set(
+        mergeBuiltInGenerationJobInternal$,
+        {
+          generationId: args.generationId,
+          internal: {
+            imageReferenceSource: resolution.imageReferenceSource,
+          },
+        },
+        signal,
+      );
+    }
+    const generation = await (
+      isOpenAi ? generateOpenAiImage : generateBytePlusImage
+    )(args.options, resolution.references, apiKey, signal);
     signal.throwIfAborted();
     if (isErrorResponse(generation)) {
       await set(
@@ -431,6 +559,18 @@ const postImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return options;
   }
 
+  const referenceId = options.imageReferenceIds[0];
+  if (referenceId) {
+    const access = await set(
+      authorizeImageReferenceForGeneration$,
+      { orgId: auth.orgId, userId: auth.userId, referenceId },
+      signal,
+    );
+    if (access.kind !== "authorized") {
+      return imageReferenceAccessError(access);
+    }
+  }
+
   const hasCredits = await set(
     checkImageCredits$,
     { orgId: auth.orgId, userId: auth.userId, runId },
@@ -503,6 +643,10 @@ const postImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
           publicBrand,
           provider: options.provider,
           providerTask: "image",
+          imageReferenceCount:
+            options.savedImageReferenceCount === 0
+              ? undefined
+              : options.savedImageReferenceCount,
         },
       ),
     },

--- a/turbo/apps/api/src/signals/routes/image-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/image-io-generate.ts
@@ -566,7 +566,6 @@ const startImageProviderJob$ = command(
 
 const postImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
-  const db = get(db$);
   const bodyResult = await get(imageBody$);
   signal.throwIfAborted();
   if (!bodyResult.ok) {
@@ -577,9 +576,8 @@ const postImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     auth.tokenType === "agent" || auth.tokenType === "sandbox"
       ? auth.runId
       : undefined;
-  const publicBrand = PUBLIC_BRAND;
   const runImageModelDefault = await loadRunImageModelDefault(
-    db,
+    get(db$),
     auth.orgId,
     auth.userId,
     runId,
@@ -666,13 +664,10 @@ const postImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         imageRequestRecord(options),
         {
           admissionId: admission?.id,
-          publicBrand,
+          publicBrand: PUBLIC_BRAND,
           provider: options.provider,
           providerTask: "image",
-          imageReferenceCount:
-            options.savedImageReferenceCount === 0
-              ? undefined
-              : options.savedImageReferenceCount,
+          imageReferenceCount: options.savedImageReferenceCount || undefined,
         },
       ),
     },
@@ -686,7 +681,7 @@ const postImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       orgId: auth.orgId,
       userId: auth.userId,
       runId,
-      publicBrand,
+      publicBrand: PUBLIC_BRAND,
       privateArtifacts,
       admission,
       options,

--- a/turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts
@@ -185,7 +185,10 @@ const completeAdmissionForJob$ = command(
 );
 
 function parseJobImageOptions(job: BuiltInGenerationWebhookJob): ImageOptions {
-  const options = parseImageOptions(job.request);
+  const internal = readBuiltInGenerationRequestInternal(job.request);
+  const options = parseImageOptions(job.request, {
+    savedImageReferenceCount: internal.imageReferenceCount,
+  });
   if (isErrorResponse(options)) {
     throw new Error(options.body.error.message);
   }

--- a/turbo/apps/api/src/signals/services/built-in-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/built-in-generation.service.ts
@@ -60,6 +60,8 @@ interface BuiltInGenerationRequestInternal {
   readonly providerStatusUrl?: string;
   readonly providerResponseUrl?: string;
   readonly providerTask?: string;
+  readonly imageReferenceCount?: number;
+  readonly imageReferenceSource?: "owner" | "organization";
   readonly presentation?: unknown;
 }
 
@@ -124,6 +126,8 @@ export function builtInGenerationRequestWithInternal(
       providerStatusUrl: internal.providerStatusUrl,
       providerResponseUrl: internal.providerResponseUrl,
       providerTask: internal.providerTask,
+      imageReferenceCount: internal.imageReferenceCount,
+      imageReferenceSource: internal.imageReferenceSource,
       presentation: internal.presentation,
     }),
   };
@@ -138,6 +142,25 @@ function parsePrivateArtifactsPolicy(value: unknown): boolean | undefined {
     throw new Error("Invalid built-in generation artifact storage policy");
   }
   return value;
+}
+
+function optionalImageReferenceCount(value: unknown): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === 1) {
+    return value;
+  }
+  throw new Error("Invalid built-in generation image reference count");
+}
+
+function optionalImageReferenceSource(
+  value: unknown,
+): "owner" | "organization" | undefined {
+  if (value === undefined || value === "owner" || value === "organization") {
+    return value;
+  }
+  throw new Error("Invalid built-in generation image reference source");
 }
 
 export function readBuiltInGenerationRequestInternal(
@@ -190,6 +213,10 @@ export function readBuiltInGenerationRequestInternal(
         : undefined,
     providerTask:
       typeof value.providerTask === "string" ? value.providerTask : undefined,
+    imageReferenceCount: optionalImageReferenceCount(value.imageReferenceCount),
+    imageReferenceSource: optionalImageReferenceSource(
+      value.imageReferenceSource,
+    ),
     presentation: value.presentation,
   };
 }

--- a/turbo/apps/api/src/signals/services/image-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/image-generation.service.ts
@@ -1338,7 +1338,7 @@ function validateSourceImages(
   return null;
 }
 
-export function imageSourceCount(
+function imageSourceCount(
   options: Pick<ImageOptions, "sourceImageUrls" | "savedImageReferenceCount">,
 ): number {
   return options.sourceImageUrls.length + options.savedImageReferenceCount;
@@ -1442,6 +1442,51 @@ function requestedImageSize(
   return readString(body, "size", defaultSize);
 }
 
+interface ParsedImageSources {
+  readonly sourceImageUrls: readonly string[];
+  readonly imageReferenceIds: readonly string[];
+  readonly savedImageReferenceCount: number;
+  readonly hasSourceImages: boolean;
+}
+
+function parseImageSources(
+  body: Record<string, unknown>,
+  modelConfig: ImageModelConfig,
+  savedImageReferenceCountOverride: number | undefined,
+): ParsedImageSources | ErrorResponse {
+  const sourceImageUrls = parseSourceImageUrls(body);
+  if (typeof sourceImageUrls === "object" && "status" in sourceImageUrls) {
+    return sourceImageUrls;
+  }
+  const imageReferenceIds = parseImageReferenceIds(body);
+  if (typeof imageReferenceIds === "object" && "status" in imageReferenceIds) {
+    return imageReferenceIds;
+  }
+  const savedImageReferenceCount =
+    savedImageReferenceCountOverride ?? imageReferenceIds.length;
+  if (
+    !Number.isInteger(savedImageReferenceCount) ||
+    savedImageReferenceCount < imageReferenceIds.length ||
+    savedImageReferenceCount > 1
+  ) {
+    throw new Error("Invalid saved image reference count");
+  }
+  const sourceImageError = validateSourceImages(
+    modelConfig,
+    sourceImageUrls,
+    savedImageReferenceCount,
+  );
+  if (sourceImageError) {
+    return sourceImageError;
+  }
+  return {
+    sourceImageUrls,
+    imageReferenceIds,
+    savedImageReferenceCount,
+    hasSourceImages: sourceImageUrls.length + savedImageReferenceCount > 0,
+  };
+}
+
 export function parseImageOptions(
   body: unknown,
   options?: {
@@ -1464,32 +1509,20 @@ export function parseImageOptions(
     return prompt;
   }
 
-  const sourceImageUrls = parseSourceImageUrls(body);
-  if (typeof sourceImageUrls === "object" && "status" in sourceImageUrls) {
-    return sourceImageUrls;
-  }
-  const imageReferenceIds = parseImageReferenceIds(body);
-  if (typeof imageReferenceIds === "object" && "status" in imageReferenceIds) {
-    return imageReferenceIds;
-  }
-  const savedImageReferenceCount =
-    options?.savedImageReferenceCount ?? imageReferenceIds.length;
-  if (
-    !Number.isInteger(savedImageReferenceCount) ||
-    savedImageReferenceCount < imageReferenceIds.length ||
-    savedImageReferenceCount > 1
-  ) {
-    throw new Error("Invalid saved image reference count");
-  }
-  const sourceImageError = validateSourceImages(
+  const sources = parseImageSources(
+    body,
     modelConfig,
-    sourceImageUrls,
-    savedImageReferenceCount,
+    options?.savedImageReferenceCount,
   );
-  if (sourceImageError) {
-    return sourceImageError;
+  if ("status" in sources) {
+    return sources;
   }
-  const hasSourceImages = sourceImageUrls.length + savedImageReferenceCount > 0;
+  const {
+    sourceImageUrls,
+    imageReferenceIds,
+    savedImageReferenceCount,
+    hasSourceImages,
+  } = sources;
 
   const size = requestedImageSize(body, model, hasSourceImages);
   const sizeError = validateImageSize(model, size);

--- a/turbo/apps/api/src/signals/services/image-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/image-generation.service.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
 
 import { command, computed, type Computed } from "ccstate";
+import { z } from "zod";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { usageEvent } from "@okouai/db/schema/usage-event";
 import { usagePricing } from "@okouai/db/schema/usage-pricing";
@@ -628,6 +629,8 @@ export interface ImageOptions {
   readonly safetyTolerance: ImageSafetyTolerance;
   readonly enhancePrompt: boolean;
   readonly sourceImageUrls: readonly string[];
+  readonly imageReferenceIds: readonly string[];
+  readonly savedImageReferenceCount: number;
   readonly maskImageUrl: string | undefined;
   readonly inputFidelity: ImageInputFidelity | undefined;
   readonly imagePromptStrength: number | undefined;
@@ -1235,7 +1238,6 @@ function appendSourceImageUrls(
 
 function parseSourceImageUrls(
   body: Record<string, unknown>,
-  modelConfig: ImageModelConfig,
 ): readonly string[] | ErrorResponse {
   const sourceImageUrls: string[] = [];
   for (const key of [
@@ -1250,39 +1252,96 @@ function parseSourceImageUrls(
       return error;
     }
   }
+  return sourceImageUrls;
+}
 
-  if (sourceImageUrls.length === 0) {
-    if (modelConfig.promptless) {
-      return badRequest(`${modelConfig.alias} requires imageUrl`);
-    }
-    return sourceImageUrls;
+function parseImageReferenceIds(
+  body: Record<string, unknown>,
+): readonly string[] | ErrorResponse {
+  const value = body.imageReferenceIds;
+  if (value === undefined || value === null) {
+    return [];
   }
-  const maxSourceImageUrls =
-    modelConfig.provider === "openai"
-      ? 16
-      : modelConfig.alias === "nano-banana-2" ||
-          modelConfig.alias === "nano-banana-2-lite"
-        ? NANO_BANANA_2_MAX_SOURCE_IMAGE_URLS
-        : modelConfig.alias === "flux-2-pro"
-          ? FLUX_2_PRO_MAX_SOURCE_IMAGE_URLS
-          : modelConfig.alias === "seedream5-lite"
-            ? SEEDREAM_5_LITE_MAX_SOURCE_IMAGE_URLS
-            : modelConfig.alias === "qwen-image-3"
-              ? QWEN_IMAGE_3_MAX_SOURCE_IMAGE_URLS
-              : MAX_SOURCE_IMAGE_URLS;
-  if (sourceImageUrls.length > maxSourceImageUrls) {
-    return badRequest(
-      `imageUrls supports at most ${maxSourceImageUrls} images`,
-    );
+  if (!Array.isArray(value)) {
+    return badRequest("imageReferenceIds must be an array");
+  }
+  if (value.length > 1) {
+    return badRequest("imageReferenceIds supports at most one saved reference");
+  }
+  const parsed = z.array(z.uuid()).safeParse(value);
+  if (!parsed.success) {
+    return badRequest("imageReferenceIds must contain valid UUIDs");
+  }
+  return parsed.data;
+}
+
+function multiSourceImageLimit(modelConfig: ImageModelConfig): number {
+  if (modelConfig.provider === "openai") {
+    return 16;
   }
   if (
-    modelConfig.sourceImageInput === "image_url" &&
-    sourceImageUrls.length > 1
+    modelConfig.alias === "nano-banana-2" ||
+    modelConfig.alias === "nano-banana-2-lite"
   ) {
-    return badRequest(`${modelConfig.alias} accepts one source image`);
+    return NANO_BANANA_2_MAX_SOURCE_IMAGE_URLS;
+  }
+  if (modelConfig.alias === "flux-2-pro") {
+    return FLUX_2_PRO_MAX_SOURCE_IMAGE_URLS;
+  }
+  if (modelConfig.alias === "seedream5-lite") {
+    return SEEDREAM_5_LITE_MAX_SOURCE_IMAGE_URLS;
+  }
+  if (modelConfig.alias === "qwen-image-3") {
+    return QWEN_IMAGE_3_MAX_SOURCE_IMAGE_URLS;
+  }
+  return MAX_SOURCE_IMAGE_URLS;
+}
+
+function validateSourceImages(
+  modelConfig: ImageModelConfig,
+  sourceImageUrls: readonly string[],
+  savedImageReferenceCount: number,
+): ErrorResponse | null {
+  const maxSourceImageUrls = multiSourceImageLimit(modelConfig);
+  const totalSourceImages = sourceImageUrls.length + savedImageReferenceCount;
+  if (totalSourceImages === 0) {
+    return modelConfig.promptless
+      ? badRequest(`${modelConfig.alias} requires imageUrl`)
+      : null;
   }
 
-  return sourceImageUrls;
+  if (savedImageReferenceCount === 0) {
+    if (sourceImageUrls.length > maxSourceImageUrls) {
+      return badRequest(
+        `imageUrls supports at most ${maxSourceImageUrls} images`,
+      );
+    }
+    if (
+      modelConfig.sourceImageInput === "image_url" &&
+      sourceImageUrls.length > 1
+    ) {
+      return badRequest(`${modelConfig.alias} accepts one source image`);
+    }
+    return null;
+  }
+
+  const combinedLimit =
+    modelConfig.sourceImageInput === "image_url" ? 1 : maxSourceImageUrls;
+  if (totalSourceImages > combinedLimit) {
+    const limit = combinedLimit === 1 ? "one" : String(combinedLimit);
+    const noun = combinedLimit === 1 ? "image" : "images";
+    return badRequest(
+      `${modelConfig.alias} accepts at most ${limit} source ${noun} across image URLs and saved references`,
+      "IMAGE_REFERENCE_INCOMPATIBLE",
+    );
+  }
+  return null;
+}
+
+export function imageSourceCount(
+  options: Pick<ImageOptions, "sourceImageUrls" | "savedImageReferenceCount">,
+): number {
+  return options.sourceImageUrls.length + options.savedImageReferenceCount;
 }
 
 function parseMaskImageUrl(
@@ -1385,7 +1444,10 @@ function requestedImageSize(
 
 export function parseImageOptions(
   body: unknown,
-  options?: { readonly defaultModel?: ImageModel },
+  options?: {
+    readonly defaultModel?: ImageModel;
+    readonly savedImageReferenceCount?: number;
+  },
 ): ImageOptions | ErrorResponse {
   if (!isRecord(body)) {
     return badRequest("Invalid JSON body");
@@ -1402,11 +1464,32 @@ export function parseImageOptions(
     return prompt;
   }
 
-  const sourceImageUrls = parseSourceImageUrls(body, modelConfig);
+  const sourceImageUrls = parseSourceImageUrls(body);
   if (typeof sourceImageUrls === "object" && "status" in sourceImageUrls) {
     return sourceImageUrls;
   }
-  const hasSourceImages = sourceImageUrls.length > 0;
+  const imageReferenceIds = parseImageReferenceIds(body);
+  if (typeof imageReferenceIds === "object" && "status" in imageReferenceIds) {
+    return imageReferenceIds;
+  }
+  const savedImageReferenceCount =
+    options?.savedImageReferenceCount ?? imageReferenceIds.length;
+  if (
+    !Number.isInteger(savedImageReferenceCount) ||
+    savedImageReferenceCount < imageReferenceIds.length ||
+    savedImageReferenceCount > 1
+  ) {
+    throw new Error("Invalid saved image reference count");
+  }
+  const sourceImageError = validateSourceImages(
+    modelConfig,
+    sourceImageUrls,
+    savedImageReferenceCount,
+  );
+  if (sourceImageError) {
+    return sourceImageError;
+  }
+  const hasSourceImages = sourceImageUrls.length + savedImageReferenceCount > 0;
 
   const size = requestedImageSize(body, model, hasSourceImages);
   const sizeError = validateImageSize(model, size);
@@ -1482,6 +1565,8 @@ export function parseImageOptions(
     safetyTolerance,
     enhancePrompt,
     sourceImageUrls,
+    imageReferenceIds,
+    savedImageReferenceCount,
     maskImageUrl,
     inputFidelity,
     imagePromptStrength,
@@ -1671,7 +1756,7 @@ function falImageSize(options: ImageOptions) {
   const modelConfig = IMAGE_MODEL_CONFIGS[options.model];
   if (options.size === "auto") {
     if (
-      options.sourceImageUrls.length > 0 &&
+      imageSourceCount(options) > 0 &&
       (options.model === FLUX_2_PRO_MODEL || options.model === IDEOGRAM_4_MODEL)
     ) {
       return "auto";
@@ -1732,7 +1817,7 @@ function ideogramRenderingSpeed(
 function falImageCountInput(options: ImageOptions): Record<string, unknown> {
   const providerSelectsCount =
     options.model === FLUX_2_PRO_MODEL ||
-    (options.model === IDEOGRAM_4_MODEL && options.sourceImageUrls.length > 0);
+    (options.model === IDEOGRAM_4_MODEL && imageSourceCount(options) > 0);
   return providerSelectsCount ? {} : { num_images: 1 };
 }
 
@@ -1791,7 +1876,7 @@ function falImageInput(
     ...(modelConfig.supportsEnhancePrompt
       ? { enhance_prompt: options.enhancePrompt }
       : {}),
-    ...(options.sourceImageUrls.length > 0
+    ...(imageSourceCount(options) > 0
       ? falSourceImageInput(modelConfig, references.sourceImageUrls)
       : {}),
     ...(modelConfig.supportsMaskImage && references.maskImageUrl
@@ -1809,7 +1894,7 @@ function falImageInput(
 
 function falImageEndpointId(options: ImageOptions): string {
   const modelConfig = IMAGE_MODEL_CONFIGS[options.model];
-  return options.sourceImageUrls.length > 0
+  return imageSourceCount(options) > 0
     ? modelConfig.imageToImageEndpointId
     : modelConfig.endpointId;
 }
@@ -1933,7 +2018,7 @@ function bytePlusImageInput(
   return {
     model: options.model,
     prompt: options.prompt,
-    ...(options.sourceImageUrls.length > 0 ? { image: sourceImages } : {}),
+    ...(imageSourceCount(options) > 0 ? { image: sourceImages } : {}),
     size: bytePlusImageSize(options),
     output_format: options.outputFormat,
     response_format: "url",
@@ -2336,7 +2421,7 @@ function bytePlusProviderCostUsdMicros(
       ? SEEDREAM_5_PRO_HIGH_TIER_OUTPUT_COST_USD_MICROS
       : SEEDREAM_5_PRO_LOW_TIER_OUTPUT_COST_USD_MICROS;
   const additionalInputCost =
-    Math.max(0, options.sourceImageUrls.length - 1) *
+    Math.max(0, imageSourceCount(options) - 1) *
     SEEDREAM_5_PRO_ADDITIONAL_INPUT_COST_USD_MICROS;
   return outputCost + additionalInputCost;
 }

--- a/turbo/apps/api/src/signals/services/image-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/image-generation.service.ts
@@ -1,7 +1,6 @@
 import { Buffer } from "node:buffer";
 
 import { command, computed, type Computed } from "ccstate";
-import { z } from "zod";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { usageEvent } from "@okouai/db/schema/usage-event";
 import { usagePricing } from "@okouai/db/schema/usage-pricing";

--- a/turbo/apps/api/src/signals/services/image-reference-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/image-reference-generation.service.ts
@@ -4,6 +4,7 @@ import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { db$ } from "../external/db";
 import { generatePresignedGetUrl } from "../external/s3";
+import { settle } from "../utils";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { loadAccessibleImageReference } from "./image-reference-data.service";
 import {
@@ -15,7 +16,8 @@ const IMAGE_REFERENCE_PROVIDER_URL_TTL_SECONDS = 60 * 60;
 
 type ImageReferenceGenerationAccessFailure =
   | { readonly kind: "disabled" }
-  | { readonly kind: "not-found" };
+  | { readonly kind: "not-found" }
+  | { readonly kind: "unavailable" };
 
 interface AuthorizedImageReference {
   readonly kind: "authorized";
@@ -27,7 +29,7 @@ export type ImageReferenceGenerationAccess =
   | ImageReferenceGenerationAccessFailure
   | AuthorizedImageReference;
 
-export type ResolvedImageReferenceProviderUrl =
+type ResolvedImageReferenceProviderUrl =
   | ImageReferenceGenerationAccessFailure
   | {
       readonly kind: "resolved";
@@ -71,32 +73,32 @@ export const authorizeImageReferenceForGeneration$ = command(
       return { kind: "disabled" };
     }
 
-    let reference;
-    try {
-      reference = await loadAccessibleImageReference(db, args);
-    } catch (error) {
-      signal.throwIfAborted();
-      if (containsSensitiveMetadataError(error)) {
+    const referenceResult = await settle(
+      loadAccessibleImageReference(db, args),
+      signal,
+    );
+    if (!referenceResult.ok) {
+      if (containsSensitiveMetadataError(referenceResult.error)) {
         return { kind: "not-found" };
       }
-      throw error;
+      return { kind: "unavailable" };
     }
-    signal.throwIfAborted();
+    const reference = referenceResult.value;
     if (!reference) {
       return { kind: "not-found" };
     }
 
-    let source;
-    try {
-      source = await get(privateArtifactRecord(reference.sourceFileId));
-    } catch (error) {
-      signal.throwIfAborted();
-      if (containsSensitiveMetadataError(error)) {
+    const sourceResult = await settle(
+      get(privateArtifactRecord(reference.sourceFileId)),
+      signal,
+    );
+    if (!sourceResult.ok) {
+      if (containsSensitiveMetadataError(sourceResult.error)) {
         return { kind: "not-found" };
       }
-      throw error;
+      return { kind: "unavailable" };
     }
-    signal.throwIfAborted();
+    const source = sourceResult.value;
     if (
       !source ||
       source.userId !== reference.ownerUserId ||
@@ -139,19 +141,24 @@ export const resolveImageReferenceProviderUrl$ = command(
       return access;
     }
 
-    const url = await get(
-      generatePresignedGetUrl(
-        privateArtifactsBucket(),
-        access.key,
-        IMAGE_REFERENCE_PROVIDER_URL_TTL_SECONDS,
-        undefined,
-        true,
+    const urlResult = await settle(
+      get(
+        generatePresignedGetUrl(
+          privateArtifactsBucket(),
+          access.key,
+          IMAGE_REFERENCE_PROVIDER_URL_TTL_SECONDS,
+          undefined,
+          true,
+        ),
       ),
+      signal,
     );
-    signal.throwIfAborted();
+    if (!urlResult.ok) {
+      return { kind: "unavailable" };
+    }
     return {
       kind: "resolved",
-      url,
+      url: urlResult.value,
       referenceSource: access.referenceSource,
     };
   },

--- a/turbo/apps/api/src/signals/services/image-reference-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/image-reference-generation.service.ts
@@ -1,0 +1,158 @@
+import { command } from "ccstate";
+import { isFeatureEnabled } from "@okouai/core/feature-switch";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+
+import { db$ } from "../external/db";
+import { generatePresignedGetUrl } from "../external/s3";
+import { loadUserFeatureSwitchContext } from "./feature-switches.service";
+import { loadAccessibleImageReference } from "./image-reference-data.service";
+import {
+  privateArtifactRecord,
+  privateArtifactsBucket,
+} from "./private-artifact-storage.service";
+
+const IMAGE_REFERENCE_PROVIDER_URL_TTL_SECONDS = 60 * 60;
+
+type ImageReferenceGenerationAccessFailure =
+  | { readonly kind: "disabled" }
+  | { readonly kind: "not-found" };
+
+interface AuthorizedImageReference {
+  readonly kind: "authorized";
+  readonly key: string;
+  readonly referenceSource: "owner" | "organization";
+}
+
+export type ImageReferenceGenerationAccess =
+  | ImageReferenceGenerationAccessFailure
+  | AuthorizedImageReference;
+
+export type ResolvedImageReferenceProviderUrl =
+  | ImageReferenceGenerationAccessFailure
+  | {
+      readonly kind: "resolved";
+      readonly url: string;
+      readonly referenceSource: "owner" | "organization";
+    };
+
+function containsSensitiveMetadataError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return (
+    (error.message.startsWith("Image reference ") &&
+      error.message.endsWith(" has invalid source metadata")) ||
+    (error.message.startsWith("Private artifact ") &&
+      (error.message.endsWith(" has incomplete storage metadata") ||
+        error.message.endsWith(
+          " does not match the configured private bucket",
+        )))
+  );
+}
+
+export const authorizeImageReferenceForGeneration$ = command(
+  async (
+    { get },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly referenceId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<ImageReferenceGenerationAccess> => {
+    const db = get(db$);
+    const featureContext = await loadUserFeatureSwitchContext(
+      db,
+      args.orgId,
+      args.userId,
+    );
+    signal.throwIfAborted();
+    if (!isFeatureEnabled(FeatureSwitchKey.ReferenceImages, featureContext)) {
+      return { kind: "disabled" };
+    }
+
+    let reference;
+    try {
+      reference = await loadAccessibleImageReference(db, args);
+    } catch (error) {
+      signal.throwIfAborted();
+      if (containsSensitiveMetadataError(error)) {
+        return { kind: "not-found" };
+      }
+      throw error;
+    }
+    signal.throwIfAborted();
+    if (!reference) {
+      return { kind: "not-found" };
+    }
+
+    let source;
+    try {
+      source = await get(privateArtifactRecord(reference.sourceFileId));
+    } catch (error) {
+      signal.throwIfAborted();
+      if (containsSensitiveMetadataError(error)) {
+        return { kind: "not-found" };
+      }
+      throw error;
+    }
+    signal.throwIfAborted();
+    if (
+      !source ||
+      source.userId !== reference.ownerUserId ||
+      source.orgId !== args.orgId ||
+      source.accessLevel !== "private" ||
+      source.materializationStatus !== "ready" ||
+      source.sizeBytes === null ||
+      source.key !== reference.sourceStorageKey ||
+      source.filename !== reference.sourceFilename ||
+      source.contentType !== reference.sourceContentType
+    ) {
+      return { kind: "not-found" };
+    }
+
+    return {
+      kind: "authorized",
+      key: source.key,
+      referenceSource:
+        reference.ownerUserId === args.userId ? "owner" : "organization",
+    };
+  },
+);
+
+export const resolveImageReferenceProviderUrl$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly referenceId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<ResolvedImageReferenceProviderUrl> => {
+    const access = await set(
+      authorizeImageReferenceForGeneration$,
+      args,
+      signal,
+    );
+    if (access.kind !== "authorized") {
+      return access;
+    }
+
+    const url = await get(
+      generatePresignedGetUrl(
+        privateArtifactsBucket(),
+        access.key,
+        IMAGE_REFERENCE_PROVIDER_URL_TTL_SECONDS,
+        undefined,
+        true,
+      ),
+    );
+    signal.throwIfAborted();
+    return {
+      kind: "resolved",
+      url,
+      referenceSource: access.referenceSource,
+    };
+  },
+);

--- a/turbo/apps/cli/src/commands/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/image.test.ts
@@ -539,6 +539,18 @@ describe("okou generate image command", () => {
       ],
       message: "--image-reference-id can be specified at most once",
     },
+    {
+      name: "a connector-backed saved reference request",
+      args: ["--image-reference-id", IMAGE_REFERENCE_ID, "--provider", "fal"],
+      message:
+        "--image-reference-id is only supported by the built-in provider",
+    },
+    {
+      name: "a saved reference in compile mode",
+      args: ["--image-reference-id", IMAGE_REFERENCE_ID, "--compile"],
+      message:
+        "--image-reference-id is only available for direct image generation",
+    },
   ])("should reject $name", async ({ args, message }) => {
     await expect(async () => {
       await generateCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/image.test.ts
@@ -17,6 +17,7 @@ import { DEFAULT_IMAGE_MODEL_ENV } from "@okouai/core/image-model-catalog";
 
 const IMAGE_URL = "http://localhost:3000/api/image-io/generate";
 const IMAGE_GENERATION_ID = "00000000-0000-4000-8000-000000000001";
+const IMAGE_REFERENCE_ID = "00000000-0000-4000-8000-000000000002";
 const IMAGE_STATUS_URL = `http://localhost:3000/api/built-in-generations/${IMAGE_GENERATION_ID}`;
 const IMAGE_RESULT = {
   id: "image-file-id",
@@ -480,6 +481,79 @@ describe("okou generate image command", () => {
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
     expect(stdout).toContain("Model: fal-ai/flux-pro/v1.1");
     expect(stdout).toContain("Provider: fal");
+  });
+
+  it("should serialize one saved reference after explicit image URLs", async () => {
+    let capturedBody: unknown;
+    server.use(
+      http.post(IMAGE_URL, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(IMAGE_RESULT);
+      }),
+    );
+
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "image",
+      "--raw-prompt",
+      "Use the saved visual language for a new subject",
+      "--model",
+      "nano-banana-2",
+      "--image-url",
+      "https://example.com/subject.png",
+      "--image-reference-id",
+      IMAGE_REFERENCE_ID,
+    ]);
+
+    expect(capturedBody).toEqual({
+      prompt: "Use the saved visual language for a new subject",
+      model: "nano-banana-2",
+      size: "auto",
+      quality: "medium",
+      background: "auto",
+      outputFormat: "png",
+      moderation: "auto",
+      safetyTolerance: "4",
+      imageUrls: ["https://example.com/subject.png"],
+      imageReferenceIds: [IMAGE_REFERENCE_ID],
+    });
+    expect(mockConsoleLog.mock.calls.flat().join("\n")).not.toContain(
+      IMAGE_REFERENCE_ID,
+    );
+  });
+
+  it.each([
+    {
+      name: "a malformed saved reference id",
+      args: ["--image-reference-id", "not-a-uuid"],
+      message: "--image-reference-id must be a valid UUID",
+    },
+    {
+      name: "more than one saved reference id",
+      args: [
+        "--image-reference-id",
+        IMAGE_REFERENCE_ID,
+        "--image-reference-id",
+        "00000000-0000-4000-8000-000000000003",
+      ],
+      message: "--image-reference-id can be specified at most once",
+    },
+  ])("should reject $name", async ({ args, message }) => {
+    await expect(async () => {
+      await generateCommand.parseAsync([
+        "node",
+        "cli",
+        "image",
+        "--raw-prompt",
+        "A new subject",
+        ...args,
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining(message),
+    );
   });
 
   it("should pass Nano Banana 2 edit controls to the image API", async () => {
@@ -980,6 +1054,7 @@ describe("okou generate image command", () => {
     expect(helpOutput).toContain("--seed");
     expect(helpOutput).toContain("--safety-tolerance");
     expect(helpOutput).toContain("--image-url");
+    expect(helpOutput).toContain("--image-reference-id <uuid>");
     expect(helpOutput).toContain("--image-prompt-strength");
     expect(helpOutput).toContain(
       "Nano Banana 2 models and Seedream 5 Lite accept up to 14",

--- a/turbo/apps/cli/src/commands/shared/image-generate.ts
+++ b/turbo/apps/cli/src/commands/shared/image-generate.ts
@@ -5,6 +5,7 @@ import { decodeSandboxTokenPayload } from "../../lib/api/sandbox-token";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { createStyledImageCompilationPacket } from "./image-style-authoring";
 import { runDefaultImageModelFromEnvironment } from "./run-default-image-model";
+import { isUuid } from "../../lib/utils/uuid";
 import {
   findImageStyle,
   listImageStyles,
@@ -33,6 +34,7 @@ interface ImageOptions {
   safetyTolerance: string;
   enhancePrompt?: boolean;
   imageUrl: string[];
+  imageReferenceId: string[];
   maskImageUrl?: string;
   inputFidelity?: string;
   imagePromptStrength?: string;
@@ -107,6 +109,10 @@ function collectString(value: string, previous: string[]): string[] {
   return [...previous, value];
 }
 
+function collectImageReferenceId(value: string, previous: string[]): string[] {
+  return [...previous, value.trim()];
+}
+
 function parseStyleSource(value: string): "github" | "r2" {
   if (value !== "github" && value !== "r2") {
     throw new InvalidArgumentError("style source must be github or r2");
@@ -159,7 +165,7 @@ function resolveImageRequestSize(
   if (command.getOptionValueSource("size") !== "default") {
     return options.size;
   }
-  if (options.imageUrl.length > 0) {
+  if (options.imageUrl.length > 0 || options.imageReferenceId.length > 0) {
     return "auto";
   }
 
@@ -189,7 +195,8 @@ function hasImagePromptModeRequest(options: ImageOptions): boolean {
     options.compile === true ||
     options.prompt !== undefined ||
     options.compiledPrompt !== undefined ||
-    options.rawPrompt !== undefined
+    options.rawPrompt !== undefined ||
+    options.imageReferenceId.length > 0
   );
 }
 
@@ -295,6 +302,12 @@ export function createImageGenerateCommand(
       [],
     )
     .option(
+      "--image-reference-id <uuid>",
+      "Saved reference image id for built-in generation; may be specified once",
+      collectImageReferenceId,
+      [],
+    )
+    .option(
       "--mask-image-url <url>",
       "Mask image URL for supported edit models",
     )
@@ -382,7 +395,10 @@ Options:
     --enhance-prompt for flux-pro-1.1. --compression and --moderation low are
     not supported on the fal-backed image path. Ideogram prompt expansion is
     disabled because Okou supplies the final prompt and expansion costs extra.
-  - Image-to-image: pass --image-url to use the model's edit/reference path.
+  - Image-to-image: pass --image-url to use the model's edit/reference path,
+    or --image-reference-id once to use an authorized saved reference with
+    built-in generation. Explicit URLs are submitted first, followed by the
+    saved reference.
     GPT Image 2.5 accepts up to 16 source images and an optional mask.
     Nano Banana 2 models and Seedream 5 Lite accept up to 14 source images;
     Seedream 5 Pro accepts up to 10; flux-2-pro accepts up to 9;
@@ -395,6 +411,22 @@ ${formatRegistryListing(styles, "image styles")}`;
     })
     .action(
       withErrorHandler(async (options: ImageOptions, command: Command) => {
+        if (options.imageReferenceId.some((id) => !isUuid(id))) {
+          throw new Error("--image-reference-id must be a valid UUID");
+        }
+        if (options.imageReferenceId.length > 1) {
+          throw new Error("--image-reference-id can be specified at most once");
+        }
+        if (
+          options.imageReferenceId.length > 0 &&
+          options.provider !== undefined &&
+          options.provider !== "built-in"
+        ) {
+          throw new Error(
+            "--image-reference-id is only supported by the built-in provider",
+          );
+        }
+
         const dispatch = await dispatchGenerate({
           generationType: config.generationType,
           provider: options.provider,
@@ -412,6 +444,11 @@ ${formatRegistryListing(styles, "image styles")}`;
         const mode = resolveImagePromptMode(options, config.usageCommand);
 
         if (mode === "compile") {
+          if (options.imageReferenceId.length > 0) {
+            throw new Error(
+              "--image-reference-id is only available for direct image generation",
+            );
+          }
           if (options.json) {
             throw new Error(
               "--json is only available for direct built-in generation",
@@ -467,6 +504,7 @@ ${formatRegistryListing(styles, "image styles")}`;
           safetyTolerance: options.safetyTolerance,
           enhancePrompt: options.enhancePrompt,
           imageUrls: options.imageUrl,
+          imageReferenceIds: options.imageReferenceId,
           maskImageUrl: options.maskImageUrl,
           inputFidelity,
           imagePromptStrength,

--- a/turbo/apps/cli/src/commands/shared/image-generate.ts
+++ b/turbo/apps/cli/src/commands/shared/image-generate.ts
@@ -113,6 +113,33 @@ function collectImageReferenceId(value: string, previous: string[]): string[] {
   return [...previous, value.trim()];
 }
 
+function validateSavedImageReferenceOptions(options: ImageOptions): void {
+  if (
+    options.imageReferenceId.some((id) => {
+      return !isUuid(id);
+    })
+  ) {
+    throw new Error("--image-reference-id must be a valid UUID");
+  }
+  if (options.imageReferenceId.length > 1) {
+    throw new Error("--image-reference-id can be specified at most once");
+  }
+  if (
+    options.imageReferenceId.length > 0 &&
+    options.provider !== undefined &&
+    options.provider !== "built-in"
+  ) {
+    throw new Error(
+      "--image-reference-id is only supported by the built-in provider",
+    );
+  }
+  if (options.imageReferenceId.length > 0 && options.compile === true) {
+    throw new Error(
+      "--image-reference-id is only available for direct image generation",
+    );
+  }
+}
+
 function parseStyleSource(value: string): "github" | "r2" {
   if (value !== "github" && value !== "r2") {
     throw new InvalidArgumentError("style source must be github or r2");
@@ -411,21 +438,7 @@ ${formatRegistryListing(styles, "image styles")}`;
     })
     .action(
       withErrorHandler(async (options: ImageOptions, command: Command) => {
-        if (options.imageReferenceId.some((id) => !isUuid(id))) {
-          throw new Error("--image-reference-id must be a valid UUID");
-        }
-        if (options.imageReferenceId.length > 1) {
-          throw new Error("--image-reference-id can be specified at most once");
-        }
-        if (
-          options.imageReferenceId.length > 0 &&
-          options.provider !== undefined &&
-          options.provider !== "built-in"
-        ) {
-          throw new Error(
-            "--image-reference-id is only supported by the built-in provider",
-          );
-        }
+        validateSavedImageReferenceOptions(options);
 
         const dispatch = await dispatchGenerate({
           generationType: config.generationType,
@@ -444,11 +457,6 @@ ${formatRegistryListing(styles, "image styles")}`;
         const mode = resolveImagePromptMode(options, config.usageCommand);
 
         if (mode === "compile") {
-          if (options.imageReferenceId.length > 0) {
-            throw new Error(
-              "--image-reference-id is only available for direct image generation",
-            );
-          }
           if (options.json) {
             throw new Error(
               "--json is only available for direct built-in generation",

--- a/turbo/apps/cli/src/lib/api/domains/web.ts
+++ b/turbo/apps/cli/src/lib/api/domains/web.ts
@@ -301,6 +301,7 @@ interface GenerateWebImageOptions {
   safetyTolerance?: string;
   enhancePrompt?: boolean;
   imageUrls?: readonly string[];
+  imageReferenceIds?: readonly string[];
   maskImageUrl?: string;
   inputFidelity?: string;
   imagePromptStrength?: number;
@@ -965,6 +966,9 @@ export async function generateWebImage(
         : {}),
       ...(options.imageUrls && options.imageUrls.length > 0
         ? { imageUrls: options.imageUrls }
+        : {}),
+      ...(options.imageReferenceIds && options.imageReferenceIds.length > 0
+        ? { imageReferenceIds: options.imageReferenceIds }
         : {}),
       ...(options.maskImageUrl ? { maskImageUrl: options.maskImageUrl } : {}),
       ...(options.inputFidelity

--- a/turbo/packages/api-contracts/src/contracts/image-io-generate.ts
+++ b/turbo/packages/api-contracts/src/contracts/image-io-generate.ts
@@ -10,6 +10,7 @@ const stringOrStringArraySchema = z.union([
   z.array(z.string()).readonly(),
 ]);
 const numberOrStringSchema = z.union([z.number(), z.string()]);
+const imageReferenceIdsSchema = z.array(z.string().uuid()).max(1).readonly();
 
 export const imageIoGenerateRequestSchema = z
   .object({
@@ -28,6 +29,7 @@ export const imageIoGenerateRequestSchema = z
     image_url: stringOrStringArraySchema.optional(),
     imageUrls: stringOrStringArraySchema.optional(),
     image_urls: stringOrStringArraySchema.optional(),
+    imageReferenceIds: imageReferenceIdsSchema.optional(),
     maskImageUrl: z.string().optional(),
     mask_image_url: z.string().optional(),
     inputFidelity: z.string().optional(),
@@ -86,6 +88,7 @@ export const imageIoGenerateContract = c.router({
       401: apiErrorSchema,
       402: apiErrorSchema,
       403: apiErrorSchema,
+      404: apiErrorSchema,
       500: apiErrorSchema,
       502: apiErrorSchema,
       503: apiErrorSchema,


### PR DESCRIPTION
## Stack

Review in order: [#32712](https://github.com/vm0-ai/vm0/pull/32712) → [#32713](https://github.com/vm0-ai/vm0/pull/32713) → [#32714](https://github.com/vm0-ai/vm0/pull/32714) → [#32709](https://github.com/vm0-ai/vm0/pull/32709) → [#32715](https://github.com/vm0-ai/vm0/pull/32715).

- **PR 2 of 5**
- Base: `feat/image-reference-catalog`
- Head: `feat/image-reference-generation`
- Part of #32442

## Summary

- adds the optional one-item `imageReferenceIds` built-in image-generation input
- adds `okou generate image --image-reference-id <uuid>`
- authorizes a saved reference against the caller and active organization before admission and again immediately before provider submission
- resolves a fresh private provider-readable URL only at submission time
- preserves explicit URL ordering, source limits, model capability checks, admission, and billing semantics
- persists only non-sensitive count/source classification; reference IDs, titles, filenames, storage keys, and signed URLs are not stored or returned

## Compatibility

The request field is optional. Existing URL-only behavior, masks, fidelity, prompt mode, and provider routing remain unchanged. This PR does not add chat parsing or Platform UI.

## Verification

- API and CLI type checks: passed on the rebased stack
- changed API lint plus full CLI lint: passed
- `git diff --check`: passed
- repository-wide tests are delegated to the fresh PR CI run

No full local Vitest suite or dev server was run.

## Automation

- Draft PR only
- `pr-auto` was not invoked or attached
- no review requested and no merge attempted
