### PR TITLE
fix(connectors): send pkce and refresh scope on mercury oauth

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
@@ -417,6 +417,7 @@ const LAUNCH_GATED_DIRECT_OKOU_CASES: readonly LaunchGatedDirectOkouCase[] = [
     clientEnvPrefix: "MERCURY",
     authorizationEndpoint: "https://oauth2.mercury.com/oauth2/auth",
     tokenUrl: "https://oauth2.mercury.com/oauth2/token",
+    pkce: true,
     tokenResponse: {
       access_token: "mercury-test-token",
       refresh_token: "mercury-refresh-token",

--- a/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
@@ -1345,6 +1345,7 @@ const connectors = [
         connectorSlug: "mercury",
         prefix: "MERCURY",
         tokenEnvironmentNames: ["MERCURY_TOKEN"],
+        scopes: ["read", "offline_access"],
       }),
     ],
   }),

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/mercury.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/mercury.test.ts
@@ -9,17 +9,30 @@ import { server } from "../../__tests__/test-server";
 import { authCodeGrantFixture } from "./auth-code-grant-fixture";
 
 const EXPECTED_CLIENT_AUTH = `Basic ${Buffer.from("client-id:client-secret").toString("base64")}`;
+const PKCE_VALUE_PATTERN = /^[A-Za-z0-9_-]{43}$/u;
 
 function testRefreshSignal(): AbortSignal {
   return new AbortController().signal;
 }
 
 function authCodeGrant() {
-  return authCodeGrantFixture(["offline_access"]);
+  return authCodeGrantFixture(["read", "offline_access"]);
 }
 
 function useSandboxEnvironment(): void {
   vi.stubEnv("MERCURY_OAUTH_ENVIRONMENT", "sandbox");
+}
+
+/**
+ * RFC 7636 S256 transform, so the test proves the verifier replayed at token
+ * exchange is the one behind the challenge sent at authorization.
+ */
+async function s256Challenge(codeVerifier: string): Promise<string> {
+  const hash = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(codeVerifier),
+  );
+  return Buffer.from(hash).toString("base64url");
 }
 
 afterEach(() => {
@@ -28,8 +41,8 @@ afterEach(() => {
 
 describe("connector/providers/mercury", () => {
   describe("buildMercuryAuthorizationUrl", () => {
-    it("builds a production URL requesting every configured scope", () => {
-      const url = buildMercuryAuthorizationUrl(
+    it("builds a production URL requesting every configured scope with a PKCE challenge", async () => {
+      const url = await buildMercuryAuthorizationUrl(
         authCodeGrant(),
         "test-client-id",
         "https://example.com/callback",
@@ -39,20 +52,22 @@ describe("connector/providers/mercury", () => {
       expect(url.startsWith("https://oauth2.mercury.com/oauth2/auth?")).toBe(
         true,
       );
-      expect(url).toContain("client_id=test-client-id");
-      expect(url).toContain(
-        "redirect_uri=" + encodeURIComponent("https://example.com/callback"),
-      );
-      expect(url).toContain("response_type=code");
-      expect(url).toContain("state=test-state");
-      const scope = new URL(url).searchParams.get("scope");
-      expect(scope?.split(" ")).toEqual([...authCodeGrant().scopes]);
+      const params = new URL(url).searchParams;
+      expect(params.get("client_id")).toBe("test-client-id");
+      expect(params.get("redirect_uri")).toBe("https://example.com/callback");
+      expect(params.get("response_type")).toBe("code");
+      expect(params.get("state")).toBe("test-state");
+      expect(params.get("scope")?.split(" ")).toEqual([
+        ...authCodeGrant().scopes,
+      ]);
+      expect(params.get("code_challenge")).toMatch(PKCE_VALUE_PATTERN);
+      expect(params.get("code_challenge_method")).toBe("S256");
     });
 
-    it("builds a sandbox URL when MERCURY_OAUTH_ENVIRONMENT is sandbox", () => {
+    it("builds a sandbox URL when MERCURY_OAUTH_ENVIRONMENT is sandbox", async () => {
       useSandboxEnvironment();
 
-      const url = buildMercuryAuthorizationUrl(
+      const url = await buildMercuryAuthorizationUrl(
         authCodeGrant(),
         "test-client-id",
         "https://example.com/callback",
@@ -64,22 +79,24 @@ describe("connector/providers/mercury", () => {
       ).toBe(true);
     });
 
-    it("fails when MERCURY_OAUTH_ENVIRONMENT is not a known environment", () => {
+    it("fails when MERCURY_OAUTH_ENVIRONMENT is not a known environment", async () => {
       vi.stubEnv("MERCURY_OAUTH_ENVIRONMENT", "snadbox");
 
-      expect(() => {
+      await expect(
         buildMercuryAuthorizationUrl(
           authCodeGrant(),
           "test-client-id",
           "https://example.com/callback",
           "test-state",
-        );
-      }).toThrow('MERCURY_OAUTH_ENVIRONMENT must be "sandbox" or "production"');
+        ),
+      ).rejects.toThrow(
+        'MERCURY_OAUTH_ENVIRONMENT must be "sandbox" or "production"',
+      );
     });
   });
 
   describe("exchangeMercuryCode", () => {
-    it("authenticates with HTTP Basic and returns token plus organization identity", async () => {
+    it("authenticates with HTTP Basic, replays the PKCE verifier, and returns token plus organization identity", async () => {
       let authorization: string | null = null;
       let body = "";
       const tokenHandler = http.post(
@@ -91,7 +108,7 @@ describe("connector/providers/mercury", () => {
             access_token: "mercury-access-token",
             refresh_token: "mercury-refresh-token",
             expires_in: 3600,
-            scope: "openid read offline_access",
+            scope: "read offline_access",
           });
         },
       );
@@ -107,6 +124,12 @@ describe("connector/providers/mercury", () => {
         },
       );
       server.use(tokenHandler, organizationHandler);
+      const authorizationUrl = await buildMercuryAuthorizationUrl(
+        authCodeGrant(),
+        "client-id",
+        "https://example.com/callback",
+        "test-state",
+      );
 
       const result = await exchangeMercuryCode(
         authCodeGrant(),
@@ -114,14 +137,26 @@ describe("connector/providers/mercury", () => {
         "client-secret",
         "test-code",
         "https://example.com/callback",
+        "test-state",
       );
 
       expect(authorization).toBe(EXPECTED_CLIENT_AUTH);
-      expect(body).not.toContain("client_secret");
+      const tokenBody = new URLSearchParams(body);
+      expect(tokenBody.get("client_secret")).toBeNull();
+      expect(tokenBody.get("grant_type")).toBe("authorization_code");
+      expect(tokenBody.get("code")).toBe("test-code");
+      expect(tokenBody.get("redirect_uri")).toBe(
+        "https://example.com/callback",
+      );
+      const codeVerifier = tokenBody.get("code_verifier");
+      expect(codeVerifier).toMatch(PKCE_VALUE_PATTERN);
+      expect(await s256Challenge(codeVerifier ?? "")).toBe(
+        new URL(authorizationUrl).searchParams.get("code_challenge"),
+      );
       expect(result.accessToken).toBe("mercury-access-token");
       expect(result.refreshToken).toBe("mercury-refresh-token");
       expect(result.expiresIn).toBe(3600);
-      expect(result.scopes).toEqual(["openid", "read", "offline_access"]);
+      expect(result.scopes).toEqual(["read", "offline_access"]);
       expect(result.userInfo.id).toBe("organization-123");
       expect(result.userInfo.username).toBe("Max & Zoe, Inc.");
     });
@@ -133,7 +168,7 @@ describe("connector/providers/mercury", () => {
         () => {
           return HttpResponse.json({
             access_token: "sandbox-access-token",
-            scope: "openid read offline_access",
+            scope: "read offline_access",
           });
         },
       );
@@ -156,6 +191,7 @@ describe("connector/providers/mercury", () => {
         "client-secret",
         "test-code",
         "https://example.com/callback",
+        "test-state",
       );
 
       expect(result.accessToken).toBe("sandbox-access-token");
@@ -181,13 +217,14 @@ describe("connector/providers/mercury", () => {
           "client-secret",
           "test-code",
           "https://example.com/callback",
+          "test-state",
         ),
       ).rejects.toThrow("Client authentication failed");
     });
   });
 
   describe("refreshMercuryToken", () => {
-    it("authenticates with HTTP Basic and returns the rotated tokens", async () => {
+    it("authenticates with HTTP Basic, repeats the granted scope, and returns the rotated tokens", async () => {
       let authorization: string | null = null;
       let body = "";
       const handler = http.post(
@@ -212,8 +249,11 @@ describe("connector/providers/mercury", () => {
       );
 
       expect(authorization).toBe(EXPECTED_CLIENT_AUTH);
-      expect(body).toContain("refresh_token=old-refresh-token");
-      expect(body).not.toContain("client_secret");
+      const refreshBody = new URLSearchParams(body);
+      expect(refreshBody.get("grant_type")).toBe("refresh_token");
+      expect(refreshBody.get("refresh_token")).toBe("old-refresh-token");
+      expect(refreshBody.get("scope")).toBe("read offline_access");
+      expect(refreshBody.get("client_secret")).toBeNull();
       expect(result.accessToken).toBe("new-access-token");
       expect(result.refreshToken).toBe("new-refresh-token");
     });

--- a/turbo/packages/connectors/src/auth-providers/connectors/mercury/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/mercury/oauth.ts
@@ -16,6 +16,15 @@ const MERCURY_ENDPOINTS = {
   },
 } as const;
 
+/**
+ * Mercury expects the granted scope on every refresh request as well as on
+ * the authorization request; a refresh without it fails once the first access
+ * token expires. Refresh calls carry no grant config, so the scope is pinned
+ * here and must stay equal to the Mercury connector catalog grant scopes.
+ * Mercury grants read-only access, so there is no write scope.
+ */
+const MERCURY_OAUTH_SCOPES = ["read", "offline_access"] as const;
+
 interface MercuryEndpoints {
   oauthBaseUrl: string;
   apiBaseUrl: string;
@@ -58,6 +67,40 @@ function mercuryClientAuthHeader(
   return `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`;
 }
 
+/**
+ * Derive a PKCE code_verifier deterministically from the OAuth state so the
+ * callback can replay it without storing the verifier.
+ */
+async function deriveCodeVerifier(state: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(state + ":mercury-pkce-verifier");
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return base64UrlEncode(new Uint8Array(hash));
+}
+
+/**
+ * Compute the PKCE code_challenge from a code_verifier using S256.
+ */
+async function computeCodeChallenge(codeVerifier: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(codeVerifier);
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return base64UrlEncode(new Uint8Array(hash));
+}
+
+/**
+ * Base64url encode a byte array (RFC 7636).
+ */
+function base64UrlEncode(bytes: Uint8Array): string {
+  const binString = Array.from(bytes, (b) => {
+    return String.fromCharCode(b);
+  }).join("");
+  return btoa(binString)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
 interface MercuryUserInfo {
   id: string;
   username: string | null;
@@ -80,24 +123,29 @@ interface MercuryRefreshResult {
 }
 
 /**
- * Build Mercury OAuth authorization URL.
- * Requests every scope Mercury registered for our client: openid for the
- * authenticated user's identity, read for accounts and transactions, and
- * offline_access for a refresh token. Mercury grants read-only access only,
- * so there is no write scope to request.
+ * Build Mercury OAuth authorization URL with a PKCE code_challenge.
+ * Requests every scope the connector catalog declares for the client: read
+ * for accounts and transactions, and offline_access for a refresh token.
+ * Mercury supports the authorization code grant with PKCE.
+ * Ref: https://docs.mercury.com/docs/integrations-with-oauth2
  */
-export function buildMercuryAuthorizationUrl(
+export async function buildMercuryAuthorizationUrl(
   authCodeGrant: ConnectorAuthCodeGrantConfig,
   clientId: string,
   redirectUri: string,
   state: string,
-): string {
+): Promise<string> {
+  const codeVerifier = await deriveCodeVerifier(state);
+  const codeChallenge = await computeCodeChallenge(codeVerifier);
+
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: "code",
     scope: authCodeGrant.scopes.join(" "),
     state,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
   });
 
   return `${mercuryEndpoints().oauthBaseUrl}/oauth2/auth?${params.toString()}`;
@@ -105,6 +153,7 @@ export function buildMercuryAuthorizationUrl(
 
 /**
  * Exchange authorization code for access token and user info.
+ * Replays the PKCE code_verifier derived from the same OAuth state.
  */
 export async function exchangeMercuryCode(
   authCodeGrant: ConnectorAuthCodeGrantConfig,
@@ -112,7 +161,9 @@ export async function exchangeMercuryCode(
   clientSecret: string,
   code: string,
   redirectUri: string,
+  state: string,
 ): Promise<MercuryTokenResult> {
+  const codeVerifier = await deriveCodeVerifier(state);
   const response = await fetch(
     `${mercuryEndpoints().oauthBaseUrl}/oauth2/token`,
     {
@@ -123,6 +174,7 @@ export async function exchangeMercuryCode(
       },
       body: new URLSearchParams({
         code,
+        code_verifier: codeVerifier,
         redirect_uri: redirectUri,
         grant_type: "authorization_code",
       }),
@@ -166,6 +218,7 @@ export async function exchangeMercuryCode(
 /**
  * Refresh a Mercury access token using the refresh token.
  * Returns new access token and new refresh token (both must be stored).
+ * Mercury requires the granted scope on the refresh request.
  * Access token expires_in: 3600s (1 hour). Ref: https://docs.mercury.com/reference/obtain-the-tokens
  */
 export async function refreshMercuryToken(
@@ -186,6 +239,7 @@ export async function refreshMercuryToken(
       body: new URLSearchParams({
         grant_type: "refresh_token",
         refresh_token: refreshToken,
+        scope: MERCURY_OAUTH_SCOPES.join(" "),
       }),
     },
   );

--- a/turbo/packages/connectors/src/auth-providers/connectors/mercury/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/mercury/provider.ts
@@ -21,12 +21,19 @@ export const mercuryProvider: AuthCodeConnectorAuthProvider<"mercury"> = {
       const { clientId, clientSecret } = args.authClient;
       const code = args.code;
       const redirectUri = args.redirectUri;
+      const state = args.state;
+      if (!state) {
+        throw new Error(
+          "Mercury PKCE requires state for code_verifier derivation",
+        );
+      }
       const result = await exchangeMercuryCode(
         args.authCodeGrant,
         clientId,
         clientSecret,
         code,
         redirectUri,
+        state,
       );
       return {
         outputs: {


### PR DESCRIPTION
## Summary

Mercury's partner integration guide ("Mercury API Integration: What to Expect", received 2026-09-08) states that `scope` (`read` and `offline_access`) must be present on both the authorization request and every refresh request, and that Mercury supports the authorization code grant with PKCE. The Mercury provider sent no PKCE challenge and refreshed without `scope`, which Mercury rejects once the first access token expires.

## Changes

- `mercury/oauth.ts`: derive an S256 PKCE `code_challenge` from the OAuth state on the authorization URL and replay `code_verifier` at token exchange, following the existing X/Canva/Supabase provider pattern. `buildMercuryAuthorizationUrl` becomes async and `exchangeMercuryCode` takes the state.
- `mercury/oauth.ts`: pin `MERCURY_OAUTH_SCOPES` (`read offline_access`) for refresh requests, which carry no grant config. The authorization request keeps using the catalog grant scopes; the constant is documented as needing to stay equal to them.
- `mercury/provider.ts`: require the state for PKCE derivation at exchange.
- Tests: provider unit tests cover the PKCE round trip (verifier matches the challenge), the refresh scope, sandbox endpoints, and the invalid-environment rejection; the launch-gated direct App callback case for Mercury is marked `pkce: true`; the catalog test fixture declares the Mercury scopes.

## Companion change

vm0-ai/vm0-connectors PR adding `read` to the Mercury catalog grant scopes and bearer injection for `api-sandbox.mercury.com`. Until that catalog publishes, an authorization made through this code still requests only `offline_access`, so a refresh requesting `read offline_access` may be rejected for connections created in that window; there are no live Mercury connections today because the connector is behind `MercuryConnector` (default off).

## Deployment note (no code change here)

The production invalid_client failure comes from the `production` GitHub environment setting `MERCURY_OAUTH_ENVIRONMENT=production` while Doppler holds the sandbox client credentials. Mercury only issues a production client after compliance review, so production must run `MERCURY_OAUTH_ENVIRONMENT=sandbox` with the newly issued sandbox credentials until then.

## Verification

- `pnpm exec vitest run src/auth-providers/connectors/__tests__/mercury.test.ts` in `turbo/packages/connectors`: 7 passed.
- `pnpm exec tsc --noEmit` in `turbo/packages/connectors`: clean.
- oxlint + ESLint on the changed files: clean.
- `connectors-oauth-start.test.ts` needs a local PostgreSQL, which this environment does not run; relying on CI for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
