### PR TITLE
fix(platform): drop the dashed outline on a selected freehand stroke

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-annotation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-annotation.test.tsx
@@ -407,6 +407,17 @@ test("An arrow can be selected and re-aimed by dragging its tip", async () => {
   });
 });
 
+/** The first vertex of the rendered freehand stroke, in percent-of-image units. */
+function firstPenPoint(): [number, number] {
+  const points =
+    screen.getByTestId("annotation-mark-1").getAttribute("points") ?? "";
+  const [x, y] = points.split(" ")[0]?.split(",").map(Number) ?? [];
+  if (x === undefined || y === undefined) {
+    throw new Error(`Expected stroke points, got "${points}"`);
+  }
+  return [x, y];
+}
+
 test("A freehand stroke can be selected and moved", async () => {
   const image = draftAttachment("sketch.png", {
     annotatedFileId: "draft-sketch-annotated",
@@ -423,11 +434,12 @@ test("A freehand stroke can be selected and moved", async () => {
   const surface = await openAnnotationEditor("sketch.png");
   fireEvent.click(screen.getByTestId("annotation-mark-1"));
 
-  // A stroke has nothing to resize, so the dashed extent is the whole of what
-  // "selected" looks like on one.
-  const outline = screen.getByTestId("annotation-pen-outline");
-  expect(outline).toBeVisible();
-  expect(outline).toHaveStyle({ left: "20%", top: "25%" });
+  // A stroke draws no selection furniture of its own — its note popover opening
+  // is what says the click landed on it.
+  await waitFor(() => {
+    expect(screen.getByTestId("annotation-note-popover")).toBeVisible();
+  });
+  expect(firstPenPoint()).toStrictEqual([20, 25]);
 
   fireEvent.pointerDown(screen.getByTestId("annotation-mark-1"), {
     clientX: 280,
@@ -437,13 +449,13 @@ test("A freehand stroke can be selected and moved", async () => {
   fireEvent.pointerMove(surface, { clientX: 360, clientY: 250, pointerId: 3 });
   fireEvent.pointerUp(surface, { clientX: 360, clientY: 250, pointerId: 3 });
 
-  // Compared as numbers: the offset is accumulated in floating point, so the
-  // style lands on "30.000000000000004%" and an exact string match would be
-  // asserting the arithmetic rather than the move.
+  // Compared as numbers: the offset accumulates in floating point, so the point
+  // lands on 30.000000000000004 and an exact match would be asserting the
+  // arithmetic rather than the move.
   await waitFor(() => {
-    const moved = screen.getByTestId("annotation-pen-outline");
-    expect(Number.parseFloat(moved.style.left)).toBeCloseTo(30, 6);
-    expect(Number.parseFloat(moved.style.top)).toBeCloseTo(35, 6);
+    const [x, y] = firstPenPoint();
+    expect(x).toBeCloseTo(30, 6);
+    expect(y).toBeCloseTo(35, 6);
   });
 });
 

--- a/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
+++ b/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
@@ -1016,31 +1016,6 @@ function ArrowEndpointHandles({
 }
 
 /**
- * What "selected" looks like on a freehand stroke.
- *
- * A stroke has no rectangle and no ends worth grabbing, so there is nothing for
- * grips to sit on and no state left to show. A dashed box around its extent is
- * the whole affordance: it says which stroke the ink swatch, the note and
- * Delete are now aimed at. It must not take the pointer — the band around the
- * stroke itself is what the drag is grabbed by.
- */
-function PenSelectionOutline({ mark }: { mark: ImageAnnotationMark }) {
-  const bounds = markBounds(mark);
-  return (
-    <span
-      style={{
-        left: percent(bounds.x),
-        top: percent(bounds.y),
-        width: percent(bounds.width),
-        height: percent(bounds.height),
-      }}
-      className="pointer-events-none absolute -m-1 rounded-md border border-dashed border-muted-foreground/70 p-1"
-      data-testid="annotation-pen-outline"
-    />
-  );
-}
-
-/**
  * Handles only appear for marks that have a rectangle. A freehand stroke or an
  * arrow can still be selected and deleted; resizing them would mean editing
  * every point, which is not what a handle promises.
@@ -1135,9 +1110,10 @@ function NoteLayer({
 /**
  * What the selected mark shows, which depends on what it can be reshaped into.
  *
- * A box has eight grips, an arrow has its two ends, and a stroke has neither —
- * so it gets an outline instead of nothing at all, which is what "selected"
- * used to look like on one.
+ * A box has eight grips and an arrow has its two ends. A stroke has neither, so
+ * it draws nothing: the only geometry available to mark it out is its bounding
+ * box, and a rectangle that is not part of the drawing reads as an accidental
+ * mark on the user's screenshot.
  */
 function SelectionLayer({
   mark,
@@ -1160,8 +1136,12 @@ function SelectionLayer({
   if (mark.shape === "arrow") {
     return <ArrowEndpointHandles mark={mark} onGrab={onGrabEndpoint} />;
   }
+  // A freehand stroke shows nothing extra. It briefly carried a dashed box
+  // around its extent, which read as a stray rectangle drawn on the screenshot
+  // rather than as a state — Tong: *"不需要有这个虚线，去掉虚线"*. Picking one
+  // already opens its note popover, so the selection is not silent.
   if (mark.shape === "pen") {
-    return <PenSelectionOutline mark={mark} />;
+    return null;
   }
   return <ResizeHandles mark={mark} onGrab={onGrabHandle} />;
 }


### PR DESCRIPTION
## What

Removes the dashed outline drawn around a selected freehand stroke.

The only geometry available to mark out a freehand line is its bounding box, and a rectangle that is not part of the drawing reads as an accidental mark on the user's screenshot rather than as a selection state.

Nothing replaces it. Picking a stroke already opens its note popover, so the selection is not silent, and the ink swatch and Delete act on the same mark either way.

Follow-up to #32624, which introduced the outline.

## Testing

- `A freehand stroke can be selected and moved` no longer asserts on the removed outline. Selection is now proven by the note popover opening, and the move by the rendered `polyline` vertices shifting from `20,25` to `30,35` — the actual drawn geometry rather than a helper element.
- `chat-attachment-annotation`, `chat-attachment-composer`: 18 passed.
- `check-types`, `lint`, `knip`, `format` clean on `@okouai/app`.

Behind the existing `composerImageAnnotation` feature switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
