### PR TITLE
fix(rpc): dispatch complete request frames without waiting for eof

### DIFF
--- a/.github/scripts/runner-behavior-guest-rpc.sh
+++ b/.github/scripts/runner-behavior-guest-rpc.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${METAL_USER:?}"
+: "${HOST:?}"
+: "${JOB_REF:?}"
+: "${DEFAULT_ROOTFS_HASH:?}"
+: "${DEFAULT_SNAPSHOT_HASH:?}"
+: "${TEST_BIN:?}"
+: "${GITHUB_RUN_ID:?}"
+: "${GITHUB_RUN_ATTEMPT:?}"
+
+[[ "$JOB_REF" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]
+[[ "$GITHUB_RUN_ID" =~ ^[0-9]+$ && "$GITHUB_RUN_ATTEMPT" =~ ^[0-9]+$ ]]
+[[ "$DEFAULT_ROOTFS_HASH" =~ ^[0-9a-f]{64}$ && "$DEFAULT_SNAPSHOT_HASH" =~ ^[0-9a-f]{64}$ ]]
+test -x "$TEST_BIN"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FC_VERSION=$(sed -n 's/^pub const FIRECRACKER_VERSION: &str = "\([^"]*\)";$/\1/p' "$REPO_ROOT/crates/runner/src/deps.rs")
+KERNEL_VERSION=$(sed -n 's/^pub const KERNEL_VERSION: &str = "\([^"]*\)";$/\1/p' "$REPO_ROOT/crates/runner/src/deps.rs")
+[[ "$FC_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && "$KERNEL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+
+REMOTE="${METAL_USER}@${HOST}"
+EXECUTION_KEY="${JOB_REF}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+REMOTE_BIN="/tmp/runner-guest-rpc-${EXECUTION_KEY}"
+cleanup_upload() {
+  ssh "$REMOTE" sudo rm -f -- "$REMOTE_BIN"
+}
+trap cleanup_upload EXIT
+scp "$TEST_BIN" "${REMOTE}:${REMOTE_BIN}"
+
+ssh "$REMOTE" sudo bash -s -- \
+  "$REMOTE_BIN" "$EXECUTION_KEY" "$DEFAULT_ROOTFS_HASH" "$DEFAULT_SNAPSHOT_HASH" \
+  "$FC_VERSION" "$KERNEL_VERSION" <<'REMOTE_SCRIPT'
+set -euo pipefail
+TEST_BIN=$1
+EXECUTION_KEY=$2
+ROOTFS_HASH=$3
+SNAPSHOT_HASH=$4
+FC_VERSION=$5
+KERNEL_VERSION=$6
+BASE_DIR="/var/lib/vm0-runner/guest-rpc-tests/${EXECUTION_KEY}"
+UNIT="runner-guest-rpc-${EXECUTION_KEY}"
+TEST_NAME=packaged_helper_completes_over_fresh_restored_and_reused_firecracker
+ROOTFS_DIR="/var/lib/vm0-runner/images/${ROOTFS_HASH}"
+SNAPSHOT_DIR="${ROOTFS_DIR}/snapshots/${SNAPSHOT_HASH}"
+FIRECRACKER="/var/lib/vm0-runner/firecracker/${FC_VERSION}/firecracker"
+KERNEL="/var/lib/vm0-runner/firecracker/${FC_VERSION}/vmlinux-${KERNEL_VERSION}"
+
+cleanup() {
+  systemctl stop "${UNIT}.service" || true
+  rm -f -- "$TEST_BIN"
+  rm -rf -- "$BASE_DIR"
+}
+trap cleanup EXIT
+
+# Pin both immutable image inputs against GC, in the production lock order.
+exec 3>"/var/lib/vm0-runner/locks/rootfs-${ROOTFS_HASH}.lock"
+flock --shared --timeout 60 3
+exec 4>"/var/lib/vm0-runner/locks/snapshot-${SNAPSHOT_HASH}.lock"
+flock --shared --timeout 60 4
+for fixture in "$FIRECRACKER" "$KERNEL" "$ROOTFS_DIR/rootfs.ext4" \
+  "$SNAPSHOT_DIR/snapshot.bin" "$SNAPSHOT_DIR/memory.bin" "$SNAPSHOT_DIR/cow.img"; do
+  test -s "$fixture"
+done
+"$TEST_BIN" --ignored --list | grep -Fx "${TEST_NAME}: test"
+mkdir -p "$BASE_DIR"
+echo "RPC_FIRECRACKER_ARTIFACT rootfs=$ROOTFS_HASH snapshot=$SNAPSHOT_HASH firecracker=$FC_VERSION"
+# The transient unit bounds the test and its children even if SSH disconnects.
+systemd-run --wait --collect --pipe "--unit=${UNIT}" \
+  --property=Type=exec --property=RuntimeMaxSec=180 --property=TimeoutStopSec=30 \
+  "--setenv=OKOU_TEST_RPC_FIRECRACKER=${FIRECRACKER}" \
+  "--setenv=OKOU_TEST_RPC_KERNEL=${KERNEL}" \
+  "--setenv=OKOU_TEST_RPC_ROOTFS=${ROOTFS_DIR}/rootfs.ext4" \
+  "--setenv=OKOU_TEST_RPC_SNAPSHOT_DIR=${SNAPSHOT_DIR}" \
+  "--setenv=OKOU_TEST_RPC_SNAPSHOT_HASH=${SNAPSHOT_HASH}" \
+  "--setenv=OKOU_TEST_RPC_BASE_DIR=${BASE_DIR}" \
+  "$TEST_BIN" --ignored --exact "$TEST_NAME" --nocapture --test-threads=1
+REMOTE_SCRIPT

--- a/.github/scripts/tests/runner-behavior-guest-rpc-test.sh
+++ b/.github/scripts/tests/runner-behavior-guest-rpc-test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WORKER="$REPO_ROOT/.github/scripts/runner-behavior-guest-rpc.sh"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf -- "$TEST_ROOT"' EXIT
+mkdir -p "$TEST_ROOT/bin"
+
+cat >"$TEST_ROOT/bin/scp" <<'SCP'
+#!/usr/bin/env bash
+set -euo pipefail
+cp -- "$1" "$RPC_CASE/remote-bin"
+SCP
+cat >"$TEST_ROOT/bin/ssh" <<'SSH'
+#!/usr/bin/env bash
+set -euo pipefail
+shift
+if [ "$1" = sudo ] && [ "$2" = rm ]; then
+  rm -f -- "$RPC_CASE/remote-bin"
+  exit 0
+fi
+[ "$1" = sudo ] && [ "$2" = bash ] && [ "$3" = -s ] && [ "$4" = -- ]
+shift 4
+shift # uploaded binary path
+source_text=$(cat)
+source_text=${source_text//\/var\/lib\/vm0-runner/"$RPC_CASE/fixtures"}
+bash -s -- "$RPC_CASE/remote-bin" "$@" <<<"$source_text"
+SSH
+cat >"$TEST_ROOT/bin/systemctl" <<'SYSTEMCTL'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$RPC_CASE/cleanup"
+SYSTEMCTL
+cat >"$TEST_ROOT/bin/systemd-run" <<'SYSTEMD_RUN'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" >"$RPC_CASE/launch"
+case " $* " in
+  *" --property=RuntimeMaxSec=180 "*) ;;
+  *) exit 90 ;;
+esac
+case " $* " in
+  *" --ignored --exact packaged_helper_completes_over_fresh_restored_and_reused_firecracker --nocapture --test-threads=1 ") ;;
+  *) exit 91 ;;
+esac
+rootfs_seen=false
+snapshot_seen=false
+for argument in "$@"; do
+  case "$argument" in
+    --setenv=OKOU_TEST_RPC_ROOTFS=*) test -s "${argument#*=*=}"; rootfs_seen=true ;;
+    --setenv=OKOU_TEST_RPC_SNAPSHOT_DIR=*) test -s "${argument#*=*=}/snapshot.bin"; snapshot_seen=true ;;
+  esac
+done
+test "$rootfs_seen" = true && test "$snapshot_seen" = true
+# Both image locks must remain held throughout native execution.
+for lock in "$RPC_CASE/fixtures/locks/"*; do
+  if flock --exclusive --nonblock "$lock" true; then exit 92; fi
+done
+exit "$RPC_NATIVE_STATUS"
+SYSTEMD_RUN
+cat >"$TEST_ROOT/native-test" <<'TEST_BIN'
+#!/usr/bin/env bash
+set -euo pipefail
+test "$*" = '--ignored --list'
+echo 'packaged_helper_completes_over_fresh_restored_and_reused_firecracker: test'
+TEST_BIN
+chmod +x "$TEST_ROOT/bin/"* "$TEST_ROOT/native-test"
+ROOTFS_HASH=$(printf 'a%.0s' {1..64})
+SNAPSHOT_HASH=$(printf 'b%.0s' {1..64})
+FC_VERSION=$(sed -n 's/^pub const FIRECRACKER_VERSION: &str = "\([^"]*\)";$/\1/p' "$REPO_ROOT/crates/runner/src/deps.rs")
+KERNEL_VERSION=$(sed -n 's/^pub const KERNEL_VERSION: &str = "\([^"]*\)";$/\1/p' "$REPO_ROOT/crates/runner/src/deps.rs")
+
+for native_status in 0 42; do
+  case_dir="$TEST_ROOT/case-$native_status"
+  fixture_dir="$case_dir/fixtures"
+  snapshot_dir="$fixture_dir/images/$ROOTFS_HASH/snapshots/$SNAPSHOT_HASH"
+  mkdir -p "$fixture_dir/firecracker/$FC_VERSION" "$fixture_dir/locks" "$snapshot_dir"
+  for fixture in "$fixture_dir/firecracker/$FC_VERSION/firecracker" \
+    "$fixture_dir/firecracker/$FC_VERSION/vmlinux-$KERNEL_VERSION" \
+    "$fixture_dir/images/$ROOTFS_HASH/rootfs.ext4" \
+    "$snapshot_dir/snapshot.bin" "$snapshot_dir/memory.bin" "$snapshot_dir/cow.img"; do
+    printf 'immutable fixture\n' >"$fixture"
+  done
+  status=0
+  env PATH="$TEST_ROOT/bin:$PATH" RPC_CASE="$case_dir" RPC_NATIVE_STATUS="$native_status" \
+    METAL_USER=test HOST=test JOB_REF=pr-123 DEFAULT_ROOTFS_HASH="$ROOTFS_HASH" \
+    DEFAULT_SNAPSHOT_HASH="$SNAPSHOT_HASH" TEST_BIN="$TEST_ROOT/native-test" \
+    GITHUB_RUN_ID=17 GITHUB_RUN_ATTEMPT=2 bash "$WORKER" || status=$?
+  test "$status" -eq "$native_status"
+  test -s "$case_dir/launch" && test -s "$case_dir/cleanup"
+  test ! -e "$case_dir/remote-bin"
+  test ! -e "$fixture_dir/guest-rpc-tests/pr-123-17-2"
+  test "$(cat "$fixture_dir/images/$ROOTFS_HASH/rootfs.ext4")" = 'immutable fixture'
+  for lock in "$fixture_dir/locks/"*; do
+    flock --exclusive --nonblock "$lock" true
+  done
+done
+
+if env PATH="$TEST_ROOT/bin:$PATH" METAL_USER=test HOST=test JOB_REF=../escape \
+  DEFAULT_ROOTFS_HASH="$ROOTFS_HASH" DEFAULT_SNAPSHOT_HASH="$SNAPSHOT_HASH" \
+  TEST_BIN="$TEST_ROOT/native-test" GITHUB_RUN_ID=17 GITHUB_RUN_ATTEMPT=2 \
+  bash "$WORKER"; then
+  echo 'unsafe artifact identity accepted' >&2
+  exit 1
+fi
+
+ruby -ryaml - "$REPO_ROOT/.github/workflows/crates.yml" <<'RUBY'
+jobs = YAML.load_file(ARGV.fetch(0)).fetch('jobs')
+native = jobs.fetch('guest-rpc-firecracker-test')
+raise 'native test must follow the selected image' unless native.fetch('needs') == ['runner-build']
+raise 'container steps require Bash' unless native.dig('defaults', 'run', 'shell') == 'bash'
+%w[rootfs snapshot].each do |kind|
+  expected = "${{ needs.runner-build.outputs.default-#{kind}-hash }}"
+  raise "wrong #{kind} source" unless native.fetch('env').fetch("DEFAULT_#{kind.upcase}_HASH") == expected
+end
+gate = jobs.fetch('ci-gate-crates')
+raise 'missing native gate dependency' unless gate.fetch('needs').include?('guest-rpc-firecracker-test')
+raise 'native failure must block' unless gate.fetch('steps').any? { |step| step.fetch('run', '').include?('check_result "guest-rpc-firecracker-test"') }
+RUBY
+echo 'PASS: native RPC selection, image locks, failure propagation and cleanup'

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1048,6 +1048,52 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/report-memory-peak
 
