### PR TITLE
fix(api): silence expected terminal codex reconnect failures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -18288,10 +18288,36 @@ describe("CHAT-02: run-level model overrides", () => {
 
   it.each(
     [
+      ...[
+        "refresh_token_reused",
+        "refresh_token_expired",
+        "refresh_token_invalidated",
+      ].map((refreshErrorCode) => {
+        return {
+          name: refreshErrorCode,
+          failureReason: "reconnect_required" as const,
+          errorCode: "PI_API_MODEL_CREDENTIAL_INVALID",
+          refreshErrorCode,
+          expectedReconnect: true,
+          expired: true,
+          providerCalls: 0,
+        };
+      }),
       {
-        name: "reconnect-required refresh",
+        name: "unknown refresh failure",
         failureReason: "reconnect_required" as const,
         errorCode: "PI_API_MODEL_CREDENTIAL_INVALID",
+        refreshErrorCode: "new_provider_error",
+        expectedReconnect: false,
+        expired: true,
+        providerCalls: 0,
+      },
+      {
+        name: "transient refresh failure",
+        failureReason: undefined,
+        errorCode: "PI_API_MODEL_CREDENTIAL_INVALID",
+        refreshErrorCode: null,
+        expectedReconnect: false,
         expired: true,
         providerCalls: 0,
       },
@@ -18299,6 +18325,8 @@ describe("CHAT-02: run-level model overrides", () => {
         name: "subscription usage limit",
         failureReason: "usage_limit" as const,
         errorCode: "PI_API_MODEL_FAILED",
+        refreshErrorCode: null,
+        expectedReconnect: false,
         expired: false,
         providerCalls: 1,
       },
@@ -18310,6 +18338,7 @@ describe("CHAT-02: run-level model overrides", () => {
   )(
     "classifies a $name with tier $tier without replay, billing, or private diagnostics",
     async (scenario) => {
+      mockOptionalEnv("OKOU_DEBUG", "webhook:firewall-auth,pi-api-first-turn");
       const { actor, agentId, runnerGroup } = await entitledChatActor();
       const privateMarker = `private-${scenario.failureReason}-diagnostic`;
       const externalAccountId = `chat-${scenario.failureReason}-account`;
@@ -18349,18 +18378,18 @@ describe("CHAT-02: run-level model overrides", () => {
         throw new Error("Expected subscription auth to complete");
       }
       let refreshAttempts = 0;
-      if (scenario.failureReason === "reconnect_required") {
+      if (scenario.expired) {
         server.use(
           http.post("https://auth.openai.com/oauth/token", () => {
             refreshAttempts += 1;
             return HttpResponse.json(
               {
                 error: {
-                  code: "refresh_token_invalidated",
+                  code: scenario.refreshErrorCode ?? "server_error",
                   message: privateMarker,
                 },
               },
-              { status: 401 },
+              { status: scenario.refreshErrorCode === null ? 503 : 401 },
             );
           }),
         );
@@ -18410,14 +18439,44 @@ describe("CHAT-02: run-level model overrides", () => {
       expect(modelCalls).toBe(scenario.providerCalls);
       expect(refreshAttempts).toBe(scenario.expired ? 1 : 0);
       expect(oauth.oauthToken).toHaveLength(1);
+      if (scenario.expectedReconnect) {
+        expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+        expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+        expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+        for (const log of [
+          context.mocks.axiomLogging.debug,
+          context.mocks.axiomLogging.info,
+        ]) {
+          expect(log).not.toHaveBeenCalledWith(
+            "codex-oauth-token token refresh failed",
+            expect.anything(),
+          );
+          expect(log).not.toHaveBeenCalledWith(
+            "Pi API first-turn outcome",
+            expect.objectContaining({
+              runId: run.runId,
+              outcome: "terminal_failure",
+            }),
+          );
+        }
+      } else {
+        expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+          "Pi API first-turn outcome",
+          expect.objectContaining({
+            runId: run.runId,
+            outcome: "terminal_failure",
+            reason: scenario.errorCode,
+          }),
+        );
+      }
       const events = (await chat.listThreadEvents(actor, run.threadId)).events;
-      expect(events).toContainEqual(
-        expect.objectContaining({
-          eventType: "run.failed",
-          runId: run.runId,
-          failureReason: scenario.failureReason,
-        }),
-      );
+      const failureEvent = events.find((event) => {
+        return event.eventType === "run.failed" && event.runId === run.runId;
+      });
+      if (failureEvent?.eventType !== "run.failed") {
+        throw new Error("Expected the subscription run failure event");
+      }
+      expect(failureEvent.failureReason).toBe(scenario.failureReason);
       const publicState = JSON.stringify({
         failed,
         events,
@@ -18441,6 +18500,30 @@ describe("CHAT-02: run-level model overrides", () => {
         capabilities: { piModelConfigGenerations: [1, 2, 3] },
       });
       expectApiError(claim.body);
+      if (scenario.expectedReconnect) {
+        const repeated = await sendChatRun(actor, {
+          agentId,
+          prompt: "retry the terminal subscription account",
+          model: "gpt-5.6-terra",
+          runOptions: { codexServiceTier: scenario.tier },
+        });
+        await waitForRunStatus(actor, repeated.runId, "failed", 10_000);
+        await flushWaitUntilForTest();
+        expect(refreshAttempts).toBe(1);
+        expect(modelCalls).toBe(0);
+        expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+        expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+        expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+        expect(
+          (await chat.listThreadEvents(actor, repeated.threadId)).events,
+        ).toContainEqual(
+          expect.objectContaining({
+            eventType: "run.failed",
+            runId: repeated.runId,
+            failureReason: "reconnect_required",
+          }),
+        );
+      }
     },
     90_000,
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/me-model-providers-upsert.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/me-model-providers-upsert.test.ts
@@ -938,15 +938,9 @@ describe("POST /api/me/model-providers (upsert)", () => {
 
     expect(refreshCalls).toBe(1);
     expect(usageCalls).toBe(1);
-    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledTimes(1);
-    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
-      expect.stringContaining("codex-oauth-token token refresh failed"),
-      expect.objectContaining({
-        modelProviderAccountId: connected.body.provider.id,
-        errorCode: "refresh_token_expired",
-        failureReason: "reconnect_required",
-      }),
-    );
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
   });
 
   it("retries transient Codex refresh failure without false reconnect", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -41,6 +41,11 @@ import {
 } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import {
+  createAuthDeviceApiActions,
+  mockCodexDeviceAuthProvider,
+} from "./helpers/api-bdd-auth-device";
+import { createAuthDeviceSupportApi } from "./helpers/api-bdd-auth-device-support";
+import {
   transitionRunToTerminal,
   transitionRunToTimeout,
   type TestTerminalRunStatus,
@@ -2730,6 +2735,7 @@ describe("FW-9: codex model-provider access", () => {
   });
 
   it("stops retrying terminal chatgpt refresh failures", async () => {
+    mockOptionalEnv("OKOU_DEBUG", "webhook:firewall-auth");
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
     const terminalErrorCodes = [
@@ -2783,16 +2789,164 @@ describe("FW-9: codex model-provider access", () => {
       }
 
       expect(refreshCalls).toBe(1);
-      expect(context.mocks.axiomLogging.warn).toHaveBeenCalledTimes(1);
-      expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
-        expect.stringContaining("codex-oauth-token token refresh failed"),
-        expect.objectContaining({
-          accessSourceKey: "codex-oauth-token",
-          errorCode,
-          failureReason: "reconnect_required",
-        }),
-      );
+      expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+      expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+      expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+      for (const log of [
+        context.mocks.axiomLogging.debug,
+        context.mocks.axiomLogging.info,
+      ]) {
+        expect(log).not.toHaveBeenCalledWith(
+          expect.stringContaining("token refresh failed"),
+          expect.anything(),
+        );
+      }
     }
+  });
+
+  it("keeps terminal Codex failure on the exact account until reconnect", async () => {
+    const fw = createFirewallApi(context);
+    const authDevice = createAuthDeviceApiActions(context);
+    const support = createAuthDeviceSupportApi(context);
+    const { actor, headers } = await firewallRun();
+    await support.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.PersonalModelProviderAccounts]: true,
+    });
+    const accounts: string[] = [];
+    for (const accountId of ["expired-account", "healthy-account"]) {
+      mockCodexDeviceAuthProvider({
+        tokenScope: "personal",
+        accountId,
+        accessTokenExpiresAt:
+          Math.floor(now() / 1000) +
+          (accountId === "expired-account" ? -60 : 7200),
+      });
+      const started = await authDevice.requestCodexStart(
+        actor,
+        "personal",
+        [200],
+        { mode: "add" },
+      );
+      if (started.status !== 200) {
+        throw new Error("Expected Codex account connection to start");
+      }
+      const completed = await authDevice.requestCodexComplete(
+        actor,
+        started.body.sessionToken,
+        [200],
+      );
+      if (
+        !("status" in completed.body) ||
+        completed.body.status !== "complete"
+      ) {
+        throw new Error("Expected Codex account connection to complete");
+      }
+      accounts.push(completed.body.provider.id);
+    }
+    const [expiredAccountId, healthyAccountId] = accounts;
+    if (!expiredAccountId || !healthyAccountId) {
+      throw new Error("Expected both concrete accounts");
+    }
+    await support.activatePersonalModelProviderAccount(actor, healthyAccountId);
+    let refreshCalls = 0;
+    fw.mockCodexTokenRefresh(() => {
+      refreshCalls += 1;
+      return HttpResponse.json(
+        { error: { code: "refresh_token_reused", message: "reused token" } },
+        { status: 401 },
+      );
+    });
+    const body = {
+      encryptedSecrets: fw.encryptedSecretsBody({}),
+      authHeaders: {
+        Authorization: `Bearer ${secretTemplate("CHATGPT_ACCESS_TOKEN")}`,
+      },
+      secretConnectorMap: { CHATGPT_ACCESS_TOKEN: "codex-oauth-token" },
+      secretConnectorMetadataMap: {
+        CHATGPT_ACCESS_TOKEN: {
+          sourceType: "model-provider" as const,
+          sourceUserId: actor.userId,
+          sourceId: expiredAccountId,
+          metadataKey: "codex-oauth-token",
+        },
+      },
+    };
+    context.mocks.axiomLogging.warn.mockClear();
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const failed = await fw.requestFirewallAuth(headers, body, [502]);
+      expect(failed.body).toMatchObject({
+        error: {
+          code: "TOKEN_REFRESH_FAILED",
+          failureReason: "reconnect_required",
+        },
+      });
+    }
+    expect(refreshCalls).toBe(1);
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+    const failedAccounts = await support.listPersonalModelProviders(
+      actor,
+      [200],
+    );
+    expect(failedAccounts.body).toMatchObject({
+      modelProviders: expect.arrayContaining([
+        expect.objectContaining({
+          id: expiredAccountId,
+          needsReconnect: true,
+          lastRefreshErrorCode: "refresh_token_reused",
+        }),
+        expect.objectContaining({
+          id: healthyAccountId,
+          isActive: true,
+          needsReconnect: false,
+          lastRefreshErrorCode: null,
+        }),
+      ]),
+    });
+
+    const reconnected = mockCodexDeviceAuthProvider({
+      tokenScope: "personal",
+      accountId: "expired-account",
+    });
+    const started = await authDevice.requestCodexStart(
+      actor,
+      "personal",
+      [200],
+      {
+        mode: "reconnect",
+        modelProviderId: expiredAccountId,
+      },
+    );
+    if (started.status !== 200) {
+      throw new Error("Expected exact Codex account reconnect to start");
+    }
+    await authDevice.requestCodexComplete(
+      actor,
+      started.body.sessionToken,
+      [200],
+    );
+    const recoveredAccounts = await support.listPersonalModelProviders(
+      actor,
+      [200],
+    );
+    expect(recoveredAccounts.body).toMatchObject({
+      modelProviders: expect.arrayContaining([
+        expect.objectContaining({
+          id: expiredAccountId,
+          needsReconnect: false,
+          lastRefreshErrorCode: null,
+        }),
+      ]),
+    });
+    const resolved = await fw.requestFirewallAuth(headers, body, [200]);
+    expect(resolved.body).toMatchObject({
+      headers: {
+        Authorization: `Bearer ${reconnected.oauthTokenResponses[0]?.access_token}`,
+      },
+      refreshedConnectors: [],
+    });
+    expect(reconnected.oauthToken).toHaveLength(1);
   });
 
   it("retries a transient codex refresh failure", async () => {
@@ -2841,6 +2995,10 @@ describe("FW-9: codex model-provider access", () => {
       "Bearer recovered-chatgpt-token",
     );
     expect(refreshCalls).toBe(2);
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      "codex-oauth-token token refresh failed",
+      expect.objectContaining({ failureReason: "upstream_provider" }),
+    );
   });
 
   it("omits the failure reason for unknown chatgpt refresh error codes", async () => {
@@ -2884,6 +3042,10 @@ describe("FW-9: codex model-provider access", () => {
     expect(failed.body.error.code).toBe("TOKEN_REFRESH_FAILED");
     expect(failed.body.error.failureReason).toBeUndefined();
     expect(failed.body.error.connectors).toStrictEqual(["codex-oauth-token"]);
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      "codex-oauth-token token refresh failed",
+      expect.objectContaining({ errorCode: "refresh_token_other" }),
+    );
   });
 });
 

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -949,7 +949,7 @@ function isReconnectRequiredRefreshErrorCode(
   );
 }
 
-function isTerminalChatgptRefreshErrorCode(
+export function isTerminalChatgptRefreshErrorCode(
   errorCode: string | null | undefined,
 ): boolean {
   return (
@@ -2554,7 +2554,12 @@ async function markAndReturnRefreshFailure(
 ): Promise<RefreshAccessTokenResult> {
   const message = error instanceof Error ? error.message : "Unknown error";
   const { errorCode, failureReason } = classifyRefreshFailure(error, signal);
-  if (shouldLogWarning) {
+  const terminalCodexFailure =
+    args.sourceType === "model-provider" &&
+    args.accessSourceKey === "codex-oauth-token" &&
+    failureReason === "reconnect_required" &&
+    isTerminalChatgptRefreshErrorCode(errorCode);
+  if (shouldLogWarning && !terminalCodexFailure) {
     const logMessage =
       args.accessSourceKey === "codex-oauth-token"
         ? `${args.accessSourceKey} token refresh failed`

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -60,6 +60,7 @@ import {
 } from "./agent-webhook-complete.service";
 import { createPiApiFirstTurnCheckpoint$ } from "./agent-webhook-checkpoints.service";
 import {
+  isTerminalChatgptRefreshErrorCode,
   resolveCurrentModelProviderRuntimeSecretForApi,
   resolveModelProviderRuntimeSecretForApi,
 } from "./agent-webhook-firewall-auth.service";
@@ -150,6 +151,16 @@ class PiApiFirstTurnError extends Error {
     this.name = "PiApiFirstTurnError";
     this.code = code;
     this.failureReason = options?.failureReason;
+  }
+}
+
+class PiApiFirstTurnCodexReconnectRequiredError extends PiApiFirstTurnError {
+  constructor() {
+    super(
+      "PI_API_MODEL_CREDENTIAL_INVALID",
+      "Pi API first-turn subscription access token is unavailable",
+      { failureReason: "reconnect_required" },
+    );
   }
 }
 
@@ -1029,6 +1040,14 @@ async function resolveCodexSubscriptionCredentials(
   }
   const accessToken = accessTokenResolution.value;
   if (accessToken.status === "unavailable") {
+    if (
+      accessToken.reconnectState?.needsReconnect &&
+      isTerminalChatgptRefreshErrorCode(
+        accessToken.reconnectState.lastRefreshErrorCode,
+      )
+    ) {
+      throw new PiApiFirstTurnCodexReconnectRequiredError();
+    }
     const reconnectRequired =
       accessToken.reconnectState === null ||
       accessToken.reconnectState.needsReconnect;
@@ -2229,19 +2248,21 @@ const runPiApiFirstTurnCore$ = command(
       logCanonicalApiFirstTurnCancellation(context, ownership);
       return undefined;
     }
-    L.warn("Pi API first-turn outcome", {
-      runId: activation.runId,
-      ...piApiFirstTurnOutcomeTelemetry(activation.executionContext),
-      outcome: "terminal_failure",
-      reason: failure.code,
-      ownershipStage: ownership.stage,
-      ...(resourceFallbackReason
-        ? { fallbackReason: resourceFallbackReason }
-        : {}),
-      ...(apiAttemptTimedOut
-        ? { recoveryReason: "api_attempt_timed_out" }
-        : {}),
-    });
+    if (!(failure instanceof PiApiFirstTurnCodexReconnectRequiredError)) {
+      L.warn("Pi API first-turn outcome", {
+        runId: activation.runId,
+        ...piApiFirstTurnOutcomeTelemetry(activation.executionContext),
+        outcome: "terminal_failure",
+        reason: failure.code,
+        ownershipStage: ownership.stage,
+        ...(resourceFallbackReason
+          ? { fallbackReason: resourceFallbackReason }
+          : {}),
+        ...(apiAttemptTimedOut
+          ? { recoveryReason: "api_attempt_timed_out" }
+          : {}),
+      });
+    }
     return set(
       failApiFirstTurn$,
       context,


### PR DESCRIPTION
## Summary

- Stop printing initial refresh failures for the three explicitly classified terminal Codex codes: `refresh_token_reused`, `refresh_token_expired`, and `refresh_token_invalidated`.
- Keep the corresponding Pi API first-turn terminal outcome quiet through a private typed error derived from the exact persisted reconnect state.
- Preserve failed-run/reconnect responses, exact-account isolation, terminal retry short circuits, and actual reconnect recovery. Do not replace warnings with INFO or DEBUG.

## Scope and risks

Unknown/missing credentials, provider/network failures, and storage/settlement errors keep their existing reporting. No broad filtering by `reconnect_required` or `PI_API_MODEL_CREDENTIAL_INVALID`; no UI, public API/event schema, Runner, token-store, locking, retry, or timeout changes. No extra network or database operations.

Removing these logs reduces forensic context; persisted account reconnect state remains visible. This does not establish or fix the root cause of rotating-token reuse. Old/new API versions retain the same state and user behavior, differing only in logging.

## Validation

- Demonstrated the regression before the production fix: the existing terminal route scenario failed on the first WARN.
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts src/signals/routes/__tests__/chat-events.bdd.test.ts src/signals/routes/__tests__/model-providers.test.ts src/signals/routes/__tests__/auth-device.bdd.test.ts --maxWorkers=4 --silent=passed-only` — 583 passed, no skips.
- CI found one stale WARN assertion in the personal model-provider list scenario. Updated it to require no WARN/ERROR/Sentry while preserving terminal state and upstream-call assertions; `pnpm -F api exec vitest run src/signals/routes/__tests__/me-model-providers-upsert.test.ts --maxWorkers=4 --silent=passed-only` — all 21 passed. Repeated API type checks, API Knip, and changed-file formatting/lint checks — passed.
- After a test-only type narrowing correction, reran the 12 affected subscription scenarios — all passed. Production code was unchanged after the full run.
- `pnpm -F api lint`, `pnpm -F api check-types`, `pnpm knip --workspace api` — passed. Rechecked the final test edit with Oxlint, type-aware Oxlint, and ESLint.
- Changed-file Prettier check and `git diff --check` — passed.

Coverage includes all three terminal codes, initial/repeated requests, exact inactive-account state with an unaffected active account, real device reconnect/recovery, Pi failed-run events without replay or managed billing, no failure log/capture, and unknown/503/usage-limit controls. Uses production API routes, real local persistence, and external OAuth/model fixtures.

Relates to #32758. The issue intentionally remains open for an explicitly authorized deployment and bounded 24-hour production observation. No production deployment or credential mutation was performed; absence of warnings alone will not establish exercised behavior.
