### PR TITLE
fix(runner): classify expected catalog prefetch timeouts

### DIFF
--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -181,6 +181,7 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
     let mut handle = connection
         .host()
         .start_supervised_exec(SupervisedExecRequest {
+            timeout_is_expected: false,
             role: guest_control_proto::ExecProcessRole::Agent,
             timeout: ExecTimeoutPolicy::Duration { timeout_ms: 30_000 },
             command: "",
@@ -325,6 +326,7 @@ async fn process_control_enabled_plain_run_does_not_wait_for_stdin_eof() -> Test
     let handle = connection
         .host()
         .start_supervised_exec(SupervisedExecRequest {
+            timeout_is_expected: false,
             role: guest_control_proto::ExecProcessRole::Agent,
             timeout: ExecTimeoutPolicy::Duration { timeout_ms: 30_000 },
             command: "",

--- a/crates/guest-control-client/src/exec_operation/diagnostics.rs
+++ b/crates/guest-control-client/src/exec_operation/diagnostics.rs
@@ -30,6 +30,7 @@ pub(in crate::exec_operation) enum ExecTerminalLogSeverity {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::exec_operation) enum ExecTerminalLogReason {
     ExpectedCancel,
+    ExpectedTimeout,
     Notable,
     Slow,
 }
@@ -38,6 +39,7 @@ impl ExecTerminalLogReason {
     fn as_str(self) -> &'static str {
         match self {
             ExecTerminalLogReason::ExpectedCancel => "expected_cancel",
+            ExecTerminalLogReason::ExpectedTimeout => "expected_timeout",
             ExecTerminalLogReason::Notable => "notable",
             ExecTerminalLogReason::Slow => "slow",
         }
@@ -53,6 +55,7 @@ pub(in crate::exec_operation) struct ExecTerminalLogDecision {
 #[derive(Clone, Copy)]
 pub(in crate::exec_operation) struct ExecTerminalLogContext {
     pub(in crate::exec_operation) lifecycle: ExecTerminalLogLifecycle,
+    pub(in crate::exec_operation) timeout_is_expected: bool,
     pub(in crate::exec_operation) slow: bool,
     pub(in crate::exec_operation) termination: ExecTermination,
     pub(in crate::exec_operation) stdout_truncated: bool,
@@ -65,6 +68,7 @@ pub(in crate::exec_operation) struct ExecTerminalLogContext {
 #[derive(Clone)]
 pub(in crate::exec_operation) struct ExecOperationDiagnostic {
     pub(in crate::exec_operation) seq: u32,
+    pub(in crate::exec_operation) timeout_is_expected: bool,
     pub(in crate::exec_operation) label_log: String,
     pub(in crate::exec_operation) registered_at: Instant,
     pub(in crate::exec_operation) first_output_at: Option<Instant>,
@@ -99,6 +103,7 @@ impl ExecOperationDiagnostic {
         label: &str,
         role: ExecProcessRole,
         supervised: bool,
+        timeout_is_expected: bool,
     ) -> Self {
         let process_class = match role {
             ExecProcessRole::Workload => "contained_workload",
@@ -120,6 +125,9 @@ impl ExecOperationDiagnostic {
         };
         Self {
             seq,
+            timeout_is_expected: timeout_is_expected
+                && supervised
+                && role == ExecProcessRole::Workload,
             label_log: exec_operation_label_log(label),
             registered_at: Instant::now(),
             first_output_at: None,
@@ -189,6 +197,7 @@ impl ExecOperationDiagnostic {
         let diagnostic_present = !result.diagnostic.is_empty();
         let Some(decision) = exec_terminal_log_decision(ExecTerminalLogContext {
             lifecycle,
+            timeout_is_expected: self.timeout_is_expected,
             slow,
             termination: result.termination,
             stdout_truncated,
@@ -293,6 +302,19 @@ pub(in crate::exec_operation) fn exec_terminal_log_decision(
         return Some(ExecTerminalLogDecision {
             severity: ExecTerminalLogSeverity::Info,
             reason: ExecTerminalLogReason::ExpectedCancel,
+        });
+    }
+
+    if context.timeout_is_expected
+        && matches!(context.termination, ExecTermination::TimedOut)
+        && !context.stdout_truncated
+        && !context.stderr_truncated
+        && !context.stream_overflowed
+        && !context.diagnostic_present
+    {
+        return Some(ExecTerminalLogDecision {
+            severity: ExecTerminalLogSeverity::Info,
+            reason: ExecTerminalLogReason::ExpectedTimeout,
         });
     }
 

--- a/crates/guest-control-client/src/exec_operation/start.rs
+++ b/crates/guest-control-client/src/exec_operation/start.rs
@@ -193,6 +193,7 @@ async fn start_exec_operation_on_shared_with_tracking_and_admission(
             stream_queue_capacity,
             stream_queue_kind: ExecStreamQueueKind::Events,
             lifecycle: ExecOperationLifecycle::OneShot,
+            timeout_is_expected: false,
             role,
             tracking,
         },
@@ -370,6 +371,7 @@ where
             },
             role: request.role,
             tracking: ExecOperationTracking::Tracked,
+            timeout_is_expected: request.timeout_is_expected,
         },
     )?;
     let mut start_cancel_on_drop = ExecOperationCancelOnDropGuard::new_for_route(

--- a/crates/guest-control-client/src/exec_operation/state.rs
+++ b/crates/guest-control-client/src/exec_operation/state.rs
@@ -486,6 +486,7 @@ impl ExecStreamPermit {
 
 pub(in crate::exec_operation) struct ExecOperationRegistrationInput<'a> {
     pub(in crate::exec_operation) label: &'a str,
+    pub(in crate::exec_operation) timeout_is_expected: bool,
     pub(in crate::exec_operation) stdout: ExecOutputPolicy,
     pub(in crate::exec_operation) stderr: ExecOutputPolicy,
     pub(in crate::exec_operation) stream_queue_capacity: Option<usize>,
@@ -644,6 +645,7 @@ pub(in crate::exec_operation) fn register_exec_operation_start(
 ) -> io::Result<ExecOperationRegistration> {
     let ExecOperationRegistrationInput {
         label,
+        timeout_is_expected,
         stdout,
         stderr,
         stream_queue_capacity,
@@ -680,7 +682,13 @@ pub(in crate::exec_operation) fn register_exec_operation_start(
             lifecycle,
             ExecOperationLifecycle::SupervisedAwaitingStart { .. }
         );
-        let diagnostic = ExecOperationDiagnostic::new(route_id.wire_seq(), label, role, supervised);
+        let diagnostic = ExecOperationDiagnostic::new(
+            route_id.wire_seq(),
+            label,
+            role,
+            supervised,
+            timeout_is_expected,
+        );
         let operation = ExecOperation {
             route_id,
             normal_operation,

--- a/crates/guest-control-client/src/exec_operation/tests.rs
+++ b/crates/guest-control-client/src/exec_operation/tests.rs
@@ -49,6 +49,7 @@ fn exec_operation_for_snapshot(seq: u32, label: &str) -> ExecOperation {
             label,
             guest_control_proto::ExecProcessRole::Workload,
             false,
+            false,
         ),
         result_tx,
         stream_tx: None,
@@ -176,6 +177,7 @@ fn capture_terminal_log_events_with_context(
         7,
         "terminal-log",
         guest_control_proto::ExecProcessRole::Workload,
+        false,
         false,
     );
     if slow {
@@ -522,6 +524,7 @@ fn shared_with_logged_operation(
         label,
         guest_control_proto::ExecProcessRole::Workload,
         false,
+        false,
     );
     diagnostic.registered_at =
         Instant::now() - EXEC_OPERATION_STAGE_SLOW_THRESHOLD - Duration::from_millis(1);
@@ -775,6 +778,7 @@ fn clean_terminal_log_context(
 ) -> ExecTerminalLogContext {
     ExecTerminalLogContext {
         lifecycle,
+        timeout_is_expected: false,
         slow,
         termination,
         stdout_truncated: false,
@@ -1124,6 +1128,7 @@ fn exec_operation_diagnostic_keeps_only_truncated_label_log() {
         &label,
         guest_control_proto::ExecProcessRole::Workload,
         false,
+        false,
     );
     diagnostic.registered_at =
         Instant::now() - EXEC_OPERATION_STAGE_SLOW_THRESHOLD - Duration::from_millis(1);
@@ -1153,6 +1158,7 @@ fn exec_operation_diagnostic_derives_agent_class_and_operation_kind() {
         "agent",
         guest_control_proto::ExecProcessRole::Agent,
         true,
+        false,
     );
 
     assert_eq!(diagnostic.process_class, "controlled_agent");
@@ -1169,6 +1175,7 @@ fn exec_operation_diagnostic_derives_agent_class_and_operation_kind() {
 fn exec_operation_diagnostic_marks_only_first_slow_output() {
     let mut diagnostic = ExecOperationDiagnostic {
         seq: 9,
+        timeout_is_expected: false,
         label_log: "slow-first-output".to_string(),
         registered_at: Instant::now()
             - EXEC_OPERATION_STAGE_SLOW_THRESHOLD

--- a/crates/guest-control-client/src/exec_operation/types.rs
+++ b/crates/guest-control-client/src/exec_operation/types.rs
@@ -262,6 +262,12 @@ pub struct SupervisedExecRequest<'a> {
     /// `ExecTimeoutPolicy::None` lets the process run until it exits, is
     /// cancelled, or the connection closes.
     pub timeout: ExecTimeoutPolicy,
+    /// Whether a clean Workload execution timeout should be logged at info.
+    ///
+    /// Host-only diagnostic intent, registered before writing the start frame.
+    /// Does not affect Agent timeouts, deadlines, start/wait errors, result
+    /// semantics, or warnings for diagnostics, truncation, or output overflow.
+    pub timeout_is_expected: bool,
     /// Shell command to run in the guest.
     pub command: &'a str,
     /// Environment variables injected into the guest shell command.

--- a/crates/guest-control-client/src/tests/exec_operation/supervised/logging.rs
+++ b/crates/guest-control-client/src/tests/exec_operation/supervised/logging.rs
@@ -1,0 +1,110 @@
+use std::time::Duration;
+
+use guest_control_proto::{ExecOutputStream, ExecProcessRole, ExecTermination};
+use tracing::Level;
+use tracing_subscriber::prelude::*;
+use tracing_test_support::CapturedEvents;
+
+use super::super::super::support::{
+    send_discarded_exec_result, send_exec_output, send_exec_result,
+};
+use super::support::{
+    start_supervised_exec_fixture, start_supervised_process_fixture, supervised_request,
+    supervised_stream_request,
+};
+use crate::{SupervisedExecControl, SupervisedExecRequest};
+
+#[tokio::test]
+async fn expected_timeout_keeps_output_overflow_warning() {
+    let captured = CapturedEvents::default();
+    let _guard =
+        tracing::subscriber::set_default(tracing_subscriber::registry().with(captured.clone()));
+    let mut started = start_supervised_process_fixture(SupervisedExecRequest {
+        timeout_is_expected: true,
+        timeout: guest_control_proto::ExecTimeoutPolicy::Duration { timeout_ms: 10_000 },
+        ..supervised_stream_request("bounded-stream")
+    })
+    .await;
+    let mut output = started.handle.take_process_output_receiver().unwrap();
+    for (sequence, bytes) in [(0, b"first".as_slice()), (1, b"second".as_slice())] {
+        send_exec_output(
+            &mut started.guest,
+            started.start.seq(),
+            sequence,
+            ExecOutputStream::Stdout,
+            bytes,
+            false,
+        )
+        .await;
+    }
+    send_discarded_exec_result(
+        &mut started.guest,
+        started.start.seq(),
+        ExecTermination::TimedOut,
+    )
+    .await;
+    let result = started.handle.wait(Duration::from_secs(5)).await.unwrap();
+    assert_eq!(result.termination, ExecTermination::TimedOut);
+    assert!(result.stream_overflowed);
+    assert_eq!(output.recv().await.unwrap().bytes, b"first");
+    assert!(output.recv().await.is_none());
+    let events = captured.entries();
+    let terminal = events
+        .iter()
+        .find(|event| {
+            event.fields.get("message").map(String::as_str)
+                == Some("exec operation terminal result")
+        })
+        .unwrap();
+    assert_eq!(terminal.level, Level::WARN);
+    assert_eq!(
+        terminal.fields.get("terminal_reason").map(String::as_str),
+        Some("notable")
+    );
+    assert_eq!(
+        terminal.fields.get("stream_overflowed").map(String::as_str),
+        Some("true")
+    );
+}
+
+#[tokio::test]
+async fn expected_workload_timeout_setting_does_not_demote_agent_timeout() {
+    let captured = CapturedEvents::default();
+    let _guard =
+        tracing::subscriber::set_default(tracing_subscriber::registry().with(captured.clone()));
+    let mut started = start_supervised_exec_fixture(SupervisedExecRequest {
+        role: ExecProcessRole::Agent,
+        timeout_is_expected: true,
+        timeout: guest_control_proto::ExecTimeoutPolicy::Duration { timeout_ms: 10_000 },
+        control: SupervisedExecControl::Enabled { sink: true },
+        ..supervised_request("")
+    })
+    .await;
+    send_exec_result(
+        &mut started.guest,
+        started.start.seq(),
+        ExecTermination::TimedOut,
+        b"",
+        b"",
+    )
+    .await;
+    let result = started.handle.wait(Duration::from_secs(5)).await.unwrap();
+    assert_eq!(result.termination, ExecTermination::TimedOut);
+    let events = captured.entries();
+    let terminal = events
+        .iter()
+        .find(|event| {
+            event.fields.get("message").map(String::as_str)
+                == Some("exec operation terminal result")
+        })
+        .unwrap();
+    assert_eq!(terminal.level, Level::WARN);
+    assert_eq!(
+        terminal.fields.get("terminal_reason").map(String::as_str),
+        Some("notable")
+    );
+    assert_eq!(
+        terminal.fields.get("process_class").map(String::as_str),
+        Some("controlled_agent")
+    );
+}

--- a/crates/guest-control-client/src/tests/exec_operation/supervised/mod.rs
+++ b/crates/guest-control-client/src/tests/exec_operation/supervised/mod.rs
@@ -1,6 +1,7 @@
 mod cancel;
 mod control;
 mod lifecycle;
+mod logging;
 mod output;
 mod support;
 mod timeout;

--- a/crates/guest-control-client/src/tests/exec_operation/supervised/support.rs
+++ b/crates/guest-control-client/src/tests/exec_operation/supervised/support.rs
@@ -23,6 +23,7 @@ use crate::{ExecOperationResult, GuestControlClient};
 
 pub(super) fn supervised_request(command: &str) -> SupervisedExecRequest<'_> {
     SupervisedExecRequest {
+        timeout_is_expected: false,
         role: guest_control_proto::ExecProcessRole::Workload,
         timeout: ExecTimeoutPolicy::None,
         command,

--- a/crates/guest-control-tests/tests/integration/exec.rs
+++ b/crates/guest-control-tests/tests/integration/exec.rs
@@ -138,6 +138,7 @@ async fn test_exec_while_waiting_for_exit() {
     let handle = h
         .host()
         .start_supervised_exec(SupervisedExecRequest {
+            timeout_is_expected: false,
             role: guest_control_proto::ExecProcessRole::Workload,
             timeout: ExecTimeoutPolicy::None,
             command: "exec sleep 60",

--- a/crates/guest-control-tests/tests/integration/write_file.rs
+++ b/crates/guest-control-tests/tests/integration/write_file.rs
@@ -144,6 +144,7 @@ async fn blocked_write_allows_exec_cancel_and_quiesce() {
     let handle = h
         .host()
         .start_supervised_exec(SupervisedExecRequest {
+            timeout_is_expected: false,
             role: guest_control_proto::ExecProcessRole::Workload,
             timeout: ExecTimeoutPolicy::None,
             command: "exec sleep 60",

--- a/crates/runner/src/executor/codex_model_catalog_prefetch.rs
+++ b/crates/runner/src/executor/codex_model_catalog_prefetch.rs
@@ -109,6 +109,7 @@ impl StartedCodexModelCatalogPrefetch {
         let request = StartProcessRequest {
             cmd: PREFETCH_COMMAND,
             timeout: PREFETCH_GUEST_TIMEOUT,
+            timeout_is_expected: true,
             start_timeout: PREFETCH_HOST_START_TIMEOUT,
             env: &[],
             sudo: false,

--- a/crates/runner/src/executor/tests/agent_run_tests/codex_model_catalog_prefetch.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/codex_model_catalog_prefetch.rs
@@ -803,6 +803,65 @@ async fn codex_catalog_prefetch_is_cancelled_on_pre_spawn_exit() {
 }
 
 #[tokio::test]
+async fn codex_catalog_prefetch_guest_timeout_preserves_successful_agent_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_wait_process_exit(process_exit(ExecTermination::TimedOut, Some(10_075)));
+    let start_gate = MockLifecycleGate::new();
+    start_gate.release_one();
+    overrides.set_start_process_lifecycle_gate(start_gate.clone());
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let context = codex_oauth_context();
+    let mut telemetry = test_telemetry(&config, &context);
+
+    let (result, ()) = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, async {
+        tokio::join!(
+            run_in_sandbox(
+                &*sandbox,
+                &context,
+                &config,
+                RunStart {
+                    restore_guest_state: false,
+                    reuse_result: SandboxReuseResult::PoolMiss,
+                    workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+                    prev_storage: None,
+                },
+                &mut telemetry,
+                RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+            ),
+            async {
+                start_gate
+                    .wait_entered(2, RUN_IN_SANDBOX_TEST_TIMEOUT)
+                    .await
+                    .unwrap();
+                // The Agent cannot consume the queued result while its start is
+                // held. Let the prefetch's ready terminal wait complete first.
+                while overrides.wait_process_calls().is_empty() {
+                    tokio::task::yield_now().await;
+                }
+                start_gate.release_one();
+            },
+        )
+    })
+    .await
+    .expect("prefetch timeout must not block the main run");
+
+    assert!(result.unwrap().failure.is_none());
+    assert_prefetch_outcome(
+        &telemetry,
+        false,
+        Some("process_timed_out"),
+        "guest timeout",
+    );
+    let prefetch = overrides.start_process_calls();
+    assert_eq!(prefetch.len(), 1);
+    assert!(prefetch[0].timeout_is_expected);
+    assert_eq!(overrides.start_agent_process_calls().len(), 1);
+    assert!(overrides.process_cancel_calls().is_empty());
+}
+
+#[tokio::test]
 async fn fresh_codex_oauth_run_prefetches_catalog_while_agent_prepares() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/sandbox-firecracker/src/sandbox.rs
+++ b/crates/sandbox-firecracker/src/sandbox.rs
@@ -651,6 +651,7 @@ impl SandboxNetwork {
 struct ProcessStartContractRequest<'a> {
     command: &'a str,
     timeout_ms: u32,
+    timeout_is_expected: bool,
     start_timeout: Duration,
     env: &'a [(&'a str, &'a str)],
     sudo: bool,
@@ -2054,6 +2055,7 @@ impl FirecrackerSandbox {
                 .start_supervised_process(SupervisedExecRequest {
                     role,
                     timeout: process_timeout_policy(request.timeout_ms),
+                    timeout_is_expected: request.timeout_is_expected,
                     command: request.command,
                     env: request.env,
                     sudo: request.sudo,
@@ -2900,6 +2902,7 @@ impl Sandbox for FirecrackerSandbox {
                     command: request.cmd,
                     timeout_ms: request.timeout_ms(),
                     start_timeout: request.start_timeout,
+                    timeout_is_expected: request.timeout_is_expected,
                     env: request.env,
                     sudo: request.sudo,
                     output: request.output,
@@ -2923,6 +2926,7 @@ impl Sandbox for FirecrackerSandbox {
                     command: "",
                     timeout_ms: request.timeout_ms(),
                     start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
+                    timeout_is_expected: false,
                     env: request.env,
                     sudo: false,
                     output: request.output,

--- a/crates/sandbox-firecracker/src/sandbox/tests.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests.rs
@@ -18,6 +18,7 @@ use tracing_test_support::{CapturedEvent, CapturedEvents};
 mod guest_connection_timing;
 mod guest_rpc;
 mod private_write_diagnostics;
+mod process_timeout_logging;
 mod process_write;
 
 struct TestNormalOperationFence;
@@ -333,6 +334,7 @@ async fn setup_exec_process_control_fixture() -> ExecProcessControlFixture {
     let start_task = tokio::spawn(async move {
         start_host
             .start_supervised_exec(SupervisedExecRequest {
+                timeout_is_expected: false,
                 role: guest_control_proto::ExecProcessRole::Agent,
                 timeout: ExecTimeoutPolicy::Duration { timeout_ms: 60_000 },
                 command: "sleep 60",
@@ -2332,6 +2334,7 @@ async fn start_process_output_rejects_invalid_stream_configuration() {
     ] {
         let error = match sandbox
             .start_process(&StartProcessRequest {
+                timeout_is_expected: false,
                 cmd: "agent",
                 start_timeout: sandbox::DEFAULT_PROCESS_START_TIMEOUT,
                 timeout: Duration::from_secs(5),
@@ -2370,6 +2373,7 @@ async fn start_process_output_accepts_maximum_queue_capacity() {
         stderr_capture_limit_bytes: None,
     };
     let request = StartProcessRequest {
+        timeout_is_expected: false,
         cmd: "agent",
         start_timeout: sandbox::DEFAULT_PROCESS_START_TIMEOUT,
         timeout: Duration::from_secs(5),
@@ -2423,6 +2427,7 @@ async fn start_process_timeout_before_write_preserves_guest_connection() {
     let sandbox = test_sandbox_with_state(SandboxState::Running);
     let mut guest = attach_mock_shutdown_guest(&sandbox).await;
     let timed_out_request = StartProcessRequest {
+        timeout_is_expected: true,
         cmd: "prefetch",
         timeout: Duration::from_secs(5),
         start_timeout: Duration::ZERO,
@@ -2502,6 +2507,7 @@ async fn start_process_timeout_after_write_rejects_later_guest_operation() {
     let mut guest = attach_mock_shutdown_guest(&sandbox).await;
     let start_timeout = Duration::from_millis(20);
     let request = StartProcessRequest {
+        timeout_is_expected: true,
         cmd: "prefetch",
         timeout: Duration::from_secs(5),
         start_timeout,

--- a/crates/sandbox-firecracker/src/sandbox/tests/process_timeout_logging.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests/process_timeout_logging.rs
@@ -1,0 +1,225 @@
+use super::*;
+use guest_control_proto::{ExecCapturedOutput, ExecTermination as WireTermination};
+
+#[derive(Clone, Copy)]
+struct TerminalCase {
+    expected: bool,
+    termination: WireTermination,
+    diagnostic: &'static str,
+    stdout_truncated: bool,
+    stderr_truncated: bool,
+}
+
+#[tokio::test]
+async fn expected_process_timeout_preserves_result_and_connection_without_warning() {
+    let clean = TerminalCase {
+        expected: true,
+        termination: WireTermination::TimedOut,
+        diagnostic: "",
+        stdout_truncated: false,
+        stderr_truncated: false,
+    };
+    for (case, level) in [
+        (clean, Level::INFO),
+        (
+            TerminalCase {
+                expected: false,
+                ..clean
+            },
+            Level::WARN,
+        ),
+        (
+            TerminalCase {
+                diagnostic: "cleanup failed",
+                ..clean
+            },
+            Level::WARN,
+        ),
+        (
+            TerminalCase {
+                stdout_truncated: true,
+                ..clean
+            },
+            Level::WARN,
+        ),
+        (
+            TerminalCase {
+                stderr_truncated: true,
+                ..clean
+            },
+            Level::WARN,
+        ),
+        (
+            TerminalCase {
+                termination: WireTermination::StartFailed,
+                ..clean
+            },
+            Level::WARN,
+        ),
+        (
+            TerminalCase {
+                termination: WireTermination::WaitFailed,
+                ..clean
+            },
+            Level::WARN,
+        ),
+        (
+            TerminalCase {
+                termination: WireTermination::Cancelled,
+                ..clean
+            },
+            Level::WARN,
+        ),
+    ] {
+        let sandbox = test_sandbox_with_state(SandboxState::Running);
+        let mut guest = attach_mock_shutdown_guest(&sandbox).await;
+        let request = StartProcessRequest {
+            cmd: "bounded-optional-work",
+            timeout: Duration::from_secs(10),
+            timeout_is_expected: case.expected,
+            start_timeout: Duration::from_secs(5),
+            env: &[],
+            sudo: false,
+            output: ProcessOutputMode::buffered(sandbox::EXEC_OUTPUT_LIMIT_1_MIB),
+        };
+        let ((exit, ()), events) = tokio::time::timeout(
+            Duration::from_secs(5),
+            capture_async_log_events(async {
+                tokio::join!(
+                    async {
+                        let handle = sandbox.start_process(&request).await.unwrap();
+                        sandbox
+                            .wait_process(handle, Duration::from_secs(5))
+                            .await
+                            .unwrap()
+                    },
+                    async {
+                        let start = read_vsock_message(&mut guest).await;
+                        assert_eq!(start.msg_type, guest_control_proto::MSG_EXEC_START);
+                        let decoded =
+                            guest_control_proto::decode_exec_start(&start.payload).unwrap();
+                        assert_eq!(decoded.role, ExecProcessRole::Workload);
+                        assert_eq!(
+                            decoded.timeout,
+                            ExecTimeoutPolicy::Duration { timeout_ms: 10_000 }
+                        );
+                        let mut frames = guest_control_proto::encode(
+                            guest_control_proto::MSG_EXEC_STARTED,
+                            start.seq,
+                            &guest_control_proto::encode_exec_started(73).unwrap(),
+                        )
+                        .unwrap();
+                        frames.extend(
+                            guest_control_proto::encode(
+                                guest_control_proto::MSG_EXEC_RESULT,
+                                start.seq,
+                                &guest_control_proto::encode_exec_result(
+                                    case.termination,
+                                    10_075,
+                                    ExecCapturedOutput::Captured {
+                                        bytes: b"out",
+                                        truncated: case.stdout_truncated,
+                                    },
+                                    ExecCapturedOutput::Captured {
+                                        bytes: b"err",
+                                        truncated: case.stderr_truncated,
+                                    },
+                                    case.diagnostic,
+                                )
+                                .unwrap(),
+                            )
+                            .unwrap(),
+                        );
+                        // Deliver both frames together: logging intent must exist
+                        // before the start future can return its handle.
+                        guest.write_all(&frames).await.unwrap();
+                    },
+                )
+            }),
+        )
+        .await
+        .expect("terminal process response must complete");
+        assert_eq!(
+            exit.termination,
+            exec_termination_from_vsock_termination(case.termination)
+        );
+        assert_eq!(exit.guest_duration_ms, Some(10_075));
+        assert_eq!(exit.stdout, b"out");
+        assert_eq!(exit.stderr, b"err");
+        assert_eq!(exit.diagnostic, case.diagnostic);
+        assert_eq!(exit.stdout_truncated, case.stdout_truncated);
+        assert_eq!(exit.stderr_truncated, case.stderr_truncated);
+        let event = captured_event(&events, "exec operation terminal result");
+        assert_eq!(event.level, level);
+        assert_event_field(
+            event,
+            "terminal_reason",
+            if level == Level::INFO {
+                "expected_timeout"
+            } else {
+                "notable"
+            },
+        );
+        assert_event_field(event, "guest_duration_ms", "10075");
+        assert_eq!(
+            captured_message_count(&events, "exec operation terminal result"),
+            1
+        );
+        if level == Level::INFO {
+            assert!(
+                events
+                    .iter()
+                    .all(|event| event.level != Level::WARN && event.level != Level::ERROR)
+            );
+        }
+
+        // A real terminal result releases normal-operation ownership, even when
+        // the bounded workload failed. Verify the next public guest operation.
+        let next_request = ExecRequest {
+            cmd: "true",
+            timeout: Duration::from_secs(5),
+            env: &[],
+            sudo: false,
+            expected_exit_codes: &[],
+            stdin_bytes: None,
+            output_limits: sandbox::EXEC_OUTPUT_LIMIT_1_MIB,
+        };
+        let (result, ()) = tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::join!(sandbox.exec(&next_request), async {
+                let next = read_vsock_message(&mut guest).await;
+                assert_eq!(next.msg_type, guest_control_proto::MSG_EXEC_START);
+                let payload = guest_control_proto::encode_exec_result(
+                    WireTermination::Exited { exit_code: 0 },
+                    1,
+                    ExecCapturedOutput::Captured {
+                        bytes: b"",
+                        truncated: false,
+                    },
+                    ExecCapturedOutput::Captured {
+                        bytes: b"",
+                        truncated: false,
+                    },
+                    "",
+                )
+                .unwrap();
+                guest
+                    .write_all(
+                        &guest_control_proto::encode(
+                            guest_control_proto::MSG_EXEC_RESULT,
+                            next.seq,
+                            &payload,
+                        )
+                        .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+            },)
+        })
+        .await
+        .expect("connection must remain usable after terminal result");
+        assert_eq!(
+            result.unwrap().termination,
+            ExecTermination::Exited { exit_code: 0 }
+        );
+    }
+}

--- a/crates/sandbox-firecracker/src/sandbox/tests/process_write.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests/process_write.rs
@@ -10,6 +10,7 @@ async fn start_process_partial_write_error_rejects_later_guest_work() {
         // the complete frame remains unwritten.
         let payload = "x".repeat(4 * 1024 * 1024);
         let request = StartProcessRequest {
+            timeout_is_expected: true,
             cmd: "prefetch",
             timeout: Duration::from_secs(5),
             start_timeout: Duration::from_secs(5),

--- a/crates/sandbox-mock/src/call_records.rs
+++ b/crates/sandbox-mock/src/call_records.rs
@@ -137,6 +137,8 @@ pub struct GuestStateRestoreCall {
 /// construction.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StartProcessCall {
+    /// Whether the caller classifies clean guest timeouts as expected.
+    pub timeout_is_expected: bool,
     /// Command string passed to `StartProcessRequest.cmd`.
     pub cmd: String,
     /// Timeout passed to `StartProcessRequest.timeout`.

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -1344,6 +1344,7 @@ impl Sandbox for MockSandbox {
                 .start_process_calls
                 .lock_ignoring_poison()
                 .push(StartProcessCall {
+                    timeout_is_expected: request.timeout_is_expected,
                     cmd: request.cmd.to_string(),
                     timeout: request.timeout,
                     start_timeout: request.start_timeout,
@@ -1386,6 +1387,7 @@ impl Sandbox for MockSandbox {
                 });
         }
         let process_request = StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "",
             timeout: request.timeout,
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,

--- a/crates/sandbox-mock/src/tests/process.rs
+++ b/crates/sandbox-mock/src/tests/process.rs
@@ -9,6 +9,7 @@ async fn overrides_record_start_process_output_modes_in_order() {
     let sandbox = factory.create(test_sandbox_config()).await.unwrap();
     let buffered = sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -22,6 +23,7 @@ async fn overrides_record_start_process_output_modes_in_order() {
 
     let streamed = sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -37,6 +39,7 @@ async fn overrides_record_start_process_output_modes_in_order() {
         overrides.start_process_calls(),
         vec![
             StartProcessCall {
+                timeout_is_expected: false,
                 cmd: "agent".to_string(),
                 timeout: Duration::from_secs(5),
                 start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
@@ -45,6 +48,7 @@ async fn overrides_record_start_process_output_modes_in_order() {
                 output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
             },
             StartProcessCall {
+                timeout_is_expected: false,
                 cmd: "agent".to_string(),
                 timeout: Duration::from_secs(5),
                 start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
@@ -66,6 +70,7 @@ async fn start_process_emits_queued_stdout_chunks() {
     let sandbox = MockSandbox::with_overrides("test", overrides);
     let mut handle = sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -100,6 +105,7 @@ async fn process_stream_capacity_overflow_retains_one_chunk_and_marks_exit() {
     let sandbox = MockSandbox::with_overrides("test", overrides);
     let mut handle = sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -134,6 +140,7 @@ async fn start_agent_process_returns_mandatory_control_handle() {
 
     let without_control = sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -378,6 +385,7 @@ async fn start_process_validates_stream_configuration() {
     ] {
         let error = match sandbox
             .start_process(&StartProcessRequest {
+                timeout_is_expected: false,
                 cmd: "agent",
                 start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
                 timeout: Duration::from_secs(5),
@@ -407,6 +415,7 @@ async fn start_process_validates_stream_configuration() {
     };
     let handle = sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -429,6 +438,7 @@ async fn start_process_rejects_invalid_env_key() {
     let sandbox = MockSandbox::with_overrides("test-1", Arc::clone(&overrides));
     let result = sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -466,6 +476,7 @@ async fn queued_start_process_errors_are_consumed_fifo() {
     });
     let sandbox = MockSandbox::with_overrides("test", Arc::clone(&overrides));
     let request = StartProcessRequest {
+        timeout_is_expected: false,
         cmd: "agent",
         start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
         timeout: Duration::from_secs(5),
@@ -513,6 +524,7 @@ async fn start_process_lifecycle_gate_blocks_before_recording_or_cancellation() 
         tokio::spawn(async move {
             sandbox
                 .start_process(&StartProcessRequest {
+                    timeout_is_expected: false,
                     cmd: "blocked-agent",
                     start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
                     timeout: Duration::from_secs(5),
@@ -539,6 +551,7 @@ async fn start_process_lifecycle_gate_blocks_before_recording_or_cancellation() 
     drop(
         sandbox
             .start_process(&StartProcessRequest {
+                timeout_is_expected: false,
                 cmd: "next-agent",
                 start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
                 timeout: Duration::from_secs(5),
@@ -564,6 +577,7 @@ async fn process_result_cancellations_are_success_only_and_fifo() {
 
     let invalid_start = sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "invalid-agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -578,6 +592,7 @@ async fn process_result_cancellations_are_success_only_and_fifo() {
 
     let first_handle = sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "first-agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -592,6 +607,7 @@ async fn process_result_cancellations_are_success_only_and_fifo() {
 
     let second_handle = sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "second-agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -605,6 +621,7 @@ async fn process_result_cancellations_are_success_only_and_fifo() {
 
     let mut invalid_wait_handle = sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "invalid-wait-agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -653,6 +670,7 @@ async fn wait_process_rejects_consumed_guest_process_handle() {
     let sandbox = factory.create(test_sandbox_config()).await.unwrap();
     let mut handle = sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -689,6 +707,7 @@ async fn wait_process_returns_queued_process_exit() {
     overrides.push_wait_process_exit(exit);
     let handle = sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -716,6 +735,7 @@ async fn wait_process_default_exit_is_unchanged_without_queued_exit() {
     let sandbox = MockSandbox::with_overrides("test", overrides);
     let handle = sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -773,6 +793,7 @@ async fn wait_process_lifecycle_gate_blocks_until_released() {
     let sandbox = MockSandbox::with_overrides("test", overrides);
     let handle = sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -805,6 +826,7 @@ async fn wait_process_lifecycle_gate_clear_only_affects_future_waits() {
     let first_sandbox = MockSandbox::with_overrides("first", Arc::clone(&overrides));
     let first_handle = first_sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -831,6 +853,7 @@ async fn wait_process_lifecycle_gate_clear_only_affects_future_waits() {
     let second_sandbox = MockSandbox::with_overrides("second", overrides);
     let second_handle = second_sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
@@ -868,6 +891,7 @@ async fn process_cancel_releases_wait_process_lifecycle_gate() {
     let sandbox = MockSandbox::with_overrides("test", Arc::clone(&overrides));
     let mut handle = sandbox
         .start_process(&StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "agent",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -219,6 +219,12 @@ pub struct StartProcessRequest<'a> {
     pub cmd: &'a str,
     /// Guest-side process timeout.
     pub timeout: Duration,
+    /// Whether a clean guest execution timeout is an expected best-effort outcome.
+    ///
+    /// Only changes host terminal logging to info. The timeout result, deadlines,
+    /// start/wait errors, and warnings for additional diagnostics or output loss
+    /// are unchanged.
+    pub timeout_is_expected: bool,
     /// Host deadline for writing the start request and receiving the guest
     /// process-start acknowledgement.
     pub start_timeout: Duration,
@@ -1253,6 +1259,7 @@ mod tests {
     #[test]
     fn start_process_timeout_ms_rounds_nonzero_submillisecond_up() {
         let req = StartProcessRequest {
+            timeout_is_expected: false,
             cmd: "true",
             start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_nanos(1),

--- a/docs/codex-prefetch-timeout-logging.md
+++ b/docs/codex-prefetch-timeout-logging.md
@@ -1,0 +1,41 @@
+# Codex catalog prefetch timeout diagnostics
+
+The Codex OAuth model-catalog prefetch is optional, supervised work. Its
+10-second guest execution deadline is separate from the one-second process
+start deadline and the bounded host terminal wait.
+
+The prefetch marks its host-side process request with `timeout_is_expected`.
+The guest-control client registers that intent before writing the start frame.
+A guest `TimedOut` terminal result without diagnostic text, stdout/stderr
+truncation, or stream overflow is logged at **info** with
+`terminal_reason=expected_timeout`. The result is still `TimedOut`, and
+`runner_codex_model_catalog_prefetch` still records an unsuccessful
+`process_timed_out` outcome and the guest duration. The main Agent result is
+independent.
+
+This is a host terminal-log classification, not a timeout extension or an error
+filter. Ordinary workloads and Agents retain timeout warnings. Diagnostic text,
+output loss, unexpected cancellation, start/wait failures, and transport errors
+retain their existing classification. In particular, a start timeout after a
+possible frame write still makes the sandbox unusable; its retirement and
+replacement rules are unchanged.
+
+Runner's existing Axiom layer ingests WARN+ tracing events, so the expected info
+event stays in local Runner logs, not the central warning feed. The Runner's
+Sentry integration reports panics, not these terminal tracing events. Guest
+control-server stderr forensic tags are separate and unchanged. No guest wire,
+API, persisted state, or independently deployed protocol is modified.
+
+## Rollout verification
+
+Keep [#32753](https://github.com/vm0-ai/vm0/issues/32753) open after the code PR.
+The original sanitized event has no run ID; it does not prove the historical
+main run succeeded.
+
+After the containing Runner artifact is promoted, record its version and observe
+a 24-hour window, separating draining older versions. Correlate prefetch
+`process_timed_out` telemetry with main-run completion where identifiers are
+available. Check that clean expected prefetch timeouts do not generate host
+warn/error events, while actual process/connection failures remain actionable.
+Absence of warnings without any exercised timeout is not recovery evidence;
+record that limitation or supplement with a controlled validation.


### PR DESCRIPTION
## Summary

Relates to #32753.

The optional Codex model-catalog prefetch can reach its guest execution deadline without failing the main Agent run. Its terminal result currently creates a low-level warning indistinguishable from an unexpected workload timeout.

- Add explicit host-only `timeout_is_expected` intent to supervised workload requests, registering it before the start frame is written. Only the Codex catalog prefetch opts in in production.
- Log a clean opted-in `TimedOut` terminal result at INFO with `terminal_reason=expected_timeout`. Preserve the timeout result, guest duration, unsuccessful `process_timed_out` prefetch telemetry, and independent main-run outcome.
- Retain WARN for ordinary workloads, Agents, diagnostics, stdout/stderr truncation, output overflow, start/wait failures, and unexpected cancellation. Start deadlines, transport errors, cancellation, and unusable-connection handling are unchanged.

## Scope and rollout

No guest wire, API, schema, persisted-state, timeout-budget, or independently deployed protocol change. Guest control-server stderr forensic tags are separate from the reported host tracing/Axiom warning and remain unchanged. Runner's existing WARN+ Axiom filter is not changed; the expected INFO event remains in local logs.

Keep #32753 open: the original sanitized event lacks a run ID and does not prove historical recovery. Historical correlation (or an explicit evidence limitation) and the issue's 24-hour post-promotion observation gate remain outstanding. This PR does not deploy or claim production recovery.

## Testing

- Real Unix-socket tests through public Sandbox start/wait cover eight terminal cases, packed start/result delivery, unchanged results, exact logging severity/reason, and a successful subsequent operation on the same connection.
- Public guest-control-client tests preserve warnings for stream overflow and controlled Agent timeouts. Existing pre-write timeout, post-write timeout, and partial-write tests now also exercise opted-in requests.
- A `run_in_sandbox` regression verifies a timed-out optional prefetch retains failed telemetry while the main Agent succeeds without cancellation.

Passed from `crates/`:

```sh
cargo fmt --all -- --check
cargo clippy --profile local -p guest-control-client -p sandbox -p sandbox-firecracker -p sandbox-mock -p guest-control-tests -p guest-agent -p runner --all-targets --all-features -- -D warnings
RUSTDOCFLAGS='-D warnings' cargo doc --profile local -p guest-control-client -p sandbox -p sandbox-firecracker -p sandbox-mock -p guest-control-tests -p guest-agent -p runner --all-features --no-deps
cargo test --profile local -p guest-control-client -p sandbox -p sandbox-firecracker -p sandbox-mock -p guest-control-tests -p guest-agent -p runner --all-targets --all-features -- --test-threads=4 --quiet
```

Runner: 3,592 passed; sandbox-firecracker: 871 passed; all other selected targets passed. Existing ignored privileged/environment-specific tests remain unchanged; no new skip or timeout relaxation.

Also passed: `cd turbo && pnpm exec prettier --check ../docs/codex-prefetch-timeout-logging.md` and `git diff --check`.
