### PR TITLE
refactor(ui): migrate settings choices to shared utilities

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -41,6 +41,17 @@ Token and variant changes are reviewed at their owning layer together with affec
 
 Large editable surfaces use `border-surface-focus` to emphasize their existing border on focus: neutral gray in light themes and muted amber in dark themes. Keep the border width constant across interaction states. A shadow-only focus overlay may fade through opacity, but must not duplicate the surface border or depend on a negative inset to align its edge. The chat composer uses the default `border` width for its surface and connector circles; intentional badge overlap remains independent of border geometry. `data-slot="chat-composer-card"` identifies the editable card for keyboard positioning and page tests.
 
+Standalone selectable controls use the shared `ChoiceButton` and its required
+`selected` prop. It retains native button/ref behavior and owns `aria-pressed`,
+the selected primary treatment, focus ring, and disabled appearance. The shared
+`control-surface` and `control-border` colors map to the runtime gray-50 and
+gray-400 ramps in both light and dark themes, including palette overrides.
+`bg-state-hover-overlay` layers the existing hover state over an opaque fill.
+The choice variant keeps this overlay's unconditional `:hover` behavior for
+touch compatibility; it preserves the existing media-aware text hover utility.
+Migrate consumers individually and retain the legacy definition until its last
+consumer is removed.
+
 ## Exception boundary
 
 Only two exception kinds exist:

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/chat-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/chat-section.tsx
@@ -2,7 +2,7 @@ import { useGet, useLastResolved, useLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import { Cpu, Globe, Keyboard, Loader2 } from "lucide-react";
-import { cn } from "@okouai/ui";
+import { ChoiceButton } from "@okouai/ui";
 import { Switch } from "@okouai/ui/components/ui/switch";
 import type { SendMode } from "@okouai/api-contracts/contracts/user-preferences";
 
@@ -163,27 +163,20 @@ export function SendModePreference() {
                   return $.settings.preferences.send.cmdEnter;
                 });
           return (
-            <button
+            <ChoiceButton
               key={value}
               type="button"
-              aria-pressed={isActive}
+              selected={isActive}
               disabled={saving !== null}
               onClick={() => {
                 handleChange(value);
               }}
-              className={cn(
-                "flex items-center gap-2 rounded-lg border border-[0.7px] px-3.5 py-2 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                isActive
-                  ? "border-primary/40 bg-primary/10 text-brand-text dark:border-primary/50 dark:bg-primary/15"
-                  : "okou-chip text-muted-foreground hover:text-foreground",
-                saving !== null && "opacity-60 cursor-not-allowed",
-              )}
             >
               {saving === value && (
                 <Loader2 size={14} className="animate-spin" />
               )}
               {label}
-            </button>
+            </ChoiceButton>
           );
         })}
       </div>

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/preference-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/preference-section.tsx
@@ -1,7 +1,7 @@
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import { Sun, Moon, Monitor, Palette } from "lucide-react";
-import { cn } from "@okouai/ui";
+import { ChoiceButton } from "@okouai/ui";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { featureSwitch$ } from "../../../../../signals/external/feature-switch.ts";
@@ -69,23 +69,17 @@ function AppearanceBlock() {
                       return $.settings.preferences.appearance.theme.system;
                     });
             return (
-              <button
+              <ChoiceButton
                 key={value}
                 type="button"
-                aria-pressed={isActive}
+                selected={isActive}
                 onClick={() => {
                   handleChange(value);
                 }}
-                className={cn(
-                  "flex items-center gap-2 rounded-lg border border-[0.7px] px-3.5 py-2 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                  isActive
-                    ? "border-primary/40 bg-primary/10 text-brand-text dark:border-primary/50 dark:bg-primary/15"
-                    : "okou-chip text-muted-foreground hover:text-foreground",
-                )}
               >
                 <Icon size={15} />
                 {label}
-              </button>
+              </ChoiceButton>
             );
           })}
         </div>

--- a/turbo/packages/ui/src/components/ui/choice-button.tsx
+++ b/turbo/packages/ui/src/components/ui/choice-button.tsx
@@ -1,0 +1,44 @@
+import type { ComponentProps } from "react";
+import { cva } from "class-variance-authority";
+
+import { cn } from "../../lib/utils";
+
+const choiceButtonVariants = cva(
+  "flex items-center gap-2 rounded-lg border-[0.7px] px-3.5 py-2 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed",
+  {
+    variants: {
+      selected: {
+        true: "border-primary/40 bg-primary/10 text-brand-text dark:border-primary/50 dark:bg-primary/15",
+        // Preserve the opaque fill and the legacy hover layer on touch devices.
+        false:
+          "border-control-border bg-control-surface text-muted-foreground [&:hover]:bg-state-hover-overlay hover:text-foreground",
+      },
+    },
+  },
+);
+
+interface ChoiceButtonProps extends Omit<
+  ComponentProps<"button">,
+  "aria-pressed"
+> {
+  selected: boolean;
+}
+
+/** A standalone selectable choice that retains native button and ref behavior. */
+export function ChoiceButton({
+  selected,
+  className,
+  children,
+  ...props
+}: ChoiceButtonProps) {
+  return (
+    <button
+      type="button"
+      {...props}
+      aria-pressed={selected}
+      className={cn(choiceButtonVariants({ selected }), className)}
+    >
+      {children}
+    </button>
+  );
+}

--- a/turbo/packages/ui/src/index.ts
+++ b/turbo/packages/ui/src/index.ts
@@ -13,6 +13,7 @@ export {
   CardContent,
 } from "./components/ui/card";
 export { Checkbox } from "./components/ui/checkbox";
