### PR TITLE
feat(cli): add structured json output to connector inspection

### DIFF
--- a/docs/connector-inspection-json.md
+++ b/docs/connector-inspection-json.md
@@ -1,0 +1,94 @@
+# Connector inspection JSON
+
+Use `--json` to compose connector inspection with scripts and Agents:
+
+```sh
+okou connector search github --json
+okou connector check --url https://api.github.com/repos/owner/repo --json
+okou connector list --json
+okou connector status github --json
+okou connector custom list --json
+okou connector custom status <connector-id> --json
+```
+
+An inspection result occupies all of stdout as one JSON value, without ANSI
+formatting or appended guidance. Commands without `--json` keep their existing
+human-readable output. Existing list/status JSON fields are preserved; new
+identity fields are additive.
+
+## Identity and evidence
+
+`target` preserves the stable identity: `{ kind: "builtin", connectorSlug }`
+or `{ kind: "custom", customConnectorId }`. A connector's `connectorType` is
+`builtin`, `custom-http`, or `custom-mcp`. Run inspection can retain a custom
+target whose definition is no longer available: its `connectorType` is then
+`null` and `definitionAvailable` is `false`. The target is never replaced with
+a similarly named connector. Existing `kind` fields keep their original values.
+
+Connection state, current Agent authorization, and run account availability are
+different observations. A current grant does not prove that an account was
+selected for an existing run. A reconnect-required account can still have
+available metadata. Missing evidence is explicit (`null` or a discriminated
+unavailable state), rather than being inferred from another account.
+
+## Command contexts
+
+| Command                        | Context and result                                                                                                                                                                                                                                             |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list`, `status` outside a run | `context: "current"`; current user/organization connector status and optional current Agent authorization. Existing connector fields remain available.                                                                                                         |
+| `list`, `status` inside a run  | `context: "run"`; the existing run-account view, including its exact `connectionId`, account state, and metadata. Missing projection context remains `state: "unavailable"`.                                                                                   |
+| `search`                       | Uses the same current/run distinction. `query` records the trimmed keyword and requested limit (`null` means no explicit limit); `total` counts all matches, `exactMatch` records the existing score threshold, and `connectors` retain rank order and scores. |
+| `custom list`, `custom status` | Always `context: "current"`, including inside a run: these commands inspect organization definitions and optional current Agent grants. They do not report run admission.                                                                                      |
+| `check`                        | `context` describes the CLI's current/run account view. `request` is the actual sanitized diagnostic request. The full server `diagnostic` separately reports its run scope, routing, and permission outcomes.                                                 |
+
+Current discovery/status does not always have an exact account ID. It preserves
+the metadata returned by that API and does not select an account to fill the
+gap. Custom current results expose `connectionId` when their definition
+response supplies it, otherwise `null`.
+
+Run accounts retain the existing `available`, `metadata-unavailable`, and
+`not-admitted` states. Search/check also retain `context-unavailable` with its
+reason. A deleted account retains its exact ID. Search's `availableForRun` is
+`null` when account context is unavailable; otherwise it follows the existing
+account-availability column, including reconnect-required status. It is not an
+assessment of a particular endpoint's permission policy. Search's `agent`
+identifies the subject of current authorization inspection. Outside a run,
+`--agent` selects that subject; inside a run, it must match the run's Agent.
+This selector rule also applies to custom inventory despite its current context.
+
+## Actions and diagnostics
+
+Search's `actions` contain labels, exact URLs, and callback support. The usual
+single-match and callback restrictions apply. Preserve returned action URLs,
+including all query parameters.
+
+Check emits the validated diagnostic without collapsing `deny`, `ask`,
+`unavailable`, unknown endpoints, ambiguous targets, or missing run context.
+The additional `connector`, `account`, `connection`, `authorization`, and
+`environment` fields describe the corresponding available local/current
+evidence. `account` is run-bound; `connection` is current-context data. Environment
+entries contain only names and presence booleans, never values. URL userinfo is
+rejected, and query strings/fragments are stripped before transport and output.
+
+Check's `actions` contain commands, links, or guidance. Builtin permission
+requests are offered only for denied/ask outcomes from a URL diagnostic.
+Custom connectors retain their settings-based remediation; unknown custom
+endpoints are not turned into builtin permission requests. Retry commands retain
+the sanitized request selectors and JSON mode. Routing and permission results
+describe intended state, not confirmation that the runner applied a later
+update. Connector/account changes apply to future runs.
+
+## Empty and error results
+
+- Empty inventories and searches return empty arrays. Missing custom status
+  returns `state: "unavailable"`, its requested target, and `connector: null`.
+- A non-resolved check diagnostic remains a JSON result with the original
+  outcome, an explanatory `message`, and a nonzero exit status. Missing custom
+  status likewise exits nonzero. A resolved diagnosis that reports a denied
+  permission keeps the existing successful diagnostic exit behavior; callers
+  inspect its policy outcome.
+- Computer Use retains its separate host/token guidance in a JSON result with
+  `diagnostic.outcome: "not-a-connector"`.
+- Argument validation, authentication, transport failures, and invalid API
+  response contracts retain the existing stderr error boundary and nonzero exit.
+  They do not fabricate an empty inventory or a successful JSON diagnosis.

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -30,6 +30,8 @@ surface; the index does not replace their detailed rules.
 
 ## Specialized Guidance
 
+- [Connector inspection JSON](./connector-inspection-json.md): command output
+  contracts, current versus run evidence, account identity, and next actions.
 - [Platform lint boundaries](./platform-lint.md): current transport and lifecycle
   exceptions, polling policy, and retired configuration history.
 - [React commit analysis](./react-commit.md): measuring and attributing React

--- a/turbo/apps/cli/src/commands/__tests__/helpers/custom-connectors.ts
+++ b/turbo/apps/cli/src/commands/__tests__/helpers/custom-connectors.ts
@@ -1,9 +1,13 @@
 import { http, HttpResponse } from "msw";
 import type {
   CustomConnectorHttpResponse,
+  CustomConnectorMcpResponse,
   CustomConnectorResponse,
 } from "@okouai/api-contracts/contracts/custom-connectors";
-import { customConnectorHttpResponseSchema } from "@okouai/api-contracts/contracts/custom-connectors";
+import {
+  customConnectorHttpResponseSchema,
+  customConnectorMcpResponseSchema,
+} from "@okouai/api-contracts/contracts/custom-connectors";
 import type { McpConnector } from "@okouai/api-contracts/contracts/mcp-connectors";
 import type { AgentCustomConnectorGrant } from "@okouai/api-contracts/contracts/agent-custom-connectors";
 
@@ -38,6 +42,22 @@ export function customConnector(
     configuredFieldKeys: [],
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  });
+}
+
+export function customMcpConnector(
+  overrides: Partial<CustomConnectorMcpResponse> = {},
+): CustomConnectorMcpResponse {
+  return customConnectorMcpResponseSchema.parse({
+    ...customConnector(),
+    kind: "mcp",
+    id: "44444444-4444-4444-8444-444444444444",
+    slug: "_acme-mcp",
+    displayName: "Acme MCP",
+    endpoint: "https://mcp.acme.test/server",
+    transport: "streamable-http",
+    prefixTemplates: [],
     ...overrides,
   });
 }

--- a/turbo/apps/cli/src/commands/connector/__tests__/agent-context.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/agent-context.test.ts
@@ -17,6 +17,27 @@ const commandCases = [
   { name: "list", command: listCommand, args: [] },
   { name: "status", command: statusCommand, args: ["github"] },
   { name: "search", command: searchCommand, args: ["github"] },
+  { name: "list JSON", command: listCommand, args: ["--json"] },
+  {
+    name: "status JSON",
+    command: statusCommand,
+    args: ["github", "--json"],
+  },
+  {
+    name: "search JSON",
+    command: searchCommand,
+    args: ["github", "--json"],
+  },
+  {
+    name: "custom list JSON",
+    command: customConnectorCommand,
+    args: ["list", "--json"],
+  },
+  {
+    name: "custom status JSON",
+    command: customConnectorCommand,
+    args: ["status", CUSTOM_CONNECTOR_ID, "--json"],
+  },
   { name: "custom list", command: customConnectorCommand, args: ["list"] },
   {
     name: "custom status",
@@ -68,9 +89,11 @@ describe("run-bound connector Agent selectors", () => {
     vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", undefined);
     for (const { command } of commandCases) {
       command.setOptionValue("agent", undefined);
+      command.setOptionValue("json", false);
     }
     for (const command of customConnectorCommand.commands) {
       command.setOptionValue("agent", undefined);
+      command.setOptionValue("json", false);
     }
     requests = [];
     server.use(

--- a/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
@@ -12,7 +12,10 @@ import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { server } from "../../../mocks/server";
-import { customConnector } from "../../__tests__/helpers/custom-connectors";
+import {
+  customConnector,
+  stubAgentCustomConnectors,
+} from "../../__tests__/helpers/custom-connectors";
 import {
   stubRunConnectorAccountInspection,
   writeRunConnectorAccountContext,
@@ -125,6 +128,7 @@ describe("custom connector URL diagnostics", () => {
   }
 
   beforeEach(() => {
+    checkConnectorCommand.setOptionValue("json", false);
     requests.length = 0;
     directory = mkdtempSync(join(tmpdir(), "okou-custom-check-"));
     contextPath = join(directory, "accounts.json");
@@ -138,6 +142,7 @@ describe("custom connector URL diagnostics", () => {
     ]);
     stubDiagnostic(resolvedCustom());
     server.use(
+      stubAgentCustomConnectors([]),
       http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {
         return HttpResponse.json(
           customConnector({
@@ -162,7 +167,146 @@ describe("custom connector URL diagnostics", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    process.exitCode = undefined;
     rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("emits the exact custom account, subtype, and grant state as one JSON result", async () => {
+    await check("--connector", `custom:${CUSTOM_ID}`, "--json");
+    const json: unknown = JSON.parse(output());
+    expect(json).toMatchObject({
+      context: "run",
+      connector: {
+        target: TARGET,
+        label: "Renamed Acme",
+        connectorType: "custom-http",
+        definitionAvailable: true,
+      },
+      account: {
+        state: "available",
+        connectionId: ACCOUNT_ID,
+        metadata: { connectionStatus: "connected" },
+      },
+      connection: null,
+      authorization: { authorized: false },
+      diagnostic: {
+        run: { bases: ["https://api.acme.test/pinned"] },
+        permission: {
+          permissions: [{ name: "items:write", policy: { outcome: "deny" } }],
+        },
+      },
+    });
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(output()).not.toMatch(
+      /Default sibling|new-default|permission-request/,
+    );
+  });
+
+  it("reports unavailable definition metadata explicitly without replacing its account", async () => {
+    server.use(
+      http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {
+        return HttpResponse.json(
+          { error: { code: "NOT_FOUND", message: "Not found" } },
+          { status: 404 },
+        );
+      }),
+    );
+    await check("--json");
+    const json: unknown = JSON.parse(output());
+    expect(json).toMatchObject({
+      connector: {
+        target: TARGET,
+        label: CUSTOM_ID,
+        connectorType: null,
+        definitionAvailable: false,
+      },
+      account: { connectionId: ACCOUNT_ID },
+    });
+  });
+
+  it("uses current organization connection metadata outside a run", async () => {
+    vi.stubEnv("OKOU_AGENT_ID", "");
+    stubDiagnostic({
+      ...resolvedCustom({
+        kind: "unknown-endpoint",
+        policy: { outcome: "unavailable", basis: "not-run-scoped" },
+      }),
+      run: { status: "not-scoped" },
+    });
+    server.use(
+      http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {
+        return HttpResponse.json(
+          customConnector({
+            connected: true,
+            connectedAccountId: DEFAULT_ACCOUNT_ID,
+            missingRequiredFields: [],
+          }),
+        );
+      }),
+    );
+    await check("--json");
+    const json: unknown = JSON.parse(output());
+    expect(json).toMatchObject({
+      context: "current",
+      account: null,
+      authorization: null,
+      connection: { connected: true, connectionId: DEFAULT_ACCOUNT_ID },
+      diagnostic: { run: { status: "not-scoped" } },
+    });
+    expect(output()).not.toContain(ACCOUNT_ID);
+  });
+
+  it("keeps unavailable run context separate from current custom connection metadata", async () => {
+    vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", "");
+    await check("--json");
+    const json: unknown = JSON.parse(output());
+    expect(json).toMatchObject({
+      context: "run",
+      connection: null,
+      account: { state: "context-unavailable", reason: "legacy-or-missing" },
+    });
+    expect(output()).not.toContain(DEFAULT_ACCOUNT_ID);
+  });
+
+  it("retains custom unknown-endpoint remediation without inventing a permission request", async () => {
+    stubDiagnostic(
+      resolvedCustom({
+        kind: "unknown-endpoint",
+        policy: { outcome: "ask", basis: "unknown-policy" },
+      }),
+    );
+    await check("--json");
+    const json: unknown = JSON.parse(output());
+    expect(json).toMatchObject({
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          kind: "link",
+          guidance: expect.stringContaining(
+            "There is no custom unknown-endpoint approval control",
+          ),
+        }),
+      ]),
+    });
+    expect(output()).not.toContain("permission-request");
+  });
+
+  it("retains target-unavailable reasons and the exact custom target in JSON", async () => {
+    stubDiagnostic({
+      outcome: "target-unavailable",
+      target: TARGET,
+      reason: "not-admitted",
+    });
+    await check("--json");
+    const json: unknown = JSON.parse(output());
+    expect(json).toMatchObject({
+      diagnostic: {
+        outcome: "target-unavailable",
+        target: TARGET,
+        reason: "not-admitted",
+      },
+      message: expect.stringContaining("was not admitted"),
+    });
+    expect(process.exitCode).toBe(1);
   });
 
   it("selects a stable UUID and displays current metadata with the pinned account and bases", async () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/check.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check.test.ts
@@ -324,11 +324,13 @@ describe("okou connector check command", () => {
     vi.stubEnv("OKOU_CHAT_THREAD_ID", "");
     vi.stubEnv("GH_TOKEN", "");
     vi.stubEnv("GITHUB_TOKEN", "");
+    checkConnectorCommand.setOptionValue("json", false);
     setRunAccount("github", "connected");
   });
 
   afterEach(() => {
     rmSync(directory, { recursive: true, force: true });
+    process.exitCode = undefined;
   });
 
   function getOutput(): string {
@@ -345,6 +347,214 @@ describe("okou connector check command", () => {
     ).rejects.toThrow("process.exit called");
     expect(mockExit).toHaveBeenCalledWith(1);
   }
+
+  describe("JSON output", () => {
+    it("preserves sanitized diagnostics, exact accounts, separate grants, and permission actions", async () => {
+      stubDiagnostic(
+        resolvedUrl({
+          permission: {
+            kind: "matched",
+            permissions: [
+              {
+                name: "contents:read",
+                policy: { outcome: "deny", basis: "deny-list" },
+              },
+            ],
+          },
+        }),
+      );
+      stubResolvedDependencies("github", { enabledConnectorSlugs: [] });
+      setRunAccount("github", "reconnect-required");
+      vi.stubEnv("GITHUB_TOKEN", "environment-value-must-not-be-printed");
+      chalk.level = 3;
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://api.github.com/repos/vm0-ai/vm0?token=private-query#private-fragment",
+        "--json",
+      ]);
+      const json: unknown = JSON.parse(getOutput());
+      expect(json).toMatchObject({
+        context: "run",
+        request: {
+          mode: "url",
+          method: "GET",
+          url: "https://api.github.com/repos/vm0-ai/vm0",
+        },
+        diagnostic: {
+          outcome: "resolved",
+          permission: {
+            kind: "matched",
+            permissions: [
+              { name: "contents:read", policy: { outcome: "deny" } },
+            ],
+          },
+        },
+        connector: {
+          connectorType: "builtin",
+          target: { kind: "builtin", connectorSlug: "github" },
+        },
+        account: {
+          state: "available",
+          connectionId: SELECTED_CONNECTION_ID,
+          metadata: { connectionStatus: "reconnect-required" },
+        },
+        connection: null,
+        authorization: { agentId: AGENT_ID, authorized: false },
+        environment: [{ name: "GITHUB_TOKEN", present: true }],
+        actions: expect.arrayContaining([
+          expect.objectContaining({
+            kind: "command",
+            command:
+              "okou connector permission-request 'github' --permission 'contents:read' --url 'https://api.github.com/repos/vm0-ai/vm0' --method 'GET'",
+          }),
+          expect.objectContaining({
+            kind: "link",
+            url: expect.stringContaining(
+              `/reconnect/${SELECTED_CONNECTION_ID}`,
+            ),
+          }),
+        ]),
+      });
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(getOutput()).not.toMatch(
+        /private-query|private-fragment|environment-value-must-not-be-printed/,
+      );
+      expect(getOutput()).not.toContain("\u001b[");
+    });
+
+    it("keeps a standalone connection and unscoped policy distinct from a run account", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", "");
+      stubDiagnostic(
+        resolvedEnvironment({
+          run: { status: "not-scoped" },
+          permission: { outcome: "unavailable", basis: "not-run-scoped" },
+        }),
+      );
+      stubConnector("github");
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+        "--check-permission",
+        "contents:read",
+        "--json",
+      ]);
+      const json: unknown = JSON.parse(getOutput());
+      expect(json).toMatchObject({
+        context: "current",
+        account: null,
+        authorization: null,
+        connection: { id: connectorResponse("github").id },
+        diagnostic: {
+          run: { status: "not-scoped" },
+          permission: { outcome: "unavailable", basis: "not-run-scoped" },
+        },
+      });
+    });
+
+    it.each([
+      { outcome: "run-context-unavailable" },
+      { outcome: "no-match", scope: "run" },
+      { outcome: "unresolved-dynamic-base", connector: connectorIdentity() },
+    ] satisfies ConnectorCheckDiagnosticResult[])(
+      "retains $outcome as JSON with a failing exit status",
+      async (diagnostic) => {
+        stubDiagnostic(diagnostic);
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--url",
+          "https://api.github.com/repos/vm0-ai/vm0",
+          "--json",
+        ]);
+        const json: unknown = JSON.parse(getOutput());
+        expect(json).toMatchObject({
+          context: "run",
+          diagnostic: { outcome: diagnostic.outcome },
+          message: expect.any(String),
+          actions: [
+            expect.objectContaining({
+              kind: "command",
+              command: expect.stringContaining("--json"),
+            }),
+          ],
+        });
+        expect(process.exitCode).toBe(1);
+        expect(getErrorOutput()).toBe("");
+        expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    it("preserves unavailable environment and unknown-endpoint policy information", async () => {
+      stubDiagnostic(
+        resolvedUrl({
+          environmentNames: null,
+          permission: {
+            kind: "unknown-endpoint",
+            policy: { outcome: "unavailable", basis: "policies-unavailable" },
+          },
+        }),
+      );
+      stubResolvedDependencies();
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://api.github.com/unknown",
+        "--json",
+      ]);
+      const json: unknown = JSON.parse(getOutput());
+      expect(json).toMatchObject({
+        environment: null,
+        diagnostic: {
+          permission: {
+            kind: "unknown-endpoint",
+            policy: { outcome: "unavailable", basis: "policies-unavailable" },
+          },
+        },
+      });
+      expect(getOutput()).not.toContain("permission-request");
+    });
+
+    it("keeps Computer Use guidance machine-readable", async () => {
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://app.okou.ai/computer-use/hosts",
+        "--json",
+      ]);
+      const json: unknown = JSON.parse(getOutput());
+      expect(json).toMatchObject({
+        diagnostic: {
+          outcome: "not-a-connector",
+          capability: "computer-use:write",
+        },
+        guidance: expect.arrayContaining([
+          expect.stringContaining("Existing run tokens cannot be upgraded"),
+        ]),
+        actions: [{ command: "okou whoami" }],
+      });
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+    });
+
+    it("preserves API failures on stderr without fabricating a JSON diagnosis", async () => {
+      server.use(
+        http.post(diagnosticEndpoint(), () => {
+          return HttpResponse.json(
+            { error: { code: "INTERNAL", message: "Diagnostic failed" } },
+            { status: 500 },
+          );
+        }),
+      );
+      await expectCommandFailure(["--env-name", "GH_TOKEN", "--json"]);
+      expect(getOutput()).toBe("");
+      expect(getErrorOutput()).toContain("Diagnostic failed");
+    });
+  });
 
   describe("request construction and local validation", () => {
     it("sends a sanitized URL request and preserves every selector in the re-diagnosis hint", async () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/list.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../../__tests__/helpers/connector-catalog";
 import {
   customConnector,
+  customMcpConnector,
   stubAgentCustomConnectors,
   stubCustomConnectors,
 } from "../../__tests__/helpers/custom-connectors";
@@ -211,11 +212,16 @@ describe("okou connector list command", () => {
     });
 
     it("emits parseable current-context JSON without ANSI", async () => {
-      server.use(stubConnectors([connectedGithub]));
+      const custom = customConnector();
+      const mcp = customMcpConnector();
+      server.use(
+        stubConnectors([connectedGithub]),
+        stubCustomConnectors([custom, mcp]),
+      );
 
       await listCommand.parseAsync(["node", "cli", "--json"]);
 
-      const output = String(mockConsoleLog.mock.calls[0]?.[0]);
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
       const json: unknown = JSON.parse(output);
       expect(json).toStrictEqual(
         expect.objectContaining({
@@ -223,8 +229,23 @@ describe("okou connector list command", () => {
           connectors: expect.arrayContaining([
             expect.objectContaining({
               kind: "builtin",
+              connectorType: "builtin",
+              target: { kind: "builtin", connectorSlug: "github" },
               slug: "github",
               connectionStatus: "connected",
+            }),
+            expect.objectContaining({
+              kind: "custom",
+              id: custom.id,
+              connectorType: "custom-http",
+              connected: false,
+              missingRequiredFields: ["apiKey"],
+            }),
+            expect.objectContaining({
+              kind: "custom",
+              id: mcp.id,
+              connectorType: "custom-mcp",
+              target: { kind: "custom", customConnectorId: mcp.id },
             }),
           ]),
         }),

--- a/turbo/apps/cli/src/commands/connector/__tests__/run-account-context.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/run-account-context.test.ts
@@ -182,6 +182,8 @@ describe("run connector account inspection", () => {
           state: "available",
           connector: expect.objectContaining({
             target: { kind: "builtin", connectorSlug: "github" },
+            connectorType: "builtin",
+            definitionAvailable: true,
             account: expect.objectContaining({
               state: "available",
               connectionId: PINNED_CONNECTION_ID,
@@ -317,6 +319,60 @@ describe("run connector account inspection", () => {
     output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain(mcpConnectionId);
     expect(output).toContain("Current Status:");
+
+    mockConsoleLog.mockClear();
+    await listCommand.parseAsync(["node", "cli", "--json"]);
+    const json: unknown = JSON.parse(
+      mockConsoleLog.mock.calls.flat().join("\n"),
+    );
+    expect(json).toMatchObject({
+      context: "run",
+      connectors: [
+        {
+          target: { kind: "custom", customConnectorId: httpConnector.id },
+          connectorType: "custom-http",
+          definitionAvailable: true,
+          account: {
+            state: "metadata-unavailable",
+            connectionId: httpConnectionId,
+          },
+        },
+        {
+          target: { kind: "custom", customConnectorId: mcpConnector.id },
+          connectorType: "custom-mcp",
+          definitionAvailable: true,
+          account: {
+            state: "metadata-unavailable",
+            connectionId: mcpConnectionId,
+          },
+        },
+      ],
+    });
+    expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains a missing custom definition's UUID with an explicitly unknown subtype", async () => {
+    const customConnectorId = "33333333-3333-4333-8333-333333333333";
+    writeContext([{ kind: "custom", customConnectorId, connectionId: null }]);
+    server.use(stubConnectorCatalog([]), stubCustomConnectors([]));
+    await statusCommand.parseAsync([
+      "node",
+      "cli",
+      `custom:${customConnectorId}`,
+      "--json",
+    ]);
+    const json: unknown = JSON.parse(
+      mockConsoleLog.mock.calls.flat().join("\n"),
+    );
+    expect(json).toMatchObject({
+      context: "run",
+      connector: {
+        target: { kind: "custom", customConnectorId },
+        connectorType: null,
+        definitionAvailable: false,
+        account: { state: "not-admitted", connectionId: null },
+      },
+    });
   });
 
   it("retains exact IDs when the enrichment route is unavailable", async () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/search.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../../__tests__/helpers/connector-catalog";
 import {
   customConnector,
+  customMcpConnector,
   stubAgentCustomConnectors,
   stubCustomConnectors,
 } from "../../__tests__/helpers/custom-connectors";
@@ -173,6 +174,7 @@ describe("okou connector search command", () => {
     searchCommand.setOptionValue("agent", undefined);
     searchCommand.setOptionValue("limit", undefined);
     searchCommand.setOptionValue("callbackPrompt", undefined);
+    searchCommand.setOptionValue("json", false);
     server.use(stubCustomConnectors([]), stubAgentCustomConnectors([]));
   });
 
@@ -182,6 +184,245 @@ describe("okou connector search command", () => {
     mockConsoleError.mockClear();
     vi.unstubAllEnvs();
     rmSync(directory, { recursive: true, force: true });
+  });
+
+  describe("JSON output", () => {
+    it("identifies all three connector types and separates current connection from Agent grants", async () => {
+      const custom = customConnector({ connectedAccountId: RUN_CONNECTION_ID });
+      const mcp = customMcpConnector();
+      server.use(
+        stubConnectorCatalogStatus([
+          catalogStatusItem({ connectorSlug: "acme", label: "Acme Builtin" }),
+        ]),
+        stubCustomConnectors([custom, mcp]),
+        stubAgent(AGENT_UUID, "Agent"),
+        stubUserConnectors(AGENT_UUID, ["acme"]),
+        stubAgentCustomConnectors([
+          { customConnectorId: custom.id, permissionNames: [] },
+        ]),
+      );
+      chalk.level = 3;
+      await searchCommand.parseAsync([
+        "node",
+        "cli",
+        " Acme ",
+        "--agent",
+        AGENT_UUID,
+        "--json",
+      ]);
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      const json: unknown = JSON.parse(output);
+      expect(json).toMatchObject({
+        context: "current",
+        query: { keyword: "Acme", limit: null },
+        agent: { agentId: AGENT_UUID },
+        total: 3,
+        exactMatch: true,
+        connectors: expect.arrayContaining([
+          expect.objectContaining({
+            connectorType: "builtin",
+            kind: "builtin",
+            target: { kind: "builtin", connectorSlug: "acme" },
+            connected: false,
+            authorized: true,
+          }),
+          expect.objectContaining({
+            connectorType: "custom-http",
+            kind: "custom",
+            id: custom.id,
+            connectionId: RUN_CONNECTION_ID,
+            authorized: true,
+          }),
+          expect.objectContaining({
+            connectorType: "custom-mcp",
+            target: { kind: "custom", customConnectorId: mcp.id },
+            authorized: false,
+          }),
+        ]),
+      });
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(output).not.toContain("\u001b[");
+    });
+
+    it("retains the total match count when results are limited", async () => {
+      server.use(
+        stubAvailableConnectors([
+          "google-ads",
+          "google-calendar",
+          "google-docs",
+        ]),
+      );
+      await searchCommand.parseAsync([
+        "node",
+        "cli",
+        "google",
+        "--limit",
+        "1",
+        "--json",
+      ]);
+      const json: unknown = JSON.parse(
+        mockConsoleLog.mock.calls.flat().join("\n"),
+      );
+      expect(json).toMatchObject({
+        total: 3,
+        query: { limit: 1 },
+        connectors: [expect.objectContaining({ slug: expect.any(String) })],
+      });
+    });
+
+    it("returns a parseable empty result without guidance prose", async () => {
+      server.use(stubConnectors([]));
+      await searchCommand.parseAsync([
+        "node",
+        "cli",
+        "not-a-real-service-xyz",
+        "--json",
+      ]);
+      const json: unknown = JSON.parse(
+        mockConsoleLog.mock.calls.flat().join("\n"),
+      );
+      expect(json).toMatchObject({
+        context: "current",
+        total: 0,
+        exactMatch: false,
+        connectors: [],
+        actions: [],
+      });
+    });
+
+    it("reports the exact reconnect-required run account independently of current grants", async () => {
+      const target = { kind: "builtin", connectorSlug: "github" } as const;
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
+      writeRunConnectorAccountContext(contextPath, [
+        { ...target, connectionId: RUN_CONNECTION_ID },
+      ]);
+      server.use(
+        stubConnectorCatalog([catalogItem({ connectorSlug: "github" })]),
+        stubConnectors([connectedGithub]),
+        stubAgent(AGENT_UUID, "Agent"),
+        stubUserConnectors(AGENT_UUID, []),
+        stubRunConnectorAccountInspection([
+          {
+            kind: "available",
+            target,
+            connectionId: RUN_CONNECTION_ID,
+            authMethod: "oauth",
+            displayName: "Selected account",
+            externalId: "selected",
+            externalUsername: null,
+            externalEmail: null,
+            connectionStatus: "reconnect-required",
+            reconnectReason: "authorization_expired_or_revoked",
+          },
+        ]),
+      );
+      await searchCommand.parseAsync(["node", "cli", "github", "--json"]);
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      const json: unknown = JSON.parse(output);
+      expect(json).toMatchObject({
+        context: "run",
+        connectors: [
+          {
+            connectorType: "builtin",
+            target,
+            account: {
+              state: "available",
+              connectionId: RUN_CONNECTION_ID,
+              metadata: { connectionStatus: "reconnect-required" },
+            },
+            availableForRun: false,
+            authorized: false,
+          },
+        ],
+        actions: [
+          {
+            url: expect.stringContaining(
+              `/connectors/github/reconnect/${RUN_CONNECTION_ID}`,
+            ),
+          },
+        ],
+      });
+      expect(output).not.toContain("octocat");
+    });
+
+    it.each([
+      "not-admitted",
+      "context-unavailable",
+      "metadata-unavailable",
+    ] as const)("preserves the %s run state in JSON", async (state) => {
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
+      if (state === "not-admitted") {
+        writeRunConnectorAccountContext(contextPath, []);
+      } else if (state === "context-unavailable") {
+        vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", "");
+      } else {
+        writeRunConnectorAccountContext(contextPath, [
+          {
+            kind: "builtin",
+            connectorSlug: "github",
+            connectionId: RUN_CONNECTION_ID,
+          },
+        ]);
+      }
+      server.use(
+        stubConnectorCatalog([catalogItem({ connectorSlug: "github" })]),
+        stubAgent(AGENT_UUID, "Agent"),
+        stubUserConnectors(AGENT_UUID, ["github"]),
+        stubRunConnectorAccountInspection([]),
+      );
+      await searchCommand.parseAsync(["node", "cli", "github", "--json"]);
+      const json: unknown = JSON.parse(
+        mockConsoleLog.mock.calls.flat().join("\n"),
+      );
+      expect(json).toMatchObject({
+        context: "run",
+        connectors: [
+          {
+            account: { state },
+            availableForRun: state === "context-unavailable" ? null : false,
+            authorized: true,
+          },
+        ],
+      });
+      if (state === "metadata-unavailable") {
+        expect(json).toMatchObject({
+          connectors: [{ account: { connectionId: RUN_CONNECTION_ID } }],
+        });
+      }
+    });
+
+    it("preserves the callback URL and task inside the JSON action", async () => {
+      vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
+      vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_UUID);
+      writeRunConnectorAccountContext(contextPath, []);
+      server.use(
+        stubConnectorCatalog([catalogItem({ connectorSlug: "github" })]),
+        stubAgent(AGENT_UUID, "Agent"),
+        stubUserConnectors(AGENT_UUID, []),
+      );
+      await searchCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--limit",
+        "1",
+        "--callback-prompt",
+        "Continue issue review",
+        "--json",
+      ]);
+      const json: unknown = JSON.parse(
+        mockConsoleLog.mock.calls.flat().join("\n"),
+      );
+      expect(json).toMatchObject({
+        actions: [
+          { supportsCallback: true, url: expect.stringContaining(THREAD_UUID) },
+        ],
+      });
+      expect(json).toMatchObject({
+        actions: [{ url: expect.stringContaining("Continue") }],
+      });
+      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("keyword validation", () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
@@ -215,6 +215,8 @@ describe("okou connector status command", () => {
           connector: expect.objectContaining({
             slug: "github",
             connectionStatus: "connected",
+            connectorType: "builtin",
+            target: { kind: "builtin", connectorSlug: "github" },
           }),
           authorization: null,
         }),

--- a/turbo/apps/cli/src/commands/connector/check-diagnostic.ts
+++ b/turbo/apps/cli/src/commands/connector/check-diagnostic.ts
@@ -8,6 +8,7 @@ import { isComputerUsePermissionTarget } from "./computer-use-guidance";
 import { customConnectorIdFromSelector } from "./custom-connector-guidance";
 
 export interface CheckConnectorOptions {
+  readonly json?: boolean;
   readonly connector?: string;
   readonly envName?: string;
   readonly url?: string;
@@ -38,7 +39,7 @@ export type UrlDiagnosticRequest = Extract<
   { readonly mode: "url" }
 >;
 
-export function stripUrlQueryAndFragment(url: string): string {
+function stripUrlQueryAndFragment(url: string): string {
   const queryIndex = url.indexOf("?");
   const fragmentIndex = url.indexOf("#");
   let end = url.length;
@@ -62,7 +63,7 @@ function rawUrlAuthorityHasUserinfo(url: string): boolean {
   return url.slice(authorityStart, authorityEnd).includes("@");
 }
 
-export function shellQuoteArg(value: string): string {
+function shellQuoteArg(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
@@ -326,29 +327,40 @@ export function resolveConnectorCheckDiagnostic(
   request: ConnectorCheckRequestBody,
   result: ConnectorCheckTargetAwareDiagnosticResult,
 ): ResolvedDiagnostic {
+  if (result.outcome === "resolved") {
+    return result;
+  }
+  throw connectorCheckDiagnosticError(request, result);
+}
+
+export function connectorCheckDiagnosticError(
+  request: ConnectorCheckRequestBody,
+  result: Exclude<
+    ConnectorCheckTargetAwareDiagnosticResult,
+    ResolvedDiagnostic
+  >,
+): Error {
   switch (result.outcome) {
-    case "resolved":
-      return result;
     case "unsafe-input":
-      throw unsafeInputError(result.reason);
+      return unsafeInputError(result.reason);
     case "unknown-connector":
-      throw unknownConnectorError(request);
+      return unknownConnectorError(request);
     case "unknown-environment":
-      throw new Error(
+      return new Error(
         `Unknown environment name: ${requestedEnvironmentName(request)} — not managed by any connector`,
       );
     case "no-match":
-      throw noMatchError(result);
+      return noMatchError(result);
     case "ambiguous":
-      throw ambiguousConnectorError(requireUrlRequest(request), result);
+      return ambiguousConnectorError(requireUrlRequest(request), result);
     case "connector-mismatch":
-      throw connectorMismatchError(requireUrlRequest(request), result);
+      return connectorMismatchError(requireUrlRequest(request), result);
     case "environment-not-owned":
-      throw environmentNotOwnedError(request, result);
+      return environmentNotOwnedError(request, result);
     case "environment-not-used":
-      throw environmentNotUsedError(request, result);
+      return environmentNotUsedError(request, result);
     case "unresolved-dynamic-base":
-      throw new Error(
+      return new Error(
         `No authoritative ${result.connector.label} base URL is available for this diagnostic. Verify the ${connectorSelector(result.connector.target)} connector configuration for the affected context and retry.`,
       );
     case "target-unavailable": {
@@ -362,15 +374,54 @@ export function resolveConnectorCheckDiagnostic(
         "runtime-configuration-unavailable":
           "has unavailable runtime configuration. Review its required fields and the account selected for this run",
       };
-      throw new Error(
+      return new Error(
         `Connector ${connectorSelector(result.target)} ${reasons[result.reason]}.`,
       );
     }
     case "run-context-unavailable":
-      throw new Error(
+      return new Error(
         "The current run context is unavailable for connector diagnosis. Retry from an active run or start a new run.",
       );
   }
+}
+
+export function connectorPermissionRequestCommand(
+  connectorSlug: string,
+  permission: string,
+  request: UrlDiagnosticRequest,
+): string {
+  return `okou connector permission-request ${shellQuoteArg(connectorSlug)} --permission ${shellQuoteArg(permission)} --url ${shellQuoteArg(request.url)} --method ${shellQuoteArg(request.method)}`;
+}
+
+export function connectorCheckRetryCommand(
+  request: ConnectorCheckRequestBody,
+): string {
+  const args: string[] = [];
+  if (request.mode === "url") {
+    args.push(`--url ${shellQuoteArg(request.url)}`);
+    if ("target" in request && request.target) {
+      args.push(
+        `--connector ${shellQuoteArg(connectorSelector(request.target))}`,
+      );
+    } else if (
+      "connectorSlug" in request &&
+      request.connectorSlug !== undefined
+    ) {
+      args.push(`--connector ${shellQuoteArg(request.connectorSlug)}`);
+    }
+    if (request.environmentName !== undefined) {
+      args.push(`--env-name ${shellQuoteArg(request.environmentName)}`);
+    }
+    if (request.method !== "GET") {
+      args.push(`--method ${shellQuoteArg(request.method)}`);
+    }
+  } else {
+    args.push(`--env-name ${shellQuoteArg(request.environmentName)}`);
+    if (request.permission !== undefined) {
+      args.push(`--check-permission ${shellQuoteArg(request.permission)}`);
+    }
+  }
+  return `okou connector check ${args.join(" ")}`;
 }
 
 export function printDiagnosticSummary(

--- a/turbo/apps/cli/src/commands/connector/check-json.ts
+++ b/turbo/apps/cli/src/commands/connector/check-json.ts
@@ -1,0 +1,333 @@
+import type {
+  ConnectorCheckRequestBody,
+  ConnectorCheckTargetAwareDiagnosticResult,
+} from "@okouai/api-contracts/contracts/connector-check";
+import type { ConnectorAccountTarget } from "@okouai/api-contracts/contracts/connector-accounts";
+
+import {
+  getAgentCustomConnectorGrants,
+  getAgentUserConnectors,
+} from "../../lib/api/domains/agents";
+import {
+  getConnector,
+  getCustomConnector,
+} from "../../lib/api/domains/connectors";
+import { getOkouAgentId } from "../../lib/okou-env";
+import { getPlatformOrigin } from "../doctor/platform-url";
+import {
+  CALLBACK_PROMPT_PLACEHOLDER,
+  currentChatSupportsActionCallback,
+} from "./action-url";
+import {
+  connectorCheckDiagnosticError,
+  connectorCheckRetryCommand,
+  connectorPermissionRequestCommand,
+  diagnosticEnvironmentNames,
+  requireUrlRequest,
+  type ResolvedDiagnostic,
+} from "./check-diagnostic";
+import { customConnectorSettingsGuidance } from "./custom-connector-guidance";
+import { connectorInspectionType } from "./inspection";
+import {
+  isRunBoundConnectorContext,
+  resolveRunConnectorAccountLookups,
+} from "./run-account-context";
+import {
+  connectorSearchActionLinks,
+  runConnectorSearchAction,
+  type ConnectorSearchAction,
+} from "./search-guidance";
+
+type CheckAction =
+  | {
+      readonly kind: "command";
+      readonly command: string;
+      readonly callbackCommand?: string;
+    }
+  | {
+      readonly kind: "link";
+      readonly label: string;
+      readonly url: string;
+      readonly guidance?: string;
+    }
+  | { readonly kind: "guidance"; readonly message: string };
+
+function permissionActions(
+  request: ConnectorCheckRequestBody,
+  diagnostic: ResolvedDiagnostic,
+  origin: string,
+  agentId: string | undefined,
+): CheckAction[] {
+  const permissions =
+    diagnostic.mode === "url"
+      ? diagnostic.permission.kind === "matched"
+        ? diagnostic.permission.permissions
+        : [{ name: "__unknown__", policy: diagnostic.permission.policy }]
+      : diagnostic.permission === null
+        ? []
+        : [
+            {
+              name: environmentPermissionName(request),
+              policy: diagnostic.permission,
+            },
+          ];
+  const target = diagnostic.connector.target;
+  return permissions.flatMap((permission): CheckAction[] => {
+    if (
+      permission.policy.outcome !== "deny" &&
+      permission.policy.outcome !== "ask"
+    ) {
+      return [];
+    }
+    if (target.kind === "custom") {
+      return [
+        {
+          kind: "link",
+          label: `Review ${permission.name} for custom connector ${target.customConnectorId}`,
+          url: new URL("/connectors", origin).toString(),
+          guidance: customConnectorSettingsGuidance(
+            target.customConnectorId,
+            origin,
+            permission.name,
+          ),
+        },
+      ];
+    }
+    if (request.mode !== "url") {
+      return [
+        {
+          kind: "guidance",
+          message:
+            "Diagnose the failed request with okou connector check --url <FAILED_URL> --method <METHOD> before requesting this permission.",
+        },
+      ];
+    }
+    const command = connectorPermissionRequestCommand(
+      target.connectorSlug,
+      permission.name,
+      request,
+    );
+    return [
+      {
+        kind: "command",
+        command,
+        ...(currentChatSupportsActionCallback(agentId)
+          ? {
+              callbackCommand: `${command} --callback-prompt "${CALLBACK_PROMPT_PLACEHOLDER}"`,
+            }
+          : {}),
+      },
+    ];
+  });
+}
+
+function environmentPermissionName(request: ConnectorCheckRequestBody): string {
+  if (request.mode !== "environment" || request.permission === undefined) {
+    throw new Error(
+      "Connector diagnostic returned a permission outcome without a requested permission.",
+    );
+  }
+  return request.permission;
+}
+
+async function loadCheckEvidence(
+  target: ConnectorAccountTarget,
+  runBound: boolean,
+  agentId: string | undefined,
+) {
+  const [definition, currentConnection, accounts, authorized, origin] =
+    await Promise.all([
+      target.kind === "custom"
+        ? getCustomConnector(target.customConnectorId)
+        : null,
+      !runBound && target.kind === "builtin"
+        ? getConnector(target.connectorSlug)
+        : null,
+      runBound ? resolveRunConnectorAccountLookups([target]) : null,
+      agentId === undefined
+        ? null
+        : target.kind === "builtin"
+          ? getAgentUserConnectors(agentId).then((slugs) => {
+              return slugs.includes(target.connectorSlug);
+            })
+          : getAgentCustomConnectorGrants(agentId).then((grants) => {
+              return grants.some((grant) => {
+                return grant.customConnectorId === target.customConnectorId;
+              });
+            }),
+      getPlatformOrigin(),
+    ]);
+  const account = accounts === null ? null : accounts[0];
+  if (account === undefined) {
+    throw new Error("Missing run account lookup for connector");
+  }
+  return { definition, currentConnection, account, authorized, origin };
+}
+
+function checkConnectionActions(
+  target: ConnectorAccountTarget,
+  label: string,
+  evidence: Awaited<ReturnType<typeof loadCheckEvidence>>,
+): ConnectorSearchAction[] {
+  const { definition, currentConnection, account, authorized } = evidence;
+  const connectionActions: ConnectorSearchAction[] = [];
+  if (account !== null) {
+    const action = runConnectorSearchAction(
+      {
+        kind: target.kind === "builtin" ? "catalog" : "custom",
+        slug:
+          target.kind === "builtin"
+            ? target.connectorSlug
+            : `custom:${target.customConnectorId}`,
+        label,
+      },
+      account,
+    );
+    if (action !== null) {
+      connectionActions.push(action);
+    }
+  } else if (target.kind === "builtin") {
+    if (
+      currentConnection === null ||
+      currentConnection.connectionStatus === "reconnect-required"
+    ) {
+      connectionActions.push({
+        label: `Connect or reconnect ${label}`,
+        path: `/connectors/${target.connectorSlug}/connect`,
+        supportsCallback: true,
+      });
+    }
+  } else if (definition === null || !definition.connected) {
+    connectionActions.push({
+      label: `Review ${label} accounts and agent access`,
+      path: "/connectors",
+      supportsCallback: false,
+    });
+  }
+  if (authorized === false) {
+    connectionActions.push(
+      target.kind === "builtin"
+        ? {
+            label: `Authorize ${label}`,
+            path: `/connectors/${target.connectorSlug}/authorize`,
+            supportsCallback: true,
+          }
+        : {
+            label: `Review ${label} agent access`,
+            path: "/connectors",
+            supportsCallback: false,
+          },
+    );
+  }
+  return connectionActions;
+}
+
+export async function printConnectorCheckJson(
+  request: ConnectorCheckRequestBody,
+  diagnostic: ConnectorCheckTargetAwareDiagnosticResult,
+): Promise<void> {
+  const runBound = isRunBoundConnectorContext();
+  const context = runBound ? "run" : "current";
+  const agentId = getOkouAgentId();
+  const retry: CheckAction = {
+    kind: "command",
+    command: `${connectorCheckRetryCommand(request)} --json`,
+  };
+  if (diagnostic.outcome !== "resolved") {
+    console.log(
+      JSON.stringify(
+        {
+          context,
+          request,
+          diagnostic,
+          message: connectorCheckDiagnosticError(request, diagnostic).message,
+          actions: [retry],
+        },
+        null,
+        2,
+      ),
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (diagnostic.mode === "url") {
+    requireUrlRequest(request);
+  }
+  const target = diagnostic.connector.target;
+  const evidence = await loadCheckEvidence(target, runBound, agentId);
+  const { definition, currentConnection, account, authorized, origin } =
+    evidence;
+  const label =
+    target.kind === "builtin"
+      ? diagnostic.connector.label
+      : (definition?.displayName ?? target.customConnectorId);
+  const connectionActions = checkConnectionActions(target, label, evidence);
+  const actions: CheckAction[] = [
+    ...connectorSearchActionLinks({
+      actions: connectionActions,
+      origin,
+      agentId,
+      callbackPrompt: undefined,
+    }).map((link): CheckAction => {
+      return { kind: "link", ...link };
+    }),
+    ...permissionActions(request, diagnostic, origin, agentId),
+  ];
+  if (diagnostic.run.status === "not-configured") {
+    actions.push({
+      kind: "guidance",
+      message:
+        "Review the connector's agent access and selected account, then start a new run.",
+    });
+  }
+  actions.push(retry);
+  const environmentNames = diagnosticEnvironmentNames(diagnostic);
+  console.log(
+    JSON.stringify(
+      {
+        context,
+        request,
+        diagnostic,
+        connector: {
+          ...diagnostic.connector,
+          label,
+          connectorType: connectorInspectionType(target, definition),
+          definitionAvailable:
+            target.kind === "custom"
+              ? definition !== null
+              : diagnostic.connector.visibility === "available",
+        },
+        environment:
+          environmentNames === null
+            ? null
+            : environmentNames.map((name) => {
+                return { name, present: Boolean(process.env[name]) };
+              }),
+        account,
+        connection: runBound
+          ? null
+          : target.kind === "builtin"
+            ? currentConnection
+            : definition === null
+              ? null
+              : {
+                  connected: definition.connected,
+                  connectionId: definition.connectedAccountId ?? null,
+                  missingRequiredFields: definition.missingRequiredFields,
+                },
+        authorization: agentId === undefined ? null : { agentId, authorized },
+        guidance: [
+          "Routing and permission diagnostics describe current intended state; they do not confirm that the runner has applied the latest update.",
+          ...(runBound
+            ? [
+                "Connector changes apply to future runs. Reconnect or change the thread selection, then start a new run.",
+              ]
+            : []),
+        ],
+        actions,
+      },
+      null,
+      2,
+    ),
+  );
+}

--- a/turbo/apps/cli/src/commands/connector/check.ts
+++ b/turbo/apps/cli/src/commands/connector/check.ts
@@ -5,13 +5,13 @@ import type { ConnectorCheckPolicy } from "@okouai/api-contracts/contracts/conne
 
 import {
   buildDiagnosticRequest,
+  connectorCheckRetryCommand,
+  connectorPermissionRequestCommand,
   diagnosticEnvironmentNames,
   isComputerUseCheckTarget,
   printDiagnosticSummary,
   requireUrlRequest,
   resolveConnectorCheckDiagnostic,
-  shellQuoteArg,
-  stripUrlQueryAndFragment,
   validateCheckConnectorOptions,
   type CheckConnectorOptions,
   type ResolvedDiagnostic,
@@ -26,6 +26,7 @@ import {
   printCustomConnectorCheckStatus,
 } from "./check-custom";
 import { customConnectorSettingsGuidance } from "./custom-connector-guidance";
+import { printConnectorCheckJson } from "./check-json";
 import {
   diagnoseConnectorCheck,
   getConnector,
@@ -34,7 +35,10 @@ import { getAgentUserConnectors } from "../../lib/api/domains/agents";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { getOkouAgentId } from "../../lib/okou-env";
 import { toPlatformUrl } from "../doctor/platform-url";
-import { printComputerUsePermissionGuidance } from "./computer-use-guidance";
+import {
+  computerUsePermissionGuidance,
+  printComputerUsePermissionGuidance,
+} from "./computer-use-guidance";
 import {
   CALLBACK_PROMPT_PLACEHOLDER,
   connectorActionUrl,
@@ -433,14 +437,6 @@ function printNamedPolicyResult(
   }
 }
 
-function permissionRequestCommand(
-  connectorSlug: string,
-  permission: string,
-  request: UrlDiagnosticRequest,
-): string {
-  return `okou connector permission-request ${shellQuoteArg(connectorSlug)} --permission ${shellQuoteArg(permission)} --url ${shellQuoteArg(request.url)} --method ${shellQuoteArg(request.method)}`;
-}
-
 function printPermissionRequestCommands(
   target: ConnectorRuntimeTarget,
   permission: string,
@@ -465,7 +461,7 @@ function printPermissionRequestCommands(
     );
     return;
   }
-  const command = permissionRequestCommand(
+  const command = connectorPermissionRequestCommand(
     target.connectorSlug,
     permission,
     request,
@@ -608,38 +604,12 @@ function printEnvironmentPermissionDiagnostic(
   console.log("");
 }
 
-function printRediagnoseHint(
-  opts: CheckConnectorOptions,
-  method: string,
-): void {
-  const args: string[] = [];
-  if (opts.url !== undefined) {
-    args.push(`--url ${shellQuoteArg(stripUrlQueryAndFragment(opts.url))}`);
-    if (opts.connector !== undefined) {
-      args.push(`--connector ${shellQuoteArg(opts.connector)}`);
-    }
-    if (opts.envName !== undefined) {
-      args.push(`--env-name ${shellQuoteArg(opts.envName)}`);
-    }
-    if (method !== "GET") {
-      args.push(`--method ${shellQuoteArg(method)}`);
-    }
-  } else if (opts.envName !== undefined) {
-    args.push(`--env-name ${shellQuoteArg(opts.envName)}`);
-  }
-  if (opts.checkPermission !== undefined) {
-    args.push(`--check-permission ${shellQuoteArg(opts.checkPermission)}`);
-  }
-  console.log(
-    `To re-diagnose after changes, run: okou connector check ${args.join(" ")}`,
-  );
-}
-
 export const checkConnectorCommand = new Command()
   .name("check")
   .description(
     "Diagnose connector health: environment names, connector configuration, and permission policies",
   )
+  .option("--json", "Output connector diagnostics and next actions as JSON")
   .addOption(
     new Option(
       "--env-name <ENV_NAME>",
@@ -693,12 +663,34 @@ How connectors work:
     withErrorHandler(async (opts: CheckConnectorOptions, command: Command) => {
       validateCheckConnectorOptions(opts, command);
       if (isComputerUseCheckTarget(opts)) {
-        printComputerUsePermissionGuidance();
+        if (opts.json) {
+          console.log(
+            JSON.stringify(
+              {
+                context: isRunBoundConnectorContext() ? "run" : "current",
+                diagnostic: {
+                  outcome: "not-a-connector",
+                  capability: "computer-use:write",
+                },
+                guidance: computerUsePermissionGuidance,
+                actions: [{ kind: "command", command: "okou whoami" }],
+              },
+              null,
+              2,
+            ),
+          );
+        } else {
+          printComputerUsePermissionGuidance();
+        }
         return;
       }
       const method = opts.method.toUpperCase();
       const request = buildDiagnosticRequest(opts, method);
       const diagnostic = await diagnoseConnectorCheck(request);
+      if (opts.json) {
+        await printConnectorCheckJson(request, diagnostic);
+        return;
+      }
       const resolved = resolveConnectorCheckDiagnostic(request, diagnostic);
       const target = resolved.connector.target;
       const custom =
@@ -771,6 +763,8 @@ How connectors work:
         );
       }
 
-      printRediagnoseHint(opts, method);
+      console.log(
+        `To re-diagnose after changes, run: ${connectorCheckRetryCommand(request)}`,
+      );
     }),
   );

--- a/turbo/apps/cli/src/commands/connector/computer-use-guidance.ts
+++ b/turbo/apps/cli/src/commands/connector/computer-use-guidance.ts
@@ -20,15 +20,15 @@ export function isComputerUsePermissionTarget(
   );
 }
 
+export const computerUsePermissionGuidance = [
+  "Computer Use access is not managed as a connector permission.",
+  "The current run token needs computer-use:write, which is issued only when an Okou Desktop Computer Use host is selected for the chat or thread before the run starts.",
+  "Open Okou Desktop, make sure Computer Use is online, select the Computer Use host for this chat/thread, then start a new run. Existing run tokens cannot be upgraded in place.",
+  "Run `okou whoami` to confirm whether the current OKOU_TOKEN includes computer-use:write.",
+] as const;
+
 export function printComputerUsePermissionGuidance(): void {
-  console.log("Computer Use access is not managed as a connector permission.");
-  console.log(
-    "The current run token needs computer-use:write, which is issued only when an Okou Desktop Computer Use host is selected for the chat or thread before the run starts.",
-  );
-  console.log(
-    "Open Okou Desktop, make sure Computer Use is online, select the Computer Use host for this chat/thread, then start a new run. Existing run tokens cannot be upgraded in place.",
-  );
-  console.log(
-    "Run `okou whoami` to confirm whether the current OKOU_TOKEN includes computer-use:write.",
-  );
+  for (const line of computerUsePermissionGuidance) {
+    console.log(line);
+  }
 }

--- a/turbo/apps/cli/src/commands/connector/custom/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/__tests__/index.test.ts
@@ -6,6 +6,7 @@ import type { CustomConnectorMcpResponse } from "@okouai/api-contracts/contracts
 import { server } from "../../../../mocks/server";
 import {
   customConnector,
+  customMcpConnector,
   stubAgentCustomConnectors,
   stubCustomConnectors,
 } from "../../../__tests__/helpers/custom-connectors";
@@ -23,12 +24,135 @@ describe("okou connector custom readers", () => {
     vi.stubEnv("OKOU_TOKEN", "test-token");
     for (const command of customConnectorCommand.commands) {
       command.setOptionValue("agent", undefined);
+      command.setOptionValue("json", false);
     }
   });
 
   afterEach(() => {
     consoleLog.mockClear();
     vi.unstubAllEnvs();
+    process.exitCode = undefined;
+  });
+
+  it("emits current org JSON with protocol and grants even from inside a run", async () => {
+    const connector = customConnector({
+      connectedAccountId: "55555555-5555-4555-8555-555555555555",
+    });
+    const mcp = customMcpConnector();
+    vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
+    server.use(
+      stubCustomConnectors([connector, mcp]),
+      http.get(`http://localhost:3000/api/agents/${AGENT_ID}`, () => {
+        return HttpResponse.json({
+          agentId: AGENT_ID,
+          ownerId: "owner-1",
+          description: null,
+          displayName: "Maya",
+          sound: null,
+          avatarUrl: null,
+        });
+      }),
+      stubAgentCustomConnectors([
+        { customConnectorId: connector.id, permissionNames: [] },
+      ]),
+    );
+    chalk.level = 3;
+    await customConnectorCommand.parseAsync(["node", "okou", "list", "--json"]);
+    const output = consoleLog.mock.calls.flat().join("\n");
+    const json: unknown = JSON.parse(output);
+    expect(json).toMatchObject({
+      context: "current",
+      agent: { agentId: AGENT_ID },
+      connectors: [
+        {
+          kind: "http",
+          connectorType: "custom-http",
+          target: { kind: "custom", customConnectorId: connector.id },
+          connectionId: connector.connectedAccountId,
+          connected: false,
+          authorized: true,
+        },
+        {
+          kind: "mcp",
+          connectorType: "custom-mcp",
+          target: { kind: "custom", customConnectorId: mcp.id },
+          authorized: false,
+        },
+      ],
+    });
+    expect(consoleLog).toHaveBeenCalledTimes(1);
+    expect(output).not.toContain("\u001b[");
+  });
+
+  it("returns an empty org inventory as JSON", async () => {
+    server.use(stubCustomConnectors([]));
+    await customConnectorCommand.parseAsync(["node", "okou", "list", "--json"]);
+    const json: unknown = JSON.parse(consoleLog.mock.calls.flat().join("\n"));
+    expect(json).toMatchObject({
+      context: "current",
+      agent: null,
+      connectors: [],
+    });
+  });
+
+  it.each([customConnector(), customMcpConnector()])(
+    "exposes $kind definition details through status JSON",
+    async (connector) => {
+      server.use(
+        http.get(
+          `http://localhost:3000/api/custom-connectors/${connector.id}`,
+          () => {
+            return HttpResponse.json(connector);
+          },
+        ),
+      );
+      await customConnectorCommand.parseAsync([
+        "node",
+        "okou",
+        "status",
+        connector.id,
+        "--json",
+      ]);
+      const json: unknown = JSON.parse(consoleLog.mock.calls.flat().join("\n"));
+      expect(json).toMatchObject({
+        context: "current",
+        state: "available",
+        connector: {
+          ...connector,
+          connectorType: `custom-${connector.kind}`,
+          authorized: null,
+        },
+      });
+    },
+  );
+
+  it("preserves an unavailable definition's target and nonzero exit in JSON", async () => {
+    server.use(
+      http.get(
+        `http://localhost:3000/api/custom-connectors/${CONNECTOR_ID}`,
+        () => {
+          return HttpResponse.json(
+            { error: { code: "NOT_FOUND", message: "Not found" } },
+            { status: 404 },
+          );
+        },
+      ),
+    );
+    await customConnectorCommand.parseAsync([
+      "node",
+      "okou",
+      "status",
+      CONNECTOR_ID,
+      "--json",
+    ]);
+    const json: unknown = JSON.parse(consoleLog.mock.calls.flat().join("\n"));
+    expect(json).toMatchObject({
+      context: "current",
+      target: { kind: "custom", customConnectorId: CONNECTOR_ID },
+      state: "unavailable",
+      connector: null,
+    });
+    expect(process.exitCode).toBe(1);
   });
 
   it("renders tagged HTTP connectors in list output", async () => {

--- a/turbo/apps/cli/src/commands/connector/custom/index.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/index.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import type { CustomConnectorResponse } from "@okouai/api-contracts/contracts/custom-connectors";
 import {
   getAgent,
   getAgentCustomConnectorGrants,
@@ -12,8 +13,23 @@ import { withErrorHandler } from "../../../lib/command/with-error-handler";
 import { resolveConnectorAgentId } from "../agent-context";
 import { createCustomConnectorCommand } from "./create";
 import { updateCustomConnectorCommand } from "./update";
+import { connectorInspectionType } from "../inspection";
 
 const LABEL_WIDTH = 18;
+
+function customConnectorJson(
+  connector: CustomConnectorResponse,
+  agent: Awaited<ReturnType<typeof resolveCustomAgentContext>>,
+) {
+  const target = { kind: "custom", customConnectorId: connector.id } as const;
+  return {
+    ...connector,
+    target,
+    connectorType: connectorInspectionType(target, connector),
+    connectionId: connector.connectedAccountId ?? null,
+    authorized: agent ? agent.authorizedIds.has(connector.id) : null,
+  };
+}
 
 function renderConnected(connector: {
   readonly connected: boolean;
@@ -59,13 +75,35 @@ const listCommand = new Command()
     "--agent <id>",
     "Show per-agent authorization column (must match the current Agent inside a run)",
   )
+  .option("--json", "Output current org custom connectors as JSON")
   .action(
-    withErrorHandler(async (options: { agent?: string }) => {
+    withErrorHandler(async (options: { agent?: string; json?: boolean }) => {
       const agentId = resolveConnectorAgentId(options.agent);
       const [connectors, agentCtx] = await Promise.all([
         listCustomConnectors(),
         resolveCustomAgentContext(agentId),
       ]);
+      if (options.json) {
+        console.log(
+          JSON.stringify(
+            {
+              context: "current",
+              agent: agentCtx
+                ? {
+                    agentId: agentCtx.agentId,
+                    displayName: agentCtx.displayName,
+                  }
+                : null,
+              connectors: connectors.map((connector) => {
+                return customConnectorJson(connector, agentCtx);
+              }),
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
       const idWidth = Math.max(
         2,
         ...connectors.map((connector) => {
@@ -115,14 +153,45 @@ const statusCommand = new Command()
     "--agent <id>",
     "Show authorization state for the given Agent (must match the current Agent inside a run)",
   )
+  .option("--json", "Output current org custom connector status as JSON")
   .action(
     withErrorHandler(
-      async (connectorId: string, options: { agent?: string }) => {
+      async (
+        connectorId: string,
+        options: { agent?: string; json?: boolean },
+      ) => {
         const agentId = resolveConnectorAgentId(options.agent);
         const [connector, agentCtx] = await Promise.all([
           getCustomConnector(connectorId),
           resolveCustomAgentContext(agentId),
         ]);
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              {
+                context: "current",
+                target: { kind: "custom", customConnectorId: connectorId },
+                state: connector === null ? "unavailable" : "available",
+                agent: agentCtx
+                  ? {
+                      agentId: agentCtx.agentId,
+                      displayName: agentCtx.displayName,
+                    }
+                  : null,
+                connector:
+                  connector === null
+                    ? null
+                    : customConnectorJson(connector, agentCtx),
+              },
+              null,
+              2,
+            ),
+          );
+          if (connector === null) {
+            process.exitCode = 1;
+          }
+          return;
+        }
         if (!connector) {
           throw new Error(`Custom connector not found: ${connectorId}`);
         }

--- a/turbo/apps/cli/src/commands/connector/discovery.ts
+++ b/turbo/apps/cli/src/commands/connector/discovery.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../lib/api/domains/connectors";
 import type { ConnectorDiscoveryAgentContext } from "./agent-context";
 import { renderConnectedAsCell } from "./connected-as";
+import { connectorInspectionType } from "./inspection";
 
 interface CatalogConnectorDiscoveryDefinition {
   readonly kind: "catalog";
@@ -122,6 +123,41 @@ export function renderConnectorDiscoveryConnectedAsCell(
   return chalk.yellow(
     `missing ${connector.customConnector.missingRequiredFields.join(", ")}`,
   );
+}
+
+export function connectorDiscoveryJson(
+  connector: ConnectorDiscoveryItem,
+  agentContext: ConnectorDiscoveryAgentContext | null,
+) {
+  const target = connectorDiscoveryTarget(connector);
+  const identity = {
+    target,
+    connectorType: connectorInspectionType(
+      target,
+      connector.kind === "custom" ? connector.customConnector : null,
+    ),
+    slug: connector.slug,
+    label: connector.label,
+    authorized: agentContext
+      ? isConnectorDiscoveryAuthorized(connector, agentContext)
+      : null,
+  };
+  return connector.kind === "catalog"
+    ? {
+        ...identity,
+        kind: "builtin" as const,
+        connected: connector.catalogConnector.connected,
+        connectionStatus: connector.catalogConnector.connectionStatus,
+        connection: connector.catalogConnector.connection,
+      }
+    : {
+        ...identity,
+        kind: "custom" as const,
+        id: connector.customConnector.id,
+        connected: connector.customConnector.connected,
+        connectionId: connector.customConnector.connectedAccountId ?? null,
+        missingRequiredFields: connector.customConnector.missingRequiredFields,
+      };
 }
 
 export function isConnectorDiscoveryAuthorized(

--- a/turbo/apps/cli/src/commands/connector/inspection.ts
+++ b/turbo/apps/cli/src/commands/connector/inspection.ts
@@ -1,0 +1,15 @@
+import type { ConnectorAccountTarget } from "@okouai/api-contracts/contracts/connector-accounts";
+import type { CustomConnectorResponse } from "@okouai/api-contracts/contracts/custom-connectors";
+
+export function connectorInspectionType(
+  target: ConnectorAccountTarget,
+  definition: Pick<CustomConnectorResponse, "kind"> | null,
+): "builtin" | "custom-http" | "custom-mcp" | null {
+  if (target.kind === "builtin") {
+    return "builtin";
+  }
+  if (definition === null) {
+    return null;
+  }
+  return definition.kind === "http" ? "custom-http" : "custom-mcp";
+}

--- a/turbo/apps/cli/src/commands/connector/list.ts
+++ b/turbo/apps/cli/src/commands/connector/list.ts
@@ -12,6 +12,7 @@ import {
 import { padEndAnsi, stripAnsi } from "./connected-as";
 import {
   connectorDiscoveryItems,
+  connectorDiscoveryJson,
   isConnectorDiscoveryAuthorized,
   renderConnectorDiscoveryConnectedAsCell,
 } from "./discovery";
@@ -91,31 +92,14 @@ export const listCommand = new Command()
           JSON.stringify(
             {
               context: "current",
+              agent: agentCtx
+                ? {
+                    agentId: agentCtx.agentId,
+                    displayName: agentCtx.displayName,
+                  }
+                : null,
               connectors: discoveredConnectors.map((connector) => {
-                return connector.kind === "catalog"
-                  ? {
-                      kind: "builtin",
-                      slug: connector.slug,
-                      label: connector.label,
-                      connectionStatus:
-                        connector.catalogConnector.connectionStatus,
-                      connection: connector.catalogConnector.connection,
-                      authorized: agentCtx
-                        ? isConnectorDiscoveryAuthorized(connector, agentCtx)
-                        : null,
-                    }
-                  : {
-                      kind: "custom",
-                      id: connector.customConnector.id,
-                      slug: connector.slug,
-                      label: connector.label,
-                      connected: connector.customConnector.connected,
-                      missingRequiredFields:
-                        connector.customConnector.missingRequiredFields,
-                      authorized: agentCtx
-                        ? isConnectorDiscoveryAuthorized(connector, agentCtx)
-                        : null,
-                    };
+                return connectorDiscoveryJson(connector, agentCtx);
               }),
             },
             null,

--- a/turbo/apps/cli/src/commands/connector/run-account-context.ts
+++ b/turbo/apps/cli/src/commands/connector/run-account-context.ts
@@ -21,6 +21,7 @@ import {
   getOkouConnectorAccountContextFile,
 } from "../../lib/okou-env";
 import { connectorAccountCliLabel } from "./account-label";
+import { connectorInspectionType } from "./inspection";
 
 export const RUN_CONNECTOR_ACCOUNT_CONTEXT_MAX_BYTES = 1024 * 1024;
 
@@ -90,6 +91,8 @@ export type RunConnectorAccountLookup =
 
 export interface RunConnectorAccountEntry {
   readonly target: ConnectorAccountTarget;
+  readonly connectorType: ReturnType<typeof connectorInspectionType>;
+  readonly definitionAvailable: boolean;
   readonly slug: string;
   readonly connectorLabel: string;
   readonly account: RunConnectorAccountState;
@@ -275,7 +278,12 @@ function connectorIdentity(
   target: ConnectorAccountTarget,
   catalog: readonly ConnectorCatalogItem[],
   customConnectors: readonly CustomConnectorResponse[],
-): { readonly slug: string; readonly label: string } {
+): {
+  readonly slug: string;
+  readonly label: string;
+  readonly connectorType: ReturnType<typeof connectorInspectionType>;
+  readonly definitionAvailable: boolean;
+} {
   if (target.kind === "builtin") {
     const definition = catalog.find((connector) => {
       return connector.slug === target.connectorSlug;
@@ -283,6 +291,8 @@ function connectorIdentity(
     return {
       slug: target.connectorSlug,
       label: definition?.label ?? target.connectorSlug,
+      connectorType: "builtin",
+      definitionAvailable: definition !== undefined,
     };
   }
   const definition = customConnectors.find((connector) => {
@@ -291,6 +301,8 @@ function connectorIdentity(
   return {
     slug: definition?.slug ?? `custom:${target.customConnectorId}`,
     label: definition?.displayName ?? target.customConnectorId,
+    connectorType: connectorInspectionType(target, definition ?? null),
+    definitionAvailable: definition !== undefined,
   };
 }
 
@@ -353,6 +365,8 @@ export async function resolveRunConnectorAccountView(): Promise<RunConnectorAcco
       const identity = connectorIdentity(target, catalog, customConnectors);
       return {
         target,
+        connectorType: identity.connectorType,
+        definitionAvailable: identity.definitionAvailable,
         slug: identity.slug,
         connectorLabel: identity.label,
         account: accountState(projected, metadata),

--- a/turbo/apps/cli/src/commands/connector/search-guidance.ts
+++ b/turbo/apps/cli/src/commands/connector/search-guidance.ts
@@ -18,7 +18,7 @@ export interface ConnectorSearchAction {
 }
 
 function accountSettingsAction(
-  connector: ConnectorDiscoveryDefinition,
+  connector: Pick<ConnectorDiscoveryDefinition, "kind" | "slug" | "label">,
 ): ConnectorSearchAction {
   return {
     label: `Review ${connector.label} accounts and agent access`,
@@ -28,7 +28,7 @@ function accountSettingsAction(
 }
 
 function connectAction(
-  connector: ConnectorDiscoveryDefinition,
+  connector: Pick<ConnectorDiscoveryDefinition, "kind" | "slug" | "label">,
 ): ConnectorSearchAction {
   return connector.kind === "custom"
     ? accountSettingsAction(connector)
@@ -40,7 +40,7 @@ function connectAction(
 }
 
 export function runConnectorSearchAction(
-  connector: ConnectorDiscoveryDefinition,
+  connector: Pick<ConnectorDiscoveryDefinition, "kind" | "slug" | "label">,
   lookup: RunConnectorAccountLookup,
 ): ConnectorSearchAction | null {
   switch (lookup.state) {
@@ -89,18 +89,13 @@ export function currentConnectorSearchAction(
       };
 }
 
-export function printConnectorSearchGuidance(args: {
+export function connectorSearchActionLinks(args: {
   readonly actions: readonly ConnectorSearchAction[];
   readonly origin: string;
   readonly agentId: string | undefined;
-  readonly runBound: boolean;
   readonly callbackPrompt: string | undefined;
-}): void {
-  if (args.actions.length === 0) {
-    return;
-  }
-
-  const links = args.actions.map((action) => {
+}) {
+  return args.actions.map((action) => {
     if (args.callbackPrompt !== undefined && !action.supportsCallback) {
       throw new Error(
         "This connector needs an account or access review in Connectors settings, which does not support --callback-prompt.",
@@ -111,8 +106,25 @@ export function printConnectorSearchGuidance(args: {
       path: action.path,
       agentId: args.agentId,
     });
-    return `[${action.label}](${finalizeActionUrl(new URL(url), args.callbackPrompt, args.agentId)})`;
+    return {
+      label: action.label,
+      url: finalizeActionUrl(new URL(url), args.callbackPrompt, args.agentId),
+      supportsCallback: action.supportsCallback,
+    };
   });
+}
+
+export function printConnectorSearchGuidance(args: {
+  readonly actions: readonly ConnectorSearchAction[];
+  readonly origin: string;
+  readonly agentId: string | undefined;
+  readonly runBound: boolean;
+  readonly callbackPrompt: string | undefined;
+}): void {
+  if (args.actions.length === 0) {
+    return;
+  }
+  const links = connectorSearchActionLinks(args);
 
   console.log("");
   console.log("Connection context:");
@@ -125,7 +137,7 @@ export function printConnectorSearchGuidance(args: {
     );
   }
   for (const link of links) {
-    console.log(`  ${link}`);
+    console.log(`  [${link.label}](${link.url})`);
   }
 
   if (args.callbackPrompt !== undefined) {

--- a/turbo/apps/cli/src/commands/connector/search.ts
+++ b/turbo/apps/cli/src/commands/connector/search.ts
@@ -16,6 +16,7 @@ import { padEndAnsi, stripAnsi } from "./connected-as";
 import {
   connectorDiscoveryDefinitions,
   connectorDiscoveryItems,
+  connectorDiscoveryJson,
   connectorDiscoveryTarget,
   isConnectorDiscoveryAuthorized,
   renderConnectorDiscoveryConnectedAsCell,
@@ -25,6 +26,7 @@ import {
 import { searchConnectorCatalog } from "./public-catalog";
 import {
   currentConnectorSearchAction,
+  connectorSearchActionLinks,
   printConnectorSearchGuidance,
   runConnectorSearchAction,
   type ConnectorSearchAction,
@@ -34,6 +36,7 @@ import {
   resolveRunConnectorAccountLookups,
   type RunConnectorAccountLookup,
 } from "./run-account-context";
+import { connectorInspectionType } from "./inspection";
 
 const EXACT_MATCH_THRESHOLD = 80;
 
@@ -103,6 +106,8 @@ function printSearchResults<T extends ConnectorDiscoveryDefinition>(args: {
   readonly connectors: readonly T[];
   readonly keyword: string;
   readonly limit: number | undefined;
+  readonly json: boolean | undefined;
+  readonly jsonConnector: (connector: T) => object;
   readonly availabilityHeader: string;
   readonly renderAvailability: (connector: T) => string;
   readonly accountHeader: string;
@@ -126,6 +131,45 @@ function printSearchResults<T extends ConnectorDiscoveryDefinition>(args: {
     throw new Error(
       "--callback-prompt requires a single connector match. Narrow the search to the intended connector with --limit 1.",
     );
+  }
+
+  if (args.json) {
+    const actions = results.flatMap((result) => {
+      const action = args.connectionAction(result.connector);
+      return action ? [action] : [];
+    });
+    console.log(
+      JSON.stringify(
+        {
+          context: args.runBound ? "run" : "current",
+          query: { keyword: args.keyword, limit: args.limit ?? null },
+          agent: args.agentContext
+            ? {
+                agentId: args.agentContext.agentId,
+                displayName: args.agentContext.displayName,
+              }
+            : null,
+          total,
+          exactMatch:
+            results.length > 0 && results[0]!.score >= EXACT_MATCH_THRESHOLD,
+          connectors: results.map((result) => {
+            return {
+              ...args.jsonConnector(result.connector),
+              score: result.score,
+            };
+          }),
+          actions: connectorSearchActionLinks({
+            actions,
+            origin: args.origin,
+            agentId: args.agentContext?.agentId,
+            callbackPrompt: args.callbackPrompt,
+          }),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
   }
 
   if (results.length === 0) {
@@ -218,6 +262,7 @@ export const searchCommand = new Command()
     "--agent <id>",
     "Show per-agent authorization column (must match the current Agent inside a run)",
   )
+  .option("--json", "Output connector matches and actions as JSON")
   .option(
     "--callback-prompt <prompt>",
     "Continue the current web chat after one connector action (use --limit 1)",
@@ -231,7 +276,12 @@ export const searchCommand = new Command()
     withErrorHandler(
       async (
         keyword: string,
-        options: { agent?: string; limit?: number; callbackPrompt?: string },
+        options: {
+          agent?: string;
+          limit?: number;
+          callbackPrompt?: string;
+          json?: boolean;
+        },
       ) => {
         const agentId = resolveConnectorAgentId(options.agent);
         const trimmed = keyword.trim();
@@ -276,6 +326,32 @@ export const searchCommand = new Command()
             connectors: definitions,
             keyword: trimmed,
             limit: options.limit,
+            json: options.json,
+            jsonConnector: (connector) => {
+              const target = connectorDiscoveryTarget(connector);
+              const account = runAccountForConnector(connector);
+              return {
+                target,
+                connectorType: connectorInspectionType(
+                  target,
+                  connector.kind === "custom"
+                    ? connector.customConnector
+                    : null,
+                ),
+                slug: connector.slug,
+                label: connector.label,
+                account,
+                availableForRun:
+                  account.state === "context-unavailable"
+                    ? null
+                    : account.state === "available" &&
+                      account.metadata.connectionStatus !==
+                        "reconnect-required",
+                authorized: agentContext
+                  ? isConnectorDiscoveryAuthorized(connector, agentContext)
+                  : null,
+              };
+            },
             availabilityHeader: "AVAILABLE THIS RUN",
             renderAvailability: (connector) => {
               return renderRunAvailabilityCell(
@@ -315,6 +391,10 @@ export const searchCommand = new Command()
           connectors: discoveredConnectors,
           keyword: trimmed,
           limit: options.limit,
+          json: options.json,
+          jsonConnector: (connector) => {
+            return connectorDiscoveryJson(connector, agentContext);
+          },
           availabilityHeader: "AVAILABLE",
           renderAvailability: (connector) => {
             return renderCurrentAvailabilityCell(connector, agentContext);

--- a/turbo/apps/cli/src/commands/connector/status.ts
+++ b/turbo/apps/cli/src/commands/connector/status.ts
@@ -303,7 +303,11 @@ export const statusCommand = new Command()
             JSON.stringify(
               {
                 context: "current",
-                connector,
+                connector: {
+                  ...connector,
+                  target: { kind: "builtin", connectorSlug: connector.slug },
+                  connectorType: "builtin",
+                },
                 authorization: agentCtx
                   ? {
                       agentId: agentCtx.agentId,


### PR DESCRIPTION
Connector inspection currently requires agents and scripts to parse tables or prose, and existing JSON discovery cannot distinguish custom HTTP from MCP connectors. Add `--json` to search, check, and custom list/status, and expose additive `connectorType` and stable target metadata across discovery/status output.

Preserve existing JSON fields and human output. Results retain current organization versus run-bound account context, exact account IDs, separate Agent authorization, unavailable metadata/diagnostics, sanitized requests, and next actions. Custom inventory remains a current-context query inside runs, while `--agent` must still match the current run's Agent. The output contract is documented in `docs/connector-inspection-json.md`.

Closes #32828

## Validation

- 226 tests passed across eight affected connector command suites, including JSON-mode rejection of conflicting run-bound Agent selectors.
- `pnpm -F @okouai/cli lint`
- `pnpm -F @okouai/cli check-types`
- `pnpm exec knip --workspace @okouai/cli`
- Prettier checked all changed TypeScript/Markdown files; `git diff --check` passed.

Focused tests entered through Commander with MSW and real run-context files:

```sh
pnpm -F @okouai/cli exec vitest run \
  src/commands/connector/__tests__/{agent-context,list,status,search,check,check-custom,run-account-context}.test.ts \
  src/commands/connector/custom/__tests__/index.test.ts
```

Full local Vitest and live-service end-to-end checks were not run. No API contract, database, access-control, account selection, or MCP execution changes are included.
