### PR TITLE
fix(runner): classify cancelled workspace promotion skips

### DIFF
--- a/crates/guest-control-client/src/connection/request.rs
+++ b/crates/guest-control-client/src/connection/request.rs
@@ -480,19 +480,13 @@ pub(super) fn complete_pending_normal_operation(
 }
 
 pub(super) fn normal_operation_rejection_error(error: NormalOperationRejection) -> io::Error {
-    match error {
-        NormalOperationRejection::Fenced => io::Error::new(
-            io::ErrorKind::WouldBlock,
-            "normal operations are currently fenced",
-        ),
-        NormalOperationRejection::NotParkable => io::Error::new(
-            io::ErrorKind::ConnectionReset,
-            "normal operations are not available on this connection",
-        ),
-        NormalOperationRejection::Closed => {
-            io::Error::new(io::ErrorKind::ConnectionReset, "connection closed")
+    let kind = match error {
+        NormalOperationRejection::Fenced => io::ErrorKind::WouldBlock,
+        NormalOperationRejection::NotParkable | NormalOperationRejection::Closed => {
+            io::ErrorKind::ConnectionReset
         }
-    }
+    };
+    io::Error::new(kind, error)
 }
 
 pub(crate) fn normal_operation_transition_error(

--- a/crates/guest-control-client/src/lib.rs
+++ b/crates/guest-control-client/src/lib.rs
@@ -108,6 +108,7 @@ pub use file::{COPY_FILE_STREAM_MAX_BYTES, CopyFileOptions, CopyFileResult, Writ
 pub use guest_dns_readiness::GuestDnsReadinessResult;
 pub use guest_state_restore::GuestStateRestoreResult;
 pub use guest_storage_manifest::GuestStorageManifestResult;
+pub use operation_tracker::NormalOperationRejection;
 pub use workspace_drive_mount::WorkspaceDriveMountResult;
 
 /// Host-observed stage at which a request deadline expired.

--- a/crates/guest-control-client/src/operation_tracker.rs
+++ b/crates/guest-control-client/src/operation_tracker.rs
@@ -137,12 +137,28 @@ pub(crate) enum NormalOperationReadiness {
     Closed,
 }
 
+/// Admission failure for a normal guest operation, carried by `io::Error`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum NormalOperationRejection {
+pub enum NormalOperationRejection {
+    /// A temporary fence excludes new normal operations.
     Fenced,
+    /// Prior operation ownership is uncertain; this connection cannot be reused.
     NotParkable,
+    /// The connection has closed.
     Closed,
 }
+
+impl std::fmt::Display for NormalOperationRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Fenced => "normal operations are currently fenced",
+            Self::NotParkable => "normal operations are not available on this connection",
+            Self::Closed => "connection closed",
+        })
+    }
+}
+
+impl std::error::Error for NormalOperationRejection {}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum NormalOperationFenceRejection {

--- a/crates/runner/src/cmd/start/tests/failure_recovery/mod.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/mod.rs
@@ -3,3 +3,4 @@ mod outer_panic;
 mod parking_cleanup;
 mod reuse_failure;
 mod support;
+mod workspace_promotion;

--- a/crates/runner/src/cmd/start/tests/failure_recovery/workspace_promotion.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/workspace_promotion.rs
@@ -1,0 +1,146 @@
+use super::super::super::*;
+use super::super::support::{
+    minimal_context, mock_run_config_with_overrides, push_job, shutdown, test_profiles,
+    wait_budget_count, wait_cancel_handle,
+};
+use crate::paths::RunnerPaths;
+use crate::workspace_image_cache::WorkspaceImageCache;
+use sandbox::{ExecResult, SandboxError, SandboxOperation, SandboxOperationReason};
+use sandbox_mock::{MockLifecycleGate, MockSandboxOverrides};
+use tracing::Level;
+use tracing_subscriber::prelude::*;
+use tracing_test_support::CapturedEvents;
+
+#[tokio::test]
+async fn startup_finalization_classifies_cache_failures_and_preserves_healthy_cancelled_cache() {
+    for (cancelled, failure, expected_level) in [
+        (true, None, None),
+        (
+            true,
+            Some(SandboxOperationReason::GuestConnectionUnavailable),
+            Some(Level::INFO),
+        ),
+        (true, Some(SandboxOperationReason::Guest), Some(Level::WARN)),
+        (
+            true,
+            Some(SandboxOperationReason::BackendCrashed),
+            Some(Level::WARN),
+        ),
+        (
+            false,
+            Some(SandboxOperationReason::GuestConnectionUnavailable),
+            Some(Level::WARN),
+        ),
+    ] {
+        let captured = CapturedEvents::default();
+        let _subscriber =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(captured.clone()));
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        let private_write_gate = MockLifecycleGate::new();
+        overrides.set_private_write_file_lifecycle_gate(private_write_gate.clone());
+        if let Some(reason) = failure {
+            if reason == SandboxOperationReason::Guest {
+                overrides.add_exec_result_matcher(
+                    "\"$workspace_fsfreeze_path\" --freeze",
+                    ExecResult::new(1, Vec::new(), b"filesystem freeze failed".to_vec()),
+                );
+            } else {
+                overrides.add_exec_error_matcher(
+                    "\"$workspace_fsfreeze_path\" --freeze",
+                    SandboxError::Operation {
+                        operation: SandboxOperation::Exec,
+                        reason,
+                        message: "guest operation unavailable".into(),
+                    },
+                );
+            }
+        }
+        let mut profiles = test_profiles();
+        profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
+        let (mut config, env) =
+            mock_run_config_with_overrides(profiles, 8, 32768, 4, Arc::clone(&overrides));
+        let paths = RunnerPaths::new(config.paths.base_dir.clone());
+        let cache =
+            WorkspaceImageCache::shared(paths.clone(), &config.paths.home, &config.runner.group);
+        Arc::get_mut(&mut config.exec_config)
+            .unwrap()
+            .workspace_cache = Some(cache.clone());
+        let budget = Arc::clone(&config.capacity.budget);
+        let run_handle = tokio::spawn(run(config));
+        let run_id = RunId::new_v4();
+        let mut context = minimal_context(run_id);
+        context.reuse_key = Some("thread:cancelled-promotion".into());
+        push_job(&env, run_id, "vm0/default", Some(context));
+        private_write_gate
+            .wait_entered(1, Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        let sandbox_id = overrides.create_configs()[0].id;
+        let active_image = paths.active_workspace_image(&sandbox_id);
+        tokio::fs::create_dir_all(active_image.parent().unwrap())
+            .await
+            .unwrap();
+        let file = tokio::fs::File::create(&active_image).await.unwrap();
+        file.set_len(16 * 1024 * 1024).await.unwrap();
+        drop(file);
+        if cancelled {
+            let cancel =
+                wait_cancel_handle(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+            cancel.request_cooperative_user_cancellation().await;
+        } else {
+            overrides.push_private_write_files_result(Err(SandboxError::Io(
+                std::io::Error::other("private preparation failed"),
+            )));
+            overrides.clear_private_write_file_lifecycle_gate();
+            private_write_gate.release_one();
+        }
+
+        let completion = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await
+            .unwrap();
+        if cancelled {
+            assert_eq!(completion.exit_code, 137);
+            assert_eq!(completion.error.as_deref(), Some("cancelled by user"));
+        } else {
+            assert_eq!(completion.exit_code, 1);
+            assert!(
+                completion
+                    .error
+                    .as_deref()
+                    .unwrap()
+                    .contains("private preparation failed")
+            );
+        }
+        wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+        assert_eq!(overrides.stop_call_count(), 1);
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert_eq!(env.idle_pool.lock().await.len(), 0);
+        let states = cache.held_workspace_states().await;
+        assert_eq!(states.len(), usize::from(failure.is_none()));
+
+        let events = captured.entries();
+        let promotion_failure = events.iter().find(|event| {
+            event.fields.get("message").map(String::as_str)
+                == Some("workspace image cache promotion skipped because guest freeze failed")
+        });
+        assert_eq!(promotion_failure.map(|event| event.level), expected_level);
+        if let Some(event) = promotion_failure {
+            assert_eq!(event.fields.get("run_id"), Some(&run_id.to_string()));
+            assert_eq!(
+                event
+                    .fields
+                    .get("skipped_after_cancellation")
+                    .map(String::as_str),
+                Some(if expected_level == Some(Level::INFO) {
+                    "true"
+                } else {
+                    "false"
+                })
+            );
+        }
+        shutdown(&env, run_handle).await;
+    }
+}

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -1593,6 +1593,10 @@ impl WorkspaceImagePromotionContext {
         self.run_id
     }
 
+    pub(crate) fn terminal_status(&self) -> WorkspaceCacheTerminalStatus {
+        self.terminal_status
+    }
+
     pub(crate) fn sandbox_id(&self) -> sandbox::SandboxId {
         self.sandbox_id
     }

--- a/crates/runner/src/workspace_promotion.rs
+++ b/crates/runner/src/workspace_promotion.rs
@@ -12,12 +12,13 @@ use guest_contracts::session_history_identity::{
 use sandbox::{CopyFileOptions, EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, Sandbox};
 use shell_quote::quote_shell_arg;
 use tokio::fs;
-use tracing::warn;
+use tracing::{Level, warn};
 
+use crate::error::RunnerError;
 use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
 use crate::paths::guest;
 use crate::workspace_image_cache::{
-    WorkspaceImagePromotionContext, WorkspaceImagePromotionOutcome,
+    WorkspaceCacheTerminalStatus, WorkspaceImagePromotionContext, WorkspaceImagePromotionOutcome,
     WorkspaceSessionHistorySidecarEntryGuard, WorkspaceSessionHistorySidecarPromotionSource,
 };
 use crate::workspace_mount::freeze_workspace_drive;
@@ -104,15 +105,11 @@ pub(crate) async fn prepare_workspace_image_from_active_sandbox(
             reason,
         }),
         Ok(Err(e)) => {
-            warn!(
-                run_id = %promotion.run_id(),
-                sandbox_id = %promotion.sandbox_id(),
-                profile_name = promotion.profile_name(),
-                reuse_key_fingerprint = %crate::paths::short_digest(promotion.reuse_key()),
-                reuse_key_kind = crate::types::reuse_key_kind(promotion.reuse_key()),
+            log_guest_operation_failure(
+                &promotion,
                 reason,
-                error = %e,
-                "workspace image cache promotion skipped because guest freeze failed"
+                &e,
+                "workspace image cache promotion skipped because guest freeze failed",
             );
             abandon_unpublished_workspace_promotion(Some(promotion), reason).await;
             None
@@ -130,6 +127,44 @@ pub(crate) async fn prepare_workspace_image_from_active_sandbox(
             abandon_unpublished_workspace_promotion(Some(promotion), reason).await;
             None
         }
+    }
+}
+
+fn log_guest_operation_failure(
+    promotion: &WorkspaceImagePromotionContext,
+    reason: &'static str,
+    error: &RunnerError,
+    message: &'static str,
+) {
+    let skipped_after_cancellation = promotion.terminal_status()
+        == WorkspaceCacheTerminalStatus::Cancelled
+        && matches!(
+            error,
+            RunnerError::Sandbox(sandbox::SandboxError::Operation {
+                reason: sandbox::SandboxOperationReason::GuestConnectionUnavailable,
+                ..
+            })
+        );
+    macro_rules! emit {
+        ($level:expr) => {
+            tracing::event!(
+                $level,
+                run_id = %promotion.run_id(),
+                sandbox_id = %promotion.sandbox_id(),
+                profile_name = promotion.profile_name(),
+                reuse_key_fingerprint = %crate::paths::short_digest(promotion.reuse_key()),
+                reuse_key_kind = crate::types::reuse_key_kind(promotion.reuse_key()),
+                reason,
+                skipped_after_cancellation,
+                error = %error,
+                "{message}"
+            );
+        };
+    }
+    if skipped_after_cancellation {
+        emit!(Level::INFO);
+    } else {
+        emit!(Level::WARN);
     }
 }
 
@@ -279,15 +314,11 @@ async fn export_session_history_sidecar(
     let result = match result {
         Ok(result) => result,
         Err(e) => {
-            warn!(
-                run_id = %promotion.run_id(),
-                sandbox_id = %promotion.sandbox_id(),
-                profile_name = promotion.profile_name(),
-                reuse_key_fingerprint = %crate::paths::short_digest(promotion.reuse_key()),
-                reuse_key_kind = crate::types::reuse_key_kind(promotion.reuse_key()),
+            log_guest_operation_failure(
+                promotion,
                 reason,
-                error = %e,
-                "workspace image cache session history sidecar export errored"
+                &e.into(),
+                "workspace image cache session history sidecar export errored",
             );
             return None;
         }
@@ -389,15 +420,11 @@ async fn export_session_history_sidecar(
         Ok(result) => result,
         Err(e) => {
             sidecar_source.discard().await;
-            warn!(
-                run_id = %promotion.run_id(),
-                sandbox_id = %promotion.sandbox_id(),
-                profile_name = promotion.profile_name(),
-                reuse_key_fingerprint = %crate::paths::short_digest(promotion.reuse_key()),
-                reuse_key_kind = crate::types::reuse_key_kind(promotion.reuse_key()),
+            log_guest_operation_failure(
+                promotion,
                 reason,
-                error = %e,
-                "workspace image cache session history sidecar copy failed"
+                &e.into(),
+                "workspace image cache session history sidecar copy failed",
             );
             return None;
         }

--- a/crates/runner/src/workspace_promotion/test_support.rs
+++ b/crates/runner/src/workspace_promotion/test_support.rs
@@ -62,12 +62,32 @@ impl WorkspacePromotionFixture {
         reuse_key: &str,
         restored_session_identity: Option<&RestoredSessionIdentity>,
     ) -> Self {
+        Self::new_with_terminal_status(
+            reuse_key,
+            restored_session_identity,
+            WorkspaceCacheTerminalStatus::Success,
+        )
+        .await
+    }
+
+    pub(crate) async fn new_with_terminal_status(
+        reuse_key: &str,
+        restored_session_identity: Option<&RestoredSessionIdentity>,
+        terminal_status: WorkspaceCacheTerminalStatus,
+    ) -> Self {
         let dir = Arc::new(tempfile::tempdir().unwrap());
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
         let cache = WorkspaceImageCache::new(paths.clone());
 
-        Self::new_with_cache(dir, cache, reuse_key, restored_session_identity).await
+        Self::new_with_cache_and_terminal_status(
+            dir,
+            cache,
+            reuse_key,
+            restored_session_identity,
+            terminal_status,
+        )
+        .await
     }
 
     pub(crate) async fn new_with_restored_session_identity_and_export_capacity(
@@ -89,6 +109,23 @@ impl WorkspacePromotionFixture {
         cache: WorkspaceImageCache,
         reuse_key: &str,
         restored_session_identity: Option<&RestoredSessionIdentity>,
+    ) -> Self {
+        Self::new_with_cache_and_terminal_status(
+            dir,
+            cache,
+            reuse_key,
+            restored_session_identity,
+            WorkspaceCacheTerminalStatus::Success,
+        )
+        .await
+    }
+
+    async fn new_with_cache_and_terminal_status(
+        dir: Arc<tempfile::TempDir>,
+        cache: WorkspaceImageCache,
+        reuse_key: &str,
+        restored_session_identity: Option<&RestoredSessionIdentity>,
+        terminal_status: WorkspaceCacheTerminalStatus,
     ) -> Self {
         let paths = cache.paths().clone();
         let run_id = RunId::new_v4();
@@ -120,7 +157,7 @@ impl WorkspacePromotionFixture {
                 run_id,
                 sandbox_id,
                 restored_session_identity,
-                terminal_status: WorkspaceCacheTerminalStatus::Success,
+                terminal_status,
                 completed_at: TEST_COMPLETED_AT.into(),
                 storage_fingerprints: StorageFingerprints::default(),
             })

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -804,6 +804,156 @@ async fn active_workspace_promotion_discards_sidecar_source_on_copy_error() {
 }
 
 #[tokio::test]
+async fn cancelled_workspace_promotion_preserves_session_history_sidecar() {
+    let history = br#"{"type":"message","content":"cancelled"}"#;
+    let identity = test_restored_session_identity("cancelled-session", history);
+    let fixture = WorkspacePromotionFixture::new_with_terminal_status(
+        "thread:cancelled-sidecar",
+        Some(&identity),
+        WorkspaceCacheTerminalStatus::Cancelled,
+    )
+    .await;
+    let sandbox = MockSandbox::new(fixture.sandbox_id.to_string());
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        0,
+        serde_json::to_vec(&SessionHistorySidecarExportMetadata {
+            representation: SessionHistorySidecarRepresentation::Raw,
+            encoded_size: history.len() as u64,
+        })
+        .unwrap(),
+        Vec::new(),
+    )));
+    sandbox.push_copy_file_result(Ok(history.to_vec()));
+
+    assert!(prepare_and_publish_workspace_image(&sandbox, fixture.promotion).await);
+    let lease = fixture
+        .cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: "vm0/default",
+                reuse_key: Some(&fixture.reuse_key),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: TEST_WORKSPACE_IMAGE_SIZE_BYTES,
+            },
+            workspace_drive_required: true,
+        })
+        .await;
+    assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Hit);
+    let sidecar = lease
+        .probe_session_history_sidecar(&identity)
+        .await
+        .unwrap();
+    assert_eq!(tokio::fs::read(sidecar.path).await.unwrap(), history);
+}
+
+#[tokio::test]
+async fn workspace_promotion_classifies_cancelled_sidecar_admission_rejections() {
+    use sandbox::{SandboxError, SandboxOperation, SandboxOperationReason};
+
+    for (terminal_status, operation, host_io_failure) in [
+        (
+            WorkspaceCacheTerminalStatus::Cancelled,
+            SandboxOperation::Exec,
+            false,
+        ),
+        (
+            WorkspaceCacheTerminalStatus::Cancelled,
+            SandboxOperation::CopyFile,
+            false,
+        ),
+        (
+            WorkspaceCacheTerminalStatus::Cancelled,
+            SandboxOperation::CopyFile,
+            true,
+        ),
+        (
+            WorkspaceCacheTerminalStatus::Success,
+            SandboxOperation::Exec,
+            false,
+        ),
+        (
+            WorkspaceCacheTerminalStatus::Success,
+            SandboxOperation::CopyFile,
+            false,
+        ),
+    ] {
+        let history = br#"{"type":"message","content":"sidecar"}"#;
+        let identity = test_restored_session_identity("sidecar-admission", history);
+        let fixture = WorkspacePromotionFixture::new_with_terminal_status(
+            "thread:sidecar-admission",
+            Some(&identity),
+            terminal_status,
+        )
+        .await;
+        let sandbox = MockSandbox::new(fixture.sandbox_id.to_string());
+        let error = if host_io_failure {
+            SandboxError::Io(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "host staging denied",
+            ))
+        } else {
+            SandboxError::Operation {
+                operation,
+                reason: SandboxOperationReason::GuestConnectionUnavailable,
+                message: "normal operation rejected".into(),
+            }
+        };
+        let message = if operation == SandboxOperation::Exec {
+            sandbox.push_exec_result(Err(error));
+            "workspace image cache session history sidecar export errored"
+        } else {
+            sandbox.push_exec_result(Ok(ExecResult::new(
+                0,
+                serde_json::to_vec(&SessionHistorySidecarExportMetadata {
+                    representation: SessionHistorySidecarRepresentation::Raw,
+                    encoded_size: history.len() as u64,
+                })
+                .unwrap(),
+                Vec::new(),
+            )));
+            sandbox.push_copy_file_result(Err(error));
+            "workspace image cache session history sidecar copy failed"
+        };
+        if !host_io_failure {
+            sandbox.push_exec_result(Err(SandboxError::Operation {
+                operation: SandboxOperation::Exec,
+                reason: SandboxOperationReason::GuestConnectionUnavailable,
+                message: "normal operation rejected".into(),
+            }));
+        }
+        let (promoted, events) = capture_promotion_events(prepare_and_publish_workspace_image(
+            &sandbox,
+            fixture.promotion,
+        ))
+        .await;
+        assert_eq!(promoted, host_io_failure);
+        let expected_level =
+            if terminal_status == WorkspaceCacheTerminalStatus::Cancelled && !host_io_failure {
+                Level::INFO
+            } else {
+                Level::WARN
+            };
+        assert_eq!(captured_event(&events, message).level, expected_level);
+        if !host_io_failure {
+            assert_eq!(
+                captured_event(
+                    &events,
+                    "workspace image cache promotion skipped because guest freeze failed"
+                )
+                .level,
+                expected_level
+            );
+            assert!(fixture.cache.held_workspace_states().await.is_empty());
+        }
+        for copy in sandbox.copy_file_calls() {
+            assert!(!copy.host_path.exists(), "failed copy must release staging");
+        }
+    }
+}
+
+#[tokio::test]
 async fn active_workspace_promotion_discards_sidecar_source_on_copy_size_mismatch() {
     let reuse_key = "thread:sidecar-copy-size-mismatch";
     let session_id = "sess-sidecar-copy-size-mismatch";

--- a/crates/sandbox-firecracker/src/sandbox.rs
+++ b/crates/sandbox-firecracker/src/sandbox.rs
@@ -796,7 +796,18 @@ impl FirecrackerSandbox {
                 timeout_ms: u64::try_from(timeout.timeout().as_millis()).unwrap_or(u64::MAX),
             };
         }
