### PR TITLE
perf(guest-storage-apply): index preserved paths during cleanup

### DIFF
--- a/crates/guest-storage-apply/src/cleanup.rs
+++ b/crates/guest-storage-apply/src/cleanup.rs
@@ -2,7 +2,7 @@ use crate::LOG_TAG;
 use crate::path::normalize_path;
 use guest_telemetry::{log_info, log_warn};
 use std::cell::OnceCell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ffi::{CString, OsStr, OsString};
 use std::fs::{self, File, OpenOptions};
 use std::io;
@@ -59,10 +59,7 @@ fn cleanup_stale_paths_with_options<M, R>(
     M: Fn(&Path) -> bool,
     R: Fn(&fs::DirEntry) -> io::Result<()>,
 {
-    let preserved = preserved
-        .iter()
-        .map(|path| normalize_path(Path::new(path)))
-        .collect::<HashSet<_>>();
+    let preserved = PreservedPaths::new(preserved);
     let mut sorted = cleanup_paths
         .iter()
         .map(|path| {
@@ -76,11 +73,11 @@ fn cleanup_stale_paths_with_options<M, R>(
     sorted.sort_by_key(|path| path.logical.components().count());
 
     for path in sorted {
-        if is_preserved_or_descendant(&path.logical, &preserved) {
+        if preserved.is_preserved_or_descendant(&path.logical) {
             continue;
         }
 
-        let preserved_child_count = count_preserved_children(&path.logical, &preserved);
+        let preserved_child_count = preserved.count_preserved_children(&path.logical);
 
         if preserved_child_count > 0 {
             if let Err(e) =
@@ -143,7 +140,7 @@ struct CleanupPath<'a> {
 fn clean_directory_contents<R>(
     original_path: &Path,
     logical_path: &Path,
-    preserved: &HashSet<PathBuf>,
+    preserved: &PreservedPaths,
     remove_entry: &R,
 ) -> io::Result<()>
 where
@@ -171,7 +168,7 @@ where
         let entry_path = original_path.join(entry.file_name());
         let logical_entry_path = logical_path.join(entry.file_name());
 
-        if entry_overlaps_preserved_path(&logical_entry_path, preserved) {
+        if preserved.entry_overlaps_preserved_path(&logical_entry_path) {
             continue;
         }
 
@@ -294,25 +291,50 @@ impl CleanupDirectory {
     }
 }
 
-fn is_preserved_or_descendant(path: &Path, preserved: &HashSet<PathBuf>) -> bool {
-    preserved
-        .iter()
-        .any(|preserved_path| path.starts_with(preserved_path))
+/// Index path relationships once per cleanup pass, so lookups depend on path
+/// depth rather than the number of unrelated preserved mounts.
+struct PreservedPaths {
+    paths: HashSet<PathBuf>,
+    descendant_counts: HashMap<PathBuf, usize>,
 }
 
-fn count_preserved_children(path: &Path, preserved: &HashSet<PathBuf>) -> usize {
-    preserved
-        .iter()
-        .filter(|preserved_path| {
-            preserved_path.as_path() != path && preserved_path.starts_with(path)
-        })
-        .count()
-}
+impl PreservedPaths {
+    fn new(preserved: &[String]) -> Self {
+        let paths = preserved
+            .iter()
+            .map(|path| normalize_path(Path::new(path)))
+            .collect::<HashSet<_>>();
+        let mut descendant_counts = HashMap::new();
 
-fn entry_overlaps_preserved_path(entry_path: &Path, preserved: &HashSet<PathBuf>) -> bool {
-    preserved.iter().any(|preserved_path| {
-        preserved_path == entry_path || preserved_path.starts_with(entry_path)
-    })
+        for path in &paths {
+            // The empty path is a prefix of absolute paths too, but their
+            // ancestors() iterator stops at `/` without yielding it.
+            let empty_prefix = path.is_absolute().then_some(Path::new(""));
+            for ancestor in path.ancestors().skip(1).chain(empty_prefix) {
+                *descendant_counts.entry(ancestor.to_path_buf()).or_insert(0) += 1;
+            }
+        }
+
+        Self {
+            paths,
+            descendant_counts,
+        }
+    }
+
+    fn is_preserved_or_descendant(&self, path: &Path) -> bool {
+        self.paths.contains(Path::new(""))
+            || path
+                .ancestors()
+                .any(|ancestor| self.paths.contains(ancestor))
+    }
+
+    fn count_preserved_children(&self, path: &Path) -> usize {
+        self.descendant_counts.get(path).copied().unwrap_or(0)
+    }
+
+    fn entry_overlaps_preserved_path(&self, entry_path: &Path) -> bool {
+        self.paths.contains(entry_path) || self.descendant_counts.contains_key(entry_path)
+    }
 }
 
 struct CleanupMountPointDetector<L>

--- a/crates/guest-storage-apply/tests/integration/cleanup.rs
+++ b/crates/guest-storage-apply/tests/integration/cleanup.rs
@@ -1,3 +1,5 @@
+use crate::binary_logging::BinaryLoggingFixture;
+use crate::process::CommandExecution;
 use crate::support::run_guest_storage_apply_manifest_json;
 use serde_json::json;
 use std::fs;
@@ -230,4 +232,169 @@ fn cleanup_normalization_does_not_bypass_intermediate_symlink() {
         fs::read_to_string(cache.join("content.txt")).unwrap(),
         "keep"
     );
+}
+
+#[test]
+fn cleanup_preserves_many_cached_siblings_and_unrelated_roots() {
+    let dir = tempfile::tempdir().unwrap();
+    let cleanup_root = dir.path().join("workspace");
+    let unrelated_root = dir.path().join("unrelated");
+    let removed_root = dir.path().join("removed");
+    let mut preserved = Vec::new();
+    let mut stale = Vec::new();
+    let mut cleanup_paths = vec![cleanup_root.clone(), removed_root.clone()];
+
+    fs::create_dir_all(&removed_root).unwrap();
+    fs::write(removed_root.join("content.txt"), "remove").unwrap();
+    for i in 0..128 {
+        let cached = cleanup_root.join(format!("cached-{i:03}"));
+        let unrelated = unrelated_root.join(format!("cached-{i:03}"));
+        let stale_sibling = cleanup_root.join(format!("cached-{i:03}-old"));
+        for path in [&cached, &unrelated] {
+            fs::create_dir_all(path.join("nested")).unwrap();
+            fs::write(path.join("nested/content.txt"), "keep").unwrap();
+            preserved.push(path.clone());
+        }
+        cleanup_paths.push(cached.join("nested"));
+        fs::create_dir_all(&stale_sibling).unwrap();
+        fs::write(stale_sibling.join("content.txt"), "remove").unwrap();
+        stale.push(stale_sibling);
+    }
+    fs::write(cleanup_root.join("stale.txt"), "remove").unwrap();
+    let storage_mounts: Vec<_> = preserved
+        .iter()
+        .enumerate()
+        .map(|(i, path)| json!({"mountPath": path, "cached": true, "writeback": i % 2 == 0}))
+        .collect();
+    let manifest = serde_json::to_vec(&json!({
+        "storageMounts": storage_mounts,
+        "cleanupPaths": cleanup_paths
+    }))
+    .unwrap();
+
+    assert!(run_guest_storage_apply_manifest_json(&manifest));
+
+    for path in preserved {
+        assert_eq!(
+            fs::read_to_string(path.join("nested/content.txt")).unwrap(),
+            "keep"
+        );
+    }
+    assert!(stale.iter().all(|path| !path.exists()));
+    assert!(!cleanup_root.join("stale.txt").exists());
+    assert!(!removed_root.exists());
+}
+
+#[test]
+fn cleanup_counts_distinct_nested_cached_paths_and_preserves_their_ancestors() {
+    let fixture = BinaryLoggingFixture::new("cleanup-nested-cached-paths").unwrap();
+    let root = fixture.dir.path().join("workspace");
+    let group = root.join("group");
+    let cached = group.join("cache");
+    let nested = cached.join("nested");
+    fs::create_dir_all(&nested).unwrap();
+    fs::create_dir_all(group.join("alias")).unwrap();
+    fs::write(nested.join("content.txt"), "keep").unwrap();
+    fs::write(group.join("stale.txt"), "remove when group is cleaned").unwrap();
+    fs::write(root.join("stale.txt"), "remove").unwrap();
+    let storage_mounts = json!([
+        {"mountPath": cached, "cached": true, "writeback": false},
+        {"mountPath": nested, "cached": true, "writeback": true},
+        {"mountPath": group.join("alias/../cache"), "cached": true, "writeback": false}
+    ]);
+    let manifest = serde_json::to_vec(&json!({
+        "storageMounts": storage_mounts,
+        "cleanupPaths": [root]
+    }))
+    .unwrap();
+
+    assert!(
+        fixture
+            .run_manifest_stdin(&manifest)
+            .unwrap()
+            .status
+            .success()
+    );
+    assert!(group.join("stale.txt").exists());
+    assert!(!root.join("stale.txt").exists());
+
+    let manifest = serde_json::to_vec(&json!({
+        "storageMounts": storage_mounts,
+        "cleanupPaths": [nested, cached, group]
+    }))
+    .unwrap();
+    assert!(
+        fixture
+            .run_manifest_stdin(&manifest)
+            .unwrap()
+            .status
+            .success()
+    );
+
+    assert_eq!(
+        fs::read_to_string(nested.join("content.txt")).unwrap(),
+        "keep"
+    );
+    assert!(!group.join("stale.txt").exists());
+    assert!(!group.join("alias").exists());
+    let log = fixture.read_system_log().unwrap();
+    for path in [&root, &group] {
+        assert!(log.contains(&format!(
+            "Selectively cleaned {} (preserved 2 children)",
+            path.display()
+        )));
+    }
+}
+
+#[test]
+fn cleanup_preserves_relative_cached_paths_and_leading_parent_components() {
+    let fixture = BinaryLoggingFixture::new("cleanup-relative-paths").unwrap();
+    let workspace = fixture.dir.path().join("workspace");
+    let outside = fixture.dir.path().join("outside");
+    for root in [&workspace, &outside] {
+        fs::create_dir_all(root.join("cache/nested")).unwrap();
+        fs::write(root.join("cache/nested/content.txt"), "keep").unwrap();
+        fs::write(root.join("stale.txt"), "remove").unwrap();
+    }
+    let manifest = serde_json::to_vec(&json!({
+        "storageMounts": [
+            {"mountPath": "cache", "cached": true, "writeback": false},
+            {"mountPath": "../outside/cache", "cached": true, "writeback": true}
+        ],
+        "cleanupPaths": ["cache/nested", "../outside/cache/nested", "../outside", "."]
+    }))
+    .unwrap();
+    let mut command = fixture.command();
+    command.current_dir(&workspace).arg("--manifest-stdin");
+
+    let output = CommandExecution::spawn(&mut command, Some(&manifest))
+        .unwrap()
+        .wait()
+        .unwrap();
+
+    assert!(output.status.success());
+    for root in [&workspace, &outside] {
+        assert_eq!(
+            fs::read_to_string(root.join("cache/nested/content.txt")).unwrap(),
+            "keep"
+        );
+        assert!(!root.join("stale.txt").exists());
+    }
+}
+
+#[test]
+fn cleanup_skips_absolute_paths_when_root_or_empty_prefix_is_preserved() {
+    let dir = tempfile::tempdir().unwrap();
+    let cleanup_root = dir.path().join("workspace");
+    fs::create_dir_all(&cleanup_root).unwrap();
+    fs::write(cleanup_root.join("content.txt"), "keep").unwrap();
+
+    for preserved in [Path::new("/"), Path::new(""), Path::new(".")] {
+        let manifest = cleanup_manifest(&[&cleanup_root], Some(preserved)).unwrap();
+        assert!(run_guest_storage_apply_manifest_json(&manifest));
+        assert_eq!(
+            fs::read_to_string(cleanup_root.join("content.txt")).unwrap(),
+            "keep"
+        );
+    }
 }


### PR DESCRIPTION
When a reused guest removes a parent mount while retaining many cached children, cleanup rescans every preserved path for each directory entry and cleanup root. Build a normalized exact-path set and strict-ancestor counts once per pass, then answer relationship queries from that index. Fixed-depth sibling cleanup now grows approximately linearly.

The change retains distinct descendant counts, component-aware matching, normalization, parent-first ordering, cached mountinfo loading, and descriptor-anchored/no-follow filesystem operations. Four new canonical-manifest integration tests cover 256 preserved paths, unrelated roots, actual stale-file removal, nested and normalized duplicate paths, relative paths, root/empty prefixes, and the observable cleanup log counts. Public contracts and download sequencing are unchanged.

Closes #32777.

## Performance

[Full measurements and reproduction harness](https://github.com/vm0-ai/vm0/issues/32777#issuecomment-5595236461).

Same-machine `rustc --edition 2024 -O` probes compile the exact baseline (`064ca1b2c78f35169b249b944c4539d4f1831391`) and changed cleanup/path sources. Three trials per case, timing cleanup including index construction and excluding fixture creation and post-call retention checks. The parent has 10 path components; children are named `cached-storage-00000`, etc. Linux x86_64, two visible CPUs, Rust 1.98.1.

| Preserved siblings | Baseline median | Indexed median |
| ---: | ---: | ---: |
| 0 | 0.194 ms | 0.170 ms |
| 1 | 0.141 ms | 0.122 ms |
| 140 | 3.633 ms | 0.418 ms |
| 1,000 | 165.884 ms | 2.216 ms |
| 2,000 | 684.896 ms | 4.432 ms |
| 5,000 | 4,402.744 ms | 10.795 ms |
| 10,000 | 17,826.840 ms | 23.488 ms |

Doubling 5,000 to 10,000 siblings increases indexed time 2.18x (baseline 4.05x). A separate case with 10,000 cleanup roots below preserved mounts improves from 14,223.058 ms to 26.286 ms. With 10,000 unrelated cleanup roots and 10,000 preserved paths, the median improves from 57,562.961 ms to 203.029 ms, covering the no-match root scans too.

A separate 10,000-sibling resource run measured whole-process peak RSS (`/proc/self/status` `VmHWM`) at 5,444 KiB for the baseline and 5,420 KiB for the index, both approximately 5.3 MiB; these are not isolated index-allocation measurements or evidence of a memory reduction.

Hash lookup bounds are expected. Additional memory depends on the total size of distinct ancestor prefixes, so deep/diverse paths have a different cost from this sibling shape. These are synthetic cleanup measurements; production mount prevalence and end-to-end startup gains were not measured. No wall-clock thresholds were added to tests.

## Validation

Passed sequentially on the final worktree:

- `cargo fmt --manifest-path crates/guest-storage-apply/Cargo.toml -- --check`
- `CARGO_BUILD_JOBS=1 cargo test --locked --profile local --manifest-path crates/guest-storage-apply/Cargo.toml --all-targets -- --quiet` — 182 passed (90 library, 9 binary, 83 integration), including existing symlink and mountpoint coverage.
- `CARGO_BUILD_JOBS=1 cargo clippy --locked --profile local --manifest-path crates/guest-storage-apply/Cargo.toml --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 cargo doc --locked --profile local --manifest-path crates/guest-storage-apply/Cargo.toml --all-features --no-deps`

The unchanged baseline also passed its complete affected-crate test suite. Live guest and production validation are outside these local results.
