### PR TITLE
feat(cli): accept unambiguous connector selectors

### DIFF
--- a/docs/connector-inspection-json.md
+++ b/docs/connector-inspection-json.md
@@ -8,13 +8,21 @@ okou connector check --url https://api.github.com/repos/owner/repo --json
 okou connector list --json
 okou connector status github --json
 okou connector custom list --json
-okou connector custom status <connector-id> --json
+okou connector custom status <selector> --json
 ```
 
 An inspection result occupies all of stdout as one JSON value, without ANSI
 formatting or appended guidance. Commands without `--json` keep their existing
 human-readable output. Existing list/status JSON fields are preserved; new
 identity fields are additive.
+
+Selectors accept full slugs, custom UUIDs, and exact unique display names
+within the command's supported connector types. Full identifiers take
+precedence over names. Use `builtin:<slug-or-name>` or
+`custom:<uuid-slug-or-name>` to disambiguate types; a remaining collision is an
+error with explicit candidate identities. Custom UUIDs remain the stable
+choice for automation. Selecting an alias preserves the canonical `target`
+and the existing run-selected account in JSON.
 
 ## Identity and evidence
 

--- a/turbo/apps/cli/src/commands/__tests__/helpers/connector-catalog.ts
+++ b/turbo/apps/cli/src/commands/__tests__/helpers/connector-catalog.ts
@@ -151,8 +151,9 @@ export function catalogPermissionDetail(
 
 export function stubConnectorCatalog(
   connectors: readonly PublicConnectorCatalogItem[],
+  origin = "http://localhost:3000",
 ) {
-  return http.get("http://localhost:3000/api/connector-catalog", () => {
+  return http.get(`${origin}/api/connector-catalog`, () => {
     return HttpResponse.json({ connectors });
   });
 }

--- a/turbo/apps/cli/src/commands/connector/__tests__/agent-context.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/agent-context.test.ts
@@ -45,6 +45,11 @@ const commandCases = [
     args: ["status", CUSTOM_CONNECTOR_ID],
   },
   {
+    name: "custom status by slug",
+    command: customConnectorCommand,
+    args: ["status", "_acme-search"],
+  },
+  {
     name: "builtin permission-request",
     command: permissionRequestCommand,
     args: [

--- a/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
@@ -177,36 +177,54 @@ describe("custom connector URL diagnostics", () => {
     rmSync(directory, { recursive: true, force: true });
   });
 
-  it("emits the exact custom account, subtype, and grant state as one JSON result", async () => {
-    await check("--connector", `custom:${CUSTOM_ID}`, "--json");
-    const json: unknown = JSON.parse(output());
-    expect(json).toMatchObject({
-      context: "run",
-      connector: {
-        target: TARGET,
-        label: "Renamed Acme",
-        connectorType: "custom-http",
-        definitionAvailable: true,
-      },
-      account: {
-        state: "available",
-        connectionId: ACCOUNT_ID,
-        metadata: { connectionStatus: "connected" },
-      },
-      connection: null,
-      authorization: { authorized: false },
-      diagnostic: {
-        run: { bases: ["https://api.acme.test/pinned"] },
-        permission: {
-          permissions: [{ name: "items:write", policy: { outcome: "deny" } }],
+  it.each([
+    `custom:${CUSTOM_ID}`,
+    CUSTOM_ID,
+    "_mutable-new-slug",
+    "Renamed Acme",
+  ])(
+    "emits the exact custom account, subtype, and grant state for %s as JSON",
+    async (selector) => {
+      server.use(
+        stubCustomConnectors([
+          customConnector({
+            id: CUSTOM_ID,
+            slug: "_mutable-new-slug",
+            displayName: "Renamed Acme",
+          }),
+        ]),
+      );
+      await check("--connector", selector, "--json");
+      const json: unknown = JSON.parse(output());
+      expect(json).toMatchObject({
+        context: "run",
+        request: { target: TARGET },
+        connector: {
+          target: TARGET,
+          label: "Renamed Acme",
+          connectorType: "custom-http",
+          definitionAvailable: true,
         },
-      },
-    });
-    expect(log).toHaveBeenCalledTimes(1);
-    expect(output()).not.toMatch(
-      /Default sibling|new-default|permission-request/,
-    );
-  });
+        account: {
+          state: "available",
+          connectionId: ACCOUNT_ID,
+          metadata: { connectionStatus: "connected" },
+        },
+        connection: null,
+        authorization: { authorized: false },
+        diagnostic: {
+          run: { bases: ["https://api.acme.test/pinned"] },
+          permission: {
+            permissions: [{ name: "items:write", policy: { outcome: "deny" } }],
+          },
+        },
+      });
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(output()).not.toMatch(
+        /Default sibling|new-default|permission-request/,
+      );
+    },
+  );
 
   it("reports unavailable definition metadata explicitly without replacing its account", async () => {
     server.use(

--- a/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
@@ -14,6 +14,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { server } from "../../../mocks/server";
 import {
+  catalogItem,
+  stubConnectorCatalog,
+} from "../../__tests__/helpers/connector-catalog";
+import {
   customConnector,
   stubAgentCustomConnectors,
   stubCustomConnectors,
@@ -374,9 +378,18 @@ describe("custom connector URL diagnostics", () => {
     );
   });
 
-  it.each(["http", "mcp"] as const)(
-    "resolves a custom %s slug and preserves the run-pinned target",
-    async (kind) => {
+  it.each([
+    ["http", "slug"],
+    ["http", "uuid"],
+    ["http", "qualified"],
+    ["http", "name"],
+    ["mcp", "slug"],
+    ["mcp", "uuid"],
+    ["mcp", "qualified"],
+    ["mcp", "name"],
+  ] as const)(
+    "resolves a custom %s %s and preserves the run-pinned target",
+    async (kind, form) => {
       const httpDefinition = customConnector({
         id: CUSTOM_ID,
         slug: `_acme-${kind}`,
@@ -401,7 +414,13 @@ describe("custom connector URL diagnostics", () => {
         }),
       );
 
-      await check("--connector", definition.slug);
+      const selectors = {
+        slug: definition.slug,
+        uuid: CUSTOM_ID,
+        qualified: `custom:${definition.slug}`,
+        name: definition.displayName,
+      };
+      await check("--connector", selectors[form]);
 
       expect(requests).toStrictEqual([
         { mode: "url", method: "POST", url: REQUEST_URL, target: TARGET },
@@ -461,13 +480,14 @@ describe("custom connector URL diagnostics", () => {
       const message = error.mock.calls.flat().join("\n");
       expect(message).toContain(
         scenario === "unknown"
-          ? "Unknown or unavailable custom connector slug"
-          : "Ambiguous custom connector slug",
+          ? "Unknown or unavailable custom connector selector"
+          : "Ambiguous connector selector",
       );
-      expect(message).toContain("okou connector custom list");
       if (scenario === "ambiguous") {
-        expect(message).toContain(`${CUSTOM_ID}, ${DEFAULT_ACCOUNT_ID}`);
-        expect(message).toContain("custom:<uuid>");
+        expect(message).toContain(`custom:${CUSTOM_ID}`);
+        expect(message).toContain(`custom:${DEFAULT_ACCOUNT_ID}`);
+      } else {
+        expect(message).toContain("okou connector custom list");
       }
     },
   );
@@ -496,7 +516,7 @@ describe("custom connector URL diagnostics", () => {
       "Inventory lookup failed",
     );
     expect(error.mock.calls.flat().join("\n")).not.toContain(
-      "Unknown or unavailable custom connector slug",
+      "Unknown or unavailable custom connector selector",
     );
   });
 
@@ -616,30 +636,57 @@ describe("custom connector URL diagnostics", () => {
     expect(message).not.toContain("connectorSlug=");
   });
 
-  it("preserves UUID-shaped builtin selectors instead of guessing they identify custom connectors", async () => {
-    stubDiagnostic({ outcome: "unknown-connector" });
+  it("rejects a UUID shared by a builtin slug and custom ID before diagnosis", async () => {
+    server.use(
+      stubConnectorCatalog([
+        catalogItem({ connectorSlug: CUSTOM_ID, label: "UUID builtin" }),
+      ]),
+      stubCustomConnectors([customConnector()]),
+    );
     await expect(check("--connector", CUSTOM_ID)).rejects.toThrow(
       "process.exit called",
     );
-    expect(requests).toStrictEqual([
-      {
-        mode: "url",
-        method: "POST",
-        url: REQUEST_URL,
-        connectorSlug: CUSTOM_ID,
-      },
-    ]);
-    expect(error.mock.calls.flat().join("\n")).toContain(
-      `Unknown connector slug: ${CUSTOM_ID}`,
-    );
+    expect(requests).toStrictEqual([]);
+    const message = error.mock.calls.flat().join("\n");
+    expect(message).toContain("Ambiguous connector selector");
+    expect(message).toContain(`builtin:${CUSTOM_ID}`);
+    expect(message).toContain(`custom:${CUSTOM_ID}`);
   });
 
-  it("rejects malformed custom identity before sending a diagnostic", async () => {
-    await expect(check("--connector", "custom:not-a-uuid")).rejects.toThrow(
+  it.each([CUSTOM_ID, `builtin:${CUSTOM_ID}`])(
+    "diagnoses a UUID-shaped builtin slug selected by %s",
+    async (selector) => {
+      server.use(
+        stubConnectorCatalog([catalogItem({ connectorSlug: CUSTOM_ID })]),
+        stubCustomConnectors([]),
+      );
+      stubDiagnostic({ outcome: "unknown-connector" });
+      await expect(check("--connector", selector)).rejects.toThrow(
+        "process.exit called",
+      );
+      expect(requests).toStrictEqual([
+        {
+          mode: "url",
+          method: "POST",
+          url: REQUEST_URL,
+          connectorSlug: CUSTOM_ID,
+        },
+      ]);
+      expect(error.mock.calls.flat().join("\n")).toContain(
+        `Unknown connector slug: ${CUSTOM_ID}`,
+      );
+    },
+  );
+
+  it("rejects an unavailable qualified name before sending a diagnostic", async () => {
+    server.use(stubCustomConnectors([]));
+    await expect(check("--connector", "custom:missing-name")).rejects.toThrow(
       "process.exit called",
     );
     expect(requests).toStrictEqual([]);
-    expect(error.mock.calls.flat().join("\n")).toContain("custom:<uuid>");
+    expect(error.mock.calls.flat().join("\n")).toContain(
+      "Unknown or unavailable custom connector selector",
+    );
   });
 
   it("does not treat custom unknown endpoints as a grantable builtin permission", async () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
@@ -498,14 +498,14 @@ describe("custom connector URL diagnostics", () => {
       const message = error.mock.calls.flat().join("\n");
       expect(message).toContain(
         scenario === "unknown"
-          ? "Unknown or unavailable custom connector selector"
+          ? "Unknown or unavailable connector selector"
           : "Ambiguous connector selector",
       );
       if (scenario === "ambiguous") {
         expect(message).toContain(`custom:${CUSTOM_ID}`);
         expect(message).toContain(`custom:${DEFAULT_ACCOUNT_ID}`);
       } else {
-        expect(message).toContain("okou connector custom list");
+        expect(message).toContain("okou connector list");
       }
     },
   );
@@ -652,6 +652,47 @@ describe("custom connector URL diagnostics", () => {
     );
     expect(message).toContain("--connector 'github' --method 'POST'");
     expect(message).not.toContain("connectorSlug=");
+  });
+
+  it("resolves a unique builtin name beginning with an underscore", async () => {
+    server.use(
+      stubConnectorCatalog([
+        catalogItem({ connectorSlug: "server-only", label: "_service-name" }),
+      ]),
+      stubCustomConnectors([]),
+    );
+    stubDiagnostic({ outcome: "unknown-connector" });
+    await expect(check("--connector", "_service-name")).rejects.toThrow(
+      "process.exit called",
+    );
+    expect(requests).toStrictEqual([
+      {
+        mode: "url",
+        method: "POST",
+        url: REQUEST_URL,
+        connectorSlug: "server-only",
+      },
+    ]);
+    expect(error.mock.calls.flat().join("\n")).toContain(
+      "Unknown connector slug: server-only",
+    );
+  });
+
+  it("rejects an underscore-prefixed name shared by builtin and custom connectors", async () => {
+    server.use(
+      stubConnectorCatalog([
+        catalogItem({ connectorSlug: "server-only", label: "_service-name" }),
+      ]),
+      stubCustomConnectors([customConnector({ displayName: "_service-name" })]),
+    );
+    await expect(check("--connector", "_service-name")).rejects.toThrow(
+      "process.exit called",
+    );
+    expect(requests).toStrictEqual([]);
+    const message = error.mock.calls.flat().join("\n");
+    expect(message).toContain("Ambiguous connector selector");
+    expect(message).toContain("builtin:server-only");
+    expect(message).toContain(`custom:${CUSTOM_ID}`);
   });
 
   it("rejects a UUID shared by a builtin slug and custom ID before diagnosis", async () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
@@ -8,6 +8,7 @@ import {
   type ConnectorCheckTargetAwareDiagnosticResult,
 } from "@okouai/api-contracts/contracts/connector-check";
 import type { ConnectorAccountInspectionResult } from "@okouai/api-contracts/contracts/connector-accounts";
+import { customConnectorMcpResponseSchema } from "@okouai/api-contracts/contracts/custom-connectors";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -15,6 +16,7 @@ import { server } from "../../../mocks/server";
 import {
   customConnector,
   stubAgentCustomConnectors,
+  stubCustomConnectors,
 } from "../../__tests__/helpers/custom-connectors";
 import {
   stubRunConnectorAccountInspection,
@@ -370,6 +372,151 @@ describe("custom connector URL diagnostics", () => {
     expect(output()).not.toContain(
       "account selected for this run is connected",
     );
+  });
+
+  it.each(["http", "mcp"] as const)(
+    "resolves a custom %s slug and preserves the run-pinned target",
+    async (kind) => {
+      const httpDefinition = customConnector({
+        id: CUSTOM_ID,
+        slug: `_acme-${kind}`,
+        displayName: "Current custom connector",
+        connected: true,
+      });
+      const definition =
+        kind === "http"
+          ? httpDefinition
+          : customConnectorMcpResponseSchema.parse({
+              ...httpDefinition,
+              kind: "mcp",
+              transport: "streamable-http",
+              endpoint: "https://api.acme.test/mcp",
+              prefixTemplates: [],
+              permissionBundleRef: null,
+            });
+      server.use(
+        stubCustomConnectors([definition]),
+        http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {
+          return HttpResponse.json(definition);
+        }),
+      );
+
+      await check("--connector", definition.slug);
+
+      expect(requests).toStrictEqual([
+        { mode: "url", method: "POST", url: REQUEST_URL, target: TARGET },
+      ]);
+      expect(output()).toContain(`custom UUID: ${CUSTOM_ID}`);
+      expect(output()).toContain(`Connection ID: ${ACCOUNT_ID}`);
+      expect(output()).toContain("Run-selected account");
+      expect(output()).toContain("https://api.acme.test/pinned");
+      expect(output()).toContain("review Permissions");
+      expect(output()).not.toMatch(
+        /Default sibling|permission-request|connectorSlug=/,
+      );
+    },
+  );
+
+  it("does not infer run admission from a connected org-visible slug", async () => {
+    const definition = customConnector({ id: CUSTOM_ID, connected: true });
+    server.use(stubCustomConnectors([definition]));
+    stubDiagnostic({
+      outcome: "target-unavailable",
+      target: TARGET,
+      reason: "not-admitted",
+    });
+
+    await expect(check("--connector", definition.slug)).rejects.toThrow(
+      "process.exit called",
+    );
+
+    expect(requests).toStrictEqual([
+      { mode: "url", method: "POST", url: REQUEST_URL, target: TARGET },
+    ]);
+    expect(error.mock.calls.flat().join("\n")).toContain(
+      "was not admitted to this run",
+    );
+    expect(output()).toBe("");
+  });
+
+  it.each(["unknown", "ambiguous"])(
+    "rejects an %s custom slug before diagnosis",
+    async (scenario) => {
+      server.use(
+        stubCustomConnectors(
+          scenario === "unknown"
+            ? []
+            : [
+                customConnector({ id: CUSTOM_ID }),
+                customConnector({ id: DEFAULT_ACCOUNT_ID }),
+              ],
+        ),
+      );
+
+      await expect(check("--connector", "_acme-search")).rejects.toThrow(
+        "process.exit called",
+      );
+
+      expect(requests).toStrictEqual([]);
+      const message = error.mock.calls.flat().join("\n");
+      expect(message).toContain(
+        scenario === "unknown"
+          ? "Unknown or unavailable custom connector slug"
+          : "Ambiguous custom connector slug",
+      );
+      expect(message).toContain("okou connector custom list");
+      if (scenario === "ambiguous") {
+        expect(message).toContain(`${CUSTOM_ID}, ${DEFAULT_ACCOUNT_ID}`);
+        expect(message).toContain("custom:<uuid>");
+      }
+    },
+  );
+
+  it("propagates failed slug discovery without trying another diagnostic target", async () => {
+    server.use(
+      http.get(`${ORIGIN}/api/custom-connectors`, () => {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "INTERNAL_SERVER_ERROR",
+              message: "Inventory lookup failed",
+            },
+          },
+          { status: 500 },
+        );
+      }),
+    );
+
+    await expect(check("--connector", "_acme-search")).rejects.toThrow(
+      "process.exit called",
+    );
+
+    expect(requests).toStrictEqual([]);
+    expect(error.mock.calls.flat().join("\n")).toContain(
+      "Inventory lookup failed",
+    );
+    expect(error.mock.calls.flat().join("\n")).not.toContain(
+      "Unknown or unavailable custom connector slug",
+    );
+  });
+
+  it("rejects embedded URL credentials before resolving a custom slug", async () => {
+    await expect(
+      checkConnectorCommand.parseAsync([
+        "node",
+        "okou",
+        "--url",
+        "https://user:password@api.acme.test/items",
+        "--connector",
+        "_acme-search",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(requests).toStrictEqual([]);
+    expect(error.mock.calls.flat().join("\n")).toContain(
+      "valid absolute http or https URL",
+    );
+    expect(error.mock.calls.flat().join("\n")).not.toContain("password");
   });
 
   it("retains a deleted pinned account identity without suggesting a sibling account", async () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/check.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check.test.ts
@@ -18,6 +18,10 @@ import {
   writeRunConnectorAccountContext,
 } from "../../__tests__/helpers/run-connector-accounts";
 import { server } from "../../../mocks/server";
+import {
+  catalogItem,
+  stubConnectorCatalog,
+} from "../../__tests__/helpers/connector-catalog";
 import { checkConnectorCommand } from "../check";
 
 const API_BASE_URL = "https://app.okou.ai";
@@ -168,6 +172,27 @@ function stubDiagnostic(
   onRequest?: (body: unknown) => void,
   baseUrl = API_BASE_URL,
 ): void {
+  if (result.outcome === "unknown-connector") {
+    server.use(
+      stubConnectorCatalog(
+        [catalogItem({ connectorSlug: "missing-connector" })],
+        baseUrl,
+      ),
+    );
+  }
+  if ("connector" in result) {
+    server.use(
+      stubConnectorCatalog(
+        [
+          catalogItem(result.connector),
+          ...(result.connector.connectorSlug === "slack"
+            ? []
+            : [catalogItem({ connectorSlug: "slack", label: "Slack" })]),
+        ],
+        baseUrl,
+      ),
+    );
+  }
   server.use(
     http.post(diagnosticEndpoint(baseUrl), async ({ request }) => {
       const body: unknown = await request.json();
@@ -1476,7 +1501,7 @@ describe("okou connector check command", () => {
           "--url",
           "https://service.example.com/path",
           "--connector",
-          "missing-connector",
+          "builtin:missing-connector",
         ],
         result: { outcome: "unknown-connector" },
         expected: "Unknown connector slug: missing-connector",

--- a/turbo/apps/cli/src/commands/connector/__tests__/connect.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/connect.test.ts
@@ -73,54 +73,58 @@ describe("okou connector connect command", () => {
     vi.unstubAllEnvs();
   });
 
-  it("preserves first-connect syntax and sends explicit add", async () => {
-    let receivedBody: unknown;
-    server.use(
-      http.get("http://localhost:3000/api/connectors/:connectorSlug", () => {
-        return HttpResponse.json(
-          {
-            error: { message: "Connector not found", code: "NOT_FOUND" },
-          },
-          { status: 404 },
-        );
-      }),
-      http.post(
-        "http://localhost:3000/api/connectors/:connectorSlug/manual-grant",
-        async ({ params, request }) => {
-          receivedBody = await request.json();
+  it.each(["zendesk", "Zendesk", "builtin:zendesk", "builtin:Zendesk"])(
+    "connects builtin selector %s and sends explicit add",
+    async (selector) => {
+      let receivedBody: unknown;
+      server.use(
+        http.get("http://localhost:3000/api/connectors/:connectorSlug", () => {
           return HttpResponse.json(
-            connectorResponse(String(params.connectorSlug)),
+            {
+              error: { message: "Connector not found", code: "NOT_FOUND" },
+            },
+            { status: 404 },
           );
+        }),
+        http.post(
+          "http://localhost:3000/api/connectors/:connectorSlug/manual-grant",
+          async ({ params, request }) => {
+            expect(params.connectorSlug).toBe("zendesk");
+            receivedBody = await request.json();
+            return HttpResponse.json(
+              connectorResponse(String(params.connectorSlug)),
+            );
+          },
+        ),
+      );
+
+      await connectCommand.parseAsync([
+        "node",
+        "cli",
+        selector,
+        "--value",
+        "apiToken=secret-token",
+        "--value",
+        "subdomain=example",
+        "--value",
+        "email=support@example.com",
+      ]);
+
+      expect(receivedBody).toStrictEqual({
+        account: { intent: "add" },
+        authMethod: "api-token",
+        values: {
+          apiToken: "secret-token",
+          subdomain: "example",
+          email: "support@example.com",
         },
-      ),
-    );
-
-    await connectCommand.parseAsync([
-      "node",
-      "cli",
-      "zendesk",
-      "--value",
-      "apiToken=secret-token",
-      "--value",
-      "subdomain=example",
-      "--value",
-      "email=support@example.com",
-    ]);
-
-    expect(receivedBody).toStrictEqual({
-      account: { intent: "add" },
-      authMethod: "api-token",
-      values: {
-        apiToken: "secret-token",
-        subdomain: "example",
-        email: "support@example.com",
-      },
-    });
-    const output = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(output).toContain("Zendesk connected");
-    expect(output).toContain("okou connector status zendesk");
-    expect(output).not.toContain("secret-token");
-  });
+      });
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain("Zendesk connected");
+      expect(output).toContain("okou connector status zendesk");
+      expect(output).not.toContain("secret-token");
+    },
+  );
 
   it("rejects a custom slug from the builtin manual-connect flow", async () => {
     const connector = customConnector();

--- a/turbo/apps/cli/src/commands/connector/__tests__/connect.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/connect.test.ts
@@ -14,6 +14,10 @@ import chalk from "chalk";
 import { server } from "../../../mocks/server";
 import { connectCommand } from "../connect";
 import {
+  customConnector,
+  stubCustomConnectors,
+} from "../../__tests__/helpers/custom-connectors";
+import {
   catalogStatusItem,
   manualAuthMethod,
   stubConnectorCatalogStatus,
@@ -116,6 +120,27 @@ describe("okou connector connect command", () => {
     expect(output).toContain("Zendesk connected");
     expect(output).toContain("okou connector status zendesk");
     expect(output).not.toContain("secret-token");
+  });
+
+  it("rejects a custom slug from the builtin manual-connect flow", async () => {
+    const connector = customConnector();
+    server.use(stubCustomConnectors([connector]));
+
+    await expect(
+      connectCommand.parseAsync([
+        "node",
+        "okou",
+        connector.slug,
+        "--add",
+        "--value",
+        "apiKey=test-custom-key",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      `Unknown or unavailable connector: ${connector.slug}`,
+    );
+    expect(mockConsoleLog).not.toHaveBeenCalled();
   });
 
   it("preserves reconnect syntax and resolves the current default exactly", async () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
@@ -15,6 +15,14 @@ import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { server } from "../../../mocks/server";
+import {
+  catalogItem,
+  stubConnectorCatalog,
+} from "../../__tests__/helpers/connector-catalog";
+import {
+  customConnector,
+  stubCustomConnectors,
+} from "../../__tests__/helpers/custom-connectors";
 import { permissionRequestCommand } from "../permission-request";
 
 const SLACK_READ_PERMISSION = "admin.conversations:read";
@@ -86,6 +94,17 @@ function stubDiagnostic(
     request: ReturnType<typeof connectorCheckRequestSchema.parse>,
   ) => void,
 ): void {
+  if (result.outcome === "unknown-connector") {
+    server.use(
+      stubConnectorCatalog(
+        [catalogItem({ connectorSlug: "unknown-service" })],
+        baseUrl,
+      ),
+    );
+  }
+  if ("connector" in result) {
+    server.use(stubConnectorCatalog([catalogItem(result.connector)], baseUrl));
+  }
   server.use(
     http.post(
       `${baseUrl}/api/connectors/diagnostics/check`,
@@ -125,81 +144,52 @@ describe("okou connector permission-request command", () => {
     mockConsoleError.mockClear();
   });
 
-  it("rejects a custom UUID target with settings guidance instead of a builtin approval link", async () => {
-    const customId = "33333333-3333-4333-8333-333333333333";
-    vi.stubEnv("OKOU_AGENT_ID", "agent-1");
-    vi.stubEnv("OKOU_CHAT_THREAD_ID", "thread-1");
-    let diagnosticCalls = 0;
-    stubDiagnostic(resolvedUrlDiagnostic(), "https://app.okou.ai", () => {
-      diagnosticCalls += 1;
-    });
+  it.each([
+    "custom:33333333-3333-4333-8333-333333333333",
+    "33333333-3333-4333-8333-333333333333",
+    "_acme-search",
+    "custom:_acme-search",
+    "Acme Search",
+  ])(
+    "resolves custom selector %s to settings guidance without builtin approval",
+    async (selector) => {
+      const customId = "33333333-3333-4333-8333-333333333333";
+      vi.stubEnv("OKOU_AGENT_ID", "agent-1");
+      vi.stubEnv("OKOU_CHAT_THREAD_ID", "thread-1");
+      server.use(
+        stubCustomConnectors([customConnector()], "https://app.okou.ai"),
+      );
+      let diagnosticCalls = 0;
+      stubDiagnostic(resolvedUrlDiagnostic(), "https://app.okou.ai", () => {
+        diagnosticCalls += 1;
+      });
 
-    await expect(
-      permissionRequestCommand.parseAsync([
-        "node",
-        "okou",
-        `custom:${customId}`,
-        "--permission",
-        "items:write",
-        "--url",
-        "https://api.acme.test/items",
-        "--callback-prompt",
-        "Continue after approval",
-      ]),
-    ).rejects.toThrow("process.exit called");
+      await expect(
+        permissionRequestCommand.parseAsync([
+          "node",
+          "okou",
+          selector,
+          "--permission",
+          "items:write",
+          "--url",
+          "https://api.acme.test/items",
+          "--callback-prompt",
+          "Continue after approval",
+        ]),
+      ).rejects.toThrow("process.exit called");
 
-    const message = mockConsoleError.mock.calls.flat().join("\n");
-    expect(message).toContain(customId);
-    expect(message).toContain("[Connectors](https://app.okou.ai/connectors)");
-    expect(message).toContain("review Permissions");
-    expect(message).not.toMatch(/connectorSlug=|action=allow|callbackPrompt=/);
-    expect(mockConsoleLog).not.toHaveBeenCalled();
-    expect(diagnosticCalls).toBe(0);
-    expect(mockExit).toHaveBeenCalledWith(1);
-  });
-
-  it("rejects custom slugs from the builtin permission-request flow", async () => {
-    vi.stubEnv("OKOU_AGENT_ID", "agent-1");
-    server.use(
-      http.post(
-        "https://app.okou.ai/api/connectors/diagnostics/check",
-        async ({ request }) => {
-          const parsed = connectorCheckRequestSchema.safeParse(
-            await request.json(),
-          );
-          if (parsed.success) {
-            return HttpResponse.json(resolvedUrlDiagnostic());
-          }
-          return HttpResponse.json(
-            {
-              error: {
-                code: "BAD_REQUEST",
-                message: "Invalid builtin connector slug",
-              },
-            },
-            { status: 400 },
-          );
-        },
-      ),
-    );
-
-    await expect(
-      permissionRequestCommand.parseAsync([
-        "node",
-        "okou",
-        "_acme-mcp",
-        "--permission",
-        "items:write",
-        "--url",
-        "https://api.acme.test/items",
-      ]),
-    ).rejects.toThrow("process.exit called");
-
-    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
-      "Invalid builtin connector slug",
-    );
-    expect(mockConsoleLog).not.toHaveBeenCalled();
-  });
+      const message = mockConsoleError.mock.calls.flat().join("\n");
+      expect(message).toContain(customId);
+      expect(message).toContain("[Connectors](https://app.okou.ai/connectors)");
+      expect(message).toContain("review Permissions");
+      expect(message).not.toMatch(
+        /connectorSlug=|action=allow|callbackPrompt=/,
+      );
+      expect(mockConsoleLog).not.toHaveBeenCalled();
+      expect(diagnosticCalls).toBe(0);
+      expect(mockExit).toHaveBeenCalledWith(1);
+    },
+  );
 
   it("outputs an allow grant link without choosing the user's duration", async () => {
     vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.okou.ai");
@@ -532,41 +522,78 @@ describe("okou connector permission-request command", () => {
     expect(logCalls).toContain("Only allow this permission below");
   });
 
-  it("validates a server-authored connector absent from the CLI bundle", async () => {
-    vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.okou.ai");
-    const url = "https://api.server-only.example/v1/records";
-    stubDiagnostic(
-      resolvedUrlDiagnostic({
-        connectorSlug: "server-only",
-        label: "Server Only",
-        base: "https://api.server-only.example",
-        relativePath: "/v1/records",
-        permission: {
-          kind: "matched",
-          permissions: [
-            {
-              name: "records.read",
-              policy: { outcome: "deny", basis: "deny-list" },
-            },
-          ],
-        },
+  it.each([
+    ["server-only", "Server Only"],
+    ["builtin:server-only", "Server Only"],
+    ["Server Only", "Server Only"],
+    ["builtin:Server Only", "Server Only"],
+    ["serveronly", "serveronly"],
+    ["builtin:serveronly", "serveronly"],
+  ])(
+    "validates server-authored selector %s absent from the CLI bundle",
+    async (selector, label) => {
+      vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.okou.ai");
+      server.use(stubCustomConnectors([], "https://app.okou.ai"));
+      const url = "https://api.server-only.example/v1/records";
+      stubDiagnostic(
+        resolvedUrlDiagnostic({
+          connectorSlug: "server-only",
+          label,
+          base: "https://api.server-only.example",
+          relativePath: "/v1/records",
+          permission: {
+            kind: "matched",
+            permissions: [
+              {
+                name: "records.read",
+                policy: { outcome: "deny", basis: "deny-list" },
+              },
+            ],
+          },
+        }),
+      );
+
+      await permissionRequestCommand.parseAsync([
+        "node",
+        "cli",
+        selector,
+        "--permission",
+        "records.read",
+        "--url",
+        url,
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(`[Manage ${label} permissions]`);
+      expect(logCalls).toContain("connectorSlug=server-only");
+      expect(logCalls).toContain("permission=records.read");
+    },
+  );
+
+  it("rejects embedded credentials before resolving a custom display name", async () => {
+    let inventoryRequests = 0;
+    server.use(
+      http.get("https://app.okou.ai/api/custom-connectors", () => {
+        inventoryRequests += 1;
+        return HttpResponse.json({ connectors: [customConnector()] });
       }),
     );
-
-    await permissionRequestCommand.parseAsync([
-      "node",
-      "cli",
-      "server-only",
-      "--permission",
-      "records.read",
-      "--url",
-      url,
-    ]);
-
-    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("[Manage Server Only permissions]");
-    expect(logCalls).toContain("connectorSlug=server-only");
-    expect(logCalls).toContain("permission=records.read");
+    await expect(
+      permissionRequestCommand.parseAsync([
+        "node",
+        "okou",
+        "Acme Search",
+        "--permission",
+        "items:write",
+        "--url",
+        "https://user:secret-password@api.acme.test/items",
+      ]),
+    ).rejects.toThrow("process.exit called");
+    const output = mockConsoleError.mock.calls.flat().join("\n");
+    expect(output).toContain("valid absolute http or https URL");
+    expect(output).not.toContain("secret-password");
+    expect(inventoryRequests).toBe(0);
+    expect(mockConsoleLog).not.toHaveBeenCalled();
   });
 
   it("exits with an error for an unknown connector slug", async () => {
@@ -575,7 +602,7 @@ describe("okou connector permission-request command", () => {
       await permissionRequestCommand.parseAsync([
         "node",
         "cli",
-        "unknown-service",
+        "builtin:unknown-service",
         "--permission",
         "foo",
         "--url",

--- a/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
@@ -161,17 +161,26 @@ describe("okou connector permission-request command", () => {
   it("rejects custom slugs from the builtin permission-request flow", async () => {
     vi.stubEnv("OKOU_AGENT_ID", "agent-1");
     server.use(
-      http.post("https://app.okou.ai/api/connectors/diagnostics/check", () => {
-        return HttpResponse.json(
-          {
-            error: {
-              code: "BAD_REQUEST",
-              message: "Invalid builtin connector slug",
+      http.post(
+        "https://app.okou.ai/api/connectors/diagnostics/check",
+        async ({ request }) => {
+          const parsed = connectorCheckRequestSchema.safeParse(
+            await request.json(),
+          );
+          if (parsed.success) {
+            return HttpResponse.json(resolvedUrlDiagnostic());
+          }
+          return HttpResponse.json(
+            {
+              error: {
+                code: "BAD_REQUEST",
+                message: "Invalid builtin connector slug",
+              },
             },
-          },
-          { status: 400 },
-        );
-      }),
+            { status: 400 },
+          );
+        },
+      ),
     );
 
     await expect(

--- a/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
@@ -158,6 +158,40 @@ describe("okou connector permission-request command", () => {
     expect(mockExit).toHaveBeenCalledWith(1);
   });
 
+  it("rejects custom slugs from the builtin permission-request flow", async () => {
+    vi.stubEnv("OKOU_AGENT_ID", "agent-1");
+    server.use(
+      http.post("https://app.okou.ai/api/connectors/diagnostics/check", () => {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "BAD_REQUEST",
+              message: "Invalid builtin connector slug",
+            },
+          },
+          { status: 400 },
+        );
+      }),
+    );
+
+    await expect(
+      permissionRequestCommand.parseAsync([
+        "node",
+        "okou",
+        "_acme-mcp",
+        "--permission",
+        "items:write",
+        "--url",
+        "https://api.acme.test/items",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "Invalid builtin connector slug",
+    );
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
   it("outputs an allow grant link without choosing the user's duration", async () => {
     vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.okou.ai");
     vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");

--- a/turbo/apps/cli/src/commands/connector/__tests__/run-account-context.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/run-account-context.test.ts
@@ -272,84 +272,93 @@ describe("run connector account inspection", () => {
     expect(inspectionRequests).toBe(0);
   });
 
-  it("uses one exact representation for custom HTTP and MCP targets", async () => {
-    const httpConnector = customConnector();
-    const mcpConnector = customMcpConnector();
-    const httpConnectionId = "33333333-3333-4333-8333-333333333334";
-    const mcpConnectionId = "44444444-4444-4444-8444-444444444445";
-    writeContext([
-      {
-        kind: "custom",
-        customConnectorId: httpConnector.id,
-        connectionId: httpConnectionId,
-      },
-      {
-        kind: "custom",
-        customConnectorId: mcpConnector.id,
-        connectionId: mcpConnectionId,
-      },
-    ]);
-    server.use(
-      stubConnectorCatalog([]),
-      stubCustomConnectors([httpConnector, mcpConnector]),
-      http.post(
-        "http://localhost:3000/api/connector-accounts/inspect",
-        async ({ request }) => {
-          const body = connectorAccountsContract.inspect.body.parse(
-            await request.json(),
-          );
-          return HttpResponse.json({
-            results: body.selections.map((selection) => {
-              return { kind: "unavailable" as const, ...selection };
-            }),
-          });
-        },
-      ),
-    );
-
-    await listCommand.parseAsync(["node", "cli"]);
-    let output = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(output).toContain(httpConnector.slug);
-    expect(output).toContain(httpConnectionId);
-    expect(output).toContain(mcpConnector.slug);
-    expect(output).toContain(mcpConnectionId);
-
-    mockConsoleLog.mockClear();
-    await statusCommand.parseAsync(["node", "cli", mcpConnector.slug]);
-    output = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(output).toContain(mcpConnectionId);
-    expect(output).toContain("Current Status:");
-
-    mockConsoleLog.mockClear();
-    await listCommand.parseAsync(["node", "cli", "--json"]);
-    const json: unknown = JSON.parse(
-      mockConsoleLog.mock.calls.flat().join("\n"),
-    );
-    expect(json).toMatchObject({
-      context: "run",
-      connectors: [
+  it.each(["slug", "uuid", "qualified", "name"] as const)(
+    "preserves pinned HTTP and MCP accounts for a %s selector",
+    async (form) => {
+      const httpConnector = customConnector();
+      const mcpConnector = customMcpConnector();
+      const httpConnectionId = "33333333-3333-4333-8333-333333333334";
+      const mcpConnectionId = "44444444-4444-4444-8444-444444444445";
+      writeContext([
         {
-          target: { kind: "custom", customConnectorId: httpConnector.id },
-          connectorType: "custom-http",
-          definitionAvailable: true,
-          account: {
-            state: "metadata-unavailable",
-            connectionId: httpConnectionId,
-          },
+          kind: "custom",
+          customConnectorId: httpConnector.id,
+          connectionId: httpConnectionId,
         },
         {
-          target: { kind: "custom", customConnectorId: mcpConnector.id },
-          connectorType: "custom-mcp",
-          definitionAvailable: true,
-          account: {
-            state: "metadata-unavailable",
-            connectionId: mcpConnectionId,
-          },
+          kind: "custom",
+          customConnectorId: mcpConnector.id,
+          connectionId: mcpConnectionId,
         },
-      ],
-    });
-    expect(mockConsoleLog).toHaveBeenCalledTimes(1);
-  });
+      ]);
+      server.use(
+        stubConnectorCatalog([]),
+        stubCustomConnectors([httpConnector, mcpConnector]),
+        http.post(
+          "http://localhost:3000/api/connector-accounts/inspect",
+          async ({ request }) => {
+            const body = connectorAccountsContract.inspect.body.parse(
+              await request.json(),
+            );
+            return HttpResponse.json({
+              results: body.selections.map((selection) => {
+                return { kind: "unavailable" as const, ...selection };
+              }),
+            });
+          },
+        ),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+      let output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain(httpConnector.slug);
+      expect(output).toContain(httpConnectionId);
+      expect(output).toContain(mcpConnector.slug);
+      expect(output).toContain(mcpConnectionId);
+
+      mockConsoleLog.mockClear();
+      const selectors = {
+        slug: mcpConnector.slug,
+        uuid: mcpConnector.id,
+        qualified: `custom:${mcpConnector.id}`,
+        name: mcpConnector.displayName,
+      };
+      await statusCommand.parseAsync(["node", "cli", selectors[form]]);
+      output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain(mcpConnectionId);
+      expect(output).toContain("Current Status:");
+
+      mockConsoleLog.mockClear();
+      await listCommand.parseAsync(["node", "cli", "--json"]);
+      const json: unknown = JSON.parse(
+        mockConsoleLog.mock.calls.flat().join("\n"),
+      );
+      expect(json).toMatchObject({
+        context: "run",
+        connectors: [
+          {
+            target: { kind: "custom", customConnectorId: httpConnector.id },
+            connectorType: "custom-http",
+            definitionAvailable: true,
+            account: {
+              state: "metadata-unavailable",
+              connectionId: httpConnectionId,
+            },
+          },
+          {
+            target: { kind: "custom", customConnectorId: mcpConnector.id },
+            connectorType: "custom-mcp",
+            definitionAvailable: true,
+            account: {
+              state: "metadata-unavailable",
+              connectionId: mcpConnectionId,
+            },
+          },
+        ],
+      });
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("retains a missing custom definition's UUID with an explicitly unknown subtype", async () => {
     const customConnectorId = "33333333-3333-4333-8333-333333333333";

--- a/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
@@ -138,18 +138,21 @@ describe("okou connector status command", () => {
   });
 
   describe("without agent context", () => {
-    it("displays connected status with details", async () => {
-      server.use(stubConnector(connectedGithub));
+    it.each(["github", "GitHub", "builtin:github", "builtin:GitHub"])(
+      "displays connected status selected by %s",
+      async (selector) => {
+        server.use(stubConnector(connectedGithub));
 
-      await statusCommand.parseAsync(["node", "cli", "github"]);
+        await statusCommand.parseAsync(["node", "cli", selector]);
 
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("github");
-      expect(logCalls).toContain("connected");
-      expect(logCalls).toContain("@octocat");
-      expect(logCalls).toContain("oauth");
-      expect(logCalls).not.toContain("Authorized:");
-    });
+        const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+        expect(logCalls).toContain("github");
+        expect(logCalls).toContain("connected");
+        expect(logCalls).toContain("@octocat");
+        expect(logCalls).toContain("oauth");
+        expect(logCalls).not.toContain("Authorized:");
+      },
+    );
 
     it("displays not connected status", async () => {
       server.use(

--- a/turbo/apps/cli/src/commands/connector/account/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/connector/account/__tests__/list.test.ts
@@ -88,6 +88,120 @@ describe("okou connector account list command", () => {
     vi.unstubAllEnvs();
   });
 
+  it.each([
+    ["Shared Name", "Shared Name", "builtin:Shared Name", "builtin"],
+    ["Shared Name", "Shared Name", "custom:Shared Name", "custom"],
+    ["GitHub", "github", "github", "builtin"],
+    ["GitHub", "GITHUB", "GITHUB", "builtin"],
+    ["_acme-search", "Acme Search", "_acme-search", "custom"],
+  ] as const)(
+    "resolves builtin label %s and custom label %s with selector %s to %s",
+    async (builtinLabel, customLabel, selector, kind) => {
+      let targetQuery: string | undefined;
+      server.use(
+        stubConnectorCatalogStatus([
+          catalogStatusItem({ connectorSlug: "github", label: builtinLabel }),
+        ]),
+        stubCustomConnectors([customConnector({ displayName: customLabel })]),
+        http.get(
+          "http://localhost:3000/api/connector-accounts/connections",
+          ({ request }) => {
+            targetQuery = new URL(request.url).search;
+            return HttpResponse.json({ connections: [], nextCursor: null });
+          },
+        ),
+      );
+      await listConnectorAccountsCommand.parseAsync([
+        "node",
+        "okou",
+        selector,
+        "--json",
+      ]);
+      const target =
+        kind === "builtin"
+          ? { kind, connectorSlug: "github" }
+          : { kind, customConnectorId: CUSTOM_CONNECTOR_ID };
+      expect(
+        JSON.parse(mockConsoleLog.mock.calls.flat().join("\n")),
+      ).toMatchObject({ connector: { target } });
+      expect(new URLSearchParams(targetQuery).get("kind")).toBe(kind);
+      expect(
+        new URLSearchParams(targetQuery).get(
+          kind === "builtin" ? "connectorSlug" : "customConnectorId",
+        ),
+      ).toBe(kind === "builtin" ? "github" : CUSTOM_CONNECTOR_ID);
+    },
+  );
+
+  it.each(["mixed names", "custom names", "UUID collision"] as const)(
+    "rejects %s without listing accounts for an arbitrary candidate",
+    async (scenario) => {
+      const builtinSlug =
+        scenario === "UUID collision" ? CUSTOM_CONNECTOR_ID : "github";
+      const selector =
+        scenario === "UUID collision" ? CUSTOM_CONNECTOR_ID : "Shared Name";
+      const custom = customConnector({ displayName: "Shared Name" });
+      server.use(
+        stubConnectorCatalogStatus([
+          catalogStatusItem({
+            connectorSlug: builtinSlug,
+            label: scenario === "custom names" ? "GitHub" : "Shared Name",
+          }),
+        ]),
+        stubCustomConnectors(
+          scenario === "custom names"
+            ? [
+                custom,
+                customConnector({
+                  id: SECOND_CONNECTION_ID,
+                  slug: "_second",
+                  displayName: "Shared Name",
+                }),
+              ]
+            : [custom],
+        ),
+      );
+      await expect(
+        listConnectorAccountsCommand.parseAsync(["node", "okou", selector]),
+      ).rejects.toThrow("process.exit called");
+      const output = mockConsoleError.mock.calls.flat().join("\n");
+      expect(output).toContain("Ambiguous connector selector");
+      expect(output).toContain(`custom:${CUSTOM_CONNECTOR_ID}`);
+      expect(output).toContain(
+        scenario === "custom names"
+          ? `custom:${SECOND_CONNECTION_ID}`
+          : `builtin:${builtinSlug}`,
+      );
+      expect(mockConsoleLog).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["builtin", "custom"] as const)(
+    "uses an explicit %s qualifier to resolve a UUID collision",
+    async (kind) => {
+      server.use(
+        stubConnectorCatalogStatus([
+          catalogStatusItem({ connectorSlug: CUSTOM_CONNECTOR_ID }),
+        ]),
+        stubCustomConnectors([customConnector()]),
+        stubAccounts([]),
+      );
+      await listConnectorAccountsCommand.parseAsync([
+        "node",
+        "okou",
+        `${kind}:${CUSTOM_CONNECTOR_ID}`,
+        "--json",
+      ]);
+      const target =
+        kind === "builtin"
+          ? { kind, connectorSlug: CUSTOM_CONNECTOR_ID }
+          : { kind, customConnectorId: CUSTOM_CONNECTOR_ID };
+      expect(
+        JSON.parse(mockConsoleLog.mock.calls.flat().join("\n")),
+      ).toMatchObject({ connector: { target } });
+    },
+  );
+
   it("renders safe account details with shared label fallbacks", async () => {
     server.use(
       stubAccounts([
@@ -140,48 +254,53 @@ describe("okou connector account list command", () => {
     expect(fallbackRow).toContain("api-token");
   });
 
-  it("resolves a custom connector slug to its connection target", async () => {
-    const custom = customConnector({
-      id: CUSTOM_CONNECTOR_ID,
-      slug: "_acme-search",
-      displayName: "Acme Search",
-    });
-    server.use(
-      stubCustomConnectors([custom]),
-      http.get(
-        "http://localhost:3000/api/connector-accounts/connections",
-        ({ request }) => {
-          const url = new URL(request.url);
-          expect(url.searchParams.get("kind")).toBe("custom");
-          expect(url.searchParams.get("customConnectorId")).toBe(
-            CUSTOM_CONNECTOR_ID,
-          );
-          expect(url.searchParams.get("limit")).toBe("100");
-          return HttpResponse.json({
-            connections: [
-              connectorAccount({
-                target: {
-                  kind: "custom",
-                  customConnectorId: CUSTOM_CONNECTOR_ID,
-                },
-              }),
-            ],
-            nextCursor: null,
-          });
-        },
-      ),
-    );
+  it.each([
+    "_acme-search",
+    CUSTOM_CONNECTOR_ID,
+    `custom:${CUSTOM_CONNECTOR_ID}`,
+    "custom:_acme-search",
+    "Acme Search",
+  ])(
+    "resolves custom selector %s to its connection target",
+    async (selector) => {
+      const custom = customConnector({
+        id: CUSTOM_CONNECTOR_ID,
+        slug: "_acme-search",
+        displayName: "Acme Search",
+      });
+      server.use(
+        stubCustomConnectors([custom]),
+        http.get(
+          "http://localhost:3000/api/connector-accounts/connections",
+          ({ request }) => {
+            const url = new URL(request.url);
+            expect(url.searchParams.get("kind")).toBe("custom");
+            expect(url.searchParams.get("customConnectorId")).toBe(
+              CUSTOM_CONNECTOR_ID,
+            );
+            expect(url.searchParams.get("limit")).toBe("100");
+            return HttpResponse.json({
+              connections: [
+                connectorAccount({
+                  target: {
+                    kind: "custom",
+                    customConnectorId: CUSTOM_CONNECTOR_ID,
+                  },
+                }),
+              ],
+              nextCursor: null,
+            });
+          },
+        ),
+      );
 
-    await listConnectorAccountsCommand.parseAsync([
-      "node",
-      "okou",
-      "_acme-search",
-    ]);
+      await listConnectorAccountsCommand.parseAsync(["node", "okou", selector]);
 
-    expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
-      "Available accounts for Acme Search (_acme-search):",
-    );
-  });
+      expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+        "Available accounts for Acme Search (_acme-search):",
+      );
+    },
+  );
 
   it("fetches all pages sequentially and forwards search", async () => {
     const cursors: (string | null)[] = [];

--- a/turbo/apps/cli/src/commands/connector/account/__tests__/switch-request.test.ts
+++ b/turbo/apps/cli/src/commands/connector/account/__tests__/switch-request.test.ts
@@ -186,7 +186,13 @@ describe("okou connector account switch-request command", () => {
     ]);
   });
 
-  it("resolves and validates a custom connector target", async () => {
+  it.each([
+    "_acme-search",
+    CUSTOM_CONNECTOR_ID,
+    `custom:${CUSTOM_CONNECTOR_ID}`,
+    "custom:_acme-search",
+    "Acme Search",
+  ])("resolves and validates custom selector %s", async (selector) => {
     const target = {
       kind: "custom" as const,
       customConnectorId: CUSTOM_CONNECTOR_ID,
@@ -208,7 +214,7 @@ describe("okou connector account switch-request command", () => {
     await switchConnectorAccountRequestCommand.parseAsync([
       "node",
       "okou",
-      "_acme-search",
+      selector,
       "--connection-id",
       CONNECTION_ID,
       "--callback-prompt",

--- a/turbo/apps/cli/src/commands/connector/account/list.ts
+++ b/turbo/apps/cli/src/commands/connector/account/list.ts
@@ -13,6 +13,7 @@ import {
   listCustomConnectors,
 } from "../../../lib/api/domains/connectors";
 import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { findConnectorBySelector } from "../connector-selector";
 import { connectorAccountCliInventoryLabel } from "../account-label";
 import {
   connectorDiscoveryItems,
@@ -140,7 +141,10 @@ export const listConnectorAccountsCommand = new Command()
   .name("list")
   .alias("ls")
   .description("List available accounts for one connector")
-  .argument("<slug>", "Connector slug")
+  .argument(
+    "<selector>",
+    "Connector slug, custom UUID, or unique display name; builtin:/custom: prefixes accepted",
+  )
   .option("--search <text>", "Filter accounts by name or provider identity")
   .option("--json", "Output available accounts as JSON")
   .action(
@@ -159,9 +163,20 @@ export const listConnectorAccountsCommand = new Command()
           connectors,
           customConnectors,
         );
-        const connector = discoveredConnectors.find((item) => {
-          return item.slug === slug;
-        });
+        const connector = findConnectorBySelector(
+          discoveredConnectors,
+          slug,
+          (item) => {
+            return item.kind === "custom"
+              ? {
+                  kind: "custom",
+                  id: item.customConnector.id,
+                  slug: item.slug,
+                  label: item.label,
+                }
+              : { kind: "builtin", slug: item.slug, label: item.label };
+          },
+        );
         if (!connector) {
           throw new Error(`Unknown or unavailable connector: ${slug}`, {
             cause: new Error(

--- a/turbo/apps/cli/src/commands/connector/account/switch-request.ts
+++ b/turbo/apps/cli/src/commands/connector/account/switch-request.ts
@@ -21,6 +21,7 @@ import {
   type ConnectorDiscoveryItem,
 } from "../discovery";
 import { resolveConnectorDiscoveryAgentContext } from "../agent-context";
+import { findConnectorBySelector } from "../connector-selector";
 
 interface SwitchConnectorAccountRequestOptions {
   readonly connectionId: string;
@@ -75,7 +76,10 @@ export const switchConnectorAccountRequestCommand = new Command()
   .description(
     "Ask the user to use one exact connector account for future runs in this chat",
   )
-  .argument("<slug>", "Connector slug")
+  .argument(
+    "<selector>",
+    "Connector slug, custom UUID, or unique display name; builtin:/custom: prefixes accepted",
+  )
   .addOption(
     new Option(
       "--connection-id <uuid>",
@@ -131,9 +135,20 @@ Notes:
           connectors,
           customConnectors,
         );
-        const connector = discoveredConnectors.find((item) => {
-          return item.slug === slug;
-        });
+        const connector = findConnectorBySelector(
+          discoveredConnectors,
+          slug,
+          (item) => {
+            return item.kind === "custom"
+              ? {
+                  kind: "custom",
+                  id: item.customConnector.id,
+                  slug: item.slug,
+                  label: item.label,
+                }
+              : { kind: "builtin", slug: item.slug, label: item.label };
+          },
+        );
         if (!connector) {
           throw new Error(`Unknown or unavailable connector: ${slug}`, {
             cause: new Error(

--- a/turbo/apps/cli/src/commands/connector/check-diagnostic.ts
+++ b/turbo/apps/cli/src/commands/connector/check-diagnostic.ts
@@ -63,6 +63,12 @@ function rawUrlAuthorityHasUserinfo(url: string): boolean {
   return url.slice(authorityStart, authorityEnd).includes("@");
 }
 
+export function validateDiagnosticUrl(url: string): void {
+  if (rawUrlAuthorityHasUserinfo(url)) {
+    throw unsafeInputError("invalid-url");
+  }
+}
+
 function shellQuoteArg(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
@@ -111,8 +117,8 @@ export function validateCheckConnectorOptions(
 ): asserts opts is ValidatedCheckConnectorOptions {
   const hasUrl = opts.url !== undefined;
   // Reject embedded credentials before the diagnostic request leaves the client.
-  if (opts.url !== undefined && rawUrlAuthorityHasUserinfo(opts.url)) {
-    throw unsafeInputError("invalid-url");
+  if (opts.url !== undefined) {
+    validateDiagnosticUrl(opts.url);
   }
   if (opts.connector !== undefined && !hasUrl) {
     throw new Error(
@@ -145,9 +151,7 @@ export function buildConnectorUrlDiagnosticRequest(args: {
   readonly connector?: string;
   readonly environmentName?: string;
 }): UrlDiagnosticRequest {
-  if (rawUrlAuthorityHasUserinfo(args.url)) {
-    throw unsafeInputError("invalid-url");
-  }
+  validateDiagnosticUrl(args.url);
   const customConnectorId = customConnectorIdFromSelector(args.connector);
   const selection =
     customConnectorId !== undefined

--- a/turbo/apps/cli/src/commands/connector/check.ts
+++ b/turbo/apps/cli/src/commands/connector/check.ts
@@ -27,7 +27,7 @@ import {
 } from "./check-custom";
 import { customConnectorSettingsGuidance } from "./custom-connector-guidance";
 import { printConnectorCheckJson } from "./check-json";
-import { resolveCustomConnectorId } from "./custom-connector-selector";
+import { resolveDiagnosticConnectorSelector } from "./diagnostic-connector-selector";
 import {
   diagnoseConnectorCheck,
   getConnector,
@@ -626,7 +626,7 @@ export const checkConnectorCommand = new Command()
   .addOption(
     new Option(
       "--connector <selector>",
-      "Select a builtin/custom slug or custom:<uuid> when connectors own the same URL route",
+      "Select a unique slug, custom UUID, or display name; qualify collisions with builtin: or custom:",
     ),
   )
   .addOption(
@@ -649,8 +649,8 @@ Scope:
   select a permission in this mode. Custom HTTP/MCP routes use --url; this checks
   HTTP routing, not MCP tool discovery or execution.
   URL mode discovers builtin and custom route owners. Use --connector with a
-  builtin slug or custom:<uuid> to disambiguate; custom public slugs are not
-  accepted here. Find UUIDs with connector custom list.
+  full slug, custom UUID, or exact unique display name; qualify collisions with
+  builtin: or custom:. Find UUIDs with connector custom list.
   --connector and --method require --url. URL permissions are derived from the
   request, so --check-permission cannot be combined with --url.
   Inside a run, account identity comes from that run's admitted accounts.
@@ -707,9 +707,10 @@ Permission recovery:
         return;
       }
       const method = opts.method.toUpperCase();
-      const connector = opts.connector?.startsWith("_")
-        ? `custom:${await resolveCustomConnectorId(opts.connector)}`
-        : opts.connector;
+      const connector =
+        opts.connector === undefined
+          ? undefined
+          : await resolveDiagnosticConnectorSelector(opts.connector);
       const request = buildDiagnosticRequest({ ...opts, connector }, method);
       const diagnostic = await diagnoseConnectorCheck(request);
       if (opts.json) {

--- a/turbo/apps/cli/src/commands/connector/check.ts
+++ b/turbo/apps/cli/src/commands/connector/check.ts
@@ -27,6 +27,7 @@ import {
 } from "./check-custom";
 import { customConnectorSettingsGuidance } from "./custom-connector-guidance";
 import { printConnectorCheckJson } from "./check-json";
+import { resolveCustomConnectorId } from "./custom-connector-selector";
 import {
   diagnoseConnectorCheck,
   getConnector,
@@ -625,7 +626,7 @@ export const checkConnectorCommand = new Command()
   .addOption(
     new Option(
       "--connector <selector>",
-      "Select a builtin slug or custom:<uuid> when connectors own the same URL route",
+      "Select a builtin/custom slug or custom:<uuid> when connectors own the same URL route",
     ),
   )
   .addOption(
@@ -661,6 +662,7 @@ Examples:
   okou connector check --url https://api.github.com/repos/owner/repo
   okou connector check --url https://api.accounts.nintendo.com/2.0.0/users/me --connector nintendo-store
   okou connector check --url https://api.acme.example/v1/items --connector custom:<connector-id>
+  okou connector check --url https://api.acme.example/v1/items --connector _acme-search
   okou connector check --url https://slack.com/api/chat.postMessage --method POST
   okou connector check --env-name SLACK_TOKEN --check-permission chat:write
 
@@ -705,7 +707,10 @@ Permission recovery:
         return;
       }
       const method = opts.method.toUpperCase();
-      const request = buildDiagnosticRequest(opts, method);
+      const connector = opts.connector?.startsWith("_")
+        ? `custom:${await resolveCustomConnectorId(opts.connector)}`
+        : opts.connector;
+      const request = buildDiagnosticRequest({ ...opts, connector }, method);
       const diagnostic = await diagnoseConnectorCheck(request);
       if (opts.json) {
         await printConnectorCheckJson(request, diagnostic);

--- a/turbo/apps/cli/src/commands/connector/connect.ts
+++ b/turbo/apps/cli/src/commands/connector/connect.ts
@@ -105,7 +105,10 @@ function parseConnectorValues(rawValues: readonly string[] | undefined) {
 export const connectCommand = new Command()
   .name("connect")
   .description("Connect a builtin connector with manual grant values")
-  .argument("<slug>", "Builtin connector slug (e.g., zendesk)")
+  .argument(
+    "<selector>",
+    "Builtin connector slug or unique display name; builtin: prefix accepted",
+  )
   .addOption(
     new Option("--add", "Create a new connector account").conflicts(
       "reconnect",

--- a/turbo/apps/cli/src/commands/connector/connector-selector.ts
+++ b/turbo/apps/cli/src/commands/connector/connector-selector.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+
+export type ConnectorSelectorIdentity =
+  | { readonly kind: "builtin"; readonly slug: string; readonly label: string }
+  | {
+      readonly kind: "custom";
+      readonly id: string;
+      readonly slug: string;
+      readonly label: string;
+    };
+
+export function parseConnectorSelector(selector: string): {
+  readonly kind: "builtin" | "custom" | undefined;
+  readonly value: string;
+} {
+  const kind = selector.startsWith("builtin:")
+    ? "builtin"
+    : selector.startsWith("custom:")
+      ? "custom"
+      : undefined;
+  const value = kind ? selector.slice(kind.length + 1) : selector;
+  if (!value.trim()) {
+    throw new Error("Connector selector cannot be empty");
+  }
+  return { kind, value };
+}
+
+function explicitConnectorSelector(
+  identity: ConnectorSelectorIdentity,
+): string {
+  return identity.kind === "custom"
+    ? `custom:${identity.id}`
+    : `builtin:${identity.slug}`;
+}
+
+export function findConnectorBySelector<T>(
+  connectors: readonly T[],
+  selector: string,
+  identityOf: (connector: T) => ConnectorSelectorIdentity,
+): T | undefined {
+  const { kind, value } = parseConnectorSelector(selector);
+  const uuid = z.uuid().safeParse(value);
+  const canonical = uuid.success ? uuid.data.toLowerCase() : value;
+  const candidates = connectors
+    .map((connector) => {
+      return { connector, identity: identityOf(connector) };
+    })
+    .filter(({ identity }) => {
+      return kind === undefined || identity.kind === kind;
+    });
+  const exact = candidates.filter(({ identity }) => {
+    return (
+      identity.slug === canonical ||
+      (identity.kind === "custom" && identity.id.toLowerCase() === canonical)
+    );
+  });
+  const slugs = exact.length
+    ? exact
+    : candidates.filter(({ identity }) => {
+        return identity.slug.toLowerCase() === value.toLowerCase();
+      });
+  const matches = slugs.length
+    ? slugs
+    : candidates.filter(({ identity }) => {
+        return identity.label === value;
+      });
+  if (matches.length > 1) {
+    const selectors = matches
+      .map(({ identity }) => {
+        return explicitConnectorSelector(identity);
+      })
+      .sort();
+    throw new Error(
+      `Ambiguous connector selector: ${selector}\nCandidates: ${selectors.join(", ")}\nUse an explicit connector selector.`,
+    );
+  }
+  return matches[0]?.connector;
+}

--- a/turbo/apps/cli/src/commands/connector/custom-connector-selector.ts
+++ b/turbo/apps/cli/src/commands/connector/custom-connector-selector.ts
@@ -1,38 +1,36 @@
 import { z } from "zod";
 import { listCustomConnectors } from "../../lib/api/domains/connectors";
+import {
+  findConnectorBySelector,
+  parseConnectorSelector,
+} from "./connector-selector";
 
 export async function resolveCustomConnectorId(
   selector: string,
 ): Promise<string> {
-  if (!selector.startsWith("_")) {
-    const id = z.uuid().safeParse(selector);
-    if (id.success) {
-      return id.data;
-    }
+  const { kind, value } = parseConnectorSelector(selector);
+  if (kind === "builtin") {
     throw new Error(
-      `Expected a custom connector slug or UUID: ${selector}\nRun: okou connector custom list`,
+      `Expected a custom connector: ${selector}\nRun: okou connector custom list`,
     );
+  }
+  const id = z.uuid().safeParse(value);
+  if (id.success) {
+    return id.data.toLowerCase();
   }
 
   const connectors = await listCustomConnectors();
-  const matches = connectors.filter((connector) => {
-    return connector.slug === selector;
+  const connector = findConnectorBySelector(connectors, selector, (item) => {
+    return {
+      kind: "custom",
+      id: item.id,
+      slug: item.slug,
+      label: item.displayName,
+    };
   });
-  if (matches.length > 1) {
-    const ids = matches
-      .map((connector) => {
-        return connector.id;
-      })
-      .sort()
-      .join(", ");
-    throw new Error(
-      `Ambiguous custom connector slug: ${selector}\nMatching IDs: ${ids}\nRun: okou connector custom list\nSelect an explicit UUID (custom:<uuid> for connector check).`,
-    );
-  }
-  const connector = matches[0];
   if (!connector) {
     throw new Error(
-      `Unknown or unavailable custom connector slug: ${selector}\nRun: okou connector custom list`,
+      `Unknown or unavailable custom connector selector: ${selector}\nRun: okou connector custom list`,
     );
   }
   return connector.id;

--- a/turbo/apps/cli/src/commands/connector/custom-connector-selector.ts
+++ b/turbo/apps/cli/src/commands/connector/custom-connector-selector.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { listCustomConnectors } from "../../lib/api/domains/connectors";
+
+export async function resolveCustomConnectorId(
+  selector: string,
+): Promise<string> {
+  if (!selector.startsWith("_")) {
+    const id = z.uuid().safeParse(selector);
+    if (id.success) {
+      return id.data;
+    }
+    throw new Error(
+      `Expected a custom connector slug or UUID: ${selector}\nRun: okou connector custom list`,
+    );
+  }
+
+  const connectors = await listCustomConnectors();
+  const matches = connectors.filter((connector) => {
+    return connector.slug === selector;
+  });
+  if (matches.length > 1) {
+    const ids = matches
+      .map((connector) => {
+        return connector.id;
+      })
+      .sort()
+      .join(", ");
+    throw new Error(
+      `Ambiguous custom connector slug: ${selector}\nMatching IDs: ${ids}\nRun: okou connector custom list\nSelect an explicit UUID (custom:<uuid> for connector check).`,
+    );
+  }
+  const connector = matches[0];
+  if (!connector) {
+    throw new Error(
+      `Unknown or unavailable custom connector slug: ${selector}\nRun: okou connector custom list`,
+    );
+  }
+  return connector.id;
+}

--- a/turbo/apps/cli/src/commands/connector/custom/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/__tests__/index.test.ts
@@ -95,10 +95,22 @@ describe("okou connector custom readers", () => {
     });
   });
 
-  it.each([customConnector(), customMcpConnector()])(
-    "exposes $kind definition details through status JSON",
-    async (connector) => {
+  it.each(
+    [customConnector(), customMcpConnector()].flatMap((connector) => {
+      return [
+        connector.id,
+        connector.slug,
+        `custom:${connector.id}`,
+        connector.displayName,
+      ].map((selector) => {
+        return { connector, selector };
+      });
+    }),
+  )(
+    "exposes $connector.kind definition details selected by $selector through JSON",
+    async ({ connector, selector }) => {
       server.use(
+        stubCustomConnectors([connector]),
         http.get(
           `http://localhost:3000/api/custom-connectors/${connector.id}`,
           () => {
@@ -110,13 +122,14 @@ describe("okou connector custom readers", () => {
         "node",
         "okou",
         "status",
-        connector.id,
+        selector,
         "--json",
       ]);
       const json: unknown = JSON.parse(consoleLog.mock.calls.flat().join("\n"));
       expect(json).toMatchObject({
         context: "current",
         state: "available",
+        target: { kind: "custom", customConnectorId: connector.id },
         connector: {
           ...connector,
           connectorType: `custom-${connector.kind}`,

--- a/turbo/apps/cli/src/commands/connector/custom/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/__tests__/index.test.ts
@@ -246,107 +246,116 @@ describe("okou connector custom readers", () => {
     },
   );
 
-  it.each([CONNECTOR_ID, "_acme-search"])(
-    "shows HTTP status selected by %s",
-    async (selector) => {
-      const connector = customConnector();
-      if (selector !== CONNECTOR_ID) {
-        server.use(
-          stubCustomConnectors([
-            customConnector({ id: AGENT_ID, slug: "_acme-search-extra" }),
-            connector,
-          ]),
-        );
-      }
+  it.each([
+    CONNECTOR_ID,
+    `custom:${CONNECTOR_ID}`,
+    "_acme-search",
+    "_ACME-SEARCH",
+    "custom:_acme-search",
+    "Acme Search",
+  ])("shows HTTP status selected by %s", async (selector) => {
+    const connector = customConnector();
+    if (selector !== CONNECTOR_ID) {
       server.use(
-        http.get(
-          `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
-          () => {
-            return HttpResponse.json(connector);
-          },
-        ),
+        stubCustomConnectors([
+          customConnector({
+            id: AGENT_ID,
+            slug: "_acme-search-extra",
+            displayName: "Another connector",
+          }),
+          connector,
+        ]),
       );
+    }
+    server.use(
+      http.get(
+        `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
+        () => {
+          return HttpResponse.json(connector);
+        },
+      ),
+    );
 
-      await customConnectorCommand.parseAsync([
-        "node",
-        "okou",
-        "status",
-        selector,
-      ]);
+    await customConnectorCommand.parseAsync([
+      "node",
+      "okou",
+      "status",
+      selector,
+    ]);
 
-      const output = consoleLog.mock.calls.flat().join("\n");
-      expect(output).toContain(`ID:               ${CONNECTOR_ID}`);
-      expect(output).toContain("Slug:             _acme-search");
-      expect(output).toContain("Kind:             http");
-      expect(output).toContain("Prefixes:         https://api.acme.test/v1/");
-    },
-  );
+    const output = consoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain(`ID:               ${CONNECTOR_ID}`);
+    expect(output).toContain("Slug:             _acme-search");
+    expect(output).toContain("Kind:             http");
+    expect(output).toContain("Prefixes:         https://api.acme.test/v1/");
+  });
 
-  it.each([CONNECTOR_ID, "_acme-mcp"])(
-    "shows MCP status selected by %s",
-    async (selector) => {
-      const connector = {
-        kind: "mcp",
-        id: CONNECTOR_ID,
-        slug: "_acme-mcp",
-        displayName: "Acme MCP",
-        endpoint: "https://mcp.acme.test/server",
-        transport: "streamable-http",
-        prefixTemplates: [],
-        fields: [
-          {
-            key: "secret",
-            label: "Secret",
-            kind: "secret",
-            required: true,
-          },
-        ],
-        headerInjections: [
-          {
-            name: "Authorization",
-            valueTemplate: "Bearer {{secrets.secret}}",
-          },
-        ],
-        queryInjections: [],
-        authMode: "manual",
-        permissionBundleRef: null,
-        storageVersion: 1,
-        connected: true,
-        missingRequiredFields: [],
-        configuredFieldKeys: ["secret"],
-        createdAt: "2026-08-10T00:00:00.000Z",
-        updatedAt: "2026-08-10T00:00:00.000Z",
-      } satisfies CustomConnectorMcpResponse;
-      if (selector !== CONNECTOR_ID) {
-        server.use(stubCustomConnectors([connector]));
-      }
-      server.use(
-        http.get(
-          `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
-          () => {
-            return HttpResponse.json(connector);
-          },
-        ),
-      );
+  it.each([
+    CONNECTOR_ID,
+    `custom:${CONNECTOR_ID}`,
+    "_acme-mcp",
+    "custom:_acme-mcp",
+    "Acme MCP",
+  ])("shows MCP status selected by %s", async (selector) => {
+    const connector = {
+      kind: "mcp",
+      id: CONNECTOR_ID,
+      slug: "_acme-mcp",
+      displayName: "Acme MCP",
+      endpoint: "https://mcp.acme.test/server",
+      transport: "streamable-http",
+      prefixTemplates: [],
+      fields: [
+        {
+          key: "secret",
+          label: "Secret",
+          kind: "secret",
+          required: true,
+        },
+      ],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{secrets.secret}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "manual",
+      permissionBundleRef: null,
+      storageVersion: 1,
+      connected: true,
+      missingRequiredFields: [],
+      configuredFieldKeys: ["secret"],
+      createdAt: "2026-08-10T00:00:00.000Z",
+      updatedAt: "2026-08-10T00:00:00.000Z",
+    } satisfies CustomConnectorMcpResponse;
+    if (selector !== CONNECTOR_ID) {
+      server.use(stubCustomConnectors([connector]));
+    }
+    server.use(
+      http.get(
+        `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
+        () => {
+          return HttpResponse.json(connector);
+        },
+      ),
+    );
 
-      await customConnectorCommand.parseAsync([
-        "node",
-        "okou",
-        "status",
-        selector,
-      ]);
+    await customConnectorCommand.parseAsync([
+      "node",
+      "okou",
+      "status",
+      selector,
+    ]);
 
-      const output = consoleLog.mock.calls.flat().join("\n");
-      expect(output).toContain(`ID:               ${CONNECTOR_ID}`);
-      expect(output).toContain("Slug:             _acme-mcp");
-      expect(output).toContain("Kind:             mcp");
-      expect(output).toContain("Transport:        streamable-http");
-      expect(output).toContain(
-        "Endpoint:         https://mcp.acme.test/server",
-      );
-      expect(output).not.toContain("Prefixes:");
-    },
-  );
+    const output = consoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain(`ID:               ${CONNECTOR_ID}`);
+    expect(output).toContain("Slug:             _acme-mcp");
+    expect(output).toContain("Kind:             mcp");
+    expect(output).toContain("Transport:        streamable-http");
+    expect(output).toContain("Endpoint:         https://mcp.acme.test/server");
+    expect(output).not.toContain("Prefixes:");
+  });
 
   it.each([CONNECTOR_ID, "_acme-search"])(
     "reports recovery guidance when status target %s is no longer available",
@@ -389,10 +398,11 @@ describe("okou connector custom readers", () => {
   );
 
   it.each([
-    ["_removed-slug", "Unknown or unavailable custom connector slug"],
-    ["_ACME-SEARCH", "Unknown or unavailable custom connector slug"],
-    ["Acme Search", "Expected a custom connector slug or UUID"],
-    ["github", "Expected a custom connector slug or UUID"],
+    ["_removed-slug", "Unknown or unavailable custom connector selector"],
+    ["Acme", "Unknown or unavailable custom connector selector"],
+    ["acme search", "Unknown or unavailable custom connector selector"],
+    ["github", "Unknown or unavailable custom connector selector"],
+    ["builtin:github", "Expected a custom connector"],
   ])("rejects unresolved status selector %s", async (selector, message) => {
     server.use(stubCustomConnectors([customConnector()]));
     const error = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/turbo/apps/cli/src/commands/connector/custom/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/__tests__/index.test.ts
@@ -348,6 +348,46 @@ describe("okou connector custom readers", () => {
     },
   );
 
+  it.each([CONNECTOR_ID, "_acme-search"])(
+    "reports recovery guidance when status target %s is no longer available",
+    async (selector) => {
+      server.use(
+        stubCustomConnectors([customConnector()]),
+        http.get(
+          `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
+          () => {
+            return HttpResponse.json(
+              { error: { code: "NOT_FOUND", message: "Connector not found" } },
+              { status: 404 },
+            );
+          },
+        ),
+      );
+      const error = vi.spyOn(console, "error").mockImplementation(() => {});
+      const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+        throw new Error("process.exit called");
+      });
+      try {
+        await expect(
+          customConnectorCommand.parseAsync([
+            "node",
+            "okou",
+            "status",
+            selector,
+          ]),
+        ).rejects.toThrow("process.exit called");
+
+        const output = error.mock.calls.flat().join("\n");
+        expect(output).toContain(`Custom connector not found: ${CONNECTOR_ID}`);
+        expect(output).toContain("okou connector custom list");
+        expect(consoleLog).not.toHaveBeenCalled();
+      } finally {
+        error.mockRestore();
+        exit.mockRestore();
+      }
+    },
+  );
+
   it.each([
     ["_removed-slug", "Unknown or unavailable custom connector slug"],
     ["_ACME-SEARCH", "Unknown or unavailable custom connector slug"],

--- a/turbo/apps/cli/src/commands/connector/custom/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/__tests__/index.test.ts
@@ -169,6 +169,9 @@ describe("okou connector custom readers", () => {
 
     const output = consoleLog.mock.calls.flat().join("\n");
     expect(output).toContain("KIND");
+    expect(output).toContain("SLUG");
+    expect(output).toContain(connector.id);
+    expect(output).toContain(connector.slug);
     expect(output).toContain("Acme Search");
     expect(output).toContain("http");
   });
@@ -243,82 +246,131 @@ describe("okou connector custom readers", () => {
     },
   );
 
-  it("shows tagged HTTP routing details in status", async () => {
-    const connector = customConnector();
-    server.use(
-      http.get(
-        `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
-        () => {
-          return HttpResponse.json(connector);
-        },
-      ),
-    );
+  it.each([CONNECTOR_ID, "_acme-search"])(
+    "shows HTTP status selected by %s",
+    async (selector) => {
+      const connector = customConnector();
+      if (selector !== CONNECTOR_ID) {
+        server.use(
+          stubCustomConnectors([
+            customConnector({ id: AGENT_ID, slug: "_acme-search-extra" }),
+            connector,
+          ]),
+        );
+      }
+      server.use(
+        http.get(
+          `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
+          () => {
+            return HttpResponse.json(connector);
+          },
+        ),
+      );
 
-    await customConnectorCommand.parseAsync([
-      "node",
-      "okou",
-      "status",
-      CONNECTOR_ID,
-    ]);
+      await customConnectorCommand.parseAsync([
+        "node",
+        "okou",
+        "status",
+        selector,
+      ]);
 
-    const output = consoleLog.mock.calls.flat().join("\n");
-    expect(output).toContain("Kind:             http");
-    expect(output).toContain("Prefixes:         https://api.acme.test/v1/");
-  });
+      const output = consoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain(`ID:               ${CONNECTOR_ID}`);
+      expect(output).toContain("Slug:             _acme-search");
+      expect(output).toContain("Kind:             http");
+      expect(output).toContain("Prefixes:         https://api.acme.test/v1/");
+    },
+  );
 
-  it("shows an MCP connector endpoint without HTTP routing fields", async () => {
-    const connector = {
-      kind: "mcp",
-      id: CONNECTOR_ID,
-      slug: "_acme-mcp",
-      displayName: "Acme MCP",
-      endpoint: "https://mcp.acme.test/server",
-      transport: "streamable-http",
-      prefixTemplates: [],
-      fields: [
-        {
-          key: "secret",
-          label: "Secret",
-          kind: "secret",
-          required: true,
-        },
-      ],
-      headerInjections: [
-        {
-          name: "Authorization",
-          valueTemplate: "Bearer {{secrets.secret}}",
-        },
-      ],
-      queryInjections: [],
-      authMode: "manual",
-      permissionBundleRef: null,
-      storageVersion: 1,
-      connected: true,
-      missingRequiredFields: [],
-      configuredFieldKeys: ["secret"],
-      createdAt: "2026-08-10T00:00:00.000Z",
-      updatedAt: "2026-08-10T00:00:00.000Z",
-    } satisfies CustomConnectorMcpResponse;
-    server.use(
-      http.get(
-        `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
-        () => {
-          return HttpResponse.json(connector);
-        },
-      ),
-    );
+  it.each([CONNECTOR_ID, "_acme-mcp"])(
+    "shows MCP status selected by %s",
+    async (selector) => {
+      const connector = {
+        kind: "mcp",
+        id: CONNECTOR_ID,
+        slug: "_acme-mcp",
+        displayName: "Acme MCP",
+        endpoint: "https://mcp.acme.test/server",
+        transport: "streamable-http",
+        prefixTemplates: [],
+        fields: [
+          {
+            key: "secret",
+            label: "Secret",
+            kind: "secret",
+            required: true,
+          },
+        ],
+        headerInjections: [
+          {
+            name: "Authorization",
+            valueTemplate: "Bearer {{secrets.secret}}",
+          },
+        ],
+        queryInjections: [],
+        authMode: "manual",
+        permissionBundleRef: null,
+        storageVersion: 1,
+        connected: true,
+        missingRequiredFields: [],
+        configuredFieldKeys: ["secret"],
+        createdAt: "2026-08-10T00:00:00.000Z",
+        updatedAt: "2026-08-10T00:00:00.000Z",
+      } satisfies CustomConnectorMcpResponse;
+      if (selector !== CONNECTOR_ID) {
+        server.use(stubCustomConnectors([connector]));
+      }
+      server.use(
+        http.get(
+          `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
+          () => {
+            return HttpResponse.json(connector);
+          },
+        ),
+      );
 
-    await customConnectorCommand.parseAsync([
-      "node",
-      "okou",
-      "status",
-      CONNECTOR_ID,
-    ]);
+      await customConnectorCommand.parseAsync([
+        "node",
+        "okou",
+        "status",
+        selector,
+      ]);
 
-    const output = consoleLog.mock.calls.flat().join("\n");
-    expect(output).toContain("Kind:             mcp");
-    expect(output).toContain("Transport:        streamable-http");
-    expect(output).toContain("Endpoint:         https://mcp.acme.test/server");
-    expect(output).not.toContain("Prefixes:");
+      const output = consoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain(`ID:               ${CONNECTOR_ID}`);
+      expect(output).toContain("Slug:             _acme-mcp");
+      expect(output).toContain("Kind:             mcp");
+      expect(output).toContain("Transport:        streamable-http");
+      expect(output).toContain(
+        "Endpoint:         https://mcp.acme.test/server",
+      );
+      expect(output).not.toContain("Prefixes:");
+    },
+  );
+
+  it.each([
+    ["_removed-slug", "Unknown or unavailable custom connector slug"],
+    ["_ACME-SEARCH", "Unknown or unavailable custom connector slug"],
+    ["Acme Search", "Expected a custom connector slug or UUID"],
+    ["github", "Expected a custom connector slug or UUID"],
+  ])("rejects unresolved status selector %s", async (selector, message) => {
+    server.use(stubCustomConnectors([customConnector()]));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+    try {
+      await expect(
+        customConnectorCommand.parseAsync(["node", "okou", "status", selector]),
+      ).rejects.toThrow("process.exit called");
+      expect(error.mock.calls.flat().join("\n")).toContain(message);
+      expect(error.mock.calls.flat().join("\n")).toContain(
+        "okou connector custom list",
+      );
+      expect(consoleLog).not.toHaveBeenCalled();
+    } finally {
+      error.mockRestore();
+      exit.mockRestore();
+    }
   });
 });

--- a/turbo/apps/cli/src/commands/connector/custom/__tests__/update.test.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/__tests__/update.test.ts
@@ -138,46 +138,45 @@ describe("okou connector custom update", () => {
     return path;
   }
 
-  it.each([CONNECTOR_ID, "_acme-mcp"])(
-    "updates an MCP definition selected by %s",
-    async (selector) => {
-      const definition = manualMcpDefinition();
-      const definitionPath = writeDefinition(definition);
-      if (selector !== CONNECTOR_ID) {
-        server.use(stubCustomConnectors([mcpResponse(definition)]));
-      }
-      let updateBody: unknown;
-      server.use(
-        http.put(
-          `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
-          async ({ request }) => {
-            updateBody = await request.json();
-            return HttpResponse.json(mcpResponse(definition));
-          },
-        ),
-      );
+  it.each([
+    CONNECTOR_ID,
+    `custom:${CONNECTOR_ID}`,
+    "_acme-mcp",
+    "custom:_acme-mcp",
+    "Acme MCP Updated",
+  ])("updates an MCP definition selected by %s", async (selector) => {
+    const definition = manualMcpDefinition();
+    const definitionPath = writeDefinition(definition);
+    if (selector !== CONNECTOR_ID) {
+      server.use(stubCustomConnectors([mcpResponse(definition)]));
+    }
+    let updateBody: unknown;
+    server.use(
+      http.put(
+        `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
+        async ({ request }) => {
+          updateBody = await request.json();
+          return HttpResponse.json(mcpResponse(definition));
+        },
+      ),
+    );
 
-      await customConnectorCommand.parseAsync([
-        "node",
-        "okou",
-        "update",
-        selector,
-        "--file",
-        definitionPath,
-      ]);
+    await customConnectorCommand.parseAsync([
+      "node",
+      "okou",
+      "update",
+      selector,
+      "--file",
+      definitionPath,
+    ]);
 
-      expect(updateBody).toStrictEqual(definition);
-      expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
-        'Custom connector "Acme MCP Updated" updated',
-      );
-      expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
-        CONNECTOR_ID,
-      );
-      expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
-        "_acme-mcp",
-      );
-    },
-  );
+    expect(updateBody).toStrictEqual(definition);
+    expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+      'Custom connector "Acme MCP Updated" updated',
+    );
+    expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(CONNECTOR_ID);
+    expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain("_acme-mcp");
+  });
 
   it("updates an HTTP connector by its exact slug", async () => {
     const connector = customConnector({ id: CONNECTOR_ID });
@@ -258,7 +257,14 @@ describe("okou connector custom update", () => {
         expect(message).toContain(
           scenario === "unknown" ? "Unknown or unavailable" : "Ambiguous",
         );
-        expect(message).toContain("okou connector custom list");
+        if (scenario === "unknown") {
+          expect(message).toContain("okou connector custom list");
+        } else {
+          expect(message).toContain(`custom:${CONNECTOR_ID}`);
+          expect(message).toContain(
+            "custom:44444444-4444-4444-8444-444444444444",
+          );
+        }
         expect(mockConsoleLog).not.toHaveBeenCalled();
       } finally {
         error.mockRestore();

--- a/turbo/apps/cli/src/commands/connector/custom/__tests__/update.test.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/__tests__/update.test.ts
@@ -312,7 +312,14 @@ describe("okou connector custom update", () => {
         prefixTemplates: ["https://api.acme.example/"],
       });
       let requests = 0;
+      let inventoryRequests = 0;
       server.use(
+        http.get("http://localhost:3000/api/custom-connectors", () => {
+          inventoryRequests += 1;
+          return HttpResponse.json({
+            connectors: [mcpResponse(manualMcpDefinition())],
+          });
+        }),
         http.put(
           `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
           () => {
@@ -339,6 +346,13 @@ describe("okou connector custom update", () => {
         ]);
 
         expect(requests).toBe(0);
+        expect(inventoryRequests).toBe(0);
+        expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+          "prefixTemplates",
+        );
+        expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+          "Invalid input",
+        );
         expect(mockExit).toHaveBeenCalledWith(1);
       } finally {
         mockConsoleError.mockRestore();

--- a/turbo/apps/cli/src/commands/connector/custom/__tests__/update.test.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/__tests__/update.test.ts
@@ -5,14 +5,21 @@ import { join } from "node:path";
 import chalk from "chalk";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CustomConnectorMcpResponse } from "@okouai/api-contracts/contracts/custom-connectors";
 
 import { server } from "../../../../mocks/server";
+import {
+  customConnector,
+  stubCustomConnectors,
+} from "../../../__tests__/helpers/custom-connectors";
 import { customConnectorCommand } from "../index";
 import { updateCustomConnectorCommand } from "../update";
 
 const CONNECTOR_ID = "33333333-3333-4333-8333-333333333333";
 
-function buildOkouToken(): string {
+function buildOkouToken(
+  capabilities: readonly string[] = ["connector:write"],
+): string {
   const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString(
     "base64url",
   );
@@ -22,7 +29,7 @@ function buildOkouToken(): string {
       runId: "run-1",
       orgId: "org-1",
       scope: "okou",
-      capabilities: ["connector:write"],
+      capabilities,
       iat: 1,
       exp: 2,
     }),
@@ -83,15 +90,17 @@ function oauthMcpDefinition() {
   } as const;
 }
 
-function mcpResponse(definition: ReturnType<typeof manualMcpDefinition>) {
+function mcpResponse(
+  definition: ReturnType<typeof manualMcpDefinition>,
+): CustomConnectorMcpResponse {
   return {
-    kind: "mcp" as const,
+    kind: "mcp",
     id: CONNECTOR_ID,
     slug: "_acme-mcp",
     displayName: definition.displayName,
     endpoint: definition.endpoint,
-    transport: "streamable-http" as const,
-    prefixTemplates: [] as const,
+    transport: "streamable-http",
+    prefixTemplates: [],
     fields: [...definition.fields],
     headerInjections: [...definition.headerInjections],
     queryInjections: [],
@@ -129,16 +138,66 @@ describe("okou connector custom update", () => {
     return path;
   }
 
-  it("updates an MCP definition with the exact file body", async () => {
-    const definition = manualMcpDefinition();
-    const definitionPath = writeDefinition(definition);
+  it.each([CONNECTOR_ID, "_acme-mcp"])(
+    "updates an MCP definition selected by %s",
+    async (selector) => {
+      const definition = manualMcpDefinition();
+      const definitionPath = writeDefinition(definition);
+      if (selector !== CONNECTOR_ID) {
+        server.use(stubCustomConnectors([mcpResponse(definition)]));
+      }
+      let updateBody: unknown;
+      server.use(
+        http.put(
+          `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
+          async ({ request }) => {
+            updateBody = await request.json();
+            return HttpResponse.json(mcpResponse(definition));
+          },
+        ),
+      );
+
+      await customConnectorCommand.parseAsync([
+        "node",
+        "okou",
+        "update",
+        selector,
+        "--file",
+        definitionPath,
+      ]);
+
+      expect(updateBody).toStrictEqual(definition);
+      expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+        'Custom connector "Acme MCP Updated" updated',
+      );
+      expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+        CONNECTOR_ID,
+      );
+      expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+        "_acme-mcp",
+      );
+    },
+  );
+
+  it("updates an HTTP connector by its exact slug", async () => {
+    const connector = customConnector({ id: CONNECTOR_ID });
+    const definition = {
+      kind: connector.kind,
+      displayName: "Updated HTTP connector",
+      prefixTemplates: connector.prefixTemplates,
+      fields: connector.fields,
+      headerInjections: connector.headerInjections,
+      queryInjections: connector.queryInjections,
+      authMode: connector.authMode,
+    };
     let updateBody: unknown;
     server.use(
+      stubCustomConnectors([connector]),
       http.put(
         `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
         async ({ request }) => {
           updateBody = await request.json();
-          return HttpResponse.json(mcpResponse(definition));
+          return HttpResponse.json({ ...connector, ...definition });
         },
       ),
     );
@@ -147,16 +206,66 @@ describe("okou connector custom update", () => {
       "node",
       "okou",
       "update",
-      CONNECTOR_ID,
+      connector.slug,
       "--file",
-      definitionPath,
+      writeDefinition(definition),
+      "--json",
     ]);
 
     expect(updateBody).toStrictEqual(definition);
-    expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
-      'Custom connector "Acme MCP Updated" updated',
-    );
+    expect(
+      JSON.parse(mockConsoleLog.mock.calls.flat().join("\n")),
+    ).toMatchObject({
+      id: CONNECTOR_ID,
+      slug: connector.slug,
+      displayName: definition.displayName,
+    });
   });
+
+  it.each(["unknown", "ambiguous"])(
+    "rejects an %s slug before updating a connector",
+    async (scenario) => {
+      const definition = manualMcpDefinition();
+      server.use(
+        stubCustomConnectors(
+          scenario === "unknown"
+            ? []
+            : [
+                mcpResponse(definition),
+                {
+                  ...mcpResponse(definition),
+                  id: "44444444-4444-4444-8444-444444444444",
+                },
+              ],
+        ),
+      );
+      const error = vi.spyOn(console, "error").mockImplementation(() => {});
+      const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+        throw new Error("process.exit called");
+      });
+      try {
+        await expect(
+          customConnectorCommand.parseAsync([
+            "node",
+            "okou",
+            "update",
+            "_acme-mcp",
+            "--file",
+            writeDefinition(definition),
+          ]),
+        ).rejects.toThrow("process.exit called");
+        const message = error.mock.calls.flat().join("\n");
+        expect(message).toContain(
+          scenario === "unknown" ? "Unknown or unavailable" : "Ambiguous",
+        );
+        expect(message).toContain("okou connector custom list");
+        expect(mockConsoleLog).not.toHaveBeenCalled();
+      } finally {
+        error.mockRestore();
+        exit.mockRestore();
+      }
+    },
+  );
 
   it("allows an OAuth update to omit the current client secret", async () => {
     const definition = oauthMcpDefinition();
@@ -195,43 +304,73 @@ describe("okou connector custom update", () => {
     expect(updateBody).not.toHaveProperty("oauthConfig.clientSecret");
   });
 
-  it("rejects hybrid protocol files before making a request", async () => {
-    const definitionPath = writeDefinition({
-      ...manualMcpDefinition(),
-      prefixTemplates: ["https://api.acme.example/"],
-    });
-    let requests = 0;
-    server.use(
-      http.put(
-        `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
-        () => {
-          requests += 1;
-          return HttpResponse.json({}, { status: 500 });
-        },
-      ),
-    );
-    const mockConsoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
-      return undefined as never;
-    });
+  it.each([CONNECTOR_ID, "_acme-mcp"])(
+    "rejects hybrid protocol files before resolving %s",
+    async (selector) => {
+      const definitionPath = writeDefinition({
+        ...manualMcpDefinition(),
+        prefixTemplates: ["https://api.acme.example/"],
+      });
+      let requests = 0;
+      server.use(
+        http.put(
+          `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
+          () => {
+            requests += 1;
+            return HttpResponse.json({}, { status: 500 });
+          },
+        ),
+      );
+      const mockConsoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+        return undefined as never;
+      });
 
+      try {
+        await customConnectorCommand.parseAsync([
+          "node",
+          "okou",
+          "update",
+          selector,
+          "--file",
+          definitionPath,
+        ]);
+
+        expect(requests).toBe(0);
+        expect(mockExit).toHaveBeenCalledWith(1);
+      } finally {
+        mockConsoleError.mockRestore();
+        mockExit.mockRestore();
+      }
+    },
+  );
+
+  it("requires write capability before resolving a slug", async () => {
+    vi.stubEnv("OKOU_TOKEN", buildOkouToken([]));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
     try {
-      await customConnectorCommand.parseAsync([
-        "node",
-        "okou",
-        "update",
-        CONNECTOR_ID,
-        "--file",
-        definitionPath,
-      ]);
-
-      expect(requests).toBe(0);
-      expect(mockExit).toHaveBeenCalledWith(1);
+      await expect(
+        customConnectorCommand.parseAsync([
+          "node",
+          "okou",
+          "update",
+          "_acme-mcp",
+          "--file",
+          writeDefinition(manualMcpDefinition()),
+        ]),
+      ).rejects.toThrow("process.exit called");
+      expect(error.mock.calls.flat().join("\n")).toContain(
+        "Custom connector update is not enabled for this agent run",
+      );
+      expect(mockConsoleLog).not.toHaveBeenCalled();
     } finally {
-      mockConsoleError.mockRestore();
-      mockExit.mockRestore();
+      error.mockRestore();
+      exit.mockRestore();
     }
   });
 

--- a/turbo/apps/cli/src/commands/connector/custom/index.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/index.ts
@@ -168,7 +168,10 @@ Omit --agent inside a run to inspect the current Agent's access.`,
 const statusCommand = new Command()
   .name("status")
   .description("Show a custom HTTP/MCP definition and member connection status")
-  .argument("<selector>", "Custom connector slug or UUID")
+  .argument(
+    "<selector>",
+    "Custom connector slug, UUID, or unique display name (custom: prefix accepted)",
+  )
   .option(
     "--agent <id>",
     "Show authorization state for the given Agent (must match the current Agent inside a run)",
@@ -177,9 +180,10 @@ const statusCommand = new Command()
   .addHelpText(
     "after",
     `
-Accepts a custom connector UUID, not a public slug or custom:<uuid> selector.
+Accepts a custom connector full slug, UUID, or exact unique display name,
+optionally prefixed with custom:. Use UUIDs for stable automation.
 Shows current org definition/member status, including inside a run. For the
-account admitted to a run, use connector status with its connector list slug.
+account admitted to a run, use connector status with its connector selector.
 Omit --agent inside a run to inspect the current Agent's access.`,
   )
   .action(

--- a/turbo/apps/cli/src/commands/connector/custom/index.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/index.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../lib/api/domains/connectors";
 import { withErrorHandler } from "../../../lib/command/with-error-handler";
 import { resolveConnectorAgentId } from "../agent-context";
+import { resolveCustomConnectorId } from "../custom-connector-selector";
 import { createCustomConnectorCommand } from "./create";
 import { updateCustomConnectorCommand } from "./update";
 import { connectorInspectionType } from "../inspection";
@@ -127,8 +128,15 @@ Omit --agent inside a run to inspect the current Agent's access.`,
           return connector.displayName.length;
         }),
       );
+      const slugWidth = Math.max(
+        4,
+        ...connectors.map((connector) => {
+          return connector.slug.length;
+        }),
+      );
       const header = [
         "ID".padEnd(idWidth),
+        "SLUG".padEnd(slugWidth),
         "NAME".padEnd(nameWidth),
         "KIND",
         "STATUS",
@@ -140,6 +148,7 @@ Omit --agent inside a run to inspect the current Agent's access.`,
       for (const connector of connectors) {
         const row = [
           connector.id.padEnd(idWidth),
+          connector.slug.padEnd(slugWidth),
           connector.displayName.padEnd(nameWidth),
           connector.kind,
           renderConnected(connector),
@@ -159,10 +168,7 @@ Omit --agent inside a run to inspect the current Agent's access.`,
 const statusCommand = new Command()
   .name("status")
   .description("Show a custom HTTP/MCP definition and member connection status")
-  .argument(
-    "<connector-id>",
-    "Custom connector UUID from connector custom list",
-  )
+  .argument("<selector>", "Custom connector slug or UUID")
   .option(
     "--agent <id>",
     "Show authorization state for the given Agent (must match the current Agent inside a run)",
@@ -179,10 +185,11 @@ Omit --agent inside a run to inspect the current Agent's access.`,
   .action(
     withErrorHandler(
       async (
-        connectorId: string,
+        connectorSelector: string,
         options: { agent?: string; json?: boolean },
       ) => {
         const agentId = resolveConnectorAgentId(options.agent);
+        const connectorId = await resolveCustomConnectorId(connectorSelector);
         const [connector, agentCtx] = await Promise.all([
           getCustomConnector(connectorId),
           resolveCustomAgentContext(agentId),
@@ -215,11 +222,14 @@ Omit --agent inside a run to inspect the current Agent's access.`,
           return;
         }
         if (!connector) {
-          throw new Error(`Custom connector not found: ${connectorId}`);
+          throw new Error(
+            `Custom connector not found: ${connectorId}\nRun: okou connector custom list`,
+          );
         }
         console.log(`Custom connector: ${chalk.cyan(connector.displayName)}`);
         console.log();
         console.log(`${"ID:".padEnd(LABEL_WIDTH)}${connector.id}`);
+        console.log(`${"Slug:".padEnd(LABEL_WIDTH)}${connector.slug}`);
         console.log(`${"Kind:".padEnd(LABEL_WIDTH)}${connector.kind}`);
         console.log(
           `${"Status:".padEnd(LABEL_WIDTH)}${renderConnected(connector)}`,

--- a/turbo/apps/cli/src/commands/connector/custom/update.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/update.ts
@@ -26,7 +26,10 @@ function requireCustomConnectorWriteCapability(): void {
 export const updateCustomConnectorCommand = new Command()
   .name("update")
   .description("Update a custom HTTP or MCP connector definition from JSON")
-  .argument("<selector>", "Custom connector slug or UUID")
+  .argument(
+    "<selector>",
+    "Custom connector slug, UUID, or unique display name (custom: prefix accepted)",
+  )
   .requiredOption("-f, --file <path>", "JSON connector definition file")
   .option("--json", "Print the updated connector as JSON")
   .addHelpText(
@@ -35,8 +38,8 @@ export const updateCustomConnectorCommand = new Command()
 The file uses the same complete HTTP or MCP definition shape as create.
 HTTP supports authMode: none, manual, oauth; MCP also supports automatic.
 authMode is required. See connector custom create --help for mode restrictions
-and valid examples. The connector argument is a UUID, not a public slug or
-custom:<uuid> diagnostic selector.
+and valid examples. The connector argument accepts a full slug, UUID, or exact
+unique display name, optionally prefixed with custom:. Use UUIDs for stable automation.
 OAuth updates may omit oauthConfig.clientSecret to preserve the encrypted
 current client secret. Never include an end-user token or values array.
 

--- a/turbo/apps/cli/src/commands/connector/custom/update.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/update.ts
@@ -6,6 +6,7 @@ import { Command } from "commander";
 import { updateCustomConnector } from "../../../lib/api/domains/connectors";
 import { decodeSandboxTokenPayload } from "../../../lib/api/sandbox-token";
 import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { resolveCustomConnectorId } from "../custom-connector-selector";
 import { updateCustomConnectorDefinitionFileSchema } from "./definition";
 
 interface UpdateOptions {
@@ -25,10 +26,7 @@ function requireCustomConnectorWriteCapability(): void {
 export const updateCustomConnectorCommand = new Command()
   .name("update")
   .description("Update a custom HTTP or MCP connector definition from JSON")
-  .argument(
-    "<connector-id>",
-    "Custom connector UUID from connector custom list",
-  )
+  .argument("<selector>", "Custom connector slug or UUID")
   .requiredOption("-f, --file <path>", "JSON connector definition file")
   .option("--json", "Print the updated connector as JSON")
   .addHelpText(
@@ -43,15 +41,17 @@ OAuth updates may omit oauthConfig.clientSecret to preserve the encrypted
 current client secret. Never include an end-user token or values array.
 
 Examples:
+  okou connector custom update _acme-mcp --file ./connector.json
   okou connector custom update <connector-id> --file ./connector.json
   okou connector custom update <connector-id> --file ./connector.json --json`,
   )
   .action(
-    withErrorHandler(async (connectorId: string, options: UpdateOptions) => {
+    withErrorHandler(async (selector: string, options: UpdateOptions) => {
       requireCustomConnectorWriteCapability();
       const raw = await readFile(options.file, "utf8");
       const input: unknown = JSON.parse(raw);
       const definition = updateCustomConnectorDefinitionFileSchema.parse(input);
+      const connectorId = await resolveCustomConnectorId(selector);
       const connector = await updateCustomConnector(connectorId, definition);
       if (options.json) {
         console.log(JSON.stringify(connector, null, 2));
@@ -61,6 +61,7 @@ Examples:
         chalk.green(`✓ Custom connector "${connector.displayName}" updated`),
       );
       console.log(chalk.dim(`  ID:   ${connector.id}`));
+      console.log(chalk.dim(`  Slug: ${connector.slug}`));
       console.log(chalk.dim(`  Kind: ${connector.kind}`));
     }),
   );

--- a/turbo/apps/cli/src/commands/connector/diagnostic-connector-selector.ts
+++ b/turbo/apps/cli/src/commands/connector/diagnostic-connector-selector.ts
@@ -15,7 +15,7 @@ export async function resolveDiagnosticConnectorSelector(
   selector: string,
 ): Promise<string> {
   const { kind, value } = parseConnectorSelector(selector);
-  if (kind === "custom" || (kind === undefined && value.startsWith("_"))) {
+  if (kind === "custom") {
     return `custom:${await resolveCustomConnectorId(selector)}`;
   }
   const catalog = await listConnectorCatalog();

--- a/turbo/apps/cli/src/commands/connector/diagnostic-connector-selector.ts
+++ b/turbo/apps/cli/src/commands/connector/diagnostic-connector-selector.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+import {
+  listConnectorCatalog,
+  listCustomConnectors,
+} from "../../lib/api/domains/connectors";
+import {
+  findConnectorBySelector,
+  parseConnectorSelector,
+  type ConnectorSelectorIdentity,
+} from "./connector-selector";
+import { resolveCustomConnectorId } from "./custom-connector-selector";
+
+export async function resolveDiagnosticConnectorSelector(
+  selector: string,
+): Promise<string> {
+  const { kind, value } = parseConnectorSelector(selector);
+  if (kind === "custom" || (kind === undefined && value.startsWith("_"))) {
+    return `custom:${await resolveCustomConnectorId(selector)}`;
+  }
+  const catalog = await listConnectorCatalog();
+  const identities: ConnectorSelectorIdentity[] = catalog.connectors.map(
+    (connector) => {
+      return { kind: "builtin", slug: connector.slug, label: connector.label };
+    },
+  );
+  const hasBuiltinSlug = identities.some((identity) => {
+    return identity.slug.toLowerCase() === value.toLowerCase();
+  });
+  if (
+    kind !== "builtin" &&
+    (z.uuid().safeParse(value).success || !hasBuiltinSlug)
+  ) {
+    const customConnectors = await listCustomConnectors();
+    identities.push(
+      ...customConnectors.map((connector): ConnectorSelectorIdentity => {
+        return {
+          kind: "custom",
+          id: connector.id,
+          slug: connector.slug,
+          label: connector.displayName,
+        };
+      }),
+    );
+  }
+  const identity = findConnectorBySelector(identities, selector, (item) => {
+    return item;
+  });
+  if (!identity) {
+    throw new Error(
+      `Unknown or unavailable connector selector: ${selector}\nRun: okou connector list`,
+    );
+  }
+  return identity.kind === "custom" ? `custom:${identity.id}` : identity.slug;
+}

--- a/turbo/apps/cli/src/commands/connector/index.ts
+++ b/turbo/apps/cli/src/commands/connector/index.ts
@@ -46,5 +46,16 @@ Run context:
   run account context means unavailable; it does not select another account.
   Outside a run, commands exposing --agent can inspect that Agent's authorization.
 
+Selectors:
+  Use a full slug, a custom UUID, or an exact unique display name.
+  Qualify a target with builtin:<slug-or-name> or custom:<uuid-slug-or-name>.
+  Full identifiers take precedence over display names; ambiguous matches are rejected.
+  Each command retains its supported connector types. Use UUIDs for stable custom automation.
+
+Examples:
+  okou connector status builtin:github
+  okou connector custom status "Acme Search"
+  okou connector check --connector custom:_acme-search --url https://api.acme.test/items
+
 Use each command's --help for its supported selectors and callback limits.`,
   );

--- a/turbo/apps/cli/src/commands/connector/permission-request.ts
+++ b/turbo/apps/cli/src/commands/connector/permission-request.ts
@@ -25,12 +25,14 @@ import {
 import {
   buildConnectorUrlDiagnosticRequest,
   resolveConnectorCheckDiagnostic,
+  validateDiagnosticUrl,
   type ResolvedDiagnostic,
 } from "./check-diagnostic";
 import {
   customConnectorIdFromSelector,
   customConnectorSettingsGuidance,
 } from "./custom-connector-guidance";
+import { resolveDiagnosticConnectorSelector } from "./diagnostic-connector-selector";
 
 function permissionDescription(permission: string): string {
   return permission === UNKNOWN_PERMISSION_GRANT
@@ -302,7 +304,10 @@ export const permissionRequestCommand = new Command()
   .description(
     "Request builtin permissions or Browser/Computer Use authorization",
   )
-  .argument("<slug>", "Builtin slug, browser, or computer-use")
+  .argument(
+    "<selector>",
+    "Connector slug, custom UUID, unique display name, browser, or computer-use; builtin:/custom: prefixes accepted",
+  )
   .addOption(
     new Option(
       "--permission <name>",
@@ -346,8 +351,8 @@ Notes:
   - Use --permission __unknown__ for diagnosed builtin unknown endpoints
   - Custom HTTP connectors with permission bundles use Connectors > agent access
     > Permissions. MCP connectors have Agent access but no HTTP permission bundle.
-    custom:<uuid> produces settings guidance, not a builtin approval link;
-    custom public slugs are not supported by this approval flow.
+    Custom UUIDs, full slugs, and exact unique display names, optionally prefixed
+    with custom:, resolve to this settings guidance rather than a builtin approval link.
   - Custom unknown endpoints have no approval control; ask an administrator
     to review the connector's routing and permission definition
   - Inside a run, --agent must match the current Agent; omit it to use OKOU_AGENT_ID.
@@ -361,7 +366,7 @@ ${callbackPromptNotes}  - Builtin permission requests update the current user's 
   .action(
     withErrorHandler(
       async (
-        connectorSlug: string,
+        selector: string,
         opts: {
           permission: string;
           agent?: string;
@@ -371,9 +376,12 @@ ${callbackPromptNotes}  - Builtin permission requests update the current user's 
         },
       ) => {
         const agentId = resolveConnectorAgentId(opts.agent);
+        if (opts.url !== undefined) {
+          validateDiagnosticUrl(opts.url);
+        }
         if (
           isBrowserPermissionTarget({
-            connectorSlug,
+            connectorSlug: selector,
             permission: opts.permission,
           })
         ) {
@@ -387,7 +395,7 @@ ${callbackPromptNotes}  - Builtin permission requests update the current user's 
         }
         if (
           isComputerUsePermissionTarget({
-            connectorSlug,
+            connectorSlug: selector,
             permission: opts.permission,
           })
         ) {
@@ -400,6 +408,8 @@ ${callbackPromptNotes}  - Builtin permission requests update the current user's 
           return;
         }
 
+        const connectorSlug =
+          await resolveDiagnosticConnectorSelector(selector);
         const customConnectorId = customConnectorIdFromSelector(connectorSlug);
         if (customConnectorId !== undefined) {
           throw new Error(

--- a/turbo/apps/cli/src/commands/connector/public-catalog.ts
+++ b/turbo/apps/cli/src/commands/connector/public-catalog.ts
@@ -1,5 +1,6 @@
 import type { PublicConnectorCatalogAuthMethodDetail } from "@okouai/api-contracts/contracts/connector-catalog";
 import type { ConnectorCatalogStatus } from "../../lib/api/domains/connectors";
+import { findConnectorBySelector } from "./connector-selector";
 
 export type PublicConnectorStatus = ConnectorCatalogStatus;
 
@@ -235,15 +236,9 @@ export function findConnectorStatusItem(
   connectors: readonly PublicConnectorStatus[],
   connectorSlug: string,
 ): PublicConnectorStatus | null {
-  const exact = connectors.find((connector) => {
-    return connector.slug === connectorSlug;
-  });
-  if (exact) return exact;
-
-  const lower = connectorSlug.toLowerCase();
   return (
-    connectors.find((connector) => {
-      return connector.slug.toLowerCase() === lower;
+    findConnectorBySelector(connectors, connectorSlug, (connector) => {
+      return { kind: "builtin", slug: connector.slug, label: connector.label };
     }) ?? null
   );
 }

--- a/turbo/apps/cli/src/commands/connector/status.ts
+++ b/turbo/apps/cli/src/commands/connector/status.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { listConnectorCatalogStatus } from "../../lib/api/domains/connectors";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { findConnectorBySelector } from "./connector-selector";
 import { resolveAgentContext, resolveConnectorAgentId } from "./agent-context";
 import { getPlatformOrigin } from "../doctor/platform-url";
 import {
@@ -229,9 +230,24 @@ async function printRunConnectorStatus(
     }
     return;
   }
-  const connector = view.connectors.find((candidate) => {
-    return candidate.slug === connectorSlug;
-  });
+  const connector = findConnectorBySelector(
+    view.connectors,
+    connectorSlug,
+    (candidate) => {
+      return candidate.target.kind === "custom"
+        ? {
+            kind: "custom",
+            id: candidate.target.customConnectorId,
+            slug: candidate.slug,
+            label: candidate.connectorLabel,
+          }
+        : {
+            kind: "builtin",
+            slug: candidate.slug,
+            label: candidate.connectorLabel,
+          };
+    },
+  );
   if (!connector) {
     throw new Error(
       `Connector is not available in this run: ${connectorSlug}`,
@@ -263,8 +279,8 @@ export const statusCommand = new Command()
   .name("status")
   .description("Show run account status, or builtin status outside a run")
   .argument(
-    "<slug>",
-    "Slug shown by connector list (builtin only outside a run)",
+    "<selector>",
+    "Connector slug or unique display name (builtin only outside a run)",
   )
   .option(
     "--agent <id>",
@@ -275,13 +291,15 @@ export const statusCommand = new Command()
     "after",
     `
 Scope:
-  Inside a run, accepts builtin or custom HTTP/MCP slugs shown by connector list
-  and reports the account selected for that run. Missing account context is
+  Inside a run, accepts builtin or custom HTTP/MCP full slugs, custom UUIDs,
+  or exact unique display names from connector list. Reports the account
+  selected for that run. Missing account context is
   reported as unavailable. Omit --agent or match the current Agent; the flag
   does not change the run's accounts.
-  Outside a run, accepts builtin catalog slugs and shows the current member's
-  connection plus optional --agent authorization.
-  For org custom definition/member status, use connector custom status <uuid>.
+  Outside a run, accepts builtin catalog full slugs or exact unique display names
+  and shows the current member's connection plus optional --agent authorization.
+  Qualify a selector with builtin: or custom: within the supported connector types.
+  For org custom definition/member status, use connector custom status <selector>.
 
 Examples:
   okou connector status github --json

--- a/turbo/apps/cli/src/commands/mcp/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/mcp/__tests__/index.test.ts
@@ -288,111 +288,141 @@ describe("okou mcp command", () => {
     expect(output).not.toContain("secrets.secret");
   });
 
-  it("discovers modern tools page by page with exact intent and cleanup", async () => {
-    const searchTool = {
-      name: "search",
-      description: "Search documents",
-      inputSchema: {
-        type: "object",
-        properties: { query: { type: "string" } },
-      },
-    } satisfies Tool;
-    const fetchTool = {
-      name: "fetch",
-      inputSchema: {
-        type: "object",
-        properties: { id: { type: "string" } },
-      },
-    } satisfies Tool;
-    const tools = [searchTool, fetchTool];
-    stubConnectorList();
-    const seen = stubMcpServer({
-      era: "modern",
-      pages: [[searchTool], [fetchTool]],
-    });
-
-    await mcpCommand.parseAsync([
-      "node",
-      "okou",
-      "list-tools",
-      "_acme-mcp",
-      "--json",
-    ]);
-
-    expect(consoleLog).toHaveBeenCalledWith(
-      JSON.stringify({ connectorSlug: "_acme-mcp", tools }),
+  it("rejects a shared admitted MCP name before opening either server", async () => {
+    const otherId = "55555555-5555-4555-8555-555555555555";
+    server.use(
+      stubRunMcpConnectors([
+        runMcpConnector(),
+        runMcpConnector({ id: otherId, slug: "_other" }),
+      ]),
     );
-    expect(
-      seen.map((request) => {
-        return request.method ?? request.httpMethod;
-      }),
-    ).toEqual(["server/discover", "tools/list", "tools/list"]);
-    expect(seen[2]?.params).toMatchObject({ cursor: "1" });
-    expect(
-      seen.every((request) => {
-        return request.intent === CONNECTOR_ID;
-      }),
-    ).toBe(true);
+    const seen = stubMcpServer({ era: "modern" });
+    await expect(
+      mcpCommand.parseAsync(["node", "okou", "list-tools", "Acme MCP"]),
+    ).rejects.toThrow("process.exit called");
+    expect(seen).toStrictEqual([]);
+    const output = outputText(consoleError);
+    expect(output).toContain(`custom:${CONNECTOR_ID}`);
+    expect(output).toContain(`custom:${otherId}`);
   });
 
-  it("falls back to the 2025 handshake and calls the exact tool once", async () => {
-    const tool = {
-      name: "search",
-      description: "Search documents",
-      inputSchema: {
-        type: "object",
-        properties: { query: { type: "string" } },
-        required: ["query"],
-      },
-    } satisfies Tool;
-    const callResult = {
-      content: [{ type: "text", text: "one result" }],
-    } satisfies CallToolResult;
-    stubConnectorList();
-    const seen = stubMcpServer({
-      era: "legacy",
-      pages: [[tool]],
-      callResult,
-    });
+  it.each([
+    "_acme-mcp",
+    CONNECTOR_ID,
+    `custom:${CONNECTOR_ID}`,
+    "custom:_acme-mcp",
+    "Acme MCP",
+  ])(
+    "discovers tools selected by %s with exact intent and cleanup",
+    async (selector) => {
+      const searchTool = {
+        name: "search",
+        description: "Search documents",
+        inputSchema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+        },
+      } satisfies Tool;
+      const fetchTool = {
+        name: "fetch",
+        inputSchema: {
+          type: "object",
+          properties: { id: { type: "string" } },
+        },
+      } satisfies Tool;
+      const tools = [searchTool, fetchTool];
+      stubConnectorList();
+      const seen = stubMcpServer({
+        era: "modern",
+        pages: [[searchTool], [fetchTool]],
+      });
 
-    await mcpCommand.parseAsync([
-      "node",
-      "okou",
-      "call",
-      "_acme-mcp",
-      "search",
-      "--input",
-      '{"query":"okou"}',
-      "--json",
-    ]);
+      await mcpCommand.parseAsync([
+        "node",
+        "okou",
+        "list-tools",
+        selector,
+        "--json",
+      ]);
 
-    expect(consoleLog).toHaveBeenCalledWith(JSON.stringify(callResult));
-    expect(
-      seen.map((request) => {
-        return request.method ?? request.httpMethod;
-      }),
-    ).toEqual([
-      "server/discover",
-      "initialize",
-      "notifications/initialized",
-      "tools/list",
-      "tools/call",
-      "DELETE",
-    ]);
-    const calls = seen.filter((request) => {
-      return request.method === "tools/call";
-    });
-    expect(calls).toHaveLength(1);
-    expect(calls[0]?.params).toMatchObject({
-      name: "search",
-      arguments: { query: "okou" },
-    });
-    expect(
-      seen.every((request) => {
-        return request.intent === CONNECTOR_ID;
-      }),
-    ).toBe(true);
-  });
+      expect(consoleLog).toHaveBeenCalledWith(
+        JSON.stringify({ connectorSlug: "_acme-mcp", tools }),
+      );
+      expect(
+        seen.map((request) => {
+          return request.method ?? request.httpMethod;
+        }),
+      ).toEqual(["server/discover", "tools/list", "tools/list"]);
+      expect(seen[2]?.params).toMatchObject({ cursor: "1" });
+      expect(
+        seen.every((request) => {
+          return request.intent === CONNECTOR_ID;
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it.each(["_acme-mcp", CONNECTOR_ID, "Acme MCP"])(
+    "calls the exact tool selected by %s once after the 2025 handshake",
+    async (selector) => {
+      const tool = {
+        name: "search",
+        description: "Search documents",
+        inputSchema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+          required: ["query"],
+        },
+      } satisfies Tool;
+      const callResult = {
+        content: [{ type: "text", text: "one result" }],
+      } satisfies CallToolResult;
+      stubConnectorList();
+      const seen = stubMcpServer({
+        era: "legacy",
+        pages: [[tool]],
+        callResult,
+      });
+
+      await mcpCommand.parseAsync([
+        "node",
+        "okou",
+        "call",
+        selector,
+        "search",
+        "--input",
+        '{"query":"okou"}',
+        "--json",
+      ]);
+
+      expect(consoleLog).toHaveBeenCalledWith(JSON.stringify(callResult));
+      expect(
+        seen.map((request) => {
+          return request.method ?? request.httpMethod;
+        }),
+      ).toEqual([
+        "server/discover",
+        "initialize",
+        "notifications/initialized",
+        "tools/list",
+        "tools/call",
+        "DELETE",
+      ]);
+      const calls = seen.filter((request) => {
+        return request.method === "tools/call";
+      });
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.params).toMatchObject({
+        name: "search",
+        arguments: { query: "okou" },
+      });
+      expect(
+        seen.every((request) => {
+          return request.intent === CONNECTOR_ID;
+        }),
+      ).toBe(true);
+    },
+  );
 
   it("reads call input from a file without exposing its contents", async () => {
     const inputPath = join(inputDirectory, "input.json");
@@ -843,19 +873,24 @@ describe("okou mcp command", () => {
     );
   });
 
-  it("rejects an HTTP custom slug from MCP commands", async () => {
+  it.each([
+    "_acme-search",
+    "33333333-3333-4333-8333-333333333333",
+    "custom:33333333-3333-4333-8333-333333333333",
+    "Acme Search",
+  ])("rejects HTTP custom selector %s from MCP commands", async (selector) => {
     const connector = customConnector();
     stubConnectorList();
     server.use(stubCustomConnectors([connector]));
     const seen = stubMcpServer({ era: "modern" });
 
     await expect(
-      mcpCommand.parseAsync(["node", "okou", "list-tools", connector.slug]),
+      mcpCommand.parseAsync(["node", "okou", "list-tools", selector]),
     ).rejects.toThrow("process.exit called");
 
     expect(seen).toHaveLength(0);
     expect(outputText(consoleError)).toContain(
-      `MCP connector "${connector.slug}" is not authorized for this Agent`,
+      `MCP connector "${selector}" is not authorized for this Agent`,
     );
   });
 

--- a/turbo/apps/cli/src/commands/mcp/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/mcp/__tests__/index.test.ts
@@ -24,7 +24,9 @@ import {
 
 import { server } from "../../../mocks/server";
 import {
+  customConnector,
   runMcpConnector,
+  stubCustomConnectors,
   stubRunMcpConnectors,
 } from "../../__tests__/helpers/custom-connectors";
 import { mcpCommand } from "../index";
@@ -838,6 +840,22 @@ describe("okou mcp command", () => {
     expect(seen).toHaveLength(0);
     expect(outputText(consoleError)).toContain(
       'MCP connector "_not-admitted" is not authorized for this Agent',
+    );
+  });
+
+  it("rejects an HTTP custom slug from MCP commands", async () => {
+    const connector = customConnector();
+    stubConnectorList();
+    server.use(stubCustomConnectors([connector]));
+    const seen = stubMcpServer({ era: "modern" });
+
+    await expect(
+      mcpCommand.parseAsync(["node", "okou", "list-tools", connector.slug]),
+    ).rejects.toThrow("process.exit called");
+
+    expect(seen).toHaveLength(0);
+    expect(outputText(consoleError)).toContain(
+      `MCP connector "${connector.slug}" is not authorized for this Agent`,
     );
   });
 

--- a/turbo/apps/cli/src/commands/mcp/index.ts
+++ b/turbo/apps/cli/src/commands/mcp/index.ts
@@ -89,7 +89,10 @@ const listCommand = new Command()
 const listToolsCommand = new Command()
   .name("list-tools")
   .description("List tools exposed by an authorized MCP connector")
-  .argument("<connector-slug>", "MCP Custom Connector slug")
+  .argument(
+    "<selector>",
+    "MCP custom connector slug, UUID, or unique display name; custom: prefix accepted",
+  )
   .option("--json", "Print compact JSON")
   .action(
     withErrorHandler(async (connectorSlug: string, options: JsonOptions) => {
@@ -142,7 +145,10 @@ const inputFileOption = new Option(
 const callCommand = new Command()
   .name("call")
   .description("Call one tool on an authorized MCP connector")
-  .argument("<connector-slug>", "MCP Custom Connector slug")
+  .argument(
+    "<selector>",
+    "MCP custom connector slug, UUID, or unique display name; custom: prefix accepted",
+  )
   .argument("<tool-name>", "Exact MCP tool name")
   .addOption(inputOption)
   .addOption(inputFileOption)
@@ -184,10 +190,12 @@ export const mcpCommand = new Command()
 Examples:
   List authorized MCP connectors: okou mcp list
   List connector tools:          okou mcp list-tools _acme-mcp --json
+  Select by display name:        okou mcp list-tools "Acme MCP" --json
   Call a tool:                   okou mcp call _acme-mcp search --input '{"query":"okou"}' --json
   Pipe tool input:               printf '{"query":"okou"}' | okou mcp call _acme-mcp search
 
 Notes:
+  - Select by full slug, UUID, custom:<selector>, or an exact unique display name
   - Available only inside an Agent Run and scoped to its Agent's current authorization
   - Runner remains execution authority; authorization changes may require a new Run
   - Runner applies endpoint policy and injects connector credentials

--- a/turbo/apps/cli/src/commands/mcp/run-connectors.ts
+++ b/turbo/apps/cli/src/commands/mcp/run-connectors.ts
@@ -1,6 +1,7 @@
 import type { McpConnector } from "@okouai/api-contracts/contracts/mcp-connectors";
 
 import { listRunMcpConnectors as listRunMcpConnectorsApi } from "../../lib/api/domains/connectors";
+import { findConnectorBySelector } from "../connector/connector-selector";
 
 export function listRunMcpConnectors(): Promise<McpConnector[]> {
   return listRunMcpConnectorsApi();
@@ -10,9 +11,18 @@ export async function resolveRunMcpConnector(
   connectorSlug: string,
 ): Promise<McpConnector> {
   const connectors = await listRunMcpConnectors();
-  const connector = connectors.find((candidate) => {
-    return candidate.slug === connectorSlug;
-  });
+  const connector = findConnectorBySelector(
+    connectors,
+    connectorSlug,
+    (candidate) => {
+      return {
+        kind: "custom",
+        id: candidate.id,
+        slug: candidate.slug,
+        label: candidate.displayName,
+      };
+    },
+  );
   if (!connector) {
     throw new Error(
       `MCP connector "${connectorSlug}" is not authorized for this Agent`,


### PR DESCRIPTION
Connector commands disagree about how to identify the same connector: custom readers require UUIDs, account and MCP commands require slugs, and diagnostics use another syntax. Resolve unambiguous selectors consistently across existing command domains.

Accept full slugs, custom UUIDs, builtin:/custom: qualification, and exact unique display names. Canonical identifiers take precedence over names; ambiguous names and cross-kind UUID collisions return explicit candidate identities. Custom list/status/create/update output includes reusable IDs and slugs.

Preserve each command's connector types, early Agent/capability/definition and URL-userinfo validation, run-pinned account identity, MCP admission, permission controls, and JSON schemas. Alias selection is resolved before existing requests and JSON rendering; no API, schema, permission, or runtime-identity migration is introduced.

### Validation

- 361 passing cases across 12 focused Commander/MSW suites, including custom HTTP/MCP selectors, status/connect, account selection, diagnostics, permission requests, Agent guards, and JSON identity/account preservation.
- CLI lint, check-types (including public declaration validation), scoped Knip, Prettier, and git diff checks passed after integration with current main.
- Full local Vitest and a local dev server were not run.

### Risks

Diagnostic selectors can add catalog/custom-inventory reads and their existing read-capability dependencies. Failed reads propagate; no alternate target is guessed. Custom UUID access keeps its direct path. Display names can change or become ambiguous between invocations, so UUIDs remain the stable automation choice.

Closes #32830
