### PR TITLE
fix(platform): move avatar heads to the chin baseline instead of resizing them

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/composer-agent-mention-node.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-agent-mention-node.ts
@@ -8,7 +8,6 @@ import {
 } from "../../views/okou-page/avatar-utils.ts";
 import {
   AVATAR_ARTWORK_SLOT,
-  AVATAR_HEAD_TRANSFORM_ORIGIN,
   avatarSvgComposition,
   avatarSvgContentTransform,
 } from "../../views/okou-page/avatar-svg-utils.ts";
@@ -122,7 +121,7 @@ function renderAgentMentionAvatar(
   container.replaceChildren();
   const svgConfig = resolveAvatarSvgConfig(avatarUrl);
   if (svgConfig) {
-    const { behind, head, front, headScale, contentOffsetY, contentScale } =
+    const { behind, head, front, headOffsetY, contentOffsetY, contentScale } =
       avatarSvgComposition(svgConfig, switches);
     const layers = document.createElement("span");
     layers.className = "absolute inset-0";
@@ -147,8 +146,7 @@ function renderAgentMentionAvatar(
     };
     const headLayers = document.createElement("span");
     headLayers.className = "absolute inset-0";
-    headLayers.style.transform = `scale(${headScale})`;
-    headLayers.style.transformOrigin = AVATAR_HEAD_TRANSFORM_ORIGIN;
+    headLayers.style.transform = `translateY(${headOffsetY}%)`;
     appendLayers(layers, behind);
     appendLayers(headLayers, head);
     layers.append(headLayers);

--- a/turbo/apps/platform/src/signals/okou-page/composer-agent-mention-node.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-agent-mention-node.ts
@@ -8,6 +8,7 @@ import {
 } from "../../views/okou-page/avatar-utils.ts";
 import {
   AVATAR_ARTWORK_SLOT,
+  AVATAR_HEAD_SLOT,
   avatarSvgComposition,
   avatarSvgContentTransform,
 } from "../../views/okou-page/avatar-svg-utils.ts";
@@ -123,11 +124,17 @@ function renderAgentMentionAvatar(
   if (svgConfig) {
     const { behind, head, front, headOffsetY, contentOffsetY, contentScale } =
       avatarSvgComposition(svgConfig, switches);
+    const applySlot = (
+      element: HTMLElement,
+      slot: Readonly<Record<string, string>>,
+    ) => {
+      for (const [name, value] of Object.entries(slot)) {
+        element.setAttribute(name, value);
+      }
+    };
     const layers = document.createElement("span");
     layers.className = "absolute inset-0";
-    for (const [name, value] of Object.entries(AVATAR_ARTWORK_SLOT)) {
-      layers.setAttribute(name, value);
-    }
+    applySlot(layers, AVATAR_ARTWORK_SLOT);
     const transform = avatarSvgContentTransform({
       contentOffsetY: switches.framing ? contentOffsetY : 0,
       contentScale,
@@ -146,6 +153,7 @@ function renderAgentMentionAvatar(
     };
     const headLayers = document.createElement("span");
     headLayers.className = "absolute inset-0";
+    applySlot(headLayers, AVATAR_HEAD_SLOT);
     headLayers.style.transform = `translateY(${headOffsetY}%)`;
     appendLayers(layers, behind);
     appendLayers(headLayers, head);

--- a/turbo/apps/platform/src/views/agents-page/__tests__/agents-page-avatar-framing.test.tsx
+++ b/turbo/apps/platform/src/views/agents-page/__tests__/agents-page-avatar-framing.test.tsx
@@ -34,13 +34,15 @@ const TALL_HAIR_AGENT_ID = "c0000000-0000-4000-a000-000000000022";
 const LEGACY_AGENT_ID = "c0000000-0000-4000-a000-000000000023";
 
 /**
- * The share of the avatar box each artwork covers as drawn, before any framing.
- * These are properties of the composer assets — the flattest hair leaves the
- * canvas's whole forehead margin empty, the tallest fills it — and they are what
- * makes one agent card look larger than the next.
+ * The share of the avatar box each artwork covers as drawn, before any framing:
+ * from the top of the hair, once the head has been moved onto the chin
+ * baseline, down to the bottom of the sweater. These are properties of the
+ * composer assets — the flattest hair leaves the canvas's whole forehead margin
+ * empty, the tallest reaches past the top of it — and they are what makes one
+ * agent card look larger than the next.
  */
-const FLAT_HAIR_SHIPPED_FILL = 264 / 380;
-const TALL_HAIR_SHIPPED_FILL = 373.6826 / 380;
+const FLAT_HAIR_DRAWN_FILL = 250.4 / 380;
+const TALL_HAIR_DRAWN_FILL = 383.4 / 380;
 
 function agent(agentId: string, avatarUrl: string): AgentResponse {
   return {
@@ -157,12 +159,11 @@ test("Center each composer avatar and pull the cast toward one size", async () =
   const flat = avatarFramingTransform(FLAT_HAIR_AGENT_ID);
   const tall = avatarFramingTransform(TALL_HAIR_AGENT_ID);
 
-  // Both move up, because both artworks hang below the middle of their canvas.
-  // The flat-haired one leaves the whole forehead margin empty, so it has much
-  // further to travel than the one whose bun already fills that margin.
-  expect(centeringOffset(flat)).toBeLessThan(0);
-  expect(centeringOffset(tall)).toBeLessThan(0);
-  expect(centeringOffset(flat)).toBeLessThan(centeringOffset(tall));
+  // The flat-haired artwork leaves the whole forehead margin of its canvas
+  // empty, so centering moves it a long way up. The one whose bun already
+  // reaches past the top of the canvas is close to centered where it is.
+  expect(centeringOffset(flat)).toBeLessThan(-10);
+  expect(Math.abs(centeringOffset(tall))).toBeLessThan(1);
 
   // The smaller artwork grows and the larger one shrinks, and neither moves far
   // enough to make its face the odd one out.
@@ -170,20 +171,66 @@ test("Center each composer avatar and pull the cast toward one size", async () =
   const tallScale = framingScale(tall);
   expect(flatScale).toBeGreaterThan(1);
   expect(tallScale).toBeLessThan(1);
-  expect(flatScale).toBeLessThan(1.2);
+  expect(flatScale).toBeLessThan(1.25);
   expect(tallScale).toBeGreaterThan(0.9);
 
-  // What the framing is for: as drawn these two differ by more than 1.4x, which
-  // is what makes a row of cards look uneven. Framed, they differ by under 1.2x.
-  const shippedRatio = TALL_HAIR_SHIPPED_FILL / FLAT_HAIR_SHIPPED_FILL;
+  // What the framing is for. As drawn these two differ by more than 1.5x, which
+  // is what makes a row of cards look uneven. Framed, they are half that far
+  // apart in log space — the rule corrects half the difference, so the framed
+  // spread is the square root of the drawn one.
+  const drawnRatio = TALL_HAIR_DRAWN_FILL / FLAT_HAIR_DRAWN_FILL;
   const framedRatio =
-    (TALL_HAIR_SHIPPED_FILL * tallScale) / (FLAT_HAIR_SHIPPED_FILL * flatScale);
-  expect(shippedRatio).toBeGreaterThan(1.4);
-  expect(framedRatio).toBeLessThan(1.2);
+    (TALL_HAIR_DRAWN_FILL * tallScale) / (FLAT_HAIR_DRAWN_FILL * flatScale);
+  expect(drawnRatio).toBeGreaterThan(1.5);
+  expect(framedRatio).toBeLessThan(drawnRatio);
+  expect(framedRatio).toBeCloseTo(Math.sqrt(drawnRatio), 2);
 });
 
 test("Keep legacy avatars on the scale they already shipped with", async () => {
   await setupAgentsPage([agent(LEGACY_AGENT_ID, "svg:r3s2h4c1f5h")], true);
 
   expect(avatarFramingTransform(LEGACY_AGENT_ID)).toBe("scale(1.25)");
+});
+
+/**
+ * The head group carries only the chin-baseline placement, so it is the layer
+ * that proves the head is moved rather than resized. Same boundary exception as
+ * above: a resized head has no page-observable result under jsdom.
+ */
+function headPlacementTransform(agentId: string): string {
+  const artwork = agentCard(agentId).querySelector<HTMLElement>(
+    "[data-avatar-artwork]",
+  );
+  const head = artwork?.querySelector<HTMLElement>(
+    ":scope > div, :scope > span",
+  );
+  if (!head) {
+    throw new Error(`${agentId} avatar head group not found`);
+  }
+  return head.style.transform;
+}
+
+test("Move the head to the chin baseline instead of resizing it", async () => {
+  await setupAgentsPage(
+    [
+      agent(FLAT_HAIR_AGENT_ID, FLAT_HAIR_AVATAR_URL),
+      agent(TALL_HAIR_AGENT_ID, TALL_HAIR_AVATAR_URL),
+    ],
+    true,
+  );
+
+  // The face assets are all drawn at one width. Resizing a head to reach the
+  // shared collar made it up to 1.24x wider than its neighbour while the neck
+  // and collar under it stayed fixed, which is what made one body look too big
+  // for its head. Neither head carries a scale any more.
+  for (const id of [FLAT_HAIR_AGENT_ID, TALL_HAIR_AGENT_ID]) {
+    expect(headPlacementTransform(id)).not.toMatch(/scale\(/u);
+    expect(headPlacementTransform(id)).toMatch(/^translateY\(-?[\d.]+%\)$/u);
+  }
+
+  // The two faces have different chins, so they move by different amounts to
+  // land on the same collar.
+  expect(headPlacementTransform(FLAT_HAIR_AGENT_ID)).not.toBe(
+    headPlacementTransform(TALL_HAIR_AGENT_ID),
+  );
 });

--- a/turbo/apps/platform/src/views/agents-page/__tests__/agents-page-avatar-framing.test.tsx
+++ b/turbo/apps/platform/src/views/agents-page/__tests__/agents-page-avatar-framing.test.tsx
@@ -198,12 +198,8 @@ test("Keep legacy avatars on the scale they already shipped with", async () => {
  * above: a resized head has no page-observable result under jsdom.
  */
 function headPlacementTransform(agentId: string): string {
-  const artwork = agentCard(agentId).querySelector<HTMLElement>(
-    "[data-avatar-artwork]",
-  );
-  const head = artwork?.querySelector<HTMLElement>(
-    ":scope > div, :scope > span",
-  );
+  const head =
+    agentCard(agentId).querySelector<HTMLElement>("[data-avatar-head]");
   if (!head) {
     throw new Error(`${agentId} avatar head group not found`);
   }

--- a/turbo/apps/platform/src/views/okou-page/avatar-svg-preview.tsx
+++ b/turbo/apps/platform/src/views/okou-page/avatar-svg-preview.tsx
@@ -5,7 +5,6 @@ import {
 } from "../../signals/external/feature-switch.ts";
 import {
   AVATAR_ARTWORK_SLOT,
-  AVATAR_HEAD_TRANSFORM_ORIGIN,
   avatarSvgComposition,
   avatarSvgContentTransform,
   type ResolvedAvatarSvgConfig,
@@ -33,7 +32,7 @@ export function AvatarSvgPreview({
 }: AvatarSvgPreviewProps) {
   const neckSweater = useGet(avatarNeckSweaterEnabled$);
   const framing = useGet(avatarFramingEnabled$);
-  const { behind, head, front, headScale, contentOffsetY, contentScale } =
+  const { behind, head, front, headOffsetY, contentOffsetY, contentScale } =
     avatarSvgComposition(config, { neckSweater, framing });
   // `centerContent` is the avatar maker asking for centering on its own while
   // the framing switch is off; the rule centers every avatar once it ships, and
@@ -63,8 +62,7 @@ export function AvatarSvgPreview({
         <div
           className="absolute inset-0"
           style={{
-            transform: `scale(${headScale})`,
-            transformOrigin: AVATAR_HEAD_TRANSFORM_ORIGIN,
+            transform: `translateY(${headOffsetY}%)`,
           }}
         >
           {head.map(layer)}

--- a/turbo/apps/platform/src/views/okou-page/avatar-svg-preview.tsx
+++ b/turbo/apps/platform/src/views/okou-page/avatar-svg-preview.tsx
@@ -5,6 +5,7 @@ import {
 } from "../../signals/external/feature-switch.ts";
 import {
   AVATAR_ARTWORK_SLOT,
+  AVATAR_HEAD_SLOT,
   avatarSvgComposition,
   avatarSvgContentTransform,
   type ResolvedAvatarSvgConfig,
@@ -60,6 +61,7 @@ export function AvatarSvgPreview({
       >
         {behind.map(layer)}
         <div
+          {...AVATAR_HEAD_SLOT}
           className="absolute inset-0"
           style={{
             transform: `translateY(${headOffsetY}%)`,

--- a/turbo/apps/platform/src/views/okou-page/avatar-svg-utils.ts
+++ b/turbo/apps/platform/src/views/okou-page/avatar-svg-utils.ts
@@ -155,12 +155,12 @@ function composerContentBounds(
     // framing rule has to see that overhang to fit and center the artwork
     // rather than let the box crop it.
     top: hairTop + headOffsetY,
+    // No offset here. Without the collar there is nothing for a chin to meet,
+    // so the head is never moved and this bound is only ever asked for at the
+    // drawn position.
     bottom: neckSweater
       ? 380
-      : Math.min(
-          380,
-          Math.max(AVATAR_FACE_CHIN_Y[config.face], hairBottom) + headOffsetY,
-        ),
+      : Math.min(380, Math.max(AVATAR_FACE_CHIN_Y[config.face], hairBottom)),
   };
 }
 
@@ -204,6 +204,14 @@ interface AvatarSvgComposition {
  * expose it so they cannot drift apart.
  */
 export const AVATAR_ARTWORK_SLOT = { "data-avatar-artwork": "" } as const;
+
+/**
+ * The element carrying the chin-baseline placement, inside the artwork slot.
+ * Same reason as `AVATAR_ARTWORK_SLOT`: the placement is a transform with no
+ * page-observable result under jsdom, and a test should not have to know which
+ * element of the layer stack holds it.
+ */
+export const AVATAR_HEAD_SLOT = { "data-avatar-head": "" } as const;
 
 /**
  * The artwork transform for a composition, or null when it is the identity.

--- a/turbo/apps/platform/src/views/okou-page/avatar-svg-utils.ts
+++ b/turbo/apps/platform/src/views/okou-page/avatar-svg-utils.ts
@@ -84,18 +84,20 @@ const AVATAR_FACE_CHIN_Y: Readonly<Record<AvatarComposerFaceShape, number>> = {
   oval: 334,
 };
 
-const AVATAR_FACE_TOP_Y = 116;
-
 /**
  * The chin of the Okou brand avatar rescaled onto the 380px canvas. The neck
  * and sweater are one shared pair of shapes, so they only fit in one place;
- * head layers are scaled about the top of the face until every chin reaches
- * this line and the same collar sits under all of them.
+ * head layers are moved down or up until every chin reaches this line and the
+ * same collar sits under all of them.
+ *
+ * Moved rather than scaled. The face assets are normalized on width — every one
+ * of them spans the same 270px — so scaling a head to reach this line also made
+ * it up to 1.24x wider or narrower than its neighbours, while the neck and the
+ * collar under it never change size. That is what made one avatar's body look
+ * too big for its head and the next one's too small. A translation reaches the
+ * same line and leaves the drawn width alone.
  */
 const AVATAR_CHIN_BASELINE_Y = 327.6;
-
-/** The face pivot (190, 116) of the 380px canvas, as a CSS transform origin. */
-export const AVATAR_HEAD_TRANSFORM_ORIGIN = "50% 30.5263%";
 
 /**
  * Visible hair tops, including strokes, on the 380px composer canvas. Square
@@ -134,7 +136,7 @@ interface AvatarContentBounds {
 
 function composerContentBounds(
   config: AvatarSvgConfig,
-  headScale: number,
+  headOffsetY: number,
   neckSweater: boolean,
 ): AvatarContentBounds {
   const hairTop =
@@ -148,13 +150,17 @@ function composerContentBounds(
         ? 316
         : AVATAR_FACE_CHIN_Y[config.face];
   return {
-    top: Math.max(
-      0,
-      AVATAR_FACE_TOP_Y + (hairTop - AVATAR_FACE_TOP_Y) * headScale,
-    ),
+    // Not clamped to the canvas. A face whose chin sits below the baseline
+    // moves up, and tall hair then reaches past the top of its own canvas; the
+    // framing rule has to see that overhang to fit and center the artwork
+    // rather than let the box crop it.
+    top: hairTop + headOffsetY,
     bottom: neckSweater
       ? 380
-      : Math.min(380, Math.max(AVATAR_FACE_CHIN_Y[config.face], hairBottom)),
+      : Math.min(
+          380,
+          Math.max(AVATAR_FACE_CHIN_Y[config.face], hairBottom) + headOffsetY,
+        ),
   };
 }
 
@@ -177,13 +183,14 @@ function contentScale({ top, bottom }: AvatarContentBounds): number {
 }
 
 interface AvatarSvgComposition {
-  /** Drawn behind the head, and never scaled with it. */
+  /** Drawn behind the head, and never moved with it. */
   readonly behind: readonly string[];
-  /** Head layers, scaled about `AVATAR_HEAD_TRANSFORM_ORIGIN`. */
+  /** Head layers, moved together so the chin meets the collar. */
   readonly head: readonly string[];
-  /** Drawn in front of the head, and never scaled with it. */
+  /** Drawn in front of the head, and never moved with it. */
   readonly front: readonly string[];
-  readonly headScale: number;
+  /** Percentage translation that lands the chin on the shared baseline. */
+  readonly headOffsetY: number;
   /** Percentage translation that centers the visible artwork vertically. */
   readonly contentOffsetY: number;
   /** Scale applied to the whole artwork, about the center of its box. */
@@ -221,9 +228,9 @@ export function avatarSvgContentTransform(placement: {
 
 /**
  * `neckSweater` is the `avatarNeckSweater` switch. With it off the result is
- * byte-for-byte the four head layers at their original scale, because the neck
- * and the chin baseline are one change: a scaled head with no collar under it
- * is just a smaller or larger avatar than the one already saved.
+ * byte-for-byte the four head layers where they were drawn, because the neck
+ * and the chin baseline are one change: a moved head with no collar under it is
+ * just a misplaced version of the avatar already saved.
  *
  * `framing` is the `avatarFraming` switch. With it off `contentScale` stays at
  * the scale each family already shipped with, so only the callers that ask for
@@ -249,7 +256,7 @@ export function avatarSvgComposition(
         ),
       ],
       front: [],
-      headScale: 1,
+      headOffsetY: 0,
       contentOffsetY: 0,
       // Legacy heads are drawn without a neck, and this is the scale that has
       // always sized them against the rest. It is the framing rule for that
@@ -269,25 +276,23 @@ export function avatarSvgComposition(
     ),
   ];
   if (!neckSweater) {
-    const bounds = composerContentBounds(config, 1, false);
+    const bounds = composerContentBounds(config, 0, false);
     return {
       behind: [],
       head,
       front: [],
-      headScale: 1,
+      headOffsetY: 0,
       contentOffsetY: contentOffsetY(bounds),
       contentScale: framing ? contentScale(bounds) : 1,
     };
   }
-  const headScale =
-    (AVATAR_CHIN_BASELINE_Y - AVATAR_FACE_TOP_Y) /
-    (AVATAR_FACE_CHIN_Y[config.face] - AVATAR_FACE_TOP_Y);
-  const bounds = composerContentBounds(config, headScale, true);
+  const headOffsetY = AVATAR_CHIN_BASELINE_Y - AVATAR_FACE_CHIN_Y[config.face];
+  const bounds = composerContentBounds(config, headOffsetY, true);
   return {
     behind: [avatarComposerAssetUrl(`neck/${config.skin}.svg`)],
     head,
     front: [avatarComposerAssetUrl(`sweater/${config.sweater}.svg`)],
-    headScale,
+    headOffsetY: (headOffsetY / 380) * 100,
     contentOffsetY: contentOffsetY(bounds),
     contentScale: framing ? contentScale(bounds) : 1,
   };


### PR DESCRIPTION
## The bug

The neck and the sweater are one fixed pair of shapes shared by every avatar. The head is not.

To bring each chin down to that shared collar, `avatarSvgComposition` scaled the head layers about the top of the face — and scaling changes the head's **width** as well as its height:

| Face | `headScale` | Rendered head width |
| --- | --- | --- |
| `tall` | 0.893 | 63.7% of the box |
| `square` / `oval` | 0.971 | 69.2% |
| `round-angled-ears` | 1.048 | 74.7% |
| `round` | 1.069 | 76.2% |
| `wide` | 1.108 | 79.0% |

A **1.24× spread**, while the neck (49.9px) and the collar (94.9px) on the same 380px canvas never change size. So the body reads as too big for the head on a `tall` face and too small on a `wide` one — which is what shows up as "some necks look big, some look small".

## The fix

The face assets are already normalized on width — every one of them spans the same 270px, which is what the composer's own comment means by "normalized on width rather than height". Scaling was the wrong operator for a goal that is only ever *put this chin on that line*.

Translating reaches the same line, leaves all six faces at one width (71.3% of the box), and keeps the neck and collar in proportion on every one of them.

`headScale` is replaced by `headOffsetY`, and `AVATAR_HEAD_TRANSFORM_ORIGIN` goes with it — a translation needs no pivot.

## Consequence handled

Artwork bounds are no longer clamped to the canvas. A face whose chin sits below the baseline now moves **up**, and tall hair can reach past the top of its own canvas — `high-bun` on `square` overhangs by 3.4px, `topknot-locks` on `tall` by 8.4px. The DES-45 framing rule has to see that overhang to fit and center the artwork; with the clamp in place the box would simply crop the bun.

This slightly widens the input spread the framing rule sees for the extreme pair (1.42× → 1.53×), and since that rule corrects half the difference in log space the framed spread moves with it (1.19× → 1.24×). That is the rule behaving as specified, not a regression.

## Rollout

**Not gated.** This fixes `avatarNeckSweater`, which is already released, and the repository's feature-switch guide does not require a switch for a bug fix to an existing feature. Carrying both placements would mean two head transforms and two sets of artwork bounds for a state nobody wants to keep. Say the word if you would rather it ride behind `avatarFraming` until that switch flips.

## Verification

- New case in `agents-page-avatar-framing.test.tsx`: neither head carries a scale, both carry a translation, and two different chins move by different amounts to reach the same collar.
- The existing framing case is updated for the new artwork bounds and now asserts the rule's actual invariant — the framed spread is the square root of the drawn spread — instead of a fixed threshold that moved with the input.
- `agents-page`, `settings-tab` (avatar maker), `chat-composer-mentions`, `user-message-document` suites pass.
- `format`, `lint`, `check-types`, `knip`, `lint:style` clean.
- Full `@okouai/app` suite left to CI.

Side-by-side of all six faces, bare and with hair, at card size and 4×: https://avatar-neck-proportion.okou.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
