### PR TITLE
fix(api): quietly degrade codex expiry 503 responses

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/codex-reset-credit-expiry.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/codex-reset-credit-expiry.test.ts
@@ -235,6 +235,141 @@ describe("Codex expiry metadata resilience", () => {
     expect(remote.detailsCalls).toBe(3);
   });
 
+  it.each([false, true])(
+    "quietly cools down after 503 and restores expiry at 60 seconds, accounts=%s",
+    async (accounts) => {
+      mockNow(Date.UTC(2030, 0, 1));
+      const remote = upstream();
+      const user = await fixture({ accounts });
+      remote.details = () => {
+        return new HttpResponse(null, {
+          status: 503,
+          headers: { "Retry-After": "120" },
+        });
+      };
+      const expiryLogs = () => {
+        return context.mocks.axiomLogging.info.mock.calls.filter(
+          ([message]) => {
+            return (
+              typeof message === "string" &&
+              message.includes("codex reset credit expiry")
+            );
+          },
+        );
+      };
+      const start = now();
+      expectExpiry(await user.list(), null, 2);
+      expectExpiry(await user.list(), null, 3);
+      mockNow(start + 59_999);
+      expectExpiry(await user.list(), null, 4);
+      expect(remote.detailsCalls).toBe(2);
+      expect(expiryLogs()).toHaveLength(0);
+
+      remote.details = () => {
+        return expiryResponse(remote.expiry);
+      };
+      mockNow(start + 60_000);
+      expectExpiry(await user.list(), remote.expiry, 5);
+      expect(remote.detailsCalls).toBe(3);
+      // The warm-instance aggregate spans bindings; its window need not align
+      // with this entry's cooldown. It may emit at most once in this minute.
+      const summaries = expiryLogs();
+      expect(summaries.length).toBeLessThanOrEqual(1);
+      for (const [message] of summaries) {
+        expect(message).toBe("codex reset credit expiry outcomes");
+      }
+      for (const sensitive of [
+        user.orgId,
+        user.userId,
+        user.auth.accountId,
+        user.auth.accessToken,
+      ]) {
+        expect(JSON.stringify(summaries)).not.toContain(sensitive);
+      }
+      expectExpiry(await user.list(), remote.expiry, 6);
+      expect(remote.detailsCalls).toBe(3);
+      expect(expiryLogs()).toHaveLength(summaries.length);
+      expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+      expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+      expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([false, true])(
+    "does not revive a cached date after its TTL expires during a 503 outage, accounts=%s",
+    async (accounts) => {
+      mockNow(Date.UTC(2030, 0, 1));
+      const remote = upstream();
+      const user = await fixture({ accounts });
+      const start = now();
+      expectExpiry(await user.list(), remote.expiry, 2);
+      remote.details = () => {
+        return new HttpResponse(null, { status: 503 });
+      };
+      mockNow(start + 299_999);
+      expectExpiry(await user.list(), remote.expiry, 3);
+      expect(remote.detailsCalls).toBe(2);
+      mockNow(start + 300_000);
+      expectExpiry(await user.list(), null, 4);
+      expect(remote.detailsCalls).toBe(3);
+      mockNow(start + 359_999);
+      expectExpiry(await user.list(), null, 5);
+      expect(remote.detailsCalls).toBe(3);
+      mockNow(start + 360_000);
+      expectExpiry(await user.list(), null, 6);
+      expect(remote.detailsCalls).toBe(4);
+
+      const recoveredExpiry = new Date(start + 7_200_000).toISOString();
+      remote.details = () => {
+        return expiryResponse(recoveredExpiry);
+      };
+      mockNow(start + 419_999);
+      expectExpiry(await user.list(), null, 7);
+      expect(remote.detailsCalls).toBe(4);
+      mockNow(start + 420_000);
+      expectExpiry(await user.list(), recoveredExpiry, 8);
+      expect(remote.detailsCalls).toBe(5);
+      expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([false, true])(
+    "shares a concurrent 503 attempt and its cooldown while refreshing each count, accounts=%s",
+    async (accounts) => {
+      mockNow(Date.UTC(2030, 0, 1));
+      const remote = upstream();
+      const user = await fixture({ accounts });
+      const started = createDeferredPromise<void>(context.signal);
+      const release = createDeferredPromise<Response>(context.signal);
+      const bothUsage = createDeferredPromise<void>(context.signal);
+      remote.details = () => {
+        started.resolve();
+        return release.promise;
+      };
+      remote.usage = () => {
+        if (remote.usageCalls === 3) {
+          bothUsage.resolve();
+        }
+        return HttpResponse.json({
+          rate_limit_reset_credits: { available_count: remote.usageCalls },
+        });
+      };
+      const first = user.list();
+      await started.promise;
+      const second = user.list();
+      await bothUsage.promise;
+      release.resolve(new HttpResponse(null, { status: 503 }));
+      const results = await Promise.all([first, second]);
+      expectExpiry(results[0], null, 2);
+      expectExpiry(results[1], null, 3);
+      expectExpiry(await user.list(), null, 4);
+      expect(remote.detailsCalls).toBe(2);
+      expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+      expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+      expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+    },
+  );
+
   it.each([
     ["120", 120_000],
     ["Tue, 01 Jan 2030 00:02:00 GMT", 120_000],
@@ -387,17 +522,21 @@ describe("Codex expiry metadata resilience", () => {
     expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
   });
 
-  it.each([401, 500, "schema", "transport"] as const)(
+  it.each([401, 500, "json", "schema", "transport"] as const)(
     "keeps unexpected %s failures diagnosable and preserves the count",
     async (failure) => {
       const remote = upstream();
       const user = await fixture();
       remote.details = () => {
-        return failure === "schema"
-          ? HttpResponse.json({ credits: "invalid" })
-          : failure === "transport"
-            ? HttpResponse.error()
-            : new HttpResponse(null, { status: failure });
+        return failure === "json"
+          ? new HttpResponse("{invalid json", {
+              headers: { "Content-Type": "application/json" },
+            })
+          : failure === "schema"
+            ? HttpResponse.json({ credits: "invalid" })
+            : failure === "transport"
+              ? HttpResponse.error()
+              : new HttpResponse(null, { status: failure });
       };
       expectExpiry(await user.list(), null, 2);
       expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(

--- a/turbo/apps/api/src/signals/services/codex-reset-credit-expiry.service.ts
+++ b/turbo/apps/api/src/signals/services/codex-reset-credit-expiry.service.ts
@@ -59,6 +59,7 @@ const observation = singleton(() => {
       cooldown: 0,
       success: 0,
       rate_limited: 0,
+      unavailable: 0,
       local_timeout: 0,
       unexpected_failure: 0,
     },
@@ -211,6 +212,12 @@ async function fetchDetails(args: Credentials, signal: AbortSignal) {
       cooldownUntil: retryAfterDeadline(response.headers.get("retry-after")),
     };
   }
+  if (response.status === 503) {
+    return {
+      outcome: "unavailable" as const,
+      cooldownUntil: now() + COOLDOWN_MS,
+    };
+  }
   if (!response.ok) {
     throw new Error(
       `Codex reset credit details request failed with status ${response.status}`,
@@ -268,11 +275,11 @@ async function load(
   }
   if (result.ok) {
     record(result.value.outcome);
-    if (result.value.outcome === "rate_limited") {
-      entry.cooldownUntil = result.value.cooldownUntil;
-    } else {
+    if (result.value.outcome === "success") {
       entry.expiresAt = result.value.expiresAt;
       entry.trustedUntil = now() + TTL_MS;
+    } else {
+      entry.cooldownUntil = result.value.cooldownUntil;
     }
   } else if (timedOut) {
     record("local_timeout");


### PR DESCRIPTION
When the optional Codex reset-credit expiry GET returns HTTP 503, subscription refresh currently logs a warning and can repeat that lookup on every request. Classify this one status as `unavailable`, retain the independently refreshed credit count, and expose an unknown expiry through the existing null/date display contract.

Reuse the existing 60-second cooldown and demand-driven, bounded outcome aggregate. A 503 does not renew the five-minute successful-value TTL, revive an expired cached date, trigger a retry, or use a new Retry-After policy. Existing 429 Retry-After handling, local timeout handling, shared flights, cancellation, invalidation, account/credential/tenant isolation, and the 256-entry bound remain in place. Genuine failures, including 401, 500, malformed JSON/schema, and transport failures, retain their warning diagnostics.

Closes #32757

## Validation

- Focused route integration file: `pnpm -F api exec vitest run src/signals/routes/__tests__/codex-reset-credit-expiry.test.ts` — 45 tests passed against a fresh local PostgreSQL database.
- Both account-binding variants cover 503/null/count behavior, unchanged main usage refreshes during cooldown, demand-driven recovery at exactly 60 seconds even with a 503 Retry-After header, repeated outages after successful-value TTL expiry, concurrent request sharing, and no warning/error/Sentry capture for handled 503s.
- The existing real-failure controls remain, with malformed JSON added. The file also retains successful date/null caching, 429, local timeout, cancellation, invalidation, credential/account isolation, and capacity coverage.
- Changed-file Oxlint, type-aware Oxlint, and ESLint passed. Formatting and `git diff --check` passed. Normal repository commit hooks also passed: Prettier, style policy, Knip, workspace type checks, file-size policy, and commitlint. Required PR and merge-group CI remain the merge gates.
- No full local Vitest suite or local development server was run.

## Fallbacks

- `codex-reset-credit-expiry.service.ts:fetchDetails/load/readerForEntry` — HTTP 503 from the optional external expiry GET is an expected unavailable result with a 60-second cooldown. The existing public field remains null without a trusted, unexpired date; the independent usage response still supplies the count. This is the permanent optional-display-data contract approved in #32757, not a cross-version rollout fallback. There is no rollout removal window or migration; removal would require an explicit change to that optional metadata contract.

## Scope and boundaries

The diff changes only the expiry service and its existing route regression file. It starts from fetched `origin/main` at `b2d6e43aa259351c7a26906b3039be88a9f1aee9`; an inventory of all 40 open PRs found no overlap in the affected service, callers, tests, or count/expiry display paths. There is no UI, public schema, main usage, consume POST/idempotency, authentication refresh, run, billing, migration, or feature-switch change.

Caching/cooldown remains best-effort per warm instance: cold starts, different instances, and eviction can independently cause a new optional request. This PR authorizes code merge only; production release and production verification are outside this change's acceptance evidence.
