### PR TITLE
fix(api): validate dataforseo labs locations

### DIFF
--- a/turbo/apps/api/src/lib/dataforseo-labs-locations.ts
+++ b/turbo/apps/api/src/lib/dataforseo-labs-locations.ts
@@ -1,0 +1,117 @@
+// DataForSEO Labs Google locations, snapshot published 2026-09-01.
+// Source: https://cdn.dataforseo.com/v3/locations/locations_and_languages_dataforseo_labs_2026_09_01.csv
+// Refresh from the latest CSV linked at https://docs.dataforseo.com/v3/dataforseo_labs_locations_and_languages/
+// Keep Google entries, deduplicate by location_code, and retain supported regions.
+// This local snapshot avoids a provider lookup on every request.
+const DATAFORSEO_LABS_LOCATIONS = [
+  { code: 2008, name: "Albania", isoCode: "AL" },
+  { code: 2012, name: "Algeria", isoCode: "DZ" },
+  { code: 2024, name: "Angola", isoCode: "AO" },
+  { code: 2031, name: "Azerbaijan", isoCode: "AZ" },
+  { code: 2032, name: "Argentina", isoCode: "AR" },
+  { code: 2036, name: "Australia", isoCode: "AU" },
+  { code: 2040, name: "Austria", isoCode: "AT" },
+  { code: 2048, name: "Bahrain", isoCode: "BH" },
+  { code: 2050, name: "Bangladesh", isoCode: "BD" },
+  { code: 2051, name: "Armenia", isoCode: "AM" },
+  { code: 2056, name: "Belgium", isoCode: "BE" },
+  { code: 2068, name: "Bolivia", isoCode: "BO" },
+  { code: 2070, name: "Bosnia and Herzegovina", isoCode: "BA" },
+  { code: 2076, name: "Brazil", isoCode: "BR" },
+  { code: 2100, name: "Bulgaria", isoCode: "BG" },
+  { code: 2104, name: "Myanmar (Burma)", isoCode: "MM" },
+  { code: 2116, name: "Cambodia", isoCode: "KH" },
+  { code: 2120, name: "Cameroon", isoCode: "CM" },
+  { code: 2124, name: "Canada", isoCode: "CA" },
+  { code: 2144, name: "Sri Lanka", isoCode: "LK" },
+  { code: 2152, name: "Chile", isoCode: "CL" },
+  { code: 2158, name: "Taiwan", isoCode: "TW" },
+  { code: 2170, name: "Colombia", isoCode: "CO" },
+  { code: 2188, name: "Costa Rica", isoCode: "CR" },
+  { code: 2191, name: "Croatia", isoCode: "HR" },
+  { code: 2196, name: "Cyprus", isoCode: "CY" },
+  { code: 2203, name: "Czechia", isoCode: "CZ" },
+  { code: 2208, name: "Denmark", isoCode: "DK" },
+  { code: 2218, name: "Ecuador", isoCode: "EC" },
+  { code: 2222, name: "El Salvador", isoCode: "SV" },
+  { code: 2233, name: "Estonia", isoCode: "EE" },
+  { code: 2246, name: "Finland", isoCode: "FI" },
+  { code: 2250, name: "France", isoCode: "FR" },
+  { code: 2276, name: "Germany", isoCode: "DE" },
+  { code: 2288, name: "Ghana", isoCode: "GH" },
+  { code: 2300, name: "Greece", isoCode: "GR" },
+  { code: 2320, name: "Guatemala", isoCode: "GT" },
+  { code: 2344, name: "Hong Kong", isoCode: "HK" },
+  { code: 2348, name: "Hungary", isoCode: "HU" },
+  { code: 2356, name: "India", isoCode: "IN" },
+  { code: 2360, name: "Indonesia", isoCode: "ID" },
+  { code: 2372, name: "Ireland", isoCode: "IE" },
+  { code: 2376, name: "Israel", isoCode: "IL" },
+  { code: 2380, name: "Italy", isoCode: "IT" },
+  { code: 2384, name: "Cote d'Ivoire", isoCode: "CI" },
+  { code: 2392, name: "Japan", isoCode: "JP" },
+  { code: 2398, name: "Kazakhstan", isoCode: "KZ" },
+  { code: 2400, name: "Jordan", isoCode: "JO" },
+  { code: 2404, name: "Kenya", isoCode: "KE" },
+  { code: 2410, name: "South Korea", isoCode: "KR" },
+  { code: 2428, name: "Latvia", isoCode: "LV" },
+  { code: 2440, name: "Lithuania", isoCode: "LT" },
+  { code: 2458, name: "Malaysia", isoCode: "MY" },
+  { code: 2470, name: "Malta", isoCode: "MT" },
+  { code: 2484, name: "Mexico", isoCode: "MX" },
+  { code: 2492, name: "Monaco", isoCode: "MC" },
+  { code: 2498, name: "Moldova", isoCode: "MD" },
+  { code: 2504, name: "Morocco", isoCode: "MA" },
+  { code: 2528, name: "Netherlands", isoCode: "NL" },
+  { code: 2554, name: "New Zealand", isoCode: "NZ" },
+  { code: 2558, name: "Nicaragua", isoCode: "NI" },
+  { code: 2566, name: "Nigeria", isoCode: "NG" },
+  { code: 2578, name: "Norway", isoCode: "NO" },
+  { code: 2586, name: "Pakistan", isoCode: "PK" },
+  { code: 2591, name: "Panama", isoCode: "PA" },
+  { code: 2600, name: "Paraguay", isoCode: "PY" },
+  { code: 2604, name: "Peru", isoCode: "PE" },
+  { code: 2608, name: "Philippines", isoCode: "PH" },
+  { code: 2616, name: "Poland", isoCode: "PL" },
+  { code: 2620, name: "Portugal", isoCode: "PT" },
+  { code: 2642, name: "Romania", isoCode: "RO" },
+  { code: 2682, name: "Saudi Arabia", isoCode: "SA" },
+  { code: 2686, name: "Senegal", isoCode: "SN" },
+  { code: 2688, name: "Serbia", isoCode: "RS" },
+  { code: 2702, name: "Singapore", isoCode: "SG" },
+  { code: 2703, name: "Slovakia", isoCode: "SK" },
+  { code: 2704, name: "Vietnam", isoCode: "VN" },
+  { code: 2705, name: "Slovenia", isoCode: "SI" },
+  { code: 2710, name: "South Africa", isoCode: "ZA" },
+  { code: 2724, name: "Spain", isoCode: "ES" },
+  { code: 2752, name: "Sweden", isoCode: "SE" },
+  { code: 2756, name: "Switzerland", isoCode: "CH" },
+  { code: 2764, name: "Thailand", isoCode: "TH" },
+  { code: 2784, name: "United Arab Emirates", isoCode: "AE" },
+  { code: 2788, name: "Tunisia", isoCode: "TN" },
+  { code: 2792, name: "Turkiye", isoCode: "TR" },
+  { code: 2804, name: "Ukraine", isoCode: "UA" },
+  { code: 2807, name: "North Macedonia", isoCode: "MK" },
+  { code: 2818, name: "Egypt", isoCode: "EG" },
+  { code: 2826, name: "United Kingdom", isoCode: "GB" },
+  { code: 2840, name: "United States", isoCode: "US" },
+  { code: 2854, name: "Burkina Faso", isoCode: "BF" },
+  { code: 2858, name: "Uruguay", isoCode: "UY" },
+  { code: 2862, name: "Venezuela", isoCode: "VE" },
+] as const;
+
+export function dataForSeoLabsLocationCode(
+  location: string,
+): number | undefined {
+  let normalized = location.trim().replace(/\s+/g, " ").toLowerCase();
+  if (normalized === "usa") {
+    normalized = "us";
+  } else if (normalized === "uk") {
+    normalized = "gb";
+  }
+  return DATAFORSEO_LABS_LOCATIONS.find(({ name, isoCode }) => {
+    return (
+      name.toLowerCase() === normalized || isoCode.toLowerCase() === normalized
+    );
+  })?.code;
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/seo.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/seo.test.ts
@@ -106,6 +106,25 @@ function configureProviders(): void {
   mockEnv("OKOU_SEO_DATAFORSEO_PASSWORD", "test-dataforseo-password");
 }
 
+function requestLabsLocation(
+  actor: OrgApiTestUser,
+  operation: "keyword-ideas" | "ranked-keywords",
+  location: string,
+) {
+  const seoClient = client(actor.usagePricingResolution)(seoContract);
+  const headers = authenticate(actor);
+  const body = { location, languageCode: "en", limit: 10 };
+  return operation === "keyword-ideas"
+    ? seoClient.keywordIdeas({
+        headers,
+        body: { ...body, keyword: "technical seo" },
+      })
+    : seoClient.rankedKeywords({
+        headers,
+        body: { ...body, target: "example.com" },
+      });
+}
+
 function dataForSeoResponse(cost: number, result: unknown) {
   return {
     version: "0.1.20260810",
@@ -168,6 +187,146 @@ function noSearchResultsResponse(cost: number) {
 }
 
 describe("SEO routes", () => {
+  describe.each([
+    { operation: "keyword-ideas", endpoint: "keyword_ideas" },
+    { operation: "ranked-keywords", endpoint: "ranked_keywords" },
+  ] as const)("$operation Labs locations", ({ operation, endpoint }) => {
+    it.each([
+      { location: " us ", code: 2840 },
+      { location: "uSa", code: 2840 },
+      { location: "  united   states  ", code: 2840 },
+      { location: "GB", code: 2826 },
+      { location: "uk", code: 2826 },
+      { location: "Hong Kong", code: 2344 },
+    ])(
+      "resolves $location to the supported location code",
+      async ({ location, code }) => {
+        const actor = await seedActor();
+        configureProviders();
+        const beforeCredits = await credits(actor);
+        const observed: unknown[] = [];
+        const providerResponse = dataForSeoResponse(0.024, [
+          { keyword: "seo audit", location_code: code },
+        ]);
+        server.use(
+          http.post(
+            `${DATAFORSEO_BASE_URL}/v3/dataforseo_labs/${endpoint}/live`,
+            async ({ request }) => {
+              observed.push(await request.json());
+              return HttpResponse.json(providerResponse);
+            },
+          ),
+        );
+
+        const response = await accept(
+          requestLabsLocation(actor, operation, location),
+          [200],
+        );
+
+        expect(response.body.result).toStrictEqual(providerResponse);
+        expect(response.body.creditsCharged).toBe(30);
+        expect(observed).toStrictEqual([
+          [
+            {
+              ...(operation === "keyword-ideas"
+                ? { keywords: ["technical seo"] }
+                : { target: "example.com" }),
+              location_code: code,
+              language_code: "en",
+              limit: 10,
+            },
+          ],
+        ]);
+        await expect(credits(actor)).resolves.toBe(beforeCredits - 30);
+      },
+    );
+
+    it.each(["Austin, Texas, United States", "Texas", "Atlantis", "ZZ", "RU"])(
+      "rejects unsupported location %s before the provider without charging or alerting",
+      async (location) => {
+        const actor = await seedActor();
+        configureProviders();
+        const beforeCredits = await credits(actor);
+        let providerRequests = 0;
+        server.use(
+          http.post(
+            `${DATAFORSEO_BASE_URL}/v3/dataforseo_labs/${endpoint}/live`,
+            () => {
+              providerRequests += 1;
+              return HttpResponse.json(dataForSeoResponse(0.024, []));
+            },
+          ),
+        );
+        context.mocks.axiomLogging.warn.mockClear();
+        context.mocks.axiomLogging.error.mockClear();
+        context.mocks.sentry.captureException.mockClear();
+
+        const response = await accept(
+          requestLabsLocation(actor, operation, location),
+          [400],
+        );
+
+        expect(response.body.error.code).toBe("DATAFORSEO_INVALID_REQUEST");
+        expect(response.body.error.message).toContain(
+          "supported country or region",
+        );
+        expect(response.body.error.message).toContain(
+          '"United States" or "US"',
+        );
+        expect(providerRequests).toBe(0);
+        expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+        expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+        expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+        await expect(credits(actor)).resolves.toBe(beforeCredits);
+      },
+    );
+
+    it("keeps diagnostics when the provider rejects a validated location without retrying or charging", async () => {
+      const actor = await seedActor();
+      configureProviders();
+      const beforeCredits = await credits(actor);
+      const providerResponse = dataForSeoResponse(0, null);
+      let providerRequests = 0;
+      server.use(
+        http.post(
+          `${DATAFORSEO_BASE_URL}/v3/dataforseo_labs/${endpoint}/live`,
+          () => {
+            providerRequests += 1;
+            return HttpResponse.json({
+              ...providerResponse,
+              tasks_error: 1,
+              tasks: providerResponse.tasks.map((task) => {
+                return {
+                  ...task,
+                  status_code: 40_501,
+                  status_message: "Invalid Field: 'location_code'.",
+                  result_count: 0,
+                };
+              }),
+            });
+          },
+        ),
+      );
+      context.mocks.axiomLogging.warn.mockClear();
+
+      const response = await accept(
+        requestLabsLocation(actor, operation, "United States"),
+        [400],
+      );
+
+      expect(response.body.error).toStrictEqual({
+        code: "DATAFORSEO_INVALID_REQUEST",
+        message: "Invalid Field: 'location_code'.",
+      });
+      expect(providerRequests).toBe(1);
+      expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+        "DataForSEO task failed",
+        expect.objectContaining({ operation, taskStatusCode: 40_501 }),
+      );
+      await expect(credits(actor)).resolves.toBe(beforeCredits);
+    });
+  });
+
   it("rejects agent tokens without the seo capability", async () => {
     const actor = await seedActor();
     if (!actor.orgId) {
@@ -728,7 +887,7 @@ describe("SEO routes", () => {
       [
         {
           keywords: ["technical seo"],
-          location_name: "United States",
+          location_code: 2840,
           language_code: "en",
           limit: 100,
         },
@@ -736,7 +895,7 @@ describe("SEO routes", () => {
       [
         {
           target: "example.com",
-          location_name: "United States",
+          location_code: 2840,
           language_code: "en",
           limit: 50,
         },

--- a/turbo/apps/api/src/signals/services/seo.service.ts
+++ b/turbo/apps/api/src/signals/services/seo.service.ts
@@ -9,6 +9,7 @@ import type {
 import { command } from "ccstate";
 import { z } from "zod";
 
+import { dataForSeoLabsLocationCode } from "../../lib/dataforseo-labs-locations";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import type { AuthContext } from "../../types/auth";
@@ -52,7 +53,11 @@ const DATAFORSEO_SERP_PATHS: Readonly<Record<SeoEngine, string>> = {
   google_news: "/v3/serp/google/news/live/advanced",
 };
 
-type DataForSeoRequest = SeoRequest;
+type DataForSeoRequest =
+  | Extract<SeoRequest, { operation: "serp" | "backlinks-summary" }>
+  | (Extract<SeoRequest, { operation: "keyword-ideas" | "ranked-keywords" }> & {
+      readonly locationCode: number;
+    });
 
 interface AuthedSeoArgs {
   readonly auth: AuthContext & { readonly orgId: string };
@@ -389,6 +394,25 @@ async function fetchDataForSeoJson(
   return result.value;
 }
 
+function prepareDataForSeoRequest(
+  request: SeoRequest,
+): DataForSeoRequest | SeoErrorResponse {
+  if (
+    request.operation !== "keyword-ideas" &&
+    request.operation !== "ranked-keywords"
+  ) {
+    return request;
+  }
+
+  const locationCode = dataForSeoLabsLocationCode(request.body.location);
+  if (locationCode === undefined) {
+    return invalidDataForSeoRequest(
+      `DataForSEO ${request.operation} requires a supported country or region, such as "United States" or "US". City and state locations are not supported. See https://docs.dataforseo.com/v3/dataforseo_labs_locations_and_languages/`,
+    );
+  }
+  return { ...request, locationCode };
+}
+
 function dataForSeoPath(request: DataForSeoRequest): string {
   switch (request.operation) {
     case "serp": {
@@ -422,7 +446,7 @@ function dataForSeoTask(request: DataForSeoRequest): Record<string, unknown> {
     case "keyword-ideas": {
       return {
         keywords: [request.body.keyword],
-        location_name: normalizeDataForSeoLocation(request.body.location),
+        location_code: request.locationCode,
         language_code: request.body.languageCode,
         limit: request.body.limit,
       };
@@ -430,7 +454,7 @@ function dataForSeoTask(request: DataForSeoRequest): Record<string, unknown> {
     case "ranked-keywords": {
       return {
         target: request.body.target,
-        location_name: normalizeDataForSeoLocation(request.body.location),
+        location_code: request.locationCode,
         language_code: request.body.languageCode,
         limit: request.body.limit,
       };
@@ -674,6 +698,10 @@ const runDataForSeo$ = command(
 
     const providerSignal = AbortSignal.any([signal, get(requestSignal$)]);
     providerSignal.throwIfAborted();
+    const request = prepareDataForSeoRequest(args.request);
+    if ("status" in request) {
+      return request;
+    }
     const creditError = await set(
       checkManagedCredits$,
       {
@@ -684,7 +712,7 @@ const runDataForSeo$ = command(
           kind: USAGE_KIND,
           provider: DATAFORSEO_PROVIDER,
           category: DATAFORSEO_BILLING_CATEGORY,
-          quantity: dataForSeoPreflightQuantity(args.request),
+          quantity: dataForSeoPreflightQuantity(request),
         },
         label: "Okou SEO DataForSEO",
       },
@@ -699,7 +727,7 @@ const runDataForSeo$ = command(
     const providerResult = await fetchDataForSeo(
       login,
       password,
-      args.request,
+      request,
       providerSignal,
     );
     signal.throwIfAborted();

--- a/turbo/apps/cli/src/commands/seo/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/seo/__tests__/index.test.ts
@@ -261,4 +261,62 @@ describe("okou seo command", () => {
     expect(help).toContain("google_news  desktop only");
     expect(help).toContain("google_maps returns at most 20 results on mobile");
   });
+
+  it.each(["keyword-ideas", "ranked-keywords"])(
+    "explains supported locations in %s help",
+    (operation) => {
+      const command = seoCommand.commands.find((candidate) => {
+        return candidate.name() === operation;
+      });
+      if (!command) {
+        throw new Error(`Okou SEO ${operation} command is missing`);
+      }
+      let help = "";
+      command.configureOutput({
+        writeOut: (value) => {
+          help += value;
+        },
+      });
+
+      command.outputHelp();
+
+      expect(help).toContain("country or region");
+      expect(help).toContain("US/USA");
+      expect(help).toContain("GB/UK");
+      expect(help).toContain("City and state locations are not supported");
+      expect(help).toContain(
+        "https://docs.dataforseo.com/v3/dataforseo_labs_locations_and_languages/",
+      );
+    },
+  );
+
+  it("shows the API location guidance and exits unsuccessfully", async () => {
+    const message =
+      'Use a supported country or region, such as "United States" or "US". City and state locations are not supported.';
+    let apiRequests = 0;
+    server.use(
+      http.post("http://localhost:3000/api/seo/keyword-ideas", () => {
+        apiRequests += 1;
+        return HttpResponse.json(
+          { error: { code: "DATAFORSEO_INVALID_REQUEST", message } },
+          { status: 400 },
+        );
+      }),
+    );
+
+    await expect(
+      seoCommand.parseAsync([
+        "node",
+        "okou",
+        "keyword-ideas",
+        "technical seo",
+        "--location",
+        "Austin, Texas, United States",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(message);
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(apiRequests).toBe(1);
+  });
 });

--- a/turbo/apps/cli/src/commands/seo/index.ts
+++ b/turbo/apps/cli/src/commands/seo/index.ts
@@ -121,9 +121,10 @@ function renderResponse(response: SeoResponse, json?: boolean): void {
 function addAnalysisOptions(command: Command): Command {
   return command
     .addOption(
-      new Option("--location <name>", "Search location").default(
-        SEO_DEFAULT_LOCATION,
-      ),
+      new Option(
+        "--location <name>",
+        "Supported country or region name, or ISO country code",
+      ).default(SEO_DEFAULT_LOCATION),
     )
     .addOption(
       new Option("--language <code>", "Search language code")
@@ -135,7 +136,16 @@ function addAnalysisOptions(command: Command): Command {
         .default(SEO_DEFAULT_ANALYSIS_LIMIT)
         .argParser(parseLimit(SEO_MAX_ANALYSIS_LIMIT)),
     )
-    .option("--json", "Print the raw Okou SEO response as JSON");
+    .option("--json", "Print the raw Okou SEO response as JSON")
+    .addHelpText(
+      "after",
+      `
+Locations:
+  Use a supported country or region name, or its ISO country code.
+  Examples: "United States", US/USA, "United Kingdom", GB/UK.
+  City and state locations are not supported.
+  Supported locations: https://docs.dataforseo.com/v3/dataforseo_labs_locations_and_languages/`,
+    );
 }
 
 const serpCommand = new Command()


### PR DESCRIPTION
DataForSEO Labs requests currently forward arbitrary location strings, allowing cities and unrecognized country aliases to reach the provider and produce `40501` task warnings. Validate `keyword-ideas` and `ranked-keywords` locations before credit admission or provider requests, resolve supported names and ISO codes (including US/USA and GB/UK) to `location_code`, and return an actionable HTTP 400 for unsupported locations.

The resolver uses all 94 Google locations from the [official 2026-09-01 CSV](https://cdn.dataforseo.com/v3/locations/locations_and_languages_dataforseo_labs_2026_09_01.csv), including supported regions, with source and refresh instructions next to the snapshot. Validation adds no runtime network dependency. CLI help documents the accepted inputs and links to the provider's supported locations.

Local validation failures produce no provider requests, credit charges, warn/error logs, or Sentry exceptions. Provider failures after successful local validation retain their existing diagnostics. Existing API request shapes remain compatible, and SERP continues to accept city locations.

Addresses #32754. The production logs omit the original location values, so this fixes the confirmed validation gap without asserting which input caused those two historical events.

## Verification

- API SEO route integration suites: 53 tests passed, covering aliases, whitespace/case normalization, supported regions, invalid locations, billing, diagnostic controls, SERP city requests, and backlinks recovery.
- CLI SEO command suite: 8 tests passed, including location guidance and nonzero exit on an actionable API validation error.
- Before the production change, 22 new location cases failed against main; the two provider-diagnostic control cases passed.
- Independently reconciled all 94 snapshot entries against the official CSV. Provider responses in route tests use MSW and billing verification uses a real local PostgreSQL database.
- API Oxlint/type-aware checks and ESLint, CLI lint, and the repository pre-commit checks passed: type checking, Knip, Prettier, style policy, file size, and commitlint.

## Deployment verification

After the API release, exercise a supported location and an unsupported city, then inspect the following 24 hours of production Axiom logs for Labs location validation failures. Investigate any provider rejection of a catalog-validated location; do not suppress it as an expected caller error. Production verification remains pending deployment.
