### PR TITLE
docs(rust): correct codex snapshot prewarm runtime claims

### DIFF
--- a/crates/sandbox-firecracker/src/factory/invariant.rs
+++ b/crates/sandbox-firecracker/src/factory/invariant.rs
@@ -28,10 +28,12 @@ const HASH_VSOCK_PATH: &str = "/vsock";
 ///   "Invalid API key" but still loads the complete module graph. The claude
 ///   binary is a Bun-compiled executable (not Node.js), so
 ///   `NODE_COMPILE_CACHE` has no effect.
-/// - `codex --help`: codex ships as a Node.js CLI (npm `@openai/codex`); the
-///   `--help` path exits cleanly without credentials yet `require`s the full
-///   module graph and triggers V8 JIT compilation, so the resolved-and-parsed
-///   bytecode is captured in the snapshot. Each warmup is wrapped in its own
+/// - `codex --help`: npm `@openai/codex` uses a Node.js launcher to run the
+///   native Rust CLI. The help command runs without credentials and exits
+///   before the VM is paused, so no live CLI process or reusable process-local
+///   V8 JIT state is preserved. It may warm the guest's file/page cache for
+///   files read during startup; any startup benefit requires measurement.
+///   Each warmup is wrapped in its own
 ///   `(... || true)` sub-shell so a failure on one framework does not block
 ///   the other from warming.
 pub const PREWARM_SCRIPT: &str = "\


### PR DESCRIPTION
Correct the snapshot prewarm documentation: npm `@openai/codex` uses a Node.js launcher for a native Rust CLI, and `codex --help` completes before the VM is paused. Replace the full-module-graph/V8-JIT preservation claim with qualified file/page-cache warming and an explicit requirement to measure startup benefits.

This changes only the Codex comment. The prewarm script, configuration hash inputs, credential/process-group warning, and independent failure suppression are unchanged.

Validation passed:

- `cargo fmt --manifest-path crates/sandbox-firecracker/Cargo.toml -- --check`
- `cargo doc --manifest-path crates/Cargo.toml --profile local -p sandbox-firecracker --no-deps --locked`, with generated constant documentation and its `config_hash` link inspected
- `git diff --check` and byte-for-byte source comparison confirming the command, hash implementation, warning, and all executable code are unchanged
- `./scripts/check-file-size.sh crates/sandbox-firecracker/src/factory/invariant.rs`

Source claims were checked against Codex `0.153.4`'s upstream launcher/Rust manifest and the snapshot lifecycle. No runtime benchmark or behavior test was needed for this documentation-only change.

Closes #32837
