### PR TITLE
fix(cli): show custom connector authorization in whoami

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/whoami.test.ts
@@ -3,6 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { ConnectorAccountInspectionResult } from "@okouai/api-contracts/contracts/connector-accounts";
+import type { AgentCustomConnectorGrant } from "@okouai/api-contracts/contracts/agent-custom-connectors";
+import type {
+  CustomConnectorMcpResponse,
+  CustomConnectorPermissionBundleResponse,
+  CustomConnectorResponse,
+} from "@okouai/api-contracts/contracts/custom-connectors";
 import chalk from "chalk";
 import { http, HttpResponse } from "msw";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -14,7 +20,11 @@ import {
   stubConnectorCatalog,
   stubConnectorCatalogPermissions,
 } from "./helpers/connector-catalog";
-import { stubCustomConnectors } from "./helpers/custom-connectors";
+import {
+  customConnector,
+  stubAgentCustomConnectors,
+  stubCustomConnectors,
+} from "./helpers/custom-connectors";
 import {
   stubRunConnectorAccountInspection,
   writeRunConnectorAccountContext,
@@ -1067,7 +1077,7 @@ describe("okou whoami command", () => {
       ).toBe(false);
     });
 
-    it("should omit supplementary connectors when permission metadata fails", async () => {
+    it("should retain exact account identity when permission metadata fails", async () => {
       const token = buildOkouToken({
         userId: "user-1",
         runId: "run-abc",
@@ -1125,7 +1135,8 @@ describe("okou whoami command", () => {
         output.some((line) => {
           return line.includes("Connectors:");
         }),
-      ).toBe(false);
+      ).toBe(true);
+      expect(output.join("\n")).toContain("@octocat");
     });
 
     it("should show identity only when connector access API fails with --permissions", async () => {
@@ -1237,6 +1248,472 @@ describe("okou whoami command", () => {
           return line.includes("axiom") && line.includes("Account #22222222");
         }),
       ).toBe(true);
+    });
+  });
+
+  describe("custom connector authorization", () => {
+    const ordinaryHttp = customConnector({
+      permissionBundleRef: null,
+      connected: true,
+      connectedAccountId: "11111111-1111-4111-8111-111111111111",
+      missingRequiredFields: [],
+      configuredFieldKeys: ["apiKey"],
+    });
+    const mcp: CustomConnectorMcpResponse = {
+      kind: "mcp",
+      id: "44444444-4444-4444-8444-444444444444",
+      slug: "_acme-mcp",
+      displayName: "Acme MCP",
+      endpoint: "https://mcp.acme.test/server",
+      transport: "streamable-http",
+      prefixTemplates: [],
+      fields: [],
+      headerInjections: [],
+      queryInjections: [],
+      permissionBundleRef: null,
+      authMode: "none",
+      storageVersion: 1,
+      connected: true,
+      missingRequiredFields: [],
+      configuredFieldKeys: [],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    const bundledHttp = customConnector({
+      ...ordinaryHttp,
+      permissionBundleRef: "builtin:airtable@1",
+    });
+    const bundle: CustomConnectorPermissionBundleResponse = {
+      ref: "builtin:airtable@1",
+      permissions: [
+        { name: "records:read", description: "Read records" },
+        { name: "records:write", description: "Write records" },
+        { name: "records:delete", description: "Delete records" },
+        { name: "schema:write", description: "Change the schema" },
+        { name: "records:export", description: "Export records" },
+      ],
+      defaultPolicies: {
+        "records:read": "allow",
+        "records:write": "deny",
+        "records:delete": "deny",
+        "schema:write": "ask",
+      },
+    };
+
+    beforeEach(() => {
+      vi.stubEnv("OKOU_AGENT_ID", "agent-123");
+      vi.stubEnv(
+        "OKOU_TOKEN",
+        buildOkouToken({
+          userId: "user-1",
+          runId: "run-abc",
+          orgId: "org-xyz",
+          scope: "okou",
+          capabilities: ["agent:read", "connector:read"],
+          iat: 1000,
+          exp: 2000,
+        }),
+      );
+    });
+
+    function setCustomRunConnectors(
+      definitions: readonly CustomConnectorResponse[],
+      grants: readonly AgentCustomConnectorGrant[],
+    ): void {
+      const accounts: AvailableConnectorAccount[] = [
+        {
+          kind: "available",
+          target: { kind: "builtin", connectorSlug: "github" },
+          connectionId: "22222222-2222-4222-8222-222222222222",
+          authMethod: "oauth",
+          displayName: null,
+          externalId: "github-run-account",
+          externalUsername: "octocat",
+          externalEmail: null,
+          connectionStatus: "connected",
+          reconnectReason: null,
+        },
+        ...definitions.map((definition, index): AvailableConnectorAccount => {
+          return {
+            kind: "available",
+            target: { kind: "custom", customConnectorId: definition.id },
+            connectionId: `00000000-0000-4000-8000-${(index + 100).toString().padStart(12, "0")}`,
+            authMethod: "api-token",
+            displayName: "Run account B",
+            externalId: "run-account-b",
+            externalUsername: "run-account-b",
+            externalEmail: null,
+            connectionStatus: "connected",
+            reconnectReason: null,
+          };
+        }),
+      ];
+      writeRunConnectorAccountContext(
+        contextPath,
+        accounts.map((account) => {
+          return { ...account.target, connectionId: account.connectionId };
+        }),
+      );
+      server.use(
+        stubConnectorCatalog([catalogItem({ connectorSlug: "github" })]),
+        stubCustomConnectors(definitions),
+        stubRunConnectorAccountInspection(accounts),
+        stubAgentCustomConnectors(grants),
+        mockUserPermissionGrantsHandler(),
+        http.get(
+          "http://localhost:3000/api/agents/agent-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledConnectorSlugs: ["github"] });
+          },
+        ),
+        http.get(
+          "http://localhost:3000/api/custom-connectors/:id",
+          ({ params }) => {
+            const definition = definitions.find((item) => {
+              return item.id === params.id;
+            });
+            return definition
+              ? HttpResponse.json(definition)
+              : HttpResponse.json({}, { status: 404 });
+          },
+        ),
+        http.get(
+          "http://localhost:3000/api/custom-connectors/:id/permissions",
+          () => {
+            return HttpResponse.json(bundle);
+          },
+        ),
+      );
+    }
+
+    function connectorOutput(slug: string): string {
+      const lines = getAllOutput();
+      const start = lines.findIndex((line) => {
+        return line.startsWith(`  ${slug}`);
+      });
+      expect(start).toBeGreaterThanOrEqual(0);
+      const following = lines.slice(start + 1);
+      const next = following.findIndex((line) => {
+        return /^ {2}\S/u.test(line);
+      });
+      return [
+        lines[start],
+        ...following.slice(0, next === -1 ? undefined : next),
+      ].join("\n");
+    }
+
+    it.each([
+      { name: "ordinary HTTP", definition: ordinaryHttp },
+      { name: "MCP", definition: mcp },
+    ])(
+      "shows $name enablement with an empty permission selection",
+      async ({ definition }) => {
+        setCustomRunConnectors(
+          [definition],
+          [{ customConnectorId: definition.id, permissionNames: [] }],
+        );
+
+        await runWhoami(["--permissions"]);
+
+        const output = connectorOutput(definition.slug);
+        expect(output).toContain("@run-account-b");
+        expect(output).toContain("Agent enablement: enabled");
+        expect(output).toContain(
+          "Connector-level authorization (no named permissions)",
+        );
+        expect(output).not.toContain("full access");
+        expect(output).not.toContain("Named permissions:");
+        expect(output).not.toContain(ordinaryHttp.connectedAccountId);
+        expect(connectorOutput("github")).toContain("@octocat");
+      },
+    );
+
+    it.each([ordinaryHttp, mcp])(
+      "shows $slug as not enabled despite a connected account",
+      async (definition) => {
+        setCustomRunConnectors([definition], []);
+
+        await runWhoami(["--permissions"]);
+
+        const output = connectorOutput(definition.slug);
+        expect(output).toContain("@run-account-b");
+        expect(output).toContain("Agent enablement: not enabled");
+        expect(output).toContain("Connector-level authorization");
+      },
+    );
+
+    it("shows selected permissions and effective bundle defaults", async () => {
+      setCustomRunConnectors(
+        [bundledHttp],
+        [
+          {
+            customConnectorId: bundledHttp.id,
+            permissionNames: ["records:write"],
+          },
+        ],
+      );
+
+      await runWhoami(["--permissions"]);
+
+      const output = connectorOutput(bundledHttp.slug);
+      expect(output).toContain("Agent enablement: enabled");
+      expect(output).toMatch(/✓ records:write\s+Write records \(selected\)/u);
+      expect(output).toMatch(/✓ records:read\s+Read records \(default\)/u);
+      expect(output).toMatch(/✗ records:delete\s+Delete records \(default\)/u);
+      expect(output).toMatch(
+        /\? schema:write\s+Change the schema \(default\)/u,
+      );
+      expect(output).toMatch(/✗ records:export\s+Export records \(default\)/u);
+      expect(output).toContain("✗ unknown endpoints");
+    });
+
+    it("uses server-resolved Feishu defaults with an empty explicit selection", async () => {
+      const feishu = customConnector({
+        ...ordinaryHttp,
+        slug: "_feishu-managed",
+        permissionBundleRef: "builtin:feishu@1",
+      });
+      setCustomRunConnectors(
+        [feishu],
+        [{ customConnectorId: feishu.id, permissionNames: [] }],
+      );
+      server.use(
+        http.get(
+          `http://localhost:3000/api/custom-connectors/${feishu.id}/permissions`,
+          () => {
+            return HttpResponse.json({
+              ref: "builtin:feishu@1",
+              permissions: [
+                { name: "messages:read", description: "Read messages" },
+                { name: "messages:send-as-user", description: "Send as user" },
+              ],
+              defaultPolicies: {
+                "messages:read": "allow",
+                "messages:send-as-user": "deny",
+              },
+            } satisfies CustomConnectorPermissionBundleResponse);
+          },
+        ),
+      );
+
+      await runWhoami(["--permissions"]);
+
+      const output = connectorOutput(feishu.slug);
+      expect(output).toContain("Agent enablement: enabled");
+      expect(output).toMatch(/✓ messages:read\s+Read messages \(default\)/u);
+      expect(output).toMatch(
+        /✗ messages:send-as-user\s+Send as user \(default\)/u,
+      );
+      expect(output).not.toContain("(selected)");
+    });
+
+    it("keeps bundled permission names visible without granting defaults to a disabled Agent", async () => {
+      setCustomRunConnectors([bundledHttp], []);
+
+      await runWhoami(["--permissions"]);
+
+      const output = connectorOutput(bundledHttp.slug);
+      expect(output).toContain("Agent enablement: not enabled");
+      expect(output).toContain("records:read");
+      expect(output).toContain("Read records");
+      expect(output).not.toMatch(/[✓✗?]/u);
+      expect(output).not.toContain("(default)");
+    });
+
+    it.each([
+      { name: "forbidden", status: 403, body: {} },
+      { name: "server error", status: 500, body: {} },
+      {
+        name: "malformed grants",
+        status: 200,
+        body: {
+          grants: [
+            { customConnectorId: bundledHttp.id, permissionNames: null },
+          ],
+        },
+      },
+    ])(
+      "reports $name as unavailable enablement while retaining bundle metadata",
+      async ({ status, body }) => {
+        setCustomRunConnectors([bundledHttp], []);
+        server.use(
+          http.get(
+            "http://localhost:3000/api/agents/agent-123/custom-connectors",
+            () => {
+              return HttpResponse.json(body, { status });
+            },
+          ),
+        );
+
+        await runWhoami(["--permissions"]);
+
+        const output = connectorOutput(bundledHttp.slug);
+        expect(output).toContain("@run-account-b");
+        expect(output).toContain("Agent enablement: unavailable");
+        expect(output).toContain("records:read");
+        expect(output).not.toContain("not enabled");
+        expect(output).not.toContain("(default)");
+        expect(output).not.toMatch(/[✓✗?]/u);
+        expect(connectorOutput("github")).toContain("unknown endpoints");
+      },
+    );
+
+    it.each([
+      { name: "missing definition", path: "", status: 404, body: {} },
+      { name: "failed definition", path: "", status: 500, body: {} },
+      {
+        name: "mismatched definition",
+        path: "",
+        status: 200,
+        body: { ...bundledHttp, id: mcp.id },
+      },
+      {
+        name: "incomplete HTTP metadata",
+        path: "",
+        status: 200,
+        body: { ...bundledHttp, permissionBundleRef: undefined },
+      },
+      { name: "missing bundle", path: "/permissions", status: 404, body: {} },
+      { name: "failed bundle", path: "/permissions", status: 500, body: {} },
+      {
+        name: "malformed bundle",
+        path: "/permissions",
+        status: 200,
+        body: { ...bundle, defaultPolicies: null },
+      },
+      {
+        name: "changed bundle reference",
+        path: "/permissions",
+        status: 200,
+        body: { ...bundle, ref: "builtin:feishu@1" },
+      },
+    ])(
+      "reports $name as unavailable metadata while retaining Agent enablement",
+      async ({ path, status, body }) => {
+        setCustomRunConnectors(
+          [bundledHttp],
+          [{ customConnectorId: bundledHttp.id, permissionNames: [] }],
+        );
+        server.use(
+          http.get(
+            `http://localhost:3000/api/custom-connectors/${bundledHttp.id}${path}`,
+            () => {
+              return HttpResponse.json(body, { status });
+            },
+          ),
+        );
+
+        await runWhoami(["--permissions"]);
+
+        const output = connectorOutput(bundledHttp.slug);
+        expect(output).toContain("@run-account-b");
+        expect(output).toContain("Agent enablement: enabled");
+        expect(output).toContain("Permission information unavailable");
+        expect(output).not.toContain("Connector-level authorization");
+        expect(output).not.toContain("full access");
+        expect(connectorOutput("github")).toContain("unknown endpoints");
+      },
+    );
+
+    it("retains healthy custom siblings when one definition read fails", async () => {
+      setCustomRunConnectors(
+        [ordinaryHttp, mcp],
+        [
+          { customConnectorId: ordinaryHttp.id, permissionNames: [] },
+          { customConnectorId: mcp.id, permissionNames: [] },
+        ],
+      );
+      server.use(
+        http.get(
+          `http://localhost:3000/api/custom-connectors/${mcp.id}`,
+          () => {
+            return HttpResponse.json({}, { status: 500 });
+          },
+        ),
+      );
+
+      await runWhoami(["--permissions"]);
+
+      expect(connectorOutput(ordinaryHttp.slug)).toContain(
+        "Connector-level authorization",
+      );
+      expect(connectorOutput(mcp.slug)).toContain(
+        "Permission information unavailable",
+      );
+      expect(connectorOutput(mcp.slug)).toContain("Agent enablement: enabled");
+      expect(connectorOutput("github")).toContain("unknown endpoints");
+    });
+
+    it("retains custom authorization and account identity when builtin metadata fails", async () => {
+      setCustomRunConnectors(
+        [ordinaryHttp],
+        [{ customConnectorId: ordinaryHttp.id, permissionNames: [] }],
+      );
+      server.use(
+        http.get(
+          "http://localhost:3000/api/connector-catalog/github/permissions",
+          () => {
+            return HttpResponse.json({}, { status: 500 });
+          },
+        ),
+      );
+
+      await runWhoami(["--permissions"]);
+
+      expect(connectorOutput(ordinaryHttp.slug)).toContain(
+        "Agent enablement: enabled",
+      );
+      expect(connectorOutput("github")).toContain("@octocat");
+    });
+
+    it("keeps enablement independent from unavailable exact accounts", async () => {
+      setCustomRunConnectors(
+        [ordinaryHttp],
+        [{ customConnectorId: ordinaryHttp.id, permissionNames: [] }],
+      );
+      server.use(stubRunConnectorAccountInspection([]));
+
+      await runWhoami(["--permissions"]);
+
+      const output = connectorOutput(ordinaryHttp.slug);
+      expect(output).toContain("metadata unavailable or deleted");
+      expect(output).toContain("Agent enablement: enabled");
+      expect(output).not.toContain(ordinaryHttp.connectedAccountId);
+    });
+
+    it("does not read custom authorization details for ordinary whoami", async () => {
+      setCustomRunConnectors([bundledHttp], []);
+      const requests: string[] = [];
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agents/agent-123/custom-connectors",
+          ({ request }) => {
+            requests.push(request.url);
+            return HttpResponse.json({ grants: [] });
+          },
+        ),
+        http.get(
+          `http://localhost:3000/api/custom-connectors/${bundledHttp.id}`,
+          ({ request }) => {
+            requests.push(request.url);
+            return HttpResponse.json(bundledHttp);
+          },
+        ),
+        http.get(
+          `http://localhost:3000/api/custom-connectors/${bundledHttp.id}/permissions`,
+          ({ request }) => {
+            requests.push(request.url);
+            return HttpResponse.json(bundle);
+          },
+        ),
+      );
+
+      await runWhoami();
+
+      const output = connectorOutput(bundledHttp.slug);
+      expect(output).toContain("@run-account-b");
+      expect(output).not.toContain("Agent enablement:");
+      expect(requests).toEqual([]);
     });
   });
 

