### PR TITLE
perf(db): scale production kms verification

### DIFF
--- a/.github/workflows/kms-production-preflight.yml
+++ b/.github/workflows/kms-production-preflight.yml
@@ -40,6 +40,48 @@ jobs:
           corepack enable pnpm
           pnpm install --frozen-lockfile --ignore-scripts --filter @okouai/db...
           command -v aws
+      - name: Create synthetic fixtures using the current production credentials
+        working-directory: turbo/packages/db
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ""
+          AWS_REGION: us-west-2
+          SECRETS_KMS_KEY_ID: ${{ secrets.SECRETS_KMS_KEY_ID }}
+        run: |
+          mkdir -m 700 "$RUNNER_TEMP/kms-canary"
+          aws sts get-caller-identity > "$RUNNER_TEMP/kms-canary/identity.json"
+          pnpm exec tsx scripts/migrations/013-kms-account-rotation/runtime-canary.ts prepare-old "$RUNNER_TEMP/kms-canary"
+      - name: Load the existing target production credentials
+        id: target
+        uses: dopplerhq/secrets-fetch-action@451892f16195f9ac360e1a5bcbf0b5fd0e957534 # v2.0.0
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: vm0
+          doppler-config: prd_kms_migration_32264
+      - name: Verify target production runtime reads and writes
+        working-directory: turbo/packages/db
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.target.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.target.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ""
+          AWS_REGION: us-west-2
+          SECRETS_KMS_KEY_ID: ${{ steps.target.outputs.SECRETS_KMS_KEY_ID }}
+        run: |
+          aws sts get-caller-identity > "$RUNNER_TEMP/kms-canary/identity.json"
+          pnpm exec tsx scripts/migrations/013-kms-account-rotation/runtime-canary.ts verify-new "$RUNNER_TEMP/kms-canary"
+      - name: Verify rollback using the current production credentials
+        working-directory: turbo/packages/db
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ""
+          AWS_REGION: us-west-2
+          SECRETS_KMS_KEY_ID: ${{ secrets.SECRETS_KMS_KEY_ID }}
+        run: |
+          aws sts get-caller-identity > "$RUNNER_TEMP/kms-canary/identity.json"
+          pnpm exec tsx scripts/migrations/013-kms-account-rotation/runtime-canary.ts verify-rollback "$RUNNER_TEMP/kms-canary"
       - name: Resolve the production database
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
@@ -92,52 +134,10 @@ jobs:
           args=()
           if [ -n "$CURSOR" ]; then args+=(--cursor "$CURSOR"); fi
           pnpm exec tsx scripts/migrations/013-kms-account-rotation/backfill.ts \
-            --verify --batch-size 100 --max-rows 100000 \
+            --verify --verify-concurrency 8 --batch-size 100 --max-rows 1000000 \
             --source-key arn:aws:kms:us-west-2:072707626411:key/a1b3922b-fab1-4ed3-aa9e-40f86f92a7a8 \
             --target-key arn:aws:kms:us-west-2:251964670836:key/e68917e2-5541-4597-b6ef-7e9eb5670947 \
             --report-path "$RUNNER_TEMP/kms-production-inventory.json" "${args[@]}"
