### PR TITLE
fix(api): stop retrying expired aws sign-in refresh tokens

### DIFF
--- a/docs/aws-signin-refresh-expiry.md
+++ b/docs/aws-signin-refresh-expiry.md
@@ -1,0 +1,48 @@
+# AWS Sign-In refresh expiry
+
+Firewall auth treats an AWS CLI account's refresh response with HTTP 401 and
+the parsed provider code `TOKEN_EXPIRED` as expected credential expiry. It
+returns the existing `502 TOKEN_REFRESH_FAILED` / `reconnect_required`
+response without credentials and records `needsReconnect=true` with the
+existing `credential_expired` reason. The account remains unavailable until
+the user reconnects it.
+
+The transition emits a fixed structured DEBUG message instead of WARN. The
+provider code is independent of normalized OAuth `invalid_grant`; AWS currently
+normalizes other 4xx responses to that OAuth code too. Message text alone never
+selects the expiry policy. Unknown 4xx, 429, 5xx, transport failures and malformed
+responses keep their existing handling and warning policy. Storage exceptions
+still propagate through normal API error reporting; DEBUG is not a certificate
+that a database transaction committed or a run succeeded.
+
+Every refresh checks the selected account's current state under the existing
+refresh locks. AWS CLI accounts marked `credential_expired` return the same
+reconnect-required result without another provider request, including concurrent
+and `forceRefresh` requests. This does not select a healthy sibling or change
+the default account. Reconnecting atomically replaces credentials and clears
+the reconnect state. Other providers' retry/recovery policies are unchanged.
+
+## Deployment and verification
+
+No database migration, frontend change or runner protocol change is required.
+The reason is already supported by existing API and frontend readers. Old rows
+with generic reconnect reasons are not assumed to be expired: their next
+explicit expiry response establishes the terminal state. An overlapping old
+API can still refresh and write its generic reason; the new no-repeat guarantee
+applies after API promotion and old requests finish.
+
+Keep [#32756](https://github.com/vm0-ai/vm0/issues/32756) open after merge until
+verification records a 24-hour half-open window after that rollout boundary:
+
+- Exercise or observe actual expiry and successful user reconnect. Confirm the
+  account's unavailable/connected states and denial of credentials while expired.
+- Verify no further AWS refresh attempts for that unchanged expired account
+  state, and no expiry-attributable WARN/ERROR logs or Sentry error events.
+- Retain actionable diagnostics for a genuine provider or persistence failure.
+- Record the deployed API identity, window, sanitized evidence and limitations.
+  No matching warning, without expiry traffic, is not verification of the path.
+
+Local route tests cover provider failures, persistence through account reads,
+concurrent/repeated requests, multi-account isolation, and reconnect recovery.
+They do not inject database statement or commit failure. They are not evidence
+that production has been deployed or observed.

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth-aws.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth-aws.test.ts
@@ -1,0 +1,344 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it, onTestFinished } from "vitest";
+
+import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
+
+import { testContext } from "../../../__tests__/test-context";
+import { server } from "../../../mocks/server";
+import { createDeferredPromise } from "../../utils";
+import { createBddApi } from "./helpers/api-bdd";
+import {
+  awsVerificationCode,
+  createConnectorBddApi,
+  mockAwsExternalCodeProvider,
+} from "./helpers/api-bdd-connectors";
+import { createFirewallApi, secretTemplate } from "./helpers/api-bdd-firewall";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+
+const context = testContext();
+const AWS_TOKEN_URL = "https://us-east-1.signin.aws.amazon.com/v1/token";
+const AWS_STS_URL = "https://sts.us-east-1.amazonaws.com/";
+
+async function setupAwsFirewall() {
+  const bdd = createBddApi(context);
+  const fw = createFirewallApi(context);
+  const runs = createRunsApi(context);
+  const connectors = createConnectorBddApi(context);
+  const actor = bdd.user();
+  bdd.acceptAgentStorageWrites();
+  runs.acceptStorageDownloads();
+  runs.acceptTelemetryIngest();
+  runs.configureRunnerGroup();
+  context.mocks.ably.publish.mockResolvedValue(undefined);
+  await fw.provisionRunReadyOrg(actor);
+  await runs.ensureOrgModelProvider(actor);
+  const agent = await bdd.createAgent(actor, {
+    displayName: "AWS refresh agent",
+    description: "Exercises AWS refresh and reconnect.",
+    visibility: "private",
+  });
+  const run = await runs.createRun(actor, {
+    agentId: agent.agentId,
+    prompt: "resolve AWS firewall auth",
+    modelProvider: "anthropic-api-key",
+  });
+  const headers = fw.sandboxHeaders(actor, run.runId);
+  mockAwsExternalCodeProvider();
+
+  async function connect(account: ConnectorAccountMutationIntent) {
+    const session = await connectors.startExternalCode(
+      actor,
+      "aws",
+      "cli",
+      account,
+    );
+    const result = await connectors.completeExternalCode(actor, "aws", {
+      sessionId: session.sessionId,
+      sessionToken: session.sessionToken,
+      code: awsVerificationCode(session.authorizationUrl),
+    });
+    return result.connector;
+  }
+
+  const account = await connect({ intent: "add" });
+  const createdAccountIds = [account.id];
+  onTestFinished(async () => {
+    for (const connectionId of createdAccountIds) {
+      await connectors.deleteBuiltinConnectorAccount(
+        actor,
+        "aws",
+        connectionId,
+      );
+    }
+  });
+
+  function request(connectionId: string, forceRefresh: boolean) {
+    return fw.requestFirewallAuth(
+      headers,
+      {
+        encryptedSecrets: fw.encryptedSecretsBody({}),
+        authHeaders: {},
+        authAwsSigv4: {
+          accessKeyId: secretTemplate("AWS_ACCESS_KEY_ID"),
+          secretAccessKey: secretTemplate("AWS_SECRET_ACCESS_KEY"),
+          sessionToken: secretTemplate("AWS_SESSION_TOKEN"),
+        },
+        secretConnectorMap: {
+          AWS_ACCESS_KEY_ID: "aws",
+          AWS_SECRET_ACCESS_KEY: "aws",
+          AWS_SESSION_TOKEN: "aws",
+        },
+        secretConnectorMetadataMap: {
+          AWS_ACCESS_KEY_ID: {
+            sourceType: "connector",
+            sourceId: connectionId,
+          },
+          AWS_SECRET_ACCESS_KEY: {
+            sourceType: "connector",
+            sourceId: connectionId,
+          },
+          AWS_SESSION_TOKEN: {
+            sourceType: "connector",
+            sourceId: connectionId,
+          },
+        },
+        forceRefresh,
+      },
+      [200, 502],
+    );
+  }
+
+  return { actor, account, connect, connectors, createdAccountIds, request };
+}
+
+describe("AWS Sign-In refresh expiry", () => {
+  it("stops repeated and concurrent refreshes until the exact account reconnects", async () => {
+    const aws = await setupAwsFirewall();
+    const started = createDeferredPromise<void>(context.signal);
+    const release = createDeferredPromise<void>(context.signal);
+    onTestFinished(() => {
+      if (!release.settled()) {
+        release.resolve(undefined);
+      }
+    });
+    let refreshCalls = 0;
+    server.use(
+      http.post(AWS_TOKEN_URL, async () => {
+        refreshCalls += 1;
+        if (!started.settled()) {
+          started.resolve(undefined);
+        }
+        await release.promise;
+        return HttpResponse.json(
+          { code: "TOKEN_EXPIRED", message: "The refresh token has expired." },
+          { status: 401 },
+        );
+      }),
+    );
+    context.mocks.axiomLogging.debug.mockClear();
+    context.mocks.axiomLogging.warn.mockClear();
+    context.mocks.axiomLogging.error.mockClear();
+    context.mocks.sentry.captureException.mockClear();
+
+    const first = aws.request(aws.account.id, true);
+    await started.promise;
+    const concurrent = aws.request(aws.account.id, true);
+    release.resolve(undefined);
+    const responses = await Promise.all([first, concurrent]);
+    responses.push(await aws.request(aws.account.id, false));
+    responses.push(await aws.request(aws.account.id, true));
+    for (const response of responses) {
+      expect(response.status).toBe(502);
+      expect(response.body).toStrictEqual({
+        error: expect.objectContaining({
+          code: "TOKEN_REFRESH_FAILED",
+          failureReason: "reconnect_required",
+          connectors: ["aws"],
+        }),
+      });
+    }
+    expect(refreshCalls).toBe(1);
+    const expired = await aws.connectors.readConnectorBySlug(aws.actor, "aws");
+    expect(expired.connectionStatus).toBe("reconnect-required");
+    expect(expired.reconnectReason).toBe("credential_expired");
+    const expiryLogs = context.mocks.axiomLogging.debug.mock.calls.filter(
+      ([message]) => {
+        return (
+          message === "AWS Sign-In refresh token expired; reconnect required"
+        );
+      },
+    );
+    expect(expiryLogs).toHaveLength(1);
+    expect(expiryLogs[0]).toStrictEqual([
+      "AWS Sign-In refresh token expired; reconnect required",
+      expect.objectContaining({
+        connectorId: aws.account.id,
+        providerErrorCode: "TOKEN_EXPIRED",
+        failureReason: "reconnect_required",
+        oauthStatus: 401,
+      }),
+    ]);
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+
+    const provider = mockAwsExternalCodeProvider();
+    const reconnected = await aws.connect({
+      intent: "reconnect",
+      connectionId: aws.account.id,
+    });
+    expect(reconnected.id).toBe(aws.account.id);
+    expect(reconnected.connectionStatus).toBe("connected");
+    expect(reconnected.reconnectReason).toBeNull();
+    const recovered = await aws.request(aws.account.id, true);
+    expect(recovered.status).toBe(200);
+    expect(recovered.body).toStrictEqual(
+      expect.objectContaining({
+        awsSigv4: {
+          accessKeyId: "aws-external-code-credential-id",
+          secretAccessKey: "aws-secret-access-key",
+          sessionToken: "aws-session-token",
+        },
+      }),
+    );
+    expect(
+      provider.tokenRequests.map(({ grantType }) => {
+        return grantType;
+      }),
+    ).toStrictEqual(["authorization_code", "refresh_token"]);
+  });
+
+  it("keeps a healthy sibling account usable without substituting it for the expired account", async () => {
+    const aws = await setupAwsFirewall();
+    server.use(
+      http.get(AWS_STS_URL, () => {
+        return HttpResponse.xml(
+          "<GetCallerIdentityResponse><GetCallerIdentityResult>" +
+            "<UserId>AIDASIBLING</UserId><Account>123456789012</Account>" +
+            "<Arn>arn:aws:iam::123456789012:user/sibling</Arn>" +
+            "</GetCallerIdentityResult></GetCallerIdentityResponse>",
+        );
+      }),
+    );
+    const sibling = await aws.connect({ intent: "add" });
+    aws.createdAccountIds.push(sibling.id);
+    expect(sibling.id).not.toBe(aws.account.id);
+    let refreshCalls = 0;
+    server.use(
+      http.post(AWS_TOKEN_URL, () => {
+        refreshCalls += 1;
+        return HttpResponse.json({ code: "TOKEN_EXPIRED" }, { status: 401 });
+      }),
+    );
+    expect((await aws.request(aws.account.id, true)).status).toBe(502);
+    await aws.connectors.setDefaultBuiltinConnectorAccount(
+      aws.actor,
+      "aws",
+      sibling.id,
+    );
+    expect((await aws.request(aws.account.id, false)).status).toBe(502);
+    expect((await aws.request(sibling.id, false)).status).toBe(200);
+    expect(refreshCalls).toBe(1);
+    const accounts = await aws.connectors.listBuiltinConnectorAccounts(
+      aws.actor,
+      "aws",
+    );
+    expect(
+      accounts.find(({ id }) => {
+        return id === aws.account.id;
+      }),
+    ).toStrictEqual(
+      expect.objectContaining({
+        connectionStatus: "reconnect-required",
+        reconnectReason: "credential_expired",
+      }),
+    );
+    expect(
+      accounts.find(({ id }) => {
+        return id === sibling.id;
+      }),
+    ).toStrictEqual(
+      expect.objectContaining({
+        connectionStatus: "connected",
+        reconnectReason: null,
+      }),
+    );
+  });
+
+  it("recognizes explicit expiry after an older generic reconnect state", async () => {
+    const aws = await setupAwsFirewall();
+    server.use(
+      http.post(AWS_TOKEN_URL, () => {
+        return HttpResponse.json({ error: "invalid_grant" }, { status: 401 });
+      }),
+    );
+    expect((await aws.request(aws.account.id, true)).status).toBe(502);
+    const generic = await aws.connectors.readConnectorBySlug(aws.actor, "aws");
+    expect(generic.reconnectReason).toBe("authorization_expired_or_revoked");
+
+    let refreshCalls = 0;
+    server.use(
+      http.post(AWS_TOKEN_URL, () => {
+        refreshCalls += 1;
+        return HttpResponse.json({ code: "TOKEN_EXPIRED" }, { status: 401 });
+      }),
+    );
+    context.mocks.axiomLogging.warn.mockClear();
+    expect((await aws.request(aws.account.id, true)).status).toBe(502);
+    expect((await aws.request(aws.account.id, true)).status).toBe(502);
+    expect(refreshCalls).toBe(1);
+    const expired = await aws.connectors.readConnectorBySlug(aws.actor, "aws");
+    expect(expired.reconnectReason).toBe("credential_expired");
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      status: 401,
+      code: "INVALID_CLIENT",
+      failureReason: "reconnect_required",
+    },
+    { status: 400, code: "TOKEN_EXPIRED", failureReason: "reconnect_required" },
+    { status: 429, code: "TOKEN_EXPIRED", failureReason: "upstream_provider" },
+    { status: 503, code: "TOKEN_EXPIRED", failureReason: "upstream_provider" },
+  ])(
+    "keeps HTTP $status $code actionable and recoverable",
+    async ({ status, code, failureReason }) => {
+      const aws = await setupAwsFirewall();
+      server.use(
+        http.post(AWS_TOKEN_URL, () => {
+          return HttpResponse.json(
+            { code, message: "TOKEN_EXPIRED (The refresh token has expired.)" },
+            { status },
+          );
+        }),
+      );
+      context.mocks.axiomLogging.warn.mockClear();
+      const failed = await aws.request(aws.account.id, true);
+      expect(failed.status).toBe(502);
+      expect(failed.body).toStrictEqual({
+        error: expect.objectContaining({
+          code: "TOKEN_REFRESH_FAILED",
+          failureReason,
+        }),
+      });
+      expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+        expect.stringContaining("aws token refresh failed"),
+        expect.objectContaining({ oauthStatus: status, failureReason }),
+      );
+      const account = await aws.connectors.readConnectorBySlug(
+        aws.actor,
+        "aws",
+      );
+      expect(account.reconnectReason).not.toBe("credential_expired");
+
+      const provider = mockAwsExternalCodeProvider();
+      expect((await aws.request(aws.account.id, true)).status).toBe(200);
+      expect(provider.tokenRequests).toHaveLength(1);
+      expect(
+        (await aws.connectors.readConnectorBySlug(aws.actor, "aws"))
+          .connectionStatus,
+      ).toBe("connected");
+    },
+  );
+});

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -518,6 +518,7 @@ interface RefreshState {
   readonly inputValues: Readonly<Record<string, string | null>>;
   readonly tokenExpiresAt: Date | null;
   readonly needsReconnect: boolean;
+  readonly reconnectReason: string | null;
   readonly lastRefreshErrorCode: string | null;
   readonly updatedAtMicros: bigint;
 }
