### PR TITLE
chore(core): open image annotation to the staff org

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -380,9 +380,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Let an attached image be marked up in the composer lightbox — boxes, arrows, freehand, text, highlight and redaction, each able to carry a note — and send a rendered copy carrying the editable marks.",
     enabled: false,
-    // Scoped to the maintainer rather than the whole staff org while the
-    // render-on-confirm upload is still unexercised outside tests.
-    enabledEmailHashes: ["56bef1aa"], // fnv1a("tongx@vm0.ai")
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ResponsiveFollowupCards]: {
     maintainer: "ethan@okou.ai",


### PR DESCRIPTION
## What

Moves the `composerImageAnnotation` rollout from a single maintainer email to the staff org.

```diff
  enabled: false,
- // Scoped to the maintainer rather than the whole staff org while the
- // render-on-confirm upload is still unexercised outside tests.
- enabledEmailHashes: ["56bef1aa"], // fnv1a("tongx@vm0.ai")
+ enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
```

## Why

The switch was deliberately narrowed to one email in #28976 because the render-on-confirm flatten and the resulting two-file send had only ever run in tests. Both have since been exercised end to end, and the editor has had two rounds of fixes on top (#32624 made arrows and freehand strokes selectable, movable and keyboard-driven; #32735 removed the stroke selection outline). The reason for the narrow scope no longer holds, so the rollout moves to the same staff-org shape every other pre-GA switch uses.

`enabled: false` is unchanged — nothing changes for anyone outside the staff org, and this is not a GA promotion.

## Testing

- `@okouai/core` `feature-switch.test.ts`: 30 passed.
- `check-types`, `lint`, `knip`, `format` clean on `@okouai/core`.
- No stale reference to the removed `56bef1aa` hash remains anywhere in `turbo/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
