### PR TITLE
feat(cli): provide targeted custom connector recovery links

### DIFF
--- a/docs/connector-inspection-json.md
+++ b/docs/connector-inspection-json.md
@@ -70,6 +70,10 @@ Search's `actions` contain labels, exact URLs, and callback support. The usual
 single-match and callback restrictions apply. Preserve returned action URLs,
 including all query parameters.
 
+Recovery URLs use `OKOU_APP_URL` when configured; otherwise the CLI derives the
+app origin from the API URL. Custom connection actions use the connector's
+directed Connect flow or the exact run-selected account's reconnect flow.
+
 Check emits the validated diagnostic without collapsing `deny`, `ask`,
 `unavailable`, unknown endpoints, ambiguous targets, or missing run context.
 The additional `connector`, `account`, `connection`, `authorization`, and
@@ -80,8 +84,10 @@ rejected, and query strings/fragments are stripped before transport and output.
 
 Check's `actions` contain commands, links, or guidance. Builtin permission
 requests are offered only for denied/ask outcomes from a URL diagnostic.
-Custom connectors retain their settings-based remediation; unknown custom
-endpoints are not turned into builtin permission requests. Retry commands retain
+Custom permission actions open the targeted access settings with the Agent and
+permission context, without granting access. Missing definitions or ambiguous
+accounts retain manual settings guidance. Unknown custom endpoints are not
+turned into builtin permission requests. Retry commands retain
 the sanitized request selectors and JSON mode. Routing and permission results
 describe intended state, not confirmation that the runner applied a later
 update. Connector/account changes apply to future runs.

--- a/docs/connector-inspection-json.md
+++ b/docs/connector-inspection-json.md
@@ -73,6 +73,12 @@ including all query parameters.
 Recovery URLs use `OKOU_APP_URL` when configured; otherwise the CLI derives the
 app origin from the API URL. Custom connection actions use the connector's
 directed Connect flow or the exact run-selected account's reconnect flow.
