### PR TITLE
test(app): avoid keyboard scroll restoration test timeouts

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-position-restoration.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-position-restoration.test.tsx
@@ -57,8 +57,9 @@ interface ChatScrollGeometry {
 function conversationEvents(
   prefix: string,
   label: string,
+  count = 6,
 ): MockChatEventInput[] {
-  return Array.from({ length: 6 }, (_, index) => {
+  return Array.from({ length: count }, (_, index) => {
     const item = index + 1;
     const runId = `${prefix}-run-${item.toString()}`;
     const userSecond = (item * 3 - 2).toString().padStart(2, "0");
@@ -434,12 +435,14 @@ async function expectAtLatestActivity(
 test("Restore the reading position during keyboard thread navigation", async () => {
   context.mocks.browser.userAgent(LINUX_CHROME_USER_AGENT);
   const user = userEvent.setup();
-  const currentEvents = conversationEvents("keyboard-current", "Current");
+  // Three exchanges keep the reading anchor between the top and tail. The
+  // neighboring threads only need content that proves navigation completed.
+  const currentEvents = conversationEvents("keyboard-current", "Current", 3);
   mockThreadStories(KEYBOARD_CURRENT_THREAD_ID, [
     {
       id: KEYBOARD_PREVIOUS_THREAD_ID,
       title: "Previous keyboard thread",
-      events: conversationEvents("keyboard-previous", "Previous"),
+      events: conversationEvents("keyboard-previous", "Previous", 1),
     },
     {
       id: KEYBOARD_CURRENT_THREAD_ID,
@@ -449,7 +452,7 @@ test("Restore the reading position during keyboard thread navigation", async () 
     {
       id: KEYBOARD_NEXT_THREAD_ID,
       title: "Next keyboard thread",
-      events: conversationEvents("keyboard-next", "Next"),
+      events: conversationEvents("keyboard-next", "Next", 1),
     },
   ]);
 
@@ -459,7 +462,7 @@ test("Restore the reading position during keyboard thread navigation", async () 
     path: `/chats/${KEYBOARD_CURRENT_THREAD_ID}`,
   });
 
-  const targetText = "Current message 3";
+  const targetText = "Current message 2";
   await waitForInteractiveThread(
     KEYBOARD_CURRENT_THREAD_ID,
     "Current keyboard thread",
@@ -480,7 +483,7 @@ test("Restore the reading position during keyboard thread navigation", async () 
   await waitForInteractiveThread(
     KEYBOARD_PREVIOUS_THREAD_ID,
     "Previous keyboard thread",
-    "Previous message 6",
+    "Previous message 1",
   );
 
   await user.click(threadSection(KEYBOARD_PREVIOUS_THREAD_ID));


### PR DESCRIPTION
The keyboard reading-position regression exceeded its 5-second budget in [test-app (3) on #32821](https://github.com/vm0-ai/vm0/actions/runs/34312039031/job/102340644107?pr=32821). The identical test file passed on adjacent main in [4.2 seconds](https://github.com/vm0-ai/vm0/actions/runs/34312811495/job/102343927249); local profiling shows page startup and thread switching dominate its runtime.

Size the fixtures for the behavior under test: three exchanges in the current thread and one in each neighbor, instead of six in every thread. Keep the reading anchor between the top and tail, both real keyboard navigation steps, focus and selected-thread checks, and exact 64-pixel position restoration. The other six tests retain their existing fixtures. This changes only test data, with the existing timeout and assertions preserved.

Validation:
- All 15 tests in `chat-navigation-position-restoration.test.tsx` and `chat-continuity-keyboard.test.tsx` passed with V8 coverage and one worker. The target took 3.019 seconds.
- A temporary alternating comparison exercised each fixture six times in one worker. Excluding the first warm-up pair, the five paired runs averaged 1,395 ms before and 1,116 ms after, a 20% reduction.
- Mutation check: temporarily discarding the saved position during navigation made the revised test fail on its restoration assertion (`-240` instead of `64`). The mutation and all profiling code were removed.
- Prettier, focused ESLint and Oxlint, style policy, all three App TypeScript configurations (`TSC_CHECKERS=2 pnpm -F @okouai/app check-types`), App-scoped Knip, and `git diff --check` passed.

The original wall-clock timeout was not reproduced locally; this fix reduces the measured rendering workload. The linked job contains no earlier rejection or position assertion failure from this test. Its later Ably warnings belong to other tests, and the coverage-upload warning follows the failed test step.
