### PR TITLE
fix(runner): recover blank runs after unsafe codex prefetch start

### DIFF
--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -180,8 +180,11 @@ impl ExecutorInvocation {
         let inner = tokio::spawn(async move {
             if let Some(idle_entry) = reuse_entry {
                 executor::execute_job_reuse_with_hooks(
-                    idle_entry,
-                    reuse_result,
+                    executor::ReusedSandboxDispatch {
+                        factory: &**factory,
+                        idle_sandbox: idle_entry,
+                        reuse_result,
+                    },
                     context,
                     &exec_config,
                     &params,

--- a/crates/runner/src/cmd/start/tests/idle_reuse/blank_prefetch.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/blank_prefetch.rs
@@ -68,6 +68,7 @@ async fn blank_prefetch_recovery_preserves_history_identity_budget_and_one_compl
         assert_eq!(overrides.create_configs().len(), 1);
         assert_eq!(budget.allocated().2, 1);
         assert!(env.active_runs.contains(run_id));
+        assert!(overrides.write_file_calls().is_empty());
         assert!(overrides.start_agent_process_calls().is_empty());
         assert!(env.handle.completions.lock().unwrap().is_empty());
         drop(holder);
@@ -98,11 +99,17 @@ async fn blank_prefetch_recovery_preserves_history_identity_budget_and_one_compl
         let creates = overrides.create_configs();
         assert_eq!(creates.len(), if cancelled { 1 } else { 2 });
         assert!(creates.iter().all(|config| config.id == blank_id));
+        let writes = overrides.write_file_calls();
+        assert_eq!(
+            writes.len(),
+            usize::from(!cancelled),
+            "restore retained history exactly once, and never after cancellation"
+        );
         if !cancelled {
+            assert_eq!(writes[0].content, HISTORY);
             assert_eq!(
-                overrides.write_file_calls().len(),
-                1,
-                "restore the retained history once"
+                writes[0].path,
+                "/home/user/.codex/sessions/2026/07/13/rollout-2026-07-13T01-02-03-019e9154-c304-70f0-adde-36efb1be1701.jsonl"
             );
         }
         server.assert_finished().await;

--- a/crates/runner/src/cmd/start/tests/idle_reuse/blank_prefetch.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/blank_prefetch.rs
@@ -1,0 +1,114 @@
+use super::super::super::*;
+use super::super::support::{
+    mock_run_config_with_overrides, push_job, shutdown, test_profiles, wait_cancel_handle,
+    wait_idle_pool_len,
+};
+use super::blank_session_history::history_context;
+use crate::test_fixtures::raw_http::{RawHttpAction, RawHttpTestServer, http_response};
+use crate::types::{FirewallEntry, SandboxReuseResult};
+use sandbox::{SandboxError, SandboxOperation, SandboxOperationTimeoutStage};
+use sandbox_mock::{MockLifecycleGate, MockSandboxOverrides};
+use tokio::sync::oneshot;
+
+const WAIT: Duration = Duration::from_secs(5);
+const HISTORY: &[u8] = br#"{"type":"session_meta","payload":{"id":"019e9154-c304-70f0-adde-36efb1be1701","timestamp":"2026-07-13T01:02:03Z"}}"#;
+
+#[tokio::test]
+async fn blank_prefetch_recovery_preserves_history_identity_budget_and_one_completion() {
+    for cancelled in [false, true] {
+        let (release_history, history_release) = oneshot::channel();
+        let history_action = if cancelled {
+            RawHttpAction::WaitForDisconnect
+        } else {
+            RawHttpAction::WaitThenRespond {
+                release: history_release,
+                response: http_response("200 OK", HISTORY),
+            }
+        };
+        let mut server = RawHttpTestServer::spawn(vec![history_action]).await;
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        let (config, env) =
+            mock_run_config_with_overrides(test_profiles(), 16, 32_768, 8, Arc::clone(&overrides));
+        let admission = config.exec_config.pre_spawn_admission.clone();
+        let budget = Arc::clone(&config.capacity.budget);
+        let run_handle = tokio::spawn(run(config));
+        wait_idle_pool_len(&env.idle_pool, 1, WAIT).await;
+        let holder = admission
+            .acquire(u32::MAX, &CancellationToken::new())
+            .await
+            .unwrap();
+        let blank_id = env.idle_pool.lock().await.status_snapshot().blank_sandboxes[0].sandbox_id;
+        let run_id = RunId::new_v4();
+        let mut context = history_context(run_id, server.url(), HISTORY);
+        context.cli_agent_type = "codex".into();
+        context
+            .resume_session
+            .as_mut()
+            .unwrap()
+            .cli_agent_session_id = "019e9154-c304-70f0-adde-36efb1be1701".into();
+        context.encrypted_secrets = Some("encrypted".into());
+        context.firewalls = Some(vec![FirewallEntry::Builtin {
+            name: "model-provider:codex-oauth-token".into(),
+            base_url_vars: None,
+            source_id: None,
+        }]);
+        overrides.push_start_process_error(SandboxError::OperationTimeout {
+            operation: SandboxOperation::StartProcess,
+            stage: SandboxOperationTimeoutStage::AwaitingTerminalResponse,
+            timeout_ms: 1_000,
+        });
+        let destroy = MockLifecycleGate::new();
+        overrides.set_destroy_lifecycle_gate(destroy.clone());
+        push_job(&env, run_id, "vm0/default", Some(context));
+        destroy.wait_entered(1, WAIT).await.unwrap();
+        env.drain();
+        server
+            .next_request("history prestarted before blank retirement")
+            .await;
+        assert_eq!(overrides.create_configs().len(), 1);
+        assert_eq!(budget.allocated().2, 1);
+        assert!(env.active_runs.contains(run_id));
+        assert!(overrides.start_agent_process_calls().is_empty());
+        assert!(env.handle.completions.lock().unwrap().is_empty());
+        drop(holder);
+
+        if cancelled {
+            let cancellation = wait_cancel_handle(&env.cancel_tokens, run_id, WAIT).await;
+            cancellation.request_hard_cancellation().await;
+            destroy.release_one();
+        } else {
+            destroy.release_one();
+            release_history.send(()).unwrap();
+            // The successful replacement is destroyed by ordinary finalization.
+            destroy.wait_entered(2, WAIT).await.unwrap();
+            destroy.release_one();
+        }
+        let completion = env.handle.wait_completion(run_id, WAIT).await.unwrap();
+        assert_eq!(completion.exit_code, if cancelled { 137 } else { 0 });
+        assert_eq!(completion.sandbox_id, Some(blank_id));
+        assert_eq!(
+            completion.reuse_result,
+            Some(SandboxReuseResult::NoReuseKey)
+        );
+        assert_eq!(overrides.start_process_calls().len(), 1);
+        assert_eq!(
+            overrides.start_agent_process_calls().len(),
+            usize::from(!cancelled)
+        );
+        let creates = overrides.create_configs();
+        assert_eq!(creates.len(), if cancelled { 1 } else { 2 });
+        assert!(creates.iter().all(|config| config.id == blank_id));
+        if !cancelled {
+            assert_eq!(
+                overrides.write_file_calls().len(),
+                1,
+                "restore the retained history once"
+            );
+        }
+        server.assert_finished().await;
+        shutdown(&env, run_handle).await;
+        assert_eq!(budget.allocated().2, 0);
+        assert!(!env.active_runs.contains(run_id));
+        assert_eq!(env.handle.completions.lock().unwrap().len(), 1);
+    }
+}

--- a/crates/runner/src/cmd/start/tests/idle_reuse/mod.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/mod.rs
@@ -1,4 +1,5 @@
 mod blank_pool;
+mod blank_prefetch;
 mod blank_session_history;
 mod device_limits;
 mod drain;

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -1241,6 +1241,40 @@ impl PreparedGuestRuntime {
 }
 
 impl RunControls {
+    pub(super) async fn prepare_codex_model_catalog_prefetch(
+        &mut self,
+        sandbox: &dyn Sandbox,
+        context: &ExecutionContext,
+        start: &RunStart<'_>,
+        telemetry: &mut JobTelemetry,
+    ) -> Option<PreparedGuestRuntime> {
+        if !is_codex_model_catalog_prefetch_eligible(context, start.reuse_result) {
+            return None;
+        }
+        if self.guest_state_prepared {
+            Some(
+                PreparedGuestRuntime::start_codex_model_catalog_prefetch(
+                    sandbox,
+                    context,
+                    start.reuse_result,
+                    &self.cancel,
+                    telemetry,
+                )
+                .await,
+            )
+        } else {
+            PreparedGuestRuntime::prepare_for_codex_model_catalog_prefetch(
+                sandbox,
+                context,
+                start.restore_guest_state,
+                start.reuse_result,
+                &self.cancel,
+                telemetry,
+            )
+            .await
+        }
+    }
+
     #[cfg(test)]
     pub(super) fn new(
         cancel: CancellationToken,
@@ -1633,12 +1667,14 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             if let Some(prepared) = prepared_storage.as_mut() {
                 prepared.delivery.cancel_and_drain(telemetry).await;
             }
+            session_history_restore_plan.cancel_and_drain().await;
             return Err(error);
         }
         PreparedGuestRuntime::Failed(error) => {
             if let Some(prepared) = prepared_storage.as_mut() {
                 prepared.delivery.cancel_and_drain(telemetry).await;
             }
+            session_history_restore_plan.cancel_and_drain().await;
             return Err(error);
         }
         PreparedGuestRuntime::Cancelled => {
@@ -1659,6 +1695,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     .as_ref()
                     .map(|failure| failure.error.as_str()),
             );
+            session_history_restore_plan.cancel_and_drain().await;
             return Ok(result);
         }
     };
@@ -1684,6 +1721,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 prepared.delivery.cancel_and_drain(telemetry).await;
             }
             model_catalog_prefetch.finish(telemetry).await;
+            session_history_restore_plan.cancel_and_drain().await;
             return Err(error);
         }
         None => {
@@ -1705,6 +1743,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     .as_ref()
                     .map(|failure| failure.error.as_str()),
             );
+            session_history_restore_plan.cancel_and_drain().await;
             return Ok(result);
         }
     };

