### PR TITLE
fix(app): open shared thread artifacts in a new tab

### DIFF
--- a/turbo/apps/platform/src/signals/image-load.ts
+++ b/turbo/apps/platform/src/signals/image-load.ts
@@ -70,6 +70,8 @@ export function createImageLoadRegistry(): ImageLoadRegistry {
 declare module "hast" {
   interface Data {
     imageLoadSignals?: ImageLoadSignals;
+    /** An enclosing Markdown link already owns this image's destination. */
+    imageInsideLink?: boolean;
   }
 }
 
@@ -88,17 +90,21 @@ export function embedImageLoadSignals(
   tree: Root,
   resolve: (url: string) => ImageLoadSignals,
 ): void {
-  const visitNode = (node: Root | Element): void => {
+  const visitNode = (node: Root | Element, insideLink: boolean): void => {
     for (const child of node.children) {
       if (child.type !== "element" || child.data?.card) {
         continue;
       }
       const url = mediaImageUrl(child);
       if (url !== undefined) {
-        child.data = { ...child.data, imageLoadSignals: resolve(url) };
+        child.data = {
+          ...child.data,
+          imageLoadSignals: resolve(url),
+          imageInsideLink: insideLink,
+        };
       }
-      visitNode(child);
+      visitNode(child, insideLink || child.tagName === "a");
     }
   };
-  visitNode(tree);
+  visitNode(tree, false);
 }

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -89,7 +89,7 @@ export function MarkdownEventBody({
 }: {
   readonly onRetry?: () => void;
   readonly tree: Root | undefined;
-  readonly mediaPreview: boolean;
+  readonly mediaPreview: boolean | "link";
 }) {
   if (tree === undefined) {
     if (onRetry !== undefined) {

--- a/turbo/apps/platform/src/views/components/rich-markdown.tsx
+++ b/turbo/apps/platform/src/views/components/rich-markdown.tsx
@@ -68,11 +68,15 @@ function MediaImage({
   url,
   alt,
   load,
+  asLink = false,
+  insideLink = false,
 }: {
   src: string | undefined;
   url: string;
   alt: string;
   load: ImageLoadSignals;
+  asLink?: boolean;
+  insideLink?: boolean;
 }) {
   const imageStatus = useGet(load.status$);
   const markLoaded = useSet(load.loaded$);
@@ -86,17 +90,10 @@ function MediaImage({
   const openImageLightbox = useSet(openImageLightbox$);
   const showPlaceholder = imageStatus !== "loaded";
 
-  return (
-    <button
-      type="button"
-      onClick={(event) => {
-        const threadId = event.currentTarget.closest<HTMLElement>(
-          "[data-chat-thread-container-id]",
-        )?.dataset.chatThreadContainerId;
-        openImageLightbox(threadId ? { threadId, url } : url);
-      }}
-      className="my-1 inline-grid aspect-[10/9] w-[200px] max-w-full cursor-pointer grid-cols-[minmax(0,1fr)] grid-rows-[minmax(0,1fr)] align-top overflow-hidden rounded-lg border border-foreground/10 bg-muted/30"
-    >
+  const className =
+    "my-1 inline-grid aspect-[10/9] w-[200px] max-w-full cursor-pointer grid-cols-[minmax(0,1fr)] grid-rows-[minmax(0,1fr)] align-top overflow-hidden rounded-lg border border-foreground/10 bg-muted/30";
+  const preview = (
+    <>
       {showPlaceholder && (
         <span
           data-testid="markdown-image-preview-loading"
@@ -122,6 +119,38 @@ function MediaImage({
           }`}
         />
       )}
+    </>
+  );
+
+  if (asLink) {
+    // A linked Markdown thumbnail already has its own destination.
+    if (insideLink) {
+      return <span className={className}>{preview}</span>;
+    }
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={className}
+      >
+        {preview}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        const threadId = event.currentTarget.closest<HTMLElement>(
+          "[data-chat-thread-container-id]",
+        )?.dataset.chatThreadContainerId;
+        openImageLightbox(threadId ? { threadId, url } : url);
+      }}
+      className={className}
+    >
+      {preview}
     </button>
   );
 }
@@ -241,6 +270,24 @@ function MediaImageRenderer(props: MarkdownImageProps) {
   return <img {...omitMarkdownNodeProp(rest)} src={src} alt={alt} />;
 }
 
+function LinkedMediaImageRenderer(props: MarkdownImageProps) {
+  const { src, alt } = props;
+  const load = props.node?.data?.imageLoadSignals;
+  if (typeof src === "string" && isSafeMediaUrl(src) && load) {
+    return (
+      <MediaImage
+        src={src}
+        url={src}
+        alt={alt ?? ""}
+        load={load}
+        asLink
+        insideLink={props.node?.data?.imageInsideLink}
+      />
+    );
+  }
+  return <PlainImageRenderer {...props} />;
+}
+
 function containsBlockArtifact(node: Element): boolean {
   return node.children.some((child) => {
     if (child.type !== "element") {
@@ -340,6 +387,11 @@ const MEDIA_MARKDOWN_COMPONENTS = {
   div: MarkdownDivRenderer,
 } as const;
 
+const LINKED_MEDIA_MARKDOWN_COMPONENTS = {
+  ...PLAIN_MARKDOWN_COMPONENTS,
+  img: LinkedMediaImageRenderer,
+} as const;
+
 // Neutralize raw HTML by escaping only `<`: a tag cannot start without it, so
 // escaping `<` alone stops tag injection. Leaving `>` intact preserves Markdown
 // block syntax that relies on a leading `>` — most importantly blockquotes,
@@ -347,7 +399,7 @@ const MEDIA_MARKDOWN_COMPONENTS = {
 interface MarkdownTreeFrameProps {
   readonly className?: string;
   readonly style?: CSSProperties;
-  readonly mediaPreview?: boolean;
+  readonly mediaPreview?: boolean | "link";
   readonly tree: Root;
 }
 
@@ -361,9 +413,12 @@ function MarkdownTreeFrame({
     <MarkdownFrame className={className} style={style}>
       {toJsxRuntime(tree, {
         Fragment,
-        components: mediaPreview
-          ? MEDIA_MARKDOWN_COMPONENTS
-          : PLAIN_MARKDOWN_COMPONENTS,
+        components:
+          mediaPreview === "link"
+            ? LINKED_MEDIA_MARKDOWN_COMPONENTS
+            : mediaPreview
+              ? MEDIA_MARKDOWN_COMPONENTS
+              : PLAIN_MARKDOWN_COMPONENTS,
         ignoreInvalidStyle: true,
         jsx,
         jsxs,
@@ -383,7 +438,7 @@ export function MarkdownEventBody({
   mediaPreview,
 }: {
   readonly tree: Root;
-  readonly mediaPreview: boolean;
+  readonly mediaPreview: boolean | "link";
 }) {
   return (
     <MarkdownTreeFrame

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -224,7 +224,7 @@ function SharedAssistantGroup({
                     richContent={richContent}
                   />
                 ) : (
-                  <MarkdownEventBody tree={message.tree} mediaPreview />
+                  <MarkdownEventBody tree={message.tree} mediaPreview="link" />
                 )}
               </ChatAssistantMessageBody>
             );
@@ -266,7 +266,9 @@ function SharedRichMessageBody({
           );
         }
       : undefined;
-  return <MarkdownEventBody tree={tree} mediaPreview onRetry={onRetry} />;
+  return (
+    <MarkdownEventBody tree={tree} mediaPreview="link" onRetry={onRetry} />
+  );
 }
 
 function SharedThreadHandoff({


### PR DESCRIPTION
## Summary

Public shared conversations reuse chat media actions, so clicking an artifact thumbnail or image link can enter an in-app preview. Open shared-page artifacts through native anchors with `href`, `target="_blank"`, and `rel="noopener noreferrer"`, without JavaScript click handlers.

Preserve thumbnail loading and error states, retain enclosing Markdown link destinations without nesting anchors, and keep the linked rendering mode scoped to public shared threads.

## Verification

- Formatting, targeted ESLint/Oxlint, and Platform type checks passed.
- Existing shared-thread presentation/actions and Markdown artifact/content tests: 4 files, 20 tests passed.
- Repository commit hooks passed, including style policy, Knip, workspace type checks, file-size checks, and commitlint.
