### PR TITLE
fix(api): batch connector runtime sync wakeups

### DIFF
--- a/crates/ably-subscriber/tests/integration/connection_messages.rs
+++ b/crates/ably-subscriber/tests/integration/connection_messages.rs
@@ -298,6 +298,13 @@ async fn batched_messages_in_single_frame() {
     let ws = MockAblyServer::start().await.unwrap();
     mock_token_endpoint(&http, "testKey.testId");
 
+    let payloads = vec![
+        serde_json::json!({"runId": "run-1", "target": {"kind": "builtin", "connectorSlug": "slack"}}),
+        serde_json::json!({"runId": "run-1", "target": {"kind": "custom", "customConnectorId": "custom-1"}}),
+        serde_json::json!({"runId": "run-2", "target": {"kind": "custom", "customConnectorId": "custom-1"}}),
+    ];
+    let expected = payloads.clone();
+
     let ws_port = ws.port;
     let server_task = tokio::spawn(async move {
         let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
@@ -305,23 +312,17 @@ async fn batched_messages_in_single_frame() {
             action: action::MESSAGE,
             channel: Some("ch".into()),
             channel_serial: Some("serial-1".into()),
-            messages: Some(vec![
-                AblyMessage {
-                    name: Some("a".into()),
-                    data: Some(serde_json::json!(1)),
-                    ..Default::default()
-                },
-                AblyMessage {
-                    name: Some("b".into()),
-                    data: Some(serde_json::json!(2)),
-                    ..Default::default()
-                },
-                AblyMessage {
-                    name: Some("c".into()),
-                    data: Some(serde_json::json!(3)),
-                    ..Default::default()
-                },
-            ]),
+            messages: Some(
+                payloads
+                    .into_iter()
+                    .map(|payload| AblyMessage {
+                        name: Some("connector-runtime-sync".into()),
+                        data: Some(serde_json::Value::String(payload.to_string())),
+                        encoding: Some("json".into()),
+                        ..Default::default()
+                    })
+                    .collect(),
+            ),
             ..Default::default()
         };
         conn.send(tungstenite::Message::Binary(
@@ -337,15 +338,15 @@ async fn batched_messages_in_single_frame() {
 
     expect_connected(&mut sub, "Connected event").await.unwrap();
 
-    let mut names = Vec::new();
-    for _ in 0..3 {
+    for payload in expected {
         match expect_event(&mut sub, "batched message").await.unwrap() {
-            Event::Message(m) => names.push(m.name.unwrap_or_default()),
+            Event::Message(m) => {
+                assert_eq!(m.name.as_deref(), Some("connector-runtime-sync"));
+                assert_eq!(m.data, payload);
+            }
             other => panic!("expected Message, got {other:?}"),
         }
     }
-
-    assert_eq!(names, vec!["a", "b", "c"]);
 
     join_server_task(server_task, "mock server").await.unwrap();
 }

--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -1,5 +1,12 @@
 import { Buffer } from "node:buffer";
 import type StripeSDK from "stripe";
+import type {
+  BatchPublishSpec,
+  BatchResult,
+  BatchPublishSuccessResult,
+  BatchPublishFailureResult,
+  ClientOptions,
+} from "ably";
 import type { LookupFunction } from "node:net";
 import { computed } from "ccstate";
 import { ws } from "msw";
@@ -9,6 +16,11 @@ import { z } from "zod";
 import { mockStripeClient } from "../signals/external/stripe-client";
 
 type AsyncMock = Mock<(...args: unknown[]) => Promise<unknown>>;
+type AblyBatchPublish = (
+  spec: BatchPublishSpec,
+) => Promise<
+  BatchResult<BatchPublishSuccessResult | BatchPublishFailureResult>
+>;
 type BooleanMock = Mock<(...args: unknown[]) => boolean>;
 type SignalTimerDelayOptions = { readonly signal?: AbortSignal };
 type SignalTimerDelayMock = Mock<
@@ -109,6 +121,8 @@ export interface ApiTestMocks {
   };
   readonly ably: {
     readonly channelGet: Mock<(channelName: string) => void>;
+    readonly batchPublish: Mock<AblyBatchPublish>;
+    readonly useRealBatchPublish: Mock<() => boolean>;
     readonly publish: AsyncMock;
     readonly createTokenRequest: AsyncMock;
     readonly requestToken: AsyncMock;
@@ -524,6 +538,8 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
     },
     ably: {
       channelGet: vi.fn<(channelName: string) => void>(),
+      batchPublish: vi.fn<AblyBatchPublish>(),
+      useRealBatchPublish: vi.fn<() => boolean>(),
       publish: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       createTokenRequest: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       requestToken: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -965,8 +981,33 @@ vi.mock("signal-timers", async (importOriginal) => {
   };
 });
 
-vi.mock("ably", () => {
+vi.mock("ably", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ably")>();
   class MockRest {
+    constructor(private readonly options: ClientOptions) {}
+
+    readonly batchPublish: AblyBatchPublish = async (spec) => {
+      const mocked = apiTestMocks.ably.batchPublish(spec);
+      if (apiTestMocks.ably.useRealBatchPublish()) {
+        return await new actual.Rest(this.options).batchPublish(spec);
+      }
+      if (mocked !== undefined) {
+        return await mocked;
+      }
+      return {
+        successCount: spec.channels.length,
+        failureCount: 0,
+        results: spec.channels.map((channel) => {
+          return {
+            channel,
+            messageId: "test-batch",
+            serials: spec.messages.map(() => {
+              return null;
+            }),
+          };
+        }),
+      };
+    };
     readonly channels = {
       get: (channelName: string) => {
         apiTestMocks.ably.channelGet(channelName);
@@ -1290,6 +1331,8 @@ export function apiTestS3PresignedUrl(command: unknown): string {
 export function resetApiTestMocks(): void {
   apiTestMocks.abortSignal.timeout.mockReset();
   apiTestMocks.ably.channelGet.mockReset();
+  apiTestMocks.ably.batchPublish.mockReset();
+  apiTestMocks.ably.useRealBatchPublish.mockReset();
   apiTestMocks.ably.publish.mockReset();
   apiTestMocks.ably.publish.mockResolvedValue(undefined);
   apiTestMocks.ably.createTokenRequest.mockReset();

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -4,10 +4,7 @@ import type {
   BrowserSessionChangedPayload,
   UserPreferenceChangedPayload,
 } from "@okouai/api-contracts/contracts/realtime";
-import type {
-  ConnectorRuntimeTarget,
-  RunnerPreference,
-} from "@okouai/api-contracts/contracts/runners";
+import type { RunnerPreference } from "@okouai/api-contracts/contracts/runners";
 import type { BuiltInGenerationRealtimeSubscription } from "@okouai/api-contracts/contracts/built-in-generation";
 
 import { env } from "../../lib/env";
@@ -373,16 +370,29 @@ export async function publishCancelToRunnerGroup(
   L.debug(`Published ${mode} cancel ${runId} to runner-group:${group}`);
 }
 
-export async function publishConnectorRuntimeSyncToRunnerGroup(
+export async function publishConnectorRuntimeSyncBatch(
   group: string,
-  runId: string,
-  target: ConnectorRuntimeTarget,
+  messages: Ably.Message[],
 ): Promise<void> {
-  const channel = ablyClient().channels.get(`runner-group:${group}`);
-  await channel.publish("connector-runtime-sync", { runId, target });
-  L.debug(
-    `Published connector runtime sync ${runId}/${target.kind} to runner-group:${group}`,
-  );
+  const channel = `runner-group:${group}`;
+  const batch = await ablyClient().batchPublish({
+    channels: [channel],
+    messages,
+  });
+  const [result] = batch.results;
+  if (result && "error" in result) {
+    throw result.error;
+  }
+  if (
+    batch.successCount !== 1 ||
+    batch.failureCount !== 0 ||
+    batch.results.length !== 1 ||
+    result?.channel !== channel
+  ) {
+    throw new Error(
+      "Ably did not acknowledge the connector runtime sync batch",
+    );
+  }
 }
 
 export async function publishSshInvalidationToRunnerGroup(

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-runtime-wakeups.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-runtime-wakeups.test.ts
@@ -1,0 +1,489 @@
+import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
+import type { BatchPublishSpec } from "ably";
+import { MsgPack } from "ably/modular";
+import { http, HttpResponse } from "msw";
+import { z } from "zod";
+
+import { testContext } from "../../../__tests__/test-context";
+import { mockEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
+import { createDeferredPromise } from "../../utils";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import {
+  createConnectorBddApi,
+  manualHttpCustomConnectorCreateBody,
+} from "./helpers/api-bdd-connectors";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+
+const context = testContext();
+const bdd = createBddApi(context);
+const connectors = createConnectorBddApi(context);
+const runs = createRunsApi(context);
+
+async function prepareActor(tier: "pro" | "team" = "pro") {
+  mockEnv("ABLY_API_KEY", "test.key:secret");
+  const actor = bdd.user();
+  bdd.acceptAgentStorageWrites();
+  runs.acceptStorageDownloads();
+  const runnerGroup = runs.configureRunnerGroup();
+  await runs.grantProEntitlement(actor, { tier });
+  await runs.ensureOrgModelProvider(actor);
+  const { agentId } = await bdd.createAgent(actor);
+  return { actor, agentId, runnerGroup };
+}
+
+async function startRun(
+  actor: ApiTestUser,
+  agentId: string,
+  runnerGroup: string,
+) {
+  const run = await runs.createRun(actor, {
+    agentId,
+    prompt: "Exercise runtime wakeups",
+    modelProvider: "anthropic-api-key",
+  });
+  await runs.heartbeatRunner(runnerGroup);
+  await runs.claimRunnerJob(run.runId, {
+    runnerIdentity: { runnerId: randomUUID(), heartbeatGeneration: 1 },
+  });
+  return run.runId;
+}
+
+async function createConnector(actor: ApiTestUser, permissioned = false) {
+  return await connectors.createCustomConnector(
+    actor,
+    manualHttpCustomConnectorCreateBody({
+      slug: `_wakeup-${randomUUID()}`,
+      displayName: "Runtime wakeup test",
+      prefixTemplates: [`https://${randomUUID()}.wakeup.example.test/`],
+      ...(permissioned ? { permissionBundleRef: "builtin:slack@1" } : {}),
+    }),
+  );
+}
+
+function message(runId: string, customConnectorId: string) {
+  return {
+    name: "connector-runtime-sync",
+    data: JSON.stringify({
+      runId,
+      target: { kind: "custom", customConnectorId },
+    }),
+    encoding: "json",
+  };
+}
+
+function acceptedBatch(spec: BatchPublishSpec) {
+  return {
+    successCount: 1,
+    failureCount: 0,
+    results: spec.channels.map((channel) => {
+      return {
+        channel,
+        messageId: "accepted-batch",
+        serials: spec.messages.map(() => {
+          return null;
+        }),
+      };
+    }),
+  };
+}
+
+function expectWakeups(
+  runnerGroup: string,
+  runId: string,
+  ids: readonly string[],
+) {
+  expect(context.mocks.ably.batchPublish).toHaveBeenCalledExactlyOnceWith({
+    channels: [`runner-group:${runnerGroup}`],
+    messages: expect.arrayContaining(
+      ids.map((id) => {
+        return message(runId, id);
+      }),
+    ),
+  });
+  expect(
+    context.mocks.ably.batchPublish.mock.calls[0]?.[0].messages,
+  ).toHaveLength(ids.length);
+  context.mocks.ably.batchPublish.mockClear();
+}
+
+describe("connector runtime wakeups", () => {
+  it("notifies semantic grant changes, including empty membership, but not unchanged or reordered saves", async () => {
+    const { actor, agentId, runnerGroup } = await prepareActor();
+    const first = await createConnector(actor, true);
+    const second = await createConnector(actor);
+    const runId = await startRun(actor, agentId, runnerGroup);
+    context.mocks.ably.batchPublish.mockClear();
+
+    await connectors.requestUpdateAgentCustomConnectorGrants(
+      actor,
+      agentId,
+      [
+        {
+          customConnectorId: first.id,
+          permissionNames: ["chat:write", "files:write"],
+        },
+        { customConnectorId: second.id, permissionNames: [] },
+      ],
+      [200],
+    );
+    expectWakeups(runnerGroup, runId, [first.id, second.id]);
+
+    await connectors.requestUpdateAgentCustomConnectorGrants(
+      actor,
+      agentId,
+      [
+        { customConnectorId: second.id, permissionNames: [] },
+        {
+          customConnectorId: first.id,
+          permissionNames: ["files:write", "chat:write"],
+        },
+      ],
+      [200],
+    );
+    expect(context.mocks.ably.batchPublish).not.toHaveBeenCalled();
+    await connectors.requestUpdateAgentCustomConnectorGrants(
+      actor,
+      agentId,
+      [{ customConnectorId: first.id, permissionNames: ["files:write"] }],
+      [200],
+      "add",
+    );
+    expectWakeups(runnerGroup, runId, [first.id]);
+
+    await connectors.updateAgentCustomConnectors(
+      actor,
+      agentId,
+      [second.id],
+      "add",
+    );
+    await connectors.updateAgentCustomConnectors(
+      actor,
+      agentId,
+      [randomUUID()],
+      "remove",
+    );
+    expect(context.mocks.ably.batchPublish).not.toHaveBeenCalled();
+    await connectors.updateAgentCustomConnectors(
+      actor,
+      agentId,
+      [second.id],
+      "remove",
+    );
+    expectWakeups(runnerGroup, runId, [second.id]);
+    await connectors.updateAgentCustomConnectors(
+      actor,
+      agentId,
+      [second.id],
+      "remove",
+    );
+    expect(context.mocks.ably.batchPublish).not.toHaveBeenCalled();
+
+    await connectors.updateAgentCustomConnectors(actor, agentId, [second.id]);
+    expectWakeups(runnerGroup, runId, [first.id, second.id]);
+    await expect(
+      connectors.readAgentCustomConnectorGrants(actor, agentId),
+    ).resolves.toStrictEqual([
+      { customConnectorId: second.id, permissionNames: [] },
+    ]);
+  });
+
+  it("preserves unrequested grants during add/remove and does not notify rejected updates", async () => {
+    const { actor, agentId, runnerGroup } = await prepareActor();
+    const first = await createConnector(actor);
+    const retained = await createConnector(actor);
+    await connectors.updateAgentCustomConnectors(actor, agentId, [
+      first.id,
+      retained.id,
+    ]);
+    const runId = await startRun(actor, agentId, runnerGroup);
+    context.mocks.ably.batchPublish.mockClear();
+
+    await expect(
+      connectors.updateAgentCustomConnectors(actor, agentId, [first.id], "add"),
+    ).resolves.toStrictEqual(expect.arrayContaining([first.id, retained.id]));
+    await connectors.updateAgentCustomConnectors(
+      actor,
+      agentId,
+      [randomUUID()],
+      "remove",
+    );
+    await connectors.requestUpdateAgentCustomConnectors(
+      actor,
+      agentId,
+      [randomUUID()],
+      [400],
+    );
+    await connectors.requestUpdateAgentCustomConnectorGrants(
+      actor,
+      agentId,
+      [{ customConnectorId: first.id, permissionNames: ["invalid"] }],
+      [400],
+    );
+    expect(context.mocks.ably.batchPublish).not.toHaveBeenCalled();
+    await expect(
+      connectors.readAgentCustomConnectors(actor, agentId),
+    ).resolves.toStrictEqual(expect.arrayContaining([first.id, retained.id]));
+    await connectors.updateAgentCustomConnectors(actor, agentId, []);
+    expectWakeups(runnerGroup, runId, [first.id, retained.id]);
+  });
+
+  it("keeps agent scope for grants and all running groups in org scope for definition deletion", async () => {
+    const { actor, agentId, runnerGroup } = await prepareActor("team");
+    const custom = await createConnector(actor);
+    const runId = await startRun(actor, agentId, runnerGroup);
+    const secondGroup = runs.configureRunnerGroup();
+    const otherAgent = await bdd.createAgent(actor);
+    const otherRun = await startRun(actor, otherAgent.agentId, secondGroup);
+    const cancelled = await startRun(actor, agentId, secondGroup);
+    await runs.requestCancelRun(actor, cancelled, [200]);
+    const outsider = await prepareActor();
+    await startRun(outsider.actor, outsider.agentId, outsider.runnerGroup);
+    context.mocks.ably.batchPublish.mockClear();
+
+    await connectors.updateAgentCustomConnectors(actor, agentId, [custom.id]);
+    expectWakeups(runnerGroup, runId, [custom.id]);
+    await connectors.deleteCustomConnector(actor, custom.id);
+    expect(
+      context.mocks.ably.batchPublish.mock.calls.map(([spec]) => {
+        return spec;
+      }),
+    ).toStrictEqual(
+      expect.arrayContaining([
+        {
+          channels: [`runner-group:${runnerGroup}`],
+          messages: [message(runId, custom.id)],
+        },
+        {
+          channels: [`runner-group:${secondGroup}`],
+          messages: [message(otherRun, custom.id)],
+        },
+      ]),
+    );
+    expect(context.mocks.ably.batchPublish).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds batch sizes and concurrency, continues after a rejected chunk, and keeps committed grants", async () => {
+    const { actor, agentId, runnerGroup } = await prepareActor("team");
+    const ids: string[] = [];
+    // Small DB-only definitions and five API-created runs; no sandboxes are started.
+    for (let index = 0; index < 20; index += 1) {
+      const created = await Promise.all(
+        Array.from({ length: 4 }, async () => {
+          return await createConnector(actor);
+        }),
+      );
+      ids.push(
+        ...created.map((connector) => {
+          return connector.id;
+        }),
+      );
+    }
+    const runIds: string[] = [];
+    for (let index = 0; index < 5; index += 1) {
+      runIds.push(await startRun(actor, agentId, runnerGroup));
+    }
+    context.mocks.ably.batchPublish.mockClear();
+    const started = createDeferredPromise<void>(context.signal);
+    const release = createDeferredPromise<void>(context.signal);
+    let active = 0;
+    let peak = 0;
+    let calls = 0;
+    let failedWakeups = 0;
+    context.mocks.ably.batchPublish.mockImplementation(async (spec) => {
+      calls += 1;
+      const reject = calls === 1;
+      active += 1;
+      peak = Math.max(peak, active);
+      if (calls === 4) {
+        started.resolve();
+      }
+      await release.promise;
+      active -= 1;
+      if (reject) {
+        failedWakeups = spec.messages.length;
+        throw new Error("Rejected atomic batch");
+      }
+      return acceptedBatch(spec);
+    });
+    const saving = connectors.updateAgentCustomConnectors(actor, agentId, ids);
+    const atGate = await Promise.race([started.promise, saving])
+      .then(() => {
+        return { calls, active };
+      })
+      .finally(() => {
+        release.resolve();
+      });
+    await saving;
+    expect(atGate).toStrictEqual({ calls: 4, active: 4 });
+    expect(peak).toBe(4);
+    expect(calls).toBeGreaterThan(4);
+    const batches = context.mocks.ably.batchPublish.mock.calls.map(([spec]) => {
+      return spec;
+    });
+    for (const batch of batches) {
+      expect(batch.channels).toStrictEqual([`runner-group:${runnerGroup}`]);
+      expect(batch.messages.length).toBeLessThanOrEqual(1000);
+      expect(Buffer.byteLength(JSON.stringify([batch]))).toBeLessThanOrEqual(
+        16 * 1024,
+      );
+    }
+    const published = batches.flatMap((batch) => {
+      return batch.messages;
+    });
+    expect(published).toHaveLength(runIds.length * ids.length);
+    expect(published).toStrictEqual(
+      expect.arrayContaining(
+        runIds.flatMap((runId) => {
+          return ids.map((id) => {
+            return message(runId, id);
+          });
+        }),
+      ),
+    );
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Failed to publish connector runtime sync wakeups",
+      ),
+      expect.objectContaining({
+        failedWakeupCount: failedWakeups,
+        failedBatchCount: 1,
+        batchCount: calls,
+      }),
+    );
+    await expect(
+      connectors.readAgentCustomConnectors(actor, agentId),
+    ).resolves.toStrictEqual(expect.arrayContaining(ids));
+  }, 15_000);
+
+  it.each([
+    "accepted",
+    "channel-rejected",
+    "http-rejected",
+    "missing-result",
+  ] as const)(
+    "uses the native Ably HTTP batch contract: %s",
+    async (outcome) => {
+      const { actor, agentId, runnerGroup } = await prepareActor();
+      const custom = await createConnector(actor);
+      const runId = await startRun(actor, agentId, runnerGroup);
+      context.mocks.ably.batchPublish.mockClear();
+      context.mocks.ably.useRealBatchPublish.mockReturnValue(true);
+      const received: unknown[] = [];
+      server.use(
+        http.post(
+          "https://main.realtime.ably.net/messages",
+          async ({ request }) => {
+            expect(request.headers.get("content-type")).toContain(
+              "application/x-msgpack",
+            );
+            if (
+              typeof MsgPack !== "object" ||
+              MsgPack === null ||
+              !("decode" in MsgPack) ||
+              typeof MsgPack.decode !== "function" ||
+              !("encode" in MsgPack) ||
+              typeof MsgPack.encode !== "function"
+            ) {
+              throw new Error("Expected the Ably MessagePack codec");
+            }
+            const decoded: unknown = MsgPack.decode(
+              await request.arrayBuffer(),
+            );
+            received.push(decoded);
+            const specs = z
+              .array(
+                z.object({
+                  channels: z.array(z.string()),
+                  messages: z.array(
+                    z.object({
+                      name: z.string(),
+                      data: z.string(),
+                      encoding: z.string(),
+                    }),
+                  ),
+                }),
+              )
+              .parse(decoded);
+            expect(specs).toStrictEqual([
+              {
+                channels: [`runner-group:${runnerGroup}`],
+                messages: [message(runId, custom.id)],
+              },
+            ]);
+            if (outcome === "http-rejected") {
+              return HttpResponse.json(
+                {
+                  error: {
+                    code: 42_913,
+                    statusCode: 429,
+                    message: "Channel publish rate exceeded",
+                  },
+                },
+                { status: 429 },
+              );
+            }
+            const results =
+              outcome === "missing-result"
+                ? []
+                : outcome === "channel-rejected"
+                  ? [
+                      {
+                        channel: `runner-group:${runnerGroup}`,
+                        error: {
+                          code: 42_913,
+                          statusCode: 429,
+                          message: "Channel publish rate exceeded",
+                        },
+                      },
+                    ]
+                  : [
+                      {
+                        channel: `runner-group:${runnerGroup}`,
+                        messageId: "accepted",
+                        serials: [null],
+                      },
+                    ];
+            const encoded: unknown = MsgPack.encode([
+              {
+                successCount: outcome === "accepted" ? 1 : 0,
+                failureCount: outcome === "channel-rejected" ? 1 : 0,
+                results,
+              },
+            ]);
+            if (!(encoded instanceof ArrayBuffer)) {
+              throw new Error("Expected an encoded MessagePack response");
+            }
+            return new HttpResponse(encoded, {
+              headers: { "content-type": "application/x-msgpack" },
+            });
+          },
+        ),
+      );
+      await connectors.updateAgentCustomConnectors(actor, agentId, [custom.id]);
+      expect(received).toHaveLength(1);
+      await expect(
+        connectors.readAgentCustomConnectors(actor, agentId),
+      ).resolves.toStrictEqual([custom.id]);
+      if (outcome === "accepted") {
+        expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalledWith(
+          expect.stringContaining(
+            "Failed to publish connector runtime sync wakeups",
+          ),
+          expect.anything(),
+        );
+      } else {
+        expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+          expect.stringContaining(
+            "Failed to publish connector runtime sync wakeups",
+          ),
+          expect.objectContaining({
+            failedBatchCount: 1,
+            failedWakeupCount: 1,
+          }),
+        );
+      }
+    },
+  );
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -3289,20 +3289,23 @@ describe("connector catalog valid lifecycle", () => {
     });
     serveObjects(catalogObjects([initial, replacement], replacement));
     await syncCatalog();
-    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
-      "connector-runtime-sync",
-      {
-        runId: run.runId,
-        target: { kind: "custom", customConnectorId: custom.id },
-      },
-    );
+    expect(context.mocks.ably.batchPublish).toHaveBeenCalledWith({
+      channels: [expect.stringMatching(/^runner-group:/)],
+      messages: expect.arrayContaining([
+        {
+          name: "connector-runtime-sync",
+          data: JSON.stringify({
+            runId: run.runId,
+            target: { kind: "custom", customConnectorId: custom.id },
+          }),
+          encoding: "json",
+        },
+      ]),
+    });
 
-    context.mocks.ably.publish.mockClear();
+    context.mocks.ably.batchPublish.mockClear();
     await syncCatalog();
-    expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
-      "connector-runtime-sync",
-      expect.anything(),
-    );
+    expect(context.mocks.ably.batchPublish).not.toHaveBeenCalled();
   }, 15_000);
 
   it("composes accepted connector and local model-provider runner firewalls", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -11663,12 +11663,18 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       headers: { Authorization: "Bearer restored-custom-secret-value" },
     });
 
-    context.mocks.ably.publish.mockClear();
+    context.mocks.ably.batchPublish.mockClear();
     await connectors.updateAgentCustomConnectors(actor, agentId, []);
-    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
-      "connector-runtime-sync",
-      { runId: run.runId, target: targetIdentity },
-    );
+    expect(context.mocks.ably.batchPublish).toHaveBeenCalledWith({
+      channels: [expect.stringMatching(/^runner-group:/)],
+      messages: [
+        {
+          name: "connector-runtime-sync",
+          data: JSON.stringify({ runId: run.runId, target: targetIdentity }),
+          encoding: "json",
+        },
+      ],
+    });
     const [defaultPermissionRuntime] = await api.syncConnectorRuntime(
       run.runId,
       {
@@ -11681,16 +11687,18 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     expect(defaultPermissionRuntime?.nextSyncAt).toBeUndefined();
 
-    context.mocks.ably.publish.mockClear();
+    context.mocks.ably.batchPublish.mockClear();
     await connectors.updateAgentCustomConnectors(actor, agentId, [custom.id]);
-    const restoredGrantWakeups = context.mocks.ably.publish.mock.calls.filter(
-      ([eventName]) => {
-        return eventName === "connector-runtime-sync";
-      },
-    );
-    expect(restoredGrantWakeups).toStrictEqual([
-      ["connector-runtime-sync", { runId: run.runId, target: targetIdentity }],
-    ]);
+    expect(context.mocks.ably.batchPublish).toHaveBeenCalledExactlyOnceWith({
+      channels: [expect.stringMatching(/^runner-group:/)],
+      messages: [
+        {
+          name: "connector-runtime-sync",
+          data: JSON.stringify({ runId: run.runId, target: targetIdentity }),
+          encoding: "json",
+        },
+      ],
+    });
     const [restoredRuntime] = await api.syncConnectorRuntime(run.runId, {
       targets: [target],
     });
@@ -11775,8 +11783,8 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       headers: { Authorization: "Bearer restored-custom-secret-value" },
     });
 
-    context.mocks.ably.publish.mockClear();
-    context.mocks.ably.publish.mockRejectedValueOnce(
+    context.mocks.ably.batchPublish.mockClear();
+    context.mocks.ably.batchPublish.mockRejectedValueOnce(
       new Error("Custom runtime wakeup unavailable"),
     );
     await connectors.updateCustomConnector(actor, custom.id, {
@@ -11794,10 +11802,16 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       queryInjections: custom.queryInjections,
       authMode: custom.authMode,
     });
-    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
-      "connector-runtime-sync",
-      { runId: run.runId, target: targetIdentity },
-    );
+    expect(context.mocks.ably.batchPublish).toHaveBeenCalledWith({
+      channels: [expect.stringMatching(/^runner-group:/)],
+      messages: [
+        {
+          name: "connector-runtime-sync",
+          data: JSON.stringify({ runId: run.runId, target: targetIdentity }),
+          encoding: "json",
+        },
+      ],
+    });
     await connectors.updateAgentCustomConnectors(actor, agentId, [custom.id]);
     const lastKnownGoodAuth = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
@@ -13715,7 +13729,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     expect(kms.decryptCalls).toBe(1);
 
-    context.mocks.ably.publish.mockClear();
+    context.mocks.ably.batchPublish.mockClear();
     await connectors.setCustomConnectorValues(
       actor,
       saved.connector.id,
@@ -13732,10 +13746,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
         ),
       },
     );
-    expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
-      "connector-runtime-sync",
-      expect.anything(),
-    );
+    expect(context.mocks.ably.batchPublish).not.toHaveBeenCalled();
     const [pinnedRuntimeResult] = await api.syncConnectorRuntime(run.runId, {
       targets: [pinnedTarget],
     });
@@ -15048,20 +15059,26 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(otherUserRuntime.body.error.message).toBe(
       "Run does not belong to user",
     );
-    context.mocks.ably.publish.mockClear();
+    context.mocks.ably.batchPublish.mockClear();
     await api.applyUserPermissionGrant(actor, {
       agentId,
       connectorSlug: "slack",
       permission: "files:write",
       action: "allow",
     });
-    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
-      "connector-runtime-sync",
-      {
-        runId: snapshotRun.runId,
-        target: { kind: "builtin", connectorSlug: "slack" },
-      },
-    );
+    expect(context.mocks.ably.batchPublish).toHaveBeenCalledWith({
+      channels: [expect.stringMatching(/^runner-group:/)],
+      messages: expect.arrayContaining([
+        {
+          name: "connector-runtime-sync",
+          data: JSON.stringify({
+            runId: snapshotRun.runId,
+            target: { kind: "builtin", connectorSlug: "slack" },
+          }),
+          encoding: "json",
+        },
+      ]),
+    });
     const [refreshedRuntime] = await api.syncConnectorRuntime(
       snapshotRun.runId,
       { targets: [snapshotSlackTarget] },

--- a/turbo/apps/api/src/signals/services/connector-runtime-wakeup-batches.ts
+++ b/turbo/apps/api/src/signals/services/connector-runtime-wakeup-batches.ts
@@ -1,0 +1,70 @@
+import { Buffer } from "node:buffer";
+import type { Message } from "ably";
+import type { ConnectorRuntimeTarget } from "@okouai/api-contracts/contracts/runners";
+
+const MAX_BATCH_MESSAGES = 1000;
+// Include JSON framing and escaping, staying below Ably's smallest message-size limit.
+const MAX_BATCH_BYTES = 16 * 1024;
+
+export interface ConnectorRuntimeWakeup {
+  readonly runId: string;
+  readonly runnerGroup: string;
+  readonly target: ConnectorRuntimeTarget;
+}
+
+interface ConnectorRuntimeWakeupBatch {
+  readonly runnerGroup: string;
+  readonly wakeups: ConnectorRuntimeWakeup[];
+  readonly messages: Message[];
+}
+
+export function connectorRuntimeWakeupBatches(
+  wakeups: readonly ConnectorRuntimeWakeup[],
+): readonly ConnectorRuntimeWakeupBatch[] {
+  const groups = new Map<string, ConnectorRuntimeWakeup[]>();
+  for (const wakeup of wakeups) {
+    const group = groups.get(wakeup.runnerGroup) ?? [];
+    group.push(wakeup);
+    groups.set(wakeup.runnerGroup, group);
+  }
+  const batches: ConnectorRuntimeWakeupBatch[] = [];
+  for (const [runnerGroup, group] of groups) {
+    const framingBytes = Buffer.byteLength(
+      JSON.stringify([
+        { channels: [`runner-group:${runnerGroup}`], messages: [] },
+      ]),
+    );
+    let batch: ConnectorRuntimeWakeupBatch = {
+      runnerGroup,
+      wakeups: [],
+      messages: [],
+    };
+    let bytes = framingBytes;
+    for (const wakeup of group) {
+      // Native batchPublish serializes DTOs directly, unlike channel.publish.
+      const message: Message = {
+        name: "connector-runtime-sync",
+        data: JSON.stringify({ runId: wakeup.runId, target: wakeup.target }),
+        encoding: "json",
+      };
+      const messageBytes = Buffer.byteLength(JSON.stringify(message));
+      if (framingBytes + messageBytes > MAX_BATCH_BYTES) {
+        throw new Error("Connector runtime wakeup exceeds batch size limit");
+      }
+      const separatorBytes = batch.messages.length > 0 ? 1 : 0;
+      if (
+        batch.messages.length >= MAX_BATCH_MESSAGES ||
+        bytes + separatorBytes + messageBytes > MAX_BATCH_BYTES
+      ) {
+        batches.push(batch);
+        batch = { runnerGroup, wakeups: [], messages: [] };
+        bytes = framingBytes;
+      }
+      bytes += messageBytes + (batch.messages.length > 0 ? 1 : 0);
+      batch.messages.push(message);
+      batch.wakeups.push(wakeup);
+    }
+    batches.push(batch);
+  }
+  return batches;
+}

--- a/turbo/apps/api/src/signals/services/connector-runtime-wakeup.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-runtime-wakeup.service.ts
@@ -8,7 +8,11 @@ import { and, eq, isNotNull, type SQL } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
 import type { ReadonlyDb } from "../external/db";
-import { publishConnectorRuntimeSyncToRunnerGroup } from "../external/realtime";
+import { publishConnectorRuntimeSyncBatch } from "../external/realtime";
+import {
+  connectorRuntimeWakeupBatches,
+  type ConnectorRuntimeWakeup,
+} from "./connector-runtime-wakeup-batches";
 import { settle } from "../utils";
 
 const L = logger("ConnectorRuntimeWakeup");
@@ -39,12 +43,6 @@ export async function commitConnectorRuntimeMutation<T>(
     await publishConnectorRuntimeSyncWakeups(wakeup);
   }
   return result;
-}
-
-interface ConnectorRuntimeWakeup {
-  readonly runId: string;
-  readonly runnerGroup: string;
-  readonly target: ConnectorRuntimeTarget;
 }
 
 function uniqueConnectorRuntimeTargets(
@@ -106,28 +104,32 @@ async function publishConnectorRuntimeSyncWakeupsInner(
     }
   }
 
-  const outcomes = await Promise.all(
-    wakeups.map(async (wakeup) => {
-      const outcome = await settle(
-        publishConnectorRuntimeSyncToRunnerGroup(
-          wakeup.runnerGroup,
-          wakeup.runId,
-          wakeup.target,
-        ),
-      );
-      return { wakeup, outcome };
-    }),
-  );
+  const batches = connectorRuntimeWakeupBatches(wakeups);
+  const pending = batches.values();
+  let failedBatchCount = 0;
   let failedWakeupCount = 0;
   let firstFailure:
     | { readonly wakeup: ConnectorRuntimeWakeup; readonly error: unknown }
     | undefined;
-  for (const { wakeup, outcome } of outcomes) {
-    if (!outcome.ok) {
-      failedWakeupCount += 1;
-      firstFailure ??= { wakeup, error: outcome.error };
+  async function publishBatches(): Promise<void> {
+    for (const batch of pending) {
+      const outcome = await settle(
+        publishConnectorRuntimeSyncBatch(batch.runnerGroup, batch.messages),
+      );
+      if (!outcome.ok) {
+        failedBatchCount += 1;
+        failedWakeupCount += batch.wakeups.length;
+        const [wakeup] = batch.wakeups;
+        if (wakeup) {
+          firstFailure ??= { wakeup, error: outcome.error };
+        }
+      }
     }
   }
+  // Bound request concurrency per mutation; this is not a cross-instance rate limiter.
+  await Promise.all(
+    Array.from({ length: Math.min(4, batches.length) }, publishBatches),
+  );
 
   if (firstFailure) {
     L.warn("Failed to publish connector runtime sync wakeups", {
@@ -136,6 +138,8 @@ async function publishConnectorRuntimeSyncWakeupsInner(
       scopedToAgent: args.scope.agentId !== undefined,
       targetCount: targets.length,
       examinedRunCount: rows.length,
+      batchCount: batches.length,
+      failedBatchCount,
       failedWakeupCount,
       firstFailedRunId: firstFailure.wakeup.runId,
       firstFailedRunnerGroup: firstFailure.wakeup.runnerGroup,
@@ -152,6 +156,9 @@ async function publishConnectorRuntimeSyncWakeupsInner(
     matchedWakeupCount: wakeups.length,
     publishedWakeupCount: wakeups.length - failedWakeupCount,
     failedWakeupCount,
+    batchCount: batches.length,
+    publishedBatchCount: batches.length - failedBatchCount,
+    failedBatchCount,
   });
 }
 

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -18,6 +18,7 @@ import {
 import { isCustomConnectorMcpEnabled } from "./custom-connector-mcp-feature.service";
 import { loadCustomConnectorPermissionBundle } from "./custom-connector-permission-bundle.service";
 import { publishConnectorRuntimeSyncWakeups } from "./connector-runtime-wakeup.service";
+import { changedCustomConnectorIds } from "./user-custom-connector-changes";
 import {
   effectiveCustomConnectorPermissionBundleRef,
   FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF,
@@ -60,7 +61,7 @@ type DbTransaction = Tx;
 
 interface UserCustomConnectorTransactionResult {
   readonly result: UpdateUserCustomConnectorsResult;
-  readonly previousIds: readonly string[];
+  readonly changedConnectorIds: readonly string[];
 }
 
 interface UpdateUserCustomConnectorsArgs {
@@ -588,7 +589,7 @@ async function persistUserCustomConnectorTransaction(args: {
     args.request,
   );
   if (!agentLocked) {
-    return { result: { status: "agentNotFound" }, previousIds: [] };
+    return { result: { status: "agentNotFound" }, changedConnectorIds: [] };
   }
   const previousRows = await args.tx
     .select({
@@ -620,7 +621,11 @@ async function persistUserCustomConnectorTransaction(args: {
         grants: args.grants,
         operation: args.operation,
       }),
-      previousIds,
+      changedConnectorIds: changedCustomConnectorIds(
+        previousRows,
+        args.grants,
+        args.operation,
+      ),
     };
   }
   const definitions = await lockCustomConnectorDefinitionsForGrant(args.tx, {
@@ -633,7 +638,7 @@ async function persistUserCustomConnectorTransaction(args: {
         status: "customConnectorsNotFound",
         missingIds: definitions.missingIds,
       },
-      previousIds,
+      changedConnectorIds: [],
     };
   }
   const previousIdSet = new Set(previousIds);
@@ -652,7 +657,7 @@ async function persistUserCustomConnectorTransaction(args: {
     if (!isCustomConnectorMcpEnabled(featureSwitchContext)) {
       return {
         result: { status: "mcpFeatureDisabled" },
-        previousIds,
+        changedConnectorIds: [],
       };
     }
   }
@@ -669,26 +674,31 @@ async function persistUserCustomConnectorTransaction(args: {
     snapshot: args.connectorCatalogSnapshot,
   });
   if (!permissionSelection.ok) {
-    return { result: permissionSelection.error, previousIds };
+    return { result: permissionSelection.error, changedConnectorIds: [] };
   }
+  const validatedGrants = connectorIds.map((customConnectorId) => {
+    return {
+      customConnectorId,
+      permissionNames: [
+        ...(permissionSelection.permissionNamesByConnectorId.get(
+          customConnectorId,
+        ) ?? []),
+      ],
+    };
+  });
   return {
     result: await persistUserCustomConnectorUpdate(args.tx, {
       orgId: args.request.orgId,
       userId: args.request.userId,
       agentId: args.request.agentId,
-      grants: connectorIds.map((customConnectorId) => {
-        return {
-          customConnectorId,
-          permissionNames: [
-            ...(permissionSelection.permissionNamesByConnectorId.get(
-              customConnectorId,
-            ) ?? []),
-          ],
-        };
-      }),
+      grants: validatedGrants,
       operation: args.operation,
     }),
-    previousIds,
+    changedConnectorIds: changedCustomConnectorIds(
+      previousRows,
+      validatedGrants,
+      args.operation,
+    ),
   };
 }
 
@@ -733,15 +743,7 @@ export async function updateUserCustomConnectors(
         userId: args.userId,
         agentId: args.agentId,
       },
-      targets: [
-        ...committed.previousIds,
-        ...committed.result.grants.map((grant) => {
-          return grant.customConnectorId;
-        }),
-        ...grants.map((grant) => {
-          return grant.customConnectorId;
-        }),
-      ].map((customConnectorId) => {
+      targets: committed.changedConnectorIds.map((customConnectorId) => {
         return { kind: "custom" as const, customConnectorId };
       }),
     });

--- a/turbo/apps/api/src/signals/services/user-custom-connector-changes.ts
+++ b/turbo/apps/api/src/signals/services/user-custom-connector-changes.ts
@@ -1,0 +1,37 @@
+import type { AgentCustomConnectorGrant } from "@okouai/api-contracts/contracts/agent-custom-connectors";
+
+export function changedCustomConnectorIds(
+  previous: readonly AgentCustomConnectorGrant[],
+  requested: readonly AgentCustomConnectorGrant[],
+  operation: "replace" | "add" | "remove",
+): readonly string[] {
+  const before = new Map(
+    previous.map((grant) => {
+      return [grant.customConnectorId, new Set(grant.permissionNames)] as const;
+    }),
+  );
+  const after =
+    operation === "replace" ? new Map<string, Set<string>>() : new Map(before);
+  for (const grant of requested) {
+    if (operation === "remove") {
+      after.delete(grant.customConnectorId);
+    } else {
+      after.set(grant.customConnectorId, new Set(grant.permissionNames));
+    }
+  }
+
+  return [...new Set([...before.keys(), ...after.keys()])].filter((id) => {
+    const oldPermissions = before.get(id);
+    const newPermissions = after.get(id);
+    // Membership is meaningful even when the selected permission set is empty.
+    if (!oldPermissions || !newPermissions) {
+      return true;
+    }
+    return (
+      oldPermissions.size !== newPermissions.size ||
+      [...oldPermissions].some((permission) => {
+        return !newPermissions.has(permission);
+      })
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Relates to #32752. The issue remains open for its post-deployment observation gate.

- Notify only Custom Connectors whose grant membership or permission set actually changed. Compare the locked previous grants with the validated intended persisted state, not the filtered API response. Preserve replace/add/remove behavior and outer-transaction notification deferral.
- Group existing run/target wakeups by runner group and use Ably's native atomic batch publisher. Split at 1000 messages or a conservative 16 KiB JSON-serialized request budget; allow at most four requests in flight per mutation.
- Validate the expected channel's batch result, including channel-level rejection inside a successful HTTP response. Continue independent batches after failure and preserve logical failure counts, adding batch counts.

## Compatibility and scope

The event remains `connector-runtime-sync` with JSON-decoded `{runId,target}`. Native batching explicitly sets `encoding: "json"`; the real installed SDK's MessagePack request/response boundary and the existing Rust WebSocket subscriber are exercised in tests. No production Runner code, API/schema/UI, channel layout, scope filters, account-selection rules, or permissions policy changes.

This retains best-effort post-commit notification: publication failures do not undo successful mutations. There is no outbox, retry worker, polling, global limiter, or reconnect reconciliation. No-op saves no longer incidentally resend earlier missed hints. An atomic rejected chunk loses all hints in that chunk, and concurrent API instances can still pressure the shared channel. Actionable warnings remain.

## Verification

Passed locally:

- 420 API integration tests across `connector-runtime-wakeups`, `agent-custom-connectors`, `run-lifecycle.bdd`, `cron-connector-catalog`, and `feishu-integration`; one Vitest process at a time, `--maxWorkers=4 --silent=passed-only`.
- New regression coverage: empty-permission membership, order-only/no-op saves, additions/removals, failed validation, preserved unrequested grants, agent/org/group scope, cancelled/other-org exclusions, definition deletion, native HTTP/MessagePack contracts, partial chunk failure, and truthful failure accounting.
- The bounded fanout test uses 80 small API-created definitions and five API-created runs (400 identities), without starting sandboxes. It verifies request byte/count limits, four in-flight requests, continuation after rejection, and committed grants.
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace apps/api`
- After `scripts/prepare.sh` synchronized stale local dependencies, reran all 420 API tests, API lint, full-workspace `TSC_CHECKERS=2 pnpm check-types`, and `pnpm knip`; all passed. Normal commit hooks also passed, including full-workspace Cargo Clippy/Rustdoc.
- Prettier checks for all changed TypeScript files; `git diff --check`.
- `cargo fmt -p ably-subscriber --check`
- `CARGO_BUILD_JOBS=2 cargo test --locked --profile local -p ably-subscriber --all-features`
- `CARGO_BUILD_JOBS=2 cargo clippy --locked --profile local -p ably-subscriber --all-targets --all-features -- -D warnings`
- `CARGO_BUILD_JOBS=2 RUSTDOCFLAGS='-D warnings' cargo doc --locked --profile local -p ably-subscriber --all-features --no-deps`

## Deployment follow-up

After deployment, observe the shared runner-group channel for 24 hours using #32752's scenarios and failure metrics. Local tests do not establish production delivery or convergence. No merge is authorized by this workflow invocation.