--- a/crates/runner/src/executor/codex_model_catalog_prefetch.rs
+++ b/crates/runner/src/executor/codex_model_catalog_prefetch.rs
@@ -9,7 +9,7 @@ use sandbox::{
     SandboxOperationWriteStage, StartProcessRequest,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
+use tracing::{info, warn};
 
 use super::cli_framework::EffectiveCliFramework;
 use super::effective_cli_framework;
@@ -149,7 +149,7 @@ impl StartedCodexModelCatalogPrefetch {
                 ))
             }
             Err(error) if is_unusable_sandbox_start_timeout(&error) => {
-                warn!(error = %error, "Codex model catalog prefetch start timed out after write boundary");
+                info!(error = %error, "Codex model catalog prefetch start timed out after write boundary");
                 CodexModelCatalogPrefetchStart::SandboxUnusable(
                     UnusableCodexModelCatalogPrefetchStart {
                         error,
@@ -165,7 +165,7 @@ impl StartedCodexModelCatalogPrefetch {
                     ..
                 },
             ) => {
-                warn!(error = %error, "Codex model catalog prefetch start write failed after write boundary");
+                info!(error = %error, "Codex model catalog prefetch start write failed after write boundary");
                 CodexModelCatalogPrefetchStart::SandboxUnusable(
                     UnusableCodexModelCatalogPrefetchStart {
                         error,

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -6,7 +6,8 @@
 //!
 //! The fresh path starts and prepares a new Firecracker VM and can notify the
 //! caller once the sandbox is ready to run the job. The reuse path runs in a
-//! kept-alive idle sandbox.
+//! kept-alive idle sandbox. An unusable blank can be retired before Agent start
+//! and replaced once through fresh preparation; exact reuse does not prefetch.
 //!
 //! Both paths return `ExecuteOutcome` plus a pending `JobTelemetry`
 //! buffer. When `ExecuteOutcome::sandbox` is `Some`, the executor transfers
@@ -33,6 +34,7 @@ mod codex_model_catalog_prefetch;
 mod diagnostics;
 mod env;
 mod guest_state;
+mod reused_sandbox;
 mod sandbox_run;
 mod session_history_cpu;
 mod session_history_download;
@@ -61,9 +63,8 @@ use crate::active_input::ActiveInputSource;
 use agent_run::{PreparedRunInputs, ProcessCancelTimeouts, RunControls, RunStart};
 use env::validate_execution_context_before_sandbox;
 pub(crate) use env::validate_resume_session_id;
-use sandbox_run::{
-    NewSandboxHooks, execute_new_sandbox_with_prepared_notifier, execute_reused_sandbox,
-};
+use reused_sandbox::{ReusedSandboxRun, execute_reused_sandbox};
+use sandbox_run::{FreshPreparation, NewSandboxHooks, execute_new_sandbox_with_prepared_notifier};
 pub(crate) use telemetry::{
     ExactReuseSpeculationTiming, FinalizingDiagnostics, FinalizingExactIdleLookup,
     FinalizingHandoffOutcome, FinalizingHandoffReason, RunnerPreSpawnConcurrency,
@@ -382,6 +383,21 @@ pub struct ExecuteOutcome {
 }
 
 impl ExecuteOutcome {
+    fn preparation_failure(error: impl ToString) -> Self {
+        Self {
+            failure: Some(ExecutionFailure::from_error(error.to_string())),
+            active_input_delivery_ids: Vec::new(),
+            sandbox_reuse_disposition: SandboxReuseDisposition::default(),
+            sandbox: None,
+            source_ip: String::new(),
+            network_log_session: None,
+            workspace_image: None,
+            workspace_reuse_result: None,
+            discovered_cli_agent_session_id: None,
+            restored_session_identity: None,
+        }
+    }
+
     fn reused_sandbox_failure(
         failure: ExecutionFailure,
         sandbox: Box<dyn Sandbox>,
@@ -653,6 +669,7 @@ pub(crate) async fn execute_job_with_prepared_notifier(
             params,
             &mut telemetry,
             NewSandboxHooks {
+                preparation: FreshPreparation::Initial,
                 controls: RunControls::from_cancellation(cancellation, active_input_source)
                     .with_spawn_timing(spawn_timing)
                     .with_session_history_restore_plan(session_history_restore_plan),
@@ -697,8 +714,11 @@ pub async fn execute_job_reuse(
     cancel: CancellationToken,
 ) -> (ExecuteOutcome, JobTelemetry) {
     execute_job_reuse_with_hooks(
-        idle_sandbox,
-        SandboxReuseResult::Reused,
+        ReusedSandboxDispatch {
+            factory: &sandbox_mock::MockSandboxFactory::new(),
+            idle_sandbox,
+            reuse_result: SandboxReuseResult::Reused,
+        },
         context,
         config,
         params,
@@ -708,15 +728,25 @@ pub async fn execute_job_reuse(
     .await
 }
 
+pub(crate) struct ReusedSandboxDispatch<'a> {
+    pub(crate) factory: &'a dyn SandboxFactory,
+    pub(crate) idle_sandbox: ReusableIdleSandbox,
+    pub(crate) reuse_result: SandboxReuseResult,
+}
+
 pub(crate) async fn execute_job_reuse_with_hooks(
-    idle_sandbox: ReusableIdleSandbox,
-    reuse_result: SandboxReuseResult,
+    dispatch: ReusedSandboxDispatch<'_>,
     context: ExecutionContext,
     config: &ExecutorConfig,
     params: &JobParams,
     cancellation: RunCancellationSignals,
     hooks: ExecutionHooks,
 ) -> (ExecuteOutcome, JobTelemetry) {
+    let ReusedSandboxDispatch {
+        factory,
+        idle_sandbox,
+        reuse_result,
+    } = dispatch;
     let ExecutionHooks {
         sandbox_prepared: _,
         active_input_source,
@@ -814,8 +844,8 @@ pub(crate) async fn execute_job_reuse_with_hooks(
         (None, None) => None,
     };
 
-    // execute_reused_sandbox never returns Err — it always returns the sandbox
-    // in the outcome so the caller can stop + destroy it on failure.
+    // The reuse owner either returns a live sandbox for caller finalization or
+    // retires an unusable blank before attempting its single replacement.
     let sandbox_id_string = sandbox_id.to_string();
     let outcome = match validate_execution_context_before_sandbox(
         &context,
@@ -830,9 +860,16 @@ pub(crate) async fn execute_job_reuse_with_hooks(
             workspace_image,
         ),
         Ok(prepared_run_payload) => {
-            let mut outcome = execute_reused_sandbox(
-                sandbox,
-                &source_ip,
+            execute_reused_sandbox(
+                ReusedSandboxRun {
+                    sandbox_id,
+                    factory,
+                    params,
+                    sandbox,
+                    source_ip,
+                    workspace_image,
+                    kind,
+                },
                 &context,
                 config,
                 RunStart {
@@ -856,9 +893,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
                     prepared_run_payload,
                 ),
             )
-            .await;
-            outcome.workspace_image = workspace_image;
-            outcome
+            .await
         }
     };
 

--- a/crates/runner/src/executor/reused_sandbox.rs
+++ b/crates/runner/src/executor/reused_sandbox.rs
@@ -1,0 +1,241 @@
+//! Own reused preparation until optional prefetch can safely hand off to Agent execution.
+
+use std::time::{Duration, Instant};
+
+use sandbox::{Sandbox, SandboxFactory};
+use tracing::{info, warn};
+
+use super::agent_run::{PreparedGuestRuntime, PreparedRunInputs, RunStart};
+use super::sandbox_run::{
+    FreshPreparation, NewSandboxHooks, PreparedSandboxRun, cancel_prepared_storage,
+    destroy_sandbox_panic_safe, execute_new_sandbox_with_prepared_notifier,
+    execute_prepared_sandbox_run, prepare_storage, register_proxy, unregister_proxy_registry,
+};
+use super::{ExecuteOutcome, ExecutionFailure, ExecutorConfig, JobParams, NewSandboxDispatch};
+use crate::error::RunnerError;
+use crate::idle_pool::IdleSandboxKind;
+use crate::telemetry::JobTelemetry;
+use crate::types::ExecutionContext;
+use crate::workspace_image_cache::WorkspaceImageLease;
+
+const BLANK_PREFETCH_REPLACEMENT: &str = "runner_blank_sandbox_retry_without_codex_prefetch";
+
+pub(super) struct ReusedSandboxRun<'a> {
+    pub(super) sandbox_id: sandbox::SandboxId,
+    pub(super) factory: &'a dyn SandboxFactory,
+    pub(super) params: &'a JobParams,
+    pub(super) sandbox: Box<dyn Sandbox>,
+    pub(super) source_ip: String,
+    pub(super) workspace_image: Option<WorkspaceImageLease>,
+    pub(super) kind: IdleSandboxKind,
+}
+
+pub(super) async fn execute_reused_sandbox(
+    run: ReusedSandboxRun<'_>,
+    context: &ExecutionContext,
+    config: &ExecutorConfig,
+    start: RunStart<'_>,
+    telemetry: &mut JobTelemetry,
+    mut inputs: PreparedRunInputs,
+) -> ExecuteOutcome {
+    info!(run_id = %context.run_id, sandbox_id = %run.sandbox.id(), "reusing kept-alive sandbox");
+    let prepare_started = Instant::now();
+    let prepared_storage = prepare_storage(
+        context,
+        start.prev_storage,
+        config,
+        &inputs.controls.cancel,
+        telemetry,
+    )
+    .await;
+    let network_log_session = match prepared_storage {
+        Ok(storage) => {
+            inputs.controls.prepared_storage = storage;
+            register_proxy(config, context, &run.source_ip).await
+        }
+        Err(error) => Err(error),
+    };
+    let network_log_session = match network_log_session {
+        Ok(session) => session,
+        Err(error) => {
+            cancel_prepared_storage(&mut inputs.controls, telemetry).await;
+            inputs
+                .controls
+                .session_history_restore_plan
+                .cancel_and_drain()
+                .await;
+            telemetry.record(
+                "runner_reused_sandbox_prepare",
+                prepare_started.elapsed(),
+                false,
+                Some(&error.to_string()),
+            );
+            return ExecuteOutcome::reused_sandbox_failure(
+                ExecutionFailure::from_error(error.to_string()),
+                run.sandbox,
+                run.source_ip,
+                run.workspace_image,
+            );
+        }
+    };
+    telemetry.record(
+        "runner_reused_sandbox_prepare",
+        prepare_started.elapsed(),
+        true,
+        None,
+    );
+
+    // Exact reuse does not prefetch. For blanks, inspect the existing preparation
+    // result while inputs and sandbox ownership are still available for recovery.
+    let prepared_guest_runtime = if run.kind == IdleSandboxKind::Blank {
+        inputs
+            .controls
+            .prepare_codex_model_catalog_prefetch(run.sandbox.as_ref(), context, &start, telemetry)
+            .await
+    } else {
+        None
+    };
+    let prepared = PreparedSandboxRun {
+        sandbox: run.sandbox,
+        source_ip: run.source_ip,
+        network_log_session,
+        prepared_guest_runtime: None,
+    };
+    if let Some(PreparedGuestRuntime::SandboxUnusable(error)) = prepared_guest_runtime {
+        // Drop the retired blank's lease without publishing or freezing its image.
+        drop(run.workspace_image);
+        return replace_unusable_blank(
+            run.factory,
+            run.params,
+            prepared,
+            context,
+            config,
+            telemetry,
+            BlankReplacement {
+                sandbox_id: run.sandbox_id,
+                error,
+                reuse_result: start.reuse_result,
+                inputs,
+            },
+        )
+        .await;
+    }
+    let mut outcome = execute_prepared_sandbox_run(
+        PreparedSandboxRun {
+            prepared_guest_runtime,
+            ..prepared
+        },
+        context,
+        config,
+        start,
+        telemetry,
+        inputs,
+    )
+    .await;
+    outcome.workspace_image = run.workspace_image;
+    outcome
+}
+
+struct BlankReplacement {
+    sandbox_id: sandbox::SandboxId,
+    error: RunnerError,
+    reuse_result: crate::types::SandboxReuseResult,
+    inputs: PreparedRunInputs,
+}
+
+async fn replace_unusable_blank(
+    factory: &dyn SandboxFactory,
+    params: &JobParams,
+    prepared: PreparedSandboxRun,
+    context: &ExecutionContext,
+    config: &ExecutorConfig,
+    telemetry: &mut JobTelemetry,
+    replacement: BlankReplacement,
+) -> ExecuteOutcome {
+    let BlankReplacement {
+        sandbox_id,
+        error,
+        reuse_result,
+        mut inputs,
+    } = replacement;
+    info!(run_id = %context.run_id, %sandbox_id, %error,
+        "retiring unusable blank before Agent start; skipping guest cleanup");
+    cancel_prepared_storage(&mut inputs.controls, telemetry).await;
+    let unregister_completed =
+        match unregister_proxy_registry(config, &prepared.source_ip, context.run_id).await {
+            Ok(()) => true,
+            Err(cleanup_error) => {
+                warn!(run_id = %context.run_id, %sandbox_id, error = %cleanup_error,
+                "failed to unregister proxy for unusable blank");
+                false
+            }
+        };
+    prepared
+        .network_log_session
+        .close_for_upload(context.run_id, &config.network_log_drain)
+        .await;
+    let destroy_completed = destroy_sandbox_panic_safe(factory, prepared.sandbox)
+        .await
+        .is_completed();
+    if !unregister_completed || !destroy_completed {
+        telemetry.record(
+            BLANK_PREFETCH_REPLACEMENT,
+            Duration::ZERO,
+            false,
+            Some("cleanup_uncertain"),
+        );
+        inputs
+            .controls
+            .session_history_restore_plan
+            .cancel_and_drain()
+            .await;
+        warn!(run_id = %context.run_id, %sandbox_id,
+            "blank Codex prefetch replacement suppressed after uncertain cleanup");
+        return ExecuteOutcome::preparation_failure(error);
+    }
+    if inputs.controls.cancel.is_cancelled() {
+        telemetry.record(
+            BLANK_PREFETCH_REPLACEMENT,
+            Duration::ZERO,
+            false,
+            Some("cancelled"),
+        );
+        inputs
+            .controls
+            .session_history_restore_plan
+            .cancel_and_drain()
+            .await;
+        let mut outcome = ExecuteOutcome::preparation_failure(RunnerError::Cancelled);
+        outcome.mark_cancelled();
+        return outcome;
+    }
+    // Like the fresh retry action, this records admission to the replacement
+    // attempt. Fresh preparation and Agent execution retain their own outcomes.
+    telemetry.record(BLANK_PREFETCH_REPLACEMENT, Duration::ZERO, true, None);
+    info!(run_id = %context.run_id, %sandbox_id,
+        "retrying retired blank with Codex prefetch disabled");
+    let cancel = inputs.controls.cancel.clone();
+    let result = execute_new_sandbox_with_prepared_notifier(
+        factory,
+        context,
+        NewSandboxDispatch {
+            id: sandbox_id,
+            reuse_result,
+        },
+        config,
+        params,
+        telemetry,
+        NewSandboxHooks {
+            preparation: FreshPreparation::WithoutCodexPrefetchReplacement,
+            controls: inputs.controls.with_guest_state_prepared(false),
+            prepared_run_payload: inputs.run_payload,
+            sandbox_prepared: None,
+        },
+    )
+    .await;
+    let mut outcome = result.unwrap_or_else(ExecuteOutcome::preparation_failure);
+    if cancel.is_cancelled() {
+        outcome.mark_cancelled();
+    }
+    outcome
+}

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -446,6 +446,7 @@ pub(super) async fn execute_new_sandbox(
         params,
         telemetry,
         NewSandboxHooks {
+            preparation: crate::executor::sandbox_run::FreshPreparation::Initial,
             controls: RunControls::new(cancel, None),
             prepared_run_payload,
             sandbox_prepared: None,
@@ -454,7 +455,7 @@ pub(super) async fn execute_new_sandbox(
     .await
 }
 
-async fn prepare_storage(
+pub(super) async fn prepare_storage(
     context: &ExecutionContext,
     previous_storage: Option<&StorageFingerprints>,
     config: &ExecutorConfig,
@@ -490,7 +491,10 @@ async fn prepare_storage(
     result
 }
 
-async fn cancel_prepared_storage(controls: &mut RunControls, telemetry: &mut JobTelemetry) {
+pub(super) async fn cancel_prepared_storage(
+    controls: &mut RunControls,
+    telemetry: &mut JobTelemetry,
+) {
     if let Some(mut prepared) = controls.prepared_storage.take() {
         prepared.delivery.cancel_and_drain(telemetry).await;
     }
@@ -510,6 +514,7 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
         reuse_result,
     } = dispatch;
     let NewSandboxHooks {
+        preparation,
         mut controls,
         prepared_run_payload,
         sandbox_prepared,
@@ -546,6 +551,9 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                 false,
                 Some(&error.to_string()),
             );
+            std::mem::take(&mut controls.session_history_restore_plan)
+                .cancel_and_drain()
+                .await;
             return Err(error);
         }
     };
@@ -580,6 +588,9 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                 false,
                 Some(&error.to_string()),
             );
+            std::mem::take(&mut controls.session_history_restore_plan)
+                .cancel_and_drain()
+                .await;
             return Err(error);
         }
     }
@@ -592,11 +603,18 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
         telemetry,
     )
     .await;
-    let mut used_retry = false;
+    let mut used_retry = preparation == FreshPreparation::WithoutCodexPrefetchReplacement;
     let mut used_workspace_fallback = false;
-    let mut codex_model_catalog_prefetch = true;
+    let mut codex_model_catalog_prefetch = preparation == FreshPreparation::Initial;
     let mut dns_replacement: Option<DnsReadinessReplacement> = None;
     let prepared = loop {
+        if controls.cancel.is_cancelled() {
+            cancel_prepared_storage(&mut controls, telemetry).await;
+            std::mem::take(&mut controls.session_history_restore_plan)
+                .cancel_and_drain()
+                .await;
+            return Err(RunnerError::Cancelled);
+        }
         let result = create_started_sandbox(
             factory,
             context,
@@ -623,17 +641,6 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
             Ok(prepared) => break prepared,
             Err(failure) => failure,
         };
-        if used_retry {
-            let error = failure.error;
-            telemetry.record(
-                "runner_fresh_sandbox_prepare",
-                prepare_started.elapsed(),
-                false,
-                Some(&error.to_string()),
-            );
-            cancel_prepared_storage(&mut controls, telemetry).await;
-            return Err(error);
-        }
 
         let cache_hit = workspace_image
             .as_ref()
@@ -649,6 +656,20 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                 "sandbox_prepare_failed",
             )
             .await;
+        }
+        if used_retry {
+            let error = failure.error;
+            telemetry.record(
+                "runner_fresh_sandbox_prepare",
+                prepare_started.elapsed(),
+                false,
+                Some(&error.to_string()),
+            );
+            cancel_prepared_storage(&mut controls, telemetry).await;
+            std::mem::take(&mut controls.session_history_restore_plan)
+                .cancel_and_drain()
+                .await;
+            return Err(error);
         }
         let retry_guest_dns = failure.retry == SandboxPrepareRetry::GuestDnsReadiness;
         let retry_without_workspace =
@@ -701,6 +722,9 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                 Some(&error.to_string()),
             );
             cancel_prepared_storage(&mut controls, telemetry).await;
+            std::mem::take(&mut controls.session_history_restore_plan)
+                .cancel_and_drain()
+                .await;
             return Err(error);
         }
         if !retry_guest_dns && !retry_without_workspace && !retry_without_codex_prefetch {
@@ -712,6 +736,9 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                 Some(&error.to_string()),
             );
             cancel_prepared_storage(&mut controls, telemetry).await;
+            std::mem::take(&mut controls.session_history_restore_plan)
+                .cancel_and_drain()
+                .await;
             return Err(error);
         }
 
@@ -726,7 +753,7 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
         }
 
         if retry_without_codex_prefetch {
-            warn!(
+            info!(
                 run_id = %context.run_id,
                 sandbox_id = %sandbox_id,
                 error = %failure.error,
@@ -784,6 +811,9 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                         false,
                         Some(&error.to_string()),
                     );
+                    std::mem::take(&mut controls.session_history_restore_plan)
+                        .cancel_and_drain()
+                        .await;
                     return Err(error);
                 }
             }
@@ -845,9 +875,17 @@ enum SandboxPrepareRetry {
 }
 
 pub(super) struct NewSandboxHooks<'a> {
+    pub(super) preparation: FreshPreparation,
     pub(super) controls: RunControls,
     pub(super) prepared_run_payload: PreparedRunPayload,
     pub(super) sandbox_prepared: Option<&'a SandboxPreparedNotifier>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum FreshPreparation {
+    Initial,
+    /// The blank has already consumed the only replacement attempt.
+    WithoutCodexPrefetchReplacement,
 }
 
 struct StartSandboxOptions<'a> {
@@ -1539,7 +1577,7 @@ pub(super) enum DestroySandboxOutcome {
 }
 
 impl DestroySandboxOutcome {
-    fn is_completed(self) -> bool {
+    pub(super) fn is_completed(self) -> bool {
         matches!(self, Self::Completed)
     }
 }
@@ -1558,93 +1596,6 @@ pub(super) async fn destroy_sandbox_panic_safe(
     } else {
         DestroySandboxOutcome::Completed
     }
-}
-
-/// Run a job inside a reused (kept-alive) sandbox.
-///
-/// Skips create + start. Starts bounded archive delivery, re-registers the
-/// proxy, fixes clock/entropy, then runs.
-pub(super) async fn execute_reused_sandbox(
-    sandbox: Box<dyn Sandbox>,
-    source_ip: &str,
-    context: &ExecutionContext,
-    config: &ExecutorConfig,
-    start: RunStart<'_>,
-    telemetry: &mut JobTelemetry,
-    mut inputs: PreparedRunInputs,
-) -> ExecuteOutcome {
-    info!(
-        run_id = %context.run_id,
-        sandbox_id = %sandbox.id(),
-        "reusing kept-alive sandbox"
-    );
-
-    let source_ip = source_ip.to_string();
-    let prepare_started = Instant::now();
-    let prepared_storage = prepare_storage(
-        context,
-        start.prev_storage,
-        config,
-        &inputs.controls.cancel,
-        telemetry,
-    )
-    .await;
-    match prepared_storage {
-        Ok(prepared_storage) => inputs.controls.prepared_storage = prepared_storage,
-        Err(error) => {
-            telemetry.record(
-                "runner_reused_sandbox_prepare",
-                prepare_started.elapsed(),
-                false,
-                Some(&error.to_string()),
-            );
-            return ExecuteOutcome::reused_sandbox_failure(
-                ExecutionFailure::from_error(error.to_string()),
-                sandbox,
-                source_ip,
-                None,
-            );
-        }
-    }
-    let network_log_session = match register_proxy(config, context, &source_ip).await {
-        Ok(session) => session,
-        Err(error) => {
-            cancel_prepared_storage(&mut inputs.controls, telemetry).await;
-            telemetry.record(
-                "runner_reused_sandbox_prepare",
-                prepare_started.elapsed(),
-                false,
-                Some(&error.to_string()),
-            );
-            return ExecuteOutcome::reused_sandbox_failure(
-                ExecutionFailure::from_error(error.to_string()),
-                sandbox,
-                source_ip,
-                None,
-            );
-        }
-    };
-    telemetry.record(
-        "runner_reused_sandbox_prepare",
-        prepare_started.elapsed(),
-        true,
-        None,
-    );
-
-    execute_prepared_sandbox_run(
-        PreparedSandboxRun {
-            sandbox,
-            source_ip,
-            network_log_session,
-            prepared_guest_runtime: None,
-        },
-        context,
-        config,
-        start,
-        telemetry,
-        inputs,
-    )
-    .await
 }
 
 pub(super) async fn execute_prepared_sandbox_run(

--- a/crates/runner/src/executor/session_history_restore_plan.rs
+++ b/crates/runner/src/executor/session_history_restore_plan.rs
@@ -157,6 +157,20 @@ pub(crate) enum SessionHistoryRestorePlan {
     SkipVerified(RestoredSessionIdentity),
 }
 
+impl SessionHistoryRestorePlan {
+    pub(super) async fn cancel_and_drain(self) {
+        match self {
+            Self::Prestarted { materializer, .. } => {
+                let cancel = CancellationToken::new();
+                cancel.cancel();
+                let _ = materializer.finish(&cancel).await;
+            }
+            Self::LocalSidecar { materializer, .. } => materializer.cancel().await,
+            Self::Default | Self::DeferredHashBacked { .. } | Self::SkipVerified(_) => {}
+        }
+    }
+}
+
 /// Inputs available at the post-reuse restore-planning boundary.
 ///
 /// The caller has already resolved resume validity, sandbox reuse, and any

--- a/crates/runner/src/executor/tests/sandbox_run_tests/blank_prefetch.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/blank_prefetch.rs
@@ -1,0 +1,341 @@
+use super::*;
+use crate::executor::{ExecuteOutcome, ExecutorConfig};
+use crate::idle_pool::IdleSandboxKind;
+use crate::telemetry::JobTelemetry;
+use sandbox::{SandboxOperation, SandboxOperationTimeoutStage, SandboxOperationWriteStage};
+use sandbox_mock::MockSandboxOverrides;
+use tokio_util::sync::CancellationToken;
+
+const WAIT: Duration = Duration::from_secs(5);
+const REPLACEMENT: &str = "runner_blank_sandbox_retry_without_codex_prefetch";
+
+fn post_write_timeout() -> SandboxError {
+    SandboxError::OperationTimeout {
+        operation: SandboxOperation::StartProcess,
+        stage: SandboxOperationTimeoutStage::AwaitingTerminalResponse,
+        timeout_ms: 1_000,
+    }
+}
+
+async fn execute_blank(
+    config: ExecutorConfig,
+    overrides: Arc<MockSandboxOverrides>,
+    cancel: CancellationToken,
+) -> (ExecuteOutcome, JobTelemetry) {
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let sandbox = create_overridden_sandbox(overrides).await;
+    let mut context = codex_oauth_context();
+    context.reuse_key = Some("thread:blank-prefetch-recovery".into());
+    let sandbox_id = sandbox.id().parse().unwrap();
+    let workspace_image = match &config.workspace_cache {
+        Some(cache) => Some(
+            cache
+                .lease_active(
+                    crate::workspace_image_cache::WorkspaceImageActiveLeaseRequest {
+                        identity: WorkspaceImageLeaseIdentity {
+                            run_id: context.run_id,
+                            sandbox_id,
+                            profile_name: "vm0/default",
+                            reuse_key: context.reuse_key(),
+                            working_dir: CANONICAL_WORKING_DIR,
+                            image_size_bytes: u64::from(default_params().workspace_disk_mb)
+                                * 1024
+                                * 1024,
+                        },
+                        workspace_drive_available: true,
+                    },
+                )
+                .await,
+        ),
+        None => None,
+    };
+    let mut telemetry = test_telemetry(&config, &context);
+    let outcome = execute_reused_sandbox(
+        ReusedSandboxRun {
+            sandbox_id,
+            factory: &factory,
+            params: &JobParams {
+                restore_guest_state: true,
+                ..default_params()
+            },
+            source_ip: sandbox.source_ip().to_string(),
+            sandbox,
+            workspace_image,
+            kind: IdleSandboxKind::Blank,
+        },
+        &context,
+        &config,
+        RunStart {
+            restore_guest_state: true,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        PreparedRunInputs::new(
+            RunControls::new(cancel, None).with_guest_state_prepared(true),
+            prepare_run_payload_for_run(&context).unwrap(),
+        ),
+    )
+    .await;
+    (outcome, telemetry)
+}
+
+#[tokio::test]
+async fn blank_prefetch_retires_before_one_replacement_and_one_agent() {
+    for error in [
+        post_write_timeout(),
+        SandboxError::OperationTimeout {
+            operation: SandboxOperation::StartProcess,
+            stage: SandboxOperationTimeoutStage::FrameWrite,
+            timeout_ms: 1_000,
+        },
+        SandboxError::OperationWrite {
+            operation: SandboxOperation::StartProcess,
+            stage: SandboxOperationWriteStage::FrameWrite,
+            source: std::io::Error::new(std::io::ErrorKind::BrokenPipe, "partial frame"),
+        },
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.push_start_process_error(error);
+        let destroy = MockLifecycleGate::new();
+        overrides.set_destroy_lifecycle_gate(destroy.clone());
+        let task = tokio::spawn(execute_blank(
+            config,
+            Arc::clone(&overrides),
+            CancellationToken::new(),
+        ));
+        destroy.wait_entered(1, WAIT).await.unwrap();
+        assert_eq!(overrides.create_configs().len(), 1);
+        assert!(overrides.copy_file_calls().is_empty());
+        assert!(overrides.exec_calls().is_empty());
+        assert!(overrides.private_write_files_calls().is_empty());
+        assert!(overrides.start_agent_process_calls().is_empty());
+        assert_proxy_registry_empty(dir.path()).await;
+        assert!(!task.is_finished());
+        destroy.release_one();
+        let (outcome, telemetry) = tokio::time::timeout(WAIT, task).await.unwrap().unwrap();
+        assert_eq!(outcome.exit_code(), 0, "{:?}", outcome.error());
+        let creates = overrides.create_configs();
+        assert_eq!(creates.len(), 2);
+        assert_eq!(creates[0].id, creates[1].id);
+        assert_eq!(
+            outcome.sandbox.as_ref().unwrap().id(),
+            creates[0].id.to_string()
+        );
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert_eq!(overrides.start_process_calls().len(), 1);
+        assert_eq!(overrides.start_agent_process_calls().len(), 1);
+        assert_eq!(overrides.guest_state_restore_calls().len(), 1);
+        assert_eq!(overrides.workspace_drive_mount_calls(), 1);
+        assert_telemetry_action(&telemetry, REPLACEMENT, true, None);
+        assert_telemetry_action(
+            &telemetry,
+            "runner_fresh_pre_spawn_admission_wait",
+            true,
+            None,
+        );
+        assert_proxy_registry_empty(dir.path()).await;
+    }
+}
+
+#[tokio::test]
+async fn blank_prefetch_success_and_safe_failure_bypass_fresh_admission() {
+    for error in [
+        None,
+        Some(SandboxError::OperationWrite {
+            operation: SandboxOperation::StartProcess,
+            stage: SandboxOperationWriteStage::BeforeFrameWrite,
+            source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "before frame"),
+        }),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let holder = config
+            .pre_spawn_admission
+            .acquire(2, &CancellationToken::new())
+            .await
+            .unwrap();
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        if let Some(error) = error {
+            overrides.push_start_process_error(error);
+        }
+        let (outcome, telemetry) = tokio::time::timeout(
+            WAIT,
+            execute_blank(config, Arc::clone(&overrides), CancellationToken::new()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(outcome.exit_code(), 0);
+        assert_eq!(overrides.create_configs().len(), 1);
+        assert_eq!(overrides.destroy_call_count(), 0);
+        assert_eq!(overrides.start_process_calls().len(), 1);
+        assert_eq!(overrides.start_agent_process_calls().len(), 1);
+        assert!(overrides.guest_state_restore_calls().is_empty());
+        assert_eq!(overrides.workspace_drive_mount_calls(), 0);
+        assert_no_telemetry_action(&telemetry, REPLACEMENT);
+        assert_no_telemetry_action(&telemetry, "runner_fresh_pre_spawn_admission_wait");
+        drop(holder);
+    }
+}
+
+#[tokio::test]
+async fn blank_prefetch_uncertain_destroy_suppresses_replacement_and_guest_cleanup() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.push_start_process_error(post_write_timeout());
+    overrides.push_destroy_panic("uncertain destroy");
+    let (outcome, telemetry) =
+        execute_blank(config, Arc::clone(&overrides), CancellationToken::new()).await;
+    assert_eq!(outcome.exit_code(), 1);
+    assert!(outcome.sandbox.is_none());
+    assert!(outcome.workspace_image.is_none());
+    assert!(outcome.network_log_session.is_none());
+    assert_eq!(overrides.create_configs().len(), 1);
+    assert!(overrides.start_agent_process_calls().is_empty());
+    assert!(overrides.copy_file_calls().is_empty());
+    assert!(overrides.exec_calls().is_empty());
+    assert_telemetry_action(&telemetry, REPLACEMENT, false, Some("cleanup_uncertain"));
+    assert_proxy_registry_empty(dir.path()).await;
+}
+
+#[tokio::test]
+async fn blank_prefetch_cancellation_drains_destroy_without_creating_replacement() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.push_start_process_error(post_write_timeout());
+    let destroy = MockLifecycleGate::new();
+    overrides.set_destroy_lifecycle_gate(destroy.clone());
+    let cancel = CancellationToken::new();
+    let task = tokio::spawn(execute_blank(
+        config,
+        Arc::clone(&overrides),
+        cancel.clone(),
+    ));
+    destroy.wait_entered(1, WAIT).await.unwrap();
+    cancel.cancel();
+    assert!(!task.is_finished());
+    destroy.release_one();
+    let (outcome, telemetry) = tokio::time::timeout(WAIT, task).await.unwrap().unwrap();
+    assert_eq!(outcome.exit_code(), 137);
+    assert!(outcome.sandbox.is_none());
+    assert_eq!(overrides.create_configs().len(), 1);
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert!(overrides.start_agent_process_calls().is_empty());
+    assert_telemetry_action(&telemetry, REPLACEMENT, false, Some("cancelled"));
+}
+
+#[tokio::test]
+async fn blank_prefetch_replacement_failure_cannot_retry_again() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.push_start_process_error(post_write_timeout());
+    overrides.push_start_result(Err(SandboxError::GuestDnsReadiness {
+        reason: SandboxGuestDnsReadinessReason::DnsPath,
+        message: "replacement DNS failed".into(),
+    }));
+    let (outcome, _) =
+        execute_blank(config, Arc::clone(&overrides), CancellationToken::new()).await;
+    assert_eq!(outcome.exit_code(), 1);
+    assert_eq!(overrides.create_configs().len(), 2);
+    assert_eq!(overrides.destroy_call_count(), 2);
+    assert!(outcome.sandbox.is_none());
+    assert!(overrides.start_agent_process_calls().is_empty());
+    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert!(overrides.copy_file_calls().is_empty());
+    assert_proxy_registry_empty(dir.path()).await;
+}
+
+#[tokio::test]
+async fn blank_prefetch_replacement_releases_old_workspace_lease() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut config = test_executor_config(dir.path()).await;
+    config.workspace_cache = Some(WorkspaceImageCache::new(RunnerPaths::new(
+        dir.path().join("runner"),
+    )));
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.push_start_process_error(post_write_timeout());
+    let (outcome, _) = execute_blank(config, overrides, CancellationToken::new()).await;
+    assert_eq!(outcome.exit_code(), 0);
+    assert_eq!(
+        outcome.workspace_image.unwrap().result(),
+        WorkspaceCacheCheckoutResult::Miss
+    );
+}
+
+#[tokio::test]
+async fn blank_prefetch_uncertain_proxy_cleanup_never_replaces() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let log_manager = config.network_log_manager.clone();
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    let start = MockLifecycleGate::new();
+    overrides.set_start_process_lifecycle_gate(start.clone());
+    overrides.push_start_process_error(post_write_timeout());
+    let task = tokio::spawn(execute_blank(
+        config,
+        Arc::clone(&overrides),
+        CancellationToken::new(),
+    ));
+    start.wait_entered(1, WAIT).await.unwrap();
+    tokio::fs::write(dir.path().join("proxy-registry.json"), b"invalid registry")
+        .await
+        .unwrap();
+    start.release_one();
+    let (outcome, telemetry) = tokio::time::timeout(WAIT, task).await.unwrap().unwrap();
+    assert_eq!(outcome.exit_code(), 1);
+    assert_eq!(overrides.create_configs().len(), 1);
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert!(overrides.start_agent_process_calls().is_empty());
+    assert!(overrides.copy_file_calls().is_empty());
+    assert!(
+        !log_manager
+            .append_for_ip("10.0.0.1", serde_json::json!({"message":"late row"}))
+            .await
+    );
+    assert_telemetry_action(&telemetry, REPLACEMENT, false, Some("cleanup_uncertain"));
+}
+
+#[tokio::test]
+async fn blank_prefetch_cancels_while_waiting_for_replacement_admission() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let admission = config.pre_spawn_admission.clone();
+    let holder = admission
+        .acquire(2, &CancellationToken::new())
+        .await
+        .unwrap();
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.push_start_process_error(post_write_timeout());
+    let cancel = CancellationToken::new();
+    let task = tokio::spawn(execute_blank(
+        config,
+        Arc::clone(&overrides),
+        cancel.clone(),
+    ));
+    tokio::time::timeout(WAIT, async {
+        while overrides.destroy_call_count() != 1 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    assert!(!task.is_finished());
+    cancel.cancel();
+    let (outcome, _) = tokio::time::timeout(WAIT, task).await.unwrap().unwrap();
+    assert_eq!(outcome.exit_code(), 137);
+    assert_eq!(overrides.create_configs().len(), 1);
+    assert!(overrides.start_agent_process_calls().is_empty());
+    drop(holder);
+    assert!(
+        admission
+            .acquire(2, &CancellationToken::new())
+            .await
+            .is_ok()
+    );
+}

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -460,6 +460,7 @@ async fn execute_new_sandbox_notifies_after_successful_prepare() {
         &default_params(),
         &mut telemetry,
         NewSandboxHooks {
+            preparation: crate::executor::sandbox_run::FreshPreparation::Initial,
             controls: RunControls::new(tokio_util::sync::CancellationToken::new(), None),
             prepared_run_payload: prepare_run_payload_for_run(&ctx).unwrap(),
             sandbox_prepared: Some(&notifier),
@@ -703,6 +704,7 @@ async fn execute_new_sandbox_destroys_before_workload_when_prepared_notification
         &default_params(),
         &mut telemetry,
         NewSandboxHooks {
+            preparation: crate::executor::sandbox_run::FreshPreparation::Initial,
             controls: RunControls::new(tokio_util::sync::CancellationToken::new(), None),
             prepared_run_payload: prepare_run_payload_for_run(&ctx).unwrap(),
             sandbox_prepared: Some(&notifier),
@@ -806,6 +808,7 @@ async fn execute_new_sandbox_replaces_one_dns_unready_attachment_before_workload
         &default_params(),
         &mut telemetry,
         NewSandboxHooks {
+            preparation: crate::executor::sandbox_run::FreshPreparation::Initial,
             controls: RunControls::new(tokio_util::sync::CancellationToken::new(), None),
             prepared_run_payload: prepare_run_payload_for_run(&ctx).unwrap(),
             sandbox_prepared: Some(&notifier),
@@ -1183,6 +1186,7 @@ async fn execute_new_sandbox_does_not_notify_before_start_failure() {
         &default_params(),
         &mut telemetry,
         NewSandboxHooks {
+            preparation: crate::executor::sandbox_run::FreshPreparation::Initial,
             controls: RunControls::new(tokio_util::sync::CancellationToken::new(), None),
             prepared_run_payload: prepare_run_payload_for_run(&ctx).unwrap(),
             sandbox_prepared: Some(&notifier),
@@ -1227,6 +1231,7 @@ async fn execute_new_sandbox_does_not_notify_after_post_start_prepare_failure() 
         &default_params(),
         &mut telemetry,
         NewSandboxHooks {
+            preparation: crate::executor::sandbox_run::FreshPreparation::Initial,
             controls: RunControls::new(tokio_util::sync::CancellationToken::new(), None),
             prepared_run_payload: prepare_run_payload_for_run(&ctx).unwrap(),
             sandbox_prepared: Some(&notifier),

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -22,11 +22,12 @@ use super::super::env::{
     guest_connector_account_context_file_path, guest_run_payload_file_path,
     guest_user_env_file_path, prepare_run_payload_for_run,
 };
+use super::super::reused_sandbox::{ReusedSandboxRun, execute_reused_sandbox};
 use super::super::sandbox_run::{
     NewSandboxHooks, PreparedSandboxRun, execute_new_sandbox,
     execute_new_sandbox_with_prepared_notifier, execute_prepared_sandbox_run,
-    execute_prepared_sandbox_run_with_process_cancel_timeouts, execute_reused_sandbox,
-    log_proxy_register_failure, log_proxy_register_success, register_proxy,
+    execute_prepared_sandbox_run_with_process_cancel_timeouts, log_proxy_register_failure,
+    log_proxy_register_success, register_proxy,
 };
 use super::super::{
     AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT, EXIT_SIGKILL, ExecutionFailureKind, JOB_TIMEOUT,
@@ -55,6 +56,7 @@ use crate::workspace_image_cache::{
 use tracing::Level;
 use tracing_subscriber::prelude::*;
 
+mod blank_prefetch;
 mod execution_diagnostics;
 mod fresh_sandbox;
 mod idle_pool;

--- a/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
@@ -214,8 +214,15 @@ async fn execute_reused_sandbox_proxy_register_failure_returns_sandbox_before_ag
     let task = tokio::spawn(async move {
         let mut telemetry = test_telemetry(&config, &ctx);
         let outcome = execute_reused_sandbox(
-            sandbox,
-            &source_ip,
+            ReusedSandboxRun {
+                sandbox_id: sandbox.id().parse().unwrap(),
+                factory: &MockSandboxFactory::new(),
+                params: &default_params(),
+                sandbox,
+                source_ip,
+                workspace_image: None,
+                kind: crate::idle_pool::IdleSandboxKind::Exact,
+            },
             &ctx,
             &config,
             RunStart {

--- a/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
@@ -354,8 +354,15 @@ async fn execute_reused_sandbox_drains_archive_when_guest_state_restore_fails() 
     let task = tokio::spawn(async move {
         let mut telemetry = test_telemetry(&config, &context);
         let outcome = execute_reused_sandbox(
-            sandbox,
-            &source_ip,
+            ReusedSandboxRun {
+                sandbox_id: sandbox.id().parse().unwrap(),
+                factory: &MockSandboxFactory::new(),
+                params: &default_params(),
+                sandbox,
+                source_ip,
+                workspace_image: None,
+                kind: crate::idle_pool::IdleSandboxKind::Exact,
+            },
             &context,
             &config,
             RunStart {

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -136,6 +136,7 @@ async fn workspace_sidecar_materialization_overlaps_sandbox_creation() {
             &params,
             &mut telemetry,
             NewSandboxHooks {
+                preparation: crate::executor::sandbox_run::FreshPreparation::Initial,
                 controls: RunControls::new(tokio_util::sync::CancellationToken::new(), None)
                     .with_session_history_restore_plan(
                         SessionHistoryRestorePlan::DeferredHashBacked {
@@ -245,6 +246,7 @@ async fn workspace_sidecar_probe_miss_falls_back_and_records_reason() {
             &params,
             &mut telemetry,
             NewSandboxHooks {
+                preparation: crate::executor::sandbox_run::FreshPreparation::Initial,
                 controls: RunControls::new(tokio_util::sync::CancellationToken::new(), None)
                     .with_session_history_restore_plan(
                         SessionHistoryRestorePlan::DeferredHashBacked {
@@ -346,6 +348,7 @@ async fn workspace_retry_cancels_sidecar_materialization_before_cache_invalidati
             &params,
             &mut telemetry,
             NewSandboxHooks {
+                preparation: crate::executor::sandbox_run::FreshPreparation::Initial,
                 controls: RunControls::new(tokio_util::sync::CancellationToken::new(), None)
                     .with_session_history_restore_plan(
                         SessionHistoryRestorePlan::DeferredHashBacked {
@@ -1394,6 +1397,7 @@ async fn execute_inner_does_not_retry_workspace_cache_hit_after_proxy_register_f
             &params,
             &mut telemetry,
             NewSandboxHooks {
+                preparation: crate::executor::sandbox_run::FreshPreparation::Initial,
                 controls: RunControls::new(tokio_util::sync::CancellationToken::new(), None)
                     .with_session_history_restore_plan(
                         SessionHistoryRestorePlan::DeferredHashBacked {

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -1958,8 +1958,11 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
     let mut context = minimal_context();
     context.api_start_time = Some(chrono::Utc::now().timestamp_millis().max(0) as u64);
     let (_outcome, telemetry) = execute_job_reuse_with_hooks(
-        idle_sandbox,
-        SandboxReuseResult::Reused,
+        crate::executor::ReusedSandboxDispatch {
+            factory: &MockSandboxFactory::new(),
+            idle_sandbox,
+            reuse_result: SandboxReuseResult::Reused,
+        },
         context,
         &config,
         &default_params(),
@@ -2073,8 +2076,11 @@ async fn execute_job_claims_blank_sandbox_without_changing_cold_path_attribution
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (outcome, telemetry) = execute_job_reuse_with_hooks(
-        idle_sandbox,
-        SandboxReuseResult::PoolMiss,
+        crate::executor::ReusedSandboxDispatch {
+            factory: &MockSandboxFactory::new(),
+            idle_sandbox,
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
         minimal_context(),
         &config,
         &params,
@@ -2124,8 +2130,11 @@ async fn assert_reused_private_write_timeout_telemetry(
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (outcome, telemetry) = execute_job_reuse_with_hooks(
-        idle_sandbox,
-        SandboxReuseResult::Reused,
+        crate::executor::ReusedSandboxDispatch {
+            factory: &MockSandboxFactory::new(),
+            idle_sandbox,
+            reuse_result: SandboxReuseResult::Reused,
+        },
         context,
         &config,
         &default_params(),
@@ -2178,8 +2187,11 @@ async fn assert_reused_required_private_batch_failure(
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (outcome, telemetry) = execute_job_reuse_with_hooks(
-        idle_sandbox,
-        SandboxReuseResult::Reused,
+        crate::executor::ReusedSandboxDispatch {
+            factory: &MockSandboxFactory::new(),
+            idle_sandbox,
+            reuse_result: SandboxReuseResult::Reused,
+        },
         context,
         &config,
         &default_params(),

--- a/docs/runner-guest-process-lifecycle.md
+++ b/docs/runner-guest-process-lifecycle.md
@@ -148,9 +148,25 @@ Possible partial writes and start deadlines during/after writing stop further
 workspace, storage, and Agent preparation on that sandbox. Fresh preparation
 destroys it and may retry once with prefetch disabled, only after cleanup is
 confirmed. This consumes the existing shared preparation retry budget; uncertain
-cleanup or an already-consumed retry prevents another attempt. A direct run on
-an already-owned sandbox fails through its existing cleanup owner instead of
-replacing the sandbox in place.
+cleanup or an already-consumed retry prevents another attempt.
+
+Blank-pool runs inspect the same typed result before handing inputs to Agent
+execution. An unusable blank drains its prepared storage, unregisters its proxy,
+closes its network-log session and is destroyed before one fresh replacement
+with prefetch disabled. The replacement keeps the run/sandbox identity and caller
+budget ownership, acquires ordinary fresh pre-spawn admission, and cannot spend
+another DNS, workspace or prefetch retry. Run-scoped remote history work remains
+owned across replacement and is drained on terminal failure or cancellation.
+The retired blank's workspace lease is released without guest freeze or cache
+publication; guest-log copying and session-ID discovery are also skipped on that
+known-unusable connection. Cleanup uncertainty or cancellation suppresses creation.
+
+Successful fresh and blank paths keep their existing prefetch deadline and guest
+operations; already-prepared guest state is not restored twice. Exact reuse does
+not prefetch or enter this replacement path. A direct Agent-lifecycle invocation
+without the enclosing preparation owner still returns the typed start failure.
+Recoverable unsafe-prefetch/retirement messages are informational; final failure
+or uncertain cleanup remains a warning/error with unsuccessful telemetry.
 
 Ordinary write failures retain `start_failed` prefetch telemetry; typed request
 deadlines retain `start_timed_out`. The original write cause remains available


### PR DESCRIPTION
## Summary

Closes #32748.

- Recover blank-pool runs when optional Codex model-catalog prefetch crosses the write boundary but cannot establish a safe process handle. Keep the typed preparation result outside Agent execution so the unusable VM is never asked to run an Agent or guest cleanup.
- Drain old storage delivery, unregister the proxy, close the log session, destroy the old VM and release its workspace lease before creating one fresh replacement with prefetch disabled. Preserve run/sandbox identity, caller budget/completion ownership and prestarted remote history. Cancellation or uncertain cleanup suppresses replacement.
- Spend the existing preparation retry budget on that replacement, preventing nested DNS/workspace/prefetch retries. Acquire ordinary fresh admission only for the abnormal replacement. Keep ordinary blank/fresh guest operations and deadlines, and exact-reuse behavior unchanged.

This does not identify or eliminate the initiating one-second guest stall. It does not raise timeouts, add probes, change guest/API protocols, deploy to production, or retry an Agent that has already started. Runner and guest/API versions may still deploy independently: this is internal runner ownership/control flow only.

## Fallbacks

- **Implementation:** `crates/runner/src/executor/reused_sandbox.rs:replace_unusable_blank`, using `crates/runner/src/executor/sandbox_run.rs:execute_new_sandbox_with_prepared_notifier` in `FreshPreparation::WithoutCodexPrefetchReplacement` mode.

- **Surface:** optional Codex OAuth model-catalog prefetch on a blank-pool VM, before Agent start.
- **Trigger and bound:** existing typed partial/post-write start failure; replacement is allowed only after confirmed proxy unregistration and VM destruction, with cancellation checked. Exactly one fresh replacement, with prefetch disabled and no additional preparation retry.
- **Safety and visibility:** preserve the original run identity and one completion; retire all old VM resources without guest-log copy/session discovery/freeze; preserve or drain run-owned history explicitly. Record typed prefetch failure and replacement admission/suppression telemetry; fresh preparation/Agent actions report the replacement outcome. Expected recovery logs are informational; terminal failures and cleanup uncertainty remain visible.
- **Lifetime/removal:** permanent operational recovery, not a rollout compatibility shim. Remove if optional prefetch is retired or its transport/ownership contract no longer permits an unusable pre-Agent VM. No time-based removal or compatibility follow-up is needed.

## Validation

Passed on the committed tree:

- `cargo fmt --all -- --check`
- `cargo clippy --profile local -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --profile local --no-deps -p runner --all-features`
- `cargo run --profile local -p xtask -- check-rust-path-attributes`
- `cargo test --profile local -p runner --all-targets --all-features -- --test-threads=4 --quiet`: 3610 runner tests + 1 guest inventory test passed; 27 existing ignored tests unchanged.
- Markdown formatting, staged diff/file-size checks, and normal commit hooks including workspace Clippy/docs passed.

Nine new tests cover typed post-write/partial-write failure, destroy-before-create, one replacement/Agent, safe pre-write continuation, cancellation during retirement/admission, uncertain destroy/proxy cleanup, no nested DNS retry, workspace lease release, and full run-loop history/identity/budget/completion ownership. The run-loop regression verifies the exact restored history bytes and canonical Codex path, no history writes before old-VM retirement, and no writes after cancellation.

### Startup comparison

Matched isolated service on local-11, baseline `2715689151` versus this tree, identical x86_64-musl local-profile builds and guest snapshot. Order baseline/candidate/candidate/baseline; 100 successful mock-CLI runs, including 20 exact warmups. Every measured run's fresh/blank/exact classification and timing actions were asserted.

| Path | Samples per version | Executor-to-ready p50, baseline → candidate | p95, baseline → candidate |
| --- | --- | --- | --- |
| fresh | 10 | 289 → 294.5 ms | 306 → 333 ms |
| blank | 10 | 66.5 → 65 ms | 82 → 74 ms |
| exact | 20 | 23 → 22 ms | 36 → 36 ms |

Blank/exact show no startup shift in this sample; fresh has a small median/tail increase. This small shared-host, unoptimized sample is not statistical equivalence or a production-latency guarantee. No live OAuth catalog request or real lost-ACK latency was measured; integration tests cover eligible-prefetch operation counts and typed abnormal recovery. Earlier calibration attempts used an incompatible older image / expired local telemetry sink and were rejected, not counted as successful measurements. All task-owned services were stopped; production and other developers' services were not changed.
