### PR TITLE
fix(naming): refresh remaining desktop and developer copy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to vm0
+# Contributing to Okou
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/vm0-ai/vm0?quickstart=1)
 

--- a/docs/runner-multi-architecture.md
+++ b/docs/runner-multi-architecture.md
@@ -1,6 +1,6 @@
 # Runner Multi-Architecture Rollout
 
-This document describes the operational contract for running vm0 runners on
+This document describes the operational contract for running Okou runners on
 more than one host CPU architecture.
 
 ## Core Invariant

--- a/docs/testing/cli-e2e-testing.md
+++ b/docs/testing/cli-e2e-testing.md
@@ -105,7 +105,7 @@ shards. Coverage that needs mutable account-level state requires a dedicated
 identity or a serialized lane.
 
 Use a different organization-scoped connector slug in each file that can run in
-parallel. Assert sandbox-visible output and vm0-owned telemetry; do not treat an
+parallel. Assert sandbox-visible output and Okou-owned telemetry; do not treat an
 external provider's exact response status or body as the test oracle.
 
 For active-run connector refresh cases, coordinate through a run-scoped output

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -682,7 +682,7 @@ interface ExplicitConnectorScope {
 }
 
 // Session naming in this service:
-// - agentSessionId is the vm0 application session (`agent_sessions.id`) used
+// - agentSessionId is the Okou application session (`agent_sessions.id`) used
 //   for product-level continuation and future correctness checks.
 // - cliAgentSessionId is the Claude/Codex/Pi agent session stored on
 //   `conversations.cli_agent_session_id`.

--- a/turbo/apps/api/src/signals/services/artifact-catalog.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-catalog.service.ts
@@ -208,7 +208,7 @@ function fileThumbnail(row: CatalogFileRow): ArtifactThumbnail | null {
 /**
  * The owning Okou user for an artifact. Chat-backed runs are owned by the thread
  * user, so an artifact produced from a Slack or Feishu message is filed under
- * the vm0 account behind that thread rather than the external sender.
+ * the Okou account behind that thread rather than the external sender.
  */
 async function resolveChatThreadId(
   db: Db,

--- a/turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts
+++ b/turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts
@@ -5,7 +5,7 @@ import type {
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 /**
- * vm0 owns rollout associations. Deploy an association before publishing a
+ * Okou owns rollout associations. Deploy an association before publishing a
  * method that should be gated, and remove it when its switch graduates.
  */
 const FEATURE_SWITCH_BY_AUTH_METHOD = Object.freeze<

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -3284,7 +3284,7 @@ func throwBrowserNavigationFailure(result: AppleScriptRunResult) throws -> Never
             code: "automation_permission_denied",
             message:
                 "macOS denied Automation permission for browser navigation. "
-                + "Allow vm0 to control the target browser in System Settings > Privacy & Security > Automation. "
+                + "Allow Okou to control the target browser in System Settings > Privacy & Security > Automation. "
                 + message
         )
     }


### PR DESCRIPTION
Closes #32815.

Correct the native browser Automation-denial guidance to say `Allow Okou`, and apply the six exact current-product substitutions in the issue's documentation/API comments. The diff contains seven one-word replacements in seven files.

The native change preserves `automation_permission_denied`, `browser_navigation_failed`, AppleScript permission detection and timeouts, control flow, and the appended original diagnostic. Repository links, `vm0/default`, `agent_sessions.id`, feature-switch associations, and all other bytes are unchanged. Database inventory, schema/migrations, compatibility retirement, and release operations remain outside this PR.

## Validation

- One-time full-file comparison confirms exactly the seven issue mappings and no other changes, including unchanged URLs.
- Focused Prettier, Oxlint, type-aware Oxlint, ESLint, API-scoped Knip, repository style policy, and `git diff --check`: passed.
- API production type checks (`check-types:deps`, `check-types:gateways`, `check-types:core`): passed.
- Existing Desktop Automation permission and native-helper protocol tests: **39/39 passed in two targeted test files**.
- Commitlint and file-size checks: passed.
- No existing test expectation contains the replaced native phrase; no tests or permanent branding inventories were added.
- Linux cannot execute the macOS Swift helper suite. The existing `build-macos-arm64` / `Test native helper` PR CI provides native coverage. No full local Vitest or local development server was run.

## Concurrent work

Pre-implementation refresh inspected all 38 open PRs and reconciled their 663 changed-file entries; none overlapped the seven target files. Started from freshly fetched/rebased main `4124c769f0d72342d73b2806ace7bf73c0605962`. The merged precedents #32588, #32619, and #32728 were read and preserved.
