### PR TITLE
fix(runner): isolate codex timing across websocket flows

### DIFF
--- a/crates/runner/mitm-addon/src/codex_output_timing.py
+++ b/crates/runner/mitm-addon/src/codex_output_timing.py
@@ -1,8 +1,15 @@
 """Run-scoped, content-free provider request/output timing for Codex runs.
 
-State is keyed by ``run_id``, not WebSocket flow, so first-milestone selection
-spans provider responses, tool turns, and Responses WebSocket reconnections.
-The process-global run map is LRU-bounded by ``_MAX_TRACKED_RUNS``.
+First-milestone selection is keyed by ``run_id`` so it spans provider responses,
+tool turns, and Responses WebSocket reconnections. Candidates belong to each
+flow's ordered response lifecycle, not the run: unrelated connections cannot
+replace its timestamps or reclassify its text. This observer does not implement
+named-lane multiplexing within a connection.
+
+Each flow retains at most one pending create timestamp and one active response.
+The run retains only the first selected response's content-free identity, never
+the flow. Terminal cleanup releases flow candidates independently of run reports.
+The process-global run map remains LRU-bounded by ``_MAX_TRACKED_RUNS``.
 
 Pending milestones keep their original observation timestamps when reporting
 context or bounded webhook admission is unavailable. This module retries
@@ -34,15 +41,26 @@ FIRST_TEXT_IN_LATER_GENERATED_RESPONSE = "codex_proxy_first_text_in_later_genera
 
 _MAX_TRACKED_RUNS = 10_000
 _LOG_TYPE = "codex_output_timing"
+_FLOW_TIMING_STATE = "_codex_output_timing_state"
+
+
+@dataclass(eq=False, slots=True)
+class _ResponseTimingState:
+    create_sent_at: str | None = None
+    created_at: str | None = None
+
+
+@dataclass(slots=True)
+class _FlowTimingState:
+    run_id: str
+    pending_create_sent_at: str | None = None
+    active_response: _ResponseTimingState | None = None
 
 
 @dataclass
 class _RunTimingState(provider_timing_store.ProviderTimingState):
-    candidate_response_create_sent_at: str | None = None
-    candidate_response_created_at: str | None = None
-    generated_response_selected: bool = False
+    first_generated_response: _ResponseTimingState | None = None
     first_text_observed: bool = False
-    later_response_before_text: bool = False
 
 
 _store = provider_timing_store.ProviderTimingStore(
@@ -67,16 +85,15 @@ def observe_client_event(
 
     with _store.locked():
         state = _store.state_for_run_locked(run_id)
-        if state.generated_response_selected:
-            if not state.first_text_observed:
-                state.later_response_before_text = True
+        if state.first_text_observed:
+            flow.metadata.pop(_FLOW_TIMING_STATE, None)
             _store.admit_pending_locked(flow, run_id, state)
             return
 
-        state.candidate_response_create_sent_at = datetime.fromtimestamp(
-            received_at, UTC
-        ).isoformat()
-        state.candidate_response_created_at = None
+        flow_state = _flow_state_locked(flow, run_id)
+        # A queued next request must not replace the active response's timestamp.
+        flow_state.pending_create_sent_at = datetime.fromtimestamp(received_at, UTC).isoformat()
+        _store.admit_pending_locked(flow, run_id, state)
 
 
 def observe_server_event(flow: http.HTTPFlow, event_type: str | None) -> None:
@@ -86,8 +103,8 @@ def observe_server_event(flow: http.HTTPFlow, event_type: str | None) -> None:
     ``response.output_item.added`` confirms generated output, promotes any
     candidate timestamp, and records the output-item milestone. The first
     subsequent ``response.output_text.delta`` records the text milestone. A
-    terminal event discards an unconfirmed candidate as prewarm; confirmed
-    state remains run-scoped for later tool turns and reconnections.
+    terminal event discards only this flow's active candidate; confirmed state
+    remains run-scoped for later tool turns and reconnections.
     """
     if event_type is None:
         return
@@ -97,64 +114,105 @@ def observe_server_event(flow: http.HTTPFlow, event_type: str | None) -> None:
         return
 
     with _store.locked():
