### PR TITLE
fix(runner): reject local input when forwarding is disabled

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -103,6 +103,18 @@ binary overrides must use flags and environment keys matching the runner revisio
 - [Multi-architecture rollout](../docs/runner-multi-architecture.md): select,
   build, deploy, and validate architecture-specific runner artifacts.
 
+### Local active input
+
+`runner local input` requires a claimed local job with active-input forwarding
+enabled. Ordinary submissions leave forwarding disabled. Enable it when submitting
+the job with `runner local submit --active-input after=1s,text=hello` and the other
+required submission arguments. An already-running job cannot enable forwarding
+retroactively; resubmit it with the option when input is needed.
+
+The input command rejects disabled forwarding or unavailable job metadata without
+creating an input entry. A successful command reports file publication, not an
+acknowledgement that the running agent consumed the input.
+
 ### Orphan sandbox termination
 
 `runner kill --sandbox <ID>` first asks the owning runner to terminate the

--- a/crates/runner/src/cmd/local/input.rs
+++ b/crates/runner/src/cmd/local/input.rs
@@ -12,6 +12,8 @@ use crate::ids::RunId;
 use crate::local_queue::{self, ActiveInputEntry};
 use crate::paths::HomePaths;
 
+/// The job must have been submitted with --active-input to enable forwarding.
+/// Successful publication does not acknowledge delivery to the running agent.
 #[derive(Args)]
 pub struct InputArgs {
     /// Run ID of the claimed local job
@@ -79,7 +81,18 @@ fn run_input_with_home(args: InputArgs, home: HomePaths) -> RunnerResult<ExitCod
         )));
     }
 
