### PR TITLE
ci: preserve production kms rollback configuration

### DIFF
--- a/.github/scripts/kms-production-backup.py
+++ b/.github/scripts/kms-production-backup.py
@@ -2,6 +2,7 @@
 """Escrow effective production KMS configuration without changing deployments."""
 
 import datetime
+import hashlib
 import json
 import os
 import re
@@ -261,6 +262,7 @@ def main():
         "deployment": deployment,
         "runId": run_id,
         "readbackVerified": True,
+        "snapshotSha256": hashlib.sha256(snapshot.encode()).hexdigest(),
         "productionConfigurationChanged": False,
     }
     report_path = Path(required_env("RUNNER_TEMP")) / "kms-production-backup.json"

--- a/.github/scripts/kms-production-backup.py
+++ b/.github/scripts/kms-production-backup.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Escrow effective production KMS configuration without changing deployments."""
+
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.parse
+from pathlib import Path
+
+
+PROJECT = "vm0-kms-rollback-32264"
+CONFIG = "prd"
+BACKUP_SECRET = "KMS_BACKUP_JSON"
+IDENTITY = "c0c87790-e651-45dd-b7fa-c5ed07bb990f"
+SOURCE_ACCOUNT = "072707626411"
+SOURCE_KEY = (
+    "arn:aws:kms:us-west-2:072707626411:key/a1b3922b-fab1-4ed3-aa9e-40f86f92a7a8"
+)
+PRINCIPAL = f"arn:aws:iam::{SOURCE_ACCOUNT}:user/vm0-kms-prod"
+VERCEL_PROJECT = "prj_6mw0CgYjECVrJV57VJ47VN03B4UR"
+VERCEL_TEAM = "team_WRqI0kCoX5KcRInRWgZ1nBF0"
+
+
+class BackupError(Exception):
+    """Only fixed, non-sensitive failure codes may reach workflow logs."""
+
+
+def require(condition, code):
+    if not condition:
+        raise BackupError(code)
+
+
+def required_env(name):
+    value = os.environ.get(name, "")
+    require(bool(value), "missing_required_environment")
+    return value
+
+
+def request_json(url, bearer=None, body=None):
+    # Response bodies can contain credentials, even on a provider error.
+    # Keep both output streams in memory and never relay provider diagnostics.
+    command = [
+        "curl",
+        "--silent",
+        "--show-error",
+        "--max-time",
+        "30",
+        "--request",
+        "POST" if body is not None else "GET",
+        "--header",
+        "Accept: application/json",
+        "--write-out",
+        "\n%{http_code}",
+        url,
+    ]
+    if bearer is not None:
+        command.extend(["--header", "Authorization: Bearer " + bearer])
+    if body is not None:
+        command.extend(
+            ["--header", "Content-Type: application/json", "--data-binary", "@-"]
+        )
+    result = subprocess.run(
+        command,
+        input=None if body is None else json.dumps(body),
+        text=True,
+        capture_output=True,
+        timeout=45,
+        check=False,
+    )
+    require(result.returncode == 0, "provider_transport_failed")
+    payload, status = result.stdout.rsplit("\n", 1)
+    require(status.startswith("2"), "provider_request_rejected")
+    response = json.loads(payload)
+    require(isinstance(response, dict), "invalid_provider_response")
+    require(response.get("success") is not False, "provider_operation_failed")
+    return response
+
+
+def aws(*arguments):
+    result = subprocess.run(
+        ["aws", *arguments, "--region", "us-west-2", "--output", "json"],
+        text=True,
+        capture_output=True,
+        timeout=45,
+        check=False,
+    )
+    require(result.returncode == 0, "source_aws_verification_failed")
+    return json.loads(result.stdout)
+
+
+def production_deployment(token, expected):
+    project = request_json(
+        f"https://api.vercel.com/v9/projects/{VERCEL_PROJECT}?teamId={VERCEL_TEAM}",
+        token,
+    )
+    require(
+        project["id"] == VERCEL_PROJECT and project["accountId"] == VERCEL_TEAM,
+        "vercel_scope_mismatch",
+    )
+    deployment = project["targets"]["production"]
+    require(deployment["id"] == expected, "production_deployment_changed")
+    require(
+        deployment["readyState"] == "READY" and deployment["target"] == "production",
+        "production_deployment_not_ready",
+    )
+    require("api.okou.ai" in deployment["alias"], "production_alias_missing")
+    commit = deployment["meta"]["githubCommitSha"]
+    require(re.fullmatch(r"[0-9a-f]{40}", commit), "invalid_deployment_commit")
+    return {"id": deployment["id"], "url": deployment["url"], "commit": commit}
+
+
+def main():
+    require(
+        required_env("GITHUB_REPOSITORY") == "vm0-ai/vm0", "repository_scope_mismatch"
+    )
+    require(required_env("GITHUB_REF") == "refs/heads/main", "main_branch_required")
+    require(
+        required_env("GITHUB_EVENT_NAME") == "workflow_dispatch",
+        "manual_dispatch_required",
+    )
+    require(
+        required_env("GITHUB_WORKFLOW_REF")
+        == "vm0-ai/vm0/.github/workflows/kms-production-backup.yml@refs/heads/main",
+        "workflow_scope_mismatch",
+    )
+    require(
+        required_env("DOPPLER_SERVICE_IDENTITY_ID") == IDENTITY,
+        "production_oidc_identity_required",
+    )
+    expected = required_env("EXPECTED_DEPLOYMENT_ID")
+    require(re.fullmatch(r"dpl_[A-Za-z0-9]+", expected), "invalid_expected_deployment")
+    run_id = required_env("GITHUB_RUN_ID")
+    commit = required_env("GITHUB_SHA")
+    require(
+        run_id.isdigit() and re.fullmatch(r"[0-9a-f]{40}", commit),
+        "invalid_workflow_metadata",
+    )
+    values = {
+        name: required_env(name)
+        for name in [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "SECRETS_KMS_KEY_ID",
+            "AWS_REGION",
+        ]
+    }
+    require(
+        values["AWS_REGION"] == "us-west-2" and not os.environ.get("AWS_SESSION_TOKEN"),
+        "static_production_credentials_required",
+    )
+    require(
+        values["SECRETS_KMS_KEY_ID"]
+        in [
+            SOURCE_KEY,
+            SOURCE_KEY.rsplit("/", 1)[1],
+            "alias/vm0-secrets-prod",
+            f"arn:aws:kms:us-west-2:{SOURCE_ACCOUNT}:alias/vm0-secrets-prod",
+        ],
+        "source_key_required",
+    )
+    caller = aws("sts", "get-caller-identity")
+    require(
+        caller["Account"] == SOURCE_ACCOUNT and caller["Arn"] == PRINCIPAL,
+        "source_principal_mismatch",
+    )
+    # The CLI only returns KeyId; its generated plaintext data key is never emitted.
+    resolved_key = aws(
+        "kms",
+        "generate-data-key",
+        "--key-id",
+        values["SECRETS_KMS_KEY_ID"],
+        "--key-spec",
+        "AES_256",
+        "--encryption-context",
+        "purpose=vm0-stored-secret",
+        "--query",
+        "KeyId",
+    )
+    require(resolved_key == SOURCE_KEY, "resolved_source_key_mismatch")
+    vercel_token = required_env("VERCEL_TOKEN")
+    deployment = production_deployment(vercel_token, expected)
+    request_url = urllib.parse.urlsplit(required_env("ACTIONS_ID_TOKEN_REQUEST_URL"))
+    require(
+        request_url.scheme == "https"
+        and request_url.hostname.endswith(".actions.githubusercontent.com"),
+        "invalid_oidc_origin",
+    )
+    query = dict(urllib.parse.parse_qsl(request_url.query))
+    query["audience"] = "https://github.com/vm0-ai"
+    oidc_url = urllib.parse.urlunsplit(
+        request_url._replace(query=urllib.parse.urlencode(query))
+    )
+    oidc = request_json(oidc_url, required_env("ACTIONS_ID_TOKEN_REQUEST_TOKEN"))[
+        "value"
+    ]
+    token = request_json(
+        "https://api.doppler.com/v3/auth/oidc",
+        body={"identity": IDENTITY, "token": oidc},
+    )["token"]
+    secrets_url = f"https://api.doppler.com/v3/configs/config/secrets?project={PROJECT}&config={CONFIG}&include_managed_secrets=false"
+    require(
+        request_json(secrets_url, token)["secrets"] == {},
+        "backup_destination_not_empty",
+    )
+    require(
+        production_deployment(vercel_token, expected) == deployment,
+        "production_deployment_changed",
+    )
+    snapshot = json.dumps(
+        {
+            "version": 1,
+            "capturedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "sourcePrincipal": PRINCIPAL,
+            "sourceKeyArn": SOURCE_KEY,
+            "configuration": values,
+            "deployment": deployment,
+            "workflow": {"repository": "vm0-ai/vm0", "commit": commit, "runId": run_id},
+        },
+        separators=(",", ":"),
+    )
+    request_json(
+        "https://api.doppler.com/v3/configs/config/secrets",
+        token,
+        {
+            "project": PROJECT,
+            "config": CONFIG,
+            "change_requests": [
+                {
+                    "name": BACKUP_SECRET,
+                    "originalName": None,
+                    "originalValue": None,
+                    "value": snapshot,
+                    "visibility": "masked",
+                }
+            ],
+        },
+    )
+    stored = request_json(secrets_url, token)["secrets"]
+    require(set(stored) == {BACKUP_SECRET}, "backup_secret_set_mismatch")
+    require(
+        stored[BACKUP_SECRET]["raw"] == snapshot
+        and stored[BACKUP_SECRET]["computed"] == snapshot,
+        "backup_readback_mismatch",
+    )
+    require(
+        stored[BACKUP_SECRET]["rawVisibility"] == "masked"
+        and stored[BACKUP_SECRET]["computedVisibility"] == "masked",
+        "backup_visibility_mismatch",
+    )
+    report = {
+        "result": "passed",
+        "backupProject": PROJECT,
+        "backupConfig": CONFIG,
+        "backupSecret": BACKUP_SECRET,
+        "sourcePrincipal": PRINCIPAL,
+        "sourceKeyArn": SOURCE_KEY,
+        "configurationNames": sorted(values),
+        "deployment": deployment,
+        "runId": run_id,
+        "readbackVerified": True,
+        "productionConfigurationChanged": False,
+    }
+    report_path = Path(required_env("RUNNER_TEMP")) / "kms-production-backup.json"
+    with report_path.open("x", encoding="utf-8") as output:
+        os.chmod(report_path, 0o600)
+        json.dump(report, output, indent=2)
+        output.write("\n")
+    print(json.dumps(report))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        code = str(error) if isinstance(error, BackupError) else "unexpected_error"
+        print("Production KMS backup failed: " + code, file=sys.stderr)
+        sys.exit(1)

--- a/.github/scripts/tests/fixtures/kms-production-backup-tools.py
+++ b/.github/scripts/tests/fixtures/kms-production-backup-tools.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Isolated AWS/curl command boundary for the production backup CLI tests."""
+
+import json
+import os
+import sys
+import urllib.parse
+from pathlib import Path
+
+state_path = Path(os.environ["BACKUP_FIXTURE_STATE"])
+state = json.loads(state_path.read_text())
+scenario = state["scenario"]
+arguments = sys.argv[1:]
+source_key = (
+    "arn:aws:kms:us-west-2:072707626411:key/a1b3922b-fab1-4ed3-aa9e-40f86f92a7a8"
+)
+status = 200
+
+if Path(sys.argv[0]).name == "aws":
+    assert arguments[arguments.index("--region") + 1] == "us-west-2"
+    if arguments[:2] == ["sts", "get-caller-identity"]:
+        response = {
+            "Account": "072707626411",
+            "Arn": "arn:aws:iam::072707626411:user/vm0-kms-prod",
+        }
+        if scenario == "wrong-principal":
+            response["Arn"] = "arn:aws:iam::072707626411:user/unexpected"
+    else:
+        assert arguments[:2] == ["kms", "generate-data-key"]
+        assert arguments[arguments.index("--query") + 1] == "KeyId"
+        response = source_key
+    print(json.dumps(response))
+    sys.exit(0)
+
+assert Path(sys.argv[0]).name == "curl"
+method = arguments[arguments.index("--request") + 1]
+url = next(value for value in arguments if value.startswith("https://"))
+parsed = urllib.parse.urlsplit(url)
+body = json.load(sys.stdin) if method == "POST" else None
+headers = [
+    arguments[index + 1] for index, value in enumerate(arguments) if value == "--header"
+]
+state["requests"].append(
+    {"method": method, "host": parsed.hostname, "path": parsed.path}
+)
+
+if parsed.hostname == "pipelines.actions.githubusercontent.com":
+    assert urllib.parse.parse_qs(parsed.query)["audience"] == [
+        "https://github.com/vm0-ai"
+    ]
+    assert "Authorization: Bearer github-request-fixture" in headers
+    response = {"value": "oidc-fixture-secret"}
+elif parsed.hostname == "api.vercel.com":
+    assert "Authorization: Bearer vercel-fixture-secret" in headers
+    state["deploymentReads"] += 1
+    deployment_id = "dpl_fixture"
+    if scenario == "changed-deployment" and state["deploymentReads"] == 2:
+        deployment_id = "dpl_changed"
+    response = {
+        "id": "prj_6mw0CgYjECVrJV57VJ47VN03B4UR",
+        "accountId": "team_WRqI0kCoX5KcRInRWgZ1nBF0",
+        "targets": {
+            "production": {
+                "id": deployment_id,
+                "url": "fixture.vm6.ai",
+                "readyState": "READY",
+                "target": "production",
+                "alias": ["api.okou.ai"],
+                "meta": {"githubCommitSha": "b" * 40},
+            }
+        },
+    }
+elif parsed.hostname == "api.doppler.com" and parsed.path == "/v3/auth/oidc":
+    assert body == {
+        "identity": "c0c87790-e651-45dd-b7fa-c5ed07bb990f",
+        "token": "oidc-fixture-secret",
+    }
+    response = {"token": "doppler-fixture-secret", "expires_at": "2026-09-09T08:00:00Z"}
+    if scenario == "provider-error":
+        status = 403
+        response = {
+            "message": "oidc-fixture-secret doppler-fixture-secret "
+            + os.environ["AWS_SECRET_ACCESS_KEY"]
+        }
+elif (
+    parsed.hostname == "api.doppler.com" and parsed.path == "/v3/configs/config/secrets"
+):
+    assert "Authorization: Bearer doppler-fixture-secret" in headers
+    if method == "GET":
+        query = urllib.parse.parse_qs(parsed.query)
+        assert query == {
+            "project": ["vm0-kms-rollback-32264"],
+            "config": ["prd"],
+            "include_managed_secrets": ["false"],
+        }
+        response = {"secrets": state["secrets"]}
+        if scenario == "readback-mismatch" and state["writes"]:
+            response = json.loads(json.dumps(response))
+            response["secrets"]["KMS_BACKUP_JSON"]["computed"] = "changed"
+    else:
+        assert body["project"] == "vm0-kms-rollback-32264" and body["config"] == "prd"
+        assert len(body["change_requests"]) == 1
+        change = body["change_requests"][0]
+        assert change["name"] == "KMS_BACKUP_JSON"
+        assert change["originalName"] is None and change["originalValue"] is None
+        assert change["visibility"] == "masked"
+        if scenario == "concurrent-backup":
+            state["secrets"]["KMS_BACKUP_JSON"] = {
+                "raw": "concurrent-original",
+                "computed": "concurrent-original",
+            }
+        if "KMS_BACKUP_JSON" in state["secrets"]:
+            status = 400
+            response = {"success": False, "messages": ["Secret already exists"]}
+        else:
+            state["secrets"]["KMS_BACKUP_JSON"] = {
+                "raw": change["value"],
+                "computed": change["value"],
+                "rawVisibility": "masked",
+                "computedVisibility": "masked",
+            }
+            state["writes"] += 1
+            response = {"success": True, "secrets": state["secrets"]}
+else:
+    raise RuntimeError("Unexpected external operation")
+
+state_path.write_text(json.dumps(state))
+print(json.dumps(response))
+print(status, end="")

