### PR TITLE
fix(api): cap chat search at 25 and bound sparse keyword scans

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
@@ -149,7 +149,6 @@ describe("CHAT-01 chat thread lifecycle", () => {
 
     const search = await api.searchChat(actor, "launch");
     expect(search.results).toStrictEqual([]);
-    expect(search.hasMore).toBeFalsy();
 
     await api.deleteThread(actor, created.id);
     const deletedRead = await api.requestReadThread(actor, created.id, [404]);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-search-reader.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-search-reader.test.ts
@@ -78,6 +78,60 @@ async function sendNoCreditMessage(
 }
 
 describe("GET /api/chat/search durable reader", () => {
+  it("finds older sparse matches and keeps frequent matches newest first", async () => {
+    const owner = bdd.user();
+    const source = await createSearchThread(
+      owner,
+      `search-history-${randomUUID().slice(0, 8)}`,
+    );
+    await api.ensureOrgModelProvider(owner);
+    const sparseKeyword = `sparse${randomUUID().replaceAll("-", "")}`;
+    const frequentKeyword = `frequent${randomUUID().replaceAll("-", "")}`;
+    const prompts = [
+      `${sparseKeyword} older`,
+      `${sparseKeyword} newer`,
+      ...Array.from({ length: 80 }, (_, index) => {
+        return `${frequentKeyword} ${index}`;
+      }),
+    ];
+    const baseTime = now();
+    await withMockNowForTest(baseTime, async () => {
+      for (const [index, prompt] of prompts.entries()) {
+        mockNow(baseTime + index * 1000);
+        const sent = await chat.requestSendEvent(
+          owner,
+          { ...source, prompt },
+          [201],
+        );
+        expect(sent).toMatchObject({ status: 201, body: { runId: null } });
+      }
+    });
+    await projectChatSearchMessages([source.threadId]);
+
+    const sparse = await chat.searchChat(owner, sparseKeyword, { limit: 1 });
+    expect(sparse.hasMore).toBeTruthy();
+    expect(sparse.results).toHaveLength(1);
+    expect(sparse.results[0]?.matchedMessage.content).toBe(
+      `${sparseKeyword} newer`,
+    );
+
+    const frequent = await chat.searchChat(owner, frequentKeyword, {
+      limit: 1,
+    });
+    expect(frequent.hasMore).toBeTruthy();
+    expect(frequent.results).toHaveLength(1);
+    expect(frequent.results[0]?.matchedMessage.content).toBe(
+      `${frequentKeyword} 79`,
+    );
+
+    const missing = await chat.searchChat(
+      owner,
+      `absent${randomUUID().replaceAll("-", "")}`,
+      { limit: 1 },
+    );
+    expect(missing).toStrictEqual({ results: [], hasMore: false });
+  });
+
   it("serves matched message identity after source events are deleted", async () => {
     const owner = bdd.user();
     const source = await createSearchThread(

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-search-reader.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-search-reader.test.ts
@@ -78,7 +78,7 @@ async function sendNoCreditMessage(
 }
 
 describe("GET /api/chat/search durable reader", () => {
-  it("finds older sparse matches and keeps frequent matches newest first", async () => {
+  it("returns up to 25 newest matches without pagination", async () => {
     const owner = bdd.user();
     const source = await createSearchThread(
       owner,
@@ -108,28 +108,43 @@ describe("GET /api/chat/search durable reader", () => {
     });
     await projectChatSearchMessages([source.threadId]);
 
-    const sparse = await chat.searchChat(owner, sparseKeyword, { limit: 1 });
-    expect(sparse.hasMore).toBeTruthy();
-    expect(sparse.results).toHaveLength(1);
-    expect(sparse.results[0]?.matchedMessage.content).toBe(
-      `${sparseKeyword} newer`,
-    );
+    const sparse = await chat.searchChat(owner, sparseKeyword);
+    expect(
+      sparse.results.map((result) => {
+        return result.matchedMessage.content;
+      }),
+    ).toStrictEqual([`${sparseKeyword} newer`, `${sparseKeyword} older`]);
+    expect(sparse).not.toHaveProperty("hasMore");
 
-    const frequent = await chat.searchChat(owner, frequentKeyword, {
-      limit: 1,
-    });
-    expect(frequent.hasMore).toBeTruthy();
-    expect(frequent.results).toHaveLength(1);
-    expect(frequent.results[0]?.matchedMessage.content).toBe(
-      `${frequentKeyword} 79`,
+    const frequent = await chat.searchChat(owner, frequentKeyword);
+    expect(
+      frequent.results.map((result) => {
+        return result.matchedMessage.content;
+      }),
+    ).toStrictEqual(
+      Array.from({ length: 25 }, (_, index) => {
+        return `${frequentKeyword} ${79 - index}`;
+      }),
     );
+    expect(frequent).not.toHaveProperty("hasMore");
+
+    // Retired limits from open browser tabs or older CLIs cannot change the cap.
+    for (const limit of [1, 50]) {
+      const previousClient = await chat.requestSearchChat(
+        owner,
+        frequentKeyword,
+        { limit },
+        [200],
+      );
+      expect(previousClient.status).toBe(200);
+      expect(previousClient.body).toStrictEqual(frequent);
+    }
 
     const missing = await chat.searchChat(
       owner,
       `absent${randomUUID().replaceAll("-", "")}`,
-      { limit: 1 },
     );
-    expect(missing).toStrictEqual({ results: [], hasMore: false });
+    expect(missing).toStrictEqual({ results: [] });
   });
 
   it("serves matched message identity after source events are deleted", async () => {
@@ -162,7 +177,6 @@ describe("GET /api/chat/search durable reader", () => {
     ).resolves.toBeGreaterThan(0);
 
     const search = await chat.searchChat(owner, keyword);
-    expect(search).toMatchObject({ hasMore: false });
     expect(search.results).toHaveLength(1);
     const result = search.results[0];
     if (!result) {
@@ -237,7 +251,7 @@ describe("GET /api/chat/search durable reader", () => {
     expect(otherOrgSearch.results).toStrictEqual([]);
   });
 
-  it("continues past orphan-only candidate pages and preserves hasMore", async () => {
+  it("continues past orphan-only candidate batches to find visible matches", async () => {
     const owner = bdd.user();
     const keyword = `orphanpage${randomUUID().replaceAll("-", "")}`;
     const baseTime = now();
@@ -259,11 +273,13 @@ describe("GET /api/chat/search durable reader", () => {
           `orphan-reader-${randomUUID().slice(0, 8)}`,
         );
         orphanThreadIds.push(orphan.threadId);
-        await sendNoCreditMessage(owner, {
-          agentId: orphan.agentId,
-          threadId: orphan.threadId,
-          prompt: keyword,
-        });
+        for (let messageIndex = 0; messageIndex < 5; messageIndex++) {
+          await sendNoCreditMessage(owner, {
+            agentId: orphan.agentId,
+            threadId: orphan.threadId,
+            prompt: keyword,
+          });
+        }
       }
     });
 
@@ -300,10 +316,9 @@ describe("GET /api/chat/search durable reader", () => {
       }),
     );
 
-    const search = await chat.searchChat(owner, keyword, { limit: 1 });
+    const search = await chat.searchChat(owner, keyword);
     expect(search.results).toHaveLength(1);
     expect(search.results[0]?.chatThreadId).toBe(visible.threadId);
-    expect(search.hasMore).toBeFalsy();
 
     const cleanup = await requestChatSearchProjection(orphanThreadIds);
     expect(cleanup.orphanedThreads).toBe(orphanThreadIds.length);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -3403,8 +3403,7 @@ describe("CHAT-01 chat search", () => {
     });
 
     const emptyResults = await chat.searchChat(owner, "quokka");
-    expect(emptyResults.results).toStrictEqual([]);
-    expect(emptyResults.hasMore).toBeFalsy();
+    expect(emptyResults).toStrictEqual({ results: [] });
 
     const blankKeyword = await chat.requestSearchChat(owner, "   ", {}, [400]);
     expectApiError(blankKeyword.body);
@@ -3567,24 +3566,6 @@ describe("CHAT-01 chat search", () => {
       throw new Error("Expected one okapi match");
     }
     expect(match.matchedMessage.content).toBe("the okapi was here");
-
-    // hasMore flips when matches exceed the limit.
-    await sendNoCreditMessage(owner, {
-      agentId: agentA.agentId,
-      prompt: "capybara sighting one",
-    });
-    await sendNoCreditMessage(owner, {
-      agentId: agentA.agentId,
-      prompt: "capybara sighting two",
-    });
-    await sendNoCreditMessage(owner, {
-      agentId: agentA.agentId,
-      prompt: "capybara sighting three",
-    });
-    await projectChatEventSearch();
-    const limited = await chat.searchChat(owner, "capybara", { limit: 2 });
-    expect(limited.results).toHaveLength(2);
-    expect(limited.hasMore).toBeTruthy();
   }, 60_000);
 
   it("returns batched matched messages without context across threads", async () => {
@@ -3617,10 +3598,7 @@ describe("CHAT-01 chat search", () => {
     });
 
     await projectChatEventSearch();
-    const contextual = await chat.searchChat(owner, `${marker} needle`, {
-      limit: 3,
-    });
-    expect(contextual.hasMore).toBeFalsy();
+    const contextual = await chat.searchChat(owner, `${marker} needle`);
     expect(
       contextual.results
         .map((result) => {
@@ -3848,7 +3826,7 @@ describe("CHAT-01 chat search index", () => {
     expectApiError(deleted.body);
   }, 60_000);
 
-  it("applies agent, since and limit filters inside the projection", async () => {
+  it("applies agent and since filters inside the projection", async () => {
     const orgId = `org_${randomUUID()}`;
     const owner = bdd.user({ orgId });
     bdd.acceptAgentStorageWrites();
@@ -3909,14 +3887,6 @@ describe("CHAT-01 chat search index", () => {
     });
     expect(byAgent.results).toHaveLength(1);
     expect(byAgent.results[0]?.chatThreadId).toBe(threadB);
-
-    // The limit and its hasMore probe are applied while matching.
-    const limited = await chat.searchChat(owner, "水豚", { limit: 2 });
-    expect(limited.results).toHaveLength(2);
-    expect(limited.hasMore).toBeTruthy();
-    const exact = await chat.searchChat(owner, "水豚", { limit: 4 });
-    expect(exact.results).toHaveLength(4);
-    expect(exact.hasMore).toBeFalsy();
   }, 60_000);
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -1225,7 +1225,6 @@ export function createChatFilesBddApi(context: TestContext) {
       query: {
         readonly agentId?: string;
         readonly since?: number;
-        readonly limit?: number;
       } = {},
     ): Promise<ChatSearchResponse> {
       const response = await accept(
@@ -1244,6 +1243,7 @@ export function createChatFilesBddApi(context: TestContext) {
       query: {
         readonly agentId?: string;
         readonly since?: number;
+        // Previous clients still send this retired parameter during rollout.
         readonly limit?: number;
       },
       statuses: readonly (200 | 400 | 401 | 403)[],

--- a/turbo/apps/api/src/signals/routes/chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads.ts
@@ -365,13 +365,12 @@ const searchChatInner$ = computed(async (get) => {
       keyword: query.keyword,
       agentId: query.agentId,
       since: query.since,
-      limit: query.limit,
     }),
   );
 
   return {
     status: 200 as const,
-    body: { results: [...result.results], hasMore: result.hasMore },
+    body: { results: [...result.results] },
   };
 });
 

--- a/turbo/apps/api/src/signals/services/chat-search.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-search.service.ts
@@ -1,7 +1,8 @@
 import { computed, type Computed } from "ccstate";
-import type {
-  ChatSearchMessage,
-  ChatSearchResult,
+import {
+  CHAT_SEARCH_RESULT_LIMIT,
+  type ChatSearchMessage,
+  type ChatSearchResult,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { visiblePiMemoryCitationText } from "@okouai/api-contracts/contracts/pi-memory-citations";
 import { agents } from "@okouai/db/schema/agent";
@@ -266,9 +267,9 @@ async function chatSearchIndexedMatchBatch(
 }
 
 /**
- * Over-fetches bounded candidate pages and discards rows whose source thread
- * has already been deleted. A stable keyset cursor continues past orphan-heavy
- * pages until the caller's result probe is full or the index is exhausted.
+ * Discards matches whose source thread has already been deleted. The internal
+ * keyset cursor continues past those rows until 25 visible results are found
+ * or the index is exhausted; it is never exposed as search pagination.
  */
 async function chatSearchIndexedMatches(
   db: ReadonlyDb,
@@ -278,14 +279,13 @@ async function chatSearchIndexedMatches(
     readonly keyword: string;
     readonly agentId?: string;
     readonly since?: Date;
-    readonly limit: number;
   },
 ): Promise<ChatSearchMatchRow[]> {
-  const candidateLimit = args.limit * 2;
   const matches: ChatSearchMatchRow[] = [];
   let cursor: ChatSearchCandidateCursor | undefined;
 
-  while (matches.length < args.limit) {
+  while (matches.length < CHAT_SEARCH_RESULT_LIMIT) {
+    const candidateLimit = CHAT_SEARCH_RESULT_LIMIT - matches.length;
     const candidates = await chatSearchIndexedMatchBatch(db, {
       ...args,
       limit: candidateLimit,
@@ -311,12 +311,15 @@ async function chatSearchIndexedMatches(
         text: candidate.text,
         agentName: candidate.agentName,
       });
-      if (matches.length === args.limit) {
+      if (matches.length === CHAT_SEARCH_RESULT_LIMIT) {
         break;
       }
     }
 
-    if (matches.length === args.limit || candidates.length < candidateLimit) {
+    if (
+      matches.length === CHAT_SEARCH_RESULT_LIMIT ||
+      candidates.length < candidateLimit
+    ) {
       break;
     }
     const lastCandidate = candidates[candidates.length - 1];
@@ -339,11 +342,9 @@ export function chatSearch(args: {
   readonly keyword: string;
   readonly agentId?: string;
   readonly since?: number;
-  readonly limit: number;
 }): Computed<
   Promise<{
     readonly results: readonly ChatSearchResult[];
-    readonly hasMore: boolean;
   }>
 > {
   return computed(async (get) => {
@@ -355,12 +356,9 @@ export function chatSearch(args: {
       keyword: args.keyword,
       agentId: args.agentId,
       since: sinceDate,
-      limit: args.limit + 1,
     });
 
-    const hasMore = matches.length > args.limit;
-    const truncated = hasMore ? matches.slice(0, args.limit) : matches;
-    const results = truncated.map((match): ChatSearchResult => {
+    const results = matches.map((match): ChatSearchResult => {
       const matchedMessage = toChatSearchMessage(match);
       return {
         chatThreadId: match.chatThreadId,
@@ -373,6 +371,6 @@ export function chatSearch(args: {
       };
     });
 
-    return { results, hasMore };
+    return { results };
   });
 }

--- a/turbo/apps/api/src/signals/services/chat-search.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-search.service.ts
@@ -7,7 +7,7 @@ import { visiblePiMemoryCitationText } from "@okouai/api-contracts/contracts/pi-
 import { agents } from "@okouai/db/schema/agent";
 import { chatEventSearchMessages } from "@okouai/db/schema/chat-event-search";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
-import { and, desc, eq, gte, lt, or, sql } from "drizzle-orm";
+import { and, count, desc, eq, gte, lt, or, sql, type SQL } from "drizzle-orm";
 
 import {
   chatSearchBigramTsquery,
@@ -50,6 +50,8 @@ const searchMessageColumns = {
   text: chatEventSearchMessages.text,
 } as const;
 
+const RECENT_SEARCH_CANDIDATE_MULTIPLIER = 16;
+
 function toChatSearchMessage(row: ChatSearchMessageRow): ChatSearchMessage {
   return {
     chatThreadId: row.chatThreadId,
@@ -85,6 +87,55 @@ function chatSearchCursorCondition(
   );
 }
 
+function chatSearchRecentMatches(
+  db: ReadonlyDb,
+  args: {
+    readonly scopeCondition: SQL | undefined;
+    readonly tsquery: string;
+    readonly limit: number;
+  },
+) {
+  // Common terms can fill a page from recent messages. Bound this ordered
+  // scan before applying the keyword so rare terms cannot scan all history.
+  const recentMessages = db
+    .select({
+      ...searchMessageColumns,
+      agentId: chatEventSearchMessages.agentId,
+      tsv: chatEventSearchMessages.tsv,
+    })
+    .from(chatEventSearchMessages)
+    .where(args.scopeCondition)
+    .orderBy(
+      sql`${desc(chatEventSearchMessages.createdAt)} NULLS LAST`,
+      desc(chatEventSearchMessages.chatThreadId),
+      desc(chatEventSearchMessages.seqId),
+    )
+    .limit(args.limit * RECENT_SEARCH_CANDIDATE_MULTIPLIER)
+    .as("chat_search_recent_messages");
+  return db.$with("chat_search_recent_matches").as(
+    db
+      .select({
+        chatThreadId: recentMessages.chatThreadId,
+        seqId: recentMessages.seqId,
+        runId: recentMessages.runId,
+        role: recentMessages.role,
+        createdAt: recentMessages.createdAt,
+        text: recentMessages.text,
+        agentId: recentMessages.agentId,
+      })
+      .from(recentMessages)
+      .where(
+        sql`${recentMessages.tsv} @@ to_tsquery('simple', ${args.tsquery})`,
+      )
+      .orderBy(
+        sql`${desc(recentMessages.createdAt)} NULLS LAST`,
+        desc(recentMessages.chatThreadId),
+        desc(recentMessages.seqId),
+      )
+      .limit(args.limit),
+  );
+}
+
 /**
  * Selects one bounded candidate page entirely from the durable projection.
  * Parent existence and the agent's current name are resolved only after the
@@ -107,37 +158,90 @@ async function chatSearchIndexedMatchBatch(
     return [];
   }
 
-  const indexedMatches = db
-    .select({
-      ...searchMessageColumns,
-      agentId: chatEventSearchMessages.agentId,
-    })
+  const scopeCondition = and(
+    eq(chatEventSearchMessages.userId, args.userId),
+    eq(chatEventSearchMessages.orgId, args.orgId),
+    args.agentId
+      ? eq(chatEventSearchMessages.agentId, args.agentId)
+      : undefined,
+    args.since ? gte(chatEventSearchMessages.createdAt, args.since) : undefined,
+    chatSearchCursorCondition(args.cursor),
+  );
+
+  const recentMatches = chatSearchRecentMatches(db, {
+    scopeCondition,
+    tsquery,
+    limit: args.limit,
+  });
+  const recentMatchCount = db.select({ count: count() }).from(recentMatches);
+
+  const projectionColumns = {
+    ...searchMessageColumns,
+    agentId: chatEventSearchMessages.agentId,
+  };
+  const keywordQuery = db
+    .select(projectionColumns)
     .from(chatEventSearchMessages)
     .where(
       and(
-        eq(chatEventSearchMessages.userId, args.userId),
-        eq(chatEventSearchMessages.orgId, args.orgId),
+        scopeCondition,
         sql`${chatEventSearchMessages.tsv} @@ to_tsquery('simple', ${tsquery})`,
-        args.agentId
-          ? eq(chatEventSearchMessages.agentId, args.agentId)
-          : undefined,
-        args.since
-          ? gte(chatEventSearchMessages.createdAt, args.since)
-          : undefined,
-        chatSearchCursorCondition(args.cursor),
       ),
-    )
-    // Keep the created_at prefix aligned with the scoped index while the
-    // remaining columns provide a stable keyset order for equal timestamps.
+    );
+  // OFFSET 0 keeps Top-N planning outside the complete keyword match. Unlike
+  // materializing every message body, it streams matches into a bounded sort.
+  // Drizzle omits a numeric .offset(0), so retain this SQL optimization fence.
+  const keywordMatches = db
+    .$with("chat_search_keyword_matches", projectionColumns)
+    .as(sql`${keywordQuery} OFFSET 0`);
+  const fullMatches = db
+    .select({
+      chatThreadId: keywordMatches.chatThreadId,
+      seqId: keywordMatches.seqId,
+      runId: keywordMatches.runId,
+      role: keywordMatches.role,
+      createdAt: keywordMatches.createdAt,
+      text: keywordMatches.text,
+      agentId: keywordMatches.agentId,
+    })
+    .from(keywordMatches)
     .orderBy(
-      sql`${desc(chatEventSearchMessages.createdAt)} NULLS LAST`,
-      desc(chatEventSearchMessages.chatThreadId),
-      desc(chatEventSearchMessages.seqId),
+      sql`${desc(keywordMatches.createdAt)} NULLS LAST`,
+      desc(keywordMatches.chatThreadId),
+      desc(keywordMatches.seqId),
     )
     .limit(args.limit)
+    .as("chat_search_full_matches");
+  const indexedMatches = db
+    .select({
+      chatThreadId: recentMatches.chatThreadId,
+      seqId: recentMatches.seqId,
+      runId: recentMatches.runId,
+      role: recentMatches.role,
+      createdAt: recentMatches.createdAt,
+      text: recentMatches.text,
+      agentId: recentMatches.agentId,
+    })
+    .from(recentMatches)
+    .where(eq(recentMatchCount, args.limit))
+    .unionAll(
+      db
+        .select({
+          chatThreadId: fullMatches.chatThreadId,
+          seqId: fullMatches.seqId,
+          runId: fullMatches.runId,
+          role: fullMatches.role,
+          createdAt: fullMatches.createdAt,
+          text: fullMatches.text,
+          agentId: fullMatches.agentId,
+        })
+        .from(fullMatches)
+        .where(lt(recentMatchCount, args.limit)),
+    )
     .as("chat_search_indexed_matches");
 
   return await db
+    .with(recentMatches, keywordMatches)
     .select({
       chatThreadId: indexedMatches.chatThreadId,
       seqId: indexedMatches.seqId,

--- a/turbo/apps/cli/src/commands/search/__tests__/chat-source.test.ts
+++ b/turbo/apps/cli/src/commands/search/__tests__/chat-source.test.ts
@@ -62,8 +62,10 @@ describe("okou search --source chat", () => {
   });
 
   it("renders the matched message grouped by thread", async () => {
+    let capturedUrl: URL | undefined;
     server.use(
-      http.get("http://localhost:3000/api/chat/search", () => {
+      http.get("http://localhost:3000/api/chat/search", ({ request }) => {
+        capturedUrl = new URL(request.url);
         return HttpResponse.json({
           results: [
             {
@@ -74,7 +76,6 @@ describe("okou search --source chat", () => {
               }),
             },
           ],
-          hasMore: false,
         });
       }),
     );
@@ -85,6 +86,7 @@ describe("okou search --source chat", () => {
     expect(logs).toContain("thread-abc");
     expect(logs).toContain("my-agent");
     expect(logs).toContain("OOM killed the build");
+    expect(capturedUrl?.searchParams.has("limit")).toBeFalsy();
   });
 
   it("tolerates invalid chat message timestamps", async () => {
@@ -101,7 +103,6 @@ describe("okou search --source chat", () => {
               }),
             },
           ],
-          hasMore: false,
         });
       }),
     );
@@ -116,7 +117,7 @@ describe("okou search --source chat", () => {
   it("handles no matches", async () => {
     server.use(
       http.get("http://localhost:3000/api/chat/search", () => {
-        return HttpResponse.json({ results: [], hasMore: false });
+        return HttpResponse.json({ results: [] });
       }),
     );
 
@@ -138,7 +139,7 @@ describe("okou search --source chat", () => {
     server.use(
       http.get("http://localhost:3000/api/chat/search", ({ request }) => {
         capturedUrl = new URL(request.url);
-        return HttpResponse.json({ results: [], hasMore: false });
+        return HttpResponse.json({ results: [] });
       }),
     );
 
@@ -161,7 +162,7 @@ describe("okou search --source chat", () => {
     server.use(
       http.get("http://localhost:3000/api/chat/search", ({ request }) => {
         capturedUrl = new URL(request.url);
-        return HttpResponse.json({ results: [], hasMore: false });
+        return HttpResponse.json({ results: [] });
       }),
     );
 
@@ -213,59 +214,7 @@ describe("okou search --source chat", () => {
     expect(errors).toContain("Invalid agent ID");
   });
 
-  it("rejects --limit outside the 1..50 range", async () => {
-    await expect(
-      searchCommand.parseAsync([
-        "node",
-        "cli",
-        "hello",
-        "--source",
-        "chat",
-        "--limit",
-        "500",
-      ]),
-    ).rejects.toThrow("process.exit called");
-
-    const errors = mockConsoleError.mock.calls.flat().join("\n");
-    expect(errors).toContain("--limit must be between 1 and 50");
-  });
-
-  it("rejects partial numeric limit values", async () => {
-    await expect(
-      searchCommand.parseAsync([
-        "node",
-        "cli",
-        "hello",
-        "--source",
-        "chat",
-        "--limit",
-        "1abc",
-      ]),
-    ).rejects.toThrow("process.exit called");
-
-    let errors = mockConsoleError.mock.calls.flat().join("\n");
-    expect(errors).toContain("--limit must be between 1 and 50");
-
-    mockConsoleError.mockClear();
-    searchCommand.setOptionValue("source", []);
-
-    await expect(
-      searchCommand.parseAsync([
-        "node",
-        "cli",
-        "hello",
-        "--source",
-        "chat",
-        "--limit",
-        "",
-      ]),
-    ).rejects.toThrow("process.exit called");
-
-    errors = mockConsoleError.mock.calls.flat().join("\n");
-    expect(errors).toContain("--limit must be between 1 and 50");
-  });
-
-  it("shows the hasMore hint when the API reports more results", async () => {
+  it("renders an older API response without a pagination hint", async () => {
     server.use(
       http.get("http://localhost:3000/api/chat/search", () => {
         return HttpResponse.json({
@@ -290,7 +239,10 @@ describe("okou search --source chat", () => {
     ]);
 
     const logs = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logs).toContain("--limit");
+    expect(logs).toContain("thread-x");
+    expect(logs).toContain("match");
+    expect(logs).not.toContain("--limit");
+    expect(logs).not.toContain("Showing first");
   });
 
   it("surfaces API authentication errors", async () => {

--- a/turbo/apps/cli/src/commands/search/__tests__/slack-source.test.ts
+++ b/turbo/apps/cli/src/commands/search/__tests__/slack-source.test.ts
@@ -108,7 +108,6 @@ describe("okou search --source slack", () => {
       ]);
 
       const output = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(output).toContain("--limit");
       expect(output).toContain("--since");
       expect(output).toContain("ignored");
     });
@@ -177,8 +176,6 @@ describe("okou search --source slack", () => {
         "hello",
         "--source",
         "slack",
-        "--limit",
-        "100",
         "--since",
         "30d",
       ]);

--- a/turbo/apps/cli/src/commands/search/index.ts
+++ b/turbo/apps/cli/src/commands/search/index.ts
@@ -8,7 +8,6 @@ import type {
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { parseTime } from "../../lib/utils/time-parser";
 import { formatIsoTimestamp } from "../../lib/utils/time-format";
-import { parseBoundedLogCount } from "../../lib/utils/log-pagination";
 import { parseSearchQuery } from "../../lib/utils/search-query";
 import { isUuid } from "../../lib/utils/uuid";
 
@@ -20,7 +19,7 @@ const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 export const SEARCH_EXPLAINER = `
 Available sources:
   agent-session  locates local Claude Code and Codex session files for direct analysis
-  chat           user/assistant text messages as shown in the web chat UI
+  chat           user/assistant text messages from web chat (up to 25 newest matches)
   slack          returns a recipe for calling the Slack API directly; requires the Slack connector
 
 Usage: okou search <query> --source <agent-session|chat|slack> [flags]
@@ -52,25 +51,18 @@ To verify the token and network policy end-to-end:
 
 Slack API docs: https://api.slack.com/methods/search.messages
 
-Note: CLI-local flags (--limit, --since) are ignored for the slack source.
-Pass equivalents to Slack's API via count= / highlight=
-query parameters instead.`;
+Note: --since is ignored for the slack source.
+Add time filters directly to the Slack search query.`;
 }
 
 interface SearchOptions {
   source: string[];
   agent?: string;
   since?: string;
-  limit?: string;
 }
 
 function collectSource(value: string, previous: string[]): string[] {
   return [...previous, value];
-}
-
-function parseLimit(value: string | undefined): number | undefined {
-  if (value === undefined) return undefined;
-  return parseBoundedLogCount(value, "--limit", 1, 50);
 }
 
 function formatTimestamp(iso: string): string {
@@ -96,15 +88,6 @@ function renderChatResults(response: ChatSearchResponse): void {
     );
     renderChatMessage(result.matchedMessage);
   }
-
-  if (response.hasMore) {
-    console.log();
-    console.log(
-      chalk.dim(
-        `  Showing first ${response.results.length} matches. Use --limit to see more.`,
-      ),
-    );
-  }
 }
 
 async function runChatSource(
@@ -118,7 +101,6 @@ async function runChatSource(
     process.exit(1);
   }
 
-  const limit = parseLimit(options.limit);
   const since =
     options.since !== undefined
       ? parseTime(options.since)
@@ -128,7 +110,6 @@ async function runChatSource(
     keyword: query,
     agentId: options.agent,
     since,
-    limit,
   });
 
   if (response.results.length === 0) {
@@ -170,7 +151,6 @@ export const searchCommand = new Command()
   )
   .option("--agent <id>", "Filter by agent ID")
   .option("--since <time>", "Time window (e.g., 7d, 2h)")
-  .option("--limit <n>", "Maximum number of matches")
   .addHelpText("after", SEARCH_EXPLAINER)
   .action(
     withErrorHandler(async (query: string, options: SearchOptions) => {

--- a/turbo/apps/cli/src/lib/api/domains/chat.ts
+++ b/turbo/apps/cli/src/lib/api/domains/chat.ts
@@ -104,7 +104,6 @@ export async function searchChat(options: {
   keyword: string;
   agentId?: string;
   since?: number;
-  limit?: number;
 }): Promise<ChatSearchResponse> {
   const config = await getClientConfig();
   const client = initClient(chatSearchContract, config);
@@ -113,7 +112,6 @@ export async function searchChat(options: {
       keyword: options.keyword,
       agentId: options.agentId,
       since: options.since,
-      limit: options.limit,
     },
   });
   if (result.status === 200) return result.body;

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -228,7 +228,7 @@ export const apiAgentsHandlers = [
 
   // GET /api/chat/search
   mockApi(chatSearchContract.search, ({ respond }) => {
-    return respond(200, { results: [], hasMore: false });
+    return respond(200, { results: [] });
   }),
 
   // GET /api/indicators

--- a/turbo/apps/platform/src/signals/okou-page/workspace-chat-search.ts
+++ b/turbo/apps/platform/src/signals/okou-page/workspace-chat-search.ts
@@ -13,7 +13,6 @@ import { stableChatThreadNavigationEnabled$ } from "../external/feature-switch.t
 import { chatListQuery$, debouncedChatListQuery$ } from "./sidebar-state.ts";
 
 const MAX_VISIBLE_CHAT_THREAD_RESULTS = 25;
-const MAX_CHAT_SEARCH_RESULTS = 25;
 
 export interface WorkspaceSearchChatThread {
   readonly id: string;
@@ -154,7 +153,6 @@ export const workspaceSearchChatMessages$ = computed(
       client.search({
         query: {
           keyword: query,
-          limit: MAX_CHAT_SEARCH_RESULTS,
         },
       }),
       [200],

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-search-debounce.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-search-debounce.test.tsx
@@ -51,7 +51,6 @@ function installMessageSearch(threadId: string): string[] {
           matchedRanges: [{ start: 0, end: query.keyword.length }],
         },
       ],
-      hasMore: false,
     });
   });
   return keywords;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
@@ -374,7 +374,6 @@ test("Search numbers follow fresh matches and restart after filtering", async ()
               },
             ]
           : [],
-      hasMore: false,
     });
   });
   await setupPage({

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -2524,7 +2524,6 @@ test("Search workspace chats and messages", async () => {
               },
             ]
           : [],
-      hasMore: false,
     });
   });
   context.mocks.api(artifactCatalogContract.list, ({ respond }) => {
@@ -2680,7 +2679,7 @@ test("Show useful search-result ages and an illustrated empty state", async () =
     }),
   ]);
   context.mocks.api(chatSearchContract.search, ({ respond }) => {
-    return respond(200, { results: [], hasMore: false });
+    return respond(200, { results: [] });
   });
   context.mocks.api(artifactCatalogContract.list, ({ respond }) => {
     return respond(200, { artifacts: [], nextCursor: null });

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -1809,17 +1809,11 @@ const chatSearchResultSchema = z.object({
   matchedRanges: z.array(chatSearchMatchRangeSchema),
 });
 
-/**
- * `hasMore` indicates that the server truncated the result set at `limit`.
- * There is intentionally no cursor/offset: `limit` is capped at 50 (see the
- * query schema below) and chat-message search is a lookup tool, not a bulk
- * export. Callers that hit `hasMore=true` should narrow the query (add
- * `agentId`, `since`, or a more specific `keyword`) rather than paginate. If
- * genuine pagination is ever needed, introduce `nextCursor` here.
- */
+export const CHAT_SEARCH_RESULT_LIMIT = 25;
+
+/** The newest matching messages, capped at 25 without pagination. */
 const chatSearchResponseSchema = z.object({
-  results: z.array(chatSearchResultSchema),
-  hasMore: z.boolean(),
+  results: z.array(chatSearchResultSchema).max(CHAT_SEARCH_RESULT_LIMIT),
 });
 
 /**
@@ -1836,7 +1830,6 @@ export const chatSearchContract = c.router({
       keyword: z.string().trim().min(1),
       agentId: z.string().uuid().optional(),
       since: z.coerce.number().optional(),
-      limit: z.coerce.number().min(1).max(50).default(20),
     }),
     responses: {
       200: chatSearchResponseSchema,
@@ -1844,7 +1837,7 @@ export const chatSearchContract = c.router({
       401: apiErrorSchema,
       403: apiErrorSchema,
     },
-    summary: "Search chat messages within caller's org",
+    summary: "Search up to 25 newest chat messages within caller's org",
   },
 });
 


### PR DESCRIPTION
## Summary

Chat search should return up to 25 newest matching messages as a single lookup. It also needs to avoid the 40-second ordered-history scan reproduced for sparse keywords such as `depbot`.

- Fix `GET /api/chat/search` at 25 results. Remove the public `limit` parameter and `hasMore` response field; there is no cursor or offset pagination.
- Update the app and CLI callers, remove the CLI `--limit` flag and its "see more" hint, and stop fetching an extra result to detect truncation.
- Bound the recent-message probe to at most 400 messages on the first batch. Return up to 25 recent matches when that fills the batch; otherwise evaluate the complete keyword match behind an `OFFSET 0` optimization fence. Both paths share one SQL statement, and the complete-match branch is skipped when the recent batch fills.
- Preserve authorization, agent/time filters, stable newest-first ordering, and internal continuation past deleted threads so orphaned matches cannot hide valid results.

## Validation

Read-only `EXPLAIN (ANALYZE, BUFFERS)` on the production Neon primary, using SQL generated by the final Drizzle implementation with the default planner:

| Keyword | Previous query | Fixed-25 query | Plan evidence |
| --- | ---: | ---: | --- |
| `depbot` | 40,477 ms | 69 ms | Previous ordered scan rejected 373,361 rows. The update inspects at most 400 recent messages, then uses the GIN index; shared buffer accesses fall from 482,159 to 874. |
| `api` | 88 ms | 15 ms | The recent probe fills 25 results, and the complete-match branch has zero execution loops. |

These are diagnostic samples against changing live data and cache state, not controlled benchmark thresholds. The previous query collected 52 candidates for a 25-result request; the updated query collects only the remaining number needed to reach 25. No production data, indexes, or database configuration were changed.

Regression coverage verifies newest-first truncation at 25, sparse/empty results without `hasMore`, ignored legacy limits, and continuation past a full batch of deleted matches. CLI and app fixtures use the new response shape; CLI coverage also checks that an older response containing `hasMore` renders without pagination guidance.

- Passed the four CLI search test files: 28 tests.
- Passed type checks for API contracts, API (including test types and bootstrap wiring), CLI, and app.
- Passed changed-file Oxlint, type-aware Oxlint, ESLint, formatting, and style policy checks.
- Passed Knip (configuration hints only).
- API and app Vitest suites will run in the PR pipeline; they were not run locally.

## Rollout compatibility

Old request limits are accepted as unknown query parameters and ignored, including values below and above 25. The existing app reads only `results`; the old CLI treats a missing `hasMore` as false, and neither enables response-schema validation for this endpoint in production. New callers can also read the older response, whose default result cap is 20. This change does not require a database migration or client version-floor increase.
