### PR TITLE
fix(connectors): verify browser oauth completion by attempt

### DIFF
--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -792,3 +792,15 @@ criteria after the old version is gone.
 ## Pi native provider reader preparation
 
 For the generation 4 reader-first release, see [Pi native provider preparation](pi-native-provider-preparation.md). Its model generation is independent of launch snapshot V3. Native writers remain absent until the controller verifies compatible API readers and rollback targets, Runner capabilities, pinned CLI artifacts and existing-route health. The preparation merge alone does not close these gates.
+
+## Connector OAuth completion receipts
+
+Browser OAuth/OpenID start responses add an optional `oauthAttemptId`. A successful callback records a short-lived receipt only after credential persistence and required Agent authorization/linking finish. The authenticated, uncached `/api/connector-accounts/oauth-completions/:attemptId` lookup validates the current user, organization, connector target, and actual connected account. Receipts expire 15 minutes after success; account deletion cascades to receipts, and the existing OAuth-state cleanup cron removes expired receipts in bounded batches.
+
+The App uses the exact attempt receipt, not account timestamps, account counts, or sibling-account presence, to continue the flow. The callback's existing single-use state claim remains unchanged. Counts still determine the first-account Agent-grant policy, not OAuth success.
+
+- Old App → new API: existing requests remain valid; the new response field is additive. Already-loaded old pages retain their previous completion heuristic until refreshed.
+- New App → old API, or a new start handled by an old callback instance: absence of a receipt cannot prove success. The App does not automatically continue or grant access; credentials may have been saved and the user may need to retry after rollout.
+- The new table is additive and does not change existing OAuth-state or connector-account rows. No Runner protocol changes or immediate App minimum-version increase are required.
+
+Remove the optional field and absent-ID compatibility branch only after receipt-capable API versions are the serving and rollback floor. Track that contraction in [#32870](https://github.com/vm0-ai/vm0/issues/32870).

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-oauth-completion.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-oauth-completion.test.ts
@@ -1,0 +1,351 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  connectorAccountsContract,
+  type ConnectorAccountTarget,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { expect, test } from "vitest";
+
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
+import { now, withMockNowForTest } from "../../../lib/time";
+import { installApiTestConnectorCatalog } from "../../../test-fixtures/connector-catalog";
+import { connectorAccountRoutes } from "../connector-accounts";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import {
+  createConnectorBddApi,
+  mockGitHubConnectorOAuth,
+  mockCustomConnectorOAuth2Provider,
+} from "./helpers/api-bdd-connectors";
+import { createRouteMocks } from "./helpers/route-test";
+import {
+  testCronDeleteCleanupsStateContract,
+  testCronDeleteCleanupsStateRoutes,
+} from "../test-cron-delete-cleanups-state";
+
+const context = testContext();
+const mocks = createRouteMocks(context);
+const bdd = createBddApi(context);
+const connectors = createConnectorBddApi(context);
+const githubTarget = { kind: "builtin", connectorSlug: "github" } as const;
+
+function accountClient(actor: ApiTestUser) {
+  mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+  return setupApp({ context, routes: connectorAccountRoutes })(
+    connectorAccountsContract,
+  );
+}
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function attemptId(start: { readonly oauthAttemptId?: string }): string {
+  if (!start.oauthAttemptId) {
+    throw new Error("Expected an OAuth attempt ID");
+  }
+  return start.oauthAttemptId;
+}
+
+function state(start: { readonly authorizationUrl: string }): string {
+  const value = new URL(start.authorizationUrl).searchParams.get("state");
+  if (!value) {
+    throw new Error("Expected OAuth state");
+  }
+  return value;
+}
+
+async function receipt(
+  actor: ApiTestUser,
+  id: string,
+  target: ConnectorAccountTarget = githubTarget,
+) {
+  return await accept(
+    accountClient(actor).oauthCompletion({
+      headers: authHeaders(),
+      params: { attemptId: id },
+      query: target,
+    }),
+    [200, 404],
+  );
+}
+
+async function createGithubAccount(actor: ApiTestUser) {
+  mockGitHubConnectorOAuth({ userId: 32_503, login: "completion-account" });
+  const start = await connectors.startOauth(actor, "github", "oauth");
+  const completed = await connectors.completeOauthCallbackResult("github", {
+    code: "create",
+    state: state(start),
+  });
+  expect(completed.body.status).toBe("success");
+  const result = await receipt(actor, attemptId(start));
+  expect(result.status).toBe(200);
+  if (result.status !== 200) {
+    throw new Error("Expected completed GitHub account");
+  }
+  return { start, connectionId: result.body.connectionId };
+}
+
+test("exposes a receipt only to its owner and exact current connector target", async () => {
+  await installApiTestConnectorCatalog();
+  const actor = bdd.user();
+  const { start, connectionId } = await createGithubAccount(actor);
+  const id = attemptId(start);
+  const completed = await receipt(actor, id);
+  expect(completed.body).toStrictEqual({ connectionId });
+  expect(completed.headers.get("cache-control")).toBe("no-store");
+
+  const wrongTarget = await receipt(actor, id, {
+    kind: "builtin",
+    connectorSlug: "linear",
+  });
+  const wrongOrg = await receipt(bdd.user({ userId: actor.userId }), id);
+  const wrongUser = await receipt(bdd.user({ orgId: actor.orgId }), id);
+  const missing = await receipt(actor, randomUUID());
+  for (const unavailable of [wrongTarget, wrongOrg, wrongUser, missing]) {
+    expect(unavailable.status).toBe(404);
+    expect(unavailable.body).toStrictEqual(missing.body);
+    expect(unavailable.headers.get("cache-control")).toBe("no-store");
+  }
+  const anonymous = await accountClient(actor).oauthCompletion({
+    params: { attemptId: id },
+    query: githubTarget,
+  });
+  expect(anonymous.status).toBe(401);
+
+  await connectors.deleteBuiltinConnectorAccount(actor, "github", connectionId);
+  expect((await receipt(actor, id)).status).toBe(404);
+});
+
+test("does not complete a denied reconnect after rename or default-account changes and allows retry", async () => {
+  await installApiTestConnectorCatalog();
+  const actor = bdd.user();
+  const { connectionId } = await createGithubAccount(actor);
+  const account = { intent: "reconnect", connectionId } as const;
+  const cancelled = await connectors.startOauth(
+    actor,
+    "github",
+    "oauth",
+    undefined,
+    account,
+  );
+  await accept(
+    accountClient(actor).rename({
+      headers: authHeaders(),
+      params: { connectionId },
+      body: { target: githubTarget, displayName: "Renamed during consent" },
+    }),
+    [200],
+  );
+  await connectors.setDefaultBuiltinConnectorAccount(
+    actor,
+    "github",
+    connectionId,
+  );
+  expect((await receipt(actor, attemptId(cancelled))).status).toBe(404);
+  const denied = await connectors.completeOauthCallbackResult("github", {
+    error: "access_denied",
+    state: state(cancelled),
+  });
+  expect(denied.body.status).toBe("error");
+  expect((await receipt(actor, attemptId(cancelled))).status).toBe(404);
+
+  const retry = await connectors.startOauth(
+    actor,
+    "github",
+    "oauth",
+    undefined,
+    account,
+  );
+  await connectors.completeOauthCallbackResult("github", {
+    code: "retry",
+    state: state(retry),
+  });
+  expect((await receipt(actor, attemptId(retry))).body).toStrictEqual({
+    connectionId,
+  });
+  expect((await receipt(actor, attemptId(cancelled))).status).toBe(404);
+  const replay = await connectors.completeOauthCallbackResult("github", {
+    code: "replay",
+    state: state(cancelled),
+  });
+  expect(replay.body.status).toBe("error");
+  expect((await receipt(actor, attemptId(cancelled))).status).toBe(404);
+});
+
+test("retains independent receipts for overlapping GitHub adds that reuse the same account", async () => {
+  await installApiTestConnectorCatalog();
+  const actor = bdd.user();
+  const { connectionId } = await createGithubAccount(actor);
+  const first = await connectors.startOauth(actor, "github", "oauth");
+  const second = await connectors.startOauth(actor, "github", "oauth");
+  await connectors.completeOauthCallbackResult("github", {
+    code: "second",
+    state: state(second),
+  });
+  expect((await receipt(actor, attemptId(first))).status).toBe(404);
+  await connectors.completeOauthCallbackResult("github", {
+    code: "first",
+    state: state(first),
+  });
+  for (const start of [first, second]) {
+    expect(start.connectionId).not.toBe(connectionId);
+    expect((await receipt(actor, attemptId(start))).body).toStrictEqual({
+      connectionId,
+    });
+  }
+});
+
+test("expires completed attempts without expiring their connector account", async () => {
+  await installApiTestConnectorCatalog();
+  const actor = bdd.user();
+  const { start, connectionId } = await createGithubAccount(actor);
+  await withMockNowForTest(now() + 16 * 60 * 1000, async () => {
+    expect((await receipt(actor, attemptId(start))).status).toBe(404);
+    const account = await accept(
+      accountClient(actor).connection({
+        headers: authHeaders(),
+        params: { connectionId },
+        query: githubTarget,
+      }),
+      [200],
+    );
+    expect(account.body.id).toBe(connectionId);
+  });
+});
+
+test("cleans expired receipts in bounded batches without deleting current receipts or accounts", async () => {
+  await installApiTestConnectorCatalog();
+  const marker = `oauth-completion-cleanup-${randomUUID()}`;
+  const actor = bdd.user({ userId: marker, orgId: marker });
+  const expired = await withMockNowForTest(now() - 20 * 60 * 1000, async () => {
+    const first = await createGithubAccount(actor);
+    const second = await createGithubAccount(actor);
+    return [first, second];
+  });
+  const current = await createGithubAccount(actor);
+  const cleanup = await accept(
+    setupApp({ context, routes: testCronDeleteCleanupsStateRoutes })(
+      testCronDeleteCleanupsStateContract,
+    ).action({
+      body: { action: "cleanup-connector", marker },
+    }),
+    [200],
+  );
+  expect(cleanup.body.deleted).toBe(2);
+  for (const previous of expired) {
+    expect((await receipt(actor, attemptId(previous.start))).status).toBe(404);
+  }
+  expect((await receipt(actor, attemptId(current.start))).body).toStrictEqual({
+    connectionId: current.connectionId,
+  });
+  await connectors.deleteBuiltinConnectorAccount(
+    actor,
+    "github",
+    current.connectionId,
+  );
+});
+
+test.each(["http", "mcp"] as const)(
+  "tracks successful and cancelled custom %s OAuth attempts independently",
+  async (kind) => {
+    const actor = bdd.user();
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.CustomConnectorMcp]: true,
+    });
+    const provider = mockCustomConnectorOAuth2Provider(context, {
+      initialScope: "read",
+    });
+    const definition = {
+      displayName: `OAuth completion ${randomUUID()}`,
+      fields: [],
+      headerInjections: [
+        {
+          name: "Authorization",
+          valueTemplate: "Bearer {{oauth.access_token}}",
+        },
+      ],
+      queryInjections: [],
+      authMode: "oauth" as const,
+      oauthConfig: {
+        providerAdapter: "standard" as const,
+        clientId: "completion-client",
+        clientSecret: "completion-secret",
+        authorizationUrl: provider.authorizationUrl,
+        tokenUrl: provider.tokenUrl,
+        tokenEndpointAuthMethod: "client_secret_post" as const,
+        pkceMethod: "none" as const,
+        scopes: ["read"],
+        authorizationParams: {},
+      },
+    };
+    const connector = await connectors.createCustomConnector(
+      actor,
+      kind === "http"
+        ? {
+            ...definition,
+            kind,
+            prefixTemplates: [`https://${randomUUID()}.example.test/api/`],
+          }
+        : {
+            ...definition,
+            kind,
+            endpoint: `https://${randomUUID()}.example.test/mcp`,
+            transport: "streamable-http",
+          },
+    );
+    const target = { kind: "custom", customConnectorId: connector.id } as const;
+    const started = await connectors.requestStartCustomConnectorOAuth2(
+      actor,
+      connector.id,
+      [200],
+    );
+    if (started.status !== 200 || started.body.result !== "authorization") {
+      throw new Error("Expected custom OAuth authorization");
+    }
+    expect((await receipt(actor, attemptId(started.body), target)).status).toBe(
+      404,
+    );
+    const completed =
+      await connectors.completeCustomConnectorOAuth2CallbackResult({
+        code: "custom-success",
+        state: state(started.body),
+      });
+    expect(completed.body.status).toBe("success");
+    const connected = await receipt(actor, attemptId(started.body), target);
+    if (connected.status !== 200) {
+      throw new Error("Expected a completed custom account");
+    }
+    const connectionId = connected.body.connectionId;
+    const cancelled = await connectors.requestStartCustomConnectorOAuth2(
+      actor,
+      connector.id,
+      [200],
+      undefined,
+      { intent: "reconnect", connectionId },
+    );
+    if (cancelled.status !== 200 || cancelled.body.result !== "authorization") {
+      throw new Error("Expected custom OAuth reconnect");
+    }
+    await accept(
+      accountClient(actor).rename({
+        headers: authHeaders(),
+        params: { connectionId },
+        body: { target, displayName: "Renamed" },
+      }),
+      [200],
+    );
+    const denied = await connectors.completeCustomConnectorOAuth2CallbackResult(
+      { error: "access_denied", state: state(cancelled.body) },
+    );
+    expect(denied.body.status).toBe("error");
+    expect(
+      (await receipt(actor, attemptId(cancelled.body), target)).status,
+    ).toBe(404);
+    expect(
+      (await receipt(actor, attemptId(started.body), target)).body,
+    ).toStrictEqual({ connectionId });
+    await connectors.deleteCustomConnector(actor, connector.id);
+  },
+);

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 
 import { connectorsSlugCallbackContract } from "@okouai/api-contracts/contracts/connectors-slug-callback";
-import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
+import {
+  connectorAccountsContract,
+  type ConnectorAccountMutationIntent,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import { connectorAccountRoutes } from "../connector-accounts";
 import {
   connectorOpenIdStartContract,
   connectorsBySlugContract,
@@ -52,7 +56,10 @@ function mockSteamRuntimeEnv(): void {
 async function startSteamOpenId(
   actor: TestActor,
   account: ConnectorAccountMutationIntent = { intent: "add" },
-): Promise<URL> {
+): Promise<{
+  readonly authorizationUrl: URL;
+  readonly oauthAttemptId: string;
+}> {
   mockSession(actor);
   const response = await accept(
     setupApp({ context, routes: connectorsRoutes })(
@@ -64,7 +71,13 @@ async function startSteamOpenId(
     }),
     [200],
   );
-  return new URL(response.body.authorizationUrl);
+  if (!response.body.oauthAttemptId) {
+    throw new Error("Expected OpenID attempt ID");
+  }
+  return {
+    authorizationUrl: new URL(response.body.authorizationUrl),
+    oauthAttemptId: response.body.oauthAttemptId,
+  };
 }
 
 function stateFromSteamAuthorizationUrl(authorizationUrl: URL): string {
@@ -190,7 +203,7 @@ describe("Steam OpenID connector", () => {
     const actor = testActor();
     mockSteamRuntimeEnv();
 
-    const authorizationUrl = await startSteamOpenId(actor);
+    const { authorizationUrl, oauthAttemptId } = await startSteamOpenId(actor);
     expect(authorizationUrl.origin + authorizationUrl.pathname).toBe(
       "https://steamcommunity.com/openid/login",
     );
@@ -213,6 +226,17 @@ describe("Steam OpenID connector", () => {
       }),
       [200],
     );
+    const completion = await accept(
+      setupApp({ context, routes: connectorAccountRoutes })(
+        connectorAccountsContract,
+      ).oauthCompletion({
+        headers: authHeaders(),
+        params: { attemptId: oauthAttemptId },
+        query: { kind: "builtin", connectorSlug: "steam" },
+      }),
+      [200],
+    );
+    expect(completion.body).toStrictEqual({ connectionId: connector.body.id });
     expect(connector.body).toMatchObject({
       slug: "steam",
       authMethod: "openid",
@@ -226,7 +250,8 @@ describe("Steam OpenID connector", () => {
   it("keeps the active Steam connection until a verified replacement succeeds", async () => {
     const actor = testActor();
     mockSteamRuntimeEnv();
-    const initialAuthorizationUrl = await startSteamOpenId(actor);
+    const { authorizationUrl: initialAuthorizationUrl } =
+      await startSteamOpenId(actor);
     await completeSteamOpenIdCallback(initialAuthorizationUrl);
 
     mockSession(actor);
@@ -240,8 +265,16 @@ describe("Steam OpenID connector", () => {
       [200],
     );
 
-    const authorizationUrl = await startSteamOpenId(actor);
+    const { authorizationUrl, oauthAttemptId } = await startSteamOpenId(actor);
     mockSession(actor);
+    const pending = await setupApp({ context, routes: connectorAccountRoutes })(
+      connectorAccountsContract,
+    ).oauthCompletion({
+      headers: authHeaders(),
+      params: { attemptId: oauthAttemptId },
+      query: { kind: "builtin", connectorSlug: "steam" },
+    });
+    expect(pending.status).toBe(404);
     const whilePending = await accept(
       setupApp({ context, routes: connectorsRoutes })(
         connectorsBySlugContract,
@@ -283,10 +316,11 @@ describe("Steam OpenID connector", () => {
     );
     expect(connector.body).toStrictEqual(initial.body);
 
-    const replacementAuthorizationUrl = await startSteamOpenId(actor, {
-      intent: "reconnect",
-      connectionId: initial.body.id,
-    });
+    const { authorizationUrl: replacementAuthorizationUrl } =
+      await startSteamOpenId(actor, {
+        intent: "reconnect",
+        connectionId: initial.body.id,
+      });
     await completeSteamOpenIdCallback(replacementAuthorizationUrl);
     mockSession(actor);
     const replaced = await accept(

--- a/turbo/apps/api/src/signals/routes/connector-accounts.ts
+++ b/turbo/apps/api/src/signals/routes/connector-accounts.ts
@@ -10,6 +10,8 @@ import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
 import { db$, writeDb$ } from "../external/db";
+import { setResHeader$ } from "../context/hono";
+import { readConnectorOAuthCompletion } from "../services/connector-oauth-completion.service";
 import type { RouteEntry } from "../route-entry";
 import { bestEffort } from "../utils";
 import {
@@ -39,6 +41,30 @@ function targetFromQuery(
     ? { kind: "builtin", connectorSlug: query.connectorSlug }
     : { kind: "custom", customConnectorId: query.customConnectorId };
 }
+
+const oauthCompletionInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const { attemptId } = get(
+      pathParamsOf(connectorAccountsContract.oauthCompletion),
+    );
+    const target = get(queryOf(connectorAccountsContract.oauthCompletion));
+    set(setResHeader$, "Cache-Control", "no-store");
+    const completion = await readConnectorOAuthCompletion(
+      set(writeDb$),
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        attemptId,
+        target,
+      },
+      signal,
+    );
+    return completion
+      ? { status: 200 as const, body: completion }
+      : notFound("OAuth completion not found");
+  },
+);
 
 const inspectInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
@@ -369,6 +395,10 @@ const writeAuth = {
 } as const;
 
 export const connectorAccountRoutes: readonly RouteEntry[] = [
+  {
+    route: connectorAccountsContract.oauthCompletion,
+    handler: authRoute(readAuth, oauthCompletionInner$),
+  },
   {
     route: connectorAccountsContract.inspect,
     handler: authRoute(readAuth, inspectInner$),

--- a/turbo/apps/api/src/signals/routes/connectors-slug-callback.ts
+++ b/turbo/apps/api/src/signals/routes/connectors-slug-callback.ts
@@ -29,6 +29,8 @@ import {
   type StoredBuiltinOAuthState,
 } from "../services/connector-oauth-state.service";
 import { authorizeConnectedConnector$ } from "../services/connected-connector-authorization.service";
+import { recordConnectorOAuthCompletion } from "../services/connector-oauth-completion.service";
+import { publishBuiltinConnectorInvalidationAfterCommit } from "../services/connector-client-invalidation.service";
 import {
   connectorActionResolverForSnapshot,
   type ConnectorActionResolver,
@@ -67,6 +69,7 @@ type CallbackIdentity = {
 };
 
 type CompleteOAuthCallbackInput = {
+  readonly oauthAttemptId: string;
   readonly resolvedMethod: ResolvedConnectorActionMethod;
   readonly oauthRequestedScopes: readonly string[];
   readonly authorizationUrl: string | null;
@@ -85,6 +88,7 @@ type CompleteOAuthCallbackInput = {
 };
 
 type CompleteOpenIdCallbackInput = {
+  readonly oauthAttemptId: string;
   readonly resolvedMethod: ResolvedConnectorActionMethod;
   readonly oauthRequestedScopes: readonly string[];
   readonly callbackParams: Readonly<Record<string, string>>;
@@ -634,6 +638,23 @@ const completeOAuthCallback$ = command(
     );
     signal.throwIfAborted();
 
+    await recordConnectorOAuthCompletion(
+      set(writeDb$),
+      {
+        attemptId: args.oauthAttemptId,
+        connectionId: result.connector.id,
+        ...args.identity,
+      },
+      signal,
+    );
+    await publishBuiltinConnectorInvalidationAfterCommit(
+      {
+        userId: args.identity.userId,
+        connectorSlug: args.connectorSlug,
+      },
+      signal,
+    );
+
     return successRedirectResponse({
       origin: args.origin,
       connectorSlug: args.connectorSlug,
@@ -708,6 +729,23 @@ const completeOpenIdCallback$ = command(
         );
       }
     }
+
+    await recordConnectorOAuthCompletion(
+      set(writeDb$),
+      {
+        attemptId: args.oauthAttemptId,
+        connectionId: result.connector.id,
+        ...args.identity,
+      },
+      signal,
+    );
+    await publishBuiltinConnectorInvalidationAfterCommit(
+      {
+        userId: args.identity.userId,
+        connectorSlug: args.connectorSlug,
+      },
+      signal,
+    );
 
     return successRedirectResponse({
       origin: args.origin,
@@ -897,6 +935,7 @@ const handleOpenIdConnectorCallback$ = command(
       set(
         completeOpenIdCallback$,
         {
+          oauthAttemptId: claimedState.storedState.id,
           resolvedMethod: resolvedState.resolvedMethod,
           oauthRequestedScopes: resolvedState.oauthRequestedScopes,
           callbackParams: openIdCallbackParamsFromQuery(args.query),
@@ -1141,6 +1180,7 @@ const handleAuthCodeConnectorCallback$ = command(
       set(
         completeOAuthCallback$,
         {
+          oauthAttemptId: claimedState.storedState.id,
           resolvedMethod: resolvedState.resolvedMethod,
           oauthRequestedScopes: resolvedState.oauthRequestedScopes,
           authorizationUrl: resolvedState.authorizationUrl,

--- a/turbo/apps/api/src/signals/routes/connectors.ts
+++ b/turbo/apps/api/src/signals/routes/connectors.ts
@@ -495,7 +495,7 @@ const startConnectorOauthInner$ = command(
         allowSiblings: true,
       });
       if (resolution.kind !== "ready") {
-        return { resolution, connectionId: null };
+        return { resolution, connectionId: null, oauthAttemptId: null };
       }
       const oauthStateId = await insertConnectorOAuthState(tx, {
         state: prepared.state,
@@ -515,6 +515,7 @@ const startConnectorOauthInner$ = command(
       });
       return {
         resolution,
+        oauthAttemptId: oauthStateId,
         connectionId:
           bodyResult.data.account.intent === "add" ? oauthStateId : null,
       };
@@ -531,6 +532,7 @@ const startConnectorOauthInner$ = command(
       body: {
         authorizationUrl: authResult.url,
         connectionId: mutationStart.connectionId ?? undefined,
+        oauthAttemptId: mutationStart.oauthAttemptId ?? undefined,
       },
     };
   },
@@ -619,7 +621,7 @@ const startConnectorOpenIdInner$ = command(
         allowSiblings: true,
       });
       if (resolution.kind !== "ready") {
-        return { resolution, connectionId: null };
+        return { resolution, connectionId: null, oauthAttemptId: null };
       }
       const oauthStateId = await insertConnectorOAuthState(tx, {
         state: prepared.state,
@@ -638,6 +640,7 @@ const startConnectorOpenIdInner$ = command(
       });
       return {
         resolution,
+        oauthAttemptId: oauthStateId,
         connectionId:
           bodyResult.data.account.intent === "add" ? oauthStateId : null,
       };
@@ -654,6 +657,7 @@ const startConnectorOpenIdInner$ = command(
       body: {
         authorizationUrl: authResult.url,
         connectionId: mutationStart.connectionId ?? undefined,
+        oauthAttemptId: mutationStart.oauthAttemptId ?? undefined,
       },
     };
   },

--- a/turbo/apps/api/src/signals/routes/custom-connectors-oauth2.ts
+++ b/turbo/apps/api/src/signals/routes/custom-connectors-oauth2.ts
@@ -51,6 +51,7 @@ import {
   clearConnectorOAuthCookies,
 } from "../../lib/connector-oauth-state";
 import { env } from "../../lib/env";
+import { recordConnectorOAuthCompletion } from "../services/connector-oauth-completion.service";
 import { connectorConnectionWriteFailureMessage } from "../services/connector-data.service";
 import { PUBLIC_BRAND } from "@okouai/core/public-brand";
 import {
@@ -260,6 +261,36 @@ async function authorizeCustomConnectorAgent(
   }
 }
 
+async function recordAuthorizedCustomOAuthCompletion(
+  args: {
+    readonly db: Db;
+    readonly state: StoredCustomConnectorOAuthState;
+    readonly connectorId: string;
+    readonly connectionId: string;
+  },
+  signal: AbortSignal,
+): Promise<string | null> {
+  const error = await authorizeCustomConnectorAgent(args, signal);
+  if (error) {
+    return error;
+  }
+  await recordConnectorOAuthCompletion(
+    args.db,
+    {
+      attemptId: args.state.id,
+      connectionId: args.connectionId,
+      orgId: args.state.orgId,
+      userId: args.state.userId,
+    },
+    signal,
+  );
+  return null;
+}
+
+type CustomOAuthPersistenceResult =
+  | { readonly ok: true; readonly connectionId: string }
+  | { readonly ok: false; readonly message: string };
+
 async function persistCustomConnectorOAuth2Connection(
   args: {
     readonly db: Db;
@@ -286,9 +317,7 @@ async function persistCustomConnectorOAuth2Connection(
     };
   },
   signal: AbortSignal,
-): Promise<
-  { readonly ok: true } | { readonly ok: false; readonly message: string }
-> {
+): Promise<CustomOAuthPersistenceResult> {
   const connectionStorage = storeCustomConnectorOAuth2Connection(args, signal);
   const result = await commitConnectorRuntimeMutation(connectionStorage, () => {
     return {
@@ -310,18 +339,21 @@ async function persistCustomConnectorOAuth2Connection(
     };
   }
   await publishCustomUserInvalidation(args.userId, signal);
-  return { ok: true };
+  return { ok: true, connectionId: result.connectionId };
 }
 
-function customConnectorOAuthPersistenceFailure(
+function customConnectorOAuthPersistenceResult(
   result:
     | Awaited<ReturnType<typeof persistCustomConnectorOAuth2Connection>>
     | undefined,
-): string | null {
+): CustomOAuthPersistenceResult {
   if (!result) {
-    return "OAuth token exchange failed - please try again";
+    return {
+      ok: false,
+      message: "OAuth token exchange failed - please try again",
+    };
   }
-  return result.ok ? null : result.message;
+  return result;
 }
 
 async function codeLessCustomOAuthCallbackResponse(
@@ -357,7 +389,7 @@ async function completeAutomaticOAuthCallback(
     readonly featureContext: FeatureSwitchContext;
   },
   signal: AbortSignal,
-): Promise<string | null> {
+): Promise<CustomOAuthPersistenceResult> {
   const completed = await tapError(
     (async () => {
       if (!args.state.codeVerifier) {
@@ -420,7 +452,7 @@ async function completeAutomaticOAuthCallback(
     })(),
   );
   signal.throwIfAborted();
-  return customConnectorOAuthPersistenceFailure(completed);
+  return customConnectorOAuthPersistenceResult(completed);
 }
 
 async function completeCustomOAuthCallback(
@@ -435,9 +467,12 @@ async function completeCustomOAuthCallback(
     readonly featureContext: FeatureSwitchContext;
   },
   signal: AbortSignal,
-): Promise<string | null> {
+): Promise<CustomOAuthPersistenceResult> {
   if (args.connector.oauthConfig.providerAdapter !== "standard") {
-    return "OAuth callback was sent to the wrong connector endpoint";
+    return {
+      ok: false,
+      message: "OAuth callback was sent to the wrong connector endpoint",
+    };
   }
   const credentials = await tapError(
     decryptCustomConnectorOAuth2Credentials(
@@ -447,7 +482,7 @@ async function completeCustomOAuthCallback(
   );
   signal.throwIfAborted();
   if (!credentials) {
-    return "Could not read OAuth client credentials";
+    return { ok: false, message: "Could not read OAuth client credentials" };
   }
   const completed = await tapError(
     (async () => {
@@ -482,7 +517,7 @@ async function completeCustomOAuthCallback(
     })(),
   );
   signal.throwIfAborted();
-  return customConnectorOAuthPersistenceFailure(completed);
+  return customConnectorOAuthPersistenceResult(completed);
 }
 
 async function completeCurrentOAuthCallback(
@@ -499,7 +534,7 @@ async function completeCurrentOAuthCallback(
     readonly featureContext: FeatureSwitchContext;
   },
   signal: AbortSignal,
-): Promise<string | null> {
+): Promise<CustomOAuthPersistenceResult> {
   if (isCustomConnectorAutomaticOAuthStateContext(args.context)) {
     if (!isCurrentAutomaticOAuthCustomConnector(args.connector, args.context)) {
       throw new Error(
@@ -629,7 +664,7 @@ const completeOAuth2Callback$ = command(
         "MCP custom connector management is not enabled",
       );
     }
-    const persistenceFailure = await completeCurrentOAuthCallback(
+    const persistence = await completeCurrentOAuthCallback(
       {
         db: set(writeDb$),
         request: get(request$).raw,
@@ -643,20 +678,21 @@ const completeOAuth2Callback$ = command(
       signal,
     );
     signal.throwIfAborted();
-    if (persistenceFailure) {
-      return callbackError(origin, persistenceFailure);
+    if (!persistence.ok) {
+      return callbackError(origin, persistence.message);
     }
-    const authorizationError = await authorizeCustomConnectorAgent(
+    const completionError = await recordAuthorizedCustomOAuthCompletion(
       {
         db: set(writeDb$),
         state: claimed.state,
         connectorId: connector.id,
+        connectionId: persistence.connectionId,
       },
       signal,
     );
     signal.throwIfAborted();
-    if (authorizationError) {
-      return callbackError(origin, authorizationError);
+    if (completionError) {
+      return callbackError(origin, completionError);
     }
     return callbackRedirect({ origin, status: "success" });
   },

--- a/turbo/apps/api/src/signals/services/connector-oauth-completion.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-completion.service.ts
@@ -1,0 +1,64 @@
+import type { ConnectorAccountTarget } from "@okouai/api-contracts/contracts/connector-accounts";
+import { connectorOauthCompletions } from "@okouai/db/schema/connector-oauth-state";
+import { and, eq, gt } from "drizzle-orm";
+
+import { connectorOAuthStateExpiresAt } from "../../lib/connector-oauth-state";
+import { nowDate } from "../../lib/time";
+import type { Db } from "../external/db";
+import { getConnectorAccount } from "./connector-account-lifecycle.service";
+
+export async function recordConnectorOAuthCompletion(
+  db: Db,
+  args: {
+    readonly attemptId: string;
+    readonly connectionId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  await db.insert(connectorOauthCompletions).values({
+    id: args.attemptId,
+    connectionId: args.connectionId,
+    orgId: args.orgId,
+    userId: args.userId,
+    expiresAt: connectorOAuthStateExpiresAt(),
+  });
+  signal.throwIfAborted();
+}
+
+export async function readConnectorOAuthCompletion(
+  db: Db,
+  args: {
+    readonly attemptId: string;
+    readonly target: ConnectorAccountTarget;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+  signal: AbortSignal,
+): Promise<{ readonly connectionId: string } | null> {
+  const [receipt] = await db
+    .select({ connectionId: connectorOauthCompletions.connectionId })
+    .from(connectorOauthCompletions)
+    .where(
+      and(
+        eq(connectorOauthCompletions.id, args.attemptId),
+        eq(connectorOauthCompletions.orgId, args.orgId),
+        eq(connectorOauthCompletions.userId, args.userId),
+        gt(connectorOauthCompletions.expiresAt, nowDate()),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  if (!receipt) {
+    return null;
+  }
+  const account = await getConnectorAccount(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    target: args.target,
+    connectionId: receipt.connectionId,
+  });
+  signal.throwIfAborted();
+  return account ? receipt : null;
+}

--- a/turbo/apps/api/src/signals/services/cron-connector-oauth-state-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-connector-oauth-state-cleanup.service.ts
@@ -1,5 +1,8 @@
 import { command } from "ccstate";
-import { connectorOauthStates } from "@okouai/db/schema/connector-oauth-state";
+import {
+  connectorOauthStates,
+  connectorOauthCompletions,
+} from "@okouai/db/schema/connector-oauth-state";
 import { and, asc, eq, inArray, lte } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
@@ -14,32 +17,36 @@ interface ConnectorOauthStateCleanupOwner {
   readonly orgId: string;
 }
 
-async function cleanupConnectorOauthStates(
+async function cleanupExpiredOAuthRows(
   db: Db,
-  cutoff: Date,
-  owner: ConnectorOauthStateCleanupOwner | undefined,
-  batchSize: number,
+  table: typeof connectorOauthStates | typeof connectorOauthCompletions,
+  args: {
+    readonly cutoff: Date;
+    readonly owner: ConnectorOauthStateCleanupOwner | undefined;
+    readonly batchSize: number;
+  },
   signal: AbortSignal,
 ): Promise<number> {
+  const { cutoff, owner, batchSize } = args;
   const expiredWhere = owner
     ? and(
-        lte(connectorOauthStates.expiresAt, cutoff),
-        eq(connectorOauthStates.userId, owner.userId),
-        eq(connectorOauthStates.orgId, owner.orgId),
+        lte(table.expiresAt, cutoff),
+        eq(table.userId, owner.userId),
+        eq(table.orgId, owner.orgId),
       )
-    : lte(connectorOauthStates.expiresAt, cutoff);
+    : lte(table.expiresAt, cutoff);
   let totalDeleted = 0;
 
   for (let batch = 0; batch < MAX_BATCHES; batch += 1) {
     const expiredStates = db
-      .select({ id: connectorOauthStates.id })
-      .from(connectorOauthStates)
+      .select({ id: table.id })
+      .from(table)
       .where(expiredWhere)
-      .orderBy(asc(connectorOauthStates.expiresAt))
+      .orderBy(asc(table.expiresAt))
       .limit(batchSize);
     const { rowCount } = await db
-      .delete(connectorOauthStates)
-      .where(inArray(connectorOauthStates.id, expiredStates));
+      .delete(table)
+      .where(inArray(table.id, expiredStates));
     signal.throwIfAborted();
 
     const batchDeleted = rowCount ?? 0;
@@ -50,6 +57,28 @@ async function cleanupConnectorOauthStates(
   }
 
   return totalDeleted;
+}
+
+async function cleanupConnectorOauthStates(
+  db: Db,
+  cutoff: Date,
+  owner: ConnectorOauthStateCleanupOwner | undefined,
+  batchSize: number,
+  signal: AbortSignal,
+): Promise<number> {
+  const states = await cleanupExpiredOAuthRows(
+    db,
+    connectorOauthStates,
+    { cutoff, owner, batchSize },
+    signal,
+  );
+  const completions = await cleanupExpiredOAuthRows(
+    db,
+    connectorOauthCompletions,
+    { cutoff, owner, batchSize },
+    signal,
+  );
+  return states + completions;
 }
 
 export const cleanupConnectorOauthStates$ = command(

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -777,7 +777,12 @@ async function persistCustomConnectorOAuthStart(
       allowSiblings: !isIntegrationManagedCustomConnector(connector),
     });
     if (resolution.kind !== "ready") {
-      return { resolution, connectionId: null, expiresAt };
+      return {
+        resolution,
+        connectionId: null,
+        oauthAttemptId: null,
+        expiresAt,
+      };
     }
     const oauthStateId = await insertConnectorOAuthState(tx, {
       state: prepared.state,
@@ -798,6 +803,7 @@ async function persistCustomConnectorOAuthStart(
     });
     return {
       resolution,
+      oauthAttemptId: oauthStateId,
       connectionId: args.account.intent === "add" ? oauthStateId : null,
       expiresAt,
     };
@@ -1041,6 +1047,7 @@ export const startCustomConnectorOAuth2$ = command(
       result: "authorization" as const,
       authorizationUrl: prepared.authorizationUrl,
       connectionId: mutationStart.connectionId ?? undefined,
+      oauthAttemptId: mutationStart.oauthAttemptId ?? undefined,
     };
   },
 );

--- a/turbo/apps/platform/src/signals/okou-page/settings/connector-accounts.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connector-accounts.ts
@@ -14,73 +14,55 @@ import {
   reloadConnectorAccountSummaries$,
 } from "../connector-accounts.ts";
 
-export type ConnectorAccountMutationVersion = number | string | null;
-
-export async function readConnectorAccountMutationVersion(
+export async function readConnectorAccountCount(
   createClient: ApiClientFactory,
   target: ConnectorAccountTarget,
-  account: PlatformConnectorAccountMutationIntent,
   signal: AbortSignal,
-): Promise<ConnectorAccountMutationVersion> {
-  if (account.intent === "add") {
-    const result = await accept(
-      createClient(connectorAccountsContract).summaries({
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
-    return (
-      result.body.summaries.find((summary) => {
-        return (
-          connectorAccountTargetKey(summary.target) ===
-          connectorAccountTargetKey(target)
-        );
-      })?.accountCount ?? 0
-    );
-  }
+): Promise<number> {
   const result = await accept(
-    createClient(connectorAccountsContract).connection({
-      params: { connectionId: account.connectionId },
-      query: target,
+    createClient(connectorAccountsContract).summaries({
       fetchOptions: { signal },
     }),
-    [200, 404],
+    [200],
   );
-  return result.status === 404 ? null : result.body.updatedAt;
-}
-
-export async function connectorAccountConnectionExists(
-  createClient: ApiClientFactory,
-  target: ConnectorAccountTarget,
-  connectionId: string,
-  signal: AbortSignal,
-): Promise<boolean> {
-  const result = await accept(
-    createClient(connectorAccountsContract).connection({
-      params: { connectionId },
-      query: target,
-      fetchOptions: { signal },
-    }),
-    [200, 404],
-  );
-  return result.status === 200;
-}
-
-export function connectorAccountMutationCompleted(
-  account: PlatformConnectorAccountMutationIntent,
-  initialVersion: ConnectorAccountMutationVersion,
-  currentVersion: ConnectorAccountMutationVersion,
-): boolean {
-  if (account.intent === "add") {
-    return (
-      typeof initialVersion === "number" &&
-      typeof currentVersion === "number" &&
-      currentVersion > initialVersion
-    );
-  }
   return (
-    typeof currentVersion === "string" && currentVersion !== initialVersion
+    result.body.summaries.find((summary) => {
+      return (
+        connectorAccountTargetKey(summary.target) ===
+        connectorAccountTargetKey(target)
+      );
+    })?.accountCount ?? 0
   );
+}
+
+export async function readConnectorOAuthCompletion(
+  createClient: ApiClientFactory,
+  target: ConnectorAccountTarget,
+  account: PlatformConnectorAccountMutationIntent,
+  attemptId: string | undefined,
+  signal: AbortSignal,
+): Promise<string | null> {
+  // New App -> old API: absent attempt IDs cannot prove authorization.
+  // Remove after receipt-capable APIs are the serving and rollback floor (#32870).
+  if (!attemptId) {
+    return null;
+  }
+  const result = await accept(
+    createClient(connectorAccountsContract).oauthCompletion({
+      params: { attemptId },
+      query: target,
+      fetchOptions: { signal },
+    }),
+    [200, 404],
+  );
+  if (
+    result.status === 404 ||
+    (account.intent === "reconnect" &&
+      result.body.connectionId !== account.connectionId)
+  ) {
+    return null;
+  }
+  return result.body.connectionId;
 }
 
 export const settingsConnectorAccounts = createConnectorAccountListSignals({

--- a/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
@@ -23,7 +23,6 @@ import {
   connectorOauthStartContract,
   connectorManualGrantContract,
   connectorNoAuthGrantContract,
-  connectorsMainContract,
 } from "@okouai/api-contracts/contracts/connectors";
 import { userConnectorsContract } from "@okouai/api-contracts/contracts/user-connectors";
 import type {
@@ -71,10 +70,8 @@ import type {
   PlatformConnectorCatalogStatusItem,
 } from "../../connector-domain.ts";
 import {
-  connectorAccountConnectionExists,
-  connectorAccountMutationCompleted,
-  readConnectorAccountMutationVersion,
-  type ConnectorAccountMutationVersion,
+  readConnectorAccountCount,
+  readConnectorOAuthCompletion,
 } from "./connector-accounts.ts";
 import { syncGoogleAdsConversionMilestones$ } from "../../bootstrap/google-ads-conversion-milestones.ts";
 
@@ -112,10 +109,9 @@ const resolveConnectorPostConnectOptions$ = command(
     }
     const authorizeVisibleAgents =
       options.account.intent === "add" &&
-      (await readConnectorAccountMutationVersion(
+      (await readConnectorAccountCount(
         get(apiClient$),
         { kind: "builtin", connectorSlug },
-        options.account,
         signal,
       )) === 0;
     return { ...options, authorizeVisibleAgents };
@@ -2153,88 +2149,12 @@ function connectorMatchesAuthMethod(
   );
 }
 
-function createConnectorOAuthAuthCodeChangedCommand(
-  connectorSlug: ConnectorSlug,
-  authMethod: ConnectorAuthMethodId,
-  agentId: string | undefined,
-  account: PlatformConnectorAccountMutationIntent,
-  useDefaultConnectorProjection: boolean,
-) {
-  // Snapshot taken on the first body invocation: `null` marks "no connector
-  // yet" and an `updatedAt` value marks "reconnect scenario — wait for it to
-  // change". The snapshot must happen inside the loop body so we start from the
-  // freshest server state, not a cached signal value.
-  let initialUpdatedAt: string | null | undefined;
-  let initialAccountVersion: ConnectorAccountMutationVersion | undefined;
-
-  return command(async ({ get }, sig: AbortSignal): Promise<boolean> => {
-    if (!useDefaultConnectorProjection) {
-      const currentVersion = await readConnectorAccountMutationVersion(
-        get(apiClient$),
-        { kind: "builtin", connectorSlug },
-        account,
-        sig,
-      );
-      if (initialAccountVersion === undefined) {
-        initialAccountVersion = currentVersion;
-        return false;
-      }
-      return connectorAccountMutationCompleted(
-        account,
-        initialAccountVersion,
-        currentVersion,
-      );
-    }
-    const client = get(apiClient$)(connectorsMainContract);
-    const result = await accept(
-      client.list({ fetchOptions: { signal: sig } }),
-      [200],
-    );
-    const polled = result.body.connectors;
-    const current = polled.find((c) => {
-      return connectorMatchesAuthMethod(c, connectorSlug, authMethod);
-    });
-
-    if (initialUpdatedAt === undefined) {
-      initialUpdatedAt = current?.updatedAt ?? null;
-      return false;
-    }
-    if (current) {
-      if (
-        account.intent === "reconnect" &&
-        current.id !== account.connectionId
-      ) {
-        return false;
-      }
-      // initialUpdatedAt === null means the connector didn't exist on the first
-      // fetch; any subsequent appearance signals completion.
-      const connectionChanged =
-        initialUpdatedAt === null || current.updatedAt !== initialUpdatedAt;
-      if (!connectionChanged || !agentId) {
-        return connectionChanged;
-      }
-      const authorization = await accept(
-        get(apiClient$)(userConnectorsContract).get({
-          params: { id: agentId },
-          fetchOptions: { signal: sig },
-        }),
-        [200, 404],
-      );
-      return (
-        authorization.status === 200 &&
-        authorization.body.enabledConnectorSlugs.includes(connectorSlug)
-      );
-    }
-    return false;
-  });
-}
-
 const defaultConnectorProjectionMatchesAuthMethod$ = command(
   async (
     { get },
     connectorSlug: ConnectorSlug,
     authMethod: ConnectorAuthMethodId,
-    connectionId: string | null,
+    connectionId: string,
     signal: AbortSignal,
   ): Promise<boolean> => {
     const { connectors } = await get(connectors$);
@@ -2242,49 +2162,11 @@ const defaultConnectorProjectionMatchesAuthMethod$ = command(
     return connectors.some((connector) => {
       return (
         connectorMatchesAuthMethod(connector, connectorSlug, authMethod) &&
-        (connectionId === null || connector.id === connectionId)
+        connector.id === connectionId
       );
     });
   },
 );
-
-function getDefaultConnectorProjectionConnectionId(
-  account: PlatformConnectorAccountMutationIntent,
-  expectedConnectionId: string | null,
-  useDefaultConnectorProjection: boolean,
-): string | null {
-  if (!useDefaultConnectorProjection) {
-    return null;
-  }
-  return account.intent === "reconnect"
-    ? account.connectionId
-    : expectedConnectionId;
-}
-
-function createExpectedConnectorConnectionAvailableCommand(
-  connectorSlug: ConnectorSlug,
-  expectedConnectionId: string | null,
-  requiresAccountMutation: boolean,
-  onConnectorChanged$: ReturnType<
-    typeof createConnectorOAuthAuthCodeChangedCommand
-  >,
-) {
-  return command(
-    async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
-      if (requiresAccountMutation) {
-        return await set(onConnectorChanged$, signal);
-      }
-      return expectedConnectionId
-        ? await connectorAccountConnectionExists(
-            get(apiClient$),
-            { kind: "builtin", connectorSlug },
-            expectedConnectionId,
-            signal,
-          )
-        : false;
-    },
-  );
-}
 
 const openConnectorOAuthAuthCodeWindow$ = command(
   async (
@@ -2303,7 +2185,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
     signal: AbortSignal,
   ): Promise<{
     readonly authWindow: Window | null;
-    readonly connectionId: string | null;
+    readonly oauthAttemptId: string | undefined;
     readonly options: PostConnectOptions;
   }> => {
     const standalone = isStandaloneMode();
@@ -2339,7 +2221,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
     }
 
     let navigated = false;
-    let connectionId: string | null = null;
+    let oauthAttemptId: string | undefined;
     const options = await withCleanup(
       (async () => {
         if (!isBrowserAuthGrantKind(args.method.grantKind)) {
@@ -2391,7 +2273,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
                 [200],
               );
         signal.throwIfAborted();
-        connectionId = startResult.body.connectionId ?? null;
+        oauthAttemptId = startResult.body.oauthAttemptId;
 
         if (authWindow) {
           authWindow.location.href = startResult.body.authorizationUrl;
@@ -2418,7 +2300,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
     );
     signal.throwIfAborted();
 
-    return { authWindow, connectionId, options };
+    return { authWindow, oauthAttemptId, options };
   },
 );
 
@@ -2430,42 +2312,33 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
       readonly method: PublicConnectorCatalogAuthMethodDetail;
       readonly options: PostConnectOptions;
       readonly account: PlatformConnectorAccountMutationIntent;
-      readonly onConnectorChanged$: ReturnType<
-        typeof createConnectorOAuthAuthCodeChangedCommand
-      >;
       readonly oauthStart: {
         readonly authWindow: Window | null;
-        readonly connectionId: string | null;
+        readonly oauthAttemptId: string | undefined;
       };
     },
     signal: AbortSignal,
   ): Promise<ConnectorConnectionResult | false> => {
-    const {
-      connectorSlug,
-      method,
-      options,
-      account,
-      onConnectorChanged$,
-      oauthStart,
-    } = args;
-    const { authWindow, connectionId: expectedConnectionId } = oauthStart;
-    const expectedConnectionAvailable$ =
-      createExpectedConnectorConnectionAvailableCommand(
-        connectorSlug,
-        expectedConnectionId,
-        account.intent === "reconnect" ||
-          (options.useDefaultConnectorProjection ?? false),
-        onConnectorChanged$,
+    const { connectorSlug, method, options, account, oauthStart } = args;
+    let completedConnectionId: string | null = null;
+    const completionAvailable$ = command(async ({ get }, sig: AbortSignal) => {
+      const connectionId = await readConnectorOAuthCompletion(
+        get(apiClient$),
+        { kind: "builtin", connectorSlug },
+        account,
+        oauthStart.oauthAttemptId,
+        sig,
       );
+      sig.throwIfAborted();
+      completedConnectionId = connectionId;
+      return completedConnectionId !== null;
+    });
     const waitSignal = set(resetOAuthAuthCodeWaitSignal$, signal);
     const onMatchingConnectorChanged$ = command(
       async ({ set }, payload: unknown, sig: AbortSignal): Promise<boolean> => {
-        if (!isConnectorChangedPayloadFor(payload, connectorSlug)) {
-          return false;
-        }
-        return expectedConnectionId
-          ? await set(expectedConnectionAvailable$, sig)
-          : await set(onConnectorChanged$, sig);
+        return isConnectorChangedPayloadFor(payload, connectorSlug)
+          ? await set(completionAvailable$, sig)
+          : false;
       },
     );
     const changedPromise = (async () => {
@@ -2474,9 +2347,7 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
         {
           topic: "connector:changed",
           loopCommand$: onMatchingConnectorChanged$,
-          catchUpCommand$: expectedConnectionId
-            ? expectedConnectionAvailable$
-            : onConnectorChanged$,
+          catchUpCommand$: completionAvailable$,
           options: { runOnSubscribe: true },
         },
         waitSignal,
@@ -2484,11 +2355,11 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
       return "connectorChanged" as const;
     })();
     const waitResult = await withCleanup(
-      authWindow === null
+      oauthStart.authWindow === null
         ? changedPromise
         : Promise.race([
             changedPromise,
-            waitForOAuthAuthCodePopupClosed(authWindow, waitSignal),
+            waitForOAuthAuthCodePopupClosed(oauthStart.authWindow, waitSignal),
           ]),
       () => {
         set(resetOAuthAuthCodeWaitSignal$, signal);
@@ -2496,20 +2367,12 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
     );
     signal.throwIfAborted();
 
-    let completedConnectionId = expectedConnectionId;
     if (waitResult === "popupClosed") {
-      const connectedAfterClose = expectedConnectionId
-        ? await set(expectedConnectionAvailable$, signal)
-        : // Older API responses omit the exact ID. Remove this bounded account
-          // mutation fallback with the final rollout contraction in #28571.
-          await set(onConnectorChanged$, signal);
+      await set(completionAvailable$, signal);
       signal.throwIfAborted();
-      if (!connectedAfterClose) {
-        return false;
-      }
-    } else if (!expectedConnectionId) {
-      completedConnectionId =
-        account.intent === "reconnect" ? account.connectionId : null;
+    }
+    if (completedConnectionId === null) {
+      return false;
     }
 
     set(reloadConnectorConnectionState$);
@@ -2519,11 +2382,7 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
         defaultConnectorProjectionMatchesAuthMethod$,
         connectorSlug,
         method.id,
-        getDefaultConnectorProjectionConnectionId(
-          account,
-          expectedConnectionId,
-          options.useDefaultConnectorProjection ?? false,
-        ),
+        completedConnectionId,
         signal,
       ));
     if (isConnected) {
@@ -2570,17 +2429,6 @@ const connectConnectorOAuthAuthCodeCommand$ = command(
 
     return await withCleanup(
       (async () => {
-        // Snapshot before starting the provider flow. The popup is already open
-        // by the time this runs, so we keep browser popup blockers satisfied
-        // while avoiding a race where a very fast callback completes before the
-        // first poll baseline is captured.
-        const onConnectorChanged$ = createConnectorOAuthAuthCodeChangedCommand(
-          connectorSlug,
-          method.id,
-          options.agentId,
-          account,
-          options.useDefaultConnectorProjection ?? false,
-        );
         const oauthStart = await set(
           openConnectorOAuthAuthCodeWindow$,
           {
@@ -2597,7 +2445,6 @@ const connectConnectorOAuthAuthCodeCommand$ = command(
                 options,
                 sig,
               );
-              await set(onConnectorChanged$, sig);
               return resolvedOptions;
             },
           },
@@ -2611,7 +2458,6 @@ const connectConnectorOAuthAuthCodeCommand$ = command(
             method,
             options: oauthStart.options,
             account,
-            onConnectorChanged$,
             oauthStart,
           },
           signal,

--- a/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
@@ -21,17 +21,15 @@ import type { AgentResponse } from "@okouai/api-contracts/contracts/agents";
 import { IN_VITEST } from "../../../env.ts";
 import { i18n } from "../../../i18n/index.ts";
 import { accept } from "../../../lib/accept.ts";
-import { apiClient$, type ApiClientFactory } from "../../api-client.ts";
+import { apiClient$ } from "../../api-client.ts";
 import { agents$ } from "../../agent.ts";
 import { searchParams$, updateSearchParams$ } from "../../route.ts";
 import { setAblyLoop$ } from "../../realtime.ts";
 import { setLoop, withCleanup } from "../../utils.ts";
 import type { PlatformConnectorAccountMutationIntent } from "../../connector-domain.ts";
 import {
-  connectorAccountConnectionExists,
-  connectorAccountMutationCompleted,
-  readConnectorAccountMutationVersion,
-  type ConnectorAccountMutationVersion,
+  readConnectorAccountCount,
+  readConnectorOAuthCompletion,
 } from "./connector-accounts.ts";
 import { resetConnectorAccountDialogs$ } from "./connector-account-dialogs.ts";
 
@@ -388,13 +386,12 @@ const setCustomConnectorValuesForTarget$ = command(
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionResult> => {
     const createClient = get(apiClient$);
-    const initialAccountVersion =
+    const initialAccountCount =
       args.authorizationTarget.kind === "visible-agents" &&
       args.account.intent === "add"
-        ? await readConnectorAccountMutationVersion(
+        ? await readConnectorAccountCount(
             createClient,
             { kind: "custom", customConnectorId: args.id },
-            args.account,
             signal,
           )
         : undefined;
@@ -425,7 +422,7 @@ const setCustomConnectorValuesForTarget$ = command(
       {
         connector,
         target: args.authorizationTarget,
-        initialAccountVersion,
+        initialAccountCount,
       },
       signal,
     );
@@ -488,114 +485,11 @@ export const setCustomConnectorValuesForAgent$ = command(
   },
 );
 
-async function customConnectorAccountMutationCompleted(
-  createClient: ApiClientFactory,
-  connectorId: string,
-  account: PlatformConnectorAccountMutationIntent,
-  initialVersion: ConnectorAccountMutationVersion | undefined,
-  signal: AbortSignal,
-): Promise<boolean> {
-  const currentVersion = await readConnectorAccountMutationVersion(
-    createClient,
-    { kind: "custom", customConnectorId: connectorId },
-    account,
-    signal,
-  );
-  return (
-    initialVersion !== undefined &&
-    connectorAccountMutationCompleted(account, initialVersion, currentVersion)
-  );
-}
-
 interface CustomConnectorAuthorizationTargetArgs {
   readonly id: string;
   readonly authorizationTarget: CustomConnectorAuthorizationTarget;
   readonly account: PlatformConnectorAccountMutationIntent;
   readonly useDefaultConnectorProjection?: boolean;
-}
-
-interface CustomConnectorOAuthCompletion {
-  readonly completed: boolean;
-  readonly connectionId: string | null;
-}
-
-function defaultCustomConnectorOAuthCompletion(args: {
-  readonly connector: CustomConnectorResponse | undefined;
-  readonly account: PlatformConnectorAccountMutationIntent;
-  readonly expectedConnectionId: string | null;
-  readonly initialUpdatedAt: string | null | undefined;
-}): CustomConnectorOAuthCompletion {
-  const connectionId =
-    args.account.intent === "reconnect"
-      ? args.account.connectionId
-      : args.expectedConnectionId;
-  const projectedAccountMatches =
-    args.connector?.connectedAccountId === connectionId ||
-    (args.account.intent === "add" &&
-      args.connector?.connectedAccountId === undefined);
-  const completed =
-    connectionId !== null &&
-    args.connector?.connected === true &&
-    projectedAccountMatches &&
-    (args.account.intent === "add"
-      ? args.initialUpdatedAt === null
-      : args.initialUpdatedAt !== undefined &&
-        args.connector.connectedAccountUpdatedAt !== undefined &&
-        args.connector.connectedAccountUpdatedAt !== args.initialUpdatedAt);
-  return {
-    completed,
-    connectionId: completed ? connectionId : null,
-  };
-}
-
-async function customConnectorOAuthCompletion(
-  args: {
-    readonly createClient: ApiClientFactory;
-    readonly connector: CustomConnectorResponse | undefined;
-    readonly target: CustomConnectorAuthorizationTargetArgs;
-    readonly expectedConnectionId: string | null;
-    readonly initialAccountVersion: ConnectorAccountMutationVersion | undefined;
-    readonly initialDefaultUpdatedAt: string | null | undefined;
-  },
-  signal: AbortSignal,
-): Promise<CustomConnectorOAuthCompletion> {
-  if (args.target.useDefaultConnectorProjection) {
-    return defaultCustomConnectorOAuthCompletion({
-      connector: args.connector,
-      account: args.target.account,
-      expectedConnectionId: args.expectedConnectionId,
-      initialUpdatedAt: args.initialDefaultUpdatedAt,
-    });
-  }
-  if (args.target.account.intent === "add" && args.expectedConnectionId) {
-    const completed = await connectorAccountConnectionExists(
-      args.createClient,
-      { kind: "custom", customConnectorId: args.target.id },
-      args.expectedConnectionId,
-      signal,
-    );
-    return {
-      completed,
-      connectionId: completed ? args.expectedConnectionId : null,
-    };
-  }
-  // Reconnect must update the selected account; its existence alone is not
-  // completion. Adds without an exact ID retain the bounded older-API fallback
-  // until the final rollout contraction in #28571.
-  const completed = await customConnectorAccountMutationCompleted(
-    args.createClient,
-    args.target.id,
-    args.target.account,
-    args.initialAccountVersion,
-    signal,
-  );
-  return {
-    completed,
-    connectionId:
-      completed && args.target.account.intent === "reconnect"
-        ? args.target.account.connectionId
-        : null,
-  };
 }
 
 const authorizeCompletedCustomConnectorTarget$ = command(
@@ -604,9 +498,7 @@ const authorizeCompletedCustomConnectorTarget$ = command(
     args: {
       readonly connector: CustomConnectorResponse | undefined;
       readonly target: CustomConnectorAuthorizationTarget;
-      readonly initialAccountVersion:
-        | ConnectorAccountMutationVersion
-        | undefined;
+      readonly initialAccountCount: number | undefined;
     },
     signal: AbortSignal,
   ): Promise<boolean> => {
@@ -615,7 +507,7 @@ const authorizeCompletedCustomConnectorTarget$ = command(
     }
     if (
       args.target.kind === "visible-agents" &&
-      args.initialAccountVersion !== 0
+      args.initialAccountCount !== 0
     ) {
       return false;
     }
@@ -654,25 +546,16 @@ const connectCustomConnectorAuthorizationForTargetCommand$ = command(
     }
     authWindow.opener = null;
     let navigated = false;
-    let initialAccountVersion: ConnectorAccountMutationVersion | undefined;
-    let initialDefaultUpdatedAt: string | null | undefined;
+    let initialAccountCount: number | undefined;
     const startResult = await withCleanup(
       (async () => {
         const createClient = get(apiClient$);
-        if (args.useDefaultConnectorProjection) {
-          const connectors = await get(customConnectors$);
-          initialDefaultUpdatedAt =
-            connectors.find((connector) => {
-              return connector.id === args.id;
-            })?.connectedAccountUpdatedAt ?? null;
-        }
-        initialAccountVersion =
-          !args.useDefaultConnectorProjection ||
-          args.authorizationTarget.kind === "visible-agents"
-            ? await readConnectorAccountMutationVersion(
+        initialAccountCount =
+          args.authorizationTarget.kind === "visible-agents" &&
+          args.account.intent === "add"
+            ? await readConnectorAccountCount(
                 createClient,
                 { kind: "custom", customConnectorId: args.id },
-                args.account,
                 signal,
               )
             : undefined;
@@ -709,7 +592,7 @@ const connectCustomConnectorAuthorizationForTargetCommand$ = command(
         {
           connector: startResult.connector,
           target: args.authorizationTarget,
-          initialAccountVersion,
+          initialAccountCount,
         },
         signal,
       );
@@ -733,18 +616,19 @@ const connectCustomConnectorAuthorizationForTargetCommand$ = command(
     const connector = connectors.find((candidate) => {
       return candidate.id === args.id;
     });
-    const completion = await customConnectorOAuthCompletion(
-      {
-        createClient: get(apiClient$),
-        connector,
-        target: args,
-        expectedConnectionId: startResult.connectionId ?? null,
-        initialAccountVersion,
-        initialDefaultUpdatedAt,
-      },
+    const connectionId = await readConnectorOAuthCompletion(
+      get(apiClient$),
+      { kind: "custom", customConnectorId: args.id },
+      args.account,
+      startResult.oauthAttemptId,
       signal,
     );
-    if (!completion.completed) {
+    signal.throwIfAborted();
+    if (
+      connectionId === null ||
+      (args.useDefaultConnectorProjection &&
+        connector?.connectedAccountId !== connectionId)
+    ) {
       return {
         connected: false,
         targetAuthorized: false,
@@ -756,14 +640,14 @@ const connectCustomConnectorAuthorizationForTargetCommand$ = command(
       {
         connector,
         target: args.authorizationTarget,
-        initialAccountVersion,
+        initialAccountCount,
       },
       signal,
     );
     return {
       connected: connector?.connected ?? false,
       targetAuthorized,
-      connectionId: completion.connectionId,
+      connectionId,
     };
   },
 );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-connectors.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-connectors.test.tsx
@@ -1,3 +1,5 @@
+import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
+import { mockOAuthCompletions } from "./connector-page-test-helpers.ts";
 import {
   agentCustomConnectorsContract,
   type AgentCustomConnectorGrant,
@@ -390,6 +392,8 @@ test("Connect and authorize a custom MCP connector", async () => {
 });
 
 test("Connect a single available connector without an unnecessary chooser", async () => {
+  const completedAttempts = mockOAuthCompletions(context);
+  const oauthAttemptId = crypto.randomUUID();
   const sends: CapturedChatSend[] = [];
   const slug = "drive-demo";
   const method = browserAuthMethod();
@@ -410,6 +414,7 @@ test("Connect a single available connector without an unnecessary chooser", asyn
   context.mocks.api(connectorOauthStartContract.start, ({ respond }) => {
     return respond(200, {
       authorizationUrl: "https://provider.example.test/authorize-drive",
+      oauthAttemptId,
       connectionId: CONNECTOR_CONNECTION_ID,
     });
   });
@@ -442,6 +447,7 @@ test("Connect a single available connector without an unnecessary chooser", asyn
   context.mocks.data.connectors([
     connectedConnectorResponse({ slug, authMethod: method.id }),
   ]);
+  completedAttempts.set(oauthAttemptId, CONNECTOR_CONNECTION_ID);
   popup.openedWindow.close();
   await waitFor(() => {
     expect(sentPrompts(sends)).toStrictEqual([
@@ -596,7 +602,20 @@ test("Reconnect an expired connector before resuming the task", async () => {
     updatedAt: "2026-08-01T09:00:00.000Z",
   });
   let restored = false;
-  let listCalls = 0;
+  let completionReads = 0;
+  const oauthAttemptId = crypto.randomUUID();
+  context.mocks.api(
+    connectorAccountsContract.oauthCompletion,
+    ({ params, respond }) => {
+      expect(params.attemptId).toBe(oauthAttemptId);
+      completionReads += 1;
+      return restored
+        ? respond(200, { connectionId: CONNECTOR_CONNECTION_ID })
+        : respond(404, {
+            error: { code: "NOT_FOUND", message: "OAuth completion not found" },
+          });
+    },
+  );
   const popup = mockOpenedWindow();
   installCatalogLookup((requestedSlug) => {
     return requestedSlug === slug
@@ -614,11 +633,11 @@ test("Reconnect an expired connector before resuming the task", async () => {
   context.mocks.api(connectorOauthStartContract.start, ({ respond }) => {
     return respond(200, {
       authorizationUrl: "https://provider.example.test/reconnect-drive",
+      oauthAttemptId,
       connectionId: CONNECTOR_CONNECTION_ID,
     });
   });
   context.mocks.api(connectorsMainContract.list, ({ respond }) => {
-    listCalls += 1;
     return respond(200, {
       connectors: [
         restored
@@ -662,10 +681,10 @@ test("Reconnect an expired connector before resuming the task", async () => {
     );
   });
 
-  const callsBeforeEarlyReturn = listCalls;
+  const callsBeforeEarlyReturn = completionReads;
   context.mocks.ably.trigger("connector:changed", { connectorSlug: slug });
   await waitFor(() => {
-    expect(listCalls).toBeGreaterThan(callsBeforeEarlyReturn);
+    expect(completionReads).toBeGreaterThan(callsBeforeEarlyReturn);
     expect(sends).toHaveLength(0);
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-mail.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-mail.test.tsx
@@ -1,3 +1,4 @@
+import { mockOAuthCompletions } from "./connector-page-test-helpers.ts";
 import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
 import type { ConnectorResponse } from "@okouai/api-contracts/contracts/connector-schemas";
 import { connectorOauthStartContract } from "@okouai/api-contracts/contracts/connectors";
@@ -227,11 +228,14 @@ test("Reconnect the exact Gmail account required by a persisted mail card", asyn
       ),
     );
   });
+  const completedAttempts = mockOAuthCompletions(context);
+  const oauthAttemptId = crypto.randomUUID();
   const oauthAccounts: ConnectorAccountMutationIntent[] = [];
   context.mocks.api(connectorOauthStartContract.start, ({ body, respond }) => {
     oauthAccounts.push(body.account);
     return respond(200, {
       authorizationUrl: "https://accounts.example.test/gmail/authorize",
+      oauthAttemptId,
     });
   });
   const authorization = openedAuthorizationWindow();
@@ -273,6 +277,7 @@ test("Reconnect the exact Gmail account required by a persisted mail card", asyn
       updatedAt: "2026-08-01T10:00:00.000Z",
     }),
   ]);
+  completedAttempts.set(oauthAttemptId, GMAIL_CONNECTION_ID);
   authorization.complete();
   context.mocks.ably.trigger("connector:changed", { connectorSlug: "gmail" });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connectors-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connectors-test-helpers.ts
@@ -1,3 +1,4 @@
+import { mockOAuthCompletions } from "./connector-page-test-helpers.ts";
 import {
   agentCustomConnectorsContract,
   type AgentCustomConnectorGrant,
@@ -128,6 +129,7 @@ interface ComposerConnectorFixture {
   readonly manualConnectionRequests: readonly BuiltinConnectionRequest[];
   readonly noAuthConnectionRequests: readonly BuiltinConnectionRequest[];
   readonly oauthConnectionRequests: readonly OAuthConnectionRequest[];
+  readonly completeOAuth: (connectionId: string) => void;
   readonly threadSelectionUpdates: readonly ThreadSelectionUpdate[];
   readonly clearedThreadSelections: readonly {
     readonly threadId: string;
@@ -246,6 +248,8 @@ export function installComposerConnectorFixture(
   const manualConnectionRequests: BuiltinConnectionRequest[] = [];
   const noAuthConnectionRequests: BuiltinConnectionRequest[] = [];
   const oauthConnectionRequests: OAuthConnectionRequest[] = [];
+  const completedAttempts = mockOAuthCompletions(context);
+  let oauthAttemptId = crypto.randomUUID();
   const threadSelectionUpdates: ThreadSelectionUpdate[] = [];
   const clearedThreadSelections: {
     threadId: string;
@@ -560,6 +564,7 @@ export function installComposerConnectorFixture(
   context.mocks.api(
     connectorOauthStartContract.start,
     ({ body, params, respond }) => {
+      oauthAttemptId = crypto.randomUUID();
       oauthConnectionRequests.push({
         agentId: body.agentId,
         authorizeAgent: body.authorizeAgent,
@@ -569,6 +574,7 @@ export function installComposerConnectorFixture(
       });
       return respond(200, {
         authorizationUrl: `https://accounts.example.test/${params.connectorSlug}`,
+        oauthAttemptId,
         connectionId: "f0000000-0000-4000-a000-000000000064",
       });
     },
@@ -581,6 +587,9 @@ export function installComposerConnectorFixture(
     manualConnectionRequests,
     noAuthConnectionRequests,
     oauthConnectionRequests,
+    completeOAuth: (connectionId: string) => {
+      completedAttempts.set(oauthAttemptId, connectionId);
+    },
     threadSelectionUpdates,
     clearedThreadSelections,
     createdThreadRequests,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connectors.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connectors.test.tsx
@@ -593,7 +593,7 @@ test.each([null, "Close", "Escape", "backdrop"] as const)(
   "Keep chat OAuth in one dialog through completion (dismissal: %s)",
   async (dismissal) => {
     const user = userEvent.setup({ delay: null });
-    installComposerConnectorFixture({
+    const fixture = installComposerConnectorFixture({
       catalog: [
         builtinConnector({
           slug: GOOGLE_ANALYTICS_SLUG,
@@ -674,6 +674,7 @@ test.each([null, "Close", "Escape", "backdrop"] as const)(
     context.mocks.data.connectors([
       { ...account, slug: GOOGLE_ANALYTICS_SLUG },
     ]);
+    fixture.completeOAuth(account.id);
     authWindow.close();
     await authorizationStarted.promise;
     expect(screen.queryAllByRole("dialog", { hidden: true })).toHaveLength(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-artifact-drive.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-artifact-drive.test.tsx
@@ -1,3 +1,4 @@
+import { mockOAuthCompletions } from "./connector-page-test-helpers.ts";
 import type { ArtifactDetail } from "@okouai/api-contracts/contracts/artifact-catalog";
 import { connectorCatalogContract } from "@okouai/api-contracts/contracts/connector-catalog";
 import {
@@ -90,6 +91,9 @@ function installDriveMocks(
   initialConnectionState: DriveConnectionState,
   options: DriveMockOptions = {},
 ): DriveMockControl {
+  const completedAttempts = mockOAuthCompletions(targetContext);
+  let oauthAttemptId = crypto.randomUUID();
+  let oauthConnectionId = SELECTED_DRIVE_CONNECTION_ID;
   let connectionState = initialConnectionState;
   let agentAuthorized = options.agentAuthorized ?? false;
   let artifactSynced = false;
@@ -197,8 +201,14 @@ function installDriveMocks(
     connectorOauthStartContract.start,
     ({ body, respond }) => {
       oauthRequests.push(body);
+      oauthAttemptId = crypto.randomUUID();
+      oauthConnectionId =
+        body.account.intent === "add"
+          ? NEW_DRIVE_CONNECTION_ID
+          : body.account.connectionId;
       return respond(200, {
         authorizationUrl: AUTHORIZATION_URL,
+        oauthAttemptId,
         ...(body.account.intent === "add"
           ? { connectionId: NEW_DRIVE_CONNECTION_ID }
           : {}),
@@ -287,6 +297,7 @@ function installDriveMocks(
   return {
     authorizationUpdates,
     completeAuthorization: () => {
+      completedAttempts.set(oauthAttemptId, oauthConnectionId);
       connectionState = "connected";
       agentAuthorized = true;
       targetContext.mocks.ably.trigger("connector:changed", {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connector-connection-progress.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connector-connection-progress.test.tsx
@@ -26,6 +26,7 @@ import {
   listAgent,
   mcpCustomConnector,
   mockConnectors,
+  mockOAuthCompletions,
   mockPublicConnectorStatus,
   publicStatusItem,
 } from "./connector-page-test-helpers.ts";
@@ -128,6 +129,8 @@ test.each([
     const permissionRequest = context.mocks.deferred<void>();
     const details = context.mocks.deferred<void>();
     const detailRequest = context.mocks.deferred<void>();
+    const completedAttempts = mockOAuthCompletions(context);
+    const oauthAttemptId = crypto.randomUUID();
     let authorized = false;
     let granting = false;
     mockConnectors(context, []);
@@ -165,6 +168,7 @@ test.each([
     const popup = authorizationWindow();
     const start = {
       authorizationUrl: "https://oauth.test/stripe/authorize",
+      oauthAttemptId,
       connectionId: account.id,
     };
     context.mocks.api(connectorOauthStartContract.start, ({ respond }) => {
@@ -227,6 +231,7 @@ test.each([
     expect(connect).toBeDisabled();
 
     authorized = true;
+    completedAttempts.set(oauthAttemptId, account.id);
     context.mocks.data.connectors([{ ...account, slug: "stripe" }]);
     popup.close();
     await permissionRequest.promise;
@@ -272,6 +277,8 @@ test.each([false, true])(
       kind: "builtin",
       connectorSlug: "stripe",
     });
+    const completedAttempts = mockOAuthCompletions(context);
+    const oauthAttemptId = crypto.randomUUID();
     let authorized = false;
     const existingAccounts = mockConnectors(context, [
       { connectorSlug: "axiom", authMethod: "api-token" },
@@ -322,7 +329,11 @@ test.each([false, true])(
     const popup = authorizationWindow();
     const authorizationUrl = "https://oauth.test/stripe/authorize";
     context.mocks.api(connectorOauthStartContract.start, ({ respond }) => {
-      return respond(200, { authorizationUrl, connectionId: account.id });
+      return respond(200, {
+        authorizationUrl,
+        connectionId: account.id,
+        oauthAttemptId,
+      });
     });
     context.mocks.api(connectorAccountsContract.connection, ({ respond }) => {
       return authorized
@@ -360,6 +371,7 @@ test.each([false, true])(
     expect(screen.getAllByRole("dialog", { hidden: true })).toHaveLength(1);
 
     authorized = true;
+    completedAttempts.set(oauthAttemptId, account.id);
     context.mocks.data.connectors([
       ...existingAccounts,
       { ...account, slug: "stripe" },
@@ -467,6 +479,16 @@ test.each([
     const confirmRequest = context.mocks.deferred<void>();
     const details = context.mocks.deferred<void>();
     const detailRequest = context.mocks.deferred<void>();
+    const oauthAttemptId = crypto.randomUUID();
+    context.mocks.api(
+      connectorAccountsContract.oauthCompletion,
+      async ({ params, respond }) => {
+        expect(params.attemptId).toBe(oauthAttemptId);
+        confirmRequest.resolve();
+        await confirmation.promise;
+        return respond(200, { connectionId: account.id });
+      },
+    );
     let authorized = false;
     let granting = false;
     context.mocks.data.agents([listAgent(AGENT_ID, "Research")]);
@@ -508,9 +530,6 @@ test.each([
         if (granting) {
           detailRequest.resolve();
           await details.promise;
-        } else {
-          confirmRequest.resolve();
-          await confirmation.promise;
         }
         return respond(200, account);
       },
@@ -519,6 +538,7 @@ test.each([
     const start = {
       result: "authorization" as const,
       authorizationUrl: "https://oauth.test/custom/authorize",
+      oauthAttemptId,
       connectionId: account.id,
     };
     context.mocks.api(customConnectorOAuth2Contract.start, ({ respond }) => {
@@ -590,6 +610,8 @@ test("Finish custom OAuth without covering a new connector draft", async () => {
     kind: "custom",
     customConnectorId: connector.id,
   });
+  const completedAttempts = mockOAuthCompletions(context);
+  const oauthAttemptId = crypto.randomUUID();
   let authorized = false;
   context.mocks.data.org({ id: "org_1", name: "Test Org", role: "admin" });
   context.mocks.api(customConnectorsContract.list, ({ respond }) => {
@@ -622,6 +644,7 @@ test("Finish custom OAuth without covering a new connector draft", async () => {
     return respond(200, {
       result: "authorization",
       authorizationUrl,
+      oauthAttemptId,
       connectionId: account.id,
     });
   });
@@ -642,6 +665,7 @@ test("Finish custom OAuth without covering a new connector draft", async () => {
   await fill(within(draft).getByLabelText("Display name"), "Another API");
 
   authorized = true;
+  completedAttempts.set(oauthAttemptId, account.id);
   connector = {
     ...connector,
     connected: true,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connector-page-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connector-page-test-helpers.ts
@@ -28,6 +28,24 @@ import { screen, within } from "@testing-library/react";
 import { queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
 import type { TestContext } from "../../../signals/__tests__/test-helpers.ts";
 
+export function mockOAuthCompletions(
+  context: TestContext,
+): Map<string, string> {
+  const completed = new Map<string, string>();
+  context.mocks.api(
+    connectorAccountsContract.oauthCompletion,
+    ({ params, respond }) => {
+      const connectionId = completed.get(params.attemptId);
+      return connectionId
+        ? respond(200, { connectionId })
+        : respond(404, {
+            error: { code: "NOT_FOUND", message: "OAuth completion not found" },
+          });
+    },
+  );
+  return completed;
+}
+
 export function getConnectorAction(
   role: "button" | "link" | "menuitem" | "tab",
   name: string,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-accounts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-accounts.test.tsx
@@ -24,6 +24,7 @@ import {
   listAgent,
   mockConnectors,
   mockGithubAccounts,
+  mockOAuthCompletions,
   queryConnectorAction,
 } from "./connector-page-test-helpers.ts";
 
@@ -649,189 +650,218 @@ test("Load connector accounts progressively", async () => {
   expect(accountActions(dialog)).toHaveLength(8);
 });
 
-test("Reconnect the selected non-default account", async () => {
-  const agentIds = [
-    "c0000000-0000-4000-a000-000000000001",
-    "c0000000-0000-4000-a000-000000000002",
-  ];
-  context.mocks.data.agents(
-    agentIds.map((id) => {
-      return listAgent(id, id);
-    }),
-  );
-  const authorizedAgents = new Set<string>();
-  context.mocks.api(userConnectorsContract.get, ({ params, respond }) => {
-    return respond(200, {
-      enabledConnectorSlugs: authorizedAgents.has(params.id) ? ["stripe"] : [],
-    });
-  });
-  context.mocks.api(
-    userConnectorsContract.update,
-    ({ params, body, respond }) => {
-      if (
-        body.operation === "add" &&
-        body.enabledConnectorSlugs.includes("stripe")
-      ) {
-        authorizedAgents.add(params.id);
-      }
+test.each([false, true])(
+  "Reconnect the selected non-default account after cancellation (old API: %s)",
+  async (oldApi) => {
+    const completedAttempts = mockOAuthCompletions(context);
+    let oauthAttemptId = crypto.randomUUID();
+    const agentIds = [
+      "c0000000-0000-4000-a000-000000000001",
+      "c0000000-0000-4000-a000-000000000002",
+    ];
+    context.mocks.data.agents(
+      agentIds.map((id) => {
+        return listAgent(id, id);
+      }),
+    );
+    const authorizedAgents = new Set<string>();
+    context.mocks.api(userConnectorsContract.get, ({ params, respond }) => {
       return respond(200, {
         enabledConnectorSlugs: authorizedAgents.has(params.id)
           ? ["stripe"]
           : [],
       });
-    },
-  );
-  const [connector] = mockConnectors(context, [
-    {
-      connectorSlug: "stripe",
-      authMethod: "api-token",
-      externalUsername: "work",
-    },
-  ]);
-  if (!connector) {
-    throw new Error("Expected Stripe connector");
-  }
-  const work = builtinAccount({
-    id: connector.id,
-    slug: "stripe",
-    authMethod: "api-token",
-    displayName: "Work",
-    isDefault: true,
-    externalUsername: "work",
-  });
-  let personal = builtinAccount({
-    id: crypto.randomUUID(),
-    slug: "stripe",
-    displayName: "Personal",
-    isDefault: false,
-    externalUsername: "personal",
-    status: "reconnect-required",
-  });
-  context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
-    return respond(200, {
-      summaries: [
-        {
-          target: work.target,
-          accountCount: 2,
-          attentionCount:
-            personal.connectionStatus === "reconnect-required" ? 1 : 0,
-          defaultConnection: work,
-        },
-      ],
     });
-  });
-  context.mocks.api(
-    connectorAccountsContract.connection,
-    ({ params, respond }) => {
-      if (params.connectionId !== personal.id) {
-        return respond(404, {
-          error: { message: "Account not found", code: "NOT_FOUND" },
+    context.mocks.api(
+      userConnectorsContract.update,
+      ({ params, body, respond }) => {
+        if (
+          body.operation === "add" &&
+          body.enabledConnectorSlugs.includes("stripe")
+        ) {
+          authorizedAgents.add(params.id);
+        }
+        return respond(200, {
+          enabledConnectorSlugs: authorizedAgents.has(params.id)
+            ? ["stripe"]
+            : [],
         });
-      }
-      return respond(200, personal);
-    },
-  );
-  // Register the static collection route after the parameterized item route so
-  // `/connections` cannot be interpreted as a connection ID by MSW.
-  context.mocks.api(connectorAccountsContract.connections, ({ respond }) => {
-    return respond(200, { connections: [work, personal], nextCursor: null });
-  });
-  let submitted: unknown;
-  context.mocks.api(connectorOauthStartContract.start, ({ body, respond }) => {
-    submitted = body.account;
-    expect(body.authorizeAgent).not.toBeTruthy();
-    return respond(200, {
-      connectionId: personal.id,
-      authorizationUrl: "https://oauth.test/stripe/authorize",
-    });
-  });
-  let authWindow = createAuthWindow();
-  context.mocks.browser.open(authWindow);
-  await setupPage({
-    context,
-    path: "/connectors",
-    sharedWorkerTestTransport: "message-port",
-  });
-  click(
-    await waitFor(() => {
-      return getConnectorAction("button", "Manage Stripe accounts");
-    }),
-  );
-  const manager = await screen.findByRole("dialog", {
-    name: "Manage Stripe accounts",
-  });
-  const personalRow = await within(manager).findByRole("group", {
-    name: "Personal",
-  });
-  click(getConnectorAction("button", "Reconnect", personalRow));
-  const connect = await waitFor(() => {
-    const reconnectDialog = screen
-      .getAllByRole("dialog", { name: "Stripe" })
-      .find((candidate) => {
-        return queryConnectorAction("button", "Reconnect", candidate);
-      });
-    if (!reconnectDialog) {
-      throw new Error("Expected Stripe reconnect dialog");
+      },
+    );
+    const [connector] = mockConnectors(context, [
+      {
+        connectorSlug: "stripe",
+        authMethod: "api-token",
+        externalUsername: "work",
+      },
+    ]);
+    if (!connector) {
+      throw new Error("Expected Stripe connector");
     }
-    return reconnectDialog;
-  });
-
-  click(getConnectorAction("button", "Reconnect", connect));
-  await waitFor(() => {
-    expect(authWindow.location.href).toBe(
-      "https://oauth.test/stripe/authorize",
+    const work = builtinAccount({
+      id: connector.id,
+      slug: "stripe",
+      authMethod: "api-token",
+      displayName: "Work",
+      isDefault: true,
+      externalUsername: "work",
+    });
+    let personal = builtinAccount({
+      id: crypto.randomUUID(),
+      slug: "stripe",
+      displayName: "Personal",
+      isDefault: false,
+      externalUsername: "personal",
+      status: "reconnect-required",
+    });
+    context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+      return respond(200, {
+        summaries: [
+          {
+            target: work.target,
+            accountCount: 2,
+            attentionCount:
+              personal.connectionStatus === "reconnect-required" ? 1 : 0,
+            defaultConnection: work,
+          },
+        ],
+      });
+    });
+    context.mocks.api(
+      connectorAccountsContract.connection,
+      ({ params, respond }) => {
+        if (params.connectionId !== personal.id) {
+          return respond(404, {
+            error: { message: "Account not found", code: "NOT_FOUND" },
+          });
+        }
+        return respond(200, personal);
+      },
     );
-  });
-  authWindow.close();
-  await waitFor(() => {
-    expect(getConnectorAction("button", "Reconnect", connect)).toBeEnabled();
-  });
-  expect(connect).toBeInTheDocument();
-  expect(getConnectorCard("Stripe")).toHaveTextContent("Add access");
-
-  authWindow = createAuthWindow();
-  context.mocks.browser.open(authWindow);
-  const connectorChangedSubscribe = context.mocks.ably.deferNextSubscribe();
-  click(getConnectorAction("button", "Reconnect", connect));
-
-  await connectorChangedSubscribe.started;
-  connectorChangedSubscribe.attach();
-  await waitFor(() => {
-    expect(authWindow.location.href).toBe(
-      "https://oauth.test/stripe/authorize",
+    // Register the static collection route after the parameterized item route so
+    // `/connections` cannot be interpreted as a connection ID by MSW.
+    context.mocks.api(connectorAccountsContract.connections, ({ respond }) => {
+      return respond(200, { connections: [work, personal], nextCursor: null });
+    });
+    let submitted: unknown;
+    let startCount = 0;
+    context.mocks.api(
+      connectorOauthStartContract.start,
+      ({ body, respond }) => {
+        submitted = body.account;
+        oauthAttemptId = crypto.randomUUID();
+        startCount += 1;
+        expect(body.authorizeAgent).not.toBeTruthy();
+        return respond(200, {
+          oauthAttemptId:
+            oldApi && startCount === 1 ? undefined : oauthAttemptId,
+          connectionId: personal.id,
+          authorizationUrl: "https://oauth.test/stripe/authorize",
+        });
+      },
     );
-  });
-  expect(submitted).toStrictEqual({
-    intent: "reconnect",
-    connectionId: personal.id,
-  });
-  personal = {
-    ...personal,
-    connectionStatus: "connected",
-    reconnectReason: null,
-    updatedAt: "2026-01-01T00:00:01.000Z",
-  };
-  context.mocks.ably.trigger("connector:changed", { connectorSlug: "stripe" });
+    let authWindow = createAuthWindow();
+    context.mocks.browser.open(authWindow);
+    await setupPage({
+      context,
+      path: "/connectors",
+      sharedWorkerTestTransport: "message-port",
+    });
+    click(
+      await waitFor(() => {
+        return getConnectorAction("button", "Manage Stripe accounts");
+      }),
+    );
+    const manager = await screen.findByRole("dialog", {
+      name: "Manage Stripe accounts",
+    });
+    const personalRow = await within(manager).findByRole("group", {
+      name: "Personal",
+    });
+    click(getConnectorAction("button", "Reconnect", personalRow));
+    const connect = await waitFor(() => {
+      const reconnectDialog = screen
+        .getAllByRole("dialog", { name: "Stripe" })
+        .find((candidate) => {
+          return queryConnectorAction("button", "Reconnect", candidate);
+        });
+      if (!reconnectDialog) {
+        throw new Error("Expected Stripe reconnect dialog");
+      }
+      return reconnectDialog;
+    });
 
-  await waitFor(() => {
+    click(getConnectorAction("button", "Reconnect", connect));
+    await waitFor(() => {
+      expect(authWindow.location.href).toBe(
+        "https://oauth.test/stripe/authorize",
+      );
+    });
+    personal = {
+      ...personal,
+      displayName: "Renamed in another tab",
+      updatedAt: "2026-01-01T00:00:00.500Z",
+    };
+    const cancelledAttemptId = oauthAttemptId;
+    authWindow.close();
+    await waitFor(() => {
+      expect(getConnectorAction("button", "Reconnect", connect)).toBeEnabled();
+    });
+    expect(connect).toBeInTheDocument();
+    expect(getConnectorCard("Stripe")).toHaveTextContent("Add access");
+
+    authWindow = createAuthWindow();
+    context.mocks.browser.open(authWindow);
+    const connectorChangedSubscribe = context.mocks.ably.deferNextSubscribe();
+    click(getConnectorAction("button", "Reconnect", connect));
+
+    await connectorChangedSubscribe.started;
+    connectorChangedSubscribe.attach();
+    await waitFor(() => {
+      expect(authWindow.location.href).toBe(
+        "https://oauth.test/stripe/authorize",
+      );
+    });
+    expect(submitted).toStrictEqual({
+      intent: "reconnect",
+      connectionId: personal.id,
+    });
+    personal = {
+      ...personal,
+      connectionStatus: "connected",
+      reconnectReason: null,
+      updatedAt: "2026-01-01T00:00:01.000Z",
+    };
+    expect(oauthAttemptId).not.toBe(cancelledAttemptId);
+    completedAttempts.set(oauthAttemptId, personal.id);
+    context.mocks.ably.trigger("connector:changed", {
+      connectorSlug: "stripe",
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Stripe" }),
+      ).not.toBeInTheDocument();
+    });
     expect(
-      screen.queryByRole("dialog", { name: "Stripe" }),
+      screen.queryByRole("dialog", { name: "Name your Stripe account" }),
     ).not.toBeInTheDocument();
-  });
-  expect(
-    screen.queryByRole("dialog", { name: "Name your Stripe account" }),
-  ).not.toBeInTheDocument();
-  expect(
-    getConnectorAction("button", "Manage Stripe access"),
-  ).toHaveTextContent("Add access");
-  click(getConnectorAction("button", "Manage Stripe accounts"));
-  const reopenedManager = await screen.findByRole("dialog", {
-    name: "Manage Stripe accounts",
-  });
-  const workRow = within(reopenedManager).getByRole("group", { name: "Work" });
-  expect(within(workRow).getByRole("radio", { name: "Default" })).toBeChecked();
-  expect(within(workRow).queryByText("Reconnect required")).toBeNull();
-});
+    expect(
+      getConnectorAction("button", "Manage Stripe access"),
+    ).toHaveTextContent("Add access");
+    click(getConnectorAction("button", "Manage Stripe accounts"));
+    const reopenedManager = await screen.findByRole("dialog", {
+      name: "Manage Stripe accounts",
+    });
+    const workRow = within(reopenedManager).getByRole("group", {
+      name: "Work",
+    });
+    expect(
+      within(workRow).getByRole("radio", { name: "Default" }),
+    ).toBeChecked();
+    expect(within(workRow).queryByText("Reconnect required")).toBeNull();
+  },
+);
 
 test("Rename and delete a specific connector account", async () => {
   const [connector] = mockConnectors(context, [

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
@@ -30,6 +30,7 @@ import {
   getConnectorSwitch,
   listAgent,
   mockConnectors,
+  mockOAuthCompletions,
   mockPublicConnectorStatus,
   publicStatusItem,
 } from "./connector-page-test-helpers.ts";
@@ -298,6 +299,8 @@ test("Add an AWS account with an external code", async () => {
 });
 
 test("Add an account through OpenID", async () => {
+  const completedAttempts = mockOAuthCompletions(context);
+  const oauthAttemptId = crypto.randomUUID();
   const slug = "server-authored-steam";
   mockConnectors(context, []);
   context.mocks.data.agents([
@@ -334,6 +337,7 @@ test("Add an account through OpenID", async () => {
     });
     return respond(200, {
       authorizationUrl: "https://openid.test/partner-steam/authorize",
+      oauthAttemptId,
     });
   });
   await setupPage({
@@ -353,7 +357,8 @@ test("Add an account through OpenID", async () => {
       "https://openid.test/partner-steam/authorize",
     );
   });
-  storeConnectedConnector(slug, "partner-openid");
+  const connected = storeConnectedConnector(slug, "partner-openid");
+  completedAttempts.set(oauthAttemptId, connected.id);
   context.mocks.ably.trigger("connector:changed", { connectorSlug: slug });
   await waitFor(() => {
     expect(
@@ -764,7 +769,9 @@ test("Follow provider-authored external-code instructions", async () => {
   expect(within(dialog).getByPlaceholderText("Code")).toBeInTheDocument();
 });
 
-test("Complete OAuth only after the selected connector changes", async () => {
+test("Complete OAuth only after the current attempt succeeds", async () => {
+  const completedAttempts = mockOAuthCompletions(context);
+  let oauthAttemptId = crypto.randomUUID();
   const researchId = "c0000000-0000-4000-a000-000000000002";
   let listed = mockConnectors(context, []);
   context.mocks.data.agents([
@@ -794,7 +801,9 @@ test("Complete OAuth only after the selected connector changes", async () => {
   let authWindow = createAuthWindow();
   context.mocks.browser.open(authWindow);
   context.mocks.api(connectorOauthStartContract.start, ({ respond }) => {
+    oauthAttemptId = crypto.randomUUID();
     return respond(200, {
+      oauthAttemptId,
       authorizationUrl: "https://oauth.test/stripe/authorize",
     });
   });
@@ -851,6 +860,11 @@ test("Complete OAuth only after the selected connector changes", async () => {
   listed = mockConnectors(context, [
     { connectorSlug: "stripe", authMethod: "oauth" },
   ]);
+  const connected = listed[0];
+  if (!connected) {
+    throw new Error("Expected completed Stripe account");
+  }
+  completedAttempts.set(oauthAttemptId, connected.id);
   context.mocks.ably.trigger("connector:changed", { connectorSlug: "stripe" });
 
   await waitFor(() => {
@@ -859,6 +873,10 @@ test("Complete OAuth only after the selected connector changes", async () => {
       within(getConnectorCard("Public Stripe")).getByText("Unnamed account"),
     ).toBeInTheDocument();
   });
+  const naming = await screen.findByRole("dialog", {
+    name: "Name your Public Stripe account",
+  });
+  click(getConnectorAction("button", "Skip", naming));
   await waitFor(() => {
     expect(
       getConnectorAction(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-custom.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-custom.test.tsx
@@ -40,6 +40,7 @@ import {
   listAgent,
   mcpCustomConnector,
   mockCustomConnectorStory,
+  mockOAuthCompletions,
   queryConnectorAction,
 } from "./connector-page-test-helpers.ts";
 
@@ -873,6 +874,8 @@ test("Manage a custom HTTP connector through its lifecycle", async () => {
 });
 
 test("Configure and maintain OAuth for a custom HTTP connector", async () => {
+  const completedAttempts = mockOAuthCompletions(context);
+  const oauthAttemptId = crypto.randomUUID();
   let connector: CustomConnectorHttpResponse | null = null;
   const created: CreateCustomConnectorBody[] = [];
   const updated: UpdateCustomConnectorBody[] = [];
@@ -928,9 +931,14 @@ test("Configure and maintain OAuth for a custom HTTP connector", async () => {
         throw new Error("Expected OAuth connector");
       }
       connector = { ...connector, connected: true, missingRequiredFields: [] };
+      const connectedAccountId =
+        connector.connectedAccountId ?? crypto.randomUUID();
+      connector = { ...connector, connectedAccountId };
+      completedAttempts.set(oauthAttemptId, connectedAccountId);
       authWindow.close();
       return respond(200, {
         result: "authorization",
+        oauthAttemptId,
         authorizationUrl: "https://oauth.acme.test/authorize?state=ui-test",
       });
     },
@@ -1374,15 +1382,48 @@ test("Create and connect an MCP server with automatic authentication", async () 
   });
 });
 
-test.each([false, true])(
-  "Reconnect an MCP account with a reusable dialog (close while pending: %s)",
-  async (dismiss) => {
-    const connector = mcpCustomConnector({
-      authMode: "automatic",
-      fields: [],
-      headerInjections: [],
-      configuredFieldKeys: [],
-    });
+test.each([
+  { kind: "http", dismiss: false },
+  { kind: "mcp", dismiss: false },
+  { kind: "mcp", dismiss: true },
+])(
+  "Reconnect a $kind account after cancelled consent and metadata changes (dismiss: $dismiss)",
+  async ({ kind, dismiss }) => {
+    const completedAttempts = mockOAuthCompletions(context);
+    let oauthAttemptId = crypto.randomUUID();
+    const connector =
+      kind === "http"
+        ? customConnector({
+            displayName: "Acme OAuth",
+            authMode: "oauth",
+            fields: [],
+            headerInjections: [
+              {
+                name: "Authorization",
+                valueTemplate: "Bearer {{oauth.access_token}}",
+              },
+            ],
+            configuredFieldKeys: [],
+            connected: true,
+            missingRequiredFields: [],
+            oauthConfig: {
+              providerAdapter: "standard",
+              clientId: "test-client",
+              authorizationUrl: "https://oauth.acme.test/authorize",
+              tokenUrl: "https://oauth.acme.test/token",
+              tokenEndpointAuthMethod: "client_secret_post",
+              pkceMethod: "none",
+              scopes: ["read"],
+              authorizationParams: {},
+            },
+          })
+        : mcpCustomConnector({
+            displayName: "Acme OAuth",
+            authMode: "automatic",
+            fields: [],
+            headerInjections: [],
+            configuredFieldKeys: [],
+          });
     const work = customAccount(connector.id, crypto.randomUUID(), {
       displayName: "Work",
     });
@@ -1434,7 +1475,9 @@ test.each([false, true])(
           intent: "reconnect",
           connectionId: personal.id,
         });
+        oauthAttemptId = crypto.randomUUID();
         return respond(200, {
+          oauthAttemptId,
           result: "authorization",
           connectionId: personal.id,
           authorizationUrl: "https://oauth.acme.test/reconnect",
@@ -1443,18 +1486,18 @@ test.each([false, true])(
     );
     await setupCustomPage({ mcp: true });
     const manageAccounts = await waitFor(() => {
-      return getConnectorAction("button", "Manage Acme MCP accounts");
+      return getConnectorAction("button", "Manage Acme OAuth accounts");
     });
     click(manageAccounts);
     const manager = await screen.findByRole("dialog", {
-      name: "Manage Acme MCP accounts",
+      name: "Manage Acme OAuth accounts",
     });
     const personalRow = await within(manager).findByRole("group", {
       name: "Personal",
     });
     click(getConnectorAction("button", "Reconnect", personalRow));
     const dialog = await screen.findByRole("dialog", {
-      name: "Connect Acme MCP",
+      name: "Connect Acme OAuth",
     });
 
     const cancelledWindow = createAuthWindow();
@@ -1471,13 +1514,19 @@ test.each([false, true])(
     expect(getConnectorAction("button", "Connecting…", dialog)).toBeDisabled();
     expect(screen.getAllByRole("dialog", { hidden: true })).toHaveLength(1);
     expect(within(dialog).getByLabelText("Close")).toBeEnabled();
+    personal = {
+      ...personal,
+      displayName: "Renamed in another tab",
+      updatedAt: "2026-01-01T00:00:00.500Z",
+    };
+    const cancelledAttemptId = oauthAttemptId;
     cancelledWindow.close();
     await waitFor(() => {
       expect(getConnectorAction("button", "Continue", dialog)).toBeEnabled();
     });
     expect(dialog).toBeInTheDocument();
     await waitFor(() => {
-      expect(getConnectorCard("Acme MCP")).toHaveTextContent("Add access");
+      expect(getConnectorCard("Acme OAuth")).toHaveTextContent("Add access");
     });
 
     const completedWindow = createAuthWindow();
@@ -1505,15 +1554,17 @@ test.each([false, true])(
       reconnectReason: null,
       updatedAt: "2026-01-01T00:00:01.000Z",
     };
+    expect(oauthAttemptId).not.toBe(cancelledAttemptId);
+    completedAttempts.set(oauthAttemptId, personal.id);
     completedWindow.close();
     await waitFor(() => {
       expect(
-        getConnectorAction("button", "Manage Acme MCP access"),
+        getConnectorAction("button", "Manage Acme OAuth access"),
       ).toHaveTextContent("Add access");
       expect(dialog).not.toBeInTheDocument();
     });
     expect(
-      screen.queryByRole("dialog", { name: "Name your Acme MCP account" }),
+      screen.queryByRole("dialog", { name: "Name your Acme OAuth account" }),
     ).not.toBeInTheDocument();
   },
 );
@@ -1653,6 +1704,8 @@ test("Create, edit, and connect an OAuth MCP connector", async () => {
 });
 
 test("Add and optionally name a custom OAuth account", async () => {
+  const completedAttempts = mockOAuthCompletions(context);
+  const oauthAttemptId = crypto.randomUUID();
   let connector = customConnector({
     fields: [],
     headerInjections: [
@@ -1704,9 +1757,13 @@ test("Add and optionally name a custom OAuth account", async () => {
         authMethod: "oauth",
         oauthScopes: ["search.read"],
       });
+      const connectedAccountId = connectionId;
+      connector = { ...connector, connectedAccountId };
+      completedAttempts.set(oauthAttemptId, connectedAccountId);
       authWindow.close();
       return respond(200, {
         result: "authorization",
+        oauthAttemptId,
         authorizationUrl: "https://oauth.acme.test/authorize?state=test",
         connectionId,
       });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/directed-authorize-page.test.tsx
@@ -1,3 +1,4 @@
+import { mockOAuthCompletions } from "./connector-page-test-helpers.ts";
 import {
   connectorManualGrantContract,
   connectorNoAuthGrantContract,
@@ -132,7 +133,10 @@ function mockConnectorOauthStart(): { readonly authWindow: Window } {
   return { authWindow };
 }
 
-function mockConnectorOpenIdStart(args?: { readonly onStart?: () => void }): {
+function mockConnectorOpenIdStart(args: {
+  readonly oauthAttemptId: string;
+  readonly onStart: () => void;
+}): {
   readonly authWindow: Window;
 } {
   const authWindow = context.mocks.browser.authWindow();
@@ -154,6 +158,7 @@ function mockConnectorOpenIdStart(args?: { readonly onStart?: () => void }): {
       args?.onStart?.();
       return respond(200, {
         authorizationUrl: `https://openid.test/${params.connectorSlug}/authorize`,
+        oauthAttemptId: args.oauthAttemptId,
       });
     },
   );
@@ -365,13 +370,18 @@ test("Connect a manual-token connector while authorizing an agent", async () => 
 
 test("Connect and authorize an agent through OpenID", async () => {
   context.mocks.data.connectors([]);
+  const completedAttempts = mockOAuthCompletions(context);
+  const oauthAttemptId = crypto.randomUUID();
+  const connectionId = crypto.randomUUID();
   let authorized = false;
   const { authWindow } = mockConnectorOpenIdStart({
+    oauthAttemptId,
     onStart: () => {
       authorized = true;
+      completedAttempts.set(oauthAttemptId, connectionId);
       context.mocks.data.connectors([
         {
-          id: crypto.randomUUID(),
+          id: connectionId,
           slug: "steam",
           authMethod: "openid",
           externalId: null,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/directed-connect-page.test.tsx
@@ -1,3 +1,4 @@
+import { mockOAuthCompletions } from "./connector-page-test-helpers.ts";
 import {
   connectorManualGrantContract,
   connectorNoAuthGrantContract,
@@ -346,7 +347,8 @@ function mockConnectorOauthStart(args?: {
   return { authWindow };
 }
 
-function mockConnectorOpenIdStart(args?: {
+function mockConnectorOpenIdStart(args: {
+  readonly oauthAttemptId: string;
   readonly onStart?: () => void;
   readonly popupClosed?: boolean;
 }): {
@@ -365,6 +367,7 @@ function mockConnectorOpenIdStart(args?: {
       args?.onStart?.();
       return respond(200, {
         authorizationUrl: `https://openid.test/${params.connectorSlug}/authorize`,
+        oauthAttemptId: args.oauthAttemptId,
       });
     },
   );
@@ -456,6 +459,8 @@ test("Connect and authorize a manual MCP connector", async () => {
 });
 
 test("Let an MCP server discover authentication from a directed connection", async () => {
+  const completedAttempts = mockOAuthCompletions(context);
+  const oauthAttemptId = crypto.randomUUID();
   const connectionId = "a0000000-0000-4000-a000-000000000095";
   let connected = false;
   let grants: AgentCustomConnectorGrant[] = [];
@@ -491,8 +496,10 @@ test("Let an MCP server discover authentication from a directed connection", asy
       expect(params.id).toBe(connector.id);
       expect(body.account).toStrictEqual({ intent: "add" });
       connected = true;
+      completedAttempts.set(oauthAttemptId, connectionId);
       return respond(200, {
         result: "authorization",
+        oauthAttemptId,
         authorizationUrl: "https://mcp.discovery.test/authorize",
         connectionId,
       });
@@ -610,6 +617,8 @@ test("Reconnect the exact manual custom-connector account", async () => {
 });
 
 test("Connect and authorize a custom OAuth connector", async () => {
+  const completedAttempts = mockOAuthCompletions(context);
+  const oauthAttemptId = crypto.randomUUID();
   let connected = false;
   const connectionId = crypto.randomUUID();
   let grants: AgentCustomConnectorGrant[] = [];
@@ -658,8 +667,10 @@ test("Connect and authorize a custom OAuth connector", async () => {
       expect(params.id).toBe(connector.id);
       expect(body.account).toStrictEqual({ intent: "add" });
       connected = true;
+      completedAttempts.set(oauthAttemptId, connectionId);
       return respond(200, {
         result: "authorization",
+        oauthAttemptId,
         authorizationUrl: "https://acme.test/oauth/authorize",
         connectionId,
       });
@@ -702,6 +713,8 @@ test("Connect and authorize a custom OAuth connector", async () => {
 });
 
 test("Reconnect the exact custom OAuth account", async () => {
+  const completedAttempts = mockOAuthCompletions(context);
+  const oauthAttemptId = crypto.randomUUID();
   const connectionId = crypto.randomUUID();
   const siblingConnectionId = crypto.randomUUID();
   let connectedAccountUpdatedAt = "2026-01-01T00:00:00Z";
@@ -746,8 +759,10 @@ test("Reconnect the exact custom OAuth account", async () => {
         connectionId,
       });
       connectedAccountUpdatedAt = "2026-01-01T00:00:01Z";
+      completedAttempts.set(oauthAttemptId, connectionId);
       return respond(200, {
         result: "authorization",
+        oauthAttemptId,
         authorizationUrl: "https://acme.test/oauth/reconnect",
         connectionId: siblingConnectionId,
       });
@@ -790,6 +805,8 @@ test("Reconnect the exact custom OAuth account", async () => {
 });
 
 test("Preserve existing agent permissions after connecting custom OAuth", async () => {
+  const completedAttempts = mockOAuthCompletions(context);
+  const oauthAttemptId = crypto.randomUUID();
   let connected = false;
   const connectionId = crypto.randomUUID();
   let authorizationUpdates = 0;
@@ -821,7 +838,13 @@ test("Preserve existing agent permissions after connecting custom OAuth", async 
   });
   context.mocks.api(customConnectorsContract.list, ({ respond }) => {
     return respond(200, {
-      connectors: [{ ...connector, connected }],
+      connectors: [
+        {
+          ...connector,
+          connected,
+          connectedAccountId: connected ? connectionId : undefined,
+        },
+      ],
     });
   });
   context.mocks.api(
@@ -830,8 +853,10 @@ test("Preserve existing agent permissions after connecting custom OAuth", async 
       expect(params.id).toBe(connector.id);
       expect(body.account).toStrictEqual({ intent: "add" });
       connected = true;
+      completedAttempts.set(oauthAttemptId, connectionId);
       return respond(200, {
         result: "authorization",
+        oauthAttemptId,
         authorizationUrl: "https://acme.test/oauth/authorize",
         connectionId,
       });
@@ -1034,13 +1059,20 @@ test("Connect a no-auth connector and continue the originating chat", async () =
 });
 
 test("Complete OpenID and continue the originating chat", async () => {
+  const completedAttempts = mockOAuthCompletions(context);
+  const oauthAttemptId = crypto.randomUUID();
   context.mocks.data.connectors([]);
   const threadId = "00000000-0000-4000-a000-000000000102";
   const callbackPrompt = "Re-check Steam, then continue";
   let continuationPrompt: string | null = null;
   const { authWindow } = mockConnectorOpenIdStart({
+    oauthAttemptId,
     popupClosed: false,
     onStart: () => {
+      completedAttempts.set(
+        oauthAttemptId,
+        "00000000-0000-4000-8000-000000000001",
+      );
       context.mocks.data.connectors([
         connectedConnectorResponse({
           slug: "steam",

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1,3 +1,4 @@
+import { mockOAuthCompletions } from "../../okou-page/__tests__/connector-page-test-helpers.ts";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as timers from "signal-timers";
@@ -3755,6 +3756,8 @@ function mockCalendarReconnect(
   workflow: WorkflowDetailResponse,
   selectedAccount: "work" | "personal" = "personal",
 ) {
+  const completedAttempts = mockOAuthCompletions(context);
+  const oauthAttemptId = crypto.randomUUID();
   let healthyAccount = googleCalendarAccount({
     id: "10000000-0000-4000-a000-000000000020",
     displayName: "Work Calendar",
@@ -3823,6 +3826,7 @@ function mockCalendarReconnect(
     submittedAccounts.push(body.account);
     return respond(200, {
       authorizationUrl: "https://oauth.test/google-calendar/authorize",
+      oauthAttemptId,
     });
   });
   const authWindow = createAuthWindow();
@@ -3909,6 +3913,10 @@ function mockCalendarReconnect(
       ]);
     },
     complete: () => {
+      completedAttempts.set(
+        oauthAttemptId,
+        selectedAccount === "work" ? healthyAccount.id : reconnectAccount.id,
+      );
       if (selectedAccount === "work") {
         healthyAccount = {
           ...healthyAccount,

--- a/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
@@ -176,6 +176,21 @@ const connectorAccountExactTargetBodySchema = z
   .strict();
 
 export const connectorAccountsContract = c.router({
+  oauthCompletion: {
+    method: "GET",
+    path: "/api/connector-accounts/oauth-completions/:attemptId",
+    headers: authHeadersSchema,
+    pathParams: z.object({ attemptId: z.uuid() }),
+    query: connectorAccountTargetQuerySchema,
+    responses: {
+      200: z.object({ connectionId: z.uuid() }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Read an owned OAuth attempt's completed account",
+  },
   inspect: {
     method: "POST",
     path: "/api/connector-accounts/inspect",

--- a/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-schemas.ts
@@ -124,6 +124,7 @@ export type ScopeDiffResponse = z.infer<typeof scopeDiffResponseSchema>;
 export const connectorOauthStartResponseSchema = z.object({
   authorizationUrl: z.string(),
   connectionId: z.uuid().optional(),
+  oauthAttemptId: z.uuid().optional(),
 });
 
 export type ConnectorOauthStartResponse = z.infer<

--- a/turbo/packages/api-contracts/src/contracts/custom-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/custom-connectors.ts
@@ -522,6 +522,7 @@ const startCustomConnectorOAuth2AuthorizationResponseSchema = z.object({
   result: z.literal("authorization"),
   authorizationUrl: z.string().url(),
   connectionId: z.uuid().optional(),
+  oauthAttemptId: z.uuid().optional(),
 });
 
 const startCustomConnectorOAuth2ConnectedResponseSchema = z.object({

--- a/turbo/packages/db/src/migrations/1097_puzzling_retro_girl.sql
+++ b/turbo/packages/db/src/migrations/1097_puzzling_retro_girl.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "connector_oauth_completions" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"connection_id" uuid NOT NULL,
+	"user_id" text NOT NULL,
+	"org_id" text NOT NULL,
+	"expires_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "connector_oauth_completions" ADD CONSTRAINT "connector_oauth_completions_connection_id_connectors_id_fk" FOREIGN KEY ("connection_id") REFERENCES "public"."connectors"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_connector_oauth_completions_expires_at" ON "connector_oauth_completions" USING btree ("expires_at");

--- a/turbo/packages/db/src/migrations/meta/1097_snapshot.json
+++ b/turbo/packages/db/src/migrations/meta/1097_snapshot.json
@@ -1,0 +1,31116 @@
+{
+  "id": "8e2f639d-e0b7-4d52-91c1-7b6bc3837838",
+  "prevId": "9d70d1d8-9a12-4993-866d-75c1abac693a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.active_input_deliveries": {
+      "name": "active_input_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        }
+      },
+      "indexes": {
+        "active_input_deliveries_run_open_unique": {
+          "name": "active_input_deliveries_run_open_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"active_input_deliveries\".\"status\" = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_input_deliveries_thread_open_idx": {
+          "name": "active_input_deliveries_thread_open_idx",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"active_input_deliveries\".\"status\" = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "active_input_deliveries_run_id_agent_runs_id_fk": {
+          "name": "active_input_deliveries_run_id_agent_runs_id_fk",
+          "tableFrom": "active_input_deliveries",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "active_input_deliveries_chat_thread_id_chat_threads_id_fk": {
+          "name": "active_input_deliveries_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "active_input_deliveries",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "active_input_deliveries_status_check": {
+          "name": "active_input_deliveries_status_check",
+          "value": "\"active_input_deliveries\".\"status\" IN ('open', 'settled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.active_input_delivery_items": {
+      "name": "active_input_delivery_items",
+      "schema": "",
+      "columns": {
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "active_input_delivery_items_delivery_position_unique": {
+          "name": "active_input_delivery_items_delivery_position_unique",
+          "columns": [
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_input_delivery_items_source_open_unique": {
+          "name": "active_input_delivery_items_source_open_unique",
+          "columns": [
+            {
+              "expression": "source_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"active_input_delivery_items\".\"disposition\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "active_input_delivery_items_delivery_id_active_input_deliveries_id_fk": {
+          "name": "active_input_delivery_items_delivery_id_active_input_deliveries_id_fk",
+          "tableFrom": "active_input_delivery_items",
+          "tableTo": "active_input_deliveries",
+          "columnsFrom": [
+            "delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "active_input_delivery_items_source_event_id_chat_events_id_fk": {
+          "name": "active_input_delivery_items_source_event_id_chat_events_id_fk",
+          "tableFrom": "active_input_delivery_items",
+          "tableTo": "chat_events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "active_input_delivery_items_delivery_id_source_event_id_pk": {
+          "name": "active_input_delivery_items_delivery_id_source_event_id_pk",
+          "columns": [
+            "delivery_id",
+            "source_event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "active_input_delivery_items_position_check": {
+          "name": "active_input_delivery_items_position_check",
+          "value": "\"active_input_delivery_items\".\"position\" >= 0"
+        },
+        "active_input_delivery_items_disposition_check": {
+          "name": "active_input_delivery_items_disposition_check",
+          "value": "\"active_input_delivery_items\".\"disposition\" IS NULL OR \"active_input_delivery_items\".\"disposition\" IN ('delivered', 'released', 'expired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_drafts": {
+      "name": "agent_drafts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_user_message": {
+          "name": "draft_user_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_attachments": {
+          "name": "draft_attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_drafts_user_org_agent": {
+          "name": "idx_agent_drafts_user_org_agent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_drafts_agent_id_agents_id_fk": {
+          "name": "agent_drafts_agent_id_agents_id_fk",
+          "tableFrom": "agent_drafts",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_drafts_draft_user_message_check": {
+          "name": "agent_drafts_draft_user_message_check",
+          "value": "\"agent_drafts\".\"draft_user_message\" IS NOT NULL\n          OR COALESCE(\"agent_drafts\".\"draft_attachments\", '[]'::jsonb) = '[]'::jsonb"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_kind": {
+          "name": "internal_kind",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_connector_diagnostic_registrations": {
+      "name": "agent_run_connector_diagnostic_registrations",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_run_connector_diagnostic_registrations_created_idx": {
+          "name": "agent_run_connector_diagnostic_registrations_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_connector_diagnostic_registrations_run_id_agent_runs_id_fk": {
+          "name": "agent_run_connector_diagnostic_registrations_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_connector_diagnostic_registrations",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_queue": {
+      "name": "agent_run_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_queue_user_created_idx": {
+          "name": "agent_run_queue_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_org_created_idx": {
+          "name": "agent_run_queue_org_created_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_expires_at_idx": {
+          "name": "agent_run_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_queue_run_id_agent_runs_id_fk": {
+          "name": "agent_run_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_mounts": {
+          "name": "storage_mounts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launch_snapshot": {
+          "name": "launch_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_workflow_provenance": {
+          "name": "official_workflow_provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_reuse_result": {
+          "name": "sandbox_reuse_result",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_reuse_result": {
+          "name": "workspace_reuse_result",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_recovery_completed": {
+          "name": "cancellation_recovery_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_sequence": {
+          "name": "last_event_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "credit_admitted": {
+          "name": "credit_admitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_id": {
+          "name": "runner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_heartbeat_generation": {
+          "name": "runner_heartbeat_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_hostname": {
+          "name": "runner_hostname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_version": {
+          "name": "runner_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_input_enabled": {
+          "name": "active_input_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autonomy_budget": {
+          "name": "autonomy_budget",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_automation_id": {
+          "name": "workflow_automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_credential_scope": {
+          "name": "model_provider_credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_runtime_provider": {
+          "name": "model_runtime_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_runtime_model": {
+          "name": "model_runtime_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "built_in_model_key_id": {
+          "name": "built_in_model_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_service_tier": {
+          "name": "codex_service_tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_video_model": {
+          "name": "selected_video_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_image_model": {
+          "name": "selected_image_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_started_at": {
+          "name": "api_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_assistant_event_acknowledged_at": {
+          "name": "first_assistant_event_acknowledged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_brief": {
+          "name": "trigger_brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org": {
+          "name": "idx_agent_runs_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org_status_created": {
+          "name": "idx_agent_runs_org_status_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_session": {
+          "name": "idx_agent_runs_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_chat_thread_id": {
+          "name": "idx_agent_runs_chat_thread_id",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_runs\".\"chat_thread_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_workflow_automation": {
+          "name": "idx_agent_runs_workflow_automation",
+          "columns": [
+            {
+              "expression": "workflow_automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_runs\".\"workflow_automation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_goal": {
+          "name": "idx_agent_runs_goal",
+          "columns": [
+            {
+              "expression": "goal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_runs\".\"goal_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_session_id_agent_sessions_id_fk": {
+          "name": "agent_runs_session_id_agent_sessions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_workflow_automation_id_workflow_automations_id_fk": {
+          "name": "agent_runs_workflow_automation_id_workflow_automations_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "workflow_automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_goal_id_thread_goals_id_fk": {
+          "name": "agent_runs_goal_id_thread_goals_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "thread_goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_chat_thread_id_chat_threads_id_fk": {
+          "name": "agent_runs_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_runs_autonomy_budget_check": {
+          "name": "agent_runs_autonomy_budget_check",
+          "value": "\"agent_runs\".\"autonomy_budget\" >= 0 AND \"agent_runs\".\"autonomy_budget\" <= 10"
+        },
+        "agent_runs_metadata_presence_check": {
+          "name": "agent_runs_metadata_presence_check",
+          "value": "(\n          (\n            \"agent_runs\".\"trigger_source\" IS NULL AND\n            \"agent_runs\".\"autonomy_budget\" IS NULL AND\n            \"agent_runs\".\"workflow_automation_id\" IS NULL AND\n            \"agent_runs\".\"goal_id\" IS NULL AND\n            \"agent_runs\".\"model_provider\" IS NULL AND\n            \"agent_runs\".\"model_provider_id\" IS NULL AND\n            \"agent_runs\".\"model_provider_credential_scope\" IS NULL AND\n            \"agent_runs\".\"selected_model\" IS NULL AND\n            \"agent_runs\".\"model_runtime_provider\" IS NULL AND\n            \"agent_runs\".\"model_runtime_model\" IS NULL AND\n            \"agent_runs\".\"built_in_model_key_id\" IS NULL AND\n            \"agent_runs\".\"codex_service_tier\" IS NULL AND\n            \"agent_runs\".\"selected_video_model\" IS NULL AND\n            \"agent_runs\".\"selected_image_model\" IS NULL AND\n            \"agent_runs\".\"chat_thread_id\" IS NULL AND\n            \"agent_runs\".\"api_started_at\" IS NULL AND\n            \"agent_runs\".\"first_assistant_event_acknowledged_at\" IS NULL AND\n            \"agent_runs\".\"summary\" IS NULL AND\n            \"agent_runs\".\"trigger_brief\" IS NULL\n          ) OR (\n            \"agent_runs\".\"trigger_source\" IS NOT NULL AND\n            \"agent_runs\".\"autonomy_budget\" IS NOT NULL\n          )\n        )"
+        },
+        "agent_runs_launch_snapshot_check": {
+          "name": "agent_runs_launch_snapshot_check",
+          "value": "(\n          \"agent_runs\".\"launch_snapshot\" IS NULL OR (\n            jsonb_typeof(\"agent_runs\".\"launch_snapshot\") = 'object' AND\n            jsonb_typeof(\"agent_runs\".\"launch_snapshot\" -> 'framework') = 'string' AND\n            \"agent_runs\".\"launch_snapshot\" ->> 'framework' = ANY (\n              ARRAY['claude-code', 'codex', 'pi']\n            ) AND\n            jsonb_typeof(\n              \"agent_runs\".\"launch_snapshot\" -> 'runnerProfile'\n            ) = 'string' AND\n            char_length(\"agent_runs\".\"launch_snapshot\" ->> 'runnerProfile') >= 1 AND\n            char_length(\"agent_runs\".\"launch_snapshot\" ->> 'runnerProfile') <= 255 AND\n            (\n              (\n                \"agent_runs\".\"launch_snapshot\" ?& ARRAY[\n                  'schemaVersion',\n                  'framework',\n                  'runnerProfile'\n                ] AND\n                (\n                  \"agent_runs\".\"launch_snapshot\" -\n                  'schemaVersion' -\n                  'framework' -\n                  'runnerProfile'\n                ) = '{}'::jsonb AND\n                \"agent_runs\".\"launch_snapshot\" -> 'schemaVersion' = '1'::jsonb\n              ) OR (\n                \"agent_runs\".\"launch_snapshot\" ?& ARRAY[\n                  'schemaVersion',\n                  'framework',\n                  'runnerProfile',\n                  'piMemoryGenerationEnabled'\n                ] AND\n                (\n                  \"agent_runs\".\"launch_snapshot\" -\n                  'schemaVersion' -\n                  'framework' -\n                  'runnerProfile' -\n                  'piMemoryGenerationEnabled'\n                ) = '{}'::jsonb AND\n                \"agent_runs\".\"launch_snapshot\" -> 'schemaVersion' = '2'::jsonb AND\n                jsonb_typeof(\n                  \"agent_runs\".\"launch_snapshot\" -> 'piMemoryGenerationEnabled'\n                ) = 'boolean'\n              ) OR (\n                \"agent_runs\".\"launch_snapshot\" ?& ARRAY[\n                  'schemaVersion',\n                  'framework',\n                  'runnerProfile'\n                ] AND\n                (\n                  \"agent_runs\".\"launch_snapshot\" -\n                  'schemaVersion' -\n                  'framework' -\n                  'runnerProfile'\n                ) = '{}'::jsonb AND\n                \"agent_runs\".\"launch_snapshot\" -> 'schemaVersion' = '3'::jsonb\n              )\n            )\n          )\n        )"
+        },
+        "agent_runs_official_workflow_provenance_check": {
+          "name": "agent_runs_official_workflow_provenance_check",
+          "value": "(\n          \"agent_runs\".\"official_workflow_provenance\" IS NULL OR (\n            jsonb_typeof(\"agent_runs\".\"official_workflow_provenance\") = 'object' AND\n            \"agent_runs\".\"official_workflow_provenance\" ?& ARRAY[\n              'schemaVersion',\n              'definitions'\n            ] AND\n            (\n              \"agent_runs\".\"official_workflow_provenance\" -\n              'schemaVersion' -\n              'definitions'\n            ) = '{}'::jsonb AND\n            \"agent_runs\".\"official_workflow_provenance\" -> 'schemaVersion' = '1'::jsonb AND\n            jsonb_typeof(\n              \"agent_runs\".\"official_workflow_provenance\" -> 'definitions'\n            ) = 'array' AND\n            jsonb_array_length(\n              \"agent_runs\".\"official_workflow_provenance\" -> 'definitions'\n            ) > 0 AND\n            NOT jsonb_path_exists(\n              \"agent_runs\".\"official_workflow_provenance\",\n              '$.definitions[*] ? (\n                @.type() != \"object\" ||\n                !exists(@.name) ||\n                @.name.type() != \"string\" ||\n                !(@.name like_regex \"^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$\") ||\n                !exists(@.revision) ||\n                @.revision.type() != \"string\" ||\n                !(@.revision like_regex \"^[0-9a-f]{64}$\") ||\n                !exists(@.artifact) ||\n                @.artifact.type() != \"object\" ||\n                exists(\n                  @.keyvalue() ? (\n                    @.key != \"name\" &&\n                    @.key != \"revision\" &&\n                    @.key != \"artifact\"\n                  )\n                ) ||\n                !exists(@.artifact.orgId) ||\n                @.artifact.orgId != \"__system__\" ||\n                !exists(@.artifact.userId) ||\n                @.artifact.userId != \"__org__\" ||\n                !exists(@.artifact.storageName) ||\n                @.artifact.storageName.type() != \"string\" ||\n                !(@.artifact.storageName like_regex \"^.{1,255}.?$\") ||\n                !exists(@.artifact.storageId) ||\n                @.artifact.storageId.type() != \"string\" ||\n                !(@.artifact.storageId like_regex \"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$\") ||\n                !exists(@.artifact.storageVersion) ||\n                @.artifact.storageVersion.type() != \"string\" ||\n                !(@.artifact.storageVersion like_regex \"^[0-9a-f]{64}$\") ||\n                exists(\n                  @.artifact.keyvalue() ? (\n                    @.key != \"orgId\" &&\n                    @.key != \"userId\" &&\n                    @.key != \"storageName\" &&\n                    @.key != \"storageId\" &&\n                    @.key != \"storageVersion\"\n                  )\n                )\n              )'\n            )\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_mounts": {
+          "name": "storage_mounts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_agent": {
+          "name": "idx_agent_sessions_user_agent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_sessions_org": {
+          "name": "idx_agent_sessions_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_id_agents_id_fk": {
+          "name": "agent_sessions_agent_id_agents_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_ssh_access": {
+      "name": "agent_ssh_access",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_ssh_access_agent": {
+          "name": "idx_agent_ssh_access_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_ssh_access_agent_owner_fk": {
+          "name": "agent_ssh_access_agent_owner_fk",
+          "tableFrom": "agent_ssh_access",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id",
+            "org_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id",
+            "owner"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_ssh_access_pkey": {
+          "name": "agent_ssh_access_pkey",
+          "columns": [
+            "org_id",
+            "user_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sound": {
+          "name": "sound",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefer_personal_provider": {
+          "name": "prefer_personal_provider",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agents_org_name": {
+          "name": "idx_agents_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_org": {
+          "name": "idx_agents_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_model_provider_id_model_providers_id_fk": {
+          "name": "agents_model_provider_id_model_providers_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "idx_agents_id_org_owner": {
+          "name": "idx_agents_id_org_owner",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "org_id",
+            "owner"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_chat_thread_routes": {
+      "name": "agentphone_chat_thread_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agentphone_user_link_id": {
+          "name": "agentphone_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_chat_thread_routes_link_root": {
+          "name": "idx_agentphone_chat_thread_routes_link_root",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_chat_thread_routes_user_link": {
+          "name": "idx_agentphone_chat_thread_routes_user_link",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_chat_thread_routes_conversation": {
+          "name": "idx_agentphone_chat_thread_routes_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentphone_chat_thread_routes_agentphone_user_link_id_agentphone_user_links_id_fk": {
+          "name": "agentphone_chat_thread_routes_agentphone_user_link_id_agentphone_user_links_id_fk",
+          "tableFrom": "agentphone_chat_thread_routes",
+          "tableTo": "agentphone_user_links",
+          "columnsFrom": [
+            "agentphone_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agentphone_chat_thread_routes_chat_thread_id_chat_threads_id_fk": {
+          "name": "agentphone_chat_thread_routes_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "agentphone_chat_thread_routes",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_messages": {
+      "name": "agentphone_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentphone_message_id": {
+          "name": "agentphone_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentphone_agent_id": {
+          "name": "agentphone_agent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentphone_user_link_id": {
+          "name": "agentphone_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_handle": {
+          "name": "phone_handle",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_messages_agentphone_message": {
+          "name": "idx_agentphone_messages_agentphone_message",
+          "columns": [
+            {
+              "expression": "agentphone_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_webhook_id": {
+          "name": "idx_agentphone_messages_webhook_id",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "webhook_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_handle_created": {
+          "name": "idx_agentphone_messages_handle_created",
+          "columns": [
+            {
+              "expression": "phone_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_messages_user_link": {
+          "name": "idx_agentphone_messages_user_link",
+          "columns": [
+            {
+              "expression": "agentphone_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentphone_messages_agentphone_user_link_id_agentphone_user_links_id_fk": {
+          "name": "agentphone_messages_agentphone_user_link_id_agentphone_user_links_id_fk",
+          "tableFrom": "agentphone_messages",
+          "tableTo": "agentphone_user_links",
+          "columnsFrom": [
+            "agentphone_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_user_agent_preferences": {
+      "name": "agentphone_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_agent_id": {
+          "name": "selected_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agentphone_user_agent_preferences_selected_agent_id_agents_id_fk": {
+          "name": "agentphone_user_agent_preferences_selected_agent_id_agents_id_fk",
+          "tableFrom": "agentphone_user_agent_preferences",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "selected_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agentphone_user_agent_preferences_user_id_org_id_pk": {
+          "name": "agentphone_user_agent_preferences_user_id_org_id_pk",
+          "columns": [
+            "user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_user_links": {
+      "name": "agentphone_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone_handle": {
+          "name": "phone_handle",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentphone_user_links_phone_handle": {
+          "name": "idx_agentphone_user_links_phone_handle",
+          "columns": [
+            {
+              "expression": "phone_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_user_links_user_org": {
+          "name": "idx_agentphone_user_links_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentphone_user_links_org": {
+          "name": "idx_agentphone_user_links_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentphone_verification_send_cooldowns": {
+      "name": "agentphone_verification_send_cooldowns",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agentphone_verification_send_cooldowns_pkey": {
+          "name": "agentphone_verification_send_cooldowns_pkey",
+          "columns": [
+            "scope",
+            "scope_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.archived_task_runs": {
+      "name": "archived_task_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_run_id": {
+          "name": "archived_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_archived_task_runs_unique": {
+          "name": "idx_archived_task_runs_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifact_shares": {
+      "name": "artifact_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_artifact_shares_target": {
+          "name": "idx_artifact_shares_target",
+          "columns": [
+            {
+              "expression": "target_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifact_catalog_pending_files": {
+      "name": "artifact_catalog_pending_files",
+      "schema": "",
+      "columns": {
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artifact_catalog_pending_owner_idx": {
+          "name": "artifact_catalog_pending_owner_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifact_catalog_pending_files_file_id_run_uploaded_files_id_fk": {
+          "name": "artifact_catalog_pending_files_file_id_run_uploaded_files_id_fk",
+          "tableFrom": "artifact_catalog_pending_files",
+          "tableTo": "run_uploaded_files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logical_key": {
+          "name": "logical_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projection_file_id": {
+          "name": "projection_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projection_created_at": {
+          "name": "projection_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artifacts_kind_entity_unique": {
+          "name": "artifacts_kind_entity_unique",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_author_logical_key_unique": {
+          "name": "artifacts_author_logical_key_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "logical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_author_created_idx": {
+          "name": "artifacts_author_created_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_author_kind_created_idx": {
+          "name": "artifacts_author_kind_created_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.image_artifacts": {
+      "name": "image_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation_job_id": {
+          "name": "generation_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "image_artifacts_file_unique": {
+          "name": "image_artifacts_file_unique",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "image_artifacts_file_id_run_uploaded_files_id_fk": {
+          "name": "image_artifacts_file_id_run_uploaded_files_id_fk",
+          "tableFrom": "image_artifacts",
+          "tableTo": "run_uploaded_files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "image_artifacts_generation_job_id_built_in_generation_jobs_id_fk": {
+          "name": "image_artifacts_generation_job_id_built_in_generation_jobs_id_fk",
+          "tableFrom": "image_artifacts",
+          "tableTo": "built_in_generation_jobs",
+          "columnsFrom": [
+            "generation_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.presentation_artifacts": {
+      "name": "presentation_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "hosted_site_id": {
+          "name": "hosted_site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation_job_id": {
+          "name": "generation_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "presentation_artifacts_site_unique": {
+          "name": "presentation_artifacts_site_unique",
+          "columns": [
+            {
+              "expression": "hosted_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "presentation_artifacts_hosted_site_id_hosted_sites_id_fk": {
+          "name": "presentation_artifacts_hosted_site_id_hosted_sites_id_fk",
+          "tableFrom": "presentation_artifacts",
+          "tableTo": "hosted_sites",
+          "columnsFrom": [
+            "hosted_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "presentation_artifacts_generation_job_id_built_in_generation_jobs_id_fk": {
+          "name": "presentation_artifacts_generation_job_id_built_in_generation_jobs_id_fk",
+          "tableFrom": "presentation_artifacts",
+          "tableTo": "built_in_generation_jobs",
+          "columnsFrom": [
+            "generation_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.video_artifacts": {
+      "name": "video_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation_job_id": {
+          "name": "generation_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "video_artifacts_file_unique": {
+          "name": "video_artifacts_file_unique",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "video_artifacts_file_id_run_uploaded_files_id_fk": {
+          "name": "video_artifacts_file_id_run_uploaded_files_id_fk",
+          "tableFrom": "video_artifacts",
+          "tableTo": "run_uploaded_files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "video_artifacts_generation_job_id_built_in_generation_jobs_id_fk": {
+          "name": "video_artifacts_generation_job_id_built_in_generation_jobs_id_fk",
+          "tableFrom": "video_artifacts",
+          "tableTo": "built_in_generation_jobs",
+          "columnsFrom": [
+            "generation_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_access_audit_events": {
+      "name": "banking_access_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finicity'"
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_access_audit_org_user": {
+          "name": "idx_banking_access_audit_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_access_audit_run": {
+          "name": "idx_banking_access_audit_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_access_audit_created": {
+          "name": "idx_banking_access_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_accounts": {
+      "name": "banking_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institution_name": {
+          "name": "institution_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institution_login_id": {
+          "name": "institution_login_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number_last4": {
+          "name": "account_number_last4",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "repair_required_at": {
+          "name": "repair_required_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_accounts_connection_provider_account": {
+          "name": "idx_banking_accounts_connection_provider_account",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_accounts_org_user": {
+          "name": "idx_banking_accounts_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banking_accounts_connection_id_banking_connections_id_fk": {
+          "name": "banking_accounts_connection_id_banking_connections_id_fk",
+          "tableFrom": "banking_accounts",
+          "tableTo": "banking_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_agent_enablements": {
+      "name": "banking_agent_enablements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_provider_ids": {
+          "name": "account_provider_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "operation_scopes": {
+          "name": "operation_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"accounts.read\",\"balances.read\",\"transactions.read\"]'::jsonb"
+        },
+        "allow_automation_runs": {
+          "name": "allow_automation_runs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_agent_enablements_unique": {
+          "name": "idx_banking_agent_enablements_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_agent_enablements_agent_user": {
+          "name": "idx_banking_agent_enablements_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banking_agent_enablements_connection_id_banking_connections_id_fk": {
+          "name": "banking_agent_enablements_connection_id_banking_connections_id_fk",
+          "tableFrom": "banking_agent_enablements",
+          "tableTo": "banking_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "banking_agent_enablements_agent_id_agents_id_fk": {
+          "name": "banking_agent_enablements_agent_id_agents_id_fk",
+          "tableFrom": "banking_agent_enablements",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_connect_events": {
+      "name": "banking_connect_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_occurred_at": {
+          "name": "provider_occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_connect_events_session": {
+          "name": "idx_banking_connect_events_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banking_connect_events_session_id_banking_connect_sessions_id_fk": {
+          "name": "banking_connect_events_session_id_banking_connect_sessions_id_fk",
+          "tableFrom": "banking_connect_events",
+          "tableTo": "banking_connect_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_connect_sessions": {
+      "name": "banking_connect_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "institution_login_id": {
+          "name": "institution_login_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_at": {
+          "name": "done_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_connect_sessions_owner": {
+          "name": "idx_banking_connect_sessions_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_connect_sessions_connection": {
+          "name": "idx_banking_connect_sessions_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_connect_sessions_one_pending": {
+          "name": "idx_banking_connect_sessions_one_pending",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"banking_connect_sessions\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banking_connect_sessions_connection_id_banking_connections_id_fk": {
+          "name": "banking_connect_sessions_connection_id_banking_connections_id_fk",
+          "tableFrom": "banking_connect_sessions",
+          "tableTo": "banking_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banking_connections": {
+      "name": "banking_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finicity'"
+        },
+        "provider_customer_id": {
+          "name": "provider_customer_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "consent_expires_at": {
+          "name": "consent_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repair_required_at": {
+          "name": "repair_required_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_metadata": {
+          "name": "audit_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_banking_connections_owner_provider": {
+          "name": "idx_banking_connections_owner_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banking_connections_org_user": {
+          "name": "idx_banking_connections_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raw_size": {
+          "name": "raw_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encoding": {
+          "name": "encoding",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encoded_size": {
+          "name": "encoded_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_authorization_requests": {
+      "name": "browser_authorization_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_token_hash": {
+          "name": "request_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_browser_authorization_requests_token_hash": {
+          "name": "uq_browser_authorization_requests_token_hash",
+          "columns": [
+            {
+              "expression": "request_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_browser_authorization_requests_owner": {
+          "name": "idx_browser_authorization_requests_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_browser_authorization_requests_expires": {
+          "name": "idx_browser_authorization_requests_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_profiles": {
+      "name": "browser_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_profile_id": {
+          "name": "provider_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_browser_profiles_owner": {
+          "name": "uq_browser_profiles_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_browser_profiles_provider_profile": {
+          "name": "uq_browser_profiles_provider_profile",
+          "columns": [
+            {
+              "expression": "provider_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_session_instances": {
+      "name": "browser_session_instances",
+      "schema": "",
+      "columns": {
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "browser_session_id": {
+          "name": "browser_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeout_at": {
+          "name": "timeout_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_touched_at": {
+          "name": "last_touched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "idle_expires_at": {
+          "name": "idle_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + interval '10 minutes'"
+        },
+        "stop_requested_at": {
+          "name": "stop_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_browser_session_instances_session": {
+          "name": "idx_browser_session_instances_session",
+          "columns": [
+            {
+              "expression": "browser_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_browser_session_instances_thread": {
+          "name": "idx_browser_session_instances_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_browser_session_instances_run_status": {
+          "name": "idx_browser_session_instances_run_status",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_browser_session_instances_reconcile": {
+          "name": "idx_browser_session_instances_reconcile",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_browser_session_instances_thread_owned": {
+          "name": "uq_browser_session_instances_thread_owned",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"browser_session_instances\".\"status\" IN ('active', 'stopping')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "browser_session_instances_browser_session_id_browser_sessions_id_fk": {
+          "name": "browser_session_instances_browser_session_id_browser_sessions_id_fk",
+          "tableFrom": "browser_session_instances",
+          "tableTo": "browser_sessions",
+          "columnsFrom": [
+            "browser_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_session_resize_states": {
+      "name": "browser_session_resize_states",
+      "schema": "",
+      "columns": {
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "screen_width": {
+          "name": "screen_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "screen_height": {
+          "name": "screen_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "browser_session_resize_states_provider_session_id_browser_session_instances_provider_session_id_fk": {
+          "name": "browser_session_resize_states_provider_session_id_browser_session_instances_provider_session_id_fk",
+          "tableFrom": "browser_session_resize_states",
+          "tableTo": "browser_session_instances",
+          "columnsFrom": [
+            "provider_session_id"
+          ],
+          "columnsTo": [
+            "provider_session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_session_screenshot_deletions": {
+      "name": "browser_session_screenshot_deletions",
+      "schema": "",
+      "columns": {
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_session_screenshots": {
+      "name": "browser_session_screenshots",
+      "schema": "",
+      "columns": {
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_session_tab_snapshots": {
+      "name": "browser_session_tab_snapshots",
+      "schema": "",
+      "columns": {
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "encrypted_tab_urls": {
+          "name": "encrypted_tab_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "browser_session_tab_snapshots_chat_thread_id_chat_threads_id_fk": {
+          "name": "browser_session_tab_snapshots_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "browser_session_tab_snapshots",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_sessions": {
+      "name": "browser_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_profile_id": {
+          "name": "browser_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_thread_profile_id": {
+          "name": "browser_thread_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_country_code": {
+          "name": "proxy_country_code",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_minutes": {
+          "name": "timeout_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspension_reason": {
+          "name": "suspension_reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_browser_sessions_chat_thread_created": {
+          "name": "idx_browser_sessions_chat_thread_created",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_browser_sessions_owner_created": {
+          "name": "idx_browser_sessions_owner_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_browser_sessions_reconcile": {
+          "name": "idx_browser_sessions_reconcile",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_browser_sessions_thread_owned": {
+          "name": "uq_browser_sessions_thread_owned",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"browser_sessions\".\"status\" IN ('creating', 'active', 'resuming', 'stopping')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "browser_sessions_run_id_agent_runs_id_fk": {
+          "name": "browser_sessions_run_id_agent_runs_id_fk",
+          "tableFrom": "browser_sessions",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "browser_sessions_browser_profile_id_browser_profiles_id_fk": {
+          "name": "browser_sessions_browser_profile_id_browser_profiles_id_fk",
+          "tableFrom": "browser_sessions",
+          "tableTo": "browser_profiles",
+          "columnsFrom": [
+            "browser_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "browser_sessions_browser_thread_profile_id_browser_thread_profiles_id_fk": {
+          "name": "browser_sessions_browser_thread_profile_id_browser_thread_profiles_id_fk",
+          "tableFrom": "browser_sessions",
+          "tableTo": "browser_thread_profiles",
+          "columnsFrom": [
+            "browser_thread_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_thread_profiles": {
+      "name": "browser_thread_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_profile_id": {
+          "name": "provider_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_browser_thread_profiles_thread": {
+          "name": "uq_browser_thread_profiles_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_browser_thread_profiles_provider_profile": {
+          "name": "uq_browser_thread_profiles_provider_profile",
+          "columns": [
+            {
+              "expression": "provider_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_browser_thread_profiles_owner": {
+          "name": "idx_browser_thread_profiles_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.built_in_generation_jobs": {
+      "name": "built_in_generation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_built_in_generation_jobs_user_created": {
+          "name": "idx_built_in_generation_jobs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_built_in_generation_jobs_org_status": {
+          "name": "idx_built_in_generation_jobs_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_built_in_generation_jobs_run": {
+          "name": "idx_built_in_generation_jobs_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "built_in_generation_jobs_run_id_agent_runs_id_fk": {
+          "name": "built_in_generation_jobs_run_id_agent_runs_id_fk",
+          "tableFrom": "built_in_generation_jobs",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.built_in_model_candidate_cooldown": {
+      "name": "built_in_model_candidate_cooldown",
+      "schema": "",
+      "columns": {
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_model": {
+          "name": "upstream_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unavailable_until": {
+          "name": "unavailable_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_observation_started_at": {
+          "name": "connection_observation_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_observation_until": {
+          "name": "connection_observation_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "built_in_model_candidate_cooldown_selected_model_provider_type_upstream_model_pk": {
+          "name": "built_in_model_candidate_cooldown_selected_model_provider_type_upstream_model_pk",
+          "columns": [
+            "selected_model",
+            "provider_type",
+            "upstream_model"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "built_in_model_cooldown_observation_pair_check": {
+          "name": "built_in_model_cooldown_observation_pair_check",
+          "value": "(\"built_in_model_candidate_cooldown\".\"connection_observation_started_at\" IS NULL AND \"built_in_model_candidate_cooldown\".\"connection_observation_until\" IS NULL) OR (\"built_in_model_candidate_cooldown\".\"connection_observation_started_at\" IS NOT NULL AND \"built_in_model_candidate_cooldown\".\"connection_observation_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.built_in_model_keys": {
+      "name": "built_in_model_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_built_in_model_keys_vendor": {
+          "name": "idx_built_in_model_keys_vendor",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_agent_run_context": {
+      "name": "chat_agent_run_context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_chat_thread_id": {
+          "name": "source_chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_agent_id": {
+          "name": "source_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_agentphone_context": {
+      "name": "chat_agentphone_context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_text": {
+          "name": "message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_context": {
+          "name": "thread_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_handle": {
+          "name": "phone_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_link_id": {
+          "name": "user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentphone_agent_id": {
+          "name": "agentphone_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_agentphone_context_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_agentphone_context_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_agentphone_context",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_automation_context": {
+      "name": "chat_automation_context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_brief": {
+          "name": "trigger_brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connector_source_id": {
+          "name": "connector_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "event_payload": {
+          "name": "event_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_automation_context_automation_id_idx": {
+          "name": "chat_automation_context_automation_id_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_automation_context_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_automation_context_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_automation_context",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_event_search_message_watermarks": {
+      "name": "chat_event_search_message_watermarks",
+      "schema": "",
+      "columns": {
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "indexed_seq_id": {
+          "name": "indexed_seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_event_search_messages": {
+      "name": "chat_event_search_messages",
+      "schema": "",
+      "columns": {
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq_id": {
+          "name": "seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_bigram": {
+          "name": "text_bigram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tsv": {
+          "name": "tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', text_bigram)",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "chat_event_search_messages_user_org_created_idx": {
+          "name": "chat_event_search_messages_user_org_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_event_search_messages_user_org_agent_id_created_idx": {
+          "name": "chat_event_search_messages_user_org_agent_id_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_event_search_messages_tsv_idx": {
+          "name": "chat_event_search_messages_tsv_idx",
+          "columns": [
+            {
+              "expression": "tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_event_search_messages_chat_thread_id_seq_id_pk": {
+          "name": "chat_event_search_messages_chat_thread_id_seq_id_pk",
+          "columns": [
+            "chat_thread_id",
+            "seq_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_event_snapshot_scan_state": {
+      "name": "chat_event_snapshot_scan_state",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor_chat_thread_id": {
+          "name": "cursor_chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cycle_upper_bound_last_message_at": {
+          "name": "cycle_upper_bound_last_message_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_event_snapshot_scan_state_scope_check": {
+          "name": "chat_event_snapshot_scan_state_scope_check",
+          "value": "\"chat_event_snapshot_scan_state\".\"scope\" = 'global'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_event_snapshots": {
+      "name": "chat_event_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seq_id": {
+          "name": "last_seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_event_id": {
+          "name": "terminal_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_seq_id": {
+          "name": "terminal_seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_schema_version": {
+          "name": "archive_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_event_snapshots_thread_idx": {
+          "name": "chat_event_snapshots_thread_idx",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_event_snapshots_object_key_idx": {
+          "name": "chat_event_snapshots_object_key_idx",
+          "columns": [
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_event_snapshots_thread_version_unique": {
+          "name": "chat_event_snapshots_thread_version_unique",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archive_schema_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_event_snapshots_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_event_snapshots_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_event_snapshots",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_event_snapshots_archive_schema_version_check": {
+          "name": "chat_event_snapshots_archive_schema_version_check",
+          "value": "\"chat_event_snapshots\".\"archive_schema_version\" = 7"
+        },
+        "chat_event_snapshots_terminal_cursor_check": {
+          "name": "chat_event_snapshots_terminal_cursor_check",
+          "value": "(\n          \"chat_event_snapshots\".\"terminal_event_id\" IS NULL\n          AND \"chat_event_snapshots\".\"terminal_seq_id\" = 0\n        ) OR (\n          \"chat_event_snapshots\".\"terminal_event_id\" IS NOT NULL\n          AND \"chat_event_snapshots\".\"terminal_seq_id\" > 0\n          AND \"chat_event_snapshots\".\"terminal_seq_id\" <= \"chat_event_snapshots\".\"last_seq_id\"\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_events": {
+      "name": "chat_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokes_event_id": {
+          "name": "revokes_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_official_workflow_ids": {
+          "name": "required_official_workflow_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_event_sequence_number": {
+          "name": "run_event_sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_event_id": {
+          "name": "run_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq_id": {
+          "name": "seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_events_created_at_id": {
+          "name": "idx_chat_events_created_at_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_events_thread_created": {
+          "name": "idx_chat_events_thread_created",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_events_thread_run_terminal_created": {
+          "name": "idx_chat_events_thread_run_terminal_created",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_events\".\"event_type\" IN ('run.completed', 'run.failed', 'run.cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_events_run_id": {
+          "name": "idx_chat_events_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_events_revokes_event_id_not_null_unique": {
+          "name": "chat_events_revokes_event_id_not_null_unique",
+          "columns": [
+            {
+              "expression": "revokes_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_events\".\"revokes_event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_events_input_automation_context_idx": {
+          "name": "chat_events_input_automation_context_idx",
+          "columns": [
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_events\".\"event_type\" = 'input.automation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_events_pending_queue_idx": {
+          "name": "chat_events_pending_queue_idx",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_events\".\"run_id\" IS NULL AND \"chat_events\".\"event_type\" IN ('input.prompt', 'input.automation', 'input.goal')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_events_run_event_seq_unique": {
+          "name": "chat_events_run_event_seq_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_event_sequence_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_events_thread_seq_unique": {
+          "name": "chat_events_thread_seq_unique",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_events_run_terminal_unique": {
+          "name": "chat_events_run_terminal_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_events\".\"event_type\" IN ('run.completed', 'run.failed', 'run.cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_events_control_interrupt_run_id_unique": {
+          "name": "chat_events_control_interrupt_run_id_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_events\".\"event_type\" = 'control.interrupt' AND \"chat_events\".\"run_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_events_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_events_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_events",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_events_event_type_check": {
+          "name": "chat_events_event_type_check",
+          "value": "\"chat_events\".\"event_type\" IN (\n          'input.prompt',\n          'input.automation',\n          'input.goal',\n          'input.budget',\n          'input.rejected',\n          'output.message',\n          'output.error',\n          'output.thinking',\n          'output.followups',\n          'run.queued',\n          'run.dequeued',\n          'run.completed',\n          'run.failed',\n          'run.cancelled',\n          'control.interrupt',\n          'control.revoke',\n          'browser.open',\n          'browser.close',\n          'goal.open',\n          'goal.close',\n          'usage.recorded'\n        )"
+        },
+        "chat_events_input_user_message_payload_check": {
+          "name": "chat_events_input_user_message_payload_check",
+          "value": "\"chat_events\".\"event_type\" NOT IN ('input.prompt', 'input.budget', 'input.rejected')\n          OR (\n            \"chat_events\".\"payload\" IS NOT NULL\n            AND \"chat_events\".\"payload\" ? 'userMessage'\n          )"
+        },
+        "chat_events_failure_reason_event_type_check": {
+          "name": "chat_events_failure_reason_event_type_check",
+          "value": "\"chat_events\".\"failure_reason\" IS NULL OR \"chat_events\".\"event_type\" = 'run.failed'"
+        },
+        "chat_events_input_payload_content_check": {
+          "name": "chat_events_input_payload_content_check",
+          "value": "\"chat_events\".\"event_type\" NOT IN ('input.prompt', 'input.budget', 'input.rejected')\n          OR \"chat_events\".\"payload\" IS NULL\n          OR NOT (\"chat_events\".\"payload\" ? 'content')"
+        },
+        "chat_events_official_workflow_queue_claim_check": {
+          "name": "chat_events_official_workflow_queue_claim_check",
+          "value": "\"chat_events\".\"required_official_workflow_ids\" IS NULL OR (\n          \"chat_events\".\"event_type\" = 'input.prompt'\n          AND cardinality(\"chat_events\".\"required_official_workflow_ids\") > 0\n        )"
+        },
+        "chat_events_goal_open_payload_check": {
+          "name": "chat_events_goal_open_payload_check",
+          "value": "\"chat_events\".\"event_type\" <> 'goal.open'\n          OR (\n            \"chat_events\".\"payload\" IS NOT NULL\n            AND \"chat_events\".\"payload\" ? 'content'\n            AND jsonb_typeof(\"chat_events\".\"payload\" -> 'content') = 'string'\n            AND \"chat_events\".\"payload\" ->> 'content' = btrim(\"chat_events\".\"payload\" ->> 'content')\n            AND char_length(\"chat_events\".\"payload\" ->> 'content') > 0\n            AND \"chat_events\".\"payload\" - 'content' = '{}'::jsonb\n          )"
+        },
+        "chat_events_goal_close_payload_check": {
+          "name": "chat_events_goal_close_payload_check",
+          "value": "\"chat_events\".\"event_type\" <> 'goal.close' OR \"chat_events\".\"payload\" IS NULL"
+        },
+        "chat_events_goal_marker_payload_check": {
+          "name": "chat_events_goal_marker_payload_check",
+          "value": "\"chat_events\".\"event_type\" NOT IN ('goal.open', 'goal.close')\n          OR (\n            \"chat_events\".\"run_id\" IS NULL\n            AND \"chat_events\".\"revokes_event_id\" IS NULL\n            AND \"chat_events\".\"context_type\" IS NULL\n            AND \"chat_events\".\"context_id\" IS NULL\n            AND \"chat_events\".\"run_event_sequence_number\" IS NULL\n            AND \"chat_events\".\"run_event_id\" IS NULL\n          )"
+        },
+        "chat_events_context_pair_check": {
+          "name": "chat_events_context_pair_check",
+          "value": "\"chat_events\".\"context_id\" IS NULL OR \"chat_events\".\"context_type\" IS NOT NULL"
+        },
+        "chat_events_context_type_check": {
+          "name": "chat_events_context_type_check",
+          "value": "\"chat_events\".\"context_type\" IN (\n          'web',\n          'slack',\n          'feishu',\n          'teams',\n          'telegram',\n          'github',\n          'agentphone',\n          'automation',\n          'goal',\n          'agent_run'\n        )"
+        },
+        "chat_events_input_context_type_check": {
+          "name": "chat_events_input_context_type_check",
+          "value": "\"chat_events\".\"event_type\" NOT IN ('input.prompt', 'input.automation', 'input.goal', 'input.budget')\n          OR \"chat_events\".\"context_type\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_feishu_context": {
+      "name": "chat_feishu_context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_history": {
+          "name": "conversation_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_text": {
+          "name": "message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_files": {
+          "name": "message_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_in_thread": {
+          "name": "reply_in_thread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_id": {
+          "name": "reaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_open_id": {
+          "name": "sender_open_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_feishu_context_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_feishu_context_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_feishu_context",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_github_context": {
+      "name": "chat_github_context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_number": {
+          "name": "subject_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_comment_id": {
+          "name": "trigger_comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_context": {
+          "name": "issue_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_text": {
+          "name": "message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_reaction_id": {
+          "name": "trigger_reaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_comment_body": {
+          "name": "trigger_comment_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_github_context_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_github_context_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_github_context",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_github_context_subject_kind_check": {
+          "name": "chat_github_context_subject_kind_check",
+          "value": "\"chat_github_context\".\"subject_kind\" IN ('issue', 'pull_request')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_slack_context": {
+      "name": "chat_slack_context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_ts": {
+          "name": "message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_context": {
+          "name": "conversation_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_text": {
+          "name": "message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_files": {
+          "name": "message_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_assets": {
+          "name": "message_assets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mention_display_names": {
+          "name": "mention_display_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_display_name": {
+          "name": "sender_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_user_id": {
+          "name": "sender_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_ts": {
+          "name": "thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_thread_ts": {
+          "name": "route_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_slack_context_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_slack_context_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_slack_context",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_teams_context": {
+      "name": "chat_teams_context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_type": {
+          "name": "conversation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_context": {
+          "name": "thread_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_text": {
+          "name": "message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_files": {
+          "name": "message_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_name": {
+          "name": "tenant_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_url": {
+          "name": "service_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_app_id": {
+          "name": "teams_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_user_id": {
+          "name": "sender_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_display_name": {
+          "name": "sender_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_principal_name": {
+          "name": "sender_principal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_teams_context_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_teams_context_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_teams_context",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_telegram_context": {
+      "name": "chat_telegram_context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_thread_id": {
+          "name": "message_thread_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_text": {
+          "name": "message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_context": {
+          "name": "thread_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thinking_message_id": {
+          "name": "thinking_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_link_id": {
+          "name": "user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_link_kind": {
+          "name": "user_link_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_user_id": {
+          "name": "sender_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_display_name": {
+          "name": "sender_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_username": {
+          "name": "sender_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_language": {
+          "name": "sender_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_telegram_context_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_telegram_context_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_telegram_context",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_thread_connector_selections": {
+      "name": "chat_thread_connector_selections",
+      "schema": "",
+      "columns": {
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_chat_thread_connector_selections_thread_slug": {
+          "name": "idx_chat_thread_connector_selections_thread_slug",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_thread_connector_selections\".\"connector_slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_connector_selections_thread_custom_connector": {
+          "name": "idx_chat_thread_connector_selections_thread_custom_connector",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"chat_thread_connector_selections\".\"custom_connector_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_connector_selections_connector": {
+          "name": "idx_chat_thread_connector_selections_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_connector_selections_custom_connector": {
+          "name": "idx_chat_thread_connector_selections_custom_connector",
+          "columns": [
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_chat_thread_connector_selections_thread": {
+          "name": "fk_chat_thread_connector_selections_thread",
+          "tableFrom": "chat_thread_connector_selections",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_chat_thread_connector_selections_connector_slug": {
+          "name": "fk_chat_thread_connector_selections_connector_slug",
+          "tableFrom": "chat_thread_connector_selections",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id",
+            "connector_slug"
+          ],
+          "columnsTo": [
+            "id",
+            "connector_slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fk_chat_thread_connector_selections_custom_connector": {
+          "name": "fk_chat_thread_connector_selections_custom_connector",
+          "tableFrom": "chat_thread_connector_selections",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id",
+            "custom_connector_id"
+          ],
+          "columnsTo": [
+            "id",
+            "custom_connector_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "chat_thread_connector_selections_thread_connector_pk": {
+          "name": "chat_thread_connector_selections_thread_connector_pk",
+          "columns": [
+            "chat_thread_id",
+            "connector_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_chat_thread_connector_selections_target": {
+          "name": "chk_chat_thread_connector_selections_target",
+          "value": "num_nonnulls(\"chat_thread_connector_selections\".\"connector_slug\", \"chat_thread_connector_selections\".\"custom_connector_id\") = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_thread_event_sequences": {
+      "name": "chat_thread_event_sequences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seq_id": {
+          "name": "last_seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_thread_event_sequences_user_id_org_id_pk": {
+          "name": "chat_thread_event_sequences_user_id_org_id_pk",
+          "columns": [
+            "user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_thread_events": {
+      "name": "chat_thread_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq_id": {
+          "name": "seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "chat_thread_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_order": {
+          "name": "pin_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computer_use_host_id": {
+          "name": "computer_use_host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_browser_enabled": {
+          "name": "cloud_browser_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_video_model": {
+          "name": "selected_video_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_image_model": {
+          "name": "selected_image_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_thread_events_user_org_created": {
+          "name": "idx_chat_thread_events_user_org_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_events_thread_created": {
+          "name": "idx_chat_thread_events_thread_created",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_thread_events_user_org_seq_unique": {
+          "name": "chat_thread_events_user_org_seq_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_thread_events_computer_access_check": {
+          "name": "chat_thread_events_computer_access_check",
+          "value": "NOT (\"chat_thread_events\".\"cloud_browser_enabled\" AND \"chat_thread_events\".\"computer_use_host_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_thread_snapshots": {
+      "name": "chat_thread_snapshots",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_event_id": {
+          "name": "latest_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_event_seq_id": {
+          "name": "latest_event_seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_threads": {
+          "name": "chat_threads",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_thread_snapshots_user_id_org_id_pk": {
+          "name": "chat_thread_snapshots_user_id_org_id_pk",
+          "columns": [
+            "user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_threads": {
+      "name": "chat_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_schedule_run_id": {
+          "name": "source_schedule_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_session_run_id": {
+          "name": "agent_session_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_user_message": {
+          "name": "draft_user_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_attachments": {
+          "name": "draft_attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_type": {
+          "name": "model_provider_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_credential_scope": {
+          "name": "model_provider_credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_service_tier": {
+          "name": "codex_service_tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_video_model": {
+          "name": "selected_video_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_image_model": {
+          "name": "selected_image_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computer_use_host_id": {
+          "name": "computer_use_host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_browser_enabled": {
+          "name": "cloud_browser_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_order": {
+          "name": "pin_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "renamed_at": {
+          "name": "renamed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_chat_event_seq_id": {
+          "name": "last_chat_event_seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_user_agent_updated": {
+          "name": "idx_chat_threads_user_agent_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_last_read": {
+          "name": "idx_chat_threads_user_last_read",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_agent_pinned": {
+          "name": "idx_chat_threads_user_agent_pinned",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"chat_threads\".\"pinned_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user_agent_last_message": {
+          "name": "idx_chat_threads_user_agent_last_message",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_agent_id_agents_id_fk": {
+          "name": "chat_threads_agent_id_agents_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_threads_agent_session_id_agent_sessions_id_fk": {
+          "name": "chat_threads_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_threads_agent_session_run_id_agent_runs_id_fk": {
+          "name": "chat_threads_agent_session_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_session_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_threads_computer_use_host_id_computer_use_hosts_id_fk": {
+          "name": "chat_threads_computer_use_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "computer_use_host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_threads_computer_access_check": {
+          "name": "chat_threads_computer_access_check",
+          "value": "NOT (\"chat_threads\".\"cloud_browser_enabled\" AND \"chat_threads\".\"computer_use_host_id\" IS NOT NULL)"
+        },
+        "chat_threads_draft_user_message_check": {
+          "name": "chat_threads_draft_user_message_check",
+          "value": "\"chat_threads\".\"draft_user_message\" IS NOT NULL\n          OR COALESCE(\"chat_threads\".\"draft_attachments\", '[]'::jsonb) = '[]'::jsonb"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_mounts": {
+          "name": "storage_mounts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_user_active": {
+          "name": "idx_compose_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_authorization_requests": {
+      "name": "computer_use_authorization_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_token_hash": {
+          "name": "request_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_connection_id": {
+          "name": "slack_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_connection_id": {
+          "name": "teams_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_conversation_id": {
+          "name": "teams_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_thread_id": {
+          "name": "teams_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_auth_requests_token_hash": {
+          "name": "idx_computer_use_auth_requests_token_hash",
+          "columns": [
+            {
+              "expression": "request_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_auth_requests_org_user": {
+          "name": "idx_computer_use_auth_requests_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_auth_requests_expires": {
+          "name": "idx_computer_use_auth_requests_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "computer_use_auth_requests_source_check": {
+          "name": "computer_use_auth_requests_source_check",
+          "value": "source IN ('chat', 'slack', 'teams')"
+        },
+        "computer_use_auth_requests_scope_check": {
+          "name": "computer_use_auth_requests_scope_check",
+          "value": "(\n          source = 'chat'\n          AND chat_thread_id IS NOT NULL\n          AND slack_connection_id IS NULL\n          AND slack_channel_id IS NULL\n          AND slack_thread_ts IS NULL\n          AND teams_connection_id IS NULL\n          AND teams_conversation_id IS NULL\n          AND teams_thread_id IS NULL\n        ) OR (\n          source = 'slack'\n          AND chat_thread_id IS NULL\n          AND slack_connection_id IS NOT NULL\n          AND slack_channel_id IS NOT NULL\n          AND slack_thread_ts IS NOT NULL\n          AND teams_connection_id IS NULL\n          AND teams_conversation_id IS NULL\n          AND teams_thread_id IS NULL\n        ) OR (\n          source = 'teams'\n          AND chat_thread_id IS NULL\n          AND slack_connection_id IS NULL\n          AND slack_channel_id IS NULL\n          AND slack_thread_ts IS NULL\n          AND teams_connection_id IS NOT NULL\n          AND teams_conversation_id IS NOT NULL\n          AND teams_thread_id IS NOT NULL\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.computer_use_command_audit_events": {
+      "name": "computer_use_command_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approval_outcome": {
+          "name": "approval_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redacted_result": {
+          "name": "redacted_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_command_audit_command": {
+          "name": "idx_computer_use_command_audit_command",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_command_audit_org_user": {
+          "name": "idx_computer_use_command_audit_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_command_audit_created": {
+          "name": "idx_computer_use_command_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_use_command_audit_events_command_id_computer_use_commands_id_fk": {
+          "name": "computer_use_command_audit_events_command_id_computer_use_commands_id_fk",
+          "tableFrom": "computer_use_command_audit_events",
+          "tableTo": "computer_use_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "computer_use_command_audit_events_host_id_computer_use_hosts_id_fk": {
+          "name": "computer_use_command_audit_events_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "computer_use_command_audit_events",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_commands": {
+      "name": "computer_use_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_commands_host_status": {
+          "name": "idx_computer_use_commands_host_status",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_commands_org_user": {
+          "name": "idx_computer_use_commands_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_commands_created": {
+          "name": "idx_computer_use_commands_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_use_commands_host_id_computer_use_hosts_id_fk": {
+          "name": "computer_use_commands_host_id_computer_use_hosts_id_fk",
+          "tableFrom": "computer_use_commands",
+          "tableTo": "computer_use_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_hosts": {
+      "name": "computer_use_hosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_product": {
+          "name": "client_product",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "os_version": {
+          "name": "os_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_capabilities": {
+          "name": "supported_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"accessibility\":false,\"screenRecording\":false}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_hosts_token_hash": {
+          "name": "idx_computer_use_hosts_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_hosts_active_installation": {
+          "name": "idx_computer_use_hosts_active_installation",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL AND revoked_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_hosts_org_user": {
+          "name": "idx_computer_use_hosts_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_hosts_last_seen": {
+          "name": "idx_computer_use_hosts_last_seen",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "computer_use_hosts_client_product_check": {
+          "name": "computer_use_hosts_client_product_check",
+          "value": "client_product IN ('zero', 'okou')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connector_catalog_active_snapshot": {
+      "name": "connector_catalog_active_snapshot",
+      "schema": "",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_version": {
+          "name": "catalog_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_key": {
+          "name": "catalog_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_digest": {
+          "name": "catalog_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_raw_size": {
+          "name": "catalog_raw_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_gzip": {
+          "name": "catalog_gzip",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connector_catalog_active_snapshot_sync_state_fk": {
+          "name": "connector_catalog_active_snapshot_sync_state_fk",
+          "tableFrom": "connector_catalog_active_snapshot",
+          "tableTo": "connector_catalog_sync_state",
+          "columnsFrom": [
+            "source_id",
+            "schema_version"
+          ],
+          "columnsTo": [
+            "source_id",
+            "schema_version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "connector_catalog_active_snapshot_pk": {
+          "name": "connector_catalog_active_snapshot_pk",
+          "columns": [
+            "source_id",
+            "schema_version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "connector_catalog_active_snapshot_schema_version_positive": {
+          "name": "connector_catalog_active_snapshot_schema_version_positive",
+          "value": "\"connector_catalog_active_snapshot\".\"schema_version\" > 0"
+        },
+        "connector_catalog_active_snapshot_catalog_raw_size_positive": {
+          "name": "connector_catalog_active_snapshot_catalog_raw_size_positive",
+          "value": "\"connector_catalog_active_snapshot\".\"catalog_raw_size\" > 0"
+        },
+        "connector_catalog_active_snapshot_catalog_digest_valid": {
+          "name": "connector_catalog_active_snapshot_catalog_digest_valid",
+          "value": "\"connector_catalog_active_snapshot\".\"catalog_digest\" ~ '^sha256:[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connector_catalog_compatibility_evaluation": {
+      "name": "connector_catalog_compatibility_evaluation",
+      "schema": "",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_version": {
+          "name": "catalog_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_digest": {
+          "name": "catalog_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executable_capability_digest": {
+          "name": "executable_capability_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_validation_backend_version": {
+          "name": "catalog_validation_backend_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catalog_validation_build_commit_sha": {
+          "name": "catalog_validation_build_commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluated_at": {
+          "name": "evaluated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filtered_auth_methods": {
+          "name": "filtered_auth_methods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connector_catalog_compatibility_evaluation_sync_state_fk": {
+          "name": "connector_catalog_compatibility_evaluation_sync_state_fk",
+          "tableFrom": "connector_catalog_compatibility_evaluation",
+          "tableTo": "connector_catalog_sync_state",
+          "columnsFrom": [
+            "source_id",
+            "schema_version"
+          ],
+          "columnsTo": [
+            "source_id",
+            "schema_version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "connector_catalog_compatibility_evaluation_pk": {
+          "name": "connector_catalog_compatibility_evaluation_pk",
+          "columns": [
+            "source_id",
+            "schema_version",
+            "catalog_version",
+            "catalog_digest",
+            "executable_capability_digest"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "connector_catalog_compat_eval_schema_version_positive": {
+          "name": "connector_catalog_compat_eval_schema_version_positive",
+          "value": "\"connector_catalog_compatibility_evaluation\".\"schema_version\" > 0"
+        },
+        "connector_catalog_compatibility_evaluation_digest_valid": {
+          "name": "connector_catalog_compatibility_evaluation_digest_valid",
+          "value": "\"connector_catalog_compatibility_evaluation\".\"executable_capability_digest\" ~ '^sha256:[a-f0-9]{64}$'"
+        },
+        "connector_catalog_compatibility_catalog_digest_valid": {
+          "name": "connector_catalog_compatibility_catalog_digest_valid",
+          "value": "\"connector_catalog_compatibility_evaluation\".\"catalog_digest\" ~ '^sha256:[a-f0-9]{64}$'"
+        },
+        "connector_catalog_compat_validation_authority_complete": {
+          "name": "connector_catalog_compat_validation_authority_complete",
+          "value": "(\n          \"connector_catalog_compatibility_evaluation\".\"catalog_validation_backend_version\" IS NULL\n          AND \"connector_catalog_compatibility_evaluation\".\"catalog_validation_build_commit_sha\" IS NULL\n        ) OR (\n          \"connector_catalog_compatibility_evaluation\".\"catalog_validation_backend_version\" IS NOT NULL\n          AND \"connector_catalog_compatibility_evaluation\".\"catalog_validation_backend_version\" ~ '^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$'\n          AND (\n            \"connector_catalog_compatibility_evaluation\".\"catalog_validation_build_commit_sha\" IS NULL\n            OR \"connector_catalog_compatibility_evaluation\".\"catalog_validation_build_commit_sha\" ~ '^[a-f0-9]{40}$'\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connector_catalog_runtime_projection_sets": {
+      "name": "connector_catalog_runtime_projection_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_version": {
+          "name": "catalog_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_digest": {
+          "name": "catalog_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projection_version": {
+          "name": "projection_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_count": {
+          "name": "connector_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_validation_backend_version": {
+          "name": "catalog_validation_backend_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_validation_build_commit_sha": {
+          "name": "catalog_validation_build_commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connector_catalog_runtime_projection_sets_source_schema_unique": {
+          "name": "connector_catalog_runtime_projection_sets_source_schema_unique",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "schema_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connector_catalog_runtime_projection_sets_sync_state_fk": {
+          "name": "connector_catalog_runtime_projection_sets_sync_state_fk",
+          "tableFrom": "connector_catalog_runtime_projection_sets",
+          "tableTo": "connector_catalog_sync_state",
+          "columnsFrom": [
+            "source_id",
+            "schema_version"
+          ],
+          "columnsTo": [
+            "source_id",
+            "schema_version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "connector_catalog_projection_sets_schema_positive": {
+          "name": "connector_catalog_projection_sets_schema_positive",
+          "value": "\"connector_catalog_runtime_projection_sets\".\"schema_version\" > 0"
+        },
+        "connector_catalog_projection_sets_version_supported": {
+          "name": "connector_catalog_projection_sets_version_supported",
+          "value": "\"connector_catalog_runtime_projection_sets\".\"projection_version\" = 2"
+        },
+        "connector_catalog_projection_sets_count_positive": {
+          "name": "connector_catalog_projection_sets_count_positive",
+          "value": "\"connector_catalog_runtime_projection_sets\".\"connector_count\" > 0"
+        },
+        "connector_catalog_projection_sets_digest_valid": {
+          "name": "connector_catalog_projection_sets_digest_valid",
+          "value": "\"connector_catalog_runtime_projection_sets\".\"catalog_digest\" ~ '^sha256:[a-f0-9]{64}$'"
+        },
+        "connector_catalog_projection_sets_validator_complete": {
+          "name": "connector_catalog_projection_sets_validator_complete",
+          "value": "\"connector_catalog_runtime_projection_sets\".\"catalog_validation_backend_version\" ~ '^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$'\n          AND (\n            \"connector_catalog_runtime_projection_sets\".\"catalog_validation_build_commit_sha\" IS NULL\n            OR \"connector_catalog_runtime_projection_sets\".\"catalog_validation_build_commit_sha\" ~ '^[a-f0-9]{40}$'\n          )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connector_catalog_runtime_projections": {
+      "name": "connector_catalog_runtime_projections",
+      "schema": "",
+      "columns": {
+        "projection_set_id": {
+          "name": "projection_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_digest": {
+          "name": "connector_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_payload": {
+          "name": "connector_payload",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connector_catalog_runtime_projections_set_fk": {
+          "name": "connector_catalog_runtime_projections_set_fk",
+          "tableFrom": "connector_catalog_runtime_projections",
+          "tableTo": "connector_catalog_runtime_projection_sets",
+          "columnsFrom": [
+            "projection_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "connector_catalog_runtime_projections_pk": {
+          "name": "connector_catalog_runtime_projections_pk",
+          "columns": [
+            "projection_set_id",
+            "connector_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "connector_catalog_projections_connector_digest_valid": {
+          "name": "connector_catalog_projections_connector_digest_valid",
+          "value": "\"connector_catalog_runtime_projections\".\"connector_digest\" ~ '^sha256:[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connector_catalog_sync_state": {
+      "name": "connector_catalog_sync_state",
+      "schema": "",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_observed_catalog_version": {
+          "name": "last_observed_catalog_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_catalog_key": {
+          "name": "last_observed_catalog_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_catalog_digest": {
+          "name": "last_observed_catalog_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_pointer_etag": {
+          "name": "last_observed_pointer_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_outcome": {
+          "name": "last_attempt_outcome",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_reused_cached_rejection": {
+          "name": "last_attempt_reused_cached_rejection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_code": {
+          "name": "last_failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_catalog_version": {
+          "name": "last_rejected_catalog_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_catalog_key": {
+          "name": "last_rejected_catalog_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_catalog_digest": {
+          "name": "last_rejected_catalog_digest",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_pointer_etag": {
+          "name": "last_rejected_pointer_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_failure_code": {
+          "name": "last_rejected_failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_backend_version": {
+          "name": "last_rejected_backend_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rejected_build_commit_sha": {
+          "name": "last_rejected_build_commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connector_catalog_sync_state_pk": {
+          "name": "connector_catalog_sync_state_pk",
+          "columns": [
+            "source_id",
+            "schema_version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "connector_catalog_sync_state_schema_version_positive": {
+          "name": "connector_catalog_sync_state_schema_version_positive",
+          "value": "\"connector_catalog_sync_state\".\"schema_version\" > 0"
+        },
+        "connector_catalog_sync_state_revision_nonnegative": {
+          "name": "connector_catalog_sync_state_revision_nonnegative",
+          "value": "\"connector_catalog_sync_state\".\"revision\" >= 0"
+        },
+        "connector_catalog_sync_state_observed_identity_complete": {
+          "name": "connector_catalog_sync_state_observed_identity_complete",
+          "value": "(\n          \"connector_catalog_sync_state\".\"last_observed_catalog_version\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_observed_catalog_key\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_observed_catalog_digest\" IS NULL\n        ) OR (\n          \"connector_catalog_sync_state\".\"last_observed_catalog_version\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_observed_catalog_key\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_observed_catalog_digest\" IS NOT NULL\n        )"
+        },
+        "connector_catalog_sync_state_attempt_complete": {
+          "name": "connector_catalog_sync_state_attempt_complete",
+          "value": "(\n          \"connector_catalog_sync_state\".\"last_attempt_outcome\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_attempt_at\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_failure_code\" IS NULL\n        ) OR (\n          \"connector_catalog_sync_state\".\"last_attempt_outcome\" = 'rejected'\n          AND \"connector_catalog_sync_state\".\"last_attempt_at\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_failure_code\" IS NOT NULL\n        ) OR (\n          \"connector_catalog_sync_state\".\"last_attempt_outcome\" IN ('accepted', 'unchanged')\n          AND \"connector_catalog_sync_state\".\"last_attempt_at\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_failure_code\" IS NULL\n        )"
+        },
+        "connector_catalog_sync_state_attempt_cache_reuse_complete": {
+          "name": "connector_catalog_sync_state_attempt_cache_reuse_complete",
+          "value": "(\n          \"connector_catalog_sync_state\".\"last_attempt_outcome\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_attempt_reused_cached_rejection\" IS NULL\n        ) OR (\n          \"connector_catalog_sync_state\".\"last_attempt_outcome\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_attempt_reused_cached_rejection\" IS NOT NULL\n          AND (\n            \"connector_catalog_sync_state\".\"last_attempt_reused_cached_rejection\" = FALSE\n            OR \"connector_catalog_sync_state\".\"last_attempt_outcome\" = 'rejected'\n          )\n        )"
+        },
+        "connector_catalog_sync_state_rejected_candidate_complete": {
+          "name": "connector_catalog_sync_state_rejected_candidate_complete",
+          "value": "(\n          \"connector_catalog_sync_state\".\"last_rejected_catalog_version\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_catalog_key\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_catalog_digest\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_pointer_etag\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_failure_code\" IS NULL\n        ) OR (\n          \"connector_catalog_sync_state\".\"last_rejected_failure_code\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_failure_code\" <> 'source-unavailable'\n          AND (\n            (\n              \"connector_catalog_sync_state\".\"last_rejected_catalog_version\" IS NOT NULL\n              AND \"connector_catalog_sync_state\".\"last_rejected_catalog_key\" IS NOT NULL\n              AND \"connector_catalog_sync_state\".\"last_rejected_catalog_digest\" IS NOT NULL\n            ) OR \"connector_catalog_sync_state\".\"last_rejected_pointer_etag\" IS NOT NULL\n          )\n          AND (\n            (\n              \"connector_catalog_sync_state\".\"last_rejected_catalog_version\" IS NULL\n              AND \"connector_catalog_sync_state\".\"last_rejected_catalog_key\" IS NULL\n              AND \"connector_catalog_sync_state\".\"last_rejected_catalog_digest\" IS NULL\n            ) OR (\n              \"connector_catalog_sync_state\".\"last_rejected_catalog_version\" IS NOT NULL\n              AND \"connector_catalog_sync_state\".\"last_rejected_catalog_key\" IS NOT NULL\n              AND \"connector_catalog_sync_state\".\"last_rejected_catalog_digest\" IS NOT NULL\n            )\n          )\n        )"
+        },
+        "connector_catalog_sync_state_rejection_authority_complete": {
+          "name": "connector_catalog_sync_state_rejection_authority_complete",
+          "value": "(\n          \"connector_catalog_sync_state\".\"last_rejected_failure_code\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_backend_version\" IS NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_build_commit_sha\" IS NULL\n        ) OR (\n          \"connector_catalog_sync_state\".\"last_rejected_failure_code\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_backend_version\" IS NOT NULL\n          AND \"connector_catalog_sync_state\".\"last_rejected_backend_version\" ~ '^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$'\n          AND (\n            \"connector_catalog_sync_state\".\"last_rejected_build_commit_sha\" IS NULL\n            OR \"connector_catalog_sync_state\".\"last_rejected_build_commit_sha\" ~ '^[a-f0-9]{40}$'\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connector_external_code_sessions": {
+      "name": "connector_external_code_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorize_agent": {
+          "name": "authorize_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_external_code_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "session_token_hash": {
+          "name": "session_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_provider_state": {
+          "name": "encrypted_provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_mutation": {
+          "name": "account_mutation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_connector_id": {
+          "name": "completed_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_requested_scopes": {
+          "name": "oauth_requested_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_external_code_sessions_token": {
+          "name": "idx_connector_external_code_sessions_token",
+          "columns": [
+            {
+              "expression": "session_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_external_code_sessions_owner_slug_status": {
+          "name": "idx_connector_external_code_sessions_owner_slug_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auth_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_external_code_sessions_expiration": {
+          "name": "idx_connector_external_code_sessions_expiration",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_oauth_device_authorization_sessions": {
+      "name": "connector_oauth_device_authorization_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorize_agent": {
+          "name": "authorize_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_oauth_device_authorization_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'awaiting_user_authorization'"
+        },
+        "session_token_hash": {
+          "name": "session_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_provider_state": {
+          "name": "encrypted_provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_mutation": {
+          "name": "account_mutation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_connector_id": {
+          "name": "completed_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_requested_scopes": {
+          "name": "oauth_requested_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_uri": {
+          "name": "verification_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_uri_complete": {
+          "name": "verification_uri_complete",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_oauth_device_authorization_sessions_token": {
+          "name": "idx_connector_oauth_device_authorization_sessions_token",
+          "columns": [
+            {
+              "expression": "session_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_device_sessions_owner_slug_status": {
+          "name": "idx_connector_oauth_device_sessions_owner_slug_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auth_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_device_authorization_sessions_expiration": {
+          "name": "idx_connector_oauth_device_authorization_sessions_expiration",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_oauth_completions": {
+      "name": "connector_oauth_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_connector_oauth_completions_expires_at": {
+          "name": "idx_connector_oauth_completions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connector_oauth_completions_connection_id_connectors_id_fk": {
+          "name": "connector_oauth_completions_connection_id_connectors_id_fk",
+          "tableFrom": "connector_oauth_completions",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_oauth_states": {
+      "name": "connector_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_version": {
+          "name": "storage_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorize_agent": {
+          "name": "authorize_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_requested_scopes": {
+          "name": "oauth_requested_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_context": {
+          "name": "oauth_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_mutation": {
+          "name": "account_mutation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_oauth_states_state": {
+          "name": "idx_connector_oauth_states_state",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_states_user_org": {
+          "name": "idx_connector_oauth_states_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_oauth_states_expires_at": {
+          "name": "idx_connector_oauth_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_connector_oauth_states_custom_connector": {
+          "name": "fk_connector_oauth_states_custom_connector",
+          "tableFrom": "connector_oauth_states",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "custom_connector_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_connector_oauth_states_identity": {
+          "name": "chk_connector_oauth_states_identity",
+          "value": "num_nonnulls(\"connector_oauth_states\".\"connector_slug\", \"connector_oauth_states\".\"custom_connector_id\") = 1"
+        },
+        "chk_connector_oauth_states_custom_storage_version": {
+          "name": "chk_connector_oauth_states_custom_storage_version",
+          "value": "(\n          \"connector_oauth_states\".\"custom_connector_id\" IS NULL\n          AND \"connector_oauth_states\".\"storage_version\" IS NULL\n        ) OR (\n          \"connector_oauth_states\".\"custom_connector_id\" IS NOT NULL\n          AND (\n            \"connector_oauth_states\".\"storage_version\" IS NULL\n            OR \"connector_oauth_states\".\"storage_version\" > 0\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_version": {
+          "name": "storage_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_granted_scopes": {
+          "name": "oauth_granted_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconnect_reason": {
+          "name": "reconnect_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_org": {
+          "name": "idx_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_stripe_oauth_external_id": {
+          "name": "idx_connectors_stripe_oauth_external_id",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connectors\".\"connector_slug\" = 'stripe' AND \"connectors\".\"auth_method\" = 'oauth'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_custom_connector": {
+          "name": "idx_connectors_org_user_custom_connector",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connectors\".\"custom_connector_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_custom_connector_default": {
+          "name": "idx_connectors_org_user_custom_connector_default",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connectors\".\"custom_connector_id\" IS NOT NULL AND \"connectors\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_slug": {
+          "name": "idx_connectors_org_user_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connectors\".\"connector_slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_slug_default": {
+          "name": "idx_connectors_org_user_slug_default",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connectors\".\"connector_slug\" IS NOT NULL AND \"connectors\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_connectors_custom_connector": {
+          "name": "fk_connectors_custom_connector",
+          "tableFrom": "connectors",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "custom_connector_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "idx_connectors_id_org_user": {
+          "name": "idx_connectors_id_org_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "org_id",
+            "user_id"
+          ]
+        },
+        "idx_connectors_id_slug": {
+          "name": "idx_connectors_id_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "connector_slug"
+          ]
+        },
+        "idx_connectors_id_custom_connector": {
+          "name": "idx_connectors_id_custom_connector",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "custom_connector_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "chk_connectors_identity": {
+          "name": "chk_connectors_identity",
+          "value": "num_nonnulls(\"connectors\".\"connector_slug\", \"connectors\".\"custom_connector_id\") = 1"
+        },
+        "chk_connectors_storage_version_positive": {
+          "name": "chk_connectors_storage_version_positive",
+          "value": "\"connectors\".\"storage_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credit_expires_record": {
+      "name": "credit_expires_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_credit_expires_org_active": {
+          "name": "idx_credit_expires_org_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "remaining > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_credit_expires_invoice": {
+          "name": "uq_credit_expires_invoice",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "stripe_invoice_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_credit_expires_starter_grant": {
+          "name": "uq_credit_expires_starter_grant",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "source = 'starter_grant'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_connector_account_oauth_bindings": {
+      "name": "custom_connector_account_oauth_bindings",
+      "schema": "",
+      "columns": {
+        "connector_account_id": {
+          "name": "connector_account_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_metadata_url": {
+          "name": "resource_metadata_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint": {
+          "name": "token_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_method": {
+          "name": "registration_method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dcr_registration_id": {
+          "name": "dcr_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_custom_connector_account_oauth_bindings_connector": {
+          "name": "idx_custom_connector_account_oauth_bindings_connector",
+          "columns": [
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_custom_connector_account_oauth_bindings_dcr": {
+          "name": "idx_custom_connector_account_oauth_bindings_dcr",
+          "columns": [
+            {
+              "expression": "dcr_registration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_custom_connector_account_oauth_bindings_account": {
+          "name": "fk_custom_connector_account_oauth_bindings_account",
+          "tableFrom": "custom_connector_account_oauth_bindings",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_account_id",
+            "custom_connector_id"
+          ],
+          "columnsTo": [
+            "id",
+            "custom_connector_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_custom_connector_account_oauth_bindings_dcr_registration": {
+          "name": "fk_custom_connector_account_oauth_bindings_dcr_registration",
+          "tableFrom": "custom_connector_account_oauth_bindings",
+          "tableTo": "org_custom_connector_dcr_registrations",
+          "columnsFrom": [
+            "dcr_registration_id",
+            "custom_connector_id"
+          ],
+          "columnsTo": [
+            "id",
+            "custom_connector_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_custom_connector_account_oauth_binding_identity": {
+          "name": "chk_custom_connector_account_oauth_binding_identity",
+          "value": "(\n          btrim(\"custom_connector_account_oauth_bindings\".\"issuer\") <> ''\n          AND btrim(\"custom_connector_account_oauth_bindings\".\"resource\") <> ''\n          AND btrim(\"custom_connector_account_oauth_bindings\".\"token_endpoint\") <> ''\n          AND btrim(\"custom_connector_account_oauth_bindings\".\"client_id\") <> ''\n          AND (\n            \"custom_connector_account_oauth_bindings\".\"resource_metadata_url\" IS NULL\n            OR btrim(\"custom_connector_account_oauth_bindings\".\"resource_metadata_url\") <> ''\n          )\n        )"
+        },
+        "chk_custom_connector_account_oauth_binding_token_auth_method": {
+          "name": "chk_custom_connector_account_oauth_binding_token_auth_method",
+          "value": "\"custom_connector_account_oauth_bindings\".\"token_endpoint_auth_method\" IN (\n          'none',\n          'client_secret_basic',\n          'client_secret_post'\n        )"
+        },
+        "chk_custom_connector_account_oauth_binding_registration": {
+          "name": "chk_custom_connector_account_oauth_binding_registration",
+          "value": "(\n          (\n            \"custom_connector_account_oauth_bindings\".\"registration_method\" = 'cimd'\n            AND \"custom_connector_account_oauth_bindings\".\"dcr_registration_id\" IS NULL\n            AND \"custom_connector_account_oauth_bindings\".\"token_endpoint_auth_method\" = 'none'\n          ) OR (\n            \"custom_connector_account_oauth_bindings\".\"registration_method\" = 'dcr'\n            AND \"custom_connector_account_oauth_bindings\".\"dcr_registration_id\" IS NOT NULL\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.desktop_auth_handoff_codes": {
+      "name": "desktop_auth_handoff_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_desktop_auth_handoff_codes_expires": {
+          "name": "idx_desktop_auth_handoff_codes_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_desktop_auth_handoff_codes_user_created": {
+          "name": "idx_desktop_auth_handoff_codes_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "desktop_auth_handoff_codes_code_hash_unique": {
+          "name": "desktop_auth_handoff_codes_code_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_outbox": {
+      "name": "email_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_run_id": {
+          "name": "source_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_workflow_automation_id": {
+          "name": "source_workflow_automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_outbox_drain_idx": {
+          "name": "email_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_created_at_idx": {
+          "name": "email_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_source_run_automation_unique": {
+          "name": "email_outbox_source_run_automation_unique",
+          "columns": [
+            {
+              "expression": "source_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_workflow_automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_outbox_source_identity_check": {
+          "name": "email_outbox_source_identity_check",
+          "value": "(\n          \"email_outbox\".\"source_run_id\" IS NULL\n          AND \"email_outbox\".\"source_workflow_automation_id\" IS NULL\n        ) OR (\n          \"email_outbox\".\"source_run_id\" IS NOT NULL\n          AND \"email_outbox\".\"source_workflow_automation_id\" IS NOT NULL\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_suppressions_email_lower_idx": {
+          "name": "email_suppressions_email_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"email_address\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.export_jobs": {
+      "name": "export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_urls": {
+          "name": "artifact_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_export_jobs_user_status": {
+          "name": "idx_export_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_created": {
+          "name": "idx_export_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_user_active": {
+          "name": "idx_export_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feishu_chat_ingress": {
+      "name": "feishu_chat_ingress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reaction_id": {
+          "name": "reaction_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_feishu_chat_ingress_installation_event": {
+          "name": "idx_feishu_chat_ingress_installation_event",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feishu_chat_ingress_installation_id_feishu_org_installations_id_fk": {
+          "name": "feishu_chat_ingress_installation_id_feishu_org_installations_id_fk",
+          "tableFrom": "feishu_chat_ingress",
+          "tableTo": "feishu_org_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_feishu_chat_ingress_status": {
+          "name": "chk_feishu_chat_ingress_status",
+          "value": "\"feishu_chat_ingress\".\"status\" IN ('pending', 'processing', 'processed', 'failed')"
+        },
+        "chk_feishu_chat_ingress_retry_count": {
+          "name": "chk_feishu_chat_ingress_retry_count",
+          "value": "\"feishu_chat_ingress\".\"retry_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feishu_chat_thread_routes": {
+      "name": "feishu_chat_thread_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_feishu_chat_thread_routes_conn_chat_thread_user": {
+          "name": "idx_feishu_chat_thread_routes_conn_chat_thread_user",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feishu_chat_thread_routes_connection_id_feishu_org_connections_id_fk": {
+          "name": "feishu_chat_thread_routes_connection_id_feishu_org_connections_id_fk",
+          "tableFrom": "feishu_chat_thread_routes",
+          "tableTo": "feishu_org_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feishu_chat_thread_routes_chat_thread_id_chat_threads_id_fk": {
+          "name": "feishu_chat_thread_routes_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "feishu_chat_thread_routes",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feishu_org_connections": {
+      "name": "feishu_org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feishu_open_id": {
+          "name": "feishu_open_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feishu_user_name": {
+          "name": "feishu_user_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_feishu_org_connections_user_installation": {
+          "name": "idx_feishu_org_connections_user_installation",
+          "columns": [
+            {
+              "expression": "feishu_open_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feishu_org_connections_user_id_installation": {
+          "name": "idx_feishu_org_connections_user_id_installation",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feishu_org_connections_installation": {
+          "name": "idx_feishu_org_connections_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feishu_org_connections_connector": {
+          "name": "idx_feishu_org_connections_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"feishu_org_connections\".\"connector_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feishu_org_connections_installation_id_feishu_org_installations_id_fk": {
+          "name": "feishu_org_connections_installation_id_feishu_org_installations_id_fk",
+          "tableFrom": "feishu_org_connections",
+          "tableTo": "feishu_org_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feishu_org_connections_connector_id_connectors_id_fk": {
+          "name": "feishu_org_connections_connector_id_connectors_id_fk",
+          "tableFrom": "feishu_org_connections",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feishu_org_events": {
+      "name": "feishu_org_events",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feishu_org_events_installation_id_feishu_org_installations_id_fk": {
+          "name": "feishu_org_events_installation_id_feishu_org_installations_id_fk",
+          "tableFrom": "feishu_org_events",
+          "tableTo": "feishu_org_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feishu_org_events_pkey": {
+          "name": "feishu_org_events_pkey",
+          "columns": [
+            "installation_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feishu_org_installations": {
+      "name": "feishu_org_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_open_id": {
+          "name": "bot_open_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_name": {
+          "name": "bot_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_avatar_url": {
+          "name": "bot_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "encrypted_app_secret": {
+          "name": "encrypted_app_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_verification_token": {
+          "name": "encrypted_verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_encrypt_key": {
+          "name": "encrypted_encrypt_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_agent_id": {
+          "name": "default_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feishu_tenant_key": {
+          "name": "feishu_tenant_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feishu_tenant_name": {
+          "name": "feishu_tenant_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_tenant_access_token": {
+          "name": "encrypted_tenant_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_access_token_expires_at": {
+          "name": "tenant_access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "callback_verified_at": {
+          "name": "callback_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_completed_at": {
+          "name": "setup_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_received_at": {
+          "name": "message_received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_feishu_org_installations_org": {
+          "name": "idx_feishu_org_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feishu_org_installations_custom_connector": {
+          "name": "idx_feishu_org_installations_custom_connector",
+          "columns": [
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feishu_org_installations_app": {
+          "name": "idx_feishu_org_installations_app",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feishu_org_installations_tenant": {
+          "name": "idx_feishu_org_installations_tenant",
+          "columns": [
+            {
+              "expression": "feishu_tenant_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feishu_org_installations_default_agent_id_agents_id_fk": {
+          "name": "feishu_org_installations_default_agent_id_agents_id_fk",
+          "tableFrom": "feishu_org_installations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "default_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_feishu_org_installations_custom_connector": {
+          "name": "fk_feishu_org_installations_custom_connector",
+          "tableFrom": "feishu_org_installations",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "custom_connector_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feishu_user_agent_preferences": {
+      "name": "feishu_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_agent_id": {
+          "name": "selected_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feishu_user_agent_preferences_selected_agent_id_agents_id_fk": {
+          "name": "feishu_user_agent_preferences_selected_agent_id_agents_id_fk",
+          "tableFrom": "feishu_user_agent_preferences",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "selected_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feishu_user_agent_preferences_user_id_org_id_pk": {
+          "name": "feishu_user_agent_preferences_user_id_org_id_pk",
+          "columns": [
+            "user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_chat_thread_routes": {
+      "name": "github_chat_thread_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_number": {
+          "name": "subject_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_chat_thread_routes_install_repo_subject_user": {
+          "name": "idx_github_chat_thread_routes_install_repo_subject_user",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_chat_thread_routes_installation_id_github_installations_id_fk": {
+          "name": "github_chat_thread_routes_installation_id_github_installations_id_fk",
+          "tableFrom": "github_chat_thread_routes",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_chat_thread_routes_chat_thread_id_chat_threads_id_fk": {
+          "name": "github_chat_thread_routes_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "github_chat_thread_routes",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_slug": {
+          "name": "app_slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'okou'"
+        },
+        "setup_public_brand": {
+          "name": "setup_public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_agent_id": {
+          "name": "default_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installations_org": {
+          "name": "idx_github_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_agent_id_agents_id_fk": {
+          "name": "github_installations_default_agent_id_agents_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "default_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_processed_events": {
+      "name": "gmail_processed_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "watch_state_id": {
+          "name": "watch_state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pubsub_message_id": {
+          "name": "pubsub_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_id": {
+          "name": "history_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gmail_processed_events_automation_event": {
+          "name": "idx_gmail_processed_events_automation_event",
+          "columns": [
+            {
+              "expression": "watch_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gmail_processed_events_pubsub_message": {
+          "name": "idx_gmail_processed_events_pubsub_message",
+          "columns": [
+            {
+              "expression": "pubsub_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_processed_events_watch_state_id_gmail_watch_states_id_fk": {
+          "name": "gmail_processed_events_watch_state_id_gmail_watch_states_id_fk",
+          "tableFrom": "gmail_processed_events",
+          "tableTo": "gmail_watch_states",
+          "columnsFrom": [
+            "watch_state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gmail_processed_events_automation_id_workflow_automations_id_fk": {
+          "name": "gmail_processed_events_automation_id_workflow_automations_id_fk",
+          "tableFrom": "gmail_processed_events",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_watch_states": {
+      "name": "gmail_watch_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_name": {
+          "name": "topic_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_history_id": {
+          "name": "last_history_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watch_expiration_at": {
+          "name": "watch_expiration_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_watch_renewed_at": {
+          "name": "last_watch_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_rewatch": {
+          "name": "needs_rewatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gmail_watch_states_connector_topic": {
+          "name": "idx_gmail_watch_states_connector_topic",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gmail_watch_states_email_topic": {
+          "name": "idx_gmail_watch_states_email_topic",
+          "columns": [
+            {
+              "expression": "email_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gmail_watch_states_renewal": {
+          "name": "idx_gmail_watch_states_renewal",
+          "columns": [
+            {
+              "expression": "watch_expiration_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_watch_states_connector_id_connectors_id_fk": {
+          "name": "gmail_watch_states_connector_id_connectors_id_fk",
+          "tableFrom": "gmail_watch_states",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_calendar_event_snapshots": {
+      "name": "google_calendar_event_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "watch_state_id": {
+          "name": "watch_state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "etag": {
+          "name": "etag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_updated_at": {
+          "name": "event_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_calendar_event_snapshots_event": {
+          "name": "idx_google_calendar_event_snapshots_event",
+          "columns": [
+            {
+              "expression": "watch_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendar_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_calendar_event_snapshots_updated": {
+          "name": "idx_google_calendar_event_snapshots_updated",
+          "columns": [
+            {
+              "expression": "event_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_event_snapshots_watch_state_id_google_calendar_watch_states_id_fk": {
+          "name": "google_calendar_event_snapshots_watch_state_id_google_calendar_watch_states_id_fk",
+          "tableFrom": "google_calendar_event_snapshots",
+          "tableTo": "google_calendar_watch_states",
+          "columnsFrom": [
+            "watch_state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_calendar_processed_events": {
+      "name": "google_calendar_processed_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "watch_state_id": {
+          "name": "watch_state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_state": {
+          "name": "resource_state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_change_key": {
+          "name": "event_change_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_updated_at": {
+          "name": "event_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_calendar_processed_events_automation_event": {
+          "name": "idx_google_calendar_processed_events_automation_event",
+          "columns": [
+            {
+              "expression": "watch_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendar_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_change_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_calendar_processed_events_channel": {
+          "name": "idx_google_calendar_processed_events_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_processed_events_watch_state_id_google_calendar_watch_states_id_fk": {
+          "name": "google_calendar_processed_events_watch_state_id_google_calendar_watch_states_id_fk",
+          "tableFrom": "google_calendar_processed_events",
+          "tableTo": "google_calendar_watch_states",
+          "columnsFrom": [
+            "watch_state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_calendar_processed_events_automation_id_workflow_automations_id_fk": {
+          "name": "google_calendar_processed_events_automation_id_workflow_automations_id_fk",
+          "tableFrom": "google_calendar_processed_events",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_calendar_watch_states": {
+      "name": "google_calendar_watch_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_token": {
+          "name": "channel_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_uri": {
+          "name": "resource_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_channel_id": {
+          "name": "previous_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_channel_token": {
+          "name": "previous_channel_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_resource_id": {
+          "name": "previous_resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_token": {
+          "name": "sync_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watch_expiration_at": {
+          "name": "watch_expiration_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_watch_renewed_at": {
+          "name": "last_watch_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_rewatch": {
+          "name": "needs_rewatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "action_required_reason": {
+          "name": "action_required_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_required_at": {
+          "name": "action_required_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_calendar_watch_states_connector_calendar": {
+          "name": "idx_google_calendar_watch_states_connector_calendar",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_calendar_watch_states_channel": {
+          "name": "idx_google_calendar_watch_states_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_calendar_watch_states_resource": {
+          "name": "idx_google_calendar_watch_states_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_calendar_watch_states_renewal": {
+          "name": "idx_google_calendar_watch_states_renewal",
+          "columns": [
+            {
+              "expression": "watch_expiration_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_watch_states_connector_id_connectors_id_fk": {
+          "name": "google_calendar_watch_states_connector_id_connectors_id_fk",
+          "tableFrom": "google_calendar_watch_states",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_forms_automation_cursors": {
+      "name": "google_forms_automation_cursors",
+      "schema": "",
+      "columns": {
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watch_state_id": {
+          "name": "watch_state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_submitted_time": {
+          "name": "last_seen_submitted_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_forms_automation_cursors_watch": {
+          "name": "idx_google_forms_automation_cursors_watch",
+          "columns": [
+            {
+              "expression": "watch_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_forms_automation_cursors_automation_id_workflow_automations_id_fk": {
+          "name": "google_forms_automation_cursors_automation_id_workflow_automations_id_fk",
+          "tableFrom": "google_forms_automation_cursors",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_forms_automation_cursors_watch_state_id_google_forms_watch_states_id_fk": {
+          "name": "google_forms_automation_cursors_watch_state_id_google_forms_watch_states_id_fk",
+          "tableFrom": "google_forms_automation_cursors",
+          "tableTo": "google_forms_watch_states",
+          "columnsFrom": [
+            "watch_state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_forms_processed_events": {
+      "name": "google_forms_processed_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "watch_state_id": {
+          "name": "watch_state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pubsub_message_id": {
+          "name": "pubsub_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_submitted_time": {
+          "name": "last_submitted_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_forms_processed_events_automation_response": {
+          "name": "idx_google_forms_processed_events_automation_response",
+          "columns": [
+            {
+              "expression": "watch_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_submitted_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_forms_processed_events_pubsub_message": {
+          "name": "idx_google_forms_processed_events_pubsub_message",
+          "columns": [
+            {
+              "expression": "pubsub_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_forms_processed_events_watch_state_id_google_forms_watch_states_id_fk": {
+          "name": "google_forms_processed_events_watch_state_id_google_forms_watch_states_id_fk",
+          "tableFrom": "google_forms_processed_events",
+          "tableTo": "google_forms_watch_states",
+          "columnsFrom": [
+            "watch_state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_forms_processed_events_automation_id_workflow_automations_id_fk": {
+          "name": "google_forms_processed_events_automation_id_workflow_automations_id_fk",
+          "tableFrom": "google_forms_processed_events",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_forms_watch_states": {
+      "name": "google_forms_watch_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watch_id": {
+          "name": "watch_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_name": {
+          "name": "topic_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expire_time": {
+          "name": "expire_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_renewed_at": {
+          "name": "last_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_rewatch": {
+          "name": "needs_rewatch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_forms_watch_states_connector_form": {
+          "name": "idx_google_forms_watch_states_connector_form",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "form_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_forms_watch_states_watch": {
+          "name": "idx_google_forms_watch_states_watch",
+          "columns": [
+            {
+              "expression": "watch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_forms_watch_states_renewal": {
+          "name": "idx_google_forms_watch_states_renewal",
+          "columns": [
+            {
+              "expression": "expire_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_forms_watch_states_connector_id_connectors_id_fk": {
+          "name": "google_forms_watch_states_connector_id_connectors_id_fk",
+          "tableFrom": "google_forms_watch_states",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_workspace_event_subscription_states": {
+      "name": "google_workspace_event_subscription_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_resource": {
+          "name": "target_resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types_key": {
+          "name": "event_types_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_name": {
+          "name": "subscription_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pubsub_topic": {
+          "name": "pubsub_topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expire_time": {
+          "name": "expire_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_renewed_at": {
+          "name": "last_renewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_repair": {
+          "name": "needs_repair",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_workspace_event_subscription_scope": {
+          "name": "idx_google_workspace_event_subscription_scope",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pubsub_topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_types_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_workspace_event_subscription_name": {
+          "name": "idx_google_workspace_event_subscription_name",
+          "columns": [
+            {
+              "expression": "subscription_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_workspace_event_subscription_owner": {
+          "name": "idx_google_workspace_event_subscription_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_workspace_event_subscription_renewal": {
+          "name": "idx_google_workspace_event_subscription_renewal",
+          "columns": [
+            {
+              "expression": "expire_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_workspace_event_subscription_states_connector_id_connectors_id_fk": {
+          "name": "google_workspace_event_subscription_states_connector_id_connectors_id_fk",
+          "tableFrom": "google_workspace_event_subscription_states",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_workspace_processed_events": {
+      "name": "google_workspace_processed_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subscription_state_id": {
+          "name": "subscription_state_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pubsub_message_id": {
+          "name": "pubsub_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_event_id": {
+          "name": "cloud_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cloud_event_type": {
+          "name": "cloud_event_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conference_record_name": {
+          "name": "conference_record_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_name": {
+          "name": "transcript_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_google_workspace_processed_events_automation_cloudevent": {
+          "name": "idx_google_workspace_processed_events_automation_cloudevent",
+          "columns": [
+            {
+              "expression": "subscription_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cloud_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_workspace_processed_events_automation_transcript": {
+          "name": "idx_google_workspace_processed_events_automation_transcript",
+          "columns": [
+            {
+              "expression": "subscription_state_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transcript_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_google_workspace_processed_events_pubsub_message": {
+          "name": "idx_google_workspace_processed_events_pubsub_message",
+          "columns": [
+            {
+              "expression": "pubsub_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_workspace_processed_events_subscription_state_id_google_workspace_event_subscription_states_id_fk": {
+          "name": "google_workspace_processed_events_subscription_state_id_google_workspace_event_subscription_states_id_fk",
+          "tableFrom": "google_workspace_processed_events",
+          "tableTo": "google_workspace_event_subscription_states",
+          "columnsFrom": [
+            "subscription_state_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_workspace_processed_events_automation_id_workflow_automations_id_fk": {
+          "name": "google_workspace_processed_events_automation_id_workflow_automations_id_fk",
+          "tableFrom": "google_workspace_processed_events",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_deployments": {
+      "name": "hosted_deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "deployment_version": {
+          "name": "deployment_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_url": {
+          "name": "artifact_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "r2_prefix": {
+          "name": "r2_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrypoint": {
+          "name": "entrypoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/index.html'"
+        },
+        "spa_fallback": {
+          "name": "spa_fallback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_hosted_deployments_site": {
+          "name": "idx_hosted_deployments_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_deployments_site_version": {
+          "name": "idx_hosted_deployments_site_version",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deployment_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"hosted_deployments\".\"deployment_version\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_deployments_org": {
+          "name": "idx_hosted_deployments_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_deployments_status": {
+          "name": "idx_hosted_deployments_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hosted_deployments_site_id_hosted_sites_id_fk": {
+          "name": "hosted_deployments_site_id_hosted_sites_id_fk",
+          "tableFrom": "hosted_deployments",
+          "tableTo": "hosted_sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_hosted_deployments_site_public_brand": {
+          "name": "fk_hosted_deployments_site_public_brand",
+          "tableFrom": "hosted_deployments",
+          "tableTo": "hosted_sites",
+          "columnsFrom": [
+            "site_id",
+            "public_brand"
+          ],
+          "columnsTo": [
+            "id",
+            "public_brand"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_sites": {
+      "name": "hosted_sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_slug": {
+          "name": "requested_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_slug": {
+          "name": "public_slug",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_deployment_id": {
+          "name": "active_deployment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_deployment_version": {
+          "name": "active_deployment_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_deployment_version": {
+          "name": "next_deployment_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_from_run_id": {
+          "name": "created_from_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_hosted_sites_org": {
+          "name": "idx_hosted_sites_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_sites_org_slug": {
+          "name": "idx_hosted_sites_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_sites_org_chat_thread_requested_slug": {
+          "name": "idx_hosted_sites_org_chat_thread_requested_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"hosted_sites\".\"chat_thread_id\" IS NOT NULL AND \"hosted_sites\".\"requested_slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_sites_org_requested_slug_non_chat": {
+          "name": "idx_hosted_sites_org_requested_slug_non_chat",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"hosted_sites\".\"chat_thread_id\" IS NULL AND \"hosted_sites\".\"requested_slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hosted_sites_public_slug": {
+          "name": "idx_hosted_sites_public_slug",
+          "columns": [
+            {
+              "expression": "public_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "idx_hosted_sites_id_public_brand": {
+          "name": "idx_hosted_sites_id_public_brand",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "public_brand"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.private_hosted_deployments": {
+      "name": "private_hosted_deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "deployment_version": {
+          "name": "deployment_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_url": {
+          "name": "artifact_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "r2_prefix": {
+          "name": "r2_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrypoint": {
+          "name": "entrypoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/index.html'"
+        },
+        "spa_fallback": {
+          "name": "spa_fallback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_private_hosted_deployments_site": {
+          "name": "idx_private_hosted_deployments_site",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_private_hosted_deployments_site_version": {
+          "name": "idx_private_hosted_deployments_site_version",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deployment_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_private_hosted_deployments_org": {
+          "name": "idx_private_hosted_deployments_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_private_hosted_deployments_status": {
+          "name": "idx_private_hosted_deployments_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "private_hosted_deployments_site_id_hosted_sites_id_fk": {
+          "name": "private_hosted_deployments_site_id_hosted_sites_id_fk",
+          "tableFrom": "private_hosted_deployments",
+          "tableTo": "hosted_sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_private_hosted_deployments_site_public_brand": {
+          "name": "fk_private_hosted_deployments_site_public_brand",
+          "tableFrom": "private_hosted_deployments",
+          "tableTo": "hosted_sites",
+          "columnsFrom": [
+            "site_id",
+            "public_brand"
+          ],
+          "columnsTo": [
+            "id",
+            "public_brand"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.image_artifact_edit_snapshots": {
+      "name": "image_artifact_edit_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_url": {
+          "name": "artifact_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_image_artifact_edit_snapshots_owner_artifact": {
+          "name": "idx_image_artifact_edit_snapshots_owner_artifact",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_drafts": {
+      "name": "mail_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gmail_draft_id": {
+          "name": "gmail_draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gmail_thread_id": {
+          "name": "gmail_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gmail_message_id": {
+          "name": "gmail_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_gmail_message_id": {
+          "name": "sent_gmail_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_address": {
+          "name": "sender_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mail_drafts_chat_thread": {
+          "name": "idx_mail_drafts_chat_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_drafts_connector_gmail_draft_unique": {
+          "name": "mail_drafts_connector_gmail_draft_unique",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_drafts_chat_thread_id_chat_threads_id_fk": {
+          "name": "mail_drafts_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "mail_drafts",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mail_drafts_connector_id_connectors_id_fk": {
+          "name": "mail_drafts_connector_id_connectors_id_fk",
+          "tableFrom": "mail_drafts",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_summary_projections": {
+      "name": "memory_summary_projections",
+      "schema": "",
+      "columns": {
+        "memory_storage_id": {
+          "name": "memory_storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_version_id": {
+          "name": "storage_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error_class": {
+          "name": "last_error_class",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_size": {
+          "name": "source_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_memory_summary_projections_pending": {
+          "name": "idx_memory_summary_projections_pending",
+          "columns": [
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "storage_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"memory_summary_projections\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_summary_projections_expired_lease": {
+          "name": "idx_memory_summary_projections_expired_lease",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "storage_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"memory_summary_projections\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_summary_projections_owner": {
+          "name": "idx_memory_summary_projections_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "storage_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_summary_projections_memory_storage_id_storages_id_fk": {
+          "name": "memory_summary_projections_memory_storage_id_storages_id_fk",
+          "tableFrom": "memory_summary_projections",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "memory_storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_summary_projections_storage_version_id_storage_versions_id_fk": {
+          "name": "memory_summary_projections_storage_version_id_storage_versions_id_fk",
+          "tableFrom": "memory_summary_projections",
+          "tableTo": "storage_versions",
+          "columnsFrom": [
+            "storage_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "memory_summary_projections_memory_storage_id_storage_version_id_pk": {
+          "name": "memory_summary_projections_memory_storage_id_storage_version_id_pk",
+          "columns": [
+            "memory_storage_id",
+            "storage_version_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "memory_summary_projections_status_check": {
+          "name": "memory_summary_projections_status_check",
+          "value": "\"memory_summary_projections\".\"status\" IN ('pending', 'running', 'ready', 'missing', 'invalid', 'over_limit')"
+        },
+        "memory_summary_projections_lease_check": {
+          "name": "memory_summary_projections_lease_check",
+          "value": "(\n          \"memory_summary_projections\".\"status\" = 'running'\n          AND \"memory_summary_projections\".\"lease_id\" IS NOT NULL\n          AND \"memory_summary_projections\".\"lease_expires_at\" IS NOT NULL\n        ) OR (\n          \"memory_summary_projections\".\"status\" <> 'running'\n          AND \"memory_summary_projections\".\"lease_id\" IS NULL\n          AND \"memory_summary_projections\".\"lease_expires_at\" IS NULL\n        )"
+        },
+        "memory_summary_projections_content_check": {
+          "name": "memory_summary_projections_content_check",
+          "value": "(\n          \"memory_summary_projections\".\"status\" = 'ready'\n          AND \"memory_summary_projections\".\"content\" IS NOT NULL\n          AND \"memory_summary_projections\".\"source_hash\" IS NOT NULL\n          AND \"memory_summary_projections\".\"source_size\" IS NOT NULL\n          AND \"memory_summary_projections\".\"token_count\" IS NOT NULL\n        ) OR (\n          \"memory_summary_projections\".\"status\" <> 'ready'\n          AND \"memory_summary_projections\".\"content\" IS NULL\n          AND \"memory_summary_projections\".\"source_hash\" IS NULL\n          AND \"memory_summary_projections\".\"source_size\" IS NULL\n          AND \"memory_summary_projections\".\"token_count\" IS NULL\n        )"
+        },
+        "memory_summary_projections_attempt_count_check": {
+          "name": "memory_summary_projections_attempt_count_check",
+          "value": "\"memory_summary_projections\".\"attempt_count\" >= 0"
+        },
+        "memory_summary_projections_source_size_check": {
+          "name": "memory_summary_projections_source_size_check",
+          "value": "\"memory_summary_projections\".\"source_size\" IS NULL OR \"memory_summary_projections\".\"source_size\" >= 0"
+        },
+        "memory_summary_projections_token_count_check": {
+          "name": "memory_summary_projections_token_count_check",
+          "value": "\"memory_summary_projections\".\"token_count\" IS NULL OR \"memory_summary_projections\".\"token_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_provider_account_secrets": {
+      "name": "model_provider_account_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "model_provider_account_id": {
+          "name": "model_provider_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_provider_account_secrets_account_name": {
+          "name": "idx_model_provider_account_secrets_account_name",
+          "columns": [
+            {
+              "expression": "model_provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_provider_account_secrets_model_provider_account_id_model_provider_accounts_id_fk": {
+          "name": "model_provider_account_secrets_model_provider_account_id_model_provider_accounts_id_fk",
+          "tableFrom": "model_provider_account_secrets",
+          "tableTo": "model_provider_accounts",
+          "columnsFrom": [
+            "model_provider_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider_accounts": {
+      "name": "model_provider_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_refresh_error_code": {
+          "name": "last_refresh_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_reset_period": {
+          "name": "subscription_reset_period",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_next_reset_at": {
+          "name": "subscription_next_reset_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_provider_accounts_provider": {
+          "name": "idx_model_provider_accounts_provider",
+          "columns": [
+            {
+              "expression": "model_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_accounts_owner_type": {
+          "name": "idx_model_provider_accounts_owner_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_accounts_one_active": {
+          "name": "idx_model_provider_accounts_one_active",
+          "columns": [
+            {
+              "expression": "model_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"model_provider_accounts\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_provider_accounts_model_provider_id_model_providers_id_fk": {
+          "name": "model_provider_accounts_model_provider_id_model_providers_id_fk",
+          "tableFrom": "model_provider_accounts",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider_auth_sessions": {
+      "name": "model_provider_auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "model_provider_auth_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'initializing'"
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_url": {
+          "name": "approval_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_code": {
+          "name": "verification_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_provider_state": {
+          "name": "encrypted_provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_model_provider_auth_sessions_owner_status": {
+          "name": "idx_model_provider_auth_sessions_owner_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_auth_sessions_expiration": {
+          "name": "idx_model_provider_auth_sessions_expiration",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_auth_sessions_sandbox": {
+          "name": "idx_model_provider_auth_sessions_sandbox",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"model_provider_auth_sessions\".\"sandbox_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider_connections": {
+      "name": "model_provider_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_provider_connections_org": {
+          "name": "idx_model_provider_connections_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_connections_secret": {
+          "name": "idx_model_provider_connections_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_provider_connections_secret_id_secrets_id_fk": {
+          "name": "model_provider_connections_secret_id_secrets_id_fk",
+          "tableFrom": "model_provider_connections",
+          "tableTo": "secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider_surfaces": {
+      "name": "model_provider_surfaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_header_name": {
+          "name": "auth_header_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_header_template": {
+          "name": "auth_header_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_mappings": {
+          "name": "model_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_provider_surfaces_connection": {
+          "name": "idx_model_provider_surfaces_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_surfaces_connection_protocol": {
+          "name": "idx_model_provider_surfaces_connection_protocol",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "protocol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_provider_surfaces_connection_id_model_provider_connections_id_fk": {
+          "name": "model_provider_surfaces_connection_id_model_provider_connections_id_fk",
+          "tableFrom": "model_provider_surfaces",
+          "tableTo": "model_provider_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_model_provider_surfaces_protocol": {
+          "name": "chk_model_provider_surfaces_protocol",
+          "value": "\"model_provider_surfaces\".\"protocol\" IN ('anthropic-messages', 'openai-responses')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_refresh_error_code": {
+          "name": "last_refresh_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_reset_period": {
+          "name": "subscription_reset_period",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_next_reset_at": {
+          "name": "subscription_next_reset_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org": {
+          "name": "idx_model_providers_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org_user_type": {
+          "name": "idx_model_providers_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_one_default_per_user": {
+          "name": "idx_model_providers_one_default_per_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notion_webhook_events": {
+      "name": "notion_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "notion_event_id": {
+          "name": "notion_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notion_webhook_events_event_id": {
+          "name": "idx_notion_webhook_events_event_id",
+          "columns": [
+            {
+              "expression": "notion_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_webhook_events_page": {
+          "name": "idx_notion_webhook_events_page",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notion_webhook_secrets": {
+      "name": "notion_webhook_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_verification_token": {
+          "name": "encrypted_verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notion_webhook_secrets_active": {
+          "name": "idx_notion_webhook_secrets_active",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_webhook_secrets_active_single": {
+          "name": "idx_notion_webhook_secrets_active_single",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "active = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notion_workflow_pending_events": {
+      "name": "notion_workflow_pending_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_family": {
+          "name": "event_family",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new_child_page'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "first_notion_event_id": {
+          "name": "first_notion_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_notion_event_id": {
+          "name": "latest_notion_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_event_at": {
+          "name": "first_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_event_at": {
+          "name": "latest_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_event_context": {
+          "name": "latest_event_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_after": {
+          "name": "run_after",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_title": {
+          "name": "parent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_url": {
+          "name": "parent_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notion_pending_events_automation_page_family_active": {
+          "name": "idx_notion_pending_events_automation_page_family_active",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_family",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_pending_events_due": {
+          "name": "idx_notion_pending_events_due",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_pending_events_connector": {
+          "name": "idx_notion_pending_events_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_pending_events_page_pending": {
+          "name": "idx_notion_pending_events_page_pending",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notion_pending_events_scope": {
+          "name": "idx_notion_pending_events_scope",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notion_workflow_pending_events_automation_id_workflow_automations_id_fk": {
+          "name": "notion_workflow_pending_events_automation_id_workflow_automations_id_fk",
+          "tableFrom": "notion_workflow_pending_events",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notion_workflow_pending_events_connector_id_connectors_id_fk": {
+          "name": "notion_workflow_pending_events_connector_id_connectors_id_fk",
+          "tableFrom": "notion_workflow_pending_events",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.official_automation_result_email_claims": {
+      "name": "official_automation_result_email_claims",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_automation_id": {
+          "name": "workflow_automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_outbox_id": {
+          "name": "email_outbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "official_automation_result_email_claims_outbox_unique": {
+          "name": "official_automation_result_email_claims_outbox_unique",
+          "columns": [
+            {
+              "expression": "email_outbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "official_automation_result_email_claims_pkey": {
+          "name": "official_automation_result_email_claims_pkey",
+          "columns": [
+            "run_id",
+            "workflow_automation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.official_workflow_catalog_releases": {
+      "name": "official_workflow_catalog_releases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "official_workflow_catalog_release_hash_format": {
+          "name": "official_workflow_catalog_release_hash_format",
+          "value": "\"official_workflow_catalog_releases\".\"id\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.official_workflow_catalog_state": {
+      "name": "official_workflow_catalog_state",
+      "schema": "",
+      "columns": {
+        "authority": {
+          "name": "authority",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accepted_release_id": {
+          "name": "accepted_release_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "official_workflow_catalog_state_accepted_release_id_official_workflow_catalog_releases_id_fk": {
+          "name": "official_workflow_catalog_state_accepted_release_id_official_workflow_catalog_releases_id_fk",
+          "tableFrom": "official_workflow_catalog_state",
+          "tableTo": "official_workflow_catalog_releases",
+          "columnsFrom": [
+            "accepted_release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "official_workflow_catalog_state_authority": {
+          "name": "official_workflow_catalog_state_authority",
+          "value": "\"official_workflow_catalog_state\".\"authority\" = 'official'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.official_workflow_definition_revisions": {
+      "name": "official_workflow_definition_revisions",
+      "schema": "",
+      "columns": {
+        "definition_name": {
+          "name": "definition_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_name": {
+          "name": "storage_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_version": {
+          "name": "storage_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "official_workflow_definition_revisions_storage_id_storages_id_fk": {
+          "name": "official_workflow_definition_revisions_storage_id_storages_id_fk",
+          "tableFrom": "official_workflow_definition_revisions",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "official_workflow_definition_revisions_storage_version_storage_versions_id_fk": {
+          "name": "official_workflow_definition_revisions_storage_version_storage_versions_id_fk",
+          "tableFrom": "official_workflow_definition_revisions",
+          "tableTo": "storage_versions",
+          "columnsFrom": [
+            "storage_version"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "official_workflow_definition_revisions_pk": {
+          "name": "official_workflow_definition_revisions_pk",
+          "columns": [
+            "definition_name",
+            "revision"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "official_workflow_definition_revision_hash_format": {
+          "name": "official_workflow_definition_revision_hash_format",
+          "value": "\"official_workflow_definition_revisions\".\"revision\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.official_workflow_reconciliation_work": {
+      "name": "official_workflow_reconciliation_work",
+      "schema": "",
+      "columns": {
+        "definition_name": {
+          "name": "definition_name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requested_release_id": {
+          "name": "requested_release_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor_workflow_id": {
+          "name": "cursor_workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_official_workflow_reconciliation_work_due": {
+          "name": "idx_official_workflow_reconciliation_work_due",
+          "columns": [
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "official_workflow_reconciliation_work_requested_release_id_official_workflow_catalog_releases_id_fk": {
+          "name": "official_workflow_reconciliation_work_requested_release_id_official_workflow_catalog_releases_id_fk",
+          "tableFrom": "official_workflow_reconciliation_work",
+          "tableTo": "official_workflow_catalog_releases",
+          "columnsFrom": [
+            "requested_release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "official_workflow_reconciliation_work_state_check": {
+          "name": "official_workflow_reconciliation_work_state_check",
+          "value": "(\n          \"official_workflow_reconciliation_work\".\"state\" = 'pending'\n          AND \"official_workflow_reconciliation_work\".\"lease_id\" IS NULL\n          AND \"official_workflow_reconciliation_work\".\"lease_expires_at\" IS NULL\n        ) OR (\n          \"official_workflow_reconciliation_work\".\"state\" = 'running'\n          AND \"official_workflow_reconciliation_work\".\"lease_id\" IS NOT NULL\n          AND \"official_workflow_reconciliation_work\".\"lease_expires_at\" IS NOT NULL\n        )"
+        },
+        "official_workflow_reconciliation_work_attempt_count_check": {
+          "name": "official_workflow_reconciliation_work_attempt_count_check",
+          "value": "\"official_workflow_reconciliation_work\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_cache": {
+      "name": "org_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_concurrency_entitlements": {
+      "name": "org_concurrency_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_line_id": {
+          "name": "stripe_invoice_line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_concurrency_entitlements_invoice_line": {
+          "name": "uq_org_concurrency_entitlements_invoice_line",
+          "columns": [
+            {
+              "expression": "stripe_invoice_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_concurrency_entitlements_org_active": {
+          "name": "idx_org_concurrency_entitlements_org_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_concurrency_entitlements_slots": {
+          "name": "chk_org_concurrency_entitlements_slots",
+          "value": "\"org_concurrency_entitlements\".\"slots\" > 0"
+        },
+        "chk_org_concurrency_entitlements_window": {
+          "name": "chk_org_concurrency_entitlements_window",
+          "value": "\"org_concurrency_entitlements\".\"expires_at\" > \"org_concurrency_entitlements\".\"starts_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_concurrency_subscriptions": {
+      "name": "org_concurrency_subscriptions",
+      "schema": "",
+      "columns": {
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_slots": {
+          "name": "scheduled_slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_change_at": {
+          "name": "scheduled_change_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_concurrency_subscriptions_org": {
+          "name": "idx_org_concurrency_subscriptions_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_concurrency_subscriptions_status_period": {
+          "name": "idx_org_concurrency_subscriptions_status_period",
+          "columns": [
+            {
+              "expression": "subscription_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_concurrency_subscriptions_slots": {
+          "name": "chk_org_concurrency_subscriptions_slots",
+          "value": "\"org_concurrency_subscriptions\".\"slots\" > 0"
+        },
+        "chk_org_concurrency_subscriptions_scheduled_slots": {
+          "name": "chk_org_concurrency_subscriptions_scheduled_slots",
+          "value": "\"org_concurrency_subscriptions\".\"scheduled_slots\" IS NULL OR \"org_concurrency_subscriptions\".\"scheduled_slots\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_custom_connector_dcr_registrations": {
+      "name": "org_custom_connector_dcr_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_client_secret": {
+          "name": "encrypted_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_scopes": {
+          "name": "registered_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_custom_connector_dcr_registrations_org": {
+          "name": "idx_org_custom_connector_dcr_registrations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_org_custom_connector_dcr_registrations_connector": {
+          "name": "fk_org_custom_connector_dcr_registrations_connector",
+          "tableFrom": "org_custom_connector_dcr_registrations",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "custom_connector_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_org_custom_connector_dcr_registration_id_connector": {
+          "name": "uq_org_custom_connector_dcr_registration_id_connector",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "custom_connector_id"
+          ]
+        },
+        "uq_org_custom_connector_dcr_registration_issuer": {
+          "name": "uq_org_custom_connector_dcr_registration_issuer",
+          "nullsNotDistinct": false,
+          "columns": [
+            "custom_connector_id",
+            "issuer"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_custom_connector_dcr_registration_identity": {
+          "name": "chk_org_custom_connector_dcr_registration_identity",
+          "value": "(\n          btrim(\"org_custom_connector_dcr_registrations\".\"issuer\") <> ''\n          AND btrim(\"org_custom_connector_dcr_registrations\".\"client_id\") <> ''\n          AND btrim(\"org_custom_connector_dcr_registrations\".\"redirect_uri\") <> ''\n        )"
+        },
+        "chk_org_custom_connector_dcr_registration_token_auth_method": {
+          "name": "chk_org_custom_connector_dcr_registration_token_auth_method",
+          "value": "(\n          (\n            \"org_custom_connector_dcr_registrations\".\"token_endpoint_auth_method\" = 'none'\n            AND \"org_custom_connector_dcr_registrations\".\"encrypted_client_secret\" IS NULL\n          ) OR (\n            \"org_custom_connector_dcr_registrations\".\"token_endpoint_auth_method\" IN (\n              'client_secret_basic',\n              'client_secret_post'\n            )\n            AND \"org_custom_connector_dcr_registrations\".\"encrypted_client_secret\" IS NOT NULL\n          )\n        )"
+        },
+        "chk_org_custom_connector_dcr_registration_expiry": {
+          "name": "chk_org_custom_connector_dcr_registration_expiry",
+          "value": "\"org_custom_connector_dcr_registrations\".\"expires_at\" IS NULL OR \"org_custom_connector_dcr_registrations\".\"expires_at\" > \"org_custom_connector_dcr_registrations\".\"issued_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_custom_connector_oauth_configs": {
+      "name": "org_custom_connector_oauth_configs",
+      "schema": "",
+      "columns": {
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_adapter": {
+          "name": "provider_adapter",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_client_secret": {
+          "name": "encrypted_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pkce_method": {
+          "name": "pkce_method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "authorization_params": {
+          "name": "authorization_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_org_custom_connector_oauth_configs_connector": {
+          "name": "fk_org_custom_connector_oauth_configs_connector",
+          "tableFrom": "org_custom_connector_oauth_configs",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "connector_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_custom_connector_oauth_configs_provider_adapter": {
+          "name": "chk_org_custom_connector_oauth_configs_provider_adapter",
+          "value": "\"org_custom_connector_oauth_configs\".\"provider_adapter\" IN ('standard', 'feishu')"
+        },
+        "chk_org_custom_connector_oauth_configs_pkce_method": {
+          "name": "chk_org_custom_connector_oauth_configs_pkce_method",
+          "value": "\"org_custom_connector_oauth_configs\".\"pkce_method\" IN ('none', 'S256')"
+        },
+        "chk_org_custom_connector_oauth_configs_token_auth_method": {
+          "name": "chk_org_custom_connector_oauth_configs_token_auth_method",
+          "value": "\"org_custom_connector_oauth_configs\".\"token_endpoint_auth_method\" IN (\n          'client_secret_basic',\n          'client_secret_post'\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_custom_connectors": {
+      "name": "org_custom_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix_templates": {
+          "name": "prefix_templates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "header_injections": {
+          "name": "header_injections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "query_injections": {
+          "name": "query_injections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "permission_bundle_ref": {
+          "name": "permission_bundle_ref",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_endpoint": {
+          "name": "mcp_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_transport": {
+          "name": "mcp_transport",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skill_markdown": {
+          "name": "skill_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skill_storage_version_id": {
+          "name": "skill_storage_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_version": {
+          "name": "storage_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_custom_connectors_org": {
+          "name": "idx_org_custom_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connectors_org_slug": {
+          "name": "idx_org_custom_connectors_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_custom_connectors_skill_storage_version": {
+          "name": "idx_org_custom_connectors_skill_storage_version",
+          "columns": [
+            {
+              "expression": "skill_storage_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_org_custom_connectors_skill_storage_version": {
+          "name": "fk_org_custom_connectors_skill_storage_version",
+          "tableFrom": "org_custom_connectors",
+          "tableTo": "storage_versions",
+          "columnsFrom": [
+            "skill_storage_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "idx_org_custom_connectors_id_org": {
+          "name": "idx_org_custom_connectors_id_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_custom_connectors_slug": {
+          "name": "chk_org_custom_connectors_slug",
+          "value": "left(\"org_custom_connectors\".\"slug\", 1) = '_'"
+        },
+        "chk_org_custom_connectors_auth_mode": {
+          "name": "chk_org_custom_connectors_auth_mode",
+          "value": "\"org_custom_connectors\".\"auth_mode\" IN ('none', 'manual', 'oauth', 'automatic')"
+        },
+        "chk_org_custom_connectors_automatic_oauth_mcp": {
+          "name": "chk_org_custom_connectors_automatic_oauth_mcp",
+          "value": "(\n          \"org_custom_connectors\".\"auth_mode\" <> 'automatic'\n          OR (\n            \"org_custom_connectors\".\"mcp_endpoint\" IS NOT NULL\n            AND \"org_custom_connectors\".\"mcp_transport\" = 'streamable-http'\n          )\n        )"
+        },
+        "chk_org_custom_connectors_mcp": {
+          "name": "chk_org_custom_connectors_mcp",
+          "value": "(\n          jsonb_typeof(\"org_custom_connectors\".\"prefix_templates\") = 'array'\n          AND jsonb_typeof(\"org_custom_connectors\".\"fields\") = 'array'\n          AND jsonb_typeof(\"org_custom_connectors\".\"header_injections\") = 'array'\n          AND jsonb_typeof(\"org_custom_connectors\".\"query_injections\") = 'array'\n          AND (\n            (\n              \"org_custom_connectors\".\"mcp_endpoint\" IS NULL\n              AND \"org_custom_connectors\".\"mcp_transport\" IS NULL\n              AND \"org_custom_connectors\".\"prefix_templates\" <> '[]'::jsonb\n              AND (\n                (\n                  \"org_custom_connectors\".\"auth_mode\" = 'none'\n                  AND NOT jsonb_path_exists(\n                    \"org_custom_connectors\".\"fields\",\n                    '$[*] ? (@.kind == \"secret\")'\n                  )\n                  AND \"org_custom_connectors\".\"header_injections\" = '[]'::jsonb\n                  AND \"org_custom_connectors\".\"query_injections\" = '[]'::jsonb\n                ) OR (\n                  \"org_custom_connectors\".\"auth_mode\" IN ('manual', 'oauth')\n                  AND (\n                    \"org_custom_connectors\".\"header_injections\" <> '[]'::jsonb\n                    OR \"org_custom_connectors\".\"query_injections\" <> '[]'::jsonb\n                  )\n                )\n              )\n            ) OR (\n              \"org_custom_connectors\".\"mcp_endpoint\" IS NOT NULL\n              AND btrim(\"org_custom_connectors\".\"mcp_endpoint\") <> ''\n              AND \"org_custom_connectors\".\"mcp_transport\" IS NOT NULL\n              AND \"org_custom_connectors\".\"mcp_transport\" = 'streamable-http'\n              AND \"org_custom_connectors\".\"prefix_templates\" = '[]'::jsonb\n              AND (\n                (\n                  \"org_custom_connectors\".\"auth_mode\" IN ('none', 'automatic')\n                  AND \"org_custom_connectors\".\"fields\" = '[]'::jsonb\n                  AND \"org_custom_connectors\".\"header_injections\" = '[]'::jsonb\n                  AND \"org_custom_connectors\".\"query_injections\" = '[]'::jsonb\n                ) OR (\n                  \"org_custom_connectors\".\"auth_mode\" IN ('manual', 'oauth')\n                  AND (\n                    \"org_custom_connectors\".\"header_injections\" <> '[]'::jsonb\n                    OR \"org_custom_connectors\".\"query_injections\" <> '[]'::jsonb\n                  )\n                )\n              )\n              AND \"org_custom_connectors\".\"permission_bundle_ref\" IS NULL\n            )\n          )\n        )"
+        },
+        "chk_org_custom_connectors_storage_version_positive": {
+          "name": "chk_org_custom_connectors_storage_version_positive",
+          "value": "\"org_custom_connectors\".\"storage_version\" > 0"
+        },
+        "chk_org_custom_connectors_skill_size": {
+          "name": "chk_org_custom_connectors_skill_size",
+          "value": "\"org_custom_connectors\".\"skill_markdown\" IS NULL OR octet_length(\"org_custom_connectors\".\"skill_markdown\") <= 65536"
+        },
+        "chk_org_custom_connectors_skill_version_pair": {
+          "name": "chk_org_custom_connectors_skill_version_pair",
+          "value": "(\n          (\"org_custom_connectors\".\"skill_markdown\" IS NULL AND \"org_custom_connectors\".\"skill_storage_version_id\" IS NULL)\n          OR (\n            \"org_custom_connectors\".\"skill_markdown\" IS NOT NULL\n            AND \"org_custom_connectors\".\"skill_storage_version_id\" IS NOT NULL\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_members_cache": {
+      "name": "org_members_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_cache_org_id_user_id_pk": {
+          "name": "org_members_cache_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_metadata": {
+      "name": "org_members_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translation_language": {
+          "name": "translation_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_role": {
+          "name": "onboarding_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_agent_ids": {
+          "name": "pinned_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "send_mode": {
+          "name": "send_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enter'"
+        },
+        "cloud_browser_enabled_by_default": {
+          "name": "cloud_browser_enabled_by_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_theme": {
+          "name": "color_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_video_model": {
+          "name": "selected_video_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_image_model": {
+          "name": "selected_image_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_input_model": {
+          "name": "voice_input_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_done": {
+          "name": "onboarding_done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "morning_brief_default_eligible_at": {
+          "name": "morning_brief_default_eligible_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_network_bodies_remaining": {
+          "name": "capture_network_bodies_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_metadata_org_id_user_id_pk": {
+          "name": "org_members_metadata_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_metadata": {
+      "name": "org_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'limited-free-1'"
+        },
+        "default_agent_id": {
+          "name": "default_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_payment_pending": {
+          "name": "onboarding_payment_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pending_subscription_schedule_id": {
+          "name": "pending_subscription_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_subscription_target_tier": {
+          "name": "pending_subscription_target_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_subscription_change_at": {
+          "name": "pending_subscription_change_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processed_invoice_id": {
+          "name": "last_processed_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_source_type": {
+          "name": "acquisition_source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_campaign_id": {
+          "name": "acquisition_campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_ad_group_id": {
+          "name": "acquisition_ad_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_campaign": {
+          "name": "acquisition_campaign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_utm_source": {
+          "name": "acquisition_utm_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_utm_medium": {
+          "name": "acquisition_utm_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_utm_content": {
+          "name": "acquisition_utm_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_utm_term": {
+          "name": "acquisition_utm_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_gclid": {
+          "name": "acquisition_gclid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_gbraid": {
+          "name": "acquisition_gbraid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_wbraid": {
+          "name": "acquisition_wbraid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_ga_client_id": {
+          "name": "acquisition_ga_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_landing_host": {
+          "name": "acquisition_landing_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_landing_path": {
+          "name": "acquisition_landing_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_referrer_domain": {
+          "name": "acquisition_referrer_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_recorded_at": {
+          "name": "acquisition_recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_enabled": {
+          "name": "auto_recharge_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_recharge_threshold": {
+          "name": "auto_recharge_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_amount": {
+          "name": "auto_recharge_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_pending_at": {
+          "name": "auto_recharge_pending_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acquisition_first_party_source": {
+          "name": "acquisition_first_party_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_org_stripe_customer": {
+          "name": "uq_org_stripe_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_metadata_acquisition_campaign_id": {
+          "name": "idx_org_metadata_acquisition_campaign_id",
+          "columns": [
+            {
+              "expression": "acquisition_campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_metadata_acquisition_ad_group_id": {
+          "name": "idx_org_metadata_acquisition_ad_group_id",
+          "columns": [
+            {
+              "expression": "acquisition_ad_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_metadata_default_agent_id_agents_id_fk": {
+          "name": "org_metadata_default_agent_id_agents_id_fk",
+          "tableFrom": "org_metadata",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "default_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_model_policies": {
+      "name": "org_model_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_provider_type": {
+          "name": "default_provider_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'built-in'"
+        },
+        "credential_scope": {
+          "name": "credential_scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'org'"
+        },
+        "model_provider_id": {
+          "name": "model_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider_surface_id": {
+          "name": "model_provider_surface_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_model_policies_org_model": {
+          "name": "idx_org_model_policies_org_model",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_model_policies_one_default_per_org": {
+          "name": "idx_org_model_policies_one_default_per_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_model_policies_provider": {
+          "name": "idx_org_model_policies_provider",
+          "columns": [
+            {
+              "expression": "model_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "model_provider_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_model_policies_surface": {
+          "name": "idx_org_model_policies_surface",
+          "columns": [
+            {
+              "expression": "model_provider_surface_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "model_provider_surface_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_model_policies_model_provider_id_model_providers_id_fk": {
+          "name": "org_model_policies_model_provider_id_model_providers_id_fk",
+          "tableFrom": "org_model_policies",
+          "tableTo": "model_providers",
+          "columnsFrom": [
+            "model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "org_model_policies_model_provider_surface_id_model_provider_surfaces_id_fk": {
+          "name": "org_model_policies_model_provider_surface_id_model_provider_surfaces_id_fk",
+          "tableFrom": "org_model_policies",
+          "tableTo": "model_provider_surfaces",
+          "columnsFrom": [
+            "model_provider_surface_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_model_policies_credential_scope": {
+          "name": "chk_org_model_policies_credential_scope",
+          "value": "credential_scope IN ('org', 'member')"
+        },
+        "chk_org_model_policies_member_scope_no_provider_id": {
+          "name": "chk_org_model_policies_member_scope_no_provider_id",
+          "value": "credential_scope <> 'member' OR (model_provider_id IS NULL AND model_provider_surface_id IS NULL)"
+        },
+        "chk_org_model_policies_builtin_route_no_provider_id": {
+          "name": "chk_org_model_policies_builtin_route_no_provider_id",
+          "value": "default_provider_type <> 'built-in' OR (model_provider_id IS NULL AND model_provider_surface_id IS NULL)"
+        },
+        "chk_org_model_policies_one_route_id": {
+          "name": "chk_org_model_policies_one_route_id",
+          "value": "model_provider_id IS NULL OR model_provider_surface_id IS NULL"
+        },
+        "chk_org_model_policies_member_scope_oauth_provider": {
+          "name": "chk_org_model_policies_member_scope_oauth_provider",
+          "value": "credential_scope <> 'member' OR default_provider_type IN ('claude-code-oauth-token', 'codex-oauth-token')"
+        },
+        "chk_org_model_policies_oauth_provider_member_scope": {
+          "name": "chk_org_model_policies_oauth_provider_member_scope",
+          "value": "default_provider_type NOT IN ('claude-code-oauth-token', 'codex-oauth-token') OR credential_scope = 'member'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_plan_entitlements": {
+      "name": "org_plan_entitlements",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_key": {
+          "name": "plan_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_rank": {
+          "name": "plan_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "base_concurrency_limit": {
+          "name": "base_concurrency_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "can_buy_concurrency": {
+          "name": "can_buy_concurrency",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "can_buy_credits": {
+          "name": "can_buy_credits",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "member_invite_usage_pack_required": {
+          "name": "member_invite_usage_pack_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "show_usage_pack": {
+          "name": "show_usage_pack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "member_invitation_allowed": {
+          "name": "member_invitation_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_recharge_allowed": {
+          "name": "auto_recharge_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "support_byok": {
+          "name": "support_byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "video_generation_allowed": {
+          "name": "video_generation_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "workflow_webhook_trigger_allowed": {
+          "name": "workflow_webhook_trigger_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "audio_lifetime_limit": {
+          "name": "audio_lifetime_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_daily_rate_limit": {
+          "name": "audio_daily_rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "audio_daily_duration_seconds": {
+          "name": "audio_daily_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_version": {
+          "name": "metadata_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "metadata_hash": {
+          "name": "metadata_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "restricted_built_in_models": {
+          "name": "restricted_built_in_models",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_org_plan_entitlements_stripe_subscription": {
+          "name": "uq_org_plan_entitlements_stripe_subscription",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_plan_entitlements_status": {
+          "name": "idx_org_plan_entitlements_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_plan_entitlements_source": {
+          "name": "idx_org_plan_entitlements_source",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_plan_entitlements_expires": {
+          "name": "idx_org_plan_entitlements_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_plan_entitlements_plan_rank": {
+          "name": "chk_org_plan_entitlements_plan_rank",
+          "value": "\"org_plan_entitlements\".\"plan_rank\" >= 0"
+        },
+        "chk_org_plan_entitlements_base_concurrency": {
+          "name": "chk_org_plan_entitlements_base_concurrency",
+          "value": "\"org_plan_entitlements\".\"base_concurrency_limit\" >= 0"
+        },
+        "chk_org_plan_entitlements_audio_lifetime": {
+          "name": "chk_org_plan_entitlements_audio_lifetime",
+          "value": "\"org_plan_entitlements\".\"audio_lifetime_limit\" IS NULL OR \"org_plan_entitlements\".\"audio_lifetime_limit\" >= 0"
+        },
+        "chk_org_plan_entitlements_audio_daily_rate": {
+          "name": "chk_org_plan_entitlements_audio_daily_rate",
+          "value": "\"org_plan_entitlements\".\"audio_daily_rate_limit\" >= 0"
+        },
+        "chk_org_plan_entitlements_audio_daily_duration": {
+          "name": "chk_org_plan_entitlements_audio_daily_duration",
+          "value": "\"org_plan_entitlements\".\"audio_daily_duration_seconds\" >= 0"
+        },
+        "chk_org_plan_entitlements_period": {
+          "name": "chk_org_plan_entitlements_period",
+          "value": "\"org_plan_entitlements\".\"current_period_start\" IS NULL OR \"org_plan_entitlements\".\"current_period_end\" IS NULL OR \"org_plan_entitlements\".\"current_period_end\" > \"org_plan_entitlements\".\"current_period_start\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_promo_redemption": {
+      "name": "org_promo_redemption",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_key": {
+          "name": "campaign_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_promo_redemption": {
+          "name": "uq_org_promo_redemption",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "campaign_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_usage_allowance_entitlements": {
+      "name": "org_usage_allowance_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "short_window_seconds": {
+          "name": "short_window_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_window_units": {
+          "name": "short_window_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_window_seconds": {
+          "name": "weekly_window_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 604800
+        },
+        "weekly_window_units": {
+          "name": "weekly_window_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_usage_allowance_entitlements_org": {
+          "name": "uq_org_usage_allowance_entitlements_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_usage_allowance_entitlements_status": {
+          "name": "idx_org_usage_allowance_entitlements_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_usage_allowance_entitlements_stripe_subscription": {
+          "name": "idx_org_usage_allowance_entitlements_stripe_subscription",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_usage_allowance_short_window_seconds": {
+          "name": "chk_org_usage_allowance_short_window_seconds",
+          "value": "\"org_usage_allowance_entitlements\".\"short_window_seconds\" > 0"
+        },
+        "chk_org_usage_allowance_short_window_units": {
+          "name": "chk_org_usage_allowance_short_window_units",
+          "value": "\"org_usage_allowance_entitlements\".\"short_window_units\" > 0"
+        },
+        "chk_org_usage_allowance_weekly_window_seconds": {
+          "name": "chk_org_usage_allowance_weekly_window_seconds",
+          "value": "\"org_usage_allowance_entitlements\".\"weekly_window_seconds\" > 0"
+        },
+        "chk_org_usage_allowance_weekly_window_units": {
+          "name": "chk_org_usage_allowance_weekly_window_units",
+          "value": "\"org_usage_allowance_entitlements\".\"weekly_window_units\" > 0"
+        },
+        "chk_org_usage_allowance_entitlement_time": {
+          "name": "chk_org_usage_allowance_entitlement_time",
+          "value": "\"org_usage_allowance_entitlements\".\"expires_at\" IS NULL OR \"org_usage_allowance_entitlements\".\"expires_at\" > \"org_usage_allowance_entitlements\".\"effective_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_usage_allowance_windows": {
+      "name": "org_usage_allowance_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_limit": {
+          "name": "unit_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_units": {
+          "name": "consumed_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_run_id": {
+          "name": "created_by_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_usage_allowance_windows_org_kind_starts": {
+          "name": "idx_org_usage_allowance_windows_org_kind_starts",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_usage_allowance_windows_org_kind_expires": {
+          "name": "idx_org_usage_allowance_windows_org_kind_expires",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_usage_allowance_windows_entitlement_id_org_usage_allowance_entitlements_id_fk": {
+          "name": "org_usage_allowance_windows_entitlement_id_org_usage_allowance_entitlements_id_fk",
+          "tableFrom": "org_usage_allowance_windows",
+          "tableTo": "org_usage_allowance_entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_usage_allowance_windows_created_by_run_id_agent_runs_id_fk": {
+          "name": "org_usage_allowance_windows_created_by_run_id_agent_runs_id_fk",
+          "tableFrom": "org_usage_allowance_windows",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "created_by_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_org_usage_allowance_windows_kind": {
+          "name": "chk_org_usage_allowance_windows_kind",
+          "value": "\"org_usage_allowance_windows\".\"kind\" IN ('short', 'weekly')"
+        },
+        "chk_org_usage_allowance_windows_limit": {
+          "name": "chk_org_usage_allowance_windows_limit",
+          "value": "\"org_usage_allowance_windows\".\"unit_limit\" > 0"
+        },
+        "chk_org_usage_allowance_windows_consumed": {
+          "name": "chk_org_usage_allowance_windows_consumed",
+          "value": "\"org_usage_allowance_windows\".\"consumed_units\" >= 0"
+        },
+        "chk_org_usage_allowance_windows_time": {
+          "name": "chk_org_usage_allowance_windows_time",
+          "value": "\"org_usage_allowance_windows\".\"expires_at\" > \"org_usage_allowance_windows\".\"starts_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_allowance_allocations": {
+      "name": "usage_allowance_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "usage_event_id": {
+          "name": "usage_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_window_id": {
+          "name": "short_window_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_window_id": {
+          "name": "weekly_window_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "units_applied": {
+          "name": "units_applied",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_allowance_allocations_usage_event": {
+          "name": "uq_usage_allowance_allocations_usage_event",
+          "columns": [
+            {
+              "expression": "usage_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_allowance_allocations_org": {
+          "name": "idx_usage_allowance_allocations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_allowance_allocations_run": {
+          "name": "idx_usage_allowance_allocations_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_allowance_allocations_usage_event_id_usage_event_id_fk": {
+          "name": "usage_allowance_allocations_usage_event_id_usage_event_id_fk",
+          "tableFrom": "usage_allowance_allocations",
+          "tableTo": "usage_event",
+          "columnsFrom": [
+            "usage_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_allowance_allocations_run_id_agent_runs_id_fk": {
+          "name": "usage_allowance_allocations_run_id_agent_runs_id_fk",
+          "tableFrom": "usage_allowance_allocations",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_allowance_allocations_short_window_id_org_usage_allowance_windows_id_fk": {
+          "name": "usage_allowance_allocations_short_window_id_org_usage_allowance_windows_id_fk",
+          "tableFrom": "usage_allowance_allocations",
+          "tableTo": "org_usage_allowance_windows",
+          "columnsFrom": [
+            "short_window_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_allowance_allocations_weekly_window_id_org_usage_allowance_windows_id_fk": {
+          "name": "usage_allowance_allocations_weekly_window_id_org_usage_allowance_windows_id_fk",
+          "tableFrom": "usage_allowance_allocations",
+          "tableTo": "org_usage_allowance_windows",
+          "columnsFrom": [
+            "weekly_window_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_allowance_allocations_units": {
+          "name": "chk_usage_allowance_allocations_units",
+          "value": "\"usage_allowance_allocations\".\"units_applied\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pi_memory_phase2_checkpoints": {
+      "name": "pi_memory_phase2_checkpoints",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "memory_storage_id": {
+          "name": "memory_storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_revision": {
+          "name": "claimed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_base_version_id": {
+          "name": "claimed_base_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selection_digest": {
+          "name": "selection_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pi_memory_phase2_checkpoints_run_id_agent_runs_id_fk": {
+          "name": "pi_memory_phase2_checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "pi_memory_phase2_checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pi_memory_phase2_checkpoints_storage_owner_fk": {
+          "name": "pi_memory_phase2_checkpoints_storage_owner_fk",
+          "tableFrom": "pi_memory_phase2_checkpoints",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "memory_storage_id",
+            "org_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pi_memory_phase2_checkpoints_identity_check": {
+          "name": "pi_memory_phase2_checkpoints_identity_check",
+          "value": "\"pi_memory_phase2_checkpoints\".\"claimed_revision\" > 0 AND\n      \"pi_memory_phase2_checkpoints\".\"claimed_base_version_id\" ~ '^[0-9a-f]{64}$' AND\n      \"pi_memory_phase2_checkpoints\".\"selection_digest\" ~ '^[0-9a-f]{64}$' AND\n      \"pi_memory_phase2_checkpoints\".\"version_id\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pi_memory_phase2_jobs": {
+      "name": "pi_memory_phase2_jobs",
+      "schema": "",
+      "columns": {
+        "memory_storage_id": {
+          "name": "memory_storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input_revision": {
+          "name": "input_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "completed_revision": {
+          "name": "completed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciliation_revision": {
+          "name": "reconciliation_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_revision": {
+          "name": "claimed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_base_version_id": {
+          "name": "claimed_base_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_lease_token": {
+          "name": "legacy_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_lease_token": {
+          "name": "sandbox_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maintenance_run_id": {
+          "name": "maintenance_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retry_at": {
+          "name": "retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_class": {
+          "name": "last_error_class",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_succeeded_at": {
+          "name": "last_succeeded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_selection_digest": {
+          "name": "claimed_selection_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_selected_count": {
+          "name": "claimed_selected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_selected_utf8_bytes": {
+          "name": "claimed_selected_utf8_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_head_version_id": {
+          "name": "last_observed_head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conflict_count": {
+          "name": "conflict_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_conflict_at": {
+          "name": "last_conflict_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_conflicting_head_version_id": {
+          "name": "last_conflicting_head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_published_version_id": {
+          "name": "last_published_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_published_at": {
+          "name": "last_published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_maintenance_run_id": {
+          "name": "last_maintenance_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_maintenance_revision": {
+          "name": "last_maintenance_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_maintenance_base_version_id": {
+          "name": "last_maintenance_base_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_maintenance_selection_digest": {
+          "name": "last_maintenance_selection_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_maintenance_checkpoint_id": {
+          "name": "last_maintenance_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_maintenance_checkpoint_version_id": {
+          "name": "last_maintenance_checkpoint_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_maintenance_outcome": {
+          "name": "last_maintenance_outcome",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pi_memory_phase2_jobs_claimable": {
+          "name": "idx_pi_memory_phase2_jobs_claimable",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_succeeded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pi_memory_phase2_jobs\".\"completed_revision\" < \"pi_memory_phase2_jobs\".\"input_revision\" AND \"pi_memory_phase2_jobs\".\"status\" IN ('pending', 'leased', 'retryable_failure')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pi_memory_phase2_jobs_user_export": {
+          "name": "idx_pi_memory_phase2_jobs_user_export",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pi_memory_phase2_jobs_maintenance_run": {
+          "name": "idx_pi_memory_phase2_jobs_maintenance_run",
+          "columns": [
+            {
+              "expression": "maintenance_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pi_memory_phase2_jobs\".\"maintenance_run_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pi_memory_phase2_jobs_storage_owner_fk": {
+          "name": "pi_memory_phase2_jobs_storage_owner_fk",
+          "tableFrom": "pi_memory_phase2_jobs",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "memory_storage_id",
+            "org_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pi_memory_phase2_jobs_pkey": {
+          "name": "pi_memory_phase2_jobs_pkey",
+          "columns": [
+            "memory_storage_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pi_memory_phase2_jobs_status_check": {
+          "name": "pi_memory_phase2_jobs_status_check",
+          "value": "\"pi_memory_phase2_jobs\".\"status\" IN ('idle', 'pending', 'leased', 'retryable_failure', 'terminal_failure')"
+        },
+        "pi_memory_phase2_jobs_revisions_check": {
+          "name": "pi_memory_phase2_jobs_revisions_check",
+          "value": "\"pi_memory_phase2_jobs\".\"input_revision\" > 0 AND\n          \"pi_memory_phase2_jobs\".\"completed_revision\" >= 0 AND\n          \"pi_memory_phase2_jobs\".\"completed_revision\" <= \"pi_memory_phase2_jobs\".\"input_revision\" AND\n          \"pi_memory_phase2_jobs\".\"reconciliation_revision\" >= 0 AND\n          \"pi_memory_phase2_jobs\".\"reconciliation_revision\" <= \"pi_memory_phase2_jobs\".\"input_revision\" AND\n          (\n            \"pi_memory_phase2_jobs\".\"claimed_revision\" IS NULL OR (\n              \"pi_memory_phase2_jobs\".\"completed_revision\" < \"pi_memory_phase2_jobs\".\"claimed_revision\" AND\n              \"pi_memory_phase2_jobs\".\"claimed_revision\" <= \"pi_memory_phase2_jobs\".\"input_revision\"\n            )\n          )"
+        },
+        "pi_memory_phase2_jobs_retry_count_check": {
+          "name": "pi_memory_phase2_jobs_retry_count_check",
+          "value": "\"pi_memory_phase2_jobs\".\"retry_count\" >= 0 AND \"pi_memory_phase2_jobs\".\"retry_count\" <= 3"
+        },
+        "pi_memory_phase2_jobs_error_class_check": {
+          "name": "pi_memory_phase2_jobs_error_class_check",
+          "value": "\"pi_memory_phase2_jobs\".\"last_error_class\" IS NULL OR \"pi_memory_phase2_jobs\".\"last_error_class\" ~ '^[a-z][a-z0-9_]{0,127}$'"
+        },
+        "pi_memory_phase2_jobs_version_ids_check": {
+          "name": "pi_memory_phase2_jobs_version_ids_check",
+          "value": "(\"pi_memory_phase2_jobs\".\"claimed_base_version_id\" IS NULL OR \"pi_memory_phase2_jobs\".\"claimed_base_version_id\" ~ '^[0-9a-f]{64}$') AND\n          (\"pi_memory_phase2_jobs\".\"last_observed_head_version_id\" IS NULL OR \"pi_memory_phase2_jobs\".\"last_observed_head_version_id\" ~ '^[0-9a-f]{64}$') AND\n          (\"pi_memory_phase2_jobs\".\"last_conflicting_head_version_id\" IS NULL OR \"pi_memory_phase2_jobs\".\"last_conflicting_head_version_id\" ~ '^[0-9a-f]{64}$') AND\n          (\"pi_memory_phase2_jobs\".\"last_published_version_id\" IS NULL OR \"pi_memory_phase2_jobs\".\"last_published_version_id\" ~ '^[0-9a-f]{64}$') AND\n          (\"pi_memory_phase2_jobs\".\"last_maintenance_base_version_id\" IS NULL OR \"pi_memory_phase2_jobs\".\"last_maintenance_base_version_id\" ~ '^[0-9a-f]{64}$') AND\n          (\"pi_memory_phase2_jobs\".\"last_maintenance_selection_digest\" IS NULL OR \"pi_memory_phase2_jobs\".\"last_maintenance_selection_digest\" ~ '^[0-9a-f]{64}$') AND\n          (\"pi_memory_phase2_jobs\".\"last_maintenance_checkpoint_version_id\" IS NULL OR \"pi_memory_phase2_jobs\".\"last_maintenance_checkpoint_version_id\" ~ '^[0-9a-f]{64}$')"
+        },
+        "pi_memory_phase2_jobs_execution_fence_check": {
+          "name": "pi_memory_phase2_jobs_execution_fence_check",
+          "value": "(\n          \"pi_memory_phase2_jobs\".\"status\" = 'leased' AND (\n            (\n              \"pi_memory_phase2_jobs\".\"legacy_lease_token\" IS NOT NULL AND\n              \"pi_memory_phase2_jobs\".\"legacy_lease_token\" = \"pi_memory_phase2_jobs\".\"lease_token\" AND\n              \"pi_memory_phase2_jobs\".\"sandbox_lease_token\" IS NULL AND\n              \"pi_memory_phase2_jobs\".\"maintenance_run_id\" IS NULL\n            ) OR (\n              \"pi_memory_phase2_jobs\".\"legacy_lease_token\" IS NULL AND\n              \"pi_memory_phase2_jobs\".\"sandbox_lease_token\" IS NOT NULL AND\n              \"pi_memory_phase2_jobs\".\"sandbox_lease_token\" = \"pi_memory_phase2_jobs\".\"lease_token\"\n            )\n          )\n        ) OR (\n          \"pi_memory_phase2_jobs\".\"status\" <> 'leased' AND\n          \"pi_memory_phase2_jobs\".\"sandbox_lease_token\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"maintenance_run_id\" IS NULL\n        )"
+        },
+        "pi_memory_phase2_jobs_maintenance_history_check": {
+          "name": "pi_memory_phase2_jobs_maintenance_history_check",
+          "value": "(\n          \"pi_memory_phase2_jobs\".\"last_maintenance_run_id\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"last_maintenance_revision\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"last_maintenance_base_version_id\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"last_maintenance_selection_digest\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"last_maintenance_checkpoint_id\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"last_maintenance_checkpoint_version_id\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"last_maintenance_outcome\" IS NULL\n        ) OR (\n          \"pi_memory_phase2_jobs\".\"last_maintenance_run_id\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"last_maintenance_revision\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"last_maintenance_revision\" > 0 AND\n          \"pi_memory_phase2_jobs\".\"last_maintenance_base_version_id\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"last_maintenance_selection_digest\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"last_maintenance_outcome\" IN ('published', 'no_diff', 'failed') AND\n          (\n            (\n              \"pi_memory_phase2_jobs\".\"last_maintenance_outcome\" = 'failed' AND\n              \"pi_memory_phase2_jobs\".\"last_maintenance_checkpoint_id\" IS NULL AND\n              \"pi_memory_phase2_jobs\".\"last_maintenance_checkpoint_version_id\" IS NULL\n            ) OR (\n              \"pi_memory_phase2_jobs\".\"last_maintenance_outcome\" IN ('published', 'no_diff') AND\n              \"pi_memory_phase2_jobs\".\"last_maintenance_checkpoint_version_id\" IS NOT NULL\n            )\n          )\n        )"
+        },
+        "pi_memory_phase2_jobs_conflict_check": {
+          "name": "pi_memory_phase2_jobs_conflict_check",
+          "value": "(\"pi_memory_phase2_jobs\".\"conflict_count\" = 0 AND \"pi_memory_phase2_jobs\".\"last_conflict_at\" IS NULL AND \"pi_memory_phase2_jobs\".\"last_conflicting_head_version_id\" IS NULL) OR\n          (\"pi_memory_phase2_jobs\".\"conflict_count\" > 0 AND \"pi_memory_phase2_jobs\".\"last_conflict_at\" IS NOT NULL AND \"pi_memory_phase2_jobs\".\"last_conflicting_head_version_id\" IS NOT NULL)"
+        },
+        "pi_memory_phase2_jobs_publication_check": {
+          "name": "pi_memory_phase2_jobs_publication_check",
+          "value": "(\"pi_memory_phase2_jobs\".\"last_published_version_id\" IS NULL AND \"pi_memory_phase2_jobs\".\"last_published_at\" IS NULL) OR\n          (\"pi_memory_phase2_jobs\".\"last_published_version_id\" IS NOT NULL AND \"pi_memory_phase2_jobs\".\"last_published_at\" IS NOT NULL)"
+        },
+        "pi_memory_phase2_jobs_selection_check": {
+          "name": "pi_memory_phase2_jobs_selection_check",
+          "value": "(\n          \"pi_memory_phase2_jobs\".\"claimed_selection_digest\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" IS NULL\n        ) OR (\n          \"pi_memory_phase2_jobs\".\"claimed_selection_digest\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selection_digest\" ~ '^[0-9a-f]{64}$' AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" >= 0 AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" <= 256 AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" >= 0 AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" <= 21036800\n        )"
+        },
+        "pi_memory_phase2_jobs_state_check": {
+          "name": "pi_memory_phase2_jobs_state_check",
+          "value": "(\n          \"pi_memory_phase2_jobs\".\"status\" = 'idle' AND\n          \"pi_memory_phase2_jobs\".\"completed_revision\" = \"pi_memory_phase2_jobs\".\"input_revision\" AND\n          \"pi_memory_phase2_jobs\".\"claimed_revision\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_base_version_id\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_token\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_expires_at\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"retry_count\" = 0 AND\n          \"pi_memory_phase2_jobs\".\"retry_at\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"last_error_class\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selection_digest\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" IS NULL\n        ) OR (\n          \"pi_memory_phase2_jobs\".\"status\" = 'pending' AND\n          \"pi_memory_phase2_jobs\".\"completed_revision\" < \"pi_memory_phase2_jobs\".\"input_revision\" AND\n          \"pi_memory_phase2_jobs\".\"claimed_revision\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_base_version_id\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_token\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_expires_at\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"retry_count\" = 0 AND\n          \"pi_memory_phase2_jobs\".\"retry_at\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"last_error_class\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selection_digest\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" IS NULL\n        ) OR (\n          \"pi_memory_phase2_jobs\".\"status\" = 'leased' AND\n          \"pi_memory_phase2_jobs\".\"claimed_revision\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_base_version_id\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"completed_revision\" < \"pi_memory_phase2_jobs\".\"claimed_revision\" AND\n          \"pi_memory_phase2_jobs\".\"claimed_revision\" <= \"pi_memory_phase2_jobs\".\"input_revision\" AND\n          \"pi_memory_phase2_jobs\".\"lease_token\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_expires_at\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"retry_count\" >= 0 AND\n          \"pi_memory_phase2_jobs\".\"retry_count\" < 3 AND\n          \"pi_memory_phase2_jobs\".\"retry_at\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"last_error_class\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selection_digest\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" IS NOT NULL\n        ) OR (\n          \"pi_memory_phase2_jobs\".\"status\" = 'retryable_failure' AND\n          \"pi_memory_phase2_jobs\".\"completed_revision\" < \"pi_memory_phase2_jobs\".\"input_revision\" AND\n          \"pi_memory_phase2_jobs\".\"claimed_revision\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_base_version_id\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_token\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_expires_at\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"retry_count\" > 0 AND\n          \"pi_memory_phase2_jobs\".\"retry_count\" < 3 AND\n          \"pi_memory_phase2_jobs\".\"retry_at\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"last_error_class\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selection_digest\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" IS NULL\n        ) OR (\n          \"pi_memory_phase2_jobs\".\"status\" = 'terminal_failure' AND\n          \"pi_memory_phase2_jobs\".\"completed_revision\" < \"pi_memory_phase2_jobs\".\"input_revision\" AND\n          \"pi_memory_phase2_jobs\".\"claimed_revision\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_base_version_id\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_token\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"lease_expires_at\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"retry_count\" = 3 AND\n          \"pi_memory_phase2_jobs\".\"retry_at\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"last_error_class\" IS NOT NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selection_digest\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_count\" IS NULL AND\n          \"pi_memory_phase2_jobs\".\"claimed_selected_utf8_bytes\" IS NULL\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pi_memory_publication_provenance": {
+      "name": "pi_memory_publication_provenance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "memory_storage_id": {
+          "name": "memory_storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_revision": {
+          "name": "claimed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_revision": {
+          "name": "input_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reconciliation_revision": {
+          "name": "reconciliation_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selection_digest": {
+          "name": "selection_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_count": {
+          "name": "selected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_utf8_bytes": {
+          "name": "selected_utf8_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_version_id": {
+          "name": "base_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prepared_version_id": {
+          "name": "prepared_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_head_version_id": {
+          "name": "observed_head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "writer": {
+          "name": "writer",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archive_size": {
+          "name": "archive_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_pi_memory_publication_provenance_attempt": {
+          "name": "idx_pi_memory_publication_provenance_attempt",
+          "columns": [
+            {
+              "expression": "memory_storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimed_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "base_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prepared_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pi_memory_publication_provenance_user_export": {
+          "name": "idx_pi_memory_publication_provenance_user_export",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pi_memory_publication_provenance_storage_owner_fk": {
+          "name": "pi_memory_publication_provenance_storage_owner_fk",
+          "tableFrom": "pi_memory_publication_provenance",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "memory_storage_id",
+            "org_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pi_memory_publication_provenance_pkey": {
+          "name": "pi_memory_publication_provenance_pkey",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pi_memory_publication_provenance_revisions_check": {
+          "name": "pi_memory_publication_provenance_revisions_check",
+          "value": "\"pi_memory_publication_provenance\".\"claimed_revision\" > 0 AND\n          \"pi_memory_publication_provenance\".\"input_revision\" >= \"pi_memory_publication_provenance\".\"claimed_revision\" AND\n          \"pi_memory_publication_provenance\".\"reconciliation_revision\" >= 0 AND\n          \"pi_memory_publication_provenance\".\"reconciliation_revision\" <= \"pi_memory_publication_provenance\".\"input_revision\""
+        },
+        "pi_memory_publication_provenance_selection_check": {
+          "name": "pi_memory_publication_provenance_selection_check",
+          "value": "\"pi_memory_publication_provenance\".\"selection_digest\" ~ '^[0-9a-f]{64}$' AND\n          \"pi_memory_publication_provenance\".\"selected_count\" >= 0 AND \"pi_memory_publication_provenance\".\"selected_count\" <= 256 AND\n          \"pi_memory_publication_provenance\".\"selected_utf8_bytes\" >= 0 AND \"pi_memory_publication_provenance\".\"selected_utf8_bytes\" <= 21036800"
+        },
+        "pi_memory_publication_provenance_versions_check": {
+          "name": "pi_memory_publication_provenance_versions_check",
+          "value": "\"pi_memory_publication_provenance\".\"base_version_id\" ~ '^[0-9a-f]{64}$' AND\n          \"pi_memory_publication_provenance\".\"prepared_version_id\" ~ '^[0-9a-f]{64}$' AND\n          \"pi_memory_publication_provenance\".\"observed_head_version_id\" ~ '^[0-9a-f]{64}$' AND\n          \"pi_memory_publication_provenance\".\"base_version_id\" <> \"pi_memory_publication_provenance\".\"prepared_version_id\""
+        },
+        "pi_memory_publication_provenance_writer_check": {
+          "name": "pi_memory_publication_provenance_writer_check",
+          "value": "\"pi_memory_publication_provenance\".\"writer\" IN ('pi', 'reconciler')"
+        },
+        "pi_memory_publication_provenance_outcome_check": {
+          "name": "pi_memory_publication_provenance_outcome_check",
+          "value": "\"pi_memory_publication_provenance\".\"outcome\" IN ('published', 'conflicted') AND\n          (\"pi_memory_publication_provenance\".\"outcome\" <> 'published' OR \"pi_memory_publication_provenance\".\"observed_head_version_id\" = \"pi_memory_publication_provenance\".\"prepared_version_id\")"
+        },
+        "pi_memory_publication_provenance_counts_check": {
+          "name": "pi_memory_publication_provenance_counts_check",
+          "value": "\"pi_memory_publication_provenance\".\"size\" >= 0 AND \"pi_memory_publication_provenance\".\"archive_size\" >= 0 AND \"pi_memory_publication_provenance\".\"file_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pi_memory_stage1_candidates": {
+      "name": "pi_memory_stage1_candidates",
+      "schema": "",
+      "columns": {
+        "memory_storage_id": {
+          "name": "memory_storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pi_session_id": {
+          "name": "pi_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_run_id": {
+          "name": "source_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_history_hash": {
+          "name": "source_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_completed_at": {
+          "name": "source_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eligible_at": {
+          "name": "eligible_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_at": {
+          "name": "retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error_class": {
+          "name": "last_error_class",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_memory": {
+          "name": "raw_memory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollout_summary": {
+          "name": "rollout_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollout_slug": {
+          "name": "rollout_slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_selected_source_history_hash": {
+          "name": "last_selected_source_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pi_memory_stage1_candidates_eligible": {
+          "name": "idx_pi_memory_stage1_candidates_eligible",
+          "columns": [
+            {
+              "expression": "eligible_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pi_memory_stage1_candidates\".\"status\" IN ('pending', 'retryable_failure')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pi_memory_stage1_candidates_expired_lease": {
+          "name": "idx_pi_memory_stage1_candidates_expired_lease",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pi_memory_stage1_candidates\".\"status\" = 'leased'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pi_memory_stage1_candidates_phase2": {
+          "name": "idx_pi_memory_stage1_candidates_phase2",
+          "columns": [
+            {
+              "expression": "memory_storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pi_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pi_memory_stage1_candidates\".\"status\" IN ('succeeded', 'succeeded_no_output')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pi_memory_stage1_candidates_source_history_hash_blobs_hash_fk": {
+          "name": "pi_memory_stage1_candidates_source_history_hash_blobs_hash_fk",
+          "tableFrom": "pi_memory_stage1_candidates",
+          "tableTo": "blobs",
+          "columnsFrom": [
+            "source_history_hash"
+          ],
+          "columnsTo": [
+            "hash"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pi_memory_stage1_candidates_storage_owner_fk": {
+          "name": "pi_memory_stage1_candidates_storage_owner_fk",
+          "tableFrom": "pi_memory_stage1_candidates",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "memory_storage_id",
+            "org_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pi_memory_stage1_candidates_pkey": {
+          "name": "pi_memory_stage1_candidates_pkey",
+          "columns": [
+            "memory_storage_id",
+            "pi_session_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pi_memory_stage1_candidates_status_check": {
+          "name": "pi_memory_stage1_candidates_status_check",
+          "value": "\"pi_memory_stage1_candidates\".\"status\" IN (\n          'pending',\n          'leased',\n          'succeeded',\n          'succeeded_no_output',\n          'retryable_failure',\n          'terminal_failure'\n        )"
+        },
+        "pi_memory_stage1_candidates_source_hash_check": {
+          "name": "pi_memory_stage1_candidates_source_hash_check",
+          "value": "\"pi_memory_stage1_candidates\".\"source_history_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "pi_memory_stage1_candidates_selected_hash_check": {
+          "name": "pi_memory_stage1_candidates_selected_hash_check",
+          "value": "\"pi_memory_stage1_candidates\".\"last_selected_source_history_hash\" IS NULL OR \"pi_memory_stage1_candidates\".\"last_selected_source_history_hash\" = \"pi_memory_stage1_candidates\".\"source_history_hash\""
+        },
+        "pi_memory_stage1_candidates_counts_check": {
+          "name": "pi_memory_stage1_candidates_counts_check",
+          "value": "\"pi_memory_stage1_candidates\".\"retry_count\" >= 0 AND \"pi_memory_stage1_candidates\".\"usage_count\" >= 0"
+        },
+        "pi_memory_stage1_candidates_lease_check": {
+          "name": "pi_memory_stage1_candidates_lease_check",
+          "value": "(\n          \"pi_memory_stage1_candidates\".\"status\" = 'leased' AND\n          \"pi_memory_stage1_candidates\".\"lease_token\" IS NOT NULL AND\n          \"pi_memory_stage1_candidates\".\"lease_expires_at\" IS NOT NULL\n        ) OR (\n          \"pi_memory_stage1_candidates\".\"status\" <> 'leased' AND\n          \"pi_memory_stage1_candidates\".\"lease_token\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"lease_expires_at\" IS NULL\n        )"
+        },
+        "pi_memory_stage1_candidates_state_check": {
+          "name": "pi_memory_stage1_candidates_state_check",
+          "value": "(\n          \"pi_memory_stage1_candidates\".\"status\" IN ('pending', 'leased') AND\n          \"pi_memory_stage1_candidates\".\"retry_at\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"last_error_class\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"raw_memory\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_summary\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_slug\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"generated_at\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"last_selected_source_history_hash\" IS NULL\n        ) OR (\n          \"pi_memory_stage1_candidates\".\"status\" = 'succeeded' AND\n          \"pi_memory_stage1_candidates\".\"retry_at\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"last_error_class\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"raw_memory\" IS NOT NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_summary\" IS NOT NULL AND\n          \"pi_memory_stage1_candidates\".\"generated_at\" IS NOT NULL\n        ) OR (\n          \"pi_memory_stage1_candidates\".\"status\" = 'succeeded_no_output' AND\n          \"pi_memory_stage1_candidates\".\"retry_at\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"last_error_class\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"raw_memory\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_summary\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_slug\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"generated_at\" IS NOT NULL\n        ) OR (\n          \"pi_memory_stage1_candidates\".\"status\" = 'retryable_failure' AND\n          \"pi_memory_stage1_candidates\".\"retry_at\" IS NOT NULL AND\n          \"pi_memory_stage1_candidates\".\"last_error_class\" IS NOT NULL AND\n          \"pi_memory_stage1_candidates\".\"raw_memory\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_summary\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_slug\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"generated_at\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"last_selected_source_history_hash\" IS NULL\n        ) OR (\n          \"pi_memory_stage1_candidates\".\"status\" = 'terminal_failure' AND\n          \"pi_memory_stage1_candidates\".\"retry_at\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"last_error_class\" IS NOT NULL AND\n          \"pi_memory_stage1_candidates\".\"raw_memory\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_summary\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"rollout_slug\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"generated_at\" IS NULL AND\n          \"pi_memory_stage1_candidates\".\"last_selected_source_history_hash\" IS NULL\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pi_resource_snapshots": {
+      "name": "pi_resource_snapshots",
+      "schema": "",
+      "columns": {
+        "digest": {
+          "name": "digest",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pi_resource_snapshots_created_at_idx": {
+          "name": "pi_resource_snapshots_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.presentation_templates": {
+      "name": "presentation_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_storage_key": {
+          "name": "source_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_filename": {
+          "name": "source_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_keys": {
+          "name": "page_keys",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_presentation_templates_owner_created": {
+          "name": "idx_presentation_templates_owner_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_presentation_templates_visibility": {
+          "name": "chk_presentation_templates_visibility",
+          "value": "\"presentation_templates\".\"visibility\" IN ('private', 'public')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_push_subscriptions_user_id": {
+          "name": "idx_push_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_push_subscriptions_endpoint": {
+          "name": "idx_push_subscriptions_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_activity_snapshots": {
+      "name": "run_activity_snapshots",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "activity_revision": {
+          "name": "activity_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'empty'"
+        },
+        "message_cursor": {
+          "name": "message_cursor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC') + interval '24 hours'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_revision": {
+          "name": "summary_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_sequence": {
+          "name": "summary_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_message_cursor": {
+          "name": "summary_message_cursor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summarized_at": {
+          "name": "summarized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_revision": {
+          "name": "claim_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "run_activity_snapshots_expiry_idx": {
+          "name": "run_activity_snapshots_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_activity_snapshots_run_id_agent_runs_id_fk": {
+          "name": "run_activity_snapshots_run_id_agent_runs_id_fk",
+          "tableFrom": "run_activity_snapshots",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_activity_snapshots_entries_bound": {
+          "name": "run_activity_snapshots_entries_bound",
+          "value": "jsonb_typeof(\"run_activity_snapshots\".\"entries\") = 'array' AND jsonb_array_length(\"run_activity_snapshots\".\"entries\") <= 16 AND octet_length(\"run_activity_snapshots\".\"entries\"::text) <= 16384"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_built_in_admissions": {
+      "name": "run_built_in_admissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_run_builtin_admissions_run_status": {
+          "name": "idx_run_builtin_admissions_run_status",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_builtin_admissions_run_created": {
+          "name": "idx_run_builtin_admissions_run_created",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_builtin_admissions_expires_at": {
+          "name": "idx_run_builtin_admissions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_built_in_admissions_run_id_agent_runs_id_fk": {
+          "name": "run_built_in_admissions_run_id_agent_runs_id_fk",
+          "tableFrom": "run_built_in_admissions",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_output_legacy_pi_events": {
+      "name": "run_output_legacy_pi_events",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serialized_event": {
+          "name": "serialized_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_output_legacy_pi_events_run_id_agent_runs_id_fk": {
+          "name": "run_output_legacy_pi_events_run_id_agent_runs_id_fk",
+          "tableFrom": "run_output_legacy_pi_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_output_legacy_pi_events_run_id_sequence_number_pk": {
+          "name": "run_output_legacy_pi_events_run_id_sequence_number_pk",
+          "columns": [
+            "run_id",
+            "sequence_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_output_materializations": {
+      "name": "chat_output_materializations",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "processed_through_sequence": {
+          "name": "processed_through_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": -1
+        },
+        "pending_sequence_numbers": {
+          "name": "pending_sequence_numbers",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::integer[]"
+        },
+        "latest_result_sequence": {
+          "name": "latest_result_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_result_text": {
+          "name": "latest_result_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_output_sequence": {
+          "name": "latest_output_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_output_text": {
+          "name": "latest_output_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_output_materializations_run_id_agent_runs_id_fk": {
+          "name": "chat_output_materializations_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_output_materializations",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_output_memory_citations": {
+      "name": "run_output_memory_citations",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "citation": {
+          "name": "citation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_output_memory_citations_run_id_agent_runs_id_fk": {
+          "name": "run_output_memory_citations_run_id_agent_runs_id_fk",
+          "tableFrom": "run_output_memory_citations",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_output_memory_citations_run_id_sequence_number_pk": {
+          "name": "run_output_memory_citations_run_id_sequence_number_pk",
+          "columns": [
+            "run_id",
+            "sequence_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canonical_asset_deliveries": {
+      "name": "canonical_asset_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "canonical_asset_deliveries_asset_provider_operation_unique": {
+          "name": "canonical_asset_deliveries_asset_provider_operation_unique",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "canonical_asset_deliveries_asset_idx": {
+          "name": "canonical_asset_deliveries_asset_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canonical_asset_deliveries_asset_id_run_uploaded_files_id_fk": {
+          "name": "canonical_asset_deliveries_asset_id_run_uploaded_files_id_fk",
+          "tableFrom": "canonical_asset_deliveries",
+          "tableTo": "run_uploaded_files",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_uploaded_files": {
+      "name": "run_uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "asset_version": {
+          "name": "asset_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_level": {
+          "name": "access_level",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "materialization_status": {
+          "name": "materialization_status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "materialization_error": {
+          "name": "materialization_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_scope": {
+          "name": "idempotency_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_uploaded_files_run": {
+          "name": "idx_run_uploaded_files_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_uploaded_files_run_source_external": {
+          "name": "idx_run_uploaded_files_run_source_external",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_uploaded_files_source_external": {
+          "name": "idx_run_uploaded_files_source_external",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_uploaded_files_updated": {
+          "name": "idx_run_uploaded_files_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"run_uploaded_files\".\"url\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_uploaded_files_canonical_idempotency_unique": {
+          "name": "run_uploaded_files_canonical_idempotency_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"run_uploaded_files\".\"asset_version\" = 1",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_uploaded_files_chat_thread_idx": {
+          "name": "run_uploaded_files_chat_thread_idx",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"run_uploaded_files\".\"chat_thread_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_uploaded_files_run_id_agent_runs_id_fk": {
+          "name": "run_uploaded_files_run_id_agent_runs_id_fk",
+          "tableFrom": "run_uploaded_files",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_uploaded_files_chat_thread_id_chat_threads_id_fk": {
+          "name": "run_uploaded_files_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "run_uploaded_files",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0/default'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reuse_key": {
+          "name": "reuse_key",
+          "type": "varchar(263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_profile_idx": {
+          "name": "runner_job_queue_group_profile_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_state": {
+      "name": "runner_state",
+      "schema": "",
+      "columns": {
+        "runner_id": {
+          "name": "runner_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_generation": {
+          "name": "heartbeat_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "heartbeat_sequence": {
+          "name": "heartbeat_sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_vcpu": {
+          "name": "total_vcpu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_memory_mb": {
+          "name": "total_memory_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_concurrent": {
+          "name": "max_concurrent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "allocated_vcpu": {
+          "name": "allocated_vcpu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "allocated_memory_mb": {
+          "name": "allocated_memory_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "admittable_profiles": {
+          "name": "admittable_profiles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "held_sandbox_states": {
+          "name": "held_sandbox_states",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "held_workspace_states": {
+          "name": "held_workspace_states",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_state_group_idx": {
+          "name": "runner_state_group_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_state_last_seen_idx": {
+          "name": "runner_state_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org": {
+          "name": "idx_secrets_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_connector": {
+          "name": "idx_secrets_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"secrets\".\"connector_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org_user_name_type": {
+          "name": "idx_secrets_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"secrets\".\"connector_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_connector_name": {
+          "name": "idx_secrets_connector_name",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"secrets\".\"connector_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_secrets_connector_owner": {
+          "name": "fk_secrets_connector_owner",
+          "tableFrom": "secrets",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id",
+            "org_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_secrets_connector_owner_type": {
+          "name": "chk_secrets_connector_owner_type",
+          "value": "(\"secrets\".\"type\" = 'connector') = (\"secrets\".\"connector_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.shared_threads": {
+      "name": "shared_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_chat_thread_id": {
+          "name": "source_chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shared_threads_user_created_idx": {
+          "name": "shared_threads_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shared_threads_source_created_idx": {
+          "name": "shared_threads_source_created_idx",
+          "columns": [
+            {
+              "expression": "source_chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shared_threads_source_chat_thread_id_chat_threads_id_fk": {
+          "name": "shared_threads_source_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "shared_threads",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "source_chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_path": {
+          "name": "full_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_hash": {
+          "name": "version_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frontmatter": {
+          "name": "frontmatter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skills_name": {
+          "name": "idx_skills_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skills_storage_id": {
+          "name": "idx_skills_storage_id",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_storage_id_storages_id_fk": {
+          "name": "skills_storage_id_storages_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skills_url_unique": {
+          "name": "skills_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_chat_ingress": {
+      "name": "slack_chat_ingress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_chat_ingress_event_id": {
+          "name": "idx_slack_chat_ingress_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_chat_ingress_route_id_slack_chat_thread_routes_id_fk": {
+          "name": "slack_chat_ingress_route_id_slack_chat_thread_routes_id_fk",
+          "tableFrom": "slack_chat_ingress",
+          "tableTo": "slack_chat_thread_routes",
+          "columnsFrom": [
+            "route_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_slack_chat_ingress_status": {
+          "name": "chk_slack_chat_ingress_status",
+          "value": "\"slack_chat_ingress\".\"status\" IN ('pending', 'processing', 'processed', 'failed')"
+        },
+        "chk_slack_chat_ingress_retry_count": {
+          "name": "chk_slack_chat_ingress_retry_count",
+          "value": "\"slack_chat_ingress\".\"retry_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_chat_thread_routes": {
+      "name": "slack_chat_thread_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_ts": {
+          "name": "thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_chat_thread_routes_conn_channel_thread_user": {
+          "name": "idx_slack_chat_thread_routes_conn_channel_thread_user",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_chat_thread_routes_connection_id_slack_org_connections_id_fk": {
+          "name": "slack_chat_thread_routes_connection_id_slack_org_connections_id_fk",
+          "tableFrom": "slack_chat_thread_routes",
+          "tableTo": "slack_org_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_chat_thread_routes_chat_thread_id_chat_threads_id_fk": {
+          "name": "slack_chat_thread_routes_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "slack_chat_thread_routes",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_connections": {
+      "name": "slack_org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_connections_user_workspace": {
+          "name": "idx_slack_org_connections_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_workspace": {
+          "name": "idx_slack_org_connections_workspace",
+          "columns": [
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_user_id_workspace": {
+          "name": "idx_slack_org_connections_user_id_workspace",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk": {
+          "name": "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk",
+          "tableFrom": "slack_org_connections",
+          "tableTo": "slack_org_installations",
+          "columnsFrom": [
+            "slack_workspace_id"
+          ],
+          "columnsTo": [
+            "slack_workspace_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_installations": {
+      "name": "slack_org_installations",
+      "schema": "",
+      "columns": {
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_scopes": {
+          "name": "bot_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'okou'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_installations_org": {
+          "name": "idx_slack_org_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_installations_org_unique": {
+          "name": "idx_slack_org_installations_org_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user_agent_preferences": {
+      "name": "slack_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_agent_id": {
+          "name": "selected_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_user_agent_preferences_selected_agent_id_agents_id_fk": {
+          "name": "slack_user_agent_preferences_selected_agent_id_agents_id_fk",
+          "tableFrom": "slack_user_agent_preferences",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "selected_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "slack_user_agent_preferences_user_id_org_id_pk": {
+          "name": "slack_user_agent_preferences_user_id_org_id_pk",
+          "columns": [
+            "user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.socialkit_download_jobs": {
+      "name": "socialkit_download_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitting'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_job_id": {
+          "name": "provider_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_result": {
+          "name": "provider_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_socialkit_download_jobs_provider_job": {
+          "name": "uq_socialkit_download_jobs_provider_job",
+          "columns": [
+            {
+              "expression": "provider_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_socialkit_download_jobs_user_active": {
+          "name": "uq_socialkit_download_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('submitting', 'processing', 'materializing', 'artifact_failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_socialkit_download_jobs_owner_created": {
+          "name": "idx_socialkit_download_jobs_owner_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_socialkit_download_jobs_reconcile": {
+          "name": "idx_socialkit_download_jobs_reconcile",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claim_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_socialkit_download_jobs_run": {
+          "name": "idx_socialkit_download_jobs_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "socialkit_download_jobs_run_id_agent_runs_id_fk": {
+          "name": "socialkit_download_jobs_run_id_agent_runs_id_fk",
+          "tableFrom": "socialkit_download_jobs",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssh_connection_credentials": {
+      "name": "ssh_connection_credentials",
+      "schema": "",
+      "columns": {
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "encrypted_private_key": {
+          "name": "encrypted_private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_passphrase": {
+          "name": "encrypted_passphrase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ssh_connection_credentials_connection_id_ssh_connections_id_fk": {
+          "name": "ssh_connection_credentials_connection_id_ssh_connections_id_fk",
+          "tableFrom": "ssh_connection_credentials",
+          "tableTo": "ssh_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssh_connections": {
+      "name": "ssh_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 22
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "learned_host_key_algorithm": {
+          "name": "learned_host_key_algorithm",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "learned_host_key_fingerprint": {
+          "name": "learned_host_key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ssh_connections_owner_host_port": {
+          "name": "idx_ssh_connections_owner_host_port",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "port",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ssh_connections_owner_created": {
+          "name": "idx_ssh_connections_owner_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_ssh_connections_display_name": {
+          "name": "chk_ssh_connections_display_name",
+          "value": "char_length(\"ssh_connections\".\"display_name\") BETWEEN 1 AND 128"
+        },
+        "chk_ssh_connections_host": {
+          "name": "chk_ssh_connections_host",
+          "value": "char_length(\"ssh_connections\".\"host\") BETWEEN 1 AND 253"
+        },
+        "chk_ssh_connections_port": {
+          "name": "chk_ssh_connections_port",
+          "value": "\"ssh_connections\".\"port\" BETWEEN 1 AND 65535"
+        },
+        "chk_ssh_connections_username": {
+          "name": "chk_ssh_connections_username",
+          "value": "char_length(\"ssh_connections\".\"username\") BETWEEN 1 AND 255"
+        },
+        "chk_ssh_connections_generation": {
+          "name": "chk_ssh_connections_generation",
+          "value": "\"ssh_connections\".\"generation\" > 0"
+        },
+        "chk_ssh_connections_learned_host_key_pair": {
+          "name": "chk_ssh_connections_learned_host_key_pair",
+          "value": "(\"ssh_connections\".\"learned_host_key_algorithm\" IS NULL) = (\"ssh_connections\".\"learned_host_key_fingerprint\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.storage_version_lineage": {
+      "name": "storage_version_lineage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storage_version_lineage_storage_version": {
+          "name": "idx_storage_version_lineage_storage_version",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_storage_parent": {
+          "name": "idx_storage_version_lineage_storage_parent",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_run": {
+          "name": "idx_storage_version_lineage_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_version_lineage_storage_id_storages_id_fk": {
+          "name": "storage_version_lineage_storage_id_storages_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_version_lineage_run_id_agent_runs_id_fk": {
+          "name": "storage_version_lineage_run_id_agent_runs_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archive_size": {
+          "name": "archive_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_storage_versions_archive_size_nonnegative": {
+          "name": "chk_storage_versions_archive_size_nonnegative",
+          "value": "\"storage_versions\".\"archive_size\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_org": {
+          "name": "idx_storages_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_org_user_name": {
+          "name": "idx_storages_org_user_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": [
+            "head_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "idx_storages_id_org_user": {
+          "name": "idx_storages_id_org_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_workflow_automation_health": {
+      "name": "stripe_workflow_automation_health",
+      "schema": "",
+      "columns": {
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_matching_event_received_at": {
+          "name": "last_matching_event_received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_delivery_id": {
+          "name": "latest_delivery_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_delivery_status": {
+          "name": "latest_delivery_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_delivery_status_at": {
+          "name": "latest_delivery_status_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stripe_workflow_automation_health_automation_id_workflow_automations_id_fk": {
+          "name": "stripe_workflow_automation_health_automation_id_workflow_automations_id_fk",
+          "tableFrom": "stripe_workflow_automation_health",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_workflow_deliveries": {
+      "name": "stripe_workflow_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "livemode": {
+          "name": "livemode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_event_created_at": {
+          "name": "stripe_event_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_reason": {
+          "name": "billing_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_at": {
+          "name": "skipped_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_stripe_workflow_deliveries_dedupe": {
+          "name": "idx_stripe_workflow_deliveries_dedupe",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "livemode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stripe_workflow_deliveries_due": {
+          "name": "idx_stripe_workflow_deliveries_due",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claim_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"stripe_workflow_deliveries\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stripe_workflow_deliveries_automation": {
+          "name": "idx_stripe_workflow_deliveries_automation",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_storage_presigned_url_cache": {
+      "name": "system_storage_presigned_url_cache",
+      "schema": "",
+      "columns": {
+        "cache_key": {
+          "name": "cache_key",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system_storage'"
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_version_id": {
+          "name": "storage_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_org_id": {
+          "name": "resolved_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_endpoint": {
+          "name": "public_endpoint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presigned_url": {
+          "name": "presigned_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_after": {
+          "name": "refresh_after",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_requested_at": {
+          "name": "last_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_system_storage_presigned_url_cache_refresh_after": {
+          "name": "idx_system_storage_presigned_url_cache_refresh_after",
+          "columns": [
+            {
+              "expression": "refresh_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_storage_presigned_url_cache_last_requested_at": {
+          "name": "idx_system_storage_presigned_url_cache_last_requested_at",
+          "columns": [
+            {
+              "expression": "last_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_storage_presigned_url_cache_active_refresh": {
+          "name": "idx_system_storage_presigned_url_cache_active_refresh",
+          "columns": [
+            {
+              "expression": "last_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "refresh_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_storage_presigned_url_cache_scope_refresh_after": {
+          "name": "idx_system_storage_presigned_url_cache_scope_refresh_after",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "refresh_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_storage_presigned_url_cache_scope_active_refresh": {
+          "name": "idx_system_storage_presigned_url_cache_scope_active_refresh",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "refresh_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams_chat_thread_routes": {
+      "name": "teams_chat_thread_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_teams_chat_thread_routes_conn_conversation_thread_user": {
+          "name": "idx_teams_chat_thread_routes_conn_conversation_thread_user",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_chat_thread_routes_connection_id_teams_org_connections_id_fk": {
+          "name": "teams_chat_thread_routes_connection_id_teams_org_connections_id_fk",
+          "tableFrom": "teams_chat_thread_routes",
+          "tableTo": "teams_org_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teams_chat_thread_routes_chat_thread_id_chat_threads_id_fk": {
+          "name": "teams_chat_thread_routes_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "teams_chat_thread_routes",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams_org_connections": {
+      "name": "teams_org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "teams_user_id": {
+          "name": "teams_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_aad_object_id": {
+          "name": "teams_aad_object_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_tenant_id": {
+          "name": "teams_tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams_user_display_name": {
+          "name": "teams_user_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_user_principal_name": {
+          "name": "teams_user_principal_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_teams_org_connections_user_tenant": {
+          "name": "idx_teams_org_connections_user_tenant",
+          "columns": [
+            {
+              "expression": "teams_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teams_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "teams_user_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_connections_aad_tenant": {
+          "name": "idx_teams_org_connections_aad_tenant",
+          "columns": [
+            {
+              "expression": "teams_aad_object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teams_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "teams_aad_object_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_connections_user_id_tenant": {
+          "name": "idx_teams_org_connections_user_id_tenant",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teams_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_connections_tenant": {
+          "name": "idx_teams_org_connections_tenant",
+          "columns": [
+            {
+              "expression": "teams_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_org_connections_teams_tenant_id_teams_org_installations_teams_tenant_id_fk": {
+          "name": "teams_org_connections_teams_tenant_id_teams_org_installations_teams_tenant_id_fk",
+          "tableFrom": "teams_org_connections",
+          "tableTo": "teams_org_installations",
+          "columnsFrom": [
+            "teams_tenant_id"
+          ],
+          "columnsTo": [
+            "teams_tenant_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams_org_installations": {
+      "name": "teams_org_installations",
+      "schema": "",
+      "columns": {
+        "teams_tenant_id": {
+          "name": "teams_tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "teams_tenant_name": {
+          "name": "teams_tenant_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_team_id": {
+          "name": "teams_team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_team_name": {
+          "name": "teams_team_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_app_id": {
+          "name": "teams_app_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_name": {
+          "name": "bot_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_url": {
+          "name": "service_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'okou'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_teams_org_installations_org": {
+          "name": "idx_teams_org_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_installations_org_unique": {
+          "name": "idx_teams_org_installations_org_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams_user_agent_preferences": {
+      "name": "teams_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_agent_id": {
+          "name": "selected_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_user_agent_preferences_selected_agent_id_agents_id_fk": {
+          "name": "teams_user_agent_preferences_selected_agent_id_agents_id_fk",
+          "tableFrom": "teams_user_agent_preferences",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "selected_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teams_user_agent_preferences_user_id_org_id_pk": {
+          "name": "teams_user_agent_preferences_user_id_org_id_pk",
+          "columns": [
+            "user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_chat_thread_routes": {
+      "name": "telegram_chat_thread_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_official_user_link_id": {
+          "name": "telegram_official_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_chat_thread_routes_chat_user_link": {
+          "name": "idx_telegram_chat_thread_routes_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "telegram_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_chat_thread_routes_chat_official_link": {
+          "name": "idx_telegram_chat_thread_routes_chat_official_link",
+          "columns": [
+            {
+              "expression": "telegram_official_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "telegram_official_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_chat_thread_routes_user_link": {
+          "name": "idx_telegram_chat_thread_routes_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "telegram_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_chat_thread_routes_official_user_link": {
+          "name": "idx_telegram_chat_thread_routes_official_user_link",
+          "columns": [
+            {
+              "expression": "telegram_official_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "telegram_official_user_link_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_chat_thread_routes_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_chat_thread_routes_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_chat_thread_routes",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": [
+            "telegram_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_chat_thread_routes_telegram_official_user_link_id_telegram_official_user_links_id_fk": {
+          "name": "telegram_chat_thread_routes_telegram_official_user_link_id_telegram_official_user_links_id_fk",
+          "tableFrom": "telegram_chat_thread_routes",
+          "tableTo": "telegram_official_user_links",
+          "columnsFrom": [
+            "telegram_official_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_chat_thread_routes_chat_thread_id_chat_threads_id_fk": {
+          "name": "telegram_chat_thread_routes_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "telegram_chat_thread_routes",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_telegram_chat_thread_routes_one_owner": {
+          "name": "chk_telegram_chat_thread_routes_one_owner",
+          "value": "(telegram_user_link_id IS NOT NULL) <> (telegram_official_user_link_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_agent_id": {
+          "name": "default_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_installations_owner": {
+          "name": "idx_telegram_installations_owner",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_installations_org": {
+          "name": "idx_telegram_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_installations_default_agent_id_agents_id_fk": {
+          "name": "telegram_installations_default_agent_id_agents_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "default_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_org_id": {
+          "name": "official_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_user_link_id": {
+          "name": "official_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_display_name": {
+          "name": "from_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_mime_type": {
+          "name": "file_mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_width": {
+          "name": "file_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_height": {
+          "name": "file_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_duration": {
+          "name": "file_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_official_unique": {
+          "name": "idx_telegram_messages_official_unique",
+          "columns": [
+            {
+              "expression": "official_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "official_org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_official_chat": {
+          "name": "idx_telegram_messages_official_chat",
+          "columns": [
+            {
+              "expression": "official_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "official_org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_telegram_bot_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_telegram_bot_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "telegram_bot_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_messages_official_user_link_id_telegram_official_user_links_id_fk": {
+          "name": "telegram_messages_official_user_link_id_telegram_official_user_links_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_official_user_links",
+          "columnsFrom": [
+            "official_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_telegram_messages_one_owner": {
+          "name": "chk_telegram_messages_one_owner",
+          "value": "(installation_id IS NOT NULL) <> (official_org_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.telegram_official_user_links": {
+      "name": "telegram_official_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_display_name": {
+          "name": "telegram_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_official_user_links_tg_user": {
+          "name": "idx_telegram_official_user_links_tg_user",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_official_user_links_user_org": {
+          "name": "idx_telegram_official_user_links_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_official_user_links_org": {
+          "name": "idx_telegram_official_user_links_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_agent_preferences": {
+      "name": "telegram_user_agent_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_agent_id": {
+          "name": "selected_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_user_agent_preferences_selected_agent_id_agents_id_fk": {
+          "name": "telegram_user_agent_preferences_selected_agent_id_agents_id_fk",
+          "tableFrom": "telegram_user_agent_preferences",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "selected_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "telegram_user_agent_preferences_user_id_org_id_pk": {
+          "name": "telegram_user_agent_preferences_user_id_org_id_pk",
+          "columns": [
+            "user_id",
+            "org_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_display_name": {
+          "name": "telegram_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_user_links_user_id_installation": {
+          "name": "idx_telegram_user_links_user_id_installation",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_telegram_bot_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_telegram_bot_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "telegram_bot_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_goals": {
+      "name": "thread_goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective_brief": {
+          "name": "objective_brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retirement_archive_event_id": {
+          "name": "retirement_archive_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retirement_archive_seq_id": {
+          "name": "retirement_archive_seq_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autonomy_budget": {
+          "name": "autonomy_budget",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_thread_goals_chat_thread_unique": {
+          "name": "idx_thread_goals_chat_thread_unique",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thread_goals_org_owner": {
+          "name": "idx_thread_goals_org_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thread_goals_org_status": {
+          "name": "idx_thread_goals_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "thread_goals_chat_thread_id_chat_threads_id_fk": {
+          "name": "thread_goals_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "thread_goals",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_goals_agent_id_agents_id_fk": {
+          "name": "thread_goals_agent_id_agents_id_fk",
+          "tableFrom": "thread_goals",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "thread_goals_status_check": {
+          "name": "thread_goals_status_check",
+          "value": "status IN ('active', 'paused', 'blocked', 'complete')"
+        },
+        "thread_goals_autonomy_budget_check": {
+          "name": "thread_goals_autonomy_budget_check",
+          "value": "\"thread_goals\".\"autonomy_budget\" BETWEEN 0 AND 10"
+        },
+        "thread_goals_retirement_archive_receipt_check": {
+          "name": "thread_goals_retirement_archive_receipt_check",
+          "value": "(\"thread_goals\".\"retirement_archive_event_id\" IS NULL AND \"thread_goals\".\"retirement_archive_seq_id\" IS NULL)\n          OR (\"thread_goals\".\"retirement_archive_event_id\" IS NOT NULL\n            AND \"thread_goals\".\"retirement_archive_seq_id\" IS NOT NULL\n            AND \"thread_goals\".\"retirement_archive_seq_id\" > 0\n            AND \"thread_goals\".\"retirement_archive_seq_id\" <= 9007199254740991)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_event_hourly_rollup": {
+      "name": "usage_event_hourly_rollup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "processed_hour": {
+          "name": "processed_hour",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_window_id": {
+          "name": "short_window_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_window_id": {
+          "name": "weekly_window_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowance_units": {
+          "name": "allowance_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_usage_event_hourly_rollup_org_hour": {
+          "name": "idx_usage_event_hourly_rollup_org_hour",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processed_hour",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_hourly_rollup_physical_grain": {
+          "name": "idx_usage_event_hourly_rollup_physical_grain",
+          "columns": [
+            {
+              "expression": "processed_hour",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "short_window_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weekly_window_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_hourly_rollup_run_id": {
+          "name": "idx_usage_event_hourly_rollup_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_hourly_rollup_user_id": {
+          "name": "idx_usage_event_hourly_rollup_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_hourly_rollup_short_window_id": {
+          "name": "idx_usage_event_hourly_rollup_short_window_id",
+          "columns": [
+            {
+              "expression": "short_window_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_hourly_rollup_weekly_window_id": {
+          "name": "idx_usage_event_hourly_rollup_weekly_window_id",
+          "columns": [
+            {
+              "expression": "weekly_window_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_event_hourly_rollup_run_id_agent_runs_id_fk": {
+          "name": "usage_event_hourly_rollup_run_id_agent_runs_id_fk",
+          "tableFrom": "usage_event_hourly_rollup",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fk_usage_event_hourly_rollup_short_window": {
+          "name": "fk_usage_event_hourly_rollup_short_window",
+          "tableFrom": "usage_event_hourly_rollup",
+          "tableTo": "org_usage_allowance_windows",
+          "columnsFrom": [
+            "short_window_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_usage_event_hourly_rollup_weekly_window": {
+          "name": "fk_usage_event_hourly_rollup_weekly_window",
+          "tableFrom": "usage_event_hourly_rollup",
+          "tableTo": "org_usage_allowance_windows",
+          "columnsFrom": [
+            "weekly_window_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_event_hourly_rollup_processed_hour": {
+          "name": "chk_usage_event_hourly_rollup_processed_hour",
+          "value": "\"usage_event_hourly_rollup\".\"processed_hour\" = date_trunc('hour', \"usage_event_hourly_rollup\".\"processed_hour\")"
+        },
+        "chk_usage_event_hourly_rollup_quantity": {
+          "name": "chk_usage_event_hourly_rollup_quantity",
+          "value": "\"usage_event_hourly_rollup\".\"quantity\" >= 0"
+        },
+        "chk_usage_event_hourly_rollup_credits_charged": {
+          "name": "chk_usage_event_hourly_rollup_credits_charged",
+          "value": "\"usage_event_hourly_rollup\".\"credits_charged\" >= 0"
+        },
+        "chk_usage_event_hourly_rollup_allowance_units": {
+          "name": "chk_usage_event_hourly_rollup_allowance_units",
+          "value": "\"usage_event_hourly_rollup\".\"allowance_units\" >= 0"
+        },
+        "chk_usage_event_hourly_rollup_allowance_window_pair": {
+          "name": "chk_usage_event_hourly_rollup_allowance_window_pair",
+          "value": "(\n          \"usage_event_hourly_rollup\".\"allowance_units\" = 0\n          AND \"usage_event_hourly_rollup\".\"short_window_id\" IS NULL\n          AND \"usage_event_hourly_rollup\".\"weekly_window_id\" IS NULL\n        ) OR (\n          \"usage_event_hourly_rollup\".\"allowance_units\" > 0\n          AND \"usage_event_hourly_rollup\".\"short_window_id\" IS NOT NULL\n          AND \"usage_event_hourly_rollup\".\"weekly_window_id\" IS NOT NULL\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_event": {
+      "name": "usage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "billing_error": {
+          "name": "billing_error",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_usage_event_idempotency_key": {
+          "name": "uq_usage_event_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_run_id": {
+          "name": "idx_usage_event_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_status": {
+          "name": "idx_usage_event_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_created": {
+          "name": "idx_usage_event_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_model_created": {
+          "name": "idx_usage_event_model_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_event\".\"kind\" = 'model'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_org_user_status_processed": {
+          "name": "idx_usage_event_org_user_status_processed",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_event_processed_org_user": {
+          "name": "idx_usage_event_processed_org_user",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_event\".\"status\" = 'processed' AND \"usage_event\".\"processed_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_event_run_id_agent_runs_id_fk": {
+          "name": "usage_event_run_id_agent_runs_id_fk",
+          "tableFrom": "usage_event",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_credit_grants": {
+      "name": "usage_pack_credit_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_type": {
+          "name": "grant_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_amount": {
+          "name": "original_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remaining_amount": {
+          "name": "remaining_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_credit_grants_idempotency": {
+          "name": "uq_usage_pack_credit_grants_idempotency",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_credit_grants_member_spendable": {
+          "name": "idx_usage_pack_credit_grants_member_spendable",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grant_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_pack_credit_grants\".\"remaining_amount\" > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_credit_grants_type": {
+          "name": "chk_usage_pack_credit_grants_type",
+          "value": "\"usage_pack_credit_grants\".\"grant_type\" IN ('purchased', 'bonus')"
+        },
+        "chk_usage_pack_credit_grants_original_amount": {
+          "name": "chk_usage_pack_credit_grants_original_amount",
+          "value": "\"usage_pack_credit_grants\".\"original_amount\" > 0"
+        },
+        "chk_usage_pack_credit_grants_remaining_amount": {
+          "name": "chk_usage_pack_credit_grants_remaining_amount",
+          "value": "\"usage_pack_credit_grants\".\"remaining_amount\" >= 0 AND \"usage_pack_credit_grants\".\"remaining_amount\" <= \"usage_pack_credit_grants\".\"original_amount\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_credit_refunds": {
+      "name": "usage_pack_credit_refunds",
+      "schema": "",
+      "columns": {
+        "credit_grant_id": {
+          "name": "credit_grant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_line_id": {
+          "name": "stripe_invoice_line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_amount_cents": {
+          "name": "source_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "refund_credits": {
+          "name": "refund_credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_amount_cents": {
+          "name": "requested_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_amount_cents": {
+          "name": "refunded_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_credit_note_id": {
+          "name": "stripe_credit_note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_refund_id": {
+          "name": "stripe_refund_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_usage_pack_credit_refunds_member": {
+          "name": "idx_usage_pack_credit_refunds_member",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_credit_refunds_reconcile": {
+          "name": "idx_usage_pack_credit_refunds_reconcile",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_credit_refunds_credit_note": {
+          "name": "uq_usage_pack_credit_refunds_credit_note",
+          "columns": [
+            {
+              "expression": "stripe_credit_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_credit_refunds\".\"stripe_credit_note_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_credit_refunds_refund": {
+          "name": "uq_usage_pack_credit_refunds_refund",
+          "columns": [
+            {
+              "expression": "stripe_refund_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_credit_refunds\".\"stripe_refund_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_pack_credit_refunds_credit_grant_id_usage_pack_credit_grants_id_fk": {
+          "name": "usage_pack_credit_refunds_credit_grant_id_usage_pack_credit_grants_id_fk",
+          "tableFrom": "usage_pack_credit_refunds",
+          "tableTo": "usage_pack_credit_grants",
+          "columnsFrom": [
+            "credit_grant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_credit_refunds_source": {
+          "name": "chk_usage_pack_credit_refunds_source",
+          "value": "(\"usage_pack_credit_refunds\".\"source_type\" = 'invoice' AND \"usage_pack_credit_refunds\".\"stripe_invoice_id\" IS NOT NULL AND \"usage_pack_credit_refunds\".\"stripe_payment_intent_id\" IS NULL) OR (\"usage_pack_credit_refunds\".\"source_type\" = 'payment_intent' AND \"usage_pack_credit_refunds\".\"stripe_invoice_id\" IS NULL AND \"usage_pack_credit_refunds\".\"stripe_invoice_line_id\" IS NULL AND \"usage_pack_credit_refunds\".\"stripe_payment_intent_id\" IS NOT NULL)"
+        },
+        "chk_usage_pack_credit_refunds_status": {
+          "name": "chk_usage_pack_credit_refunds_status",
+          "value": "\"usage_pack_credit_refunds\".\"status\" IN ('available', 'pending', 'processing', 'succeeded', 'failed')"
+        },
+        "chk_usage_pack_credit_refunds_source_amount": {
+          "name": "chk_usage_pack_credit_refunds_source_amount",
+          "value": "\"usage_pack_credit_refunds\".\"source_amount_cents\" >= 0"
+        },
+        "chk_usage_pack_credit_refunds_snapshot": {
+          "name": "chk_usage_pack_credit_refunds_snapshot",
+          "value": "(\"usage_pack_credit_refunds\".\"status\" = 'available' AND \"usage_pack_credit_refunds\".\"refund_credits\" IS NULL AND \"usage_pack_credit_refunds\".\"requested_amount_cents\" IS NULL) OR (\"usage_pack_credit_refunds\".\"status\" <> 'available' AND \"usage_pack_credit_refunds\".\"refund_credits\" > 0 AND \"usage_pack_credit_refunds\".\"requested_amount_cents\" > 0)"
+        },
+        "chk_usage_pack_credit_refunds_refunded_amount": {
+          "name": "chk_usage_pack_credit_refunds_refunded_amount",
+          "value": "\"usage_pack_credit_refunds\".\"refunded_amount_cents\" IS NULL OR \"usage_pack_credit_refunds\".\"refunded_amount_cents\" >= 0"
+        },
+        "chk_usage_pack_credit_refunds_attempt": {
+          "name": "chk_usage_pack_credit_refunds_attempt",
+          "value": "\"usage_pack_credit_refunds\".\"attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_allocation_changes": {
+      "name": "usage_pack_allocation_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "usage_pack_subscription_id": {
+          "name": "usage_pack_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_change_id": {
+          "name": "subscription_change_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_allocation_id": {
+          "name": "source_allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacement_allocation_id": {
+          "name": "replacement_allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_usage_pack_usd": {
+          "name": "source_usage_pack_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_stripe_price_id": {
+          "name": "source_stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_usage_pack_usd": {
+          "name": "target_usage_pack_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_stripe_price_id": {
+          "name": "target_stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proration_timestamp": {
+          "name": "proration_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immediate_amount_cents": {
+          "name": "immediate_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_recurring_amount_cents": {
+          "name": "next_recurring_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_schedule_id": {
+          "name": "stripe_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_pending_update_expires_at": {
+          "name": "stripe_pending_update_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_changes_active_org": {
+          "name": "uq_usage_pack_changes_active_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_allocation_changes\".\"subscription_change_id\" IS NULL AND \"usage_pack_allocation_changes\".\"status\" IN ('previewed', 'applying', 'pending_payment')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_changes_current_user": {
+          "name": "uq_usage_pack_changes_current_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"usage_pack_allocation_changes\".\"subscription_change_id\" IS NULL AND \"usage_pack_allocation_changes\".\"status\" IN ('previewed', 'applying', 'pending_payment')) OR \"usage_pack_allocation_changes\".\"status\" IN ('scheduled', 'applied')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_changes_stripe_invoice": {
+          "name": "uq_usage_pack_changes_stripe_invoice",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_allocation_changes\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_changes_subscription_status": {
+          "name": "idx_usage_pack_changes_subscription_status",
+          "columns": [
+            {
+              "expression": "usage_pack_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_changes_subscription_change": {
+          "name": "idx_usage_pack_changes_subscription_change",
+          "columns": [
+            {
+              "expression": "subscription_change_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_changes_reconcile": {
+          "name": "idx_usage_pack_changes_reconcile",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_pack_allocation_changes_usage_pack_subscription_id_usage_pack_subscriptions_id_fk": {
+          "name": "usage_pack_allocation_changes_usage_pack_subscription_id_usage_pack_subscriptions_id_fk",
+          "tableFrom": "usage_pack_allocation_changes",
+          "tableTo": "usage_pack_subscriptions",
+          "columnsFrom": [
+            "usage_pack_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_pack_allocation_changes_subscription_change_id_usage_pack_subscription_changes_id_fk": {
+          "name": "usage_pack_allocation_changes_subscription_change_id_usage_pack_subscription_changes_id_fk",
+          "tableFrom": "usage_pack_allocation_changes",
+          "tableTo": "usage_pack_subscription_changes",
+          "columnsFrom": [
+            "subscription_change_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_pack_allocation_changes_source_allocation_id_usage_pack_allocations_id_fk": {
+          "name": "usage_pack_allocation_changes_source_allocation_id_usage_pack_allocations_id_fk",
+          "tableFrom": "usage_pack_allocation_changes",
+          "tableTo": "usage_pack_allocations",
+          "columnsFrom": [
+            "source_allocation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_changes_kind": {
+          "name": "chk_usage_pack_changes_kind",
+          "value": "\"usage_pack_allocation_changes\".\"kind\" IN ('addition', 'upgrade', 'downgrade', 'removal')"
+        },
+        "chk_usage_pack_changes_status": {
+          "name": "chk_usage_pack_changes_status",
+          "value": "\"usage_pack_allocation_changes\".\"status\" IN ('previewed', 'applying', 'pending_payment', 'scheduled', 'applied', 'completed', 'failed')"
+        },
+        "chk_usage_pack_changes_source": {
+          "name": "chk_usage_pack_changes_source",
+          "value": "(\"usage_pack_allocation_changes\".\"kind\" = 'addition' AND \"usage_pack_allocation_changes\".\"source_allocation_id\" IS NULL AND \"usage_pack_allocation_changes\".\"source_usage_pack_usd\" IS NULL AND \"usage_pack_allocation_changes\".\"source_stripe_price_id\" IS NULL) OR (\"usage_pack_allocation_changes\".\"kind\" <> 'addition' AND \"usage_pack_allocation_changes\".\"source_allocation_id\" IS NOT NULL AND \"usage_pack_allocation_changes\".\"source_usage_pack_usd\" IN (20, 50, 100, 200) AND \"usage_pack_allocation_changes\".\"source_stripe_price_id\" IS NOT NULL)"
+        },
+        "chk_usage_pack_changes_target_package": {
+          "name": "chk_usage_pack_changes_target_package",
+          "value": "(\"usage_pack_allocation_changes\".\"kind\" = 'removal' AND \"usage_pack_allocation_changes\".\"target_usage_pack_usd\" IS NULL AND \"usage_pack_allocation_changes\".\"target_stripe_price_id\" IS NULL) OR (\"usage_pack_allocation_changes\".\"kind\" <> 'removal' AND \"usage_pack_allocation_changes\".\"target_usage_pack_usd\" IN (20, 50, 100, 200) AND \"usage_pack_allocation_changes\".\"target_stripe_price_id\" IS NOT NULL)"
+        },
+        "chk_usage_pack_changes_amounts": {
+          "name": "chk_usage_pack_changes_amounts",
+          "value": "(\"usage_pack_allocation_changes\".\"immediate_amount_cents\" IS NULL OR \"usage_pack_allocation_changes\".\"immediate_amount_cents\" >= 0) AND (\"usage_pack_allocation_changes\".\"next_recurring_amount_cents\" IS NULL OR \"usage_pack_allocation_changes\".\"next_recurring_amount_cents\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_allocations": {
+      "name": "usage_pack_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "usage_pack_subscription_id": {
+          "name": "usage_pack_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_pack_usd": {
+          "name": "usage_pack_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_payment'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_allocations_current_user": {
+          "name": "uq_usage_pack_allocations_current_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_allocations\".\"user_id\" IS NOT NULL AND \"usage_pack_allocations\".\"status\" <> 'inactive'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_allocations_current_invitation": {
+          "name": "uq_usage_pack_allocations_current_invitation",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_allocations\".\"invitation_id\" IS NOT NULL AND \"usage_pack_allocations\".\"status\" <> 'inactive'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_allocations_subscription_status": {
+          "name": "idx_usage_pack_allocations_subscription_status",
+          "columns": [
+            {
+              "expression": "usage_pack_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_allocations_org_user": {
+          "name": "idx_usage_pack_allocations_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_allocations_org_invitation": {
+          "name": "idx_usage_pack_allocations_org_invitation",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_pack_allocations_usage_pack_subscription_id_usage_pack_subscriptions_id_fk": {
+          "name": "usage_pack_allocations_usage_pack_subscription_id_usage_pack_subscriptions_id_fk",
+          "tableFrom": "usage_pack_allocations",
+          "tableTo": "usage_pack_subscriptions",
+          "columnsFrom": [
+            "usage_pack_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_allocations_owner": {
+          "name": "chk_usage_pack_allocations_owner",
+          "value": "(\"usage_pack_allocations\".\"user_id\" IS NOT NULL AND \"usage_pack_allocations\".\"invitation_id\" IS NULL) OR (\"usage_pack_allocations\".\"user_id\" IS NULL AND \"usage_pack_allocations\".\"invitation_id\" IS NOT NULL)"
+        },
+        "chk_usage_pack_allocations_package": {
+          "name": "chk_usage_pack_allocations_package",
+          "value": "\"usage_pack_allocations\".\"usage_pack_usd\" IN (20, 50, 100, 200)"
+        },
+        "chk_usage_pack_allocations_status": {
+          "name": "chk_usage_pack_allocations_status",
+          "value": "\"usage_pack_allocations\".\"status\" IN ('pending_payment', 'active', 'pending_invitation', 'paid_pending_invitation', 'inactive')"
+        },
+        "chk_usage_pack_allocations_period": {
+          "name": "chk_usage_pack_allocations_period",
+          "value": "(\"usage_pack_allocations\".\"current_period_start\" IS NULL AND \"usage_pack_allocations\".\"current_period_end\" IS NULL) OR (\"usage_pack_allocations\".\"current_period_start\" IS NOT NULL AND \"usage_pack_allocations\".\"current_period_end\" IS NOT NULL AND \"usage_pack_allocations\".\"current_period_end\" > \"usage_pack_allocations\".\"current_period_start\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_invitation_purchases": {
+      "name": "usage_pack_invitation_purchases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "usage_pack_subscription_id": {
+          "name": "usage_pack_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocation_id": {
+          "name": "allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_brand": {
+          "name": "public_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0'"
+        },
+        "normalized_email": {
+          "name": "normalized_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_user_id": {
+          "name": "inviter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_pack_usd": {
+          "name": "usage_pack_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'checkout_pending'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proration_timestamp": {
+          "name": "proration_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_amount_cents": {
+          "name": "unit_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_amount_cents": {
+          "name": "expected_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_paid_cents": {
+          "name": "amount_paid_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchased_credits": {
+          "name": "purchased_credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_credits": {
+          "name": "bonus_credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_expires_at": {
+          "name": "stripe_checkout_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_refund_id": {
+          "name": "stripe_refund_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_attempt": {
+          "name": "refund_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "clerk_invitation_id": {
+          "name": "clerk_invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_user_id": {
+          "name": "accepted_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_invitation_purchases_current_email": {
+          "name": "uq_usage_pack_invitation_purchases_current_email",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_invitation_purchases\".\"status\" IN ('checkout_pending', 'payment_succeeded', 'creating_invitation', 'invitation_pending', 'accepted_pending_activation', 'activating')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_invitation_purchases_allocation": {
+          "name": "uq_usage_pack_invitation_purchases_allocation",
+          "columns": [
+            {
+              "expression": "allocation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_invitation_purchases\".\"allocation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_invitation_purchases_checkout": {
+          "name": "uq_usage_pack_invitation_purchases_checkout",
+          "columns": [
+            {
+              "expression": "stripe_checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_invitation_purchases\".\"stripe_checkout_session_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_invitation_purchases_payment_intent": {
+          "name": "idx_usage_pack_invitation_purchases_payment_intent",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_pack_invitation_purchases\".\"stripe_payment_intent_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_invitation_purchases_refund": {
+          "name": "uq_usage_pack_invitation_purchases_refund",
+          "columns": [
+            {
+              "expression": "stripe_refund_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_invitation_purchases\".\"stripe_refund_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_invitation_purchases_clerk_invitation": {
+          "name": "uq_usage_pack_invitation_purchases_clerk_invitation",
+          "columns": [
+            {
+              "expression": "clerk_invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_invitation_purchases\".\"clerk_invitation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_invitation_purchases_reconcile": {
+          "name": "idx_usage_pack_invitation_purchases_reconcile",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_invitation_purchases_org": {
+          "name": "idx_usage_pack_invitation_purchases_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_pack_invitation_purchases_usage_pack_subscription_id_usage_pack_subscriptions_id_fk": {
+          "name": "usage_pack_invitation_purchases_usage_pack_subscription_id_usage_pack_subscriptions_id_fk",
+          "tableFrom": "usage_pack_invitation_purchases",
+          "tableTo": "usage_pack_subscriptions",
+          "columnsFrom": [
+            "usage_pack_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_pack_invitation_purchases_allocation_id_usage_pack_allocations_id_fk": {
+          "name": "usage_pack_invitation_purchases_allocation_id_usage_pack_allocations_id_fk",
+          "tableFrom": "usage_pack_invitation_purchases",
+          "tableTo": "usage_pack_allocations",
+          "columnsFrom": [
+            "allocation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_invitation_purchases_role": {
+          "name": "chk_usage_pack_invitation_purchases_role",
+          "value": "\"usage_pack_invitation_purchases\".\"role\" IN ('admin', 'member')"
+        },
+        "chk_usage_pack_invitation_purchases_package": {
+          "name": "chk_usage_pack_invitation_purchases_package",
+          "value": "\"usage_pack_invitation_purchases\".\"usage_pack_usd\" IN (20, 50, 100, 200)"
+        },
+        "chk_usage_pack_invitation_purchases_status": {
+          "name": "chk_usage_pack_invitation_purchases_status",
+          "value": "\"usage_pack_invitation_purchases\".\"status\" IN ('checkout_pending', 'payment_succeeded', 'creating_invitation', 'invitation_pending', 'accepted_pending_activation', 'activating', 'accepted', 'refund_pending', 'refunding', 'refunded', 'failed')"
+        },
+        "chk_usage_pack_invitation_purchases_period": {
+          "name": "chk_usage_pack_invitation_purchases_period",
+          "value": "\"usage_pack_invitation_purchases\".\"current_period_end\" > \"usage_pack_invitation_purchases\".\"current_period_start\""
+        },
+        "chk_usage_pack_invitation_purchases_amounts": {
+          "name": "chk_usage_pack_invitation_purchases_amounts",
+          "value": "\"usage_pack_invitation_purchases\".\"unit_amount_cents\" > 0 AND \"usage_pack_invitation_purchases\".\"expected_amount_cents\" >= 0 AND (\"usage_pack_invitation_purchases\".\"amount_paid_cents\" IS NULL OR \"usage_pack_invitation_purchases\".\"amount_paid_cents\" >= 0) AND \"usage_pack_invitation_purchases\".\"purchased_credits\" >= 0 AND \"usage_pack_invitation_purchases\".\"bonus_credits\" >= 0 AND \"usage_pack_invitation_purchases\".\"refund_attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_invoice_fulfillments": {
+      "name": "usage_pack_invoice_fulfillments",
+      "schema": "",
+      "columns": {
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "usage_pack_subscription_id": {
+          "name": "usage_pack_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_usage_pack_invoice_fulfillments_subscription": {
+          "name": "idx_usage_pack_invoice_fulfillments_subscription",
+          "columns": [
+            {
+              "expression": "usage_pack_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_pack_invoice_fulfillments_usage_pack_subscription_id_usage_pack_subscriptions_id_fk": {
+          "name": "usage_pack_invoice_fulfillments_usage_pack_subscription_id_usage_pack_subscriptions_id_fk",
+          "tableFrom": "usage_pack_invoice_fulfillments",
+          "tableTo": "usage_pack_subscriptions",
+          "columnsFrom": [
+            "usage_pack_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_invoice_fulfillments_period": {
+          "name": "chk_usage_pack_invoice_fulfillments_period",
+          "value": "\"usage_pack_invoice_fulfillments\".\"period_start\" IS NULL OR \"usage_pack_invoice_fulfillments\".\"period_end\" > \"usage_pack_invoice_fulfillments\".\"period_start\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_pending_snapshot_guards": {
+      "name": "usage_pack_pending_snapshot_guards",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_snapshot_count": {
+          "name": "pending_snapshot_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_subscriptions_pending_org": {
+          "name": "uq_usage_pack_subscriptions_pending_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_pending_snapshot_guard_count": {
+          "name": "chk_usage_pack_pending_snapshot_guard_count",
+          "value": "\"usage_pack_pending_snapshot_guards\".\"pending_snapshot_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_subscription_changes": {
+      "name": "usage_pack_subscription_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "usage_pack_subscription_id": {
+          "name": "usage_pack_subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_tier": {
+          "name": "source_tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_tier": {
+          "name": "target_tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "proration_timestamp": {
+          "name": "proration_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "immediate_amount_cents": {
+          "name": "immediate_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_recurring_amount_cents": {
+          "name": "next_recurring_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_pending_update_expires_at": {
+          "name": "stripe_pending_update_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_subscription_changes_active_org": {
+          "name": "uq_usage_pack_subscription_changes_active_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscription_changes\".\"status\" IN ('previewed', 'applying', 'pending_payment')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_subscription_changes_stripe_invoice": {
+          "name": "uq_usage_pack_subscription_changes_stripe_invoice",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscription_changes\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_subscription_changes_subscription_status": {
+          "name": "idx_usage_pack_subscription_changes_subscription_status",
+          "columns": [
+            {
+              "expression": "usage_pack_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_subscription_changes_reconcile": {
+          "name": "idx_usage_pack_subscription_changes_reconcile",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_pack_subscription_changes_usage_pack_subscription_id_usage_pack_subscriptions_id_fk": {
+          "name": "usage_pack_subscription_changes_usage_pack_subscription_id_usage_pack_subscriptions_id_fk",
+          "tableFrom": "usage_pack_subscription_changes",
+          "tableTo": "usage_pack_subscriptions",
+          "columnsFrom": [
+            "usage_pack_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_subscription_changes_tiers": {
+          "name": "chk_usage_pack_subscription_changes_tiers",
+          "value": "\"usage_pack_subscription_changes\".\"source_tier\" IN ('pro', 'team') AND \"usage_pack_subscription_changes\".\"target_tier\" IN ('pro', 'team')"
+        },
+        "chk_usage_pack_subscription_changes_status": {
+          "name": "chk_usage_pack_subscription_changes_status",
+          "value": "\"usage_pack_subscription_changes\".\"status\" IN ('previewed', 'applying', 'pending_payment', 'completed', 'failed')"
+        },
+        "chk_usage_pack_subscription_changes_amounts": {
+          "name": "chk_usage_pack_subscription_changes_amounts",
+          "value": "\"usage_pack_subscription_changes\".\"immediate_amount_cents\" >= 0 AND \"usage_pack_subscription_changes\".\"next_recurring_amount_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_subscription_migration_selections": {
+      "name": "usage_pack_subscription_migration_selections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "migration_id": {
+          "name": "migration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_email": {
+          "name": "normalized_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_user_id": {
+          "name": "inviter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_pack_usd": {
+          "name": "usage_pack_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_amount_cents": {
+          "name": "unit_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchased_credits": {
+          "name": "purchased_credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_credits": {
+          "name": "bonus_credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_migration_selections_user": {
+          "name": "uq_usage_pack_migration_selections_user",
+          "columns": [
+            {
+              "expression": "migration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscription_migration_selections\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_migration_selections_invitation": {
+          "name": "uq_usage_pack_migration_selections_invitation",
+          "columns": [
+            {
+              "expression": "migration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscription_migration_selections\".\"invitation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_migration_selections_migration": {
+          "name": "idx_usage_pack_migration_selections_migration",
+          "columns": [
+            {
+              "expression": "migration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_pack_subscription_migration_selections_migration_id_usage_pack_subscription_migrations_id_fk": {
+          "name": "usage_pack_subscription_migration_selections_migration_id_usage_pack_subscription_migrations_id_fk",
+          "tableFrom": "usage_pack_subscription_migration_selections",
+          "tableTo": "usage_pack_subscription_migrations",
+          "columnsFrom": [
+            "migration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_migration_selections_owner": {
+          "name": "chk_usage_pack_migration_selections_owner",
+          "value": "(\"usage_pack_subscription_migration_selections\".\"user_id\" IS NOT NULL AND \"usage_pack_subscription_migration_selections\".\"invitation_id\" IS NULL AND \"usage_pack_subscription_migration_selections\".\"normalized_email\" IS NULL AND \"usage_pack_subscription_migration_selections\".\"role\" IS NULL AND \"usage_pack_subscription_migration_selections\".\"inviter_user_id\" IS NULL) OR (\"usage_pack_subscription_migration_selections\".\"user_id\" IS NULL AND \"usage_pack_subscription_migration_selections\".\"invitation_id\" IS NOT NULL AND \"usage_pack_subscription_migration_selections\".\"normalized_email\" IS NOT NULL AND \"usage_pack_subscription_migration_selections\".\"role\" IS NOT NULL AND \"usage_pack_subscription_migration_selections\".\"inviter_user_id\" IS NOT NULL)"
+        },
+        "chk_usage_pack_migration_selections_role": {
+          "name": "chk_usage_pack_migration_selections_role",
+          "value": "\"usage_pack_subscription_migration_selections\".\"role\" IS NULL OR \"usage_pack_subscription_migration_selections\".\"role\" IN ('admin', 'member')"
+        },
+        "chk_usage_pack_migration_selections_package": {
+          "name": "chk_usage_pack_migration_selections_package",
+          "value": "\"usage_pack_subscription_migration_selections\".\"usage_pack_usd\" IN (20, 50, 100, 200)"
+        },
+        "chk_usage_pack_migration_selections_amounts": {
+          "name": "chk_usage_pack_migration_selections_amounts",
+          "value": "\"usage_pack_subscription_migration_selections\".\"unit_amount_cents\" > 0 AND \"usage_pack_subscription_migration_selections\".\"purchased_credits\" > 0 AND \"usage_pack_subscription_migration_selections\".\"bonus_credits\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_subscription_migrations": {
+      "name": "usage_pack_subscription_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_tier": {
+          "name": "source_tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_tier": {
+          "name": "target_tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_stripe_price_id": {
+          "name": "legacy_stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_stripe_item_id": {
+          "name": "legacy_stripe_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_plan_price_id": {
+          "name": "stripe_plan_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "current_recurring_amount_cents": {
+          "name": "current_recurring_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_recurring_amount_cents": {
+          "name": "next_recurring_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring_difference_cents": {
+          "name": "recurring_difference_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_schedule_id": {
+          "name": "stripe_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hosted_invoice_url": {
+          "name": "hosted_invoice_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_subscription_migrations_open_org": {
+          "name": "uq_usage_pack_subscription_migrations_open_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscription_migrations\".\"status\" IN ('previewed', 'applying', 'revising', 'scheduled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_subscription_migrations_open_subscription": {
+          "name": "uq_usage_pack_subscription_migrations_open_subscription",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscription_migrations\".\"status\" IN ('previewed', 'applying', 'revising', 'scheduled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_subscription_migrations_invoice": {
+          "name": "uq_usage_pack_subscription_migrations_invoice",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscription_migrations\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_subscription_migrations_schedule": {
+          "name": "uq_usage_pack_subscription_migrations_schedule",
+          "columns": [
+            {
+              "expression": "stripe_schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscription_migrations\".\"stripe_schedule_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_subscription_migrations_reconcile": {
+          "name": "idx_usage_pack_subscription_migrations_reconcile",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_subscription_migrations_tiers": {
+          "name": "chk_usage_pack_subscription_migrations_tiers",
+          "value": "\"usage_pack_subscription_migrations\".\"source_tier\" IN ('pro', 'team') AND \"usage_pack_subscription_migrations\".\"target_tier\" IN ('pro', 'team')"
+        },
+        "chk_usage_pack_subscription_migrations_status": {
+          "name": "chk_usage_pack_subscription_migrations_status",
+          "value": "\"usage_pack_subscription_migrations\".\"status\" IN ('previewed', 'applying', 'revising', 'scheduled', 'completed', 'failed')"
+        },
+        "chk_usage_pack_subscription_migrations_amounts": {
+          "name": "chk_usage_pack_subscription_migrations_amounts",
+          "value": "\"usage_pack_subscription_migrations\".\"current_recurring_amount_cents\" >= 0 AND \"usage_pack_subscription_migrations\".\"next_recurring_amount_cents\" >= 0 AND \"usage_pack_subscription_migrations\".\"recurring_difference_cents\" = \"usage_pack_subscription_migrations\".\"next_recurring_amount_cents\" - \"usage_pack_subscription_migrations\".\"current_recurring_amount_cents\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pack_subscriptions": {
+      "name": "usage_pack_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_plan_price_id": {
+          "name": "stripe_plan_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'checkout_pending'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pack_subscriptions_checkout_session": {
+          "name": "uq_usage_pack_subscriptions_checkout_session",
+          "columns": [
+            {
+              "expression": "stripe_checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscriptions\".\"stripe_checkout_session_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_pack_subscriptions_stripe_subscription": {
+          "name": "uq_usage_pack_subscriptions_stripe_subscription",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"usage_pack_subscriptions\".\"stripe_subscription_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_subscriptions_org": {
+          "name": "idx_usage_pack_subscriptions_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_pack_subscriptions_reconcile": {
+          "name": "idx_usage_pack_subscriptions_reconcile",
+          "columns": [
+            {
+              "expression": "subscription_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_usage_pack_subscriptions_tier": {
+          "name": "chk_usage_pack_subscriptions_tier",
+          "value": "\"usage_pack_subscriptions\".\"tier\" IN ('pro', 'team')"
+        },
+        "chk_usage_pack_subscriptions_period": {
+          "name": "chk_usage_pack_subscriptions_period",
+          "value": "(\"usage_pack_subscriptions\".\"current_period_start\" IS NULL AND \"usage_pack_subscriptions\".\"current_period_end\" IS NULL) OR (\"usage_pack_subscriptions\".\"current_period_start\" IS NOT NULL AND \"usage_pack_subscriptions\".\"current_period_end\" IS NOT NULL AND \"usage_pack_subscriptions\".\"current_period_end\" > \"usage_pack_subscriptions\".\"current_period_start\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_pricing": {
+      "name": "usage_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_size": {
+          "name": "unit_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_pricing_kind_provider_category": {
+          "name": "uq_usage_pricing_kind_provider_category",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_artifact_favorites": {
+      "name": "user_artifact_favorites",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_url": {
+          "name": "artifact_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_artifact_favorites_org_id_user_id_artifact_url_pk": {
+          "name": "user_artifact_favorites_org_id_user_id_artifact_url_pk",
+          "columns": [
+            "org_id",
+            "user_id",
+            "artifact_url"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_behavior_count": {
+      "name": "user_behavior_count",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "behavior_key": {
+          "name": "behavior_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_at": {
+          "name": "last_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_behavior_count_org_id_user_id_behavior_key_pk": {
+          "name": "user_behavior_count_org_id_user_id_behavior_key_pk",
+          "columns": [
+            "org_id",
+            "user_id",
+            "behavior_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_cache": {
+      "name": "user_cache",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_list_cached_at": {
+          "name": "org_list_cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_connectors": {
+      "name": "user_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_connectors_unique_slug": {
+          "name": "idx_user_connectors_unique_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_connectors_agent_user": {
+          "name": "idx_user_connectors_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_connectors_agent_id_agents_id_fk": {
+          "name": "user_connectors_agent_id_agents_id_fk",
+          "tableFrom": "user_connectors",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_custom_connectors": {
+      "name": "user_custom_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_connector_id": {
+          "name": "custom_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_names": {
+          "name": "permission_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_custom_connectors_unique": {
+          "name": "idx_user_custom_connectors_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "custom_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_custom_connectors_agent_user": {
+          "name": "idx_user_custom_connectors_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_custom_connectors_agent_id_agents_id_fk": {
+          "name": "user_custom_connectors_agent_id_agents_id_fk",
+          "tableFrom": "user_custom_connectors",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_user_custom_connectors_custom_connector": {
+          "name": "fk_user_custom_connectors_custom_connector",
+          "tableFrom": "user_custom_connectors",
+          "tableTo": "org_custom_connectors",
+          "columnsFrom": [
+            "custom_connector_id",
+            "org_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feature_switches": {
+      "name": "user_feature_switches",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "switches": {
+          "name": "switches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_feature_switches_org_id_user_id_pk": {
+          "name": "user_feature_switches_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_permission_grants": {
+      "name": "user_permission_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_slug": {
+          "name": "connector_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_user_permission_grants_slug_permission": {
+          "name": "uq_user_permission_grants_slug_permission",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_permission_grants_lookup": {
+          "name": "idx_user_permission_grants_lookup",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_permission_grants_user_id": {
+          "name": "idx_user_permission_grants_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_permission_grants_agent_id": {
+          "name": "idx_user_permission_grants_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_permission_grants_agent_id_agents_id_fk": {
+          "name": "user_permission_grants_agent_id_agents_id_fk",
+          "tableFrom": "user_permission_grants",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_user_permission_grants_action": {
+          "name": "chk_user_permission_grants_action",
+          "value": "\"user_permission_grants\".\"action\" IN ('allow', 'deny')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_unsubscribed": {
+          "name": "email_unsubscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_org": {
+          "name": "idx_variables_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_connector": {
+          "name": "idx_variables_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"variables\".\"connector_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_org_user_type_name": {
+          "name": "idx_variables_org_user_type_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"variables\".\"connector_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_connector_name": {
+          "name": "idx_variables_connector_name",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"variables\".\"connector_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_variables_connector_owner": {
+          "name": "fk_variables_connector_owner",
+          "tableFrom": "variables",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_id",
+            "org_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "org_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_variables_connector_owner_type": {
+          "name": "chk_variables_connector_owner_type",
+          "value": "(\"variables\".\"type\" = 'connector') = (\"variables\".\"connector_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.official_workflow_automation_identities": {
+      "name": "official_workflow_automation_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blueprint_key": {
+          "name": "blueprint_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retained_parameter_bindings": {
+          "name": "retained_parameter_bindings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retained_intended_enabled": {
+          "name": "retained_intended_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retained_applied_fingerprint": {
+          "name": "retained_applied_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_official_workflow_automation_identities_key": {
+          "name": "idx_official_workflow_automation_identities_key",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "blueprint_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_official_workflow_automation_identities_automation_unique": {
+          "name": "idx_official_workflow_automation_identities_automation_unique",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"official_workflow_automation_identities\".\"automation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_official_workflow_automation_identities_workflow": {
+          "name": "idx_official_workflow_automation_identities_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "official_workflow_automation_identity_workflow_fk": {
+          "name": "official_workflow_automation_identity_workflow_fk",
+          "tableFrom": "official_workflow_automation_identities",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "official_workflow_automation_identity_automation_fk": {
+          "name": "official_workflow_automation_identity_automation_fk",
+          "tableFrom": "official_workflow_automation_identities",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "official_workflow_automation_identities_state_check": {
+          "name": "official_workflow_automation_identities_state_check",
+          "value": "(\n          \"official_workflow_automation_identities\".\"state\" = 'active'\n          AND \"official_workflow_automation_identities\".\"automation_id\" IS NOT NULL\n          AND \"official_workflow_automation_identities\".\"retained_parameter_bindings\" IS NULL\n          AND \"official_workflow_automation_identities\".\"retained_intended_enabled\" IS NULL\n          AND \"official_workflow_automation_identities\".\"retained_applied_fingerprint\" IS NULL\n        ) OR (\n          \"official_workflow_automation_identities\".\"state\" IN ('reconciling', 'needs_reconfiguration', 'failed', 'removed')\n          AND \"official_workflow_automation_identities\".\"automation_id\" IS NULL\n          AND jsonb_typeof(\"official_workflow_automation_identities\".\"retained_parameter_bindings\") = 'array'\n          AND \"official_workflow_automation_identities\".\"retained_intended_enabled\" IS NOT NULL\n          AND (\n            \"official_workflow_automation_identities\".\"retained_applied_fingerprint\" IS NULL\n            OR \"official_workflow_automation_identities\".\"retained_applied_fingerprint\" ~ '^[0-9a-f]{64}$'\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_automations": {
+      "name": "workflow_automations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'schedule'"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_config": {
+          "name": "event_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_connector_id": {
+          "name": "event_connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "autonomy_budget": {
+          "name": "autonomy_budget",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "official_blueprint_key": {
+          "name": "official_blueprint_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_applied_fingerprint": {
+          "name": "official_applied_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_reconciliation_status": {
+          "name": "official_reconciliation_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_parameter_bindings": {
+          "name": "official_parameter_bindings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_intended_enabled": {
+          "name": "official_intended_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_result_email_enabled": {
+          "name": "official_result_email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_automations_workflow": {
+          "name": "idx_workflow_automations_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_automations_org": {
+          "name": "idx_workflow_automations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_automations_event_connector": {
+          "name": "idx_workflow_automations_event_connector",
+          "columns": [
+            {
+              "expression": "event_connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_automations_next_run": {
+          "name": "idx_workflow_automations_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_automations_official_blueprint_unique": {
+          "name": "idx_workflow_automations_official_blueprint_unique",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "official_blueprint_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_automations\".\"official_blueprint_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_automations_workflow_id_workflows_id_fk": {
+          "name": "workflow_automations_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_automations",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_automations_event_connector_id_connectors_id_fk": {
+          "name": "workflow_automations_event_connector_id_connectors_id_fk",
+          "tableFrom": "workflow_automations",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "event_connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_automations_schedule_config_check": {
+          "name": "workflow_automations_schedule_config_check",
+          "value": "(\n            kind = 'schedule'\n            AND event_type IS NULL\n            AND event_config IS NULL\n            AND (\n              (schedule_type = 'cron' AND cron_expression IS NOT NULL AND interval_seconds IS NULL AND at_time IS NULL)\n              OR (schedule_type = 'loop' AND interval_seconds IS NOT NULL AND cron_expression IS NULL AND at_time IS NULL)\n              OR (schedule_type = 'once' AND at_time IS NOT NULL AND cron_expression IS NULL AND interval_seconds IS NULL)\n            )\n          )\n          OR (\n            kind = 'event'\n            AND event_type IN ('chat-run-finished', 'gmail-new-message', 'gmail-label-applied', 'github-deployment-status-created', 'github-issue-comment-created', 'github-pull-request', 'github-pull-request-review-submitted', 'github-workflow-job-completed', 'github-workflow-run-completed', 'google-calendar-event-created', 'google-calendar-event-updated', 'google-calendar-event-cancelled', 'google-forms-response-submitted', 'google-meet-transcript-generated', 'notion-child-page-created', 'notion-database-item-created', 'notion-page-content-updated', 'stripe-invoice-paid', 'webhook-received')\n            AND event_config IS NOT NULL\n            AND schedule_type IS NULL\n            AND cron_expression IS NULL\n            AND interval_seconds IS NULL\n            AND at_time IS NULL\n          )"
+        },
+        "workflow_automations_autonomy_budget_check": {
+          "name": "workflow_automations_autonomy_budget_check",
+          "value": "\"workflow_automations\".\"autonomy_budget\" BETWEEN 0 AND 10"
+        },
+        "workflow_automations_official_binding_check": {
+          "name": "workflow_automations_official_binding_check",
+          "value": "(\n          \"workflow_automations\".\"official_blueprint_key\" IS NULL\n          AND \"workflow_automations\".\"official_applied_fingerprint\" IS NULL\n          AND \"workflow_automations\".\"official_reconciliation_status\" IS NULL\n          AND \"workflow_automations\".\"official_parameter_bindings\" IS NULL\n          AND \"workflow_automations\".\"official_intended_enabled\" IS NULL\n          AND \"workflow_automations\".\"official_result_email_enabled\" IS NULL\n        ) OR (\n          \"workflow_automations\".\"official_blueprint_key\" IS NOT NULL\n          AND \"workflow_automations\".\"official_applied_fingerprint\" ~ '^[0-9a-f]{64}$'\n          AND \"workflow_automations\".\"official_reconciliation_status\" IN ('current', 'reconciling', 'needs_reconfiguration', 'failed')\n          AND jsonb_typeof(\"workflow_automations\".\"official_parameter_bindings\") = 'array'\n          AND \"workflow_automations\".\"official_intended_enabled\" IS NOT NULL\n          AND \"workflow_automations\".\"official_result_email_enabled\" IS NOT NULL\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_github_processed_events": {
+      "name": "workflow_github_processed_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_delivery_id": {
+          "name": "github_delivery_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_number": {
+          "name": "subject_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_name_normalized": {
+          "name": "label_name_normalized",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_github_processed_automation_delivery": {
+          "name": "idx_workflow_github_processed_automation_delivery",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_github_processed_subject": {
+          "name": "idx_workflow_github_processed_subject",
+          "columns": [
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_github_processed_events_automation_id_workflow_automations_id_fk": {
+          "name": "workflow_github_processed_events_automation_id_workflow_automations_id_fk",
+          "tableFrom": "workflow_github_processed_events",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_user_automation_threads": {
+      "name": "workflow_user_automation_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_user_automation_threads_unique": {
+          "name": "idx_workflow_user_automation_threads_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_user_automation_threads_chat_thread": {
+          "name": "idx_workflow_user_automation_threads_chat_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_user_automation_threads_workflow_user": {
+          "name": "idx_workflow_user_automation_threads_workflow_user",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_user_automation_threads_workflow_id_workflows_id_fk": {
+          "name": "workflow_user_automation_threads_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_user_automation_threads",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_user_automation_threads_chat_thread_id_chat_threads_id_fk": {
+          "name": "workflow_user_automation_threads_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "workflow_user_automation_threads",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "chat_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_webhook_automations": {
+      "name": "workflow_webhook_automations",
+      "schema": "",
+      "columns": {
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_token": {
+          "name": "encrypted_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_last_four": {
+          "name": "secret_last_four",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_received_at": {
+          "name": "last_received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_webhook_automations_token_hash": {
+          "name": "idx_workflow_webhook_automations_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_webhook_automations_automation_id_workflow_automations_id_fk": {
+          "name": "workflow_webhook_automations_automation_id_workflow_automations_id_fk",
+          "tableFrom": "workflow_webhook_automations",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_webhook_deliveries": {
+      "name": "workflow_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_key": {
+          "name": "delivery_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_sha256": {
+          "name": "body_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_webhook_deliveries_automation_key": {
+          "name": "idx_workflow_webhook_deliveries_automation_key",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivery_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_webhook_deliveries_automation_received": {
+          "name": "idx_workflow_webhook_deliveries_automation_received",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_webhook_deliveries_automation_id_workflow_automations_id_fk": {
+          "name": "workflow_webhook_deliveries_automation_id_workflow_automations_id_fk",
+          "tableFrom": "workflow_webhook_deliveries",
+          "tableTo": "workflow_automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_definition_name": {
+          "name": "official_definition_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "official_installation_state": {
+          "name": "official_installation_state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflows_agent": {
+          "name": "idx_workflows_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflows_public_agent_name_unique": {
+          "name": "idx_workflows_public_agent_name_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "visibility = 'public'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflows_private_owner_agent_name_unique": {
+          "name": "idx_workflows_private_owner_agent_name_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "visibility = 'private'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflows_org": {
+          "name": "idx_workflows_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflows_org_owner": {
+          "name": "idx_workflows_org_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_agent_id_agents_id_fk": {
+          "name": "workflows_agent_id_agents_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_official_installation_check": {
+          "name": "workflows_official_installation_check",
+          "value": "(\n          \"workflows\".\"official_definition_name\" IS NULL\n          AND \"workflows\".\"official_installation_state\" IS NULL\n        ) OR (\n          \"workflows\".\"official_definition_name\" IS NOT NULL\n          AND \"workflows\".\"official_installation_state\" IN ('installing', 'installed')\n          AND \"workflows\".\"official_definition_name\" = \"workflows\".\"name\"\n          AND \"workflows\".\"visibility\" = 'private'\n          AND \"workflows\".\"instruction\" IS NULL\n          AND \"workflows\".\"display_name\" IS NULL\n          AND \"workflows\".\"description\" IS NULL\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.chat_thread_event_kind": {
+      "name": "chat_thread_event_kind",
+      "schema": "public",
+      "values": [
+        "created",
+        "renamed",
+        "deleted",
+        "pinned",
+        "unpinned",
+        "model_selection_updated",
+        "service_tier_updated",
+        "computer_use_host_updated",
+        "video_model_updated",
+        "image_model_updated",
+        "sort_touched"
+      ]
+    },
+    "public.connector_external_code_session_status": {
+      "name": "connector_external_code_session_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completing",
+        "complete",
+        "expired",
+        "error"
+      ]
+    },
+    "public.connector_oauth_device_authorization_session_status": {
+      "name": "connector_oauth_device_authorization_session_status",
+      "schema": "public",
+      "values": [
+        "awaiting_user_authorization",
+        "polling",
+        "complete",
+        "denied",
+        "expired",
+        "error"
+      ]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "authenticated",
+        "approved",
+        "consumed",
+        "expired",
+        "denied"
+      ]
+    },
+    "public.model_provider_auth_session_status": {
+      "name": "model_provider_auth_session_status",
+      "schema": "public",
+      "values": [
+        "initializing",
+        "awaiting_user_approval",
+        "completing",
+        "imported",
+        "expired",
+        "cancelled",
+        "error"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/packages/db/src/migrations/meta/_journal.json
+++ b/turbo/packages/db/src/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1788934062730,
       "tag": "1096_shiny_black_bolt",
       "breakpoints": true
+    },
+    {
+      "idx": 1097,
+      "version": "7",
+      "when": 1788942150364,
+      "tag": "1097_puzzling_retro_girl",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/packages/db/src/schema/connector-oauth-state.ts
+++ b/turbo/packages/db/src/schema/connector-oauth-state.ts
@@ -16,6 +16,30 @@ import { sql } from "drizzle-orm";
 import type { StoredConnectorAccountMutation } from "@okouai/db/jsonb-contracts/connector-account-mutation";
 
 import { orgCustomConnectors } from "./org-custom-connector";
+import { connectors } from "./connector";
+
+export const connectorOauthCompletions = pgTable(
+  "connector_oauth_completions",
+  {
+    id: uuid("id").primaryKey(),
+    connectionId: uuid("connection_id")
+      .notNull()
+      .references(
+        () => {
+          return connectors.id;
+        },
+        { onDelete: "cascade" },
+      ),
+    userId: text("user_id").notNull(),
+    orgId: text("org_id").notNull(),
+    expiresAt: timestamp("expires_at").notNull(),
+  },
+  (table) => {
+    return [
+      index("idx_connector_oauth_completions_expires_at").on(table.expiresAt),
+    ];
+  },
+);
 
 export const connectorOauthStates = pgTable(
   "connector_oauth_states",


### PR DESCRIPTION
## Summary

Closes #32503.

- Replace browser OAuth completion inferred from account timestamps, counts, or existence with server-authored receipts for the exact authorization attempt. Renaming or changing a default account during cancelled consent no longer triggers success, continuation, or Agent grants.
- Add an authenticated, uncached completion lookup and an additive receipt table. Successful built-in OAuth/OpenID and custom HTTP/MCP callbacks record the actual connected account only after credential persistence and required authorization/linking. Preserve single-use OAuth state claims, selected-account checks, popup cleanup, and first-account grant policy.
- Expire receipts after 15 minutes, cascade account deletion, and extend the existing bounded cleanup cron. Notify built-in clients after receipt persistence.

No new UI, Runner protocol, device/external-code flow, integration-managed Feishu linking, or synchronous custom no-auth behavior is included.

## Fallbacks

- **Surface:** `oauthAttemptId` remains optional in start responses. The new App treats an absent ID or unavailable completion receipt as not completed; it never falls back to account metadata.
- **Exposure window:** API/App deploy independently; old API instances and supported API rollback targets may overlap new App code. A new start followed by an old callback can save credentials without producing a receipt. Already-loaded old App pages retain their previous heuristic until refreshed.
- **Behavior/risk:** automatic continuation and grants stop without proof; users may need to retry after rollout even when credentials were saved. There is no immediate App minimum-version increase.
- **Removal gate:** every serving and supported rollback API version must support receipts. The contraction is tracked in #32870 (not closed by this PR).

## Validation

All commands below ran from `turbo/`, with one Vitest process at a time.

- API: 10 route test files, **300 passed**.
- App: 13 page test files, **287 passed**.
- Contracts: `pnpm -F @okouai/api-contracts exec vitest run --maxWorkers=2 --silent=passed-only` — **814 passed**.
- `pnpm -F api check-types`; `pnpm -F @okouai/app check-types`.
- `pnpm turbo run check-types --filter=@okouai/db --filter=@okouai/api-contracts --filter=@okouai/cli --concurrency=1` — passed, including contract consumers.
- Affected API/App/DB/contracts lint, Prettier, and full `pnpm knip` — passed.
- `TZ=UTC pnpm -F @okouai/db test:migration-consistency` — full migration consistency chain passed. The initial local Asia/Shanghai run exposed the existing fixture's timestamp-without-timezone assumption; rerunning with the CI timezone passed without changing unrelated code.
- Generated snapshot comparison confirms the only schema addition is `connector_oauth_completions`; migration applied locally.

<details>
<summary>Exact API and App regression commands</summary>

```sh
pnpm -F api exec vitest run \
  src/signals/routes/__tests__/connector-oauth-completion.test.ts \
  src/signals/routes/__tests__/connectors-openid.bdd.test.ts \
  src/signals/routes/__tests__/cron-connector-oauth-state-cleanup.test.ts \
  src/signals/routes/__tests__/connectors-oauth-start.test.ts \
  src/signals/routes/__tests__/connectors.bdd.test.ts \
  src/signals/routes/__tests__/custom-connectors-oauth2.test.ts \
  src/signals/routes/__tests__/github-oauth-account-mutations.test.ts \
  src/signals/routes/__tests__/connector-accounts.test.ts \
  src/signals/routes/__tests__/mcp-oauth-foundations.test.ts \
  src/signals/routes/__tests__/connector-runtime-wakeups.test.ts \
  --maxWorkers=2 --silent=passed-only

pnpm -F @okouai/app exec vitest run \
  src/views/okou-page/__tests__/connectors-accounts.test.tsx \
  src/views/okou-page/__tests__/connectors-custom.test.tsx \
  src/views/okou-page/__tests__/connectors-auth-methods.test.tsx \
  src/views/okou-page/__tests__/connectors-catalog.test.tsx \
  src/views/okou-page/__tests__/connector-connection-progress.test.tsx \
  src/views/okou-page/__tests__/chat-capability-connectors.test.tsx \
  src/views/okou-page/__tests__/chat-capability-mail.test.tsx \
  src/views/okou-page/__tests__/chat-composer-connectors.test.tsx \
  src/views/okou-page/__tests__/chat-navigation-artifact-drive.test.tsx \
  src/views/okou-page/__tests__/directed-connect-page.test.tsx \
  src/views/okou-page/__tests__/directed-authorize-page.test.tsx \
  src/views/workflows-page/__tests__/workflows-page.test.tsx \
  src/views/onboarding/__tests__/onboarding-flow.test.tsx \
  --maxWorkers=2 --silent=passed-only
```

</details>

## Remaining risks

Receipt writes add a small database operation after credential persistence; a failure is propagated and can leave saved credentials without browser completion. The lookup validates the current user, organization, target, expiry, and account existence but does not promise credentials remain valid forever. Live provider consent and production multi-version deployment were not exercised locally; external-provider HTTP boundaries are covered by integration fixtures.