+        state = _store.get_locked(run_id)
+        if state is not None and state.first_text_observed:
+            flow.metadata.pop(_FLOW_TIMING_STATE, None)
+            if event_type in (
+                openai_responses_events.OUTPUT_ITEM_ADDED_EVENT,
+                openai_responses_events.OUTPUT_TEXT_DELTA_EVENT,
+            ):
+                _store.touch_locked(run_id)
+            if (
+                event_type == openai_responses_events.SERVER_CREATED_EVENT
+                or event_type in openai_responses_events.TERMINAL_EVENTS
+            ):
+                _store.touch_locked(run_id)
+                _store.admit_pending_locked(flow, run_id, state)
+            return
+
         if event_type == openai_responses_events.SERVER_CREATED_EVENT:
             state = _store.state_for_run_locked(run_id)
-            if not state.generated_response_selected:
-                state.candidate_response_created_at = _observation_time()
-            elif not state.first_text_observed:
-                state.later_response_before_text = True
+            flow_state = _flow_state_locked(flow, run_id)
+            flow_state.active_response = _ResponseTimingState(
+                create_sent_at=flow_state.pending_create_sent_at,
+                created_at=_observation_time(),
+            )
+            flow_state.pending_create_sent_at = None
             _store.admit_pending_locked(flow, run_id, state)
             return
 
-        state = _store.get_locked(run_id)
         if event_type == openai_responses_events.OUTPUT_ITEM_ADDED_EVENT:
             if state is None:
                 state = _store.state_for_run_locked(run_id)
             else:
                 _store.touch_locked(run_id)
-            if not state.generated_response_selected:
-                state.generated_response_selected = True
-                if state.candidate_response_create_sent_at is not None:
+            flow_state = _flow_state_locked(flow, run_id)
+            if flow_state.active_response is None:
+                flow_state.active_response = _ResponseTimingState(
+                    create_sent_at=flow_state.pending_create_sent_at,
+                )
+                flow_state.pending_create_sent_at = None
+            response = flow_state.active_response
+            if state.first_generated_response is None:
+                state.first_generated_response = response
+                if response.create_sent_at is not None:
                     state.pending_operations[FIRST_GENERATED_RESPONSE_CREATE_SENT] = (
-                        state.candidate_response_create_sent_at
+                        response.create_sent_at
                     )
-                if state.candidate_response_created_at is not None:
-                    state.pending_operations[FIRST_GENERATED_RESPONSE_CREATED] = (
-                        state.candidate_response_created_at
-                    )
-                state.candidate_response_create_sent_at = None
-                state.candidate_response_created_at = None
+                if response.created_at is not None:
+                    state.pending_operations[FIRST_GENERATED_RESPONSE_CREATED] = response.created_at
+                response.create_sent_at = None
+                response.created_at = None
                 state.pending_operations[FIRST_OUTPUT_ITEM_ADDED] = _observation_time()
                 _store.admit_pending_locked(flow, run_id, state)
             return
 
         if event_type == openai_responses_events.OUTPUT_TEXT_DELTA_EVENT:
-            if state is None or not state.generated_response_selected:
+            if state is None or state.first_generated_response is None:
                 return
             _store.touch_locked(run_id)
-            if not state.first_text_observed:
-                state.first_text_observed = True
-                observed_at = _observation_time()
-                state.pending_operations[FIRST_OUTPUT_TEXT_DELTA] = observed_at
-                text_path = (
-                    FIRST_TEXT_IN_LATER_GENERATED_RESPONSE
-                    if state.later_response_before_text
-                    else FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE
-                )
-                state.pending_operations[text_path] = observed_at
-                _store.admit_pending_locked(flow, run_id, state)
+            flow_state = _flow_state_locked(flow, run_id)
+            state.first_text_observed = True
+            observed_at = _observation_time()
+            state.pending_operations[FIRST_OUTPUT_TEXT_DELTA] = observed_at
+            text_path = (
+                FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE
+                if flow_state.active_response is state.first_generated_response
+                else FIRST_TEXT_IN_LATER_GENERATED_RESPONSE
+            )
+            state.pending_operations[text_path] = observed_at
+            flow.metadata.pop(_FLOW_TIMING_STATE, None)
+            _store.admit_pending_locked(flow, run_id, state)
             return
 
         if event_type not in openai_responses_events.TERMINAL_EVENTS or state is None:
             return
 
         _store.touch_locked(run_id)
