### PR TITLE
test(api): isolate chat thread snapshot compaction fixtures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-pin-order.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-pin-order.test.ts
@@ -18,8 +18,8 @@ import { seedOrgMembership$ } from "./helpers/org-membership";
 import { chatThreadGetRoutes } from "../chat-threads-get";
 import { chatThreadPinOrderRoutes } from "../chat-threads-pin-order";
 import { chatThreadPinRoutes } from "../chat-threads-pin";
-import { cronCompactChatThreadSnapshotsContract } from "@okouai/api-contracts/contracts/cron";
-import { cronCompactChatThreadSnapshotsRoutes } from "../cron-compact-chat-thread-snapshots";
+import { testChatThreadSnapshotCompactionContract } from "@okouai/api-contracts/contracts/test-chat-thread-snapshot-compaction";
+import { testChatThreadSnapshotCompactionRoutes } from "../test-chat-thread-snapshot-compaction";
 import { replayChatThreadEvents } from "@okouai/core/chat-thread-event-replay";
 import { comparePinnedThreads } from "@okouai/core/chat-thread-pin-order";
 
@@ -171,11 +171,13 @@ describe("pinned thread ordering", () => {
     ).toStrictEqual([fixture.threadId, second.id]);
     const compact = setupApp({
       context,
-      routes: cronCompactChatThreadSnapshotsRoutes,
-    })(cronCompactChatThreadSnapshotsContract);
+      routes: testChatThreadSnapshotCompactionRoutes,
+    })(testChatThreadSnapshotCompactionContract);
     await accept(
       compact.compact({
-        headers: { authorization: "Bearer test-cron-secret" },
+        body: {
+          scopes: [{ user_id: fixture.userId, org_id: fixture.orgId }],
+        },
       }),
       [200],
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -8,10 +8,7 @@ import {
   type ChatThreadArtifactGoogleDriveSync,
   type UserMessageInputDocument,
 } from "@okouai/api-contracts/contracts/chat-threads";
-import {
-  cronCompactChatThreadSnapshotsContract,
-  cronProjectChatEventSearchContract,
-} from "@okouai/api-contracts/contracts/cron";
+import { cronProjectChatEventSearchContract } from "@okouai/api-contracts/contracts/cron";
 import { goalsContract } from "@okouai/api-contracts/contracts/goals";
 import {
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
@@ -19,6 +16,7 @@ import {
 } from "@okouai/api-contracts/contracts/model-providers";
 import { CANCELLATION_RECOVERY_STALE_AFTER_MS } from "@okouai/api-contracts/contracts/runners";
 import { testCronCleanupSandboxesStateContract } from "@okouai/api-contracts/contracts/test-cron-cleanup-sandboxes-state";
+import { testChatThreadSnapshotCompactionContract } from "@okouai/api-contracts/contracts/test-chat-thread-snapshot-compaction";
 import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
 import { createHash, randomUUID } from "node:crypto";
@@ -58,7 +56,7 @@ import {
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { chatThreadRoutes } from "../chat-threads";
-import { cronCompactChatThreadSnapshotsRoutes } from "../cron-compact-chat-thread-snapshots";
+import { testChatThreadSnapshotCompactionRoutes } from "../test-chat-thread-snapshot-compaction";
 import { cronProjectChatEventSearchRoutes } from "../cron-project-chat-event-search";
 import { goalsRoutes } from "../goals";
 import { testCronCleanupSandboxesStateRoutes } from "../test-cron-cleanup-sandboxes-state";
@@ -95,7 +93,6 @@ import {
 } from "./helpers/usage-state";
 
 const TEST_APP_ROUTES = Object.freeze([
-  ...cronCompactChatThreadSnapshotsRoutes,
   ...cronProjectChatEventSearchRoutes,
   ...chatThreadRoutes,
   ...goalsRoutes,
@@ -125,7 +122,6 @@ const connectorsApi = createConnectorBddApi(context);
 const authOrg = createAuthOrgAgentsBddApi(context);
 const routeMocks = createRouteMocks(context);
 const store = createStore();
-const CHAT_THREAD_SNAPSHOT_CRON_SECRET = "chat-thread-snapshot-cron-secret";
 const DAY_MS = 24 * 60 * 60 * 1000;
 const FORWARD_CLEANUP_CUTOFF_MS = Date.parse("2026-08-03T05:40:26.000Z");
 const FORWARD_CLEANUP_TEST_CREATED_AT = "2026-08-03T05:40:26.001Z";
@@ -156,15 +152,23 @@ type UserMessage = Extract<
 type AssistantMessage = Exclude<ChatEvent, UserMessage>;
 type RunnerClaim = Awaited<ReturnType<typeof api.claimRunnerJob>>;
 
-async function compactChatThreadSnapshots() {
+async function compactChatThreadSnapshots(
+  actor: ApiTestUser,
+  ...otherActors: readonly ApiTestUser[]
+) {
   const client = setupApp({
     context,
-    routes: cronCompactChatThreadSnapshotsRoutes,
-  })(cronCompactChatThreadSnapshotsContract);
+    routes: testChatThreadSnapshotCompactionRoutes,
+  })(testChatThreadSnapshotCompactionContract);
   const response = await accept(
     client.compact({
-      headers: {
-        authorization: `Bearer ${CHAT_THREAD_SNAPSHOT_CRON_SECRET}`,
+      body: {
+        scopes: [actor, ...otherActors].map((ownedActor) => {
+          if (!ownedActor.orgId) {
+            throw new Error("Expected an organization-scoped snapshot actor");
+          }
+          return { user_id: ownedActor.userId, org_id: ownedActor.orgId };
+        }),
       },
     }),
     [200],
@@ -426,7 +430,6 @@ async function allThreadEvents(actor: ApiTestUser) {
 }
 
 async function createSnapshotCursorScenario(label: string) {
-  mockEnv("CRON_SECRET", CHAT_THREAD_SNAPSHOT_CRON_SECRET);
   const actor = bdd.user();
   if (!actor.orgId) {
     throw new Error("Expected an organization-scoped chat actor");
@@ -455,7 +458,7 @@ async function createSnapshotCursorScenario(label: string) {
     throw new Error("Expected snapshot cursor lifecycle events");
   }
 
-  await compactChatThreadSnapshots();
+  await compactChatThreadSnapshots(actor);
   const snapshot = await chat.getThreadSnapshot(actor);
   const { latestEventId, latestSeqId } = snapshot;
   expect(latestEventId).toBe(markerEvent.id);
@@ -1213,7 +1216,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       eventId: removedThreadEventId,
     });
 
-    await compactChatThreadSnapshots();
+    await compactChatThreadSnapshots(actor);
     const boundary = await chat.getThreadSnapshot(actor);
     expect(boundary.latestEventId).toBe(removedThreadEventId);
     expect(boundary.chatThreads).toContainEqual(
@@ -1254,10 +1257,26 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       threadEventPage(actor, boundary.latestSeqId),
     ).resolves.toStrictEqual({ events: [], hasMore: false });
 
+    const unrelatedActor = bdd.user();
+    const unrelatedAgent = await bdd.createAgent(unrelatedActor, {
+      displayName: "Unrelated snapshot compaction agent",
+    });
+    await chat.createThread(unrelatedActor, {
+      agentId: unrelatedAgent.agentId,
+      title: "Unrelated event arriving before stale compaction",
+    });
+
     mockNow(snapshotAt + DAY_MS + 1);
-    const staleCompact = await compactChatThreadSnapshots();
+    const staleCompact = await compactChatThreadSnapshots(actor);
     expect(staleCompact.eventsApplied).toBe(0);
     expect(staleCompact.removedDeletedAgentThreads).toBeGreaterThanOrEqual(1);
+    await expect(chat.getThreadSnapshot(unrelatedActor)).resolves.toStrictEqual(
+      {
+        chatThreads: [],
+        latestEventId: null,
+        latestSeqId: null,
+      },
+    );
     const preserved = await chat.getThreadSnapshot(actor);
     expect({
       latestEventId: preserved.latestEventId,
@@ -1308,7 +1327,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     expect(laterEvent.seqId).toBe(boundary.latestSeqId + 2);
     await expectExpiredThreadEventCursor(actor, firstEvent.seqId);
 
-    const advancedCompact = await compactChatThreadSnapshots();
+    const advancedCompact = await compactChatThreadSnapshots(actor);
     expect(advancedCompact.eventsApplied).toBeGreaterThanOrEqual(1);
     const advanced = await chat.getThreadSnapshot(actor);
     expect({
@@ -1319,7 +1338,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       latestSeqId: laterEvent.seqId,
     });
 
-    await compactChatThreadSnapshots();
+    await compactChatThreadSnapshots(actor);
     const repeated = await chat.getThreadSnapshot(actor);
     expect({
       latestEventId: repeated.latestEventId,
@@ -1330,8 +1349,100 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     });
   }, 90_000);
 
+  it("isolates snapshot refresh and retention by both user and organization", async () => {
+    const createdAt = now();
+    mockNow(createdAt);
+    const actor = bdd.user();
+    const otherOrg = bdd.user({ userId: actor.userId });
+    const otherUser = bdd.user({ orgId: actor.orgId });
+    const fixtures = [];
+    for (const owner of [actor, otherOrg, otherUser]) {
+      const agent = await bdd.createAgent(owner, {
+        displayName: "Scoped snapshot retention agent",
+      });
+      const createdEventId = randomUUID();
+      const thread = await chat.createThread(owner, {
+        agentId: agent.agentId,
+        title: "Before scoped compaction",
+        eventId: createdEventId,
+      });
+      fixtures.push({
+        owner,
+        thread,
+        createdEventId,
+        renamedEventId: randomUUID(),
+      });
+    }
+    await compactChatThreadSnapshots(actor, otherOrg, otherUser);
+
+    for (const fixture of fixtures) {
+      await chat.renameThread(
+        fixture.owner,
+        fixture.thread.id,
+        "After scoped compaction",
+        fixture.renamedEventId,
+      );
+    }
+
+    mockNow(createdAt + 8 * DAY_MS);
+    await expect(compactChatThreadSnapshots(actor)).resolves.toStrictEqual({
+      success: true,
+      scopes: 1,
+      eventsApplied: 1,
+      removedDeletedAgentThreads: 0,
+      eventsPruned: 2,
+    });
+    for (const fixture of fixtures) {
+      const selected = fixture.owner === actor;
+      const snapshot = await chat.getThreadSnapshot(fixture.owner);
+      expect(snapshot.latestEventId).toBe(
+        selected ? fixture.renamedEventId : fixture.createdEventId,
+      );
+      expect(snapshot.chatThreads).toStrictEqual([
+        expect.objectContaining({
+          id: fixture.thread.id,
+          title: selected
+            ? "After scoped compaction"
+            : "Before scoped compaction",
+        }),
+      ]);
+      const events = await allThreadEvents(fixture.owner);
+      expect(
+        events.map((event) => {
+          return event.id;
+        }),
+      ).toStrictEqual(
+        selected ? [] : [fixture.createdEventId, fixture.renamedEventId],
+      );
+    }
+  });
+
+  it("rejects snapshot compaction test requests in production", async () => {
+    mockEnv("ENV", "production");
+    const client = setupApp({
+      context,
+      routes: testChatThreadSnapshotCompactionRoutes,
+    })(testChatThreadSnapshotCompactionContract);
+    const response = await client.compact({
+      body: {
+        scopes: [
+          { user_id: `user_${randomUUID()}`, org_id: `org_${randomUUID()}` },
+        ],
+      },
+    });
+    expect(response.status).toBe(404);
+  });
+
+  it("rejects snapshot compaction without explicitly owned scopes", async () => {
+    const client = setupApp({
+      context,
+      routes: testChatThreadSnapshotCompactionRoutes,
+    })(testChatThreadSnapshotCompactionContract);
+    const response = await client.compact({ body: { scopes: [] } });
+    expect(response.status).toBe(400);
+  });
+
   it("prunes covered lifecycle events in retry-safe deterministic batches", async () => {
-    mockEnv("CRON_SECRET", CHAT_THREAD_SNAPSHOT_CRON_SECRET);
     mockOptionalEnv("CHAT_THREAD_EVENT_PRUNE_BATCH_SIZE", "2");
     const actor = bdd.user();
     if (!actor.orgId) {
@@ -1418,15 +1529,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     });
 
     mockNow(snapshotAt);
-    let boundaryCompact = await compactChatThreadSnapshots();
-    for (
-      let attempt = 0;
-      attempt < 4 && boundaryCompact.scopes > 0;
-      attempt++
-    ) {
-      expect(boundaryCompact.eventsPruned).toBe(0);
-      boundaryCompact = await compactChatThreadSnapshots();
-    }
+    const boundaryCompact = await compactChatThreadSnapshots(actor);
     expect(boundaryCompact).toMatchObject({ scopes: 0, eventsPruned: 0 });
     await expect(
       readChatThreadEventIdsFixture({
@@ -1452,8 +1555,8 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
 
     mockNow(snapshotAt.getTime() + 1);
     const overlappingCompactions = await Promise.all([
-      compactChatThreadSnapshots(),
-      compactChatThreadSnapshots(),
+      compactChatThreadSnapshots(actor),
+      compactChatThreadSnapshots(actor),
     ]);
     expect(
       overlappingCompactions
@@ -1472,7 +1575,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       }),
     ).resolves.toStrictEqual([nullAgentMarker.id]);
 
-    const converged = await compactChatThreadSnapshots();
+    const converged = await compactChatThreadSnapshots(actor);
     expect(converged.eventsPruned).toBe(1);
     await expect(
       readChatThreadEventIdsFixture({
@@ -1481,7 +1584,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
         eventIds: coveredEventIds,
       }),
     ).resolves.toStrictEqual([]);
-    const retry = await compactChatThreadSnapshots();
+    const retry = await compactChatThreadSnapshots(actor);
     expect(retry.eventsPruned).toBe(0);
 
     concurrentAppend.release();
@@ -1536,7 +1639,11 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       title: "Keep the retention scope out of this snapshot batch",
     });
 
-    const aboveWatermarkCompact = await compactChatThreadSnapshots();
+    const aboveWatermarkCompact = await compactChatThreadSnapshots(
+      actor,
+      isolatedActor,
+      compactionBlocker,
+    );
     expect(aboveWatermarkCompact.eventsPruned).toBe(0);
     const unchangedBoundary = await chat.getThreadSnapshot(actor);
     expect({
@@ -1708,7 +1815,6 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       clearMockNow();
       stubTestTimezone("UTC");
     });
-    mockEnv("CRON_SECRET", CHAT_THREAD_SNAPSHOT_CRON_SECRET);
     const actor = bdd.user();
     await api.ensureOrgModelProvider(actor);
     const liveAgent = await bdd.createAgent(actor, {
@@ -1747,7 +1853,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
         Date.parse(deletedCreateEvent.createdAt),
       ) + 1000;
     mockNow(initialSnapshotAt);
-    const initialCompact = await compactChatThreadSnapshots();
+    const initialCompact = await compactChatThreadSnapshots(actor);
     expect(initialCompact.eventsApplied).toBeGreaterThanOrEqual(2);
 
     const baselineSnapshot = await chat.getThreadSnapshot(actor);
@@ -1784,14 +1890,14 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
 
     const incrementalSnapshotAt = initialSnapshotAt + 1000;
     mockNow(incrementalSnapshotAt);
-    const incrementalCompact = await compactChatThreadSnapshots();
+    const incrementalCompact = await compactChatThreadSnapshots(actor);
     expect(incrementalCompact.eventsApplied).toBeGreaterThanOrEqual(1);
 
     chat.mockObjectStorageObjectsExist();
     await authOrg.deleteAgent(actor, deletedAgent.agentId);
 
     mockNow(incrementalSnapshotAt + DAY_MS);
-    await compactChatThreadSnapshots();
+    await compactChatThreadSnapshots(actor);
     const boundarySnapshot = await chat.getThreadSnapshot(actor);
     expect(
       boundarySnapshot.chatThreads.map((thread) => {
@@ -1800,7 +1906,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     ).toContain(deletedAgentThread.id);
 
     mockNow(incrementalSnapshotAt + DAY_MS + 1);
-    const staleCompact = await compactChatThreadSnapshots();
+    const staleCompact = await compactChatThreadSnapshots(actor);
     expect(staleCompact.removedDeletedAgentThreads).toBeGreaterThanOrEqual(1);
     const compactedSnapshot = await chat.getThreadSnapshot(actor);
     expect(compactedSnapshot.latestEventId).not.toBeNull();
@@ -1822,7 +1928,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     const retentionBoundary =
       Date.parse(liveCreateEvent.createdAt) + 7 * DAY_MS;
     mockNow(retentionBoundary);
-    await compactChatThreadSnapshots();
+    await compactChatThreadSnapshots(actor);
     expect(
       (await allThreadEvents(actor)).some((event) => {
         return event.id === liveCreateEvent.id;
@@ -1841,7 +1947,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     });
 
     mockNow(retentionBoundary + 1);
-    const retentionCompact = await compactChatThreadSnapshots();
+    const retentionCompact = await compactChatThreadSnapshots(actor);
     expect(retentionCompact.eventsPruned).toBeGreaterThanOrEqual(1);
     const prunedCursor = await chat.requestThreadEvents(
       actor,
@@ -1856,7 +1962,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     });
 
     mockNow(Date.parse(deletedCreateEvent.createdAt) + 7 * DAY_MS + 1);
-    await compactChatThreadSnapshots();
+    await compactChatThreadSnapshots(actor);
     const coveredDeletedAgentCursor = await chat.requestThreadEvents(
       actor,
       { sinceSeqId: deletedCreateEvent.seqId },

--- a/turbo/apps/api/src/signals/routes/__tests__/global-sweep-contracts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/global-sweep-contracts.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { testContext } from "../../../__tests__/test-context";
 import { mockEnv } from "../../../lib/env";
 import { cronCleanupSandboxesRoutes } from "../cron-cleanup-sandboxes";
+import { cronCompactChatThreadSnapshotsRoutes } from "../cron-compact-chat-thread-snapshots";
 import { cronConnectorOauthStateCleanupRoutes } from "../cron-connector-oauth-state-cleanup";
 import { cronDrainEmailOutboxRoutes } from "../cron-drain-email-outbox";
 import { cronExecuteWorkflowAutomationsRoutes } from "../cron-execute-workflow-automations";
@@ -21,6 +22,24 @@ const CRON_SECRET = "test-cron-secret";
 describe("production-global sweep route contracts", () => {
   beforeEach(() => {
     mockEnv("CRON_SECRET", CRON_SECRET);
+  });
+
+  it("rejects snapshot compaction requests without authorization", async () => {
+    expect.hasAssertions();
+    await expectGlobalSweepMissingAuth(
+      context,
+      cronCompactChatThreadSnapshotsRoutes,
+      "/api/cron/compact-chat-thread-snapshots",
+    );
+  });
+
+  it("rejects snapshot compaction requests with an invalid cron secret", async () => {
+    expect.hasAssertions();
+    await expectGlobalSweepWrongAuth(
+      context,
+      cronCompactChatThreadSnapshotsRoutes,
+      "/api/cron/compact-chat-thread-snapshots",
+    );
   });
 
   it("rejects cleanup-sandboxes requests with an invalid cron secret", async () => {

--- a/turbo/apps/api/src/signals/routes/cron-compact-chat-thread-snapshots.ts
+++ b/turbo/apps/api/src/signals/routes/cron-compact-chat-thread-snapshots.ts
@@ -11,7 +11,11 @@ const compactChatThreadSnapshotsRoute$ = command(
       return cronUnauthorized();
     }
 
-    const result = await set(compactChatThreadSnapshots$, signal);
+    const result = await set(
+      compactChatThreadSnapshots$,
+      { kind: "global" },
+      signal,
+    );
     signal.throwIfAborted();
     return {
       status: 200 as const,

--- a/turbo/apps/api/src/signals/routes/test-chat-thread-snapshot-compaction.ts
+++ b/turbo/apps/api/src/signals/routes/test-chat-thread-snapshot-compaction.ts
@@ -1,0 +1,50 @@
+import { testChatThreadSnapshotCompactionContract } from "@okouai/api-contracts/contracts/test-chat-thread-snapshot-compaction";
+import { command } from "ccstate";
+
+import { request$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+import { compactChatThreadSnapshots$ } from "../services/cron-compact-chat-thread-snapshots.service";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-endpoint-helpers";
+
+const compactBody$ = bodyResultOf(
+  testChatThreadSnapshotCompactionContract.compact,
+);
+
+const compactChatThreadSnapshotFixturesRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const bodyResult = await get(compactBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+    const result = await set(
+      compactChatThreadSnapshots$,
+      {
+        kind: "fixtures",
+        scopes: bodyResult.data.scopes.map((scope) => {
+          return { userId: scope.user_id, orgId: scope.org_id };
+        }),
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    return {
+      status: 200 as const,
+      body: { success: true as const, ...result },
+    };
+  },
+);
+
+export const testChatThreadSnapshotCompactionRoutes: readonly RouteEntry[] = [
+  {
+    route: testChatThreadSnapshotCompactionContract.compact,
+    handler: compactChatThreadSnapshotFixturesRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
@@ -14,6 +14,7 @@ import {
   or,
   sql,
   type SQL,
+  type SQLWrapper,
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { chatThreadEvents } from "@okouai/db/schema/chat-thread-event";
@@ -31,6 +32,34 @@ interface SnapshotCompactionStats {
   readonly eventsApplied: number;
   readonly removedDeletedAgentThreads: number;
   readonly eventsPruned: number;
+}
+
+type SnapshotCompactionScope =
+  | { readonly kind: "global" }
+  | {
+      readonly kind: "fixtures";
+      readonly scopes: readonly {
+        readonly userId: string;
+        readonly orgId: string;
+      }[];
+    };
+
+function snapshotScopePredicate(
+  scope: SnapshotCompactionScope,
+  userId: SQLWrapper,
+  orgId: SQLWrapper,
+): SQL | undefined {
+  if (scope.kind === "global") {
+    return undefined;
+  }
+  if (scope.scopes.length === 0) {
+    return sql`false`;
+  }
+  return or(
+    ...scope.scopes.map((ownedScope) => {
+      return and(eq(userId, ownedScope.userId), eq(orgId, ownedScope.orgId));
+    }),
+  );
 }
 
 type SnapshotRootDb = Pick<Db, "execute" | "select" | "transaction">;
@@ -101,7 +130,11 @@ function allScopesCte(staleCutoff: Date): SQL {
   `;
 }
 
-function candidateScopesCte(staleCutoff: Date, batchSize: number): SQL {
+function candidateScopesCte(
+  staleCutoff: Date,
+  batchSize: number,
+  scope: SnapshotCompactionScope,
+): SQL {
   return sql`
     candidate_scopes AS (
       SELECT
@@ -127,10 +160,13 @@ function candidateScopesCte(staleCutoff: Date, batchSize: number): SQL {
         ORDER BY ${desc(event.seqId)}
         LIMIT 1
       ) latest_event ON true
-      WHERE ${or(
-        isNull(snapshot.userId),
-        isNotNull(sql`latest_event.id`),
-        lt(snapshot.updatedAt, staleCutoff),
+      WHERE ${and(
+        or(
+          isNull(snapshot.userId),
+          isNotNull(sql`latest_event.id`),
+          lt(snapshot.updatedAt, staleCutoff),
+        ),
+        snapshotScopePredicate(scope, sql`scope.user_id`, sql`scope.org_id`),
       )}
       ORDER BY
         ${asc(snapshot.updatedAt)} NULLS FIRST,
@@ -298,11 +334,12 @@ function compactChatThreadSnapshotBatchSql(
     readonly updatedAt: Date;
     readonly staleCutoff: Date;
     readonly batchSize: number;
+    readonly scope: SnapshotCompactionScope;
   },
 ): SQL {
   return sql`
     WITH ${allScopesCte(args.staleCutoff)},
-    ${candidateScopesCte(args.staleCutoff, args.batchSize)},
+    ${candidateScopesCte(args.staleCutoff, args.batchSize, args.scope)},
     ${rebuiltCte(db)},
     ${upsertedCte(args.updatedAt)}
     SELECT
@@ -319,6 +356,7 @@ function compactChatThreadSnapshotBatchSql(
 async function compactChatThreadSnapshotBatch(
   db: SnapshotRootDb,
   batchSize: number,
+  scope: SnapshotCompactionScope,
 ): Promise<Omit<SnapshotCompactionStats, "eventsPruned">> {
   const updatedAt = nowDate();
   const staleCutoff = new Date(
@@ -330,6 +368,7 @@ async function compactChatThreadSnapshotBatch(
       updatedAt,
       staleCutoff,
       batchSize,
+      scope,
     }),
     snapshotBatchRowSchema,
   );
@@ -341,15 +380,16 @@ async function compactChatThreadSnapshotBatch(
   };
 }
 
-async function compactChatThreadSnapshotsForAllScopes(
+async function compactChatThreadSnapshotsForScope(
   db: SnapshotRootDb,
+  scope: SnapshotCompactionScope,
   signal?: AbortSignal,
 ): Promise<SnapshotCompactionStats> {
   const snapshotBatchSize = chatThreadSnapshotBatchSize();
   const eventPruneBatchSize = chatThreadEventPruneBatchSize();
   const compacted = await db.transaction(
     async (tx) => {
-      return await compactChatThreadSnapshotBatch(tx, snapshotBatchSize);
+      return await compactChatThreadSnapshotBatch(tx, snapshotBatchSize, scope);
     },
     { isolationLevel: "repeatable read" },
   );
@@ -368,6 +408,7 @@ async function compactChatThreadSnapshotsForAllScopes(
             eq(snapshot.orgId, event.orgId),
           )}
         WHERE ${and(
+          snapshotScopePredicate(scope, event.userId, event.orgId),
           isNotNull(snapshot.latestEventSeqId),
           lt(event.createdAt, cutoff),
           lte(event.seqId, snapshot.latestEventSeqId),
@@ -402,7 +443,15 @@ async function compactChatThreadSnapshotsForAllScopes(
 }
 
 export const compactChatThreadSnapshots$ = command(
-  async ({ set }, signal: AbortSignal): Promise<SnapshotCompactionStats> => {
-    return await compactChatThreadSnapshotsForAllScopes(set(writeDb$), signal);
+  async (
+    { set },
+    scope: SnapshotCompactionScope,
+    signal: AbortSignal,
+  ): Promise<SnapshotCompactionStats> => {
+    return await compactChatThreadSnapshotsForScope(
+      set(writeDb$),
+      scope,
+      signal,
+    );
   },
 );

--- a/turbo/packages/api-contracts/src/contracts/test-chat-thread-snapshot-compaction.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-chat-thread-snapshot-compaction.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+import { cronCompactChatThreadSnapshotsResponseSchema } from "./cron";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const testChatThreadSnapshotCompactionContract = c.router({
+  compact: {
+    method: "POST",
+    path: "/api/test/compact-chat-thread-snapshots",
+    body: z.object({
+      scopes: z
+        .array(
+          z.object({
+            user_id: z.string().min(1),
+            org_id: z.string().min(1),
+          }),
+        )
+        .min(1)
+        .max(100),
+    }),
+    responses: {
+      200: cronCompactChatThreadSnapshotsResponseSchema,
+      400: apiErrorSchema,
+      404: z.string(),
+    },
+    summary: "Compact explicitly owned chat thread snapshot test fixtures",
+  },
+});


### PR DESCRIPTION
## Summary

Chat thread snapshot API tests created unique user/organization identities but invoked the production-wide compactor. An unrelated thread event could therefore make a markerless refresh report `eventsApplied: 1` instead of `0`, as in [the failed API shard](https://github.com/vm0-ai/vm0/actions/runs/34241719503/job/102113422387). Adding one unrelated API-created event reproduces that failure; the original CI log does not identify its owning fixture.

Add a guarded test route that passes explicitly owned user/organization pairs into the existing compaction service. Apply the scope to both snapshot batch selection and retention pruning, while the production cron explicitly retains global scope. Preserve the watermark, cursor, sequence-gap, retry, and concurrent-pruning assertions, and cover isolation across users and organizations, production rejection, empty scopes, and cron authentication.

## Validation

- Before syncing with `main` (baseline `cf76592924af6576d5a73116bc307b0173185af6`): the three affected API test files passed, 61/61 tests. Six focused regression cases also passed in five sequential processes against the same persistent database, 30/30 executions.
- Formatting, Oxlint/type-aware lint, ESLint, API and API-contract type checks, and affected-workspace Knip passed during local validation.
- After syncing with `main`, the normal commit hooks passed: Prettier, style policy, workspace-wide Knip and type checks, file-size checks, and commitlint.
- Synced cleanly onto `bf29b32672ca38d03979754e8a022bbdab35fb6a`; the repair patch is unchanged. The full API shard remains for the PR pipeline.