@@ -528,6 +529,7 @@ interface RefreshStateRow {
   readonly storageVersion: number | null;
   readonly tokenExpiresAt: Date | null;
   readonly needsReconnect: boolean;
+  readonly reconnectReason: string | null;
   readonly lastRefreshErrorCode: string | null;
   readonly updatedAtMicros: bigint;
 }
@@ -968,6 +970,21 @@ function isTerminalCodexRefreshState(
     prepared.providerKey === "codex-oauth-token" &&
     state.needsReconnect &&
     isTerminalChatgptRefreshErrorCode(state.lastRefreshErrorCode)
+  );
+}
+
+function isExpiredAwsSigninRefreshState(
+  prepared: PreparedRefreshTokenContext,
+  state: RefreshState,
+): boolean {
+  // Reconnect clears this reason with the credentials under the same lock.
+  // Other needsReconnect states retain their existing refresh/recovery policy.
+  return (
+    prepared.sourceType === "connector" &&
+    prepared.connectorSlug === "aws" &&
+    state.authMethod === "cli" &&
+    state.needsReconnect &&
+    state.reconnectReason === "credential_expired"
   );
 }
 
@@ -2100,6 +2117,7 @@ async function loadModelProviderRefreshStateRow(
         tokenExpiresAt: modelProviderAccounts.tokenExpiresAt,
         needsReconnect: modelProviderAccounts.needsReconnect,
         lastRefreshErrorCode: modelProviderAccounts.lastRefreshErrorCode,
+        reconnectReason: sql`NULL`.mapWith(pgNullDecoder),
         updatedAtMicros:
           sql`(EXTRACT(EPOCH FROM ${modelProviderAccounts.updatedAt}) * 1000000)::bigint`.mapWith(
             pgInt8ToBigIntDecoder,
@@ -2133,6 +2151,7 @@ async function loadModelProviderRefreshStateRow(
       tokenExpiresAt: modelProviders.tokenExpiresAt,
       needsReconnect: modelProviders.needsReconnect,
       lastRefreshErrorCode: modelProviders.lastRefreshErrorCode,
+      reconnectReason: sql`NULL`.mapWith(pgNullDecoder),
       updatedAtMicros:
         sql`(EXTRACT(EPOCH FROM ${modelProviders.updatedAt}) * 1000000)::bigint`.mapWith(
           pgInt8ToBigIntDecoder,
@@ -2177,6 +2196,7 @@ async function loadConnectorRefreshStateRow(
       tokenExpiresAt: connectors.tokenExpiresAt,
       needsReconnect: connectors.needsReconnect,
       lastRefreshErrorCode: sql`NULL`.mapWith(pgNullDecoder),
+      reconnectReason: connectors.reconnectReason,
       updatedAtMicros:
         sql`(EXTRACT(EPOCH FROM ${connectors.updatedAt}) * 1000000)::bigint`.mapWith(
           pgInt8ToBigIntDecoder,
@@ -2268,6 +2288,7 @@ async function loadRefreshState(
     tokenExpiresAt: row.tokenExpiresAt,
     needsReconnect: row.needsReconnect,
     lastRefreshErrorCode: row.lastRefreshErrorCode,
+    reconnectReason: row.reconnectReason,
     updatedAtMicros: row.updatedAtMicros,
   };
 }
@@ -2552,6 +2573,34 @@ async function markAndReturnRefreshFailure(
   signal: AbortSignal,
   shouldLogWarning: boolean,
 ): Promise<RefreshAccessTokenResult> {
+  const connectorAccess = args.connectorAccessBySlug.get(args.accessSourceKey);
+  if (
+    args.sourceType === "connector" &&
+    args.accessSourceKey === "aws" &&
+    connectorAccess?.authMethod === "cli" &&
+    isOAuthProviderHttpError(error) &&
+    error.status === 401 &&
+    error.providerErrorCode === "TOKEN_EXPIRED"
+  ) {
+    await markRefreshFailure(
+      args,
+      context,
+      "invalid_grant",
+      "reconnect_required",
+      "credential_expired",
+    );
+    L.debug("AWS Sign-In refresh token expired; reconnect required", {
+      accessSourceKey: args.accessSourceKey,
+      orgId: args.orgId,
+      userId: args.userId,
+      connectorId: connectorAccess.connectorId,
+      errorCode: "invalid_grant",
+      failureReason: "reconnect_required",
+      providerErrorCode: "TOKEN_EXPIRED",
+      oauthStatus: error.status,
+    });
+    return refreshFailedResult("reconnect_required");
+  }
   const message = error instanceof Error ? error.message : "Unknown error";
   const { errorCode, failureReason } = classifyRefreshFailure(error, signal);
   if (shouldLogWarning) {
@@ -2819,7 +2868,10 @@ async function refreshLockedAccessToken(args: {
     return sourceMissingResult();
   }
 
-  if (isTerminalCodexRefreshState(args.prepared, lockedState)) {
+  if (
+    isTerminalCodexRefreshState(args.prepared, lockedState) ||
+    isExpiredAwsSigninRefreshState(args.prepared, lockedState)
+  ) {
     return refreshFailedResult("reconnect_required");
   }
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/aws.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/aws.test.ts
@@ -549,6 +549,34 @@ describe("AWS external-code provider", () => {
     });
   });
 
+  it.each(["error", "code", "Code", "__type"])(
+    "preserves the AWS %s error code independently of OAuth normalization",
+    async (field) => {
+      server.use(
+        http.post(AWS_TOKEN_URL, () => {
+          return HttpResponse.json(
+            { [field]: "TOKEN_EXPIRED", message: "Refresh token expired" },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(
+        refreshConnectorAuthProviderAccessToken({
+          connectorSlug: "aws",
+          authMethod: "cli",
+          authClient: awsAuthClient(),
+          inputs: awsRefreshInputs(),
+          signal: new AbortController().signal,
+        }),
+      ).rejects.toMatchObject({
+        status: 401,
+        oauthError: "invalid_grant",
+        providerErrorCode: "TOKEN_EXPIRED",
+      });
+    },
+  );
+
   it("redacts AWS token exchange sensitive values from provider errors", async () => {
     const start = await startConnectorExternalCodeAuthorization({
       connectorSlug: "aws",
@@ -604,7 +632,7 @@ describe("AWS external-code provider", () => {
       http.post(AWS_TOKEN_URL, () => {
         return HttpResponse.json(
           {
-            error: "invalid_grant",
+            error: "aws-refresh-token",
             error_description: "Refresh token aws-refresh-token expired",
           },
           { status: 400 },
@@ -623,7 +651,8 @@ describe("AWS external-code provider", () => {
     ).rejects.toSatisfy((error: unknown) => {
       return (
         isOAuthProviderHttpError(error) &&
-        !error.message.includes("aws-refresh-token")
+        !error.message.includes("aws-refresh-token") &&
+        error.providerErrorCode === "[REDACTED]"
       );
     });
   });

--- a/turbo/packages/connectors/src/auth-providers/connectors/aws/signin.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/aws/signin.ts
@@ -95,6 +95,7 @@ interface AwsSigninVerificationCode {
 interface AwsSigninErrorDetails {
   readonly message: string;
   readonly oauthError: string | undefined;
+  readonly providerErrorCode: string | undefined;
 }
 
 interface AwsDpopPublicJwk {
@@ -477,6 +478,8 @@ async function throwAwsSigninHttpError(args: {
     `AWS Sign-In token ${args.operation} failed: ${args.response.status}${suffix}`,
     args.response.status,
     oauthError,
+    undefined,
+    details.providerErrorCode,
   );
 }
 
@@ -486,7 +489,7 @@ async function readAwsSigninErrorDetails(
 ): Promise<AwsSigninErrorDetails> {
   const raw = await response.text();
   if (!raw) {
-    return { message: "", oauthError: undefined };
+    return { message: "", oauthError: undefined, providerErrorCode: undefined };
   }
 
   const truncated = truncateAwsSigninErrorText(
@@ -499,6 +502,7 @@ async function readAwsSigninErrorDetails(
       return {
         message: redactAwsSigninErrorText(truncated, sensitiveValues),
         oauthError: undefined,
+        providerErrorCode: undefined,
       };
     }
     const errorCode =
@@ -520,11 +524,18 @@ async function readAwsSigninErrorDetails(
         redactAwsSigninErrorText(message, sensitiveValues),
       ),
       oauthError: parsed.data.error,
+      providerErrorCode:
+        errorCode === undefined
+          ? undefined
+          : truncateAwsSigninErrorText(
+              redactAwsSigninErrorText(errorCode, sensitiveValues),
+            ),
     };
   } catch {
     return {
       message: redactAwsSigninErrorText(truncated, sensitiveValues),
       oauthError: undefined,
+      providerErrorCode: undefined,
     };
   }
 }

--- a/turbo/packages/connectors/src/auth-providers/oauth/error.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/error.ts
@@ -5,17 +5,21 @@ const MAX_DIAGNOSTIC_LENGTH = 500;
 export class OAuthProviderHttpError extends ProviderHttpError {
   readonly oauthError: string | undefined;
   readonly oauthErrorSubtype: string | undefined;
+  // Provider-specific code, independent of any OAuth error normalization.
+  readonly providerErrorCode: string | undefined;
 
   constructor(
     message: string,
     status: number,
     oauthError: string | undefined = undefined,
     oauthErrorSubtype: string | undefined = undefined,
+    providerErrorCode: string | undefined = undefined,
   ) {
     super(message, status);
     this.name = "OAuthProviderHttpError";
     this.oauthError = oauthError;
     this.oauthErrorSubtype = oauthErrorSubtype;
+    this.providerErrorCode = providerErrorCode;
   }
 }
 


### PR DESCRIPTION
## Summary

- recognize AWS CLI refresh HTTP 401 `TOKEN_EXPIRED` from structured, redacted provider metadata instead of normalized `invalid_grant` or message text
- persist the existing account-scoped `credential_expired` reconnect reason and stop repeated, concurrent and forced refresh attempts under the existing locks
- keep the existing reconnect-required response, restore access after explicit reconnect, and classify expected expiry at DEBUG without suppressing nearby actionable failures

## Scope and compatibility

No schema migration, API contract, UI, runner protocol, dependency or generic OAuth retry-policy changes. Healthy sibling accounts remain usable and are never substituted for the selected expired account.

Old generic reconnect states remain eligible until an explicit expiry is observed. Old API instances can still retry during traffic overlap; the terminal guarantee applies after new API promotion and old requests finish. Existing clients already understand `credential_expired`.

## Validation

- `pnpm -F @okouai/connectors exec vitest run --maxWorkers=4 --silent=passed-only` — 1,138 tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth-aws.test.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts src/signals/routes/__tests__/connectors.bdd.test.ts --maxWorkers=4 --silent=passed-only` — 168 tests
- `pnpm -F @okouai/connectors lint`
- `pnpm -F @okouai/connectors check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace @okouai/connectors --workspace api`
- Prettier check for all six changed files; `git diff --check`

The new API tests cover reconnect state and recovery through real endpoints, repeated/forced/concurrent requests, account isolation, old generic reconnect state, DEBUG/WARN/ERROR/Sentry classification, and unknown 4xx/429/503 controls. Provider tests cover code aliases and secret redaction.

## Remaining verification

No production deployment or observation was performed. Database statement/commit failure was not injected; persistence exceptions still propagate through the existing error boundary.

Relates to #32756. Keep the issue open for its 24-hour post-promotion verification gate; merging this PR alone does not establish production completion. See [rollout notes](docs/aws-signin-refresh-expiry.md).
