### PR TITLE
fix: preserve google ads first-touch attribution

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -1944,6 +1944,80 @@ describe("POST /api/billing/checkout", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("keeps a stored click separate from a later campaign during checkout", async () => {
+    const fixture = await trackedSeed();
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    context.mocks.clerk.users.getUserList.mockResolvedValue({
+      data: [
+        {
+          id: fixture.userId,
+          privateMetadata: {
+            signup_attribution: {
+              source_type: "paid",
+              gclid: "first-click",
+              gclid_present: "true",
+              utm_source: "google",
+              recorded_at: "2026-09-01T00:00:00.000Z",
+            },
+          },
+        },
+      ],
+    });
+    context.mocks.stripe.customers.create.mockResolvedValue({
+      id: `cus_${randomUUID().slice(0, 8)}`,
+    });
+    context.mocks.stripe.checkout.sessions.create.mockResolvedValue({
+      url: "https://checkout.stripe.com/session/first-touch",
+    });
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
+      billingCheckoutContract,
+    );
+    await accept(
+      client.create({
+        body: {
+          tier: "pro",
+          successUrl: `${APP_ORIGIN}/billing?billing=success`,
+          cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
+          adAttribution: {
+            gclid: "later-click",
+            vm0_campaign_id: "24220469665",
+            vm0_ad_group_id: "123456",
+            utm_campaign: "later-campaign",
+            ga_client_id: "123.456",
+          },
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    const expectedMetadata = {
+      orgId: fixture.orgId,
+      tier: "pro",
+      priceId: TEST_PRICE_PRO,
+      source_type: "paid",
+      gclid: "first-click",
+      gclid_present: "true",
+      utm_source: "google",
+      ga_client_id: "123.456",
+    };
+    expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expectedMetadata,
+        subscription_data: expect.objectContaining({
+          metadata: expectedMetadata,
+        }),
+      }),
+    );
+    await expect(
+      readOrgAcquisitionAttributionFixture(fixture.orgId),
+    ).resolves.toMatchObject({
+      acquisitionGclid: "first-click",
+      acquisitionCampaignId: null,
+      acquisitionAdGroupId: null,
+      acquisitionCampaign: null,
+    });
+  });
+
   it("attaches ad attribution to Stripe checkout and subscription metadata", async () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");

--- a/turbo/apps/api/src/signals/services/acquisition-attribution.service.ts
+++ b/turbo/apps/api/src/signals/services/acquisition-attribution.service.ts
@@ -73,10 +73,15 @@ export function mergeFirstTouchAttribution(
     return undefined;
   }
 
-  // Clerk contains the first-touch record. It wins over a later browser
-  // payload, while the payload can fill fields that were not available when
-  // the user record was created, such as a newly added client identifier.
-  return { ...provided, ...stored };
+  if (!stored) {
+    return provided;
+  }
+
+  // The click and its campaign belong to one touch. Filling missing campaign
+  // fields from a later visit can send the original click to another Ads account.
+  // A GA client identifier is independent of that advertising attribution.
+  const gaClientId = stored.ga_client_id ?? provided?.ga_client_id;
+  return { ...stored, ...(gaClientId ? { ga_client_id: gaClientId } : {}) };
 }
 
 export const persistOrgAcquisitionAttribution$ = command(

--- a/turbo/apps/platform/src/lib/google-ads-attribution.ts
+++ b/turbo/apps/platform/src/lib/google-ads-attribution.ts
@@ -1,0 +1,27 @@
+// Keep the stored/API names stable across the vm0 -> okou URL rename.
+// Conflicting values remain comma-separated evidence, never a silently chosen ID.
+export function normalizeGoogleAdsAttributionParams(
+  input: URLSearchParams,
+): URLSearchParams {
+  const params = new URLSearchParams(input);
+  for (const [canonical, alias] of [
+    ["vm0_campaign_id", "okou_campaign_id"],
+    ["vm0_ad_group_id", "okou_ad_group_id"],
+  ] as const) {
+    const values = [
+      ...new Set(
+        [...params.getAll(canonical), ...params.getAll(alias)]
+          .map((value) => {
+            return value.trim();
+          })
+          .filter(Boolean),
+      ),
+    ];
+    params.delete(canonical);
+    params.delete(alias);
+    if (values.length > 0) {
+      params.set(canonical, values.join(","));
+    }
+  }
+  return params;
+}

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import { normalizeGoogleAdsAttributionParams } from "../lib/google-ads-attribution.ts";
 import { isDesktopAuthFlow } from "../lib/desktop-auth-flow.ts";
 import {
   derivePlatformServiceOrigin,
@@ -167,8 +168,9 @@ export function getAllowedAuthRedirectOriginsForCurrentPage(): AllowedAuthRedire
 }
 
 function hasAdTraffic(params: URLSearchParams): boolean {
+  const normalized = normalizeGoogleAdsAttributionParams(params);
   return AD_TRAFFIC_MARKERS.some((param) => {
-    return params.has(param);
+    return normalized.has(param);
   });
 }
 
@@ -176,7 +178,9 @@ function appendHomepageAttributionParams(
   url: URLSearchParams,
   landingSearch: string,
 ): void {
-  const landingParams = new URLSearchParams(landingSearch);
+  const landingParams = normalizeGoogleAdsAttributionParams(
+    new URLSearchParams(landingSearch),
+  );
   url.set(ATTRIBUTION_SOURCE_PARAM, HOMEPAGE_ATTRIBUTION_VALUE);
   for (const param of AD_ATTRIBUTION_PARAMS) {
     for (const value of landingParams.getAll(param)) {
@@ -195,7 +199,9 @@ function setCurrentLandingContext(params: URLSearchParams): void {
 }
 
 function buildOnboardingEntryUrl(paramsInit?: URLSearchParams): string {
-  const params = new URLSearchParams(paramsInit);
+  const params = normalizeGoogleAdsAttributionParams(
+    new URLSearchParams(paramsInit),
+  );
   setCurrentLandingContext(params);
   const url = new URL(ONBOARDING_PATH, resolveAppOrigin());
   url.search = params.toString();

--- a/turbo/apps/platform/src/signals/bootstrap/ad-attribution.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/ad-attribution.ts
@@ -5,6 +5,7 @@ import {
   type SourceType,
 } from "@okouai/api-contracts/contracts/acquisition-attribution";
 import { command } from "ccstate";
+import { normalizeGoogleAdsAttributionParams } from "../../lib/google-ads-attribution.ts";
 import { registerPostHogAttribution } from "../../lib/posthog.ts";
 import { sessionStorageSignals } from "../external/session-storage.ts";
 
@@ -66,9 +67,10 @@ function collectAttributionParams(
   searchParams: URLSearchParams,
 ): URLSearchParams {
   const attributionParams = new URLSearchParams();
+  const normalized = normalizeGoogleAdsAttributionParams(searchParams);
 
   for (const param of AD_ATTRIBUTION_PARAMS) {
-    for (const value of searchParams.getAll(param)) {
+    for (const value of normalized.getAll(param)) {
       attributionParams.append(param, value);
     }
   }
@@ -184,11 +186,13 @@ export const applyStoredAdAttribution$ = command(({ get }, url: URL): void => {
     return;
   }
 
-  const attributionParams = new URLSearchParams(storedAttribution);
+  const attributionParams = collectAttributionParams(
+    new URLSearchParams(storedAttribution),
+  );
+  url.searchParams.delete("okou_campaign_id");
+  url.searchParams.delete("okou_ad_group_id");
   for (const param of AD_ATTRIBUTION_PARAMS) {
-    if (url.searchParams.has(param)) {
-      continue;
-    }
+    url.searchParams.delete(param);
 
     for (const value of attributionParams.getAll(param)) {
       url.searchParams.append(param, value);
@@ -200,7 +204,9 @@ function adAttributionMetadataFromStoredValue(
   storedAttribution: string | null,
   cookieString: string,
 ): AdAttributionMetadata | undefined {
-  const attributionParams = new URLSearchParams(storedAttribution ?? "");
+  const attributionParams = collectAttributionParams(
+    new URLSearchParams(storedAttribution ?? ""),
+  );
   const metadata: AdAttributionMetadata = {};
 
   const sourceType = attributionParams.get("source_type");

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-attribution-branding.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-attribution-branding.test.tsx
@@ -161,7 +161,7 @@ async function completePasswordSignIn(): Promise<void> {
 
 test("Campaign attribution survives a switch from sign-in to sign-up", async () => {
   const path =
-    "/sign-in?gclid=click-123&utm_campaign=summer#/factor-one?step=code";
+    "/sign-in?gclid=click-123&utm_campaign=summer&okou_campaign_id=24220469665&okou_ad_group_id=123456#/factor-one?step=code";
   mockSignInResource({ status: "needs_identifier" });
   mockedClerk.clientSignInCreate.mockImplementation(() => {
     return moveSignInToAsync({
@@ -192,6 +192,8 @@ test("Campaign attribution survives a switch from sign-in to sign-up", async () 
   expect(completion.pathname).toBe("/onboarding");
   expect(completion.searchParams.get("gclid")).toBe("click-123");
   expect(completion.searchParams.get("utm_campaign")).toBe("summer");
+  expect(completion.searchParams.get("vm0_campaign_id")).toBe("24220469665");
+  expect(completion.searchParams.get("vm0_ad_group_id")).toBe("123456");
 
   click(signUp);
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/signup-attribution.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/signup-attribution.test.tsx
@@ -310,3 +310,43 @@ test("A temporary attribution failure does not block Platform", async () => {
     screen.findByRole("heading", { name: /^Where .+ works$/u }),
   ).resolves.toBeInTheDocument();
 });
+
+test.each(["url", "cookie"])(
+  "Okou campaign IDs from the %s reach signup in the stable API fields",
+  async (source) => {
+    mockNow(NOW, context.signal);
+    let recordedAttribution: AdAttributionMetadata | undefined;
+    context.mocks.api(
+      acquisitionAttributionContract.recordSignup,
+      ({ body, respond }) => {
+        recordedAttribution = body.attribution;
+        return respond(200, { recorded: true });
+      },
+    );
+    const attribution =
+      "gclid=original-click&okou_campaign_id=24220469665&okou_ad_group_id=123456";
+    if (source === "cookie") {
+      context.mocks.browser.cookie(
+        `vm0_attribution=${encodeURIComponent(attribution)}`,
+      );
+    }
+    await setupPage({
+      context,
+      path: source === "url" ? `/agents?${attribution}` : "/agents",
+      auth: {
+        user: {
+          id: "test-user-123",
+          fullName: "Test User",
+          email: "test@example.com",
+          createdAt: new Date(NOW),
+        },
+      },
+    });
+    await waitForAgentsPage();
+    expect(recordedAttribution).toMatchObject({
+      gclid: "original-click",
+      vm0_campaign_id: "24220469665",
+      vm0_ad_group_id: "123456",
+    });
+  },
+);


### PR DESCRIPTION
Google Ads links now use `okou_campaign_id` and `okou_ad_group_id`, but app attribution only collected the `vm0_*` spellings. Checkout also filled missing fields in the stored first touch from a later visit, which could pair an original click with another campaign.

Normalize both URL spellings into the existing API fields for direct links, shared cookies and auth redirects. Forward the complete stored attribution and preserve it through checkout; only the independent GA client ID can be filled later. Conflicting campaign IDs remain unresolved evidence instead of silently selecting one.

The API field names and database schema stay unchanged, so old/new frontend and API combinations remain compatible. Companion marketing PR: https://github.com/vm0-ai/vm0-marketing/pull/671. Either deployment order is supported.

## Verification

- Signup and auth attribution suites: 13 tests passed.
- Two focused billing checkout integration tests passed against an isolated local PostgreSQL database, including persisted attribution and Stripe metadata.
- App/API type checks and lint, affected-workspace Knip, formatting and style checks passed.
- Full local Vitest and local app dev servers were not run. PR CI owns the full suites.