+  guest-rpc-firecracker-test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260825
+    needs: [runner-build]
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
+    env:
+      TARGET_TRIPLE: ${{ needs.runner-build.outputs.target }}
+      METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+      HOST: ${{ needs.runner-build.outputs.host }}
+      JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
+      DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+      DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+        with:
+          workspaces: crates -> target
+          shared-key: ${{ needs.runner-build.outputs.target }}-guest-rpc
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Cross-compile native guest RPC test
+        run: |
+          cd crates
+          TEST_BIN=$(cargo test --no-run --profile ci --target "$TARGET_TRIPLE" \
+            -p sandbox-firecracker --test guest_rpc --message-format=json \
+            | jq -r 'select(.reason == "compiler-artifact" and .target.name == "guest_rpc" and .profile.test) | .executable // empty')
+          test -x "$TEST_BIN"
+          echo "TEST_BIN=$TEST_BIN" >> "$GITHUB_ENV"
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-user: ${{ env.METAL_USER }}
+          ssh-hosts: ${{ env.HOST }}
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Verify packaged RPC over fresh and restored Firecracker
+        run: bash .github/scripts/runner-behavior-guest-rpc.sh
+
   ci-gate-crates:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1067,6 +1113,7 @@ jobs:
       - runner-behavior-lane-c
       - runner-behavior-lane-d
       - host-cpu-fairness-test