-        let reason = if error.kind() == io::ErrorKind::TimedOut {
+        let admission_rejection = error.get_ref().and_then(|source| {
+            source.downcast_ref::<guest_control_client::NormalOperationRejection>()
+        });
+        let reason = if matches!(
+            admission_rejection,
+            Some(
+                guest_control_client::NormalOperationRejection::NotParkable
+                    | guest_control_client::NormalOperationRejection::Closed
+            )
+        ) {
+            SandboxOperationReason::GuestConnectionUnavailable
+        } else if error.kind() == io::ErrorKind::TimedOut {
             SandboxOperationReason::Timeout
         } else {
             SandboxOperationReason::Guest

--- a/crates/sandbox-firecracker/src/sandbox/tests.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests.rs
@@ -2550,11 +2550,77 @@ async fn start_process_timeout_after_write_rejects_later_guest_operation() {
         Ok(_) => panic!("post-write timeout connection must reject later operations"),
         Err(error) => error,
     };
-    assert!(
-        later_error
-            .to_string()
-            .contains("normal operations are not available on this connection"),
-        "got: {later_error}"
+    assert_operation_error(
+        later_error,
+        SandboxOperation::Exec,
+        SandboxOperationReason::GuestConnectionUnavailable,
+    );
+}
+
+#[tokio::test]
+async fn cancelled_guest_write_classifies_later_admission_without_another_frame() {
+    let sandbox = test_sandbox_with_state(SandboxState::Running);
+    let mut guest = attach_mock_shutdown_guest(&sandbox).await;
+    {
+        let write = sandbox.write_file("/tmp/cancelled-write", b"contents");
+        tokio::pin!(write);
+        tokio::select! {
+            result = &mut write => panic!("write completed without guest acknowledgement: {result:?}"),
+            request = read_vsock_message(&mut guest) => {
+                assert_eq!(request.msg_type, guest_control_proto::MSG_WRITE_FILE);
+            }
+        }
+        // Dropping this in-flight request abandons its terminal proof.
+    }
+
+    let error = sandbox
+        .write_file("/tmp/later-write", b"later")
+        .await
+        .unwrap_err();
+    assert_operation_error(
+        error,
+        SandboxOperation::WriteFile,
+        SandboxOperationReason::GuestConnectionUnavailable,
+    );
+    assert_eq!(
+        guest.try_read(&mut [0_u8; 1]).unwrap_err().kind(),
+        io::ErrorKind::WouldBlock
+    );
+}
+
+#[tokio::test]
+async fn closed_guest_connection_is_distinct_from_temporary_fencing() {
+    let sandbox = test_sandbox_with_state(SandboxState::Running);
+    let guest = attach_mock_shutdown_guest(&sandbox).await;
+    let host = sandbox.guest.lock().await.as_ref().unwrap().clone();
+    let fence = host.try_fence_normal_operations().unwrap();
+    assert_operation_error(
+        sandbox
+            .write_file("/tmp/fenced", b"contents")
+            .await
+            .unwrap_err(),
+        SandboxOperation::WriteFile,
+        SandboxOperationReason::Guest,
+    );
+    drop(fence);
+    drop(guest);
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !matches!(
+            host.try_fence_normal_operations(),
+            Err(guest_control_client::NormalOperationFenceRejection::Closed)
+        ) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    assert_operation_error(
+        sandbox
+            .write_file("/tmp/closed", b"contents")
+            .await
+            .unwrap_err(),
+        SandboxOperation::WriteFile,
+        SandboxOperationReason::GuestConnectionUnavailable,
     );
 }
 

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -171,6 +171,9 @@ impl fmt::Display for SandboxOperation {
 pub enum SandboxOperationReason {
     /// The guest-side operation or IPC call returned an error.
     Guest,
+    /// Normal-operation admission rejected a permanently unusable guest connection.
+    /// This does not classify transport errors or temporary operation fences.
+    GuestConnectionUnavailable,
     /// The backend process crashed while the operation was in flight.
     BackendCrashed,
     /// The operation timed out.
@@ -222,6 +225,7 @@ impl fmt::Display for SandboxOperationReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Guest => f.write_str("guest"),
+            Self::GuestConnectionUnavailable => f.write_str("guest connection unavailable"),
             Self::BackendCrashed => f.write_str("backend crashed"),
             Self::Timeout => f.write_str("timeout"),
             Self::Other => f.write_str("other"),


### PR DESCRIPTION
## Summary

- Preserve normal guest-operation admission rejection as a typed I/O error, and classify only permanent NotParkable/Closed rejection as `GuestConnectionUnavailable`.
- Log dependent workspace freeze and session-history sidecar exec/copy failures at INFO only when the promotion's existing terminal status is Cancelled and the failure has that typed reason.
- Retain warnings for non-cancelled rejections, real helper/guest/host failures, backend crashes, temporary fences, invalid metadata, cleanup failures and panics.

Relates to #32749. Implementation is contained in this PR; the issue remains open for its explicit post-deployment observation gate.

## Scope and risk

The verified production occurrence followed cancellation before Agent startup; the Runner recorded cancellation and successfully stopped/destroyed the sandbox. It was not a prefetch timeout or evidence of a stuck run.

This changes classification and logging, not cancellation, connection ownership, cache-saving attempts, freeze/stop/publication ordering, or destruction. Healthy cancelled runs can still save workspace and applicable session-history caches. No API, guest wire, persisted cache format, feature flag, timeout or configuration change is introduced. The Rust error types are compiled into the same Runner artifact.

The main risk is over-classifying genuine failures. Both authoritative terminal cancellation and typed permanent admission rejection are required; no error-string matching or readiness precheck is used. Existing partial-write, timeout and backend-crash precedence is preserved. No cache-hit-rate or latency improvement is claimed.

## Validation

Passed from `crates/`:

- `cargo fmt --all -- --check`
- `cargo clippy --profile local --workspace --all-targets --all-features -j 4`
- `RUSTDOCFLAGS='-D warnings' cargo doc --profile local --workspace --all-features --no-deps -j 4`
- `cargo test --profile local -p guest-control-client -p sandbox -p sandbox-firecracker -p sandbox-mock -p runner --all-features -j 4 -- --test-threads=1`

Results include 3594 Runner tests, 411 guest-control-client tests, 872 sandbox-firecracker tests, 95 sandbox-mock tests, and the remaining selected Sandbox/integration/doc tests. Existing opt-in/child-process ignored declarations are unchanged; no skip or timeout changes were made.

Coverage includes a cancelled written request over real sockets, closed connection versus temporary fencing, full Runner startup cancellation and completion/stop/destroy/cache outcomes, sidecar staging cleanup, genuine failure controls, and healthy cancelled cache/sidecar preservation.

The first broader run exposed an existing SSH single-byte-fragment test timeout. After local environment preparation and same-binary/control checks, both standalone tests and the final complete single-threaded suite passed with the original timeout. No SSH implementation or tests were changed.

## Remaining verification

CI is pending at submission. After deployment of the fixing Runner artifact and drain of old artifacts, complete #32749's bounded 24-hour observation using real cancelled-run samples and local INFO skip markers. Confirm no corresponding cancellation-only promotion warnings or stuck cleanup and preserve genuine-failure visibility. Zero relevant cancellations is inconclusive. No production deployment or recovery observation was performed by this PR workflow.
