### PR TITLE
fix(platform): align assistant response layout

### DIFF
--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -60,14 +60,16 @@ function RichContentLoading({
 }
 
 function RichContentError({
+  className,
   onRetry,
   style,
 }: {
+  readonly className?: string;
   readonly onRetry: () => void;
   readonly style?: CSSProperties;
 }) {
   return (
-    <MarkdownFrame style={style}>
+    <MarkdownFrame className={className} style={style}>
       <button
         type="button"
         className="rounded-md border border-border px-2 py-1 text-sm text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground"
@@ -83,10 +85,12 @@ function RichContentError({
 
 /** Renders prepared plain trees immediately and rich trees synchronously. */
 export function MarkdownEventBody({
+  className,
   onRetry,
   tree,
   mediaPreview,
 }: {
+  readonly className?: string;
   readonly onRetry?: () => void;
   readonly tree: Root | undefined;
   readonly mediaPreview: boolean | "link";
@@ -95,6 +99,7 @@ export function MarkdownEventBody({
     if (onRetry !== undefined) {
       return (
         <RichContentError
+          className={className}
           onRetry={onRetry}
           style={{ fontSize: "inherit", lineHeight: "inherit" }}
         />
@@ -102,6 +107,7 @@ export function MarkdownEventBody({
     }
     return (
       <RichContentLoading
+        className={className}
         style={{ fontSize: "inherit", lineHeight: "inherit" }}
       />
     );
@@ -110,12 +116,19 @@ export function MarkdownEventBody({
   if (plainText !== null) {
     return (
       <PlainMarkdown
+        className={className}
         text={plainText}
         style={{ fontSize: "inherit", lineHeight: "inherit" }}
       />
     );
   }
-  return <RichMarkdownEventBody tree={tree} mediaPreview={mediaPreview} />;
+  return (
+    <RichMarkdownEventBody
+      className={className}
+      tree={tree}
+      mediaPreview={mediaPreview}
+    />
+  );
 }
 
 /** One-off Markdown entry point. */

--- a/turbo/apps/platform/src/views/components/rich-markdown.tsx
+++ b/turbo/apps/platform/src/views/components/rich-markdown.tsx
@@ -434,14 +434,17 @@ function MarkdownTreeFrame({
  * ahead of time, so opening a thread re-renders without re-parsing.
  */
 export function MarkdownEventBody({
+  className,
   tree,
   mediaPreview,
 }: {
+  readonly className?: string;
   readonly tree: Root;
   readonly mediaPreview: boolean | "link";
 }) {
   return (
     <MarkdownTreeFrame
+      className={className}
       tree={tree}
       mediaPreview={mediaPreview}
       style={{ fontSize: "inherit", lineHeight: "inherit" }}

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
@@ -166,7 +166,6 @@ test("Expose an artifact referenced only by history from the main result actions
   if (!mainMessage) {
     throw new Error("Expected the result inside the main message region");
   }
-  expect(mainMessage.parentElement).toHaveClass("pl-1.5", "@[900px]:pl-0");
   expect(mainMessage).toContainElement(actions);
   const artifactTrigger = screen.getByTestId(
     "chat-run-related-artifacts-trigger",
@@ -176,17 +175,7 @@ test("Expose an artifact referenced only by history from the main result actions
   expect(viewAgentProfileLinks()).toHaveLength(1);
   const dialog = await openRelatedArtifacts();
   expect(relatedArtifactRow(dialog, reportUrl)).toHaveTextContent("Report");
-  const workToggle = queryWorkHistoryToggle("collapsed");
-  expect(workToggle).toBeVisible();
-  const workIconRail = workToggle?.querySelector("svg")?.parentElement;
-  expect(workIconRail).toHaveClass("w-6", "justify-start");
-  expect(workIconRail).not.toHaveClass("w-7", "justify-center");
-  expect(workToggle?.querySelector("[data-chat-run-work-label]")).toHaveClass(
-    "text-sm",
-    "font-normal",
-    "leading-5",
-    "text-muted-foreground/80",
-  );
+  expect(queryWorkHistoryToggle("collapsed")).toBeVisible();
 
   click(within(dialog).getByLabelText("Close"));
   await waitFor(() => {
@@ -197,22 +186,6 @@ test("Expose an artifact referenced only by history from the main result actions
   click(await findWorkHistoryToggle("collapsed"));
   const history = screen.getByText("Generated supporting evidence.");
   expect(history).toBeVisible();
-  const historyBody = history.closest<HTMLElement>(
-    "[data-chat-run-work-history-item]",
-  );
-  expect(history.closest("[data-chat-run-work-history-list]")).toHaveClass(
-    "ml-2",
-    "w-[calc(100%-0.5rem)]",
-    "pl-[15px]",
-  );
-  expect(historyBody).toHaveClass(
-    "text-sm",
-    "leading-5",
-    "text-muted-foreground",
-  );
-  expect(history.closest("[data-color-mode]")).toHaveClass(
-    "!text-muted-foreground",
-  );
   await expect(
     findNamedLink("Open pdf preview for supporting-report.pdf"),
   ).resolves.toBeVisible();
@@ -459,37 +432,10 @@ test("Keep completed result actions before recommended followups", async () => {
   }
   const keepGoing = await screen.findByRole("group", { name: "Keep going" });
   const followupButton = within(keepGoing).getByTitle("Summarize the report");
-  const followupLabel = within(followupButton).getByText(
-    "Summarize the report",
-  );
-  const followupHoverIcon = followupButton.querySelector(
-    "[data-chat-followup-hover-icon]",
-  );
-  const followupIconRail =
-    followupButton.querySelector("span > svg")?.parentElement;
-  const mainBody = main.closest<HTMLElement>(
-    "[data-chat-scroll-anchor-event-id]",
-  );
-  const divider = keepGoing.previousElementSibling;
-  const dividerLabel = screen.getByText(/Keep going ·/u);
 
   expect(actions).toBeVisible();
-  expect(actions).toHaveClass("-ml-1.5");
-  expect(followupButton).toHaveClass("relative");
-  expect(followupIconRail).toHaveClass("w-6", "justify-start");
-  expect(followupIconRail).not.toHaveClass("w-7", "justify-center");
-  expect(followupLabel).toHaveClass(
-    "text-sm",
-    "font-normal",
-    "leading-5",
-    "text-muted-foreground/80",
-  );
-  expect(followupHoverIcon).toHaveClass("absolute", "opacity-0");
-  expect(followupHoverIcon).not.toHaveClass("ml-2", "shrink-0");
-  expect(mainBody).toHaveClass("pl-0");
-  expect(divider).toHaveClass("pl-0");
-  expect(dividerLabel).toHaveClass("text-sm", "leading-5");
-  expect(dividerLabel).not.toHaveClass("text-[13px]");
+  expect(followupButton).toBeVisible();
+  expect(screen.getByText(/Keep going ·/u)).toBeVisible();
   expect(mainMessage).toContainElement(actions);
   expect(mainMessage).not.toContainElement(keepGoing);
   expect(assistantGroupFor(main)).toContainElement(keepGoing);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
@@ -177,6 +177,9 @@ test("Expose an artifact referenced only by history from the main result actions
   expect(relatedArtifactRow(dialog, reportUrl)).toHaveTextContent("Report");
   const workToggle = queryWorkHistoryToggle("collapsed");
   expect(workToggle).toBeVisible();
+  const workIconRail = workToggle?.querySelector("svg")?.parentElement;
+  expect(workIconRail).toHaveClass("w-6", "justify-start");
+  expect(workIconRail).not.toHaveClass("w-7", "justify-center");
   expect(workToggle?.querySelector("[data-chat-run-work-label]")).toHaveClass(
     "text-sm",
     "font-normal",
@@ -195,6 +198,11 @@ test("Expose an artifact referenced only by history from the main result actions
   expect(history).toBeVisible();
   const historyBody = history.closest<HTMLElement>(
     "[data-chat-run-work-history-item]",
+  );
+  expect(history.closest("[data-chat-run-work-history-list]")).toHaveClass(
+    "ml-2",
+    "w-[calc(100%-0.5rem)]",
+    "pl-[15px]",
   );
   expect(historyBody).toHaveClass(
     "text-sm",
@@ -456,13 +464,18 @@ test("Keep completed result actions before recommended followups", async () => {
   const followupHoverIcon = followupButton.querySelector(
     "[data-chat-followup-hover-icon]",
   );
+  const followupIconRail =
+    followupButton.querySelector("span > svg")?.parentElement;
   const mainBody = main.closest<HTMLElement>(
     "[data-chat-scroll-anchor-event-id]",
   );
   const divider = keepGoing.previousElementSibling;
 
   expect(actions).toBeVisible();
+  expect(actions).toHaveClass("-ml-1.5");
   expect(followupButton).toHaveClass("relative");
+  expect(followupIconRail).toHaveClass("w-6", "justify-start");
+  expect(followupIconRail).not.toHaveClass("w-7", "justify-center");
   expect(followupLabel).toHaveClass(
     "text-sm",
     "font-normal",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
@@ -166,7 +166,7 @@ test("Expose an artifact referenced only by history from the main result actions
   if (!mainMessage) {
     throw new Error("Expected the result inside the main message region");
   }
-  expect(mainMessage.parentElement).toHaveClass("pl-3.5", "@[900px]:pl-0");
+  expect(mainMessage.parentElement).toHaveClass("pl-1.5", "@[900px]:pl-0");
   expect(mainMessage).toContainElement(actions);
   const artifactTrigger = screen.getByTestId(
     "chat-run-related-artifacts-trigger",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
@@ -184,7 +184,16 @@ test("Expose an artifact referenced only by history from the main result actions
     ).toBeNull();
   });
   click(await findWorkHistoryToggle("collapsed"));
-  expect(screen.getByText("Generated supporting evidence.")).toBeVisible();
+  const history = screen.getByText("Generated supporting evidence.");
+  expect(history).toBeVisible();
+  const historyList = history.closest<HTMLElement>(
+    "[data-chat-run-work-history-list]",
+  );
+  expect(historyList).toHaveClass(
+    "[&_.okou-chat-bubble-assistant]:text-sm",
+    "[&_.okou-chat-bubble-assistant]:leading-5",
+    "[&_.wmde-markdown]:!text-muted-foreground",
+  );
   await expect(
     findNamedLink("Open pdf preview for supporting-report.pdf"),
   ).resolves.toBeVisible();
@@ -430,8 +439,12 @@ test("Keep completed result actions before recommended followups", async () => {
     throw new Error("Expected the completed result action bar");
   }
   const keepGoing = await screen.findByRole("group", { name: "Keep going" });
+  const mainBody = main.closest<HTMLElement>(".okou-chat-bubble-assistant");
+  const divider = keepGoing.previousElementSibling;
 
   expect(actions).toBeVisible();
+  expect(mainBody).toHaveClass("pl-0");
+  expect(divider).toHaveClass("pl-0");
   expect(mainMessage).toContainElement(actions);
   expect(mainMessage).not.toContainElement(keepGoing);
   expect(assistantGroupFor(main)).toContainElement(keepGoing);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
@@ -166,6 +166,7 @@ test("Expose an artifact referenced only by history from the main result actions
   if (!mainMessage) {
     throw new Error("Expected the result inside the main message region");
   }
+  expect(mainMessage.parentElement).toHaveClass("pl-3.5", "@[900px]:pl-0");
   expect(mainMessage).toContainElement(actions);
   const artifactTrigger = screen.getByTestId(
     "chat-run-related-artifacts-trigger",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
@@ -186,13 +186,16 @@ test("Expose an artifact referenced only by history from the main result actions
   click(await findWorkHistoryToggle("collapsed"));
   const history = screen.getByText("Generated supporting evidence.");
   expect(history).toBeVisible();
-  const historyList = history.closest<HTMLElement>(
-    "[data-chat-run-work-history-list]",
+  const historyBody = history.closest<HTMLElement>(
+    "[data-chat-run-work-history-item]",
   );
-  expect(historyList).toHaveClass(
-    "[&_.okou-chat-bubble-assistant]:text-sm",
-    "[&_.okou-chat-bubble-assistant]:leading-5",
-    "[&_.wmde-markdown]:!text-muted-foreground",
+  expect(historyBody).toHaveClass(
+    "text-sm",
+    "leading-5",
+    "text-muted-foreground",
+  );
+  expect(history.closest("[data-color-mode]")).toHaveClass(
+    "!text-muted-foreground",
   );
   await expect(
     findNamedLink("Open pdf preview for supporting-report.pdf"),
@@ -439,7 +442,9 @@ test("Keep completed result actions before recommended followups", async () => {
     throw new Error("Expected the completed result action bar");
   }
   const keepGoing = await screen.findByRole("group", { name: "Keep going" });
-  const mainBody = main.closest<HTMLElement>(".okou-chat-bubble-assistant");
+  const mainBody = main.closest<HTMLElement>(
+    "[data-chat-scroll-anchor-event-id]",
+  );
   const divider = keepGoing.previousElementSibling;
 
   expect(actions).toBeVisible();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
@@ -471,6 +471,7 @@ test("Keep completed result actions before recommended followups", async () => {
     "[data-chat-scroll-anchor-event-id]",
   );
   const divider = keepGoing.previousElementSibling;
+  const dividerLabel = screen.getByText(/Keep going ·/u);
 
   expect(actions).toBeVisible();
   expect(actions).toHaveClass("-ml-1.5");
@@ -487,6 +488,8 @@ test("Keep completed result actions before recommended followups", async () => {
   expect(followupHoverIcon).not.toHaveClass("ml-2", "shrink-0");
   expect(mainBody).toHaveClass("pl-0");
   expect(divider).toHaveClass("pl-0");
+  expect(dividerLabel).toHaveClass("text-sm", "leading-5");
+  expect(dividerLabel).not.toHaveClass("text-[13px]");
   expect(mainMessage).toContainElement(actions);
   expect(mainMessage).not.toContainElement(keepGoing);
   expect(assistantGroupFor(main)).toContainElement(keepGoing);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
@@ -175,7 +175,14 @@ test("Expose an artifact referenced only by history from the main result actions
   expect(viewAgentProfileLinks()).toHaveLength(1);
   const dialog = await openRelatedArtifacts();
   expect(relatedArtifactRow(dialog, reportUrl)).toHaveTextContent("Report");
-  expect(queryWorkHistoryToggle("collapsed")).toBeVisible();
+  const workToggle = queryWorkHistoryToggle("collapsed");
+  expect(workToggle).toBeVisible();
+  expect(workToggle?.querySelector("[data-chat-run-work-label]")).toHaveClass(
+    "text-sm",
+    "font-normal",
+    "leading-5",
+    "text-muted-foreground/80",
+  );
 
   click(within(dialog).getByLabelText("Close"));
   await waitFor(() => {
@@ -442,12 +449,28 @@ test("Keep completed result actions before recommended followups", async () => {
     throw new Error("Expected the completed result action bar");
   }
   const keepGoing = await screen.findByRole("group", { name: "Keep going" });
+  const followupButton = within(keepGoing).getByTitle("Summarize the report");
+  const followupLabel = within(followupButton).getByText(
+    "Summarize the report",
+  );
+  const followupHoverIcon = followupButton.querySelector(
+    "[data-chat-followup-hover-icon]",
+  );
   const mainBody = main.closest<HTMLElement>(
     "[data-chat-scroll-anchor-event-id]",
   );
   const divider = keepGoing.previousElementSibling;
 
   expect(actions).toBeVisible();
+  expect(followupButton).toHaveClass("relative");
+  expect(followupLabel).toHaveClass(
+    "text-sm",
+    "font-normal",
+    "leading-5",
+    "text-muted-foreground/80",
+  );
+  expect(followupHoverIcon).toHaveClass("absolute", "opacity-0");
+  expect(followupHoverIcon).not.toHaveClass("ml-2", "shrink-0");
   expect(mainBody).toHaveClass("pl-0");
   expect(divider).toHaveClass("pl-0");
   expect(mainMessage).toContainElement(actions);

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -23,11 +23,15 @@ export const CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS =
 export const CHAT_THREAD_RESPONSE_LINE_CLASS =
   "h-auto min-h-9 py-[calc((2.25rem-1lh)/2)] leading-[1.59375rem]";
 
-// Response text starts after the 28px action-button rail. Bare icons use the
-// canonical 16px glyph size and stay centered on that same rail.
-export const CHAT_THREAD_RESPONSE_CONTENT_CLASS = "min-w-0 pl-7";
+// Rows without a leading icon stay flush with the response column. Icon rows
+// reserve a 28px rail and keep their canonical 16px glyph centered inside it.
+export const CHAT_THREAD_RESPONSE_FLUSH_CLASS = "min-w-0 pl-0";
 export const CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS =
   "inline-flex w-7 shrink-0 items-center justify-center [&_svg]:size-4";
+
+// Work-history commentary is supporting context, not the final response.
+export const CHAT_THREAD_WORK_HISTORY_TEXT_CLASS =
+  "[&_.okou-chat-bubble-assistant]:text-sm [&_.okou-chat-bubble-assistant]:leading-5 [&_.wmde-markdown]:!text-muted-foreground";
 
 // Keep the entry animation, but do not let its duration also animate the
 // responsive margin: that would continue changing layout after resize.

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -24,10 +24,11 @@ export const CHAT_THREAD_RESPONSE_LINE_CLASS =
   "h-auto min-h-9 py-[calc((2.25rem-1lh)/2)] leading-[1.59375rem]";
 
 // Rows without a leading icon stay flush with the response column. Icon rows
-// reserve a 28px rail and keep their canonical 16px glyph centered inside it.
+// put their canonical 16px glyph on that same left edge, then reserve 8px
+// before the label.
 export const CHAT_THREAD_RESPONSE_FLUSH_CLASS = "min-w-0 pl-0";
 export const CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS =
-  "inline-flex w-7 shrink-0 items-center justify-center [&_svg]:size-4";
+  "inline-flex w-6 shrink-0 items-center justify-start [&_svg]:size-4";
 
 // Supporting rows should read as one quiet unit: the 14px regular label sits
 // behind its 16px line icon instead of competing with the final response.

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -31,7 +31,8 @@ export const CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS =
 
 // Work-history commentary is supporting context, not the final response.
 export const CHAT_THREAD_WORK_HISTORY_TEXT_CLASS =
-  "[&_.okou-chat-bubble-assistant]:text-sm [&_.okou-chat-bubble-assistant]:leading-5 [&_.wmde-markdown]:!text-muted-foreground";
+  "text-sm leading-5 text-muted-foreground";
+export const CHAT_THREAD_WORK_HISTORY_MARKDOWN_CLASS = "!text-muted-foreground";
 
 // Keep the entry animation, but do not let its duration also animate the
 // responsive margin: that would continue changing layout after resize.

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -29,6 +29,11 @@ export const CHAT_THREAD_RESPONSE_FLUSH_CLASS = "min-w-0 pl-0";
 export const CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS =
   "inline-flex w-7 shrink-0 items-center justify-center [&_svg]:size-4";
 
+// Supporting rows should read as one quiet unit: the 14px regular label sits
+// behind its 16px line icon instead of competing with the final response.
+export const CHAT_THREAD_RESPONSE_SUPPORTING_TEXT_CLASS =
+  "text-sm font-normal leading-5 text-muted-foreground/80";
+
 // Work-history commentary is supporting context, not the final response.
 export const CHAT_THREAD_WORK_HISTORY_TEXT_CLASS =
   "text-sm leading-5 text-muted-foreground";

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -23,9 +23,11 @@ export const CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS =
 export const CHAT_THREAD_RESPONSE_LINE_CLASS =
   "h-auto min-h-9 py-[calc((2.25rem-1lh)/2)] leading-[1.59375rem]";
 
-// Bare response icons share the 28px action-button rail.
+// Response text starts after the 28px action-button rail. Bare icons use the
+// canonical 16px glyph size and stay centered on that same rail.
+export const CHAT_THREAD_RESPONSE_CONTENT_CLASS = "min-w-0 pl-7";
 export const CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS =
-  "inline-flex w-7 shrink-0 items-center justify-center";
+  "inline-flex w-7 shrink-0 items-center justify-center [&_svg]:size-4";
 
 // Keep the entry animation, but do not let its duration also animate the
 // responsive margin: that would continue changing layout after resize.

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -51,6 +51,12 @@ export const CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS =
 export const CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS =
   "flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
 
+// In the stacked mobile layout, start the response on the centre line of the
+// 28px avatar above it. The desktop grid already puts the response on the
+// thread axis, so the inset must disappear at that breakpoint.
+export const CHAT_THREAD_ASSISTANT_RESPONSE_COLUMN_CLASS =
+  "pl-3.5 @[900px]:pl-0";
+
 export const CHAT_THREAD_ASSISTANT_AVATAR_FRAME_CLASS =
   "h-7 w-7 shrink-0 overflow-hidden rounded-xl @[900px]:h-9 @[900px]:w-9";
 
@@ -61,7 +67,7 @@ export const CHAT_THREAD_USER_MESSAGE_ACTIONS_CLASS =
   "flex justify-end gap-1 mt-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150";
 
 export const CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_ROW_CLASS =
-  "@[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px]";
+  "pl-3.5 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:pl-0";
 
 export const CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_CLASS =
   "flex items-center justify-between gap-2";

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -51,11 +51,12 @@ export const CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS =
 export const CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS =
   "flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
 
-// In the stacked mobile layout, start the response on the centre line of the
-// 28px avatar above it. The desktop grid already puts the response on the
-// thread axis, so the inset must disappear at that breakpoint.
+// In the stacked mobile layout, inset the response by 6px so the centre of its
+// canonical 16px leading icons lines up with the centre of the 28px avatar
+// above it. The desktop grid already owns that alignment, so reset the inset
+// at that breakpoint.
 export const CHAT_THREAD_ASSISTANT_RESPONSE_COLUMN_CLASS =
-  "pl-3.5 @[900px]:pl-0";
+  "pl-1.5 @[900px]:pl-0";
 
 export const CHAT_THREAD_ASSISTANT_AVATAR_FRAME_CLASS =
   "h-7 w-7 shrink-0 overflow-hidden rounded-xl @[900px]:h-9 @[900px]:w-9";
@@ -67,7 +68,7 @@ export const CHAT_THREAD_USER_MESSAGE_ACTIONS_CLASS =
   "flex justify-end gap-1 mt-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150";
 
 export const CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_ROW_CLASS =
-  "pl-3.5 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:pl-0";
+  "pl-1.5 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:pl-0";
 
 export const CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_CLASS =
   "flex items-center justify-between gap-2";

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -309,6 +309,7 @@ import {
   CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_ROW_CLASS,
   CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS,
   CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS,
+  CHAT_THREAD_ASSISTANT_RESPONSE_COLUMN_CLASS,
   CHAT_THREAD_CONTENT_MAIN_CLASS,
   CHAT_THREAD_MESSAGE_LIST_CLASS,
   CHAT_THREAD_MESSAGE_STACK_PULL_CLASS,
@@ -4456,7 +4457,12 @@ function WaitingForAssistantResponse({
     >
       <div className={CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS}>
         <AssistantBubbleAvatar thread={thread} />
-        <div className="relative flex min-w-0 flex-col gap-2">
+        <div
+          className={cn(
+            "relative flex min-w-0 flex-col gap-2",
+            CHAT_THREAD_ASSISTANT_RESPONSE_COLUMN_CLASS,
+          )}
+        >
           <ChatAssistantMessageBody>
             <InlineThinkingRow
               blockStyle={blockStyle}
@@ -7201,7 +7207,13 @@ function PagedAssistantGroup({
     >
       <div className={CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS}>
         <AssistantBubbleAvatar thread={thread} />
-        <div className={cn("relative", CHAT_THREAD_RESPONSE_STACK_CLASS)}>
+        <div
+          className={cn(
+            "relative",
+            CHAT_THREAD_RESPONSE_STACK_CLASS,
+            CHAT_THREAD_ASSISTANT_RESPONSE_COLUMN_CLASS,
+          )}
+        >
           {usesRunWorkPresentation ? (
             <PagedRunWorkAssistantContent
               group={group}

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -3415,7 +3415,7 @@ function formatCompactDuration(totalSeconds: number): string {
 }
 
 const RUN_SECTION_LABEL_CLASS =
-  "min-w-0 max-w-full shrink-0 break-words font-serif text-[13px] italic text-muted-foreground/50";
+  "min-w-0 max-w-full shrink-0 break-words font-serif text-sm leading-5 italic text-muted-foreground/50";
 const RUN_SECTION_ROW_CLASS =
   "@[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
 

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -317,6 +317,7 @@ import {
   CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS,
   CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS,
   CHAT_THREAD_RESPONSE_STACK_CLASS,
+  CHAT_THREAD_WORK_HISTORY_MARKDOWN_CLASS,
   CHAT_THREAD_WORK_HISTORY_TEXT_CLASS,
   CHAT_THREAD_USER_MESSAGE_ACTIONS_CLASS,
   CHAT_THREAD_USER_MESSAGE_ROW_CLASS,
@@ -7006,10 +7007,12 @@ function PagedAssistantTimeline({
   items,
   thread,
   mainActions,
+  workHistory = false,
 }: {
   items: readonly PagedAssistantTimelineItem[];
   thread: ChatPanelSignals;
   mainActions?: ReactNode;
+  workHistory?: boolean;
 }) {
   return items.map((item) => {
     if (item.kind === "model-change") {
@@ -7038,12 +7041,12 @@ function PagedAssistantTimeline({
               className={cn(
                 "ml-3.5 w-[calc(100%-0.875rem)] border-l border-border/70 pl-[13px]",
                 CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS,
-                CHAT_THREAD_WORK_HISTORY_TEXT_CLASS,
               )}
             >
               <PagedAssistantTimeline
                 items={item.historyItems}
                 thread={thread}
+                workHistory
               />
             </div>
           )}
@@ -7067,6 +7070,7 @@ function PagedAssistantTimeline({
         key={item.event.id}
         event={item.event}
         thread={thread}
+        workHistory={workHistory}
       />
     );
   });
@@ -7223,9 +7227,11 @@ function PagedAssistantGroup({
 function PagedAssistantEventItem({
   event,
   thread,
+  workHistory = false,
 }: {
   event: EnrichedChatEvent;
   thread: ChatPanelSignals;
+  workHistory?: boolean;
 }) {
   const retryRichEventTree = useSet(thread.retryRichEventTree$);
   const pageSignal = useGet(pageSignal$);
@@ -7233,6 +7239,8 @@ function PagedAssistantEventItem({
   if (error) {
     return (
       <ChatAssistantMessageBody
+        className={cn(workHistory && CHAT_THREAD_WORK_HISTORY_TEXT_CLASS)}
+        data-chat-run-work-history-item={workHistory ? "" : undefined}
         data-chat-scroll-anchor-event-id={event.id}
         data-chat-run-id={event.runId}
       >
@@ -7254,11 +7262,16 @@ function PagedAssistantEventItem({
         className={cn(
           CHAT_THREAD_RESPONSE_LINE_CLASS,
           CHAT_THREAD_RESPONSE_FLUSH_CLASS,
+          workHistory && CHAT_THREAD_WORK_HISTORY_TEXT_CLASS,
         )}
+        data-chat-run-work-history-item={workHistory ? "" : undefined}
         data-chat-scroll-anchor-event-id={event.id}
         data-chat-run-id={event.runId}
       >
         <MarkdownEventBody
+          className={
+            workHistory ? CHAT_THREAD_WORK_HISTORY_MARKDOWN_CLASS : undefined
+          }
           tree={event.tree}
           mediaPreview
           onRetry={

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -3528,7 +3528,6 @@ function RunWorkSectionRow({
         <Hourglass aria-hidden />
       </span>
       <span
-        data-chat-run-work-label
         className={cn(
           "inline-flex min-w-0 items-center gap-1",
           CHAT_THREAD_RESPONSE_SUPPORTING_TEXT_CLASS,
@@ -4066,7 +4065,6 @@ function RecommendedFollowupList({
             </span>
             <ArrowUpRight
               aria-hidden
-              data-chat-followup-hover-icon
               size={16}
               className={cn(
                 "pointer-events-none absolute right-2 top-1/2 box-content -translate-y-1/2 bg-state-hover pl-3 text-muted-foreground/60 opacity-0 transition-[color,opacity] group-hover:text-foreground group-hover:opacity-100",
@@ -7262,7 +7260,6 @@ function PagedAssistantEventItem({
     return (
       <ChatAssistantMessageBody
         className={cn(workHistory && CHAT_THREAD_WORK_HISTORY_TEXT_CLASS)}
-        data-chat-run-work-history-item={workHistory ? "" : undefined}
         data-chat-scroll-anchor-event-id={event.id}
         data-chat-run-id={event.runId}
       >
@@ -7286,7 +7283,6 @@ function PagedAssistantEventItem({
           CHAT_THREAD_RESPONSE_FLUSH_CLASS,
           workHistory && CHAT_THREAD_WORK_HISTORY_TEXT_CLASS,
         )}
-        data-chat-run-work-history-item={workHistory ? "" : undefined}
         data-chat-scroll-anchor-event-id={event.id}
         data-chat-run-id={event.runId}
       >

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -315,6 +315,7 @@ import {
   CHAT_THREAD_RESPONSE_FLUSH_CLASS,
   CHAT_THREAD_RESPONSE_LINE_CLASS,
   CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS,
+  CHAT_THREAD_RESPONSE_SUPPORTING_TEXT_CLASS,
   CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS,
   CHAT_THREAD_RESPONSE_STACK_CLASS,
   CHAT_THREAD_WORK_HISTORY_MARKDOWN_CLASS,
@@ -3525,7 +3526,13 @@ function RunWorkSectionRow({
       <span className={CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS}>
         <Hourglass aria-hidden />
       </span>
-      <span className="inline-flex min-w-0 items-center gap-1">
+      <span
+        data-chat-run-work-label
+        className={cn(
+          "inline-flex min-w-0 items-center gap-1",
+          CHAT_THREAD_RESPONSE_SUPPORTING_TEXT_CLASS,
+        )}
+      >
         <ElapsedTime startTime={startTime} endTime={endTime}>
           {(elapsedTime) => {
             const duration = formatCompactDuration(
@@ -3576,7 +3583,7 @@ function RunWorkSectionRow({
     </>
   );
   const className = cn(
-    "inline-flex min-h-9 w-fit items-center gap-0 rounded-lg pr-1 text-[13px] font-normal text-muted-foreground",
+    "inline-flex min-h-9 w-fit items-center gap-0 rounded-lg pr-1 font-normal text-muted-foreground",
     CHAT_THREAD_RESPONSE_LINE_CLASS,
   );
   return (
@@ -4008,7 +4015,7 @@ function RecommendedFollowupList({
             type="button"
             title={followup.prompt}
             className={cn(
-              "group flex text-left transition-colors",
+              "group relative flex text-left transition-colors",
               // A quick reply sizes to its own text, so a short suggestion
               // stays small and more than one fits on screen. The rail equalises
               // their heights, which is why the contents align to the top: a
@@ -4029,7 +4036,7 @@ function RecommendedFollowupList({
           >
             <span
               className={cn(
-                "text-muted-foreground/70 transition-colors group-hover:text-foreground",
+                "text-muted-foreground transition-colors group-hover:text-foreground",
                 // A quick reply drops the 28px response rail, but keeps the
                 // icon for `generate`: mispicking one there costs a real
                 // generation rather than another message. `h-6` is one line
@@ -4045,7 +4052,8 @@ function RecommendedFollowupList({
             </span>
             <span
               className={cn(
-                "min-w-0 flex-1 break-words text-[0.9375rem] font-medium leading-6 text-muted-foreground group-hover:text-foreground",
+                "min-w-0 flex-1 break-words group-hover:text-foreground",
+                CHAT_THREAD_RESPONSE_SUPPORTING_TEXT_CLASS,
                 // Prompt length is unbounded server-side, so a runaway
                 // suggestion is clamped rather than allowed to grow the rail.
                 // Two lines is also the rail's ceiling: every card matches the
@@ -4056,9 +4064,11 @@ function RecommendedFollowupList({
               {followup.prompt}
             </span>
             <ArrowUpRight
+              aria-hidden
+              data-chat-followup-hover-icon
               size={16}
               className={cn(
-                "shrink-0 text-muted-foreground/60 opacity-0 transition-all group-hover:text-foreground group-hover:opacity-100 ml-2",
+                "pointer-events-none absolute right-2 top-1/2 box-content -translate-y-1/2 bg-state-hover pl-3 text-muted-foreground/60 opacity-0 transition-[color,opacity] group-hover:text-foreground group-hover:opacity-100",
                 showFollowupCards && "hidden",
               )}
             />

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -312,6 +312,7 @@ import {
   CHAT_THREAD_CONTENT_MAIN_CLASS,
   CHAT_THREAD_MESSAGE_LIST_CLASS,
   CHAT_THREAD_MESSAGE_STACK_PULL_CLASS,
+  CHAT_THREAD_RESPONSE_CONTENT_CLASS,
   CHAT_THREAD_RESPONSE_LINE_CLASS,
   CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS,
   CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS,
@@ -3417,9 +3418,11 @@ const RUN_SECTION_ROW_CLASS =
 function RunSectionDivider({
   label,
   labelPosition = "left",
+  className,
 }: {
   label: string;
   labelPosition?: "left" | "right";
+  className?: string;
 }) {
   return (
     <div
@@ -3427,6 +3430,7 @@ function RunSectionDivider({
         "flex min-h-5 items-center gap-2",
         CHAT_THREAD_RESPONSE_LINE_CLASS,
         labelPosition === "right" && "flex-row-reverse",
+        className,
       )}
     >
       <p
@@ -3560,6 +3564,7 @@ function RunWorkSectionRow({
       {collapsible ? (
         <ChevronRight
           aria-hidden
+          size={16}
           className={cn(
             "ml-1 shrink-0 text-muted-foreground/70 transition-transform",
             expanded && "rotate-90",
@@ -3569,7 +3574,7 @@ function RunWorkSectionRow({
     </>
   );
   const className = cn(
-    "inline-flex min-h-9 w-fit items-center gap-0 rounded-lg pr-1 text-[13px] font-normal text-muted-foreground [&_svg]:size-3.5",
+    "inline-flex min-h-9 w-fit items-center gap-0 rounded-lg pr-1 text-[13px] font-normal text-muted-foreground",
     CHAT_THREAD_RESPONSE_LINE_CLASS,
   );
   return (
@@ -3888,22 +3893,22 @@ function RecommendedFollowupIcon({
   followup: RecommendedFollowup;
 }) {
   if (followup.kind !== "generate") {
-    return <MessageCircle size={14} />;
+    return <MessageCircle size={16} />;
   }
 
   if (followup.generationType === "image") {
-    return <Image size={14} />;
+    return <Image size={16} />;
   }
   if (followup.generationType === "video") {
-    return <Video size={14} />;
+    return <Video size={16} />;
   }
   if (followup.generationType === "presentation") {
-    return <ChartLine size={14} />;
+    return <ChartLine size={16} />;
   }
   if (followup.generationType === "website") {
-    return <LinkIcon size={14} />;
+    return <LinkIcon size={16} />;
   }
-  return <Package size={14} />;
+  return <Package size={16} />;
 }
 
 function recommendedFollowupShownKey(
@@ -4049,7 +4054,7 @@ function RecommendedFollowupList({
               {followup.prompt}
             </span>
             <ArrowUpRight
-              size={14}
+              size={16}
               className={cn(
                 "shrink-0 text-muted-foreground/60 opacity-0 transition-all group-hover:text-foreground group-hover:opacity-100 ml-2",
                 showFollowupCards && "hidden",
@@ -4290,12 +4295,12 @@ function ThinkingLoader({
       <span
         aria-hidden
         data-thinking-loader="spinner"
-        className="okou-thinking-spinner-frame inline-flex size-[11.5px] shrink-0 items-center justify-center"
+        className="okou-thinking-spinner-frame inline-flex size-4 shrink-0 items-center justify-center"
       >
         <img
           src={thinkingSpinnerImg}
           alt=""
-          className="okou-thinking-spinner size-3.5 max-w-none shrink-0 animate-spin motion-reduce:animate-none"
+          className="okou-thinking-spinner size-4 max-w-none shrink-0 animate-spin motion-reduce:animate-none"
         />
       </span>
     );
@@ -4304,7 +4309,7 @@ function ThinkingLoader({
   return (
     <span
       data-thinking-loader="blocks"
-      className="okou-blocks shrink-0"
+      className="okou-blocks size-4 shrink-0 place-content-center"
       style={blockStyle}
     >
       <span />
@@ -4381,7 +4386,10 @@ function FinishedRunRow({
 
   return (
     <div className={CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS}>
-      <RunSectionDivider label={label} />
+      <RunSectionDivider
+        label={label}
+        className={CHAT_THREAD_RESPONSE_CONTENT_CLASS}
+      />
       {source ? (
         <RecommendedFollowupList thread={thread} source={source} />
       ) : null}
@@ -5007,7 +5015,7 @@ function assistantRecoveryResetText(
 }
 
 function AssistantRecoveryActionSpinner({ loading }: { loading: boolean }) {
-  return loading ? <Loader2 size={14} className="animate-spin" /> : null;
+  return loading ? <Loader2 size={16} className="animate-spin" /> : null;
 }
 
 function AssistantRecoveryActions({
@@ -5188,7 +5196,7 @@ function AssistantErrorRecoveryCard({
         </span>
         {resetText && (
           <span className="hidden shrink-0 items-center gap-1.5 text-sm font-medium text-foreground sm:inline-flex">
-            <Clock size={14} className="text-muted-foreground" />
+            <Clock size={16} className="text-muted-foreground" />
             {resetText}
           </span>
         )}
@@ -5230,7 +5238,7 @@ function AssistantErrorFallback({ error }: { error: string }) {
           borderRadius: "12px",
         }}
       >
-        <Hand size={14} className="shrink-0" />
+        <Hand size={16} className="shrink-0" />
         <span>
           {t(($) => {
             return $.chat.errors.runCancelled;
@@ -5864,7 +5872,7 @@ function UserMessageActions({
         type="button"
         variant="quiet"
         size="icon-xs"
-        iconSize="md"
+        iconSize="sm"
         showTooltip
         onClick={onCopy}
         className="text-muted-foreground/60"
@@ -7047,7 +7055,11 @@ function PagedAssistantTimeline({
           data-chat-run-work-main
           className={CHAT_THREAD_RESPONSE_STACK_CLASS}
         >
-          <PagedAssistantEventItem event={item.event} thread={thread} />
+          <PagedAssistantEventItem
+            event={item.event}
+            thread={thread}
+            reserveLeadingIconRail
+          />
           {mainActions}
         </div>
       );
@@ -7213,9 +7225,11 @@ function PagedAssistantGroup({
 function PagedAssistantEventItem({
   event,
   thread,
+  reserveLeadingIconRail = false,
 }: {
   event: EnrichedChatEvent;
   thread: ChatPanelSignals;
+  reserveLeadingIconRail?: boolean;
 }) {
   const retryRichEventTree = useSet(thread.retryRichEventTree$);
   const pageSignal = useGet(pageSignal$);
@@ -7241,7 +7255,10 @@ function PagedAssistantEventItem({
   ) {
     return (
       <ChatAssistantMessageBody
-        className={CHAT_THREAD_RESPONSE_LINE_CLASS}
+        className={cn(
+          CHAT_THREAD_RESPONSE_LINE_CLASS,
+          reserveLeadingIconRail && CHAT_THREAD_RESPONSE_CONTENT_CLASS,
+        )}
         data-chat-scroll-anchor-event-id={event.id}
         data-chat-run-id={event.runId}
       >
@@ -7353,7 +7370,7 @@ function UsageChip({
           className="inline-flex h-7 items-center gap-1 rounded-md px-1.5 text-xs font-medium text-muted-foreground/70 hover:bg-state-hover hover:text-foreground transition-colors duration-150"
           aria-label={`${ariaLabel} ${total}`}
         >
-          <Coins size={17} />
+          <Coins size={16} />
           <span>{total}</span>
         </button>
       </PopoverTrigger>
@@ -7517,7 +7534,7 @@ function RelatedArtifactsDialog({
                 type="button"
                 variant="quiet"
                 size="xs"
-                iconSize="md"
+                iconSize="sm"
                 className="gap-1.5 px-2 text-xs text-muted-foreground/60 tabular-nums"
                 aria-label={triggerLabel}
                 data-testid="chat-run-related-artifacts-trigger"
@@ -7581,7 +7598,7 @@ function PagedGroupPrimaryActions({
                 asChild
                 variant="quiet"
                 size="icon-xs"
-                iconSize="md"
+                iconSize="sm"
                 className="text-muted-foreground/60"
               >
                 <Link
@@ -7613,7 +7630,7 @@ function PagedGroupPrimaryActions({
                 type="button"
                 variant="quiet"
                 size="icon-xs"
-                iconSize="md"
+                iconSize="sm"
                 onClick={onCopy}
                 className="text-muted-foreground/60"
                 aria-label={t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -7049,7 +7049,7 @@ function PagedAssistantTimeline({
             <div
               data-chat-run-work-history-list
               className={cn(
-                "ml-3.5 w-[calc(100%-0.875rem)] border-l border-border/70 pl-[13px]",
+                "ml-2 w-[calc(100%-0.5rem)] border-l border-border/70 pl-[15px]",
                 CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS,
               )}
             >
@@ -7607,8 +7607,20 @@ function PagedGroupPrimaryActions({
 }) {
   const { t } = useTranslation();
   const showActivityLogs = useGet(featureSwitch$)[FeatureSwitchKey.OkouDebug];
+  const hasLeadingIconAction = Boolean(
+    (showActivityLogs && firstRunId) || hasContent,
+  );
   return (
-    <div className="flex items-center gap-1" data-testid="chat-event-actions">
+    <div
+      className={cn(
+        "flex items-center gap-1",
+        // Icon buttons keep their 28px hit target centered around the 16px
+        // glyph. Let the target overhang so the visible glyph, not its box,
+        // starts on the response column.
+        hasLeadingIconAction && "-ml-1.5",
+      )}
+      data-testid="chat-event-actions"
+    >
       {showActivityLogs && firstRunId && (
         <TooltipProvider delayDuration={300}>
           <Tooltip>

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -312,11 +312,12 @@ import {
   CHAT_THREAD_CONTENT_MAIN_CLASS,
   CHAT_THREAD_MESSAGE_LIST_CLASS,
   CHAT_THREAD_MESSAGE_STACK_PULL_CLASS,
-  CHAT_THREAD_RESPONSE_CONTENT_CLASS,
+  CHAT_THREAD_RESPONSE_FLUSH_CLASS,
   CHAT_THREAD_RESPONSE_LINE_CLASS,
   CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS,
   CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS,
   CHAT_THREAD_RESPONSE_STACK_CLASS,
+  CHAT_THREAD_WORK_HISTORY_TEXT_CLASS,
   CHAT_THREAD_USER_MESSAGE_ACTIONS_CLASS,
   CHAT_THREAD_USER_MESSAGE_ROW_CLASS,
 } from "./chat-message-surface.tsx";
@@ -4388,7 +4389,7 @@ function FinishedRunRow({
     <div className={CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS}>
       <RunSectionDivider
         label={label}
-        className={CHAT_THREAD_RESPONSE_CONTENT_CLASS}
+        className={CHAT_THREAD_RESPONSE_FLUSH_CLASS}
       />
       {source ? (
         <RecommendedFollowupList thread={thread} source={source} />
@@ -7037,6 +7038,7 @@ function PagedAssistantTimeline({
               className={cn(
                 "ml-3.5 w-[calc(100%-0.875rem)] border-l border-border/70 pl-[13px]",
                 CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS,
+                CHAT_THREAD_WORK_HISTORY_TEXT_CLASS,
               )}
             >
               <PagedAssistantTimeline
@@ -7055,11 +7057,7 @@ function PagedAssistantTimeline({
           data-chat-run-work-main
           className={CHAT_THREAD_RESPONSE_STACK_CLASS}
         >
-          <PagedAssistantEventItem
-            event={item.event}
-            thread={thread}
-            reserveLeadingIconRail
-          />
+          <PagedAssistantEventItem event={item.event} thread={thread} />
           {mainActions}
         </div>
       );
@@ -7225,11 +7223,9 @@ function PagedAssistantGroup({
 function PagedAssistantEventItem({
   event,
   thread,
-  reserveLeadingIconRail = false,
 }: {
   event: EnrichedChatEvent;
   thread: ChatPanelSignals;
-  reserveLeadingIconRail?: boolean;
 }) {
   const retryRichEventTree = useSet(thread.retryRichEventTree$);
   const pageSignal = useGet(pageSignal$);
@@ -7257,7 +7253,7 @@ function PagedAssistantEventItem({
       <ChatAssistantMessageBody
         className={cn(
           CHAT_THREAD_RESPONSE_LINE_CLASS,
-          reserveLeadingIconRail && CHAT_THREAD_RESPONSE_CONTENT_CLASS,
+          CHAT_THREAD_RESPONSE_FLUSH_CLASS,
         )}
         data-chat-scroll-anchor-event-id={event.id}
         data-chat-run-id={event.runId}

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -29,6 +29,7 @@ import {
   CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_ROW_CLASS,
   CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS,
   CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS,
+  CHAT_THREAD_ASSISTANT_RESPONSE_COLUMN_CLASS,
   CHAT_THREAD_CONTENT_MAIN_CLASS,
   CHAT_THREAD_MESSAGE_LIST_CLASS,
   CHAT_THREAD_MESSAGE_STACK_PULL_CLASS,
@@ -211,7 +212,12 @@ function SharedAssistantGroup({
     >
       <div className={CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS}>
         <SharedAssistantAvatar assistantName={assistantName} />
-        <div className="relative flex min-w-0 flex-col gap-2">
+        <div
+          className={cn(
+            "relative flex min-w-0 flex-col gap-2",
+            CHAT_THREAD_ASSISTANT_RESPONSE_COLUMN_CLASS,
+          )}
+        >
           {group.messages.map((message) => {
             return (
               <ChatAssistantMessageBody

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -17,7 +17,6 @@ import {
 import type { SharedThreadRichContentSignals } from "../../signals/shared-thread-page/shared-thread-rich-content.ts";
 import { writeToClipboard } from "../../signals/okou-page/clipboard.ts";
 import { detach, Reason } from "../../signals/utils.ts";
-import { IconTooltipButton } from "../components/icon-tooltip.tsx";
 import { MarkdownEventBody } from "../components/markdown.tsx";
 import { ProductBrandMark } from "../components/product-brand-mark.tsx";
 import {
@@ -122,10 +121,14 @@ function SharedMessageCopyButton({ content }: { readonly content: string }) {
   });
 
   return (
-    <IconTooltipButton
+    <Button
       type="button"
+      variant="quiet"
+      size="icon-xs"
+      iconSize="sm"
+      showTooltip
       data-shared-message-copy=""
-      className="rounded-md p-1 text-muted-foreground/60 transition-colors duration-150 hover:bg-state-hover hover:text-foreground"
+      className="text-muted-foreground/60"
       aria-label={label}
       onClick={() => {
         detach(
@@ -150,8 +153,8 @@ function SharedMessageCopyButton({ content }: { readonly content: string }) {
         );
       }}
     >
-      <Copy size={18} />
-    </IconTooltipButton>
+      <Copy />
+    </Button>
   );
 }
 
@@ -243,7 +246,7 @@ function SharedAssistantGroup({
           data-shared-message-actions="assistant"
           className={CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_CLASS}
         >
-          <div className="flex items-center gap-1">
+          <div className="-ml-1.5 flex items-center gap-1">
             <SharedMessageCopyButton content={content} />
           </div>
         </div>


### PR DESCRIPTION
## Summary

- align the visible 16px work, copy, and follow-up glyphs to one response axis, with an 8px icon-to-label gap and the existing 28px action hit target preserved
- on stacked mobile layouts, inset the shared response column by 6px so each 16px icon centre aligns with the centre of the 28px Okou avatar above it
- keep the main response, completion divider, work state, actions, and follow-ups on the same shared left edge while moving that whole column 8px left from the previous revision
- remove the inset at the 900px container breakpoint so the established desktop response axis remains unchanged
- retain secondary 14px / 20px muted supporting text, the 15px final response, and an absolutely positioned follow-up hover arrow that reserves no layout space

## Verification

- `pnpm --dir turbo/apps/platform exec vitest run src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx src/views/shared-thread-page/__tests__/shared-thread-presentation.test.tsx src/views/shared-thread-page/__tests__/shared-thread-actions.test.tsx --pool=threads --maxWorkers=1` (3 files, 26 tests passed)
- targeted ESLint on the 4 files changed by the mobile-axis follow-up
- targeted Prettier check on the same 4 files
- `pnpm --dir turbo lint:style`

No local development server or full local Vitest run, per repository instructions.

### Deployed preview

- exact PR head: `e97f86622cc40a4b3468aac9ea9f3af6c90b5751`
- App: https://pr-32879-app-okou-app-preview.vm0.workers.dev
- API: https://pr-32879-api.vm6.ai
- the first API deploy attempt hit a transient Vercel archive-extraction error; the failed job was rerun successfully
- all current checks passed or were skipped (`79` passed, `22` skipped; no failures or pending checks)

### Browser validation

Validated the exact-head deployed preview in headless Chromium with a reusable Clerk test account and an out-of-scope onboarding bypass. A deterministic GPT 5.6 Luna preview-mock run supplied the message content through the deployed API. Because the preview-protection header does not propagate into this build's SharedWorker, the five API-returned event rows were copied into that browser's local event cache solely to render the completed fixture. The chat components, CSS, responsive rules, actions, and follow-ups remained the deployed implementation.

- mobile 390x844: avatar frame is x=`16px`, width=`28px`, so its centre is x=`30px`
- response inset computes to `6px`; the shared response edge is x=`22px`
- work, copy, and all three follow-up glyphs are x=`22px`, width=`16px`, so every icon centre is x=`30px` and the avatar/icon centre delta is `0px`
- main response and completion tail also begin at x=`22px`; follow-up labels begin at x=`46px`, preserving the 8px glyph-to-label gap
- desktop 1440x900: inset computes to `0px`; work, main, copy, completion tail, and follow-up icons retain their x=`447px` response axis
- document horizontal overflow is `0px` at both widths

Screenshots:

- [390px exact-head preview with QA centre guide](https://a.okou.io/0n5hj4l5tp.png) (the blue guide is a browser-only annotation)
- [390px exact-head preview without annotation](https://a.okou.io/gc4damwz15.png)