+For a custom HTTP connector with a permission bundle, connection alone cannot
+grant Agent access. When the Agent is not already authorized, the connection
+action retains its exact destination but sets `supportsCallback: false` and
+includes `guidance` for the separate permission review. Passing
+`--callback-prompt` is rejected for that action. Already-authorized Agents retain
+confirmed connection callbacks.
 
 Check emits the validated diagnostic without collapsing `deny`, `ask`,
 `unavailable`, unknown endpoints, ambiguous targets, or missing run context.

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -1282,6 +1282,23 @@ describe("connector account lifecycle routes", () => {
         [200],
       );
 
+      const incomplete = await accept(
+        customConnectorValuesClient().set({
+          headers: authHeaders(),
+          params: { id: definition.body.id },
+          body: {
+            account: { intent: "reconnect", connectionId: selectedId },
+            values: [
+              { key: "secret", kind: "secret", value: "replacement-token" },
+            ],
+          },
+        }),
+        [400],
+      );
+      expect(incomplete.body).toMatchObject({
+        error: { message: expect.stringContaining("region") },
+      });
+
       const recovered = await accept(
         customConnectorValuesClient().set({
           headers: authHeaders(),
@@ -1297,6 +1314,24 @@ describe("connector account lifecycle routes", () => {
         [200],
       );
       expect(recovered.body).toMatchObject({
+        connected: true,
+        connectedAccountId: selectedId,
+        configuredFieldKeys: ["region", "secret"],
+        missingRequiredFields: [],
+      });
+
+      const rotated = await accept(
+        customConnectorValuesClient().set({
+          headers: authHeaders(),
+          params: { id: definition.body.id },
+          body: {
+            account: { intent: "reconnect", connectionId: selectedId },
+            values: [{ key: "secret", kind: "secret", value: "rotated-token" }],
+          },
+        }),
+        [200],
+      );
+      expect(rotated.body).toMatchObject({
         connected: true,
         connectedAccountId: selectedId,
         configuredFieldKeys: ["region", "secret"],

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -1194,6 +1194,153 @@ describe("connector account lifecycle routes", () => {
     },
   );
 
+  it.each(["http", "mcp"] as const)(
+    "reports the recovered custom %s account while its default remains outdated",
+    async (kind) => {
+      const fixture = await seedFixture();
+      mockClerkMembership(
+        context,
+        { ...fixture, orgRole: "org:admin", email: "recovery@example.test" },
+        "org:admin",
+      );
+      await accept(
+        featureClient().update({
+          headers: authHeaders(),
+          body: {
+            switches: { [FeatureSwitchKey.CustomConnectorMcp]: true },
+          },
+        }),
+        [200],
+      );
+      const fields = [
+        {
+          key: "secret",
+          label: "Secret",
+          kind: "secret" as const,
+          required: true,
+        },
+      ];
+      const body: CreateCustomConnectorBody = {
+        ...(kind === "http"
+          ? { kind, prefixTemplates: ["https://api.example.com/"] }
+          : {
+              kind,
+              endpoint: "https://mcp.example.com/",
+              transport: "streamable-http",
+            }),
+        displayName: "Recovery account",
+        authMode: "manual",
+        fields,
+        headerInjections: [
+          { name: "Authorization", valueTemplate: "Bearer {{secrets.secret}}" },
+        ],
+        queryInjections: [],
+      };
+      const definition = await accept(
+        customConnectorClient().create({ headers: authHeaders(), body }),
+        [201],
+      );
+      const ids: string[] = [];
+      for (const displayName of ["Default", "Selected"]) {
+        const connected = await accept(
+          customConnectorValuesClient().set({
+            headers: authHeaders(),
+            params: { id: definition.body.id },
+            body: {
+              account: { intent: "add", displayName },
+              values: [{ key: "secret", kind: "secret", value: "test-token" }],
+            },
+          }),
+          [200],
+        );
+        if (!connected.body.connectedAccountId) {
+          throw new Error("Expected the newly connected account ID");
+        }
+        ids.push(connected.body.connectedAccountId);
+      }
+      const [defaultId, selectedId] = ids;
+      if (!defaultId || !selectedId) {
+        throw new Error("Expected both custom accounts");
+      }
+      await accept(
+        customConnectorByIdClient().update({
+          headers: authHeaders(),
+          params: { id: definition.body.id },
+          body: {
+            ...body,
+            fields: [
+              ...fields,
+              {
+                key: "region",
+                label: "Region",
+                kind: "variable",
+                required: true,
+              },
+            ],
+          },
+        }),
+        [200],
+      );
+
+      const recovered = await accept(
+        customConnectorValuesClient().set({
+          headers: authHeaders(),
+          params: { id: definition.body.id },
+          body: {
+            account: { intent: "reconnect", connectionId: selectedId },
+            values: [
+              { key: "secret", kind: "secret", value: "replacement-token" },
+              { key: "region", kind: "variable", value: "eu" },
+            ],
+          },
+        }),
+        [200],
+      );
+      expect(recovered.body).toMatchObject({
+        connected: true,
+        connectedAccountId: selectedId,
+        configuredFieldKeys: ["region", "secret"],
+        missingRequiredFields: [],
+      });
+
+      const current = await accept(
+        customConnectorByIdClient().get({
+          headers: authHeaders(),
+          params: { id: definition.body.id },
+        }),
+        [200],
+      );
+      expect(current.body.connected).toBeFalsy();
+      expect(current.body.configuredFieldKeys).toStrictEqual([]);
+      const accounts = await accept(
+        accountClient().connections({
+          headers: authHeaders(),
+          query: {
+            kind: "custom",
+            customConnectorId: definition.body.id,
+            limit: 100,
+          },
+        }),
+        [200],
+      );
+      expect(accounts.body.connections).toHaveLength(2);
+      expect(accounts.body.connections).toStrictEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: defaultId,
+            isDefault: true,
+            connectionStatus: "reconnect-required",
+          }),
+          expect.objectContaining({
+            id: selectedId,
+            isDefault: false,
+            connectionStatus: "connected",
+          }),
+        ]),
+      );
+    },
+  );
+
   it.each([
     {
       label: "HTTP",

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
@@ -20,6 +20,7 @@ import {
   connectorCredentialStatusForAccess,
   connectorRuntimeCredentialStatusForAccess,
 } from "./connector-credential-status.service";
+import type { ConnectorAccountSelectionMode } from "./connector-account-resolution.service";
 
 const OAUTH_ACCESS_TOKEN_SECRET_NAME = "access_token";
 const OAUTH_REFRESH_TOKEN_SECRET_NAME = "refresh_token";
@@ -518,17 +519,22 @@ function customConnectorRuntimeStorageSnapshot(
   return { accesses, values };
 }
 
-export async function loadCurrentCustomConnectorValueMarkers(
+export async function loadCustomConnectorValueMarkers(
   db: Pick<ReadonlyDb, "select">,
   args: {
     readonly orgId: string;
     readonly userId: string;
     readonly connectorIds?: readonly string[];
+    readonly selection: ConnectorAccountSelectionMode;
   },
 ): Promise<readonly CustomConnectorCredentialValueMarker[]> {
   if (args.connectorIds?.length === 0) {
     return [];
   }
+  const accountSelection =
+    args.selection.kind === "exact"
+      ? eq(connectors.id, args.selection.sourceId)
+      : eq(connectors.isDefault, true);
   const secretQuery = db
     .select({
       connectorId: orgCustomConnectors.id,
@@ -563,7 +569,7 @@ export async function loadCurrentCustomConnectorValueMarkers(
         eq(secrets.type, "connector"),
         eq(secrets.orgId, args.orgId),
         eq(secrets.userId, args.userId),
-        eq(connectors.isDefault, true),
+        accountSelection,
         args.connectorIds
           ? inArray(orgCustomConnectors.id, [...args.connectorIds])
           : undefined,
@@ -603,7 +609,7 @@ export async function loadCurrentCustomConnectorValueMarkers(
         eq(variables.type, "connector"),
         eq(variables.orgId, args.orgId),
         eq(variables.userId, args.userId),
-        eq(connectors.isDefault, true),
+        accountSelection,
         args.connectorIds
           ? inArray(orgCustomConnectors.id, [...args.connectorIds])
           : undefined,

--- a/turbo/apps/api/src/signals/services/custom-connector-list.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-list.service.ts
@@ -12,7 +12,7 @@ import {
 import { customConnectorDefinitionSelection } from "./custom-connector-definition-selection";
 import {
   customConnectorDefinitionConnectedAccount,
-  loadCurrentCustomConnectorValueMarkers,
+  loadCustomConnectorValueMarkers,
   loadConnectedCustomConnectorConnections,
 } from "./custom-connector-credential-access.service";
 
@@ -41,7 +41,10 @@ export function customConnectorList(args: {
         )
         .where(eq(orgCustomConnectors.orgId, args.orgId))
         .orderBy(orgCustomConnectors.displayName),
-      loadCurrentCustomConnectorValueMarkers(db, args),
+      loadCustomConnectorValueMarkers(db, {
+        ...args,
+        selection: { kind: "default" },
+      }),
       loadConnectedCustomConnectorConnections(db, args),
     ]);
     return connectorRows.map((row) => {

--- a/turbo/apps/api/src/signals/services/custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector.service.ts
@@ -63,7 +63,7 @@ import { loadCustomConnectorPermissionBundle } from "./custom-connector-permissi
 import {
   customConnectorDefinitionConnectedAccount,
   loadCurrentCustomConnectorStoredValues,
-  loadCurrentCustomConnectorValueMarkers,
+  loadCustomConnectorValueMarkers,
   loadConnectedCustomConnectorConnections,
   type CustomConnectorCredentialAccess,
   type CustomConnectorCredentialValueMarker,
@@ -2645,9 +2645,10 @@ export function getCustomConnectorResponse(args: {
       return null;
     }
     const [markers, connectedConnections] = await Promise.all([
-      loadCurrentCustomConnectorValueMarkers(db, {
+      loadCustomConnectorValueMarkers(db, {
         orgId: args.orgId,
         userId: args.userId,
+        selection: { kind: "default" },
       }),
       loadConnectedCustomConnectorConnections(db, {
         orgId: args.orgId,
@@ -3117,9 +3118,11 @@ export const setCustomConnectorValues$ = command(
     );
 
     const db = get(db$);
-    const markers = await loadCurrentCustomConnectorValueMarkers(db, {
+    const markers = await loadCustomConnectorValueMarkers(db, {
       orgId: args.orgId,
       userId: args.userId,
+      connectorIds: [args.connectorId],
+      selection: { kind: "exact", sourceId: writeResult.connectedAccountId },
     });
     signal.throwIfAborted();
     return {

--- a/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
@@ -562,6 +562,25 @@ describe("custom connector URL diagnostics", () => {
     expect(error.mock.calls.flat().join("\n")).not.toContain("password");
   });
 
+  it("uses the configured app origin for reconnect, permission review, and callback links", async () => {
+    const appOrigin = "https://preview-app.example.com";
+    vi.stubEnv("OKOU_APP_URL", appOrigin);
+    server.use(
+      stubRunConnectorAccountInspection([account("reconnect-required")]),
+    );
+
+    await check();
+
+    const reconnectUrl = `${appOrigin}/connectors/_mutable-new-slug/reconnect/${ACCOUNT_ID}?agentId=agent-1`;
+    expect(output()).toContain(`[Reconnect Renamed Acme](${reconnectUrl})`);
+    expect(output()).toContain(
+      `${reconnectUrl}&threadId=thread-1&callbackPrompt=`,
+    );
+    expect(output()).toContain(
+      `[Custom connector settings](${appOrigin}/connectors?tab=custom&customConnectorId=${CUSTOM_ID}&view=access&permission=items%3Awrite&agentId=agent-1)`,
+    );
+  });
+
   it("retains a deleted pinned account identity without suggesting a sibling account", async () => {
     server.use(stubRunConnectorAccountInspection([]));
     await check();

--- a/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
@@ -322,6 +322,105 @@ describe("custom connector URL diagnostics", () => {
     },
   );
 
+  it.each([false, true])(
+    "requires separate Agent permission review for custom recovery with reconnect=%s in JSON",
+    async (reconnect) => {
+      const connector = customConnector({
+        permissionBundleRef: "builtin:feishu@1",
+      });
+      writeRunConnectorAccountContext(
+        contextPath,
+        reconnect ? [{ ...TARGET, connectionId: ACCOUNT_ID }] : [],
+      );
+      server.use(
+        stubRunConnectorAccountInspection([account("reconnect-required")]),
+        http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {
+          return HttpResponse.json(connector);
+        }),
+      );
+
+      await check("--json");
+
+      const json: unknown = JSON.parse(output());
+      expect(json).toMatchObject({
+        actions: expect.arrayContaining([
+          expect.objectContaining({
+            kind: "link",
+            url: `${ORIGIN}/connectors/${connector.slug}/${reconnect ? `reconnect/${ACCOUNT_ID}` : "connect"}?agentId=agent-1`,
+            supportsCallback: false,
+            guidance: expect.stringContaining(
+              "separate Agent permission review",
+            ),
+          }),
+        ]),
+      });
+      expect(output()).not.toContain("callbackPrompt=");
+    },
+  );
+
+  it.each([false, true])(
+    "explains separate Agent permission review for custom recovery with reconnect=%s in text",
+    async (reconnect) => {
+      const connector = customConnector({
+        permissionBundleRef: "builtin:feishu@1",
+      });
+      writeRunConnectorAccountContext(
+        contextPath,
+        reconnect ? [{ ...TARGET, connectionId: ACCOUNT_ID }] : [],
+      );
+      server.use(
+        stubRunConnectorAccountInspection([account("reconnect-required")]),
+        http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {
+          return HttpResponse.json(connector);
+        }),
+      );
+
+      await check();
+
+      expect(output()).toContain(
+        `/connectors/${connector.slug}/${reconnect ? `reconnect/${ACCOUNT_ID}` : "connect"}?agentId=agent-1`,
+      );
+      expect(output()).toContain("separate Agent permission review");
+      expect(output()).not.toContain("callbackPrompt=");
+    },
+  );
+
+  it.each([false, true])(
+    "retains permission-bundled recovery callbacks for authorized Agents with reconnect=%s",
+    async (reconnect) => {
+      const connector = customConnector({
+        permissionBundleRef: "builtin:feishu@1",
+      });
+      writeRunConnectorAccountContext(
+        contextPath,
+        reconnect ? [{ ...TARGET, connectionId: ACCOUNT_ID }] : [],
+      );
+      server.use(
+        stubAgentCustomConnectors([
+          { customConnectorId: CUSTOM_ID, permissionNames: [] },
+        ]),
+        stubRunConnectorAccountInspection([account("reconnect-required")]),
+        http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {
+          return HttpResponse.json(connector);
+        }),
+      );
+
+      await check("--json");
+
+      const json: unknown = JSON.parse(output());
+      expect(json).toMatchObject({
+        actions: expect.arrayContaining([
+          expect.objectContaining({
+            kind: "link",
+            url: `${ORIGIN}/connectors/${connector.slug}/${reconnect ? `reconnect/${ACCOUNT_ID}` : "connect"}?agentId=agent-1`,
+            supportsCallback: true,
+          }),
+        ]),
+      });
+      expect(output()).not.toContain("separate Agent permission review");
+    },
+  );
+
   it("keeps an authorized connected custom account out of text recovery", async () => {
     stubDiagnostic(
       resolvedCustom({

--- a/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
@@ -352,7 +352,7 @@ describe("custom connector URL diagnostics", () => {
     expect(output()).toContain("current intended state");
     expect(output()).toContain('"items:write" is in the deny list');
     expect(output()).toContain(
-      "[Connectors](http://localhost:3000/connectors)",
+      `[Custom connector settings](http://localhost:3000/connectors?tab=custom&customConnectorId=${CUSTOM_ID}&view=access&permission=items%3Awrite&agentId=agent-1)`,
     );
     expect(output()).toContain("review Permissions");
     expect(output()).toContain(`--connector 'custom:${CUSTOM_ID}'`);
@@ -391,6 +391,11 @@ describe("custom connector URL diagnostics", () => {
     expect(output()).toContain(
       "account selected for this run needs to be reconnected",
     );
+    expect(output()).toContain(
+      `/connectors/_acme-search/reconnect/${ACCOUNT_ID}?agentId=agent-1`,
+    );
+    expect(output()).toContain("threadId=thread-1&callbackPrompt=");
+    expect(output()).not.toContain(DEFAULT_ACCOUNT_ID);
     expect(output()).not.toContain(
       "account selected for this run is connected",
     );
@@ -567,6 +572,10 @@ describe("custom connector URL diagnostics", () => {
     expect(output()).not.toMatch(
       /Default sibling|\/connectors\/[^\s]+\/connect|is connected/,
     );
+    expect(output()).toContain(
+      `customConnectorId=${CUSTOM_ID}&view=accounts&agentId=agent-1`,
+    );
+    expect(output()).not.toContain("callbackPrompt=");
   });
 
   it("does not infer an account when run account context is missing", async () => {
@@ -591,6 +600,9 @@ describe("custom connector URL diagnostics", () => {
       "Current custom connector metadata is unavailable or deleted",
     );
     expect(output()).not.toContain("Earlier display name");
+    expect(output()).toContain("/connectors?tab=custom&agentId=agent-1");
+    expect(output()).toContain("select an available connector manually");
+    expect(output()).not.toMatch(/\/reconnect\/|callbackPrompt=/);
   });
 
   it("propagates metadata read failures rather than reporting the connector as deleted", async () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
@@ -288,6 +288,69 @@ describe("custom connector URL diagnostics", () => {
     });
   });
 
+  it.each([
+    customConnector({ id: CUSTOM_ID }),
+    customMcpConnector({ id: CUSTOM_ID }),
+  ])(
+    "offers the directed $kind connect flow outside a run in text output",
+    async (connector) => {
+      vi.stubEnv("OKOU_AGENT_ID", "");
+      vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", "");
+      vi.stubEnv("OKOU_APP_URL", "https://preview-app.example.com");
+      stubDiagnostic({
+        ...resolvedCustom({
+          kind: "unknown-endpoint",
+          policy: { outcome: "unavailable", basis: "not-run-scoped" },
+        }),
+        run: { status: "not-scoped" },
+      });
+      server.use(
+        http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {
+          return HttpResponse.json(connector);
+        }),
+      );
+
+      await check();
+
+      expect(output()).toContain(
+        "Current organization connection: not connected.",
+      );
+      expect(output()).toContain(
+        `[Connect ${connector.displayName}](https://preview-app.example.com/connectors/${connector.slug}/connect)`,
+      );
+      expect(output()).not.toMatch(
+        /Account used by this run|\/reconnect\/|callbackPrompt=/,
+      );
+    },
+  );
+
+  it("ignores leftover run accounts when reporting a current custom connection in text", async () => {
+    vi.stubEnv("OKOU_AGENT_ID", "");
+    stubDiagnostic({
+      ...resolvedCustom({
+        kind: "unknown-endpoint",
+        policy: { outcome: "unavailable", basis: "not-run-scoped" },
+      }),
+      run: { status: "not-scoped" },
+    });
+    server.use(
+      http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {
+        return HttpResponse.json(
+          customConnector({ connected: true, missingRequiredFields: [] }),
+        );
+      }),
+      stubRunConnectorAccountInspection([account("reconnect-required")]),
+    );
+
+    await check();
+
+    expect(output()).toContain("Current organization connection: connected.");
+    expect(output()).not.toContain(ACCOUNT_ID);
+    expect(output()).not.toMatch(
+      /Account used by this run|\/reconnect\/|callbackPrompt=/,
+    );
+  });
+
   it("reports unavailable definition metadata explicitly without replacing its account", async () => {
     server.use(
       http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../../__tests__/helpers/connector-catalog";
 import {
   customConnector,
+  customMcpConnector,
   stubAgentCustomConnectors,
   stubCustomConnectors,
 } from "../../__tests__/helpers/custom-connectors";
@@ -226,6 +227,67 @@ describe("custom connector URL diagnostics", () => {
     },
   );
 
+  it.each([
+    customConnector({ connected: true, missingRequiredFields: [] }),
+    customMcpConnector({
+      id: CUSTOM_ID,
+      connected: true,
+      missingRequiredFields: [],
+    }),
+  ])(
+    "preserves the configured origin and exact $kind account in JSON recovery links",
+    async (connector) => {
+      const appOrigin = "https://preview-app.example.com";
+      vi.stubEnv("OKOU_APP_URL", appOrigin);
+      server.use(
+        stubRunConnectorAccountInspection([account("reconnect-required")]),
+        http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {
+          return HttpResponse.json(connector);
+        }),
+      );
+
+      await check("--json");
+
+      const json: unknown = JSON.parse(output());
+      expect(json).toMatchObject({
+        actions: expect.arrayContaining([
+          expect.objectContaining({
+            kind: "link",
+            url: `${appOrigin}/connectors/${connector.slug}/reconnect/${ACCOUNT_ID}?agentId=agent-1`,
+            supportsCallback: true,
+          }),
+          expect.objectContaining({
+            kind: "link",
+            url: `${appOrigin}/connectors?tab=custom&customConnectorId=${CUSTOM_ID}&view=access&permission=items%3Awrite&agentId=agent-1`,
+            guidance: expect.stringContaining(
+              "Settings review does not support callbacks",
+            ),
+          }),
+        ]),
+      });
+      expect(output()).not.toContain(DEFAULT_ACCOUNT_ID);
+      expect(log).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("offers the directed custom connect flow outside a run in JSON", async () => {
+    vi.stubEnv("OKOU_AGENT_ID", "");
+
+    await check("--json");
+
+    const json: unknown = JSON.parse(output());
+    expect(json).toMatchObject({
+      context: "current",
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          kind: "link",
+          url: `${ORIGIN}/connectors/_mutable-new-slug/connect`,
+          supportsCallback: true,
+        }),
+      ]),
+    });
+  });
+
   it("reports unavailable definition metadata explicitly without replacing its account", async () => {
     server.use(
       http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {
@@ -245,6 +307,13 @@ describe("custom connector URL diagnostics", () => {
         definitionAvailable: false,
       },
       account: { connectionId: ACCOUNT_ID },
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          kind: "link",
+          url: `${ORIGIN}/connectors?tab=custom&customConnectorId=${CUSTOM_ID}&view=accounts&agentId=agent-1`,
+          supportsCallback: false,
+        }),
+      ]),
     });
   });
 

--- a/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
@@ -270,6 +270,105 @@ describe("custom connector URL diagnostics", () => {
     },
   );
 
+  it.each(
+    [
+      customConnector({ connected: true, missingRequiredFields: [] }),
+      customMcpConnector({
+        id: CUSTOM_ID,
+        connected: true,
+        missingRequiredFields: [],
+      }),
+    ].flatMap((connector) => {
+      return [true, false].map((admitted) => {
+        return { kind: connector.kind, connector, admitted };
+      });
+    }),
+  )(
+    "targets Agent access in text for a connected $kind connector with admitted=$admitted",
+    async ({ connector, admitted }) => {
+      vi.stubEnv("OKOU_APP_URL", "https://preview-app.example.com");
+      writeRunConnectorAccountContext(
+        contextPath,
+        admitted ? [{ ...TARGET, connectionId: ACCOUNT_ID }] : [],
+      );
+      stubDiagnostic({
+        ...resolvedCustom({
+          kind: "unknown-endpoint",
+          policy: {
+            outcome: "unavailable",
+            basis: "connector-not-configured",
+          },
+        }),
+        run: { status: "not-configured" },
+      });
+      server.use(
+        http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {
+          return HttpResponse.json(connector);
+        }),
+      );
+
+      await check();
+
+      expect(output()).toContain(
+        `${connector.displayName} is not authorized for this agent (agent-1).`,
+      );
+      expect(output()).toContain(
+        `https://preview-app.example.com/connectors?tab=custom&customConnectorId=${CUSTOM_ID}&view=access&agentId=agent-1`,
+      );
+      expect(output()).toContain("Settings review does not support callbacks");
+      expect(output()).not.toMatch(
+        /view=accounts|\/connectors\/[^\s]+\/(connect|authorize|reconnect)|callbackPrompt=/,
+      );
+    },
+  );
+
+  it("keeps an authorized connected custom account out of text recovery", async () => {
+    stubDiagnostic(
+      resolvedCustom({
+        kind: "matched",
+        permissions: [
+          {
+            name: "items:write",
+            policy: { outcome: "allow", basis: "allow-list" },
+          },
+        ],
+      }),
+    );
+    server.use(
+      stubAgentCustomConnectors([
+        { customConnectorId: CUSTOM_ID, permissionNames: ["items:write"] },
+      ]),
+    );
+
+    await check();
+
+    expect(output()).toContain(
+      "Renamed Acme is authorized for this agent (agent-1).",
+    );
+    expect(output()).toContain(`Connection ID: ${ACCOUNT_ID}`);
+    expect(output()).not.toMatch(/view=|\/connectors\/|callbackPrompt=/);
+  });
+
+  it("propagates a custom authorization lookup failure in text without suggesting a grant", async () => {
+    server.use(
+      http.get(`${ORIGIN}/api/agents/agent-1/custom-connectors`, () => {
+        return HttpResponse.json(
+          {
+            error: { code: "INTERNAL", message: "Authorization lookup failed" },
+          },
+          { status: 500 },
+        );
+      }),
+    );
+
+    await expect(check()).rejects.toThrow("process.exit called");
+
+    expect(error.mock.calls.flat().join("\n")).toContain(
+      "Authorization lookup failed",
+    );
+    expect(output()).toBe("");
+  });
+
   it("offers the directed custom connect flow outside a run in JSON", async () => {
     vi.stubEnv("OKOU_AGENT_ID", "");
 

--- a/turbo/apps/cli/src/commands/connector/__tests__/check.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check.test.ts
@@ -343,6 +343,7 @@ describe("okou connector check command", () => {
     vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("OKOU_API_BACKEND_URL", API_BASE_URL);
+    vi.stubEnv("OKOU_APP_URL", undefined);
     vi.stubEnv("OKOU_TOKEN", buildOkouToken());
     vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
     vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", contextPath);

--- a/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
@@ -180,8 +180,11 @@ describe("okou connector permission-request command", () => {
 
       const message = mockConsoleError.mock.calls.flat().join("\n");
       expect(message).toContain(customId);
-      expect(message).toContain("[Connectors](https://app.okou.ai/connectors)");
+      expect(message).toContain(
+        `[Custom connector settings](https://app.okou.ai/connectors?tab=custom&customConnectorId=${customId}&view=access&permission=items%3Awrite&agentId=agent-1)`,
+      );
       expect(message).toContain("review Permissions");
+      expect(message).toContain("Settings review does not support callbacks");
       expect(message).not.toMatch(
         /connectorSlug=|action=allow|callbackPrompt=/,
       );

--- a/turbo/apps/cli/src/commands/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/search.test.ts
@@ -16,6 +16,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
 import { searchCommand } from "../search";
 import chalk from "chalk";
+import { customConnectorMcpResponseSchema } from "@okouai/api-contracts/contracts/custom-connectors";
 import {
   authCodeMethod,
   catalogItem,
@@ -1087,17 +1088,130 @@ describe("okou connector search command", () => {
       );
     });
 
-    it("uses connector settings for custom connector setup", async () => {
-      const connector = customConnector();
-      server.use(stubConnectorCatalog([]), stubCustomConnectors([connector]));
+    it.each(["http", "mcp"] as const)(
+      "offers a confirmed-action callback for custom %s connection",
+      async (kind) => {
+        const { prefixTemplates: _prefixTemplates, ...common } =
+          customConnector();
+        const connector =
+          kind === "http"
+            ? customConnector()
+            : customConnectorMcpResponseSchema.parse({
+                ...common,
+                kind: "mcp",
+                prefixTemplates: [],
+                endpoint: "https://mcp.acme.test/mcp",
+                transport: "streamable-http",
+              });
+        server.use(stubConnectorCatalog([]), stubCustomConnectors([connector]));
 
-      await searchCommand.parseAsync(["node", "cli", connector.slug]);
+        await searchCommand.parseAsync([
+          "node",
+          "cli",
+          connector.slug,
+          "--callback-prompt",
+          "Continue the original task",
+        ]);
 
+        const output = mockConsoleLog.mock.calls.flat().join("\n");
+        expect(output).toContain(
+          `/connectors/${connector.slug}/connect?agentId=${AGENT_UUID}&threadId=${THREAD_UUID}&callbackPrompt=Continue+the+original+task`,
+        );
+        expect(output).not.toContain(`/connectors/${connector.slug}/authorize`);
+        expect(output).toContain("changes apply to future runs");
+      },
+    );
+
+    it("targets the reconnect-required custom run account instead of a connected default", async () => {
+      const connector = customConnector({
+        connected: true,
+        connectedAccountId: "55555555-5555-4555-8555-555555555555",
+      });
+      const target = {
+        kind: "custom",
+        customConnectorId: connector.id,
+      } as const;
+      writeRunConnectorAccountContext(contextPath, [
+        { ...target, connectionId: RUN_CONNECTION_ID },
+      ]);
+      server.use(
+        stubConnectorCatalog([]),
+        stubCustomConnectors([connector]),
+        stubRunConnectorAccountInspection([
+          {
+            kind: "available",
+            target,
+            connectionId: RUN_CONNECTION_ID,
+            authMethod: "manual",
+            displayName: "Selected Acme account",
+            externalId: null,
+            externalUsername: null,
+            externalEmail: null,
+            connectionStatus: "reconnect-required",
+            reconnectReason: "authorization_expired_or_revoked",
+          },
+        ]),
+      );
+      await searchCommand.parseAsync([
+        "node",
+        "cli",
+        connector.slug,
+        "--callback-prompt",
+        "Continue after reconnect",
+      ]);
       const output = mockConsoleLog.mock.calls.flat().join("\n");
       expect(output).toContain(
-        `[Review ${connector.displayName} accounts and agent access](http://localhost:3000/connectors?agentId=${AGENT_UUID})`,
+        `/connectors/${connector.slug}/reconnect/${RUN_CONNECTION_ID}?agentId=${AGENT_UUID}&threadId=${THREAD_UUID}&callbackPrompt=Continue+after+reconnect`,
       );
-      expect(output).not.toContain(`/connectors/${connector.slug}/authorize`);
+      expect(output).not.toContain(connector.connectedAccountId);
+    });
+
+    it("targets custom Agent access review without claiming a callback", async () => {
+      const connector = customConnector({ connected: true });
+      server.use(stubConnectorCatalog([]), stubCustomConnectors([connector]));
+      await searchCommand.parseAsync(["node", "cli", connector.slug]);
+      expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+        `/connectors?tab=custom&customConnectorId=${connector.id}&view=access&agentId=${AGENT_UUID}`,
+      );
+      mockConsoleLog.mockClear();
+      await expect(
+        searchCommand.parseAsync([
+          "node",
+          "cli",
+          connector.slug,
+          "--callback-prompt",
+          "Continue after review",
+        ]),
+      ).rejects.toThrow("process.exit called");
+      expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+        "does not support --callback-prompt",
+      );
+      expect(mockConsoleLog.mock.calls.flat().join("\n")).not.toContain(
+        "callbackPrompt=",
+      );
+    });
+
+    it("keeps unavailable custom account recovery in manual account selection", async () => {
+      const connector = customConnector({ connected: true });
+      writeRunConnectorAccountContext(contextPath, [
+        {
+          kind: "custom",
+          customConnectorId: connector.id,
+          connectionId: RUN_CONNECTION_ID,
+        },
+      ]);
+      server.use(
+        stubConnectorCatalog([]),
+        stubCustomConnectors([connector]),
+        stubRunConnectorAccountInspection([]),
+      );
+      await searchCommand.parseAsync(["node", "cli", connector.slug]);
+      const output = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain(
+        `/connectors?tab=custom&customConnectorId=${connector.id}&view=accounts&agentId=${AGENT_UUID}`,
+      );
+      expect(output).toContain("metadata unavailable or deleted");
+      expect(output).not.toMatch(/\/reconnect\/|callbackPrompt=/);
     });
 
     it("offers authorization for a connected service when inspecting an agent outside a run", async () => {

--- a/turbo/apps/cli/src/commands/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/search.test.ts
@@ -1166,6 +1166,79 @@ describe("okou connector search command", () => {
       expect(output).not.toContain(connector.connectedAccountId);
     });
 
+    it.each(["run", "current"] as const)(
+      "declines a callback requiring separate Agent permission review in %s context",
+      async (mode) => {
+        const connector = customConnector({
+          permissionBundleRef: "builtin:feishu@1",
+        });
+        server.use(stubConnectorCatalog([]), stubCustomConnectors([connector]));
+        if (mode === "current") {
+          vi.stubEnv("OKOU_AGENT_ID", "");
+        }
+        const args = ["node", "cli", connector.slug, "--agent", AGENT_UUID];
+
+        await searchCommand.parseAsync(args);
+
+        expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+          `/connectors/${connector.slug}/connect?agentId=${AGENT_UUID}`,
+        );
+        expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
+          "separate Agent permission review",
+        );
+        mockConsoleLog.mockClear();
+
+        await expect(
+          searchCommand.parseAsync([
+            ...args,
+            "--callback-prompt",
+            "Continue after connecting",
+          ]),
+        ).rejects.toThrow("process.exit called");
+
+        expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+          "does not support --callback-prompt",
+        );
+        expect(mockConsoleLog.mock.calls.flat().join("\n")).not.toContain(
+          "callbackPrompt=",
+        );
+      },
+    );
+
+    it("keeps permission-bundled connection callbacks for an authorized Agent", async () => {
+      const connector = customConnector({
+        permissionBundleRef: "builtin:feishu@1",
+      });
+      server.use(
+        stubConnectorCatalog([]),
+        stubCustomConnectors([connector]),
+        stubAgentCustomConnectors([
+          { customConnectorId: connector.id, permissionNames: [] },
+        ]),
+      );
+
+      await searchCommand.parseAsync([
+        "node",
+        "cli",
+        connector.slug,
+        "--json",
+        "--callback-prompt",
+        "Continue after connecting",
+      ]);
+
+      const json: unknown = JSON.parse(
+        mockConsoleLog.mock.calls.flat().join("\n"),
+      );
+      expect(json).toMatchObject({
+        actions: [
+          {
+            url: `http://localhost:3000/connectors/${connector.slug}/connect?agentId=${AGENT_UUID}&threadId=${THREAD_UUID}&callbackPrompt=Continue+after+connecting`,
+            supportsCallback: true,
+          },
+        ],
+      });
+    });
+
     it("targets custom Agent access review without claiming a callback", async () => {
       const connector = customConnector({ connected: true });
       server.use(stubConnectorCatalog([]), stubCustomConnectors([connector]));

--- a/turbo/apps/cli/src/commands/connector/check-custom.ts
+++ b/turbo/apps/cli/src/commands/connector/check-custom.ts
@@ -5,6 +5,7 @@ import {
   printCallbackActionUrlExample,
 } from "./action-url";
 import {
+  isRunBoundConnectorContext,
   resolveRunConnectorAccountLookups,
   runConnectorAccountUnavailableMessage,
   type RunConnectorAccountLookup,
@@ -15,7 +16,7 @@ interface CustomConnectorCheckContext {
   readonly id: string;
   readonly label: string;
   readonly definition: CustomConnectorResponse | null;
-  readonly account: RunConnectorAccountLookup;
+  readonly account: RunConnectorAccountLookup | null;
 }
 
 export async function loadCustomConnectorCheckContext(
@@ -23,10 +24,14 @@ export async function loadCustomConnectorCheckContext(
 ): Promise<CustomConnectorCheckContext> {
   const [definition, accounts] = await Promise.all([
     getCustomConnector(customConnectorId),
-    resolveRunConnectorAccountLookups([{ kind: "custom", customConnectorId }]),
+    isRunBoundConnectorContext()
+      ? resolveRunConnectorAccountLookups([
+          { kind: "custom", customConnectorId },
+        ])
+      : null,
   ]);
-  const account = accounts[0];
-  if (!account) {
+  const account = accounts === null ? null : accounts[0];
+  if (account === undefined) {
     throw new Error("Missing run account lookup for custom connector");
   }
   return {
@@ -48,36 +53,46 @@ export function printCustomConnectorCheckStatus(
     console.log("Current custom connector metadata is unavailable or deleted.");
   }
   const account = context.account;
-  switch (account.state) {
-    case "context-unavailable":
-      console.log(runConnectorAccountUnavailableMessage(account.reason));
-      break;
-    case "not-admitted":
-      console.log(`No ${context.label} account was admitted for this run.`);
-      console.log("Select an available account, then start a new run.");
-      break;
-    case "metadata-unavailable":
-      console.log(`Account used by this run: ${account.connectionId}`);
-      console.log("Current account metadata is unavailable or deleted.");
-      console.log("Select an available account, then start a new run.");
-      break;
-    case "available":
-      console.log(`Account used by this run: ${account.label}`);
-      console.log(`Connection ID: ${account.connectionId}`);
-      if (account.metadata.connectionStatus === "reconnect-required") {
-        console.log(
-          "The account selected for this run needs to be reconnected.",
-        );
-        console.log("After reconnecting, start a new run.");
-      } else {
-        console.log("The account selected for this run is connected.");
-      }
-      break;
+  if (account === null) {
+    if (context.definition) {
+      console.log(
+        `Current organization connection: ${context.definition.connected ? "connected" : "not connected"}.`,
+      );
+    }
+  } else {
+    switch (account.state) {
+      case "context-unavailable":
+        console.log(runConnectorAccountUnavailableMessage(account.reason));
+        break;
+      case "not-admitted":
+        console.log(`No ${context.label} account was admitted for this run.`);
+        console.log("Select an available account, then start a new run.");
+        break;
+      case "metadata-unavailable":
+        console.log(`Account used by this run: ${account.connectionId}`);
+        console.log("Current account metadata is unavailable or deleted.");
+        console.log("Select an available account, then start a new run.");
+        break;
+      case "available":
+        console.log(`Account used by this run: ${account.label}`);
+        console.log(`Connection ID: ${account.connectionId}`);
+        if (account.metadata.connectionStatus === "reconnect-required") {
+          console.log(
+            "The account selected for this run needs to be reconnected.",
+          );
+          console.log("After reconnecting, start a new run.");
+        } else {
+          console.log("The account selected for this run is connected.");
+        }
+        break;
+    }
   }
   if (
     !context.definition ||
-    account.state !== "available" ||
-    account.metadata.connectionStatus === "reconnect-required"
+    (account === null
+      ? !context.definition.connected
+      : account.state !== "available" ||
+        account.metadata.connectionStatus === "reconnect-required")
   ) {
     printCustomConnectorRecovery(context, platformOrigin, agentId);
   }
@@ -100,10 +115,11 @@ function printCustomConnectorRecovery(
     return;
   }
   const path =
-    account.state === "available" &&
+    account?.state === "available" &&
     account.metadata.connectionStatus === "reconnect-required"
       ? `/connectors/${definition.slug}/reconnect/${account.connectionId}`
-      : account.state === "not-admitted" && !definition.connected
+      : (account === null || account.state === "not-admitted") &&
+          !definition.connected
         ? `/connectors/${definition.slug}/connect`
         : null;
   if (path === null) {
@@ -119,7 +135,7 @@ function printCustomConnectorRecovery(
   }
   const url = connectorActionUrl({ origin: platformOrigin, path, agentId });
   console.log(
-    `Open [${account.state === "available" ? "Reconnect" : "Connect"} ${context.label}](${url}). Changes apply to future runs.`,
+    `Open [${account?.state === "available" ? "Reconnect" : "Connect"} ${context.label}](${url}). Changes apply to future runs.`,
   );
   printCallbackActionUrlExample(url, agentId);
 }

--- a/turbo/apps/cli/src/commands/connector/check-custom.ts
+++ b/turbo/apps/cli/src/commands/connector/check-custom.ts
@@ -11,7 +11,10 @@ import {
   runConnectorAccountUnavailableMessage,
   type RunConnectorAccountLookup,
 } from "./run-account-context";
-import { runConnectorSearchAction } from "./search-guidance";
+import {
+  connectorConnectAction,
+  runConnectorSearchAction,
+} from "./search-guidance";
 
 interface CustomConnectorCheckContext {
   readonly label: string;
@@ -132,11 +135,15 @@ function printCustomConnectorRecovery(
           authorized,
         )
       : !definition.connected
-        ? {
-            label: `Connect ${context.label}`,
-            path: `/connectors/${definition.slug}/connect`,
-            supportsCallback: true,
-          }
+        ? connectorConnectAction(
+            {
+              kind: "custom",
+              slug: definition.slug,
+              label: context.label,
+              customConnector: definition,
+            },
+            authorized,
+          )
         : null;
   if (action === null) {
     return;
@@ -149,7 +156,8 @@ function printCustomConnectorRecovery(
   if (!action.supportsCallback) {
     console.log(`Open [${action.label}](${url}).`);
     console.log(
-      "Settings review does not support callbacks. Opening this link does not grant access or select an account. Connection and selection changes apply to future runs.",
+      action.guidance ??
+        "Settings review does not support callbacks. Opening this link does not grant access or select an account. Connection and selection changes apply to future runs.",
     );
     return;
   }

--- a/turbo/apps/cli/src/commands/connector/check-custom.ts
+++ b/turbo/apps/cli/src/commands/connector/check-custom.ts
@@ -1,4 +1,9 @@
 import { getCustomConnector } from "../../lib/api/domains/connectors";
+import type { CustomConnectorResponse } from "@okouai/api-contracts/contracts/custom-connectors";
+import {
+  connectorActionUrl,
+  printCallbackActionUrlExample,
+} from "./action-url";
 import {
   resolveRunConnectorAccountLookups,
   runConnectorAccountUnavailableMessage,
@@ -9,7 +14,7 @@ import { customConnectorSettingsGuidance } from "./custom-connector-guidance";
 interface CustomConnectorCheckContext {
   readonly id: string;
   readonly label: string;
-  readonly definitionAvailable: boolean;
+  readonly definition: CustomConnectorResponse | null;
   readonly account: RunConnectorAccountLookup;
 }
 
@@ -27,7 +32,7 @@ export async function loadCustomConnectorCheckContext(
   return {
     id: customConnectorId,
     label: definition?.displayName ?? customConnectorId,
-    definitionAvailable: definition !== null,
+    definition,
     account,
   };
 }
@@ -35,10 +40,11 @@ export async function loadCustomConnectorCheckContext(
 export function printCustomConnectorCheckStatus(
   context: CustomConnectorCheckContext,
   platformOrigin: string,
+  agentId: string | undefined,
 ): void {
   console.log("## Step 2: Custom connector configuration");
   console.log("");
-  if (!context.definitionAvailable) {
+  if (!context.definition) {
     console.log("Current custom connector metadata is unavailable or deleted.");
   }
   const account = context.account;
@@ -69,14 +75,51 @@ export function printCustomConnectorCheckStatus(
       break;
   }
   if (
-    !context.definitionAvailable ||
+    !context.definition ||
     account.state !== "available" ||
     account.metadata.connectionStatus === "reconnect-required"
   ) {
-    console.log(customConnectorSettingsGuidance(context.id, platformOrigin));
+    printCustomConnectorRecovery(context, platformOrigin, agentId);
   }
   console.log(
     "Routing and permission diagnostics describe current intended state; they do not confirm that the runner has applied the latest update.",
   );
   console.log("");
+}
+
+function printCustomConnectorRecovery(
+  context: CustomConnectorCheckContext,
+  platformOrigin: string,
+  agentId: string | undefined,
+): void {
+  const { definition, account } = context;
+  if (!definition) {
+    console.log(
+      `Open [Custom connectors](${connectorActionUrl({ origin: platformOrigin, path: "/connectors?tab=custom", agentId })}) and select an available connector manually. Changes apply to future runs; settings review does not support callbacks.`,
+    );
+    return;
+  }
+  const path =
+    account.state === "available" &&
+    account.metadata.connectionStatus === "reconnect-required"
+      ? `/connectors/${definition.slug}/reconnect/${account.connectionId}`
+      : account.state === "not-admitted" && !definition.connected
+        ? `/connectors/${definition.slug}/connect`
+        : null;
+  if (path === null) {
+    console.log(
+      customConnectorSettingsGuidance(
+        context.id,
+        platformOrigin,
+        undefined,
+        agentId,
+      ),
+    );
+    return;
+  }
+  const url = connectorActionUrl({ origin: platformOrigin, path, agentId });
+  console.log(
+    `Open [${account.state === "available" ? "Reconnect" : "Connect"} ${context.label}](${url}). Changes apply to future runs.`,
+  );
+  printCallbackActionUrlExample(url, agentId);
 }

--- a/turbo/apps/cli/src/commands/connector/check-custom.ts
+++ b/turbo/apps/cli/src/commands/connector/check-custom.ts
@@ -1,4 +1,5 @@
 import { getCustomConnector } from "../../lib/api/domains/connectors";
+import { getAgentCustomConnectorGrants } from "../../lib/api/domains/agents";
 import type { CustomConnectorResponse } from "@okouai/api-contracts/contracts/custom-connectors";
 import {
   connectorActionUrl,
@@ -10,35 +11,42 @@ import {
   runConnectorAccountUnavailableMessage,
   type RunConnectorAccountLookup,
 } from "./run-account-context";
-import { customConnectorSettingsGuidance } from "./custom-connector-guidance";
+import { runConnectorSearchAction } from "./search-guidance";
 
 interface CustomConnectorCheckContext {
-  readonly id: string;
   readonly label: string;
   readonly definition: CustomConnectorResponse | null;
   readonly account: RunConnectorAccountLookup | null;
+  readonly authorized: boolean | null;
 }
 
 export async function loadCustomConnectorCheckContext(
   customConnectorId: string,
+  agentId: string | undefined,
 ): Promise<CustomConnectorCheckContext> {
-  const [definition, accounts] = await Promise.all([
+  const [definition, accounts, grants] = await Promise.all([
     getCustomConnector(customConnectorId),
     isRunBoundConnectorContext()
       ? resolveRunConnectorAccountLookups([
           { kind: "custom", customConnectorId },
         ])
       : null,
+    agentId ? getAgentCustomConnectorGrants(agentId) : null,
   ]);
   const account = accounts === null ? null : accounts[0];
   if (account === undefined) {
     throw new Error("Missing run account lookup for custom connector");
   }
   return {
-    id: customConnectorId,
     label: definition?.displayName ?? customConnectorId,
     definition,
     account,
+    authorized:
+      grants === null
+        ? null
+        : grants.some((grant) => {
+            return grant.customConnectorId === customConnectorId;
+          }),
   };
 }
 
@@ -87,15 +95,12 @@ export function printCustomConnectorCheckStatus(
         break;
     }
   }
-  if (
-    !context.definition ||
-    (account === null
-      ? !context.definition.connected
-      : account.state !== "available" ||
-        account.metadata.connectionStatus === "reconnect-required")
-  ) {
-    printCustomConnectorRecovery(context, platformOrigin, agentId);
+  if (context.definition && context.authorized !== null) {
+    console.log(
+      `${context.label} is ${context.authorized ? "authorized" : "not authorized"} for this agent (${agentId}).`,
+    );
   }
+  printCustomConnectorRecovery(context, platformOrigin, agentId);
   console.log(
     "Routing and permission diagnostics describe current intended state; they do not confirm that the runner has applied the latest update.",
   );
@@ -107,33 +112,47 @@ function printCustomConnectorRecovery(
   platformOrigin: string,
   agentId: string | undefined,
 ): void {
-  const { definition, account } = context;
+  const { definition, account, authorized } = context;
   if (!definition) {
     console.log(
       `Open [Custom connectors](${connectorActionUrl({ origin: platformOrigin, path: "/connectors?tab=custom", agentId })}) and select an available connector manually. Changes apply to future runs; settings review does not support callbacks.`,
     );
     return;
   }
-  const path =
-    account?.state === "available" &&
-    account.metadata.connectionStatus === "reconnect-required"
-      ? `/connectors/${definition.slug}/reconnect/${account.connectionId}`
-      : (account === null || account.state === "not-admitted") &&
-          !definition.connected
-        ? `/connectors/${definition.slug}/connect`
+  const action =
+    account !== null
+      ? runConnectorSearchAction(
+          {
+            kind: "custom",
+            slug: definition.slug,
+            label: context.label,
+            customConnector: definition,
+          },
+          account,
+          authorized,
+        )
+      : !definition.connected
+        ? {
+            label: `Connect ${context.label}`,
+            path: `/connectors/${definition.slug}/connect`,
+            supportsCallback: true,
+          }
         : null;
-  if (path === null) {
+  if (action === null) {
+    return;
+  }
+  const url = connectorActionUrl({
+    origin: platformOrigin,
+    path: action.path,
+    agentId,
+  });
+  if (!action.supportsCallback) {
+    console.log(`Open [${action.label}](${url}).`);
     console.log(
-      customConnectorSettingsGuidance(
-        context.id,
-        platformOrigin,
-        undefined,
-        agentId,
-      ),
+      "Settings review does not support callbacks. Opening this link does not grant access or select an account. Connection and selection changes apply to future runs.",
     );
     return;
   }
-  const url = connectorActionUrl({ origin: platformOrigin, path, agentId });
   console.log(
     `Open [${account?.state === "available" ? "Reconnect" : "Connect"} ${context.label}](${url}). Changes apply to future runs.`,
   );

--- a/turbo/apps/cli/src/commands/connector/check-json.ts
+++ b/turbo/apps/cli/src/commands/connector/check-json.ts
@@ -16,6 +16,7 @@ import { getOkouAgentId } from "../../lib/okou-env";
 import { getPlatformOrigin } from "../doctor/platform-url";
 import {
   CALLBACK_PROMPT_PLACEHOLDER,
+  connectorActionUrl,
   currentChatSupportsActionCallback,
 } from "./action-url";
 import {
@@ -26,7 +27,10 @@ import {
   requireUrlRequest,
   type ResolvedDiagnostic,
 } from "./check-diagnostic";
-import { customConnectorSettingsGuidance } from "./custom-connector-guidance";
+import {
+  customConnectorSettingsGuidance,
+  customConnectorSettingsPath,
+} from "./custom-connector-guidance";
 import { connectorInspectionType } from "./inspection";
 import {
   isRunBoundConnectorContext,
@@ -84,11 +88,20 @@ function permissionActions(
         {
           kind: "link",
           label: `Review ${permission.name} for custom connector ${target.customConnectorId}`,
-          url: new URL("/connectors", origin).toString(),
+          url: connectorActionUrl({
+            origin,
+            path: customConnectorSettingsPath(
+              target.customConnectorId,
+              "access",
+              permission.name,
+            ),
+            agentId,
+          }),
           guidance: customConnectorSettingsGuidance(
             target.customConnectorId,
             origin,
             permission.name,
+            agentId,
           ),
         },
       ];
@@ -164,29 +177,78 @@ async function loadCheckEvidence(
   return { definition, currentConnection, account, authorized, origin };
 }
 
+function customCheckConnectionActions(
+  target: Extract<ConnectorAccountTarget, { kind: "custom" }>,
+  label: string,
+  evidence: Awaited<ReturnType<typeof loadCheckEvidence>>,
+): ConnectorSearchAction[] {
+  const { definition, account, authorized } = evidence;
+  if (definition === null) {
+    return [
+      {
+        label: `Review ${label} accounts and agent access`,
+        path: customConnectorSettingsPath(target.customConnectorId, "accounts"),
+        supportsCallback: false,
+      },
+    ];
+  }
+  if (account !== null) {
+    const action = runConnectorSearchAction(
+      {
+        kind: "custom",
+        slug: definition.slug,
+        label,
+        customConnector: definition,
+      },
+      account,
+      authorized,
+    );
+    return action === null ? [] : [action];
+  }
+  if (!definition.connected) {
+    return [
+      {
+        label: `Connect or authorize ${label}`,
+        path: `/connectors/${definition.slug}/connect`,
+        supportsCallback: true,
+      },
+    ];
+  }
+  return authorized === false
+    ? [
+        {
+          label: `Review ${label} agent access`,
+          path: customConnectorSettingsPath(target.customConnectorId, "access"),
+          supportsCallback: false,
+        },
+      ]
+    : [];
+}
+
 function checkConnectionActions(
   target: ConnectorAccountTarget,
   label: string,
   evidence: Awaited<ReturnType<typeof loadCheckEvidence>>,
 ): ConnectorSearchAction[] {
-  const { definition, currentConnection, account, authorized } = evidence;
+  if (target.kind === "custom") {
+    return customCheckConnectionActions(target, label, evidence);
+  }
+  const { currentConnection, account, authorized } = evidence;
   const connectionActions: ConnectorSearchAction[] = [];
   if (account !== null) {
     const action = runConnectorSearchAction(
       {
-        kind: target.kind === "builtin" ? "catalog" : "custom",
-        slug:
-          target.kind === "builtin"
-            ? target.connectorSlug
-            : `custom:${target.customConnectorId}`,
+        kind: "catalog",
+        slug: target.connectorSlug,
         label,
       },
       account,
+      authorized,
     );
     if (action !== null) {
       connectionActions.push(action);
     }
-  } else if (target.kind === "builtin") {
+  } else {
     if (
       currentConnection === null ||
       currentConnection.connectionStatus === "reconnect-required"
@@ -197,27 +259,13 @@ function checkConnectionActions(
         supportsCallback: true,
       });
     }
-  } else if (definition === null || !definition.connected) {
-    connectionActions.push({
-      label: `Review ${label} accounts and agent access`,
-      path: "/connectors",
-      supportsCallback: false,
-    });
   }
   if (authorized === false) {
-    connectionActions.push(
-      target.kind === "builtin"
-        ? {
-            label: `Authorize ${label}`,
-            path: `/connectors/${target.connectorSlug}/authorize`,
-            supportsCallback: true,
-          }
-        : {
-            label: `Review ${label} agent access`,
-            path: "/connectors",
-            supportsCallback: false,
-          },
-    );
+    connectionActions.push({
+      label: `Authorize ${label}`,
+      path: `/connectors/${target.connectorSlug}/authorize`,
+      supportsCallback: true,
+    });
   }
   return connectionActions;
 }

--- a/turbo/apps/cli/src/commands/connector/check-json.ts
+++ b/turbo/apps/cli/src/commands/connector/check-json.ts
@@ -37,6 +37,7 @@ import {
   resolveRunConnectorAccountLookups,
 } from "./run-account-context";
 import {
+  connectorConnectAction,
   connectorSearchActionLinks,
   runConnectorSearchAction,
   type ConnectorSearchAction,
@@ -207,11 +208,15 @@ function customCheckConnectionActions(
   }
   if (!definition.connected) {
     return [
-      {
-        label: `Connect or authorize ${label}`,
-        path: `/connectors/${definition.slug}/connect`,
-        supportsCallback: true,
-      },
+      connectorConnectAction(
+        {
+          kind: "custom",
+          slug: definition.slug,
+          label,
+          customConnector: definition,
+        },
+        authorized,
+      ),
     ];
   }
   return authorized === false

--- a/turbo/apps/cli/src/commands/connector/check.ts
+++ b/turbo/apps/cli/src/commands/connector/check.ts
@@ -719,9 +719,13 @@ Permission recovery:
       }
       const resolved = resolveConnectorCheckDiagnostic(request, diagnostic);
       const target = resolved.connector.target;
+      const agentId = getOkouAgentId();
       const custom =
         target.kind === "custom"
-          ? await loadCustomConnectorCheckContext(target.customConnectorId)
+          ? await loadCustomConnectorCheckContext(
+              target.customConnectorId,
+              agentId,
+            )
           : null;
       const result = custom
         ? {
@@ -741,7 +745,7 @@ Permission recovery:
         credentialResolution: result.connector.credentialResolution,
         run: result.run,
         platformOrigin,
-        agentId: getOkouAgentId(),
+        agentId,
         runBound: isRunBoundConnectorContext(),
       };
 

--- a/turbo/apps/cli/src/commands/connector/check.ts
+++ b/turbo/apps/cli/src/commands/connector/check.ts
@@ -452,6 +452,7 @@ function printPermissionRequestCommands(
         target.customConnectorId,
         platformOrigin,
         permission,
+        agentId,
       ),
     );
     return;
@@ -754,7 +755,11 @@ Permission recovery:
             })
           : null;
       if (custom) {
-        printCustomConnectorCheckStatus(custom, ctx.platformOrigin);
+        printCustomConnectorCheckStatus(
+          custom,
+          ctx.platformOrigin,
+          ctx.agentId,
+        );
       }
       const configuredForRun = checkConnectorDomains(ctx);
 

--- a/turbo/apps/cli/src/commands/connector/check.ts
+++ b/turbo/apps/cli/src/commands/connector/check.ts
@@ -20,7 +20,6 @@ import {
   type UrlDiagnosticRequest,
 } from "./check-diagnostic";
 
-import { getApiUrl } from "../../lib/api/config";
 import {
   loadCustomConnectorCheckContext,
   printCustomConnectorCheckStatus,
@@ -35,7 +34,7 @@ import {
 import { getAgentUserConnectors } from "../../lib/api/domains/agents";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { getOkouAgentId } from "../../lib/okou-env";
-import { toPlatformUrl } from "../doctor/platform-url";
+import { getPlatformOrigin } from "../doctor/platform-url";
 import {
   computerUsePermissionGuidance,
   printComputerUsePermissionGuidance,
@@ -734,14 +733,14 @@ Permission recovery:
       printDiagnosticSummary(request, result);
       console.log("");
 
-      const platformUrl = toPlatformUrl(await getApiUrl());
+      const platformOrigin = await getPlatformOrigin();
       const ctx: DiagContext = {
         environmentNames: diagnosticEnvironmentNames(result),
         label: result.connector.label,
         connectorAvailable: result.connector.visibility === "available",
         credentialResolution: result.connector.credentialResolution,
         run: result.run,
-        platformOrigin: platformUrl.origin,
+        platformOrigin,
         agentId: getOkouAgentId(),
         runBound: isRunBoundConnectorContext(),
       };

--- a/turbo/apps/cli/src/commands/connector/custom-connector-guidance.ts
+++ b/turbo/apps/cli/src/commands/connector/custom-connector-guidance.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { connectorActionUrl } from "./action-url";
 
 export function customConnectorIdFromSelector(
   selector: string | undefined,
@@ -15,17 +16,42 @@ export function customConnectorIdFromSelector(
   return id.data;
 }
 
+export function customConnectorSettingsPath(
+  customConnectorId: string,
+  view: "accounts" | "access",
+  permission?: string,
+): string {
+  const params = new URLSearchParams({
+    tab: "custom",
+    customConnectorId,
+    view,
+  });
+  if (permission !== undefined && permission !== "__unknown__") {
+    params.set("permission", permission);
+  }
+  return `/connectors?${params.toString()}`;
+}
+
 export function customConnectorSettingsGuidance(
   customConnectorId: string,
   platformOrigin: string,
   permission?: string,
+  agentId?: string,
 ): string {
-  const url = new URL("/connectors", platformOrigin).toString();
+  const url = connectorActionUrl({
+    origin: platformOrigin,
+    path: customConnectorSettingsPath(
+      customConnectorId,
+      permission === undefined ? "accounts" : "access",
+      permission,
+    ),
+    agentId,
+  });
   const steps =
     permission === undefined
       ? "Review its accounts and agent access. Reconnect or select an available account as needed."
       : permission === "__unknown__"
         ? "There is no custom unknown-endpoint approval control. Ask an administrator to review the connector's routing and permission definition."
-        : "Open the custom connector's agent access management, select the affected agent, and review Permissions.";
-  return `Custom connector ${customConnectorId} uses the existing connector settings flow, not a builtin permission approval link.\nOpen [Connectors](${url}) and select this custom connector. ${steps}`;
+        : "Review the affected agent's access and review Permissions. No permission is granted by opening this link.";
+  return `Custom connector ${customConnectorId} uses the existing connector settings flow, not a builtin permission approval link.\nOpen [Custom connector settings](${url}). ${steps}\nIf the connector is unavailable or deleted, select an available connector manually. Settings review does not support callbacks. Connection and selection changes apply to future runs.`;
 }

--- a/turbo/apps/cli/src/commands/connector/permission-request.ts
+++ b/turbo/apps/cli/src/commands/connector/permission-request.ts
@@ -417,6 +417,7 @@ ${callbackPromptNotes}  - Builtin permission requests update the current user's 
               customConnectorId,
               await getPlatformOrigin(),
               opts.permission,
+              agentId,
             ),
           );
         }

--- a/turbo/apps/cli/src/commands/connector/search-guidance.ts
+++ b/turbo/apps/cli/src/commands/connector/search-guidance.ts
@@ -16,6 +16,7 @@ export interface ConnectorSearchAction {
   readonly label: string;
   readonly path: string;
   readonly supportsCallback: boolean;
+  readonly guidance?: string;
 }
 
 type ConnectorSearchTarget =
@@ -41,14 +42,37 @@ function accountSettingsAction(
   };
 }
 
-function connectAction(
-  connector: Pick<ConnectorDiscoveryDefinition, "kind" | "slug" | "label">,
+function connectionAction(
+  connector: ConnectorSearchTarget,
+  authorized: boolean | null,
+  action: Pick<ConnectorSearchAction, "label" | "path">,
 ): ConnectorSearchAction {
+  if (
+    connector.kind === "custom" &&
+    connector.customConnector.permissionBundleRef &&
+    authorized !== true
+  ) {
+    return {
+      ...action,
+      supportsCallback: false,
+      guidance:
+        "This connector requires a separate Agent permission review, so this connection does not support --callback-prompt. Connect or reconnect the account, then review Agent access in Connectors settings and continue manually. Changes apply to future runs.",
+    };
+  }
   return {
-    label: `Connect or authorize ${connector.label}`,
-    path: `/connectors/${connector.slug}/connect`,
+    ...action,
     supportsCallback: true,
   };
+}
+
+export function connectorConnectAction(
+  connector: ConnectorSearchTarget,
+  authorized: boolean | null,
+): ConnectorSearchAction {
+  return connectionAction(connector, authorized, {
+    label: `Connect or authorize ${connector.label}`,
+    path: `/connectors/${connector.slug}/connect`,
+  });
 }
 
 function customAccessAction(
@@ -73,18 +97,17 @@ export function runConnectorSearchAction(
           ? customAccessAction(connector)
           : null;
       }
-      return {
+      return connectionAction(connector, authorized, {
         label: `Reconnect ${connector.label} (${lookup.label})`,
         path: `/connectors/${connector.slug}/reconnect/${lookup.connectionId}`,
-        supportsCallback: true,
-      };
+      });
     case "not-admitted":
       if (connector.kind === "custom" && connector.customConnector.connected) {
         return authorized === false
           ? customAccessAction(connector)
           : accountSettingsAction(connector);
       }
-      return connectAction(connector);
+      return connectorConnectAction(connector, authorized);
     case "metadata-unavailable":
     case "context-unavailable":
       return accountSettingsAction(connector);
@@ -95,21 +118,22 @@ export function currentConnectorSearchAction(
   connector: ConnectorDiscoveryItem,
   agentContext: ConnectorDiscoveryAgentContext | null,
 ): ConnectorSearchAction | null {
-  const authorized =
-    !agentContext || isConnectorDiscoveryAuthorized(connector, agentContext);
+  const authorized = agentContext
+    ? isConnectorDiscoveryAuthorized(connector, agentContext)
+    : null;
   if (connector.kind === "custom") {
     if (!connector.customConnector.connected) {
-      return connectAction(connector);
+      return connectorConnectAction(connector, authorized);
     }
-    return authorized ? null : customAccessAction(connector);
+    return authorized === false ? customAccessAction(connector) : null;
   }
   if (connector.catalogConnector.connectionStatus === "reconnect-required") {
     return accountSettingsAction(connector);
   }
   if (!connector.catalogConnector.connected) {
-    return connectAction(connector);
+    return connectorConnectAction(connector, authorized);
   }
-  return authorized
+  return authorized !== false
     ? null
     : {
         label: `Authorize ${connector.label}`,
@@ -127,7 +151,8 @@ export function connectorSearchActionLinks(args: {
   return args.actions.map((action) => {
     if (args.callbackPrompt !== undefined && !action.supportsCallback) {
       throw new Error(
-        "This connector needs an account or access review in Connectors settings, which does not support --callback-prompt.",
+        action.guidance ??
+          "This connector needs an account or access review in Connectors settings, which does not support --callback-prompt.",
       );
     }
     const url = connectorActionUrl({
@@ -139,6 +164,7 @@ export function connectorSearchActionLinks(args: {
       label: action.label,
       url: finalizeActionUrl(new URL(url), args.callbackPrompt, args.agentId),
       supportsCallback: action.supportsCallback,
+      ...(action.guidance ? { guidance: action.guidance } : {}),
     };
   });
 }
@@ -167,6 +193,9 @@ export function printConnectorSearchGuidance(args: {
   }
   for (const link of links) {
     console.log(`  [${link.label}](${link.url})`);
+    if (link.guidance) {
+      console.log(`  ${link.guidance}`);
+    }
   }
 
   if (args.callbackPrompt !== undefined) {

--- a/turbo/apps/cli/src/commands/connector/search-guidance.ts
+++ b/turbo/apps/cli/src/commands/connector/search-guidance.ts
@@ -10,6 +10,7 @@ import {
   type ConnectorDiscoveryItem,
 } from "./discovery";
 import type { RunConnectorAccountLookup } from "./run-account-context";
+import { customConnectorSettingsPath } from "./custom-connector-guidance";
 
 export interface ConnectorSearchAction {
   readonly label: string;
@@ -22,7 +23,10 @@ function accountSettingsAction(
 ): ConnectorSearchAction {
   return {
     label: `Review ${connector.label} accounts and agent access`,
-    path: "/connectors",
+    path:
+      connector.kind === "custom"
+        ? customConnectorSettingsPath(connector.customConnector.id, "accounts")
+        : "/connectors",
     supportsCallback: false,
   };
 }
@@ -30,32 +34,49 @@ function accountSettingsAction(
 function connectAction(
   connector: Pick<ConnectorDiscoveryDefinition, "kind" | "slug" | "label">,
 ): ConnectorSearchAction {
-  return connector.kind === "custom"
-    ? accountSettingsAction(connector)
-    : {
-        label: `Connect or authorize ${connector.label}`,
-        path: `/connectors/${connector.slug}/connect`,
-        supportsCallback: true,
-      };
+  return {
+    label: `Connect or authorize ${connector.label}`,
+    path: `/connectors/${connector.slug}/connect`,
+    supportsCallback: true,
+  };
+}
+
+function customAccessAction(
+  connector: Extract<ConnectorDiscoveryDefinition, { kind: "custom" }>,
+): ConnectorSearchAction {
+  return {
+    label: `Review ${connector.label} agent access`,
+    path: customConnectorSettingsPath(connector.customConnector.id, "access"),
+    supportsCallback: false,
+  };
 }
 
 export function runConnectorSearchAction(
   connector: Pick<ConnectorDiscoveryDefinition, "kind" | "slug" | "label">,
   lookup: RunConnectorAccountLookup,
+  agentContext: ConnectorDiscoveryAgentContext | null,
 ): ConnectorSearchAction | null {
   switch (lookup.state) {
     case "available":
       if (lookup.metadata.connectionStatus !== "reconnect-required") {
-        return null;
+        return connector.kind === "custom" &&
+          agentContext &&
+          !isConnectorDiscoveryAuthorized(connector, agentContext)
+          ? customAccessAction(connector)
+          : null;
       }
-      return connector.kind === "custom"
-        ? accountSettingsAction(connector)
-        : {
-            label: `Reconnect ${connector.label} (${lookup.label})`,
-            path: `/connectors/${connector.slug}/reconnect/${lookup.connectionId}`,
-            supportsCallback: true,
-          };
+      return {
+        label: `Reconnect ${connector.label} (${lookup.label})`,
+        path: `/connectors/${connector.slug}/reconnect/${lookup.connectionId}`,
+        supportsCallback: true,
+      };
     case "not-admitted":
+      if (connector.kind === "custom" && connector.customConnector.connected) {
+        return agentContext &&
+          !isConnectorDiscoveryAuthorized(connector, agentContext)
+          ? customAccessAction(connector)
+          : accountSettingsAction(connector);
+      }
       return connectAction(connector);
     case "metadata-unavailable":
     case "context-unavailable":
@@ -70,9 +91,10 @@ export function currentConnectorSearchAction(
   const authorized =
     !agentContext || isConnectorDiscoveryAuthorized(connector, agentContext);
   if (connector.kind === "custom") {
-    return connector.customConnector.connected && authorized
-      ? null
-      : accountSettingsAction(connector);
+    if (!connector.customConnector.connected) {
+      return connectAction(connector);
+    }
+    return authorized ? null : customAccessAction(connector);
   }
   if (connector.catalogConnector.connectionStatus === "reconnect-required") {
     return accountSettingsAction(connector);

--- a/turbo/apps/cli/src/commands/connector/search-guidance.ts
+++ b/turbo/apps/cli/src/commands/connector/search-guidance.ts
@@ -18,8 +18,18 @@ export interface ConnectorSearchAction {
   readonly supportsCallback: boolean;
 }
 
+type ConnectorSearchTarget =
+  | Pick<
+      Extract<ConnectorDiscoveryDefinition, { kind: "catalog" }>,
+      "kind" | "slug" | "label"
+    >
+  | Pick<
+      Extract<ConnectorDiscoveryDefinition, { kind: "custom" }>,
+      "kind" | "slug" | "label" | "customConnector"
+    >;
+
 function accountSettingsAction(
-  connector: Pick<ConnectorDiscoveryDefinition, "kind" | "slug" | "label">,
+  connector: ConnectorSearchTarget,
 ): ConnectorSearchAction {
   return {
     label: `Review ${connector.label} accounts and agent access`,
@@ -42,7 +52,7 @@ function connectAction(
 }
 
 function customAccessAction(
-  connector: Extract<ConnectorDiscoveryDefinition, { kind: "custom" }>,
+  connector: Extract<ConnectorSearchTarget, { kind: "custom" }>,
 ): ConnectorSearchAction {
   return {
     label: `Review ${connector.label} agent access`,
@@ -52,16 +62,14 @@ function customAccessAction(
 }
 
 export function runConnectorSearchAction(
-  connector: Pick<ConnectorDiscoveryDefinition, "kind" | "slug" | "label">,
+  connector: ConnectorSearchTarget,
   lookup: RunConnectorAccountLookup,
-  agentContext: ConnectorDiscoveryAgentContext | null,
+  authorized: boolean | null,
 ): ConnectorSearchAction | null {
   switch (lookup.state) {
     case "available":
       if (lookup.metadata.connectionStatus !== "reconnect-required") {
-        return connector.kind === "custom" &&
-          agentContext &&
-          !isConnectorDiscoveryAuthorized(connector, agentContext)
+        return connector.kind === "custom" && authorized === false
           ? customAccessAction(connector)
           : null;
       }
@@ -72,8 +80,7 @@ export function runConnectorSearchAction(
       };
     case "not-admitted":
       if (connector.kind === "custom" && connector.customConnector.connected) {
-        return agentContext &&
-          !isConnectorDiscoveryAuthorized(connector, agentContext)
+        return authorized === false
           ? customAccessAction(connector)
           : accountSettingsAction(connector);
       }

--- a/turbo/apps/cli/src/commands/connector/search.ts
+++ b/turbo/apps/cli/src/commands/connector/search.ts
@@ -286,8 +286,10 @@ Scope:
 Callbacks:
   Use --callback-prompt only in the current web chat for its current Agent,
   when the task needs exactly one connector action; use --limit 1.
-  Only direct connection, reconnect, or Agent authorization actions support it.
-  Custom connectors and other actions that open Connectors settings do not.
+  Direct connection and reconnect actions support it for builtin and custom
+  connectors. Custom HTTP connectors with a permission bundle require existing
+  Agent access. Builtin Agent authorization actions also support callbacks.
+  Actions that open Connectors settings do not support callbacks.
   Keep the prompt free of secrets because it is included in the action URL.
 
 Examples:

--- a/turbo/apps/cli/src/commands/connector/search.ts
+++ b/turbo/apps/cli/src/commands/connector/search.ts
@@ -388,6 +388,7 @@ Examples:
               return runConnectorSearchAction(
                 connector,
                 runAccountForConnector(connector),
+                agentContext,
               );
             },
             origin,

--- a/turbo/apps/cli/src/commands/connector/search.ts
+++ b/turbo/apps/cli/src/commands/connector/search.ts
@@ -388,7 +388,9 @@ Examples:
               return runConnectorSearchAction(
                 connector,
                 runAccountForConnector(connector),
-                agentContext,
+                agentContext
+                  ? isConnectorDiscoveryAuthorized(connector, agentContext)
+                  : null,
               );
             },
             origin,

--- a/turbo/apps/cli/src/commands/doctor/platform-url.ts
+++ b/turbo/apps/cli/src/commands/doctor/platform-url.ts
@@ -13,7 +13,7 @@ import { getOkouAppUrl } from "../../lib/okou-env";
  *   localhost:3000                → localhost:3000
  *   custom.example.com            → app.custom.example.com
  */
-export function toPlatformUrl(apiUrl: string): URL {
+function toPlatformUrl(apiUrl: string): URL {
   const parsed = new URL(apiUrl);
   const parts = parsed.hostname.split(".");
   const serviceLabel = parts[0]!;

--- a/turbo/apps/platform/src/signals/connectors-page/connectors-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connectors-page-setup.ts
@@ -7,6 +7,7 @@ import { updatePage$ } from "../react-router.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { resetConnectorAccountDialogs$ } from "../okou-page/settings/connector-account-dialogs.ts";
 import { refreshSsh$ } from "../ssh.ts";
+import { setupCustomConnectorRecovery$ } from "./custom-connector-recovery.ts";
 
 export const setupConnectorsPage$ = command(
   async ({ set }, signal: AbortSignal) => {
@@ -20,5 +21,6 @@ export const setupConnectorsPage$ = command(
       }),
     );
     await set(hideAppSkeleton$, signal);
+    await set(setupCustomConnectorRecovery$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/connectors-page/custom-connector-recovery.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/custom-connector-recovery.ts
@@ -1,0 +1,108 @@
+import { command } from "ccstate";
+import { z } from "zod";
+import type { CustomConnectorResponse } from "@okouai/api-contracts/contracts/custom-connectors";
+import { searchParams$ } from "../route.ts";
+import {
+  closeCustomConnectorDialog$,
+  customConnectorAgentAuthorizations$,
+  customConnectorDialog$,
+  customConnectors$,
+  openCustomConnectorAccessDialog$,
+} from "../okou-page/settings/custom-connectors.ts";
+import { openCustomAccountManager$ } from "../okou-page/settings/connector-account-dialogs.ts";
+import { setConnectorAccessManagementSearch$ } from "../okou-page/settings/connector-access-management.ts";
+import {
+  closeCustomConnectorPermissions$,
+  customConnectorPermissionDraft$,
+  openCustomConnectorPermissions$,
+} from "../okou-page/settings/custom-connector-permissions.ts";
+
+const setupCustomConnectorAccessRecovery$ = command(
+  async (
+    { get, set },
+    connector: CustomConnectorResponse,
+    params: URLSearchParams,
+    signal: AbortSignal,
+  ) => {
+    set(openCustomConnectorAccessDialog$, connector);
+    const agentId = params.get("agentId");
+    if (!agentId) {
+      return;
+    }
+    const authorizations = await get(customConnectorAgentAuthorizations$);
+    signal.throwIfAborted();
+    const dialog = get(customConnectorDialog$);
+    if (
+      get(searchParams$).toString() !== params.toString() ||
+      dialog.kind !== "access" ||
+      dialog.connector.id !== connector.id
+    ) {
+      return;
+    }
+    const authorization = authorizations.find((row) => {
+      return row.agent.agentId === agentId;
+    });
+    if (!authorization) {
+      return;
+    }
+    if (authorization.agent.displayName) {
+      set(setConnectorAccessManagementSearch$, authorization.agent.displayName);
+    }
+    const permission = params.get("permission");
+    if (
+      !permission ||
+      permission === "__unknown__" ||
+      !connector.permissionBundleRef
+    ) {
+      return;
+    }
+    const grant = authorization.access.grants.find((item) => {
+      return item.customConnectorId === connector.id;
+    });
+    set(openCustomConnectorPermissions$, {
+      surface: "access-management",
+      agentId,
+      connectorId: connector.id,
+      initiallyAuthorized: grant !== undefined,
+      permissionNames: grant?.permissionNames ?? [],
+    });
+  },
+);
+
+export const setupCustomConnectorRecovery$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    set(closeCustomConnectorDialog$);
+    set(setConnectorAccessManagementSearch$, "");
+    const draft = get(customConnectorPermissionDraft$);
+    if (draft?.surface === "access-management") {
+      set(closeCustomConnectorPermissions$, draft);
+    }
+
+    const params = get(searchParams$);
+    const id = z.uuid().safeParse(params.get("customConnectorId"));
+    const view = params.get("view");
+    if (
+      params.get("tab") !== "custom" ||
+      !id.success ||
+      (view !== "accounts" && view !== "access")
+    ) {
+      return;
+    }
+    const connectors = await get(customConnectors$);
+    signal.throwIfAborted();
+    if (get(searchParams$).toString() !== params.toString()) {
+      return;
+    }
+    const connector = connectors.find((item) => {
+      return item.id === id.data;
+    });
+    if (!connector) {
+      return;
+    }
+    if (view === "accounts") {
+      set(openCustomAccountManager$, connector, signal);
+      return;
+    }
+    await set(setupCustomConnectorAccessRecovery$, connector, params, signal);
+  },
+);

--- a/turbo/apps/platform/src/signals/connectors-page/custom-connector-recovery.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/custom-connector-recovery.ts
@@ -10,7 +10,10 @@ import {
   openCustomConnectorAccessDialog$,
 } from "../okou-page/settings/custom-connectors.ts";
 import { openCustomAccountManager$ } from "../okou-page/settings/connector-account-dialogs.ts";
-import { setConnectorAccessManagementSearch$ } from "../okou-page/settings/connector-access-management.ts";
+import {
+  connectorAccessManagementSearch$,
+  setConnectorAccessManagementSearch$,
+} from "../okou-page/settings/connector-access-management.ts";
 import {
   closeCustomConnectorPermissions$,
   customConnectorPermissionDraft$,
@@ -29,13 +32,14 @@ const setupCustomConnectorAccessRecovery$ = command(
     if (!agentId) {
       return;
     }
+    const initialDialog = get(customConnectorDialog$);
+    const initialSearch = get(connectorAccessManagementSearch$);
     const authorizations = await get(customConnectorAgentAuthorizations$);
     signal.throwIfAborted();
-    const dialog = get(customConnectorDialog$);
     if (
       get(searchParams$).toString() !== params.toString() ||
-      dialog.kind !== "access" ||
-      dialog.connector.id !== connector.id
+      get(customConnectorDialog$) !== initialDialog ||
+      get(connectorAccessManagementSearch$) !== initialSearch
     ) {
       return;
     }

--- a/turbo/apps/platform/src/signals/connectors-page/custom-connector-recovery.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/custom-connector-recovery.ts
@@ -88,9 +88,13 @@ export const setupCustomConnectorRecovery$ = command(
     ) {
       return;
     }
+    const initialDialog = get(customConnectorDialog$);
     const connectors = await get(customConnectors$);
     signal.throwIfAborted();
-    if (get(searchParams$).toString() !== params.toString()) {
+    if (
+      get(searchParams$).toString() !== params.toString() ||
+      get(customConnectorDialog$) !== initialDialog
+    ) {
       return;
     }
     const connector = connectors.find((item) => {

--- a/turbo/apps/platform/src/signals/connectors-page/directed-connect-slug.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-connect-slug.ts
@@ -18,6 +18,8 @@ import { pathParams$, searchParams$ } from "../route.ts";
 import { agents$ } from "../agent.ts";
 import { pageSignal$ } from "../page-signal.ts";
 import { resetManualGrantForm$ } from "../okou-page/settings/connectors.ts";
+import { customConnectors$ } from "../okou-page/settings/custom-connectors.ts";
+import { customConnectorMcpEnabled$ } from "../external/feature-switch.ts";
 
 /**
  * Connector slug extracted from `/connectors/:connectorSlug/connect` route params.
@@ -64,14 +66,33 @@ export const directedConnectExactAccount$ = computed(
   async (get): Promise<ConnectorAccountConnection | null> => {
     const target = get(directedConnectAccountTarget$);
     const connectorSlug = get(directedConnectSlug$);
-    if (target.kind !== "exact" || !connectorSlug) {
+    const customSlug = get(directedConnectCustomSlug$);
+    if (target.kind !== "exact" || (!connectorSlug && !customSlug)) {
       return null;
     }
     const signal = get(pageSignal$);
+    const mcpEnabled = get(customConnectorMcpEnabled$);
+    const customConnector = customSlug
+      ? (await get(customConnectors$)).find((connector) => {
+          return (
+            connector.slug === customSlug &&
+            (connector.kind === "http" || mcpEnabled)
+          );
+        })
+      : undefined;
+    signal.throwIfAborted();
+    const query = connectorSlug
+      ? { kind: "builtin" as const, connectorSlug }
+      : customConnector
+        ? { kind: "custom" as const, customConnectorId: customConnector.id }
+        : null;
+    if (!query) {
+      return null;
+    }
     const result = await accept(
       get(apiClient$)(connectorAccountsContract).connection({
         params: { connectionId: target.connectionId },
-        query: { kind: "builtin", connectorSlug },
+        query,
         fetchOptions: { signal },
       }),
       [200, 404],

--- a/turbo/apps/platform/src/signals/okou-page/settings/connector-access-management.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connector-access-management.ts
@@ -32,7 +32,10 @@ interface SetConnectorAgentAuthorizationParams {
 }
 
 const managedConnectorAccessSlugState$ = state<ConnectorSlug | null>(null);
-const connectorAccessManagementSearchState$ = state("");
+// Identity distinguishes an untouched search from one edited and then cleared.
+const connectorAccessManagementSearchState$ = state<{
+  readonly value: string;
+}>({ value: "" });
 const connectorAccessManagementSavingAgentIdState$ = state<string | null>(null);
 const connectorAccessManagementPermissionAgentIdState$ = state<string | null>(
   null,
@@ -62,14 +65,14 @@ export const setManagedConnectorAccessSlug$ = command(
 
 export const closeConnectorAccessManagement$ = command(({ set }) => {
   set(managedConnectorAccessSlugState$, null);
-  set(connectorAccessManagementSearchState$, "");
+  set(connectorAccessManagementSearchState$, { value: "" });
   set(connectorAccessManagementSavingAgentIdState$, null);
   set(connectorAccessManagementPermissionAgentIdState$, null);
 });
 
 export const setConnectorAccessManagementSearch$ = command(
   ({ set }, search: string) => {
-    set(connectorAccessManagementSearchState$, search);
+    set(connectorAccessManagementSearchState$, { value: search });
   },
 );
 

--- a/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
@@ -502,7 +502,7 @@ const authorizeCompletedCustomConnectorTarget$ = command(
     },
     signal: AbortSignal,
   ): Promise<boolean> => {
-    if (!args.connector?.connected) {
+    if (!args.connector) {
       return false;
     }
     if (
@@ -645,7 +645,8 @@ const connectCustomConnectorAuthorizationForTargetCommand$ = command(
       signal,
     );
     return {
-      connected: connector?.connected ?? false,
+      // The receipt confirms this account; the projection describes the default.
+      connected: true,
       targetAuthorized,
       connectionId,
     };

--- a/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
@@ -23,6 +23,7 @@ import {
   getConnectorCard,
   queryConnectorAction,
   listAgent,
+  mockOAuthCompletions,
 } from "./connector-page-test-helpers.ts";
 
 const context = testContext();
@@ -203,17 +204,28 @@ test.each(["missing", "invalid"] as const)(
   },
 );
 
-test.each(["completed", "cancelled"] as const)(
-  "Confirm a %s custom OAuth reconnect from the exact account's update",
+test.each([
+  "completed",
+  "completed-unhealthy-default",
+  "cancelled",
+  "account-updated",
+  "other-account",
+] as const)(
+  "Confirm a custom OAuth reconnect using its exact completion receipt: %s",
   async (outcome) => {
+    const completed =
+      outcome === "completed" || outcome === "completed-unhealthy-default";
+    const defaultConnected = outcome !== "completed-unhealthy-default";
     const connector = customConnector({
       slug: "_acme-oauth",
       authMode: "oauth",
-      connected: true,
-      connectedAccountId: DEFAULT_ACCOUNT_ID,
-      connectedAccountUpdatedAt: "2026-01-01T00:00:00Z",
+      connected: defaultConnected,
+      connectedAccountId: defaultConnected ? DEFAULT_ACCOUNT_ID : undefined,
+      connectedAccountUpdatedAt: defaultConnected
+        ? "2026-01-01T00:00:00Z"
+        : undefined,
       fields: [],
-      missingRequiredFields: [],
+      missingRequiredFields: defaultConnected ? [] : ["oauth"],
       configuredFieldKeys: [],
       headerInjections: [
         {
@@ -233,6 +245,28 @@ test.each(["completed", "cancelled"] as const)(
       },
     });
     mockDefinition(connector);
+    if (!defaultConnected) {
+      context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+        return respond(200, {
+          summaries: [
+            {
+              target: { kind: "custom", customConnectorId: connector.id },
+              accountCount: 2,
+              attentionCount: 2,
+              defaultConnection: {
+                ...account(connector),
+                id: DEFAULT_ACCOUNT_ID,
+                displayName: "Expired default",
+                authMethod: "oauth",
+                isDefault: true,
+              },
+            },
+          ],
+        });
+      });
+    }
+    const completedAttempts = mockOAuthCompletions(context);
+    const oauthAttemptId = crypto.randomUUID();
     let reconnected = false;
     context.mocks.api(
       connectorAccountsContract.connection,
@@ -262,11 +296,18 @@ test.each(["completed", "cancelled"] as const)(
           intent: "reconnect",
           connectionId: ACCOUNT_ID,
         });
-        reconnected = outcome === "completed";
+        reconnected = completed || outcome === "account-updated";
+        if (completed || outcome === "other-account") {
+          completedAttempts.set(
+            oauthAttemptId,
+            completed ? ACCOUNT_ID : DEFAULT_ACCOUNT_ID,
+          );
+        }
         return respond(200, {
           result: "authorization",
           authorizationUrl: "https://acme.test/oauth/reconnect",
           connectionId: ACCOUNT_ID,
+          oauthAttemptId,
         });
       },
     );
@@ -309,10 +350,9 @@ test.each(["completed", "cancelled"] as const)(
         "https://acme.test/oauth/reconnect",
       );
     });
-    const expected =
-      outcome === "completed"
-        ? { prompts: ["Continue after OAuth"], canContinue: false }
-        : { prompts: [], canContinue: true };
+    const expected = completed
+      ? { prompts: ["Continue after OAuth"], canContinue: false }
+      : { prompts: [], canContinue: true };
     await waitFor(() => {
       const currentDialog = screen.queryByRole("dialog", {
         name: `Connect ${connector.displayName}`,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
@@ -715,6 +715,85 @@ test.each(
   },
 );
 
+test.each(
+  [false, true].flatMap((namedPermission) => {
+    return [false, true].map((cleared) => {
+      return { namedPermission, cleared };
+    });
+  }),
+)(
+  "Keep manual Agent search during delayed recovery with permission=$namedPermission and cleared=$cleared",
+  async ({ namedPermission, cleared }) => {
+    const connector = customConnector({
+      connected: true,
+      permissionBundleRef: "builtin:feishu@1",
+      missingRequiredFields: [],
+    });
+    mockDefinition(connector);
+    const release = context.mocks.deferred<void>();
+    context.mocks.api(
+      agentCustomConnectorsContract.get,
+      async ({ params, respond }) => {
+        await release.promise;
+        return respond(200, {
+          grants:
+            params.id === AGENT_ID
+              ? [
+                  {
+                    customConnectorId: connector.id,
+                    permissionNames: ["standard:use"],
+                  },
+                ]
+              : [],
+        });
+      },
+    );
+    context.mocks.api(
+      customConnectorByIdContract.permissions,
+      ({ respond }) => {
+        return respond(200, {
+          ref: "builtin:feishu@1",
+          permissions: [{ name: "standard:use", description: "Read data" }],
+          defaultPolicies: { "standard:use": "allow" },
+        });
+      },
+    );
+    const params = new URLSearchParams({
+      tab: "custom",
+      customConnectorId: connector.id,
+      view: "access",
+      agentId: AGENT_ID,
+    });
+    if (namedPermission) {
+      params.set("permission", "standard:use");
+    }
+    await setupPage({ context, path: `/connectors?${params.toString()}` });
+    const dialog = await screen.findByRole("dialog", {
+      name: `Manage ${connector.displayName} access`,
+    });
+    const search = within(dialog).getByRole("textbox");
+    await fill(search, "Support");
+    if (cleared) {
+      await fill(search, "");
+    }
+    const expectedSearch = cleared ? "" : "Support";
+    expect(search).toHaveValue(expectedSearch);
+
+    release.resolve();
+
+    await waitFor(() => {
+      expect(
+        within(getConnectorCard(connector.displayName)).getByTestId(
+          "connector-card-agent-access",
+        ),
+      ).toHaveTextContent("Used by Research");
+    });
+    expect(search).toHaveValue(expectedSearch);
+    expect(screen.queryAllByRole("dialog")).toHaveLength(1);
+    expect(within(dialog).getByText("Support")).toBeInTheDocument();
+  },
+);
+
 test("Keep a closed custom access review closed when Agent grants arrive", async () => {
   const connector = customConnector({
     connected: true,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
@@ -516,6 +516,98 @@ test.each(["deleted", "ambiguous"] as const)(
   },
 );
 
+test.each([
+  { accountCount: 0, authorized: false },
+  { accountCount: 1, authorized: false },
+  { accountCount: 0, authorized: true },
+])(
+  "Respect account availability for a permission link with $accountCount accounts and authorized=$authorized",
+  async ({ accountCount, authorized }) => {
+    const connector = customConnector({
+      connected: accountCount > 0,
+      connectedAccountId: accountCount > 0 ? DEFAULT_ACCOUNT_ID : undefined,
+      missingRequiredFields: accountCount > 0 ? [] : ["secret"],
+      configuredFieldKeys: accountCount > 0 ? ["secret"] : [],
+      permissionBundleRef: "builtin:feishu@1",
+    });
+    mockDefinition(connector);
+    context.mocks.api(
+      agentCustomConnectorsContract.get,
+      ({ params, respond }) => {
+        return respond(200, {
+          grants:
+            authorized && params.id === AGENT_ID
+              ? [{ customConnectorId: connector.id, permissionNames: [] }]
+              : [],
+        });
+      },
+    );
+    context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+      return respond(200, {
+        summaries: [
+          {
+            target: { kind: "custom", customConnectorId: connector.id },
+            accountCount,
+            attentionCount: 0,
+            defaultConnection:
+              accountCount > 0
+                ? {
+                    ...account(connector),
+                    id: DEFAULT_ACCOUNT_ID,
+                    isDefault: true,
+                    connectionStatus: "connected",
+                    reconnectReason: null,
+                  }
+                : null,
+          },
+        ],
+      });
+    });
+    context.mocks.api(
+      customConnectorByIdContract.permissions,
+      ({ respond }) => {
+        return respond(200, {
+          ref: "builtin:feishu@1",
+          permissions: [
+            { name: "messages:send-as-user", description: "Send as user" },
+          ],
+          defaultPolicies: { "messages:send-as-user": "deny" },
+        });
+      },
+    );
+    await setupPage({
+      context,
+      path: `/connectors?tab=custom&customConnectorId=${connector.id}&view=access&permission=messages%3Asend-as-user&agentId=${AGENT_ID}`,
+    });
+    await screen.findByDisplayValue("Research");
+
+    const shouldOpen = authorized || accountCount > 0;
+    const expected = {
+      permissionReviewOpen: shouldOpen,
+      applyEnabled: shouldOpen ? !authorized : null,
+      authorizationEnabled: shouldOpen ? null : false,
+    };
+    await waitFor(() => {
+      const drawer = screen.queryByRole("dialog", {
+        name: `${connector.displayName} permissions for Research`,
+      });
+      const apply = drawer
+        ? queryConnectorAction("button", "Apply", drawer)
+        : null;
+      const authorizationSwitch = screen.queryByRole("switch", {
+        name: /Research/,
+      });
+      expect({
+        permissionReviewOpen: drawer !== null,
+        applyEnabled: apply ? !apply.hasAttribute("disabled") : null,
+        authorizationEnabled: authorizationSwitch
+          ? authorizationSwitch.getAttribute("aria-disabled") !== "true"
+          : null,
+      }).toStrictEqual(expected);
+    });
+  },
+);
+
 test("Keep a closed custom access review closed when Agent grants arrive", async () => {
   const connector = customConnector({
     connected: true,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
@@ -88,9 +88,13 @@ function mockDefinition(connector: CustomConnectorResponse): void {
           defaultConnection: {
             ...account(connector),
             id: DEFAULT_ACCOUNT_ID,
-            displayName: "Healthy default",
+            displayName: connector.connected
+              ? "Healthy default"
+              : "Outdated default",
             isDefault: true,
-            connectionStatus: "connected",
+            connectionStatus: connector.connected
+              ? "connected"
+              : "reconnect-required",
             reconnectReason: null,
           },
         },
@@ -168,6 +172,91 @@ test.each(["http", "mcp"] as const)(
     });
     await waitFor(() => {
       return expect(dialog).not.toBeInTheDocument();
+    });
+  },
+);
+
+test.each(["http", "mcp"] as const)(
+  "Continue a recovered custom %s account while its default remains outdated",
+  async (kind) => {
+    const overrides = {
+      connected: false,
+      missingRequiredFields: ["secret"],
+      configuredFieldKeys: [],
+    };
+    const connector =
+      kind === "http"
+        ? customConnector({ ...overrides, slug: "_acme-search" })
+        : mcpCustomConnector(overrides);
+    mockDefinition(connector);
+    let selected = account(connector);
+    context.mocks.api(
+      connectorAccountsContract.connection,
+      ({ params, query, respond }) => {
+        expect(params.connectionId).toBe(ACCOUNT_ID);
+        expect(query).toStrictEqual({
+          kind: "custom",
+          customConnectorId: connector.id,
+        });
+        return respond(200, selected);
+      },
+    );
+    context.mocks.api(
+      customConnectorValuesContract.set,
+      ({ body, respond }) => {
+        expect(body.account).toStrictEqual({
+          intent: "reconnect",
+          connectionId: ACCOUNT_ID,
+        });
+        selected = {
+          ...selected,
+          connectionStatus: "connected",
+          reconnectReason: null,
+        };
+        return respond(200, {
+          ...connector,
+          connected: true,
+          connectedAccountId: ACCOUNT_ID,
+          configuredFieldKeys: ["secret"],
+          missingRequiredFields: [],
+        });
+      },
+    );
+    context.mocks.api(
+      agentCustomConnectorsContract.update,
+      ({ body, respond }) => {
+        return respond(200, { grants: body.grants });
+      },
+    );
+    const prompts: string[] = [];
+    context.mocks.api(chatEventsContract.send, ({ body, respond }) => {
+      if ("prompt" in body && body.prompt) {
+        prompts.push(body.prompt);
+      }
+      return respond(201, {
+        threadId: THREAD_ID,
+        runId: "66666666-6666-4666-8666-666666666666",
+      });
+    });
+
+    await setupPage({
+      context,
+      path: `/connectors/${connector.slug}/reconnect/${ACCOUNT_ID}?agentId=${AGENT_ID}&threadId=${THREAD_ID}&callbackPrompt=Continue+the+recovered+account`,
+      featureSwitches: { [FeatureSwitchKey.CustomConnectorMcp]: true },
+    });
+    await screen.findByText("Run-selected account");
+    click(getConnectorAction("button", "Reconnect"));
+    const dialog = await screen.findByRole("dialog", {
+      name: `Connect ${connector.displayName}`,
+    });
+    await fill(within(dialog).getByLabelText("Secret"), "replacement-secret");
+    click(getConnectorAction("button", "Save", dialog));
+
+    await waitFor(() => {
+      expect(prompts).toStrictEqual(["Continue the recovered account"]);
+    });
+    await waitFor(() => {
+      expect(dialog).not.toBeInTheDocument();
     });
   },
 );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
@@ -6,6 +6,7 @@ import { agentCustomConnectorsContract } from "@okouai/api-contracts/contracts/a
 import { chatEventsContract } from "@okouai/api-contracts/contracts/chat-threads";
 import {
   customConnectorByIdContract,
+  customConnectorOAuth2Contract,
   customConnectorsContract,
   customConnectorValuesContract,
   type CustomConnectorResponse,
@@ -19,6 +20,8 @@ import {
   customConnector,
   mcpCustomConnector,
   getConnectorAction,
+  getConnectorCard,
+  queryConnectorAction,
   listAgent,
 } from "./connector-page-test-helpers.ts";
 
@@ -197,6 +200,132 @@ test.each(["missing", "invalid"] as const)(
     await expect(
       screen.findByText(connector.displayName),
     ).resolves.toBeInTheDocument();
+  },
+);
+
+test.each(["completed", "cancelled"] as const)(
+  "Confirm a %s custom OAuth reconnect from the exact account's update",
+  async (outcome) => {
+    const connector = customConnector({
+      slug: "_acme-oauth",
+      authMode: "oauth",
+      connected: true,
+      connectedAccountId: DEFAULT_ACCOUNT_ID,
+      connectedAccountUpdatedAt: "2026-01-01T00:00:00Z",
+      fields: [],
+      missingRequiredFields: [],
+      configuredFieldKeys: [],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{oauth.access_token}}",
+        },
+      ],
+      oauthConfig: {
+        providerAdapter: "standard",
+        clientId: "client-id",
+        authorizationUrl: "https://acme.test/oauth/authorize",
+        tokenUrl: "https://acme.test/oauth/token",
+        tokenEndpointAuthMethod: "client_secret_post",
+        pkceMethod: "S256",
+        scopes: ["read"],
+        authorizationParams: {},
+      },
+    });
+    mockDefinition(connector);
+    let reconnected = false;
+    context.mocks.api(
+      connectorAccountsContract.connection,
+      ({ params, query, respond }) => {
+        expect(params.connectionId).toBe(ACCOUNT_ID);
+        expect(query).toStrictEqual({
+          kind: "custom",
+          customConnectorId: connector.id,
+        });
+        return respond(200, {
+          ...account(connector),
+          authMethod: "oauth",
+          connectionStatus: reconnected ? "connected" : "reconnect-required",
+          reconnectReason: reconnected
+            ? null
+            : "authorization_expired_or_revoked",
+          updatedAt: reconnected
+            ? "2026-01-02T00:00:00Z"
+            : "2026-01-01T00:00:00Z",
+        });
+      },
+    );
+    context.mocks.api(
+      customConnectorOAuth2Contract.start,
+      ({ body, respond }) => {
+        expect(body.account).toStrictEqual({
+          intent: "reconnect",
+          connectionId: ACCOUNT_ID,
+        });
+        reconnected = outcome === "completed";
+        return respond(200, {
+          result: "authorization",
+          authorizationUrl: "https://acme.test/oauth/reconnect",
+          connectionId: ACCOUNT_ID,
+        });
+      },
+    );
+    context.mocks.api(
+      agentCustomConnectorsContract.update,
+      ({ params, body, respond }) => {
+        expect(params.id).toBe(AGENT_ID);
+        return respond(200, { grants: body.grants });
+      },
+    );
+    const prompts: string[] = [];
+    context.mocks.api(chatEventsContract.send, ({ body, respond }) => {
+      if ("prompt" in body && body.prompt) {
+        prompts.push(body.prompt);
+      }
+      return respond(201, {
+        threadId: THREAD_ID,
+        runId: "66666666-6666-4666-8666-666666666666",
+      });
+    });
+    const authWindow = context.mocks.browser.authWindow();
+    authWindow.closed = true;
+    Object.defineProperty(authWindow, "location", {
+      value: { href: "" },
+      configurable: true,
+    });
+    context.mocks.browser.open(authWindow);
+    await setupPage({
+      context,
+      path: `/connectors/${connector.slug}/reconnect/${ACCOUNT_ID}?agentId=${AGENT_ID}&threadId=${THREAD_ID}&callbackPrompt=Continue+after+OAuth`,
+    });
+    await screen.findByText("Run-selected account");
+    click(getConnectorAction("button", "Reconnect"));
+    const dialog = await screen.findByRole("dialog", {
+      name: `Connect ${connector.displayName}`,
+    });
+    click(getConnectorAction("button", "Continue", dialog));
+    await waitFor(() => {
+      expect(authWindow.location.href).toBe(
+        "https://acme.test/oauth/reconnect",
+      );
+    });
+    const expected =
+      outcome === "completed"
+        ? { prompts: ["Continue after OAuth"], canContinue: false }
+        : { prompts: [], canContinue: true };
+    await waitFor(() => {
+      const currentDialog = screen.queryByRole("dialog", {
+        name: `Connect ${connector.displayName}`,
+      });
+      const continueAction = currentDialog
+        ? queryConnectorAction("button", "Continue", currentDialog)
+        : null;
+      expect({
+        prompts,
+        canContinue:
+          continueAction !== null && !continueAction.hasAttribute("disabled"),
+      }).toStrictEqual(expected);
+    });
   },
 );
 
@@ -386,3 +515,65 @@ test.each(["deleted", "ambiguous"] as const)(
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   },
 );
+
+test("Keep a closed custom access review closed when Agent grants arrive", async () => {
+  const connector = customConnector({
+    connected: true,
+    permissionBundleRef: "builtin:feishu@1",
+    missingRequiredFields: [],
+  });
+  mockDefinition(connector);
+  const requested = context.mocks.deferred<void>();
+  const release = context.mocks.deferred<void>();
+  context.mocks.api(
+    agentCustomConnectorsContract.get,
+    async ({ params, respond }) => {
+      if (!requested.settled()) {
+        requested.resolve();
+      }
+      await release.promise;
+      return respond(200, {
+        grants:
+          params.id === AGENT_ID
+            ? [
+                {
+                  customConnectorId: connector.id,
+                  permissionNames: ["standard:use"],
+                },
+              ]
+            : [],
+      });
+    },
+  );
+  context.mocks.api(customConnectorByIdContract.permissions, ({ respond }) => {
+    return respond(200, {
+      ref: "builtin:feishu@1",
+      permissions: [
+        { name: "standard:use", description: "Read data" },
+        { name: "messages:send-as-user", description: "Send as user" },
+      ],
+      defaultPolicies: {
+        "standard:use": "allow",
+        "messages:send-as-user": "deny",
+      },
+    });
+  });
+  await setupPage({
+    context,
+    path: `/connectors?tab=custom&customConnectorId=${connector.id}&view=access&permission=messages%3Asend-as-user&agentId=${AGENT_ID}`,
+  });
+  await requested.promise;
+  const dialog = await screen.findByRole("dialog", {
+    name: `Manage ${connector.displayName} access`,
+  });
+  click(getConnectorAction("button", "Close", dialog));
+  release.resolve();
+  await waitFor(() => {
+    expect(
+      within(getConnectorCard(connector.displayName)).getByTestId(
+        "connector-card-agent-access",
+      ),
+    ).toHaveTextContent("Used by Research");
+  });
+  expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
@@ -1,0 +1,388 @@
+import {
+  connectorAccountsContract,
+  type ConnectorAccountConnection,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import { agentCustomConnectorsContract } from "@okouai/api-contracts/contracts/agent-custom-connectors";
+import { chatEventsContract } from "@okouai/api-contracts/contracts/chat-threads";
+import {
+  customConnectorByIdContract,
+  customConnectorsContract,
+  customConnectorValuesContract,
+  type CustomConnectorResponse,
+} from "@okouai/api-contracts/contracts/custom-connectors";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { screen, waitFor, within } from "@testing-library/react";
+import { expect, test } from "vitest";
+import { click, fill, setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import {
+  customConnector,
+  mcpCustomConnector,
+  getConnectorAction,
+  listAgent,
+} from "./connector-page-test-helpers.ts";
+
+const context = testContext();
+const AGENT_ID = "c0000000-0000-4000-a000-000000000051";
+const OTHER_AGENT_ID = "c0000000-0000-4000-a000-000000000052";
+const ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
+const DEFAULT_ACCOUNT_ID = "22222222-2222-4222-8222-222222222222";
+const THREAD_ID = "55555555-5555-4555-8555-555555555555";
+
+function account(
+  connector: CustomConnectorResponse,
+): ConnectorAccountConnection {
+  return {
+    id: ACCOUNT_ID,
+    target: { kind: "custom", customConnectorId: connector.id },
+    authMethod: "manual",
+    displayName: "Run-selected account",
+    isDefault: false,
+    externalId: null,
+    externalUsername: null,
+    externalEmail: null,
+    oauthScopes: null,
+    connectionStatus: "reconnect-required",
+    reconnectReason: "authorization_expired_or_revoked",
+    tokenExpiresAt: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+function connectedDefinition(kind: "http" | "mcp"): CustomConnectorResponse {
+  const overrides = {
+    slug: kind === "http" ? "_acme-search" : "_acme-mcp",
+    connected: true,
+    connectedAccountId: DEFAULT_ACCOUNT_ID,
+    missingRequiredFields: [],
+    configuredFieldKeys: ["secret"],
+  };
+  return kind === "http"
+    ? customConnector(overrides)
+    : mcpCustomConnector(overrides);
+}
+
+function mockDefinition(connector: CustomConnectorResponse): void {
+  context.mocks.api(customConnectorsContract.list, ({ respond }) => {
+    return respond(200, { connectors: [connector] });
+  });
+  context.mocks.data.agents([
+    listAgent(AGENT_ID, "Research"),
+    listAgent(OTHER_AGENT_ID, "Support"),
+  ]);
+  context.mocks.api(agentCustomConnectorsContract.get, ({ respond }) => {
+    return respond(200, { grants: [] });
+  });
+  context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+    return respond(200, {
+      summaries: [
+        {
+          target: { kind: "custom", customConnectorId: connector.id },
+          accountCount: 2,
+          attentionCount: 1,
+          defaultConnection: {
+            ...account(connector),
+            id: DEFAULT_ACCOUNT_ID,
+            displayName: "Healthy default",
+            isDefault: true,
+            connectionStatus: "connected",
+            reconnectReason: null,
+          },
+        },
+      ],
+    });
+  });
+}
+
+test.each(["http", "mcp"] as const)(
+  "Reconnect the selected custom %s account and continue only after confirmation",
+  async (kind) => {
+    const connector = connectedDefinition(kind);
+    mockDefinition(connector);
+    const selected = account(connector);
+    context.mocks.api(
+      connectorAccountsContract.connection,
+      ({ params, query, respond }) => {
+        expect(params.connectionId).toBe(ACCOUNT_ID);
+        expect(query).toStrictEqual({
+          kind: "custom",
+          customConnectorId: connector.id,
+        });
+        return respond(200, selected);
+      },
+    );
+    context.mocks.api(
+      customConnectorValuesContract.set,
+      ({ params, body, respond }) => {
+        expect(params.id).toBe(connector.id);
+        expect(body.account).toStrictEqual({
+          intent: "reconnect",
+          connectionId: ACCOUNT_ID,
+        });
+        expect(body.values).toStrictEqual([
+          { key: "secret", kind: "secret", value: "replacement-secret" },
+        ]);
+        return respond(200, { ...connector, connectedAccountId: ACCOUNT_ID });
+      },
+    );
+    context.mocks.api(
+      agentCustomConnectorsContract.update,
+      ({ params, body, respond }) => {
+        expect(params.id).toBe(AGENT_ID);
+        return respond(200, { grants: body.grants });
+      },
+    );
+    const prompts: string[] = [];
+    context.mocks.api(chatEventsContract.send, ({ body, respond }) => {
+      if ("prompt" in body && body.prompt) {
+        prompts.push(body.prompt);
+      }
+      return respond(201, {
+        threadId: THREAD_ID,
+        runId: "66666666-6666-4666-8666-666666666666",
+      });
+    });
+    await setupPage({
+      context,
+      path: `/connectors/${connector.slug}/reconnect/${ACCOUNT_ID}?agentId=${AGENT_ID}&threadId=${THREAD_ID}&callbackPrompt=Continue+the+original+task`,
+      featureSwitches: { [FeatureSwitchKey.CustomConnectorMcp]: true },
+    });
+    await expect(
+      screen.findByText("Run-selected account"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.queryByText("Healthy default")).not.toBeInTheDocument();
+    click(getConnectorAction("button", "Reconnect"));
+    const dialog = await screen.findByRole("dialog", {
+      name: `Connect ${connector.displayName}`,
+    });
+    expect(prompts).toStrictEqual([]);
+    await fill(within(dialog).getByLabelText("Secret"), "replacement-secret");
+    click(getConnectorAction("button", "Save", dialog));
+    await waitFor(() => {
+      return expect(prompts).toStrictEqual(["Continue the original task"]);
+    });
+    await waitFor(() => {
+      return expect(dialog).not.toBeInTheDocument();
+    });
+  },
+);
+
+test.each(["missing", "invalid"] as const)(
+  "Keep a %s exact custom account unavailable despite a healthy default",
+  async (state) => {
+    const connector = connectedDefinition("http");
+    mockDefinition(connector);
+    context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
+      return respond(404, {
+        error: { code: "NOT_FOUND", message: "Account unavailable" },
+      });
+    });
+    context.mocks.api(customConnectorValuesContract.set, () => {
+      throw new Error("An unavailable target must not reconnect a sibling");
+    });
+    context.mocks.api(chatEventsContract.send, () => {
+      throw new Error("An unavailable target cannot confirm a callback");
+    });
+    await setupPage({
+      context,
+      path: `/connectors/${connector.slug}/reconnect/${state === "missing" ? ACCOUNT_ID : "invalid"}?agentId=${AGENT_ID}&threadId=${THREAD_ID}&callbackPrompt=Continue`,
+    });
+    await expect(
+      screen.findByText("Accounts are unavailable for this connector."),
+    ).resolves.toBeInTheDocument();
+    const settings = getConnectorAction("link", "Connectors");
+    expect(settings).toHaveAttribute("href", "/connectors?tab=custom");
+    click(settings);
+    await expect(
+      screen.findByText(connector.displayName),
+    ).resolves.toBeInTheDocument();
+  },
+);
+
+test("Do not continue a custom reconnect callback when the dialog is cancelled", async () => {
+  const connector = connectedDefinition("http");
+  mockDefinition(connector);
+  context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
+    return respond(200, account(connector));
+  });
+  context.mocks.api(chatEventsContract.send, () => {
+    throw new Error("Cancelling a reconnect must not continue the chat");
+  });
+  await setupPage({
+    context,
+    path: `/connectors/${connector.slug}/reconnect/${ACCOUNT_ID}?agentId=${AGENT_ID}&threadId=${THREAD_ID}&callbackPrompt=Continue`,
+  });
+  await screen.findByText("Run-selected account");
+  click(getConnectorAction("button", "Reconnect"));
+  const dialog = await screen.findByRole("dialog", {
+    name: `Connect ${connector.displayName}`,
+  });
+  click(getConnectorAction("button", "Cancel", dialog));
+  await waitFor(() => {
+    return expect(dialog).not.toBeInTheDocument();
+  });
+  expect(getConnectorAction("button", "Reconnect")).toBeEnabled();
+});
+
+test("Open the targeted custom account manager for manual account selection", async () => {
+  const connector = connectedDefinition("http");
+  mockDefinition(connector);
+  context.mocks.api(
+    connectorAccountsContract.connections,
+    ({ query, respond }) => {
+      expect(query).toMatchObject({
+        kind: "custom",
+        customConnectorId: connector.id,
+      });
+      return respond(200, {
+        connections: [account(connector)],
+        nextCursor: null,
+      });
+    },
+  );
+  await setupPage({
+    context,
+    path: `/connectors?tab=custom&customConnectorId=${connector.id}&view=accounts&agentId=${AGENT_ID}`,
+  });
+  const dialog = await screen.findByRole("dialog", {
+    name: `Manage ${connector.displayName} accounts`,
+  });
+  await expect(
+    within(dialog).findByText("Run-selected account"),
+  ).resolves.toBeInTheDocument();
+});
+
+test("Keep a failed reconnect open without confirming the chat callback", async () => {
+  const connector = connectedDefinition("http");
+  mockDefinition(connector);
+  context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
+    return respond(200, account(connector));
+  });
+  context.mocks.api(customConnectorValuesContract.set, ({ respond }) => {
+    return respond(500, {
+      error: { code: "INTERNAL_SERVER_ERROR", message: "Reconnect failed" },
+    });
+  });
+  context.mocks.api(chatEventsContract.send, () => {
+    throw new Error("A failed connection cannot continue the chat");
+  });
+  await setupPage({
+    context,
+    path: `/connectors/${connector.slug}/reconnect/${ACCOUNT_ID}?agentId=${AGENT_ID}&threadId=${THREAD_ID}&callbackPrompt=Continue`,
+  });
+  await screen.findByText("Run-selected account");
+  click(getConnectorAction("button", "Reconnect"));
+  const dialog = await screen.findByRole("dialog", {
+    name: `Connect ${connector.displayName}`,
+  });
+  await fill(within(dialog).getByLabelText("Secret"), "replacement-secret");
+  click(getConnectorAction("button", "Save", dialog));
+  await expect(
+    screen.findByText("Reconnect failed"),
+  ).resolves.toBeInTheDocument();
+  expect(dialog).toBeInTheDocument();
+});
+
+test("Keep directed custom MCP reconnect behind its existing feature switch", async () => {
+  const connector = connectedDefinition("mcp");
+  mockDefinition(connector);
+  context.mocks.api(connectorAccountsContract.connection, () => {
+    throw new Error("Hidden MCP accounts must not be selected");
+  });
+  await setupPage({
+    context,
+    path: `/connectors/${connector.slug}/reconnect/${ACCOUNT_ID}?agentId=${AGENT_ID}`,
+    featureSwitches: { [FeatureSwitchKey.CustomConnectorMcp]: false },
+  });
+  await expect(
+    screen.findByText("Accounts are unavailable for this connector."),
+  ).resolves.toBeInTheDocument();
+  expect(getConnectorAction("link", "Connectors")).toHaveAttribute(
+    "href",
+    "/connectors?tab=custom",
+  );
+});
+
+test("Review the named custom permission for the exact Agent without granting it or continuing chat", async () => {
+  const connector = customConnector({
+    connected: true,
+    permissionBundleRef: "builtin:feishu@1",
+    missingRequiredFields: [],
+  });
+  mockDefinition(connector);
+  context.mocks.api(
+    agentCustomConnectorsContract.get,
+    ({ params, respond }) => {
+      return respond(200, {
+        grants:
+          params.id === AGENT_ID
+            ? [
+                {
+                  customConnectorId: connector.id,
+                  permissionNames: ["standard:use"],
+                },
+              ]
+            : [],
+      });
+    },
+  );
+  context.mocks.api(customConnectorByIdContract.permissions, ({ respond }) => {
+    return respond(200, {
+      ref: "builtin:feishu@1",
+      permissions: [
+        { name: "standard:use", description: "Read data" },
+        { name: "messages:send-as-user", description: "Send as user" },
+      ],
+      defaultPolicies: {
+        "standard:use": "allow",
+        "messages:send-as-user": "deny",
+      },
+    });
+  });
+  context.mocks.api(agentCustomConnectorsContract.update, () => {
+    throw new Error("Opening a review must not grant permissions");
+  });
+  context.mocks.api(chatEventsContract.send, () => {
+    throw new Error("Settings review does not confirm a callback");
+  });
+  await setupPage({
+    context,
+    path: `/connectors?tab=custom&customConnectorId=${connector.id}&view=access&permission=messages%3Asend-as-user&agentId=${AGENT_ID}&threadId=${THREAD_ID}&callbackPrompt=Continue`,
+  });
+  const drawer = await screen.findByRole("dialog", {
+    name: `${connector.displayName} permissions for Research`,
+  });
+  expect(within(drawer).getByText("messages:send-as-user")).toBeInTheDocument();
+  expect(getConnectorAction("button", "Allow", drawer)).toHaveAttribute(
+    "aria-pressed",
+    "false",
+  );
+  expect(getConnectorAction("button", "Deny", drawer)).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  expect(getConnectorAction("button", "Apply", drawer)).toBeDisabled();
+  expect(
+    screen.queryByRole("dialog", {
+      name: `${connector.displayName} permissions for Support`,
+    }),
+  ).not.toBeInTheDocument();
+  expect(window.location.pathname).toBe("/connectors");
+});
+
+test.each(["deleted", "ambiguous"] as const)(
+  "Keep %s custom settings navigation available for manual selection",
+  async (state) => {
+    const connector = connectedDefinition("http");
+    mockDefinition(connector);
+    await setupPage({
+      context,
+      path: `/connectors?tab=custom&customConnectorId=${state === "deleted" ? "77777777-7777-4777-8777-777777777777" : connector.id}&view=${state === "ambiguous" ? "unknown" : "access"}`,
+    });
+    await expect(
+      screen.findByText(connector.displayName),
+    ).resolves.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  },
+);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
@@ -172,6 +172,66 @@ test.each(["http", "mcp"] as const)(
   },
 );
 
+test.each([false, true])(
+  "Continue a permission-bundled reconnect only with existing Agent access: %s",
+  async (authorized) => {
+    const connector = customConnector({
+      slug: "_acme-search",
+      connected: true,
+      connectedAccountId: DEFAULT_ACCOUNT_ID,
+      missingRequiredFields: [],
+      configuredFieldKeys: ["secret"],
+      permissionBundleRef: "builtin:feishu@1",
+    });
+    mockDefinition(connector);
+    context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
+      return respond(200, account(connector));
+    });
+    context.mocks.api(customConnectorValuesContract.set, ({ respond }) => {
+      return respond(200, { ...connector, connectedAccountId: ACCOUNT_ID });
+    });
+    context.mocks.api(agentCustomConnectorsContract.get, ({ respond }) => {
+      return respond(200, {
+        grants: authorized
+          ? [{ customConnectorId: connector.id, permissionNames: [] }]
+          : [],
+      });
+    });
+    context.mocks.api(agentCustomConnectorsContract.update, () => {
+      throw new Error(
+        "Connecting must not implicitly grant bundled permissions",
+      );
+    });
+    const prompts: string[] = [];
+    context.mocks.api(chatEventsContract.send, ({ body, respond }) => {
+      if ("prompt" in body && body.prompt) {
+        prompts.push(body.prompt);
+      }
+      return respond(201, {
+        threadId: THREAD_ID,
+        runId: "66666666-6666-4666-8666-666666666666",
+      });
+    });
+    await setupPage({
+      context,
+      path: `/connectors/${connector.slug}/reconnect/${ACCOUNT_ID}?agentId=${AGENT_ID}&threadId=${THREAD_ID}&callbackPrompt=Continue+after+reconnect`,
+    });
+    await screen.findByText("Run-selected account");
+    click(getConnectorAction("button", "Reconnect"));
+    const dialog = await screen.findByRole("dialog", {
+      name: `Connect ${connector.displayName}`,
+    });
+    await fill(within(dialog).getByLabelText("Secret"), "replacement-secret");
+    click(getConnectorAction("button", "Save", dialog));
+    await waitFor(() => {
+      expect(dialog).not.toBeInTheDocument();
+    });
+    expect(prompts).toStrictEqual(
+      authorized ? ["Continue after reconnect"] : [],
+    );
+  },
+);
+
 test.each(["missing", "invalid"] as const)(
   "Keep a %s exact custom account unavailable despite a healthy default",
   async (state) => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
@@ -648,6 +648,73 @@ test.each([
   },
 );
 
+test.each(
+  (["accounts", "access"] as const).flatMap((view) => {
+    return [false, true].map((dismissed) => {
+      return { view, dismissed };
+    });
+  }),
+)(
+  "Preserve manual dialog intent when delayed $view recovery finishes with dismissed=$dismissed",
+  async ({ view, dismissed }) => {
+    const connector = connectedDefinition("http");
+    mockDefinition(connector);
+    context.mocks.data.org({ id: "org_1", name: "Test Org", role: "admin" });
+    const release = context.mocks.deferred<void>();
+    context.mocks.api(customConnectorsContract.list, async ({ respond }) => {
+      await release.promise;
+      return respond(200, { connectors: [connector] });
+    });
+    context.mocks.api(connectorAccountsContract.connections, ({ respond }) => {
+      return respond(200, {
+        connections: [account(connector)],
+        nextCursor: null,
+      });
+    });
+    await setupPage({
+      context,
+      path: `/connectors?tab=custom&customConnectorId=${connector.id}&view=${view}&agentId=${AGENT_ID}`,
+    });
+    const create = await waitFor(() => {
+      return getConnectorAction("button", "New connector");
+    });
+    click(create);
+    const draft = await screen.findByRole("dialog", {
+      name: "New custom connector",
+    });
+    await fill(within(draft).getByLabelText("Display name"), "My draft");
+    if (dismissed) {
+      click(getConnectorAction("button", "Close", draft));
+    }
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "New custom connector" }) !== null,
+      ).toBe(!dismissed);
+    });
+
+    release.resolve();
+
+    await waitFor(() => {
+      expect(getConnectorCard(connector.displayName)).toBeInTheDocument();
+    });
+    expect({
+      draftOpen:
+        screen.queryByRole("dialog", { name: "New custom connector" }) !== null,
+      draftValuePresent: screen.queryByDisplayValue("My draft") !== null,
+      dialogCount: screen.queryAllByRole("dialog").length,
+    }).toStrictEqual({
+      draftOpen: !dismissed,
+      draftValuePresent: !dismissed,
+      dialogCount: dismissed ? 0 : 1,
+    });
+    expect(
+      screen.queryByRole("dialog", {
+        name: `Manage ${connector.displayName} ${view}`,
+      }),
+    ).not.toBeInTheDocument();
+  },
+);
+
 test("Keep a closed custom access review closed when Agent grants arrive", async () => {
   const connector = customConnector({
     connected: true,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/custom-connector-recovery.test.tsx
@@ -164,6 +164,7 @@ test.each(["http", "mcp"] as const)(
     const dialog = await screen.findByRole("dialog", {
       name: `Connect ${connector.displayName}`,
     });
+    expect(dialog).not.toHaveTextContent("Configured");
     expect(prompts).toStrictEqual([]);
     await fill(within(dialog).getByLabelText("Secret"), "replacement-secret");
     click(getConnectorAction("button", "Save", dialog));
@@ -177,11 +178,25 @@ test.each(["http", "mcp"] as const)(
 );
 
 test.each(["http", "mcp"] as const)(
-  "Continue a recovered custom %s account while its default remains outdated",
+  "Update selected custom %s credentials while its default remains outdated",
   async (kind) => {
     const overrides = {
       connected: false,
-      missingRequiredFields: ["secret"],
+      fields: [
+        {
+          key: "secret",
+          label: "Secret",
+          kind: "secret" as const,
+          required: true,
+        },
+        {
+          key: "region",
+          label: "Region",
+          kind: "variable" as const,
+          required: true,
+        },
+      ],
+      missingRequiredFields: ["secret", "region"],
       configuredFieldKeys: [],
     };
     const connector =
@@ -189,7 +204,11 @@ test.each(["http", "mcp"] as const)(
         ? customConnector({ ...overrides, slug: "_acme-search" })
         : mcpCustomConnector(overrides);
     mockDefinition(connector);
-    let selected = account(connector);
+    const selected = {
+      ...account(connector),
+      connectionStatus: "connected" as const,
+      reconnectReason: null,
+    };
     context.mocks.api(
       connectorAccountsContract.connection,
       ({ params, query, respond }) => {
@@ -208,16 +227,14 @@ test.each(["http", "mcp"] as const)(
           intent: "reconnect",
           connectionId: ACCOUNT_ID,
         });
-        selected = {
-          ...selected,
-          connectionStatus: "connected",
-          reconnectReason: null,
-        };
+        expect(body.values).toStrictEqual([
+          { key: "secret", kind: "secret", value: "replacement-secret" },
+        ]);
         return respond(200, {
           ...connector,
           connected: true,
           connectedAccountId: ACCOUNT_ID,
-          configuredFieldKeys: ["secret"],
+          configuredFieldKeys: ["region", "secret"],
           missingRequiredFields: [],
         });
       },
@@ -250,6 +267,8 @@ test.each(["http", "mcp"] as const)(
       name: `Connect ${connector.displayName}`,
     });
     await fill(within(dialog).getByLabelText("Secret"), "replacement-secret");
+    expect(within(dialog).getByLabelText("Region")).toHaveValue("");
+    expect(getConnectorAction("button", "Save", dialog)).toBeEnabled();
     click(getConnectorAction("button", "Save", dialog));
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-access-management-dialog.tsx
@@ -472,7 +472,7 @@ export function ConnectorAccessManagementDialog({
     managedConnectorFirewallPermissionMetadata$,
   );
   const pageSignal = useGet(pageSignal$);
-  const search = useGet(connectorAccessManagementSearch$);
+  const search = useGet(connectorAccessManagementSearch$).value;
   const pendingSavingAgentId = useGet(connectorAccessManagementSavingAgentId$);
   const permissionAgentId = useGet(connectorAccessManagementPermissionAgentId$);
   const setSearch = useSet(setConnectorAccessManagementSearch$);
@@ -703,7 +703,7 @@ export function CustomConnectorAccessManagementDialog({
   const permissionBundleLoadable = useLoadable(
     customConnectorPermissionBundle$,
   );
-  const search = useGet(connectorAccessManagementSearch$);
+  const search = useGet(connectorAccessManagementSearch$).value;
   const setSearch = useSet(setConnectorAccessManagementSearch$);
   const openPermissions = useSet(openCustomConnectorPermissions$);
   const closePermissions = useSet(closeCustomConnectorPermissions$);

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-access-management-dialog.tsx
@@ -776,7 +776,11 @@ export function CustomConnectorAccessManagementDialog({
         onManage={openAgentPermissions}
       />
       <CustomConnectorAccessPermissionsDrawer
-        draft={activePermissionDraft}
+        draft={
+          activePermissionDraft?.initiallyAuthorized || allowAccessIncrease
+            ? activePermissionDraft
+            : null
+        }
         agent={permissionAgent}
         connector={connector}
         bundle={

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-connect-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-connect-dialog.tsx
@@ -286,6 +286,7 @@ interface CustomConnectorConnectDialogProps {
 function CustomConnectorConnectForm({
   connector,
   accountMode,
+  accountOptions,
   values,
   setField,
   submitting,
@@ -295,6 +296,7 @@ function CustomConnectorConnectForm({
 }: {
   readonly connector: CustomConnectorResponse;
   readonly accountMode: ConnectorAccountConnectMode | undefined;
+  readonly accountOptions: ConnectorAccountMutationOptions;
   readonly values: Readonly<Record<string, string>>;
   readonly setField: (args: {
     readonly key: string;
@@ -322,7 +324,11 @@ function CustomConnectorConnectForm({
       ) : (
         <CredentialFields
           connector={connector}
-          configuredFieldKeys={accountMode ? [] : connector.configuredFieldKeys}
+          configuredFieldKeys={
+            accountOptions.useDefaultConnectorProjection && !accountMode
+              ? connector.configuredFieldKeys
+              : []
+          }
           values={values}
           setField={setField}
         />
@@ -381,12 +387,15 @@ export function CustomConnectorConnectDialog({
       return value.key;
     }),
   );
+  // Exact reconnects can preserve stored values; the API owns their completeness.
   const requiredFieldKeys =
-    accountMode?.kind === "add"
+    accountOptions.account.intent === "add"
       ? connector.fields.flatMap((field) => {
           return field.required ? [field.key] : [];
         })
-      : connector.missingRequiredFields;
+      : accountOptions.useDefaultConnectorProjection
+        ? connector.missingRequiredFields
+        : [];
   const hasRequiredValues = requiredFieldKeys.every((key) => {
     return submittedKeys.has(key);
   });
@@ -465,6 +474,7 @@ export function CustomConnectorConnectDialog({
           <CustomConnectorConnectForm
             connector={connector}
             accountMode={accountMode}
+            accountOptions={accountOptions}
             values={form.values}
             setField={setField}
             submitting={submitting}

--- a/turbo/apps/platform/src/views/okou-page/directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-connect-page.tsx
@@ -1,4 +1,4 @@
-import { useGet, useSet, useLastLoadable } from "ccstate-react";
+import { useGet, useSet, useLastLoadable, useLoadable } from "ccstate-react";
 import { Button } from "@okouai/ui";
 import {
   connectorSlugSchema,
@@ -86,11 +86,12 @@ import { CustomConnectorIcon } from "./components/settings/custom-connector-icon
 import { CustomConnectorConnectDialog } from "./components/settings/custom-connector-connect-dialog.tsx";
 import { customConnectorTarget } from "./components/settings/custom-connector-display.ts";
 import { customConnectorMcpEnabled$ } from "../../signals/external/feature-switch.ts";
+import { useConnectorAccountLabel } from "./components/settings/use-connector-account-label.ts";
+import { Link } from "../router/link.tsx";
 import {
   defaultBuiltinConnectorAccountOptions,
   defaultCustomConnectorAccountOptions,
   type ConnectorAccountMutationOptions,
-  type DefaultConnectorAccountMutationOptions,
 } from "../../signals/okou-page/settings/connector-account-dialogs.ts";
 
 function runDirectedConnect(
@@ -582,7 +583,7 @@ type DirectedConnectAccountState =
 
 function useDirectedConnectAccountState(): DirectedConnectAccountState {
   const target = useGet(directedConnectAccountTarget$);
-  const accountLoadable = useLastLoadable(directedConnectExactAccount$);
+  const accountLoadable = useLoadable(directedConnectExactAccount$);
   if (target.kind === "default") {
     return target;
   }
@@ -892,14 +893,30 @@ function customConnectorForSlug(
 
 interface CustomConnectorConnection {
   readonly connector: CustomConnectorResponse;
-  readonly accountOptions: DefaultConnectorAccountMutationOptions;
+  readonly accountOptions: ConnectorAccountMutationOptions;
 }
 
 function customConnectorConnection(
   connector: CustomConnectorResponse | undefined,
+  accountState: DirectedConnectAccountState,
 ): CustomConnectorConnection | null {
+  if (
+    !connector ||
+    accountState.kind === "unavailable" ||
+    accountState.kind === "loading"
+  ) {
+    return null;
+  }
+  if (accountState.kind === "exact") {
+    return {
+      connector,
+      accountOptions: {
+        account: { intent: "reconnect", connectionId: accountState.account.id },
+      },
+    };
+  }
   const accountOptions = defaultCustomConnectorAccountOptions(connector);
-  return connector && accountOptions ? { connector, accountOptions } : null;
+  return accountOptions ? { connector, accountOptions } : null;
 }
 
 function CustomDirectedConnectorDialog({
@@ -929,15 +946,67 @@ function CustomDirectedConnectorDialog({
   );
 }
 
+function CustomDirectedConnectCardContent({
+  connector,
+  connectorSlug,
+  accountState,
+  agentName,
+  isLoading,
+  canConnect,
+  onConnect,
+}: {
+  readonly connector: CustomConnectorResponse | undefined;
+  readonly connectorSlug: CustomConnectorSlug;
+  readonly accountState: DirectedConnectAccountState;
+  readonly agentName: string;
+  readonly isLoading: boolean;
+  readonly canConnect: boolean;
+  readonly onConnect: () => void;
+}) {
+  const accountLabel = useConnectorAccountLabel();
+  return (
+    <DirectedConnectCardContent
+      icon={
+        connector ? (
+          <CustomConnectorIcon
+            id={connector.id}
+            displayName={connector.displayName}
+            size={20}
+          />
+        ) : null
+      }
+      connectorLabel={connector?.displayName ?? connectorSlug}
+      connectorDescription={
+        accountState.kind === "exact"
+          ? accountLabel(accountState.account)
+          : connector
+            ? customConnectorTarget(connector)
+            : ""
+      }
+      agentName={agentName}
+      isLoading={isLoading || accountState.kind === "loading"}
+      isConnected={
+        accountState.kind === "exact" ||
+        (accountState.kind === "default" && (connector?.connected ?? false))
+      }
+      isConnecting={false}
+      canConnect={canConnect}
+      onConnect={onConnect}
+    />
+  );
+}
+
 function CustomDirectedConnectCard({
   connectorSlug,
 }: {
   readonly connectorSlug: CustomConnectorSlug;
 }) {
+  const { t } = useTranslation();
   const assistantName = useGet(assistantName$);
   const agentId = useGet(directedConnectAgentId$);
   const agentNameLoadable = useLastLoadable(directedConnectAgentName$);
   const connectorsLoadable = useLastLoadable(customConnectors$);
+  const accountState = useDirectedConnectAccountState();
   const mcpEnabled = useGet(customConnectorMcpEnabled$);
   const dialogKey = useGet(directedConnectCustomDialogKey$);
   const setDialogKey = useSet(setDirectedConnectCustomDialogKey$);
@@ -952,14 +1021,35 @@ function CustomDirectedConnectCard({
     connectorSlug,
     mcpEnabled,
   );
-  const connection = customConnectorConnection(connector);
+  const connection = customConnectorConnection(connector, accountState);
   const dialogOpen =
     dialogKey?.connectorSlug === connectorSlug &&
     dialogKey.agentId === agentId &&
     dialogKey.signal === signal;
 
-  if (connectorsLoadable.state === "hasData" && !connector) {
-    return null;
+  if (
+    (connectorsLoadable.state === "hasData" && !connector) ||
+    accountState.kind === "unavailable"
+  ) {
+    return (
+      <DirectedCardShell
+        icon={null}
+        title={connector?.displayName ?? connectorSlug}
+        description={t(($) => {
+          return $.connectors.accounts.accountsUnavailable;
+        })}
+        isLoading={false}
+      >
+        <Link
+          pathname="/connectors"
+          options={{ searchParams: new URLSearchParams({ tab: "custom" }) }}
+        >
+          {t(($) => {
+            return $.connectors.catalog.title;
+          })}
+        </Link>
+      </DirectedCardShell>
+    );
   }
 
   const agentName =
@@ -986,22 +1076,12 @@ function CustomDirectedConnectCard({
 
   return (
     <>
-      <DirectedConnectCardContent
-        icon={
-          connector ? (
-            <CustomConnectorIcon
-              id={connector.id}
-              displayName={connector.displayName}
-              size={20}
-            />
-          ) : null
-        }
-        connectorLabel={connector?.displayName ?? connectorSlug}
-        connectorDescription={connector ? customConnectorTarget(connector) : ""}
+      <CustomDirectedConnectCardContent
+        connector={connector}
+        connectorSlug={connectorSlug}
+        accountState={accountState}
         agentName={agentName}
         isLoading={connectorsLoadable.state === "loading"}
-        isConnected={connector?.connected ?? false}
-        isConnecting={false}
         canConnect={connection !== null}
         onConnect={() => {
           if (!connection) {
@@ -1026,10 +1106,6 @@ function CustomDirectedConnectCard({
 
 export function DirectedConnectPage() {
   const customConnectorSlug = useGet(directedConnectCustomSlug$);
-  const accountTarget = useGet(directedConnectAccountTarget$);
-  if (customConnectorSlug && accountTarget.kind !== "default") {
-    return null;
-  }
   return customConnectorSlug ? (
     <CustomDirectedConnectCard connectorSlug={customConnectorSlug} />
   ) : (


### PR DESCRIPTION
## Summary

Custom connector recovery lost known connector and account context by linking to the generic Connectors page. CLI search/check now opens the HTTP/MCP connection flow, reconnects the exact run-selected account, or opens targeted account/Agent-access settings. Text and JSON diagnostics preserve current versus run-bound context.

Recovery confirms the requested account independently of its default sibling. OAuth uses the owned attempt receipt; manual saves report the written account's credential markers. Form validation and configured-field labels use account intent and projection scope, so an outdated default cannot block a valid partial update of another account.

Closes #32832

## Behavior and compatibility

- Exact reconnects retain the requested account ID. Missing/deleted metadata and unresolved selection retain explicit manual guidance. Account changes apply to future runs.
- Named permission links open the existing review using current grants. Settings navigation neither grants access nor executes callbacks, and retains account-availability/MCP access-increase restrictions. Delayed setup respects dialogs and searches the user has opened, dismissed, edited or cleared.
- Directed callbacks require confirmed connection completion. Custom HTTP connectors with a permission bundle also require an existing Agent grant; search/check otherwise explain the separate permission review and reject `--callback-prompt`. Existing first-account and grant policies remain in effect.
- Manual-save responses read markers from the written account, scoped to its user, organization and definition. List/get retain default-account projection. New accounts require all required fields; exact reconnects allow partial updates, while the API rejects incomplete restoration of incompatible credentials. Credential writes, query count, schemas and grant authority are unchanged.
- Targeted settings queries are additive; older pages retain manual navigation and reject unsupported exact custom reconnects. Existing OAuth completion and selector/inspection contracts remain compatible with current main. API promotion precedes the corresponding frontend promotion.
- `OKOU_APP_URL` takes precedence across search, check and permission-request. Legacy preview-origin inference without it remains explicitly deferred.

## Validation

Rebased onto `0c27252592810ab55baa97169773056a7453ab30`. The sole conflict was adjacent page-setup imports; both main's SSH refresh and custom recovery initialization are retained. Range-diff confirms the remaining 12 commits are patch-identical.

Using pinned pnpm 10.33.4, with heavy checks sequential and one Vitest process at a time:

- **72/72 Platform Router cases** passed across `custom-connector-recovery.test.tsx`, `connectors-custom.test.tsx` and `connectors-ssh.test.tsx`, one worker. This covers account isolation, partial updates, callback/failure/cancellation behavior, delayed manual intent and returning from SSH host management after deleting the final host.
- **232/232 CLI parser/MSW cases** passed across check-custom, check, search and permission-request, one worker.
- **44/44 API regressions** passed across account lifecycle, Agent custom grants and custom OAuth with a real isolated database and current migrations. Both HTTP/MCP cases reject incomplete incompatible restoration, recover the exact account and preserve existing fields on a later partial update while its default remains outdated.
- Changed-file formatting, full CLI/API/Platform lint, style policy, file-size checks, Knip and repository-wide type checks all passed. Heavy checks ran sequentially; type checking used two checkers and one Turbo task at a time.

No full local Vitest or local product dev server was run. Historical [browser evidence](https://a.okou.io/2ucumo50e5.png) at `ae8ee85382e28775746fdbecb3637e5237da674f` covers the initial dummy-credential flow; subsequent corrections have integration coverage. Real-provider OAuth browser authorization remains unverified. Broader checks run in the PR pipeline.
