### PR TITLE
fix(ci): enforce goal retirement rollback floor

### DIFF
--- a/.github/scripts/resolve-production-rollback-target.sh
+++ b/.github/scripts/resolve-production-rollback-target.sh
@@ -5,6 +5,8 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly CHAT_EVENT_FAILURE_REASON_READER_COMMIT=c093e0ffdab988d2a8a071809f90d87fa3e79f20
 readonly CHAT_EVENT_FAILURE_REASON_READER_RELEASE=89c6a521944e2ac8550da424f164db08f4f80f0c
 readonly BLANK_SANDBOX_STATUS_READER_COMMIT=febec8a3399be74b0f14a89cb9f42e39dd5ce69f
+readonly OKOU_GOAL_RETIREMENT_COMMIT=6d391117e4fead19e2105136fb2792a6e77801d8
+readonly OKOU_GOAL_RETIREMENT_RELEASE=1f68f182a2457ec3aea52d8063be2bd2d2263abd
 
 fail() {
   echo "::error::$*" >&2
@@ -51,6 +53,11 @@ if ! git merge-base --is-ancestor "$BLANK_SANDBOX_STATUS_READER_COMMIT" "$TARGET
 fi
 if [ -z "$release_tags" ]; then
   fail "Target commit has no release tags: ${TARGET_COMMIT}"
+fi
+
+# The API retirement boundary legitimately retains a pre-retirement Runner tag.
+if ! git merge-base --is-ancestor "$OKOU_GOAL_RETIREMENT_COMMIT" "$TARGET_COMMIT"; then
+  fail "Target commit predates the Okou Goal retirement boundary. The first compatible release is ${OKOU_GOAL_RETIREMENT_RELEASE} (API 1.571.1)."
 fi
 
 deployments=$(curl -fsS --get "https://api.vercel.com/v6/deployments" \

--- a/.github/scripts/tests/resolve-production-rollback-target-test.sh
+++ b/.github/scripts/tests/resolve-production-rollback-target-test.sh
@@ -30,6 +30,12 @@ case "${1:-}" in
       else
         [ "${MOCK_BLANK_TARGET_FLOOR_VALID:-1}" = "1" ]
       fi
+    elif [ "${3:-}" = "6d391117e4fead19e2105136fb2792a6e77801d8" ]; then
+      # The retained Runner predates S1 even when the API target contains it.
+      if [ "${4:-}" = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ]; then
+        exit 1
+      fi
+      [ "${MOCK_GOAL_TARGET_FLOOR_VALID:-1}" = "1" ]
     else
       [ "${MOCK_ANCESTRY_VALID:-1}" = "1" ]
     fi
@@ -80,6 +86,7 @@ SH
 cat >"${fake_bin}/ssh" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
+printf 'ssh %s\n' "$*" >>"$MOCK_BOUNDARY_LOG"
 if [ "${1:-}" = "-n" ]; then shift; fi
 remote=$1
 host=${remote#*@}
@@ -121,12 +128,14 @@ assert_failure() {
   grep -q "$expected_message" "${tmp_dir}/failure.err" || fail "missing failure message: ${expected_message}"
 }
 
+# An S1-compatible API target must still resolve its valid pre-S1 Runner.
 : >"${tmp_dir}/boundaries.log"
 output_file="${tmp_dir}/success.output"
 run_resolver "$output_file" >"${tmp_dir}/success.log"
 grep -qx "target_commit=${target_commit}" "$output_file" || fail "missing target commit output"
 grep -qx "api_deployment_url=https://api-0.vercel.app" "$output_file" || fail "missing API deployment output"
 grep -qx "runner_version=1.2.3" "$output_file" || fail "missing Runner version output"
+grep -qx "runner_tag=runner-rs-v1.2.3" "$output_file" || fail "missing retained Runner tag output"
 runner_matrix=$(sed -n 's/^runner_matrix=//p' "$output_file")
 jq -e 'length == 2 and .[0].id == "arm64" and .[1].id == "x86_64"' >/dev/null <<<"$runner_matrix" || fail "unexpected Runner matrix"
 
@@ -167,6 +176,18 @@ assert_failure "Target commit predates the blank sandbox status reader" \
 [ ! -s "${tmp_dir}/blank-target-floor.output" ] || fail "old blank reader target must not publish outputs"
 if grep -q '^curl ' "${tmp_dir}/boundaries.log"; then
   fail "blank reader target rejection must precede artifact resolution"
+fi
+
+: >"${tmp_dir}/boundaries.log"
+assert_failure "Target commit predates the Okou Goal retirement boundary" \
+  run_resolver "${tmp_dir}/goal-target-floor.output" \
+  MOCK_READER_FLOOR_VALID=1 MOCK_BLANK_TARGET_FLOOR_VALID=1 MOCK_GOAL_TARGET_FLOOR_VALID=0
+grep -Fq "first compatible release is 1f68f182a2457ec3aea52d8063be2bd2d2263abd (API 1.571.1)" \
+  "${tmp_dir}/failure.err" || fail "Goal rejection must identify the first compatible API release"
+[ ! -s "${tmp_dir}/goal-target-floor.output" ] || fail "pre-S1 API target must not publish outputs"
+[ ! -s "${tmp_dir}/failure.out" ] || fail "pre-S1 API target must not print resolved targets"
+if grep -qE '^(curl|ssh|git (show|rev-list)) ' "${tmp_dir}/boundaries.log"; then
+  fail "Goal target rejection must precede API and Runner artifact resolution"
 fi
 
 : >"${tmp_dir}/boundaries.log"

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -429,6 +429,24 @@ Compatibility code should be temporary and explicit. Include a short comment
 with the rollout reason and the condition for deletion, or track the cleanup in
 a follow-up issue when the deletion cannot happen in the same PR.
 
+### Okou Goal retirement rollback floor
+
+The production rollback resolver requires the release/API target to contain
+Goal retirement commit `6d391117e4fead19e2105136fb2792a6e77801d8`. The first
+compatible release is `1f68f182a2457ec3aea52d8063be2bd2d2263abd` (API 1.571.1).
+This permanent floor prevents canonical rollback from restoring Goal creation,
+reactivation, or continuation. It rejects pre-boundary targets before API or
+Runner artifact resolution and output publication, even if the rollback
+dashboard still lists those historical releases.
+
+Apply this floor only to the release/API target: the first compatible release
+retained an older Runner tag. All independent Runner ancestry, reader, host
+architecture, and release-asset checks still apply. The rollback workflow loads
+the resolver from current `main`, so merging the guard constrains future
+canonical executions without a release or test rollback. This does not prove
+that old fixed API deployments are non-writable or authorize Goal archival;
+those remain separate gates in [EPIC #32653](https://github.com/vm0-ai/vm0/issues/32653).
+
 ### Workflow automation connector-account projections
 
 Connector-backed workflow event automations persist account authority in an


### PR DESCRIPTION
## Summary

Production rollback could select a release that predates Okou Goal retirement and restore Goal creation or continuation. Require the release/API target to contain S1 commit `6d391117e4fead19e2105136fb2792a6e77801d8`, rejecting it before API or Runner artifact resolution and output publication. The error identifies the first compatible release, `1f68f182a2457ec3aea52d8063be2bd2d2263abd` (API 1.571.1).

The floor applies only to the API target. That first compatible release retained `runner-rs-v0.188.16`, whose commit predates S1; existing Runner ancestry, reader, architecture, deployment uniqueness, and asset checks remain intact. Extend the existing shell fixtures for that positive pairing and pre-S1 rejection after the earlier floors pass, and document the boundary.

The rollback workflow already loads the resolver from current `main`, so the guard constrains future canonical executions after merge. This PR performs no production workflow dispatch, release, rollback, data mutation, or dashboard edit. Old fixed-deployment writer cutoff and the remaining EPIC gates require independent controller acceptance.

Closes #32770. Part of #32653.

## Verification

- `bash .github/scripts/tests/resolve-production-rollback-target-test.sh` passes, retaining the existing negative cases.
- Bash syntax checks and `shellcheck -x --source-path=SCRIPTDIR` pass for both changed shell files.
- `bash .github/scripts/check-workflow-shell-compatibility.sh .github/workflows/rollback-production.yml` passes.
- Prettier, file-size checks, and `git diff --check` pass.
- Isolated mutation checks fail as expected when the Goal floor is removed, incorrectly applied to the retained Runner, or moved after API artifact lookup.
- Real Git ancestry confirms the pre-S1 Runner release passes the earlier reader floors, and API 1.571.1 contains S1 while its retained Runner does not.

No full local Vitest suite or local development server was used.