-    local_queue::LocalQueue::new(group_dir)
+    let queue = local_queue::LocalQueue::new(group_dir);
+    let request = queue
+        .read_job_request_sync(args.run)
+        .map_err(|e| RunnerError::Config(format!("read claimed local job {}: {e}", args.run)))?;
+    if request.active_input != Some(true) {
+        return Err(RunnerError::Config(format!(
+            "local job {} does not have active-input forwarding enabled; resubmit with --active-input to enable forwarding",
+            args.run
+        )));
+    }
+
+    queue
         .write_active_input_sync(&ActiveInputEntry {
             run_id: args.run,
             sequence: args.sequence,
@@ -95,72 +108,225 @@ fn run_input_with_home(args: InputArgs, home: HomePaths) -> RunnerResult<ExitCod
 mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+
+    use clap::Parser;
+
+    struct InputFixture {
+        dir: tempfile::TempDir,
+        queue: local_queue::LocalQueue,
+        run_id: RunId,
+    }
+
+    impl InputFixture {
+        fn new() -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            let home = HomePaths::with_root(dir.path().to_path_buf());
+            let group_dir = home.groups_dir().join("test/group");
+            local_queue::ensure_claims_dir(&group_dir).unwrap();
+            Self {
+                dir,
+                queue: local_queue::LocalQueue::new(group_dir),
+                run_id: RunId::new_v4(),
+            }
+        }
+
+        fn write_job(&self, active_input: Option<bool>, profile: &str) -> PathBuf {
+            local_queue::ensure_profile_jobs_dir(self.queue.group_dir(), profile).unwrap();
+            let path = local_queue::job_path(self.queue.group_dir(), profile, self.run_id).unwrap();
+            let request = local_queue::JobRequest {
+                job_id: self.run_id,
+                prompt: "initial prompt".into(),
+                cli_agent_type: "claude-code".into(),
+                vars: None,
+                environment: None,
+                secret_environment: None,
+                user_timezone: None,
+                profile: Some(profile.into()),
+                reuse_key: None,
+                session_id: None,
+                feature_flags: None,
+                active_input,
+            };
+            local_queue::write_private_file(
+                &path,
+                &serde_json::to_vec(&request).unwrap(),
+                "test job request",
+            )
+            .unwrap();
+            path
+        }
+
+        fn claim_job(&self, active_input: Option<bool>, profile: &str) -> PathBuf {
+            let path = self.write_job(active_input, profile);
+            assert!(matches!(
+                self.queue.claim_job_sync(self.run_id, profile, &path),
+                local_queue::LocalClaimResult::Claimed { .. }
+            ));
+            path
+        }
+
+        fn input(&self) -> RunnerResult<ExitCode> {
+            let cli = crate::Cli::try_parse_from([
+                "runner",
+                "local",
+                "input",
+                "--group",
+                "test/group",
+                "--run",
+                &self.run_id.to_string(),
+                "--sequence",
+                "5",
+                "--text",
+                "pressure-finish",
+            ])
+            .unwrap();
+            let crate::Command::Local(local) = cli.command else {
+                panic!("expected local command");
+            };
+            let crate::cmd::local::LocalCommand::Input(args) = local.command else {
+                panic!("expected input command");
+            };
+            run_input_with_home(args, HomePaths::with_root(self.dir.path().to_path_buf()))
+        }
+
+        fn assert_rejected(&self, message: &str) {
+            let error = self.input().unwrap_err();
+            assert!(error.to_string().contains(message), "got: {error}");
+            assert!(!local_queue::run_inputs_dir(self.queue.group_dir(), self.run_id).exists());
+        }
+    }
 
     #[test]
     fn writes_active_input_for_claimed_job() {
-        let dir = tempfile::tempdir().unwrap();
-        let home = HomePaths::with_root(dir.path().to_path_buf());
-        let group_dir = home.groups_dir().join("test/group");
-        let run_id = RunId::new_v4();
-        local_queue::ensure_claims_dir(&group_dir).unwrap();
+        for profile in [crate::profile::DEFAULT_PROFILE, "test/custom"] {
+            let fixture = InputFixture::new();
+            fixture.claim_job(Some(true), profile);
+
+            assert_eq!(fixture.input().unwrap(), ExitCode::SUCCESS);
+            let input_path =
+                local_queue::active_input_path(fixture.queue.group_dir(), fixture.run_id, 5);
+            let entry: ActiveInputEntry =
+                serde_json::from_slice(&std::fs::read(&input_path).unwrap()).unwrap();
+            assert_eq!(
+                entry,
+                ActiveInputEntry {
+                    run_id: fixture.run_id,
+                    sequence: 5,
+                    text: "pressure-finish".into(),
+                }
+            );
+            assert_eq!(
+                std::fs::metadata(input_path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_input_when_claimed_job_has_forwarding_disabled() {
+        for active_input in [None, Some(false)] {
+            let fixture = InputFixture::new();
+            fixture.claim_job(active_input, crate::profile::DEFAULT_PROFILE);
+
+            fixture.assert_rejected("resubmit with --active-input");
+        }
+    }
+
+    #[test]
+    fn rejects_input_when_claim_marker_has_no_job_request() {
+        let fixture = InputFixture::new();
         local_queue::write_private_marker(
-            &local_queue::claim_path(&group_dir, run_id),
+            &local_queue::claim_path(fixture.queue.group_dir(), fixture.run_id),
             "test claim marker",
         )
         .unwrap();
 
-        let code = run_input_with_home(
-            InputArgs {
-                run: run_id,
-                group: "test/group".into(),
-                sequence: 5,
-                text: "pressure-finish".into(),
-            },
-            home,
+        fixture.assert_rejected("no local job request found");
+    }
+
+    #[test]
+    fn rejects_input_when_run_has_multiple_job_requests() {
+        let fixture = InputFixture::new();
+        fixture.claim_job(Some(true), crate::profile::DEFAULT_PROFILE);
+        fixture.write_job(Some(false), "test/custom");
+
+        fixture.assert_rejected("multiple local job requests found");
+    }
+
+    #[test]
+    fn rejects_input_when_job_scan_fails() {
+        let fixture = InputFixture::new();
+        local_queue::write_private_marker(
+            &local_queue::claim_path(fixture.queue.group_dir(), fixture.run_id),
+            "test claim marker",
+        )
+        .unwrap();
+        std::fs::write(
+            local_queue::jobs_dir(fixture.queue.group_dir()),
+            b"not a directory",
         )
         .unwrap();
 
-        assert_eq!(code, ExitCode::SUCCESS);
-        let entries = local_queue::LocalQueue::new(group_dir.clone())
-            .read_active_input_entries_from_sequence_sync(run_id, 0);
-        assert_eq!(
-            entries,
-            vec![ActiveInputEntry {
-                run_id,
-                sequence: 5,
-                text: "pressure-finish".into(),
-            }]
-        );
-        let input_path = local_queue::active_input_path(&group_dir, run_id, 5);
-        assert_eq!(
-            std::fs::metadata(input_path).unwrap().permissions().mode() & 0o777,
-            0o600
-        );
+        fixture.assert_rejected("cannot scan local job requests");
+    }
+
+    #[test]
+    fn rejects_input_when_job_request_is_invalid() {
+        let fixture = InputFixture::new();
+        let path = fixture.claim_job(Some(true), crate::profile::DEFAULT_PROFILE);
+        local_queue::write_private_file(&path, b"{", "test job request").unwrap();
+
+        fixture.assert_rejected("invalid local job request");
+    }
+
+    #[test]
+    fn rejects_input_when_job_request_has_different_run_id() {
+        let fixture = InputFixture::new();
+        let path = fixture.claim_job(Some(true), crate::profile::DEFAULT_PROFILE);
+        let mut request: local_queue::JobRequest =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        request.job_id = RunId::new_v4();
+        local_queue::write_private_file(
+            &path,
+            &serde_json::to_vec(&request).unwrap(),
+            "test job request",
+        )
+        .unwrap();
+
+        fixture.assert_rejected("job id mismatch");
+    }
+
+    #[test]
+    fn rejects_input_when_job_request_is_a_symlink() {
+        let fixture = InputFixture::new();
+        let path = fixture.claim_job(Some(true), crate::profile::DEFAULT_PROFILE);
+        let target = fixture.dir.path().join("request.json");
+        std::fs::rename(&path, &target).unwrap();
+        std::os::unix::fs::symlink(&target, &path).unwrap();
+
+        fixture.assert_rejected("read claimed local job");
+    }
+
+    #[test]
+    fn rejects_input_when_job_request_exceeds_size_limit() {
+        let fixture = InputFixture::new();
+        let path = fixture.claim_job(Some(true), crate::profile::DEFAULT_PROFILE);
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_len(local_queue::LOCAL_JOB_MAX_BYTES as u64 + 1)
+            .unwrap();
+
+        fixture.assert_rejected("exceeds");
     }
 
     #[test]
     fn rejects_input_for_unclaimed_job() {
-        let dir = tempfile::tempdir().unwrap();
-        let home = HomePaths::with_root(dir.path().to_path_buf());
-        let group_dir = home.groups_dir().join("test/group");
-        local_queue::ensure_claims_dir(&group_dir).unwrap();
-        let run_id = RunId::new_v4();
+        let fixture = InputFixture::new();
+        fixture.write_job(Some(true), crate::profile::DEFAULT_PROFILE);
 
-        let error = run_input_with_home(
-            InputArgs {
-                run: run_id,
-                group: "test/group".into(),
-                sequence: 1,
-                text: "late-input".into(),
-            },
-            home,
-        )
-        .unwrap_err();
-
-        assert!(
-            error.to_string().contains("no claimed local job found"),
-            "got: {error}"
-        );
-        assert!(!local_queue::run_inputs_dir(&group_dir, run_id).exists());
+        fixture.assert_rejected("no claimed local job found");
     }
 }

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -499,6 +499,51 @@ impl LocalQueue {
         self.cleanup_active_inputs_sync(run_id);
     }
 
+    /// Read the retained request for a run without assuming its profile partition.
+    pub(crate) fn read_job_request_sync(&self, run_id: RunId) -> std::io::Result<JobRequest> {
+        let paths = match self.collect_job_file_paths(run_id) {
+            JobFileScan::Complete(paths) => paths,
+            JobFileScan::ScanFailed(_) => {
+                return Err(std::io::Error::other(format!(
+                    "cannot scan local job requests for {run_id}"
+                )));
+            }
+        };
+        let path = match paths.as_slice() {
+            [path] => path,
+            [] => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("no local job request found for {run_id}"),
+                ));
+            }
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("multiple local job requests found for {run_id}"),
+                ));
+            }
+        };
+        let bytes =
+            super::read_private_file_with_max(path, "local job file", super::LOCAL_JOB_MAX_BYTES)?;
+        let request: JobRequest = serde_json::from_slice(&bytes).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("invalid local job request for {run_id}: {e}"),
+            )
+        })?;
+        if request.job_id != run_id {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "job id mismatch: request={}, filename={run_id}",
+                    request.job_id
+                ),
+            ));
+        }
+        Ok(request)
+    }
+
     pub(crate) fn write_active_input_sync(&self, entry: &ActiveInputEntry) -> std::io::Result<()> {
         if entry.sequence == 0 {
             return Err(std::io::Error::new(


### PR DESCRIPTION
## Summary

`runner local input` previously returned success for claimed jobs whose active-input forwarding was disabled, even though their input would never be consumed. Validate the retained job request before publication and return an actionable error for absent/false capability, with no input entry created.

Reuse the queue's profile lookup and bounded private-file reader, rejecting missing, ambiguous, invalid, or unsafe requests. Add real claimed-job regressions and document the submission-time opt-in requirement. Existing queue formats and forwarding defaults are preserved; delivery acknowledgement remains outside this change.

Closes #32840

## Validation

The new disabled-forwarding regression failed on unchanged production code before the fix. After the fix, 58 selected Runner tests passed using `cargo test --manifest-path crates/Cargo.toml --profile local --locked -p runner --bin runner` with these filters:

- `cmd::local::input::tests` — 10 passed.
- `local_queue::` — 39 passed.
- `provider::local::tests::discovery::discover_claim_complete -- --exact` — 1 passed.
- `cmd::local::submit::tests::active_inputs` — 8 passed.

Additional checks:

- `cargo fmt --manifest-path crates/runner/Cargo.toml -- --check` — passed.
- `npx --yes --package=prettier@3.6.2 prettier crates/README.md --check` — passed.
- `cargo clippy --manifest-path crates/Cargo.toml --profile local --locked -p runner --all-targets --all-features -- -D warnings` — passed.
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml --profile local --locked -p runner --all-features --no-deps` — passed.

Tests use real temporary queue files and the production parser, claim handler, and input handler. Live Firecracker delivery was not exercised locally.