-        if not state.generated_response_selected:
-            _store.discard_locked(run_id)
-            return
-        if not state.first_text_observed:
-            state.later_response_before_text = True
+        flow_state = flow.metadata.get(_FLOW_TIMING_STATE)
+        if isinstance(flow_state, _FlowTimingState):
+            if flow_state.active_response is None or flow_state.pending_create_sent_at is None:
+                flow.metadata.pop(_FLOW_TIMING_STATE, None)
+            else:
+                # The next request may already be queued while this response ends.
+                flow_state.active_response = None
         _store.admit_pending_locked(flow, run_id, state)
+
+
+def _flow_state_locked(flow: http.HTTPFlow, run_id: str) -> _FlowTimingState:
+    state = flow.metadata.get(_FLOW_TIMING_STATE)
+    if not isinstance(state, _FlowTimingState) or state.run_id != run_id:
+        state = _FlowTimingState(run_id)
+        flow.metadata[_FLOW_TIMING_STATE] = state
+    return state
+
+
+def release_flow_state(flow: http.HTTPFlow) -> None:
+    """Release connection candidates without discarding pending run telemetry."""
+    if _FLOW_TIMING_STATE not in flow.metadata:
+        return
+    with _store.locked():
+        flow.metadata.pop(_FLOW_TIMING_STATE, None)
 
 
 def retry_all_pending() -> None:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1701,6 +1701,7 @@ def _release_terminal_flow_state(
         websocket_framing.log_limit_violation(flow)
         websocket_retention.release_terminal_messages(flow)
         terminal_usage.release_model_websocket_terminal_state(flow)
+        codex_output_timing.release_flow_state(flow)
     request_classification.pop_cached_classification(flow)
     flow.metadata.pop(_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS, None)
     flow.metadata.pop(metadata_keys.FIREWALL_AUTH_PROBE_FAILURE, None)

--- a/crates/runner/mitm-addon/src/provider_timing_store.py
+++ b/crates/runner/mitm-addon/src/provider_timing_store.py
@@ -13,7 +13,7 @@ transfers delivery ownership to ``usage.webhook``. The store then clears its pen
 releases the buffered lease.
 Retry-eligible run IDs are indexed in the pending subset of current LRU order so global retries do
 not visit completed or incomplete-context state.
-Eviction, explicit discard, and reset release any lease that remains locally retained.
+Eviction and reset release any lease that remains locally retained.
 
 See ``codex_output_timing.py`` and ``claude_output_timing.py`` for provider usage, and
 ``tests/test_provider_output_timing.py``, ``tests/test_codex_output_timing.py``, and
@@ -127,16 +127,6 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
         self._run_states.move_to_end(run_id)
         if run_id in self._retryable_run_ids:
             self._retryable_run_ids.move_to_end(run_id)
-
-    def discard_locked(self, run_id: str) -> None:
-        """Discard a tracked run and release any retained buffered-report lease.
-
-        The caller must hold ``locked()``. Pending operations and reporting context for the run are
-        discarded with its state; no delivery retry remains after this terminal removal.
-        """
-        state = self._run_states.pop(run_id)
-        self._retryable_run_ids.pop(run_id, None)
-        self._release_buffered_report_locked(state)
 
     def admit_pending_locked(
         self,

--- a/crates/runner/mitm-addon/tests/test_codex_output_timing.py
+++ b/crates/runner/mitm-addon/tests/test_codex_output_timing.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pytest
 from mitmproxy import http
+from mitmproxy.flow import Error
 
 import codex_output_timing
 import flow_metadata_keys as metadata_keys
@@ -155,6 +156,188 @@ def test_default_codex_excludes_prewarm_and_reports_content_free_milestones(
     serialized_requests = b"".join(request.body for request in requests)
     assert secret.encode() not in serialized_requests
     assert secret not in read_jsonl_text_after_flush(proxy_log)
+
+
+@pytest.mark.parametrize(
+    "interleaving",
+    ["single-flow", "before-output", "terminal-before-output", "before-text"],
+)
+def test_concurrent_prewarm_preserves_generated_response_timing(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+    sync_usage_executor,
+    interleaving: str,
+) -> None:
+    first = make_openai_responses_websocket_flow(real_flow, tmp_path)
+    prewarm = make_openai_responses_websocket_flow(real_flow, tmp_path)
+    first_sent_at = 1_700_000_000.125
+
+    with mitm_ctx(api_url=usage_webhook_server.api_url):
+        mitm_addon.responseheaders(first)
+        mitm_addon.responseheaders(prewarm)
+        _feed_client_event(first, _event("response.create"), received_at=first_sent_at)
+        before_created = datetime.now(UTC)
+        feed_websocket_server_message(
+            first, b'{"type":"response.created","response":{"id":"first-response"}}'
+        )
+        after_created = datetime.now(UTC)
+        if interleaving == "before-text":
+            feed_websocket_server_message(first, _event("response.output_item.added"))
+
+        if interleaving != "single-flow":
+            _feed_client_event(
+                prewarm,
+                b'{"type":"response.create","generate":false}',
+                received_at=first_sent_at + 10,
+            )
+            feed_websocket_server_message(
+                prewarm, b'{"type":"response.created","response":{"id":"prewarm-response"}}'
+            )
+            if interleaving != "before-output":
+                feed_websocket_server_message(
+                    prewarm,
+                    b'{"type":"response.completed","response":{"id":"prewarm-response"}}',
+                )
+
+        if interleaving != "before-text":
+            feed_websocket_server_message(first, _event("response.output_item.added"))
+        feed_websocket_server_message(first, _event("response.output_text.delta"))
+
+    operations = _operations(_timing_requests(usage_webhook_server))
+    assert [operation["action_type"] for operation in operations] == [
+        _FIRST_GENERATED_RESPONSE_CREATE_SENT,
+        _FIRST_GENERATED_RESPONSE_CREATED,
+        _FIRST_OUTPUT_ITEM_ADDED,
+        _FIRST_OUTPUT_TEXT_DELTA,
+        _FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE,
+    ]
+    assert operations[0]["ts"] == datetime.fromtimestamp(first_sent_at, UTC).isoformat()
+    assert before_created <= datetime.fromisoformat(str(operations[1]["ts"])) <= after_created
+
+
+@pytest.mark.parametrize("first_output_index", [0, 1])
+@pytest.mark.parametrize("first_text_index", [0, 1])
+def test_concurrent_generated_responses_select_their_own_timestamps_and_text_path(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+    sync_usage_executor,
+    first_output_index: int,
+    first_text_index: int,
+) -> None:
+    flows = [make_openai_responses_websocket_flow(real_flow, tmp_path) for _ in range(2)]
+    sent_at = [1_700_000_000.125, 1_700_000_010.125]
+
+    with mitm_ctx(api_url=usage_webhook_server.api_url):
+        for index, flow in enumerate(flows):
+            mitm_addon.responseheaders(flow)
+            _feed_client_event(flow, _event("response.create"), received_at=sent_at[index])
+            feed_websocket_server_message(flow, _event("response.created"))
+
+        feed_websocket_server_message(
+            flows[first_output_index], _event("response.output_item.added")
+        )
+        feed_websocket_server_message(
+            flows[1 - first_output_index], _event("response.output_item.added")
+        )
+        feed_websocket_server_message(flows[first_text_index], _event("response.output_text.delta"))
+        feed_websocket_server_message(
+            flows[1 - first_text_index], _event("response.output_text.delta")
+        )
+
+    operations = _operations(_timing_requests(usage_webhook_server))
+    text_path = (
+        _FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE
+        if first_text_index == first_output_index
+        else _FIRST_TEXT_IN_LATER_GENERATED_RESPONSE
+    )
+    assert [operation["action_type"] for operation in operations] == [
+        _FIRST_GENERATED_RESPONSE_CREATE_SENT,
+        _FIRST_GENERATED_RESPONSE_CREATED,
+        _FIRST_OUTPUT_ITEM_ADDED,
+        _FIRST_OUTPUT_TEXT_DELTA,
+        text_path,
+    ]
+    assert (
+        operations[0]["ts"] == datetime.fromtimestamp(sent_at[first_output_index], UTC).isoformat()
+    )
+
+
+@pytest.mark.parametrize("text_response", ["first", "next"])
+def test_queued_request_does_not_replace_active_response_timing(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+    sync_usage_executor,
+    text_response: str,
+) -> None:
+    flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+    first_sent_at = 1_700_000_000.125
+
+    with mitm_ctx(api_url=usage_webhook_server.api_url):
+        mitm_addon.responseheaders(flow)
+        _feed_client_event(flow, _event("response.create"), received_at=first_sent_at)
+        feed_websocket_server_message(flow, _event("response.created"))
+        _feed_client_event(flow, _event("response.create"), received_at=first_sent_at + 10)
+        feed_websocket_server_message(flow, _event("response.output_item.added"))
+        if text_response == "next":
+            feed_websocket_server_message(flow, _event("response.completed"))
+            feed_websocket_server_message(flow, _event("response.created"))
+            feed_websocket_server_message(flow, _event("response.output_item.added"))
+        feed_websocket_server_message(flow, _event("response.output_text.delta"))
+
+    operations = _operations(_timing_requests(usage_webhook_server))
+    assert [operation["action_type"] for operation in operations] == [
+        _FIRST_GENERATED_RESPONSE_CREATE_SENT,
+        _FIRST_GENERATED_RESPONSE_CREATED,
+        _FIRST_OUTPUT_ITEM_ADDED,
+        _FIRST_OUTPUT_TEXT_DELTA,
+        (
+            _FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE
+            if text_response == "first"
+            else _FIRST_TEXT_IN_LATER_GENERATED_RESPONSE
+        ),
+    ]
+    assert operations[0]["ts"] == datetime.fromtimestamp(first_sent_at, UTC).isoformat()
+
+
+@pytest.mark.parametrize("terminal_hook", ["websocket_end", "error"])
+def test_terminated_flow_does_not_supply_unconfirmed_timing_to_reconnect(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+    sync_usage_executor,
+    terminal_hook: str,
+) -> None:
+    flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+    reconnect = make_openai_responses_websocket_flow(real_flow, tmp_path)
+
+    with mitm_ctx(api_url=usage_webhook_server.api_url):
+        mitm_addon.responseheaders(flow)
+        _feed_client_event(flow, _event("response.create"))
+        feed_websocket_server_message(flow, _event("response.created"))
+        if terminal_hook == "websocket_end":
+            mitm_addon.websocket_end(flow)
+        else:
+            flow.error = Error("connection closed")
+            mitm_addon.error(flow)
+        mitm_addon.responseheaders(reconnect)
+        feed_websocket_server_message(reconnect, _event("response.output_item.added"))
+        feed_websocket_server_message(reconnect, _event("response.output_text.delta"))
+
+    assert [
+        operation["action_type"]
+        for operation in _operations(_timing_requests(usage_webhook_server))
+    ] == [
+        _FIRST_OUTPUT_ITEM_ADDED,
+        _FIRST_OUTPUT_TEXT_DELTA,
+        _FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE,
+    ]
 
 
 @pytest.mark.parametrize("terminal_event", sorted(openai_responses_events.TERMINAL_EVENTS))


### PR DESCRIPTION
## Summary

- Keep Codex timing candidates on their owning WebSocket flow/response lifecycle, with constant-size pending-request and active-response state.
- Keep first-output selection and milestone delivery deduplicated per run. Classify first text by the selected response's identity, so another connection cannot replace timestamps, discard candidates, or relabel that text.
- Release flow candidates during terminal cleanup without dropping deferred run telemetry. Preserve the event-type fast path and existing billing/model payload behavior.
- Remove the shared timing store's obsolete `discard_locked` helper after its last caller is retired.

Closes #32858

## Scope and compatibility

Python addon only; no UI, CLI, API, persisted schema, dependency, billing, or provider-request changes. The addon and its process-local metadata ship together inside the Runner artifact; telemetry fields are unchanged. This fixes concurrency across flows and ordered response lifecycles within each flow, not new named-lane multiplexing support.

## Validation

- Before the fix, new real-hook regression matrix: **3 failed, 1 passed**, reproducing the issue's three errors and passing its single-flow control.
- After the fix, focused timing/shared-store tests: **30 passed**. Includes prewarm interleavings, normal concurrent responses, genuine later-response text, queued request timing and end/error reconnect boundaries.
- Complete addon suite: `uv run --no-sync python -m pytest tests/` — **7,404 passed**, no failures or skips.
- `uv lock --check`, `uv sync --locked`, Ruff format/check, BasedPyright, flow metadata key check, and `git diff --check` — passed.
- Existing tests continue covering sequential tool turns, run boundaries, LRU/reset, content-free output, one event-type probe, ambiguity fast path, admission saturation and runner flush retries.

## Risks

New flow state must not outlive terminal cleanup or change run-wide delivery ownership. The tests exercise hook-level telemetry and reconnect behavior; the shared store's admission, eviction, reset and lease ownership remain unchanged. No live provider or production deployment validation was performed.
