### PR TITLE
docs(cli): align connector help with supported scopes and auth modes

### DIFF
--- a/turbo/apps/cli/src/commands/connector/check.ts
+++ b/turbo/apps/cli/src/commands/connector/check.ts
@@ -607,13 +607,13 @@ function printEnvironmentPermissionDiagnostic(
 export const checkConnectorCommand = new Command()
   .name("check")
   .description(
-    "Diagnose connector health: environment names, connector configuration, and permission policies",
+    "Diagnose builtin/custom routing, account configuration, and run permissions",
   )
   .option("--json", "Output connector diagnostics and next actions as JSON")
   .addOption(
     new Option(
       "--env-name <ENV_NAME>",
-      "The connector environment name to check (e.g. GITHUB_TOKEN)",
+      "Builtin connector environment name (e.g. GITHUB_TOKEN)",
     ),
   )
   .addOption(
@@ -637,12 +637,25 @@ export const checkConnectorCommand = new Command()
   .addOption(
     new Option(
       "--check-permission <name>",
-      "Check whether a specific permission is allowed or denied (e.g. contents:read)",
+      "Permission to check with --env-name only (e.g. contents:read)",
     ),
   )
   .addHelpText(
     "after",
     `
+Scope:
+  --env-name diagnoses a builtin environment binding; --check-permission can
+  select a permission in this mode. Custom HTTP/MCP routes use --url; this checks
+  HTTP routing, not MCP tool discovery or execution.
+  URL mode discovers builtin and custom route owners. Use --connector with a
+  builtin slug or custom:<uuid> to disambiguate; custom public slugs are not
+  accepted here. Find UUIDs with connector custom list.
+  --connector and --method require --url. URL permissions are derived from the
+  request, so --check-permission cannot be combined with --url.
+  Inside a run, account identity comes from that run's admitted accounts.
+  Outside a run, run routing/policy checks may be unavailable. Unavailable
+  policy data is not an allow decision.
+
 Examples:
   okou connector check --env-name GITHUB_TOKEN
   okou connector check --url https://api.github.com/repos/owner/repo
@@ -652,12 +665,19 @@ Examples:
   okou connector check --env-name SLACK_TOKEN --check-permission chat:write
 
 How connectors work:
-  A Connector holds the real credentials for an external service. These credentials
-  are never injected into the sandbox. Instead, when the sandbox sends an HTTP
-  request to a base URL registered by the Connector, the network boundary intercepts
-  the request and replaces the auth headers with real credentials.
+  Authenticated connectors resolve credentials at the network boundary for
+  matching registered URLs. No-auth connectors do not inject credentials.
+  This command diagnoses configuration and intended routing/permission state;
+  it does not replay the failed request or confirm the runner applied an update.
 
-  This command checks each part of that pipeline and reports what it finds.`,
+Permission recovery:
+  For builtin deny/ask outcomes, use the exact permission-request command printed
+  for the failed URL and method. Custom HTTP permission bundles use Connectors
+  > agent access > Permissions. MCP connectors have no HTTP permission bundle.
+  Custom unknown endpoints require an administrator to review routing/permission
+  definitions; there is no custom approval control.
+  Callback examples are for a single supported action in the current web chat
+  for its current Agent. Custom settings guidance has no callback approval flow.`,
   )
   .action(
     withErrorHandler(async (opts: CheckConnectorOptions, command: Command) => {

--- a/turbo/apps/cli/src/commands/connector/connect.ts
+++ b/turbo/apps/cli/src/commands/connector/connect.ts
@@ -104,8 +104,8 @@ function parseConnectorValues(rawValues: readonly string[] | undefined) {
 
 export const connectCommand = new Command()
   .name("connect")
-  .description("Connect a connector with manual grant values")
-  .argument("<slug>", "Connector slug (e.g., zendesk)")
+  .description("Connect a builtin connector with manual grant values")
+  .argument("<slug>", "Builtin connector slug (e.g., zendesk)")
   .addOption(
     new Option("--add", "Create a new connector account").conflicts(
       "reconnect",
@@ -124,7 +124,7 @@ export const connectCommand = new Command()
       .conflicts("reconnect")
       .argParser(parseAccountName),
   )
-  .option("--auth-method <method>", "Connector auth method to use")
+  .option("--auth-method <method>", "Builtin manual-grant auth method to use")
   .option(
     "--value <name=value>",
     "Connector field value; repeat for multiple fields",
@@ -135,6 +135,13 @@ export const connectCommand = new Command()
   .addHelpText(
     "after",
     `
+Scope:
+  Supports builtin catalog connectors with a manual-grant authentication method.
+  OAuth authorization and custom HTTP/MCP account connections use the web
+  connection flow. Use connector search <slug> --limit 1 for connection guidance.
+  This command manages member connections. Use connector list/status to inspect
+  the account admitted to the current run.
+
 Examples:
   okou connector connect openai --value apiKey=...
   okou connector connect openai --add --account-name Work --value apiKey=...

--- a/turbo/apps/cli/src/commands/connector/custom/create.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/create.ts
@@ -59,17 +59,31 @@ async function printCreateResult(
 
 export const createCustomConnectorCommand = new Command()
   .name("create")
-  .description("Create a manual or OAuth custom connector definition from JSON")
+  .description("Create a custom HTTP or MCP connector definition from JSON")
   .requiredOption("-f, --file <path>", "JSON connector definition file")
   .option("--json", "Print the created connector as JSON")
   .addHelpText(
     "after",
     `
+Types and authentication:
+  HTTP uses prefixTemplates and supports authMode: none, manual, oauth.
+  MCP requires kind: "mcp", endpoint, transport: "streamable-http" and supports
+  authMode: none, manual, oauth, automatic. Omit prefixTemplates for MCP.
+  Always supply authMode explicitly.
+
+  none: No authentication injections or OAuth configuration. HTTP may declare
+    non-secret variable fields; MCP requires empty fields.
+  manual: Declare credential fields and Header/Query injection templates.
+  oauth: Use empty fields, OAuth token injection, and standard OAuth app config.
+    Creation requires the app client secret; members authorize their accounts later.
+  automatic: MCP-only discovery of no-auth or OAuth during connection/reconnect.
+    Use empty fields and injections, without static OAuth configuration.
+
 Definition file:
   Describe only the connector metadata, Header/Query injection templates, and
   OAuth app configuration when applicable. Never include an API token,
   end-user OAuth token, or values array. Creating the definition is separate
-  from connecting it with a user's credential or OAuth grant.
+  from connecting a member account, including for none and automatic modes.
 
 Agent workflow:
   1. For manual connectors, ask only for missing metadata: name, HTTPS API
@@ -83,7 +97,17 @@ Agent workflow:
      for an end-user access token or refresh token.
   4. Write a temporary JSON definition, run this command, then remove the file.
   5. Share the emitted Connect link so the user can finish the separate
-     credential or OAuth flow when they are ready.
+     account connection flow, including for none and automatic modes.
+
+No-auth HTTP connector example:
+  {
+    "displayName": "Acme Public API",
+    "prefixTemplates": ["https://api.acme.example/v1/"],
+    "fields": [],
+    "headerInjections": [],
+    "queryInjections": [],
+    "authMode": "none"
+  }
 
 Manual API connector example:
   {
@@ -108,7 +132,7 @@ Manual API connector example:
     "authMode": "manual"
   }
 
-OAuth connector example:
+OAuth HTTP connector example:
   {
     "displayName": "Acme OAuth API",
     "prefixTemplates": ["https://api.acme.example/v1/"],
@@ -158,6 +182,23 @@ Manual Streamable HTTP MCP connector example:
     "authMode": "manual"
   }
 
+Automatic Streamable HTTP MCP connector example:
+  {
+    "kind": "mcp",
+    "displayName": "Acme Automatic MCP",
+    "endpoint": "https://mcp.acme.example/mcp",
+    "transport": "streamable-http",
+    "fields": [],
+    "headerInjections": [],
+    "queryInjections": [],
+    "authMode": "automatic"
+  }
+
+For a fixed no-auth MCP server, use the same MCP shape with authMode: "none".
+For an MCP OAuth app, use the OAuth HTTP example's fields, injections and
+oauthConfig, replacing prefixTemplates with kind, endpoint and transport from
+the MCP example. Set authMode: "oauth".
+
 Examples:
   okou connector custom create --file ./connector.json
   okou connector custom create --file ./connector.json --json
@@ -167,6 +208,10 @@ Notes:
     manual API token, start OAuth authorization, or authorize an agent.
   - Manual credentials and end-user OAuth grants are supplied later through
     the Connect dialog.
+  - Connected accounts still need Agent access and any fine-grained permissions.
+  - In the current web chat, a callback link example is printed when the action
+    targets the current Agent. Use it only for a single connector/permission
+    action, keeping the callback prompt free of secrets.
   - OAuth app client secrets are definition-time configuration, matching UI
     creation, and should be kept in a temporary file that is never committed.
   - Requires an organization admin.`,

--- a/turbo/apps/cli/src/commands/connector/custom/definition.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/definition.ts
@@ -13,7 +13,7 @@ const customConnectorDefinitionFileSchema = z
     (definition) => {
       return definition.authMode !== undefined;
     },
-    { message: 'Custom connector authMode must be "manual" or "oauth"' },
+    { message: "Custom connector authMode is required" },
   )
   .refine(
     (definition) => {

--- a/turbo/apps/cli/src/commands/connector/custom/index.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/index.ts
@@ -70,12 +70,23 @@ async function resolveCustomAgentContext(agentId: string | undefined): Promise<{
 const listCommand = new Command()
   .name("list")
   .alias("ls")
-  .description("List org custom connectors")
+  .description(
+    "List org custom HTTP/MCP definitions and member connection status",
+  )
   .option(
     "--agent <id>",
     "Show per-agent authorization column (must match the current Agent inside a run)",
   )
   .option("--json", "Output current org custom connectors as JSON")
+  .addHelpText(
+    "after",
+    `
+Lists org definitions with the current member's connection status, including
+inside a run. This is separate from the accounts admitted to the current run;
+use connector list for that view. The ID column contains UUIDs for custom
+status/update and custom:<uuid> diagnostic selectors.
+Omit --agent inside a run to inspect the current Agent's access.`,
+  )
   .action(
     withErrorHandler(async (options: { agent?: string; json?: boolean }) => {
       const agentId = resolveConnectorAgentId(options.agent);
@@ -147,13 +158,24 @@ const listCommand = new Command()
 
 const statusCommand = new Command()
   .name("status")
-  .description("Show detailed status of a custom connector")
-  .argument("<connector-id>", "Custom connector id")
+  .description("Show a custom HTTP/MCP definition and member connection status")
+  .argument(
+    "<connector-id>",
+    "Custom connector UUID from connector custom list",
+  )
   .option(
     "--agent <id>",
     "Show authorization state for the given Agent (must match the current Agent inside a run)",
   )
   .option("--json", "Output current org custom connector status as JSON")
+  .addHelpText(
+    "after",
+    `
+Accepts a custom connector UUID, not a public slug or custom:<uuid> selector.
+Shows current org definition/member status, including inside a run. For the
+account admitted to a run, use connector status with its connector list slug.
+Omit --agent inside a run to inspect the current Agent's access.`,
+  )
   .action(
     withErrorHandler(
       async (
@@ -262,6 +284,21 @@ export const customConnectorCommand = new Command()
   .addHelpText(
     "after",
     `
+Types and authentication:
+  HTTP: none, manual, oauth.
+  MCP over Streamable HTTP: none, manual, oauth, automatic.
+  The definition's authMode is required. Automatic is MCP-only and discovers
+  the server's authentication requirements when a member connects.
+
+Definitions and access:
+  create/update manage org definitions; list/status show current-member metadata.
+  Creating a definition is separate from connecting a member account, granting
+  Agent access, and selecting any fine-grained permissions. This also applies
+  to none/automatic definitions. Members finish connection in the web flow.
+  Custom HTTP connectors with a permission bundle use Connectors > agent access
+  > Permissions. MCP connectors have Agent access but no HTTP permission bundle.
+  Builtin permission-request approval links do not apply to custom connectors.
+
 To add a custom connector:
   Run "okou connector custom create -h" and follow the definition-only creation workflow.`,
   );

--- a/turbo/apps/cli/src/commands/connector/custom/update.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/update.ts
@@ -24,14 +24,21 @@ function requireCustomConnectorWriteCapability(): void {
 
 export const updateCustomConnectorCommand = new Command()
   .name("update")
-  .description("Update a custom connector definition from JSON")
-  .argument("<connector-id>", "Custom connector id")
+  .description("Update a custom HTTP or MCP connector definition from JSON")
+  .argument(
+    "<connector-id>",
+    "Custom connector UUID from connector custom list",
+  )
   .requiredOption("-f, --file <path>", "JSON connector definition file")
   .option("--json", "Print the updated connector as JSON")
   .addHelpText(
     "after",
     `
 The file uses the same complete HTTP or MCP definition shape as create.
+HTTP supports authMode: none, manual, oauth; MCP also supports automatic.
+authMode is required. See connector custom create --help for mode restrictions
+and valid examples. The connector argument is a UUID, not a public slug or
+custom:<uuid> diagnostic selector.
 OAuth updates may omit oauthConfig.clientSecret to preserve the encrypted
 current client secret. Never include an end-user token or values array.
 

--- a/turbo/apps/cli/src/commands/connector/index.ts
+++ b/turbo/apps/cli/src/commands/connector/index.ts
@@ -18,4 +18,33 @@ export const connectorCommand = new Command()
   .addCommand(listCommand)
   .addCommand(searchCommand)
   .addCommand(statusCommand)
-  .addCommand(permissionRequestCommand);
+  .addCommand(permissionRequestCommand)
+  .addHelpText(
+    "after",
+    `
+Choose a command:
+  list/status   Inspect the current run's admitted accounts. Outside a run,
+                list includes builtin and custom connectors; status is builtin-only.
+  search        Discover builtin and custom HTTP/MCP connectors and connection guidance.
+  custom        Create/update definitions and inspect org custom connector metadata.
+  connect       Connect builtin connectors using manual grant values.
+  check         Diagnose a failed URL or a builtin environment name.
+  permission-request
+                Request a diagnosed builtin permission; custom permissions use settings.
+
+Connection and access:
+  A definition describes the service and its authentication setup. Members then
+  connect their own accounts, grant Agent access, and select any fine-grained
+  permissions. Creating a custom definition alone does not complete these steps.
+  OAuth and custom account connections use the web connection flow; search and
+  custom create provide guidance for the next action.
+
+Run context:
+  Inside a run, omit --agent to use the current Agent (OKOU_AGENT_ID).
+  An explicit --agent must match the current Agent.
+  Agent selection does not replace the accounts admitted to that run. Missing
+  run account context means unavailable; it does not select another account.
+  Outside a run, commands exposing --agent can inspect that Agent's authorization.
+
+Use each command's --help for its supported selectors and callback limits.`,
+  );

--- a/turbo/apps/cli/src/commands/connector/list.ts
+++ b/turbo/apps/cli/src/commands/connector/list.ts
@@ -64,12 +64,27 @@ async function printRunConnectorList(json: boolean): Promise<void> {
 export const listCommand = new Command()
   .name("list")
   .alias("ls")
-  .description("List all connectors and their status")
+  .description("List connector status in the current run or member context")
   .option(
     "--agent <id>",
-    "Show per-agent authorization column (must match the current Agent inside a run)",
+    "Show per-agent authorization outside a run (must match the current Agent inside a run)",
   )
   .option("--json", "Output connector status as JSON")
+  .addHelpText(
+    "after",
+    `
+Scope:
+  Inside a run, lists builtin and custom HTTP/MCP targets from the current run's
+  account context, with the exact selected account or its unavailable state.
+  This is not the full connector catalog. Omit --agent or match the current
+  Agent; the flag does not select another Agent's run or accounts.
+  Outside a run, lists the builtin catalog and org custom definitions with the
+  current member's connection status and optional --agent authorization.
+
+Examples:
+  okou connector list --json
+  okou connector search github`,
+  )
   .action(
     withErrorHandler(async (options: { agent?: string; json?: boolean }) => {
       const agentId = resolveConnectorAgentId(options.agent);

--- a/turbo/apps/cli/src/commands/connector/permission-request.ts
+++ b/turbo/apps/cli/src/commands/connector/permission-request.ts
@@ -299,8 +299,10 @@ const callbackPromptNotes = callbackPromptAvailable
 
 export const permissionRequestCommand = new Command()
   .name("permission-request")
-  .description("Request permission to use a connector capability")
-  .argument("<slug>", "The connector slug (e.g. github)")
+  .description(
+    "Request builtin permissions or Browser/Computer Use authorization",
+  )
+  .argument("<slug>", "Builtin slug, browser, or computer-use")
   .addOption(
     new Option(
       "--permission <name>",
@@ -339,12 +341,22 @@ Notes:
   - First run okou connector check --url <FAILED_URL> --method <METHOD>
   - Use the exact permission-request command printed by connector check
   - A platform URL is output only when that request maps to a denied or approval-required permission
-  - Use --permission __unknown__ to request access to unknown endpoints
-  - Custom connectors use Connectors > agent access > Permissions, not this builtin approval flow
-  - Inside a run, --agent must match the current Agent; omit it to use OKOU_AGENT_ID
-  - Outside a run, use --agent to select the Agent whose permission page should be opened
+  - Builtin requests require --url and run-scoped policy data; an unavailable
+    non-run diagnostic cannot produce a builtin permission approval
+  - Use --permission __unknown__ for diagnosed builtin unknown endpoints
+  - Custom HTTP connectors with permission bundles use Connectors > agent access
+    > Permissions. MCP connectors have Agent access but no HTTP permission bundle.
+    custom:<uuid> produces settings guidance, not a builtin approval link;
+    custom public slugs are not supported by this approval flow.
+  - Custom unknown endpoints have no approval control; ask an administrator
+    to review the connector's routing and permission definition
+  - Inside a run, --agent must match the current Agent; omit it to use OKOU_AGENT_ID.
+    Outside a run, --agent selects the Agent's permission page.
+    Agent selection does not change the accounts admitted to a run.
   - The user chooses the permission duration on the confirmation page
-${callbackPromptNotes}  - Permission requests update the current user's connector grants after confirmation`,
+  - --callback-prompt requires the current web chat and its current Agent;
+    it is unsupported for custom, Browser, and Computer Use authorization
+${callbackPromptNotes}  - Builtin permission requests update the current user's connector grants after confirmation`,
   )
   .action(
     withErrorHandler(

--- a/turbo/apps/cli/src/commands/connector/search.ts
+++ b/turbo/apps/cli/src/commands/connector/search.ts
@@ -272,6 +272,28 @@ export const searchCommand = new Command()
     "Maximum number of results to display (default: all matches)",
     parseLimit,
   )
+  .addHelpText(
+    "after",
+    `
+Scope:
+  Searches the builtin catalog and org custom HTTP/MCP definitions.
+  Inside a run, availability and account identity describe the accounts admitted
+  to that run. A supported connector can still be unavailable in this run.
+  Outside a run, connection status describes the current member's accounts.
+  Omit --agent inside a run to use the current Agent's authorization context;
+  an explicit --agent must match that Agent and cannot change admitted accounts.
+
+Callbacks:
+  Use --callback-prompt only in the current web chat for its current Agent,
+  when the task needs exactly one connector action; use --limit 1.
+  Only direct connection, reconnect, or Agent authorization actions support it.
+  Custom connectors and other actions that open Connectors settings do not.
+  Keep the prompt free of secrets because it is included in the action URL.
+
+Examples:
+  okou connector search github --limit 1
+  okou connector search notion`,
+  )
   .action(
     withErrorHandler(
       async (

--- a/turbo/apps/cli/src/commands/connector/status.ts
+++ b/turbo/apps/cli/src/commands/connector/status.ts
@@ -261,13 +261,33 @@ async function printRunConnectorStatus(
 
 export const statusCommand = new Command()
   .name("status")
-  .description("Show detailed status of a connector")
-  .argument("<slug>", "Connector slug (e.g., github)")
+  .description("Show run account status, or builtin status outside a run")
+  .argument(
+    "<slug>",
+    "Slug shown by connector list (builtin only outside a run)",
+  )
   .option(
     "--agent <id>",
-    "Show authorization state for the given Agent (must match the current Agent inside a run)",
+    "Show per-agent authorization outside a run (must match the current Agent inside a run)",
   )
   .option("--json", "Output connector status as JSON")
+  .addHelpText(
+    "after",
+    `
+Scope:
+  Inside a run, accepts builtin or custom HTTP/MCP slugs shown by connector list
+  and reports the account selected for that run. Missing account context is
+  reported as unavailable. Omit --agent or match the current Agent; the flag
+  does not change the run's accounts.
+  Outside a run, accepts builtin catalog slugs and shows the current member's
+  connection plus optional --agent authorization.
+  For org custom definition/member status, use connector custom status <uuid>.
+
+Examples:
+  okou connector status github --json
+  okou connector custom list
+  okou connector custom status <connector-id>`,
+  )
   .action(
     withErrorHandler(
       async (

--- a/turbo/apps/cli/src/commands/whoami.ts
+++ b/turbo/apps/cli/src/commands/whoami.ts
@@ -346,7 +346,10 @@ async function showLocalInfo(): Promise<void> {
 export const whoamiCommand = new Command()
   .name("whoami")
   .description("Show agent identity, run ID, and capabilities")
-  .option("--permissions", "Show connector enablement and permission details")
+  .option(
+    "--permissions",
+    "Show connector enablement and permission details in a sandbox",
+  )
   .addHelpText(
     "after",
     `
@@ -356,8 +359,14 @@ Examples:
 
 Notes:
   - Inside sandbox: shows agent ID, run ID, org ID, and granted capabilities
-  - Use --permissions to see connector permissions and custom connector Agent enablement
-  - Custom connectors with permission bundles also show selections and effective policies
+  - Connector account identity comes from the current run's admitted accounts
+  - --permissions shows builtin permission rules and custom connector Agent enablement
+  - Custom HTTP permission bundles also show selections and effective policies
+    when available. MCP connectors and custom HTTP connectors without bundles
+    use connector-level authorization. Missing details do not establish access.
+  - Manage custom HTTP permissions in Connectors > agent access > Permissions
+  - Outside a sandbox, shows authentication and org information;
+    --permissions does not expand connector permissions
   - Your agent ID is also available as $OKOU_AGENT_ID`,
   )
   .action(


### PR DESCRIPTION
Connector help currently overstates query/connection scope and omits supported custom authentication modes, so agents can choose an unsupported command or infer that valid `none`/MCP `automatic` definitions are invalid. Document the implemented builtin/custom HTTP/custom MCP and run/member boundaries at each command, add copyable missing-mode examples, and correct the `authMode`-required error.

The guidance separates definition creation, member connection, Agent access and applicable HTTP permission bundles, including the actual callback and diagnostic limitations. Command actions, accepted authentication modes, account selection and permission enforcement remain unchanged.

Closes #32831.

## Validation

- Rendered 13 Commander help entry points with and without current Web Chat context; parsed five displayed JSON examples and two documented MCP variants through the real create/update schemas, covering all seven HTTP/MCP mode combinations. Verified missing `authMode` and HTTP `automatic` rejection.
- `pnpm --filter @okouai/cli exec vitest run src/commands/connector/custom/__tests__/create.test.ts src/commands/connector/custom/__tests__/update.test.ts --maxWorkers=2` — 11 tests passed.
- `pnpm --filter @okouai/cli lint`
- `pnpm --filter @okouai/cli check-types`
- `pnpm exec knip --workspace apps/cli`
- Prettier check on all 12 changed files and `git diff --check`.

Validation uses local help/schema checks and existing MSW command tests; it does not claim a live connector authentication exercise. No full local Vitest run or local dev server was used.
