### PR TITLE
fix(desktop): refresh cua application discovery

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -95,6 +95,21 @@ jobs:
           sdk="$native/node_modules/@trycua/cua-driver/dist/index.js"
           python3 cua/guardian-proof/run-macos.py "$electron" \
             "$RUNNER_TEMP/cua-guardian-build" "$sdk" "$RUNNER_TEMP/cua-guardian-evidence" "$native"
+      - name: Prove live application discovery across launch and quit
+        working-directory: turbo/apps/desktop
+        shell: bash
+        run: |
+          set -euo pipefail
+          # LaunchServices refuses app bundles under macOS's system temp path.
+          proof="$PWD/.cache/cua-discovery-proof"
+          mkdir -p "$(dirname "$proof")"
+          node cua/discovery-proof/build.mjs "$proof" \
+            "$RUNNER_TEMP/cua-guardian-build" "$RUNNER_TEMP/cua-guardian-runtime"
+          electron="$(node -p 'require("electron")')"
+          proof_status=0
+          "$electron" "$proof/discovery.js" "$proof" || proof_status=$?
+          cp "$proof/discovery.json" "$RUNNER_TEMP/cua-guardian-evidence/discovery.json"
+          exit "$proof_status"
       - name: Prove nine commands and Quit across the production process channel
         working-directory: turbo/apps/desktop
         shell: bash

--- a/turbo/apps/desktop/cua/ACCEPTANCE-RESULTS.md
+++ b/turbo/apps/desktop/cua/ACCEPTANCE-RESULTS.md
@@ -141,3 +141,39 @@ from missing samples, CI speed or upstream claims.
 
 The first row records reviewed automation only; it cannot mark any other row
 passed. Keep the Epic open and manual acceptance unchecked until the user decides.
+
+## Targeted Calculator regression — 2026-09-09
+
+Issue #32784 was reproduced on macOS 15.6 (24G84), arm64, using the installed
+0.48.14 distribution's CUA 0.23.2 SDK/daemon. With `noOverlay: true`, a successful
+Calculator launch returned a live PID while subsequent discovery in the same
+daemon still reported PID 0 / stopped. A daemon started before Calculator quit
+instead retained the obsolete PID. Enabling the AppKit loop corrected both.
+
+The repair was tested from local source through the production driver controller,
+shared executor, bundled SDK helper, Unix socket and native guardian, with the
+unmodified signed CUA payload and native supervisor from Desktop 0.48.14.
+The installed Electron 42.5.1 executable ran the isolated harness in Node mode;
+the installed app and its preferences were not replaced. This is local source
+acceptance, not a deployed cloud-to-Desktop run or signed-upgrade/TCC acceptance.
+
+| Check                                             | Observed result                                                                                |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Existing Calculator discovery and window snapshot | Exact live PID/window, CUA PNG and AX tree obtained                                            |
+| Calculator `100 + 250`                            | Nine AX button actions including clear; CUA screenshot and independent UI read both show `350` |
+| Calculator quit then `app.open`                   | Stopped PID 0, then new live PID, launch confirmation and usable post-state                    |
+| Old snapshot after quit/reopen                    | Rejected before action; displayed `350` preserved                                              |
+| External quit and reopen                          | Stopped state and new PID correctly discovered in the same generation                          |
+| Reopened window in another Space                  | Explicit `window_unavailable`; raw CUA inventory confirms every window is off-screen           |
+| Target process cleanup                            | Controller retired, no pending cleanup, daemon exit independently observed                     |
+
+The separate [native discovery proof](discovery-proof/README.md) passed seven
+same-generation lifecycle observations for its disposable application. Changing
+only the generated helper back to `noOverlay: true` made the post-launch assertion
+fail; both versions still cleaned up. The adapter proof also passed refusal,
+incorrect-success and cancellation cases for cursor suppression, with no target
+launch and completed retirement.
+
+Raw AX trees and screenshots remain private; no unrelated app inventory is
+published. These results do not fill the broader paired application, permissions,
+recording, plugin continuity, or signed upgrade/rollback tables above.

--- a/turbo/apps/desktop/cua/ADAPTER.md
+++ b/turbo/apps/desktop/cua/ADAPTER.md
@@ -35,6 +35,13 @@ upstream suggestion triggers escalation, another route, another driver or replay
 
 ## Addressing, observations and facts
 
+Window discovery considers only on-screen windows for the exact live PID.
+Hidden auxiliary windows, minimized windows and windows in other Spaces do not
+compete with a visible target. Initial observation requires exactly one such
+window; multiple visible windows remain ambiguous. A retained window must still
+be on-screen with the same ID and frame before an action. The adapter does not
+choose by title, size or z-order, or restore hidden windows automatically.
+
 One generation owns one embedded process/client/session and one current
 observation. Host-generated session labels are not authorization. Every host
 snapshot and opaque element ID binds bundle/PID/path/window, CUA snapshot and

--- a/turbo/apps/desktop/cua/README.md
+++ b/turbo/apps/desktop/cua/README.md
@@ -71,8 +71,13 @@ permissions UI, snapshots, deadlines and first-party lifecycle supervision;
 ordinary startup and passive permission reads neither load CUA nor launch it.
 The helper uses the bundled Electron executable, never system Node. It starts
 the absolute packaged daemon with the build's real bundle ID, standard permission
