### PR TITLE
test(runner): fail promptly when canonical reconciliation misses a process

### DIFF
--- a/crates/runner/src/proxy/runtime.rs
+++ b/crates/runner/src/proxy/runtime.rs
@@ -745,7 +745,11 @@ mod tests {
 
         let runtime = MitmdumpRuntime::acquire(root, lock_path).await.unwrap();
 
-        let status = child.child.wait().unwrap();
+        let status = child
+            .child
+            .try_wait()
+            .unwrap()
+            .expect("canonical-marked process is still running after reconciliation");
         assert!(
             !status.success(),
             "canonical-marked process was not signalled"


### PR DESCRIPTION
`acquisition_reconciles_canonical_process` can hang indefinitely when reconciliation misses the probe. Replace its blocking child wait with a nonblocking exit assertion so a surviving probe fails immediately and unwinds through the fixture's existing kill-and-reap cleanup. The abnormal-exit and stale-launch-removal assertions remain intact.

Fixes #32838.

Validation:

- `cargo fmt --manifest-path crates/runner/Cargo.toml -- --check`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml --profile local -p runner --bin runner proxy::runtime::tests::acquisition_reconciles_canonical_process -- --exact` — passed.
- All 8 `proxy::runtime::tests::` cases passed using the retained Cargo-built executable for the exact restored source (source blob `18d7cd5759ebdf1993a50cbc6708fb2d6cf14752`).
- A temporary omitted-marker mutation caused the exact canonical test to fail with the new diagnostic and exit code 101 in 0.1721 s. The five-second external fail-safe did not fire, and the recorded probe PID was absent from `/proc` after the test exited. All mutation instrumentation was removed before submission.
- `CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml --profile local -p runner --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 cargo doc --manifest-path crates/Cargo.toml --profile local -p runner --all-features --no-deps`