--- a/turbo/apps/cli/src/commands/shared/custom-connector-permissions.ts
+++ b/turbo/apps/cli/src/commands/shared/custom-connector-permissions.ts
@@ -1,0 +1,94 @@
+import type { CustomConnectorPermissionBundleResponse } from "@okouai/api-contracts/contracts/custom-connectors";
+
+import { getAgentCustomConnectorGrants } from "../../lib/api/domains/agents";
+import {
+  getCustomConnector,
+  getCustomConnectorPermissionBundle,
+} from "../../lib/api/domains/connectors";
+
+type CustomConnectorAuthorization =
+  | { readonly state: "enabled"; readonly permissionNames: readonly string[] }
+  | { readonly state: "not-enabled" }
+  | { readonly state: "unavailable" };
+
+type CustomConnectorPermissionModel =
+  | { readonly kind: "connector" }
+  | {
+      readonly kind: "bundle";
+      readonly bundle: CustomConnectorPermissionBundleResponse;
+    }
+  | { readonly kind: "unavailable" };
+
+export interface CustomConnectorPermissionInfo {
+  readonly authorization: CustomConnectorAuthorization;
+  readonly model: CustomConnectorPermissionModel;
+}
+
+async function loadCustomConnectorPermissionModel(
+  connectorId: string,
+): Promise<CustomConnectorPermissionModel> {
+  try {
+    const definition = await getCustomConnector(connectorId);
+    if (!definition || definition.id !== connectorId) {
+      return { kind: "unavailable" };
+    }
+    if (definition.kind === "mcp" || definition.permissionBundleRef === null) {
+      return { kind: "connector" };
+    }
+    if (definition.permissionBundleRef === undefined) {
+      return { kind: "unavailable" };
+    }
+
+    const bundle = await getCustomConnectorPermissionBundle(connectorId);
+    if (!bundle || bundle.ref !== definition.permissionBundleRef) {
+      return { kind: "unavailable" };
+    }
+    return { kind: "bundle", bundle };
+  } catch {
+    // A failed metadata read must not discard this target's Agent grant or
+    // the independently available information for other run targets.
+    return { kind: "unavailable" };
+  }
+}
+
+export async function loadCustomConnectorPermissionInfos(args: {
+  readonly agentId: string;
+  readonly customConnectorIds: readonly string[];
+}): Promise<Map<string, CustomConnectorPermissionInfo>> {
+  if (args.customConnectorIds.length === 0) return new Map();
+
+  const [grants, models] = await Promise.all([
+    getAgentCustomConnectorGrants(args.agentId).catch(() => {
+      return null;
+    }),
+    Promise.all(
+      args.customConnectorIds.map(async (connectorId) => {
+        return [
+          connectorId,
+          await loadCustomConnectorPermissionModel(connectorId),
+        ] as const;
+      }),
+    ),
+  ]);
+  const grantsById =
+    grants === null
+      ? null
+      : new Map(
+          grants.map((grant) => {
+            return [grant.customConnectorId, grant];
+          }),
+        );
+
+  return new Map(
+    models.map(([connectorId, model]) => {
+      const grant = grantsById?.get(connectorId);
+      const authorization: CustomConnectorAuthorization =
+        grantsById === null
+          ? { state: "unavailable" }
+          : grant
+            ? { state: "enabled", permissionNames: grant.permissionNames }
+            : { state: "not-enabled" };
+      return [connectorId, { authorization, model }];
+    }),
+  );
+}

