### PR TITLE
fix(runner): classify recovered cooperative cancellation races

### DIFF
--- a/crates/guest-control-client/src/exec_operation/types.rs
+++ b/crates/guest-control-client/src/exec_operation/types.rs
@@ -384,7 +384,7 @@ fn exec_control_status_error_kind(status: ExecControlStatus) -> io::ErrorKind {
         ExecControlStatus::SinkUnavailable => io::ErrorKind::NotConnected,
         ExecControlStatus::SinkTimeout => io::ErrorKind::TimedOut,
         ExecControlStatus::QueueFull => io::ErrorKind::WouldBlock,
-        ExecControlStatus::SinkError => io::ErrorKind::BrokenPipe,
+        ExecControlStatus::SinkError | ExecControlStatus::SinkClosed => io::ErrorKind::BrokenPipe,
     }
 }
 
@@ -399,5 +399,6 @@ fn default_exec_control_status_message(status: ExecControlStatus) -> &'static st
         ExecControlStatus::SinkTimeout => "exec control sink timed out",
         ExecControlStatus::QueueFull => "exec control queue is full",
         ExecControlStatus::SinkError => "exec control sink error",
+        ExecControlStatus::SinkClosed => "exec control sink closed",
     }
 }

--- a/crates/guest-control-client/src/tests/exec_operation/supervised/control.rs
+++ b/crates/guest-control-client/src/tests/exec_operation/supervised/control.rs
@@ -364,28 +364,43 @@ async fn supervised_exec_control_reports_guest_status_and_error() {
     } = start_control_supervised_exec_fixture("control-status").await;
     let start_seq = start.seq();
 
-    let status_task = tokio::spawn({
-        let control_handle = control_handle.clone();
-        async move {
-            control_handle
-                .control("status", b"payload", Duration::from_secs(5))
-                .await
-        }
-    });
-    let status_control = read_guest_message(&mut guest).await;
-    send_exec_control_result(
-        &mut guest,
-        status_control.seq,
-        start_seq,
-        control_nonce,
-        "status",
-        ExecControlStatus::QueueFull,
-        "queue full",
-    )
-    .await;
-    let err = status_task.await.unwrap().unwrap_err();
-    assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
-    assert_eq!(err.to_string(), "queue full");
+    for (status, diagnostic, error_kind, error_message) in [
+        (
+            ExecControlStatus::QueueFull,
+            "queue full",
+            io::ErrorKind::WouldBlock,
+            "queue full",
+        ),
+        (
+            ExecControlStatus::SinkClosed,
+            "",
+            io::ErrorKind::BrokenPipe,
+            "exec control sink closed",
+        ),
+    ] {
+        let status_task = tokio::spawn({
+            let control_handle = control_handle.clone();
+            async move {
+                control_handle
+                    .control("status", b"payload", Duration::from_secs(5))
+                    .await
+            }
+        });
+        let status_control = read_guest_message(&mut guest).await;
+        send_exec_control_result(
+            &mut guest,
+            status_control.seq,
+            start_seq,
+            control_nonce,
+            "status",
+            status,
+            diagnostic,
+        )
+        .await;
+        let err = status_task.await.unwrap().unwrap_err();
+        assert_eq!(err.kind(), error_kind);
+        assert_eq!(err.to_string(), error_message);
+    }
 
     let error_task = tokio::spawn({
         let control_handle = control_handle.clone();

--- a/crates/guest-control-proto/src/payloads/exec_operation/control.rs
+++ b/crates/guest-control-proto/src/payloads/exec_operation/control.rs
@@ -36,6 +36,8 @@ pub enum ExecControlStatus {
     QueueFull = 0x07,
     /// Wire value `0x08`: the sink failed while processing or exchanging the request.
     SinkError = 0x08,
+    /// Wire value `0x09`: the connected control sink closed during request I/O.
+    SinkClosed = 0x09,
 }
 
 const EXEC_CONTROL_STATUS_DELIVERED: u8 = ExecControlStatus::Delivered as u8;
@@ -47,6 +49,7 @@ const EXEC_CONTROL_STATUS_SINK_UNAVAILABLE: u8 = ExecControlStatus::SinkUnavaila
 const EXEC_CONTROL_STATUS_SINK_TIMEOUT: u8 = ExecControlStatus::SinkTimeout as u8;
 const EXEC_CONTROL_STATUS_QUEUE_FULL: u8 = ExecControlStatus::QueueFull as u8;
 const EXEC_CONTROL_STATUS_SINK_ERROR: u8 = ExecControlStatus::SinkError as u8;
+const EXEC_CONTROL_STATUS_SINK_CLOSED: u8 = ExecControlStatus::SinkClosed as u8;
 
 /// Decoded exec_control payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -163,6 +166,7 @@ fn status_to_wire(status: ExecControlStatus) -> u8 {
         ExecControlStatus::SinkTimeout => EXEC_CONTROL_STATUS_SINK_TIMEOUT,
         ExecControlStatus::QueueFull => EXEC_CONTROL_STATUS_QUEUE_FULL,
         ExecControlStatus::SinkError => EXEC_CONTROL_STATUS_SINK_ERROR,
+        ExecControlStatus::SinkClosed => EXEC_CONTROL_STATUS_SINK_CLOSED,
     }
 }
 
