### PR TITLE
feat: add gpt image 2.5 models

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -64,6 +64,9 @@ const IMAGE_IO_MODEL = "gpt-image-1";
 const FAL_GPT_IMAGE_1_URL =
   "https://queue.fal.run/fal-ai/gpt-image-1/text-to-image";
 const FAL_GPT_IMAGE_2_URL = "https://queue.fal.run/openai/gpt-image-2";
+const OPENAI_IMAGE_GENERATIONS_URL =
+  "https://api.openai.com/v1/images/generations";
+const OPENAI_IMAGE_EDITS_URL = "https://api.openai.com/v1/images/edits";
 const BYTEPLUS_IMAGE_GENERATIONS_URL =
   "https://ark.ap-southeast.bytepluses.com/api/v3/images/generations";
 const BYTEPLUS_SEEDREAM_5_LITE_MEDIA_URL =
@@ -159,6 +162,19 @@ const IMAGE_PRICING_CATEGORIES = [
   "output_image.high.standard",
   "output_image.high.large",
 ] as const;
+const GPT_IMAGE_2_5_MODELS = [
+  "gpt-image-2.5-flare",
+  "gpt-image-2.5-sunburst",
+] as const;
+const GPT_IMAGE_2_5_PRICING = GPT_IMAGE_2_5_MODELS.flatMap((provider) => {
+  return [
+    { category: "tokens.input.text", unitPrice: 6000 },
+    { category: "tokens.input.image", unitPrice: 9600 },
+    { category: "tokens.output.image", unitPrice: 36_000 },
+  ].map((row) => {
+    return { ...row, kind: "image", provider, unitSize: 1_000_000 };
+  });
+}) satisfies readonly UsagePricingRow[];
 
 const tokenRequest = Object.freeze({
   keyName: "test-key",
@@ -758,6 +774,240 @@ describe("POST /api/image-io/generate", () => {
       },
     });
     expect(calledFal).toBeFalsy();
+  });
+
+  it.each([
+    { model: "gpt-image-2.5-flare", quality: "xhigh", editing: false },
+    { model: "gpt-image-2.5-sunburst", quality: "max", editing: true },
+  ])(
+    "generates $model images through OpenAI and bills actual tokens",
+    async ({ model, quality, editing }) => {
+      const fixture = await seedImageFixture({ credits: 1000 });
+      const pricingFixture = await createScopedImagePricing({
+        configured: GPT_IMAGE_2_5_PRICING,
+      });
+      mocks.clerk.session(fixture.userId, fixture.orgId);
+      let observedBody: unknown;
+      let observedAuthorization: string | null = null;
+      server.use(
+        http.post(
+          editing ? OPENAI_IMAGE_EDITS_URL : OPENAI_IMAGE_GENERATIONS_URL,
+          async ({ request }) => {
+            observedBody = await request.json();
+            observedAuthorization = request.headers.get("authorization");
+            return HttpResponse.json({
+              created: currentSecond(),
+              data: [{ b64_json: IMAGE_BYTES.toString("base64") }],
+              size: "1536x1024",
+              quality,
+              background: "transparent",
+              output_format: "webp",
+              usage: {
+                input_tokens: editing ? 1700 : 200,
+                input_tokens_details: {
+                  text_tokens: 200,
+                  image_tokens: editing ? 1500 : 0,
+                },
+                output_tokens: editing ? 2501 : 2500,
+                ...(editing
+                  ? {
+                      output_tokens_details: {
+                        image_tokens: 2500,
+                        text_tokens: 1,
+                      },
+                    }
+                  : {}),
+                total_tokens: editing ? 4201 : 2700,
+              },
+            });
+          },
+        ),
+      );
+      const app = createImageIoTestApp(pricingFixture.resolution);
+      const response = await app.request("/api/image-io/generate", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          model,
+          prompt: "a product illustration",
+          size: "1536x1024",
+          quality,
+          background: "transparent",
+          outputFormat: "webp",
+          outputCompression: 80,
+          ...(editing
+            ? {
+                imageUrls: [MOCKUP_IMAGE_URL, SECOND_MOCKUP_IMAGE_URL],
+                maskImageUrl: THIRD_MOCKUP_IMAGE_URL,
+              }
+            : {}),
+        }),
+      });
+      expect(response.status).toBe(202);
+      const generationId = readAcceptedGenerationId(
+        await response.json(),
+        "image",
+        fixture.userId,
+      );
+      await flushWaitUntilForTest();
+
+      const status = await app.request(
+        `/api/built-in-generations/${generationId}`,
+        { headers: authHeaders() },
+      );
+      expect(status.status).toBe(200);
+      const creditsCharged = editing ? 107 : 92;
+      await expect(status.json()).resolves.toMatchObject({
+        status: "completed",
+        result: {
+          model,
+          provider: "openai",
+          imageSize: "1536x1024",
+          quality,
+          background: "transparent",
+          outputFormat: "webp",
+          outputCompression: 80,
+          contentType: "image/webp",
+          size: IMAGE_BYTES.byteLength,
+          creditsCharged,
+          url: expect.any(String),
+        },
+      });
+      expect(observedAuthorization).toBe("Bearer test-openai-key");
+      expect(observedBody).toStrictEqual({
+        model,
+        prompt: "a product illustration",
+        n: 1,
+        size: "1536x1024",
+        quality,
+        background: "transparent",
+        output_format: "webp",
+        output_compression: 80,
+        moderation: "auto",
+        ...(editing
+          ? {
+              images: [
+                { image_url: MOCKUP_IMAGE_URL },
+                { image_url: SECOND_MOCKUP_IMAGE_URL },
+              ],
+              mask: { image_url: THIRD_MOCKUP_IMAGE_URL },
+            }
+          : {}),
+      });
+      await expect(orgCredits(fixture)).resolves.toBe(1000 - creditsCharged);
+    },
+  );
+
+  it.each(GPT_IMAGE_2_5_MODELS)(
+    "rejects %s before generation when pricing is missing",
+    async (model) => {
+      const fixture = await seedImageFixture({ credits: 1000 });
+      const pricingFixture = await createScopedImagePricing({
+        missing: GPT_IMAGE_2_5_PRICING.filter((row) => {
+          return row.provider === model;
+        }),
+      });
+      mocks.clerk.session(fixture.userId, fixture.orgId);
+      let providerCalls = 0;
+      server.use(
+        http.post(OPENAI_IMAGE_GENERATIONS_URL, () => {
+          providerCalls += 1;
+          return HttpResponse.json({});
+        }),
+      );
+      const app = createImageIoTestApp(pricingFixture.resolution);
+      const response = await app.request("/api/image-io/generate", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ model, prompt: "a product illustration" }),
+      });
+      expect(response.status).toBe(503);
+      await expect(response.json()).resolves.toMatchObject({
+        error: {
+          code: "NOT_CONFIGURED",
+          message: "Image generation pricing is not configured",
+        },
+      });
+      expect(providerCalls).toBe(0);
+      await expect(orgCredits(fixture)).resolves.toBe(1000);
+    },
+  );
+
+  it.each([
+    {
+      upstreamStatus: 200,
+      responseBody: { data: [{ b64_json: IMAGE_BYTES.toString("base64") }] },
+      code: "OPENAI_IMAGE_BAD_RESPONSE",
+    },
+    {
+      upstreamStatus: 429,
+      responseBody: { error: { message: "Rate limit exceeded" } },
+      code: "OPENAI_IMAGE_REQUEST_FAILED",
+    },
+  ])(
+    "fails OpenAI jobs without charging for $code",
+    async ({ upstreamStatus, responseBody, code }) => {
+      const fixture = await seedImageFixture({ credits: 1000 });
+      const pricingFixture = await createScopedImagePricing({
+        configured: GPT_IMAGE_2_5_PRICING,
+      });
+      mocks.clerk.session(fixture.userId, fixture.orgId);
+      server.use(
+        http.post(OPENAI_IMAGE_GENERATIONS_URL, () => {
+          return HttpResponse.json(responseBody, { status: upstreamStatus });
+        }),
+      );
+      const app = createImageIoTestApp(pricingFixture.resolution);
+      const response = await app.request("/api/image-io/generate", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          model: "gpt-image-2.5-flare",
+          prompt: "a product illustration",
+        }),
+      });
+      expect(response.status).toBe(202);
+      const generationId = readAcceptedGenerationId(
+        await response.json(),
+        "image",
+        fixture.userId,
+      );
+      await flushWaitUntilForTest();
+      const status = await app.request(
+        `/api/built-in-generations/${generationId}`,
+        { headers: authHeaders() },
+      );
+      expect(status.status).toBe(200);
+      await expect(status.json()).resolves.toMatchObject({
+        status: "failed",
+        error: { code },
+      });
+      await expect(orgCredits(fixture)).resolves.toBe(1000);
+    },
+  );
+
+  it("keeps GPT Image 2 limited to its supported quality levels", async () => {
+    const fixture = await seedImageFixture({});
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const response = await createImageIoTestApp().request(
+      "/api/image-io/generate",
+      {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          model: "gpt-image-2",
+          prompt: "a product illustration",
+          quality: "xhigh",
+        }),
+      },
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "BAD_REQUEST",
+        message: "Unsupported image quality: xhigh",
+      },
+    });
   });
 
   it("uses the stable run snapshot for omitted and blank models", async () => {

--- a/turbo/apps/api/src/signals/routes/image-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/image-io-generate.ts
@@ -26,6 +26,7 @@ import { createBuiltInGenerationRealtimeSubscription } from "../external/realtim
 import {
   checkImageCredits$,
   generateBytePlusImage,
+  generateOpenAiImage,
   getMissingImagePricing,
   imagePricing$,
   insufficientCredits,
@@ -260,14 +261,15 @@ const submitImageProviderWebhookJob$ = command(
   },
 );
 
-const executeBytePlusImageProviderJob$ = command(
+const executeDirectImageProviderJob$ = command(
   async ({ set }, args: ImageJobArgs, signal: AbortSignal): Promise<void> => {
     await set(markBuiltInGenerationRunning$, args.generationId, signal);
     signal.throwIfAborted();
-    const apiKey = env("BYTEPLUS_API_KEY");
+    const isOpenAi = args.options.provider === "openai";
+    const apiKey = env(isOpenAi ? "OPENAI_API_KEY" : "BYTEPLUS_API_KEY");
     if (!apiKey) {
       const unavailable = serviceUnavailable(
-        "BytePlus image generation is not configured",
+        `${isOpenAi ? "OpenAI" : "BytePlus"} image generation is not configured`,
         "NOT_CONFIGURED",
       );
       await set(
@@ -288,7 +290,12 @@ const executeBytePlusImageProviderJob$ = command(
     const generation =
       "status" in references
         ? references
-        : await generateBytePlusImage(args.options, references, apiKey, signal);
+        : await (isOpenAi ? generateOpenAiImage : generateBytePlusImage)(
+            args.options,
+            references,
+            apiKey,
+            signal,
+          );
     signal.throwIfAborted();
     if (isErrorResponse(generation)) {
       await set(
@@ -337,10 +344,10 @@ const executeBytePlusImageProviderJob$ = command(
   },
 );
 
-const runBytePlusImageProviderJob$ = command(
+const runDirectImageProviderJob$ = command(
   async ({ set }, args: ImageJobArgs, signal: AbortSignal): Promise<void> => {
     const execution = await settle(
-      set(executeBytePlusImageProviderJob$, args, signal),
+      set(executeDirectImageProviderJob$, args, signal),
       signal,
     );
     signal.throwIfAborted();
@@ -348,9 +355,10 @@ const runBytePlusImageProviderJob$ = command(
       return;
     }
 
-    L.error("BytePlus image generation failed", {
+    L.error("Image generation failed", {
       generationId: args.generationId,
       model: args.options.model,
+      provider: args.options.provider,
       error:
         execution.error instanceof Error
           ? execution.error.message
@@ -362,7 +370,10 @@ const runBytePlusImageProviderJob$ = command(
         generationId: args.generationId,
         error: {
           message: "Image generation failed",
-          code: "BYTEPLUS_IMAGE_REQUEST_FAILED",
+          code:
+            args.options.provider === "openai"
+              ? "OPENAI_IMAGE_REQUEST_FAILED"
+              : "BYTEPLUS_IMAGE_REQUEST_FAILED",
         },
       },
       signal,
@@ -382,9 +393,9 @@ const startImageProviderJob$ = command(
     args: ImageJobArgs,
     signal: AbortSignal,
   ): Promise<GenerationErrorResponse | null> => {
-    if (args.options.provider === "byteplus") {
+    if (args.options.provider !== "fal") {
       waitUntil(
-        set(runBytePlusImageProviderJob$, args, new AbortController().signal),
+        set(runDirectImageProviderJob$, args, new AbortController().signal),
       );
       return null;
     }
@@ -452,6 +463,12 @@ const postImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (options.provider === "byteplus" && !env("BYTEPLUS_API_KEY")) {
     return serviceUnavailable(
       "BytePlus image generation is not configured",
+      "NOT_CONFIGURED",
+    );
+  }
+  if (options.provider === "openai" && !env("OPENAI_API_KEY")) {
+    return serviceUnavailable(
+      "OpenAI image generation is not configured",
       "NOT_CONFIGURED",
     );
   }

--- a/turbo/apps/api/src/signals/services/image-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/image-generation.service.ts
@@ -11,6 +11,7 @@ import {
 } from "@okouai/core/image-model-catalog";
 import { r2ImageTransformUrl } from "@okouai/core/r2-image-transform";
 import { and, eq, inArray } from "drizzle-orm";
+import { z } from "zod";
 
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
@@ -34,6 +35,7 @@ import {
 
 const FAL_IMAGE_QUEUE_URL_PREFIX = "https://queue.fal.run";
 const FAL_BILLABLE_UNITS_HEADER = "x-fal-billable-units";
+const OPENAI_IMAGES_URL_PREFIX = "https://api.openai.com/v1/images";
 const BYTEPLUS_IMAGE_GENERATIONS_URL =
   "https://ark.ap-southeast.bytepluses.com/api/v3/images/generations";
 const IMAGE_IO_MAX_PROMPT_LENGTH = 32_000;
@@ -97,6 +99,11 @@ const IDEOGRAM_4_PRICING_CATEGORIES = [
   "output_megapixel.balanced",
   "output_megapixel.quality",
 ] as const;
+const OPENAI_IMAGE_PRICING_CATEGORIES = [
+  "tokens.input.text",
+  "tokens.input.image",
+  "tokens.output.image",
+] as const;
 const IMAGE_PRICING_CATEGORIES = [
   FAL_OUTPUT_IMAGE_CATEGORY,
   FAL_OUTPUT_MEGAPIXEL_CATEGORY,
@@ -105,9 +112,11 @@ const IMAGE_PRICING_CATEGORIES = [
   ...FAL_PIXEL_TIER_IMAGE_PRICING_CATEGORIES,
   ...FLUX_2_PRO_PRICING_CATEGORIES,
   ...IDEOGRAM_4_PRICING_CATEGORIES,
+  ...OPENAI_IMAGE_PRICING_CATEGORIES,
 ] as const;
 
 const IMAGE_QUALITIES = ["low", "medium", "high", "auto"] as const;
+const OPENAI_IMAGE_QUALITIES = [...IMAGE_QUALITIES, "xhigh", "max"] as const;
 const IMAGE_BACKGROUNDS = ["auto", "opaque", "transparent"] as const;
 const IMAGE_OUTPUT_FORMATS = ["png", "webp", "jpeg"] as const;
 const IMAGE_MODERATIONS = ["auto", "low"] as const;
@@ -142,7 +151,42 @@ const IMAGE_MODEL_ALIASES = {
   "clarity-upscaler": CLARITY_UPSCALER_MODEL,
 } as const;
 
+const OPENAI_IMAGE_MODEL_CONFIG = {
+  promptless: false,
+  sourceImageInput: "image_urls",
+  provider: "openai",
+  sizeMode: "flexible",
+  sizeParameter: undefined,
+  outputFormats: IMAGE_OUTPUT_FORMATS,
+  pricingCategories: OPENAI_IMAGE_PRICING_CATEGORIES,
+  billingMode: "tokens",
+  supportsTransparentBackground: true,
+  supportsOutputCompression: true,
+  supportsModeration: true,
+  supportsQuality: true,
+  supportsBackground: true,
+  usesOpenAiByok: false,
+  supportsSeed: false,
+  supportsSafetyTolerance: false,
+  supportsEnhancePrompt: false,
+  supportsMaskImage: true,
+  supportsInputFidelity: false,
+  supportsImagePromptStrength: false,
+} as const;
+
 const IMAGE_GENERATION_MODEL_CONFIGS = {
+  "gpt-image-2.5-flare": {
+    ...OPENAI_IMAGE_MODEL_CONFIG,
+    alias: "gpt-image-2.5-flare",
+    endpointId: "gpt-image-2.5-flare",
+    imageToImageEndpointId: "gpt-image-2.5-flare",
+  },
+  "gpt-image-2.5-sunburst": {
+    ...OPENAI_IMAGE_MODEL_CONFIG,
+    alias: "gpt-image-2.5-sunburst",
+    endpointId: "gpt-image-2.5-sunburst",
+    imageToImageEndpointId: "gpt-image-2.5-sunburst",
+  },
   "gpt-image-2": {
     alias: "gpt-image-2",
     promptless: false,
@@ -531,7 +575,7 @@ const IMAGE_MODEL_CONFIGS = {
 const IMAGE_MODELS = Object.keys(IMAGE_MODEL_CONFIGS) as ImageModel[];
 const L = logger("ImageGeneration");
 
-type ImageQuality = (typeof IMAGE_QUALITIES)[number];
+type ImageQuality = (typeof OPENAI_IMAGE_QUALITIES)[number];
 type ImageBackground = (typeof IMAGE_BACKGROUNDS)[number];
 type ImageOutputFormat = (typeof IMAGE_OUTPUT_FORMATS)[number];
 type ImageModeration = (typeof IMAGE_MODERATIONS)[number];
@@ -539,7 +583,7 @@ type ImageSafetyTolerance = (typeof IMAGE_SAFETY_TOLERANCES)[number];
 type ImageInputFidelity = (typeof IMAGE_INPUT_FIDELITIES)[number];
 type ImagePricingCategory = (typeof IMAGE_PRICING_CATEGORIES)[number];
 export type ImageModel = keyof typeof IMAGE_MODEL_CONFIGS;
-export type ImageProvider = "fal" | "byteplus";
+export type ImageProvider = "fal" | "byteplus" | "openai";
 type ImageModelConfig = (typeof IMAGE_MODEL_CONFIGS)[ImageModel];
 
 type ErrorStatus = 400 | 402 | 500 | 502 | 503;
@@ -1023,9 +1067,14 @@ function parseImageModel(
 
 function parseImageQuality(
   body: Record<string, unknown>,
+  modelConfig: ImageModelConfig,
 ): ImageQuality | ErrorResponse {
   const quality = readString(body, "quality", "medium");
-  if (!includesString(IMAGE_QUALITIES, quality)) {
+  const qualities =
+    modelConfig.provider === "openai"
+      ? OPENAI_IMAGE_QUALITIES
+      : IMAGE_QUALITIES;
+  if (!includesString(qualities, quality)) {
     return badRequest(`Unsupported image quality: ${quality}`);
   }
 
@@ -1209,16 +1258,18 @@ function parseSourceImageUrls(
     return sourceImageUrls;
   }
   const maxSourceImageUrls =
-    modelConfig.alias === "nano-banana-2" ||
-    modelConfig.alias === "nano-banana-2-lite"
-      ? NANO_BANANA_2_MAX_SOURCE_IMAGE_URLS
-      : modelConfig.alias === "flux-2-pro"
-        ? FLUX_2_PRO_MAX_SOURCE_IMAGE_URLS
-        : modelConfig.alias === "seedream5-lite"
-          ? SEEDREAM_5_LITE_MAX_SOURCE_IMAGE_URLS
-          : modelConfig.alias === "qwen-image-3"
-            ? QWEN_IMAGE_3_MAX_SOURCE_IMAGE_URLS
-            : MAX_SOURCE_IMAGE_URLS;
+    modelConfig.provider === "openai"
+      ? 16
+      : modelConfig.alias === "nano-banana-2" ||
+          modelConfig.alias === "nano-banana-2-lite"
+        ? NANO_BANANA_2_MAX_SOURCE_IMAGE_URLS
+        : modelConfig.alias === "flux-2-pro"
+          ? FLUX_2_PRO_MAX_SOURCE_IMAGE_URLS
+          : modelConfig.alias === "seedream5-lite"
+            ? SEEDREAM_5_LITE_MAX_SOURCE_IMAGE_URLS
+            : modelConfig.alias === "qwen-image-3"
+              ? QWEN_IMAGE_3_MAX_SOURCE_IMAGE_URLS
+              : MAX_SOURCE_IMAGE_URLS;
   if (sourceImageUrls.length > maxSourceImageUrls) {
     return badRequest(
       `imageUrls supports at most ${maxSourceImageUrls} images`,
@@ -1363,7 +1414,7 @@ export function parseImageOptions(
     return sizeError;
   }
 
-  const quality = parseImageQuality(body);
+  const quality = parseImageQuality(body, modelConfig);
   if (typeof quality === "object") {
     return quality;
   }
@@ -1962,6 +2013,137 @@ export async function generateBytePlusImage(
     return result;
   }
   return await downloadBytePlusImage(result, options, signal);
+}
+
+const openAiImageResponseSchema = z.object({
+  data: z.tuple([
+    z.object({
+      b64_json: z.string().min(1),
+      revised_prompt: z.string().optional(),
+    }),
+  ]),
+  size: z.string().optional(),
+  quality: z.enum(OPENAI_IMAGE_QUALITIES).optional(),
+  background: z.enum(IMAGE_BACKGROUNDS).optional(),
+  output_format: z.enum(IMAGE_OUTPUT_FORMATS).optional(),
+  usage: z.object({
+    input_tokens_details: z.object({
+      text_tokens: z.number().int().nonnegative(),
+      image_tokens: z.number().int().nonnegative(),
+    }),
+    output_tokens: z.number().int().positive(),
+    output_tokens_details: z
+      .object({
+        image_tokens: z.number().int().positive(),
+      })
+      .optional(),
+  }),
+});
+
+export async function generateOpenAiImage(
+  options: ImageOptions,
+  references: ImageProviderReferences,
+  apiKey: string,
+  signal: AbortSignal,
+): Promise<ParsedImageGeneration | ErrorResponse> {
+  const editing = references.sourceImageUrls.length > 0;
+  const response = await fetch(
+    `${OPENAI_IMAGES_URL_PREFIX}/${editing ? "edits" : "generations"}`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: options.model,
+        prompt: options.prompt,
+        n: 1,
+        size: options.size,
+        quality: options.quality,
+        background: options.background,
+        output_format: options.outputFormat,
+        output_compression: options.outputCompression,
+        moderation: options.moderation,
+        ...(editing
+          ? {
+              images: references.sourceImageUrls.map((imageUrl) => {
+                return { image_url: imageUrl };
+              }),
+              ...(references.maskImageUrl
+                ? {
+                    mask: { image_url: references.maskImageUrl },
+                  }
+                : {}),
+            }
+          : {}),
+      }),
+      signal,
+    },
+  );
+  if (!response.ok) {
+    const responseBody = await readImageProviderErrorBody(response, signal);
+    L.error("OpenAI image generation request failed", {
+      model: options.model,
+      status: response.status,
+      body: responseBody,
+    });
+    return badGateway("Image generation failed", "OPENAI_IMAGE_REQUEST_FAILED");
+  }
+
+  const responseText = await response.text();
+  signal.throwIfAborted();
+  const parsed = openAiImageResponseSchema.safeParse(
+    safeJsonParse(responseText),
+  );
+  if (!parsed.success) {
+    return badGateway(
+      "OpenAI returned invalid image data or token usage",
+      "OPENAI_IMAGE_BAD_RESPONSE",
+    );
+  }
+  const result = parsed.data;
+  const image = result.data[0];
+  const imageBytes = Buffer.from(image.b64_json, "base64");
+  if (imageBytes.byteLength === 0) {
+    return badGateway("Model returned empty image", "NO_IMAGE_RETURNED");
+  }
+
+  return {
+    model: options.model,
+    provider: "openai",
+    imageBytes,
+    revisedPrompt: image.revised_prompt,
+    imageSize: result.size ?? options.size,
+    quality: result.quality ?? options.quality,
+    background: result.background ?? options.background,
+    outputFormat: result.output_format ?? options.outputFormat,
+    outputCompression: options.outputCompression,
+    moderation: options.moderation,
+    safetyTolerance: undefined,
+    billing: [
+      {
+        category: "tokens.input.text",
+        quantity: result.usage.input_tokens_details.text_tokens,
+      },
+      {
+        category: "tokens.input.image",
+        quantity: result.usage.input_tokens_details.image_tokens,
+      },
+      {
+        category: "tokens.output.image",
+        quantity:
+          result.usage.output_tokens_details?.image_tokens ??
+          result.usage.output_tokens,
+      },
+    ],
+    sourceUrl: undefined,
+    seed: undefined,
+    sourceImageUrls: options.sourceImageUrls,
+    maskImageUrl: options.maskImageUrl,
+    inputFidelity: undefined,
+    imagePromptStrength: undefined,
+  };
 }
 
 function parseFalImageFile(value: unknown): FalImageFile | null {

--- a/turbo/apps/cli/src/commands/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/image.test.ts
@@ -960,6 +960,9 @@ describe("okou generate image command", () => {
     const normalizedHelpOutput = helpOutput.replace(/\s+/g, " ");
 
     expect(helpOutput).toContain("gpt-image-2");
+    expect(helpOutput).toContain("gpt-image-2.5-flare");
+    expect(helpOutput).toContain("gpt-image-2.5-sunburst");
+    expect(normalizedHelpOutput).toContain("xhigh and max");
     expect(helpOutput).toContain("gpt-image-1 (default)");
     expect(helpOutput).toContain("flux-pro-1.1");
     expect(helpOutput).toContain("qwen-image");
@@ -972,7 +975,7 @@ describe("okou generate image command", () => {
     expect(helpOutput).toContain("--compression <0-100>");
     expect(helpOutput).toContain("Moderation strictness: auto or low");
     expect(helpOutput).toContain(
-      "Uses fal.ai and BytePlus for built-in image model execution",
+      "Uses OpenAI, fal.ai, and BytePlus for built-in image model execution",
     );
     expect(helpOutput).toContain("--seed");
     expect(helpOutput).toContain("--safety-tolerance");

--- a/turbo/apps/cli/src/commands/generate/__tests__/lister.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/lister.test.ts
@@ -347,7 +347,7 @@ describe("okou generate lister", () => {
     expect(text).toContain("Okou  Built-in image generation");
     expect(text).toContain("Built-in image generation");
     expect(text).toContain(
-      "Models: fal.ai: gpt-image-1 (default), gpt-image-2, flux-2-pro, ideogram-4, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, qwen-image-3, seedream4, nano-banana-2, nano-banana-2-lite; BytePlus: seedream5-pro, seedream5-lite",
+      "Models: OpenAI: gpt-image-2.5-flare, gpt-image-2.5-sunburst; fal.ai: gpt-image-1 (default), gpt-image-2, flux-2-pro, ideogram-4, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, qwen-image-3, seedream4, nano-banana-2, nano-banana-2-lite; BytePlus: seedream5-pro, seedream5-lite",
     );
     expect(text).toContain("Use: okou generate image --provider built-in -h");
     expect(text).not.toContain(

--- a/turbo/apps/cli/src/commands/generate/lib/lister.ts
+++ b/turbo/apps/cli/src/commands/generate/lib/lister.ts
@@ -95,6 +95,20 @@ const BUILT_IN_GENERATION_PROVIDERS: Partial<
       reason: "available without connector setup",
     },
     {
+      label: "Built-in OpenAI",
+      model: "gpt-image-2.5-flare",
+      command:
+        "okou generate image --provider built-in --model gpt-image-2.5-flare -h",
+      reason: "available without connector setup",
+    },
+    {
+      label: "Built-in OpenAI",
+      model: "gpt-image-2.5-sunburst",
+      command:
+        "okou generate image --provider built-in --model gpt-image-2.5-sunburst -h",
+      reason: "available without connector setup",
+    },
+    {
       label: "Built-in fal.ai",
       model: "fal-ai/flux-pro/v1.1",
       command:
@@ -245,7 +259,7 @@ const BUILT_IN_GENERATION_COMMANDS: Partial<
     label: "Built-in image generation",
     command: "okou generate image --provider built-in -h",
     models:
-      "fal.ai: gpt-image-1 (default), gpt-image-2, flux-2-pro, ideogram-4, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, qwen-image-3, seedream4, nano-banana-2, nano-banana-2-lite; BytePlus: seedream5-pro, seedream5-lite",
+      "OpenAI: gpt-image-2.5-flare, gpt-image-2.5-sunburst; fal.ai: gpt-image-1 (default), gpt-image-2, flux-2-pro, ideogram-4, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, qwen-image-3, seedream4, nano-banana-2, nano-banana-2-lite; BytePlus: seedream5-pro, seedream5-lite",
   },
   video: {
     label: "Built-in video generation",

--- a/turbo/apps/cli/src/commands/shared/image-generate.ts
+++ b/turbo/apps/cli/src/commands/shared/image-generate.ts
@@ -260,7 +260,7 @@ export function createImageGenerateCommand(
     .option("--json", "Print the complete generation result as JSON")
     .option(
       "--model <model>",
-      "Model: gpt-image-1 (default), gpt-image-2, flux-2-pro, ideogram-4, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, qwen-image-3, seedream4, seedream5-pro, seedream5-lite, nano-banana-2, or nano-banana-2-lite",
+      "Model: gpt-image-1 (default), gpt-image-2, gpt-image-2.5-flare, gpt-image-2.5-sunburst, flux-2-pro, ideogram-4, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, qwen-image-3, seedream4, seedream5-pro, seedream5-lite, nano-banana-2, or nano-banana-2-lite",
       IMAGE_MODEL_CONFIGS[DEFAULT_IMAGE_MODEL].alias,
     )
     .option(
@@ -270,7 +270,7 @@ export function createImageGenerateCommand(
     )
     .option(
       "--quality <quality>",
-      "Image quality: low, medium, high, or auto",
+      "Image quality: low, medium, high, or auto; GPT Image 2.5 also supports xhigh and max",
       "medium",
     )
     .option(
@@ -335,9 +335,12 @@ Output:
 Notes:
   - Authenticates via OKOU_TOKEN (requires file:write capability)
   - Charges org credits after successful image generation
-  - Uses fal.ai and BytePlus for built-in image model execution
+  - Uses OpenAI, fal.ai, and BytePlus for built-in image model execution
 
 Models:
+  - OpenAI: gpt-image-2.5-flare and gpt-image-2.5-sunburst.
+    GPT Image 2.5 generations bill the returned text input, image input,
+    and image output tokens using configured model pricing.
   - fal.ai: gpt-image-1 (default), gpt-image-2, flux-2-pro, ideogram-4,
     flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, qwen-image-3, seedream4,
     nano-banana-2, nano-banana-2-lite.
@@ -358,7 +361,7 @@ Options:
     --compile to prepare a styled prompt-compilation packet, --compiled-prompt
     to generate from an agent-compiled prompt, or --raw-prompt to generate
     without a style. stdin is supported for --prompt in compile mode.
-  - Size: gpt-image-2 accepts auto or WIDTHxHEIGHT. Popular sizes include
+  - Size: GPT Image 2 and 2.5 accept auto or WIDTHxHEIGHT. Popular sizes include
     1024x1024,
     1536x1024, 1024x1536, 2048x2048, 2048x1152, 3840x2160,
     and 2160x3840. Custom sizes must have edges <= 3840px, both
@@ -369,8 +372,10 @@ Options:
     seedream5-lite accepts 2K, 3K, 4K, auto, or supported custom sizes.
     qwen-image-3 and flux-2-pro accept at most 4,194,304 total pixels.
   - Quality: low, medium, high, or auto. Low is fastest for drafts.
+    GPT Image 2.5 also accepts xhigh and max for more detailed output.
   - Background: auto, opaque, or transparent when supported. gpt-image-2,
     Flux, Qwen, and Seedream do not support transparent backgrounds.
+    GPT Image 2.5 supports transparent backgrounds with png or webp.
   - Format: png, jpeg, or webp for GPT Image, Nano Banana 2, and qwen-image-3
     models; png or jpeg for other fal and BytePlus models.
   - fal-only controls: --seed and --safety-tolerance for supported fal models;
@@ -378,6 +383,7 @@ Options:
     not supported on the fal-backed image path. Ideogram prompt expansion is
     disabled because Okou supplies the final prompt and expansion costs extra.
   - Image-to-image: pass --image-url to use the model's edit/reference path.
+    GPT Image 2.5 accepts up to 16 source images and an optional mask.
     Nano Banana 2 models and Seedream 5 Lite accept up to 14 source images;
     Seedream 5 Pro accepts up to 10; flux-2-pro accepts up to 9;
     qwen-image-3 accepts up to 3. Flux Redux accepts --image-prompt-strength

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-media-models.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-media-models.test.tsx
@@ -263,6 +263,12 @@ test("Choose an image model from a curated catalog", async () => {
   await waitFor(() => {
     expect(updates).toStrictEqual(["gpt-image-1"]);
   });
+  for (const label of ["GPT Image 2.5 Flare", "GPT Image 2.5 Sunburst"]) {
+    await chooseMediaModel("Image", label);
+    await openCategory("Image");
+    expectSelected(label);
+    await user.keyboard("{Escape}");
+  }
   await chooseMediaModel("Image", "Seedream 5 Pro");
   await chooseMediaModel("Image", "FLUX.2 Pro");
 
@@ -270,6 +276,8 @@ test("Choose an image model from a curated catalog", async () => {
   expectSelected("FLUX.2 Pro");
   expect(updates).toStrictEqual([
     "gpt-image-1",
+    "gpt-image-2.5-flare",
+    "gpt-image-2.5-sunburst",
     "dola-seedream-5-0-pro-260628",
     "fal-ai/flux-2-pro",
   ]);

--- a/turbo/apps/platform/src/views/okou-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-provider-picker.tsx
@@ -789,7 +789,9 @@ function GeminiImageModelIcon() {
 export function ImageModelBrandIcon({ model }: { model: ImageModel }) {
   switch (model) {
     case "gpt-image-1":
-    case "gpt-image-2": {
+    case "gpt-image-2":
+    case "gpt-image-2.5-flare":
+    case "gpt-image-2.5-sunburst": {
       return <ProviderIcon type="openai-api-key" size={16} />;
     }
     case "fal-ai/flux-pro/v1.1":

--- a/turbo/packages/api-contracts/src/contracts/__tests__/media-model-price-tiers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/media-model-price-tiers.test.ts
@@ -10,6 +10,8 @@ describe("media model price tiers", () => {
     expect(IMAGE_MODEL_PRICE_TIER).toEqual({
       "gpt-image-1": "$$",
       "gpt-image-2": "$$$",
+      "gpt-image-2.5-flare": "$$$",
+      "gpt-image-2.5-sunburst": "$$$",
       "fal-ai/flux-pro/v1.1": "$$$",
       "fal-ai/flux-pro/v1.1-ultra": "$$$",
       "fal-ai/flux-2-pro": "$$",

--- a/turbo/packages/api-contracts/src/contracts/image-models.ts
+++ b/turbo/packages/api-contracts/src/contracts/image-models.ts
@@ -9,6 +9,8 @@ import { z } from "zod";
 export const IMAGE_MODEL_IDS = [
   "gpt-image-1",
   "gpt-image-2",
+  "gpt-image-2.5-flare",
+  "gpt-image-2.5-sunburst",
   "fal-ai/flux-pro/v1.1",
   "fal-ai/flux-pro/v1.1-ultra",
   "fal-ai/flux-2-pro",

--- a/turbo/packages/api-contracts/src/contracts/media-model-price-tiers.ts
+++ b/turbo/packages/api-contracts/src/contracts/media-model-price-tiers.ts
@@ -16,6 +16,8 @@ export const IMAGE_MODEL_PRICE_TIER = Object.freeze<
 >({
   "gpt-image-1": "$$",
   "gpt-image-2": "$$$",
+  "gpt-image-2.5-flare": "$$$",
+  "gpt-image-2.5-sunburst": "$$$",
   "fal-ai/flux-pro/v1.1": "$$$",
   "fal-ai/flux-pro/v1.1-ultra": "$$$",
   "fal-ai/flux-2-pro": "$$",

--- a/turbo/packages/core/src/image-model-catalog.ts
+++ b/turbo/packages/core/src/image-model-catalog.ts
@@ -27,6 +27,14 @@ export const IMAGE_MODEL_CONFIGS = {
     alias: "gpt-image-2",
     label: "GPT Image 2",
   },
+  "gpt-image-2.5-flare": {
+    alias: "gpt-image-2.5-flare",
+    label: "GPT Image 2.5 Flare",
+  },
+  "gpt-image-2.5-sunburst": {
+    alias: "gpt-image-2.5-sunburst",
+    label: "GPT Image 2.5 Sunburst",
+  },
   "fal-ai/flux-pro/v1.1": {
     alias: "flux-pro-1.1",
     label: "Flux Pro v1.1",
@@ -93,6 +101,8 @@ export const IMAGE_MODELS: readonly ImageModel[] = IMAGE_MODEL_IDS;
 export const PUBLIC_IMAGE_MODELS = [
   "gpt-image-1",
   "gpt-image-2",
+  "gpt-image-2.5-flare",
+  "gpt-image-2.5-sunburst",
   "fal-ai/nano-banana-2",
   "google/nano-banana-2-lite",
   "fal-ai/flux-2-pro",
@@ -103,6 +113,8 @@ export const PUBLIC_IMAGE_MODELS = [
 
 export const IMAGE_MODEL_ALIASES = {
   "gpt-image-2": "gpt-image-2",
+  "gpt-image-2.5-flare": "gpt-image-2.5-flare",
+  "gpt-image-2.5-sunburst": "gpt-image-2.5-sunburst",
   "gpt-image-1": "gpt-image-1",
   "flux-pro-1.1": "fal-ai/flux-pro/v1.1",
   "flux-pro-1.1-ultra": "fal-ai/flux-pro/v1.1-ultra",


### PR DESCRIPTION
## Summary
Add GPT Image 2.5 Flare and Sunburst to built-in image generation, the chat model picker, and CLI discovery/help. Both models use the OpenAI Images generation/edit endpoints with the existing `OPENAI_API_KEY`, including transparent output, flexible sizes, `xhigh`/`max` quality, and up to 16 reference images with an optional mask. Existing models and defaults remain available.

Reuse the existing asynchronous job, artifact, and credit settlement flow. Bill the returned text input, image input, and image output token counts; missing pricing fails before any provider request, and invalid usage or provider failures do not charge credits.

## Pricing setup
No database migration, schema change, or development pricing seed is included. An operator must populate the six `usage_pricing` rows before using the new models. The SQL below is editable and repeatable; its values use OpenAI's published prices (1 USD = 1000 credits).

<details>
<summary>Operator pricing SQL</summary>

```sql
-- Operator-managed pricing; this is not a repository migration.
-- Source: https://developers.openai.com/api/docs/guides/image-generation
-- Both models: $5 / 1M text input tokens, $8 / 1M image input tokens,
-- and $30 / 1M image output tokens.
-- Values below convert the published prices at 1 USD = 1000 credits.
-- The Images API reports text/image input and image output token usage;
-- do not use the GPT Image 2 per-image quality/size rows for these models.
-- Populate all three categories for each model before enabling generation.

INSERT INTO usage_pricing (kind, provider, category, unit_price, unit_size)
VALUES
  ('image', 'gpt-image-2.5-flare', 'tokens.input.text', 5000, 1000000),
  ('image', 'gpt-image-2.5-flare', 'tokens.input.image', 8000, 1000000),
  ('image', 'gpt-image-2.5-flare', 'tokens.output.image', 30000, 1000000),
  ('image', 'gpt-image-2.5-sunburst', 'tokens.input.text', 5000, 1000000),
  ('image', 'gpt-image-2.5-sunburst', 'tokens.input.image', 8000, 1000000),
  ('image', 'gpt-image-2.5-sunburst', 'tokens.output.image', 30000, 1000000)
ON CONFLICT (kind, provider, category) DO UPDATE
SET unit_price = EXCLUDED.unit_price,
    unit_size = EXCLUDED.unit_size,
    updated_at = now()
RETURNING provider, category, unit_price, unit_size;
```

</details>

## Fallbacks

`turbo/apps/api/src/signals/services/image-generation.service.ts:generateOpenAiImage` handles these supported optional fields in the OpenAI Images API response:

- When `size`, `quality`, `background`, or `output_format` is omitted, retain the corresponding validated request option in the stored result. Returned provider values take precedence. This preserves the requested metadata without inventing a resolved value when the provider omits it.
- When `usage.output_tokens_details` is omitted, use the required `usage.output_tokens` total for image-output billing. OpenAI documents both GPT Image 2.5 variants as image-output-only models. When the breakdown is present, bill only `image_tokens`; text output is excluded. Missing or invalid required usage still fails generation without charging credits.

Surface: the external OpenAI Images response. Window: the lifetime of the provider's documented optional-field contract, independent of our deployment windows. Removal condition: OpenAI guarantees the corresponding response fields for these models and our response schema can require them. No rollout cleanup issue is needed for this permanent external-data boundary under `docs/fallback.md` section 6.2. The [Images API response reference](https://developers.openai.com/api/reference/resources/images/methods/generate) documents the optional fields; the model references below document image-only output.

## Verification
- CLI image generation and provider discovery: 59 tests passed.
- API image generation: 9 focused tests passed, covering both OpenAI variants, token billing, missing pricing, failure handling, quality isolation, and the existing BytePlus path.
- Platform image picker: targeted selection test passed for both new models.
- Media price-tier contract: 2 tests passed.
- Pricing SQL: insert and conflict-update paths verified against an isolated local PostgreSQL database, then rolled back.
- Affected API, Platform, CLI, core, and API-contracts type checks passed; changed-file ESLint and Oxlint (including type-aware checks), affected-workspace Knip, Prettier, style policy, and diff checks passed.

All three required PR checks (`ci-gate-turbo`, `ci-gate-security`, and `ci-gate-crates`) passed on `010bdc3bdb9be1b8bd99a787a1205614cb124aef`. The optional SCA job reports [four existing dependency advisories in pnpm audit](https://github.com/vm0-ai/vm0/actions/runs/34292312693/job/102281325181): one high-severity `js-yaml` advisory and three moderate `hono` advisories. The lockfile, affected dependency manifests, and audit workflow are unchanged from base `bf29b32672ca38d03979754e8a022bbdab35fb6a`.

Provider HTTP calls were mocked in integration tests; no paid live generation or production data write was performed. Full test suites run in the PR pipeline.

## API references
- https://developers.openai.com/api/docs/models/gpt-image-2.5-flare
- https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst
- https://developers.openai.com/api/reference/resources/images/methods/edit
