### PR TITLE
feat: add presentation slide count picker ui

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1887,6 +1887,9 @@
         "presentationPlaceholder": "Worum geht es in deiner Präsentation?",
         "question": "Was möchtest du möglich machen?",
         "settingsAdjusted": "Einige Videoeinstellungen wurden an dieses Modell angepasst",
+        "slideCount": "Folienanzahl",
+        "slideCountAuto": "Automatisch",
+        "slideCountRange": "{{range}} Folien",
         "title": "Erstellen",
         "video": "Video erstellen",
         "videoPlaceholder": "Beschreibe das gewünschte Video…"

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1887,6 +1887,9 @@
         "presentationPlaceholder": "What is your presentation about?",
         "question": "What would you like to make happen?",
         "settingsAdjusted": "Some video settings were adjusted for this model",
+        "slideCount": "Slide count",
+        "slideCountAuto": "Auto",
+        "slideCountRange": "{{range}} slides",
         "title": "Create",
         "video": "Create video",
         "videoPlaceholder": "Describe the video you want to create…"

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1916,6 +1916,9 @@
         "presentationPlaceholder": "¿De qué trata tu presentación?",
         "question": "¿Qué te gustaría hacer realidad?",
         "settingsAdjusted": "Se han ajustado algunas opciones de vídeo para este modelo",
+        "slideCount": "Número de diapositivas",
+        "slideCountAuto": "Automático",
+        "slideCountRange": "{{range}} diapositivas",
         "title": "Crear",
         "video": "Crear vídeo",
         "videoPlaceholder": "Describe el vídeo que quieres crear…"

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1916,6 +1916,9 @@
         "presentationPlaceholder": "Quel est le sujet de votre présentation ?",
         "question": "Que souhaitez-vous réaliser ?",
         "settingsAdjusted": "Certains paramètres vidéo ont été adaptés à ce modèle",
+        "slideCount": "Nombre de diapositives",
+        "slideCountAuto": "Automatique",
+        "slideCountRange": "{{range}} diapositives",
         "title": "Créer",
         "video": "Créer une vidéo",
         "videoPlaceholder": "Décrivez la vidéo à créer…"

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1887,6 +1887,9 @@
         "presentationPlaceholder": "आपकी प्रस्तुति का विषय क्या है?",
         "question": "आप क्या साकार करना चाहेंगे?",
         "settingsAdjusted": "इस मॉडल के लिए कुछ वीडियो सेटिंग समायोजित की गई हैं",
+        "slideCount": "स्लाइड की संख्या",
+        "slideCountAuto": "स्वचालित",
+        "slideCountRange": "{{range}} स्लाइड",
         "title": "बनाएँ",
         "video": "वीडियो बनाएँ",
         "videoPlaceholder": "आप जो वीडियो बनाना चाहते हैं उसका वर्णन करें…"

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1884,6 +1884,9 @@
         "presentationPlaceholder": "Apa topik presentasi Anda?",
         "question": "Apa yang ingin Anda wujudkan?",
         "settingsAdjusted": "Beberapa pengaturan video disesuaikan untuk model ini",
+        "slideCount": "Jumlah slide",
+        "slideCountAuto": "Otomatis",
+        "slideCountRange": "{{range}} slide",
         "title": "Buat",
         "video": "Buat video",
         "videoPlaceholder": "Jelaskan video yang ingin Anda buat…"

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1916,6 +1916,9 @@
         "presentationPlaceholder": "Di cosa tratta la tua presentazione?",
         "question": "Cosa vorresti realizzare?",
         "settingsAdjusted": "Alcune impostazioni video sono state adattate a questo modello",
+        "slideCount": "Numero di diapositive",
+        "slideCountAuto": "Automatico",
+        "slideCountRange": "{{range}} diapositive",
         "title": "Crea",
         "video": "Crea video",
         "videoPlaceholder": "Descrivi il video che vuoi creare…"

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1884,6 +1884,9 @@
         "presentationPlaceholder": "プレゼンテーションのテーマは何ですか？",
         "question": "何を実現したいですか？",
         "settingsAdjusted": "このモデルに合わせて一部の動画設定を調整しました",
