### PR TITLE
fix(platform): hide auth actions on shared threads

### DIFF
--- a/turbo/apps/platform/src/signals/shared-thread-page/shared-thread-page-setup.ts
+++ b/turbo/apps/platform/src/signals/shared-thread-page/shared-thread-page-setup.ts
@@ -11,6 +11,7 @@ import {
 } from "../../views/shared-thread-page/shared-thread-page.tsx";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { apiClient$ } from "../api-client.ts";
+import { clerk$ } from "../auth.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { pathParams$ } from "../route.ts";
 import { updatePage$ } from "../react-router.ts";
@@ -34,6 +35,8 @@ export const setupSharedThreadPage$ = command(
       signal,
     );
     await featureSwitchHydration;
+    signal.throwIfAborted();
+    const clerk = await get(clerk$);
     signal.throwIfAborted();
     let sharedThread: SharedDisplayThread | null = null;
     const mathEnabled = get(agentMessageMathEnabled$);
@@ -75,7 +78,13 @@ export const setupSharedThreadPage$ = command(
           return $.sharedThread.notFoundTitle;
         }),
     );
-    set(updatePage$, createElement(SharedThreadPage, { sharedThread }));
+    set(
+      updatePage$,
+      createElement(SharedThreadPage, {
+        isSignedIn: Boolean(clerk.user),
+        sharedThread,
+      }),
+    );
     const richContentLoad = sharedThread?.richContent
       ? set(sharedThread.richContent.load$, signal)
       : undefined;

--- a/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-actions.test.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-actions.test.tsx
@@ -65,6 +65,29 @@ test("A visitor can continue a shared idea in Platform", async () => {
   );
 });
 
