### PR TITLE
fix: preserve literal goal archives across historical readers

### DIFF
--- a/docs/goal-retirement-archival.md
+++ b/docs/goal-retirement-archival.md
@@ -132,3 +132,46 @@ state and its temporary helpers in that later migration. The transition test
 stays until the deployed S5 contract completes and surviving history invariants
 are covered permanently, per [MIGRATIONS.md](../turbo/packages/db/MIGRATIONS.md).
 No elapsed waiting period replaces these gates.
+
+## Literal historical projection (#32834)
+
+The full objective is arbitrary historical text. A citation envelope, unmatched
+opener, inline code, fence, Unicode, or whitespace in that suffix is not assistant
+citation transport. The reader recognizes **only** the immutable 1094 format:
+`output.message`, null run/revoker/context/run-event coordinates, exactly one string
+`content` payload key, and the entire frozen notice with a valid UUID and the exact
+status-specific explanation. Unknown formats and actual assistant copies keep the
+ordinary citation filter. This support has no Goal lifecycle or lookup authority.
+Do not rewrite 1093/1094, hot events, snapshots, or append another archive.
+
+| Consumer                                 | Preservation boundary                                                                                                                                                                         |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Raw history, Platform hot/snapshot cache | `chatEventFromRow` uses the strict shared raw-source projection. Raw CLI files remain unchanged.                                                                                              |
+| SQL history consumers                    | `canonicalChatEventVisibleContent` carries provenance only in SELECT; `canonicalChatEventContent` retains its original text/null/regex expression for predicates and run-scoped consumers.    |
+| Snapshot history and user export         | `canonicalArchivedChatEventContent` uses the same strict raw-source projection, independently of receipts or Goal tables.                                                                     |
+| New shares and saved intact shares       | Hot and snapshot selection project first; the saved reader checks absence of run/group indices plus the complete frozen grammar before preserving already-projected text.                     |
+| Search projection/results                | Canonical projection preserves exact whitespace; the result reader checks null run ID plus full grammar before avoiding a second filter.                                                      |
+| Chat and public-share pages              | Identified runless archives use a text tree with preserved whitespace, without HTML/Markdown interpretation, generated closing tags, or action cards. Copy/export retain the original source. |
+
+The remaining SQL content callers are run-scoped callback/session/incomplete-context
+readers, run-bound initial-thinking readers, or input/control/followup validation.
+Their selections and text/null/regex predicates retain the previous behavior.
+Title/followup context selection uses the provenance-aware projection because its
+thread-wide query can include runless historical output. No callback, queue,
+notification, usage, budget, or native-runtime policy is changed.
+
+An old search projector can advance its watermark after stripping objective text.
+The bounded, idempotent [014 search recovery](../turbo/packages/db/scripts/migrations/014-goal-archive-search/README.md)
+reads only receipt-addressed canonical history inside the authorized repair process
+and replaces only those derived search documents. Its default is read-only; its
+reports contain counts and opaque cursors, never objective text. This operational
+processing exception does not expand MaskDB's seven-field policy or authorize an
+objective census/export. The separate release owner must run and verify recovery
+after the repaired API serves and outgoing projectors finish, before controller S2
+acceptance and before S5 removes the repair inventory.
+
+Public shares are intentionally immutable copies. A previously stripped copy is
+not automatically changed or republished. Its owner can explicitly create a new
+share. This repair establishes that limitation with synthetic fixtures; no affected
+production public share inventory has been observed or claimed. Existing raw data
+remains lossless. Merge alone establishes neither controller acceptance nor release.

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -11334,6 +11334,10 @@ describe("CHAT-02: model-first provider policies", () => {
       { [FeatureSwitchKey.PiLoop]: true },
     );
     mockPiResourceArchiveDownloads();
+    // A real assistant can copy the entire immutable archive notice. Its run
+    // provenance must still keep citation transport private.
+    const copiedArchiveNotice =
+      "Okou Goal retired.\nGoal ID: 00000000-0000-4000-8000-000000000001\nOriginal recorded status: complete\nThe recorded status is preserved; retirement does not mark the objective complete.\n\nFull original objective:\nalpha";
     const consumedAgentEvents: Record<string, unknown>[] = [];
     server.use(
       http.post(
@@ -11365,7 +11369,10 @@ describe("CHAT-02: model-first provider policies", () => {
         return new HttpResponse(
           piResponsesContentSse({
             blocks: [
-              { type: "text", text: `alpha${hidden.slice(0, 17)}` },
+              {
+                type: "text",
+                text: `${copiedArchiveNotice}${hidden.slice(0, 17)}`,
+              },
               { type: "text", text: `${hidden.slice(17)}beta` },
               { type: "text", text: "gamma" },
               { type: "text", text: "delta" },
@@ -11441,7 +11448,11 @@ describe("CHAT-02: model-first provider policies", () => {
         };
       }),
     ).toStrictEqual([
-      { content: "alpha", sequenceNumber: 0, runEventId: "event:0" },
+      {
+        content: copiedArchiveNotice,
+        sequenceNumber: 0,
+        runEventId: "event:0",
+      },
       { content: "beta", sequenceNumber: 1, runEventId: "event:1" },
       { content: "gamma", sequenceNumber: 2, runEventId: "event:2" },
       { content: "delta", sequenceNumber: 3, runEventId: "event:3" },

--- a/turbo/apps/api/src/signals/routes/__tests__/goal-retirement-history.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/goal-retirement-history.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { testChatEventSnapshotContract } from "@okouai/api-contracts/contracts/test-chat-event-snapshot";
 import { testChatEventSearchProjectionContract } from "@okouai/api-contracts/contracts/test-chat-event-search-projection";
 import { chatEventRowSchema } from "@okouai/api-contracts/contracts/chat-event-rows";
+import { sharedThreadsContract } from "@okouai/api-contracts/contracts/shared-threads";
 import { chatThreadEventsContract } from "@okouai/api-contracts/contracts/chat-threads";
 import {
   CHAT_EVENT_SCHEMA_VERSION_HEADER,
@@ -19,10 +20,14 @@ import {
   seedGoalRetirementHistory,
   applyGoalRetirementFixture,
   removeSnapshottedGoalFixtureEvents,
+  seedFilteredGoalArchiveProjections,
+  recoverGoalArchiveSearchFixture,
+  seedMalformedGoalArchiveFixture,
 } from "../../../test-fixtures/goal-retirement";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { testChatEventSnapshotRoutes } from "../test-chat-event-snapshot";
 import { testChatEventSearchProjectionRoutes } from "../test-chat-event-search-projection";
+import { sharedThreadRoutes } from "../shared-threads";
 import { chatThreadRoutes } from "../chat-threads";
 import { createBddApi } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
@@ -103,137 +108,297 @@ describe("retired Goal logical history", () => {
     });
   });
 
-  it("keeps exactly one full archive across migration retry, snapshot deletion and a new manual message", async () => {
+  it("filters a copied notice whose historical payload has an extra prototype key", async () => {
     const actor = bdd.user({ orgId: `org_${randomUUID()}` });
     const agent = await bdd.createAgent(actor, {
-      displayName: "Retirement history",
+      displayName: "Historical payload",
     });
     const thread = await chat.createThread(actor, { agentId: agent.agentId });
-    const objective =
-      " \n完整目标 🧭 e\u0301\t\r\n```\n'quoted'; $$ | </tag>\n```\n\n";
-    // S1 rejects Goal creation. This narrowly scoped historical fixture executes
-    // the actual migration; all observable assertions use production endpoints.
-    await seedGoalRetirementHistory(thread.id, objective);
-    await applyGoalRetirementFixture(thread.id);
-    await applyGoalRetirementFixture(thread.id);
-    const before = await chat.listThreadEvents(actor, thread.id);
-    const archives = before.events.filter((event) => {
-      return event.eventType === "output.message";
-    });
-    expect(archives).toHaveLength(1);
-    expect(archives[0]?.content).toContain("Original recorded status: active");
-    expect(archives[0]?.content?.endsWith(objective)).toBeTruthy();
-    expect(
-      before.events.filter((event) => {
-        return event.eventType === "goal.close";
+    const prefix =
+      "Okou Goal retired.\nGoal ID: 00000000-0000-4000-8000-000000000001\nOriginal recorded status: complete\nThe recorded status is preserved; retirement does not mark the objective complete.\n\nFull original objective:\n";
+    // Only historical infrastructure can construct a payload rejected by current writers.
+    const eventId = await seedMalformedGoalArchiveFixture(
+      thread.id,
+      `${prefix}Before <oai-mem-citation>hiddenneedle</oai-mem-citation> after`,
+    );
+    routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const shares = setupApp({ context, routes: sharedThreadRoutes })(
+      sharedThreadsContract,
+    );
+    const created = await accept(
+      shares.create({
+        params: { threadId: thread.id },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { eventIds: [eventId] },
       }),
-    ).toHaveLength(1);
-    expect(archives[0]?.runId).toBeUndefined();
-
+      [201],
+    );
+    const shared = await accept(
+      shares.get({ params: { id: created.body.id } }),
+      [200],
+    );
+    expect(shared.body.messages[0]?.content).toBe(`${prefix}Before  after`);
     await accept(
       setupApp({ context, routes: testChatEventSearchProjectionRoutes })(
         testChatEventSearchProjectionContract,
       ).project({ body: { chat_thread_ids: [thread.id] } }),
       [200],
     );
-    await accept(
-      setupApp({ context, routes: testChatEventSnapshotRoutes })(
-        testChatEventSnapshotContract,
-      ).snapshot({
-        body: { chat_thread_ids: [thread.id], r2_object_keys: [] },
-      }),
-      [200],
-    );
-    expect(puts.length).toBeGreaterThan(0);
-    await removeSnapshottedGoalFixtureEvents(thread.id);
-    await chat.requestListThreadEvents(actor, thread.id, {}, [410]);
-    await applyGoalRetirementFixture(thread.id);
-    routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
-    const download = await accept(
-      setupApp({ context, routes: chatThreadRoutes })(
-        chatThreadEventsContract,
-      ).snapshot({
-        headers: {
-          authorization: "Bearer clerk-session",
-          [CHAT_EVENT_SCHEMA_VERSION_HEADER]:
-            CURRENT_CHAT_EVENT_SCHEMA_VERSION.toString(),
-        },
-        params: { threadId: thread.id },
-      }),
-      [200],
-    );
-    const cursor = download.body;
-    if (cursor.lastEventId === null) {
-      throw new Error("Expected nonempty retirement snapshot");
-    }
-    const snapshotPut = puts.at(-1);
-    if (snapshotPut === undefined) {
-      throw new Error("Expected snapshot publication");
-    }
-    const snapshotRows = gunzipSync(snapshotPut.body)
-      .toString("utf8")
-      .trimEnd()
-      .split("\n")
-      .map((line) => {
-        return chatEventRowSchema.parse(JSON.parse(line));
-      });
-    expect(projectChatEventRows(snapshotRows)).toStrictEqual(before.events);
-    const after = await chat.listThreadEvents(actor, thread.id, {
-      sinceSeqId: cursor.lastSeqId,
-      sinceEventId: cursor.lastEventId,
-    });
-    expect(after.events).toStrictEqual([]);
-
-    const sent = await chat.requestSendEvent(
-      actor,
-      {
-        agentId: agent.agentId,
-        threadId: thread.id,
-        prompt: "Continue with a regular message",
-      },
-      [201],
-    );
-    expect(sent.status).toBe(201);
-    const continued = await chat.listThreadEvents(actor, thread.id, {
-      sinceSeqId: cursor.lastSeqId,
-      sinceEventId: cursor.lastEventId,
-    });
     expect(
-      continued.events.filter((event) => {
-        return event.eventType === "output.message";
-      }),
+      (await chat.searchChat(actor, "hiddenneedle")).results,
     ).toStrictEqual([]);
     expect(
-      continued.events.some((event) => {
-        return event.eventType === "input.prompt";
-      }),
-    ).toBeTruthy();
+      (await chat.searchChat(actor, "Before")).results[0]?.matchedMessage
+        .content,
+    ).toBe(`${prefix}Before  after`);
+  });
 
-    const exports = createOpsLogsApi(context);
-    const started = await exports.requestPostUserExport(actor, [202]);
-    await flushWaitUntilForTest();
-    const status = await exports.requestGetUserExport(actor, [200]);
-    expect(status.body.job).toMatchObject({
-      id: started.body.jobId,
-      status: "completed",
-    });
-    const entry = exportedZip().getEntry(
-      `conversations/chat-thread-${thread.id}.json`,
-    );
-    expect(entry).not.toBeNull();
-    const messages = JSON.parse(entry!.getData().toString("utf8")) as {
-      role: string;
-      content: string;
-    }[];
-    expect(
-      messages.filter((message) => {
-        return message.content === archives[0]?.content;
-      }),
-    ).toHaveLength(1);
-    expect(
-      messages.some((message) => {
-        return message.content === "Continue with a regular message";
-      }),
-    ).toBeTruthy();
-  }, 60_000);
+  it.each(["active", "paused", "blocked", "complete"] as const)(
+    "preserves one literal %s archive through hot/snapshot reads, repair, sharing, export and retry",
+    async (status) => {
+      const actor = bdd.user({ orgId: `org_${randomUUID()}` });
+      const agent = await bdd.createAgent(actor, {
+        displayName: "Retirement history",
+      });
+      const thread = await chat.createThread(actor, { agentId: agent.agentId });
+      const objective =
+        " \n完整目标 🧭 e\u0301\t\r\nBefore <oai-mem-citation>archiveneedle</oai-mem-citation> after\n" +
+        "Inline `<oai-mem-citation>` and ```xml\n<oai-mem-citation>fenced literal</oai-mem-citation>\n```\n" +
+        "'quoted'; $$ | </tag>\nExplain <oai-mem-citation>unmatchedneedle and keep all later original text\n\n";
+      // S1 rejects Goal creation. This narrowly scoped historical fixture executes
+      // the actual migration; all observable assertions use production endpoints.
+      await seedGoalRetirementHistory(thread.id, objective, status);
+      await applyGoalRetirementFixture(thread.id);
+      await applyGoalRetirementFixture(thread.id);
+      const before = await chat.listThreadEvents(actor, thread.id);
+      const archives = before.events.filter((event) => {
+        return event.eventType === "output.message";
+      });
+      expect(archives).toHaveLength(1);
+      expect(archives[0]?.content).toContain(
+        `Original recorded status: ${status}`,
+      );
+      expect(archives[0]?.content?.endsWith(objective)).toBeTruthy();
+      expect(
+        before.events.filter((event) => {
+          return event.eventType === "goal.close";
+        }),
+      ).toHaveLength(1);
+      expect(archives[0]?.runId).toBeUndefined();
+      const archive = archives[0];
+      if (!archive?.content) {
+        throw new Error("Expected archive");
+      }
+      const shares = setupApp({ context, routes: sharedThreadRoutes })(
+        sharedThreadsContract,
+      );
+      const createShare = async () => {
+        routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+        const created = await accept(
+          shares.create({
+            params: { threadId: thread.id },
+            headers: { authorization: "Bearer clerk-session" },
+            body: { eventIds: [archive.id] },
+          }),
+          [201],
+        );
+        const shared = await accept(
+          shares.get({ params: { id: created.body.id } }),
+          [200],
+        );
+        expect(shared.body.messages).toStrictEqual([
+          { messageIndex: 0, role: "assistant", content: archive.content },
+        ]);
+        return created.body.id;
+      };
+      const hotShareId = await createShare();
+
+      await accept(
+        setupApp({ context, routes: testChatEventSearchProjectionRoutes })(
+          testChatEventSearchProjectionContract,
+        ).project({ body: { chat_thread_ids: [thread.id] } }),
+        [200],
+      );
+      const searchable = await chat.searchChat(actor, "archiveneedle");
+      expect(
+        searchable.results.map((result) => {
+          return result.matchedMessage.content;
+        }),
+      ).toStrictEqual([archive.content]);
+      // Also repair the old projector's hot-row window before retention.
+      await seedFilteredGoalArchiveProjections(thread.id);
+      const unexpectedSnapshot = () => {
+        throw new Error("Unexpected snapshot for hot history");
+      };
+      await recoverGoalArchiveSearchFixture(
+        thread.id,
+        unexpectedSnapshot,
+        false,
+      );
+      expect(
+        (await chat.searchChat(actor, "archiveneedle")).results,
+      ).toStrictEqual([]);
+      await recoverGoalArchiveSearchFixture(
+        thread.id,
+        unexpectedSnapshot,
+        true,
+      );
+      expect(
+        (await chat.searchChat(actor, "archiveneedle")).results.map(
+          (result) => {
+            return result.matchedMessage.content;
+          },
+        ),
+      ).toStrictEqual([archive.content]);
+      const oldShareId = await seedFilteredGoalArchiveProjections(thread.id);
+      const oldShare = await accept(
+        shares.get({ params: { id: oldShareId } }),
+        [200],
+      );
+      expect(oldShare.body.messages[0]?.content).not.toContain("archiveneedle");
+      expect(
+        (await chat.searchChat(actor, "archiveneedle")).results,
+      ).toStrictEqual([]);
+
+      await accept(
+        setupApp({ context, routes: testChatEventSnapshotRoutes })(
+          testChatEventSnapshotContract,
+        ).snapshot({
+          body: { chat_thread_ids: [thread.id], r2_object_keys: [] },
+        }),
+        [200],
+      );
+      expect(puts.length).toBeGreaterThan(0);
+      await removeSnapshottedGoalFixtureEvents(thread.id);
+      await chat.requestListThreadEvents(actor, thread.id, {}, [410]);
+      await applyGoalRetirementFixture(thread.id);
+      routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+      const download = await accept(
+        setupApp({ context, routes: chatThreadRoutes })(
+          chatThreadEventsContract,
+        ).snapshot({
+          headers: {
+            authorization: "Bearer clerk-session",
+            [CHAT_EVENT_SCHEMA_VERSION_HEADER]:
+              CURRENT_CHAT_EVENT_SCHEMA_VERSION.toString(),
+          },
+          params: { threadId: thread.id },
+        }),
+        [200],
+      );
+      const cursor = download.body;
+      if (cursor.lastEventId === null) {
+        throw new Error("Expected nonempty retirement snapshot");
+      }
+      const snapshotPut = puts.at(-1);
+      if (snapshotPut === undefined) {
+        throw new Error("Expected snapshot publication");
+      }
+      const snapshotRows = gunzipSync(snapshotPut.body)
+        .toString("utf8")
+        .trimEnd()
+        .split("\n")
+        .map((line) => {
+          return chatEventRowSchema.parse(JSON.parse(line));
+        });
+      expect(projectChatEventRows(snapshotRows)).toStrictEqual(before.events);
+      const snapshotBytes = (key: string) => {
+        const put = puts.find((item) => {
+          return item.key === key;
+        });
+        if (!put) {
+          throw new Error("Expected canonical snapshot bytes");
+        }
+        return Promise.resolve(put.body);
+      };
+      await expect(
+        recoverGoalArchiveSearchFixture(
+          thread.id,
+          () => {
+            return Promise.resolve(Buffer.from("corrupt snapshot"));
+          },
+          true,
+        ),
+      ).rejects.toThrow("invalid_snapshot_digest");
+      await recoverGoalArchiveSearchFixture(thread.id, snapshotBytes, false);
+      expect(
+        (await chat.searchChat(actor, "archiveneedle")).results,
+      ).toStrictEqual([]);
+      await recoverGoalArchiveSearchFixture(thread.id, snapshotBytes, true);
+      await recoverGoalArchiveSearchFixture(thread.id, snapshotBytes, true);
+      const repaired = await chat.searchChat(actor, "unmatchedneedle");
+      expect(
+        repaired.results.map((result) => {
+          return result.matchedMessage.content;
+        }),
+      ).toStrictEqual([archive.content]);
+      await createShare();
+      expect(
+        (await accept(shares.get({ params: { id: hotShareId } }), [200])).body
+          .messages[0]?.content,
+      ).toBe(archive.content);
+      expect(
+        (await accept(shares.get({ params: { id: oldShareId } }), [200])).body,
+      ).toStrictEqual(oldShare.body);
+
+      const after = await chat.listThreadEvents(actor, thread.id, {
+        sinceSeqId: cursor.lastSeqId,
+        sinceEventId: cursor.lastEventId,
+      });
+      expect(after.events).toStrictEqual([]);
+
+      const sent = await chat.requestSendEvent(
+        actor,
+        {
+          agentId: agent.agentId,
+          threadId: thread.id,
+          prompt: "Continue with a regular message",
+        },
+        [201],
+      );
+      expect(sent.status).toBe(201);
+      const continued = await chat.listThreadEvents(actor, thread.id, {
+        sinceSeqId: cursor.lastSeqId,
+        sinceEventId: cursor.lastEventId,
+      });
+      expect(
+        continued.events.filter((event) => {
+          return event.eventType === "output.message";
+        }),
+      ).toStrictEqual([]);
+      expect(
+        continued.events.some((event) => {
+          return event.eventType === "input.prompt";
+        }),
+      ).toBeTruthy();
+
+      const exports = createOpsLogsApi(context);
+      const started = await exports.requestPostUserExport(actor, [202]);
+      await flushWaitUntilForTest();
+      const exportStatus = await exports.requestGetUserExport(actor, [200]);
+      expect(exportStatus.body.job).toMatchObject({
+        id: started.body.jobId,
+        status: "completed",
+      });
+      const entry = exportedZip().getEntry(
+        `conversations/chat-thread-${thread.id}.json`,
+      );
+      expect(entry).not.toBeNull();
+      const messages = JSON.parse(entry!.getData().toString("utf8")) as {
+        role: string;
+        content: string;
+      }[];
+      expect(
+        messages.filter((message) => {
+          return message.content === archives[0]?.content;
+        }),
+      ).toHaveLength(1);
+      expect(
+        messages.some((message) => {
+          return message.content === "Continue with a regular message";
+        }),
+      ).toBeTruthy();
+    },
+    60_000,
+  );
 });

--- a/turbo/apps/api/src/signals/services/canonical-chat-event-read.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-chat-event-read.service.ts
@@ -1,9 +1,10 @@
 import { userMessageDocumentSchema } from "@okouai/api-contracts/contracts/chat-threads";
 import type { ChatEventRow } from "@okouai/api-contracts/contracts/chat-event-rows";
 import { chatEvents } from "@okouai/db/schema/chat-event";
-import { sql, type SQLWrapper } from "drizzle-orm";
+import { isNull, sql, type SQLWrapper } from "drizzle-orm";
 import { z } from "zod";
 import { visiblePiMemoryCitationText } from "@okouai/api-contracts/contracts/pi-memory-citations";
+import { visibleChatEventRowContent } from "@okouai/api-contracts/contracts/retired-goal-archive";
 
 import {
   nullableDriverValueDecoder,
@@ -32,6 +33,43 @@ export function canonicalChatEventContent(
 ) {
   return sql`${payload}->>'content'`.mapWith(
     nullableDriverValueDecoder(visibleChatEventTextDecoder),
+  );
+}
+
+const chatEventContentSourceDecoder = zodDriverValueDecoder(
+  z
+    .object({
+      event_type: z.string(),
+      run_id: z.string().nullable(),
+      revokes_event_id: z.string().nullable(),
+      context_type: z.string().nullable(),
+      context_id: z.string().nullable(),
+      run_event_sequence_number: z.number().nullable(),
+      run_event_id: z.string().nullable(),
+      payload: z.unknown(),
+    })
+    .transform((row) => {
+      return visibleChatEventRowContent({
+        eventType: row.event_type,
+        runId: row.run_id,
+        revokesEventId: row.revokes_event_id,
+        contextType: row.context_type,
+        contextId: row.context_id,
+        runEventSequenceNumber: row.run_event_sequence_number,
+        runEventId: row.run_event_id,
+        payload: row.payload,
+      });
+    }),
+);
+
+/**
+ * SELECT-only projection: carry raw provenance to the shared historical reader.
+ * Predicates must keep canonicalChatEventContent's original text/null/regex SQL.
+ */
+export function canonicalChatEventVisibleContent() {
+  return sql`CASE WHEN ${isNull(canonicalChatEventContent())} THEN NULL
+    ELSE to_jsonb(${chatEvents}) END`.mapWith(
+    nullableDriverValueDecoder(chatEventContentSourceDecoder),
   );
 }
 
@@ -75,8 +113,7 @@ export function canonicalChatEventGoalId(
 export function canonicalArchivedChatEventContent(
   row: ChatEventRow,
 ): string | null {
-  const content = row.payload?.content;
-  return content === undefined ? null : visiblePiMemoryCitationText(content);
+  return visibleChatEventRowContent(row);
 }
 
 export function canonicalArchivedChatEventUserMessage(row: ChatEventRow) {

--- a/turbo/apps/api/src/signals/services/chat-search.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-search.service.ts
@@ -5,6 +5,7 @@ import {
   type ChatSearchResult,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { visiblePiMemoryCitationText } from "@okouai/api-contracts/contracts/pi-memory-citations";
+import { isRetiredGoalArchiveText } from "@okouai/api-contracts/contracts/retired-goal-archive";
 import { agents } from "@okouai/db/schema/agent";
 import { chatEventSearchMessages } from "@okouai/db/schema/chat-event-search";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
@@ -58,7 +59,8 @@ function toChatSearchMessage(row: ChatSearchMessageRow): ChatSearchMessage {
     chatThreadId: row.chatThreadId,
     role: row.role,
     content:
-      row.role === "assistant"
+      row.role === "assistant" &&
+      !(row.runId === null && isRetiredGoalArchiveText(row.text))
         ? visiblePiMemoryCitationText(row.text)
         : row.text,
     createdAt: row.createdAt.toISOString(),

--- a/turbo/apps/api/src/signals/services/chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-title.service.ts
@@ -47,7 +47,7 @@ import {
   requiredUserMessageForEvent,
 } from "./chat-user-message.service";
 import {
-  canonicalChatEventContent,
+  canonicalChatEventVisibleContent,
   canonicalChatEventUserMessage,
 } from "./canonical-chat-event-read.service";
 
@@ -289,7 +289,7 @@ async function getLatestTitleContextMessages(
   const rows = await db
     .select({
       eventType: chatEvents.eventType,
-      content: canonicalChatEventContent(),
+      content: canonicalChatEventVisibleContent(),
       userMessage: canonicalChatEventUserMessage(),
       createdAt: chatEvents.createdAt,
       sequenceNumber: chatEvents.runEventSequenceNumber,
@@ -495,7 +495,7 @@ async function getLatestFollowupContextMessages(
   const rows = await db
     .select({
       eventType: chatEvents.eventType,
-      content: canonicalChatEventContent(),
+      content: canonicalChatEventVisibleContent(),
       userMessage: canonicalChatEventUserMessage(),
       createdAt: chatEvents.createdAt,
       sequenceNumber: chatEvents.runEventSequenceNumber,

--- a/turbo/apps/api/src/signals/services/cron-project-chat-event-search.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-project-chat-event-search.service.ts
@@ -12,6 +12,7 @@ import {
   sql,
 } from "drizzle-orm";
 import type { UserMessageDocument } from "@okouai/api-contracts/contracts/chat-threads";
+import { isRetiredGoalArchiveText } from "@okouai/api-contracts/contracts/retired-goal-archive";
 import { agents } from "@okouai/db/schema/agent";
 import {
   chatEventSearchMessages,
@@ -28,7 +29,7 @@ import {
   requiredUserMessageForEvent,
 } from "./chat-user-message.service";
 import {
-  canonicalChatEventContent,
+  canonicalChatEventVisibleContent,
   canonicalChatEventUserMessage,
 } from "./canonical-chat-event-read.service";
 import { visibleChatEventCondition } from "./chat-event-shared.service";
@@ -130,6 +131,7 @@ function searchMessageRole(eventType: string): SearchableRole | null {
 }
 
 function searchMessageText(row: {
+  readonly runId: string | null;
   readonly eventType: (typeof chatEvents.$inferSelect)["eventType"];
   readonly content: string | null;
   readonly userMessage: UserMessageDocument | null;
@@ -141,11 +143,22 @@ function searchMessageText(row: {
   const text = userMessage
     ? projectUserMessage(userMessage).displayText
     : row.content;
+  // The canonical row projection already checked the full raw provenance.
+  // Preserve the historical objective's trailing whitespace as well.
+  if (
+    row.eventType === "output.message" &&
+    row.runId === null &&
+    text !== null &&
+    isRetiredGoalArchiveText(text)
+  ) {
+    return text;
+  }
   const trimmed = text?.trim() ?? "";
   return trimmed.length > 0 ? trimmed : null;
 }
 
 function searchMessageProjection(row: {
+  readonly runId: string | null;
   readonly eventType: (typeof chatEvents.$inferSelect)["eventType"];
   readonly content: string | null;
   readonly userMessage: UserMessageDocument | null;
@@ -171,7 +184,7 @@ async function loadProjectionRows(
       id: chatEvents.id,
       runId: chatEvents.runId,
       eventType: chatEvents.eventType,
-      content: canonicalChatEventContent(),
+      content: canonicalChatEventVisibleContent(),
       userMessage: canonicalChatEventUserMessage(),
       revokesEventId: chatEvents.revokesEventId,
       seqId: chatEvents.seqId,

--- a/turbo/apps/api/src/signals/services/shared-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/shared-thread.service.ts
@@ -1,5 +1,6 @@
 import type { SharedMessage } from "@okouai/api-contracts/contracts/shared-threads";
 import { visiblePiMemoryCitationText } from "@okouai/api-contracts/contracts/pi-memory-citations";
+import { isRetiredGoalArchiveText } from "@okouai/api-contracts/contracts/retired-goal-archive";
 import type { ChatEventRow } from "@okouai/api-contracts/contracts/chat-event-rows";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { agents } from "@okouai/db/schema/agent";
@@ -27,7 +28,7 @@ import {
   canonicalArchivedChatEventError,
   canonicalArchivedChatEventGoalId,
   canonicalArchivedChatEventUserMessage,
-  canonicalChatEventContent,
+  canonicalChatEventVisibleContent,
   canonicalChatEventGoalId,
   canonicalChatEventUserMessage,
 } from "./canonical-chat-event-read.service";
@@ -147,7 +148,7 @@ function loadSharedThreadSourceRows(
       .select({
         id: chatEvents.id,
         eventType: chatEvents.eventType,
-        content: canonicalChatEventContent(),
+        content: canonicalChatEventVisibleContent(),
         userMessage: canonicalChatEventUserMessage(),
         runId: chatEvents.runId,
         runGroupId: canonicalChatEventGoalId(),
@@ -339,7 +340,12 @@ export const readSharedThread$ = command(
             return message.role === "assistant"
               ? {
                   ...message,
-                  content: visiblePiMemoryCitationText(message.content),
+                  content:
+                    message.runIndex === undefined &&
+                    message.runGroupIndex === undefined &&
+                    isRetiredGoalArchiveText(message.content)
+                      ? message.content
+                      : visiblePiMemoryCitationText(message.content),
                 }
               : message;
           }),

--- a/turbo/apps/api/src/test-fixtures/goal-retirement.ts
+++ b/turbo/apps/api/src/test-fixtures/goal-retirement.ts
@@ -1,6 +1,12 @@
 import { readFile } from "node:fs/promises";
 import { Client } from "pg";
 import { env } from "../lib/env";
+import { visiblePiMemoryCitationText } from "@okouai/api-contracts/contracts/pi-memory-citations";
+import { chatSearchIndexText } from "../lib/chat-search-bigram";
+import {
+  recoverGoalArchiveSearch,
+  type SnapshotLoader,
+} from "@okouai/db/migrations/014-goal-archive-search";
 
 /**
  * Only historical infrastructure can construct these rows after S1. Temporary
@@ -40,13 +46,14 @@ async function withGoalRetirementFixture(
 export async function seedGoalRetirementHistory(
   threadId: string,
   objective: string,
+  status: "active" | "paused" | "blocked" | "complete" = "active",
 ): Promise<void> {
   await withGoalRetirementFixture(threadId, async (client) => {
     await client.query(
       `INSERT INTO thread_goals (org_id, owner_user_id, agent_id, chat_thread_id, status, objective, objective_brief)
-      SELECT agent.org_id, thread.user_id, agent.id, thread.id, 'active', $1, 'historical brief'
+      SELECT agent.org_id, thread.user_id, agent.id, thread.id, $2, $1, 'historical brief'
       FROM chat_threads thread JOIN agents agent ON agent.id = thread.agent_id`,
-      [objective],
+      [objective, status],
     );
     await client.query(`WITH reservation AS (
       UPDATE chat_threads SET last_chat_event_seq_id = last_chat_event_seq_id + 1 RETURNING id, last_chat_event_seq_id
@@ -91,4 +98,103 @@ export async function removeSnapshottedGoalFixtureEvents(
         AND snapshot.archive_schema_version = 7 AND snapshot.last_seq_id >= event.seq_id
         AND watermark.indexed_seq_id >= event.seq_id`);
   });
+}
+
+/** Old API materialization cannot be requested after the reader is repaired. */
+export async function seedFilteredGoalArchiveProjections(
+  threadId: string,
+): Promise<string> {
+  let shareId: string | undefined;
+  await withGoalRetirementFixture(threadId, async (client) => {
+    const result = await client.query<
+      Record<string, unknown>
+    >(`SELECT event.payload->>'content' AS content, event.seq_id,
+      event.created_at, thread.user_id, agent.id AS agent_id, agent.org_id
+      FROM thread_goals goal JOIN chat_events event ON event.id = goal.retirement_archive_event_id
+      JOIN chat_threads thread ON thread.id = event.chat_thread_id JOIN agents agent ON agent.id = thread.agent_id`);
+    const row = result.rows[0];
+    if (!row || typeof row.content !== "string") {
+      throw new Error("Expected archive fixture");
+    }
+    const filtered = visiblePiMemoryCitationText(row.content).trim();
+    await client.query(
+      `INSERT INTO chat_event_search_messages
+      (chat_thread_id, seq_id, run_id, user_id, org_id, agent_id, role, created_at, text, text_bigram)
+      VALUES ($1, $2, NULL, $3, $4, $5, 'assistant', $6, $7, $8)
+      ON CONFLICT (chat_thread_id, seq_id) DO UPDATE SET text = EXCLUDED.text, text_bigram = EXCLUDED.text_bigram`,
+      [
+        threadId,
+        row.seq_id,
+        row.user_id,
+        row.org_id,
+        row.agent_id,
+        row.created_at,
+        filtered,
+        chatSearchIndexText(filtered),
+      ],
+    );
+    await client.query(`INSERT INTO chat_event_search_message_watermarks (chat_thread_id, indexed_seq_id)
+      SELECT id, last_chat_event_seq_id FROM chat_threads
+      ON CONFLICT (chat_thread_id) DO UPDATE SET indexed_seq_id = EXCLUDED.indexed_seq_id`);
+    const share = await client.query<Record<string, unknown>>(
+      `INSERT INTO shared_threads (user_id, source_chat_thread_id, title, messages)
+      VALUES ($1, $2, 'Historical public copy', $3) RETURNING id`,
+      [
+        row.user_id,
+        threadId,
+        JSON.stringify([
+          { messageIndex: 0, role: "assistant", content: filtered },
+        ]),
+      ],
+    );
+    if (typeof share.rows[0]?.id !== "string") {
+      throw new Error("Expected historical share");
+    }
+    shareId = share.rows[0].id;
+  });
+  if (shareId === undefined) {
+    throw new Error("Expected historical share ID");
+  }
+  return shareId;
+}
+
+/** Runs the one-off repair against test-owned history; no new product endpoint. */
+export async function recoverGoalArchiveSearchFixture(
+  threadId: string,
+  loadSnapshot: SnapshotLoader,
+  migrate: boolean,
+): Promise<void> {
+  await withGoalRetirementFixture(threadId, async (client) => {
+    await recoverGoalArchiveSearch(client, threadId, loadSnapshot, migrate);
+  });
+}
+
+/** Current writers cannot produce extra payload keys on assistant output. */
+export async function seedMalformedGoalArchiveFixture(
+  threadId: string,
+  content: string,
+): Promise<string> {
+  let eventId: string | undefined;
+  await withGoalRetirementFixture(threadId, async (client) => {
+    const payload = Object.fromEntries([
+      ["content", content],
+      ["__proto__", "historical extra key"],
+    ]);
+    const rows = await client.query<Record<string, unknown>>(
+      `WITH reservation AS (
+        UPDATE chat_threads SET last_chat_event_seq_id = last_chat_event_seq_id + 1
+        RETURNING id, last_chat_event_seq_id
+      ) INSERT INTO chat_events (chat_thread_id, event_type, seq_id, payload)
+      SELECT id, 'output.message', last_chat_event_seq_id, $1 FROM reservation RETURNING id`,
+      [JSON.stringify(payload)],
+    );
+    if (typeof rows.rows[0]?.id !== "string") {
+      throw new Error("Expected malformed historical event ID");
+    }
+    eventId = rows.rows[0].id;
+  });
+  if (eventId === undefined) {
+    throw new Error("Expected malformed historical event ID");
+  }
+  return eventId;
 }

--- a/turbo/apps/platform/src/lib/markdown/literal-history.ts
+++ b/turbo/apps/platform/src/lib/markdown/literal-history.ts
@@ -1,0 +1,16 @@
+import type { Root } from "hast";
+
+/** Render already-identified literal history without interpreting HTML or Markdown. */
+export function literalHistoryTree(content: string): Root {
+  return {
+    type: "root",
+    children: [
+      {
+        type: "element",
+        tagName: "p",
+        properties: { className: ["whitespace-pre-wrap"] },
+        children: [{ type: "text", value: content }],
+      },
+    ],
+  };
+}

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1,3 +1,5 @@
+import { isRetiredGoalArchiveText } from "@okouai/api-contracts/contracts/retired-goal-archive";
+import { literalHistoryTree } from "../../lib/markdown/literal-history.ts";
 import { createChatComposerLayoutOnRef } from "./chat-layout.ts";
 import {
   command,
@@ -1909,6 +1911,26 @@ function planEventTreeUpdates(
       content === null ||
       (previous?.content === content && previous.mathEnabled === mathEnabled)
     ) {
+      continue;
+    }
+    // Raw-row projection already checked every 1094 provenance field. Keep
+    // retained run coordinates here so real assistant output stays Markdown.
+    if (
+      event.eventType === "output.message" &&
+      event.runId === undefined &&
+      event.runGroupId === undefined &&
+      event.runEventId === undefined &&
+      event.sequenceNumber === null &&
+      event.revokesEventId === undefined &&
+      isRetiredGoalArchiveText(content)
+    ) {
+      next ??= new Map(current);
+      next.set(event.id, {
+        content,
+        mathEnabled,
+        tree: literalHistoryTree(content),
+        error: false,
+      });
       continue;
     }
     const plan = chatEventTreePlan(event, chatActionContext);

--- a/turbo/apps/platform/src/signals/shared-thread-page/shared-thread-page-setup.ts
+++ b/turbo/apps/platform/src/signals/shared-thread-page/shared-thread-page-setup.ts
@@ -1,3 +1,5 @@
+import { isRetiredGoalArchiveText } from "@okouai/api-contracts/contracts/retired-goal-archive";
+import { literalHistoryTree } from "../../lib/markdown/literal-history.ts";
 import { sharedThreadsContract } from "@okouai/api-contracts/contracts/shared-threads";
 import { command } from "ccstate";
 import { createElement } from "react";
@@ -45,9 +47,12 @@ export const setupSharedThreadPage$ = command(
           messages.push(message);
           continue;
         }
-        const tree = createPlainMarkdownTree(message.content, {
-          mathEnabled,
-        });
+        const tree =
+          message.runIndex === undefined &&
+          message.runGroupIndex === undefined &&
+          isRetiredGoalArchiveText(message.content)
+            ? literalHistoryTree(message.content)
+            : createPlainMarkdownTree(message.content, { mathEnabled });
         if (tree === null) {
           richMessages.push(message);
           messages.push({ ...message, tree: undefined });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/markdown-content.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/markdown-content.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { expect, test } from "vitest";
 
 import {
+  click,
   queryAllByRoleFast,
   setupPage,
 } from "../../../__tests__/page-helper.ts";
@@ -368,4 +369,54 @@ test("Mermaid content remains readable code on surfaces without diagrams", async
       return button.getAttribute("aria-label") === "Expand diagram";
     }),
   ).toBeFalsy();
+});
+
+test("Retired Goal history displays and copies the complete literal objective", async () => {
+  const clipboard = context.mocks.browser.clipboardWriteText();
+  const chat = createMarkdownChatFixture(context);
+  const content =
+    "Okou Goal retired.\nGoal ID: 00000000-0000-4000-8000-000000000001\nOriginal recorded status: complete\nThe recorded status is preserved; retirement does not mark the objective complete.\n\nFull original objective:\nBefore <oai-mem-citation>literal objective</oai-mem-citation> after\n`<oai-mem-citation>`\n```xml\n<oai-mem-citation>fenced\n```\nUnclosed <oai-mem-citation>keep the rest 🧭\n\n";
+  const row = {
+    ...chat.outputMessage(content, { seqId: 1 }),
+    runId: null,
+    runEventId: null,
+    runEventSequenceNumber: null,
+  };
+  chat.install({
+    rows: () => {
+      return [row];
+    },
+  });
+  await setupPage({ context, path: chat.path, host: "app.okou.ai" });
+  const message = await screen.findByText(
+    /Before <oai-mem-citation>literal objective/,
+  );
+  expect(message.textContent).toBe(content);
+  const copy = queryAllByRoleFast("button").find((button) => {
+    return button.getAttribute("aria-label") === "Copy message";
+  });
+  if (!copy) {
+    throw new Error("Expected message copy action");
+  }
+  click(copy);
+  await waitFor(() => {
+    expect(clipboard.writes).toStrictEqual([content]);
+  });
+});
+
+test("An actual assistant copying the Goal notice retains citation filtering and Markdown", async () => {
+  const chat = createMarkdownChatFixture(context);
+  const content =
+    "Okou Goal retired.\nGoal ID: 00000000-0000-4000-8000-000000000001\nOriginal recorded status: complete\nThe recorded status is preserved; retirement does not mark the objective complete.\n\nFull original objective:\n**Formatted actual answer** <oai-mem-citation>hidden transport</oai-mem-citation>";
+  const rows = completedMessageRows(chat, content);
+  chat.install({
+    rows: () => {
+      return rows;
+    },
+  });
+  await setupPage({ context, path: chat.path, host: "app.okou.ai" });
+  await expect(
+    screen.findByText("Formatted actual answer"),
+  ).resolves.toHaveProperty("tagName", "STRONG");
+  expect(screen.queryByText(/hidden transport/)).not.toBeInTheDocument();
 });

--- a/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-presentation.test.tsx
@@ -119,3 +119,21 @@ test("A public conversation hides owner and agent identity", async () => {
   expect(screen.queryByText("Owner")).not.toBeInTheDocument();
   expect(screen.queryByText("Agent")).not.toBeInTheDocument();
 });
+
+test("An intact public Goal archive displays its original literal text", async () => {
+  const content =
+    "Okou Goal retired.\nGoal ID: 00000000-0000-4000-8000-000000000001\nOriginal recorded status: paused\nThe recorded status is preserved; retirement does not mark the objective complete.\n\nFull original objective:\nBefore <oai-mem-citation>literal objective</oai-mem-citation> after\n`<oai-mem-citation>`\nUnclosed <oai-mem-citation>keep the rest 🧭\n\n";
+  context.mocks.api(sharedThreadsContract.get, ({ respond }) => {
+    return respond(
+      200,
+      sharedThread({
+        messages: [{ messageIndex: 0, role: "assistant", content }],
+      }),
+    );
+  });
+  await setupSharedThreadPage(context, { host: "app.okou.ai" });
+  const message = await screen.findByText(
+    /Before <oai-mem-citation>literal objective/,
+  );
+  expect(message.textContent).toBe(content);
+});

--- a/turbo/packages/api-contracts/src/contracts/__tests__/retired-goal-archive.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/retired-goal-archive.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { chatEventFromRow } from "../chat-event-row-projection";
+import { chatEventRowSchema } from "../chat-event-rows";
+import { visiblePiMemoryCitationText } from "../pi-memory-citations";
+import {
+  isRetiredGoalArchiveRow,
+  visibleChatEventRowContent,
+} from "../retired-goal-archive";
+
+const goalId = "00000000-0000-4000-8000-000000000001";
+function notice(status: string, objective: string): string {
+  const explanation =
+    status === "active"
+      ? "Retirement changed this Goal from active to paused; this does not mark the objective complete."
+      : "The recorded status is preserved; retirement does not mark the objective complete.";
+  return `Okou Goal retired.\nGoal ID: ${goalId}\nOriginal recorded status: ${status}\n${explanation}\n\nFull original objective:\n${objective}`;
+}
+function source(content: string) {
+  return {
+    id: "00000000-0000-4000-8000-000000000002",
+    chatThreadId: "00000000-0000-4000-8000-000000000003",
+    eventType: "output.message",
+    runId: null,
+    revokesEventId: null,
+    contextType: null,
+    contextId: null,
+    runEventSequenceNumber: null,
+    runEventId: null,
+    seqId: 2,
+    createdAt: "2026-09-09T00:00:00.000Z",
+    payload: { content },
+  };
+}
+const objectives = [
+  "Before <oai-mem-citation>USER OBJECTIVE CONTENT</oai-mem-citation> after",
+  "Explain <oai-mem-citation> and retain the rest of this objective",
+  "Keep <oai-mem-cit",
+  "Keep </oai-mem-citation> and later text",
+  "Inline `<oai-mem-citation>` remains exact",
+  "Inline `<oai-mem-citation>literal</oai-mem-citation>`",
+  "```xml\n<oai-mem-citation>\nfenced literal\n```\nafter",
+  "```\n<oai-mem-citation>fenced</oai-mem-citation>\n```",
+  " \n完整目标 🧭 e\u0301\t\r\n'quoted' \"double\"\n\n",
+  notice("active", "nested <oai-mem-citation>arbitrary suffix"),
+  "",
+];
+
+describe.each(["active", "paused", "blocked", "complete"])(
+  "1094 %s history",
+  (status) => {
+    it.each(objectives)(
+      "preserves the literal objective %j through raw wire projection",
+      (objective) => {
+        const content = notice(status, objective);
+        const raw = source(content);
+        const row = chatEventRowSchema.parse(JSON.parse(JSON.stringify(raw)));
+        expect(chatEventFromRow(row).content).toBe(content);
+        expect(row).toStrictEqual(raw);
+      },
+    );
+  },
+);
+
+describe("1094 provenance and grammar boundary", () => {
+  const content = notice(
+    "active",
+    "Before <oai-mem-citation>private</oai-mem-citation> after",
+  );
+  it.each([
+    { runId: goalId },
+    { revokesEventId: goalId },
+    { contextType: "web" },
+    { contextId: goalId },
+    { runEventSequenceNumber: 0 },
+    { runEventId: goalId },
+    { eventType: "output.followups" },
+    { payload: { content, error: "extra leaf" } },
+  ])("retains citation filtering with other provenance %j", (overrides) => {
+    const row = chatEventRowSchema.parse({ ...source(content), ...overrides });
+    expect(chatEventFromRow(row).content).toBe(
+      visiblePiMemoryCitationText(content),
+    );
+  });
+  it.each([
+    content.replace(goalId, "not-a-uuid"),
+    content.replace("status: active", "status: paused"),
+    content.replace("status: active", "status: unknown"),
+    content.replace("\n\nFull original", "\nFull original"),
+    content.replace("Full original objective:", "Original objective:"),
+    content.replaceAll("\n", "\r\n"),
+    `prefix\n${content}`,
+    "Okou Goal retired.\n<oai-mem-citation>ordinary assistant text",
+  ])("keeps unknown formats on the ordinary projection %j", (text) => {
+    expect(
+      chatEventFromRow(chatEventRowSchema.parse(source(text))).content,
+    ).toBe(visiblePiMemoryCitationText(text));
+  });
+  it("requires every raw provenance field and exactly the content payload", () => {
+    for (const field of [
+      "runId",
+      "revokesEventId",
+      "contextType",
+      "contextId",
+      "runEventSequenceNumber",
+      "runEventId",
+    ]) {
+      const incomplete = Object.fromEntries(
+        Object.entries(source(content)).filter(([key]) => {
+          return key !== field;
+        }),
+      );
+      expect(isRetiredGoalArchiveRow(incomplete)).toBe(false);
+    }
+    expect(
+      isRetiredGoalArchiveRow({
+        ...source(content),
+        payload: { content, unknown: null },
+      }),
+    ).toBe(false);
+  });
+
+  it("checks original payload keys before a decoder can discard them", () => {
+    const payload: unknown = Object.fromEntries([
+      ["content", content],
+      ["__proto__", "extra"],
+    ]);
+    expect(visibleChatEventRowContent({ ...source(content), payload })).toBe(
+      visiblePiMemoryCitationText(content),
+    );
+  });
+});

--- a/turbo/packages/api-contracts/src/contracts/chat-event-row-projection.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-event-row-projection.ts
@@ -1,6 +1,6 @@
 import type { ChatEventRow } from "./chat-event-rows";
 import { chatEventSchema, type ChatEvent } from "./chat-threads";
-import { visiblePiMemoryCitationText } from "./pi-memory-citations";
+import { visibleChatEventRowContent } from "./retired-goal-archive";
 
 function requiredRowField<T>(
   value: T | null,
@@ -22,10 +22,7 @@ function requiredRowField<T>(
  */
 export function chatEventFromRow(row: ChatEventRow): ChatEvent {
   const payload = row.payload;
-  const visibleContent =
-    payload?.content === undefined
-      ? null
-      : visiblePiMemoryCitationText(payload.content);
+  const visibleContent = visibleChatEventRowContent(row);
   const base = {
     id: row.id,
     threadId: row.chatThreadId,

--- a/turbo/packages/api-contracts/src/contracts/retired-goal-archive.ts
+++ b/turbo/packages/api-contracts/src/contracts/retired-goal-archive.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+import { visiblePiMemoryCitationText } from "./pi-memory-citations";
+
+// Frozen by migration 1094. This is literal historical data, with no Goal
+// lifecycle authority. Keep it readable after the Goal schema is removed.
+const retiredGoalArchivePattern =
+  /^Okou Goal retired\.\nGoal ID: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\nOriginal recorded status: (?:active\nRetirement changed this Goal from active to paused; this does not mark the objective complete\.|(?:paused|blocked|complete)\nThe recorded status is preserved; retirement does not mark the objective complete\.)\n\nFull original objective:\n[\s\S]*$/u;
+
+/** Only use on already-projected text together with retained run provenance. */
+export function isRetiredGoalArchiveText(content: string): boolean {
+  return retiredGoalArchivePattern.test(content);
+}
+
+const retiredGoalArchiveSourceSchema = z.object({
+  eventType: z.literal("output.message"),
+  runId: z.null(),
+  revokesEventId: z.null(),
+  contextType: z.null(),
+  contextId: z.null(),
+  runEventSequenceNumber: z.null(),
+  runEventId: z.null(),
+  payload: z.object({ content: z.string() }).strict(),
+});
+
+const contentPayloadSchema = z
+  .object({ content: z.string().optional() })
+  .nullable();
+
+/** Both the complete raw provenance and the complete notice are required. */
+export function isRetiredGoalArchiveRow(row: unknown): boolean {
+  const parsed = retiredGoalArchiveSourceSchema.safeParse(row);
+  return (
+    parsed.success && isRetiredGoalArchiveText(parsed.data.payload.content)
+  );
+}
+
+export function visibleChatEventRowContent(row: {
+  readonly eventType: string;
+  readonly runId: string | null;
+  readonly revokesEventId: string | null;
+  readonly contextType: string | null;
+  readonly contextId: string | null;
+  readonly runEventSequenceNumber: number | null;
+  readonly runEventId: string | null;
+  readonly payload: unknown;
+}): string | null {
+  const content = contentPayloadSchema.parse(row.payload)?.content;
+  if (content === undefined) {
+    return null;
+  }
+  // Check the original payload: object decoding can discard unknown keys.
+  return isRetiredGoalArchiveRow(row)
+    ? content
+    : visiblePiMemoryCitationText(content);
+}

--- a/turbo/packages/db/package.json
+++ b/turbo/packages/db/package.json
@@ -31,6 +31,10 @@
     "./types": {
       "import": "./src/types.ts",
       "types": "./src/types.ts"
+    },
+    "./migrations/014-goal-archive-search": {
+      "import": "./scripts/migrations/014-goal-archive-search/recover.ts",
+      "types": "./scripts/migrations/014-goal-archive-search/recover.ts"
     }
   },
   "scripts": {

--- a/turbo/packages/db/scripts/migrations/014-goal-archive-search/README.md
+++ b/turbo/packages/db/scripts/migrations/014-goal-archive-search/README.md
@@ -1,0 +1,86 @@
+# 014: Restore literal Goal archive search documents
+
+Issue #32834 repairs readable projections of the immutable 1094 notice. An old
+API can have stripped citation-shaped objective text, written the search document,
+and advanced its watermark before this API is promoted. Updating the reader does
+not recover that derived text. This one-off operation repairs only receipt-addressed
+archive documents whose watermark already covers the archive. It does not reindex
+other messages, reset watermarks, read objectives from `thread_goals`, or change
+raw events, snapshots, public shares, Goal state, or lifecycle behavior.
+
+## Release gate and execution
+
+The implementation owner stops at PR merge. The EPIC #32653 controller must
+independently accept #32813 and #32834 and delegate production work to its separate
+release-only owner. That owner runs this operation after the repaired API is serving
+and the outgoing search-projector invocations have completed, before accepting S2.
+If 1094 shipped earlier, the same operation repairs that earlier exposure. Do not
+execute a production command as part of implementation or local verification.
+
+Use the canonical candidate containing both changes, with dependencies installed,
+1093/1094 applied and the receipt columns still present. The receipt is only the
+bounded repair inventory; ordinary readers never consult it and continue to work
+after S5 drops Goal state. Complete and verify this operation before S5.
+
+Required environment: `DATABASE_URL`, `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`,
+`R2_SECRET_ACCESS_KEY`, and `R2_USER_STORAGES_BUCKET_NAME`. Use the existing
+authorized database/object-storage credentials; never place credentials in CLI
+arguments. Object storage is read-only. No content is written to files or reports.
+
+Run from `turbo/packages/db`:
+
+```bash
+# Default dry-run uses read-only SQL transactions and reports counts only.
+pnpm exec tsx scripts/migrations/014-goal-archive-search/backfill.ts
+
+# Explicitly authorized execution. Each thread commits independently.
+pnpm exec tsx scripts/migrations/014-goal-archive-search/backfill.ts --migrate
+
+# Resume a bounded/failed operation at its last reported completed page.
+pnpm exec tsx scripts/migrations/014-goal-archive-search/backfill.ts \
+  --migrate --max-threads 100 --after-thread '<last-completed-thread-uuid>'
+```
+
+A run processes at most 5,000 receipt threads (100 per candidate page), sufficient
+for the measured 4,162-Goal cohort. `--max-threads` can reduce this bound. SQL uses
+a 1-second lock timeout and a 10-second statement timeout. Repeatable-read history
+combines the validated checksum/order/terminal metadata of schema-7 snapshots with
+paged PostgreSQL tails. Missing/corrupt archives, incorrect provenance, and projection
+ownership mismatches fail without printing SQL, provider errors, or objective text.
+A retry may revisit the previous page; matching text/bigram documents are unchanged.
+A concurrently changed row causes a transaction failure rather than a stale rewrite.
+
+Only an archive whose full provenance, content-only payload, exact 1094 grammar,
+receipt ID and sequence agree can repair a document. Existing revokers retain their
+visibility authority. Current thread/agent ownership is checked, and an apply
+transaction locks those parents against concurrent deletion. Missing unindexed
+archives remain the normal projector's responsibility. Search result ownership and
+retention rules remain unchanged.
+
+A complete **fresh** dry-run after execution must report zero `repairable`, no
+errors, and `complete: true`; a resumed partial scan is not a full certificate.
+`not-indexed` requires normal projector convergence followed by another fresh
+verification. `revoked` records intentional invisibility; investigate any unexpected
+count privately. The old projector uses conflict-do-nothing inserts, so it cannot
+overwrite repaired text; waiting for its outgoing invocations also closes the
+not-yet-indexed window. No arbitrary waiting period replaces that serving/convergence
+evidence. Reports contain counts and opaque resume coordinates only.
+
+## Public shares
+
+Existing shares are immutable selected copies. This operation never changes or
+republishes them. New hot/snapshot shares and reads of intact saved archive text
+preserve literals. An already-stripped public copy cannot recover absent text from
+its own stored representation; only its owner can explicitly create a new share.
+No affected production share inventory was queried or inferred for this repair.
+
+## Verification
+
+`goal-retirement-history.test.ts` executes unchanged 1094 against real PostgreSQL,
+checks all four recorded statuses through history/search/share APIs, installs the
+old API's stripped projection and advanced watermark, snapshots and removes covered
+hot events, and runs this recovery in dry-run/apply/retry modes. It verifies repaired
+search results, unchanged old shares, new snapshot shares, exact export, and ordinary
+manual continuation through production endpoints. Shared contract tests cover strict
+provenance, the complete frozen grammar and literal delimiter variants. The regular
+API PR pipeline runs the regression; this script adds no persistent endpoint or job.

--- a/turbo/packages/db/scripts/migrations/014-goal-archive-search/backfill.ts
+++ b/turbo/packages/db/scripts/migrations/014-goal-archive-search/backfill.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env tsx
+import { parseArgs } from "node:util";
+import { Client } from "pg";
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { recoverGoalArchiveSearch, type RecoveryOutcome } from "./recover";
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error("missing_configuration");
+  return value;
+}
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      migrate: { type: "boolean", default: false },
+      "max-threads": { type: "string", default: "5000" },
+      "after-thread": { type: "string" },
+    },
+    strict: true,
+  });
+  const limit = Number(values["max-threads"]);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 5000)
+    throw new Error("invalid_limit");
+  let cursor = values["after-thread"] ?? null;
+  if (cursor !== null && !/^[0-9a-f-]{36}$/u.test(cursor))
+    throw new Error("invalid_cursor");
+  const client = new Client({ connectionString: requiredEnv("DATABASE_URL") });
+  const s3 = new S3Client({
+    region: "auto",
+    endpoint: `https://${requiredEnv("R2_ACCOUNT_ID")}.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: requiredEnv("R2_ACCESS_KEY_ID"),
+      secretAccessKey: requiredEnv("R2_SECRET_ACCESS_KEY"),
+    },
+  });
+  const bucket = requiredEnv("R2_USER_STORAGES_BUCKET_NAME");
+  const counts: Record<RecoveryOutcome, number> = {
+    unchanged: 0,
+    repairable: 0,
+    repaired: 0,
+    "not-indexed": 0,
+    revoked: 0,
+    deleted: 0,
+  };
+  let processed = 0;
+  let complete = false;
+  try {
+    await client.connect();
+    if (!values.migrate)
+      await client.query("SET default_transaction_read_only = on");
+    await client.query("SET statement_timeout = '10s'");
+    while (processed < limit) {
+      const page = await client.query<Record<string, unknown>>(
+        `SELECT chat_thread_id FROM thread_goals
+        WHERE retirement_archive_event_id IS NOT NULL AND ($1::uuid IS NULL OR chat_thread_id > $1)
+        ORDER BY chat_thread_id LIMIT $2`,
+        [cursor, Math.min(100, limit - processed)],
+      );
+      if (page.rows.length === 0) {
+        complete = true;
+        break;
+      }
+      for (const row of page.rows) {
+        if (typeof row.chat_thread_id !== "string")
+          throw new Error("invalid_thread_id");
+        const outcome = await recoverGoalArchiveSearch(
+          client,
+          row.chat_thread_id,
+          async (key) => {
+            const object = await s3.send(
+              new GetObjectCommand({ Bucket: bucket, Key: key }),
+              { abortSignal: AbortSignal.timeout(30_000) },
+            );
+            if (!object.Body) throw new Error("missing_snapshot_body");
+            return Buffer.from(await object.Body.transformToByteArray());
+          },
+          values.migrate,
+        );
+        counts[outcome] += 1;
+        processed += 1;
+        cursor = row.chat_thread_id;
+      }
+      console.log(
+        JSON.stringify({
+          mode: values.migrate ? "migrate" : "dry-run",
+          processed,
+          counts,
+          cursor,
+          complete: false,
+        }),
+      );
+    }
+    if (!complete) {
+      const remainder = await client.query(
+        "SELECT 1 FROM thread_goals WHERE retirement_archive_event_id IS NOT NULL AND chat_thread_id > $1 LIMIT 1",
+        [cursor],
+      );
+      complete = remainder.rows.length === 0;
+    }
+    console.log(
+      JSON.stringify({
+        mode: values.migrate ? "migrate" : "dry-run",
+        processed,
+        counts,
+        cursor,
+        complete,
+      }),
+    );
+  } finally {
+    await client.end();
+    s3.destroy();
+  }
+}
+// Provider/SQL/validation errors may carry historical content. Never print them.
+main().catch(() => {
+  console.error(
+    "Goal archive search recovery failed; retain the last completed cursor and investigate privately.",
+  );
+  process.exitCode = 1;
+});

--- a/turbo/packages/db/scripts/migrations/014-goal-archive-search/recover.ts
+++ b/turbo/packages/db/scripts/migrations/014-goal-archive-search/recover.ts
@@ -1,0 +1,250 @@
+import { createHash } from "node:crypto";
+import { gunzipSync } from "node:zlib";
+import type { Client } from "pg";
+import {
+  chatEventRowSchema,
+  type ChatEventRow,
+} from "@okouai/api-contracts/contracts/chat-event-rows";
+import { isRetiredGoalArchiveRow } from "@okouai/api-contracts/contracts/retired-goal-archive";
+import { chatSearchIndexText } from "../../../../../apps/api/src/lib/chat-search-bigram";
+
+export type RecoveryOutcome =
+  | "unchanged"
+  | "repairable"
+  | "repaired"
+  | "not-indexed"
+  | "revoked"
+  | "deleted";
+export type SnapshotLoader = (key: string) => Promise<Buffer>;
+
+function text(value: unknown): string {
+  if (typeof value !== "string") throw new Error("invalid_metadata");
+  return value;
+}
+function sequence(value: unknown): number {
+  const result = typeof value === "string" ? Number(value) : value;
+  if (
+    typeof result !== "number" ||
+    !Number.isSafeInteger(result) ||
+    result < 0
+  ) {
+    throw new Error("invalid_sequence");
+  }
+  return result;
+}
+
+async function history(
+  client: Client,
+  threadId: string,
+  loadSnapshot: SnapshotLoader,
+): Promise<readonly ChatEventRow[]> {
+  // A repeatable-read transaction sees the snapshot head and its PostgreSQL
+  // tail at one revision even when retention concurrently deletes covered rows.
+  const heads = await client.query<Record<string, unknown>>(
+    `SELECT last_seq_id, terminal_seq_id, terminal_event_id, object_key
+    FROM chat_event_snapshots WHERE chat_thread_id = $1 AND archive_schema_version = 7`,
+    [threadId],
+  );
+  const head = heads.rows[0];
+  const rows: ChatEventRow[] = [];
+  let cursor = 0;
+  if (head) {
+    const key = text(head.object_key);
+    if (!key.startsWith(`chat-events/${threadId}/`))
+      throw new Error("invalid_snapshot_scope");
+    const bytes = await loadSnapshot(key);
+    const digest = /-([0-9a-f]{64})\.ndjson\.gz$/u.exec(key)?.[1];
+    if (createHash("sha256").update(bytes).digest("hex") !== digest)
+      throw new Error("invalid_snapshot_digest");
+    const body = gunzipSync(bytes).toString("utf8");
+    if (!body.endsWith("\n")) throw new Error("invalid_snapshot_lines");
+    const lastSeqId = sequence(head.last_seq_id);
+    for (const line of body.slice(0, -1).split("\n")) {
+      const row = chatEventRowSchema.parse(JSON.parse(line));
+      if (
+        row.chatThreadId !== threadId ||
+        row.seqId <= cursor ||
+        row.seqId > lastSeqId
+      )
+        throw new Error("invalid_snapshot_order");
+      rows.push(row);
+      cursor = row.seqId;
+    }
+    if (
+      head.terminal_seq_id !== null &&
+      (rows.at(-1)?.id !== head.terminal_event_id ||
+        cursor !== sequence(head.terminal_seq_id))
+    )
+      throw new Error("invalid_snapshot_terminal");
+    cursor = lastSeqId;
+  }
+  for (;;) {
+    const tail = await client.query<Record<string, unknown>>(
+      `SELECT id, chat_thread_id AS "chatThreadId", event_type AS "eventType",
+      run_id AS "runId", revokes_event_id AS "revokesEventId", context_type AS "contextType", context_id AS "contextId",
+      run_event_sequence_number AS "runEventSequenceNumber", run_event_id AS "runEventId", payload,
+      seq_id AS "seqId", to_char(created_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS "createdAt",
+      CASE WHEN event_type = 'run.failed' THEN failure_reason END AS "failureReason"
+      FROM chat_events WHERE chat_thread_id = $1 AND seq_id > $2 ORDER BY seq_id LIMIT 1000`,
+      [threadId, cursor],
+    );
+    for (const raw of tail.rows) {
+      const { failureReason, ...base } = raw;
+      const row = chatEventRowSchema.parse({
+        ...base,
+        seqId: sequence(raw.seqId),
+        ...(failureReason === null ? {} : { failureReason }),
+      });
+      rows.push(row);
+      cursor = row.seqId;
+    }
+    if (tail.rows.length < 1000) return rows;
+  }
+}
+
+function validateReceiptOwnership(candidate: Record<string, unknown>): void {
+  if (
+    candidate.goal_user_id !== candidate.user_id ||
+    candidate.goal_agent_id !== candidate.agent_id ||
+    candidate.goal_org_id !== candidate.org_id
+  ) {
+    throw new Error("invalid_receipt_ownership");
+  }
+}
+
+function validateProjectionOwnership(
+  existing: Record<string, unknown> | undefined,
+  candidate: Record<string, unknown>,
+): void {
+  if (
+    existing &&
+    (existing.run_id !== null ||
+      existing.role !== "assistant" ||
+      existing.user_id !== candidate.user_id ||
+      existing.org_id !== candidate.org_id ||
+      existing.agent_id !== candidate.agent_id)
+  ) {
+    throw new Error("invalid_projection_ownership");
+  }
+}
+
+async function repairProjection(
+  client: Client,
+  threadId: string,
+  candidate: Record<string, unknown>,
+  loadSnapshot: SnapshotLoader,
+  migrate: boolean,
+): Promise<RecoveryOutcome> {
+  validateReceiptOwnership(candidate);
+  const rows = await history(client, threadId, loadSnapshot);
+  const row = rows.find((event) => {
+    return event.id === candidate.event_id;
+  });
+  if (
+    !row ||
+    row.seqId !== sequence(candidate.seq_id) ||
+    !isRetiredGoalArchiveRow(row) ||
+    !row.payload?.content?.startsWith(
+      `Okou Goal retired.\nGoal ID: ${text(candidate.id)}\n`,
+    )
+  ) {
+    throw new Error("invalid_archive_receipt");
+  }
+  const revoked = rows.some((event) => {
+    return event.revokesEventId === row.id;
+  });
+  const indexed = await client.query<Record<string, unknown>>(
+    `SELECT run_id, user_id, org_id, agent_id, role, text, text_bigram
+        FROM chat_event_search_messages WHERE chat_thread_id = $1 AND seq_id = $2`,
+    [threadId, row.seqId],
+  );
+  const existing = indexed.rows[0];
+  validateProjectionOwnership(existing, candidate);
+  const content = row.payload.content;
+  const bigram = chatSearchIndexText(content);
+  if (revoked) {
+    // Preserve the existing visibility rule, including snapshot revokers.
+    if (!migrate && existing) return "repairable";
+    if (migrate)
+      await client.query(
+        "DELETE FROM chat_event_search_messages WHERE chat_thread_id = $1 AND seq_id = $2",
+        [threadId, row.seqId],
+      );
+    return "revoked";
+  } else if (existing?.text === content && existing.text_bigram === bigram) {
+    return "unchanged";
+  } else if (!migrate) {
+    return "repairable";
+  } else {
+    await client.query(
+      `INSERT INTO chat_event_search_messages
+          (chat_thread_id, seq_id, run_id, user_id, org_id, agent_id, role, created_at, text, text_bigram)
+          VALUES ($1, $2, NULL, $3, $4, $5, 'assistant', $6, $7, $8)
+          ON CONFLICT (chat_thread_id, seq_id) DO UPDATE SET text = EXCLUDED.text, text_bigram = EXCLUDED.text_bigram`,
+      [
+        threadId,
+        row.seqId,
+        text(candidate.user_id),
+        text(candidate.org_id),
+        text(candidate.agent_id),
+        row.createdAt,
+        content,
+        bigram,
+      ],
+    );
+    return "repaired";
+  }
+}
+
+/** One receipt-scoped derived repair. Never changes raw history or watermarks. */
+export async function recoverGoalArchiveSearch(
+  client: Client,
+  threadId: string,
+  loadSnapshot: SnapshotLoader,
+  migrate: boolean,
+): Promise<RecoveryOutcome> {
+  await client.query(
+    migrate
+      ? "BEGIN ISOLATION LEVEL REPEATABLE READ"
+      : "BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY",
+  );
+  try {
+    await client.query("SET LOCAL lock_timeout = '1s'");
+    await client.query("SET LOCAL statement_timeout = '10s'");
+    const candidates = await client.query<Record<string, unknown>>(
+      `SELECT goal.id, goal.retirement_archive_event_id AS event_id,
+      goal.retirement_archive_seq_id AS seq_id, thread.user_id, agent.org_id, agent.id AS agent_id,
+      watermark.indexed_seq_id, goal.owner_user_id AS goal_user_id, goal.agent_id AS goal_agent_id, goal.org_id AS goal_org_id
+      FROM thread_goals goal JOIN chat_threads thread ON thread.id = goal.chat_thread_id
+      JOIN agents agent ON agent.id = thread.agent_id
+      LEFT JOIN chat_event_search_message_watermarks watermark ON watermark.chat_thread_id = thread.id
+      WHERE thread.id = $1 AND goal.retirement_archive_event_id IS NOT NULL
+      ${migrate ? "FOR SHARE OF thread, agent" : ""}`,
+      [threadId],
+    );
+    const candidate = candidates.rows[0];
+    let outcome: RecoveryOutcome;
+    if (!candidate) {
+      outcome = "deleted";
+    } else if (
+      candidate.indexed_seq_id === null ||
+      sequence(candidate.indexed_seq_id) < sequence(candidate.seq_id)
+    ) {
+      // New code's normal projector still owns these rows. No history rebuild.
+      outcome = "not-indexed";
+    } else {
+      outcome = await repairProjection(
+        client,
+        threadId,
+        candidate,
+        loadSnapshot,
+        migrate,
+      );
+    }
+    await client.query("COMMIT");
+    return outcome;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  }
+}


### PR DESCRIPTION
## Problem and change

The immutable 1094 retirement notice preserves the original objective in raw history, but readable projections treated citation-shaped user text as assistant transport. A complete envelope disappeared, an unmatched opener swallowed the remaining objective, and Markdown could rewrite inline literals.

Preserve the complete notice only when every raw provenance coordinate is null, the payload contains only a string `content`, and the full frozen UUID/status/explanation grammar matches. Hot and snapshot readers share that boundary; SQL SELECT projections carry source provenance while existing text/null/regex predicates and run-scoped consumers retain their behavior. Sharing and search retain their run attribution when avoiding their second filter. Chat and public-share pages render identified archives as literal text, including whitespace and copy behavior. Real assistant copies of the notice continue to filter citations and render Markdown.

Closes #32834. Parent: #32653; complements the already-merged #32813.

## Derived search recovery and release boundary

Add the bounded, default-dry-run, idempotent external-data operation in `turbo/packages/db/scripts/migrations/014-goal-archive-search/`. It repairs only receipt-addressed archive search documents already covered by a watermark, using validated canonical hot/snapshot history. It does not reset watermarks or rebuild unrelated messages. Reports contain counts and opaque resume coordinates, without objective content.

The separate release owner must execute and verify recovery after the repaired API serves and outgoing projectors complete, before S2 acceptance and S5 removes the receipt inventory. Both #32813 and this fix must be in the controller's accepted canonical candidate. This PR does not execute production migrations, promotion, release or rollback.

1093/1094, raw events and snapshots remain unchanged. Published shares remain immutable: new shares and intact saved text are lossless, while an already-stripped public copy requires an explicit owner-created replacement. Synthetic fixtures establish that limitation; no affected production share inventory or production objective was read.

## Fallbacks

`retired-goal-archive.ts:isRetiredGoalArchiveRow/isRetiredGoalArchiveText` and their provenance-aware consumers implement the frozen 1094 historical reader, an explicit retained-data compatibility contract required by #32834 and tracked by EPIC #32653. Its surfaces are raw event projections, hot SQL/snapshot readers, and already-projected sharing/search text with retained run provenance. Its lifetime is the supported immutable history, including after S5; removal requires an explicit decision ending support for those retained histories, not merely removal of the Goal producer or tables. Unknown/malformed sources retain the existing citation behavior. There is no Goal lookup, lifecycle fallback, new archive endpoint, recurring repair job, or new writer format.

## Validation

- Contract/parser matrix: 117 tests passed across three targeted files, covering all four statuses, complete/partial/unclosed/inline/fenced delimiters, Unicode/whitespace, wrong/missing provenance, extra payload keys and malformed headers.
- Five targeted API files: 47 tests passed, including unchanged 1094 SQL and retry, hot -> snapshot -> physical hot deletion, sharing/search/export/manual continuation, and concurrent share-read/deletion behavior.
- Four retirement API cases also passed with hot and snapshot repair, dry-run/apply/retry, corrupt-snapshot rejection, advanced old watermarks, stripped search documents and unchanged old public copies.
- A real Pi API-first run copying the complete notice passed the existing citation/private-provenance assertions.
- Two Platform page files: 15 tests passed, including exact visible text, clipboard content, intact public archives and normal Markdown/citation behavior for a real run.
- Scoped ESLint, Oxlint and type-aware Oxlint passed for all changed TypeScript workspaces. Normal commit hooks verify formatting, style policy, Knip and repository type checks. The initial 4 GiB local OOM was addressed with a compiler memory budget; no checks or hooks were bypassed.
- Full local Vitest and a dev server were not run, as requested. Full regression coverage is delegated to the PR pipeline; production recovery and controller acceptance remain separate release gates.