+        "slideCount": "スライド数",
+        "slideCountAuto": "自動",
+        "slideCountRange": "{{range}}枚",
         "title": "作成",
         "video": "動画を作成",
         "videoPlaceholder": "作成したい動画を説明してください…"

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1884,6 +1884,9 @@
         "presentationPlaceholder": "프레젠테이션의 주제는 무엇인가요?",
         "question": "무엇을 실현하고 싶으신가요?",
         "settingsAdjusted": "이 모델에 맞게 일부 동영상 설정을 조정했습니다",
+        "slideCount": "슬라이드 수",
+        "slideCountAuto": "자동",
+        "slideCountRange": "{{range}}장",
         "title": "만들기",
         "video": "동영상 만들기",
         "videoPlaceholder": "만들고 싶은 동영상을 설명하세요…"

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1916,6 +1916,9 @@
         "presentationPlaceholder": "Qual é o tema da sua apresentação?",
         "question": "O que você gostaria de realizar?",
         "settingsAdjusted": "Algumas configurações de vídeo foram ajustadas para este modelo",
+        "slideCount": "Número de slides",
+        "slideCountAuto": "Automático",
+        "slideCountRange": "{{range}} slides",
         "title": "Criar",
         "video": "Criar vídeo",
         "videoPlaceholder": "Descreva o vídeo que você quer criar…"

--- a/turbo/apps/platform/src/signals/okou-page/composer-create.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-create.ts
@@ -7,6 +7,17 @@ import type { ComposerUiSignalGroups } from "./chat-composer.ts";
 
 const COMPOSER_CREATE_MODES = ["presentation", "video", "image"] as const;
 
+export const PRESENTATION_SLIDE_COUNTS = [
+  "auto",
+  "4-8",
+  "8-12",
+  "12-16",
+  "16-20",
+  "20-24",
+] as const;
+
+type PresentationSlideCount = (typeof PRESENTATION_SLIDE_COUNTS)[number];
+
 export type ComposerCreateMode = (typeof COMPOSER_CREATE_MODES)[number];
 export type ComposerCreateCommand = ComposerCreateMode | "choose";
 
@@ -92,6 +103,15 @@ export function createComposerCreateSignals(
     );
   });
   const internalMode$ = state<ComposerCreateCommand | null>(null);
+  const internalPresentationSlideCount$ = state<PresentationSlideCount>("8-12");
+  const presentationSlideCount$ = computed((get) => {
+    return get(internalPresentationSlideCount$);
+  });
+  const setPresentationSlideCount$ = command(
+    ({ set }, slideCount: PresentationSlideCount) => {
+      set(internalPresentationSlideCount$, slideCount);
+    },
+  );
   const enabled$ = computed((get) => {
     return get(featureSwitch$)[FeatureSwitchKey.ComposerCreateCommands];
   });
@@ -118,6 +138,9 @@ export function createComposerCreateSignals(
       if (mode !== "video") {
         set(ui.videoOptions.setVideoRunOptions$, {});
       }
+      if (mode !== "presentation") {
+        set(internalPresentationSlideCount$, "8-12");
+      }
       if (mode !== "choose") {
         set(composer.focus$);
       }
@@ -139,7 +162,16 @@ export function createComposerCreateSignals(
       set(setMode$, mode);
     },
   );
