### PR TITLE
test(python): centralize successful firewall auth fixtures

### DIFF
--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -45,6 +45,7 @@ import upstream_admission
 import upstream_destination_binding
 import usage
 from tests.auth_state_helpers import clear_auth_state
+from tests.firewall_auth_helpers import firewall_auth_response
 from tests.process_log_helpers import capture_addon_process_events
 from tests.usage_helpers import UsageWebhookServer, fresh_usage_executor_context
 from usage.providers import connectors as _usage_connectors
@@ -440,14 +441,9 @@ def fake_firewall_headers():
         headers: dict[str, str] | None = None,
     ) -> Iterator[AsyncMock]:
         mock = AsyncMock(
-            return_value={
-                "headers": headers if headers is not None else {"Authorization": "Bearer x"},
-                "resolved_secrets": [],
-                "refreshed_connectors": [],
-                "refreshed_secrets": [],
-                "cache_hit": False,
-                "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-            }
+            return_value=firewall_auth_response(
+                headers=headers if headers is not None else {"Authorization": "Bearer x"},
+            )
         )
         with patch.object(auth, "get_firewall_headers", mock):
             yield mock

--- a/crates/runner/mitm-addon/tests/firewall_auth_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_auth_helpers.py
@@ -70,6 +70,46 @@ def firewall_auth_success(
     )
 
 
+def firewall_auth_response(
+    *,
+    headers: Mapping[str, str] | None = None,
+    resolved_secrets: list[str] | None = None,
+    refreshed_connectors: list[str] | None = None,
+    refreshed_secrets: list[str] | None = None,
+    cache_hit: bool = False,
+    cache_entry_identity: auth.FirewallAuthCacheEntryIdentity | None = None,
+    base: str | None = None,
+    query: Mapping[str, str] | None = None,
+    aws_sigv4: AwsSigV4Credentials | None = None,
+) -> dict:
+    """Build a successful cache-to-handler response for ``get_firewall_headers``.
+
+    Unlike ``firewall_auth_success``, this includes the cache-owned identity.
+    Each call owns fresh containers and a fresh identity unless a caller passes
+    the identity of the same cached entry. Malformed-response tests should
+    explicitly corrupt the result instead of making this builder accept errors.
+    """
+    response: dict = {
+        "headers": dict(headers or {}),
+        "resolved_secrets": list(resolved_secrets or []),
+        "refreshed_connectors": list(refreshed_connectors or []),
+        "refreshed_secrets": list(refreshed_secrets or []),
+        "cache_hit": cache_hit,
+        "cache_entry_identity": (
+            cache_entry_identity
+            if cache_entry_identity is not None
+            else auth.FirewallAuthCacheEntryIdentity()
+        ),
+    }
+    if base is not None:
+        response["base"] = base
+    if query is not None:
+        response["query"] = dict(query)
+    if aws_sigv4 is not None:
+        response["aws_sigv4"] = aws_sigv4
+    return response
+
+
 def _allow_current_firewall_authorization() -> bool:
     return True
 

--- a/crates/runner/mitm-addon/tests/firewall_rewrite_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_rewrite_helpers.py
@@ -2,9 +2,8 @@
 
 from urllib.parse import urlparse
 
-import auth
 import flow_metadata_keys as metadata_keys
-from tests.firewall_auth_helpers import make_allow
+from tests.firewall_auth_helpers import firewall_auth_response, make_allow
 
 
 def _make_rewrite_inputs(
@@ -74,15 +73,11 @@ def _make_rewrite_inputs(
     if match_overrides:
         allow_kwargs.update(match_overrides)
     allow = make_allow(api_entry, **allow_kwargs)
-    token_meta = {
-        "headers": {},
-        "base": resolved_base,
-        "resolved_secrets": ["WEBHOOK"],
-        "refreshed_connectors": [],
-        "refreshed_secrets": [],
-        "cache_hit": False,
-        "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-    }
+    token_meta = firewall_auth_response(
+        headers={},
+        base=resolved_base,
+        resolved_secrets=["WEBHOOK"],
+    )
     if token_overrides:
         token_meta.update(token_overrides)
     return flow, allow, sandbox_info, token_meta

--- a/crates/runner/mitm-addon/tests/test_auth_header_injection.py
+++ b/crates/runner/mitm-addon/tests/test_auth_header_injection.py
@@ -9,6 +9,7 @@ import auth
 import flow_metadata_keys as metadata_keys
 from tests.firewall_auth_helpers import (
     apply_requestheaders_auth_without_upstream_admission,
+    firewall_auth_response,
     handle_firewall_request_without_upstream_admission,
     make_allow,
 )
@@ -84,14 +85,10 @@ async def test_bulk_headers_preserve_semantics_without_per_header_rebuilds(
         "encryptedSecrets": "iv:tag:data",
         "billableFirewalls": [],
     }
-    token_meta = {
-        "headers": resolved_headers,
-        "resolved_secrets": ["VALUE"],
-        "refreshed_connectors": [],
-        "refreshed_secrets": [],
-        "cache_hit": False,
-        "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-    }
+    token_meta = firewall_auth_response(
+        headers=resolved_headers,
+        resolved_secrets=["VALUE"],
+    )
     header_set_all_calls = 0
     original_set_all = http.Headers.set_all
 

--- a/crates/runner/mitm-addon/tests/test_auth_query_injection.py
+++ b/crates/runner/mitm-addon/tests/test_auth_query_injection.py
@@ -10,6 +10,7 @@ import auth
 import flow_metadata_keys as metadata_keys
 from tests.firewall_auth_helpers import (
     apply_requestheaders_auth_without_upstream_admission,
+    firewall_auth_response,
     handle_firewall_request_without_upstream_admission,
     make_allow,
 )
@@ -53,15 +54,11 @@ def make_query_inputs(
     if match_overrides:
         allow_kwargs.update(match_overrides)
     allow = make_allow(api_entry, **allow_kwargs)
-    token_meta = {
-        "headers": {},
-        "resolved_secrets": ["SERPAPI_TOKEN"],
-        "refreshed_connectors": [],
-        "refreshed_secrets": [],
-        "cache_hit": False,
-        "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-        "query": {"api_key": "resolved-key-123"},
-    }
+    token_meta = firewall_auth_response(
+        headers={},
+        resolved_secrets=["SERPAPI_TOKEN"],
+        query={"api_key": "resolved-key-123"},
+    )
     if token_overrides:
         token_meta.update(token_overrides)
     return flow, allow, sandbox_info, token_meta
@@ -396,12 +393,10 @@ class TestAuthQueryInjection:
         allow = make_allow(
             api_entry, name="gh", permission="read", rule="GET /repos/{owner}/{repo}"
         )
-        token_meta = {
-            "headers": {"Authorization": "Bearer real"},
-            "resolved_secrets": ["TOKEN"],
-            "cache_hit": False,
-            "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-        }
+        token_meta = firewall_auth_response(
+            headers={"Authorization": "Bearer real"},
+            resolved_secrets=["TOKEN"],
+        )
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
@@ -30,6 +30,7 @@ from tests.aws_sigv4_helpers import (
     resolved_aws_sigv4_credentials,
 )
 from tests.firewall_auth_helpers import (
+    firewall_auth_response,
     firewall_auth_success,
     handle_firewall_request_without_upstream_admission,
 )
@@ -150,24 +151,6 @@ def _sandbox_info(
     return sandbox_info
 
 
-def _token_meta(
-    *,
-    headers: dict[str, str] | None = None,
-    resolved_secrets: list[str] | None = None,
-    refreshed_connectors: list[str] | None = None,
-    refreshed_secrets: list[str] | None = None,
-    cache_hit: bool = False,
-) -> dict:
-    return {
-        "headers": dict(headers or {}),
-        "resolved_secrets": list(resolved_secrets or []),
-        "refreshed_connectors": list(refreshed_connectors or []),
-        "refreshed_secrets": list(refreshed_secrets or []),
-        "cache_hit": cache_hit,
-        "cache_entry_identity": auth_cache.FirewallAuthCacheEntryIdentity(),
-    }
-
-
 class TestHandleFirewallRequest:
     async def test_success_injects_headers_and_audit_metadata(
         self, real_flow, headers, mitm_ctx, tmp_path
@@ -181,7 +164,7 @@ class TestHandleFirewallRequest:
         )
         sandbox_info = _sandbox_info(tmp_path)
         allow = _allow(api_entry, params={"owner": "octocat", "repo": "hello"})
-        token_meta = _token_meta(
+        token_meta = firewall_auth_response(
             headers={"Authorization": "Bearer real-token", "X-Custom": "value"},
             resolved_secrets=["GITHUB_TOKEN"],
         )
@@ -281,7 +264,7 @@ class TestHandleFirewallRequest:
         api_entry = _api_entry(auth_config={})
         sandbox_info = _sandbox_info(tmp_path, billable_firewalls=["github"])
         allow = _allow(api_entry)
-        token_meta = _token_meta(headers={})
+        token_meta = firewall_auth_response(headers={})
 
         get_firewall_headers = AsyncMock(return_value=token_meta)
 
@@ -496,7 +479,7 @@ class TestHandleFirewallRequest:
         )
         first_flow = _firewall_flow(real_flow, run_id="run-1")
         second_flow = _firewall_flow(real_flow, run_id="run-1")
-        mock_get_firewall_headers = AsyncMock(return_value=_token_meta())
+        mock_get_firewall_headers = AsyncMock(return_value=firewall_auth_response())
 
         with (
             patch.object(auth, "get_firewall_headers", mock_get_firewall_headers),
@@ -558,7 +541,7 @@ class TestHandleFirewallRequest:
         )
         sandbox_info = _sandbox_info(tmp_path)
         allow = _allow(api_entry)
-        token_meta = _token_meta(
+        token_meta = firewall_auth_response(
             headers={
                 "Connection": "Authorization, X-Injected",
                 "Host": "evil.example.com",
@@ -640,7 +623,7 @@ class TestHandleFirewallRequest:
         )
         sandbox_info = _sandbox_info(tmp_path)
         allow = _allow(api_entry, rule="POST /", rel_path="/")
-        token_meta = _token_meta(
+        token_meta = firewall_auth_response(
             headers={
                 "Host": "evil.example.com",
                 "X-Amz-Meta-Test": "trusted-meta",
@@ -704,7 +687,7 @@ class TestHandleFirewallRequest:
         )
         sandbox_info = _sandbox_info(tmp_path)
         allow = _allow(api_entry, rule="POST /", rel_path="/")
-        token_meta = _token_meta()
+        token_meta = firewall_auth_response()
         token_meta["aws_sigv4"] = resolved_aws_sigv4_credentials()
         get_firewall_headers = AsyncMock(return_value=token_meta)
 
@@ -742,7 +725,7 @@ class TestHandleFirewallRequest:
         )
         sandbox_info = _sandbox_info(tmp_path)
         allow = _allow(api_entry)
-        token_meta = _token_meta(headers={"Authorization": "Bearer managed-token"})
+        token_meta = firewall_auth_response(headers={"Authorization": "Bearer managed-token"})
         token_meta["query"] = {"api_key": "managed-query"}
         get_firewall_headers = AsyncMock(return_value=token_meta)
         revalidation_count = 0
@@ -804,7 +787,7 @@ class TestHandleFirewallRequest:
         api_entry = _api_entry()
         sandbox_info = _sandbox_info(tmp_path)
         allow = _allow(api_entry)
-        token_meta = _token_meta(headers={"Authorization": "Bearer token"})
+        token_meta = firewall_auth_response(headers={"Authorization": "Bearer token"})
         token_meta["base"] = "https://unexpected.example.com"
 
         with (
@@ -846,7 +829,7 @@ class TestHandleFirewallRequest:
         api_entry = _api_entry()
         sandbox_info = _sandbox_info(tmp_path)
         allow = _allow(api_entry)
-        token_meta = _token_meta(headers={"Authorization": "Bearer token"})
+        token_meta = firewall_auth_response(headers={"Authorization": "Bearer token"})
         if cache_entry_identity is None:
             token_meta.pop("cache_entry_identity")
         else:
@@ -914,7 +897,7 @@ class TestHandleFirewallRequest:
         )
         sandbox_info = _sandbox_info(tmp_path)
         allow = _allow(api_entry, rule="POST /", rel_path="/")
-        token_meta = _token_meta()
+        token_meta = firewall_auth_response()
 
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -961,7 +944,7 @@ class TestHandleFirewallRequest:
         )
         sandbox_info = _sandbox_info(tmp_path)
         allow = _allow(api_entry)
-        token_meta = _token_meta(
+        token_meta = firewall_auth_response(
             headers={
                 **resolved_headers,
                 "Authorization": "Bearer real-token",
@@ -997,7 +980,7 @@ class TestHandleFirewallRequest:
         api_entry = _api_entry(api_id="run-1:0")
         sandbox_info = _sandbox_info(tmp_path)
         allow = _allow(api_entry, rule="GET /repos")
-        token_meta = _token_meta()
+        token_meta = firewall_auth_response()
 
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -1639,14 +1622,9 @@ class TestHandleFirewallRequest:
                 auth,
                 "get_firewall_headers",
                 AsyncMock(
-                    return_value={
-                        "headers": {"Auth": "tok"},
-                        "resolved_secrets": [],
-                        "refreshed_connectors": [],
-                        "refreshed_secrets": [],
-                        "cache_hit": False,
-                        "cache_entry_identity": auth_cache.FirewallAuthCacheEntryIdentity(),
-                    }
+                    return_value=firewall_auth_response(
+                        headers={"Auth": "tok"},
+                    )
                 ),
             ),
             mitm_ctx(),

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_success.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_success.py
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock, patch
 import auth
 import flow_metadata_keys as metadata_keys
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
-from tests.firewall_auth_helpers import handle_firewall_request_without_upstream_admission
+from tests.firewall_auth_helpers import (
+    firewall_auth_response,
+    handle_firewall_request_without_upstream_admission,
+)
 from tests.firewall_rewrite_helpers import make_allow, make_success_rewrite_inputs
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
 
@@ -40,14 +43,10 @@ class TestAuthBaseUrlRewriteSuccess:
             permission="repo-read",
             rule="GET /repos/{owner}/{repo}",
         )
-        token_meta = {
-            "headers": {"Authorization": "Bearer real-token"},
-            "resolved_secrets": ["GITHUB_TOKEN"],
-            "refreshed_connectors": [],
-            "refreshed_secrets": [],
-            "cache_hit": False,
-            "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-        }
+        token_meta = firewall_auth_response(
+            headers={"Authorization": "Bearer real-token"},
+            resolved_secrets=["GITHUB_TOKEN"],
+        )
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
@@ -139,12 +138,10 @@ class TestAuthBaseUrlRewriteSuccess:
         allow = make_allow(
             api_entry, name="gh", permission="read", rule="GET /repos/{owner}/{repo}"
         )
-        token_meta = {
-            "headers": {"Authorization": "Bearer real"},
-            "resolved_secrets": ["TOKEN"],
-            "cache_hit": False,
-            "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-        }
+        token_meta = firewall_auth_response(
+            headers={"Authorization": "Bearer real"},
+            resolved_secrets=["TOKEN"],
+        )
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_codex_catalog_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_codex_catalog_framing.py
@@ -31,6 +31,7 @@ import flow_metadata_keys as metadata_keys
 import mitm_addon
 import response_streaming
 from tests.codex_model_catalog_cache_helpers import catalog_flow
+from tests.firewall_auth_helpers import firewall_auth_response
 from tests.flow_helpers import header_map, response_stream
 from tests.mitmproxy_http_framing_helpers import CLIENT_IP, start_http_layer
 from tests.request_handler_helpers import _single_firewall_sandbox, _write_registry
@@ -151,14 +152,9 @@ async def test_http2_fresh_catalog_hit_completes_without_provider_connection(
     response_streaming.release_response_stream_state(seed_flow)
 
     registry_path = _write_codex_firewall_registry(tmp_path)
-    token_meta = {
-        "headers": resolved_headers,
-        "resolved_secrets": [],
-        "refreshed_connectors": [],
-        "refreshed_secrets": [],
-        "cache_hit": False,
-        "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-    }
+    token_meta = firewall_auth_response(
+        headers=resolved_headers,
+    )
     with (
         patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
         taddons.context(Proxyserver(), mitm_addon) as addon_context,

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_request_body_admission_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_request_body_admission_framing.py
@@ -30,6 +30,7 @@ from tests.aws_sigv4_helpers import (
     aws_sigv4_authorization,
     resolved_aws_sigv4_credentials,
 )
+from tests.firewall_auth_helpers import firewall_auth_response
 from tests.firewall_aws_sigv4_helpers import aws_api_entry
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.mitmproxy_http_framing_helpers import (
@@ -157,15 +158,10 @@ async def test_http2_headers_only_sigv4_request_uses_zero_byte_admission(
     tmp_path: Path,
 ) -> None:
     registry_path = _write_aws_sigv4_firewall_registry(tmp_path)
-    token_meta = {
-        "headers": {},
-        "aws_sigv4": resolved_aws_sigv4_credentials(),
-        "resolved_secrets": [],
-        "refreshed_connectors": [],
-        "refreshed_secrets": [],
-        "cache_hit": False,
-        "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-    }
+    token_meta = firewall_auth_response(
+        headers={},
+        aws_sigv4=resolved_aws_sigv4_credentials(),
+    )
     get_headers = AsyncMock(return_value=token_meta)
 
     with (
@@ -264,15 +260,11 @@ async def test_headers_only_auth_base_request_without_length_is_forwarded(
     method: Literal["GET", "HEAD"],
 ) -> None:
     registry_path = _write_auth_base_firewall_registry(tmp_path)
-    token_meta = {
-        "headers": {},
-        "base": "https://real.example.com/webhook",
-        "resolved_secrets": ["WEBHOOK_URL"],
-        "refreshed_connectors": [],
-        "refreshed_secrets": [],
-        "cache_hit": False,
-        "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-    }
+    token_meta = firewall_auth_response(
+        headers={},
+        base="https://real.example.com/webhook",
+        resolved_secrets=["WEBHOOK_URL"],
+    )
 
     with (
         patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),

--- a/crates/runner/mitm-addon/tests/test_request_handler_auth_base_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_auth_base_body.py
@@ -19,6 +19,7 @@ from tests.buffered_auth_body_framing_cases import (
     buffered_auth_body_framing_case_id,
     buffered_auth_body_framing_rejection_cases,
 )
+from tests.firewall_auth_helpers import firewall_auth_response
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
 from tests.request_handler_helpers import _single_firewall_sandbox, _write_registry
 
@@ -475,15 +476,11 @@ async def test_auth_base_requestheaders_accepts_body_at_limit(
         ),
         request_body=b"ok",
     )
-    token_meta = {
-        "headers": {},
-        "base": "https://real.example.com/webhook",
-        "resolved_secrets": ["WEBHOOK_URL"],
-        "refreshed_connectors": [],
-        "refreshed_secrets": [],
-        "cache_hit": False,
-        "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-    }
+    token_meta = firewall_auth_response(
+        headers={},
+        base="https://real.example.com/webhook",
+        resolved_secrets=["WEBHOOK_URL"],
+    )
     mock_forward = AsyncMock(return_value=(200, b"ok", {}))
 
     with (
@@ -524,15 +521,11 @@ async def test_auth_base_requestheaders_admission_released_after_success(
         ),
         request_body=request_body,
     )
-    token_meta = {
-        "headers": {"Authorization": "Bearer resolved"},
-        "base": "https://real.example.com/webhook",
-        "resolved_secrets": ["WEBHOOK_URL"],
-        "refreshed_connectors": [],
-        "refreshed_secrets": [],
-        "cache_hit": False,
-        "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-    }
+    token_meta = firewall_auth_response(
+        headers={"Authorization": "Bearer resolved"},
+        base="https://real.example.com/webhook",
+        resolved_secrets=["WEBHOOK_URL"],
+    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -658,14 +651,10 @@ async def test_auth_base_requestheaders_admission_released_when_resolved_base_mi
         ),
         request_body=b"ok",
     )
-    token_meta = {
-        "headers": {"Authorization": "Bearer resolved"},
-        "resolved_secrets": ["WEBHOOK_URL"],
-        "refreshed_connectors": [],
-        "refreshed_secrets": [],
-        "cache_hit": False,
-        "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-    }
+    token_meta = firewall_auth_response(
+        headers={"Authorization": "Bearer resolved"},
+        resolved_secrets=["WEBHOOK_URL"],
+    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),

--- a/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
@@ -38,6 +38,7 @@ from tests.buffered_auth_body_framing_cases import (
     buffered_auth_body_framing_case_id,
     buffered_auth_body_framing_rejection_cases,
 )
+from tests.firewall_auth_helpers import firewall_auth_response
 from tests.firewall_aws_sigv4_helpers import aws_api_entry
 from tests.firewall_helpers import cancel_pending_task
 from tests.request_handler_helpers import _single_firewall_sandbox, _write_registry
@@ -90,15 +91,10 @@ async def _wait_for_hash_start(
 
 
 def _resolved_token_meta() -> dict[str, object]:
-    return {
-        "headers": {},
-        "aws_sigv4": resolved_aws_sigv4_credentials(),
-        "resolved_secrets": [],
-        "refreshed_connectors": [],
-        "refreshed_secrets": [],
-        "cache_hit": False,
-        "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-    }
+    return firewall_auth_response(
+        headers={},
+        aws_sigv4=resolved_aws_sigv4_credentials(),
+    )
 
 
 def _write_aws_registry(

--- a/crates/runner/mitm-addon/tests/test_request_handler_catalog_removal.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_catalog_removal.py
@@ -11,6 +11,7 @@ import auth
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import registry
+from tests.firewall_auth_helpers import firewall_auth_response
 from tests.firewall_helpers import cancel_pending_task
 from tests.registry_builtin_helpers import write_catalog_cache
 from tests.registry_helpers import write_multi_sandbox_registry
@@ -337,15 +338,11 @@ async def test_catalog_removal_during_auth_revalidation_discards_old_credentials
     async def resolve_auth(*_args, **_kwargs):
         auth_resolution_entered.set()
         await release_auth_resolution.wait()
-        return {
-            "headers": {"Authorization": "Bearer stale"},
-            "query": {},
-            "resolved_secrets": ["REMOVED_TOKEN"],
-            "refreshed_connectors": [],
-            "refreshed_secrets": [],
-            "cache_hit": False,
-            "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-        }
+        return firewall_auth_response(
+            headers={"Authorization": "Bearer stale"},
+            query={},
+            resolved_secrets=["REMOVED_TOKEN"],
+        )
 
     auth_fetch = AsyncMock(side_effect=resolve_auth)
     monkeypatch.setattr(auth, "get_firewall_headers", auth_fetch)

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth.py
@@ -24,6 +24,7 @@ from tests.auth_state_helpers import (
     has_auth_state,
     require_cached_headers,
 )
+from tests.firewall_auth_helpers import firewall_auth_response
 from tests.firewall_helpers import cancel_pending_task
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.request_handler_helpers import (
@@ -471,15 +472,11 @@ async def test_custom_firewall_change_during_auth_discards_stale_credentials(
     async def resolve_auth(*_args, **_kwargs):
         auth_resolution_entered.set()
         await release_auth_resolution.wait()
-        return {
-            "headers": {"Authorization": "Bearer stale"},
-            "query": {},
-            "resolved_secrets": ["CUSTOM_TOKEN"],
-            "refreshed_connectors": [],
-            "refreshed_secrets": [],
-            "cache_hit": False,
-            "cache_entry_identity": auth_cache.FirewallAuthCacheEntryIdentity(),
-        }
+        return firewall_auth_response(
+            headers={"Authorization": "Bearer stale"},
+            query={},
+            resolved_secrets=["CUSTOM_TOKEN"],
+        )
 
     auth_fetch = AsyncMock(side_effect=resolve_auth)
     request_task: asyncio.Task[None] | None = None
@@ -864,14 +861,9 @@ async def test_local_response_preserves_shared_binding_for_concurrent_auth(
     async def resolve_auth(*_args, **_kwargs):
         auth_resolution_entered.set()
         await release_auth_resolution.wait()
-        return {
-            "headers": {"Authorization": "Bearer resolved"},
-            "resolved_secrets": [],
-            "refreshed_connectors": [],
-            "refreshed_secrets": [],
-            "cache_hit": False,
-            "cache_entry_identity": auth_cache.FirewallAuthCacheEntryIdentity(),
-        }
+        return firewall_auth_response(
+            headers={"Authorization": "Bearer resolved"},
+        )
 
     auth_fetch = AsyncMock(side_effect=resolve_auth)
     with (

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
@@ -20,6 +20,7 @@ from tests.auth_base_forwarder_helpers import (
     fake_forwarder_upstream,
     forwarder_concurrency_harness,
 )
+from tests.firewall_auth_helpers import firewall_auth_response
 from tests.firewall_helpers import cancel_pending_task
 from tests.registry_builtin_helpers import write_registry_with_cache
 from tests.request_handler_helpers import _single_firewall_sandbox, _write_registry
@@ -278,26 +279,17 @@ def _firewall_flow(
 
 
 def _resolved_firewall_auth(*, auth_base: bool = False) -> dict[str, object]:
-    cache_entry_identity = auth.FirewallAuthCacheEntryIdentity()
     if auth_base:
-        return {
-            "headers": {},
-            "base": _RESOLVED_AUTH_BASE,
-            "resolved_secrets": ["WEBHOOK_URL"],
-            "refreshed_connectors": [],
-            "refreshed_secrets": [],
-            "cache_hit": False,
-            "cache_entry_identity": cache_entry_identity,
-        }
-    return {
-        "headers": {"Authorization": _RESOLVED_AUTHORIZATION},
-        "query": {"managed": "resolved-for-old-authorization"},
-        "resolved_secrets": ["GITHUB_TOKEN"],
-        "refreshed_connectors": [],
-        "refreshed_secrets": [],
-        "cache_hit": False,
-        "cache_entry_identity": cache_entry_identity,
-    }
+        return firewall_auth_response(
+            headers={},
+            base=_RESOLVED_AUTH_BASE,
+            resolved_secrets=["WEBHOOK_URL"],
+        )
+    return firewall_auth_response(
+        headers={"Authorization": _RESOLVED_AUTHORIZATION},
+        query={"managed": "resolved-for-old-authorization"},
+        resolved_secrets=["GITHUB_TOKEN"],
+    )
 
 
 def _assert_current_denial(flow: http.HTTPFlow, mutation: RegistryMutation) -> None:

--- a/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
@@ -19,6 +19,7 @@ import request_classification
 import upstream_destination_binding
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.aws_sigv4_helpers import resolved_aws_sigv4_credentials
+from tests.firewall_auth_helpers import firewall_auth_response
 from tests.firewall_helpers import cancel_pending_task
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.request_handler_helpers import _single_firewall_sandbox, _write_registry
@@ -205,27 +206,19 @@ async def test_public_destination_allows_public_runtime_destination(
     [
         pytest.param(
             {"headers": {"Authorization": "Bearer ${{ secrets.EXAMPLE_TOKEN }}"}},
-            {
-                "headers": {"Authorization": "Bearer resolved"},
-                "resolved_secrets": ["EXAMPLE_TOKEN"],
-                "refreshed_connectors": [],
-                "refreshed_secrets": [],
-                "cache_hit": False,
-                "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-            },
+            firewall_auth_response(
+                headers={"Authorization": "Bearer resolved"},
+                resolved_secrets=["EXAMPLE_TOKEN"],
+            ),
             id="header",
         ),
         pytest.param(
             {"query": {"api_key": "${{ secrets.EXAMPLE_TOKEN }}"}},
-            {
-                "headers": {},
-                "query": {"api_key": "resolved"},
-                "resolved_secrets": ["EXAMPLE_TOKEN"],
-                "refreshed_connectors": [],
-                "refreshed_secrets": [],
-                "cache_hit": False,
-                "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-            },
+            firewall_auth_response(
+                headers={},
+                query={"api_key": "resolved"},
+                resolved_secrets=["EXAMPLE_TOKEN"],
+            ),
             id="query",
         ),
         pytest.param(
@@ -235,15 +228,11 @@ async def test_public_destination_allows_public_runtime_destination(
                     "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
                 }
             },
-            {
-                "headers": {},
-                "aws_sigv4": resolved_aws_sigv4_credentials(session_token=None),
-                "resolved_secrets": ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
-                "refreshed_connectors": [],
-                "refreshed_secrets": [],
-                "cache_hit": False,
-                "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-            },
+            firewall_auth_response(
+                headers={},
+                aws_sigv4=resolved_aws_sigv4_credentials(session_token=None),
+                resolved_secrets=["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+            ),
             id="aws-sigv4",
         ),
     ],

--- a/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
@@ -17,6 +17,7 @@ import mitm_addon
 import terminal_usage
 import usage
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
+from tests.firewall_auth_helpers import firewall_auth_response
 from tests.flow_helpers import response_stream
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.pending_helpers import assert_pending
@@ -246,15 +247,11 @@ def _auth_url_rewrite_flow(real_flow):
 
 
 def _auth_url_rewrite_token_meta() -> dict[str, object]:
-    return {
-        "headers": {},
-        "base": "https://real.example.com/webhook",
-        "resolved_secrets": ["WEBHOOK_URL"],
-        "refreshed_connectors": [],
-        "refreshed_secrets": [],
-        "cache_hit": False,
-        "cache_entry_identity": auth.FirewallAuthCacheEntryIdentity(),
-    }
+    return firewall_auth_response(
+        headers={},
+        base="https://real.example.com/webhook",
+        resolved_secrets=["WEBHOOK_URL"],
+    )
 
 
 def test_repeated_eligibility_checks_keep_one_usage_flow_in_flight(

--- a/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_connector_admission.py
@@ -16,6 +16,7 @@ import request_classification
 import upstream_admission
 import upstream_destination_binding
 from body_limits import STREAM_BUFFER_LIMIT
+from tests.firewall_auth_helpers import firewall_auth_response
 from tests.firewall_helpers import cancel_pending_task
 from tests.request_handler_helpers import (
     _single_firewall_sandbox,
@@ -402,12 +403,14 @@ async def test_firewall_allow_header_auth_uses_connected_upstream_when_tls_verif
     assert binding.original_address == ("172.66.0.243", 443)
 
 
-async def test_firewall_allow_disconnect_during_header_auth_restores_probe_state(
+@pytest.mark.parametrize("disconnect_during_auth", [False, True], ids=["connected", "disconnected"])
+async def test_firewall_allow_header_auth_revalidates_connection_after_auth_wait(
     tmp_path,
     real_flow,
     mitm_ctx,
     headers,
     monkeypatch,
+    disconnect_during_auth,
 ):
     reg_path = _write_registry(
         tmp_path,
@@ -459,14 +462,11 @@ async def test_firewall_allow_disconnect_during_header_auth_restores_probe_state
     async def resolve_auth(*_args, **_kwargs):
         auth_resolution_entered.set()
         await release_auth_resolution.wait()
-        return {
-            "headers": {"Authorization": "Bearer resolved"},
-            "query": {"api_key": "resolved"},
-            "resolved_secrets": ["EXAMPLE_TOKEN"],
-            "refreshed_connectors": [],
-            "refreshed_secrets": [],
-            "cache_hit": False,
-        }
+        return firewall_auth_response(
+            headers={"Authorization": "Bearer resolved"},
+            query={"api_key": "resolved"},
+            resolved_secrets=["EXAMPLE_TOKEN"],
+        )
 
     auth_fetch = AsyncMock(side_effect=resolve_auth)
     monkeypatch.setattr(auth, "get_firewall_headers", auth_fetch)
@@ -477,8 +477,9 @@ async def test_firewall_allow_disconnect_during_header_auth_restores_probe_state
         )
         try:
             await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
-            flow.server_conn.state = connection.ConnectionState.CLOSED
-            mitm_addon.server_disconnected(SimpleNamespace(server=flow.server_conn))
+            if disconnect_during_auth:
+                flow.server_conn.state = connection.ConnectionState.CLOSED
+                mitm_addon.server_disconnected(SimpleNamespace(server=flow.server_conn))
             release_auth_resolution.set()
             await requestheaders_task
         finally:
@@ -486,15 +487,21 @@ async def test_firewall_allow_disconnect_during_header_auth_restores_probe_state
             await cancel_pending_task(requestheaders_task)
 
     auth_fetch.assert_awaited_once()
-    _assert_no_request_stream(flow)
     assert flow.response is None
     assert flow.error is None
-    assert flow.request.headers.fields == original_headers
-    assert flow.request.path == original_path
     assert flow.metadata["preexisting"] == "keep"
-    for key in request_classification.REQUEST_HEADERS_PROBE_METADATA_KEYS:
-        assert key not in flow.metadata
-    assert flow.server_conn.id not in upstream_destination_binding.binding_snapshot_for_tests()
+    if disconnect_during_auth:
+        _assert_no_request_stream(flow)
+        assert flow.request.headers.fields == original_headers
+        assert flow.request.path == original_path
+        for key in request_classification.REQUEST_HEADERS_PROBE_METADATA_KEYS:
+            assert key not in flow.metadata
+        assert flow.server_conn.id not in upstream_destination_binding.binding_snapshot_for_tests()
+    else:
+        assert callable(flow.request.stream)
+        assert flow.request.headers["Authorization"] == "Bearer resolved"
+        assert dict(flow.request.query) == {"client": "visible", "api_key": "resolved"}
+        assert flow.server_conn.id in upstream_destination_binding.binding_snapshot_for_tests()
 
 
 async def test_firewall_allow_header_auth_blocks_without_verified_connected_tls(


### PR DESCRIPTION
The disconnect-during-auth regression previously passed with an invalid success response, before reaching the post-await authorization guard. Use one shared cache-to-handler response builder across the addon tests, including headers, query, auth.base, SigV4, and cache identity, and remove the duplicate envelope-only helper.

Run the connection regression with the same valid response in both connected and disconnected cases. The connected control requires injected credentials and streaming; the disconnected case requires the original request and no stream. Intentionally malformed responses remain explicit. This changes test fixtures and coverage only; production validation and authorization behavior are unchanged.

Closes #32779

Validation in the locked addon environment (uv 0.11.32, Python 3.14.0):

- `uv lock --check` and `uv sync --locked`.
- `uv run --no-sync python -B -m pytest -q -p no:cacheprovider tests/`: **7,388 passed**.
- `uv run --no-sync ruff check .`, `uv run --no-sync ruff format --check .`, and `uv run --no-sync basedpyright -p .`: passed.
- In-process negative controls: bypassing the post-await guard fails the disconnected case; removing cache identity fails the connected case. These diagnostic mutations are not part of the change.
- `git diff --check`: passed.
