### PR TITLE
fix(ci): recover durable host cpu fairness results

### DIFF
--- a/.github/scripts/runner-behavior-host-cpu-fairness-remote.sh
+++ b/.github/scripts/runner-behavior-host-cpu-fairness-remote.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BIN_DIR=$1
+EXECUTION_KEY=$2
+ROOTFS_HASH=$3
+: "${RUNNER_BEHAVIOR_DURABLE_UNIT:?durable owner unit is required}"
+TEST_BIN="${BIN_DIR}/runner-host-cpu-fairness-${EXECUTION_KEY}"
+BASE_DIR="/var/lib/vm0-runner/host-cpu-fairness/${EXECUTION_KEY}"
+UNIT="runner-host-cpu-managed-${EXECUTION_KEY}"
+# Pre-R5c and interim workflow revisions can share this host. Acquire both
+# stable per-CPU inode namespaces in this order and never unlink their files.
+LOCK_DIRS=(
+  "/run/lock/vm0-host-cpu-fairness"
+  "/run/lock/runner-host-cpu-fairness"
+)
+LOCK_FDS=()
+
+case "$EXECUTION_KEY" in
+  ''|*[!a-zA-Z0-9._-]*)
+    echo "unsafe execution key" >&2
+    exit 2
+    ;;
+esac
+
+release_lock_fds() {
+  local lock_fd
+  for lock_fd in "$@"; do
+    flock --unlock "$lock_fd" || true
+    exec {lock_fd}>&-
+  done
+}
+
+cleanup() {
+  sudo systemctl stop "${UNIT}.service" 2>/dev/null || true
+  sudo rm -f -- "$TEST_BIN"
+  sudo rm -rf -- "$BASE_DIR"
+  release_lock_fds "${LOCK_FDS[@]}"
+}
+trap cleanup EXIT
+
+mapfile -t CPU_CANDIDATES < <(
+  LC_ALL=C lscpu --parse=CPU,ONLINE | awk -F, '$2 == "Y" { print $1 }'
+)
+if [ "${#CPU_CANDIDATES[@]}" -eq 0 ]; then
+  echo "host has no online CPUs" >&2
+  exit 1
+fi
+for cpu in "${CPU_CANDIDATES[@]}"; do
+  if [[ ! "$cpu" =~ ^[0-9]+$ ]]; then
+    echo "invalid online CPU: $cpu" >&2
+    exit 1
+  fi
+done
+if [ "${#CPU_CANDIDATES[@]}" -gt 1 ]; then
+  NONZERO_CPUS=()
+  for cpu in "${CPU_CANDIDATES[@]}"; do
+    if [ "$cpu" -ne 0 ]; then
+      NONZERO_CPUS+=("$cpu")
+    fi
+  done
+  CPU_CANDIDATES=("${NONZERO_CPUS[@]}")
+fi
+
+read -r SELECTION_HASH _ < <(printf '%s' "$EXECUTION_KEY" | cksum)
+START_INDEX=$((SELECTION_HASH % ${#CPU_CANDIDATES[@]}))
+sudo install -d -m 0755 -o "$(id -u)" -g "$(id -g)" "${LOCK_DIRS[@]}"
+
+SELECTED_CPU=""
+for ((offset = 0; offset < ${#CPU_CANDIDATES[@]}; offset++)); do
+  candidate_index=$(((START_INDEX + offset) % ${#CPU_CANDIDATES[@]}))
+  candidate_cpu=${CPU_CANDIDATES[$candidate_index]}
+  candidate_lock_fds=()
+  for lock_dir in "${LOCK_DIRS[@]}"; do
+    exec {candidate_lock_fd}>"${lock_dir}/cpu-${candidate_cpu}.lock"
+    if flock --nonblock "$candidate_lock_fd"; then
+      candidate_lock_fds+=("$candidate_lock_fd")
+      continue
+    fi
+    exec {candidate_lock_fd}>&-
+    release_lock_fds "${candidate_lock_fds[@]}"
+    continue 2
+  done
+  SELECTED_CPU=$candidate_cpu
+  LOCK_FDS=("${candidate_lock_fds[@]}")
+  break
+done
+if [ -z "$SELECTED_CPU" ]; then
+  echo "no online host CPU is available for the fairness test" >&2
+  exit 1
+fi
+echo "HOST_CPU_SELECTED_CPU=$SELECTED_CPU"
+
+SYSTEMD_VERSION=$(systemd --version | awk 'NR == 1 { print $2 }')
+case "$SYSTEMD_VERSION" in
+  ''|*[!0-9]*)
+    echo "cannot parse systemd version: $SYSTEMD_VERSION" >&2
+    exit 1
+    ;;
+esac
+if [ "$SYSTEMD_VERSION" -lt 254 ]; then
+  echo "systemd 254+ is required, found $SYSTEMD_VERSION" >&2
+  exit 1
+fi
+
+FIRECRACKER_DIR=$(find /var/lib/vm0-runner/firecracker \
+  -mindepth 1 -maxdepth 1 -type d | sort -V | tail -1)
+FIRECRACKER="${FIRECRACKER_DIR}/firecracker"
+KERNEL=$(find "$FIRECRACKER_DIR" -maxdepth 1 -type f -name 'vmlinux-*' | sort | tail -1)
+ROOTFS="/var/lib/vm0-runner/images/${ROOTFS_HASH}/rootfs.ext4"
+for fixture in "$TEST_BIN" "$FIRECRACKER" "$KERNEL" "$ROOTFS"; do
+  if [ ! -f "$fixture" ]; then
+    echo "required host CPU fairness fixture is missing: $fixture" >&2
+    exit 1
+  fi
+done
+
+sudo modprobe nbd nbds_max=4096
+sudo mkdir -p "$BASE_DIR"
+
+echo "=== Managed weighted host CPU proof ==="
+# Stop the delegated child before its durable owner releases the CPU locks.
+# Bound the native workload even when the CI observer cannot reconnect.
+sudo systemd-run \
+  --wait \
+  --collect \
+  --pipe \
+  "--unit=${UNIT}" \
+  --property=Type=exec \
+  "--property=BindsTo=${RUNNER_BEHAVIOR_DURABLE_UNIT}" \
+  "--property=After=${RUNNER_BEHAVIOR_DURABLE_UNIT}" \
+  --property=RuntimeMaxSec=180 \
+  --property=Delegate=cpu \
+  --property=DelegateSubgroup=control \
+  "--property=AllowedCPUs=${SELECTED_CPU}" \
+  --property=TimeoutStopSec=60 \
+  "--setenv=OKOU_TEST_HOST_CPU_FIRECRACKER=${FIRECRACKER}" \
+  "--setenv=OKOU_TEST_HOST_CPU_KERNEL=${KERNEL}" \
+  "--setenv=OKOU_TEST_HOST_CPU_ROOTFS=${ROOTFS}" \
+  "--setenv=OKOU_TEST_HOST_CPU_BASE_DIR=${BASE_DIR}" \
+  "$TEST_BIN" --ignored --test-threads=1 --nocapture

--- a/.github/scripts/runner-behavior-host-cpu-fairness.sh
+++ b/.github/scripts/runner-behavior-host-cpu-fairness.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 : "${METAL_USER:?METAL_USER is required}"
 : "${HOST:?HOST is required}"
 : "${JOB_REF:?JOB_REF is required}"
@@ -44,139 +46,7 @@ trap cleanup_remote_binary EXIT
 
 scp "$TEST_BIN" "${REMOTE}:${REMOTE_BIN}"
 
-ssh "$REMOTE" bash -s -- \
-  "$REMOTE_BIN" "$DEFAULT_ROOTFS_HASH" "$EXECUTION_KEY" <<'REMOTE_SCRIPT'
-set -euo pipefail
-
-TEST_BIN=$1
-ROOTFS_HASH=$2
-EXECUTION_KEY=$3
-BASE_DIR="/var/lib/vm0-runner/host-cpu-fairness/${EXECUTION_KEY}"
-UNIT="runner-host-cpu-managed-${EXECUTION_KEY}"
-# Pre-R5c and interim workflow revisions can share this host. Acquire both
-# stable per-CPU inode namespaces in this order and never unlink their files.
-LOCK_DIRS=(
-  "/run/lock/vm0-host-cpu-fairness"
-  "/run/lock/runner-host-cpu-fairness"
-)
-LOCK_FDS=()
-
-case "$EXECUTION_KEY" in
-  ''|*[!a-zA-Z0-9._-]*)
-    echo "unsafe execution key" >&2
-    exit 2
-    ;;
-esac
-
-release_lock_fds() {
-  local lock_fd
-  for lock_fd in "$@"; do
-    flock --unlock "$lock_fd" || true
-    exec {lock_fd}>&-
-  done
-}
-
-cleanup() {
-  sudo systemctl stop "${UNIT}.service" 2>/dev/null || true
-  sudo rm -f -- "$TEST_BIN"
-  sudo rm -rf -- "$BASE_DIR"
-  release_lock_fds "${LOCK_FDS[@]}"
-}
-trap cleanup EXIT
-
-mapfile -t CPU_CANDIDATES < <(
-  LC_ALL=C lscpu --parse=CPU,ONLINE | awk -F, '$2 == "Y" { print $1 }'
-)
-if [ "${#CPU_CANDIDATES[@]}" -eq 0 ]; then
-  echo "host has no online CPUs" >&2
-  exit 1
-fi
-for cpu in "${CPU_CANDIDATES[@]}"; do
-  if [[ ! "$cpu" =~ ^[0-9]+$ ]]; then
-    echo "invalid online CPU: $cpu" >&2
-    exit 1
-  fi
-done
-if [ "${#CPU_CANDIDATES[@]}" -gt 1 ]; then
-  NONZERO_CPUS=()
-  for cpu in "${CPU_CANDIDATES[@]}"; do
-    if [ "$cpu" -ne 0 ]; then
-      NONZERO_CPUS+=("$cpu")
-    fi
-  done
-  CPU_CANDIDATES=("${NONZERO_CPUS[@]}")
-fi
-
-read -r SELECTION_HASH _ < <(printf '%s' "$EXECUTION_KEY" | cksum)
-START_INDEX=$((SELECTION_HASH % ${#CPU_CANDIDATES[@]}))
-sudo install -d -m 0755 -o "$(id -u)" -g "$(id -g)" "${LOCK_DIRS[@]}"
-
-SELECTED_CPU=""
-for ((offset = 0; offset < ${#CPU_CANDIDATES[@]}; offset++)); do
-  candidate_index=$(((START_INDEX + offset) % ${#CPU_CANDIDATES[@]}))
-  candidate_cpu=${CPU_CANDIDATES[$candidate_index]}
-  candidate_lock_fds=()
-  for lock_dir in "${LOCK_DIRS[@]}"; do
-    exec {candidate_lock_fd}>"${lock_dir}/cpu-${candidate_cpu}.lock"
-    if flock --nonblock "$candidate_lock_fd"; then
-      candidate_lock_fds+=("$candidate_lock_fd")
-      continue
-    fi
-    exec {candidate_lock_fd}>&-
-    release_lock_fds "${candidate_lock_fds[@]}"
-    continue 2
-  done
-  SELECTED_CPU=$candidate_cpu
-  LOCK_FDS=("${candidate_lock_fds[@]}")
-  break
-done
-if [ -z "$SELECTED_CPU" ]; then
-  echo "no online host CPU is available for the fairness test" >&2
-  exit 1
-fi
-echo "HOST_CPU_SELECTED_CPU=$SELECTED_CPU"
-
-SYSTEMD_VERSION=$(systemd --version | awk 'NR == 1 { print $2 }')
-case "$SYSTEMD_VERSION" in
-  ''|*[!0-9]*)
-    echo "cannot parse systemd version: $SYSTEMD_VERSION" >&2
-    exit 1
-    ;;
-esac
-if [ "$SYSTEMD_VERSION" -lt 254 ]; then
-  echo "systemd 254+ is required, found $SYSTEMD_VERSION" >&2
-  exit 1
-fi
-
-FIRECRACKER_DIR=$(find /var/lib/vm0-runner/firecracker \
-  -mindepth 1 -maxdepth 1 -type d | sort -V | tail -1)
-FIRECRACKER="${FIRECRACKER_DIR}/firecracker"
-KERNEL=$(find "$FIRECRACKER_DIR" -maxdepth 1 -type f -name 'vmlinux-*' | sort | tail -1)
-ROOTFS="/var/lib/vm0-runner/images/${ROOTFS_HASH}/rootfs.ext4"
-for fixture in "$TEST_BIN" "$FIRECRACKER" "$KERNEL" "$ROOTFS"; do
-  if [ ! -f "$fixture" ]; then
-    echo "required host CPU fairness fixture is missing: $fixture" >&2
-    exit 1
-  fi
-done
-
-sudo modprobe nbd nbds_max=4096
-sudo mkdir -p "$BASE_DIR"
-
-echo "=== Managed weighted host CPU proof ==="
-sudo systemd-run \
-  --wait \
-  --collect \
-  --pipe \
-  "--unit=${UNIT}" \
-  --property=Type=exec \
-  --property=Delegate=cpu \
-  --property=DelegateSubgroup=control \
-  "--property=AllowedCPUs=${SELECTED_CPU}" \
-  --property=TimeoutStopSec=60 \
-  "--setenv=OKOU_TEST_HOST_CPU_FIRECRACKER=${FIRECRACKER}" \
-  "--setenv=OKOU_TEST_HOST_CPU_KERNEL=${KERNEL}" \
-  "--setenv=OKOU_TEST_HOST_CPU_ROOTFS=${ROOTFS}" \
-  "--setenv=OKOU_TEST_HOST_CPU_BASE_DIR=${BASE_DIR}" \
-  "$TEST_BIN" --ignored --test-threads=1 --nocapture
-REMOTE_SCRIPT
+# The durable worker receives the full run/attempt key as its job reference.
+BIN_DIR=/tmp JOB_REF="$EXECUTION_KEY" \
+  "${SCRIPT_DIR}/runner-behavior-durable.sh" host-cpu-fairness \
+  "${SCRIPT_DIR}/runner-behavior-host-cpu-fairness-remote.sh" "$DEFAULT_ROOTFS_HASH"

--- a/.github/scripts/tests/runner-behavior-host-cpu-fairness-test.sh
+++ b/.github/scripts/tests/runner-behavior-host-cpu-fairness-test.sh
@@ -47,30 +47,72 @@ cat >"${fake_bin}/ssh" <<'FAKE_SSH'
 #!/usr/bin/env bash
 set -euo pipefail
 
-[ "$#" -ge 4 ] || {
-  echo "unexpected ssh invocation: $*" >&2
-  exit 1
+# Execute the real remote scripts, mapping only host filesystem boundaries.
+map_paths() {
+  local value=$1
+  value=${value//"/tmp/vm0-runner-behavior/host-cpu-fairness-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"/"${MOCK_CASE_DIR}/durable"}
+  value=${value//"/tmp/runner-host-cpu-fairness-${JOB_REF}"/"${MOCK_CASE_DIR}/remote-bin"}
+  value=${value//"/run/lock/vm0-host-cpu-fairness"/"${MOCK_LOCK_ROOT}/pre-r5c"}
+  value=${value//"/run/lock/runner-host-cpu-fairness"/"${MOCK_LOCK_ROOT}/interim"}
+  value=${value//"/var/lib/vm0-runner/host-cpu-fairness"/"${MOCK_CASE_DIR}/base"}
+  value=${value//"/var/lib/vm0-runner/firecracker"/"${MOCK_FIXTURE_ROOT}/firecracker"}
+  value=${value//"/var/lib/vm0-runner/images"/"${MOCK_FIXTURE_ROOT}/images"}
+  printf '%s' "$value"
 }
-shift
-[ "$1" = bash ] && [ "$2" = -s ] && [ "$3" = -- ] || {
-  echo "unexpected ssh command: $*" >&2
-  exit 1
-}
-shift 3
 
-remote_arguments=("$@")
-case "${remote_arguments[0]:-}" in
-  /tmp/runner-host-cpu-fairness-*)
-    remote_arguments[0]="${MOCK_CASE_DIR}/remote-bin"
-    ;;
-esac
-remote_source=$(cat)
-remote_source=${remote_source//"/run/lock/vm0-host-cpu-fairness"/"${MOCK_LOCK_ROOT}/pre-r5c"}
-remote_source=${remote_source//"/run/lock/runner-host-cpu-fairness"/"${MOCK_LOCK_ROOT}/interim"}
-remote_source=${remote_source//"/var/lib/vm0-runner/host-cpu-fairness"/"${MOCK_CASE_DIR}/base"}
-remote_source=${remote_source//"/var/lib/vm0-runner/firecracker"/"${MOCK_FIXTURE_ROOT}/firecracker"}
-remote_source=${remote_source//"/var/lib/vm0-runner/images"/"${MOCK_FIXTURE_ROOT}/images"}
-bash -s -- "${remote_arguments[@]}" <<<"$remote_source"
+shift
+phase=cleanup
+if [ "$#" -eq 1 ]; then
+  case "$1" in
+    *worker.XXXXXX*) phase=stage ;;
+    "cat -- "*) phase=fetch ;;
+  esac
+elif [ "$#" -ge 10 ]; then
+  phase=launch
+elif [[ "${4:-}" == */status ]]; then
+  phase=state
+fi
+count_file="${MOCK_CASE_DIR}/${phase}-count"
+count=0
+[ ! -f "$count_file" ] || count=$(<"$count_file")
+count=$((count + 1))
+printf '%s\n' "$count" >"$count_file"
+if [ "${MOCK_SSH_FAILURES:-0}" = 1 ] && [ "$count" -eq 1 ] && [ "$phase" = state ]; then
+  exit 255
+fi
+
+if [ "$#" -eq 1 ]; then
+  command_source=$(map_paths "$1")
+  if [ "$phase" = stage ]; then
+    worker_source=$(cat)
+    worker_source=$(map_paths "$worker_source")
+    # BIN_DIR is the upload directory; bind the test binary to the fake host.
+    worker_source=${worker_source//'TEST_BIN="${BIN_DIR}/runner-host-cpu-fairness-${EXECUTION_KEY}"'/'TEST_BIN="${MOCK_CASE_DIR}/remote-bin"'}
+    bash -c "$command_source" <<<"$worker_source"
+  else
+    bash -c "$command_source"
+  fi
+else
+  [ "$1" = bash ] && [ "$2" = -s ] && [ "$3" = -- ]
+  shift 3
+  remote_arguments=()
+  for argument in "$@"; do
+    # Upload cleanup is called with the original, not durable, JOB_REF.
+    if [[ "$argument" == /tmp/runner-host-cpu-fairness-* ]]; then
+      remote_arguments+=("${MOCK_CASE_DIR}/remote-bin")
+    else
+      remote_arguments+=("$(map_paths "$argument")")
+    fi
+  done
+  remote_source=$(cat)
+  bash -s -- "${remote_arguments[@]}" <<<"$remote_source"
+fi
+
+if [ "${MOCK_SSH_FAILURES:-0}" = 1 ] && [ "$count" -eq 1 ]; then
+  case "$phase" in
+    launch|fetch) exit 255 ;;
+  esac
+fi
 FAKE_SSH
 
 cat >"${fake_bin}/sudo" <<'FAKE_SUDO'
@@ -98,8 +140,25 @@ FAKE_SYSTEMD
 cat >"${fake_bin}/systemctl" <<'FAKE_SYSTEMCTL'
 #!/usr/bin/env bash
 set -euo pipefail
-exit 0
+case "$*" in
+  *--property=LoadState*)
+    if [ -f "${MOCK_CASE_DIR}/active" ]; then
+      echo loaded
+    else
+      echo not-found
+    fi
+    ;;
+  *--property=ActiveState*) echo active ;;
+  stop*) printf '%s\n' "$2" >>"${MOCK_CASE_DIR}/stopped-units" ;;
+  *) exit 2 ;;
+esac
 FAKE_SYSTEMCTL
+
+cat >"${fake_bin}/sleep" <<'FAKE_SLEEP'
+#!/usr/bin/env bash
+set -euo pipefail
+/bin/sleep 0.01
+FAKE_SLEEP
 
 cat >"${fake_bin}/modprobe" <<'FAKE_MODPROBE'
 #!/usr/bin/env bash
@@ -113,14 +172,43 @@ set -euo pipefail
 
 selected_cpu=""
 saw_wait=false
+owner=""
+after=""
+runtime_bound=""
+unit=""
+environment=()
 for argument in "$@"; do
   case "$argument" in
     --wait) saw_wait=true ;;
     --property=AllowedCPUs=*) selected_cpu=${argument##*=} ;;
+    --property=BindsTo=*) owner=${argument##*=} ;;
+    --property=After=*) after=${argument##*=} ;;
+    --property=RuntimeMaxSec=*) runtime_bound=${argument##*=} ;;
+    --unit=*) unit=${argument#*=} ;;
+    --setenv=*) environment+=("${argument#*=}") ;;
   esac
 done
-[ "$saw_wait" = true ] || {
-  echo "systemd-run did not wait for the child" >&2
+if [ "$saw_wait" = false ]; then
+  while [ "$#" -gt 0 ] && [ "$1" != /bin/bash ]; do
+    shift
+  done
+  [ "$#" -gt 0 ]
+  touch "${MOCK_CASE_DIR}/active"
+  (
+    exec 9>&-
+    status=0
+    env "${environment[@]}" "$@" || status=$?
+    printf '%s\n' "$status" >"${MOCK_CASE_DIR}/unit-status"
+    rm -f "${MOCK_CASE_DIR}/active"
+  ) </dev/null >/dev/null 2>&1 &
+  exit 0
+fi
+[ "$owner" = "$RUNNER_BEHAVIOR_DURABLE_UNIT" ] && [ "$after" = "$owner" ] || {
+  echo "delegated test unit is not ordered under its durable owner" >&2
+  exit 1
+}
+[ "$runtime_bound" = 180 ] || {
+  echo "delegated test unit has no bounded runtime" >&2
   exit 1
 }
 [ -n "$selected_cpu" ] || {
@@ -135,12 +223,15 @@ case " $* " in
     ;;
 esac
 printf '%s\n' "$selected_cpu" >"${MOCK_CASE_DIR}/child-cpu"
+printf '%s\n' "$unit" >>"${MOCK_CASE_DIR}/native-invocations"
 
 if [ -n "${MOCK_CHILD_ENTER_FIFO:-}" ]; then
   printf 'entered\n' >"$MOCK_CHILD_ENTER_FIFO"
   IFS= read -r release <"$MOCK_CHILD_RELEASE_FIFO"
   [ "$release" = release ]
 fi
+echo "native fairness result: ${MOCK_NATIVE_STATUS:-0}"
+exit "${MOCK_NATIVE_STATUS:-0}"
 FAKE_SYSTEMD_RUN
 
 printf '#!/usr/bin/env bash\nexit 0\n' >"$test_bin"
@@ -195,6 +286,8 @@ run_invocation() {
     MOCK_LSCPU_OUTPUT="$online_cpus" \
     MOCK_CHILD_ENTER_FIFO="${MOCK_CHILD_ENTER_FIFO:-}" \
     MOCK_CHILD_RELEASE_FIFO="${MOCK_CHILD_RELEASE_FIFO:-}" \
+    MOCK_SSH_FAILURES="${MOCK_SSH_FAILURES:-0}" \
+    MOCK_NATIVE_STATUS="${MOCK_NATIVE_STATUS:-0}" \
     METAL_USER=test-user \
     HOST=test-host \
     JOB_REF="$job_ref" \
@@ -206,15 +299,12 @@ run_invocation() {
 }
 
 assert_selected_cpu() {
-  local output_file=$1
-  local invocation_dir=$2
-  local expected_cpu=$3
-  local reason=$4
+  local invocation_dir=$1
+  local expected_cpu=$2
+  local reason=$3
 
-  grep -Fxq "HOST_CPU_SELECTED_CPU=${expected_cpu}" "$output_file" ||
-    fail "$reason"
   [ "$(cat "${invocation_dir}/child-cpu")" = "$expected_cpu" ] ||
-    fail "AllowedCPUs did not match selected CPU ${expected_cpu}"
+    fail "$reason"
 }
 
 assert_existing_lock_available() {
@@ -263,7 +353,7 @@ test_pre_r5c_holder() (
     fail "repaired invocation failed with a pre-R5c holder"
   }
   # The #31906 single-interim-namespace implementation selects CPU 1 here.
-  assert_selected_cpu "$output" "${case_root}/invocation" 2 \
+  assert_selected_cpu "${case_root}/invocation" 2 \
     "pre-R5c holder did not rotate selection to the free candidate"
   assert_existing_lock_available \
     "${case_root}/locks/pre-r5c/cpu-2.lock" \
@@ -309,7 +399,7 @@ test_interim_holder_and_partial_release() (
   }
   [ "$marker" = entered ] || fail "invalid child entry marker"
 
-  assert_selected_cpu "$output" "${case_root}/invocation" 2 \
+  assert_selected_cpu "${case_root}/invocation" 2 \
     "interim holder did not rotate selection to the free candidate"
   [ -e "${case_root}/locks/pre-r5c/cpu-1.lock" ] ||
     fail "legacy-first partial acquisition was not attempted"
@@ -379,7 +469,7 @@ test_repaired_holder() (
     fail "repaired holder child did not start"
   }
   [ "$marker" = entered ] || fail "invalid repaired holder entry marker"
-  assert_selected_cpu "$holder_output" "${case_root}/holder" 1 \
+  assert_selected_cpu "${case_root}/holder" 1 \
     "first repaired invocation did not select the first candidate"
   assert_lock_held "${case_root}/locks/pre-r5c/cpu-1.lock" \
     "repaired holder did not retain the pre-R5c lock"
@@ -391,7 +481,7 @@ test_repaired_holder() (
     sed 's/^/  /' "$contender_errors" >&2
     fail "contender failed while another repaired invocation held CPU 1"
   }
-  assert_selected_cpu "$contender_output" "${case_root}/contender" 2 \
+  assert_selected_cpu "${case_root}/contender" 2 \
     "another repaired holder did not force rotation"
 
   printf 'release\n' >&"$release_fd"
@@ -427,7 +517,7 @@ test_all_busy_failure() (
     >"$output" 2>"$errors"; then
     fail "all-busy invocation unexpectedly succeeded"
   fi
-  grep -Fq "no online host CPU is available for the fairness test" "$errors" || {
+  grep -Fq "no online host CPU is available for the fairness test" "$output" || {
     sed 's/^/  /' "$errors" >&2
     fail "all-busy failure was not visible"
   }
@@ -439,9 +529,51 @@ test_all_busy_failure() (
     "all-busy partial acquisition was not released"
 )
 
+test_durable_recovery() (
+  local native_status=$1
+  local case_root="${tmp_dir}/recovery-${native_status}"
+  local invocation_dir="${case_root}/invocation"
+  local output="${case_root}/invocation.out"
+  local errors="${case_root}/invocation.err"
+  local status=0
+  prepare_case "$case_root"
+
+  MOCK_SSH_FAILURES=1 MOCK_NATIVE_STATUS="$native_status" \
+    run_invocation "$case_root" invocation recovery 106 \
+    >"$output" 2>"$errors" || status=$?
+  [ "$status" -eq "$native_status" ] || {
+    sed 's/^/  /' "$output" "$errors" >&2
+    fail "lost SSH responses changed native result ${native_status} to ${status}"
+  }
+  [ "$(wc -l <"${invocation_dir}/native-invocations")" -eq 1 ] ||
+    fail "lost launch response replayed the native test"
+  [ "$(cat "${invocation_dir}/launch-count")" -eq 2 ] ||
+    fail "lost launch response was not recovered"
+  [ "$(cat "${invocation_dir}/state-count")" -ge 2 ] ||
+    fail "lost state response was not recovered"
+  [ "$(cat "${invocation_dir}/fetch-count")" -eq 2 ] ||
+    fail "lost log response was not recovered"
+  [ "$(grep -Fc "native fairness result: ${native_status}" "$output")" -eq 1 ] ||
+    fail "recovered log was missing or duplicated"
+  grep -q '^HOST_CPU_SELECTED_CPU=' "$output" || fail "CPU selection log was lost"
+  [ ! -e "${invocation_dir}/remote-bin" ] || fail "uploaded binary was not cleaned"
+  [ ! -e "${invocation_dir}/durable" ] || fail "durable result was not cleaned"
+  [ ! -d "${invocation_dir}/base/recovery-106-1" ] || fail "test state was not cleaned"
+  grep -Fxq "runner-host-cpu-managed-recovery-106-1.service" \
+    "${invocation_dir}/stopped-units" || fail "delegated unit was not stopped"
+  local selected_cpu
+  selected_cpu=$(cat "${invocation_dir}/child-cpu")
+  assert_existing_lock_available "${case_root}/locks/pre-r5c/cpu-${selected_cpu}.lock" \
+    "recovered test retained pre-R5c CPU lock"
+  assert_existing_lock_available "${case_root}/locks/interim/cpu-${selected_cpu}.lock" \
+    "recovered test retained interim CPU lock"
+)
+
 test_pre_r5c_holder
 test_interim_holder_and_partial_release
 test_repaired_holder
 test_all_busy_failure
+test_durable_recovery 0
+test_durable_recovery 37
 
 echo "runner-behavior-host-cpu-fairness-test: ok"

--- a/.github/scripts/tests/runner-behavior-host-cpu-fairness-test.sh
+++ b/.github/scripts/tests/runner-behavior-host-cpu-fairness-test.sh
@@ -40,7 +40,8 @@ case "$destination" in
     exit 1
     ;;
 esac
-cp -- "$1" "${MOCK_CASE_DIR}/remote-bin"
+mkdir -p "${MOCK_CASE_DIR}/upload"
+cp -- "$1" "${MOCK_CASE_DIR}/upload/${destination##*/}"
 FAKE_SCP
 
 cat >"${fake_bin}/ssh" <<'FAKE_SSH'
@@ -51,7 +52,7 @@ set -euo pipefail
 map_paths() {
   local value=$1
   value=${value//"/tmp/vm0-runner-behavior/host-cpu-fairness-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"/"${MOCK_CASE_DIR}/durable"}
-  value=${value//"/tmp/runner-host-cpu-fairness-${JOB_REF}"/"${MOCK_CASE_DIR}/remote-bin"}
+  value=${value//"/tmp/runner-host-cpu-fairness-"/"${MOCK_CASE_DIR}/upload/runner-host-cpu-fairness-"}
   value=${value//"/run/lock/vm0-host-cpu-fairness"/"${MOCK_LOCK_ROOT}/pre-r5c"}
   value=${value//"/run/lock/runner-host-cpu-fairness"/"${MOCK_LOCK_ROOT}/interim"}
   value=${value//"/var/lib/vm0-runner/host-cpu-fairness"/"${MOCK_CASE_DIR}/base"}
@@ -86,8 +87,6 @@ if [ "$#" -eq 1 ]; then
   if [ "$phase" = stage ]; then
     worker_source=$(cat)
     worker_source=$(map_paths "$worker_source")
-    # BIN_DIR is the upload directory; bind the test binary to the fake host.
-    worker_source=${worker_source//'TEST_BIN="${BIN_DIR}/runner-host-cpu-fairness-${EXECUTION_KEY}"'/'TEST_BIN="${MOCK_CASE_DIR}/remote-bin"'}
     bash -c "$command_source" <<<"$worker_source"
   else
     bash -c "$command_source"
@@ -97,9 +96,8 @@ else
   shift 3
   remote_arguments=()
   for argument in "$@"; do
-    # Upload cleanup is called with the original, not durable, JOB_REF.
-    if [[ "$argument" == /tmp/runner-host-cpu-fairness-* ]]; then
-      remote_arguments+=("${MOCK_CASE_DIR}/remote-bin")
+    if [ "$argument" = /tmp ]; then
+      remote_arguments+=("${MOCK_CASE_DIR}/upload")
     else
       remote_arguments+=("$(map_paths "$argument")")
     fi
@@ -556,7 +554,8 @@ test_durable_recovery() (
   [ "$(grep -Fc "native fairness result: ${native_status}" "$output")" -eq 1 ] ||
     fail "recovered log was missing or duplicated"
   grep -q '^HOST_CPU_SELECTED_CPU=' "$output" || fail "CPU selection log was lost"
-  [ ! -e "${invocation_dir}/remote-bin" ] || fail "uploaded binary was not cleaned"
+  [ ! -e "${invocation_dir}/upload/runner-host-cpu-fairness-recovery-106-1" ] ||
+    fail "uploaded binary was not cleaned"
   [ ! -e "${invocation_dir}/durable" ] || fail "durable result was not cleaned"
   [ ! -d "${invocation_dir}/base/recovery-106-1" ] || fail "test state was not cleaned"
   grep -Fxq "runner-host-cpu-managed-recovery-106-1.service" \

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -989,6 +989,9 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
         run: .github/scripts/runner-behavior-upgrade-local.sh
 
+  # Keep this parallel to the elapsed-time-balanced behavior lanes: recent
+  # successful runs spend 70-149s compiling and 37-39s on the native proof.
+  # Durable result collection must not serialize this work behind a lane.
   host-cpu-fairness-test:
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
## Summary

- Run the host CPU fairness worker through the existing durable runner behavior controller. Lost SSH launch responses and transient result/log reads observe the same execution instead of replaying the workload or losing its result.
- Keep the existing CPU selection, both cross-revision per-CPU lock namespaces, native test arguments, cgroup delegation and cleanup. Bind the delegated root unit to its durable owner with stop ordering and a 180-second runtime ceiling (existing stop ceiling: 60 seconds).
- Exercise the real driver, controller and worker in shell integration tests for lock contention, interrupted observation, success, nonzero test status and cleanup.

Closes #32854

Failure evidence: https://github.com/vm0-ai/vm0/actions/runs/34316012548/job/102353358428. The CI observer exited 255 at 05:50:22 UTC, while the same dev-12 test unit completed successfully at 05:50:56 UTC. The precise transport trigger is not claimed to be resolved.

## CI elapsed-time balance

Keep fairness as an independent parallel job; do not add it to a behavior lane or add a lane prerequisite. No scenario allocation, trigger, job deadline or test assertion is changed.

Recent successful samples: [34309655507](https://github.com/vm0-ai/vm0/actions/runs/34309655507), [34316551168](https://github.com/vm0-ai/vm0/actions/runs/34316551168), [34316545812](https://github.com/vm0-ai/vm0/actions/runs/34316545812), [34315539753](https://github.com/vm0-ai/vm0/actions/runs/34315539753), [34315449284](https://github.com/vm0-ai/vm0/actions/runs/34315449284). Conditional skips are excluded.

| Job | Observed job-duration median |
| --- | ---: |
| Behavior lane A | 129s |
| Behavior lane B | 120s |
| Behavior lane C | 92s |
| Behavior lane D | 104s |
| Host CPU fairness (3 successful samples) | 165s |

Fairness cross-compilation took 70-149s and its native proof took 37-39s in these samples. Combining it with a lane would lengthen that lane; sharing the durable helper does not require serializing CI work. The workflow comment documents that constraint.

## Fallbacks

No alternate-result or compatibility fallback is added. The existing bounded SSH observation recovery is reused for this scenario: launch acknowledgment recovery checks the same run/attempt identity; result/log retries never rerun the test. Missing results and real nonzero test status remain failures. This is permanent handling of an external transport failure, not a temporary rollout fallback.

## Validation

- `bash -n` on all three changed shell scripts.
- `shellcheck` on the fairness driver, extracted worker and shell integration test.
- `bash .github/scripts/tests/runner-behavior-host-cpu-fairness-test.sh` (four lock scenarios plus success/nonzero interrupted-observation cases).
- `bash .github/scripts/tests/runner-behavior-durable-test.sh`.
- `bash .github/scripts/tests/crates-detect-workflow-test.sh`.
- `bash .github/scripts/tests/rust-ci-memory-workflow-test.sh`.
- `bash .github/scripts/check-workflow-shell-compatibility.sh`.
- `actionlint .github/workflows/crates.yml`.
- Prettier check for the workflow; `git diff --check`; normal commit hooks.
- Real Firecracker execution and native systemd lifecycle semantics are validated by PR CI, not by the local command-boundary mocks. Pending at submission.

## Scope and risks

CI-only; no production Runner/Guest, API, database, fairness weights, global SSH replay policy, or common durable-controller changes. The new ownership boundary is the detached worker's delegated child; `BindsTo`/`After` and the native runtime ceiling bound its lifetime. Test output is now recovered from the host log at completion, consistent with existing durable behavior tests.