+export { ChoiceButton } from "./components/ui/choice-button";
 export { CopyButton, type CopyButtonProps } from "./components/ui/copy-button";
 export { Input } from "./components/ui/input";
 export { Kbd, KbdGroup } from "./components/ui/kbd";

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -95,6 +95,9 @@
   --color-border: hsl(var(--border));
   --color-surface-focus: hsl(var(--surface-focus));
   --color-input: hsl(var(--input));
+  /* Neutral standalone controls follow the runtime palette in both themes. */
+  --color-control-surface: hsl(var(--gray-50));
+  --color-control-border: hsl(var(--gray-400));
   --color-ring: hsl(var(--ring));
   --color-background: hsl(var(--background));
   --color-foreground: hsl(var(--foreground));
@@ -183,6 +186,11 @@
    * gets its own pre-mixed pair below.
    * =================================== */
   --color-state-hover: hsl(var(--state-layer) / var(--state-hover-alpha));
+  /* Layer hover over an opaque control fill without replacing that fill. */
+  --background-image-state-hover-overlay: linear-gradient(
+    var(--color-state-hover),
+    var(--color-state-hover)
+  );
   --color-state-selected: hsl(var(--state-layer) / var(--state-selected-alpha));
   --color-state-selected-hover: hsl(
     var(--state-layer) / var(--state-selected-hover-alpha)

--- a/turbo/style-legacy-baseline.json
+++ b/turbo/style-legacy-baseline.json
@@ -4159,18 +4159,12 @@
     "apps/platform/src/views/okou-page/components/settings/sections/account-section.tsx": {
       "okou-border": 1
     },
-    "apps/platform/src/views/okou-page/components/settings/sections/chat-section.tsx": {
-      "okou-chip": 1
-    },
     "apps/platform/src/views/okou-page/components/settings/sections/credit-balance-section.tsx": {
       "okou-app": 1,
       "okou-border": 2
     },
     "apps/platform/src/views/okou-page/components/settings/sections/debug-section.tsx": {
       "okou-border": 1
-    },
-    "apps/platform/src/views/okou-page/components/settings/sections/preference-section.tsx": {
-      "okou-chip": 1
     },
     "apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx": {
       "okou-app": 1,


### PR DESCRIPTION
Appearance and Send mode settings depend on the legacy `okou-chip` selector and duplicate their selection/focus/disabled styling. Migrate these two consumers to a shared native `ChoiceButton` with a typed `selected` prop and canonical control-surface, control-border and hover-overlay tokens. Preserve the existing DOM semantics, refs, events, 0.7px border, icon sizes, primary selected treatment and touch hover behavior.

This independently starts from main `efb8565d32902490fee1aed18ba05925d722b1f5`. The baseline shrinks by two consumer references; the unchanged legacy definition remains for its final consumer. The repository manifest and acceptance tooling live in the independent foundation PR #32826.

Frozen BEFORE evidence was uploaded before this implementation: https://a.okou.io/e9ie0v6p2c.zip (SHA-256 `338b88df3d7de430118f2a30069d4d6b6fe31741a622839ab12986fa7dc6a4ef`). All 21 same-build replays passed before migration. The runner, cases and rounding budget were frozen before business styles changed.

Final before/after/raw-diff evidence: https://a.okou.io/rp0lazp7gc.zip (SHA-256 `1b059f559c0c1b5bab01d7413149a330a087002b5ffa4bdfbb681a5d19379115`). The tested source head is `a4a1c660f98e888ea69c6d75ccea2a53b701309c`; actual deployed App merge is `beee41651324fb0563ecdfa635cbffdf68a07a5e`. Main changes included in that merge add no further changes to the settings components, stylesheet, shared UI, theme signal or HTML shell. The archive records the App/API deployment identities, flags, source audit and exact-head checks. Anonymous browser downloads of both archives and the comparison image were verified against their SHA-256 values.

All 21 final states passed in desktop light/dark and narrow touch/DPR 2 Chromium: normal appearance, hover, keyboard focus, send mode, delayed saving, saved state and Escape dismissal. Control semantics, geometry and computed styles match exactly. Light images have 2 changed opaque pixels of at most 1 RGB level each under the pre-frozen maximum of 8; dark/narrow images have zero changed pixels. No masks are used; raw diffs retain every difference.

An earlier attempt failed the Light theme initialization precondition before taking light screenshots; its other 14 captured states passed. It is preserved in the same archive. An identical invocation then passed all 21 without changing code, runner, cases, auth-state input or limits. The trigger remains unconfirmed and is tracked in #32402; the runner is not yet certified as an unattended gate. Preferences responses are controlled, so browser evidence does not establish server persistence. Native iOS/WebKit, PWA/Desktop and normal motion are outside this pilot.

![Before and after settings choice controls](https://a.okou.io/y8pdgfpwij.png)

Validation: complete style lint, shared UI and App TypeScript checks, full Knip and the 9 existing `preferences-page.test.tsx` tests passed. Current-head [CI gate](https://github.com/vm0-ai/vm0/actions/runs/34315119359/job/102350779566), security gate and style lint passed; the PR pipeline supplies full repository checks. No full local Vitest suite or dev server was started.

Manual acceptance on the PR App preview, using a TEST account after onboarding: open Settings → Preference, inspect Light/Dark and keyboard focus, change the Enter send mode, then check the same controls at 390px width. Expect the same selected/hover/focus/disabled appearance and no new wrapping or overflow. Deterministic pending-save images are included in the archive.

Additional live acceptance on the same deployed build used native clicks without preference interception: changed the theme to Dark and send mode to Command/Ctrl+Enter, reloaded the page, and confirmed both selections persisted with enabled controls. The TEST account was then restored to System/Enter. This is separate from the deterministic screenshot fixture.

Refs #32402. This is the first consumer pilot, not completion of the issue-wide migration.