-  return { enabled$, modes, mode$, choosing$, setMode$, selectCommand$ };
+  return {
+    enabled$,
+    modes,
+    mode$,
+    choosing$,
+    setMode$,
+    selectCommand$,
+    presentationSlideCount$,
+    setPresentationSlideCount$,
+  };
 }
 
 export type ComposerCreateSignals = ReturnType<

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-presentation-options.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-presentation-options.test.tsx
@@ -1,0 +1,162 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import { browserContract } from "@okouai/api-contracts/contracts/browser";
+import type {
+  ChatRunOptionsRequest,
+  UserMessageDocument,
+} from "@okouai/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { expect, test } from "vitest";
+import {
+  click,
+  fill,
+  queryAllByRoleFast,
+  setupPage,
+} from "../../../__tests__/page-helper.ts";
+import { mockChatLifecycle } from "./chat-test-helpers.ts";
+import {
+  AGENT_ID,
+  context,
+  findComposerEditor,
+  mockAgent,
+  mockBillingCapabilities,
+  mockOrgModelRoutes,
+} from "./chat-composer-test-helpers.ts";
+
+interface SubmittedMessage {
+  readonly userMessage?: UserMessageDocument;
+  readonly runOptions?: ChatRunOptionsRequest;
+}
+
+function button(label: string, container: ParentNode = document): HTMLElement {
+  const result = queryAllByRoleFast("button", container).find((item) => {
+    return (
+      (item.getAttribute("aria-label") ?? item.textContent?.trim()) === label
+    );
+  });
+  if (!result) {
+    throw new Error(`Expected button ${label}`);
+  }
+  return result;
+}
+
+function setupModels(): void {
+  context.mocks.api(browserContract.get, ({ respond }) => {
+    return respond(404, {
+      error: {
+        code: "BROWSER_NOT_FOUND",
+        message: "Managed browser not found",
+      },
+    });
+  });
+  mockAgent();
+  mockOrgModelRoutes("claude-fable-5-1");
+  mockBillingCapabilities({ supportByok: true, restrictedVm0Models: false });
+}
+
+async function setupComposer(): Promise<HTMLElement> {
+  await setupPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+    featureSwitches: { [FeatureSwitchKey.ComposerCreateCommands]: true },
+  });
+  return await findComposerEditor();
+}
+
+async function enterPresentation(editor: HTMLElement): Promise<HTMLElement> {
+  await fill(editor, "Our launch /create presentation");
+  const menu = await screen.findByTestId("slash-workflow-menu");
+  click(button("Create presentation", menu));
+  return await screen.findByRole("combobox", { name: "Slide count" });
+}
+
+function visibleText(message: SubmittedMessage | undefined): string {
+  return (
+    message?.userMessage?.parts
+      .flatMap((part) => {
+        return part.type === "text" ? [part.text] : [];
+      })
+      .join("")
+      .replace(/\s+/g, " ")
+      .trim() ?? ""
+  );
+}
+
+test("Presentation offers six lengths without changing the submitted message", async () => {
+  setupModels();
+  const submissions: SubmittedMessage[] = [];
+  mockChatLifecycle(context, {
+    onRunCreate: (body) => {
+      submissions.push(body);
+    },
+  });
+  const editor = await setupComposer();
+  expect(screen.queryByRole("combobox", { name: "Slide count" })).toBeNull();
+  const picker = await enterPresentation(editor);
+  expect(picker).toHaveTextContent("8–12 slides");
+  click(picker);
+  const menu = await screen.findByRole("listbox");
+  expect(
+    within(menu)
+      .getAllByRole("option")
+      .map((item) => {
+        return item.textContent?.trim();
+      }),
+  ).toStrictEqual([
+    "Auto",
+    "4–8 slides",
+    "8–12 slides",
+    "12–16 slides",
+    "16–20 slides",
+    "20–24 slides",
+  ]);
+  expect(
+    within(menu).getByRole("option", { name: "8–12 slides" }),
+  ).toHaveAttribute("aria-selected", "true");
+  click(within(menu).getByRole("option", { name: "Auto" }));
+  await waitFor(() => {
+    expect(picker).toHaveTextContent("Auto");
+  });
+  click(button("Send"));
+  await waitFor(() => {
+    expect(submissions).toHaveLength(1);
+  });
+  expect(submissions[0]?.runOptions).toBeUndefined();
+  expect(visibleText(submissions[0])).toBe("Create a presentation. Our launch");
+});
+
+test("Leaving presentation hides its picker and resets its length", async () => {
+  setupModels();
+  const submissions: SubmittedMessage[] = [];
+  mockChatLifecycle(context, {
+    onRunCreate: (body) => {
+      submissions.push(body);
+    },
+  });
+  const editor = await setupComposer();
+  const picker = await enterPresentation(editor);
+  click(picker);
+  click(await screen.findByRole("option", { name: "Auto" }));
+  await waitFor(() => {
+    expect(picker).toHaveTextContent("Auto");
+  });
+  click(screen.getByRole("combobox", { name: "Choose a type" }));
+  click(await screen.findByRole("option", { name: "Image" }));
+  await screen.findByRole("combobox", { name: "Image models" });
+  expect(screen.queryByRole("combobox", { name: "Slide count" })).toBeNull();
+  click(screen.getByRole("combobox", { name: "Choose a type" }));
+  click(await screen.findByRole("option", { name: "Presentation" }));
+  await expect(
+    screen.findByRole("combobox", { name: "Slide count" }),
+  ).resolves.toHaveTextContent("8–12 slides");
+  click(button("Exit create mode"));
+  await waitFor(() => {
+    expect(screen.queryByTestId("composer-create-mode")).toBeNull();
+  });
+  expect(screen.queryByRole("combobox", { name: "Slide count" })).toBeNull();
+  click(button("Send"));
+  await waitFor(() => {
+    expect(submissions).toHaveLength(1);
+  });
+  expect(submissions[0]?.runOptions).toBeUndefined();
+  expect(visibleText(submissions[0])).toBe("Our launch");
+});

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -298,6 +298,7 @@ import {
   AvatarTemplatePickerToolbar,
 } from "./avatar-template-picker.tsx";
 import { ComposerVideoOptionsChip } from "./composer-video-options.tsx";