-      - name: Create synthetic fixtures using the current production credentials
-        working-directory: turbo/packages/db
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ""
-          AWS_REGION: us-west-2
-          SECRETS_KMS_KEY_ID: ${{ secrets.SECRETS_KMS_KEY_ID }}
-        run: |
-          mkdir -m 700 "$RUNNER_TEMP/kms-canary"
-          aws sts get-caller-identity > "$RUNNER_TEMP/kms-canary/identity.json"
-          pnpm exec tsx scripts/migrations/013-kms-account-rotation/runtime-canary.ts prepare-old "$RUNNER_TEMP/kms-canary"
-      - name: Load the existing target production credentials
-        id: target
-        uses: dopplerhq/secrets-fetch-action@451892f16195f9ac360e1a5bcbf0b5fd0e957534 # v2.0.0
-        with:
-          auth-method: oidc
-          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
-          doppler-project: vm0
-          doppler-config: prd_kms_migration_32264
-      - name: Verify target production runtime reads and writes
-        working-directory: turbo/packages/db
-        env:
-          AWS_ACCESS_KEY_ID: ${{ steps.target.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.target.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ""
-          AWS_REGION: us-west-2
-          SECRETS_KMS_KEY_ID: ${{ steps.target.outputs.SECRETS_KMS_KEY_ID }}
-        run: |
-          aws sts get-caller-identity > "$RUNNER_TEMP/kms-canary/identity.json"
-          pnpm exec tsx scripts/migrations/013-kms-account-rotation/runtime-canary.ts verify-new "$RUNNER_TEMP/kms-canary"
-      - name: Verify rollback using the current production credentials
-        working-directory: turbo/packages/db
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ""
-          AWS_REGION: us-west-2
-          SECRETS_KMS_KEY_ID: ${{ secrets.SECRETS_KMS_KEY_ID }}
-        run: |
-          aws sts get-caller-identity > "$RUNNER_TEMP/kms-canary/identity.json"
-          pnpm exec tsx scripts/migrations/013-kms-account-rotation/runtime-canary.ts verify-rollback "$RUNNER_TEMP/kms-canary"
       - name: Retain sanitized inventory
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/turbo/packages/db/scripts/migrations/013-kms-account-rotation/README.md
+++ b/turbo/packages/db/scripts/migrations/013-kms-account-rotation/README.md
@@ -17,21 +17,22 @@ After this PR merges, manually run **KMS Production Preflight** on `main`.
 It uses the existing GitHub `production` environment's protected-branch and
 required-reviewer gates. PR branches cannot access that job.
 
-The job resolves the exact `production` branch in Neon project
+The job first uses the actual old production IAM user, the existing target
+credentials from Doppler `vm0/prd_kms_migration_32264`, and the old user again to
+verify synthetic envelope/legacy reads, target writes, rollback reads, and denial
+of old-key writes, test-key access, and the wrong encryption context. STS must
+identify the exact `vm0-kms-prod` user in each expected account. Only synthetic
+ciphertext fixtures are written locally and they are removed at the end.
+Credential verification finishes before the potentially long database scan.
+This canary checks production IAM cryptography; production application business
+flows still need verification after deployment.
+
+It then resolves the exact `production` branch in Neon project
 `hidden-lab-39609750`, verifies stored ciphertext with PostgreSQL read-only mode,
 and uploads a sanitized inventory with seven-day retention. KMS plaintext is
 used only in process memory for authentication checks and nested queue parsing;
 it is never logged, written to a report, or uploaded. JavaScript strings cannot
 be explicitly zeroed; plaintext byte buffers are cleared after use.
-
-It then uses the actual old production IAM user, the existing target credentials
-from Doppler `vm0/prd_kms_migration_32264`, and the old user again to verify
-synthetic envelope/legacy reads, target writes, rollback reads, and denial of
-old-key writes, test-key access, and the wrong encryption context. STS must
-identify the exact `vm0-kms-prod` user in each expected account. Only synthetic
-ciphertext fixtures are written locally and they are removed at the end.
-This canary checks production IAM cryptography; production application business
-flows still need verification after deployment.
 
 The workflow has no deployment, secret-update, or database-mutation step. It
 does not grant runtime users `ReEncrypt`. A migrate command must run separately
@@ -57,7 +58,7 @@ pnpm exec tsx scripts/migrations/013-kms-account-rotation/backfill.ts \
 # Read-only verification: authenticate every envelope and inspect inner queue ciphertext.
 pnpm exec tsx scripts/migrations/013-kms-account-rotation/backfill.ts \
   --source-key "$SOURCE_KMS_ARN" --target-key "$TARGET_KMS_ARN" \
-  --verify --max-rows 100000 --report-path ./verified.json
+  --verify --verify-concurrency 8 --max-rows 1000000 --report-path ./verified.json
 
 # Explicit mutation, using a complete, fresh verification report (at most 24 hours old).
 pnpm exec tsx scripts/migrations/013-kms-account-rotation/backfill.ts \
@@ -66,8 +67,14 @@ pnpm exec tsx scripts/migrations/013-kms-account-rotation/backfill.ts \
   --report-path ./migration.json
 ```
 
-Default batch size is 100, maximum 500; default run limit is 5,000 field values,
-maximum 100,000. A report's `cursor` resumes after its last completed value:
+Default batch size is 100, maximum 500; default run limit is 5,000 field values.
+Verification allows up to 1,000,000 values; inventory and migration retain the
+100,000-value limit. `--verify-concurrency` runs 1–16 rows concurrently (default
+1); the production preflight uses 8. This option is rejected outside verification
+mode, and migration writes remain serial. Each bounded group finishes before its
+results are recorded in primary-key order. On failure, the checkpoint advances
+only through the successful prefix; later completed rows are verified again on
+resume. A report's `cursor` resumes after its last completed value:
 pass `--cursor '<cursor>'` with the same database, mode, keys, and manifest.
 Migration resumes also require the verified preflight. Reports checkpoint each
 page and before reporting a handled failure. An abrupt process kill can require

--- a/turbo/packages/db/scripts/migrations/013-kms-account-rotation/backfill.ts
+++ b/turbo/packages/db/scripts/migrations/013-kms-account-rotation/backfill.ts
@@ -135,6 +135,16 @@ function isVerifiedOnTarget(
   );
 }
 
+function verificationConcurrency(
+  mode: Mode,
+  value: string | undefined,
+): number {
+  if (value !== undefined && mode !== "verify") {
+    throw new Error("verify_concurrency_requires_verify_mode");
+  }
+  return integer(value, 1, 16);
+}
+
 async function main(): Promise<void> {
   const { values } = parseArgs({
     options: {
@@ -142,6 +152,7 @@ async function main(): Promise<void> {
       "target-key": { type: "string" },
       "batch-size": { type: "string" },
       "max-rows": { type: "string" },
+      "verify-concurrency": { type: "string" },
       "report-path": { type: "string" },
       cursor: { type: "string" },
       verify: { type: "boolean", default: false },
@@ -172,7 +183,15 @@ async function main(): Promise<void> {
       ? "verify"
       : "inventory";
   const batchSize = integer(values["batch-size"], 100, 500);
-  const maxRows = integer(values["max-rows"], 5_000, 100_000);
+  const maxRows = integer(
+    values["max-rows"],
+    5_000,
+    mode === "verify" ? 1_000_000 : 100_000,
+  );
+  const verifyConcurrency = verificationConcurrency(
+    mode,
+    values["verify-concurrency"],
+  );
   const reportPath = string(values["report-path"]);
   function initialCursor(): { fieldIndex: number; afterId: string | null } {
     let fieldIndex = 0;
@@ -415,8 +434,7 @@ async function main(): Promise<void> {
     async function processRow(
       raw: unknown,
       field: Field,
-      fieldCounts: Counts,
-    ): Promise<string> {
+    ): Promise<{ id: string; outcome: Counts }> {
       const row = object(raw);
       const id = string(row.id);
       const original = string(row.value);
@@ -475,11 +493,43 @@ async function main(): Promise<void> {
       if (mode === "migrate" && outcome.invalid) {
         throw new Error("invalid_ciphertext_blocks_migration");
       }
-      for (const name of Object.keys(outcome) as (keyof Counts)[]) {
-        fieldCounts[name] += outcome[name];
-        report.totals[name] += outcome[name];
+      return { id, outcome };
+    }
+
+    async function processRows(
+      rows: unknown[],
+      field: Field,
+      fieldCounts: Counts,
+    ): Promise<void> {
+      function record(result: { id: string; outcome: Counts }): void {
+        for (const name of Object.keys(result.outcome) as (keyof Counts)[]) {
+          fieldCounts[name] += result.outcome[name];
+          report.totals[name] += result.outcome[name];
+        }
+        afterId = result.id;
       }
-      return id;
+      if (mode === "verify" && verifyConcurrency > 1) {
+        for (let start = 0; start < rows.length; start += verifyConcurrency) {
+          // Drain every request before advancing the cursor or handling failure.
+          // Commit only the successful prefix in primary-key order, so a later
+          // response can never move a checkpoint past an unverified row.
+          const results = await Promise.allSettled(
+            rows.slice(start, start + verifyConcurrency).map((raw) => {
+              return processRow(raw, field);
+            }),
+          );
+          for (const result of results) {
+            if (result.status === "rejected") {
+              throw new Error("verification_failed_at_cursor");
+            }
+            record(result.value);
+          }
+        }
+      } else {
+        for (const raw of rows) {
+          record(await processRow(raw, field));
+        }
+      }
     }
 
     while (fieldIndex < fields.length && report.totals.rows < maxRows) {
@@ -501,9 +551,7 @@ async function main(): Promise<void> {
           afterId === null ? [size] : [size, afterId],
         )
       ).rows;
-      for (const raw of rows) {
-        afterId = await processRow(raw, field, fieldCounts);
-      }
+      await processRows(rows, field, fieldCounts);
       if (rows.length < size) {
         fieldIndex++;
         afterId = null;

--- a/turbo/packages/db/scripts/migrations/013-kms-account-rotation/test.ts
+++ b/turbo/packages/db/scripts/migrations/013-kms-account-rotation/test.ts
@@ -47,6 +47,7 @@ const directory = await mkdtemp(join(tmpdir(), "kms-rotation-test-"));
 const blobs = new Map<string, { key: string; plaintext: Buffer }>();
 let kmsRequests = 0;
 let beforeRewrap: (() => Promise<void>) | undefined;
+let beforeDecrypt: ((ciphertext: string) => Promise<void>) | undefined;
 let failRewrap = false;
 function wrap(plaintext: Buffer, key: string): string {
   const blob = randomBytes(64).toString("base64");
@@ -89,6 +90,7 @@ const server = createServer((request, response) => {
         operation === "ReEncrypt" ? body.SourceKeyId : body.KeyId,
       );
       if (operation === "Decrypt") {
+        await beforeDecrypt?.(string(body.CiphertextBlob));
         result = {
           KeyId: stored.key,
           Plaintext: stored.plaintext.toString("base64"),
@@ -168,6 +170,7 @@ async function cli(
   let stderr = "";
   try {
     const output = await execute("pnpm", command, {
+      timeout: 30_000,
       env: {
         ...process.env,
         DATABASE_URL: input.toString(),
@@ -223,6 +226,125 @@ try {
   for (const [table, columns] of tables) {
     await db.query(`CREATE TABLE "${table}" (${columns.join(", ")})`);
   }
+  const concurrentFixtures: { id: string; ciphertext: string }[] = [];
+  for (let index = 0; index < 9; index++) {
+    const envelope = await encrypt(kms, Buffer.from(secret), source);
+    const id = `parallel-${index}`;
+    await db.query("INSERT INTO secrets VALUES ($1, $2)", [
+      id,
+      encode(envelope),
+    ]);
+    concurrentFixtures.push({
+      id,
+      ciphertext: string(envelope.kms.encryptedDataKey),
+    });
+  }
+  const beforeConcurrentVerification: unknown[] = (
+    await db.query("SELECT * FROM secrets ORDER BY id")
+  ).rows;
+  let activeDecrypts = 0;
+  let peakDecrypts = 0;
+  const waiting: (() => void)[] = [];
+  beforeDecrypt = async () => {
+    activeDecrypts++;
+    peakDecrypts = Math.max(peakDecrypts, activeDecrypts);
+    try {
+      await new Promise<void>((resolve) => {
+        waiting.push(resolve);
+        if (waiting.length === 3) {
+          for (const release of waiting.splice(0)) {
+            release();
+          }
+        }
+      });
+    } finally {
+      activeDecrypts--;
+    }
+  };
+  try {
+    const concurrent = await cli("concurrent-verify", [
+      "--verify",
+      "--verify-concurrency",
+      "3",
+      "--batch-size",
+      "9",
+      "--max-rows",
+      "100001",
+    ]);
+    assert.equal(concurrent.complete, true);
+    assert.equal(object(concurrent.totals).verified, 9);
+    assert.equal(object(concurrent.totals).updated, 0);
+    assert.equal(
+      peakDecrypts,
+      3,
+      "Decrypts must run concurrently within the cap",
+    );
+    assert.equal(activeDecrypts, 0, "The CLI must drain all requests");
+  } finally {
+    beforeDecrypt = undefined;
+    for (const release of waiting.splice(0)) {
+      release();
+    }
+  }
+  const firstFixture = concurrentFixtures[0];
+  const failedFixture = concurrentFixtures[1];
+  const laterFixture = concurrentFixtures[2];
+  assert.ok(firstFixture && failedFixture && laterFixture);
+  let releaseFirst: (() => void) | undefined;
+  const firstMayComplete = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  beforeDecrypt = async (ciphertext) => {
+    if (ciphertext === firstFixture.ciphertext) {
+      await firstMayComplete;
+    } else if (ciphertext === failedFixture.ciphertext) {
+      throw new Error("synthetic failure in the middle of a concurrent group");
+    } else if (ciphertext === laterFixture.ciphertext) {
+      assert.ok(releaseFirst);
+      releaseFirst();
+    }
+  };
+  let concurrentFailure: Record<string, unknown>;
+  try {
+    concurrentFailure = await cli(
+      "concurrent-failure",
+      ["--verify", "--verify-concurrency", "3", "--batch-size", "9"],
+      false,
+      true,
+    );
+  } finally {
+    beforeDecrypt = undefined;
+    assert.ok(releaseFirst);
+    releaseFirst();
+  }
+  assert.equal(concurrentFailure.complete, false);
+  assert.equal(object(concurrentFailure.totals).rows, 1);
+  assert.equal(object(concurrentFailure.totals).verified, 1);
+  const failedCursor = object(
+    JSON.parse(
+      Buffer.from(string(concurrentFailure.cursor), "base64url").toString(
+        "utf8",
+      ),
+    ),
+  );
+  assert.equal(failedCursor.id, firstFixture.id);
+  const concurrentResume = await cli("concurrent-resume", [
+    "--verify",
+    "--verify-concurrency",
+    "3",
+    "--cursor",
+    string(concurrentFailure.cursor),
+  ]);
+  assert.equal(concurrentResume.complete, true);
+  assert.equal(concurrentResume.resumed, true);
+  assert.equal(object(concurrentResume.totals).verified, 8);
+  assert.equal(object(concurrentResume.totals).updated, 0);
+  assert.deepEqual(
+    (await db.query("SELECT * FROM secrets ORDER BY id")).rows,
+    beforeConcurrentVerification,
+    "Concurrent verification and resume must preserve every stored ciphertext",
+  );
+  await db.query("DELETE FROM secrets");
   const original = encode(await encrypt(kms, Buffer.from(secret), source));
   const latest = encode(
     await encrypt(kms, Buffer.from(`${secret}-updated`), source),
@@ -420,7 +542,7 @@ try {
   assert.equal(object(invalid.totals).invalid, 1);
   assert.equal(invalid.databaseVerifiedOnTarget, false);
   process.stdout.write(
-    "KMS rotation CLI integration passed: read-only inventory, nested verification, bounded resume, concurrent writes, KMS failure recovery, rewrap preservation, reverse migration, and malformed ciphertext.\n",
+    "KMS rotation CLI integration passed: read-only inventory, concurrent verification and failure checkpoints, nested verification, bounded resume, concurrent writes, KMS failure recovery, rewrap preservation, reverse migration, and malformed ciphertext.\n",
   );
 } finally {
   kms.destroy();


### PR DESCRIPTION
The production KMS preflight hit its 90-minute job limit after verifying 60,723 ciphertext values serially. Its report was incomplete, and the actual production credential and rollback canaries were skipped. Run those canaries first, then verify database ciphertext with eight concurrent rows and a verification-only limit of 1,000,000 values.

The new `--verify-concurrency` option accepts 1–16 rows, defaults to one, and is rejected outside verification mode. Each group drains before recording results in primary-key order; failures checkpoint only the successful prefix so resume cannot skip an unverified row. Migration writes remain serial, and the existing read-only, preflight, compare-and-swap, and rollback requirements remain enforced.

Validation: the isolated PostgreSQL/HTTP KMS integration suite passed, including bounded concurrency, out-of-order failure and resume, unchanged stored ciphertext, and the existing migration and rollback cases. TypeScript, ESLint, both Oxlint modes, formatting, actionlint, shell syntax, and embedded Python syntax checks passed. All 100 PR checks completed without failures, including the three required gates. The original production report reconciles 60,723 verified values with zero writes and no malformed, unknown-key, or non-ARN values among the scanned subset; it is not a complete verification certificate. Full production verification requires a new run under the protected environment gate. This PR does not change production credentials or deployments.

Related to #32264. Existing production run: https://github.com/vm0-ai/vm0/actions/runs/34305687066