+test("A signed-in user does not see authentication actions", async () => {
+  context.mocks.api(sharedThreadsContract.get, ({ respond }) => {
+    return respond(200, sharedThread());
+  });
+
+  await setupSharedThreadPage(context, {
+    auth: {
+      user: {
+        id: "signed-in-user",
+        fullName: "Signed-in user",
+      },
+    },
+    host: "app.okou.ai",
+  });
+
+  await expect(
+    screen.findByText("Make this conversation yours"),
+  ).resolves.toBeInTheDocument();
+  expect(linksByName("Sign in")).toHaveLength(0);
+  expect(linksByName("Sign up")).toHaveLength(0);
+  expect(linksByName("Try it yourself")).toHaveLength(1);
+});
+
 test("A visitor can copy complete public message content", async () => {
   const clipboard = context.mocks.browser.clipboardWriteText();
   context.mocks.api(sharedThreadsContract.get, ({ respond }) => {

--- a/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-test-helpers.ts
+++ b/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-test-helpers.ts
@@ -3,6 +3,7 @@ import type { SharedThreadResponse } from "@okouai/api-contracts/contracts/share
 import {
   queryAllByRoleFast,
   setupPage,
+  type SetupPageAuth,
 } from "../../../__tests__/page-helper.ts";
 import type { TestContext } from "../../../signals/__tests__/test-helpers.ts";
 
@@ -22,13 +23,16 @@ export function sharedThread(
 
 export function setupSharedThreadPage(
   context: TestContext,
-  options: { readonly host?: string } = {},
+  options: {
+    readonly auth?: SetupPageAuth;
+    readonly host?: string;
+  } = {},
 ): Promise<void> {
   return setupPage({
     context,
     path: `/share/threads/${SHARED_THREAD_ID}`,
     host: options.host,
-    auth: null,
+    auth: options.auth ?? null,
   });
 }
 

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -274,10 +274,12 @@ function SharedRichMessageBody({
 function SharedThreadHandoff({
   assistantName,
   handoffUrl,
+  isSignedIn,
   signInUrl,
 }: {
   readonly assistantName: string;
   readonly handoffUrl: string;
+  readonly isSignedIn: boolean;
   readonly signInUrl: string;
 }) {
   const { t } = useTranslation();
@@ -311,13 +313,15 @@ function SharedThreadHandoff({
                   </p>
                 </div>
                 <div className="flex shrink-0 items-center gap-1 sm:gap-2">
-                  <Button variant="quiet" size="sm" asChild>
-                    <a href={signInUrl}>
-                      {t(($) => {
-                        return $.sharedThread.signIn;
-                      })}
-                    </a>
-                  </Button>
+                  {isSignedIn ? null : (
+                    <Button variant="quiet" size="sm" asChild>
+                      <a href={signInUrl}>
+                        {t(($) => {
+                          return $.sharedThread.signIn;
+                        })}
+                      </a>
+                    </Button>
+                  )}
                   <Button size="sm" asChild>
                     <a href={handoffUrl}>
                       {t(($) => {
@@ -338,6 +342,7 @@ function SharedThreadHandoff({
 function SharedThreadHeader({
   brandName,
   homeUrl,
+  isSignedIn,
   shareUrl,
   signInUrl,
   signUpUrl,
@@ -345,6 +350,7 @@ function SharedThreadHeader({
 }: {
   readonly brandName: BrandName;
   readonly homeUrl: string;
+  readonly isSignedIn: boolean;
   readonly shareUrl: string | null;
   readonly signInUrl: string;
   readonly signUpUrl: string;
@@ -405,25 +411,29 @@ function SharedThreadHeader({
             <Share2 size={18} />
           </Button>
         ) : null}
-        <Button
-          variant="quiet"
-          size="sm"
-          className="hidden sm:inline-flex"
-          asChild
-        >
-          <a href={signInUrl}>
-            {t(($) => {
-              return $.sharedThread.signIn;
-            })}
-          </a>
-        </Button>
-        <Button size="sm" asChild>
-          <a href={signUpUrl}>
-            {t(($) => {
-              return $.sharedThread.signUp;
-            })}
-          </a>
-        </Button>
+        {isSignedIn ? null : (
+          <>
+            <Button
+              variant="quiet"
+              size="sm"
+              className="hidden sm:inline-flex"
+              asChild
+            >
+              <a href={signInUrl}>
+                {t(($) => {
+                  return $.sharedThread.signIn;
+                })}
+              </a>
+            </Button>
+            <Button size="sm" asChild>
+              <a href={signUpUrl}>
+                {t(($) => {
+                  return $.sharedThread.signUp;
+                })}
+              </a>
+            </Button>
+          </>
+        )}
       </div>
     </header>
   );
@@ -483,8 +493,10 @@ function SharedThreadNotFound() {
 }
 
 export function SharedThreadPage({
+  isSignedIn,
   sharedThread,
 }: {
+  readonly isSignedIn: boolean;
   readonly sharedThread: SharedDisplayThread | null;
 }) {
   const { t } = useTranslation();
@@ -517,6 +529,7 @@ export function SharedThreadPage({
       <SharedThreadHeader
         brandName={BRAND_NAME}
         homeUrl={homeUrl}
+        isSignedIn={isSignedIn}
         shareUrl={shareUrl}
         signInUrl={signInUrl.toString()}
         signUpUrl={signUpUrl.toString()}
@@ -532,6 +545,7 @@ export function SharedThreadPage({
           <SharedThreadHandoff
             assistantName={ASSISTANT_NAME}
             handoffUrl={handoffUrl.toString()}
+            isSignedIn={isSignedIn}
             signInUrl={signInUrl.toString()}
           />
         </>


### PR DESCRIPTION
## Summary

- resolve the Clerk session before rendering a public shared conversation
- hide header and handoff authentication actions for signed-in users
- preserve visitor sign-in/sign-up flows and the shared-conversation handoff

## Verification

- `pnpm vitest run --project=@okouai/app apps/platform/src/views/shared-thread-page/__tests__` (7 tests passed)
- `pnpm -F @okouai/app run check-types`
- targeted Prettier, ESLint, Oxlint, and type-aware Oxlint checks
