### PR TITLE
fix(platform): illustrate empty credit balance

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/personal-usage-tab.test.tsx
@@ -21,6 +21,7 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { emptyUsageImg } from "../platform-assets.ts";
 
 const context = testContext();
 
@@ -374,6 +375,19 @@ test("Show an empty member-package balance for the new Pro plan", async () => {
   expect(
     within(card).queryByText("Configure member packages"),
   ).not.toBeInTheDocument();
+});
+
+test("Show an illustrated empty credit balance when a member has no usage pack", async () => {
+  mockPersonalUsageStory(usageRows(), "limited-free-1", false, "member");
+
+  await openUsageSettings();
+
+  const emptyState = await screen.findByTestId("credit-balance-empty");
+  expect(emptyState.querySelector("img")).toHaveAttribute("src", emptyUsageImg);
+  expect(
+    screen.queryByTestId("usage-pack-credit-card"),
+  ).not.toBeInTheDocument();
+  expect(screen.queryByTestId("credit-balance-info")).not.toBeInTheDocument();
 });
 
 test("Hide Usage package controls when the capability is disabled, even with credits", async () => {

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/credit-balance-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/credit-balance-section.tsx
@@ -25,6 +25,7 @@ import {
   formatCreditDate,
   type CreditAddition,
 } from "../../org-manage/org-usage-tab.tsx";
+import { emptyUsageImg } from "../../../platform-assets.ts";
 import { UserAvatar } from "../../../../components/avatar.tsx";
 import { isOrgAdmin$ } from "../../../../../signals/org.ts";
 import { pageSignal$ } from "../../../../../signals/page-signal.ts";
@@ -606,6 +607,23 @@ function UsagePackCreditCard({ isAdmin }: { isAdmin: boolean }) {
   );
 }
 
+function CreditBalanceEmptyState() {
+  return (
+    <div
+      data-testid="credit-balance-empty"
+      className="flex min-h-[20rem] items-center justify-center px-6"
+    >
+      <img
+        src={emptyUsageImg}
+        alt=""
+        role="presentation"
+        loading="lazy"
+        className="h-24 w-24 object-contain opacity-80"
+      />
+    </div>
+  );
+}
+
 export function CreditBalanceSection() {
   const { t } = useTranslation();
   const setActiveSection = useSet(setSettingsActiveSection$);
@@ -639,7 +657,14 @@ export function CreditBalanceSection() {
   // Members only see credits assigned by their usage pack. Organization
   // balances remain available to organization admins.
   if (!isAdmin) {
-    return <div>{usagePackCreditCard}</div>;
+    const showEmptyState =
+      isAdminLoadable.state === "hasData" && capabilities !== undefined;
+    return (
+      <div>
+        {usagePackCreditCard ??
+          (showEmptyState ? <CreditBalanceEmptyState /> : null)}
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary

- show the existing credit usage illustration when a workspace member has no usage-pack balance
- wait for member role and plan capabilities before showing the empty state
- cover the blank limited-free member state with a Platform page test

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/personal-usage-tab.test.tsx` (14 passed)
- `pnpm -F @okouai/app lint`
- `pnpm lint:style`
- `pnpm -F @okouai/app check-types`

## Visual verification

- PASS on the PR App preview at head `1b10beeeb8f76cd841d306b17e71f68faed717d1` (deployed merge commit `44069163552ea09b3764a450caa97e3ab5101cd4`)
- App: `https://pr-32866-app-okou-app-preview.vm0.workers.dev`
- API: `https://pr-32866-api.vm6.ai`
- Viewport: 1180 x 799; Headless Chrome 152; light theme
- Fixture: invited workspace member with 0 credits and no usage pack; onboarding was bypassed for the test workspace because onboarding was out of scope
- Credit balance opened from the account menu with the illustration loaded at 96 x 96; Credit usage navigation remained available
- Screenshot: https://a.okou.io/j49fe4kycp.png