--- a/turbo/apps/cli/src/commands/whoami.ts
+++ b/turbo/apps/cli/src/commands/whoami.ts
@@ -20,6 +20,10 @@ import {
   type ConnectorPermissionInfo,
 } from "./shared/firewall-permissions";
 import {
+  loadCustomConnectorPermissionInfos,
+  type CustomConnectorPermissionInfo,
+} from "./shared/custom-connector-permissions";
+import {
   resolveRunConnectorAccountView,
   runConnectorAccountUnavailableMessage,
   type RunConnectorAccountEntry,
@@ -99,6 +103,81 @@ function printConnectorPermissions(info: ConnectorPermissionInfo): void {
   );
 }
 
+function printCustomConnectorPermissions(
+  info: CustomConnectorPermissionInfo | undefined,
+): void {
+  const authorization = info?.authorization;
+  const enablement =
+    authorization?.state === "enabled"
+      ? "enabled"
+      : authorization?.state === "not-enabled"
+        ? "not enabled"
+        : "unavailable";
+  console.log(`    Agent enablement: ${enablement}`);
+
+  if (!info || info.model.kind === "unavailable") {
+    console.log(chalk.dim("    Permission information unavailable"));
+    return;
+  }
+  if (info.model.kind === "connector") {
+    console.log(
+      chalk.dim("    Connector-level authorization (no named permissions)"),
+    );
+    return;
+  }
+
+  const { bundle } = info.model;
+  const selected =
+    authorization?.state === "enabled"
+      ? new Set(authorization.permissionNames)
+      : null;
+  const nameWidth = Math.max(
+    "unknown endpoints".length,
+    ...bundle.permissions.map((permission) => {
+      return permission.name.length;
+    }),
+  );
+  console.log(chalk.dim("    Named permissions:"));
+  for (const permission of bundle.permissions) {
+    const name = permission.name.padEnd(nameWidth);
+    const description = permission.description ?? "";
+    if (selected === null) {
+      console.log(`      ${name}  ${description}`);
+      continue;
+    }
+    const isSelected = selected.has(permission.name);
+    const policy = isSelected
+      ? "allow"
+      : (bundle.defaultPolicies[permission.name] ?? "deny");
+    const source = isSelected ? "selected" : "default";
+    console.log(
+      `    ${policyIcon(policy)} ${name}  ${description} (${source})`,
+    );
+  }
+  if (selected !== null) {
+    console.log(
+      `    ${policyIcon("deny")} ${"unknown endpoints".padEnd(nameWidth)}  Endpoints not matching any rule`,
+    );
+  }
+}
+
+function printRunConnectorPermissions(
+  connector: RunConnectorAccountEntry,
+  builtinPermissions: ReadonlyMap<string, ConnectorPermissionInfo>,
+  customPermissions: ReadonlyMap<string, CustomConnectorPermissionInfo>,
+): void {
+  if (connector.target.kind === "custom") {
+    printCustomConnectorPermissions(
+      customPermissions.get(connector.target.customConnectorId),
+    );
+    return;
+  }
+  const info = builtinPermissions.get(connector.slug);
+  if (info) {
+    printConnectorPermissions(info);
+  }
+}
+
 /**
  * Workspace identity is supplementary: whoami must still print the agent
  * identity, capabilities, and connectors when the org lookup fails or 404s.
@@ -173,29 +252,45 @@ async function showSandboxInfo(showPermissions: boolean): Promise<void> {
     if (view.connectors.length === 0) return;
 
     let permissionInfoBySlug = new Map<string, ConnectorPermissionInfo>();
-    let permissionDataAvailable = false;
+    let customPermissionInfoById = new Map<
+      string,
+      CustomConnectorPermissionInfo
+    >();
     if (permissionSources) {
       const [grantsResult, enabledResult] = permissionSources;
-
-      if (
+      const [builtinResult, customResult] = await Promise.allSettled([
         grantsResult.status === "fulfilled" &&
         enabledResult.status === "fulfilled"
-      ) {
-        permissionDataAvailable = true;
-        const permissionInfos = await loadConnectorPermissionInfos({
-          displayConnectorSlugs: view.connectors.map((connector) => {
-            return connector.slug;
+          ? loadConnectorPermissionInfos({
+              displayConnectorSlugs: view.connectors.flatMap((connector) => {
+                return connector.target.kind === "builtin"
+                  ? [connector.slug]
+                  : [];
+              }),
+              defaultPolicyConnectorSlugs: enabledResult.value,
+              storedPolicies: connectorPermissionGrantsToFirewallPolicies(
+                grantsResult.value,
+              ),
+            })
+          : Promise.resolve([]),
+        loadCustomConnectorPermissionInfos({
+          agentId: agentId!,
+          customConnectorIds: view.connectors.flatMap((connector) => {
+            return connector.target.kind === "custom"
+              ? [connector.target.customConnectorId]
+              : [];
           }),
-          defaultPolicyConnectorSlugs: enabledResult.value,
-          storedPolicies: connectorPermissionGrantsToFirewallPolicies(
-            grantsResult.value,
-          ),
-        });
+        }),
+      ]);
+      if (builtinResult.status === "fulfilled") {
         permissionInfoBySlug = new Map(
-          permissionInfos.map((info) => {
+          builtinResult.value.map((info) => {
             return [info.connectorSlug, info];
           }),
         );
+      }
+      if (customResult.status === "fulfilled") {
+        customPermissionInfoById = customResult.value;
       }
     }
 
@@ -205,11 +300,12 @@ async function showSandboxInfo(showPermissions: boolean): Promise<void> {
       const identity = formatRunConnectorIdentity(connector);
       console.log(`  ${connector.slug.padEnd(14)}${identity}`);
 
-      if (permissionDataAvailable) {
-        const info = permissionInfoBySlug.get(connector.slug);
-        if (info) {
-          printConnectorPermissions(info);
-        }
+      if (showPermissions) {
+        printRunConnectorPermissions(
+          connector,
+          permissionInfoBySlug,
+          customPermissionInfoById,
+        );
       }
     }
   } catch {
@@ -250,7 +346,7 @@ async function showLocalInfo(): Promise<void> {
 export const whoamiCommand = new Command()
   .name("whoami")
   .description("Show agent identity, run ID, and capabilities")
-  .option("--permissions", "Show full permission details for each connector")
+  .option("--permissions", "Show connector enablement and permission details")
   .addHelpText(
     "after",
     `
@@ -260,7 +356,8 @@ Examples:
 
 Notes:
   - Inside sandbox: shows agent ID, run ID, org ID, and granted capabilities
-  - Use --permissions to see detailed permission breakdown per connector
+  - Use --permissions to see connector permissions and custom connector Agent enablement
+  - Custom connectors with permission bundles also show selections and effective policies
   - Your agent ID is also available as $OKOU_AGENT_ID`,
   )
   .action(

--- a/turbo/apps/cli/src/lib/api/domains/agents.ts
+++ b/turbo/apps/cli/src/lib/api/domains/agents.ts
@@ -15,6 +15,7 @@ import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-id
 import { userConnectorsContract } from "@okouai/api-contracts/contracts/user-connectors";
 import {
   agentCustomConnectorsContract,
+  agentCustomConnectorGrantsSchema,
   type AgentCustomConnectorGrant,
 } from "@okouai/api-contracts/contracts/agent-custom-connectors";
 import { getClientConfig, handleError } from "../core/client-factory";
@@ -92,7 +93,9 @@ export async function getAgentCustomConnectorGrants(
   const config = await getClientConfig();
   const client = initClient(agentCustomConnectorsContract, config);
   const result = await client.get({ params: { id } });
-  if (result.status === 200) return result.body.grants;
+  if (result.status === 200) {
+    return agentCustomConnectorGrantsSchema.parse(result.body).grants;
+  }
   handleError(
     result,
     `Failed to get custom connector permissions for agent "${id}"`,

--- a/turbo/apps/cli/src/lib/api/domains/connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/connectors.ts
@@ -36,8 +36,10 @@ import {
   customConnectorByIdContract,
   customConnectorsContract,
   customConnectorListResponseSchema,
+  customConnectorPermissionBundleSchema,
   customConnectorResponseSchema,
   type CreateCustomConnectorBody,
+  type CustomConnectorPermissionBundleResponse,
   type CustomConnectorResponse,
   type UpdateCustomConnectorBody,
 } from "@okouai/api-contracts/contracts/custom-connectors";
@@ -400,4 +402,19 @@ export async function updateCustomConnector(
   }
 
   handleError(result, `Failed to update custom connector "${id}"`);
+}
+
+export async function getCustomConnectorPermissionBundle(
+  id: string,
+): Promise<CustomConnectorPermissionBundleResponse | null> {
+  const config = await getClientConfig();
+  const client = initClient(customConnectorByIdContract, config);
+  const result = await client.permissions({ params: { id }, headers: {} });
+  if (result.status === 200) {
+    return customConnectorPermissionBundleSchema.parse(result.body);
+  }
+  if (result.status === 404) {
+    return null;
+  }
+  handleError(result, `Failed to get custom connector permissions for "${id}"`);
 }


### PR DESCRIPTION
`okou whoami --permissions` currently shows custom connector accounts without their Agent authorization. This change shows enablement for ordinary custom HTTP/MCP connectors and named selections with effective bundle policies for special HTTP connectors, including managed Feishu defaults.

Failed or incomplete reads are explicitly unavailable, and independent account/connector information remains visible. An empty permission selection still means enabled; disabled or unreadable Agent authorization never turns bundle defaults into displayed grants. The existing run-account projection and authorization APIs remain authoritative. This changes CLI diagnostics only; it adds no permission-request flow or MCP per-tool permissions.

Closes #32829.

## Validation

Using pnpm 10.33.4:
- CLI lint, CLI check-types, and a final CLI `tsc --noEmit` pass.
- `pnpm exec knip --workspace apps/cli` passes.
- Prettier checks pass for all five changed files.
- Focused Commander/MSW tests cover `whoami.test.ts`, connector `search.test.ts`, `list.test.ts`, custom `index.test.ts`, and account `switch-request.test.ts` (117 distinct tests). Two list cases initially inherited this agent session's real run-account context; `env -u OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE ... vitest run src/commands/connector/__tests__/list.test.ts` passes all 17 list tests. No product-code change was needed for that environment issue.

Full local Vitest suites and a development server were not used; broader checks run in the PR pipeline.

## Fallbacks

- `whoami.ts:printCustomConnectorPermissions` renders an omitted optional permission description as blank. This is a permanent presentation default with no identity meaning, rollout window, or removal follow-up.
- The same renderer uses a bundle's default policy for an unselected permission and deny when that name has no default entry, matching the existing runtime rule. This is a permanent authorization-display rule, not a cross-version compatibility path.

Missing references and failed reads produce explicit unavailable diagnostic states rather than substituted accounts or grants.
