### PR TITLE
fix(runner): defer blank memory reclamation until agent readiness

### DIFF
--- a/crates/runner/src/cmd/start/blank_pool.rs
+++ b/crates/runner/src/cmd/start/blank_pool.rs
@@ -569,7 +569,7 @@ async fn prepare_blank_sandbox(
         }
     }
 
-    match run_background_stage(sandbox.park(), &cancel, &mut pre_spawn_lease).await {
+    match run_background_stage(sandbox.park_for_blank_pool(), &cancel, &mut pre_spawn_lease).await {
         BackgroundStageResult::Completed(Ok(SandboxParkOutcome::Reusable)) => {
             drop(pre_spawn_lease.take());
             BlankPrepareResult::Ready {

--- a/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
@@ -17,9 +17,12 @@ async fn blank_pool_prepares_and_serves_a_job_without_changing_reuse_attribution
     let calls = Arc::clone(&overrides);
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 16, 32_768, 8, overrides);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
 
     wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
+    assert_eq!(budget.allocated(), (2, 4096, 1));
+    assert_eq!(calls.blank_park_call_count(), 1);
     assert_eq!(calls.workspace_drive_mount_calls(), 1);
     let create_configs = calls.create_configs();
     assert_eq!(create_configs.len(), 1);

--- a/crates/sandbox-firecracker/src/balloon.rs
+++ b/crates/sandbox-firecracker/src/balloon.rs
@@ -1,6 +1,7 @@
+use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::watch;
+use tokio::sync::{Notify, watch};
 use tracing::{info, warn};
 
 use crate::api::ApiClient;
@@ -56,11 +57,15 @@ const STATUS_INTERVAL_TICKS: u64 = 12;
 
 pub(crate) struct ControllerHandle {
     task: Option<tokio::task::JoinHandle<()>>,
+    agent_ready: Option<Arc<Notify>>,
 }
 
 enum ControllerStartup {
     Active,
-    AwaitUnparkDeflation { log_id: String },
+    AwaitUnparkDeflation {
+        log_id: String,
+        agent_ready: Option<Arc<Notify>>,
+    },
 }
 
 impl ControllerHandle {
@@ -70,8 +75,19 @@ impl ControllerHandle {
         state_rx: watch::Receiver<SandboxState>,
         startup: ControllerStartup,
     ) -> Self {
+        let agent_ready = match &startup {
+            ControllerStartup::Active => None,
+            ControllerStartup::AwaitUnparkDeflation { agent_ready, .. } => agent_ready.clone(),
+        };
         Self {
             task: Some(tokio::spawn(run_loop(client, memory_mb, state_rx, startup))),
+            agent_ready,
+        }
+    }
+
+    pub(crate) fn notify_agent_ready(&self) {
+        if let Some(ready) = &self.agent_ready {
+            ready.notify_one();
         }
     }
 
@@ -90,7 +106,10 @@ impl ControllerHandle {
 
     #[cfg(test)]
     pub(crate) fn from_task_for_test(task: tokio::task::JoinHandle<()>) -> Self {
-        Self { task: Some(task) }
+        Self {
+            task: Some(task),
+            agent_ready: None,
+        }
     }
 
     #[cfg(test)]
@@ -143,7 +162,31 @@ pub(crate) fn spawn_after_unpark_deflation(
         client,
         memory_mb,
         state_rx,
-        ControllerStartup::AwaitUnparkDeflation { log_id },
+        ControllerStartup::AwaitUnparkDeflation {
+            log_id,
+            agent_ready: None,
+        },
+    )
+}
+
+/// Keep optional reclamation out of a preserved blank's first Agent startup.
+///
+/// Unpark has already requested target zero. Only this owned background task
+/// waits for convergence and Agent readiness; Guest operations remain available.
+pub(crate) fn spawn_after_blank_unpark(
+    client: ApiClient,
+    memory_mb: u32,
+    state_rx: watch::Receiver<SandboxState>,
+    log_id: String,
+) -> ControllerHandle {
+    ControllerHandle::spawn(
+        client,
+        memory_mb,
+        state_rx,
+        ControllerStartup::AwaitUnparkDeflation {
+            log_id,
+            agent_ready: Some(Arc::new(Notify::new())),
+        },
     )
 }
 
@@ -161,10 +204,20 @@ async fn run_loop(
         );
         return;
     }
-    if let ControllerStartup::AwaitUnparkDeflation { log_id } = startup
-        && !wait_for_unpark_deflation(&client, &mut state_rx, &log_id).await
+    if let ControllerStartup::AwaitUnparkDeflation {
+        log_id,
+        agent_ready,
+    } = startup
     {
-        return;
+        if !wait_for_unpark_deflation(&client, &mut state_rx, &log_id).await {
+            return;
+        }
+        if let Some(ready) = agent_ready {
+            tokio::select! {
+                () = ready.notified() => {}
+                () = wait_for_crash_or_stop(&mut state_rx) => return,
+            }
+        }
     }
     let mut interval = tokio::time::interval(POLL_INTERVAL);
     let mut tick_count: u64 = 0;
@@ -583,6 +636,53 @@ mod tests {
             api.drain_requests().is_empty(),
             "cancellation must not issue a policy request"
         );
+    }
+
+    #[tokio::test]
+    async fn blank_controller_retains_early_readiness_until_deflation_finishes() {
+        let mut api = MockFirecrackerApi::with_responses([
+            MockResponse::ok_body(
+                r#"{"target_mib":0,"actual_mib":256,"target_pages":0,"actual_pages":65536}"#,
+            ),
+            MockResponse::ok_body(
+                r#"{"target_mib":0,"actual_mib":0,"target_pages":0,"actual_pages":0}"#,
+            ),
+            MockResponse::ok_body(
+                r#"{"target_mib":0,"actual_mib":0,"target_pages":0,"actual_pages":0,"free_memory":1073741824,"available_memory":1073741824}"#,
+            ),
+            MockResponse::no_content(),
+        ]);
+        let client = ApiClient::new(api.socket_path()).unwrap();
+        let (_state_tx, state_rx) = watch::channel(SandboxState::Running);
+        let controller =
+            spawn_after_blank_unpark(client, 4096, state_rx, "blank-early-ready".into());
+        // No background work has run yet on this current-thread runtime.
+        controller.notify_agent_ready();
+        for _ in 0..3 {
+            assert_firecracker_request(&api.next_request().await, "GET", "/balloon/statistics");
+        }
+        let request = api.next_request().await;
+        assert_firecracker_request(&request, "PATCH", "/balloon");
+        assert_eq!(patch_amount_mib(&request.body), 256);
+        controller.abort_and_join().await;
+        assert!(api.drain_requests().is_empty());
+    }
+
+    #[tokio::test]
+    async fn blank_controller_without_agent_readiness_stops_without_reinflating() {
+        for state in [SandboxState::Stopped, SandboxState::Crashed] {
+            let mut api = MockFirecrackerApi::repeating(MockResponse::ok_body(
+                r#"{"target_mib":0,"actual_mib":0,"target_pages":0,"actual_pages":0,"free_memory":1073741824,"available_memory":1073741824}"#,
+            ));
+            let client = ApiClient::new(api.socket_path()).unwrap();
+            let (state_tx, state_rx) = watch::channel(SandboxState::Running);
+            let controller =
+                spawn_after_blank_unpark(client, 4096, state_rx, "blank-without-agent".into());
+            assert_firecracker_request(&api.next_request().await, "GET", "/balloon/statistics");
+            state_tx.send(state).unwrap();
+            await_controller_exit(controller, "blank controller before Agent readiness").await;
+            assert!(api.drain_requests().is_empty());
+        }
     }
 
     #[tokio::test]

--- a/crates/sandbox-firecracker/src/sandbox.rs
+++ b/crates/sandbox-firecracker/src/sandbox.rs
@@ -101,6 +101,7 @@ const GUEST_PARK_LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(5);
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum UnparkPurpose {
     Reuse,
+    BlankReuse,
     TerminalOperations,
 }
 
@@ -574,6 +575,8 @@ pub struct FirecrackerSandbox {
     /// Retained so an idempotent repeated park cannot upgrade a non-reusable
     /// sandbox to reusable.
     park_outcome: Option<SandboxParkOutcome>,
+    /// Memory policy of the completed park; consumed by the next unpark.
+    park_memory_policy: ParkMemoryPolicy,
     /// Host-side normal-operation fence held while this sandbox is parked.
     park_fence: Option<NormalOperationFence>,
     guest_rpc_endpoint: Option<crate::guest_rpc::GuestRpcEndpoint>,
@@ -694,6 +697,7 @@ impl FirecrackerSandbox {
             destroyed: false,
             is_parked: false,
             park_outcome: None,
+            park_memory_policy: ParkMemoryPolicy::Reclaim,
             park_fence: None,
             guest_rpc_endpoint: None,
             runtime_cancel: CancellationToken::new(),
@@ -2224,6 +2228,7 @@ impl FirecrackerSandbox {
                         PhysicalParkRequest {
                             guest: physical_park_guest,
                             handoff,
+                            memory_policy: ParkMemoryPolicy::Reclaim,
                         },
                         events,
                     )
@@ -2234,6 +2239,7 @@ impl FirecrackerSandbox {
             .await?;
         self.park_fence = Some(normal_operations_fence);
         drop(self.guest_rpc_endpoint.take());
+        self.park_memory_policy = ParkMemoryPolicy::Reclaim;
         match physical_outcome {
             PhysicalParkOutcome::Idle(park_outcome) => {
                 self.park_outcome = Some(park_outcome.clone());
@@ -2249,6 +2255,80 @@ impl FirecrackerSandbox {
                 Ok(SandboxFinalExecParkHandoffOutcome::Handoff { exec_result, point })
             }
         }
+    }
+
+    async fn park_with_memory_policy(
+        &mut self,
+        memory_policy: ParkMemoryPolicy,
+    ) -> sandbox::Result<SandboxParkOutcome> {
+        if self.is_parked {
+            if self.park_fence.is_none() {
+                let message = "sandbox is parked without a normal-operation fence";
+                self.park_coordinator.mark_dirty(DirtyReason::new(message));
+                return Err(idle_transition_error(SandboxIdleTransition::Park, message));
+            }
+            let Some(outcome) = self.park_outcome.clone() else {
+                let message = "sandbox is parked without a recorded park outcome";
+                self.park_coordinator.mark_dirty(DirtyReason::new(message));
+                return Err(idle_transition_error(SandboxIdleTransition::Park, message));
+            };
+            ensure_park_noop_state(&self.park_coordinator)?;
+            return Ok(outcome);
+        }
+
+        let coordinator = self.park_coordinator.clone();
+        let guest = Arc::clone(&self.guest);
+        let fence_guest = Arc::clone(&guest);
+        let physical_park_guest = Arc::clone(&guest);
+        let id = self.id.clone();
+        let api_sock = self.sock_paths.api_sock();
+        let (normal_operations_fence, outcome) = park_with_ready_for_park(
+            &id,
+            &coordinator,
+            || async move {
+                let guest = fence_guest.lock().await.as_ref().cloned().ok_or_else(|| {
+                    ParkNormalOperationFenceError::GuestUnavailable(io::Error::new(
+                        io::ErrorKind::NotConnected,
+                        "guest connection missing during park fence",
+                    ))
+                })?;
+                guest
+                    .try_fence_normal_operations()
+                    .map_err(ParkNormalOperationFenceError::Rejected)
+            },
+            || async move {
+                let guest = guest.lock().await.as_ref().cloned().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotConnected,
+                        "guest connection missing during park quiesce",
+                    )
+                })?;
+                guest.quiesce_operations(GUEST_PARK_LIFECYCLE_TIMEOUT).await
+            },
+            || async {
+                let (_, result) = park_inner_with_guest(
+                    &mut self.is_parked,
+                    self.config.resources.memory_mb,
+                    self.runtime.balloon_mut(),
+                    &api_sock,
+                    &id,
+                    PhysicalParkRequest {
+                        guest: physical_park_guest,
+                        handoff: None,
+                        memory_policy,
+                    },
+                    SandboxFinalExecParkSubstageEvents::new(None),
+                )
+                .await;
+                result
+            },
+        )
+        .await?;
+        self.park_fence = Some(normal_operations_fence);
+        self.park_outcome = Some(outcome.clone());
+        self.park_memory_policy = memory_policy;
+        drop(self.guest_rpc_endpoint.take());
+        Ok(outcome)
     }
 
     async fn unpark_with_purpose(&mut self, purpose: UnparkPurpose) -> sandbox::Result<()> {
@@ -2295,6 +2375,13 @@ impl FirecrackerSandbox {
         let is_parked = &mut self.is_parked;
         let balloon_controller = self.runtime.balloon_mut();
         let park_fence = &mut self.park_fence;
+        let purpose = if purpose == UnparkPurpose::Reuse
+            && self.park_memory_policy == ParkMemoryPolicy::Preserve
+        {
+            UnparkPurpose::BlankReuse
+        } else {
+            purpose
+        };
         unpark_with_ready_for_operations(
             &id,
             &coordinator,
@@ -2324,6 +2411,7 @@ impl FirecrackerSandbox {
         )
         .await?;
         self.park_outcome = None;
+        self.park_memory_policy = ParkMemoryPolicy::Reclaim;
         self.guest_rpc_endpoint = Some(guest_rpc_endpoint);
         Ok(())
     }
@@ -2505,6 +2593,9 @@ impl Sandbox for FirecrackerSandbox {
     // settling before pause — the guest balloon driver needs running vCPUs to
     // process the inflate.
     //
+    // Blank preparation uses the same park fences and vCPU pause, but skips
+    // aggressive idle inflation while its caller retains the full budget.
+    //
     // `unpark()` is called when the runner pulls the sandbox back out of
     // the idle pool. It resumes vCPUs, deflates the balloon, and respawns
     // the reactive controller so active workload is served with full
@@ -2533,69 +2624,13 @@ impl Sandbox for FirecrackerSandbox {
     // cannot be silently reused.
 
     async fn park(&mut self) -> sandbox::Result<SandboxParkOutcome> {
-        if self.is_parked {
-            if self.park_fence.is_none() {
-                let message = "sandbox is parked without a normal-operation fence";
-                self.park_coordinator.mark_dirty(DirtyReason::new(message));
-                return Err(idle_transition_error(SandboxIdleTransition::Park, message));
-            }
-            let Some(outcome) = self.park_outcome.clone() else {
-                let message = "sandbox is parked without a recorded park outcome";
-                self.park_coordinator.mark_dirty(DirtyReason::new(message));
-                return Err(idle_transition_error(SandboxIdleTransition::Park, message));
-            };
-            ensure_park_noop_state(&self.park_coordinator)?;
-            return Ok(outcome);
-        }
+        self.park_with_memory_policy(ParkMemoryPolicy::Reclaim)
+            .await
+    }
 
-        let coordinator = self.park_coordinator.clone();
-        let guest = Arc::clone(&self.guest);
-        let fence_guest = Arc::clone(&guest);
-        let physical_park_guest = Arc::clone(&guest);
-        let id = self.id.clone();
-        let api_sock = self.sock_paths.api_sock();
-        let (normal_operations_fence, outcome) = park_with_ready_for_park(
-            &id,
-            &coordinator,
-            || async move {
-                let guest = fence_guest.lock().await.as_ref().cloned().ok_or_else(|| {
-                    ParkNormalOperationFenceError::GuestUnavailable(io::Error::new(
-                        io::ErrorKind::NotConnected,
-                        "guest connection missing during park fence",
-                    ))
-                })?;
-                guest
-                    .try_fence_normal_operations()
-                    .map_err(ParkNormalOperationFenceError::Rejected)
-            },
-            || async move {
-                let guest = guest.lock().await.as_ref().cloned().ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::NotConnected,
-                        "guest connection missing during park quiesce",
-                    )
-                })?;
-                guest.quiesce_operations(GUEST_PARK_LIFECYCLE_TIMEOUT).await
-            },
-            || async {
-                let (_, result) = park_inner_with_guest(
-                    &mut self.is_parked,
-                    self.config.resources.memory_mb,
-                    self.runtime.balloon_mut(),
-                    &api_sock,
-                    &id,
-                    physical_park_guest,
-                    SandboxFinalExecParkSubstageEvents::new(None),
-                )
-                .await;
-                result
-            },
-        )
-        .await?;
-        self.park_fence = Some(normal_operations_fence);
-        self.park_outcome = Some(outcome.clone());
-        drop(self.guest_rpc_endpoint.take());
-        Ok(outcome)
+    async fn park_for_blank_pool(&mut self) -> sandbox::Result<SandboxParkOutcome> {
+        self.park_with_memory_policy(ParkMemoryPolicy::Preserve)
+            .await
     }
 
     async fn final_exec_and_park(
@@ -2962,7 +2997,7 @@ impl Sandbox for FirecrackerSandbox {
                 self.has_backend_crashed(),
             )
         })?;
-        GuestAgentProcessHandle::try_from_process(
+        let handle = GuestAgentProcessHandle::try_from_process(
             process,
             GuestAgentStartTiming {
                 shell_started_at: timing.shell_started_at,
@@ -2976,7 +3011,11 @@ impl Sandbox for FirecrackerSandbox {
                     ready.bootstrap_ready_wait_us,
                 )),
             },
-        )
+        )?;
+        if let Some(controller) = &self.runtime.balloon {
+            controller.notify_agent_ready();
+        }
+        Ok(handle)
     }
 
     async fn wait_process(
@@ -4406,9 +4445,16 @@ async fn terminal_guest_memory_snapshot(
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ParkMemoryPolicy {
+    Reclaim,
+    Preserve,
+}
+
 struct PhysicalParkRequest<'handoff> {
     guest: Arc<tokio::sync::Mutex<Option<Arc<GuestControlClient>>>>,
     handoff: Option<&'handoff SandboxFinalExecParkHandoff>,
+    memory_policy: ParkMemoryPolicy,
 }
 
 async fn park_inner_with_guest_and_handoff<'observer>(
@@ -4423,7 +4469,11 @@ async fn park_inner_with_guest_and_handoff<'observer>(
     SandboxFinalExecParkSubstageEvents<'observer>,
     sandbox::Result<PhysicalParkOutcome>,
 ) {
-    let PhysicalParkRequest { guest, handoff } = request;
+    let PhysicalParkRequest {
+        guest,
+        handoff,
+        memory_policy,
+    } = request;
     if *is_parked {
         return (
             events,
@@ -4451,7 +4501,17 @@ async fn park_inner_with_guest_and_handoff<'observer>(
         }
     };
 
-    let outcome = if target > 0 {
+    // Blank preparation retains its full budget and avoids an idle-only
+    // inflate/deflate cycle. Stop the writer before pausing even when its
+    // current target is retained; unpark still owns target-zero recovery.
+    if memory_policy == ParkMemoryPolicy::Preserve
+        && let Some(controller) = balloon_controller.take()
+    {
+        controller.abort_and_join().await;
+    }
+
+    let reclaim_memory = target > 0 && memory_policy == ParkMemoryPolicy::Reclaim;
+    let outcome = if reclaim_memory {
         // Stop the reactive controller so we're the sole writer to /balloon.
         // abort() + await ensures any in-flight PATCH from the controller
         // completes (or is cancelled) before ours lands.
@@ -4578,8 +4638,8 @@ async fn park_inner_with_guest_and_handoff<'observer>(
     };
 
     // Pause vCPUs to eliminate idle CPU overhead (timer ticks, kernel
-    // scheduling). For small VMs (target == 0) we skip the balloon but
-    // still pause — timer ticks waste CPU regardless of memory size.
+    // scheduling). Small VMs and blank preparation skip idle inflation
+    // but still pause — timer ticks waste CPU regardless of memory size.
     let vcpu_pause_started = Instant::now();
     if let Err(e) = client.pause().await {
         events.record(
@@ -4608,7 +4668,7 @@ async fn park_inner_with_guest_and_handoff<'observer>(
         PhysicalParkOutcome::Handoff(_) => {
             info!(id = %log_id, "sandbox parked for exact-successor handoff");
         }
-        PhysicalParkOutcome::Idle(_) if target > 0 => {
+        PhysicalParkOutcome::Idle(_) if reclaim_memory => {
             info!(
                 id = %log_id,
                 target_mib = target,
@@ -4640,7 +4700,7 @@ async fn park_inner_with_guest<'observer>(
     balloon_controller: &mut Option<balloon::ControllerHandle>,
     api_sock: &std::path::Path,
     log_id: &str,
-    guest: Arc<tokio::sync::Mutex<Option<Arc<GuestControlClient>>>>,
+    request: PhysicalParkRequest<'_>,
     events: SandboxFinalExecParkSubstageEvents<'observer>,
 ) -> (
     SandboxFinalExecParkSubstageEvents<'observer>,
@@ -4652,10 +4712,7 @@ async fn park_inner_with_guest<'observer>(
         balloon_controller,
         api_sock,
         log_id,
-        PhysicalParkRequest {
-            guest,
-            handoff: None,
-        },
+        request,
         events,
     )
     .await;
@@ -4683,7 +4740,11 @@ async fn park_inner(
         balloon_controller,
         api_sock,
         log_id,
-        Arc::new(tokio::sync::Mutex::new(None)),
+        PhysicalParkRequest {
+            guest: Arc::new(tokio::sync::Mutex::new(None)),
+            handoff: None,
+            memory_policy: ParkMemoryPolicy::Reclaim,
+        },
         SandboxFinalExecParkSubstageEvents::new(None),
     )
     .await;
@@ -4749,14 +4810,21 @@ async fn unpark_inner(
                 message: format!("balloon deflate: {e}"),
             })?;
 
-        if purpose == UnparkPurpose::Reuse {
-            *balloon_controller = Some(balloon::spawn_after_unpark_deflation(
+        *balloon_controller = match purpose {
+            UnparkPurpose::Reuse => Some(balloon::spawn_after_unpark_deflation(
                 client,
                 memory_mb,
                 state_rx,
                 log_id.to_owned(),
-            ));
-        }
+            )),
+            UnparkPurpose::BlankReuse => Some(balloon::spawn_after_blank_unpark(
+                client,
+                memory_mb,
+                state_rx,
+                log_id.to_owned(),
+            )),
+            UnparkPurpose::TerminalOperations => None,
+        };
     }
 
     *is_parked = false;

--- a/crates/sandbox-firecracker/src/sandbox/tests.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests.rs
@@ -191,6 +191,7 @@ fn test_sandbox_with_state(state: SandboxState) -> FirecrackerSandbox {
         destroyed: true,
         is_parked: false,
         park_outcome: None,
+        park_memory_policy: ParkMemoryPolicy::Reclaim,
         park_fence: None,
         guest_rpc_endpoint: None,
         runtime_cancel: CancellationToken::new(),
@@ -534,13 +535,16 @@ async fn send_exec_exit(stream: &mut UnixStream, exec_seq: u32) {
     stream.write_all(&response).await.unwrap();
 }
 
-async fn send_agent_started_and_ready(stream: &mut UnixStream, exec_seq: u32, pid: u32) {
+async fn send_exec_started(stream: &mut UnixStream, exec_seq: u32, pid: u32) {
     let started = guest_control_proto::encode_exec_started(pid).unwrap();
     let started =
         guest_control_proto::encode(guest_control_proto::MSG_EXEC_STARTED, exec_seq, &started)
             .unwrap();
     stream.write_all(&started).await.unwrap();
+}
 
+async fn send_agent_started_and_ready(stream: &mut UnixStream, exec_seq: u32, pid: u32) {
+    send_exec_started(stream, exec_seq, pid).await;
     let ready =
         guest_control_proto::encode_exec_agent_ready(guest_control_proto::ExecAgentReadyTiming {
             containment_create_us: 11,
@@ -5905,7 +5909,11 @@ async fn park_pauses_when_balloon_stats_are_unavailable() {
             &mut controller,
             api.socket_path(),
             "stats-error",
-            Arc::new(tokio::sync::Mutex::new(None)),
+            PhysicalParkRequest {
+                guest: Arc::new(tokio::sync::Mutex::new(None)),
+                handoff: None,
+                memory_policy: ParkMemoryPolicy::Reclaim,
+            },
             SandboxFinalExecParkSubstageEvents::new(Some(&mut observer)),
         ))
         .await;
@@ -5959,6 +5967,7 @@ async fn exact_handoff_skips_balloon_target_but_still_pauses() {
             PhysicalParkRequest {
                 guest: Arc::new(tokio::sync::Mutex::new(None)),
                 handoff: Some(&handoff),
+                memory_policy: ParkMemoryPolicy::Reclaim,
             },
             SandboxFinalExecParkSubstageEvents::new(Some(&mut observer)),
         )
@@ -6020,6 +6029,7 @@ async fn exact_handoff_interrupts_in_flight_balloon_settle() {
             PhysicalParkRequest {
                 guest: Arc::new(tokio::sync::Mutex::new(None)),
                 handoff: Some(&handoff),
+                memory_policy: ParkMemoryPolicy::Reclaim,
             },
             SandboxFinalExecParkSubstageEvents::new(Some(&mut observer)),
         );
@@ -6371,7 +6381,11 @@ async fn park_small_vm_skips_balloon_but_pauses_vcpus() {
             &mut controller,
             api.socket_path(),
             "test-park-small",
-            Arc::new(tokio::sync::Mutex::new(None)),
+            PhysicalParkRequest {
+                guest: Arc::new(tokio::sync::Mutex::new(None)),
+                handoff: None,
+                memory_policy: ParkMemoryPolicy::Reclaim,
+            },
             SandboxFinalExecParkSubstageEvents::new(Some(&mut observer)),
         )
         .await;
@@ -6855,7 +6869,11 @@ async fn park_balloon_failure_leaves_flag_false() {
             &mut controller,
             api.socket_path(),
             "test-park-fail",
-            Arc::new(tokio::sync::Mutex::new(None)),
+            PhysicalParkRequest {
+                guest: Arc::new(tokio::sync::Mutex::new(None)),
+                handoff: None,
+                memory_policy: ParkMemoryPolicy::Reclaim,
+            },
             SandboxFinalExecParkSubstageEvents::new(Some(&mut observer)),
         )
         .await;
@@ -7409,7 +7427,11 @@ async fn severe_park_collects_terminal_guest_memory_before_pause() {
             &mut controller,
             &socket_path,
             "terminal-memory-snapshot",
-            guest,
+            PhysicalParkRequest {
+                guest,
+                handoff: None,
+                memory_policy: ParkMemoryPolicy::Reclaim,
+            },
             SandboxFinalExecParkSubstageEvents::new(None),
         )
         .await;
@@ -7476,7 +7498,11 @@ async fn reusable_park_does_not_request_terminal_guest_memory() {
             &mut controller,
             api.socket_path(),
             "reusable-no-memory-snapshot",
-            guest,
+            PhysicalParkRequest {
+                guest,
+                handoff: None,
+                memory_policy: ParkMemoryPolicy::Reclaim,
+            },
             SandboxFinalExecParkSubstageEvents::new(Some(&mut observer)),
         )
         .await;
@@ -7532,7 +7558,11 @@ async fn park_small_vm_pause_failure_preserves_controller() {
             &mut controller,
             api.socket_path(),
             "small-fail",
-            Arc::new(tokio::sync::Mutex::new(None)),
+            PhysicalParkRequest {
+                guest: Arc::new(tokio::sync::Mutex::new(None)),
+                handoff: None,
+                memory_policy: ParkMemoryPolicy::Reclaim,
+            },
             SandboxFinalExecParkSubstageEvents::new(Some(&mut observer)),
         )
         .await;

--- a/crates/sandbox-firecracker/src/sandbox/tests/guest_rpc.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests/guest_rpc.rs
@@ -88,7 +88,7 @@ async fn sandbox_stop_kill_and_drop_remove_the_owned_endpoint() {
 
 #[tokio::test]
 async fn sandbox_park_and_final_exec_park_cannot_cross_an_accepted_guest_rpc_request() {
-    for final_exec in [false, true] {
+    for (final_exec, blank) in [(false, false), (true, false), (false, true)] {
         let dir = tempfile::tempdir().unwrap();
         let mut sandbox = test_sandbox_with_state(SandboxState::Running);
         prepare_socket_paths(&mut sandbox, dir.path());
@@ -116,6 +116,8 @@ async fn sandbox_park_and_final_exec_park_cannot_cross_an_accepted_guest_rpc_req
                 )
                 .await
                 .map(drop)
+        } else if blank {
+            sandbox.park_for_blank_pool().await.map(drop)
         } else {
             sandbox.park().await.map(drop)
         };
@@ -171,7 +173,12 @@ async fn park_rpc_sandbox(sandbox: &mut FirecrackerSandbox, peer: &mut UnixStrea
 
 #[tokio::test]
 async fn successful_park_variants_replace_the_rpc_epoch_before_guest_resume() {
-    for (final_exec, handoff) in [(false, false), (true, false), (true, true)] {
+    for (final_exec, handoff, blank) in [
+        (false, false, false),
+        (true, false, false),
+        (true, true, false),
+        (false, false, true),
+    ] {
         let dir = tempfile::tempdir().unwrap();
         let (mut sandbox, mut peer) = running_rpc_sandbox(dir.path()).await;
         let path = sandbox.sock_paths.guest_rpc();
@@ -231,6 +238,11 @@ async fn successful_park_variants_replace_the_rpc_epoch_before_guest_resume() {
                         .unwrap();
                     assert_eq!(outcome.park_outcome, SandboxParkOutcome::Reusable);
                 }
+            } else if blank {
+                assert_eq!(
+                    sandbox.park_for_blank_pool().await.unwrap(),
+                    SandboxParkOutcome::Reusable
+                );
             } else {
                 assert_eq!(sandbox.park().await.unwrap(), SandboxParkOutcome::Reusable);
             }
@@ -311,6 +323,274 @@ async fn successful_park_variants_replace_the_rpc_epoch_before_guest_resume() {
         assert_eq!(mock_request_body_json(&requests[0])["state"], "Paused");
         assert_eq!(mock_request_body_json(&requests[1])["state"], "Resumed");
     }
+}
+
+#[tokio::test]
+async fn blank_park_preserves_memory_then_returns_to_ordinary_reclamation_after_reuse() {
+    let dir = tempfile::tempdir().unwrap();
+    let (mut sandbox, mut peer) = running_rpc_sandbox(dir.path()).await;
+    sandbox.config.resources.memory_mb = 4096;
+    *sandbox.runtime.balloon_mut() = Some(test_balloon_controller());
+    let mut api = MockLifecycleApi::new(std::collections::VecDeque::new(), None);
+    std::os::unix::fs::symlink(api.socket_path(), sandbox.sock_paths.api_sock()).unwrap();
+
+    let (result, ()) = tokio::join!(
+        sandbox.park_for_blank_pool(),
+        acknowledge_lifecycle(
+            &mut peer,
+            guest_control_proto::MSG_QUIESCE_OPERATIONS,
+            guest_control_proto::MSG_OPERATIONS_QUIESCED,
+        ),
+    );
+    assert_eq!(result.unwrap(), SandboxParkOutcome::Reusable);
+    assert!(sandbox.is_parked);
+    assert!(sandbox.park_fence.is_some());
+    assert!(sandbox.runtime.balloon_mut().is_none());
+    assert!(!sandbox.sock_paths.guest_rpc().exists());
+    let requests = api.drain_requests();
+    assert_eq!(
+        requests.len(),
+        1,
+        "blank park must not inflate or poll balloon"
+    );
+    assert_eq!(requests[0].path, "/vm");
+    assert_eq!(mock_request_body_json(&requests[0])["state"], "Paused");
+
+    assert_eq!(
+        sandbox.park_for_blank_pool().await.unwrap(),
+        SandboxParkOutcome::Reusable
+    );
+    assert!(api.drain_requests().is_empty(), "repeat park is a no-op");
+
+    sandbox.bind_run_control("run-b").unwrap();
+    // The external API keeps reporting a nonzero actual balloon. Physical
+    // convergence must not prevent Guest operation admission from reopening.
+    let (result, ()) = tokio::join!(
+        sandbox.unpark(),
+        acknowledge_lifecycle(
+            &mut peer,
+            guest_control_proto::MSG_RESUME_OPERATIONS,
+            guest_control_proto::MSG_OPERATIONS_RESUMED,
+        ),
+    );
+    result.unwrap();
+    assert!(!sandbox.is_parked);
+    assert!(sandbox.park_fence.is_none());
+    assert!(sandbox.guest_rpc("run-b").is_some());
+    assert!(sandbox.runtime.balloon_mut().is_some());
+    let requests = api.drain_requests();
+    let requests = patches(&requests);
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].path, "/vm");
+    assert_eq!(mock_request_body_json(requests[0])["state"], "Resumed");
+    assert_eq!(requests[1].path, "/balloon");
+    assert_eq!(mock_request_body_json(requests[1])["amount_mib"], 0);
+
+    park_rpc_sandbox(&mut sandbox, &mut peer).await;
+    assert!(sandbox.runtime.balloon_mut().is_none());
+    let requests = api.drain_requests();
+    let requests = patches(&requests);
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].path, "/balloon");
+    assert_eq!(mock_request_body_json(requests[0])["amount_mib"], 3072);
+    assert_eq!(requests[1].path, "/vm");
+    assert_eq!(mock_request_body_json(requests[1])["state"], "Paused");
+}
+
+#[tokio::test]
+async fn blank_reclamation_starts_only_after_successful_agent_readiness() {
+    for agent_outcome in ["ready", "exit", "cancel"] {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut sandbox, mut peer) = running_rpc_sandbox(dir.path()).await;
+        sandbox.config.resources.memory_mb = 4096;
+        let zero_stats = r#"{"target_mib":0,"actual_mib":0,"target_pages":0,"actual_pages":0,"free_memory":1073741824,"available_memory":1073741824}"#;
+        let mut api = MockFirecrackerApi::with_responses([
+            MockResponse::no_content(),        // Blank pause.
+            MockResponse::no_content(),        // Resume vCPUs.
+            MockResponse::no_content(),        // Request all memory back.
+            MockResponse::ok_body(zero_stats), // Convergence guard.
+            MockResponse::ok_body(zero_stats), // Reactive tick after readiness.
+            MockResponse::no_content(),        // Reactive inflation.
+        ]);
+        std::os::unix::fs::symlink(api.socket_path(), sandbox.sock_paths.api_sock()).unwrap();
+        let (park, ()) = tokio::join!(
+            sandbox.park_for_blank_pool(),
+            acknowledge_lifecycle(
+                &mut peer,
+                guest_control_proto::MSG_QUIESCE_OPERATIONS,
+                guest_control_proto::MSG_OPERATIONS_QUIESCED,
+            ),
+        );
+        assert_eq!(park.unwrap(), SandboxParkOutcome::Reusable);
+        // An ordinary idempotent park must not replace the blank's policy.
+        assert_eq!(sandbox.park().await.unwrap(), SandboxParkOutcome::Reusable);
+        sandbox.bind_run_control("blank-first-agent").unwrap();
+        let (unpark, ()) = tokio::join!(
+            sandbox.unpark(),
+            acknowledge_lifecycle(
+                &mut peer,
+                guest_control_proto::MSG_RESUME_OPERATIONS,
+                guest_control_proto::MSG_OPERATIONS_RESUMED,
+            ),
+        );
+        unpark.unwrap();
+        for (method, path) in [
+            ("PATCH", "/vm"),
+            ("PATCH", "/vm"),
+            ("PATCH", "/balloon"),
+            ("GET", "/balloon/statistics"),
+        ] {
+            let request = api.next_request().await;
+            assert_eq!(
+                (request.method.as_str(), request.path.as_str()),
+                (method, path)
+            );
+        }
+
+        let workload = StartProcessRequest {
+            cmd: "true",
+            timeout: Duration::from_secs(5),
+            start_timeout: Duration::from_secs(5),
+            env: &[],
+            sudo: false,
+            output: ProcessOutputMode::stream(),
+        };
+        let (workload, ()) = tokio::join!(sandbox.start_process(&workload), async {
+            let start = read_vsock_message(&mut peer).await;
+            send_exec_started(&mut peer, start.seq, 72).await;
+            send_exec_exit(&mut peer, start.seq).await;
+        });
+        sandbox
+            .wait_process(workload.unwrap(), Duration::from_secs(5))
+            .await
+            .unwrap();
+        assert!(
+            api.drain_requests().is_empty(),
+            "workload released reclamation"
+        );
+
+        let request = StartAgentProcessRequest {
+            timeout: Duration::from_secs(5),
+            env: &[],
+            output: ProcessOutputMode::stream(),
+        };
+        let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
+        let start_agent = async {
+            if agent_outcome == "cancel" {
+                tokio::select! {
+                    result = sandbox.start_agent_process(&request) => Some(result),
+                    _ = cancel_rx => None,
+                }
+            } else {
+                Some(sandbox.start_agent_process(&request).await)
+            }
+        };
+        let (result, seq) = tokio::join!(start_agent, async {
+            let start = read_vsock_message(&mut peer).await;
+            assert_eq!(start.msg_type, guest_control_proto::MSG_EXEC_START);
+            assert!(
+                api.drain_requests().is_empty(),
+                "reclamation preceded Agent readiness"
+            );
+            if agent_outcome == "ready" {
+                send_agent_started_and_ready(&mut peer, start.seq, 73).await;
+            } else if agent_outcome == "cancel" {
+                cancel_tx.send(()).unwrap();
+            } else {
+                // A terminal result without readiness must not release memory protection.
+                send_exec_started(&mut peer, start.seq, 73).await;
+                send_exec_exit(&mut peer, start.seq).await;
+            }
+            start.seq
+        });
+        if agent_outcome == "ready" {
+            let (process, _control) = result.unwrap().unwrap().into_parts();
+            let tick = api.next_request().await;
+            assert_eq!(
+                (tick.method.as_str(), tick.path.as_str()),
+                ("GET", "/balloon/statistics")
+            );
+            let inflate = api.next_request().await;
+            assert_eq!(
+                (inflate.method.as_str(), inflate.path.as_str()),
+                ("PATCH", "/balloon")
+            );
+            assert_eq!(mock_request_body_json(&inflate)["amount_mib"], 256);
+            send_exec_exit(&mut peer, seq).await;
+            sandbox
+                .wait_process(process, Duration::from_secs(5))
+                .await
+                .unwrap();
+        } else if agent_outcome == "exit" {
+            assert!(result.unwrap().is_err());
+        } else {
+            assert!(result.is_none());
+        }
+        sandbox.kill().await.unwrap();
+        assert!(sandbox.runtime.balloon_mut().is_none());
+        assert_eq!(sandbox.current_state(), SandboxState::Stopped);
+        assert!(api.drain_requests().is_empty());
+    }
+}
+
+#[tokio::test]
+async fn blank_park_requires_guest_quiescence_before_touching_memory_or_vcpus() {
+    let dir = tempfile::tempdir().unwrap();
+    let (mut sandbox, mut peer) = running_rpc_sandbox(dir.path()).await;
+    sandbox.config.resources.memory_mb = 4096;
+    let controller = test_balloon_controller();
+    let controller_id = controller.id();
+    *sandbox.runtime.balloon_mut() = Some(controller);
+    let mut api = MockLifecycleApi::new(std::collections::VecDeque::new(), None);
+    std::os::unix::fs::symlink(api.socket_path(), sandbox.sock_paths.api_sock()).unwrap();
+
+    let (result, ()) = tokio::join!(sandbox.park_for_blank_pool(), async {
+        let request = read_vsock_message(&mut peer).await;
+        assert_eq!(
+            request.msg_type,
+            guest_control_proto::MSG_QUIESCE_OPERATIONS
+        );
+        drop(peer);
+    },);
+    assert!(result.is_err());
+    assert!(!sandbox.is_parked);
+    assert!(sandbox.park_outcome.is_none());
+    assert_eq!(
+        sandbox.runtime.balloon_mut().as_ref().unwrap().id(),
+        controller_id
+    );
+    assert!(api.drain_requests().is_empty());
+}
+
+#[tokio::test]
+async fn blank_park_pause_failure_does_not_publish_a_reusable_sandbox() {
+    let dir = tempfile::tempdir().unwrap();
+    let (mut sandbox, mut peer) = running_rpc_sandbox(dir.path()).await;
+    sandbox.config.resources.memory_mb = 4096;
+    *sandbox.runtime.balloon_mut() = Some(test_balloon_controller());
+    let mut api = MockLifecycleApi::new(std::collections::VecDeque::from([500]), None);
+    std::os::unix::fs::symlink(api.socket_path(), sandbox.sock_paths.api_sock()).unwrap();
+
+    let (result, ()) = tokio::join!(
+        sandbox.park_for_blank_pool(),
+        acknowledge_lifecycle(
+            &mut peer,
+            guest_control_proto::MSG_QUIESCE_OPERATIONS,
+            guest_control_proto::MSG_OPERATIONS_QUIESCED,
+        ),
+    );
+    assert!(result.unwrap_err().to_string().contains("vm pause"));
+    assert!(!sandbox.is_parked);
+    assert!(sandbox.park_outcome.is_none());
+    assert!(sandbox.runtime.balloon_mut().is_none());
+    assert!(
+        sandbox.unpark().await.is_err(),
+        "partial park is destroy-only"
+    );
+    let requests = api.drain_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].path, "/vm");
+    assert_eq!(mock_request_body_json(&requests[0])["state"], "Paused");
 }
 
 #[tokio::test]

--- a/crates/sandbox-firecracker/src/sandbox/tests/guest_rpc.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests/guest_rpc.rs
@@ -450,6 +450,7 @@ async fn blank_reclamation_starts_only_after_successful_agent_readiness() {
         let workload = StartProcessRequest {
             cmd: "true",
             timeout: Duration::from_secs(5),
+            timeout_is_expected: false,
             start_timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -161,6 +161,7 @@ pub(crate) struct LifecycleOverrideState {
     pub(crate) destroy_behaviors: Mutex<VecDeque<DestroyBehavior>>,
     /// Total `park()` calls across all sandboxes built from this override set.
     pub(crate) park_calls: Mutex<u32>,
+    pub(crate) blank_park_calls: Mutex<u32>,
     /// Total `unpark()` calls across all sandboxes built from this override set.
     pub(crate) unpark_calls: Mutex<u32>,
     /// Total terminal-only `unpark()` calls across all attached sandboxes.
@@ -957,6 +958,11 @@ impl MockSandboxOverrides {
     /// Total `park()` calls across all sandboxes built from this override set.
     pub fn park_call_count(&self) -> u32 {
         *self.lifecycle.park_calls.lock_ignoring_poison()
+    }
+
+    /// Total blank preparation park calls, also included in ordinary park counts.
+    pub fn blank_park_call_count(&self) -> u32 {
+        *self.lifecycle.blank_park_calls.lock_ignoring_poison()
     }
 
     /// Total `unpark()` calls across all sandboxes built from this override set.

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -683,6 +683,13 @@ impl Sandbox for MockSandbox {
         result
     }
 
+    async fn park_for_blank_pool(&mut self) -> Result<SandboxParkOutcome> {
+        if let Some(o) = &self.overrides {
+            *o.lifecycle.blank_park_calls.lock_ignoring_poison() += 1;
+        }
+        self.park().await
+    }
+
     async fn final_exec_and_park(
         &mut self,
         request: &ExecRequest<'_>,

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -674,6 +674,17 @@ pub trait Sandbox: Send + Sync + Any {
         Ok(SandboxParkOutcome::Reusable)
     }
 
+    /// Park a tenant-free sandbox prepared for the blank pool.
+    ///
+    /// The caller retains the full profile resource budget. Providers may
+    /// preserve guest memory to avoid reclaiming it only to return it during
+    /// startup. All fencing, idempotency, failure and cleanup requirements of
+    /// [`park`](Self::park) still apply. Providers without a distinct blank
+    /// memory policy use ordinary parking.
+    async fn park_for_blank_pool(&mut self) -> Result<SandboxParkOutcome> {
+        self.park().await
+    }
+
     /// Run one final normal guest exec and park without reopening operation
     /// admission between the exec and pause.
     ///

--- a/docs/runner-host-configuration.md
+++ b/docs/runner-host-configuration.md
@@ -47,6 +47,30 @@ telemetry/Axiom dimensions, and distinct hostnames on two hosts running one
 version. Remove any historical query fallback only after its bounded
 observation window expires.
 
+## Blank Sandbox Memory
+
+Tenant-free sandboxes prepared for the blank pool retain their full profile
+resource budget. Firecracker stops their reactive balloon controller and
+pauses vCPUs without requesting aggressive idle balloon inflation. Guest
+quiesce and operation fencing still complete before pause. This avoids a
+large idle-only inflate/deflate cycle when a prepared sandbox is claimed.
+
+Unpark still requests memory return without waiting for physical balloon
+convergence. After a preserved blank resumes, its background controller waits
+for both target-zero convergence and the first successful Agent-ready event
+before resuming reactive reclamation. Guest operations and Agent startup do not
+wait for that controller, and no fixed delay is added. Failed or cancelled
+startup does not release the gate; ordinary park, stop and destruction cancel
+the owned controller. The full profile budget stays reserved throughout.
+
+A small balloon from active preparation may remain at park. Exact/session idle
+sandboxes continue using ordinary memory reclamation, including after a
+claimed blank completes its first run.
+
+Pool sizing, full-profile admission, exact-first reuse and blank-first pressure
+eviction are unchanged. Preserving blank memory can increase physical idle
+memory usage; the profile budget is not a measurement of resident memory.
+
 ## Idle Workspace Reclamation Concurrency
 
 Workspace promotion uses two independent runner-process-local admission gates,


### PR DESCRIPTION
## Summary

- Keep tenant-free blank sandboxes paused without aggressive idle balloon inflation, while retaining the full profile resource reservation and all Guest quiesce/operation fences.
- After a preserved blank resumes, defer its first optional background reclamation until both physical target-zero convergence and the existing successful Agent-ready boundary. Unpark and startup do not wait for the controller; there is no fixed delay or new readiness protocol.
- Keep ordinary exact/session parking, terminal operations, pool sizing, admission and eviction unchanged. Failed/cancelled Agent starts and ordinary workload starts do not release the readiness gate; existing lifecycle cleanup owns cancellation.

Closes #32415. Parent context: #24203 (not closed by this PR).

## Why

The earlier investigation found Guest balloon-deflation work competing with required storage startup after blank reuse. Preserving blank memory removes the large idle-only inflate/deflate cycle, but that change alone allowed reactive inflation to restart during storage and failed the round 12 regression screen. This revision moves only the first blank-resume reclamation behind successful Agent readiness.

No memory-backed archive staging, Guest protocol changes, startup sleeps, new pool, kernel change, API/schema change or production rollout is included.

## Verification

- Affected Rust crates (`sandbox`, `sandbox-firecracker`, `sandbox-mock`, `runner`): `cargo fmt --all --check`; `cargo clippy --profile local -p sandbox -p sandbox-firecracker -p sandbox-mock -p runner --all-targets -- -D warnings`; `RUSTDOCFLAGS="-D warnings" cargo doc --profile local -p sandbox -p sandbox-firecracker -p sandbox-mock -p runner --no-deps`; `cargo test --profile local -p sandbox -p sandbox-firecracker -p sandbox-mock -p runner -- --quiet`. **4,620 tests passed on the rebased tree.** Commit hooks also passed workspace-wide Clippy and documentation checks.
- Documentation Prettier passed. Regression coverage uses real Unix Guest transport and an external Firecracker API fixture: preserved park/resume, idempotent policy, ordinary repark, successful/failed/cancelled Agent readiness, early notification, quiescence/pause failures and controller cleanup.
- **local-11: 56 real API-mode runs** in a frozen A/C/C/A comparison (48 measured, 8 warmups), all content/lifecycle checks passed. Same source/image and identical nine Guest binaries across the frozen variants. Normal/larger workflows, actual blank/fresh/exact reuse and three overlapping active requests were covered.
- A separate **7-run current-main smoke** passed after rebasing onto `4124c769f0d72342d73b2806ace7bf73c0605962`, rebuilding the current Runner and all ten current Guest binaries. Actual blank/fresh/exact paths and three-active concurrency passed; fixture hashes were unchanged. These smoke results are not pooled with the frozen comparison.
- API, queue, admission, CPU delegation, Firecracker, Guest and storage were real; the external coding-agent process was mocked. Existing privileged CI entrypoints were not run locally; no new skips or ignores were added.

## Performance and risk boundaries

The bounded comparison passed the preregistered adverse-median screen of `max(20 ms, 10% of baseline)` in every matched cell. Larger blank per-block medians (n=2 each) were storage **186→191 / 184→202.5 ms** and claim-to-ready **271→267.5 / 260→282 ms**. These small samples **do not establish overall startup acceleration, p99 equivalence or universal no-regression**. Round 12's negative evidence remains documented in the issue.

Preserving blank memory and delaying optional reclamation can increase physical residency during startup; full-profile budgeting is unchanged but is not an RSS guarantee. The frozen screen had 170 durable five-second samples, no OOM, zero sampled memory PSI avg10, at least 26,604 MiB host available, and at most three active requests. Dense/hot production workloads remain unverified. No merge or rollout is authorized by this submission.