--- a/.github/scripts/tests/kms-production-backup-test.py
+++ b/.github/scripts/tests/kms-production-backup-test.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Exercise the real backup CLI with isolated external command fixtures."""
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "kms-production-backup.py"
+TOOLS = HERE / "fixtures/kms-production-backup-tools.py"
+SOURCE_KEY = (
+    "arn:aws:kms:us-west-2:072707626411:key/a1b3922b-fab1-4ed3-aa9e-40f86f92a7a8"
+)
+CONFIGURATION = {
+    "AWS_ACCESS_KEY_ID": "AKIAFIXTURE0000000000",
+    "AWS_SECRET_ACCESS_KEY": "synthetic-secret-for-backup-verification",
+    "SECRETS_KMS_KEY_ID": SOURCE_KEY,
+    "AWS_REGION": "us-west-2",
+}
+
+
+class BackupCliTest(unittest.TestCase):
+    def invoke(self, scenario="success", overrides=None):
+        with tempfile.TemporaryDirectory(prefix="kms-backup-test-") as directory:
+            root = Path(directory)
+            binary = root / "bin"
+            binary.mkdir()
+            for name in ["aws", "curl"]:
+                wrapper = binary / name
+                wrapper.write_text(TOOLS.read_text())
+                wrapper.chmod(0o700)
+            state_path = root / "provider-state.json"
+            initial = {
+                "scenario": scenario,
+                "requests": [],
+                "secrets": {},
+                "writes": 0,
+                "deploymentReads": 0,
+            }
+            if scenario == "existing-backup":
+                initial["secrets"]["KMS_BACKUP_JSON"] = {
+                    "raw": "existing-original",
+                    "computed": "existing-original",
+                }
+            state_path.write_text(json.dumps(initial))
+            env = {
+                **os.environ,
+                **CONFIGURATION,
+                "PATH": str(binary) + os.pathsep + os.environ["PATH"],
+                "BACKUP_FIXTURE_STATE": str(state_path),
+                "RUNNER_TEMP": str(root),
+                "AWS_SESSION_TOKEN": "",
+                "GITHUB_REPOSITORY": "vm0-ai/vm0",
+                "GITHUB_REF": "refs/heads/main",
+                "GITHUB_EVENT_NAME": "workflow_dispatch",
+                "GITHUB_RUN_ID": "12345",
+                "GITHUB_SHA": "a" * 40,
+                "GITHUB_WORKFLOW_REF": "vm0-ai/vm0/.github/workflows/kms-production-backup.yml@refs/heads/main",
+                "DOPPLER_SERVICE_IDENTITY_ID": "c0c87790-e651-45dd-b7fa-c5ed07bb990f",
+                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://pipelines.actions.githubusercontent.com/oidc?existing=1",
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "github-request-fixture",
+                "VERCEL_TOKEN": "vercel-fixture-secret",
+                "EXPECTED_DEPLOYMENT_ID": "dpl_fixture",
+                "UNRELATED_SECRET": "must-not-enter-the-backup",
+            }
+            env.update(overrides or {})
+            result = subprocess.run(
+                ["python3", str(SCRIPT)],
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=20,
+                check=False,
+            )
+            state = json.loads(state_path.read_text())
+            report_path = root / "kms-production-backup.json"
+            report = (
+                json.loads(report_path.read_text()) if report_path.exists() else None
+            )
+            for secret in [
+                CONFIGURATION["AWS_ACCESS_KEY_ID"],
+                CONFIGURATION["AWS_SECRET_ACCESS_KEY"],
+                "oidc-fixture-secret",
+                "doppler-fixture-secret",
+                "vercel-fixture-secret",
+                env["UNRELATED_SECRET"],
+            ]:
+                self.assertNotIn(
+                    secret, result.stdout + result.stderr + json.dumps(report)
+                )
+            return result, state, report
+
+    def test_backup_preserves_effective_values_and_records_deployment_without_leaking(
+        self,
+    ):
+        result, state, report = self.invoke()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(state["writes"], 1)
+        self.assertEqual(set(state["secrets"]), {"KMS_BACKUP_JSON"})
+        snapshot = json.loads(state["secrets"]["KMS_BACKUP_JSON"]["raw"])
+        self.assertEqual(snapshot["configuration"], CONFIGURATION)
+        self.assertEqual(
+            snapshot["deployment"],
+            {"id": "dpl_fixture", "url": "fixture.vm6.ai", "commit": "b" * 40},
+        )
+        self.assertEqual(snapshot["workflow"]["runId"], "12345")
+        self.assertTrue(report["readbackVerified"])
+        self.assertFalse(report["productionConfigurationChanged"])
+
+    def test_wrong_principal_stops_before_backup(self):
+        result, state, report = self.invoke("wrong-principal")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("source_principal_mismatch", result.stderr)
+        self.assertEqual(state["writes"], 0)
+        self.assertIsNone(report)
+
+    def test_backup_preserves_the_original_alias_for_configuration_rollback(self):
+        result, state, report = self.invoke(
+            overrides={"SECRETS_KMS_KEY_ID": "alias/vm0-secrets-prod"}
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        snapshot = json.loads(state["secrets"]["KMS_BACKUP_JSON"]["raw"])
+        self.assertEqual(
+            snapshot["configuration"]["SECRETS_KMS_KEY_ID"], "alias/vm0-secrets-prod"
+        )
+        self.assertEqual(report["sourceKeyArn"], SOURCE_KEY)
+
+    def test_unprotected_branch_and_target_key_are_rejected(self):
+        for overrides in [
+            {"GITHUB_REF": "refs/heads/unprotected"},
+            {"SECRETS_KMS_KEY_ID": "alias/unexpected"},
+            {"DOPPLER_SERVICE_IDENTITY_ID": "development-identity"},
+            {"EXPECTED_DEPLOYMENT_ID": "dpl_unexpected"},
+        ]:
+            with self.subTest(overrides=overrides):
+                result, state, report = self.invoke(overrides=overrides)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(state["writes"], 0)
+                self.assertIsNone(report)
+
+    def test_existing_and_concurrent_backups_are_never_overwritten(self):
+        for scenario, original in [
+            ("existing-backup", "existing-original"),
+            ("concurrent-backup", "concurrent-original"),
+        ]:
+            with self.subTest(scenario=scenario):
+                result, state, report = self.invoke(scenario)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(state["secrets"]["KMS_BACKUP_JSON"]["raw"], original)
+                self.assertEqual(state["writes"], 0)
+                self.assertIsNone(report)
+
+    def test_deployment_change_prevents_creating_stale_rollback_record(self):
+        result, state, report = self.invoke("changed-deployment")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("production_deployment_changed", result.stderr)
+        self.assertEqual(state["writes"], 0)
+        self.assertIsNone(report)
+
+    def test_readback_mismatch_cannot_report_success(self):
+        result, state, report = self.invoke("readback-mismatch")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("backup_readback_mismatch", result.stderr)
+        self.assertEqual(state["writes"], 1)
+        self.assertIsNone(report)
+
+    def test_provider_error_body_is_never_emitted(self):
+        result, state, report = self.invoke("provider-error")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("provider_request_rejected", result.stderr)
+        self.assertEqual(state["writes"], 0)
+        self.assertIsNone(report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/kms-production-backup-test.py
+++ b/.github/scripts/tests/kms-production-backup-test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Exercise the real backup CLI with isolated external command fixtures."""
 
