### PR TITLE
perf(guest-control-server): spawn contained processes directly with clone3

### DIFF
--- a/crates/guest-control-server/src/agent_command.rs
+++ b/crates/guest-control-server/src/agent_command.rs
@@ -10,13 +10,15 @@ use std::io;
 use std::os::fd::{FromRawFd, OwnedFd};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::{ChildStderr, ChildStdout, Command, Stdio};
+use std::process::{ChildStderr, ChildStdout};
+
+use crate::contained_command::{CommandStdio, ContainedCommand as Command};
 
 use guest_contracts::codex_session_cleanup::CodexSessionCleanupRequest;
 use guest_contracts::session_history_identity::SessionHistoryIdentityVerifyRequest;
 
 use crate::process_containment::{ExecProcessContainment, ProcessContainmentCleanupMode};
-use crate::shell_command::{SpawnedCommand, spawn_command_in_containment};
+use crate::shell_command::SpawnedCommand;
 
 #[derive(Clone)]
 pub(crate) enum GuestAgentProgram {
@@ -74,10 +76,10 @@ pub(crate) fn spawn_session_history_identity_verifier_with_pipes(
                 guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
                 &request.runtime_dir,
             )
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+            .stdout(CommandStdio::Piped)
+            .stderr(CommandStdio::Piped);
         crate::user::configure_guest_agent_command_environment(&mut command)?;
-        spawn_command_in_containment(&mut command, false, &process_containment)
+        command.spawn(false, &process_containment)
     })();
 
     match spawn_result {
@@ -109,10 +111,10 @@ pub(crate) fn spawn_codex_session_cleanup_with_pipes(
             .arg(&request.session_id)
             .arg(&request.fallback_relative_path)
             .env_clear()
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+            .stdout(CommandStdio::Piped)
+            .stderr(CommandStdio::Piped);
         crate::user::configure_guest_agent_command_environment(&mut command)?;
-        spawn_command_in_containment(&mut command, false, &process_containment)
+        command.spawn(false, &process_containment)
     })();
 
     match spawn_result {
@@ -145,10 +147,10 @@ fn spawn_agent_executable_with_pipes(
         command
             .env_clear()
             .envs(env.iter().copied())
-            .stdout(Stdio::from(output_writer))
-            .stderr(Stdio::from(output_stderr));
+            .stdout(CommandStdio::Owned(output_writer))
+            .stderr(CommandStdio::Owned(output_stderr));
         crate::user::configure_guest_agent_command_environment(&mut command)?;
-        let mut child = spawn_command_in_containment(&mut command, false, &process_containment)?;
+        let mut child = command.spawn(false, &process_containment)?;
         child.stdout = Some(ChildStdout::from(output_reader));
         child.stderr = Some(ChildStderr::from(diagnostic_reader));
         Ok(child)
@@ -208,6 +210,7 @@ fn cloexec_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
 
 #[cfg(test)]
 mod tests {
+    use crate::process::ChildProcess;
     use std::io::{Read, Write};
 
     use guest_control_proto::ExecProcessRole;

--- a/crates/guest-control-server/src/cgroup_spawn.rs
+++ b/crates/guest-control-server/src/cgroup_spawn.rs
@@ -1,0 +1,487 @@
+//! Fork-like clone3 followed by a strictly prepared, syscall-only child path.
+//!
+//! This is not libc fork: no allocator, libc setxid coordination, atfork
+//! callbacks, Rust unwinding or destructors may run in the copied child.
+
+use std::collections::BTreeMap;
+use std::ffi::{CStr, CString, OsStr, OsString};
+use std::fs::File;
+use std::io::{self, Read};
+use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::ffi::OsStrExt;
+use std::time::{Duration, Instant};
+
+use crate::contained_command::{CommandStdio, ContainedChild, ContainedCommand};
+use crate::process::{kill_and_reap_child, private_descriptor};
+use crate::user::UserCredentials;
+
+const CLONE_CLEAR_SIGHAND: u64 = 1 << 32;
+const CLONE_INTO_CGROUP: u64 = 1 << 33;
+const CLOSE_RANGE_CLOEXEC: u32 = 1 << 2;
+const EXEC_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+// Linux UAPI clone_args, including the v2 cgroup field (Linux 5.7).
+#[repr(C)]
+#[derive(Default)]
+struct CloneArguments {
+    flags: u64,
+    pidfd: u64,
+    child_tid: u64,
+    parent_tid: u64,
+    exit_signal: u64,
+    stack: u64,
+    stack_size: u64,
+    tls: u64,
+    set_tid: u64,
+    set_tid_size: u64,
+    cgroup: u64,
+}
+
+struct PreparedStdio {
+    child: Option<OwnedFd>,
+    parent: Option<OwnedFd>,
+}
+
+impl PreparedStdio {
+    fn new(value: CommandStdio, input: bool) -> io::Result<Self> {
+        match value {
+            CommandStdio::Inherit => Ok(Self {
+                child: None,
+                parent: None,
+            }),
+            CommandStdio::Owned(fd) => Ok(Self {
+                child: Some(private_descriptor(fd)?),
+                parent: None,
+            }),
+            CommandStdio::Piped => {
+                let (reader, writer) = pipe()?;
+                let (child, parent) = if input {
+                    (reader, writer)
+                } else {
+                    (writer, reader)
+                };
+                Ok(Self {
+                    child: Some(child),
+                    parent: Some(parent),
+                })
+            }
+        }
+    }
+}
+
+fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
+    let mut descriptors = [0; 2];
+    // SAFETY: pipe2 initializes both slots on success, atomically CLOEXEC.
+    if unsafe { libc::pipe2(descriptors.as_mut_ptr(), libc::O_CLOEXEC) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let [reader, writer] = descriptors;
+    // SAFETY: each new descriptor is transferred to exactly one owner before
+    // either fallible normalization, so partial setup cannot leak the other.
+    let reader = unsafe { OwnedFd::from_raw_fd(reader) };
+    // SAFETY: this is the distinct writer returned by pipe2.
+    let writer = unsafe { OwnedFd::from_raw_fd(writer) };
+    Ok((private_descriptor(reader)?, private_descriptor(writer)?))
+}
+
+fn cstring(value: &OsStr) -> io::Result<CString> {
+    CString::new(value.as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "nul byte in process input"))
+}
+
+fn executable_paths(
+    program: &OsStr,
+    environment: &BTreeMap<OsString, OsString>,
+) -> io::Result<Vec<CString>> {
+    let bytes = program.as_bytes();
+    if bytes.contains(&b'/') || bytes.is_empty() {
+        return Ok(vec![cstring(program)?]);
+    }
+    let path = environment
+        .get(OsStr::new("PATH"))
+        .map(|path| path.as_bytes());
+    // The deployed musl execvp default. Explicit/empty PATH still wins.
+    let path = path.unwrap_or(b"/usr/local/bin:/bin:/usr/bin");
+    path.split(|byte| *byte == b':')
+        .map(|directory| {
+            let mut candidate = directory.to_vec();
+            if !candidate.is_empty() {
+                candidate.push(b'/');
+            }
+            candidate.extend_from_slice(bytes);
+            cstring(OsStr::from_bytes(&candidate))
+        })
+        .collect()
+}
+
+pub(crate) fn spawn(
+    command: ContainedCommand,
+    cgroup: BorrowedFd<'_>,
+    credentials: Option<&UserCredentials>,
+    deny_process_inspection: bool,
+) -> io::Result<ContainedChild> {
+    let mut environment: BTreeMap<OsString, OsString> = if command.inherit_environment {
+        std::env::vars_os().collect()
+    } else {
+        BTreeMap::new()
+    };
+    environment.extend(command.environment);
+    let paths = executable_paths(&command.program, &environment)?;
+    let arguments: Vec<CString> = std::iter::once(&command.program)
+        .chain(command.args.iter())
+        .map(|value| cstring(value))
+        .collect::<io::Result<_>>()?;
+    let argv: Vec<_> = arguments
+        .iter()
+        .map(|value| value.as_ptr())
+        .chain(std::iter::once(std::ptr::null()))
+        .collect();
+    let environment: Vec<CString> = environment
+        .into_iter()
+        .map(|(key, value)| {
+            if key.as_bytes().contains(&b'=') {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "equals sign in environment key",
+                ));
+            }
+            let mut entry = key.into_encoded_bytes();
+            entry.push(b'=');
+            entry.extend(value.into_encoded_bytes());
+            cstring(OsStr::from_bytes(&entry))
+        })
+        .collect::<io::Result<_>>()?;
+    let envp: Vec<_> = environment
+        .iter()
+        .map(|value| value.as_ptr())
+        .chain(std::iter::once(std::ptr::null()))
+        .collect();
+    let directory = command
+        .directory
+        .as_ref()
+        .map(|path| cstring(path.as_os_str()))
+        .transpose()?;
+    let stdin = PreparedStdio::new(command.stdin, true)?;
+    let stdout = PreparedStdio::new(command.stdout, false)?;
+    let stderr = PreparedStdio::new(command.stderr, false)?;
+    let (error_reader, error_writer) = pipe()?;
+    // SAFETY: a zeroed sigaction with SIG_DFL is a valid reset disposition.
+    let mut sigpipe: libc::sigaction = unsafe { std::mem::zeroed() };
+    sigpipe.sa_sigaction = libc::SIG_DFL;
+    let inputs = ChildInputs {
+        paths: &paths,
+        search_path: !command.program.as_bytes().contains(&b'/') && !command.program.is_empty(),
+        argv: &argv,
+        envp: &envp,
+        directory: directory.as_deref(),
+        credentials,
+        deny_process_inspection,
+        stdio: [
+            stdin.child.as_ref(),
+            stdout.child.as_ref(),
+            stderr.child.as_ref(),
+        ]
+        .map(|fd| fd.map(AsRawFd::as_raw_fd)),
+        error_fd: error_writer.as_raw_fd(),
+        sigpipe: &sigpipe,
+    };
+    let arguments = CloneArguments {
+        flags: CLONE_INTO_CGROUP | CLONE_CLEAR_SIGHAND,
+        exit_signal: libc::SIGCHLD as u64,
+        cgroup: cgroup.as_raw_fd() as u64,
+        ..CloneArguments::default()
+    };
+    let old_mask = set_signal_mask(u64::MAX)?;
+    // SAFETY: without CLONE_VM/FILES/THREAD, the child owns its copied address
+    // space, stack and descriptor table. All referenced input is prepared and
+    // live. Its branch never returns, allocates, unwinds or calls Rust Drop.
+    let pid = unsafe { libc::syscall(libc::SYS_clone3, &arguments, size_of::<CloneArguments>()) };
+    if pid == 0 {
+        child_exec(&inputs, old_mask);
+    }
+    let clone_error = (pid < 0).then(io::Error::last_os_error);
+    let restore = set_signal_mask(old_mask);
+    if let Some(error) = clone_error {
+        restore?;
+        return Err(error);
+    }
+    let mut child = ContainedChild::direct(pid as libc::pid_t);
+    child.stdin = stdin.parent.map(Into::into);
+    child.stdout = stdout.parent.map(Into::into);
+    child.stderr = stderr.parent.map(Into::into);
+    drop((stdin.child, stdout.child, stderr.child, error_writer));
+    if let Err(error) = restore.and_then(|_| exec_handshake(error_reader)) {
+        kill_and_reap_child(child);
+        return Err(error);
+    }
+    Ok(child)
+}
+
+fn set_signal_mask(mask: u64) -> io::Result<u64> {
+    let mut old = 0u64;
+    // SAFETY: Linux uses a 64-bit kernel signal set on both supported guest
+    // architectures. This masks only the calling thread, including libc's
+    // reserved signals, which pthread_sigmask deliberately leaves unblocked.
+    if unsafe {
+        libc::syscall(
+            libc::SYS_rt_sigprocmask,
+            libc::SIG_SETMASK,
+            &mask,
+            &mut old,
+            size_of::<u64>(),
+        )
+    } != 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(old)
+}
+
+fn exec_handshake(reader: OwnedFd) -> io::Result<()> {
+    let deadline = Instant::now() + EXEC_HANDSHAKE_TIMEOUT;
+    let mut reader = File::from(reader);
+    let mut poll = libc::pollfd {
+        fd: reader.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let timeout = i32::try_from(remaining.as_millis()).unwrap_or(i32::MAX);
+        // SAFETY: poll points to one initialized descriptor record.
+        let ready = unsafe { libc::poll(&mut poll, 1, timeout) };
+        if ready == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "process exec handshake timed out",
+            ));
+        }
+        if ready < 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error);
+        }
+        let mut bytes = [0; size_of::<i32>()];
+        match reader.read(&mut bytes) {
+            Ok(0) => return Ok(()),
+            Ok(4) => return Err(io::Error::from_raw_os_error(i32::from_ne_bytes(bytes))),
+            Ok(_) => return Err(io::Error::other("incomplete process exec error")),
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+struct ChildInputs<'a> {
+    paths: &'a [CString],
+    search_path: bool,
+    argv: &'a [*const libc::c_char],
+    envp: &'a [*const libc::c_char],
+    directory: Option<&'a CStr>,
+    credentials: Option<&'a UserCredentials>,
+    deny_process_inspection: bool,
+    stdio: [Option<RawFd>; 3],
+    error_fd: RawFd,
+    sigpipe: &'a libc::sigaction,
+}
+
+fn child_exec(inputs: &ChildInputs<'_>, old_mask: u64) -> ! {
+    // SAFETY: exclusive copied-child path. Every pointer refers to immutable
+    // parent-prepared storage. All called operations are raw syscalls or
+    // async-signal-safe sigaction; no libc threaded credential coordination.
+    unsafe {
+        if libc::syscall(libc::SYS_setpgid, 0, 0) != 0 {
+            child_errno(inputs.error_fd);
+        }
+        for (target, source) in inputs.stdio.iter().enumerate() {
+            if let Some(source) = source
+                && libc::syscall(libc::SYS_dup3, *source, target as RawFd, 0) < 0
+            {
+                child_errno(inputs.error_fd);
+            }
+        }
+        if libc::syscall(libc::SYS_close_range, 3u32, u32::MAX, CLOSE_RANGE_CLOEXEC) != 0 {
+            child_errno(inputs.error_fd);
+        }
+        if let Some(credentials) = inputs.credentials
+            && (libc::syscall(
+                libc::SYS_setgroups,
+                credentials.groups.len(),
+                credentials.groups.as_ptr(),
+            ) != 0
+                || libc::syscall(libc::SYS_setgid, credentials.gid) != 0
+                || libc::syscall(libc::SYS_setuid, credentials.uid) != 0)
+        {
+            child_errno(inputs.error_fd);
+        }
+        if let Some(directory) = inputs.directory
+            && libc::syscall(libc::SYS_chdir, directory.as_ptr()) != 0
+        {
+            child_errno(inputs.error_fd);
+        }
+        // setuid can reset dumpability, so preserve the existing ordering.
+        if inputs.deny_process_inspection
+            && libc::syscall(libc::SYS_prctl, libc::PR_SET_DUMPABLE, 0, 0, 0, 0) != 0
+        {
+            child_errno(inputs.error_fd);
+        }
+        if libc::sigaction(libc::SIGPIPE, inputs.sigpipe, std::ptr::null_mut()) != 0
+            || libc::syscall(
+                libc::SYS_rt_sigprocmask,
+                libc::SIG_SETMASK,
+                &old_mask,
+                std::ptr::null_mut::<u64>(),
+                size_of::<u64>(),
+            ) != 0
+        {
+            child_errno(inputs.error_fd);
+        }
+        let mut missing_error = libc::ENOENT;
+        for path in inputs.paths {
+            libc::syscall(
+                libc::SYS_execve,
+                path.as_ptr(),
+                inputs.argv.as_ptr(),
+                inputs.envp.as_ptr(),
+            );
+            let error = *libc::__errno_location();
+            if !inputs.search_path {
+                child_error(inputs.error_fd, error);
+            }
+            match error {
+                libc::EACCES => missing_error = error,
+                libc::ENOENT | libc::ENOTDIR => {}
+                _ => child_error(inputs.error_fd, error),
+            }
+        }
+        child_error(inputs.error_fd, missing_error);
+    }
+}
+
+fn child_errno(error_fd: RawFd) -> ! {
+    // SAFETY: errno is copied thread-local scalar state, not a libc lock.
+    child_error(error_fd, unsafe { *libc::__errno_location() });
+}
+
+fn child_error(error_fd: RawFd, error: i32) -> ! {
+    // SAFETY: this empty CLOEXEC pipe has exactly one child writer. The
+    // four-byte write is atomic. _exit never runs parent-owned destructors.
+    unsafe {
+        loop {
+            if libc::syscall(libc::SYS_write, error_fd, &error, size_of::<i32>()) >= 0
+                || *libc::__errno_location() != libc::EINTR
+            {
+                break;
+            }
+        }
+        libc::_exit(127);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::fd::AsFd;
+    use std::process::Command;
+
+    fn signal_mask() -> u64 {
+        let mut mask = 0u64;
+        // SAFETY: null new-set only reads the current thread's kernel mask.
+        assert_eq!(
+            unsafe {
+                libc::syscall(
+                    libc::SYS_rt_sigprocmask,
+                    libc::SIG_SETMASK,
+                    std::ptr::null::<u64>(),
+                    &mut mask,
+                    size_of::<u64>(),
+                )
+            },
+            0
+        );
+        mask
+    }
+
+    #[test]
+    fn rejected_cgroup_never_falls_back_or_changes_the_parent_mask() {
+        let directory = tempfile::tempdir().unwrap();
+        let marker = directory.path().join("must-not-exist");
+        let not_a_cgroup = File::open(directory.path()).unwrap();
+        let before = signal_mask();
+        let mut command = ContainedCommand::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg("touch \"$MARKER\"")
+            .env("MARKER", &marker);
+        match spawn(command, not_a_cgroup.as_fd(), None, false) {
+            Err(error) => assert!(error.raw_os_error().is_some(), "{error}"),
+            Ok(child) => {
+                kill_and_reap_child(child);
+                panic!("an ordinary directory cannot authorize a cgroup launch");
+            }
+        }
+        assert_eq!(signal_mask(), before);
+        assert!(!marker.exists());
+    }
+
+    #[test]
+    fn malformed_launch_inputs_fail_before_child_creation() {
+        let directory = tempfile::tempdir().unwrap();
+        let descriptor = File::open(directory.path()).unwrap();
+        for invalid in ["argument", "environment", "directory"] {
+            let mut command = ContainedCommand::new("/bin/true");
+            match invalid {
+                "argument" => {
+                    command.arg("bad\0argument");
+                }
+                "environment" => {
+                    command.env("bad=key", "value");
+                }
+                _ => {
+                    command.current_dir("bad\0directory");
+                }
+            }
+            let error = match spawn(command, descriptor.as_fd(), None, false) {
+                Err(error) => error,
+                Ok(child) => {
+                    kill_and_reap_child(child);
+                    panic!("invalid input unexpectedly spawned");
+                }
+            };
+            assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        }
+    }
+
+    #[test]
+    fn private_pipes_preserve_closed_standard_descriptors() {
+        const CHILD_ENV: &str = "OKOU_TEST_PRIVATE_PIPE_CHILD";
+        if std::env::var_os(CHILD_ENV).is_some() {
+            // Close after Rust startup, which repairs inherited closed stdio.
+            // This process runs only this test and exits before harness output.
+            for fd in [0, 1, 2] {
+                // SAFETY: only this isolated process loses its standard fds.
+                unsafe { libc::close(fd) };
+            }
+            let (reader, writer) = pipe().unwrap();
+            assert!(reader.as_raw_fd() > 2 && writer.as_raw_fd() > 2);
+            for fd in [0, 1, 2] {
+                // SAFETY: fcntl only probes whether this descriptor is open.
+                assert_eq!(unsafe { libc::fcntl(fd, libc::F_GETFD) }, -1);
+                assert_eq!(io::Error::last_os_error().raw_os_error(), Some(libc::EBADF));
+            }
+            // The isolated child intentionally has no harness output fds.
+            // SAFETY: all assertions completed; the OS owns final fd cleanup.
+            unsafe { libc::_exit(0) };
+        }
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command
+            .args([
+                "--exact",
+                "cgroup_spawn::tests::private_pipes_preserve_closed_standard_descriptors",
+            ])
+            .env(CHILD_ENV, "1");
+        assert!(command.status().unwrap().success());
+    }
+}

--- a/crates/guest-control-server/src/contained_command.rs
+++ b/crates/guest-control-server/src/contained_command.rs
@@ -1,0 +1,246 @@
+//! Explicit launch inputs for operation-owned processes.
+//!
+//! Cgroup launches prepare one command and create the child in its target
+//! cgroup. Opaque `Command::pre_exec` callbacks cannot express that boundary.
+
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::io;
+use std::os::fd::OwnedFd;
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, ExitStatus, Stdio};
+
+use crate::process::{ChildProcess, spawn_in_own_process_group};
+use crate::process_containment::ExecProcessContainment;
+
+pub(crate) enum CommandStdio {
+    Inherit,
+    Piped,
+    Owned(OwnedFd),
+}
+
+impl From<CommandStdio> for Stdio {
+    fn from(value: CommandStdio) -> Self {
+        match value {
+            CommandStdio::Inherit => Self::inherit(),
+            CommandStdio::Piped => Self::piped(),
+            CommandStdio::Owned(fd) => Self::from(fd),
+        }
+    }
+}
+
+pub(crate) struct ContainedCommand {
+    pub(crate) program: OsString,
+    pub(crate) args: Vec<OsString>,
+    pub(crate) environment: BTreeMap<OsString, OsString>,
+    pub(crate) inherit_environment: bool,
+    pub(crate) directory: Option<PathBuf>,
+    pub(crate) stdin: CommandStdio,
+    pub(crate) stdout: CommandStdio,
+    pub(crate) stderr: CommandStdio,
+}
+
+impl ContainedCommand {
+    pub(crate) fn new(program: impl AsRef<OsStr>) -> Self {
+        Self {
+            program: program.as_ref().to_owned(),
+            args: Vec::new(),
+            environment: BTreeMap::new(),
+            inherit_environment: true,
+            directory: None,
+            stdin: CommandStdio::Inherit,
+            stdout: CommandStdio::Inherit,
+            stderr: CommandStdio::Inherit,
+        }
+    }
+
+    pub(crate) fn arg(&mut self, value: impl AsRef<OsStr>) -> &mut Self {
+        self.args.push(value.as_ref().to_owned());
+        self
+    }
+
+    pub(crate) fn env(&mut self, key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) -> &mut Self {
+        self.environment
+            .insert(key.as_ref().to_owned(), value.as_ref().to_owned());
+        self
+    }
+
+    pub(crate) fn envs<K: AsRef<OsStr>, V: AsRef<OsStr>>(
+        &mut self,
+        values: impl IntoIterator<Item = (K, V)>,
+    ) -> &mut Self {
+        for (key, value) in values {
+            self.env(key, value);
+        }
+        self
+    }
+
+    pub(crate) fn env_clear(&mut self) -> &mut Self {
+        self.inherit_environment = false;
+        self.environment.clear();
+        self
+    }
+
+    pub(crate) fn current_dir(&mut self, path: impl AsRef<Path>) -> &mut Self {
+        self.directory = Some(path.as_ref().to_owned());
+        self
+    }
+
+    pub(crate) fn stdin(&mut self, value: CommandStdio) -> &mut Self {
+        self.stdin = value;
+        self
+    }
+
+    pub(crate) fn stdout(&mut self, value: CommandStdio) -> &mut Self {
+        self.stdout = value;
+        self
+    }
+
+    pub(crate) fn stderr(&mut self, value: CommandStdio) -> &mut Self {
+        self.stderr = value;
+        self
+    }
+
+    pub(crate) fn spawn(
+        mut self,
+        sudo: bool,
+        containment: &ExecProcessContainment,
+    ) -> io::Result<ContainedChild> {
+        let credentials = crate::user::command_credentials(sudo)?;
+        if let Some(credentials) = credentials {
+            self.current_dir(&credentials.home)
+                .env("HOME", &credentials.home)
+                .env("USER", &credentials.username)
+                .env("LOGNAME", &credentials.username);
+        }
+        let placement = containment.prepare_command();
+        if let Some(directory) = placement.directory {
+            return crate::cgroup_spawn::spawn(
+                self,
+                directory,
+                credentials,
+                placement.deny_process_inspection,
+            );
+        }
+
+        // Explicit TestNoop and fixed process-group-only roles, never a retry
+        // after a failed cgroup spawn. Only this backend constructs Command.
+        let mut command = self.into_standard_command();
+        if let Some(credentials) = credentials {
+            crate::user::apply_credentials(&mut command, credentials)?;
+        }
+        spawn_in_own_process_group(&mut command).map(ContainedChild::from)
+    }
+
+    /// Materialize only for an explicitly non-cgroup launch.
+    pub(crate) fn into_standard_command(self) -> Command {
+        let mut command = Command::new(self.program);
+        command.args(self.args);
+        if !self.inherit_environment {
+            command.env_clear();
+        }
+        command.envs(self.environment);
+        if let Some(directory) = self.directory {
+            command.current_dir(directory);
+        }
+        command
+            .stdin(self.stdin)
+            .stdout(self.stdout)
+            .stderr(self.stderr);
+        command
+    }
+}
+
+enum ChildBackend {
+    Standard(Child),
+    Direct {
+        pid: libc::pid_t,
+        status: Option<ExitStatus>,
+    },
+}
+
+/// Owns the direct child until the operation's common wait path reaps it.
+pub(crate) struct ContainedChild {
+    backend: ChildBackend,
+    pub(crate) stdin: Option<ChildStdin>,
+    pub(crate) stdout: Option<ChildStdout>,
+    pub(crate) stderr: Option<ChildStderr>,
+}
+
+impl From<Child> for ContainedChild {
+    fn from(mut child: Child) -> Self {
+        Self {
+            stdin: child.stdin.take(),
+            stdout: child.stdout.take(),
+            stderr: child.stderr.take(),
+            backend: ChildBackend::Standard(child),
+        }
+    }
+}
+
+impl ContainedChild {
+    /// The caller transfers a freshly created, unreaped child PID.
+    pub(crate) fn direct(pid: libc::pid_t) -> Self {
+        Self {
+            backend: ChildBackend::Direct { pid, status: None },
+            stdin: None,
+            stdout: None,
+            stderr: None,
+        }
+    }
+}
+
+impl ChildProcess for ContainedChild {
+    fn id(&self) -> u32 {
+        match &self.backend {
+            ChildBackend::Standard(child) => child.id(),
+            ChildBackend::Direct { pid, .. } => *pid as u32,
+        }
+    }
+
+    fn kill(&mut self) -> io::Result<()> {
+        match &mut self.backend {
+            ChildBackend::Standard(child) => child.kill(),
+            ChildBackend::Direct {
+                status: Some(_), ..
+            } => Ok(()),
+            ChildBackend::Direct { pid, status: None } => {
+                // SAFETY: this owner has not reaped the direct child.
+                if unsafe { libc::kill(*pid, libc::SIGKILL) } == 0 {
+                    Ok(())
+                } else {
+                    Err(io::Error::last_os_error())
+                }
+            }
+        }
+    }
+
+    fn wait(&mut self) -> io::Result<ExitStatus> {
+        // The wrapper owns stdin even for the standard backend.
+        drop(self.stdin.take());
+        match &mut self.backend {
+            ChildBackend::Standard(child) => child.wait(),
+            ChildBackend::Direct {
+                status: Some(status),
+                ..
+            } => Ok(*status),
+            ChildBackend::Direct { pid, status } => {
+                use std::os::unix::process::ExitStatusExt;
+
+                let mut raw_status = 0;
+                loop {
+                    // SAFETY: pid is our unreaped child; waitpid fills the status.
+                    if unsafe { libc::waitpid(*pid, &mut raw_status, 0) } >= 0 {
+                        let exit = ExitStatus::from_raw(raw_status);
+                        *status = Some(exit);
+                        return Ok(exit);
+                    }
+                    let error = io::Error::last_os_error();
+                    if error.kind() != io::ErrorKind::Interrupted {
+                        return Err(error);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/guest-control-server/src/drain.rs
+++ b/crates/guest-control-server/src/drain.rs
@@ -84,7 +84,9 @@ pub(crate) fn drain_until_eof_or_cancelled(
 ) {
     let pipe = pipe.into();
     let raw_fd = pipe.as_raw_fd();
-    let mut chunk = [0u8; DEFAULT_DRAIN_READ_BYTES];
+    // Keep the buffer off the stack so a short-lived drain does not fault in
+    // every stack page before reading even a small amount of output.
+    let mut chunk = Box::<[u8; DEFAULT_DRAIN_READ_BYTES]>::new_uninit();
     loop {
         if cancel.is_cancelled() {
             break;
@@ -129,9 +131,10 @@ pub(crate) fn drain_until_eof_or_cancelled(
             continue;
         }
 
-        // SAFETY: raw_fd belongs to the owned `pipe`, which remains alive until the
-        // function returns. `chunk` is valid writable memory of the given len.
-        let n = unsafe { libc::read(raw_fd, chunk.as_mut_ptr().cast(), chunk.len()) };
+        // SAFETY: raw_fd belongs to the owned pipe. read initializes up to
+        // DEFAULT_DRAIN_READ_BYTES bytes in this writable allocation; it never
+        // reads the buffer.
+        let n = unsafe { libc::read(raw_fd, chunk.as_mut_ptr().cast(), DEFAULT_DRAIN_READ_BYTES) };
         if n == 0 {
             break; // EOF
         }
@@ -143,7 +146,10 @@ pub(crate) fn drain_until_eof_or_cancelled(
             break;
         }
 
-        on_chunk(chunk.get(..n as usize).unwrap_or_default());
+        // SAFETY: the successful read initialized exactly n bytes. Only that
+        // prefix is exposed, so short reads cannot reveal uninitialized data.
+        let initialized = unsafe { std::slice::from_raw_parts(chunk.as_ptr().cast(), n as usize) };
+        on_chunk(initialized);
     }
 
     drop(pipe);

--- a/crates/guest-control-server/src/exec_operation.rs
+++ b/crates/guest-control-server/src/exec_operation.rs
@@ -43,7 +43,10 @@
 use std::collections::HashMap;
 use std::io::{self, Write};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
-use std::process::{Child, ChildStderr, ChildStdin, ChildStdout};
+use std::process::{ChildStderr, ChildStdin, ChildStdout};
+
+use crate::contained_command::ContainedChild as Child;
+use crate::process::ChildProcess;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
@@ -966,9 +969,9 @@ impl RunningExec {
                 };
             }
 
-            match self.child.try_wait() {
-                Ok(Some(_)) => return AgentReadyWaitOutcome::Terminal,
-                Ok(None) => {}
+            match crate::wait::child_has_exited_without_reap(self.child.id()) {
+                Ok(true) => return AgentReadyWaitOutcome::Terminal,
+                Ok(false) => {}
                 Err(error) => {
                     return AgentReadyWaitOutcome::Failed(format!(
                         "failed to observe Agent before readiness: {error}"

--- a/crates/guest-control-server/src/guest_storage_manifest.rs
+++ b/crates/guest-control-server/src/guest_storage_manifest.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdin, Command, Stdio};
+use std::process::ChildStdin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
@@ -11,10 +11,13 @@ use guest_control_proto::{
     ExecCapturedOutput, ExecTermination, GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES,
 };
 
+use crate::contained_command::{
+    CommandStdio, ContainedChild as Child, ContainedCommand as Command,
+};
 use crate::drain::{BoundedDrainResult, DrainCancellation, drain_bounded_cancellable};
 use crate::error::to_io_error;
 use crate::log::log;
-use crate::process::{extract_exit_code, kill_and_reap_child, spawn_in_own_process_group};
+use crate::process::{extract_exit_code, kill_and_reap_child};
 use crate::process_containment::{
     ExecProcessContainment, ProcessContainmentCleanupMode, ProcessContainmentError,
     ProcessContainmentMode,
@@ -255,17 +258,6 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
             );
         }
     };
-    let mut prepared_containment = match process_containment.prepare_command() {
-        Ok(prepared) => prepared,
-        Err(error) => {
-            let _ = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
-            return failed_output(
-                ExecTermination::StartFailed,
-                started,
-                format!("Failed to prepare storage helper process containment: {error}"),
-            );
-        }
-    };
     let mut command = Command::new(program);
     command
         .arg("--manifest-stdin")
@@ -274,20 +266,10 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
             guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
             runtime_dir,
         )
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    prepared_containment.configure_placement(&mut command);
-    if let Err(error) = crate::user::apply_command_identity(&mut command, false) {
-        let _ = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
-        return failed_output(
-            ExecTermination::StartFailed,
-            started,
-            format!("Failed to select sandbox user for storage helper: {error}"),
-        );
-    }
-    prepared_containment.configure_process_inspection(&mut command);
-    let mut child = match spawn_in_own_process_group(&mut command) {
+        .stdin(CommandStdio::Piped)
+        .stdout(CommandStdio::Piped)
+        .stderr(CommandStdio::Piped);
+    let mut child = match command.spawn(false, &process_containment) {
         Ok(child) => child,
         Err(error) => {
             let _ = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);

--- a/crates/guest-control-server/src/lib.rs
+++ b/crates/guest-control-server/src/lib.rs
@@ -6,7 +6,9 @@
 //! Protocol encoding/decoding is handled by the `guest-control-proto` crate.
 
 mod agent_command;
+mod cgroup_spawn;
 mod connection;
+mod contained_command;
 mod drain;
 mod error;
 mod exec_control;

--- a/crates/guest-control-server/src/process.rs
+++ b/crates/guest-control-server/src/process.rs
@@ -1,7 +1,43 @@
 use std::io;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::process::{Child, Command, ExitStatus};
 
 use crate::log::log;
+
+/// Common ownership operations for standard and directly contained children.
+pub(crate) trait ChildProcess {
+    fn id(&self) -> u32;
+    fn kill(&mut self) -> io::Result<()>;
+    fn wait(&mut self) -> io::Result<ExitStatus>;
+}
+
+impl ChildProcess for Child {
+    fn id(&self) -> u32 {
+        self.id()
+    }
+
+    fn kill(&mut self) -> io::Result<()> {
+        self.kill()
+    }
+
+    fn wait(&mut self) -> io::Result<ExitStatus> {
+        self.wait()
+    }
+}
+
+/// Keep a private launch descriptor out of the standard descriptor slots.
+pub(crate) fn private_descriptor(fd: OwnedFd) -> io::Result<OwnedFd> {
+    if fd.as_raw_fd() > libc::STDERR_FILENO {
+        return Ok(fd);
+    }
+    // SAFETY: fd is owned and valid. fcntl returns a distinct owned CLOEXEC fd.
+    let duplicate = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 3) };
+    if duplicate < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: the successful duplicate is transferred to exactly one owner.
+    Ok(unsafe { OwnedFd::from_raw_fd(duplicate) })
+}
 
 /// Extract exit code from ExitStatus, mapping signals to 128 + signal number.
 #[cfg(unix)]
@@ -47,7 +83,7 @@ fn process_group_signal_pid(pgid: u32) -> Option<libc::pid_t> {
 ///
 /// # Safety
 ///
-/// `child_id` must come from a direct child returned by `Command::spawn()`, and
+/// `child_id` must come from an owned direct-child spawn, and
 /// that child must not have been reaped. Keeping the child unreaped prevents
 /// its PID, and therefore its process-group ID, from being reused.
 pub(crate) unsafe fn kill_owned_child_process_group(child_id: u32) -> bool {
@@ -71,9 +107,9 @@ pub(crate) unsafe fn kill_owned_child_process_group(child_id: u32) -> bool {
 }
 
 /// Kill the direct child's process group and reap the direct child.
-pub(crate) fn kill_and_reap_child(mut child: Child) {
+pub(crate) fn kill_and_reap_child(mut child: impl ChildProcess) {
     let child_id = child.id();
-    // SAFETY: child_id comes from a live `Child` returned by Command::spawn.
+    // SAFETY: child_id comes from an owned, unreaped direct child.
     let group_killed = unsafe { kill_owned_child_process_group(child_id) };
     let child_killed = child.kill().is_ok();
     if !group_killed && !child_killed {

--- a/crates/guest-control-server/src/process_containment.rs
+++ b/crates/guest-control-server/src/process_containment.rs
@@ -2,11 +2,10 @@ use std::collections::HashSet;
 use std::fs::{self, OpenOptions};
 use std::io;
 use std::net::Shutdown;
-use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::net::{UnixListener, UnixStream};
-use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
@@ -86,23 +85,9 @@ struct CgroupGuard {
     create_elapsed: Duration,
 }
 
-pub(crate) struct PreparedProcessContainmentCommand {
-    outer_placement: Option<OwnedFd>,
-    deny_process_inspection: bool,
-}
-
-impl PreparedProcessContainmentCommand {
-    pub(crate) fn configure_placement(&mut self, command: &mut Command) {
-        if let Some(outer_placement) = self.outer_placement.take() {
-            install_child_placement(command, outer_placement);
-        }
-    }
-
-    pub(crate) fn configure_process_inspection(self, command: &mut Command) {
-        if self.deny_process_inspection {
-            install_process_inspection_denial(command);
-        }
-    }
+pub(crate) struct PreparedProcessContainmentCommand<'a> {
+    pub(crate) directory: Option<BorrowedFd<'a>>,
+    pub(crate) deny_process_inspection: bool,
 }
 
 pub(crate) struct WorkloadPlacementBootstrap {
@@ -283,22 +268,20 @@ impl ExecProcessContainment {
         })
     }
 
-    pub(crate) fn prepare_command(
-        &self,
-    ) -> Result<PreparedProcessContainmentCommand, ProcessContainmentError> {
+    pub(crate) fn prepare_command(&self) -> PreparedProcessContainmentCommand<'_> {
         match &self.backend {
             ContainmentBackend::Cgroup(guard) => guard.prepare_command(),
             ContainmentBackend::ProcessGroup | ContainmentBackend::TestNoop => {
-                Ok(PreparedProcessContainmentCommand {
-                    outer_placement: None,
+                PreparedProcessContainmentCommand {
+                    directory: None,
                     deny_process_inspection: false,
-                })
+                }
             }
             #[cfg(test)]
-            ContainmentBackend::TestDirectory(_) => Ok(PreparedProcessContainmentCommand {
-                outer_placement: None,
+            ContainmentBackend::TestDirectory(_) => PreparedProcessContainmentCommand {
+                directory: None,
                 deny_process_inspection: false,
-            }),
+            },
         }
     }
 
@@ -471,7 +454,17 @@ impl CgroupGuard {
                 } else {
                     &workload_path
                 };
-                let outer_placement = open_placement(outer_path, "open outer cgroup.procs")?;
+                // Direct creation needs the cgroup directory, not cgroup.procs.
+                // It stays private to this owner; runtime/tool brokers retain
+                // their separate, write-only placement descriptors.
+                let outer_placement = OpenOptions::new()
+                    .read(true)
+                    .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC)
+                    .open(outer_path)
+                    .and_then(|file| crate::process::private_descriptor(file.into()))
+                    .map_err(|error| {
+                        ProcessContainmentError::new("open outer cgroup directory", error)
+                    })?;
                 let workload_placement = if trusted_control {
                     Some(open_placement(
                         &workload_placement_path,
@@ -509,18 +502,12 @@ impl CgroupGuard {
         })
     }
 
-    fn prepare_command(
-        &self,
-    ) -> Result<PreparedProcessContainmentCommand, ProcessContainmentError> {
-        let outer_placement = self
-            .outer_placement
-            .try_clone()
-            .map_err(|error| ProcessContainmentError::new("clone outer cgroup.procs", error))?;
+    fn prepare_command(&self) -> PreparedProcessContainmentCommand<'_> {
         let trusted_control = self.workload_placement.is_some();
-        Ok(PreparedProcessContainmentCommand {
-            outer_placement: Some(outer_placement),
+        PreparedProcessContainmentCommand {
+            directory: Some(self.outer_placement.as_fd()),
             deny_process_inspection: trusted_control,
-        })
+        }
     }
 
     fn start_workload_placement_bootstrap(
@@ -969,26 +956,6 @@ fn cleanup_cgroup(
     })
 }
 
-fn install_child_placement(command: &mut Command, placement: OwnedFd) {
-    // SAFETY: the closure performs only raw writes and fcntl calls on already
-    // open descriptors. These operations are async-signal-safe between fork
-    // and exec.
-    unsafe {
-        command.pre_exec(move || {
-            write_self_to_cgroup(placement.as_raw_fd())?;
-            Ok(())
-        });
-    }
-}
-
-fn install_process_inspection_denial(command: &mut Command) {
-    // SAFETY: the closure performs one async-signal-safe prctl call in the
-    // child after its credential transition and before exec.
-    unsafe {
-        command.pre_exec(deny_unprivileged_process_inspection);
-    }
-}
-
 fn placement_cancel_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     let mut fds = [0; 2];
     // SAFETY: `pipe2` initializes two file descriptors in `fds` on success.
@@ -1434,34 +1401,6 @@ fn peer_matches(
     Ok(Path::new(CGROUP_V2_MOUNT_PATH).join(relative) == expected_cgroup)
 }
 
-fn deny_unprivileged_process_inspection() -> io::Result<()> {
-    // SAFETY: PR_SET_DUMPABLE changes only the calling child between fork and
-    // exec and does not access shared userspace state.
-    if unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0) } != 0 {
-        return Err(io::Error::last_os_error());
-    }
-    Ok(())
-}
-
-fn write_self_to_cgroup(fd: RawFd) -> io::Result<()> {
-    loop {
-        // SAFETY: `fd` is open for writing and the one-byte buffer is valid for
-        // the duration of the call.
-        let written = unsafe { libc::write(fd, b"0".as_ptr().cast(), 1) };
-        if written == 1 {
-            return Ok(());
-        }
-        if written < 0 {
-            let error = io::Error::last_os_error();
-            if error.kind() == io::ErrorKind::Interrupted {
-                continue;
-            }
-            return Err(error);
-        }
-        return Err(io::Error::from_raw_os_error(libc::EIO));
-    }
-}
-
 fn read_populated(group_path: &Path) -> Result<bool, ProcessContainmentError> {
     let content = fs::read_to_string(group_path.join(CGROUP_EVENTS_FILE))
         .map_err(|error| ProcessContainmentError::new("read cgroup.events", error))?;
@@ -1703,8 +1642,8 @@ fn remove_cgroup_descendants(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
-    use std::process::{Child, Stdio};
+    use std::io::{BufRead, BufReader, Write};
+    use std::process::{Child, Command, Stdio};
     use std::sync::mpsc;
 
     struct ChildGuard(Child);
@@ -1829,23 +1768,6 @@ mod tests {
 
         assert_eq!(error.stage, "read cgroup.events");
         assert_eq!(fs::read(&kill_path).unwrap(), b"1");
-    }
-
-    #[test]
-    fn pre_exec_writes_child_into_open_placement_file() {
-        let mut placement = tempfile::tempfile().unwrap();
-        let child_fd: OwnedFd = placement.try_clone().unwrap().into();
-        let mut command = Command::new("/bin/true");
-        command.stdout(Stdio::null()).stderr(Stdio::null());
-        install_child_placement(&mut command, child_fd);
-
-        let status = command.status().unwrap();
-
-        assert!(status.success());
-        placement.seek(SeekFrom::Start(0)).unwrap();
-        let mut content = String::new();
-        placement.read_to_string(&mut content).unwrap();
-        assert_eq!(content, "0");
     }
 
     #[test]
@@ -2314,12 +2236,14 @@ mod tests {
         let policy =
             WorkloadResourcePolicy::for_guest_capacity(2, u64::from(4096_u32) * 1024 * 1024)
                 .unwrap();
-        let result = CgroupGuard::create_in(base.path(), 17, ExecProcessRole::Workload, policy);
+        // A plain directory can supply the outer directory capability, but
+        // cannot supply the Agent's kernel-created runtime cgroup.procs file.
+        let result = CgroupGuard::create_in(base.path(), 17, ExecProcessRole::Agent, policy);
         let Err(error) = result else {
             panic!("placement-file open unexpectedly succeeded");
         };
 
-        assert_eq!(error.stage, "open outer cgroup.procs");
+        assert_eq!(error.stage, "open workload cgroup.procs");
         assert_eq!(error.source.kind(), io::ErrorKind::NotFound);
         assert!(fs::read_dir(base.path()).unwrap().next().is_none());
     }

--- a/crates/guest-control-server/src/shell_command.rs
+++ b/crates/guest-control-server/src/shell_command.rs
@@ -47,10 +47,12 @@
 //! only after a successful spawn. Setup failures clean that containment before
 //! returning the original spawn error.
 
+use crate::contained_command::{
+    CommandStdio, ContainedChild as Child, ContainedCommand as Command,
+};
 use std::fs::{self, DirBuilder, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
 use std::time::{Duration, SystemTime};
 
 use std::os::fd::{AsRawFd, RawFd};
@@ -589,11 +591,13 @@ pub(crate) fn spawn_shell_command_with_pipes(
             mut command,
             env_script,
         } = build_shell_command_with_env(command, env, sudo)?;
-        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        command
+            .stdout(CommandStdio::Piped)
+            .stderr(CommandStdio::Piped);
         if pipe_stdin {
-            command.stdin(Stdio::piped());
+            command.stdin(CommandStdio::Piped);
         }
-        let child = spawn_command_in_containment(&mut command, sudo, &process_containment)?;
+        let child = command.spawn(sudo, &process_containment)?;
         Ok((child, env_script))
     })();
 
@@ -608,25 +612,6 @@ pub(crate) fn spawn_shell_command_with_pipes(
             Err(error)
         }
     }
-}
-
-/// Apply the common identity and containment boundary, then spawn a command as
-/// the leader of its own process group.
-pub(crate) fn spawn_command_in_containment(
-    command: &mut Command,
-    sudo: bool,
-    process_containment: &ExecProcessContainment,
-) -> io::Result<Child> {
-    let mut prepared_containment = process_containment
-        .prepare_command()
-        .map_err(|error| io::Error::other(format!("process containment setup failed: {error}")))?;
-    // Placement requires the root-opened cgroup descriptor. Drop to the
-    // target identity only after placement, then restore non-dumpable state
-    // because setuid may reset it.
-    prepared_containment.configure_placement(command);
-    crate::user::apply_command_identity(command, sudo)?;
-    prepared_containment.configure_process_inspection(command);
-    crate::process::spawn_in_own_process_group(command)
 }
 
 #[cfg(test)]
@@ -776,10 +761,11 @@ mod tests {
             create_env_script_in_dir(&dir, "echo \"$FOO\"", &[("FOO", secret)], true).unwrap();
         let invocation = script_invocation(script.path().unwrap()).unwrap();
         let command = build_shell_command_program(&invocation, true).unwrap();
-        let argv = std::iter::once(command.get_program().to_string_lossy().to_string())
+        let argv = std::iter::once(command.program.to_string_lossy().to_string())
             .chain(
                 command
-                    .get_args()
+                    .args
+                    .iter()
                     .map(|arg| arg.to_string_lossy().into_owned()),
             )
             .collect::<Vec<_>>()
@@ -842,7 +828,7 @@ mod tests {
         let script_dir = path.parent().unwrap().to_path_buf();
         let invocation = script_invocation(&path).unwrap();
 
-        let status = Command::new("sh")
+        let status = std::process::Command::new("sh")
             .arg("-c")
             .arg(invocation)
             .status()
@@ -1062,12 +1048,13 @@ mod tests {
     }
 
     fn assert_command(command: Command, expected_program: &str, expected_args: &[&str]) {
+        assert_eq!(command.program, std::ffi::OsStr::new(expected_program));
         assert_eq!(
-            command.get_program(),
-            std::ffi::OsStr::new(expected_program)
-        );
-        assert_eq!(
-            command.get_args().collect::<Vec<_>>(),
+            command
+                .args
+                .iter()
+                .map(|arg| arg.as_os_str())
+                .collect::<Vec<_>>(),
             expected_args
                 .iter()
                 .map(std::ffi::OsStr::new)
@@ -1097,7 +1084,10 @@ mod tests {
     fn build_shell_command_for_sandbox_user() {
         let command =
             build_shell_command_for_user("echo hello", false, Some(Path::new("/home/sandbox")));
-        assert_eq!(command.get_current_dir(), Some(Path::new("/home/sandbox")));
+        assert_eq!(
+            command.directory.as_deref(),
+            Some(Path::new("/home/sandbox"))
+        );
         assert_command(command, "/bin/sh", &["-c", ". /etc/profile\necho hello"]);
     }
 

--- a/crates/guest-control-server/src/user.rs
+++ b/crates/guest-control-server/src/user.rs
@@ -1,5 +1,4 @@
 use std::io;
-#[cfg(any(test, not(any(debug_assertions, feature = "test-support"))))]
 use std::path::PathBuf;
 use std::process::Command;
 #[cfg(not(any(debug_assertions, feature = "test-support")))]
@@ -29,20 +28,13 @@ const TRUSTED_ROOTFS_ENVIRONMENT: [(&str, &str); 6] = [
     ("CARGO_HTTP_CAINFO", "/etc/ssl/certs/ca-certificates.crt"),
 ];
 
-#[cfg(any(test, not(any(debug_assertions, feature = "test-support"))))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct UserCredentials {
-    username: String,
-    uid: u32,
-    gid: u32,
-    home: PathBuf,
-    groups: Vec<u32>,
-}
-
-enum TargetIdentity {
-    Current,
-    #[cfg(not(any(debug_assertions, feature = "test-support")))]
-    User(UserCredentials),
+    pub(crate) username: String,
+    pub(crate) uid: u32,
+    pub(crate) gid: u32,
+    pub(crate) home: PathBuf,
+    pub(crate) groups: Vec<u32>,
 }
 
 #[cfg(not(any(debug_assertions, feature = "test-support")))]
@@ -83,18 +75,17 @@ pub(crate) fn shell_command_uid(sudo: bool) -> io::Result<libc::uid_t> {
 }
 
 pub(crate) fn apply_command_identity(command: &mut Command, sudo: bool) -> io::Result<()> {
-    #[cfg(any(debug_assertions, feature = "test-support"))]
-    let _ = command;
-    match target_identity(sudo)? {
-        TargetIdentity::Current => Ok(()),
-        #[cfg(not(any(debug_assertions, feature = "test-support")))]
-        TargetIdentity::User(credentials) => apply_credentials(command, credentials),
+    if let Some(credentials) = command_credentials(sudo)? {
+        apply_credentials(command, credentials)?;
     }
+    Ok(())
 }
 
 /// Install the trusted Guest Agent environment without sourcing sandbox-owned
 /// shell state during fixed launch.
-pub(crate) fn configure_guest_agent_command_environment(command: &mut Command) -> io::Result<()> {
+pub(crate) fn configure_guest_agent_command_environment(
+    command: &mut crate::contained_command::ContainedCommand,
+) -> io::Result<()> {
     command
         .envs(TRUSTED_ROOTFS_ENVIRONMENT)
         .env("SHELL", AGENT_SHELL);
@@ -122,27 +113,28 @@ fn sandbox_user_path(home: &std::path::Path) -> String {
     )
 }
 
-fn target_identity(sudo: bool) -> io::Result<TargetIdentity> {
+pub(crate) fn command_credentials(sudo: bool) -> io::Result<Option<&'static UserCredentials>> {
     if sudo {
-        return Ok(TargetIdentity::Current);
+        return Ok(None);
     }
 
     #[cfg(any(debug_assertions, feature = "test-support"))]
     {
         // Local guest-control tests run without the production rootfs user account.
         // Production release builds below resolve and drop to the sandbox user.
-        Ok(TargetIdentity::Current)
+        Ok(None)
     }
 
     #[cfg(not(any(debug_assertions, feature = "test-support")))]
     {
-        cached_system_user_credentials()
-            .map(|credentials| TargetIdentity::User(credentials.clone()))
+        cached_system_user_credentials().map(Some)
     }
 }
 
-#[cfg(not(any(debug_assertions, feature = "test-support")))]
-fn apply_credentials(command: &mut Command, credentials: UserCredentials) -> io::Result<()> {
+pub(crate) fn apply_credentials(
+    command: &mut Command,
+    credentials: &'static UserCredentials,
+) -> io::Result<()> {
     command
         .current_dir(&credentials.home)
         .env("HOME", &credentials.home)
@@ -155,11 +147,7 @@ fn apply_credentials(command: &mut Command, credentials: UserCredentials) -> io:
 
         let uid = credentials.uid as libc::uid_t;
         let gid = credentials.gid as libc::gid_t;
-        let groups: Vec<libc::gid_t> = credentials
-            .groups
-            .into_iter()
-            .map(|group| group as libc::gid_t)
-            .collect();
+        let groups = &credentials.groups;
 
         // SAFETY: The closure only calls async-signal-safe credential syscalls
         // in the child immediately before exec. It does not allocate or touch
@@ -332,21 +320,21 @@ mod tests {
 
     #[test]
     fn guest_agent_environment_preserves_trusted_defaults() {
-        let mut command = Command::new("true");
+        let mut command = crate::contained_command::ContainedCommand::new("true");
         configure_guest_agent_command_environment(&mut command).unwrap();
 
         for (key, expected) in TRUSTED_ROOTFS_ENVIRONMENT {
-            let actual = command
-                .get_envs()
-                .find_map(|(candidate, value)| (candidate == key).then_some(value))
-                .flatten();
-            assert_eq!(actual, Some(std::ffi::OsStr::new(expected)));
+            let actual = command.environment.get(std::ffi::OsStr::new(key));
+            assert_eq!(
+                actual.map(|value| value.as_os_str()),
+                Some(std::ffi::OsStr::new(expected))
+            );
         }
-        let shell = command
-            .get_envs()
-            .find_map(|(candidate, value)| (candidate == "SHELL").then_some(value))
-            .flatten();
-        assert_eq!(shell, Some(std::ffi::OsStr::new(AGENT_SHELL)));
+        let shell = command.environment.get(std::ffi::OsStr::new("SHELL"));
+        assert_eq!(
+            shell.map(|value| value.as_os_str()),
+            Some(std::ffi::OsStr::new(AGENT_SHELL))
+        );
     }
 
     #[test]

--- a/crates/guest-control-server/src/wait.rs
+++ b/crates/guest-control-server/src/wait.rs
@@ -1,12 +1,14 @@
 use std::io;
-use std::process::{Child, ExitStatus};
+use std::process::ExitStatus;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::drain::DrainCancellation;
-use crate::process::{kill_and_reap_child, kill_owned_child_process_group, process_signal_pid};
+use crate::process::{
+    ChildProcess, kill_and_reap_child, kill_owned_child_process_group, process_signal_pid,
+};
 use crate::threading::spawn_scoped_named;
 
 const WAIT_CANCEL_POLL_INTERVAL_MS: u64 = 50;
@@ -61,7 +63,7 @@ pub(crate) fn await_drain_deadline(
 /// Wait for `child` while observing its owning connection cancellation flag
 /// and allowing direct-child-group cleanup before reap after natural exit.
 pub(crate) fn wait_with_kill_timeout_or_connection_cancelled(
-    child: Child,
+    child: impl ChildProcess,
     timeout_ms: u32,
     connection_cancel: &AtomicBool,
     pre_reap_cleanup: impl FnMut() -> bool,
@@ -79,7 +81,7 @@ pub(crate) fn wait_with_kill_timeout_or_connection_cancelled(
 /// Exec operations have both connection-level cancellation and request-level
 /// cancellation.
 pub(crate) fn wait_with_kill_timeout_or_cancelled_either(
-    child: Child,
+    child: impl ChildProcess,
     timeout_ms: u32,
     first_cancel: &AtomicBool,
     second_cancel: &AtomicBool,
@@ -94,7 +96,7 @@ pub(crate) fn wait_with_kill_timeout_or_cancelled_either(
 }
 
 fn wait_with_kill_timeout_or_cancelled_by(
-    mut child: Child,
+    mut child: impl ChildProcess,
     timeout_ms: u32,
     is_cancelled: impl Fn() -> bool,
     mut pre_reap_cleanup: impl FnMut() -> bool,
@@ -268,12 +270,39 @@ fn wait_for_child_exit_without_reap(child_id: u32) -> io::Result<()> {
     }
 }
 
-fn kill_child(child: &mut Child) -> bool {
+fn kill_child(child: &mut impl ChildProcess) -> bool {
     // SAFETY: this owner has not reaped child, so its PID/process group cannot
     // have been reused.
     let group_killed = unsafe { kill_owned_child_process_group(child.id()) };
     let child_killed = child.kill().is_ok();
     group_killed || child_killed
+}
+
+/// Probe readiness without releasing the identity owned by the final waiter.
+pub(crate) fn child_has_exited_without_reap(child_id: u32) -> io::Result<bool> {
+    let child_id = process_signal_pid(child_id)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid child pid"))?;
+    // SAFETY: zero initialization also distinguishes the WNOHANG no-exit case.
+    let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+    loop {
+        // SAFETY: this is an owned direct child. WNOWAIT leaves it unreaped.
+        let result = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                child_id as libc::id_t,
+                &mut info,
+                libc::WEXITED | libc::WNOWAIT | libc::WNOHANG,
+            )
+        };
+        if result == 0 {
+            // SAFETY: waitid initialized the SIGCHLD siginfo payload.
+            return Ok(unsafe { info.si_pid() } != 0);
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -460,5 +489,37 @@ mod tests {
 
         assert!(cleanup_called);
         assert!(matches!(outcome, WaitOutcome::Exited(status) if status.success()));
+    }
+
+    #[test]
+    fn readiness_exit_probe_keeps_child_owned_until_terminal_cleanup() {
+        let mut command = Command::new("sh");
+        command.arg("-c").arg("exit 23").process_group(0);
+        let child = crate::contained_command::ContainedChild::from(command.spawn().unwrap());
+        let pid = child.id();
+        wait_for_child_exit_without_reap(pid).unwrap();
+
+        // Repeated readiness probes must not consume the waitable child.
+        assert!(child_has_exited_without_reap(pid).unwrap());
+        assert!(child_has_exited_without_reap(pid).unwrap());
+        let mut cleaned = false;
+        let outcome = wait_with_kill_timeout_or_connection_cancelled(
+            child,
+            5_000,
+            &AtomicBool::new(false),
+            || {
+                cleaned = true;
+                assert!(child_has_exited_without_reap(pid).unwrap());
+                true
+            },
+        );
+        assert!(cleaned);
+        assert!(matches!(outcome, WaitOutcome::Exited(status) if status.code() == Some(23)));
+        assert_eq!(
+            child_has_exited_without_reap(pid)
+                .unwrap_err()
+                .raw_os_error(),
+            Some(libc::ECHILD)
+        );
     }
 }

--- a/crates/guest-control-server/tests/connection/exec_output.rs
+++ b/crates/guest-control-server/tests/connection/exec_output.rs
@@ -7,14 +7,15 @@ use super::exec_helpers::{EXEC_OPERATION_TIMEOUT_TEST_MS, read_exec_stdout_outpu
 use super::support::*;
 
 #[test]
-fn exec_operation_large_stdout_stderr_capture_soak() {
+fn exec_operation_captures_binary_tails_after_large_stdout_stderr() {
     let (handle, mut host_stream) = start_guest_connection();
-    let len = 32 * 1024usize;
+    let payload_len = 64 * 1024usize;
+    let len = payload_len + 3;
 
     send_exec_start(
         &mut host_stream,
         138,
-        "head -c 32768 /dev/zero | tr '\\0' o; head -c 32768 /dev/zero | tr '\\0' e >&2",
+        "head -c 65536 /dev/zero | tr '\\0' o; printf '\\000\\377\\001'; head -c 65536 /dev/zero | tr '\\0' e >&2; printf '\\376\\000\\002' >&2",
         5000,
         ExecOutputPolicy::Capture {
             limit_bytes: len as u32,
@@ -31,8 +32,12 @@ fn exec_operation_large_stdout_stderr_capture_soak() {
     let stderr = result.stderr.unwrap();
     assert_eq!(stdout.len(), len);
     assert_eq!(stderr.len(), len);
-    assert!(stdout.iter().all(|byte| *byte == b'o'));
-    assert!(stderr.iter().all(|byte| *byte == b'e'));
+    let mut expected_stdout = vec![b'o'; payload_len];
+    expected_stdout.extend_from_slice(&[0, 255, 1]);
+    let mut expected_stderr = vec![b'e'; payload_len];
+    expected_stderr.extend_from_slice(&[254, 0, 2]);
+    assert_eq!(stdout, expected_stdout);
+    assert_eq!(stderr, expected_stderr);
     assert!(!result.stdout_truncated);
     assert!(!result.stderr_truncated);
 

--- a/docs/runner-guest-process-lifecycle.md
+++ b/docs/runner-guest-process-lifecycle.md
@@ -78,6 +78,35 @@ Controlled processes deny process inspection across the boundary.
 
 ## Ownership and Reuse
 
+### Direct cgroup creation
+
+Guest-control-server uses one contained-command launcher for typed storage,
+ordinary Workload exec (including oversized storage fallback), and controlled
+Agent startup. It prepares the operation hierarchy and resource policy, then
+uses `clone3(CLONE_INTO_CGROUP)` to create the child in its target leaf:
+`workload` for Workload, or `control` for Agent. It does not create an
+uncontained child and migrate it afterward. The outer cgroup directory
+descriptor remains private and close-on-exec; runtime/tool brokers retain
+their separate authenticated, write-only placement capabilities.
+
+The launcher prepares arguments, environment, credentials and descriptors in
+the parent. Its copied child performs only the audited pre-exec setup, with
+signals masked during that setup. Startup errors are reported through a
+close-on-exec error pipe; a failed or timed-out handshake kills and reaps the
+owned child before containment cleanup. Unsupported or denied syscalls fail
+the launch instead of retrying without containment. Agent readiness observes
+exit without reaping, so the terminal owner retains the PID through cleanup.
+
+Direct placement requires cgroup v2 and Linux 5.7; the launcher's
+`close_range(CLOSE_RANGE_CLOEXEC)` additionally requires Linux 5.11. The
+committed guest kernel is 6.1.155. Fixed process-group-only helpers and explicit
+local TestNoop backends still use standard process creation. Guest Agent's
+internal CLI launcher and the managed tool's migrate-self/exec boundary are
+unchanged. There is no persistent cgroup pool, resident launcher or cgroup
+mount-policy change.
+
+### Operation lifetime
+
 All fixed helpers and workload operations hold operation guards. Agent
 readiness keeps the exec operation, placement brokers, and containment owner
 active, so reuse cannot quiesce or park during bootstrap. Reuse first fences
@@ -85,6 +114,12 @@ new operations, waits for active ownership to reach zero, and verifies that
 the `vm0-exec` hierarchy is empty before parking. A terminal result does not
 replace descendant cleanup: the operation's containment owner remains
 responsible for graceful or forced cleanup and hierarchy removal.
+
+Output drains retain their 64 KiB read capacity but allocate the read buffer
+uninitialized on the heap. This avoids faulting every page of a large stack
+buffer when a short-lived helper emits little or no output. Only the bytes
+initialized by a successful read are exposed to capture or streaming; output
+limits, cancellation wakeups and terminal drain deadlines are unchanged.
 
 Storage remains contained even though it has a typed entry point because its
 download, extraction, cache, and filesystem work is user influenced. The DNS,


### PR DESCRIPTION
## Summary

- Share an explicit command/owned-child boundary across typed storage, generic Workload exec (including oversized storage), and controlled Agent launch. Production cgroup launches create the child directly with `clone3(CLONE_INTO_CGROUP)` instead of migrating it with a pre-exec `cgroup.procs` write.
- Prepare argv/environment, cached identity and private descriptors once in the parent. Keep the copied child on an audited syscall-only setup/exec path with masked signals and a bounded exec-error handshake. Unsupported/denied launches fail closed.
- Keep Agent readiness observation non-reaping so terminal cleanup retains ownership of the child PID and its exit status.
- Move the existing 64 KiB output-drain buffer to an uninitialized heap allocation, exposing only bytes initialized by `read`. This removes the stack-page fault cost identified while resolving the warm-path regression; strengthen the output integration test with large binary tails.

Closes #32647

Parent: #24203 (not closed by this PR).

## Scope and compatibility

Fresh per-operation cgroups, Workload/Agent resource policy, runtime/tool brokers, credentials, output limits and cleanup/park ownership remain unchanged. Fixed process-group-only helpers and explicit TestNoop backends retain standard spawning; they are not retries after cgroup failure. No cgroup pooling, favordynmods, host/kernel upgrade, public API, wire protocol, persisted format or deployment-order change. No production deployment performed.

Direct placement needs Linux 5.7/cgroup v2; `close_range(CLOSE_RANGE_CLOEXEC)` additionally requires 5.11. The committed guest is 6.1.155. Principal risks are raw child-path signal/credential/FD safety, exact PID lifetime and bounded heap-buffer initialization; these are documented and validated below.

## Performance

[Full measurements, original failure, attribution and retained evidence](https://github.com/vm0-ai/vm0/issues/32647#issuecomment-5588614385).

The first implementation failed its warm gate and remains recorded as failed. The changed heap-buffer revision passed exactly three new alternating paired fresh-VM trials under the original limits, with all **1,944 calls successful** and no truncation, OOM/PID-limit event or leaked cgroup.

Medians of the three trial metrics (ms):

| Metric | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| Warm p50 | 3.804 | 3.295 | -13.4% |
| Warm p90 | 6.311 | 4.308 | -31.7% |
| Warm p95 | 6.910 | 4.709 | -31.9% |
| High-work p50 | 57.173 | 45.722 | -20.0% |
| Oversized p50 | 22.576 | 22.285 | -1.3% |

Resumed medians improve **77.6%-86.1%** in every pair; four-concurrent-start batch median improves **12.3%**. All six actual Agent runs pass; fresh/reused readiness samples are **80/32/19 -> 66/8/6 ms**, too small for a fleet/tail claim.

Summed synthetic cohort execution is **15.576 -> 12.281 s (-21.2%)**. Complete benchmark total is **34.180 -> 26.573 s**; approximately **3.989 s** of that advantage is pre-VM initialization/prefetch variability and must not be credited to this code. These are isolated development measurements, not production end-to-end run latency.

## Validation

From `crates/`:

- `cargo fmt --all -- --check`
- `cargo clippy --profile local -p guest-control-server -p guest-init -p guest-control-tests --all-targets --all-features`
- `cargo clippy --profile ci -p guest-control-server -p guest-init --no-default-features --lib --bins`
- `cargo doc --profile local -p guest-control-server -p guest-init -p guest-control-tests --no-deps`
- `cargo test --profile local -p guest-control-server -p guest-init -p guest-control-tests -- --quiet`
- `cargo build --profile ci -p guest-init --target x86_64-unknown-linux-musl`
- `cargo build --profile ci -p guest-init --target aarch64-unknown-linux-musl`
- Production CI-profile identity test executable: all three identity cases run explicitly with the isolated UID/GID/supplementary-group fixture, then fixture cleanup verified.

From `turbo/`: `pnpm exec prettier --check ../docs/runner-guest-process-lifecycle.md`.

Real Linux 6.1.155 guest: storage identity/output/error/timeout/descendant/disconnect/busy guards, generic stdin/output and concurrent starts, setsid descendant cancellation, Agent exit before readiness, and actual Agent placement/capability/inspection-denial/resource/reuse assertions all pass. Diagnostic source and disposable probes are not shipped. Both existing dev runner services were preserved; experiment-owned services stopped.

Measured pre-rebase x86_64 guest-init SHA256: `830c5e0bc5558740498c3f2a0d9f0a458394e7b20d21f4b1588c0743b2bb6626`.
CI and submitted-head reviews will be checked separately; no merge is requested.

## Rebase validation

Rebased onto `69482746ed271dfbce548e7a32ec86869d144172`; current head `e62e97b7f4133c8812c337f93b9a54728727b939`. Preserved #32704's direct fixed workspace-mount helper, which made this PR's old standard-command conversion unnecessary. `range-diff` shows that removed conversion is the only change to this PR's patch; clone3, identity, wait and drain source remain unchanged.

Re-ran the applicable formatting, both Clippy configurations, documentation, affected Rust tests, both musl builds and all three production-configuration identity cases; all pass. The temporary identity fixture was cleaned up. Rebased x86_64 guest-init SHA256 is `755946487980d351d7d5e791827f8cf312520f62ded6a31d2081eefb644e93a9`.

The performance and real-guest measurements above are from the documented pre-rebase binaries, not a new measurement of this rebased build. Current-head CI and reviews are tracked separately.
