### PR TITLE
test(rust): synchronize queued control requests before close and fail

### DIFF
--- a/crates/guest-control-server/src/exec_control/sink.rs
+++ b/crates/guest-control-server/src/exec_control/sink.rs
@@ -70,6 +70,12 @@ pub(super) struct ControlStreamState {
     stream: Mutex<UnixStream>,
     gate: Mutex<ControlStreamGate>,
     ready: Condvar,
+    // The gate mutex protects test waiter observation; the atomic only
+    // supplies interior mutability without another mutex.
+    #[cfg(test)]
+    waiters: AtomicUsize,
+    #[cfg(test)]
+    waiter_ready: Condvar,
 }
 
 /// RAII guard for the forwarder that owns the connected-stream gate.
@@ -351,6 +357,10 @@ impl ControlStreamState {
             stream: Mutex::new(stream),
             gate: Mutex::new(ControlStreamGate::Available),
             ready: Condvar::new(),
+            #[cfg(test)]
+            waiters: AtomicUsize::new(0),
+            #[cfg(test)]
+            waiter_ready: Condvar::new(),
         }
     }
 
@@ -400,17 +410,37 @@ impl ControlStreamState {
             let Some(wait) = duration_until(deadline) else {
                 return Err(ControlStreamLockError::Timeout);
             };
+            #[cfg(test)]
+            {
+                self.waiters.fetch_add(1, Ordering::Relaxed);
+                self.waiter_ready.notify_all();
+            }
             let (next_gate, wait_result) = self
                 .ready
                 .wait_timeout(gate, wait)
                 .unwrap_or_else(|e| e.into_inner());
             gate = next_gate;
+            #[cfg(test)]
+            self.waiters.fetch_sub(1, Ordering::Relaxed);
             // A timeout can race with gate notification; re-check the gate
             // unless the request deadline has actually elapsed.
             if wait_result.timed_out() && duration_until(deadline).is_none() {
                 return Err(ControlStreamLockError::Timeout);
             }
         }
+    }
+
+    /// The wire protocol cannot acknowledge entry into this private wait.
+    /// Acquiring the same gate after observing a waiter proves that the worker
+    /// has atomically released it into the real condition-variable wait.
+    #[cfg(test)]
+    pub(super) fn wait_for_waiter(&self, timeout: std::time::Duration) -> bool {
+        let gate = self.gate.lock().unwrap_or_else(|e| e.into_inner());
+        let (_gate, _) = self
+            .waiter_ready
+            .wait_timeout_while(gate, timeout, |_| self.waiters.load(Ordering::Relaxed) == 0)
+            .unwrap_or_else(|e| e.into_inner());
+        self.waiters.load(Ordering::Relaxed) > 0
     }
 
     fn notify_waiters(&self) {

--- a/crates/guest-control-server/src/exec_control/tests/sink_lifecycle.rs
+++ b/crates/guest-control-server/src/exec_control/tests/sink_lifecycle.rs
@@ -127,6 +127,7 @@ fn queued_control_request_is_not_delivered_after_close() {
         .lock_until(request_deadline(5000), &sink.active)
         .unwrap();
     let (writer, mut host) = guest_writer_pair();
+    let (done_tx, done_rx) = std::sync::mpsc::channel();
 
     let pending_slot = sink.reserve_pending_slot().unwrap();
     let worker = std::thread::spawn({
@@ -138,10 +139,19 @@ fn queued_control_request_is_not_delivered_after_close() {
                 owned_control_request(17, 9, 5000, "msg-after-close"),
                 writer,
             );
+            done_tx.send(()).unwrap();
         }
     });
 
+    assert!(
+        stream.wait_for_waiter(Duration::from_secs(1)),
+        "forwarder should enter the connected-stream wait before close"
+    );
     sink.close();
+    done_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("close should wake the queued forwarder before its request deadline");
+    worker.join().unwrap();
 
     let (msg_type, seq, status, message_id, diagnostic) = read_exec_control_result(&mut host);
     assert_eq!(msg_type, MSG_EXEC_CONTROL_RESULT);
@@ -149,7 +159,6 @@ fn queued_control_request_is_not_delivered_after_close() {
     assert_eq!(status, ExecControlStatus::Inactive);
     assert_eq!(message_id, "msg-after-close");
     assert_eq!(diagnostic, "exec operation is not active");
-    worker.join().unwrap();
     assert_eq!(sink.pending.load(Ordering::Acquire), 0);
     drop(stream_guard);
 
@@ -168,6 +177,7 @@ fn queued_control_request_is_not_delivered_after_fail() {
         .lock_until(request_deadline(5000), &sink.active)
         .unwrap();
     let (writer, mut host) = guest_writer_pair();
+    let (done_tx, done_rx) = std::sync::mpsc::channel();
 
     let pending_slot = sink.reserve_pending_slot().unwrap();
     let worker = std::thread::spawn({
@@ -179,10 +189,19 @@ fn queued_control_request_is_not_delivered_after_fail() {
                 owned_control_request(23, 9, 5000, "msg-after-fail"),
                 writer,
             );
+            done_tx.send(()).unwrap();
         }
     });
 
+    assert!(
+        stream.wait_for_waiter(Duration::from_secs(1)),
+        "forwarder should enter the connected-stream wait before failure"
+    );
     sink.fail(ControlSinkFailure::Other("failed".to_owned()));
+    done_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("failure should wake the queued forwarder before its request deadline");
+    worker.join().unwrap();
 
     let (msg_type, seq, status, message_id, diagnostic) = read_exec_control_result(&mut host);
     assert_eq!(msg_type, MSG_EXEC_CONTROL_RESULT);
@@ -190,7 +209,6 @@ fn queued_control_request_is_not_delivered_after_fail() {
     assert_eq!(status, ExecControlStatus::SinkError);
     assert_eq!(message_id, "msg-after-fail");
     assert_eq!(diagnostic, "failed");
-    worker.join().unwrap();
     assert_eq!(sink.pending.load(Ordering::Acquire), 0);
 
     let err = process_control_ipc::read_request(&mut peer).unwrap_err();


### PR DESCRIPTION
The queued close/fail tests could pass when the forwarder started after the sink had already terminated, leaving connected-stream wakeup regressions untested. Add a per-stream observer under `cfg(test)` that confirms entry into the real condition-variable wait using the same gate mutex, then require worker completion within one second while retaining the original stream guard.

Both tests preserve exact protocol responses, pending-slot cleanup, and peer no-delivery assertions. Production synchronization and protocol behavior are unchanged.

Closes #32839

Validation:

- Both focused queued-request tests passed.
- Independently removed each connected-stream wakeup notification: the corresponding test failed at its completion bound in 5/5 runs for close and 5/5 for fail. All mutations were restored.
- `cargo fmt --manifest-path crates/guest-control-server/Cargo.toml --check`
- `cargo test --manifest-path crates/Cargo.toml --locked --offline --profile local -p guest-control-server --all-features`: 313 passed; 3 production-identity tests ignored because they require root and a production sandbox account.
- `cargo clippy --manifest-path crates/Cargo.toml --locked --offline --profile local -p guest-control-server --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml --locked --offline --profile local -p guest-control-server --all-features --no-deps`
