### PR TITLE
ci: resolve kms preflight pnpm from its workspace

### DIFF
--- a/.github/workflows/kms-production-preflight.yml
+++ b/.github/workflows/kms-production-preflight.yml
@@ -35,9 +35,10 @@ jobs:
         with:
           node-version: 22
       - name: Install migration dependencies
+        working-directory: turbo
         run: |
           corepack enable pnpm
-          pnpm --dir turbo install --frozen-lockfile --ignore-scripts --filter @okouai/db...
+          pnpm install --frozen-lockfile --ignore-scripts --filter @okouai/db...
           command -v aws
       - name: Resolve the production database
         env:


### PR DESCRIPTION
The production KMS preflight fails before reaching AWS or the database because Corepack runs from the repository root and selects pnpm 12 instead of the version pinned in `turbo/package.json`. Run the dependency installation step from `turbo` so Corepack selects pnpm 10.33.4 before pnpm processes its arguments.

Validation: the exact frozen, script-disabled, DB-filtered installation succeeded with pnpm 10.33.4 using the current repository manifests, lockfile, and patches; actionlint 1.7.12, Prettier, Bash syntax, and embedded Python syntax checks passed.

Failure evidence: https://github.com/vm0-ai/vm0/actions/runs/34304061619/job/102316961474

Follow-up to #32675 for #32264. Production approval and read-only verification behavior are unchanged.