+import hashlib
 import json
 import os
 import subprocess
@@ -109,6 +110,12 @@ class BackupCliTest(unittest.TestCase):
         )
         self.assertEqual(snapshot["workflow"]["runId"], "12345")
         self.assertTrue(report["readbackVerified"])
+        self.assertEqual(
+            report["snapshotSha256"],
+            hashlib.sha256(
+                state["secrets"]["KMS_BACKUP_JSON"]["raw"].encode()
+            ).hexdigest(),
+        )
         self.assertFalse(report["productionConfigurationChanged"])
 
     def test_wrong_principal_stops_before_backup(self):

--- a/.github/scripts/tests/kms-production-backup-test.sh
+++ b/.github/scripts/tests/kms-production-backup-test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+python3 "$repo_root/.github/scripts/tests/kms-production-backup-test.py"

--- a/.github/workflows/kms-production-backup.yml
+++ b/.github/workflows/kms-production-backup.yml
@@ -1,0 +1,48 @@
+name: KMS Production Backup
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_deployment_id:
+        description: "Current production API Vercel deployment ID, recorded before approval"
+        required: true
+        type: string
+
+concurrency:
+  group: kms-production-backup-32264
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  backup:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Back up and verify the effective production KMS configuration
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ""
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          SECRETS_KMS_KEY_ID: ${{ secrets.SECRETS_KMS_KEY_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          DOPPLER_SERVICE_IDENTITY_ID: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          EXPECTED_DEPLOYMENT_ID: ${{ inputs.expected_deployment_id }}
+        run: python3 .github/scripts/kms-production-backup.py
+      - name: Retain sanitized backup verification
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kms-production-backup-${{ github.run_id }}
+          path: ${{ runner.temp }}/kms-production-backup.json
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/kms-production-backup.yml
+++ b/.github/workflows/kms-production-backup.yml
@@ -15,6 +15,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  npm_config_audit: false
+
 jobs:
   backup:
     if: github.ref == 'refs/heads/main'

--- a/turbo/packages/db/scripts/migrations/013-kms-account-rotation/README.md
+++ b/turbo/packages/db/scripts/migrations/013-kms-account-rotation/README.md
@@ -66,9 +66,11 @@ An existing backup blocks the job. The write also uses Doppler's conditional
 new-secret operation so a concurrent writer cannot be overwritten. Both the raw
 and computed read-back must exactly match the snapshot, with masked visibility.
 Only sanitized metadata is uploaded to the seven-day GitHub artifact; credential
-values pass directly from the protected runner to Doppler. Provider error bodies
-are suppressed because they can contain secrets. A missing success report or
-failed read-back is a blocker for replacing production configuration.
+values pass directly from the protected runner to Doppler. The report includes a
+SHA-256 digest of the complete snapshot for independent verification against a
+later Doppler read. Provider error bodies are suppressed because they can contain
+secrets. A missing success report or failed read-back is a blocker for replacing
+production configuration.
 
 The stored deployment is a rollback reference, not proof that rolling back its
 code is still compatible with later schema changes. Recheck the current

--- a/turbo/packages/db/scripts/migrations/013-kms-account-rotation/README.md
+++ b/turbo/packages/db/scripts/migrations/013-kms-account-rotation/README.md
@@ -39,6 +39,44 @@ does not grant runtime users `ReEncrypt`. A migrate command must run separately
 under the existing migration operator's permissions and with an authorized
 production database connection.
 
+## Preserve the effective production configuration
+
+After preflight succeeds, run **KMS Production Backup** on `main`. Supply the
+current production API Vercel deployment ID as `expected_deployment_id` and
+approve its protected GitHub `production` environment job. This backup is a
+separate operation from deployment or ciphertext migration.
+
+The job verifies the exact old production IAM user and resolves the configured
+key through `GenerateDataKey`, emitting only the returned key ARN. It captures
+the effective `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `SECRETS_KMS_KEY_ID`,
+and `AWS_REGION` from the production environment, along with the current API
+deployment ID, URL, commit, and workflow provenance. The Vercel production target
+must still match the supplied deployment ID immediately before backup.
+
+The existing production-only Doppler OIDC identity writes one masked
+`KMS_BACKUP_JSON` secret to `vm0-kms-rollback-32264/prd`. This isolated project
+has no deployment integration. The existing `vm0` project membership remains
+read-only; only the backup project's `prd` environment receives temporary
+Collaborator access. After successful backup and independent verification,
+downgrade that backup-project membership to Viewer. The development service
+account receives no access to the backup project. No new AWS or static Doppler
+credentials are created.
+
+An existing backup blocks the job. The write also uses Doppler's conditional
+new-secret operation so a concurrent writer cannot be overwritten. Both the raw
+and computed read-back must exactly match the snapshot, with masked visibility.
+Only sanitized metadata is uploaded to the seven-day GitHub artifact; credential
+values pass directly from the protected runner to Doppler. Provider error bodies
+are suppressed because they can contain secrets. A missing success report or
+failed read-back is a blocker for replacing production configuration.
+
+The stored deployment is a rollback reference, not proof that rolling back its
+code is still compatible with later schema changes. Recheck the current
+deployment and release compatibility before cutover. Restore configuration from
+the saved snapshot through the normal protected operational process; do not
+paste credential values into issues or chat. Retain the backup and old KMS access
+until the agreed rollback and recovery windows end.
+
 ## CLI modes
 
 Run from `turbo/packages/db` with a direct, unpooled `DATABASE_URL` set in the execution environment.
@@ -129,10 +167,11 @@ dual-key read access must remain enabled for partial batches and rollback.
 1. Review a complete read-only production report and successful actual-runtime
    canary. Resolve unknown/malformed ciphertext and non-ARN references. The
    credentials and keys already exist; do not create replacements.
-2. Record the current immutable production API deployment and preserve the old
-   effective `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `SECRETS_KMS_KEY_ID` in
-   an approved secret store before replacing anything. GitHub cannot read back
-   existing secret values; metadata alone is not a rollback backup.
+2. Complete **KMS Production Backup**, verify its Doppler read-back and sanitized
+   report, and downgrade its temporary backup-project access to Viewer. This
+   preserves the old effective credentials, KMS configuration, and current
+   immutable production API deployment before replacing anything. GitHub cannot
+   read back existing secret values; metadata alone is not a rollback backup.
 3. Update those three **GitHub `production` environment secrets** to the existing
    target values. `AWS_REGION` remains `us-west-2`. The normal protected API
    release lifecycle consumes them through `.github/actions/web-api-env`.


### PR DESCRIPTION
GitHub cannot read back existing secret values, so the production KMS configuration needs a verified rollback backup before it can be replaced. Add a manual, main-only workflow protected by the `production` environment that verifies the existing IAM user/key and expected live API deployment, then escrows the effective AWS credential pair, original KMS key configuration, region, and deployment provenance in Doppler.

The existing production-only OIDC identity writes one masked `KMS_BACKUP_JSON` secret to the isolated `vm0-kms-rollback-32264/prd` project. Existing backups and concurrent creation are rejected, and both raw/computed values and visibility must match on read-back. Only sanitized metadata, including a SHA-256 snapshot digest for independent verification, reaches the seven-day Actions artifact. The workflow creates no credentials, changes no deployment or effective production configuration, and accesses no database.

The backup project is provisioned with temporary production-only Collaborator access for the existing production service account; its original `vm0` membership remains Viewer. The runbook requires downgrading backup-project access to Viewer after independent backup verification. Development has no access to this project.

Validation: eight CLI regression tests with isolated external command fixtures cover exact configuration/alias preservation, IAM and workflow scope, stale/changing deployments, existing/concurrent backups, read-back mismatch, and secret-safe failure output. A live synthetic Doppler protocol check confirmed conditional creation refuses an existing secret without changing its value; its disposable config was removed. Ruff formatting/lint, Python and Bash syntax, Prettier, and actionlint passed. The existing workflow-script CI job automatically runs the new suite. Actual production backup requires the separate protected manual run after merge.

Related to #32264. Production preflight passed in https://github.com/vm0-ai/vm0/actions/runs/34314877468.
