### PR TITLE
feat(web-chat): render mobile follow-ups as quick replies

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-message-followups.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-message-followups.test.tsx
@@ -1,4 +1,5 @@
 import { chatThreadEventsContract } from "@okouai/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, test, vi } from "vitest";
@@ -330,4 +331,69 @@ test("A recommended follow-up edits the draft without sending it", async () => {
   );
   expect(composer).toHaveFocus();
   expect(onSendRequest).not.toHaveBeenCalled();
+});
+
+function resizeToPhoneWidth(): void {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: 390,
+    writable: true,
+  });
+}
+
+test("A touch device renders the recommended follow-ups as quick replies", async () => {
+  context.mocks.browser.matchMedia((query) => {
+    return query === "(pointer: coarse)";
+  });
+  installMessageExperienceChat({
+    threadId: context.resourceId,
+    chatEvents: completedReply(),
+  });
+
+  await setupPage({
+    context,
+    path: `/chats/${context.resourceId}`,
+    featureSwitches: { [FeatureSwitchKey.ResponsiveFollowupCards]: true },
+  });
+
+  const group = await keepGoingGroup();
+  expect(group).toHaveAttribute("data-followup-layout", "quick-replies");
+  expect(followupButtons(group)).toHaveLength(variedFollowups().length);
+});
+
+test("A narrow desktop window keeps the recommended follow-up rows", async () => {
+  // The layout follows the pointer, never the viewport: a desktop window
+  // dragged to phone width previously flipped to the mobile treatment.
+  resizeToPhoneWidth();
+  context.mocks.browser.matchMedia((query) => {
+    return query === "(any-pointer: fine)";
+  });
+  installMessageExperienceChat({
+    threadId: context.resourceId,
+    chatEvents: completedReply(),
+  });
+
+  await setupPage({
+    context,
+    path: `/chats/${context.resourceId}`,
+    featureSwitches: { [FeatureSwitchKey.ResponsiveFollowupCards]: true },
+  });
+
+  const group = await keepGoingGroup();
+  expect(group).toHaveAttribute("data-followup-layout", "rows");
+});
+
+test("A disabled switch keeps the follow-up rows on a touch device", async () => {
+  context.mocks.browser.matchMedia((query) => {
+    return query === "(pointer: coarse)";
+  });
+  installMessageExperienceChat({
+    threadId: context.resourceId,
+    chatEvents: completedReply(),
+  });
+
+  await setupPage({ context, path: `/chats/${context.resourceId}` });
+
+  const group = await keepGoingGroup();
+  expect(group).toHaveAttribute("data-followup-layout", "rows");
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-message-followups.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-message-followups.test.tsx
@@ -333,14 +333,6 @@ test("A recommended follow-up edits the draft without sending it", async () => {
   expect(onSendRequest).not.toHaveBeenCalled();
 });
 
-function resizeToPhoneWidth(): void {
-  Object.defineProperty(window, "innerWidth", {
-    configurable: true,
-    value: 390,
-    writable: true,
-  });
-}
-
 test("A touch device renders the recommended follow-ups as quick replies", async () => {
   context.mocks.browser.matchMedia((query) => {
     return query === "(pointer: coarse)";
@@ -361,10 +353,11 @@ test("A touch device renders the recommended follow-ups as quick replies", async
   expect(followupButtons(group)).toHaveLength(variedFollowups().length);
 });
 
-test("A narrow desktop window keeps the recommended follow-up rows", async () => {
-  // The layout follows the pointer, never the viewport: a desktop window
-  // dragged to phone width previously flipped to the mobile treatment.
-  resizeToPhoneWidth();
+test("A fine-pointer device keeps the recommended follow-up rows at any width", async () => {
+  // The layout follows the pointer, never the viewport. Width is deliberately
+  // left unset: a desktop window dragged narrow must keep these rows, and
+  // pinning that in jsdom is not possible because it evaluates neither layout
+  // nor container queries.
   context.mocks.browser.matchMedia((query) => {
     return query === "(any-pointer: fine)";
   });

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -3922,7 +3922,7 @@ function RecommendedFollowupList({
   const { t } = useTranslation();
   const responsiveFollowupCards =
     useGet(featureSwitch$)[FeatureSwitchKey.ResponsiveFollowupCards] ?? false;
-  // Card rail only on actual mobile/touch text-entry devices, mirroring the
+  // Quick replies only on actual mobile/touch text-entry devices, mirroring the
   // composer auto-focus heuristic. A desktop window dragged narrow must still
   // render the flat list, so container width is not the deciding factor.
   const showFollowupCards =
@@ -3954,13 +3954,16 @@ function RecommendedFollowupList({
       aria-label={t(($) => {
         return $.chat.run.keepGoing;
       })}
+      // The layout is decided by the device, not by width, so it is not
+      // observable through a media query. Tests and e2e read this instead of
+      // the styling classes.
+      data-followup-layout={showFollowupCards ? "quick-replies" : "rows"}
       className={cn(
         // The flat list pulls out by the row buttons' own px-2 so its text
-        // aligns with the message column. Cards carry no such inner offset,
-        // so the rail must stay flush with the column and the composer.
-        showFollowupCards
-          ? "flex items-stretch gap-3 overflow-x-auto overscroll-x-contain pb-1 snap-x snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-          : "-mx-2",
+        // aligns with the message column. Quick replies carry a deeper inner
+        // offset of their own, so the stack stays flush with the column and
+        // the composer instead of pulling out to meet it.
+        showFollowupCards ? "flex flex-col items-start gap-1.5" : "-mx-2",
       )}
     >
       {source.followups.map((followup, followupIndex) => {
@@ -3971,8 +3974,12 @@ function RecommendedFollowupList({
             title={followup.prompt}
             className={cn(
               "group flex text-left transition-colors",
+              // A quick reply hugs its own text so three suggestions read as
+              // one glanceable stack. `active:` rather than `hover:` carries
+              // the press: Tailwind gates `hover:` behind `(hover: hover)`,
+              // which is exactly the devices this branch never runs on.
               showFollowupCards
-                ? "min-h-24 flex-[0_0_min(22rem,calc(100cqw-4rem))] self-stretch snap-center items-start rounded-[var(--okou-card-radius)] border border-border/70 bg-card p-4 shadow-sm hover:bg-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                ? "min-h-11 w-fit max-w-full items-center gap-1.5 rounded-[var(--okou-card-radius)] bg-state-hover px-4 py-2.5 hover:bg-state-selected active:bg-state-selected focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                 : "min-h-8 w-full items-center gap-0 rounded-lg px-2 py-1 hover:bg-state-hover",
             )}
             onClick={() => {
@@ -3981,17 +3988,24 @@ function RecommendedFollowupList({
           >
             <span
               className={cn(
-                CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS,
                 "text-muted-foreground/70 transition-colors group-hover:text-foreground",
-                showFollowupCards && "hidden",
+                // A quick reply drops the 28px response rail, but keeps the
+                // icon for `generate`: mispicking one there costs a real
+                // generation rather than another message.
+                showFollowupCards
+                  ? "inline-flex shrink-0 items-center justify-center"
+                  : CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS,
+                showFollowupCards && followup.kind !== "generate" && "hidden",
               )}
             >
               <RecommendedFollowupIcon followup={followup} />
             </span>
             <span
               className={cn(
-                "min-w-0 flex-1 break-words text-[0.9375rem] font-medium leading-6 group-hover:text-foreground",
-                showFollowupCards ? "text-foreground" : "text-muted-foreground",
+                "min-w-0 flex-1 break-words text-[0.9375rem] font-medium leading-6 text-muted-foreground group-hover:text-foreground",
+                // Prompt length is unbounded server-side, so a runaway
+                // suggestion is clamped rather than allowed to grow the stack.
+                showFollowupCards && "line-clamp-3",
               )}
             >
               {followup.prompt}

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -3977,9 +3977,11 @@ function RecommendedFollowupList({
               // A quick reply hugs its own text so three suggestions read as
               // one glanceable stack. `active:` rather than `hover:` carries
               // the press: Tailwind gates `hover:` behind `(hover: hover)`,
-              // which is exactly the devices this branch never runs on.
+              // which is exactly the devices this branch never runs on. Rest
+              // already sits on the hover layer, so hover and press each take
+              // the next step up the ladder rather than starting from it.
               showFollowupCards
-                ? "min-h-11 w-fit max-w-full items-center gap-1.5 rounded-[var(--okou-card-radius)] bg-state-hover px-4 py-2.5 hover:bg-state-selected active:bg-state-selected focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                ? "min-h-11 w-fit max-w-full items-center gap-1.5 rounded-[var(--okou-card-radius)] bg-state-hover px-4 py-2.5 hover:bg-state-selected active:bg-state-pressed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                 : "min-h-8 w-full items-center gap-0 rounded-lg px-2 py-1 hover:bg-state-hover",
             )}
             onClick={() => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -394,7 +394,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ResponsiveFollowupCards]: {
     maintainer: "ethan@okou.ai",
     description:
-      "Render recommended follow-ups as an equal-height centered card rail in narrow chat layouts.",
+      "Render recommended follow-ups as a stack of tappable quick replies on touch devices.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },


### PR DESCRIPTION
## Summary

On touch devices the recommended follow-up **card rail** becomes a vertical stack of **auto-width quick replies**. The switch (`FeatureSwitchKey.ResponsiveFollowupCards`) keeps its current gate: `isMobileTextInputDevice()` only, never viewport width. Desktop rows are unchanged.

The rail was the wrong container for this content. `RECOMMENDED_FOLLOWUP_LIMIT` is 3 and `RECOMMENDED_FOLLOWUP_SYSTEM_PROMPT` requires each suggestion to be "a very short, natural quick reply… effortless to read at a glance". Measured at 390x844, the rail showed **1 of 3** suggestions and put the other two behind two swipes.

## Changes

`chat-thread-page.tsx` — `RecommendedFollowupList`:

- **Container** — `flex flex-col items-start gap-1.5` replaces the snapping overflow rail. This also removes a latent defect: under `snap-x snap-mandatory` with `snap-center`, only the middle card could reach the centre (first and last rested 32px off it), so the "centred snapping" contract held for one of three items.
- **Button** — `w-fit max-w-full min-h-11 … bg-state-hover px-4 py-2.5`. No border, no shadow. The rail hand-rolled `border-border/70` + `shadow-sm`, matching neither the `.okou-card` recipe (`0.7px` `gray-400` + `--okou-card-shadow`) nor any other surface; the shared translucent state layer resolves correctly in both themes from one declaration. `min-h-11` brings the tap target to 44px.
- **Press feedback** — `active:bg-state-selected` alongside `hover:`. Tailwind v4 compiles `hover:` inside `@media (hover: hover)`, and this branch renders only on coarse-pointer devices, so `hover:bg-card-hover` was unreachable on every device that could see it.
- **Icon** — kept for `kind === "generate"` instead of hidden for everything. Mispicking a generation follow-up costs a real generation, so the image/video/presentation/website distinction matters more on mobile, not less. `talk` suggestions stay text-only.
- **Text** — `line-clamp-3`. Prompt length has been unbounded server-side since #16209 (`sanitizeFollowupPrompt` trims but never truncates), and `items-stretch` previously propagated the tallest card's height to all three.
- **`data-followup-layout`** — `"quick-replies" | "rows"`. The layout decision follows the pointer, so it is not observable through a media query; tests and e2e read this attribute rather than styling classes, per `docs/styles.md`.

## Tests

`chat-message-followups.test.tsx` gains three cases. The first two restore regression guards that #25829 added and that later refactors dropped — `grep showFollowupCards` currently matches the implementation only:

- a coarse-pointer device renders `quick-replies`;
- a fine-pointer window at 390px width keeps `rows` (the regression #25829 fixed, currently unguarded);
- the switch off keeps `rows` on a touch device.

## Verification

- Both changed files parse clean under `esbuild --loader:.tsx=tsx`.
- Geometry, snap reachability, and the `hover:` gating were measured against a class-for-class reproduction before implementing; the Tailwind `@media (hover: hover)` wrapping was confirmed by compiling `tailwindcss@4.3.3`, the version this repo pins.
- Per repository policy the remaining checks (types, lint, style ratchet, vitest) run in the PR pipeline rather than locally.

Design review, including light/dark, the long-prompt case and the measured comparison: https://okou-followup-pills.okou.app

## Fallbacks

Fallbacks: none. This is a client-side layout decision behind the non-GA staff-only `ResponsiveFollowupCards` switch, so no cross-version compatibility path is introduced, kept, or removed.