-mode, a private mode-0700 directory and both telemetry flags disabled. Overlay
-and history remain disabled.
+mode, a private mode-0700 directory and both telemetry flags disabled. The
+daemon's AppKit event loop remains active so macOS running-app inventory updates
+after launch and quit. Before exposing each owned session, the helper uses
+`setAgentCursorEnabled` to disable cursor drawing and validates the reply; failed
+or cancelled setup cannot admit an action. PiP and history remain disabled.
+CUA 0.23.2's `noOverlay: true` also disables its AppKit loop, leaving
+`NSWorkspace.runningApplications` stale, so it is not used for drawing control.
 
 The [guardian topology and macOS proof](guardian-proof/README.md) describe the
 native spawn gate, retained waitable identity, independent process-group
@@ -150,6 +155,12 @@ failed-force/identity/observation fences. A separate real-Electron nine-command
 round trip uses the production guardian/helper/IPC and substitutes only public
 SDK responses; it operates no actual apps. Native metadata/cancel stress uses
 the real pinned SDK, but neither fixture establishes the original mutex race.
+
+The [application discovery proof](discovery-proof/README.md) uses the real
+production helper, guardian and pinned SDK with a disposable native application.
+It checks cold launch, external launch, quit/reopen and stale PID removal within
+one daemon generation, then verifies process cleanup. The adapter proof also
+rejects session admission when cursor suppression fails or is cancelled.
 
 The distribution fault test uses fixture archives to inject corruption, unsafe
 entries, version/architecture mismatches, missing files, cache corruption, and

--- a/turbo/apps/desktop/cua/discovery-proof/README.md
+++ b/turbo/apps/desktop/cua/discovery-proof/README.md
@@ -1,0 +1,35 @@
+# Native application discovery regression proof
+
+This macOS arm64 gate exercises the production `CuaEmbeddedRuntime`, SDK helper,
+native guardian, and verified pinned CUA SDK/daemon. Its only application is a
+uniquely identified temporary native `.app`. It checks the same daemon generation
+before launch, after CUA cold launch, after exit, after external launch, and after
+external quit/reopen with a new PID. The fixture is windowless and requires no
+Accessibility, Screen Recording, Automation, or screenshot operation.
+
+Run from `turbo/apps/desktop` after installing dependencies, building the existing
+guardian proof's `owner.node` and `guardian`, and staging the real CUA payload:
+
+```bash
+proof="$PWD/.cache/cua-discovery-proof"
+mkdir -p .cache
+node cua/discovery-proof/build.mjs "$proof" "$native_build" "$cua_runtime"
+electron="$(node -p 'require("electron")')"
+"$electron" "$proof/discovery.js" "$proof"
+```
+
+All three build arguments are absolute paths. The dedicated `$proof` directory
+must not exist before building. The runtime argument contains the real verified
+payload from `scripts/stage-cua-runtime.py`, with native code signed for execution.
+The build copies these files; it does not edit the original runtime.
+Use a disposable workspace directory rather than `/tmp`: macOS marks app bundles
+under `/tmp` as launch-disabled even when their LaunchServices registration succeeds.
+
+`discovery.json` records each inventory observation, unchanged generation/daemon
+identity, and production guardian cleanup evidence. Each state transition has an
+eight-second observation bound; process/RPC operations retain their production
+timeouts. The fixture exits through its own private stop file and has a separate
+90-second self-expiry for failed experiments. Self-expiry cannot make a normal
+eight-second exit assertion pass. Its LaunchServices registration is removed on
+completion. No user application is launched, closed, or reconfigured. This gate
+does not establish GUI interaction, Developer ID attribution, or TCC persistence.

