### PR TITLE
fix(api): make shared conversation titles optional

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-event-archive-consumers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-event-archive-consumers.test.ts
@@ -258,7 +258,7 @@ describe("archived chat event consumers", () => {
     ]);
   }, 60_000);
 
-  it("preserves user-requested shared-title failures for archived selections", async () => {
+  it("shares archived selections with a fixed title when the title provider is unavailable", async () => {
     const fixture = await createArchiveFixture("sharing-provider-failure");
     // Expired, physically removed events are historical state with no public
     // write API. Reuse this archive harness, then observe the public share API.
@@ -276,20 +276,41 @@ describe("archived chat event consumers", () => {
     chatCallbacks.mockOpenRouterCompletions(() => {
       return new HttpResponse(null, { status: 503 });
     });
-    const client = setupApp({
-      context,
-      routes: sharedThreadRoutes,
-      rethrowErrors: true,
-    })(sharedThreadsContract);
-    await expect(
-      client.create({
+    const created = await accept(
+      sharedThreadClient().create({
         params: { threadId: fixture.threadId },
         headers: authenticate(fixture.actor),
         body: { eventIds: [eventId] },
       }),
-    ).rejects.toMatchObject({ name: "OpenRouterRequestError", status: 503 });
+      [201],
+    );
     await flushWaitUntilForTest();
-    expect(auxiliaryResults(context)).toStrictEqual([]);
+    const shared = await accept(
+      sharedThreadClient().get({ params: { id: created.body.id } }),
+      [200],
+    );
+    expect(shared.body).toStrictEqual({
+      id: created.body.id,
+      publicBrand: "okou",
+      title: "Shared conversation",
+      messages: [
+        {
+          messageIndex: 0,
+          role: "assistant",
+          content: "A completed answer to share",
+        },
+      ],
+    });
+    expect(auxiliaryResults(context)).toStrictEqual([
+      expect.objectContaining({
+        feature: "shared_thread_title",
+        outcome: "degraded",
+        reason: "provider_unavailable",
+      }),
+    ]);
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
   });
 
   it("shares an archived selection while excluding archived revoked and invisible messages", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/auxiliary-generation.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/auxiliary-generation.ts
@@ -8,6 +8,7 @@ const resultSchema = z
     source: z.literal("api"),
     feature: z.enum([
       "chat_title",
+      "shared_thread_title",
       "run_summary",
       "recommended_followups",
       "notification_summary",

--- a/turbo/apps/api/src/signals/routes/__tests__/shared-threads.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/shared-threads.test.ts
@@ -1,0 +1,606 @@
+import { randomUUID } from "node:crypto";
+import { sharedThreadsContract } from "@okouai/api-contracts/contracts/shared-threads";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it, onTestFinished } from "vitest";
+import { z } from "zod";
+
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
+import { rejectSharedThreadArtifactWrites } from "../../../test-fixtures/shared-thread";
+import { flushWaitUntilForTest } from "../../context/wait-until";
+import { createDeferredPromise } from "../../utils";
+import { sharedThreadRoutes } from "../shared-threads";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+import { createRouteMocks } from "./helpers/route-test";
+import {
+  auxiliaryResults,
+  auxiliaryWarnings,
+} from "./helpers/auxiliary-generation";
+
+const context = testContext();
+const bdd = createBddApi(context);
+const chat = createChatFilesBddApi(context);
+const runs = createRunsApi(context);
+const routeMocks = createRouteMocks(context);
+const endpoint = "https://openrouter.ai/api/v1/chat/completions";
+const privateTitle = "Unshared confidential acquisition title";
+const privateContent = "Unselected confidential acquisition message";
+const providerSecret = "Private provider response and credential details";
+const selectedContent = "Publish the agreed launch checklist";
+
+beforeEach(() => {
+  context.mocks.axiom.useRealTelemetry.mockReturnValue(true);
+  mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+});
+
+function client(rethrowErrors = false, signal = context.signal) {
+  return setupApp({
+    context,
+    routes: sharedThreadRoutes,
+    rethrowErrors,
+    signal,
+  })(sharedThreadsContract);
+}
+
+function authenticate(actor: ApiTestUser) {
+  routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+  return { authorization: "Bearer clerk-session" };
+}
+
+function completion(content = "**Launch checklist**") {
+  return HttpResponse.json({
+    choices: [{ finish_reason: "stop", message: { content } }],
+  });
+}
+
+function brokenBody(error: Error) {
+  return new HttpResponse(
+    new ReadableStream({
+      start(controller) {
+        controller.error(error);
+      },
+    }),
+  );
+}
+
+async function prepareShare(content = selectedContent) {
+  const actor = bdd.user();
+  bdd.acceptAgentStorageWrites();
+  runs.acceptStorageDownloads();
+  runs.acceptTelemetryIngest();
+  runs.configureRunnerGroup();
+  await runs.grantProEntitlement(actor);
+  await runs.ensureOrgModelProvider(actor);
+  const agent = await bdd.createAgent(actor, { displayName: "Sharing test" });
+  const sent = await accept(
+    chat.requestSendEvent(
+      actor,
+      {
+        agentId: agent.agentId,
+        prompt: content,
+      },
+      [201],
+    ),
+    [201],
+  );
+  const { threadId, runId } = sent.body;
+  if (!runId) {
+    throw new Error("Expected a new chat run");
+  }
+  await chat.renameThread(actor, threadId, privateTitle);
+  await chat.requestSendEvent(
+    actor,
+    {
+      agentId: agent.agentId,
+      threadId,
+      prompt: privateContent,
+    },
+    [201],
+  );
+  await flushWaitUntilForTest();
+  const { events } = await chat.listThreadEvents(actor, threadId);
+  const eventId = events.find((event) => {
+    return event.eventType === "input.prompt" && event.runId === runId;
+  })?.id;
+  if (!eventId) {
+    throw new Error("Expected the selected event");
+  }
+  return { actor, threadId, eventId, content };
+}
+
+type ShareFixture = Awaited<ReturnType<typeof prepareShare>>;
+
+function requestBody(fixture: ShareFixture) {
+  return {
+    params: { threadId: fixture.threadId },
+    headers: authenticate(fixture.actor),
+    body: { eventIds: [fixture.eventId, fixture.eventId] },
+  };
+}
+
+async function expectSharedSnapshot(
+  fixture: ShareFixture,
+  id: string,
+  title: string,
+) {
+  const shared = await accept(client().get({ params: { id } }), [200]);
+  expect(shared.body).toStrictEqual({
+    id,
+    title,
+    publicBrand: "okou",
+    messages: [
+      {
+        messageIndex: 0,
+        role: "user",
+        content: fixture.content,
+        runIndex: 0,
+      },
+    ],
+  });
+  expect(shared.headers.get("cache-control")).toBe("no-store");
+  const meta = await accept(client().meta({ params: { id } }), [200]);
+  expect(meta.body).toStrictEqual({ title, publicBrand: "okou" });
+  expect(meta.headers.get("cache-control")).toBe(
+    "public, max-age=31536000, s-maxage=31536000, immutable",
+  );
+  const catalog = await chat.listArtifactCatalog(fixture.actor, {
+    kind: "shared-thread",
+    chatThreadId: fixture.threadId,
+  });
+  expect(catalog.artifacts).toHaveLength(1);
+  const artifact = catalog.artifacts[0];
+  if (!artifact) {
+    throw new Error("Expected one share artifact");
+  }
+  expect(artifact).toMatchObject({ kind: "shared-thread", title });
+  const detail = await chat.getArtifactCatalogEntry(fixture.actor, artifact.id);
+  expect(detail).toMatchObject({
+    kind: "shared-thread",
+    title,
+    sharedThread: { id },
+  });
+  const publicData = JSON.stringify([shared.body, meta.body, catalog, detail]);
+  for (const secret of [privateTitle, privateContent, providerSecret]) {
+    expect(publicData).not.toContain(secret);
+  }
+}
+
+async function expectNoShare(fixture: ShareFixture) {
+  const catalog = await chat.listArtifactCatalog(fixture.actor, {
+    kind: "shared-thread",
+    chatThreadId: fixture.threadId,
+  });
+  expect(catalog.artifacts).toStrictEqual([]);
+}
+
+function expectOutcome(outcome: string, reason: string) {
+  expect(auxiliaryResults(context)).toStrictEqual([
+    expect.objectContaining({
+      feature: "shared_thread_title",
+      outcome,
+      reason,
+    }),
+  ]);
+  expect(auxiliaryWarnings(context)).toHaveLength(outcome === "error" ? 1 : 0);
+  expect(
+    context.mocks.axiomLogging.warn.mock.calls.map(([message]) => {
+      return message;
+    }),
+  ).toStrictEqual(outcome === "error" ? ["Auxiliary generation failed"] : []);
+  expect(context.mocks.axiomLogging.error.mock.calls).toStrictEqual([]);
+  expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+  const telemetry = JSON.stringify([
+    auxiliaryResults(context),
+    auxiliaryWarnings(context),
+  ]);
+  for (const secret of [
+    privateTitle,
+    privateContent,
+    selectedContent,
+    providerSecret,
+  ]) {
+    expect(telemetry).not.toContain(secret);
+  }
+}
+
+describe("optional shared-thread titles", () => {
+  const generationCases = [
+    {
+      name: "healthy title",
+      response: () => {
+        return completion();
+      },
+      outcome: "success",
+      reason: "none",
+    },
+    {
+      name: "rate limit",
+      response: () => {
+        return new HttpResponse(providerSecret, { status: 429 });
+      },
+      outcome: "degraded",
+      reason: "rate_limited",
+    },
+    {
+      name: "gateway timeout",
+      response: () => {
+        return new HttpResponse(providerSecret, { status: 504 });
+      },
+      outcome: "degraded",
+      reason: "upstream_timeout",
+    },
+    {
+      name: "provider unavailable",
+      response: () => {
+        return new HttpResponse(providerSecret, { status: 503 });
+      },
+      outcome: "degraded",
+      reason: "provider_unavailable",
+    },
+    {
+      name: "network failure",
+      response: () => {
+        return HttpResponse.error();
+      },
+      outcome: "degraded",
+      reason: "network",
+    },
+    {
+      name: "body timeout",
+      response: () => {
+        return brokenBody(
+          new TypeError("terminated", {
+            cause: { code: "UND_ERR_BODY_TIMEOUT" },
+          }),
+        );
+      },
+      outcome: "degraded",
+      reason: "upstream_timeout",
+    },
+    {
+      name: "auth failure",
+      response: () => {
+        return new HttpResponse(providerSecret, { status: 401 });
+      },
+      outcome: "error",
+      reason: "auth",
+    },
+    {
+      name: "invalid request",
+      response: () => {
+        return new HttpResponse(providerSecret, { status: 400 });
+      },
+      outcome: "error",
+      reason: "invalid_request",
+    },
+    {
+      name: "unknown defect",
+      response: () => {
+        return brokenBody(new TypeError(providerSecret));
+      },
+      outcome: "error",
+      reason: "unknown",
+    },
+    {
+      name: "TLS configuration defect",
+      response: () => {
+        return brokenBody(
+          new TypeError("fetch failed", {
+            cause: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" },
+          }),
+        );
+      },
+      outcome: "error",
+      reason: "unknown",
+    },
+    {
+      name: "empty output",
+      response: () => {
+        return completion("");
+      },
+      outcome: "error",
+      reason: "invalid_output",
+    },
+    {
+      name: "whitespace output",
+      response: () => {
+        return completion(" \n\t ");
+      },
+      outcome: "error",
+      reason: "invalid_output",
+    },
+    {
+      name: "empty interpreted title",
+      response: () => {
+        return completion("---");
+      },
+      outcome: "error",
+      reason: "invalid_output",
+    },
+    {
+      name: "invalid JSON",
+      response: () => {
+        return new HttpResponse(providerSecret);
+      },
+      outcome: "error",
+      reason: "invalid_output",
+    },
+  ];
+
+  it.each(generationCases)(
+    "creates one private-content-safe snapshot with $name",
+    async ({ response, outcome, reason }) => {
+      const fixture = await prepareShare();
+      mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
+      const prompts: string[] = [];
+      server.use(
+        http.post(endpoint, async ({ request }) => {
+          prompts.push(await request.text());
+          return response();
+        }),
+      );
+      const created = await accept(
+        client().create(requestBody(fixture)),
+        [201],
+      );
+      expect(Object.keys(created.body)).toStrictEqual(["id"]);
+      await flushWaitUntilForTest();
+      await expectSharedSnapshot(
+        fixture,
+        created.body.id,
+        outcome === "success" ? "Launch checklist" : "Shared conversation",
+      );
+      expect(prompts).toHaveLength(1);
+      expect(prompts[0]).toContain(selectedContent);
+      expect(prompts[0]).not.toContain(privateTitle);
+      expect(prompts[0]).not.toContain(privateContent);
+      expectOutcome(outcome, reason);
+    },
+  );
+
+  it("uses the fixed title and a skipped result without model configuration", async () => {
+    const fixture = await prepareShare();
+    const requests: string[] = [];
+    server.use(
+      http.post(endpoint, ({ request }) => {
+        requests.push(request.url);
+        return completion();
+      }),
+    );
+    const created = await accept(client().create(requestBody(fixture)), [201]);
+    await flushWaitUntilForTest();
+    await expectSharedSnapshot(fixture, created.body.id, "Shared conversation");
+    expect(requests).toStrictEqual([]);
+    expectOutcome("skipped", "not_applicable");
+  });
+
+  it.each(["ingest", "flush"])(
+    "preserves a valid share when telemetry %s fails",
+    async (mode) => {
+      const fixture = await prepareShare();
+      mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
+      server.use(
+        http.post(endpoint, () => {
+          return new HttpResponse(null, { status: 429 });
+        }),
+      );
+      if (mode === "ingest") {
+        context.mocks.axiom.sdkIngest.mockImplementation(() => {
+          throw new Error("Telemetry unavailable");
+        });
+      } else {
+        context.mocks.axiom.flush.mockRejectedValue(
+          new Error("Telemetry unavailable"),
+        );
+      }
+      const created = await accept(
+        client().create(requestBody(fixture)),
+        [201],
+      );
+      await expect(flushWaitUntilForTest()).resolves.toBeUndefined();
+      await expectSharedSnapshot(
+        fixture,
+        created.body.id,
+        "Shared conversation",
+      );
+      expect(auxiliaryWarnings(context)).toStrictEqual([]);
+      expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+    },
+  );
+
+  it("preserves cancellation before request dispatch", async () => {
+    const fixture = await prepareShare();
+    const controller = new AbortController();
+    const reason = new DOMException("Caller cancelled", "AbortError");
+    controller.abort(reason);
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
+    const requests: string[] = [];
+    server.use(
+      http.post(endpoint, ({ request }) => {
+        requests.push(request.url);
+        return completion();
+      }),
+    );
+    await expect(
+      client(true).create({
+        ...requestBody(fixture),
+        fetchOptions: { signal: controller.signal },
+      }),
+    ).rejects.toBe(reason);
+    await flushWaitUntilForTest();
+    await expectNoShare(fixture);
+    expect(requests).toStrictEqual([]);
+    expect(auxiliaryResults(context)).toStrictEqual([]);
+    expect(auxiliaryWarnings(context)).toStrictEqual([]);
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { late: "success", cancellation: "request" },
+    { late: "rejection", cancellation: "request" },
+    { late: "success", cancellation: "lifecycle" },
+  ])(
+    "preserves $cancellation cancellation before the provider's late $late",
+    async ({ late, cancellation }) => {
+      const fixture = await prepareShare();
+      const controller = new AbortController();
+      const reason =
+        late === "success"
+          ? new DOMException("Caller deadline", "TimeoutError")
+          : new DOMException("Caller cancelled", "AbortError");
+      const entered = createDeferredPromise<AbortSignal>(context.signal);
+      const release = createDeferredPromise<void>(context.signal);
+      const returned = createDeferredPromise<void>(context.signal);
+      mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
+      server.use(
+        http.post(endpoint, async ({ request }) => {
+          entered.resolve(request.signal);
+          await release.promise;
+          returned.resolve(undefined);
+          return late === "success" ? completion() : HttpResponse.error();
+        }),
+      );
+      const request = client(
+        late === "success",
+        cancellation === "lifecycle" ? controller.signal : context.signal,
+      ).create({
+        ...requestBody(fixture),
+        fetchOptions: {
+          signal: cancellation === "request" ? controller.signal : undefined,
+        },
+      });
+      const outcome = Promise.allSettled([request]);
+      onTestFinished(async () => {
+        controller.abort(reason);
+        if (!release.settled()) {
+          release.resolve(undefined);
+        }
+        await outcome;
+      });
+      const providerSignal = await entered.promise;
+      controller.abort(reason);
+      await expect(outcome).resolves.toStrictEqual([
+        {
+          status: "rejected",
+          reason:
+            late === "success"
+              ? reason
+              : expect.objectContaining({
+                  message: expect.stringContaining(
+                    "Unknown response status 500",
+                  ),
+                }),
+        },
+      ]);
+      expect(providerSignal.aborted).toBeTruthy();
+      expect(providerSignal.reason).toBe(reason);
+      await expectNoShare(fixture);
+      release.resolve(undefined);
+      await returned.promise;
+      await flushWaitUntilForTest();
+      await expectNoShare(fixture);
+      expectOutcome("cancelled", "caller_cancelled");
+    },
+  );
+
+  it("keeps authentication, ownership and selection failures outside optional generation", async () => {
+    const fixture = await prepareShare();
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
+    await accept(
+      client().create({ ...requestBody(fixture), headers: {} }),
+      [401],
+    );
+    for (const actor of [
+      bdd.user({ orgId: fixture.actor.orgId }),
+      bdd.user(),
+    ]) {
+      await accept(
+        client().create({
+          ...requestBody(fixture),
+          headers: authenticate(actor),
+        }),
+        [404],
+      );
+    }
+    const empty = await accept(
+      client().create({ ...requestBody(fixture), body: { eventIds: [] } }),
+      [400],
+    );
+    expect(empty.body.error.code).toBe("BAD_REQUEST");
+    const unknown = await accept(
+      client().create({
+        ...requestBody(fixture),
+        body: { eventIds: [randomUUID()] },
+      }),
+      [400],
+    );
+    expect(unknown.body.error.code).toBe("NO_SHAREABLE_MESSAGES");
+    await expectNoShare(fixture);
+    expect(auxiliaryResults(context)).toStrictEqual([]);
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized selections before title generation", async () => {
+    const fixture = await prepareShare("A".repeat(2 * 1024 * 1024));
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
+    const response = await accept(client().create(requestBody(fixture)), [413]);
+    expect(response.body.error.code).toBe("SHARED_THREAD_TOO_LARGE");
+    await expectNoShare(fixture);
+    expect(auxiliaryResults(context)).toStrictEqual([]);
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the share when the real artifact write fails after title degradation", async () => {
+    const fixture = await prepareShare();
+    if (!fixture.actor.orgId) {
+      throw new Error("Expected a test-owned organization");
+    }
+    // The scoped infrastructure fault is the only non-public setup: no user
+    // input can force this second transaction statement to fail independently.
+    const release = await rejectSharedThreadArtifactWrites(
+      fixture.actor.orgId,
+      context.signal,
+    );
+    onTestFinished(release);
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
+    server.use(
+      http.post(endpoint, () => {
+        return new HttpResponse(null, { status: 429 });
+      }),
+    );
+    await expect(client().create(requestBody(fixture))).rejects.toThrow(
+      "Unknown response status 500 for POST /api/chat-threads/:threadId/shared-threads",
+    );
+    await flushWaitUntilForTest();
+    expect(auxiliaryResults(context)).toStrictEqual([
+      expect.objectContaining({
+        feature: "shared_thread_title",
+        outcome: "degraded",
+        reason: "rate_limited",
+      }),
+    ]);
+    expect(auxiliaryWarnings(context)).toStrictEqual([]);
+    expect(context.mocks.axiomLogging.error).toHaveBeenCalledWith(
+      expect.stringContaining("Unhandled request error:"),
+      expect.objectContaining({ type: "unhandled_request_error" }),
+    );
+    expect(context.mocks.sentry.captureException).toHaveBeenCalledOnce();
+    // PostgreSQL reports the attempted public share ID through the external
+    // error capture. Verify rollback using both public read endpoints.
+    const error = z
+      .object({
+        cause: z.object({
+          code: z.literal("23514"),
+          detail: z.string().uuid(),
+        }),
+      })
+      .parse(context.mocks.sentry.captureException.mock.calls[0]?.[0]);
+    await accept(client().get({ params: { id: error.cause.detail } }), [404]);
+    await accept(client().meta({ params: { id: error.cause.detail } }), [404]);
+    await expectNoShare(fixture);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/shared-threads.ts
+++ b/turbo/apps/api/src/signals/routes/shared-threads.ts
@@ -4,7 +4,7 @@ import { command } from "ccstate";
 import { notFound } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { setResHeader$ } from "../context/hono";
+import { requestSignal$, setResHeader$ } from "../context/hono";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import {
   createSharedThread$,
@@ -38,10 +38,12 @@ const sharedThreadTooLarge = Object.freeze({
 
 const createSharedThreadInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
+    const creationSignal = AbortSignal.any([signal, get(requestSignal$)]);
     const auth = get(organizationAuthContext$);
     const publicBrand = PUBLIC_BRAND;
     const body = await get(createBody$);
     signal.throwIfAborted();
+    creationSignal.throwIfAborted();
     if (!body.ok) {
       return body.response;
     }
@@ -56,9 +58,10 @@ const createSharedThreadInner$ = command(
         eventIds: body.data.eventIds,
         publicBrand,
       },
-      signal,
+      creationSignal,
     );
     signal.throwIfAborted();
+    creationSignal.throwIfAborted();
     if (result.kind === "thread-not-found") {
       return notFound("Chat thread not found");
     }

--- a/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
@@ -14,6 +14,7 @@ import { onRejection, safeSync, settle } from "../utils";
 
 type AuxiliaryFeature =
   | "chat_title"
+  | "shared_thread_title"
   | "run_summary"
   | "recommended_followups"
   | "notification_summary"

--- a/turbo/apps/api/src/signals/services/chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-title.service.ts
@@ -243,6 +243,7 @@ function generateChatTitle(input: ChatTitleInput): Promise<string | null> {
 /** Generate the immutable title stored with a public shared-thread snapshot. */
 export async function generateSharedThreadTitle(
   messages: readonly SharedMessage[],
+  signal: AbortSignal,
 ): Promise<string> {
   const recent = messages.slice(-TITLE_PRIOR_MESSAGE_CAP);
   const conversation = recent
@@ -250,21 +251,35 @@ export async function generateSharedThreadTitle(
       return `${message.role}: ${message.content.slice(0, TITLE_CONTEXT_CHAR_CAP)}`;
     })
     .join("\n");
-  const title = await generateFastPathText([
+  const title = await generateAuxiliary(
     {
-      role: "system",
-      content:
-        "Generate a short, descriptive title (max 60 chars) for this shared conversation. Return only the title as plain text. Do not use any markdown syntax such as #, *, **, _, ---, ``` or quotes. Just plain text.",
+      feature: "shared_thread_title",
+      generate: () => {
+        return generateFastPathText(
+          [
+            {
+              role: "system",
+              content:
+                "Generate a short, descriptive title (max 60 chars) for this shared conversation. Return only the title as plain text. Do not use any markdown syntax such as #, *, **, _, ---, ``` or quotes. Just plain text.",
+            },
+            {
+              role: "user",
+              content: conversation,
+            },
+          ],
+          512,
+          undefined,
+          signal,
+        );
+      },
+      usable: (value) => {
+        return Boolean(value);
+      },
     },
-    {
-      role: "user",
-      content: conversation,
-    },
-  ]);
-  if (!title) {
-    throw new Error("Shared thread title generation returned no title");
-  }
-  return title;
+    signal,
+  );
+  // Optional presentation only: never disclose the unshared source title.
+  return title || "Shared conversation";
 }
 
 async function getLatestTitleContextMessages(

--- a/turbo/apps/api/src/signals/services/shared-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/shared-thread.service.ts
@@ -274,7 +274,7 @@ export const createSharedThread$ = command(
       return { kind: "too-large" };
     }
 
-    const title = await generateSharedThreadTitle(messages);
+    const title = await generateSharedThreadTitle(messages, signal);
     signal.throwIfAborted();
     const createdAt = nowDate();
     const id = await database.transaction(async (transaction) => {

--- a/turbo/apps/api/src/test-fixtures/shared-thread.ts
+++ b/turbo/apps/api/src/test-fixtures/shared-thread.ts
@@ -1,0 +1,42 @@
+import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
+
+import { db } from "../lib/db";
+
+/**
+ * Infrastructure-only fault: no product API can reject the artifact insert
+ * after the share insert. Business fixtures still enter through public APIs.
+ * The trigger matches only the UUID-owned test org, never another test's rows.
+ */
+export async function rejectSharedThreadArtifactWrites(
+  orgId: string,
+  signal: AbortSignal,
+): Promise<() => Promise<void>> {
+  const functionName = `test_share_failure_${randomUUID().replaceAll("-", "")}`;
+  await db().transaction(async (tx) => {
+    await tx.execute(sql`
+      CREATE FUNCTION ${sql.identifier(functionName)}() RETURNS trigger
+      LANGUAGE plpgsql AS $$
+      BEGIN
+        IF NEW.org_id = TG_NAME AND NEW.logical_key LIKE 'shared-thread:%' THEN
+          RAISE EXCEPTION 'Test shared-thread artifact write failed'
+            USING ERRCODE = '23514', DETAIL = NEW.entity_id::text;
+        END IF;
+        RETURN NEW;
+      END;
+      $$
+    `);
+    signal.throwIfAborted();
+    await tx.execute(sql`
+      CREATE TRIGGER ${sql.identifier(orgId)} BEFORE INSERT ON artifacts
+      FOR EACH ROW EXECUTE FUNCTION ${sql.identifier(functionName)}()
+    `);
+    signal.throwIfAborted();
+  });
+  return async () => {
+    await db().transaction(async (tx) => {
+      await tx.execute(sql`DROP TRIGGER ${sql.identifier(orgId)} ON artifacts`);
+      await tx.execute(sql`DROP FUNCTION ${sql.identifier(functionName)}()`);
+    });
+  };
+}


### PR DESCRIPTION
## Summary

A failed title-provider call currently prevents an otherwise valid share from being created. Treat shared-thread title generation as an optional enhancement: preserve a usable generated title, otherwise commit the immutable snapshot with `Shared conversation`.

Only title generation and output interpretation use the existing auxiliary boundary. Add `shared_thread_title` to its finite feature vocabulary and retain the existing outcome, reason, duration, and bounded diagnostic behavior. Combine the HTTP request signal with the route lifecycle signal and pass it through generation and the model request. Keep authorization, selection/size checks, pre-write cancellation checks, and the existing single share/artifact transaction outside the optional boundary.

Closes #32742

## Fallbacks

- **Surface:** the immutable title of a newly created shared conversation and its artifact projection.
- **Default:** exactly `Shared conversation` when generation is unconfigured, fails, or has no usable output. It is a presentational default explicitly approved in #32742; it never reads the source title or unselected messages and carries no identity or authorization meaning.
- **Lifetime/removal condition:** keep this default for as long as automatic share titles remain optional. Remove or replace it only with an explicitly approved change to that product behavior. It is not a compatibility reader or rollout bridge, so there is no exposure window, migration, backfill, or rollout cleanup dependency.
- **Failure boundaries:** classified transient failures degrade without warn/error/Sentry errors; auth/request/output/unknown defects retain bounded diagnostics. Cancellation propagates instead of becoming a successful fallback. Persistence errors remain failures.

## Verification

- Real authenticated create and public read/meta routes, plus artifact catalog/detail, verify the existing 201/ID shape, matching persisted titles, unchanged selected content, and exclusion of unshared private title/content.
- MSW covers a healthy title, 429, 504, 503, network failure, typed body timeout, provider 401/400, unknown/TLS defects, invalid JSON, and empty/whitespace/markdown-only output. Missing configuration makes no provider request. Each logical title attempt records exactly one bounded result; a single POST creates one artifact and introduces no retry.
- Explicit provider-entry/release synchronization covers pre-dispatch cancellation, HTTP request cancellation with late success/rejection, and route lifecycle cancellation. The exact cancellation reason reaches the model request, and cancellation creates no share artifact. Existing auxiliary tests also cover unrelated late body defects.
- Real authorization, wrong owner/org, empty/unknown selection, and size-limit failures retain their responses. A real PostgreSQL failure on the artifact insert verifies HTTP 500, retained error capture, rollback of the preceding share insert through public read/meta 404s, and an empty artifact catalog.
- Business fixtures use existing public setup APIs and real services/auth/database. The rollback control alone installs a temporary trigger scoped to its unique test org, then removes it with normal teardown: no product input can independently fail the second transaction statement. No internal business module is mocked.

Completed local checks:

- `pnpm -F api exec vitest run src/signals/routes/__tests__/shared-threads.test.ts src/signals/routes/__tests__/chat-event-archive-consumers.test.ts src/signals/routes/__tests__/auxiliary-generation.test.ts`: **63 passed in 3 files** (24 sharing, 5 archive consumers, 34 auxiliary regressions).
- Oxlint, type-aware Oxlint, and ESLint on all eight changed files: **passed**.
- Full-workspace `pnpm exec knip`: **passed** (existing configuration hints only).
- Formatting, style policy, full-workspace type checks (**15/15 tasks**), Knip, file-size checks, and commitlint: **passed through normal commit hooks**. API type checking includes gateway/core/bootstrap/test boundaries.

An existing `artifact-catalog.bdd.test.ts -t 'shared thread routes'` check has one pass and one failure before sharing starts: runner claim returns `404 Job not found in queue`. The identical failure was reproduced in an untouched worktree at base `32a5a807a5d08019a84075edc5effcc3ee67d7ba`; it is not counted as a pass or changed here.

No provider/share POST retries, budget increases, other auxiliary-consumer policy changes, schema changes, or global exactly-once guarantee are introduced. No full local Vitest, dev server, browser walkthrough, production write/probe, deployment, or production acceptance was performed. Broader verification belongs to required PR and merge-group CI.
