### PR TITLE
fix(cli): reject conflicting run-bound connector agent selectors

### DIFF
--- a/turbo/apps/cli/src/commands/connector/__tests__/agent-context.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/agent-context.test.ts
@@ -1,0 +1,126 @@
+import chalk from "chalk";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { server } from "../../../mocks/server";
+import { customConnectorCommand } from "../custom";
+import { listCommand } from "../list";
+import { permissionRequestCommand } from "../permission-request";
+import { searchCommand } from "../search";
+import { statusCommand } from "../status";
+
+const RUN_AGENT_ID = "550e8400-e29b-41d4-a716-446655440000";
+const OTHER_AGENT_ID = "550e8400-e29b-41d4-a716-446655440099";
+const CUSTOM_CONNECTOR_ID = "33333333-3333-4333-8333-333333333333";
+
+const commandCases = [
+  { name: "list", command: listCommand, args: [] },
+  { name: "status", command: statusCommand, args: ["github"] },
+  { name: "search", command: searchCommand, args: ["github"] },
+  { name: "custom list", command: customConnectorCommand, args: ["list"] },
+  {
+    name: "custom status",
+    command: customConnectorCommand,
+    args: ["status", CUSTOM_CONNECTOR_ID],
+  },
+  {
+    name: "builtin permission-request",
+    command: permissionRequestCommand,
+    args: [
+      "github",
+      "--permission",
+      "contents:read",
+      "--url",
+      "https://api.github.com/repos/vm0-ai/vm0",
+    ],
+  },
+  {
+    name: "custom permission-request",
+    command: permissionRequestCommand,
+    args: [`custom:${CUSTOM_CONNECTOR_ID}`, "--permission", "items:read"],
+  },
+  {
+    name: "browser permission-request",
+    command: permissionRequestCommand,
+    args: ["browser", "--permission", "browser:write"],
+  },
+  {
+    name: "computer-use permission-request",
+    command: permissionRequestCommand,
+    args: ["computer-use", "--permission", "computer-use:write"],
+  },
+];
+
+describe("run-bound connector Agent selectors", () => {
+  const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("process.exit called");
+  });
+  let requests: string[];
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("OKOU_TOKEN", "test-token");
+    vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
+    vi.stubEnv("OKOU_AGENT_ID", RUN_AGENT_ID);
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", "thread-1");
+    vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", undefined);
+    for (const { command } of commandCases) {
+      command.setOptionValue("agent", undefined);
+    }
+    for (const command of customConnectorCommand.commands) {
+      command.setOptionValue("agent", undefined);
+    }
+    requests = [];
+    server.use(
+      http.all("*", ({ request }) => {
+        requests.push(request.url);
+        return HttpResponse.json(
+          { error: "Unexpected request" },
+          { status: 500 },
+        );
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it.each(commandCases)(
+    "$name rejects another Agent before requests or authorization output",
+    async ({ command, args }) => {
+      await expect(
+        command.parseAsync([
+          "node",
+          "okou",
+          ...args,
+          "--agent",
+          OTHER_AGENT_ID,
+        ]),
+      ).rejects.toThrow("process.exit called");
+
+      const error = consoleError.mock.calls.flat().join("\n");
+      expect(error).toContain(`--agent ${OTHER_AGENT_ID}`);
+      expect(error).toContain(`current run's Agent ${RUN_AGENT_ID}`);
+      expect(error).toContain(`Remove --agent or use --agent ${RUN_AGENT_ID}`);
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(consoleLog).not.toHaveBeenCalled();
+      expect(requests).toEqual([]);
+    },
+  );
+
+  it("rejects an explicitly empty Agent selector during a run", async () => {
+    await expect(
+      listCommand.parseAsync(["node", "okou", "--agent", ""]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(consoleError.mock.calls.flat().join("\n")).toContain(
+      `Remove --agent or use --agent ${RUN_AGENT_ID}`,
+    );
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(consoleLog).not.toHaveBeenCalled();
+    expect(requests).toEqual([]);
+  });
+});

--- a/turbo/apps/cli/src/commands/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/list.test.ts
@@ -24,7 +24,6 @@ import {
 } from "../../__tests__/helpers/custom-connectors";
 
 const AGENT_UUID = "550e8400-e29b-41d4-a716-446655440000";
-const ALT_AGENT_UUID = "550e8400-e29b-41d4-a716-446655440099";
 
 const connectedGithub = {
   id: "1",
@@ -128,6 +127,7 @@ describe("okou connector list command", () => {
     chalk.level = 0;
     vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
+    vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", undefined);
     listCommand.setOptionValue("agent", undefined);
     listCommand.setOptionValue("json", false);
     server.use(stubCustomConnectors([]), stubAgentCustomConnectors([]));
@@ -280,8 +280,8 @@ describe("okou connector list command", () => {
       expect(logCalls).not.toContain("CONNECTED AS");
     });
 
-    it("does not let --agent bypass unavailable run context", async () => {
-      vi.stubEnv("OKOU_AGENT_ID", ALT_AGENT_UUID);
+    it("does not let matching --agent bypass unavailable run context", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
 
       await listCommand.parseAsync(["node", "cli", "--agent", AGENT_UUID]);
 

--- a/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
@@ -286,7 +286,7 @@ describe("okou connector permission-request command", () => {
 
     expect(mockConsoleError).toHaveBeenCalledWith(
       expect.stringContaining(
-        "--callback-prompt can only target the current web chat thread and agent",
+        "--agent agent-other conflicts with the current run's Agent agent-current",
       ),
     );
   });
@@ -370,9 +370,9 @@ describe("okou connector permission-request command", () => {
     expect(logCalls).toContain("action=allow");
   });
 
-  it("--agent overrides OKOU_AGENT_ID", async () => {
+  it("accepts --agent when it matches the current run's Agent", async () => {
     vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.okou.ai");
-    vi.stubEnv("OKOU_AGENT_ID", "env-agent-123");
+    vi.stubEnv("OKOU_AGENT_ID", "target-agent-123");
 
     await permissionRequestCommand.parseAsync([
       "node",
@@ -388,7 +388,6 @@ describe("okou connector permission-request command", () => {
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain("/agents/target-agent-123/permissions?");
-    expect(logCalls).not.toContain("/agents/env-agent-123/permissions?");
   });
 
   it("transforms www.okou.ai to app.okou.ai", async () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/run-account-context.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/run-account-context.test.ts
@@ -110,81 +110,98 @@ describe("run connector account inspection", () => {
     );
   }
 
-  it("shows the exact built-in account selected for this run in list, status, and JSON", async () => {
-    const inspectedBodies: unknown[] = [];
-    writeContext([
-      {
-        kind: "builtin",
-        connectorSlug: "github",
-        connectionId: PINNED_CONNECTION_ID,
-      },
-    ]);
-    server.use(
-      stubConnectorCatalog([
-        catalogItem({ connectorSlug: "github", label: "GitHub" }),
-      ]),
-      stubCustomConnectors([]),
-      http.post(
-        "http://localhost:3000/api/connector-accounts/inspect",
-        async ({ request }) => {
-          const raw = await request.json();
-          inspectedBodies.push(raw);
-          const body = connectorAccountsContract.inspect.body.parse(raw);
-          return HttpResponse.json({
-            results: body.selections.map((selection) => {
-              if (selection.target.kind !== "builtin") {
-                throw new Error("Expected a built-in selection");
-              }
-              return accountMetadata(selection.connectionId, selection.target);
-            }),
-          });
+  it.each([
+    { selector: "omitted", args: [] },
+    { selector: "matching", args: ["--agent", AGENT_ID] },
+  ])(
+    "shows the exact run account in list, status, and JSON with $selector --agent",
+    async ({ args }) => {
+      const inspectedBodies: unknown[] = [];
+      writeContext([
+        {
+          kind: "builtin",
+          connectorSlug: "github",
+          connectionId: PINNED_CONNECTION_ID,
         },
-      ),
-    );
+      ]);
+      server.use(
+        stubConnectorCatalog([
+          catalogItem({ connectorSlug: "github", label: "GitHub" }),
+        ]),
+        stubCustomConnectors([]),
+        http.post(
+          "http://localhost:3000/api/connector-accounts/inspect",
+          async ({ request }) => {
+            const raw = await request.json();
+            inspectedBodies.push(raw);
+            const body = connectorAccountsContract.inspect.body.parse(raw);
+            return HttpResponse.json({
+              results: body.selections.map((selection) => {
+                if (selection.target.kind !== "builtin") {
+                  throw new Error("Expected a built-in selection");
+                }
+                return accountMetadata(
+                  selection.connectionId,
+                  selection.target,
+                );
+              }),
+            });
+          },
+        ),
+      );
 
-    await listCommand.parseAsync(["node", "cli"]);
-    let output = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(output).toContain("ACCOUNT USED BY THIS RUN");
-    expect(output).toContain("Thread-selected work account");
-    expect(output).toContain(PINNED_CONNECTION_ID);
-    expect(output).not.toContain("CONNECTED AS");
+      await listCommand.parseAsync(["node", "cli", ...args]);
+      let output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain("ACCOUNT USED BY THIS RUN");
+      expect(output).toContain("Thread-selected work account");
+      expect(output).toContain(PINNED_CONNECTION_ID);
+      expect(output).not.toContain("CONNECTED AS");
 
-    mockConsoleLog.mockClear();
-    await statusCommand.parseAsync(["node", "cli", "github"]);
-    output = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(output).toContain("Account Used:");
-    expect(output).toContain("Thread-selected work account");
-    expect(output).toContain(PINNED_CONNECTION_ID);
-    expect(output).toContain("Current Status:");
+      mockConsoleLog.mockClear();
+      await statusCommand.parseAsync(["node", "cli", "github", ...args]);
+      output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain("Account Used:");
+      expect(output).toContain("Thread-selected work account");
+      expect(output).toContain(PINNED_CONNECTION_ID);
+      expect(output).toContain("Current Status:");
 
-    mockConsoleLog.mockClear();
-    await statusCommand.parseAsync(["node", "cli", "github", "--json"]);
-    const json: unknown = JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]));
-    expect(json).toStrictEqual(
-      expect.objectContaining({
-        context: "run",
-        state: "available",
-        connector: expect.objectContaining({
-          target: { kind: "builtin", connectorSlug: "github" },
-          account: expect.objectContaining({
-            state: "available",
-            connectionId: PINNED_CONNECTION_ID,
-            label: "Thread-selected work account",
+      mockConsoleLog.mockClear();
+      await statusCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--json",
+        ...args,
+      ]);
+      const json: unknown = JSON.parse(
+        String(mockConsoleLog.mock.calls[0]?.[0]),
+      );
+      expect(json).toStrictEqual(
+        expect.objectContaining({
+          context: "run",
+          state: "available",
+          connector: expect.objectContaining({
+            target: { kind: "builtin", connectorSlug: "github" },
+            account: expect.objectContaining({
+              state: "available",
+              connectionId: PINNED_CONNECTION_ID,
+              label: "Thread-selected work account",
+            }),
           }),
         }),
-      }),
-    );
-    expect(JSON.stringify(json)).not.toContain("sk-");
-    expect(inspectedBodies).toHaveLength(3);
-    expect(inspectedBodies[0]).toStrictEqual({
-      selections: [
-        {
-          connectionId: PINNED_CONNECTION_ID,
-          target: { kind: "builtin", connectorSlug: "github" },
-        },
-      ],
-    });
-  });
+      );
+      expect(JSON.stringify(json)).not.toContain("sk-");
+      expect(inspectedBodies).toHaveLength(3);
+      expect(inspectedBodies[0]).toStrictEqual({
+        selections: [
+          {
+            connectionId: PINNED_CONNECTION_ID,
+            target: { kind: "builtin", connectorSlug: "github" },
+          },
+        ],
+      });
+    },
+  );
 
   it("retains deleted IDs and source-less targets without choosing a sibling", async () => {
     writeContext([

--- a/turbo/apps/cli/src/commands/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/search.test.ts
@@ -391,54 +391,60 @@ describe("okou connector search command", () => {
       expect(githubRow).toMatch(/✓/);
     });
 
-    it("adds AUTHORIZED FOR column when OKOU_AGENT_ID is set", async () => {
-      vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
-      writeRunConnectorAccountContext(contextPath, [
-        {
-          kind: "builtin",
-          connectorSlug: "github",
-          connectionId: RUN_CONNECTION_ID,
-        },
-      ]);
-      server.use(
-        stubConnectorCatalog([
-          catalogItem({
-            connectorSlug: "github",
-            label: "GitHub",
-            tags: ["vcs"],
-            authMethods: [authCodeMethod("oauth")],
-          }),
-        ]),
-        stubRunConnectorAccountInspection([
+    it.each([
+      { selector: "omitted", args: [] },
+      { selector: "matching", args: ["--agent", AGENT_UUID] },
+    ])(
+      "uses the run Agent and account with $selector --agent",
+      async ({ args }) => {
+        vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
+        writeRunConnectorAccountContext(contextPath, [
           {
-            kind: "available",
+            kind: "builtin",
+            connectorSlug: "github",
             connectionId: RUN_CONNECTION_ID,
-            target: { kind: "builtin", connectorSlug: "github" },
-            authMethod: "oauth",
-            displayName: "Run account B",
-            externalId: "run-b",
-            externalUsername: "run-b",
-            externalEmail: "run-b@example.com",
-            connectionStatus: "connected",
-            reconnectReason: null,
           },
-        ]),
-        stubAgent(AGENT_UUID, "maya"),
-        stubUserConnectors(AGENT_UUID, []),
-      );
+        ]);
+        server.use(
+          stubConnectorCatalog([
+            catalogItem({
+              connectorSlug: "github",
+              label: "GitHub",
+              tags: ["vcs"],
+              authMethods: [authCodeMethod("oauth")],
+            }),
+          ]),
+          stubRunConnectorAccountInspection([
+            {
+              kind: "available",
+              connectionId: RUN_CONNECTION_ID,
+              target: { kind: "builtin", connectorSlug: "github" },
+              authMethod: "oauth",
+              displayName: "Run account B",
+              externalId: "run-b",
+              externalUsername: "run-b",
+              externalEmail: "run-b@example.com",
+              connectionStatus: "connected",
+              reconnectReason: null,
+            },
+          ]),
+          stubAgent(AGENT_UUID, "maya"),
+          stubUserConnectors(AGENT_UUID, []),
+        );
 
-      await searchCommand.parseAsync(["node", "cli", "github"]);
+        await searchCommand.parseAsync(["node", "cli", "github", ...args]);
 
-      const lines = mockConsoleLog.mock.calls.flat() as string[];
-      const output = lines.join("\n");
-      expect(output).toContain("AUTHORIZED FOR maya");
-      expect(output).toContain("ACCOUNT USED BY THIS RUN");
-      expect(output).toContain("Run account B");
-      const githubRow = findDataRows(lines).find((line) => {
-        return line.startsWith("github");
-      });
-      expect(githubRow).toMatch(/-/);
-    });
+        const lines = mockConsoleLog.mock.calls.flat() as string[];
+        const output = lines.join("\n");
+        expect(output).toContain("AUTHORIZED FOR maya");
+        expect(output).toContain("ACCOUNT USED BY THIS RUN");
+        expect(output).toContain("Run account B");
+        const githubRow = findDataRows(lines).find((line) => {
+          return line.startsWith("github");
+        });
+        expect(githubRow).toMatch(/-/);
+      },
+    );
 
     it("uses the full UUID as the header when displayName is null", async () => {
       server.use(
@@ -456,26 +462,6 @@ describe("okou connector search command", () => {
 
       const output = (mockConsoleLog.mock.calls.flat() as string[]).join("\n");
       expect(output).toContain(`AUTHORIZED FOR ${AGENT_UUID}`);
-    });
-
-    it("--agent overrides OKOU_AGENT_ID", async () => {
-      vi.stubEnv("OKOU_AGENT_ID", ALT_AGENT_UUID);
-      server.use(
-        stubAgent(AGENT_UUID, "from-flag"),
-        stubUserConnectors(AGENT_UUID, ["github"]),
-      );
-
-      await searchCommand.parseAsync([
-        "node",
-        "cli",
-        "github",
-        "--agent",
-        AGENT_UUID,
-      ]);
-
-      const output = (mockConsoleLog.mock.calls.flat() as string[]).join("\n");
-      expect(output).toContain("AUTHORIZED FOR from-flag");
-      expect(output).not.toContain(ALT_AGENT_UUID);
     });
 
     it("renders custom connector authorization for the agent", async () => {
@@ -838,10 +824,6 @@ describe("okou connector search command", () => {
     });
 
     it("rejects callback links for another agent", async () => {
-      server.use(
-        stubAgent(ALT_AGENT_UUID, "other-agent"),
-        stubUserConnectors(ALT_AGENT_UUID, []),
-      );
       await expect(
         searchCommand.parseAsync([
           "node",
@@ -857,7 +839,7 @@ describe("okou connector search command", () => {
       ).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
-        "--callback-prompt can only target the current web chat thread and agent",
+        `--agent ${ALT_AGENT_UUID} conflicts with the current run's Agent ${AGENT_UUID}`,
       );
       expect(mockConsoleLog.mock.calls.flat().join("\n")).not.toContain(
         "callbackPrompt=",

--- a/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
@@ -19,7 +19,6 @@ import {
 } from "../../__tests__/helpers/connector-catalog";
 
 const AGENT_UUID = "550e8400-e29b-41d4-a716-446655440000";
-const ALT_AGENT_UUID = "550e8400-e29b-41d4-a716-446655440099";
 
 const connectedGithub = {
   id: "1",
@@ -124,6 +123,7 @@ describe("okou connector status command", () => {
     vi.stubEnv("OKOU_APP_URL", "");
     vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
+    vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", undefined);
     vi.stubEnv("OKOU_AGENT_ID", "");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", "");
     statusCommand.setOptionValue("agent", undefined);
@@ -465,8 +465,8 @@ describe("okou connector status command", () => {
       expect(logCalls).toContain("Account used by this run is unavailable");
     });
 
-    it("does not let --agent bypass canonical run context", async () => {
-      vi.stubEnv("OKOU_AGENT_ID", ALT_AGENT_UUID);
+    it("does not let matching --agent bypass unavailable run context", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
 
       await statusCommand.parseAsync([
         "node",

--- a/turbo/apps/cli/src/commands/connector/agent-context.ts
+++ b/turbo/apps/cli/src/commands/connector/agent-context.ts
@@ -15,10 +15,25 @@ export interface ConnectorDiscoveryAgentContext extends AgentContext {
   authorizedCustomConnectorIds: Set<string>;
 }
 
-export async function resolveAgentContext(
+export function resolveConnectorAgentId(
   flagAgentId: string | undefined,
+): string | undefined {
+  const runAgentId = getOkouAgentId();
+  if (
+    runAgentId !== undefined &&
+    flagAgentId !== undefined &&
+    flagAgentId !== runAgentId
+  ) {
+    throw new Error(
+      `--agent ${flagAgentId} conflicts with the current run's Agent ${runAgentId}. Remove --agent or use --agent ${runAgentId}.`,
+    );
+  }
+  return runAgentId ?? flagAgentId;
+}
+
+export async function resolveAgentContext(
+  agentId: string | undefined,
 ): Promise<AgentContext | null> {
-  const agentId = flagAgentId ?? getOkouAgentId();
   if (!agentId) return null;
 
   const [agent, enabledConnectorSlugs] = await Promise.all([
@@ -34,9 +49,8 @@ export async function resolveAgentContext(
 }
 
 export async function resolveConnectorDiscoveryAgentContext(
-  flagAgentId: string | undefined,
+  agentId: string | undefined,
 ): Promise<ConnectorDiscoveryAgentContext | null> {
-  const agentId = flagAgentId ?? getOkouAgentId();
   if (!agentId) return null;
 
   const [agent, enabledConnectorSlugs, customConnectorGrants] =

--- a/turbo/apps/cli/src/commands/connector/custom/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/__tests__/index.test.ts
@@ -21,6 +21,9 @@ describe("okou connector custom readers", () => {
     chalk.level = 0;
     vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
+    for (const command of customConnectorCommand.commands) {
+      command.setOptionValue("agent", undefined);
+    }
   });
 
   afterEach(() => {
@@ -46,45 +49,75 @@ describe("okou connector custom readers", () => {
     expect(output).toContain("http");
   });
 
-  it("renders grant-based authorization for an agent", async () => {
-    const connector = customConnector();
-    server.use(
-      stubCustomConnectors([connector]),
-      http.get(`http://localhost:3000/api/agents/${AGENT_ID}`, () => {
-        return HttpResponse.json({
-          agentId: AGENT_ID,
-          ownerId: "owner-1",
-          description: null,
-          displayName: "Maya",
-          sound: null,
-          avatarUrl: null,
-        });
-      }),
-      stubAgentCustomConnectors([
-        {
-          customConnectorId: connector.id,
-          permissionNames: ["chat:write"],
+  it.each([
+    { context: "non-run", runAgent: undefined, args: ["--agent", AGENT_ID] },
+    { context: "run with omitted selector", runAgent: AGENT_ID, args: [] },
+    {
+      context: "run with matching selector",
+      runAgent: AGENT_ID,
+      args: ["--agent", AGENT_ID],
+    },
+  ])(
+    "renders custom grants in list and status for $context",
+    async ({ runAgent, args }) => {
+      vi.stubEnv("OKOU_AGENT_ID", runAgent);
+      const connector = customConnector();
+      server.use(
+        stubCustomConnectors([connector]),
+        http.get(
+          `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
+          () => {
+            return HttpResponse.json(connector);
+          },
+        ),
+        http.get(`http://localhost:3000/api/agents/${AGENT_ID}`, () => {
+          return HttpResponse.json({
+            agentId: AGENT_ID,
+            ownerId: "owner-1",
+            description: null,
+            displayName: "Maya",
+            sound: null,
+            avatarUrl: null,
+          });
+        }),
+        stubAgentCustomConnectors([
+          {
+            customConnectorId: connector.id,
+            permissionNames: ["chat:write"],
+          },
+        ]),
+      );
+
+      await customConnectorCommand.parseAsync([
+        "node",
+        "okou",
+        "list",
+        ...args,
+      ]);
+
+      const output = consoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain("AUTHORIZED FOR Maya");
+      const connectorRow = (consoleLog.mock.calls.flat() as string[]).find(
+        (line) => {
+          return line.startsWith(connector.id);
         },
-      ]),
-    );
+      );
+      expect(connectorRow).toMatch(/✓$/u);
 
-    await customConnectorCommand.parseAsync([
-      "node",
-      "okou",
-      "list",
-      "--agent",
-      AGENT_ID,
-    ]);
+      consoleLog.mockClear();
+      await customConnectorCommand.parseAsync([
+        "node",
+        "okou",
+        "status",
+        CONNECTOR_ID,
+        ...args,
+      ]);
 
-    const output = consoleLog.mock.calls.flat().join("\n");
-    expect(output).toContain("AUTHORIZED FOR Maya");
-    const connectorRow = (consoleLog.mock.calls.flat() as string[]).find(
-      (line) => {
-        return line.startsWith(connector.id);
-      },
-    );
-    expect(connectorRow).toMatch(/✓$/u);
-  });
+      const status = consoleLog.mock.calls.flat().join("\n");
+      expect(status).toContain("Custom connector: Acme Search");
+      expect(status).toMatch(/Authorized:\s+yes/u);
+    },
+  );
 
   it("shows tagged HTTP routing details in status", async () => {
     const connector = customConnector();

--- a/turbo/apps/cli/src/commands/connector/custom/index.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/index.ts
@@ -9,7 +9,7 @@ import {
   listCustomConnectors,
 } from "../../../lib/api/domains/connectors";
 import { withErrorHandler } from "../../../lib/command/with-error-handler";
-import { getOkouAgentId } from "../../../lib/okou-env";
+import { resolveConnectorAgentId } from "../agent-context";
 import { createCustomConnectorCommand } from "./create";
 import { updateCustomConnectorCommand } from "./update";
 
@@ -33,13 +33,12 @@ async function resolveCustomAgentContext(agentId: string | undefined): Promise<{
   readonly displayName: string;
   readonly authorizedIds: Set<string>;
 } | null> {
-  const resolvedAgentId = agentId ?? getOkouAgentId();
-  if (!resolvedAgentId) {
+  if (!agentId) {
     return null;
   }
   const [agent, grants] = await Promise.all([
-    getAgent(resolvedAgentId),
-    getAgentCustomConnectorGrants(resolvedAgentId),
+    getAgent(agentId),
+    getAgentCustomConnectorGrants(agentId),
   ]);
   return {
     agentId: agent.agentId,
@@ -56,12 +55,16 @@ const listCommand = new Command()
   .name("list")
   .alias("ls")
   .description("List org custom connectors")
-  .option("--agent <id>", "Show per-agent authorization column")
+  .option(
+    "--agent <id>",
+    "Show per-agent authorization column (must match the current Agent inside a run)",
+  )
   .action(
     withErrorHandler(async (options: { agent?: string }) => {
+      const agentId = resolveConnectorAgentId(options.agent);
       const [connectors, agentCtx] = await Promise.all([
         listCustomConnectors(),
-        resolveCustomAgentContext(options.agent),
+        resolveCustomAgentContext(agentId),
       ]);
       const idWidth = Math.max(
         2,
@@ -108,13 +111,17 @@ const statusCommand = new Command()
   .name("status")
   .description("Show detailed status of a custom connector")
   .argument("<connector-id>", "Custom connector id")
-  .option("--agent <id>", "Show authorization state for the given agent")
+  .option(
+    "--agent <id>",
+    "Show authorization state for the given Agent (must match the current Agent inside a run)",
+  )
   .action(
     withErrorHandler(
       async (connectorId: string, options: { agent?: string }) => {
+        const agentId = resolveConnectorAgentId(options.agent);
         const [connector, agentCtx] = await Promise.all([
           getCustomConnector(connectorId),
-          resolveCustomAgentContext(options.agent),
+          resolveCustomAgentContext(agentId),
         ]);
         if (!connector) {
           throw new Error(`Custom connector not found: ${connectorId}`);

--- a/turbo/apps/cli/src/commands/connector/list.ts
+++ b/turbo/apps/cli/src/commands/connector/list.ts
@@ -5,7 +5,10 @@ import {
   listCustomConnectors,
 } from "../../lib/api/domains/connectors";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
-import { resolveConnectorDiscoveryAgentContext } from "./agent-context";
+import {
+  resolveConnectorAgentId,
+  resolveConnectorDiscoveryAgentContext,
+} from "./agent-context";
 import { padEndAnsi, stripAnsi } from "./connected-as";
 import {
   connectorDiscoveryItems,
@@ -61,10 +64,14 @@ export const listCommand = new Command()
   .name("list")
   .alias("ls")
   .description("List all connectors and their status")
-  .option("--agent <id>", "Show per-agent authorization column")
+  .option(
+    "--agent <id>",
+    "Show per-agent authorization column (must match the current Agent inside a run)",
+  )
   .option("--json", "Output connector status as JSON")
   .action(
     withErrorHandler(async (options: { agent?: string; json?: boolean }) => {
+      const agentId = resolveConnectorAgentId(options.agent);
       if (isRunBoundConnectorContext()) {
         await printRunConnectorList(options.json ?? false);
         return;
@@ -72,7 +79,7 @@ export const listCommand = new Command()
       const [{ connectors }, customConnectors, agentCtx] = await Promise.all([
         listConnectorCatalogStatus(),
         listCustomConnectors(),
-        resolveConnectorDiscoveryAgentContext(options.agent),
+        resolveConnectorDiscoveryAgentContext(agentId),
       ]);
       const discoveredConnectors = connectorDiscoveryItems(
         connectors,

--- a/turbo/apps/cli/src/commands/connector/permission-request.ts
+++ b/turbo/apps/cli/src/commands/connector/permission-request.ts
@@ -15,7 +15,8 @@ import { ApiRequestError } from "../../lib/api/core/client-factory";
 import { createBrowserAuthorizationRequest } from "../../lib/api/domains/browser";
 import { createComputerUseAuthorizationRequest } from "../../lib/api/domains/computer-use";
 import { diagnoseConnectorCheck } from "../../lib/api/domains/connectors";
-import { getOkouAgentId, getOkouToken } from "../../lib/okou-env";
+import { getOkouToken } from "../../lib/okou-env";
+import { resolveConnectorAgentId } from "./agent-context";
 import {
   connectorActionCallbackAvailable,
   finalizeActionUrl,
@@ -309,7 +310,7 @@ export const permissionRequestCommand = new Command()
   .addOption(
     new Option(
       "--agent <id>",
-      "Agent ID whose permission page should be opened (defaults to OKOU_AGENT_ID)",
+      "Agent ID whose permission page should be opened (must match OKOU_AGENT_ID inside a run)",
     ),
   )
   .addOption(
@@ -340,7 +341,8 @@ Notes:
   - A platform URL is output only when that request maps to a denied or approval-required permission
   - Use --permission __unknown__ to request access to unknown endpoints
   - Custom connectors use Connectors > agent access > Permissions, not this builtin approval flow
-  - Use --agent to request a permission for another agent; defaults to OKOU_AGENT_ID
+  - Inside a run, --agent must match the current Agent; omit it to use OKOU_AGENT_ID
+  - Outside a run, use --agent to select the Agent whose permission page should be opened
   - The user chooses the permission duration on the confirmation page
 ${callbackPromptNotes}  - Permission requests update the current user's connector grants after confirmation`,
   )
@@ -356,6 +358,7 @@ ${callbackPromptNotes}  - Permission requests update the current user's connecto
           callbackPrompt?: string;
         },
       ) => {
+        const agentId = resolveConnectorAgentId(opts.agent);
         if (
           isBrowserPermissionTarget({
             connectorSlug,
@@ -385,7 +388,6 @@ ${callbackPromptNotes}  - Permission requests update the current user's connecto
           return;
         }
 
-        const agentId = opts.agent ?? getOkouAgentId();
         const customConnectorId = customConnectorIdFromSelector(connectorSlug);
         if (customConnectorId !== undefined) {
           throw new Error(

--- a/turbo/apps/cli/src/commands/connector/search.ts
+++ b/turbo/apps/cli/src/commands/connector/search.ts
@@ -8,7 +8,10 @@ import {
 } from "../../lib/api/domains/connectors";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { getPlatformOrigin } from "../doctor/platform-url";
-import { resolveConnectorDiscoveryAgentContext } from "./agent-context";
+import {
+  resolveConnectorAgentId,
+  resolveConnectorDiscoveryAgentContext,
+} from "./agent-context";
 import { padEndAnsi, stripAnsi } from "./connected-as";
 import {
   connectorDiscoveryDefinitions,
@@ -211,7 +214,10 @@ export const searchCommand = new Command()
     "Search supported connectors by slug, label, category, generation type, or tag and show availability and connection links",
   )
   .argument("<keyword>", "Search keyword (case-insensitive)")
-  .option("--agent <id>", "Show per-agent authorization column")
+  .option(
+    "--agent <id>",
+    "Show per-agent authorization column (must match the current Agent inside a run)",
+  )
   .option(
     "--callback-prompt <prompt>",
     "Continue the current web chat after one connector action (use --limit 1)",
@@ -227,6 +233,7 @@ export const searchCommand = new Command()
         keyword: string,
         options: { agent?: string; limit?: number; callbackPrompt?: string },
       ) => {
+        const agentId = resolveConnectorAgentId(options.agent);
         const trimmed = keyword.trim();
         if (!trimmed) {
           throw new Error("Keyword cannot be empty.");
@@ -237,7 +244,7 @@ export const searchCommand = new Command()
             await Promise.all([
               listConnectorCatalog(),
               listCustomConnectors(),
-              resolveConnectorDiscoveryAgentContext(options.agent),
+              resolveConnectorDiscoveryAgentContext(agentId),
               getPlatformOrigin(),
             ]);
           const definitions = connectorDiscoveryDefinitions(
@@ -297,7 +304,7 @@ export const searchCommand = new Command()
           await Promise.all([
             listConnectorCatalogStatus(),
             listCustomConnectors(),
-            resolveConnectorDiscoveryAgentContext(options.agent),
+            resolveConnectorDiscoveryAgentContext(agentId),
             getPlatformOrigin(),
           ]);
         const discoveredConnectors = connectorDiscoveryItems(

--- a/turbo/apps/cli/src/commands/connector/status.ts
+++ b/turbo/apps/cli/src/commands/connector/status.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { listConnectorCatalogStatus } from "../../lib/api/domains/connectors";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
-import { resolveAgentContext } from "./agent-context";
+import { resolveAgentContext, resolveConnectorAgentId } from "./agent-context";
 import { getPlatformOrigin } from "../doctor/platform-url";
 import {
   availableConnectorSlugs,
@@ -263,7 +263,10 @@ export const statusCommand = new Command()
   .name("status")
   .description("Show detailed status of a connector")
   .argument("<slug>", "Connector slug (e.g., github)")
-  .option("--agent <id>", "Show authorization state for the given agent")
+  .option(
+    "--agent <id>",
+    "Show authorization state for the given Agent (must match the current Agent inside a run)",
+  )
   .option("--json", "Output connector status as JSON")
   .action(
     withErrorHandler(
@@ -271,13 +274,14 @@ export const statusCommand = new Command()
         connectorSlug: string,
         options: { agent?: string; json?: boolean },
       ) => {
+        const agentId = resolveConnectorAgentId(options.agent);
         if (isRunBoundConnectorContext()) {
           await printRunConnectorStatus(connectorSlug, options.json ?? false);
           return;
         }
         const [catalog, agentCtx] = await Promise.all([
           listConnectorCatalogStatus(),
-          resolveAgentContext(options.agent),
+          resolveAgentContext(agentId),
         ]);
         const connector = findConnectorStatusItem(
           catalog.connectors,


### PR DESCRIPTION
Run-bound connector commands now reject `--agent` when it differs from `OKOU_AGENT_ID`, before issuing requests or producing authorization guidance. All six selector-bearing entry points use one resolver, including permission-request's browser, Computer Use, and custom-target branches. Omitted and matching selectors retain the current Agent; explicit non-run selection remains supported.

The change is limited to CLI argument handling and help. It preserves the Run's admitted accounts and the separate builtin/custom authorization models. Existing scripts that supply a conflicting selector inside a Run now receive an actionable error.

Closes #32827

## Validation

- 141 tests passed across nine focused CLI suites: Agent context, list, status, search, permission-request, custom readers, run-account context, account switch-request, and mail. The ten new rejection cases all failed against the original production code before the fix.
- `pnpm --filter @okouai/cli lint`
- `pnpm --filter @okouai/cli check-types`
- `pnpm exec knip --workspace @okouai/cli`
- Changed-file Prettier and `git diff --check`.

No full local Vitest suite or live cross-Agent credential operation was run. The command tests exercise the real parser and internal code, with MSW at the HTTP boundary and real account-projection files.