@@ -177,6 +181,7 @@ fn status_from_wire(value: u8) -> Result<ExecControlStatus, ProtocolError> {
         EXEC_CONTROL_STATUS_SINK_TIMEOUT => Ok(ExecControlStatus::SinkTimeout),
         EXEC_CONTROL_STATUS_QUEUE_FULL => Ok(ExecControlStatus::QueueFull),
         EXEC_CONTROL_STATUS_SINK_ERROR => Ok(ExecControlStatus::SinkError),
+        EXEC_CONTROL_STATUS_SINK_CLOSED => Ok(ExecControlStatus::SinkClosed),
         _ => Err(ProtocolError::InvalidPayload(
             "exec_control_result status invalid",
         )),

--- a/crates/guest-control-proto/src/payloads/exec_operation/tests/exec_control_properties.rs
+++ b/crates/guest-control-proto/src/payloads/exec_operation/tests/exec_control_properties.rs
@@ -9,7 +9,7 @@ const MAX_GENERATED_TEXT_CHARS: usize = 12;
 const MAX_GENERATED_PAYLOAD_BYTES: usize = 64;
 const MAX_ARBITRARY_PAYLOAD_BYTES: usize = 512;
 
-const EXEC_CONTROL_STATUSES: [ExecControlStatus; 9] = [
+const EXEC_CONTROL_STATUSES: [ExecControlStatus; 10] = [
     ExecControlStatus::Delivered,
     ExecControlStatus::Inactive,
     ExecControlStatus::NonceMismatch,
@@ -19,6 +19,7 @@ const EXEC_CONTROL_STATUSES: [ExecControlStatus; 9] = [
     ExecControlStatus::SinkTimeout,
     ExecControlStatus::QueueFull,
     ExecControlStatus::SinkError,
+    ExecControlStatus::SinkClosed,
 ];
 
 #[derive(Debug, Clone)]

--- a/crates/guest-control-proto/src/payloads/exec_operation/tests/exec_control_result.rs
+++ b/crates/guest-control-proto/src/payloads/exec_operation/tests/exec_control_result.rs
@@ -107,6 +107,7 @@ fn exec_control_result_status_wire_values_are_stable() {
         (ExecControlStatus::SinkTimeout, 0x06),
         (ExecControlStatus::QueueFull, 0x07),
         (ExecControlStatus::SinkError, 0x08),
+        (ExecControlStatus::SinkClosed, 0x09),
     ];
     let layout = ExecControlResultLayout::new(MESSAGE_ID, DIAGNOSTIC);
 

--- a/crates/guest-control-server/src/exec_control/accept.rs
+++ b/crates/guest-control-server/src/exec_control/accept.rs
@@ -5,7 +5,7 @@ use std::thread;
 
 use crate::log::log;
 
-use super::sink::ControlSinkState;
+use super::sink::{ControlSinkFailure, ControlSinkState};
 use super::{
     CONTROL_ACCEPT_POLL_TIMEOUT, CONTROL_SINK_IO_TIMEOUT, EXEC_CONTROL_LOG_NAME,
     THREAD_EXEC_CONTROL_ACCEPT, is_timeout,
@@ -57,7 +57,7 @@ fn accept_control_sink(listener: std::os::unix::net::UnixListener, sink: Arc<Con
                 "WARN",
                 &format!("{EXEC_CONTROL_LOG_NAME}: control sink accept failed: {error}"),
             );
-            sink.fail(error.to_string());
+            sink.fail(ControlSinkFailure::Other(error.to_string()));
         }
     }
 }

--- a/crates/guest-control-server/src/exec_control/forward.rs
+++ b/crates/guest-control-server/src/exec_control/forward.rs
@@ -13,7 +13,9 @@ use crate::threading::{SystemThreadSpawner, ThreadSpawner};
 use crate::writer::GuestWriter;
 
 use super::deadline_io::DeadlineStream;
-use super::sink::{ControlSinkState, ControlStreamLockError, PendingControlSlot};
+use super::sink::{
+    ControlSinkFailure, ControlSinkState, ControlStreamLockError, PendingControlSlot,
+};
 use super::{
     EXEC_CONTROL_LOG_NAME, EXEC_CONTROL_MESSAGE_ID_MISMATCH_PREFIX,
     EXEC_CONTROL_WORKER_START_ERROR_PREFIX, EXEC_OPERATION_INACTIVE_MESSAGE,
@@ -115,7 +117,11 @@ pub(super) fn forward_control_request(
                         forward_to_connected_sink(&mut stream, &message_id, payload, deadline)
                     };
                     if matches!(outcome.sink_disposition, ControlSinkDisposition::Fail) {
-                        sink.fail(outcome.diagnostic.clone());
+                        sink.fail(if outcome.status == ExecControlStatus::SinkClosed {
+                            ControlSinkFailure::Closed(outcome.diagnostic.clone())
+                        } else {
+                            ControlSinkFailure::Other(outcome.diagnostic.clone())
+                        });
                     }
                     outcome
                 }
@@ -129,9 +135,9 @@ pub(super) fn forward_control_request(
                     diagnostic: EXEC_REQUEST_TIMEOUT_DIAGNOSTIC.to_owned(),
                     sink_disposition: ControlSinkDisposition::Keep,
                 },
-                Err(ControlStreamLockError::SinkError(diagnostic)) => ControlForwardOutcome {
-                    status: ExecControlStatus::SinkError,
-                    diagnostic,
+                Err(ControlStreamLockError::SinkError(failure)) => ControlForwardOutcome {
+                    status: failure.status(),
+                    diagnostic: failure.diagnostic().to_owned(),
                     sink_disposition: ControlSinkDisposition::Keep,
                 },
             },
@@ -254,6 +260,17 @@ fn control_forward_io_error(
     error: io::Error,
     sink_disposition: ControlSinkDisposition,
 ) -> ControlForwardOutcome {
+    let status = if status == ExecControlStatus::SinkError
+        && matches!(
+            error.kind(),
+            io::ErrorKind::BrokenPipe
+                | io::ErrorKind::ConnectionReset
+                | io::ErrorKind::UnexpectedEof
+        ) {
+        ExecControlStatus::SinkClosed
+    } else {
+        status
+    };
     ControlForwardOutcome {
         status,
         diagnostic: error.to_string(),

--- a/crates/guest-control-server/src/exec_control/sink.rs
+++ b/crates/guest-control-server/src/exec_control/sink.rs
@@ -14,8 +14,8 @@
 //! sink error for later requests, and `Closed` represents operation cleanup.
 //! Requests wait in `Waiting` or `Handshaking` until the sink connects, fails,
 //! closes, or their deadline expires. Connected requests serialize over the
-//! process-control stream. Failed sinks return `SinkError`; closed or inactive
-//! sinks return `Inactive`.
+//! process-control stream. Failed sinks retain `SinkClosed` for connected-peer
+//! closure and `SinkError` otherwise; closed or inactive operations return `Inactive`.
 //!
 //! `inner` and `ready` own connection-state changes and wake waiting forwarders.
 //! `active` is the operation-lifetime gate, so close/drop can stop queued or
@@ -88,7 +88,28 @@ struct ControlStreamGateGuard<'a> {
 pub(super) enum ControlStreamLockError {
     Inactive,
     Timeout,
-    SinkError(String),
+    SinkError(ControlSinkFailure),
+}
+
+#[derive(Clone, Debug)]
+pub(super) enum ControlSinkFailure {
+    Closed(String),
+    Other(String),
+}
+
+impl ControlSinkFailure {
+    pub(super) fn status(&self) -> ExecControlStatus {
+        match self {
+            Self::Closed(_) => ExecControlStatus::SinkClosed,
+            Self::Other(_) => ExecControlStatus::SinkError,
+        }
+    }
+
+    pub(super) fn diagnostic(&self) -> &str {
+        match self {
+            Self::Closed(message) | Self::Other(message) => message,
+        }
+    }
 }
 
 pub(super) enum ControlSinkInner {
@@ -99,7 +120,7 @@ pub(super) enum ControlSinkInner {
     /// The process-control stream is ready for serialized forwarding.
     Connected(ConnectedControlSink),
     /// A terminal sink error to return to subsequent requests.
-    Failed(String),
+    Failed(ControlSinkFailure),
     /// Operation cleanup completed; subsequent requests resolve inactive.
     Closed,
 }
@@ -107,7 +128,7 @@ pub(super) enum ControlSinkInner {
 enum ControlStreamGate {
     Available,
     Locked,
-    Failed(String),
+    Failed(ControlSinkFailure),
 }
 
 /// Reserved pending capacity for one forwarding worker.
@@ -150,10 +171,10 @@ impl ControlSinkState {
             Err(error) => {
                 let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
                 if !matches!(*guard, ControlSinkInner::Closed) {
-                    *guard = ControlSinkInner::Failed(format!(
+                    *guard = ControlSinkInner::Failed(ControlSinkFailure::Other(format!(
                         "{}: {error}",
                         EXEC_CONTROL_CLONE_SINK_ERROR_PREFIX
-                    ));
+                    )));
                 }
                 self.ready.notify_all();
                 return;
@@ -194,13 +215,13 @@ impl ControlSinkState {
         Ok(true)
     }
 
-    pub(super) fn fail(&self, message: String) {
+    pub(super) fn fail(&self, failure: ControlSinkFailure) {
         if !self.active.load(Ordering::Acquire) {
             return;
         }
         let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         match &*guard {
-            ControlSinkInner::Connected(connected) => connected.fail(&message),
+            ControlSinkInner::Connected(connected) => connected.fail(&failure),
             ControlSinkInner::Waiting | ControlSinkInner::Handshaking(_) => {
                 shutdown_sink_stream(&guard);
             }
@@ -210,7 +231,7 @@ impl ControlSinkState {
             *guard,
             ControlSinkInner::Closed | ControlSinkInner::Failed(_)
         ) {
-            *guard = ControlSinkInner::Failed(message);
+            *guard = ControlSinkInner::Failed(failure);
         }
         self.ready.notify_all();
     }
@@ -258,8 +279,8 @@ impl ControlSinkState {
                         ));
                     }
                 }
-                ControlSinkInner::Failed(message) => {
-                    return Err((ExecControlStatus::SinkError, message.clone()));
+                ControlSinkInner::Failed(failure) => {
+                    return Err((failure.status(), failure.diagnostic().to_owned()));
                 }
                 ControlSinkInner::Closed => {
                     return Err((
@@ -318,9 +339,9 @@ impl ConnectedControlSink {
         self.stream.notify_waiters();
     }
 
-    fn fail(&self, message: &str) {
+    fn fail(&self, failure: &ControlSinkFailure) {
         let _ = self.shutdown.shutdown(std::net::Shutdown::Both);
-        self.stream.mark_failed(message);
+        self.stream.mark_failed(failure);
     }
 }
 
@@ -355,10 +376,10 @@ impl ControlStreamState {
                         return Err(ControlStreamLockError::Inactive);
                     }
                     match &*gate {
-                        ControlStreamGate::Failed(message) => {
-                            let message = message.clone();
+                        ControlStreamGate::Failed(failure) => {
+                            let failure = failure.clone();
                             drop(stream);
-                            return Err(ControlStreamLockError::SinkError(message));
+                            return Err(ControlStreamLockError::SinkError(failure));
                         }
                         ControlStreamGate::Available => {
                             *gate = ControlStreamGate::Locked;
@@ -371,8 +392,8 @@ impl ControlStreamState {
                         _gate: ControlStreamGateGuard { state: self },
                     });
                 }
-                ControlStreamGate::Failed(message) => {
-                    return Err(ControlStreamLockError::SinkError(message.clone()));
+                ControlStreamGate::Failed(failure) => {
+                    return Err(ControlStreamLockError::SinkError(failure.clone()));
                 }
                 ControlStreamGate::Locked => {}
             }
@@ -397,10 +418,10 @@ impl ControlStreamState {
         self.ready.notify_all();
     }
 
-    fn mark_failed(&self, message: &str) {
+    fn mark_failed(&self, failure: &ControlSinkFailure) {
         let mut gate = self.gate.lock().unwrap_or_else(|e| e.into_inner());
         if !matches!(*gate, ControlStreamGate::Failed(_)) {
-            *gate = ControlStreamGate::Failed(message.to_owned());
+            *gate = ControlStreamGate::Failed(failure.clone());
         }
         self.ready.notify_all();
     }

--- a/crates/guest-control-server/src/exec_control/tests/handle.rs
+++ b/crates/guest-control-server/src/exec_control/tests/handle.rs
@@ -7,8 +7,63 @@ use super::super::{
     EXEC_REQUEST_TIMEOUT_DIAGNOSTIC, ExecControlRegistry, handle_exec_control, is_timeout,
 };
 use super::support::{
-    guest_writer_pair, read_exec_control_result, unique_test_nonce, wait_for_sink_state,
+    connected_stream_handle, guest_writer_pair, read_exec_control_result, unique_test_nonce,
+    wait_for_sink_state,
 };
+
+#[test]
+fn connected_control_peer_closure_retains_typed_status_for_later_requests() {
+    for close_before_request in [true, false] {
+        let nonce = unique_test_nonce(32755 + u64::from(close_before_request));
+        let registry = ExecControlRegistry::default();
+        let registration = registry.register(55, nonce, true).unwrap();
+        let endpoint = registration.bootstrap_endpoint.as_ref().unwrap();
+        let sink = registry.resolve(55, nonce).unwrap();
+        let mut peer = process_control_ipc::connect_abstract(endpoint).unwrap();
+        peer.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+        process_control_ipc::write_hello(&mut peer).unwrap();
+        wait_for_sink_state(
+            &sink,
+            Duration::from_secs(3),
+            "sink should connect",
+            |inner| matches!(inner, ControlSinkInner::Connected(_)),
+        );
+        let connected = connected_stream_handle(&sink);
+        let (writer, mut host) = guest_writer_pair();
+        let payload =
+            guest_control_proto::encode_exec_control(55, nonce, "cancel", b"payload", 5000)
+                .unwrap();
+        if close_before_request {
+            drop(peer);
+            handle_exec_control(56, &payload, &registry, &writer).unwrap();
+        } else {
+            handle_exec_control(56, &payload, &registry, &writer).unwrap();
+            let request = process_control_ipc::read_request(&mut peer).unwrap();
+            assert_eq!(request.message_id, "cancel");
+            drop(peer);
+        }
+        let (_, seq, status, message_id, diagnostic) = read_exec_control_result(&mut host);
+        assert_eq!(seq, 56);
+        assert_eq!(status, ExecControlStatus::SinkClosed);
+        assert_eq!(message_id, "cancel");
+        assert!(!diagnostic.is_empty());
+
+        // Existing queued stream owners and new requests retain the first cause.
+        let error = match connected.lock_until(super::super::request_deadline(5000), &sink.active) {
+            Ok(_) => panic!("closed peer should reject queued stream owners"),
+            Err(error) => error,
+        };
+        assert!(matches!(error,
+            super::super::sink::ControlStreamLockError::SinkError(failure)
+                if failure.status() == ExecControlStatus::SinkClosed && failure.diagnostic() == diagnostic
+        ));
+        handle_exec_control(57, &payload, &registry, &writer).unwrap();
+        let (_, seq, status, _, next_diagnostic) = read_exec_control_result(&mut host);
+        assert_eq!(seq, 57);
+        assert_eq!(status, ExecControlStatus::SinkClosed);
+        assert_eq!(next_diagnostic, diagnostic);
+    }
+}
 
 #[test]
 fn handle_exec_control_forwards_to_connected_sink() {

--- a/crates/guest-control-server/src/exec_control/tests/sink_lifecycle.rs
+++ b/crates/guest-control-server/src/exec_control/tests/sink_lifecycle.rs
@@ -7,7 +7,9 @@ use std::time::Duration;
 use guest_control_proto::{ExecControlStatus, MSG_EXEC_CONTROL_RESULT};
 
 use super::super::forward::forward_control_request;
-use super::super::sink::{ControlSinkInner, ControlSinkState, ControlStreamLockError};
+use super::super::sink::{
+    ControlSinkFailure, ControlSinkInner, ControlSinkState, ControlStreamLockError,
+};
 use super::super::{EXEC_REQUEST_TIMEOUT_DIAGNOSTIC, request_deadline};
 use super::support::{
     connected_sink, connected_stream_handle, guest_writer_pair, owned_control_request,
@@ -54,7 +56,7 @@ fn fail_does_not_wait_for_busy_control_stream_lock() {
     let worker = std::thread::spawn({
         let sink = Arc::clone(&sink);
         move || {
-            sink.fail("failed".to_owned());
+            sink.fail(ControlSinkFailure::Other("failed".to_owned()));
             done_tx.send(()).unwrap();
         }
     });
@@ -78,7 +80,7 @@ fn failed_control_sink_rejects_existing_connected_stream_handle() {
         .lock_until(request_deadline(5000), &sink.active)
         .unwrap();
 
-    sink.fail("failed".to_owned());
+    sink.fail(ControlSinkFailure::Other("failed".to_owned()));
 
     let error = match stream.lock_until(request_deadline(5000), &sink.active) {
         Ok(_) => panic!("failed sink should reject existing connected stream handles"),
@@ -86,7 +88,7 @@ fn failed_control_sink_rejects_existing_connected_stream_handle() {
     };
     assert!(matches!(
         error,
-        ControlStreamLockError::SinkError(message) if message == "failed"
+        ControlStreamLockError::SinkError(ControlSinkFailure::Other(message)) if message == "failed"
     ));
     drop(stream_guard);
 }
@@ -95,8 +97,8 @@ fn control_sink_failure_preserves_first_diagnostic() {
     let (sink, _peer) = connected_sink();
     let stream = connected_stream_handle(&sink);
 
-    sink.fail("first failure".to_owned());
-    sink.fail("second failure".to_owned());
+    sink.fail(ControlSinkFailure::Other("first failure".to_owned()));
+    sink.fail(ControlSinkFailure::Other("second failure".to_owned()));
 
     let error = match sink.wait_for_stream(request_deadline(5000)) {
         Ok(_) => panic!("failed sink should reject future stream lookups"),
@@ -113,7 +115,7 @@ fn control_sink_failure_preserves_first_diagnostic() {
     };
     assert!(matches!(
         error,
-        ControlStreamLockError::SinkError(message) if message == "first failure"
+        ControlStreamLockError::SinkError(ControlSinkFailure::Other(message)) if message == "first failure"
     ));
 }
 #[test]
@@ -180,7 +182,7 @@ fn queued_control_request_is_not_delivered_after_fail() {
         }
     });
 
-    sink.fail("failed".to_owned());
+    sink.fail(ControlSinkFailure::Other("failed".to_owned()));
 
     let (msg_type, seq, status, message_id, diagnostic) = read_exec_control_result(&mut host);
     assert_eq!(msg_type, MSG_EXEC_CONTROL_RESULT);

--- a/crates/runner/src/cmd/start/tests/failure_recovery/cooperative_cancellation.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/cooperative_cancellation.rs
@@ -1,0 +1,194 @@
+use super::super::super::*;
+use super::super::support::{
+    context_with_session, mock_run_config_with_overrides_and_api_url, push_job, shutdown,
+    test_profiles, wait_budget_count, wait_cancel_handle,
+};
+use httpmock::prelude::*;
+use sandbox::{
+    ExecTermination, ProcessControlAck, ProcessControlFailureKind, ProcessControlGuestStatus,
+    ProcessControlOutcome, ProcessControlWriteState, ProcessExit,
+};
+use sandbox_mock::{MockLifecycleGate, MockSandboxOverrides};
+use tracing::Level;
+use tracing_subscriber::prelude::*;
+use tracing_test_support::CapturedEvents;
+
+enum ForcedCancellation {
+    Terminal(ExecTermination),
+    Diagnostic,
+    SendFailure,
+    WaitFailure,
+}
+
+fn guest_status(status: ProcessControlGuestStatus) -> ProcessControlOutcome {
+    ProcessControlOutcome::GuestStatus {
+        status,
+        diagnostic: "Broken pipe (os error 32)".into(),
+    }
+}
+
+#[tokio::test]
+async fn cooperative_failure_classification_preserves_completion_and_retirement() {
+    let server = MockServer::start_async().await;
+    let telemetry = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/api/webhooks/agent/telemetry");
+            then.status(200)
+                .json_body(serde_json::json!({"success": true, "id": "ok"}));
+        })
+        .await;
+    for (control, forced, expected_level) in [
+        (
+            guest_status(ProcessControlGuestStatus::SinkClosed),
+            ForcedCancellation::Terminal(ExecTermination::Cancelled),
+            Level::INFO,
+        ),
+        (
+            guest_status(ProcessControlGuestStatus::Inactive),
+            ForcedCancellation::Terminal(ExecTermination::Exited { exit_code: 0 }),
+            Level::INFO,
+        ),
+        (
+            ProcessControlOutcome::Failed {
+                kind: ProcessControlFailureKind::Operation,
+                write_state: ProcessControlWriteState::PossiblyWritten,
+                error: std::io::Error::from_raw_os_error(libc::EPIPE),
+            },
+            ForcedCancellation::Terminal(ExecTermination::Cancelled),
+            Level::INFO,
+        ),
+        (
+            guest_status(ProcessControlGuestStatus::SinkError),
+            ForcedCancellation::Terminal(ExecTermination::Cancelled),
+            Level::WARN,
+        ),
+        (
+            ProcessControlOutcome::Failed {
+                kind: ProcessControlFailureKind::BackendCrashed,
+                write_state: ProcessControlWriteState::PossiblyWritten,
+                error: std::io::Error::from_raw_os_error(libc::EPIPE),
+            },
+            ForcedCancellation::Terminal(ExecTermination::Cancelled),
+            Level::WARN,
+        ),
+        (
+            guest_status(ProcessControlGuestStatus::SinkClosed),
+            ForcedCancellation::SendFailure,
+            Level::WARN,
+        ),
+        (
+            guest_status(ProcessControlGuestStatus::SinkClosed),
+            ForcedCancellation::WaitFailure,
+            Level::WARN,
+        ),
+        (
+            guest_status(ProcessControlGuestStatus::SinkClosed),
+            ForcedCancellation::Terminal(ExecTermination::WaitFailed),
+            Level::WARN,
+        ),
+        (
+            guest_status(ProcessControlGuestStatus::SinkClosed),
+            ForcedCancellation::Diagnostic,
+            Level::WARN,
+        ),
+        (
+            ProcessControlOutcome::Delivered(ProcessControlAck {
+                message_id: "wrong-id".into(),
+            }),
+            ForcedCancellation::Terminal(ExecTermination::Cancelled),
+            Level::WARN,
+        ),
+    ] {
+        let wrong_ack = matches!(control, ProcessControlOutcome::Delivered(_));
+        let captured = CapturedEvents::default();
+        let _subscriber =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(captured.clone()));
+        let wait_gate = MockLifecycleGate::new();
+        let mut overrides = MockSandboxOverrides::new();
+        overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+        overrides.push_process_control_outcome(control);
+        match forced {
+            ForcedCancellation::Terminal(termination) => {
+                let mut exit = ProcessExit::new(1, 0, Vec::new(), Vec::new());
+                exit.termination = termination;
+                overrides.push_wait_process_exit(exit);
+            }
+            ForcedCancellation::Diagnostic => {
+                let mut exit = ProcessExit::new(1, 0, Vec::new(), Vec::new());
+                exit.termination = ExecTermination::Cancelled;
+                exit.diagnostic = "containment cleanup failed".into();
+                overrides.push_wait_process_exit(exit);
+            }
+            ForcedCancellation::SendFailure => {
+                overrides.push_process_cancel_error("cancel send failed")
+            }
+            ForcedCancellation::WaitFailure => {
+                overrides.set_wait_process_error("terminal wait failed")
+            }
+        }
+        let overrides = Arc::new(overrides);
+        let (config, env) = mock_run_config_with_overrides_and_api_url(
+            test_profiles(),
+            4,
+            8192,
+            4,
+            Arc::clone(&overrides),
+            &server.base_url(),
+        );
+        let budget = Arc::clone(&config.capacity.budget);
+        let run_handle = tokio::spawn(run(config));
+        let run_id = RunId::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(context_with_session(run_id, "cancel-race")),
+        );
+        wait_gate
+            .wait_entered(1, Duration::from_secs(5))
+            .await
+            .unwrap();
+        let cancellation =
+            wait_cancel_handle(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+        cancellation.request_cooperative_user_cancellation().await;
+
+        let completion = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await
+            .unwrap();
+        assert_eq!(completion.exit_code, 137);
+        assert_eq!(completion.error.as_deref(), Some("cancelled by user"));
+        wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+        assert_eq!(overrides.stop_call_count(), 1);
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert_eq!(env.idle_pool.lock().await.len(), 0);
+        assert_eq!(overrides.process_cancel_calls().len(), 1);
+        shutdown(&env, run_handle).await;
+        let events = captured.entries();
+        let message = if wrong_ack {
+            "guest acknowledged the wrong user-cancellation message"
+        } else {
+            "failed to send cooperative user cancellation"
+        };
+        let classified: Vec<_> = events
+            .iter()
+            .filter(|event| {
+                event.fields.get("message").map(String::as_str) == Some(message)
+                    && event.fields.get("run_id") == Some(&run_id.to_string())
+            })
+            .collect();
+        assert_eq!(classified.len(), 1);
+        assert_eq!(classified[0].level, expected_level);
+        if expected_level == Level::INFO {
+            assert_eq!(
+                classified[0]
+                    .fields
+                    .get("recovered_after_cancellation")
+                    .map(String::as_str),
+                Some("true")
+            );
+        }
+    }
+    telemetry.assert_calls_async(10).await;
+}

--- a/crates/runner/src/cmd/start/tests/failure_recovery/mod.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/mod.rs
@@ -1,3 +1,4 @@
+mod cooperative_cancellation;
 mod create_destroy;
 mod outer_panic;
 mod parking_cleanup;

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -335,7 +335,9 @@ fn classify_control_outcome(
                 }
                 ForwardDisposition::Retry
             }
-            ProcessControlGuestStatus::SinkTimeout | ProcessControlGuestStatus::SinkError => {
+            ProcessControlGuestStatus::SinkTimeout
+            | ProcessControlGuestStatus::SinkError
+            | ProcessControlGuestStatus::SinkClosed => {
                 if warn_retryable_failure {
                     warn!(
                         run_id = %run_id,
@@ -449,6 +451,7 @@ fn guest_status_label(status: ProcessControlGuestStatus) -> &'static str {
         ProcessControlGuestStatus::SinkTimeout => "sink_timeout",
         ProcessControlGuestStatus::QueueFull => "queue_full",
         ProcessControlGuestStatus::SinkError => "sink_error",
+        ProcessControlGuestStatus::SinkClosed => "sink_closed",
     }
 }
 

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -16,7 +16,8 @@ use guest_contracts::session_history_identity::{
 };
 use sandbox::{
     EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, GuestProcessCancelHandle,
-    GuestProcessControlHandle, GuestProcessHandle, ProcessOutputMode, Sandbox,
+    GuestProcessControlHandle, GuestProcessHandle, ProcessControlFailureKind,
+    ProcessControlGuestStatus, ProcessControlOutcome, ProcessOutputMode, Sandbox,
     SessionHistoryIdentityVerifyRequest, StartAgentProcessRequest,
 };
 use tokio_util::sync::CancellationToken;
@@ -693,6 +694,8 @@ struct ProcessWaitOutcome {
     result: sandbox::Result<sandbox::ProcessExit>,
     cancellation: CancellationDisposition,
     interrupt_stdout_drain: bool,
+    // Proof from the provider result, never from our synthetic Cancelled exit.
+    hard_cancel_terminal_confirmed: bool,
 }
 
 impl ProcessWaitOutcome {
@@ -702,6 +705,7 @@ impl ProcessWaitOutcome {
             result,
             cancellation: CancellationDisposition::None,
             interrupt_stdout_drain,
+            hard_cancel_terminal_confirmed: false,
         }
     }
 
@@ -710,6 +714,7 @@ impl ProcessWaitOutcome {
             result: Ok(exit),
             cancellation: CancellationDisposition::Cooperative,
             interrupt_stdout_drain: false,
+            hard_cancel_terminal_confirmed: false,
         }
     }
 
@@ -725,6 +730,7 @@ impl ProcessWaitOutcome {
             )),
             cancellation: CancellationDisposition::HardFallback,
             interrupt_stdout_drain,
+            hard_cancel_terminal_confirmed: false,
         }
     }
 }
@@ -790,7 +796,14 @@ where
                 pid = guest_process_pid,
                 "cancelled guest process reached terminal status"
             );
-            ProcessWaitOutcome::hard_fallback(guest_process_pid, exit.stream_overflowed, false)
+            let mut outcome =
+                ProcessWaitOutcome::hard_fallback(guest_process_pid, exit.stream_overflowed, false);
+            outcome.hard_cancel_terminal_confirmed = exit.diagnostic.is_empty()
+                && matches!(
+                    exit.termination,
+                    ExecTermination::Exited { .. } | ExecTermination::Cancelled
+                );
+            outcome
         }
         Ok(Err(error)) => {
             warn!(
@@ -813,23 +826,50 @@ where
     }
 }
 
+enum CooperativeCancellationSend {
+    Accepted,
+    Force,
+    Closed(std::io::Error),
+}
+
+fn control_closed_before_cancellation(outcome: &ProcessControlOutcome) -> bool {
+    match outcome {
+        ProcessControlOutcome::GuestStatus { status, .. } => matches!(
+            status,
+            ProcessControlGuestStatus::Inactive | ProcessControlGuestStatus::SinkClosed
+        ),
+        ProcessControlOutcome::Failed {
+            kind: ProcessControlFailureKind::Operation,
+            error,
+            ..
+        } => matches!(
+            error.kind(),
+            std::io::ErrorKind::BrokenPipe
+                | std::io::ErrorKind::ConnectionReset
+                | std::io::ErrorKind::UnexpectedEof
+        ),
+        _ => false,
+    }
+}
+
 async fn send_cooperative_user_cancellation(
     run_id: crate::ids::RunId,
     process_control: &GuestProcessControlHandle,
     hard_cancel: &CancellationToken,
     timeout: Duration,
-) -> bool {
+) -> CooperativeCancellationSend {
     let message_id = format!("user-cancellation:{run_id}");
     tokio::select! {
         biased;
-        () = hard_cancel.cancelled() => false,
-        result = process_control.control(
+        () = hard_cancel.cancelled() => CooperativeCancellationSend::Force,
+        outcome = process_control.control_outcome(
             &message_id,
             USER_CANCELLATION_CONTROL_PAYLOAD,
             timeout,
         ) => {
-            match result {
-                Ok(ack) if ack.message_id == message_id => true,
+            let closed = control_closed_before_cancellation(&outcome);
+            match outcome.into_ack() {
+                Ok(ack) if ack.message_id == message_id => CooperativeCancellationSend::Accepted,
                 Ok(ack) => {
                     warn!(
                         run_id = %run_id,
@@ -837,15 +877,16 @@ async fn send_cooperative_user_cancellation(
                         acknowledged_message_id = %ack.message_id,
                         "guest acknowledged the wrong user-cancellation message"
                     );
-                    false
+                    CooperativeCancellationSend::Force
                 }
+                Err(error) if closed => CooperativeCancellationSend::Closed(error),
                 Err(error) => {
                     warn!(
                         run_id = %run_id,
                         error = %error,
                         "failed to send cooperative user cancellation"
                     );
-                    false
+                    CooperativeCancellationSend::Force
                 }
             }
         }
@@ -864,15 +905,15 @@ async fn wait_for_cooperative_user_cancellation<F>(
 where
     F: Future<Output = sandbox::Result<sandbox::ProcessExit>>,
 {
-    if !send_cooperative_user_cancellation(
+    let sent = send_cooperative_user_cancellation(
         run_id,
         process_control,
         hard_cancel,
         process_cancel_timeouts.write,
     )
-    .await
-    {
-        return force_cancel_guest_process(
+    .await;
+    if !matches!(sent, CooperativeCancellationSend::Accepted) {
+        let outcome = force_cancel_guest_process(
             run_id,
             guest_process_pid,
             process_cancel,
@@ -880,6 +921,24 @@ where
             wait_process,
         )
         .await;
+        if let CooperativeCancellationSend::Closed(error) = sent {
+            if outcome.hard_cancel_terminal_confirmed {
+                info!(
+                    run_id = %run_id,
+                    error = %error,
+                    recovered_after_cancellation = true,
+                    "failed to send cooperative user cancellation"
+                );
+            } else {
+                warn!(
+                    run_id = %run_id,
+                    error = %error,
+                    recovered_after_cancellation = false,
+                    "failed to send cooperative user cancellation"
+                );
+            }
+        }
+        return outcome;
     }
 
     tokio::select! {
@@ -2346,6 +2405,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         result,
         cancellation,
         interrupt_stdout_drain,
+        ..
     } = wait_outcome;
     let cancellation_observed = cancellation.observed();
     let used_hard_cancellation_fallback = cancellation.used_hard_fallback();

--- a/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
@@ -1252,16 +1252,34 @@ async fn run_in_sandbox_retries_guest_backpressure_with_same_id() {
 
 #[tokio::test]
 async fn run_in_sandbox_suppresses_possibly_written_delivery() {
+    assert_uncertain_delivery_is_suppressed(sandbox::ProcessControlOutcome::Failed {
+        kind: sandbox::ProcessControlFailureKind::Operation,
+        write_state: sandbox::ProcessControlWriteState::PossiblyWritten,
+        error: std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "delivery acknowledgement timed out",
+        ),
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn run_in_sandbox_suppresses_delivery_when_control_sink_closed() {
+    assert_uncertain_delivery_is_suppressed(sandbox::ProcessControlOutcome::GuestStatus {
+        status: sandbox::ProcessControlGuestStatus::SinkClosed,
+        diagnostic: "control sink closed".into(),
+    })
+    .await;
+}
+
+async fn assert_uncertain_delivery_is_suppressed(outcome: sandbox::ProcessControlOutcome) {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let wait_gate = Arc::new(tokio::sync::Notify::new());
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&wait_gate),
     ));
-    overrides.push_process_control_io_error(
-        std::io::ErrorKind::TimedOut,
-        "delivery acknowledgement timed out",
-    );
+    overrides.push_process_control_outcome(outcome);
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let run_id = ctx.run_id;

--- a/crates/runner/src/executor/tests/agent_run_tests/cancellation.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/cancellation.rs
@@ -9,6 +9,9 @@ use sha2::{Digest, Sha256};
 use tokio::io::AsyncReadExt;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
+use tracing::Level;
+use tracing_subscriber::prelude::*;
+use tracing_test_support::CapturedEvents;
 
 use super::support::{
     final_identity_metadata_bytes, final_identity_runtime_paths, local_sidecar_restore_plan,
@@ -33,6 +36,72 @@ use crate::types::{
 use crate::workspace_image_cache::{
     WorkspaceSessionHistorySidecar, WorkspaceSessionHistorySidecarRepresentation,
 };
+
+#[tokio::test]
+async fn closed_cooperative_control_remains_warning_when_terminal_grace_expires() {
+    let captured = CapturedEvents::default();
+    let _subscriber =
+        tracing::subscriber::set_default(tracing_subscriber::registry().with(captured.clone()));
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    overrides.set_process_cancel_releases_wait_gate(false);
+    overrides.push_process_control_outcome(sandbox::ProcessControlOutcome::GuestStatus {
+        status: sandbox::ProcessControlGuestStatus::SinkClosed,
+        diagnostic: "closed control peer".into(),
+    });
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let cancellation = RunCancellationHandle::new();
+    let run_task = spawn_run_in_sandbox_test_with_cancellation(
+        sandbox,
+        minimal_context(),
+        config,
+        cancellation.signals(),
+        ProcessCancelTimeouts {
+            terminal_grace: Duration::ZERO,
+            ..PROCESS_CANCEL_TIMEOUTS
+        },
+    );
+    wait_gate
+        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+        .await
+        .unwrap();
+    cancellation.request_cooperative_user_cancellation().await;
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.failure.unwrap().exit_code, EXIT_SIGKILL);
+    assert_eq!(
+        result.sandbox_reuse_disposition,
+        SandboxReuseDisposition::Ineligible(SandboxReuseRejection::HardCancellation)
+    );
+    let events = captured.entries();
+    for message in [
+        "timed out waiting for cancelled guest process",
+        "failed to send cooperative user cancellation",
+    ] {
+        let event = events
+            .iter()
+            .find(|event| event.fields.get("message").map(String::as_str) == Some(message))
+            .unwrap();
+        assert_eq!(event.level, Level::WARN);
+    }
+    let event = events
+        .iter()
+        .find(|event| event.fields.contains_key("recovered_after_cancellation"))
+        .unwrap();
+    assert_eq!(
+        event
+            .fields
+            .get("recovered_after_cancellation")
+            .map(String::as_str),
+        Some("false")
+    );
+}
 
 #[tokio::test]
 async fn run_in_sandbox_preserves_wait_result_when_cancel_arrives_after_wait() {

--- a/crates/sandbox-firecracker/src/sandbox.rs
+++ b/crates/sandbox-firecracker/src/sandbox.rs
@@ -140,6 +140,7 @@ fn process_control_outcome_label(outcome: &ProcessControlOutcome) -> &'static st
             ProcessControlGuestStatus::SinkTimeout => "guest_sink_timeout",
             ProcessControlGuestStatus::QueueFull => "guest_queue_full",
             ProcessControlGuestStatus::SinkError => "guest_sink_error",
+            ProcessControlGuestStatus::SinkClosed => "guest_sink_closed",
         },
         ProcessControlOutcome::GuestError(_) => "guest_error",
         ProcessControlOutcome::Failed {
@@ -1048,6 +1049,9 @@ impl FirecrackerSandbox {
             }
             guest_control_proto::ExecControlStatus::SinkError => {
                 ProcessControlGuestStatus::SinkError
+            }
+            guest_control_proto::ExecControlStatus::SinkClosed => {
+                ProcessControlGuestStatus::SinkClosed
             }
             guest_control_proto::ExecControlStatus::Delivered => {
                 return Err(io::Error::new(

--- a/crates/sandbox-firecracker/src/sandbox/tests.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests.rs
@@ -3651,6 +3651,12 @@ async fn process_control_preserves_guest_statuses_and_legacy_errors() {
             io::ErrorKind::BrokenPipe,
             "exec control sink error",
         ),
+        (
+            ExecControlStatus::SinkClosed,
+            ProcessControlGuestStatus::SinkClosed,
+            io::ErrorKind::BrokenPipe,
+            "exec control sink closed",
+        ),
     ];
 
     for (index, (guest_status, status, error_kind, error_message)) in cases.into_iter().enumerate()

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -643,6 +643,8 @@ pub enum ProcessControlGuestStatus {
     QueueFull,
     /// The guest process-control sink returned an error.
     SinkError,
+    /// The connected guest process-control sink closed during request I/O.
+    SinkClosed,
 }
 
 impl ProcessControlGuestStatus {
@@ -654,7 +656,7 @@ impl ProcessControlGuestStatus {
             Self::SinkUnavailable => io::ErrorKind::NotConnected,
             Self::SinkTimeout => io::ErrorKind::TimedOut,
             Self::QueueFull => io::ErrorKind::WouldBlock,
-            Self::SinkError => io::ErrorKind::BrokenPipe,
+            Self::SinkError | Self::SinkClosed => io::ErrorKind::BrokenPipe,
         }
     }
 
@@ -668,6 +670,7 @@ impl ProcessControlGuestStatus {
             Self::SinkTimeout => "exec control sink timed out",
             Self::QueueFull => "exec control queue is full",
             Self::SinkError => "exec control sink error",
+            Self::SinkClosed => "exec control sink closed",
         }
     }
 }

--- a/docs/cooperative-cancellation-logging.md
+++ b/docs/cooperative-cancellation-logging.md
@@ -1,0 +1,38 @@
+# Cooperative cancellation logging
+
+A user cancellation first asks Guest Agent to save recovery state and exit.
+If delivery fails, Runner still sends the existing bounded supervised-process
+cancel request and waits for its terminal result. This fallback does not prove
+that the cooperative checkpoint completed, and its synthetic cancelled result
+does not prove that the Guest process stopped.
+
+The `failed to send cooperative user cancellation` event is INFO only when:
+
+- The structured control outcome identifies an inactive operation, a connected
+  Guest sink that closed during I/O (`SinkClosed`), or a non-backend-crash
+  transport closure (`BrokenPipe`, `ConnectionReset`, or `UnexpectedEof`).
+- The existing forced-cancellation wait observes an actual `Exited` or
+  `Cancelled` provider result without a diagnostic.
+
+These events carry `recovered_after_cancellation=true`. A candidate closure
+without that terminal proof remains WARN with the field set to false. Other
+control failures remain WARN immediately. A generic `SinkError` is not closure
+proof: it also covers protocol and application failures, even though the legacy
+acknowledgement adapter represents it as `BrokenPipe`.
+
+Guest control retains the first connected-sink failure's classification for
+queued and later requests. Active-input delivery remains uncertain after
+`SinkClosed`; a closed channel is not an acknowledgement or permission to retry
+a potentially non-idempotent delivery.
+
+The private control status ships with all producers and consumers in one Runner
+artifact. No API, database, persisted workspace-cache format, cancellation
+deadline, retry, checkpoint, or sandbox reuse rule changes. Hard cancellation
+continues to make the sandbox ineligible for reuse.
+
+For issue #32755, observe a full 24 hours after deployment before closure.
+Correlate INFO recovery events in host logs with the actual Guest terminal result
+and sandbox retirement, and inspect production WARN/ERROR logs for unconfirmed
+cancellation or genuine control failures. WARN-only Axiom queries do not contain
+the downgraded INFO events. A quiet query without exercised cancellations does
+not establish recovery coverage.


### PR DESCRIPTION
## Summary

Relates to #32755. Keep the issue open for its required 24-hour post-deployment observation.

- Preserve a typed `SinkClosed` status through the private Guest control protocol, client and sandbox provider, including the first failure seen by queued/later control requests.
- Classify cooperative-cancellation closure/inactive races as INFO only after the existing forced-cancellation wait observes a real `Exited`/`Cancelled` result without a diagnostic. Keep generic sink/protocol errors, backend crashes, wrong acknowledgements, failed cancellation and unconfirmed termination as WARN.
- Preserve active-input delivery uncertainty: a closed sink is neither an acknowledgement nor proof that retrying delivery is safe.

Read-only production correlation for the original occurrence confirmed an actual Guest terminal result roughly 45 ms after the warning, followed by hard-cancellation retirement and sandbox destruction. The historical flattened error does not identify its original control layer, so this change does not match error prose or blanket-downgrade `BrokenPipe`.

## Scope and compatibility

No changes to cancellation ordering, deadlines, retries, synthetic completion, checkpoint/session handling or sandbox reuse. No API, database, persisted cache format, UI, public configuration or dependency changes.

Runner and bundled Guest binaries ship as one artifact; all private status producers and consumers change together. Existing wire values and acknowledgement error mappings stay unchanged. No new fallback is introduced; the existing bounded forced cancellation is preserved.

## Validation

Passed from `crates/`:

- `cargo fmt --all -- --check`
- `cargo clippy --profile local --workspace --all-targets --all-features -j 4`
- `RUSTDOCFLAGS='-D warnings' cargo doc --profile local --workspace --all-features --no-deps -j 4`
- `cargo test --profile local -p guest-control-proto -p guest-control-server -p guest-control-client -p sandbox -p sandbox-firecracker -p sandbox-mock -p guest-control-tests -p guest-agent -p guest-init -p runner --all-features -j 4 -- --test-threads=1`
- Focused real IPC control tests (42 passed) and the full Runner cancellation-classification matrix.
- Final-worktree `cargo test --profile local -p runner cooperative -- --test-threads=1` (15 passed).

Documentation formatting passed with `pnpm exec prettier --write ../docs/cooperative-cancellation-logging.md` from `turbo/`.

Coverage includes actual Unix peer closure before request write and before acknowledgement, retained closure provenance, wire/provider compatibility, ten full-run classification scenarios with completion and retirement, terminal-grace expiry, and uncertain active-input delivery. No timeouts were increased or tests newly skipped. Existing explicitly ignored hardware/child-process fixtures retain their prior harness behavior.

## Risks and operational verification

- Closure-candidate logging occurs after the existing bounded cancellation attempt; it adds no wait, but a Runner crash during that interval could lose that particular deferred event.
- Confirmed recovery moves from WARN to INFO and is absent from WARN-only Axiom ingestion. The new operational note documents host-log correlation and genuine-failure checks for the 24-hour observation gate.
- Clean forced termination does not imply that a cooperative checkpoint succeeded. The run remains cancelled and the hard-cancelled sandbox remains ineligible for reuse.

No production deployment or 24-hour observation was performed by this PR workflow.
