### PR TITLE
test(runner): verify storage cache version-transition bytes

### DIFF
--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -7323,9 +7323,10 @@ mod tests {
 
         // If a stale v1 tarball exists, it's under a different cache key and
         // is unreachable via (name, v2).
+        let v1_bytes = b"STALE-V1-BYTES";
         let v1_dir = home.storage_cache_dir(name, "v1");
         std::fs::create_dir_all(&v1_dir).unwrap();
-        std::fs::write(v1_dir.join("archive.tar.gz"), b"STALE-V1-BYTES").unwrap();
+        std::fs::write(v1_dir.join("archive.tar.gz"), v1_bytes).unwrap();
 
         let mut manifest =
             fresh_storage_plan("https://r2.example.com/ignored.tar.gz".into(), name, "v2");
@@ -7338,9 +7339,21 @@ mod tests {
             storage_archive_url(&manifest, 0),
             Some(format!("file://{}", guest_archive_path(name, "v2")).as_str())
         );
+        let writes = sandbox.write_file_calls();
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes[0].path, guest_archive_path(name, "v2"));
+        assert_eq!(writes[0].content, v2_bytes);
+        assert_ne!(writes[0].content, v1_bytes);
+
         // v2 cache retained; v1 cache untouched (only a GC branch would evict it).
-        assert!(v2_dir.join("archive.tar.gz").exists());
-        assert!(v1_dir.join("archive.tar.gz").exists());
+        assert_eq!(
+            std::fs::read(v2_dir.join("archive.tar.gz")).unwrap(),
+            v2_bytes
+        );
+        assert_eq!(
+            std::fs::read(v1_dir.join("archive.tar.gz")).unwrap(),
+            v1_bytes
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
The storage cache version-transition test could pass with a v2 archive URL even if the guest received stale or incorrect bytes. Require exactly one guest archive write at the v2 path with the complete v2 content, reject the stale v1 fixture, and verify that both host cache archives retain their original contents.

The existing URL assertion remains. This change is confined to the regression test; production cache behavior and the sandbox mock API are unchanged.

Closes #32775

## Validation

- `cargo fmt --manifest-path crates/runner/Cargo.toml --check`
- `cargo test --manifest-path crates/Cargo.toml --locked --profile local -j 2 -p runner --bin runner storage_cache::tests::version_transition_cannot_serve_prev_bytes -- --exact` — passed.
- `cargo test --manifest-path crates/Cargo.toml --locked --profile local -j 2 -p runner --bin runner storage_cache::tests::` — 106 passed.
- `cargo clippy --manifest-path crates/Cargo.toml --locked --profile local -j 2 -p runner --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml --locked --profile local -j 2 -p runner --all-features --no-deps`
- Mutation check: temporarily substituted `STALE-V1-BYTES` at the v2 warm-hit staging boundary while preserving the guest path and host fixtures. The exact test failed at the new content-equality assertion after the URL/path assertions passed. Removed the mutation, verified the source hash matched the version used by all passing checks, and reran its preserved normal test executable successfully.
- `git diff --check`
