### PR TITLE
docs(guest-agent): correct pi configuration handoff documentation

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -471,17 +471,24 @@ pub struct GuestConfig {
     /// from [`guest_contracts::env::RunPayload`]. The value is parsed for
     /// Codex startup configuration and is otherwise retained in its wire form.
     pub codex_runtime_config: String,
-    /// Serialized Pi launch-config version marker from
-    /// [`guest_contracts::env::PI_LAUNCH_CONFIG_ENV`]. Pi parses this value and
-    /// uses it to create the private launch payload consumed by the Pi child.
+    /// Serialized Pi launch configuration from
+    /// [`guest_contracts::env::RunPayload::pi_launch_config`] in the private
+    /// run-payload file named by
+    /// [`guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV`]. The guest-agent
+    /// parses this value and writes it as `launchConfig` in a separate private
+    /// Pi launch-payload file, whose path is passed to the Pi child through
+    /// [`guest_contracts::env::PI_LAUNCH_PAYLOAD_FILE_ENV`].
     pub pi_launch_config: String,
     /// JSON object containing non-secret Pi model metadata from
-    /// [`guest_contracts::env::PI_MODEL_CONFIG_ENV`]. It is included in the
-    /// private Pi launch payload.
+    /// [`guest_contracts::env::RunPayload::pi_model_config`] in the incoming
+    /// run payload. The guest-agent passes it to the Pi child through the
+    /// [`guest_contracts::env::PI_MODEL_CONFIG_ENV`] environment variable.
     pub pi_model_config: String,
     /// Chat Thread identifier from
-    /// [`guest_contracts::env::PI_SESSION_ID_ENV`] used as Pi's native session
-    /// identifier and included in Pi launch and session-history inputs.
+    /// [`guest_contracts::env::RunPayload::pi_session_id`] in the incoming run
+    /// payload. It is passed to the Pi child through the
+    /// [`guest_contracts::env::PI_SESSION_ID_ENV`] environment variable and used
+    /// as Pi's native session identifier and for session-history lookup.
     pub pi_session_id: String,
     /// Stuck-tool timeout in seconds parsed from
     /// [`guest_contracts::env::CANONICAL_STUCK_TOOL_TIMEOUT_SECS_ENV`]. Empty


### PR DESCRIPTION
The public `GuestConfig` Pi field docs describe incoming environment values and incorrectly place model metadata in the Pi launch file. Correct the three field comments to identify their `RunPayload` sources and distinguish the outgoing launch file from the model/session environment variables, with links to the canonical contracts.

This is a documentation-only change to `crates/guest-agent/src/env.rs`; runtime code and schemas are outside its scope.

Closes #32773

Validation passed:

- `git diff --check` and the repository file-size check.
- `cargo fmt --manifest-path crates/guest-agent/Cargo.toml --check`.
- `RUSTDOCFLAGS='-D rustdoc::broken_intra_doc_links' CARGO_BUILD_JOBS=2 cargo doc --locked --manifest-path crates/Cargo.toml --profile local -p guest-agent -p guest-contracts --no-deps`.
- Inspected generated documentation and verified all seven contract links resolve to generated pages and anchors.