+      - guest-rpc-firecracker-test
       - nbd-cow-test
       - runner-rootfs-process-test
     # Always run so the gate reports an explicit result (not "skipped").
@@ -1119,6 +1166,12 @@ jobs:
           check_result "runner-behavior-lane-c" "${{ needs.runner-behavior-lane-c.result }}" "true"
           check_result "runner-behavior-lane-d" "${{ needs.runner-behavior-lane-d.result }}" "true"
           check_result "host-cpu-fairness-test" "${{ needs.host-cpu-fairness-test.result }}" "true"
+          # A selected Runner image must execute the native RPC regression.
+          RPC_ALLOW_SKIP=true
+          if [ "${{ needs.runner-build.result }}" = "success" ]; then
+            RPC_ALLOW_SKIP=""
+          fi
+          check_result "guest-rpc-firecracker-test" "${{ needs.guest-rpc-firecracker-test.result }}" "$RPC_ALLOW_SKIP"
           check_result "nbd-cow-test" "${{ needs.nbd-cow-test.result }}" "true"
           check_result "runner-rootfs-process-test" "${{ needs.runner-rootfs-process-test.result }}" "true"
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1065,7 +1065,7 @@ jobs:
       DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
       DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:

--- a/crates/runner-rpc-proto/src/lib.rs
+++ b/crates/runner-rpc-proto/src/lib.rs
@@ -63,20 +63,23 @@ pub fn parse_request(bytes: &[u8]) -> io::Result<Request> {
     Ok(request)
 }
 
