### PR TITLE
fix(platform): dismiss connector account chooser on list scroll

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-accounts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-accounts.test.tsx
@@ -1,11 +1,15 @@
 import type { ConnectorAccountTarget } from "@okouai/api-contracts/contracts/connector-accounts";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, test } from "vitest";
 
-import { fill, setupPage } from "../../../__tests__/page-helper.ts";
+import {
+  fill,
+  queryAllByRoleFast,
+  setupPage,
+} from "../../../__tests__/page-helper.ts";
 import {
   accountSummary,
   builtinConnector,
@@ -398,6 +402,96 @@ test("Choose which connector account a chat uses", async () => {
     ).toBeVisible();
   });
 });
+
+test.each([
+  { label: "GitHub", explicit: true },
+  { label: "DeepWiki", explicit: false },
+])(
+  "Dismiss the $label account chooser only on parent-list scroll",
+  async ({ label, explicit }) => {
+    const user = userEvent.setup({ delay: null });
+    const builtinAccounts = githubAccounts(7);
+    const customAccounts = builtinAccounts.map((account, index) => {
+      return {
+        ...account,
+        id: `f0000000-0000-4000-a000-${(index + 101).toString().padStart(12, "0")}`,
+        target: deepWikiTarget(),
+      };
+    });
+    installComposerConnectorFixture({
+      catalog: [builtinConnector({ slug: GITHUB_SLUG, label: "GitHub" })],
+      builtinAuthorizations: { [SCOUT_AGENT_ID]: [GITHUB_SLUG] },
+      customConnectors: [
+        mcpConnector({
+          id: DEEPWIKI_CONNECTOR_ID,
+          slug: "deepwiki",
+          displayName: "DeepWiki",
+          connected: true,
+        }),
+      ],
+      customAuthorizations: {
+        [SCOUT_AGENT_ID]: [
+          { customConnectorId: DEEPWIKI_CONNECTOR_ID, permissionNames: [] },
+        ],
+      },
+      accountSummaries: [
+        accountSummary(githubTarget(), builtinAccounts),
+        accountSummary(deepWikiTarget(), customAccounts),
+      ],
+      accounts: [...builtinAccounts, ...customAccounts],
+      threadSelections: {
+        [SCOUT_THREAD_ID]: [
+          { target: githubTarget(), connectionId: builtinAccounts[1]!.id },
+        ],
+      },
+      threadId: SCOUT_THREAD_ID,
+    });
+
+    await setupPage({
+      context,
+      path: `/chats/${SCOUT_THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.CustomConnectorMcp]: true },
+    });
+    await loadComposer();
+    await openConnectors(user);
+    const accountLabel = `${label} · ${explicit ? "Selected account: Personal" : "Using default account: Work"}`;
+    const chooser = await openAccountChooser(user, accountLabel);
+    const choices = within(chooser).getByRole("radiogroup", { name: label });
+    await expect(within(choices).findByText("Research")).resolves.toBeVisible();
+
+    fireEvent.scroll(choices);
+    expect(chooser).toBeVisible();
+    const connectorList = screen.getByRole("list", { name: "Connectors" });
+    fireEvent.scroll(connectorList);
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Account for this chat")).toBeNull();
+    });
+    expect(queryFastControl("button", "Add connectors")).toBeVisible();
+    expect(screen.getByLabelText(`Remove ${label}`)).toBeChecked();
+    const accountButton = await findFastControl("button", accountLabel);
+    expect(accountButton).toBeVisible();
+
+    fireEvent.scroll(connectorList);
+    await user.hover(accountButton);
+    expect(screen.queryByLabelText("Account for this chat")).toBeNull();
+    const reopened = await openAccountChooser(user, accountLabel);
+    expect(
+      queryAllByRoleFast("radio", reopened).find((radio) => {
+        return radio.getAttribute("aria-checked") === "true";
+      }),
+    ).toHaveTextContent(explicit ? "Personal" : "Use default");
+
+    fireEvent.scroll(connectorList);
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Account for this chat")).toBeNull();
+    });
+    accountButton.focus();
+    await user.keyboard("{Enter}");
+    await expect(
+      screen.findByLabelText("Account for this chat"),
+    ).resolves.toBeVisible();
+  },
+);
 
 test("Keep connector access synchronized across split chats for the same agent", async () => {
   const user = userEvent.setup({ delay: null });

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -8273,6 +8273,11 @@ function ConnectorsPopoverButton({
                   return $.chat.connectors.title;
                 })}
                 className="flex max-h-64 min-h-0 flex-1 flex-col overflow-y-auto"
+                onScroll={() => {
+                  if (accountMenuOpen) {
+                    closeAccountMenu();
+                  }
+                }}
               >
                 {visibleConnectors.map((item) => {
                   if (item.kind === "custom") {


### PR DESCRIPTION
## Summary

- Dismiss the composer's account chooser when its parent connector list scrolls, keeping the main picker open and preserving connector access and account selection.
- Keep account-list scrolling isolated and retain existing click/keyboard activation; do not add hover behavior, a timed activation lock, or shared Popover changes.
- Add page-level regressions for a built-in connector with an explicit account and a custom connector using its default account, including repeated scroll, inner scroll, preserved selection/access, and reopening.

Closes #32567

New PR requested as a replacement for #32572 (authored by @Lunarivibe). It follows the same scoped dismissal approach with expanded regression coverage and native browser validation, based on current main. The earlier PR and branch have not been modified or closed.

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-connector-accounts.test.tsx src/views/okou-page/__tests__/chat-composer-connectors.test.tsx --maxWorkers=1 --silent=passed-only` — 29 tests passed.
- Regression sensitivity: both new dismissal cases fail without the production handler at the expected post-scroll visibility assertion.
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- Changed-file Prettier check and `git diff --check`.
- Native headless Chromium at the local HTTPS app with real Clerk test-account UI authentication and connector API response fixtures: 18 connectors in a 256px list with 720px content; 12 accounts. Baseline reproduced the floating chooser after wheel scroll. Fixed code passed parent-wheel dismissal, inner-wheel isolation, repeated scrolling, preserved selected account/enabled state/main picker, click/keyboard reopening, and focus restoration without resetting scroll (0 → 180 → 330).

## Risk and scope

Frontend-only; no API, database, Runner, credentials, or persisted account-selection contract changes. Existing tabs receive the fix after refresh. Deliberate activation concurrent with a list scroll is not protected by an idle timer; the list scroll dismisses the chooser.

Native verification covers Chromium and a new-chat draft with response fixtures. Existing-thread preferences and custom/default accounts are covered in page integration tests. Safari, Firefox, touch momentum, and production deployment have not been verified.
