### PR TITLE
feat(api): resolve saved illustration references in chat runs

### DIFF
--- a/turbo/apps/api/src/lib/generation-template-prompt.ts
+++ b/turbo/apps/api/src/lib/generation-template-prompt.ts
@@ -24,11 +24,16 @@ import {
   type AvatarTemplateOptions,
 } from "@okouai/core/avatar-template";
 import {
+  isUserImageReferenceId,
+  parseUserImageReferenceId,
+} from "@okouai/core/image-reference-selection";
+import {
   PRESENTATION_IMAGE_BATCH_INSTRUCTION,
   PRESENTATION_STATIC_HTML_INSTRUCTION,
 } from "@okouai/core/presentation-generation-instructions";
 import { WEBSITE_IMAGE_BATCH_INSTRUCTION } from "@okouai/core/website-generation-instructions";
 import type { ExplainerVideoOptions } from "@okouai/api-contracts/contracts/explainer-video";
+import { IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE } from "@okouai/api-contracts/contracts/errors";
 import {
   EXPLAINER_VIDEO_TEMPLATE_ID,
   explainerVideoInstructionLines,
@@ -482,9 +487,19 @@ function buildAvatarGenerationTemplatePrompt(
 function buildIllustrationGenerationTemplatePrompt(
   generationTemplate: IllustrationGenerationTemplateInput,
 ): GenerationTemplatePromptResult {
-  const imageStyle = findImageStyle(
-    generationTemplate.selection.illustrationStyleId,
-  );
+  const { illustrationStyleId } = generationTemplate.selection;
+  if (isUserImageReferenceId(illustrationStyleId)) {
+    const referenceId = parseUserImageReferenceId(illustrationStyleId);
+    if (referenceId === undefined) {
+      return {
+        status: "invalid",
+        message: IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE,
+      };
+    }
+    return buildUserImageReferencePrompt(referenceId);
+  }
+
+  const imageStyle = findImageStyle(illustrationStyleId);
   if (!imageStyle) {
     return { status: "invalid", message: "Unknown generation image style" };
   }
@@ -508,6 +523,27 @@ function buildIllustrationGenerationTemplatePrompt(
       `- ${sourceInstruction}`,
       '- Then run `okou generate image --provider built-in --compiled-prompt "<compiled prompt>"` with the resolved compatible CLI options and required reference image URLs, without `--style`.',
       "- If a flag above no longer applies, run `okou generate image -h` to discover the current flags, models, providers, and styles.",
+    ].join("\n"),
+  };
+}
+
+function buildUserImageReferencePrompt(
+  referenceId: string,
+): GenerationTemplatePromptResult {
+  return {
+    status: "resolved",
+    prompt: [
+      ...templateFraming("an illustration or image"),
+      "Selected reference image:",
+      "- Artifact type: illustration",
+      "- Treat the saved reference id as opaque. Do not resolve or expose its URL, storage key, filename, or title.",
+      "",
+      "When you produce an illustration or image from the user's request:",
+      "- Use raw, model-native prompting. Do not compile a style package or use `--style`, `--compile`, or `--compiled-prompt`.",
+      `- Generate with \`okou generate image --provider built-in --image-reference-id ${referenceId} --raw-prompt "<user request>"\`, adding only resolved compatible CLI options.`,
+      "- Preserve only the reference's visual language: palette, texture, medium, lighting, and composition rhythm.",
+      "- The user request controls the new subject. Do not preserve depicted objects, text, people, or brand marks from the reference.",
+      "- If a flag above no longer applies, run `okou generate image -h` to discover the current flags, models, and providers.",
     ].join("\n"),
   };
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -11,6 +11,7 @@ import {
 
 import { HeadObjectCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
 import { isChatRunTerminalEventType } from "@okouai/api-contracts/contracts/chat-events";
+import { IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE as IMAGE_REFERENCE_UNAVAILABLE_MESSAGE } from "@okouai/api-contracts/contracts/errors";
 import {
   chatEventsContract,
   chatThreadConnectorSelectionContract,
@@ -68,6 +69,7 @@ import {
   DEFAULT_IMAGE_MODEL,
   DEFAULT_IMAGE_MODEL_ENV,
 } from "@okouai/core/image-model-catalog";
+import { formatUserImageReferenceId } from "@okouai/core/image-reference-selection";
 import { formatUserPresentationTemplateId } from "@okouai/core/presentation-template-selection";
 import { DEFAULT_VIDEO_MODEL } from "@okouai/core/video-model-catalog";
 import { MemoryPiSession } from "@okouai/pi-agent-runtime/node";
@@ -200,6 +202,7 @@ import {
 import { createAuthDeviceSupportApi } from "./helpers/api-bdd-auth-device-support";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
+import { createImageReferencesBddApi } from "./helpers/api-bdd-image-references";
 import { createComputerUseBddApi } from "./helpers/api-bdd-computer-use";
 import {
   createConnectorBddApi,
@@ -271,6 +274,7 @@ const context = testContext();
 const bdd = createBddApi(context);
 const api = createRunsApi(context);
 const chat = createChatFilesBddApi(context);
+const imageReferences = createImageReferencesBddApi(context);
 const webhooks = createWebhookCallbackApi(context);
 const chatCallbacks = createChatCallbacksApi(context);
 const connectors = createConnectorBddApi(context);
@@ -590,6 +594,36 @@ interface ChatRunSendBody {
  * Template markers render inline, so a client that wants the template on its
  * own line sends the blank line as an explicit text part.
  */
+function userImageReferenceTemplate(
+  referenceId: string,
+): GenerationTemplateRequest {
+  return {
+    type: "illustration",
+    selection: {
+      illustrationStyleId: formatUserImageReferenceId(referenceId),
+    },
+  };
+}
+
+function restoreChatStorageMocks(): void {
+  chatCallbacks.acceptChatObjectStorage();
+  api.acceptStorageDownloads();
+}
+
+async function setReferenceImages(
+  actor: ApiTestUser,
+  enabled: boolean,
+): Promise<void> {
+  if (!actor.orgId) {
+    throw new Error("Image reference tests require an organization");
+  }
+  await updateFeatureSwitchesForUser(
+    context,
+    { ...actor, orgId: actor.orgId },
+    { [FeatureSwitchKey.ReferenceImages]: enabled },
+  );
+}
+
 function userMessageWithTemplate(
   prompt: string,
   template: GenerationTemplateRequest,
@@ -22355,6 +22389,476 @@ describe("CHAT-02: generation templates and attachments", () => {
     expect(websitePrompt).not.toContain("resolve-images.mjs");
     expect(websitePrompt).not.toContain("render.mjs");
     await cancelChatRun(actor, website.runId);
+  }, 90_000);
+
+  it("resolves authorized saved illustration references without leaking catalog metadata", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    await setReferenceImages(actor, true);
+    const reference = await imageReferences.createReference(actor, {
+      title: "Secret campaign reference title",
+    });
+    restoreChatStorageMocks();
+    context.mocks.axiom.ingest.mockClear();
+
+    const first = await sendChatRun(actor, {
+      agentId,
+      prompt: "draw a launch-day fox",
+      template: userImageReferenceTemplate(reference.id),
+    });
+    const firstRun = await api.readRun(actor, first.runId);
+    const guidance = firstRun.appendSystemPrompt ?? "";
+    const generationCommand = guidance.split("\n").find((line) => {
+      return line.includes("okou generate image");
+    });
+    expect(generationCommand).toContain(
+      `--image-reference-id ${reference.id} --raw-prompt`,
+    );
+    expect(generationCommand).not.toContain("--style");
+    expect(generationCommand).not.toContain("--compile");
+    expect(guidance).toContain(
+      "palette, texture, medium, lighting, and composition rhythm",
+    );
+    expect(guidance).toContain(
+      "Do not preserve depicted objects, text, people, or brand marks",
+    );
+    expect(guidance).not.toContain("Secret campaign reference title");
+    expect(guidance).not.toContain("chat-reference.png");
+    expect(guidance).not.toContain("preview.example.test");
+    expect(guidance).not.toContain("upload.example.test");
+    const usage = templateUsageEvents();
+    expect(usage).toStrictEqual([
+      expect.objectContaining({
+        dispatchPath: "normal-send",
+        templateCategory: "illustration",
+        templateCount: 1,
+        templateId: "user-reference",
+        templateSlug: "user-reference",
+        templateSource: "user-reference",
+      }),
+    ]);
+    expect(JSON.stringify(usage)).not.toContain(reference.id);
+    expect(JSON.stringify(usage)).not.toContain(
+      "Secret campaign reference title",
+    );
+    await cancelChatRun(actor, first.runId);
+
+    await imageReferences.updateReference(actor, reference.id, {
+      visibility: "public",
+    });
+    restoreChatStorageMocks();
+    const orgId = requireOrgId(actor);
+    const member = bdd.user({ orgId, orgRole: "org:member" });
+    bdd.acceptAgentStorageWrites();
+    const memberAgent = await bdd.createAgent(member, {
+      displayName: "Shared reference member agent",
+    });
+    restoreChatStorageMocks();
+    const shared = await sendChatRun(member, {
+      agentId: memberAgent.agentId,
+      prompt: "draw a shared-reference poster",
+      template: userImageReferenceTemplate(reference.id),
+    });
+    expect(
+      (await api.readRun(member, shared.runId)).appendSystemPrompt,
+    ).toContain(`--image-reference-id ${reference.id} --raw-prompt`);
+    await cancelChatRun(member, shared.runId);
+
+    const followUp = await sendChatRun(member, {
+      agentId: memberAgent.agentId,
+      threadId: shared.threadId,
+      prompt: "make another with the same selected reference",
+      template: userImageReferenceTemplate(reference.id),
+    });
+    const followUpRun = await api.readRun(member, followUp.runId);
+    expect(followUpRun.appendSystemPrompt).toContain(
+      `--image-reference-id ${reference.id} --raw-prompt`,
+    );
+    expect(followUpRun.prompt).toContain(
+      "make another with the same selected reference",
+    );
+    await cancelChatRun(member, followUp.runId);
+  }, 120_000);
+
+  it("fails malformed, missing, deleted, and unauthorized saved references identically before persistence", async () => {
+    const owner = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    await setReferenceImages(owner.actor, true);
+    const reference = await imageReferences.createReference(owner.actor, {
+      title: "Private authorization fixture",
+    });
+    restoreChatStorageMocks();
+
+    const orgId = requireOrgId(owner.actor);
+    const member = bdd.user({ orgId, orgRole: "org:member" });
+    bdd.acceptAgentStorageWrites();
+    const memberAgent = await bdd.createAgent(member, {
+      displayName: "Private reference non-owner",
+    });
+    restoreChatStorageMocks();
+
+    const crossOrg = await entitledChatActor();
+    await setReferenceImages(crossOrg.actor, true);
+    const attempts: readonly {
+      readonly actor: ApiTestUser;
+      readonly agentId: string;
+      readonly template: GenerationTemplateRequest;
+    }[] = [
+      {
+        actor: member,
+        agentId: memberAgent.agentId,
+        template: userImageReferenceTemplate(reference.id),
+      },
+      {
+        actor: crossOrg.actor,
+        agentId: crossOrg.agentId,
+        template: userImageReferenceTemplate(reference.id),
+      },
+      {
+        actor: owner.actor,
+        agentId: owner.agentId,
+        template: userImageReferenceTemplate(randomUUID()),
+      },
+    ];
+    for (const attempt of attempts) {
+      const threadId = randomUUID();
+      const rejected = await chat.requestSendEvent(
+        attempt.actor,
+        {
+          agentId: attempt.agentId,
+          clientThreadId: threadId,
+          prompt: "try an unavailable saved reference",
+          userMessage: userMessageWithTemplate(
+            "try an unavailable saved reference",
+            attempt.template,
+          ),
+        },
+        [400],
+      );
+      expectApiError(rejected.body);
+      expect(rejected.body.error.message).toBe(
+        IMAGE_REFERENCE_UNAVAILABLE_MESSAGE,
+      );
+      await chat.requestReadThread(attempt.actor, threadId, [404]);
+    }
+
+    await setReferenceImages(owner.actor, false);
+    const featureOffThreadId = randomUUID();
+    const featureOff = await chat.requestSendEvent(
+      owner.actor,
+      {
+        agentId: owner.agentId,
+        clientThreadId: featureOffThreadId,
+        prompt: "try while references are off",
+        userMessage: userMessageWithTemplate(
+          "try while references are off",
+          userImageReferenceTemplate(reference.id),
+        ),
+      },
+      [400],
+    );
+    expectApiError(featureOff.body);
+    expect(featureOff.body.error.message).toBe(
+      IMAGE_REFERENCE_UNAVAILABLE_MESSAGE,
+    );
+    await chat.requestReadThread(owner.actor, featureOffThreadId, [404]);
+
+    await setReferenceImages(owner.actor, true);
+    const malformedThreadId = randomUUID();
+    const malformed = await chat.requestSendEvent(
+      owner.actor,
+      {
+        agentId: owner.agentId,
+        clientThreadId: malformedThreadId,
+        prompt: "try a malformed saved reference",
+        userMessage: userMessageWithTemplate(
+          "try a malformed saved reference",
+          {
+            type: "illustration",
+            selection: {
+              illustrationStyleId: "user-image-reference:not-a-uuid",
+            },
+          },
+        ),
+      },
+      [400],
+    );
+    expectApiError(malformed.body);
+    expect(malformed.body.error.message).toBe(
+      IMAGE_REFERENCE_UNAVAILABLE_MESSAGE,
+    );
+    await chat.requestReadThread(owner.actor, malformedThreadId, [404]);
+
+    await imageReferences.deleteReference(owner.actor, reference.id);
+    restoreChatStorageMocks();
+    const deletedThreadId = randomUUID();
+    const deleted = await chat.requestSendEvent(
+      owner.actor,
+      {
+        agentId: owner.agentId,
+        clientThreadId: deletedThreadId,
+        prompt: "try a deleted saved reference",
+        userMessage: userMessageWithTemplate(
+          "try a deleted saved reference",
+          userImageReferenceTemplate(reference.id),
+        ),
+      },
+      [400],
+    );
+    expectApiError(deleted.body);
+    expect(deleted.body.error.message).toBe(
+      IMAGE_REFERENCE_UNAVAILABLE_MESSAGE,
+    );
+    await chat.requestReadThread(owner.actor, deletedThreadId, [404]);
+  }, 120_000);
+
+  it("re-authorizes saved references for successful queued dispatch", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    await setReferenceImages(actor, true);
+    const reference = await imageReferences.createReference(actor);
+    restoreChatStorageMocks();
+
+    const anchor = await sendChatRun(actor, {
+      agentId,
+      prompt: "hold a valid reference in the queue",
+    });
+    await flushWaitUntilForTest();
+    const anchorClaim = await claimChatRun(runnerGroup, anchor.runId);
+    const queuedEventId = randomUUID();
+    const queued = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: anchor.threadId,
+        clientEventId: queuedEventId,
+        prompt: "dispatch this saved reference later",
+        userMessage: userMessageWithTemplate(
+          "dispatch this saved reference later",
+          userImageReferenceTemplate(reference.id),
+        ),
+      },
+      [201],
+    );
+    expect(queued.body).toMatchObject({ runId: null });
+    context.mocks.axiom.ingest.mockClear();
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
+
+    const messages = await waitForThreadMessages(
+      actor,
+      anchor.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return (
+            message.revokesEventId === queuedEventId &&
+            typeof message.runId === "string"
+          );
+        });
+      },
+    );
+    const dispatchedRunId = userMessages(messages.events).find((message) => {
+      return message.revokesEventId === queuedEventId;
+    })?.runId;
+    if (!dispatchedRunId) {
+      throw new Error("Expected the saved reference message to dispatch");
+    }
+    const run = await api.readRun(actor, dispatchedRunId);
+    expect(run.appendSystemPrompt).toContain(
+      `--image-reference-id ${reference.id} --raw-prompt`,
+    );
+    const usage = templateUsageEvents();
+    expect(usage).toStrictEqual([
+      expect.objectContaining({
+        dispatchPath: "queued-claim",
+        templateId: "user-reference",
+        templateSource: "user-reference",
+      }),
+    ]);
+    expect(JSON.stringify(usage)).not.toContain(reference.id);
+    await cancelChatRun(actor, dispatchedRunId);
+  }, 90_000);
+
+  it("rejects a queued saved reference after same-org access is revoked", async () => {
+    const owner = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    await setReferenceImages(owner.actor, true);
+    const reference = await imageReferences.createReference(owner.actor, {
+      visibility: "public",
+    });
+    restoreChatStorageMocks();
+    const member = bdd.user({
+      orgId: requireOrgId(owner.actor),
+      orgRole: "org:member",
+    });
+    bdd.acceptAgentStorageWrites();
+    const memberAgent = await bdd.createAgent(member, {
+      displayName: "Queued reference member agent",
+    });
+    restoreChatStorageMocks();
+
+    const anchor = await sendChatRun(member, {
+      agentId: memberAgent.agentId,
+      prompt: "hold the reference queue open",
+    });
+    await flushWaitUntilForTest();
+    const anchorClaim = await claimChatRun(owner.runnerGroup, anchor.runId);
+    const queuedEventId = randomUUID();
+    const queuedPrompt = "preserve this queued reference request";
+    const queued = await chat.requestSendEvent(
+      member,
+      {
+        agentId: memberAgent.agentId,
+        threadId: anchor.threadId,
+        clientEventId: queuedEventId,
+        prompt: queuedPrompt,
+        userMessage: userMessageWithTemplate(
+          queuedPrompt,
+          userImageReferenceTemplate(reference.id),
+        ),
+      },
+      [201],
+    );
+    expect(queued.body).toMatchObject({ runId: null });
+
+    await imageReferences.updateReference(owner.actor, reference.id, {
+      visibility: "private",
+    });
+    restoreChatStorageMocks();
+    context.mocks.axiom.ingest.mockClear();
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
+
+    const messages = await waitForThreadMessages(
+      member,
+      anchor.threadId,
+      (items) => {
+        return assistantMessages(items).some((message) => {
+          return message.content === IMAGE_REFERENCE_UNAVAILABLE_MESSAGE;
+        });
+      },
+    );
+    const rejected = userMessages(messages.events).find((message) => {
+      return message.revokesEventId === queuedEventId;
+    });
+    expect(rejected).toMatchObject({
+      eventType: "input.rejected",
+      error: "bad_request",
+    });
+    expect(rejected?.runId).toBeUndefined();
+    expect(chatEventDisplayText(rejected!)?.trimEnd()).toBe(queuedPrompt);
+    expect(templateUsageEvents()).toStrictEqual([]);
+  }, 90_000);
+
+  it("re-authorizes saved references before active-input delivery", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    await setReferenceImages(actor, true);
+    const reference = await imageReferences.createReference(actor);
+    restoreChatStorageMocks();
+
+    const active = await sendChatRun(actor, {
+      agentId,
+      prompt: "hold an active run for steering",
+    });
+    await flushWaitUntilForTest();
+    const claimed = await claimChatRun(runnerGroup, active.runId);
+    const acceptedInputId = randomUUID();
+    const accepted = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: active.threadId,
+        clientEventId: acceptedInputId,
+        prompt: "deliver this active saved reference",
+        userMessage: userMessageWithTemplate(
+          "deliver this active saved reference",
+          userImageReferenceTemplate(reference.id),
+        ),
+      },
+      [201],
+    );
+    expect(accepted.body).toMatchObject({ runId: null });
+    context.mocks.axiom.ingest.mockClear();
+    const acceptedReservation = await api.reserveRunnerActiveInputs(
+      claimed.claim.sandboxToken,
+      active.runId,
+    );
+    if (acceptedReservation.outcome !== "reserved") {
+      throw new Error("Expected the authorized active input to be reserved");
+    }
+    expect(acceptedReservation.prompt).toContain(
+      `--image-reference-id ${reference.id} --raw-prompt`,
+    );
+    expect(templateUsageEvents()).toStrictEqual([
+      expect.objectContaining({
+        dispatchPath: "active-input",
+        templateId: "user-reference",
+        templateSource: "user-reference",
+      }),
+    ]);
+    await api.recordRunnerActiveInputDelivery(
+      claimed.claim.sandboxToken,
+      active.runId,
+      acceptedReservation.deliveryId,
+    );
+
+    const activeInputId = randomUUID();
+    const activePrompt = "preserve this active reference request";
+    const steered = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: active.threadId,
+        clientEventId: activeInputId,
+        prompt: activePrompt,
+        userMessage: userMessageWithTemplate(
+          activePrompt,
+          userImageReferenceTemplate(reference.id),
+        ),
+      },
+      [201],
+    );
+    expect(steered.body).toMatchObject({ runId: null });
+    const reservedBeforeDelete = await api.reserveRunnerActiveInputs(
+      claimed.claim.sandboxToken,
+      active.runId,
+    );
+    if (reservedBeforeDelete.outcome !== "reserved") {
+      throw new Error("Expected the second active input to be reserved");
+    }
+    expect(reservedBeforeDelete.eventIds).toStrictEqual([activeInputId]);
+
+    await imageReferences.deleteReference(actor, reference.id);
+    restoreChatStorageMocks();
+    context.mocks.axiom.ingest.mockClear();
+    const reserved = await api.reserveRunnerActiveInputs(
+      claimed.claim.sandboxToken,
+      active.runId,
+    );
+    expect(reserved.outcome).toBe("empty");
+    const messages = await waitForThreadMessages(
+      actor,
+      active.threadId,
+      (items) => {
+        return assistantMessages(items).some((message) => {
+          return message.content === IMAGE_REFERENCE_UNAVAILABLE_MESSAGE;
+        });
+      },
+    );
+    const rejected = userMessages(messages.events).find((message) => {
+      return message.revokesEventId === activeInputId;
+    });
+    expect(rejected).toMatchObject({
+      eventType: "input.rejected",
+      error: "image_reference_unavailable",
+    });
+    expect(rejected?.runId).toBeUndefined();
+    expect(chatEventDisplayText(rejected!)?.trimEnd()).toBe(activePrompt);
+    expect(templateUsageEvents()).toStrictEqual([]);
+    await cancelChatRun(actor, active.runId, claimed.sandboxHeaders);
   }, 90_000);
 
   it("uses R2 for archive-backed styles", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-image-references.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-image-references.ts
@@ -1,0 +1,242 @@
+import { Readable } from "node:stream";
+
+import {
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+} from "@aws-sdk/client-s3";
+import {
+  imageReferencesContract,
+  type ImageReference,
+  type UpdateImageReferenceBody,
+} from "@okouai/api-contracts/contracts/image-references";
+import { uploadsContract } from "@okouai/api-contracts/contracts/uploads";
+
+import { accept, type TestContext } from "../../../../__tests__/test-context";
+import { setupApp } from "../../../../__tests__/test-helpers";
+import { imageReferencesRoutes } from "../../image-references";
+import { uploadsCompleteRoutes } from "../../uploads-complete";
+import { uploadsPrepareRoutes } from "../../uploads-prepare";
+import type { ApiTestUser } from "./api-bdd";
+import { createRouteMocks } from "./route-test";
+
+const headers = Object.freeze({ authorization: "Bearer clerk-session" });
+const validPng = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Z0YQAAAAASUVORK5CYII=",
+  "base64",
+);
+const routes = Object.freeze([
+  ...uploadsPrepareRoutes,
+  ...uploadsCompleteRoutes,
+  ...imageReferencesRoutes,
+]);
+
+interface StoredObject {
+  readonly id: string;
+  readonly bucket: string;
+  readonly key: string;
+  readonly contentType: string;
+  readonly body: Buffer;
+}
+
+function commandInput(command: unknown): Record<string, unknown> {
+  if (
+    typeof command === "object" &&
+    command !== null &&
+    "input" in command &&
+    typeof command.input === "object" &&
+    command.input !== null
+  ) {
+    return command.input as Record<string, unknown>;
+  }
+  return {};
+}
+
+function objectIdentity(bucket: string, key: string): string {
+  return `${bucket}\u0000${key}`;
+}
+
+export function createImageReferencesBddApi(context: TestContext) {
+  const mocks = createRouteMocks(context);
+  const storedObjects = new Map<string, StoredObject>();
+  let signedUrlSequence = 0;
+
+  function authenticate(actor: ApiTestUser): void {
+    if (!actor.orgId) {
+      throw new Error("Image reference tests require an organization");
+    }
+    mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+  }
+
+  function installStorage(): void {
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (command instanceof ListObjectsV2Command) {
+        return Promise.resolve({ Contents: [] });
+      }
+      const input = commandInput(command);
+      const bucket = typeof input.Bucket === "string" ? input.Bucket : "";
+      const key = typeof input.Key === "string" ? input.Key : "";
+      const object = storedObjects.get(objectIdentity(bucket, key));
+      if (command instanceof HeadObjectCommand) {
+        if (!object) {
+          return Promise.reject(
+            Object.assign(new Error("Missing test object"), {
+              name: "NotFound",
+            }),
+          );
+        }
+        return Promise.resolve({
+          ContentLength: object.body.length,
+          ContentType: object.contentType,
+          Metadata: { "artifact-id": object.id },
+        });
+      }
+      if (command instanceof GetObjectCommand) {
+        if (!object) {
+          return Promise.reject(
+            Object.assign(new Error("Missing test object"), {
+              name: "NoSuchKey",
+            }),
+          );
+        }
+        return Promise.resolve({
+          ContentLength: object.body.length,
+          ContentType: object.contentType,
+          Body: Readable.from([object.body]),
+        });
+      }
+      if (command instanceof DeleteObjectsCommand) {
+        const deletion = input.Delete;
+        const objects =
+          typeof deletion === "object" &&
+          deletion !== null &&
+          "Objects" in deletion &&
+          Array.isArray(deletion.Objects)
+            ? deletion.Objects
+            : [];
+        for (const candidate of objects) {
+          if (
+            typeof candidate === "object" &&
+            candidate !== null &&
+            "Key" in candidate &&
+            typeof candidate.Key === "string"
+          ) {
+            storedObjects.delete(objectIdentity(bucket, candidate.Key));
+          }
+        }
+        return Promise.resolve({});
+      }
+      throw new Error(`Unexpected storage request: ${String(command)}`);
+    });
+    context.mocks.s3.getSignedUrl.mockImplementation(
+      (_client: unknown, command: unknown) => {
+        signedUrlSequence += 1;
+        const input = commandInput(command);
+        const operation = "ContentType" in input ? "upload" : "preview";
+        return Promise.resolve(
+          `https://${operation}.example.test/access/${signedUrlSequence.toString()}?signature=test`,
+        );
+      },
+    );
+  }
+
+  function imageClient() {
+    return setupApp({ context, routes })(imageReferencesContract);
+  }
+
+  function uploadClient() {
+    return setupApp({ context, routes })(uploadsContract);
+  }
+
+  return {
+    async createReference(
+      actor: ApiTestUser,
+      options: {
+        readonly title?: string;
+        readonly visibility?: "private" | "public";
+      } = {},
+    ): Promise<ImageReference> {
+      authenticate(actor);
+      installStorage();
+      const prepared = await accept(
+        uploadClient().prepare({
+          headers,
+          body: {
+            filename: "chat-reference.png",
+            contentType: "image/png",
+            size: validPng.length,
+            purpose: "image-reference",
+          },
+        }),
+        [200],
+      );
+      const signedCommand =
+        context.mocks.s3.getSignedUrl.mock.calls.at(-1)?.[1];
+      const input = commandInput(signedCommand);
+      const bucket = typeof input.Bucket === "string" ? input.Bucket : null;
+      const key = typeof input.Key === "string" ? input.Key : null;
+      if (!bucket || !key) {
+        throw new Error("Prepared image upload did not sign a bucket and key");
+      }
+      storedObjects.set(objectIdentity(bucket, key), {
+        id: prepared.body.id,
+        bucket,
+        key,
+        contentType: "image/png",
+        body: validPng,
+      });
+      await accept(
+        uploadClient().complete({
+          headers,
+          body: { id: prepared.body.id },
+        }),
+        [200],
+      );
+      const created = await accept(
+        imageClient().create({
+          headers,
+          body: {
+            sourceFileId: prepared.body.id,
+            title: options.title ?? "Chat reference",
+            visibility: options.visibility ?? "private",
+          },
+        }),
+        [201],
+      );
+      return created.body;
+    },
+
+    async updateReference(
+      actor: ApiTestUser,
+      referenceId: string,
+      body: UpdateImageReferenceBody,
+    ): Promise<void> {
+      authenticate(actor);
+      installStorage();
+      await accept(
+        imageClient().update({
+          headers,
+          params: { referenceId },
+          body,
+        }),
+        [200, 204],
+      );
+    },
+
+    async deleteReference(
+      actor: ApiTestUser,
+      referenceId: string,
+    ): Promise<void> {
+      authenticate(actor);
+      installStorage();
+      await accept(
+        imageClient().delete({
+          headers,
+          params: { referenceId },
+        }),
+        [204],
+      );
+    },
+  };
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-image-references.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-image-references.ts
@@ -160,13 +160,12 @@ export function createImageReferencesBddApi(context: TestContext) {
       authenticate(actor);
       installStorage();
       const prepared = await accept(
-        uploadClient().prepare({
+        imageClient().prepareUpload({
           headers,
           body: {
             filename: "chat-reference.png",
             contentType: "image/png",
             size: validPng.length,
-            purpose: "image-reference",
           },
         }),
         [200],
@@ -180,7 +179,7 @@ export function createImageReferencesBddApi(context: TestContext) {
         throw new Error("Prepared image upload did not sign a bucket and key");
       }
       storedObjects.set(objectIdentity(bucket, key), {
-        id: prepared.body.id,
+        id: prepared.body.sourceFileId,
         bucket,
         key,
         contentType: "image/png",
@@ -189,7 +188,7 @@ export function createImageReferencesBddApi(context: TestContext) {
       await accept(
         uploadClient().complete({
           headers,
-          body: { id: prepared.body.id },
+          body: { id: prepared.body.sourceFileId },
         }),
         [200],
       );
@@ -197,7 +196,7 @@ export function createImageReferencesBddApi(context: TestContext) {
         imageClient().create({
           headers,
           body: {
-            sourceFileId: prepared.body.id,
+            sourceFileId: prepared.body.sourceFileId,
             title: options.title ?? "Chat reference",
             visibility: options.visibility ?? "private",
           },

--- a/turbo/apps/api/src/signals/services/active-input-delivery.service.ts
+++ b/turbo/apps/api/src/signals/services/active-input-delivery.service.ts
@@ -37,6 +37,16 @@ import type { GenerationTemplateIdentity } from "@okouai/core/generation-templat
 import { lockChatQueueThread } from "./chat-event-queue.service";
 import { replaceLoadedChatEvent } from "./chat-event.service";
 import { lockPiApiFirstTurnLifecycle } from "./pi-api-first-turn-lifecycle.service";
+import {
+  failQueuedUserMessage,
+  failQueuedUserMessageInTransaction,
+} from "./chat-queued-event.service";
+import { IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE } from "@okouai/api-contracts/contracts/errors";
+import { nowDate } from "../../lib/time";
+import {
+  publishChatThreadMessageCreatedSafely,
+  publishThreadListChangedSafely,
+} from "../external/realtime";
 
 interface ActiveInputDeliveryScope {
   readonly runId: string;
@@ -173,49 +183,137 @@ function materializedPrompt(
   return materialized;
 }
 
+async function publishUnavailableActiveInputFailure(
+  scope: ActiveInputDeliveryScope,
+  signal: AbortSignal,
+): Promise<void> {
+  await publishChatThreadMessageCreatedSafely({
+    userId: scope.userId,
+    orgId: scope.orgId,
+    threadId: scope.chatThreadId,
+  });
+  signal.throwIfAborted();
+  await publishThreadListChangedSafely({
+    userId: scope.userId,
+    orgId: scope.orgId,
+  });
+  signal.throwIfAborted();
+}
+
+async function rejectUnavailableActiveInput(
+  db: Db,
+  scope: ActiveInputDeliveryScope,
+  eventId: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const failed = await failQueuedUserMessage(db, {
+    threadId: scope.chatThreadId,
+    eventId,
+    assistantContent: IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE,
+    errorMarker: "image_reference_unavailable",
+    currentTime: nowDate(),
+  });
+  signal.throwIfAborted();
+  if (!failed) {
+    return false;
+  }
+  await publishUnavailableActiveInputFailure(scope, signal);
+  return true;
+}
+
+async function rejectUnavailableOpenActiveInput(
+  db: Db,
+  scope: ActiveInputDeliveryScope,
+  delivery: ActiveInputDeliveryReference,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const failed = await db.transaction(async (tx) => {
+    await lockPiApiFirstTurnLifecycle(tx, scope.runId);
+    if (!(await lockChatQueueThread(tx, scope.chatThreadId))) {
+      return null;
+    }
+    const open = await lockOpenDelivery(tx, scope);
+    if (
+      !open ||
+      open.deliveryId !== delivery.deliveryId ||
+      open.items.length !== 1 ||
+      open.items[0]?.sourceEventId !== delivery.sourceEventId
+    ) {
+      return null;
+    }
+    await settleOpenActiveInputDeliveryAsUndelivered(
+      tx,
+      scope,
+      open.deliveryId,
+      open.items,
+    );
+    return await failQueuedUserMessageInTransaction(tx, {
+      threadId: scope.chatThreadId,
+      eventId: delivery.sourceEventId,
+      assistantContent: IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE,
+      errorMarker: "image_reference_unavailable",
+      currentTime: nowDate(),
+    });
+  });
+  signal.throwIfAborted();
+  if (!failed) {
+    return false;
+  }
+  await publishUnavailableActiveInputFailure(scope, signal);
+  return true;
+}
+
 async function prepareReservation(
   db: Db,
   clerk: ClerkClient,
   scope: ActiveInputDeliveryScope,
   signal: AbortSignal,
 ): Promise<PreparedReservation> {
-  const rows = await pendingActiveInputRows(
-    db,
-    scope.chatThreadId,
-    scope.runId,
-  ).limit(1);
-  signal.throwIfAborted();
-  const [row] = rows;
-  if (!row) {
-    return { kind: "empty" };
-  }
-  const prompts = await materializePendingActiveInputPrompts(
-    db,
-    clerk,
-    rows,
-    scope,
-    signal,
-  );
-  if (!prompts) {
-    throw new Error("Pending active input cannot be materialized");
-  }
-  const materialized = materializedPrompt(row, prompts);
-  const deliveryId = randomUUID();
-  if (
-    !activeInputDeliveryPromptFitsControlPayload(
+  while (true) {
+    const rows = await pendingActiveInputRows(
+      db,
+      scope.chatThreadId,
+      scope.runId,
+    ).limit(1);
+    signal.throwIfAborted();
+    const [row] = rows;
+    if (!row) {
+      return { kind: "empty" };
+    }
+    const prompts = await materializePendingActiveInputPrompts(
+      db,
+      clerk,
+      rows,
+      scope,
+      signal,
+    );
+    if (!prompts) {
+      throw new Error("Pending active input cannot be materialized");
+    }
+    const materialized = materializedPrompt(row, prompts);
+    if (materialized.status === "image_reference_unavailable") {
+      if (!(await rejectUnavailableActiveInput(db, scope, row.id, signal))) {
+        return { kind: "empty" };
+      }
+      continue;
+    }
+    const deliveryId = randomUUID();
+    if (
+      !activeInputDeliveryPromptFitsControlPayload(
+        deliveryId,
+        materialized.prompt,
+      )
+    ) {
+      return { kind: "rejected", reason: "payload_too_large" };
+    }
+    return {
+      kind: "ready",
       deliveryId,
-      materialized.prompt,
-    )
-  ) {
-    return { kind: "rejected", reason: "payload_too_large" };
+      sourceEventId: row.id,
+      prompt: materialized.prompt,
+      templateIdentities: materialized.templateIdentities,
+    };
   }
-  return {
-    kind: "ready",
-    deliveryId,
-    sourceEventId: row.id,
-    prompt: materialized.prompt,
-    templateIdentities: materialized.templateIdentities,
-  };
 }
 
 async function canReturnEmptyReservation(
@@ -380,13 +478,17 @@ async function transitionReservation(
   };
 }
 
+type ActiveInputDeliveryMaterialization =
+  | { readonly status: "resolved"; readonly prompt: string }
+  | { readonly status: "image_reference_unavailable" };
+
 async function materializeDelivery(
   db: Db,
   clerk: ClerkClient,
   scope: ActiveInputDeliveryScope,
   delivery: ActiveInputDeliveryReference,
   signal: AbortSignal,
-): Promise<string> {
+): Promise<ActiveInputDeliveryMaterialization> {
   const rows = await activeInputRowsByIds(db, scope.chatThreadId, [
     delivery.sourceEventId,
   ]);
@@ -405,13 +507,17 @@ async function materializeDelivery(
   if (!prompts) {
     throw new Error("Active input delivery cannot be rematerialized");
   }
-  const { prompt } = materializedPrompt(row, prompts);
+  const materialized = materializedPrompt(row, prompts);
+  if (materialized.status === "image_reference_unavailable") {
+    return materialized;
+  }
+  const { prompt } = materialized;
   if (
     !activeInputDeliveryPromptFitsControlPayload(delivery.deliveryId, prompt)
   ) {
     throw new Error("Active input delivery exceeds the control payload limit");
   }
-  return prompt;
+  return { status: "resolved", prompt };
 }
 
 export async function reserveActiveInputDelivery(
@@ -472,11 +578,22 @@ export async function reserveActiveInputDelivery(
       };
     }
     if (result.outcome === "retrieve") {
+      const materialized = await materializeDelivery(
+        db,
+        clerk,
+        scope,
+        result,
+        signal,
+      );
+      if (materialized.status === "image_reference_unavailable") {
+        await rejectUnavailableOpenActiveInput(db, scope, result, signal);
+        continue;
+      }
       return {
         outcome: "reserved",
         deliveryId: result.deliveryId,
         sourceEventId: result.sourceEventId,
-        prompt: await materializeDelivery(db, clerk, scope, result, signal),
+        prompt: materialized.prompt,
       };
     }
     return result;

--- a/turbo/apps/api/src/signals/services/active-input-prompt.service.ts
+++ b/turbo/apps/api/src/signals/services/active-input-prompt.service.ts
@@ -23,6 +23,7 @@ import {
 import { pendingActiveInputCondition } from "./chat-event-queue.service";
 import { canonicalChatEventUserMessage } from "./canonical-chat-event-read.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
+import { imageReferenceSelectionsAreAvailable } from "./image-reference-chat-selection.service";
 
 type ChatEventContextType = NonNullable<
   (typeof chatEvents.$inferSelect)["contextType"]
@@ -174,10 +175,13 @@ export type PendingActiveInputRow = Awaited<
  * prompt several times. The caller reports it once, when the delivery row is
  * created.
  */
-export interface MaterializedActiveInputPrompt {
-  readonly prompt: string;
-  readonly templateIdentities: readonly GenerationTemplateIdentity[];
-}
+export type MaterializedActiveInputPrompt =
+  | {
+      readonly status: "resolved";
+      readonly prompt: string;
+      readonly templateIdentities: readonly GenerationTemplateIdentity[];
+    }
+  | { readonly status: "image_reference_unavailable" };
 
 export async function materializePendingActiveInputPrompts(
   db: Db,
@@ -294,6 +298,16 @@ async function materializeActiveInputPrompt(
     throw new Error("Active input event is missing userMessage");
   }
   const projection = projectUserMessage(userMessage);
+  if (
+    !(await imageReferenceSelectionsAreAvailable(db, {
+      orgId: args.orgId,
+      userId: args.userId,
+      generationTemplates: projection.templates,
+      featureSwitchContext: args.featureSwitchContext,
+    }))
+  ) {
+    return { status: "image_reference_unavailable" };
+  }
   const integration = await loadIntegrationPromptMaterial(db, args.event, args);
   if (isContextBackedContextType(args.event.contextType) && !integration) {
     throw new Error(
@@ -329,6 +343,7 @@ async function materializeActiveInputPrompt(
     throw new Error("Active input event materialized to an empty prompt");
   }
   return {
+    status: "resolved",
     prompt: materialized,
     templateIdentities: generationTemplates.identities,
   };

--- a/turbo/apps/api/src/signals/services/chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/chat-events.command.ts
@@ -148,6 +148,7 @@ import {
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { isCodexFastModeEnabled } from "@okouai/core/model-feature-switch";
 import { buildGenerationTemplatePrompt } from "../../lib/generation-template-prompt";
+import { IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE } from "@okouai/api-contracts/contracts/errors";
 import { buildVideoRunOptionsPrompt } from "@okouai/core/video-run-options-prompt";
 import {
   additionalVolumesForRun,
@@ -163,6 +164,7 @@ import {
 } from "../../lib/template-usage-log";
 import type { GenerationTemplateIdentity } from "@okouai/core/generation-template-identity";
 import { PUBLIC_BRAND } from "@okouai/core/public-brand";
+import { imageReferenceSelectionsAreAvailable } from "./image-reference-chat-selection.service";
 
 type SendBody = z.infer<typeof chatEventsContract.send.body>;
 
@@ -1132,6 +1134,16 @@ async function validateGenerationTemplatePrompt(
 ): Promise<NormalSendFailure | AuthorizedGenerationTemplates> {
   if (generationTemplates.length === 0) {
     return { userPresentationTemplateIds: [] };
+  }
+  if (
+    !(await imageReferenceSelectionsAreAvailable(db, {
+      orgId: args.orgId,
+      userId: args.userId,
+      generationTemplates,
+      featureSwitchContext: featureSwitches.featureSwitchContext,
+    }))
+  ) {
+    return badRequestMessage(IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE);
   }
   // Syntax first: every selection this message names is a candidate mount, so
   // the builder can reject a malformed private id before consulting the database.

--- a/turbo/apps/api/src/signals/services/chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-queued-event.service.ts
@@ -753,7 +753,7 @@ export async function discardUnclaimedUserMessage(
  * assistant replacements that explain a permanent integration admission
  * failure.
  */
-export interface FailQueuedUserMessageArgs {
+interface FailQueuedUserMessageArgs {
   readonly threadId: string;
   readonly eventId: string;
   readonly assistantContent: string;

--- a/turbo/apps/api/src/signals/services/chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-queued-event.service.ts
@@ -753,7 +753,7 @@ export async function discardUnclaimedUserMessage(
  * assistant replacements that explain a permanent integration admission
  * failure.
  */
-interface FailQueuedUserMessageArgs {
+export interface FailQueuedUserMessageArgs {
   readonly threadId: string;
   readonly eventId: string;
   readonly assistantContent: string;
@@ -761,7 +761,7 @@ interface FailQueuedUserMessageArgs {
   readonly currentTime: Date;
 }
 
-async function failQueuedUserMessageInTransaction(
+export async function failQueuedUserMessageInTransaction(
   tx: DbTransaction,
   args: FailQueuedUserMessageArgs,
 ): Promise<{ readonly assistantEventId: string } | null> {

--- a/turbo/apps/api/src/signals/services/image-reference-chat-selection.service.ts
+++ b/turbo/apps/api/src/signals/services/image-reference-chat-selection.service.ts
@@ -1,0 +1,76 @@
+import type { GenerationTemplateRequest } from "@okouai/api-contracts/contracts/chat-threads";
+import {
+  isFeatureEnabled,
+  type FeatureSwitchContext,
+} from "@okouai/core/feature-switch";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import {
+  isUserImageReferenceId,
+  parseUserImageReferenceId,
+} from "@okouai/core/image-reference-selection";
+
+import type { ReadonlyDb } from "../external/db";
+import { loadAccessibleImageReferencesById } from "./image-reference-data.service";
+
+interface SelectedImageReferences {
+  readonly ids: readonly string[];
+  readonly malformed: boolean;
+}
+
+function selectedImageReferences(
+  generationTemplates: readonly GenerationTemplateRequest[],
+): SelectedImageReferences {
+  const ids = new Set<string>();
+  let malformed = false;
+  for (const template of generationTemplates) {
+    if (template.type !== "illustration") {
+      continue;
+    }
+    const selectionId = template.selection.illustrationStyleId;
+    if (!isUserImageReferenceId(selectionId)) {
+      continue;
+    }
+    const referenceId = parseUserImageReferenceId(selectionId);
+    if (referenceId === undefined) {
+      malformed = true;
+      continue;
+    }
+    ids.add(referenceId);
+  }
+  return { ids: [...ids], malformed };
+}
+
+/**
+ * Re-authorize every saved reference carried by a message at the current
+ * dispatch boundary. Missing and inaccessible rows deliberately share one
+ * result so callers cannot use chat submission as an existence oracle.
+ */
+export async function imageReferenceSelectionsAreAvailable(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly generationTemplates: readonly GenerationTemplateRequest[];
+    readonly featureSwitchContext: FeatureSwitchContext;
+  },
+): Promise<boolean> {
+  const selected = selectedImageReferences(args.generationTemplates);
+  if (selected.ids.length === 0 && !selected.malformed) {
+    return true;
+  }
+  if (
+    selected.malformed ||
+    !isFeatureEnabled(
+      FeatureSwitchKey.ReferenceImages,
+      args.featureSwitchContext,
+    )
+  ) {
+    return false;
+  }
+  const rows = await loadAccessibleImageReferencesById(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    referenceIds: selected.ids,
+  });
+  return rows.length === selected.ids.length;
+}

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -7,7 +7,10 @@ import {
   chatEventCompatibilityRole,
   type ChatEventType,
 } from "@okouai/api-contracts/contracts/chat-events";
-import { formatRunErrorForExternalSurface } from "@okouai/api-contracts/contracts/errors";
+import {
+  formatRunErrorForExternalSurface,
+  IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE,
+} from "@okouai/api-contracts/contracts/errors";
 import { isBuiltInModelProviderType } from "@okouai/api-contracts/contracts/model-providers";
 import {
   serializeChatFollowupsContent,
@@ -225,6 +228,7 @@ import {
   type PresentationTemplateVolume,
 } from "./presentation-template-data.service";
 import { OFFICIAL_WORKFLOW_RUN_ADMISSION_MESSAGE } from "./official-workflow-run.service";
+import { imageReferenceSelectionsAreAvailable } from "./image-reference-chat-selection.service";
 
 const log = logger("callback:chat");
 const PG_FOREIGN_KEY_VIOLATION = "23503";
@@ -3068,6 +3072,15 @@ function resolveQueuedMessageGenerationTemplatePrompt(args: {
  * a volume this user may not read must never be assembled — so the same lookup
  * decides both what is mounted and what the prompt is allowed to mention.
  */
+type QueuedMessageTemplateContext =
+  | {
+      readonly status: "resolved";
+      readonly generationTemplatePrompt: string;
+      readonly generationTemplateIdentities: readonly GenerationTemplateIdentity[];
+      readonly presentationTemplateVolumes: readonly PresentationTemplateVolume[];
+    }
+  | { readonly status: "image_reference_unavailable" };
+
 async function resolveQueuedMessageTemplateContext(args: {
   readonly db: ReadonlyDb;
   readonly orgId: string;
@@ -3079,18 +3092,23 @@ async function resolveQueuedMessageTemplateContext(args: {
     typeof resolveQueuedMessageGenerationTemplatePrompt
   >[0]["userMessageProjection"];
   readonly featureSwitchContext: FeatureSwitchContext;
-}): Promise<{
-  readonly generationTemplatePrompt: string;
-  readonly generationTemplateIdentities: readonly GenerationTemplateIdentity[];
-  readonly presentationTemplateVolumes: readonly PresentationTemplateVolume[];
-}> {
+}): Promise<QueuedMessageTemplateContext> {
+  const templates = args.userMessageProjection?.templates ?? [];
+  if (
+    !(await imageReferenceSelectionsAreAvailable(args.db, {
+      orgId: args.orgId,
+      userId: args.userId,
+      generationTemplates: templates,
+      featureSwitchContext: args.featureSwitchContext,
+    }))
+  ) {
+    return { status: "image_reference_unavailable" };
+  }
   const mountedUserPresentationTemplateIds =
     await authorizedUserPresentationTemplateIds(args.db, {
       orgId: args.orgId,
       userId: args.userId,
-      templateIds: selectedUserPresentationTemplateIds(
-        args.userMessageProjection?.templates ?? [],
-      ),
+      templateIds: selectedUserPresentationTemplateIds(templates),
     });
   const generationTemplates =
     await resolveQueuedMessageGenerationTemplatePrompt({
@@ -3100,12 +3118,13 @@ async function resolveQueuedMessageTemplateContext(args: {
         args.db,
         args.input.clerk,
         args.userId,
-        args.userMessageProjection?.templates ?? [],
+        templates,
         args.featureSwitchContext,
       ),
       mountedUserPresentationTemplateIds,
     });
   return {
+    status: "resolved",
     generationTemplatePrompt: generationTemplates.prompt,
     generationTemplateIdentities: generationTemplates.identities,
     presentationTemplateVolumes: userPresentationTemplateVolumes(
@@ -3231,11 +3250,7 @@ async function buildCreateQueuedChatRunInput(
       });
     },
   );
-  const {
-    generationTemplatePrompt,
-    generationTemplateIdentities,
-    presentationTemplateVolumes,
-  } = await resolveQueuedMessageTemplateContext({
+  const templateContext = await resolveQueuedMessageTemplateContext({
     db: args.db,
     orgId: args.agent.orgId,
     userId: args.userId,
@@ -3243,6 +3258,12 @@ async function buildCreateQueuedChatRunInput(
     userMessageProjection,
     featureSwitchContext,
   });
+  if (templateContext.status === "image_reference_unavailable") {
+    return queuedMessageAdmissionFailure(args, launchMaterial, {
+      code: "BAD_REQUEST",
+      message: IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE,
+    });
+  }
   const computerUseHostGrant =
     await resolveQueuedMessageComputerUseHostGrant(args);
   const prompt = queuedMessagePrompt({
@@ -3259,11 +3280,11 @@ async function buildCreateQueuedChatRunInput(
       }),
       incompleteContext,
       priorContext,
-      generationTemplatePrompt,
+      templateContext.generationTemplatePrompt,
       computerUseHostGrant?.displayName ?? null,
     ),
-    presentationTemplateVolumes,
-    generationTemplateIdentities,
+    presentationTemplateVolumes: templateContext.presentationTemplateVolumes,
+    generationTemplateIdentities: templateContext.generationTemplateIdentities,
     publicBrand: launchMaterial.publicBrand,
     threadId: args.threadId,
     queuedMessage: args.queuedMessage,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -5,6 +5,7 @@ import {
   CHAT_RUN_TRANSIENT_ERROR_MESSAGE,
   formatRunErrorForExternalSurface,
   getCodexChatGptAccountUnsupportedModel,
+  IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE,
   INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE,
   isActionableRunError,
   isAgentExecutionTimeoutRunError,
@@ -29,6 +30,23 @@ describe("formatRunErrorForExternalSurface", () => {
         message: "Cannot continue session with this provider",
       }),
     ).toBe("Cannot continue session with this provider");
+  });
+
+  it("preserves the actionable unavailable-reference error", () => {
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "BAD_REQUEST",
+        message: IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE,
+      }),
+    ).toBe(IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE);
+    expect(
+      isActionableRunError(IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE),
+    ).toBe(true);
+    expect(
+      isGenericRunErrorForDisplay(
+        IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE,
+      ),
+    ).toBe(false);
   });
 
   it.each([

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -304,6 +304,8 @@ const CODEX_CHATGPT_ACCOUNT_UNSUPPORTED_MODEL_MESSAGE =
 
 export const INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE =
   "Ask a workspace admin to add credits or upgrade the workspace plan.";
+export const IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE =
+  "The selected reference image is unavailable. Choose another reference or remove it and try again.";
 
 export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
   ...Object.values(RUN_ERROR_GUIDANCE).flatMap((guidance) => {
@@ -312,6 +314,7 @@ export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
   "Cannot continue session",
   "Invalid signature in thinking block",
   "Run cancelled",
+  IMAGE_REFERENCE_SELECTION_UNAVAILABLE_MESSAGE,
   CODEX_PROVIDER_OVERLOADED_MESSAGE,
   // Upstream model usage/quota limits are shown verbatim (the CLI already
   // emits clean, user-friendly copy with reset time and upgrade links).

--- a/turbo/packages/core/src/generation-template-identity.ts
+++ b/turbo/packages/core/src/generation-template-identity.ts
@@ -1,6 +1,7 @@
 import type { GenerationTemplateRequest } from "@okouai/api-contracts/contracts/chat-threads";
 
 import { parseAvatarTemplateStylePresetId } from "./avatar-template";
+import { isUserImageReferenceId } from "./image-reference-selection";
 import { isUserPresentationTemplateId } from "./presentation-template-selection";
 import { findWorkflowTemplateItem } from "./workflow-template-items";
 
@@ -21,7 +22,10 @@ export type GenerationTemplateCategory =
   | "workflow";
 
 /** Where the selected template came from. */
-export type GenerationTemplateSource = "builtin" | "user-imported";
+export type GenerationTemplateSource =
+  | "builtin"
+  | "user-imported"
+  | "user-reference";
 
 /**
  * One template selection, normalised into a shape that is comparable across
@@ -55,6 +59,7 @@ export interface GenerationTemplateIdentity {
  * built-in templates from bring-your-own ones.
  */
 const USER_IMPORTED_TEMPLATE_ID = "user-template";
+const USER_IMAGE_REFERENCE_TEMPLATE_ID = "user-reference";
 
 function unreachableGenerationTemplateType(request: never): never {
   throw new Error(
@@ -164,6 +169,14 @@ export function generationTemplateIdentity(
       return videoIdentity(request.selection);
     }
     case "illustration": {
+      if (isUserImageReferenceId(request.selection.illustrationStyleId)) {
+        return {
+          category: "illustration",
+          templateId: USER_IMAGE_REFERENCE_TEMPLATE_ID,
+          templateSlug: USER_IMAGE_REFERENCE_TEMPLATE_ID,
+          source: "user-reference",
+        };
+      }
       return builtinIdentity(
         "illustration",
         request.selection.illustrationStyleId,

--- a/turbo/packages/core/src/image-reference-selection.ts
+++ b/turbo/packages/core/src/image-reference-selection.ts
@@ -1,0 +1,35 @@
+/** How a saved reference image is named in the Illustration selection slot. */
+const USER_IMAGE_REFERENCE_ID_PREFIX = "user-image-reference:";
+
+/** The canonical UUID form used by image_references row ids. */
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+export type UserImageReferenceSelectionId = `user-image-reference:${string}`;
+
+export function formatUserImageReferenceId(
+  referenceId: string,
+): UserImageReferenceSelectionId {
+  return `${USER_IMAGE_REFERENCE_ID_PREFIX}${referenceId}`;
+}
+
+/**
+ * Read the row id out of a saved-reference selection.
+ *
+ * Syntax only: existence and access are resolved against the image-reference
+ * authority immediately before each message or run dispatch.
+ */
+export function parseUserImageReferenceId(
+  selectionId: string,
+): string | undefined {
+  if (!isUserImageReferenceId(selectionId)) {
+    return undefined;
+  }
+  const referenceId = selectionId.slice(USER_IMAGE_REFERENCE_ID_PREFIX.length);
+  return UUID_PATTERN.test(referenceId) ? referenceId : undefined;
+}
+
+/** Distinguish malformed saved-reference ids from built-in style ids. */
+export function isUserImageReferenceId(selectionId: string): boolean {
+  return selectionId.startsWith(USER_IMAGE_REFERENCE_ID_PREFIX);
+}


### PR DESCRIPTION
## Stack

Review in order: [#32712](https://github.com/vm0-ai/vm0/pull/32712) → [#32713](https://github.com/vm0-ai/vm0/pull/32713) → [#32714](https://github.com/vm0-ai/vm0/pull/32714) → [#32709](https://github.com/vm0-ai/vm0/pull/32709) → [#32715](https://github.com/vm0-ai/vm0/pull/32715).

- **PR 3 of 5**
- Base: `feat/image-reference-generation`
- Head: `feat/image-reference-chat-runtime`
- Part of #32442

## Summary

- adds the namespaced `user-image-reference:<uuid>` Illustration identity
- validates and authorizes custom references before initial persistence and again at queued-dispatch and active-input boundaries
- rejects malformed, deleted, inaccessible, and switch-disabled references with one non-oracle actionable error
- preserves user input when later reauthorization fails and emits the canonical failure events
- emits opaque `--image-reference-id` guidance using raw/model-native prompting and the approved style-only rule
- normalizes analytics identity to `user-reference` without sensitive reference metadata
- keeps built-in Illustration behavior unchanged

## Compatibility

The existing Illustration slot remains the only selected style/reference slot. Old frontend and runner payloads remain valid, and no Platform picker UI is introduced here.

## Verification

- full API type-check pipeline: passed on the rebased stack
- changed API ESLint, Oxlint, and type-aware Oxlint: passed
- chat fixtures now prepare private sources through the dedicated image-reference upload endpoint
- `git diff --check`: passed
- repository-wide tests are delegated to the fresh PR CI run

No full local Vitest suite or dev server was run.

## Automation

- Draft PR only
- `pr-auto` was not invoked or attached
- no review requested and no merge attempted