-/// Read one request through EOF. After cancellation or failure, drop the stream.
+/// Read the first complete request frame without waiting for transport EOF.
+///
+/// A connection carries one operation: callers must dispatch at most once and
+/// then drop the stream after all handler work. Bytes after this frame are not
+/// part of the request and must never become another operation. Do not drain
+/// them: a guest may keep sending indefinitely. JSON inside the frame is strict.
+/// After cancellation or failure, drop the stream rather than resuming a frame.
 pub async fn read_request(reader: &mut (impl AsyncRead + Unpin)) -> io::Result<Request> {
     let bytes = read_frame(reader, MAX_REQUEST_BYTES)
         .await?
         .ok_or_else(|| invalid("missing RPC request"))?;
-    let request = parse_request(&bytes)?;
-    let mut trailing = [0u8; 1];
-    if reader.read(&mut trailing).await? != 0 {
-        return Err(invalid("trailing RPC request data"));
-    }
-    Ok(request)
+    parse_request(&bytes)
 }
 
-/// Write once; the caller half-closes its stream and never retries on failure.
+/// Write once and never retry on failure. The caller may half-close its stream,
+/// but only the frame length defines completion: Firecracker does not forward
+/// guest send-half shutdown as EOF on the host stream.
 pub async fn write_request(
     writer: &mut (impl AsyncWrite + Unpin),
     request: &Request,

--- a/crates/runner-rpc-proto/tests/transport.rs
+++ b/crates/runner-rpc-proto/tests/transport.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use runner_rpc_proto::*;
 use serde_json::{json, value::RawValue};
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
 use tokio::time::timeout;
 
@@ -48,9 +48,13 @@ async fn unrelated_methods_round_trip_opaque_objects_and_large_escaped_input() {
         let (mut sender, mut receiver) = UnixStream::pair().unwrap();
         let send = async {
             write_request(&mut sender, &request).await.unwrap();
-            sender.shutdown().await.unwrap();
         };
-        let ((), received) = tokio::join!(send, read_request(&mut receiver));
+        // Keep the peer open: Firecracker does not forward guest send-half EOF.
+        let ((), received) = tokio::join!(
+            send,
+            timeout(Duration::from_secs(1), read_request(&mut receiver))
+        );
+        let received = received.expect("a complete frame must not wait for peer EOF");
         let received = received.unwrap();
         assert_eq!(received.method, method);
         assert_eq!(
@@ -160,20 +164,36 @@ async fn advertised_oversize_is_rejected_before_waiting_for_a_body() {
 }
 
 #[tokio::test]
-async fn partial_malformed_and_extra_requests_fail_closed() {
-    let request =
-        raw_frame(serde_json::from_slice(&request_json("fixture.echo", json!({}))).unwrap());
+async fn partial_and_malformed_requests_fail_closed() {
     for bytes in [
         vec![],
         vec![0, 0],
         vec![0, 0, 0, 10, b'{'],
-        [request.clone(), request].concat(),
         raw_frame(json!({"version": 1})),
     ] {
         let (mut peer, mut host) = UnixStream::pair().unwrap();
         peer.write_all(&bytes).await.unwrap();
         peer.shutdown().await.unwrap();
         assert!(read_request(&mut host).await.is_err());
+    }
+}
+
+#[tokio::test]
+async fn a_request_consumes_only_its_complete_frame() {
+    let frame = raw_frame(json!({"version":1,"method":"fixture.echo","params":{}}));
+    for trailing in [vec![255], frame.clone()] {
+        let (mut peer, mut host) = UnixStream::pair().unwrap();
+        peer.write_all(&[frame.clone(), trailing.clone()].concat())
+            .await
+            .unwrap();
+        let request = timeout(Duration::from_secs(1), read_request(&mut host))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(request.method, "fixture.echo");
+        let mut unread = vec![0; trailing.len()];
+        host.read_exact(&mut unread).await.unwrap();
+        assert_eq!(unread, trailing);
     }
 }
 

--- a/crates/runner/src/ssh/tests/framing.rs
+++ b/crates/runner/src/ssh/tests/framing.rs
@@ -1,0 +1,66 @@
+use super::harness::{CONNECTION, Harness, Reply, frames};
+use serde_json::json;
+use std::{sync::atomic::Ordering, time::Duration};
+use tokio::io::AsyncWriteExt;
+
+#[tokio::test]
+async fn complete_request_dispatches_once_with_immediate_or_delayed_extra_frames() {
+    for delayed in [false, true] {
+        let mut h = Harness::new(Reply::default()).await;
+        let gate = std::sync::Arc::new(tokio::sync::Semaphore::new(0));
+        *h.network.resolve_gate.lock().unwrap() = Some(gate.clone());
+        let resolve = h.resolve(h.credential(true)).await;
+        let request = json!({
+            "version": 1, "method": "ssh.exec", "remaining_ms": 60000,
+            "params": {"sshConnectionId": CONNECTION, "command": "first"}
+        })
+        .to_string();
+        let extra = json!({
+            "version": 1, "method": "ssh.exec", "remaining_ms": 60000,
+            "params": {"sshConnectionId": CONNECTION, "command": "second"}
+        })
+        .to_string();
+        let mut guest = h.open().await;
+        guest.write_u32(request.len() as u32).await.unwrap();
+        guest.write_all(request.as_bytes()).await.unwrap();
+        if delayed {
+            // The external resolver has received the first operation's lookup.
+            // Hold its answer while sending more bytes after dispatch began.
+            super::wait_for(|| !h.observed.queries.lock().unwrap().is_empty()).await;
+        }
+        guest.write_u32(extra.len() as u32).await.unwrap();
+        guest.write_all(extra.as_bytes()).await.unwrap();
+        // Deliberately keep the write side open throughout the response.
+        gate.add_permits(1);
+        let observed = tokio::time::timeout(Duration::from_secs(5), frames(guest))
+            .await
+            .unwrap();
+        assert_eq!(super::terminal(&observed)["effects"], "completed");
+        resolve.assert_calls_async(1).await;
+        assert_eq!(
+            *h.observed.commands.lock().unwrap(),
+            vec![b"first".to_vec()]
+        );
+        assert_eq!(h.observed.auth.load(Ordering::SeqCst), 1);
+        h.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn unknown_method_rejects_without_peer_eof_or_authority_lookup() {
+    let mut h = Harness::new(Reply::default()).await;
+    let resolve = h.resolve(h.credential(true)).await;
+    let mut guest = h.open().await;
+    let request = br#"{"version":1,"method":"diagnostic.unknown","params":{}}"#;
+    guest.write_u32(request.len() as u32).await.unwrap();
+    guest.write_all(request).await.unwrap();
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(5), frames(guest))
+            .await
+            .unwrap(),
+        vec![json!({"type":"error","code":"unknown_method","delivery":"not_dispatched"})]
+    );
+    resolve.assert_calls_async(0).await;
+    assert!(h.observed.attempts.lock().unwrap().is_empty());
+    h.shutdown().await;
+}

--- a/crates/runner/src/ssh/tests/mod.rs
+++ b/crates/runner/src/ssh/tests/mod.rs
@@ -1,5 +1,6 @@
 mod cache;
 mod credentials;
+mod framing;
 mod harness;
 mod lifecycle;
 mod proof;

--- a/crates/sandbox-firecracker/tests/guest_rpc.rs
+++ b/crates/sandbox-firecracker/tests/guest_rpc.rs
@@ -1,0 +1,195 @@
+#![cfg(target_os = "linux")]
+
+//! Native vsock bridge regression, explicitly executed by metal CI.
+
+use std::{error::Error, io, path::PathBuf, time::Duration};
+
+use runner_rpc_proto::{Delivery, ErrorCode, Response, ResponseWriter};
+use sandbox::{
+    EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, FactoryConfig, ResourceLimits,
+    RuntimeConfig, Sandbox, SandboxConfig, SandboxRuntime, SnapshotRef, WorkspaceDriveConfig,
+};
+use sandbox_firecracker::FirecrackerRuntime;
+use serde_json::{Value, json, value::RawValue};
+
+type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires root, KVM, NBD and matching packaged rootfs/snapshot; run by metal CI"]
+async fn packaged_helper_completes_over_fresh_restored_and_reused_firecracker() -> TestResult<()> {
+    if !nix::unistd::getuid().is_root() {
+        return Err(io::Error::other("native guest RPC test requires root").into());
+    }
+    let base = PathBuf::from(std::env::var("OKOU_TEST_RPC_BASE_DIR")?);
+    std::fs::create_dir_all(&base)?;
+    let mut runtime = FirecrackerRuntime::new(RuntimeConfig {
+        proxy_port: None,
+        dns_port: None,
+        host_cpu_placement: None,
+    })
+    .await?;
+    let result = exercise_factories(&runtime, base).await;
+    runtime.shutdown().await;
+    result
+}
+
+async fn exercise_factories(runtime: &FirecrackerRuntime, base: PathBuf) -> TestResult<()> {
+    for restored in [false, true] {
+        let snapshot = if restored {
+            Some(SnapshotRef {
+                output_dir: PathBuf::from(std::env::var("OKOU_TEST_RPC_SNAPSHOT_DIR")?),
+                hash: std::env::var("OKOU_TEST_RPC_SNAPSHOT_HASH")?,
+            })
+        } else {
+            None
+        };
+        let mut factory = runtime
+            .create_factory(FactoryConfig {
+                profile: "vm0/rpc-metal".into(),
+                binary_path: PathBuf::from(std::env::var("OKOU_TEST_RPC_FIRECRACKER")?),
+                kernel_path: PathBuf::from(std::env::var("OKOU_TEST_RPC_KERNEL")?),
+                rootfs_path: PathBuf::from(std::env::var("OKOU_TEST_RPC_ROOTFS")?),
+                base_dir: base.join(if restored { "restored" } else { "fresh" }),
+                snapshot,
+            })
+            .await?;
+        // Match the vm0/default image selected by runner-build in metal CI.
+        let created = factory
+            .create(SandboxConfig {
+                id: sandbox::SandboxId::new_v4(),
+                resources: ResourceLimits {
+                    cpu_count: 2,
+                    memory_mb: 4096,
+                },
+                device_rate_limits: None,
+                workspace_drive: Some(WorkspaceDriveConfig {
+                    size_mb: 16384,
+                    seed_image: None,
+                }),
+            })
+            .await;
+        let result = match created {
+            Ok(mut sandbox) => {
+                let result = exercise_sandbox(&mut *sandbox).await;
+                factory.destroy(sandbox).await;
+                result
+            }
+            Err(error) => Err(error.into()),
+        };
+        factory.shutdown().await;
+        result?;
+        println!("RPC_FIRECRACKER_PASS restored={restored}");
+    }
+    Ok(())
+}
+
+async fn exercise_sandbox(sandbox: &mut dyn Sandbox) -> TestResult<()> {
+    let run = uuid::Uuid::new_v4().to_string();
+    sandbox.bind_run_control(&run)?;
+    sandbox.start().await?;
+    exercise_requests(sandbox, &run).await?;
+    let stale = sandbox
+        .guest_rpc(&run)
+        .ok_or_else(|| io::Error::other("missing RPC acceptor"))?;
+    if sandbox.park().await? != sandbox::SandboxParkOutcome::Reusable {
+        return Err(io::Error::other("sandbox could not park after RPC completion").into());
+    }
+    let next_run = uuid::Uuid::new_v4().to_string();
+    sandbox.bind_run_control(&next_run)?;
+    sandbox.unpark().await?;
+    if tokio::time::timeout(Duration::from_secs(5), stale.accept())
+        .await?
+        .is_ok()
+    {
+        return Err(io::Error::other("old Run RPC acceptor survived park/reassignment").into());
+    }
+    exercise_requests(sandbox, &next_run).await
+}
+
+async fn exercise_requests(sandbox: &dyn Sandbox, run: &str) -> TestResult<()> {
+    for method in ["fixture.echo", "diagnostic.unknown"] {
+        let acceptor = sandbox
+            .guest_rpc(run)
+            .ok_or_else(|| io::Error::other("missing RPC acceptor"))?;
+        let input = serde_json::to_vec(&json!({
+            "version": 1, "method": method, "params": {"message": "native vsock"}
+        }))?;
+        let exec_request = ExecRequest {
+            cmd: "/usr/local/bin/runner-rpc-client",
+            timeout: Duration::from_secs(10),
+            env: &[],
+            sudo: false,
+            expected_exit_codes: &[],
+            stdin_bytes: Some(&input),
+            output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
+        };
+        let guest = sandbox.exec(&exec_request);
+        let host = async {
+            let mut accepted = acceptor.accept().await?;
+            let request = runner_rpc_proto::read_request(&mut accepted.stream).await?;
+            if request.method != method || accepted.sandbox_id != sandbox.id() {
+                return Err(io::Error::other("unexpected native RPC identity or method"));
+            }
+            let mut writer = ResponseWriter::new(accepted.stream);
+            if request.method == "fixture.echo" {
+                writer
+                    .send(&Response::Event {
+                        data: RawValue::from_string("{\"progress\":1}".into())?,
+                    })
+                    .await?;
+                writer
+                    .send(&Response::Result {
+                        data: request.params,
+                    })
+                    .await?;
+            } else {
+                writer
+                    .send(&Response::error(
+                        ErrorCode::UnknownMethod,
+                        Delivery::NotDispatched,
+                    ))
+                    .await?;
+            }
+            // The join retains this writer until the helper exits: response EOF
+            // must cross Firecracker without dropping the host stream/reservation.
+            Ok::<_, io::Error>(writer)
+        };
+        let (guest, host) =
+            tokio::time::timeout(Duration::from_secs(15), async { tokio::join!(guest, host) })
+                .await?;
+        let writer = host?;
+        let guest = guest?;
+        let expected_code = if method == "fixture.echo" { 0 } else { 1 };
+        if !matches!(guest.termination, ExecTermination::Exited { exit_code } if exit_code == expected_code)
+            || !guest.stderr.is_empty()
+        {
+            return Err(io::Error::other(format!(
+                "helper failed: {:?}: {}",
+                guest.termination,
+                String::from_utf8_lossy(&guest.stderr)
+            ))
+            .into());
+        }
+        let observed: Vec<Value> = guest
+            .stdout
+            .split(|byte| *byte == b'\n')
+            .filter(|line| !line.is_empty())
+            .map(serde_json::from_slice)
+            .collect::<Result<_, _>>()?;
+        let expected = if method == "fixture.echo" {
+            vec![
+                json!({"type":"event","data":{"progress":1}}),
+                json!({"type":"result","data":{"message":"native vsock"}}),
+            ]
+        } else {
+            vec![json!({"type":"error","code":"unknown_method","delivery":"not_dispatched"})]
+        };
+        if observed != expected {
+            return Err(
+                io::Error::other(format!("unexpected helper response: {observed:?}")).into(),
+            );
+        }
+        drop(writer);
+    }
+    Ok(())
+}

--- a/docs/runner-rpc-transport.md
+++ b/docs/runner-rpc-transport.md
@@ -25,7 +25,8 @@ terminated by EOF:
 This is the SSH adapter's request; availability still depends on current API authority.
 Transport validates version 1, a nonempty method of at most 64 ASCII letters,
 digits, dots, underscores or hyphens, and object-valued params. Unknown envelope
-fields, duplicate envelope keys, invalid types and extra request bytes fail.
+fields, duplicate envelope keys, invalid types and extra JSON within the request
+frame fail. The helper also rejects extra JSON on its stdin.
 Transport does not interpret params or validate SSH UUIDs/commands. Raw JSON
 preserves nested fields, duplicate business keys and numeric tokens without
 rounding; the method schema decides whether those values are acceptable.
@@ -49,8 +50,18 @@ Each frame is a big-endian u32 length followed by JSON:
 
 Frame and remaining aggregate limits are checked before body allocation.
 Outgoing messages are checked before wire writes. Events must leave capacity
-for one maximum-sized terminal frame. The guest half-closes after the request;
-the host reads through EOF before dispatch. Drop request I/O on cancellation or
+for one maximum-sized terminal frame. The first complete request frame is the
+request boundary: the host validates it and dispatches at most once per connection,
+without waiting for EOF. Bytes after that frame are outside the one-shot request;
+they are never consumed as another request and cannot trigger another operation.
+The host does not drain or wait for trailing input and drops the connection after
+all handler work ends. This replaces connection-wide trailing-byte rejection,
+not strict JSON validation inside the frame.
+
+The guest helper half-closes after sending, but dispatch does not depend on that
+half-close. Firecracker v1.15.1 records guest send shutdown without forwarding it
+as EOF on its host Unix stream. Waiting for it before replying stalls until the
+guest's deadline. Drop request I/O on cancellation or
 failure; stateful response readers/writers cannot resume after partial I/O.
 
 ## Responses, completion and ambiguity
@@ -73,6 +84,10 @@ The helper emits events as single-line NDJSON. Only JSON whitespace outside
 strings is removed; raw numeric tokens, duplicate keys and escapes survive.
 The terminal is withheld until EOF proves there is no duplicate/trailing data.
 The stateful host writer half-closes after terminal, but retains its stream.
+Unlike guest send shutdown, Firecracker forwards host stream EOF to the guest.
+Native fresh/restored tests verify terminal delivery while the host still owns
+the stream. Do not replace terminal-plus-EOF verification with first-terminal
+success: duplicate/trailing response data remains a protocol error.
 
 A valid result means RPC completion, **not business success**. The helper exits
 zero only after delivering that result. The caller must interpret business
@@ -160,3 +175,18 @@ Local tests use real sockets, files, the real control handshake and operation
 tracker, plus unrelated external test methods. They require no web server.
 Actual fresh/restored KVM boot and packaged-helper execution remain separate
 metal-host CI/E2E checks before activation.
+
+The `guest-rpc-firecracker-test` CI job runs the native `guest_rpc` integration
+test against the matching runner-build rootfs and snapshot. It covers a generic
+echo result, an unknown-method rejection, response EOF, and park/reassignment in
+both fresh and snapshot-restored guests. Its test-only consumer does not enable
+methods in local/PAT Runners or establish SSH authorization. Unix parser/helper
+and actual Runner dispatcher tests separately protect bounds, corruption handling
+and one execution even when more request frames arrive.
+
+For #32804, Runner and bundled helper remain one artifact; guest binary bytes
+participate in rootfs identity and the snapshot identity includes that rootfs.
+There is no cross-version helper negotiation, fallback or replay. CLI stdin/stdout
+and API contracts are unchanged. Keep #32014's owner-authorized packaged CLI/SSH,
+TOFU, live inventory, revoke/invalidation and non-chat acceptance outstanding until
+actually exercised; generic native success alone does not enable #32015.


### PR DESCRIPTION
## Summary

- Complete guest RPC requests at the first bounded frame, without waiting for peer EOF. Firecracker v1.15.1 does not forward guest send-half shutdown as EOF on the host Unix stream, which previously stalled dispatch until the helper deadline.
- Preserve strict validation inside the frame and one dispatch per connection. Additional bytes/frames are outside the one-shot request and cannot execute another operation; the host does not drain unbounded input.
- Add open-peer parser and real Runner dispatcher regressions, plus a required metal CI test using the matching packaged helper/rootfs/snapshot across fresh boot, restore, and park/reassignment. The native test also verifies response EOF while the host retains the stream.

Relates to #32804. Delivery parent: #31932.

## Contracts and scope

Response terminal-plus-EOF validation, corruption rejection, deadlines, no-replay behavior, operation ownership, SSH authorization, CLI stdin/stdout, and API contracts are unchanged. Runner and bundled helper remain a single artifact; no mixed-version helper negotiation or new fallback is introduced.

The deliberate request contract change is that bytes after the first complete frame no longer invalidate that first request. They are not parsed or dispatched. This does not relax strict JSON validation inside the declared frame or helper stdin validation.

This PR does not implement or activate #32014/#32015. Keep #32804 and #31932 open until the full owner-authorized packaged CLI/SSH acceptance in #32014/#32722 is exercised, including TOFU/match, inventory, revocation/invalidation, non-chat, and two targets.

## Validation

- Confirmed the new open-peer regression fails against the original reader with a bounded timeout.
- Passed `cargo test --profile local -p runner-rpc-proto -p runner-rpc-client -p sandbox-firecracker -p runner`.
- Passed focused Runner framing tests, protocol/helper tests, and local compilation of the native `guest_rpc` integration test.
- Passed affected-crate Clippy with all targets/features and `-D warnings`, Rustdoc with `-D warnings`, and `cargo fmt --all -- --check`.
- Passed Prettier, ShellCheck, Actionlint, workflow shell compatibility, existing runner image/lifecycle shell integration tests, the new native-worker shell integration test, and `git diff --check`.
- [Native Firecracker CI passed](https://github.com/vm0-ai/vm0/actions/runs/34312039049/job/102340781280) on head `3f6b4ff64199a6dae7a7b40c4ad7a26e62891c85`: fresh boot, matching snapshot restore and park/reassignment, using the packaged helper. The actual host-only test executed (1 passed, 0 ignored); crates and security aggregate gates passed.
- Overall CI is not green: [test-app (3)](https://github.com/vm0-ai/vm0/actions/runs/34312039031/job/102340644107) timed out in the keyboard thread-navigation reading-position test, and test-app (2) was cancelled. No Turbo source/test configuration is changed by this PR; the timeout cause is not established or dismissed.
- Full owner-authorized SSH acceptance is not claimed by this transport-only repair.