+import { ComposerPresentationOptions } from "./composer-presentation-options.tsx";
 import {
   localizedWorkflowTemplate,
   localizedWorkflowTemplateCategory,
@@ -10527,6 +10528,7 @@ function ComposerFooter({
                 the model picker: it configures the message being written,
                 not which model the composer points at. */}
             <ComposerVideoOptionsChip signals={signals} />
+            <ComposerPresentationOptions signals={signals} />
           </div>
           <div
             className={cn(

--- a/turbo/apps/platform/src/views/okou-page/composer-presentation-options.tsx
+++ b/turbo/apps/platform/src/views/okou-page/composer-presentation-options.tsx
@@ -1,0 +1,57 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@okouai/ui/components/ui/select";
+import { useGet, useSet } from "ccstate-react";
+import { useTranslation } from "react-i18next";
+import { PRESENTATION_SLIDE_COUNTS } from "../../signals/okou-page/composer-create.ts";
+import type { ComposerSignals } from "../../signals/okou-page/composer-signals.ts";
+
+export function ComposerPresentationOptions({
+  signals,
+}: {
+  readonly signals: ComposerSignals;
+}) {
+  const { t } = useTranslation();
+  const mode = useGet(signals.create.mode$);
+  const slideCount = useGet(signals.create.presentationSlideCount$);
+  const setSlideCount = useSet(signals.create.setPresentationSlideCount$);
+
+  if (mode !== "presentation") {
+    return null;
+  }
+
+  return (
+    <Select value={slideCount} onValueChange={setSlideCount}>
+      <SelectTrigger
+        aria-label={t(($) => {
+          return $.chat.composer.create.slideCount;
+        })}
+        className="h-8 w-auto shrink-0 gap-1 border-transparent bg-transparent px-2 text-xs text-muted-foreground hover:bg-state-hover [&>[data-slot=select-icon]>svg]:size-3"
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent side="top" align="start">
+        {PRESENTATION_SLIDE_COUNTS.map((option) => {
+          return (
+            <SelectItem key={option} value={option}>
+              {option === "auto"
+                ? t(($) => {
+                    return $.chat.composer.create.slideCountAuto;
+                  })
+                : t(
+                    ($) => {
+                      return $.chat.composer.create.slideCountRange;
+                    },
+                    { range: option.replace("-", "–") },
+                  )}
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
+  );
+}


### PR DESCRIPTION
Create presentation now shows a slide-count picker in the composer footer with Auto, 4–8, 8–12, 12–16, 16–20, and 20–24 slides, defaulting to 8–12. The picker uses the existing Select styling and `composerCreateCommands` rollout switch. Leaving presentation mode hides the picker and resets the selection.

This PR adds UI only. The selected length stays in local composer state and is not sent with messages or used in agent prompts. All changes are in the Platform frontend; there are no API, contract, or database changes.

Validation:

- 15 focused Platform tests passed across the picker, its reset behavior, unchanged message submission, and existing create/video controls.
- Platform production/test type checks, changed-file formatting/lint, and scoped Knip passed.
- `ci-gate-turbo`, `ci-gate-security`, and `ci-gate-crates` passed on the latest head.
- No local development server or full Vitest suite was started; broader checks run in the PR pipeline.

Acceptance: open https://pr-32781-app-okou-app-preview.vm0.workers.dev, enable `composerCreateCommands` in `/_/lab` if needed, return to Chat, type `/create presentation`, choose Create presentation, and open the Slide count picker.

Browser acceptance: PASS on head `46c9c2f49ddfa95980ed8ef326475a46588d296b` (deployed merge `66f3d7fabae4512f98f58bce7d58ae55ec4893ff`). Confirmed the default 8–12 selection, all six entries, and switching to Auto. Tested in Chromium 152 at 1280×633 with a dedicated Clerk test account, onboarding bypassed through the preview API, and the per-user `composerCreateCommands` Lab override enabled. No generation request was submitted.