--- a/turbo/apps/desktop/cua/discovery-proof/build.mjs
+++ b/turbo/apps/desktop/cua/discovery-proof/build.mjs
@@ -1,0 +1,85 @@
+import { build } from "tsup";
+import { cp, copyFile, mkdir, realpath, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+const [directory, native, runtime] = process.argv.slice(2);
+if (
+  ![directory, native, runtime].every(
+    (value) => value && path.isAbsolute(value),
+  )
+)
+  throw new Error(
+    "Expected absolute proof, native build, and staged CUA paths",
+  );
+await mkdir(directory, { mode: 0o700 });
+const output = await realpath(directory);
+const common = {
+  config: false,
+  platform: "node",
+  target: "node20",
+  format: ["cjs"],
+  external: ["electron"],
+  noExternal: ["zod", /^@okouai\//],
+};
+await build({
+  ...common,
+  entry: { discovery: "cua/discovery-proof/main.ts" },
+  outDir: output,
+});
+await build({
+  ...common,
+  entry: { "cua-sdk-process": "src/cua-sdk-process.ts" },
+  outDir: path.join(output, "native"),
+});
+await copyFile(
+  path.join(native, "owner.node"),
+  path.join(output, "native/cua-owner.node"),
+);
+await copyFile(
+  path.join(native, "guardian"),
+  path.join(output, "native/cua-guardian"),
+);
+await cp(runtime, path.join(output, "cua"), { recursive: true });
+
+const bundleId = `ai.okou.discovery-proof.${randomUUID()}`;
+const fixture = path.join(output, "DiscoveryFixture.app");
+await mkdir(path.join(fixture, "Contents/MacOS"), { recursive: true });
+await writeFile(
+  path.join(fixture, "Contents/Info.plist"),
+  `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleIdentifier</key><string>${bundleId}</string>
+<key>CFBundleName</key><string>Okou Discovery Fixture</string>
+<key>CFBundleExecutable</key><string>fixture</string>
+<key>CFBundlePackageType</key><string>APPL</string>
+<key>CFBundleVersion</key><string>1</string>
+<key>NSPrincipalClass</key><string>NSApplication</string>
+</dict></plist>
+`,
+);
+execFileSync(
+  "clang",
+  [
+    "-fobjc-arc",
+    "-Wall",
+    "-Wextra",
+    "-Werror",
+    "-framework",
+    "AppKit",
+    "cua/discovery-proof/fixture.m",
+    "-o",
+    path.join(fixture, "Contents/MacOS/fixture"),
+  ],
+  { stdio: "inherit" },
+);
+execFileSync("codesign", ["--force", "--sign", "-", fixture], {
+  stdio: "inherit",
+});
+await writeFile(
+  path.join(output, "fixture.json"),
+  JSON.stringify({ bundleId, fixture }) + "\n",
+);
+console.log(`Discovery proof built in ${output}`);

--- a/turbo/apps/desktop/cua/discovery-proof/fixture.m
+++ b/turbo/apps/desktop/cua/discovery-proof/fixture.m
@@ -1,0 +1,55 @@
+#import <AppKit/AppKit.h>
+#include <string.h>
+#include <unistd.h>
+
+@interface DiscoveryFixture : NSObject <NSApplicationDelegate>
+@end
+
+@implementation DiscoveryFixture
+- (void)applicationDidFinishLaunching:(NSNotification *)notification {
+  (void)notification;
+  NSURL *directory = NSBundle.mainBundle.bundleURL.URLByDeletingLastPathComponent;
+  NSURL *marker = [directory URLByAppendingPathComponent:@"fixture-running.json"];
+  NSDictionary *identity = @{@"pid": @(getpid()),
+                             @"bundleId": NSBundle.mainBundle.bundleIdentifier};
+  NSData *data = [NSJSONSerialization dataWithJSONObject:identity options:0 error:nil];
+  if (![data writeToURL:marker atomically:YES]) {
+    [NSApp terminate:nil];
+    return;
+  }
+  NSURL *stop = [directory URLByAppendingPathComponent:@"fixture-stop"];
+  NSDate *expiry = [NSDate dateWithTimeIntervalSinceNow:90];
+  [NSTimer scheduledTimerWithTimeInterval:0.05 repeats:YES block:^(NSTimer *timer) {
+    if ([NSFileManager.defaultManager fileExistsAtPath:stop.path] ||
+        expiry.timeIntervalSinceNow <= 0) {
+      [timer invalidate];
+      [NSApp terminate:nil];
+    }
+  }];
+}
+@end
+
+int main(int argc, const char *argv[]) {
+  @autoreleasepool {
+    if (argc == 2 && strcmp(argv[1], "--running") == 0) {
+      NSMutableArray *pids = [NSMutableArray array];
+      for (NSRunningApplication *candidate in
+           [NSRunningApplication runningApplicationsWithBundleIdentifier:
+               NSBundle.mainBundle.bundleIdentifier]) {
+        if (!candidate.terminated && candidate.processIdentifier != getpid()) {
+          [pids addObject:@(candidate.processIdentifier)];
+        }
+      }
+      NSData *data = [NSJSONSerialization dataWithJSONObject:pids options:0 error:nil];
+      puts([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding].UTF8String);
+      return 0;
+    }
+    NSApplication *application = NSApplication.sharedApplication;
+    [application setActivationPolicy:NSApplicationActivationPolicyRegular];
+    static DiscoveryFixture *delegate;
+    delegate = [DiscoveryFixture new];
+    application.delegate = delegate;
+    [application run];
+  }
+  return 0;
+}

--- a/turbo/apps/desktop/cua/discovery-proof/main.ts
+++ b/turbo/apps/desktop/cua/discovery-proof/main.ts
@@ -1,0 +1,265 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { readFile, realpath, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { setTimeout as pause } from "node:timers/promises";
+import { promisify } from "node:util";
+import { app } from "electron";
+import { z } from "zod";
+import { CuaEmbeddedRuntime } from "../../src/cua-runtime";
+
+const execute = promisify(execFile);
+const directory = process.argv.at(-1);
+if (!directory || !path.isAbsolute(directory))
+  throw new Error("Missing absolute discovery proof directory");
+const requestedOutput = directory;
+const register =
+  "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister";
+const fixtureSchema = z.object({ bundleId: z.string(), fixture: z.string() });
+const identitySchema = z.object({
+  bundleId: z.string(),
+  pid: z.number().int().positive(),
+});
+const inventorySchema = z.object({
+  apps: z.array(
+    z.object({
+      bundle_id: z.string().nullable(),
+      running: z.boolean(),
+      pid: z.number().int().nonnegative(),
+    }),
+  ),
+});
+app.commandLine.appendSwitch("disable-gpu");
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ESRCH")
+      return false;
+    throw error;
+  }
+}
+
+async function until<T>(
+  label: string,
+  sample: () => Promise<T | undefined>,
+): Promise<T> {
+  const expires = performance.now() + 8_000;
+  while (performance.now() < expires) {
+    const result = await sample();
+    if (result !== undefined) return result;
+    await pause(100);
+  }
+  throw new Error(`${label} did not become observable within eight seconds`);
+}
+
+async function prove() {
+  assert.equal(process.platform, "darwin");
+  assert.equal(process.arch, "arm64");
+  assert.equal(process.versions.electron, "42.5.1");
+  const output = await realpath(requestedOutput);
+  const fixture = fixtureSchema.parse(
+    JSON.parse(await readFile(path.join(output, "fixture.json"), "utf8")),
+  );
+  assert.equal(fixture.fixture, path.join(output, "DiscoveryFixture.app"));
+  assert.match(fixture.bundleId, /^ai\.okou\.discovery-proof\.[a-f0-9-]+$/);
+  const runtime = new CuaEmbeddedRuntime({
+    runtimeRoot: path.join(output, "cua"),
+    hostBundleId: "ai.okou.desktop",
+  });
+  const stopFile = path.join(output, "fixture-stop");
+  const runningFile = path.join(output, "fixture-running.json");
+  const observations: Record<string, unknown>[] = [];
+  let fixturePid: number | undefined;
+  let failure: unknown;
+
+  async function nativePids() {
+    const { stdout } = await execute(
+      path.join(fixture.fixture, "Contents/MacOS/fixture"),
+      ["--running"],
+      { timeout: 5_000 },
+    );
+    return z.array(z.number().int().positive()).parse(JSON.parse(stdout));
+  }
+
+  async function launched(previousPid?: number) {
+    fixturePid = await until("fixture startup", async () => {
+      const text = await readFile(runningFile, "utf8").catch(
+        (error: unknown) => {
+          if (
+            error instanceof Error &&
+            "code" in error &&
+            error.code === "ENOENT"
+          )
+            return null;
+          throw error;
+        },
+      );
+      if (text === null) return undefined;
+      const identity = identitySchema.parse(JSON.parse(text));
+      assert.equal(identity.bundleId, fixture.bundleId);
+      return identity.pid !== previousPid && alive(identity.pid)
+        ? identity.pid
+        : undefined;
+    });
+    return fixturePid;
+  }
+
+  async function stopFixture() {
+    await writeFile(stopFile, "stop\n");
+    const pid = fixturePid;
+    await until("fixture process exit", async () =>
+      (await nativePids()).length === 0 && (pid === undefined || !alive(pid))
+        ? true
+        : undefined,
+    );
+    fixturePid = undefined;
+  }
+
+  async function prepareLaunch() {
+    await rm(stopFile, { force: true });
+    await rm(runningFile, { force: true });
+  }
+
+  try {
+    await execute(register, ["-f", fixture.fixture], { timeout: 10_000 });
+    const ready = await runtime.start();
+    async function check(phase: string, expectedPid?: number) {
+      assert.deepEqual(
+        await nativePids(),
+        expectedPid === undefined ? [] : [expectedPid],
+      );
+      const matches = await until(phase, async () => {
+        const result = await runtime.useClient((client, signal) =>
+          client.callTool("list_apps", "{}", { signal }),
+        );
+        assert.equal(result.isError, false, result.text);
+        const data = inventorySchema.parse(JSON.parse(result.structuredJson!));
+        const matches = data.apps.filter(
+          (entry) => entry.bundle_id === fixture.bundleId && entry.running,
+        );
+        if (expectedPid === undefined)
+          return matches.length === 0 ? matches : undefined;
+        return matches.length === 1 && matches[0]?.pid === expectedPid
+          ? matches
+          : undefined;
+      });
+      const current = await runtime.start();
+      assert.equal(current.generation, ready.generation);
+      const metadata = await runtime.useClient((client, signal) =>
+        client.metadata({ signal }),
+      );
+      assert.equal(metadata.pid, ready.metadata.pid);
+      observations.push({
+        phase,
+        generation: current.generation,
+        daemonPid: metadata.pid,
+        matches,
+      });
+      console.log(JSON.stringify(observations.at(-1)));
+    }
+
+    await check("initially stopped");
+    await prepareLaunch();
+    const launch = await runtime.useClient((client, signal) =>
+      client.callTool(
+        "launch_app",
+        JSON.stringify({ bundle_id: fixture.bundleId }),
+        { signal },
+      ),
+    );
+    assert.equal(launch.isError, false, launch.text);
+    const coldPid = await launched();
+    const launchResult = z
+      .object({
+        pid: z.number().int().positive(),
+        bundle_id: z.string(),
+        launch_state: z.object({ process_running: z.literal(true) }),
+      })
+      .parse(JSON.parse(launch.structuredJson!));
+    assert.equal(launchResult.pid, coldPid);
+    assert.equal(launchResult.bundle_id, fixture.bundleId);
+    await check("CUA cold launch", coldPid);
+    await stopFixture();
+    await check("CUA-launched process exited");
+
+    await prepareLaunch();
+    await execute("/usr/bin/open", ["-g", fixture.fixture], {
+      timeout: 10_000,
+    });
+    const externalPid = await launched(coldPid);
+    await check("external launch", externalPid);
+    await stopFixture();
+    await check("externally launched process exited");
+
+    await prepareLaunch();
+    await execute("/usr/bin/open", ["-g", fixture.fixture], {
+      timeout: 10_000,
+    });
+    const reopenedPid = await launched(externalPid);
+    await check("external reopen with new PID", reopenedPid);
+    await stopFixture();
+    await check("reopened process exited; old PIDs absent");
+  } catch (error) {
+    failure = error;
+  } finally {
+    const cleanup = await Promise.allSettled([
+      stopFixture(),
+      runtime.dispose(),
+    ]);
+    const unregister = await execute(register, ["-u", fixture.fixture], {
+      timeout: 10_000,
+    }).then(
+      () => true,
+      () => false,
+    );
+    const evidence = runtime.getCleanupEvidence();
+    const success =
+      failure === undefined &&
+      cleanup.every((result) => result.status === "fulfilled") &&
+      unregister &&
+      evidence?.directoryRemoved &&
+      evidence.process?.guardianExitObserved &&
+      evidence.process.descendantsExited;
+    await writeFile(
+      path.join(output, "discovery.json"),
+      JSON.stringify(
+        {
+          schemaVersion: 1,
+          electron: process.versions.electron,
+          fixtureBundleId: fixture.bundleId,
+          boundary:
+            "production runtime, helper, guardian and real pinned CUA SDK/daemon; no TCC or capture",
+          observations,
+          cleanup: evidence,
+          fixtureStopped: fixturePid === undefined,
+          fixtureUnregistered: unregister,
+          success: Boolean(success),
+          failure: failure instanceof Error ? failure.message : failure,
+          cleanupFailures: cleanup
+            .filter((result) => result.status === "rejected")
+            .map((result) => String(result.reason)),
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    assert.ok(
+      success,
+      `Discovery proof failed; inspect ${path.join(output, "discovery.json")}`,
+    );
+  }
+}
+
+void app
+  .whenReady()
+  .then(prove)
+  .then(
+    () => app.exit(0),
+    (error: unknown) => {
+      console.error(error);
+      app.exit(1);
+    },
+  );

--- a/turbo/apps/desktop/cua/guardian-proof/helper.mjs
+++ b/turbo/apps/desktop/cua/guardian-proof/helper.mjs
@@ -69,7 +69,9 @@ async function main() {
       { name: "HOME", value: path.dirname(socketPath) },
     ],
     inheritStderr: false,
-    noOverlay: true,
+    // Match production's AppKit loop. This proof starts no sessions or actions,
+    // so its cursor stays off screen and never draws.
+    noOverlay: false,
   });
   if (mode === "healthy" || mode === "native-cancel") {
     await healthy(sdk, host);

--- a/turbo/apps/desktop/scripts/cua-adapter-proof.ts
+++ b/turbo/apps/desktop/scripts/cua-adapter-proof.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { rm, watch, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { app } from "electron";
 import { createCuaComputerUseDriver } from "../src/computer-use-cua";
@@ -15,6 +16,85 @@ app.commandLine.appendSwitch("disable-gpu");
 function result(value: ComputerUseCommandExecutionResult) {
   if (value.status !== "succeeded") throw new Error(value.error.message);
   return value.result;
+}
+
+async function proveCursorFailure(mode: "rejected" | "mismatch" | "abort") {
+  const failurePath = path.join(directory!, "cursor-failure");
+  const enteredPath = path.join(directory!, "cursor-entered");
+  const launchedPath = path.join(directory!, "app-launched");
+  await rm(enteredPath, { force: true });
+  await rm(launchedPath, { force: true });
+  await writeFile(failurePath, mode);
+  let resolveRetired!: () => void;
+  const retirementObserved = new Promise<void>((resolve) => {
+    resolveRetired = resolve;
+  });
+  const driver = new ComputerUseDriverController(
+    createCuaComputerUseDriver({
+      runtimeRoot: path.join(directory!, "cua"),
+      hostBundleId: "ai.okou.desktop",
+    }),
+    "darwin",
+    () => {
+      const state = driver.getState();
+      if (state.actual === null && !state.cleanupPending) resolveRetired();
+    },
+  );
+  const watching = new AbortController();
+  try {
+    await driver.withPermissionProvider((provider) =>
+      provider.getPermissions(),
+    );
+    driver.activate();
+    const lease = driver.acquireCommand();
+    try {
+      const permissions = await lease.getPermissions();
+      const abortWhenEntered = async () => {
+        if (mode !== "abort") return;
+        const signal = AbortSignal.any([
+          watching.signal,
+          AbortSignal.timeout(10_000),
+        ]);
+        for await (const event of watch(directory!, { signal })) {
+          if (event.filename === "cursor-entered") {
+            assert.ok(lease.abort);
+            lease.abort();
+            return;
+          }
+        }
+      };
+      const cancellation = abortWhenEntered();
+      const [response] = await Promise.all([
+        lease.executeCommand(
+          {
+            id: `cursor-${mode}`,
+            kind: "app.open",
+            payload: { app: "test.editor" },
+          },
+          permissions,
+        ),
+        cancellation,
+      ]);
+      assert.equal(response.status, "failed");
+      if (response.status === "failed")
+        assert.equal(response.error.code, "accessibility_unavailable");
+      assert.equal(existsSync(launchedPath), false);
+    } finally {
+      lease.release();
+    }
+    await driver.retire("app_quit");
+    await retirementObserved;
+    assert.equal(driver.getState().ready, false);
+    assert.equal(driver.getState().cleanupPending, false);
+    assert.throws(() => driver.acquireCommand(), /not ready/);
+    return { mode, commandFailed: true, appUnchanged: true, retired: true };
+  } finally {
+    watching.abort();
+    await driver.retire("app_quit");
+    await rm(failurePath, { force: true });
+    await rm(enteredPath, { force: true });
+    await rm(launchedPath, { force: true });
+  }
 }
 
 async function prove() {
@@ -106,6 +186,9 @@ async function prove() {
     await retirement;
     assert.equal(driver.getState().cleanupPending, false);
     assert.equal(driver.getState().ready, false);
+    const cursorFailures = [];
+    for (const mode of ["rejected", "mismatch", "abort"] as const)
+      cursorFailures.push(await proveCursorFailure(mode));
     await writeFile(
       path.join(directory!, "adapter.json"),
       JSON.stringify(
@@ -118,6 +201,7 @@ async function prove() {
           commands,
           cancelPreservedGeneration: true,
           confirmedQuitRetired: true,
+          cursorFailures,
           stoppedState: driver.getState(),
         },
         null,

--- a/turbo/apps/desktop/scripts/test-cua-sdk.ts
+++ b/turbo/apps/desktop/scripts/test-cua-sdk.ts
@@ -1,7 +1,12 @@
 /** Public SDK test boundary only. No native code, apps, permissions or capture. */
+import { existsSync, readFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { cuaBoundary } from "../src/test/cua-boundary";
 
 const { sdk } = cuaBoundary();
+const cursorFailure = new URL("../../../../../cursor-failure", import.meta.url);
+const cursorEntered = new URL("../../../../../cursor-entered", import.meta.url);
+const appLaunched = new URL("../../../../../app-launched", import.meta.url);
 export const EmbeddedPermissionMode = { Standard: sdk.standardPermissionMode };
 export const EmbeddedDriverHostState = { Stopped: sdk.stoppedState };
 export const EmbeddedCuaDriverHost = {
@@ -11,8 +16,62 @@ export const EmbeddedCuaDriverHost = {
 export const CuaDriver = {
   connect(socket: string) {
     const client = sdk.connect(socket);
+    const hiddenSessions = new Set<string>();
     return {
       ...client,
+      async startSession(input: { session: string }) {
+        hiddenSessions.delete(input.session);
+        return client.startSession(input);
+      },
+      async setAgentCursorEnabled(
+        input: { session: string; enabled: boolean },
+        options?: { signal?: AbortSignal },
+      ) {
+        if (input.enabled) throw new Error("Session cursor must stay hidden");
+        const failure = existsSync(cursorFailure)
+          ? readFileSync(cursorFailure, "utf8")
+          : null;
+        if (failure === "abort") {
+          await writeFile(cursorEntered, "waiting for cancellation\n");
+          await new Promise<never>((_resolve, reject) => {
+            const abort = () => reject(new Error("Cursor suppression aborted"));
+            if (options?.signal?.aborted) abort();
+            else
+              options?.signal?.addEventListener("abort", abort, { once: true });
+          });
+        }
+        if (failure === "rejected")
+          return {
+            text: "Cursor suppression refused",
+            images: [],
+            isError: true,
+            degraded: false,
+            rawJson: "{}",
+            errorCode: "cursor_unavailable",
+          };
+        if (failure !== "mismatch") hiddenSessions.add(input.session);
+        return {
+          text: "",
+          images: [],
+          isError: false,
+          degraded: false,
+          rawJson: "{}",
+          structuredJson: JSON.stringify({
+            ...input,
+            enabled: failure === "mismatch",
+          }),
+        };
+      },
+      async callTool(name: string, json: string) {
+        const args: Record<string, unknown> = JSON.parse(json);
+        if (name === "launch_app") await writeFile(appLaunched, "launched\n");
+        if (
+          typeof args.session === "string" &&
+          !hiddenSessions.has(args.session)
+        )
+          throw new Error("Session was admitted before cursor suppression");
+        return client.callTool(name, json);
+      },
       async metadata() {
         const value = await client.metadata();
         return {

--- a/turbo/apps/desktop/src/computer-use-cua.test.ts
+++ b/turbo/apps/desktop/src/computer-use-cua.test.ts
@@ -261,13 +261,40 @@ describe("host-owned CUA adapter and shared executor", () => {
     },
   );
 
-  it.each(["pid", "window", "moved", "scaled", "display-scale"])(
+  it("observes the sole on-screen window despite hidden auxiliary windows", async () => {
+    const d = await desktop();
+    d.external.extraWindows = [{ windowId: 43, visible: false }];
+    const state = result(await d.observe());
+    expect(state.appState).toContain("Read-only invoice total: 123 元");
+    expect(
+      d.external.calls.find((call) => call.name === "get_window_state")?.args,
+    ).toMatchObject({ pid: 123, window_id: 42 });
+  });
+
+  it.each(["missing", "ambiguous"])(
+    "refuses a %s on-screen window before capturing",
+    async (condition) => {
+      const d = await desktop();
+      if (condition === "missing") d.external.windowVisible = false;
+      else d.external.extraWindows = [{ windowId: 43, visible: true }];
+      expect(await d.observe()).toMatchObject({
+        status: "failed",
+        error: { code: "window_unavailable" },
+      });
+      expect(
+        d.external.calls.some((call) => call.name === "get_window_state"),
+      ).toBe(false);
+    },
+  );
+
+  it.each(["pid", "window", "hidden", "moved", "scaled", "display-scale"])(
     "refuses changed %s ownership/frame",
     async (change) => {
       const d = await desktop();
       const state = result(await d.observe());
       if (change === "pid") d.external.pid = 124;
       if (change === "window") d.external.windowId = 43;
+      if (change === "hidden") d.external.windowVisible = false;
       if (change === "moved")
         d.external.bounds = { x: 30, y: 20, width: 800, height: 600 };
       if (change === "scaled")

--- a/turbo/apps/desktop/src/computer-use-cua.ts
+++ b/turbo/apps/desktop/src/computer-use-cua.ts
@@ -305,7 +305,7 @@ class CuaComputerUseBackend implements ComputerUseNativeBackend {
 
   private async resolveWindow(app: App, retained?: Window): Promise<Window> {
     const data = readResult(
-      await this.tool("list_windows", { pid: app.pid, on_screen_only: false }),
+      await this.tool("list_windows", { pid: app.pid, on_screen_only: true }),
     );
     const windows = arrayField(data.windows, 1000)
       .map((item) => {
@@ -325,7 +325,7 @@ class CuaComputerUseBackend implements ComputerUseNativeBackend {
       this.observation = null;
       throw new ComputerUseNativeHelperError(
         "window_unavailable",
-        "CUA window target is missing or ambiguous; close extra windows and re-observe",
+        "CUA requires one on-screen window; show the intended window or resolve multiple visible windows and re-observe",
       );
     }
     return matches[0]!;

--- a/turbo/apps/desktop/src/cua-process-protocol.ts
+++ b/turbo/apps/desktop/src/cua-process-protocol.ts
@@ -43,7 +43,7 @@ export const cuaToolSchema = z.discriminatedUnion("name", [
   z
     .object({
       name: z.literal("list_windows"),
-      args: z.object({ pid, on_screen_only: z.literal(false) }).strict(),
+      args: z.object({ pid, on_screen_only: z.literal(true) }).strict(),
     })
     .strict(),
   z

--- a/turbo/apps/desktop/src/cua-runtime.ts
+++ b/turbo/apps/desktop/src/cua-runtime.ts
@@ -198,7 +198,9 @@ export class CuaEmbeddedRuntime {
         { name: "HOME", value: context.directory },
       ],
       inheritStderr: false,
-      noOverlay: true,
+      // Preserve the daemon's AppKit loop; the SDK process disables session
+      // cursor drawing before making any owned session available.
+      noOverlay: false,
     });
     const connection = await context.host.start();
     context.connection = connection;

--- a/turbo/apps/desktop/src/cua-sdk-process.ts
+++ b/turbo/apps/desktop/src/cua-sdk-process.ts
@@ -11,7 +11,10 @@ import {
   readCuaFrames,
   type CuaOperation,
 } from "./cua-process-protocol";
-import { loadPackagedCuaSdk, type CuaSdk } from "./cua-runtime-files";
+import { loadPackagedCuaSdk } from "./cua-runtime-files";
+import { readResult } from "./cua-adapter-contract";
+
+type CuaSdk = Awaited<ReturnType<typeof loadPackagedCuaSdk>>;
 
 const [root, directory, bundleId, generationText] = process.argv.slice(-4);
 if (
@@ -66,7 +69,10 @@ async function execute(
         { name: "HOME", value: directory! },
       ],
       inheritStderr: false,
-      noOverlay: true,
+      // CUA 0.23.2 only pumps AppKit with the cursor renderer enabled. Its
+      // NSWorkspace app inventory otherwise never refreshes after launch/quit.
+      // Keep the loop alive and disable drawing for each owned session below.
+      noOverlay: false,
     });
     connection = await host.start();
     // The adapter does not consume the SDK MCP launcher configuration.
@@ -125,7 +131,18 @@ async function execute(
   const { session } = operation.input;
   if (operation.method === "sessionStart") {
     sessions.add(session);
-    return client.startSession({ session }, { signal });
+    const result = await client.startSession({ session }, { signal });
+    if (!result.active || result.state.session !== session)
+      throw new Error("CUA did not establish the owned session");
+    const cursor = readResult(
+      await client.setAgentCursorEnabled(
+        { session, enabled: false },
+        { signal },
+      ),
+    );
+    if (cursor.session !== session || cursor.enabled !== false)
+      throw new Error("CUA did not disable the owned session cursor");
+    return result;
   }
   if (!sessions.has(session)) throw new Error("Foreign CUA session");
   if (operation.method === "sessionEnd") {

--- a/turbo/apps/desktop/src/test/cua-boundary.ts
+++ b/turbo/apps/desktop/src/test/cua-boundary.ts
@@ -41,6 +41,8 @@ export function cuaBoundary() {
   let granted = true;
   let pid = 123;
   let windowId = 42;
+  let windowVisible = true;
+  let extraWindows: { windowId: number; visible: boolean }[] = [];
   let bounds = { x: 10, y: 20, width: 800, height: 600 };
   let scale = 2;
   let resize = 1;
@@ -160,9 +162,15 @@ export function cuaBoundary() {
             });
           if (name === "list_windows")
             return toolResult({
-              windows: [
-                { pid, window_id: windowId, title: "Document", bounds },
-              ],
+              windows: [{ windowId, visible: windowVisible }, ...extraWindows]
+                .filter((window) => !args.on_screen_only || window.visible)
+                .map((window) => ({
+                  pid,
+                  window_id: window.windowId,
+                  title: "Document",
+                  bounds,
+                  is_on_screen: window.visible,
+                })),
             });
           if (name === "launch_app")
             return toolResult({
@@ -244,6 +252,12 @@ export function cuaBoundary() {
     },
     set windowId(value: number) {
       windowId = value;
+    },
+    set windowVisible(value: boolean) {
+      windowVisible = value;
+    },
+    set extraWindows(value: typeof extraWindows) {
+      extraWindows = value;
     },
     set bounds(value: typeof bounds) {
       bounds = value;

--- a/turbo/apps/desktop/tsconfig.json
+++ b/turbo/apps/desktop/tsconfig.json
@@ -7,6 +7,6 @@
     "noEmit": true,
     "types": ["node", "vite/client", "vitest/globals"]
   },
-  "include": ["src/**/*", "scripts/**/*.ts"],
+  "include": ["src/**/*", "scripts/**/*.ts", "cua/discovery-proof/main.ts"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
CUA reported Calculator as stopped after a successful launch, or retained its old PID after quit/reopen. In the pinned CUA 0.23.2 daemon, `noOverlay: true` also stops the AppKit event loop that refreshes `NSWorkspace.runningApplications`.

Keep that loop active and disable cursor drawing through the public SDK before admitting each owned session. Failed, mismatched or cancelled cursor setup refuses the command and preserves retirement. Resolve the exact PID's on-screen windows so hidden auxiliary windows no longer make Calculator ambiguous; missing or multiple visible targets and stale retained snapshots still fail closed.

Add a real native discovery gate covering cold launch, external launch, quit/reopen and old PID removal within one daemon generation. Extend the production process-channel proof with cursor setup failures, and run the existing guardian proof with the same AppKit configuration. Document the local Calculator evidence and the visible-window policy.

Fixes #32784. This does not complete Epic #32259 or its broader manual acceptance.

## Validation

- Focused Desktop Vitest: 4 files, 126 tests passed (`computer-use-cua`, `computer-use-cua-host`, `cua-runtime`, `cua-process-protocol`).
- Desktop types and lint, explicit proof-script lint, formatting, style policy, commitlint and file-size checks passed.
- Native discovery proof: all seven lifecycle observations passed with the real pinned SDK/daemon and production runtime/helper/guardian. Reverting only the generated helper to `noOverlay: true` reproduces the post-launch failure; both runs prove cleanup.
- Production process-channel adapter proof passed, including refused cursor suppression, an incorrect success reply and cancellation before command admission.
- Existing native guardian suite: 27/27 passed with `noOverlay: false`, including native cancellation and forced cleanup.
- Actual Calculator on macOS 15.6 arm64: CUA AX actions performed `100 + 250`; CUA screenshot and independent UI observation verified **350**. Cold launch and external quit/reopen refreshed the PID; stale snapshots were refused. A reopened window in another Space correctly returned `window_unavailable`.

The GUI check used local production source in an isolated harness with Desktop 0.48.14's unmodified signed native components, Electron 42.5.1 and CUA 0.23.2. It did not replace the installed app or establish cloud-to-Desktop, signed-upgrade or TCC-persistence acceptance. Raw AX data/screenshots remain private.

Scoped Knip still reports the same two unused devDependencies (`@sentry/cli`, `sharp`) as an untouched archive of base `62541820a08410060d6cfde83887e17fa7a86429`; no unrelated cleanup was included. The local hook launcher could not find Lefthook, so the checks listed above were run directly. No full local Vitest suite or dev server was run.
