### PR TITLE
fix(platform): show minutes in chat run durations over an hour

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -3374,13 +3374,24 @@ function formatCompactDuration(totalSeconds: number): string {
       },
     );
   }
-  const totalHours = Math.round(totalMinutes / 60);
-  return i18n.t(
+  const totalHours = Math.floor(totalMinutes / 60);
+  const remainingMinutes = totalMinutes % 60;
+  const hours = i18n.t(
     ($) => {
       return $.chat.run.duration.hoursShort;
     },
     { count: totalHours },
   );
+  if (remainingMinutes === 0) {
+    return hours;
+  }
+  const minutes = i18n.t(
+    ($) => {
+      return $.chat.run.duration.minutesShort;
+    },
+    { count: remainingMinutes },
+  );
+  return `${hours} ${minutes}`;
 }
 
 const RUN_SECTION_LABEL_CLASS =


### PR DESCRIPTION
Chat work summaries currently round 1 hour 30 minutes to `2h`. Display hours and remaining minutes instead (`1h 30m`, `2h 15m`), omitting minutes when zero (`2h`). The shared formatter covers both `Working for` and `Worked for` and preserves existing minute rounding and localized unit labels.

Closes #32881

## Validation

- Prettier, Oxlint, ESLint, and Platform production TypeScript checks passed.
- Existing `chat-run-history` and `chat-run-steer` tests passed: 30 tests across 2 files.
- Checked the production formatter against 15 duration boundary examples and 2 localized-unit examples, including sub-hour durations, whole hours, remaining minutes, and minute rollover.
- Full-suite validation is left to PR CI.
