### PR TITLE
ci: add protected goal archive search recovery

### DIFF
--- a/.github/scripts/tests/goal-archive-search-recovery-workflow-test.sh
+++ b/.github/scripts/tests/goal-archive-search-recovery-workflow-test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+python3 - "$repo_root" <<'PYTHON'
+import contextlib
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+from unittest.mock import patch
+
+root = Path(sys.argv[1])
+workflow = (root / ".github/workflows/temporary-goal-archive-search-recovery.yml").read_text()
+resolver = textwrap.dedent(workflow.split("python3 - <<'PYTHON'\n", 1)[1].split("          PYTHON", 1)[0])
+source_check = textwrap.dedent(workflow.split("      - name: Validate mode and accepted operation source", 1)[1].split("        run: |\n", 1)[1].split("\n      - name:", 1)[0])
+secret = "synthetic-private-provider-detail"
+valid_uri = "postgresql://neondb_owner:synthetic-password@ep-test.us-east-2.aws.neon.tech/neondb?sslmode=require"
+branches = {"branches": [{"id": "br-test", "name": "production"}]}
+
+def check_resolution(responses, *, project="hidden-lab-39609750", success=False):
+    calls = []
+    class Opener:
+        def open(self, request, timeout):
+            assert request.full_url.startswith("https://console.neon.tech/api/v2/projects/hidden-lab-39609750/")
+            assert timeout == 30
+            calls.append(request.full_url)
+            value = responses[len(calls) - 1]
+            if isinstance(value, Exception):
+                raise value
+            return io.BytesIO(json.dumps(value).encode())
+
+    with tempfile.TemporaryDirectory() as directory:
+        transfer = Path(directory) / "environment"
+        captured = io.StringIO()
+        env = {"NEON_API_KEY": "synthetic-key", "NEON_PROJECT_ID": project, "GITHUB_ENV": str(transfer)}
+        with patch.dict(os.environ, env, clear=True), patch("urllib.request.build_opener", return_value=Opener()), contextlib.redirect_stdout(captured):
+            try:
+                exec(compile(resolver, "workflow-resolver", "exec"), {})
+            except SystemExit as error:
+                assert not success
+                assert str(error) == "production_database_resolution_failed"
+            else:
+                assert success
+        text = captured.getvalue()
+        assert secret not in text
+        if success:
+            assert len(calls) == 2
+            assert "branch_id=br-test" in calls[1] and "pooled=false" in calls[1]
+            assert text.startswith("::add-mask::postgresql://")
+            assert "sslmode=verify-full" in text
+            assert transfer.read_text() == "DATABASE_URL=" + text.split("::add-mask::", 1)[1].replace("%25", "%")
+        else:
+            assert text == ""
+            assert not transfer.exists()
+
+check_resolution([branches, {"uri": valid_uri}], success=True)
+check_resolution([branches, {"uri": valid_uri}], project="different-project")
+check_resolution([{"branches": []}])
+check_resolution([{"branches": branches["branches"] * 2}])
+check_resolution([{"branches": branches["branches"], "pagination": {"cursor": "more"}}])
+check_resolution([ValueError(secret)])
+check_resolution([branches, {"uri": None}])
+for uri in [
+    valid_uri + "\nINJECTED=value", valid_uri + "#fragment", "https://example.test/",
+    valid_uri.replace(".neon.tech", ".neon.tech.evil.test"),
+    valid_uri.replace("/neondb?", "/other?"),
+    valid_uri.replace("neondb_owner:", "other:"),
+    valid_uri.replace("synthetic-password", ""),
+    valid_uri + "&sslmode=disable", valid_uri + "&sslrootcert=/tmp/unsafe",
+    valid_uri + "&uselibpqcompat=true",
+]:
+    check_resolution([branches, {"uri": uri}])
+
+# Mock only the external Git source boundary, so these executable checks also
+# run in the PR pipeline's shallow checkout without fetching production history.
+with tempfile.TemporaryDirectory() as directory:
+    git = Path(directory) / "git"
+    git.write_text('''#!/usr/bin/env python3
+import os, sys
+args = sys.argv[1:]
+if args == ["rev-parse", "HEAD"]:
+    print("a" * 40)
+elif args[:2] == ["merge-base", "--is-ancestor"]:
+    assert args[2] in ("3e1544d55ac0dc54a1cdb21d6aee72d651a6808d", "cede9cbfb62872ddabb705de852dc6fd81a3cc6d")
+    sys.exit(1 if os.environ.get("SOURCE_FAILURE") == "ancestor" else 0)
+elif args[:2] == ["diff", "--quiet"]:
+    assert args[2] == "cede9cbfb62872ddabb705de852dc6fd81a3cc6d"
+    assert "turbo/packages/db/scripts/migrations/014-goal-archive-search" in args
+    sys.exit(1 if os.environ.get("SOURCE_FAILURE") == "changed" else 0)
+else:
+    sys.exit(1)
+''')
+    git.chmod(0o700)
+    def check_source(mode, failure="", sha="a" * 40):
+        return subprocess.run(["bash", "-c", source_check], cwd=root,
+            env={**os.environ, "PATH": directory + os.pathsep + os.environ["PATH"],
+                 "RECOVERY_MODE": mode, "GITHUB_SHA": sha, "SOURCE_FAILURE": failure},
+            capture_output=True, text=True).returncode
+    for mode in ["dry-run", "apply", "", "migrate", "apply --after-thread=x", "$(touch forbidden)"]:
+        assert (check_source(mode) == 0) == (mode in ("dry-run", "apply"))
+    assert check_source("apply", "ancestor") != 0
+    assert check_source("apply", "changed") != 0
+    assert check_source("apply", sha="b" * 40) != 0
+
+assert workflow.count("  workflow_dispatch:") == 1
+assert "github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'" in workflow
+assert workflow.index("pnpm install --frozen-lockfile --ignore-scripts") < workflow.index("${{ secrets.NEON_API_KEY }}")
+assert workflow.index("pnpm install --frozen-lockfile --ignore-scripts") < workflow.index("${{ secrets.R2_ACCESS_KEY_ID }}")
+assert "environment: production" in workflow and "cancel-in-progress: false" in workflow
+assert "ref: ${{ github.sha }}" in workflow and "persist-credentials: false" in workflow
+print("goal archive search recovery workflow: synthetic resolver and dispatch gates passed")
+PYTHON

--- a/.github/workflows/temporary-goal-archive-search-recovery.yml
+++ b/.github/workflows/temporary-goal-archive-search-recovery.yml
@@ -1,0 +1,153 @@
+name: Temporary Goal Archive Search Recovery
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Full cohort preflight, or preflight/apply/full verification"
+        type: choice
+        options: [dry-run, apply]
+        default: dry-run
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: temporary-goal-archive-search-recovery-32875
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  npm_config_audit: "false"
+
+jobs:
+  recovery:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    environment: production
+    steps:
+      - name: Check out dispatched source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          # Required for accepted-source ancestry and exact tree comparison.
+          fetch-depth: 0
+
+      - name: Validate mode and accepted operation source
+        env:
+          RECOVERY_MODE: ${{ inputs.mode }}
+        run: |
+          set -euo pipefail
+          case "$RECOVERY_MODE" in
+            dry-run|apply) ;;
+            *) echo '::error::invalid_mode'; exit 1 ;;
+          esac
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git merge-base --is-ancestor 3e1544d55ac0dc54a1cdb21d6aee72d651a6808d HEAD
+          git merge-base --is-ancestor cede9cbfb62872ddabb705de852dc6fd81a3cc6d HEAD
+          # Include the engine's local import closure and original SQL. A later
+          # source change requires controller review, never an override input.
+          git diff --quiet cede9cbfb62872ddabb705de852dc6fd81a3cc6d HEAD -- \
+            turbo/packages/db/scripts/migrations/014-goal-archive-search \
+            turbo/packages/db/src/migrations/1093_goal_retirement_receipt.sql \
+            turbo/packages/db/src/migrations/1094_archive_retired_goals.sql \
+            turbo/apps/api/src/lib/chat-search-bigram.ts \
+            turbo/packages/api-contracts/src/contracts/chat-event-rows.ts \
+            turbo/packages/api-contracts/src/contracts/chat-events.ts \
+            turbo/packages/api-contracts/src/contracts/run-failure-reasons.ts \
+            turbo/packages/api-contracts/src/contracts/retired-goal-archive.ts \
+            turbo/packages/api-contracts/src/contracts/pi-memory-citations.ts \
+            turbo/packages/api-contracts/src/contracts/pi-memory-citation-literals.ts
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24.19.0
+
+      - name: Install frozen operation dependencies before credentials
+        working-directory: turbo
+        run: |
+          corepack enable pnpm
+          pnpm install --frozen-lockfile --ignore-scripts --filter @okouai/db...
+
+      - name: Resolve protected production database
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+        run: |
+          python3 - <<'PYTHON'
+          import json
+          import os
+          import urllib.parse
+          import urllib.request
+
+          # Same HTTP resolver boundary as kms-production-preflight; fail closed
+          # without exposing provider responses, exception text or credentials.
+          class NoRedirect(urllib.request.HTTPRedirectHandler):
+              def redirect_request(self, *args, **kwargs):
+                  raise ValueError("redirect")
+
+          def resolve():
+              project = os.environ["NEON_PROJECT_ID"]
+              if project != "hidden-lab-39609750":
+                  raise ValueError("project")
+              base = f"https://console.neon.tech/api/v2/projects/{project}"
+              headers = {"Authorization": "Bearer " + os.environ["NEON_API_KEY"]}
+              opener = urllib.request.build_opener(NoRedirect())
+
+              def read(url):
+                  with opener.open(urllib.request.Request(url, headers=headers), timeout=30) as response:
+                      return json.load(response)
+
+              result = read(base + "/branches")
+              # Never infer uniqueness from an explicitly truncated listing.
+              if result.get("pagination", {}).get("cursor"):
+                  raise ValueError("partial_branches")
+              production = [b for b in result["branches"] if b["name"] == "production"]
+              if len(production) != 1 or not production[0]["id"]:
+                  raise ValueError("branch")
+              query = urllib.parse.urlencode({"branch_id": production[0]["id"], "database_name": "neondb", "role_name": "neondb_owner", "pooled": "false"})
+              uri = read(base + "/connection_uri?" + query)["uri"]
+              if not isinstance(uri, str) or any(ord(c) <= 32 or ord(c) == 127 for c in uri):
+                  raise ValueError("uri")
+              parsed = urllib.parse.urlsplit(uri)
+              if (parsed.scheme not in ("postgres", "postgresql")
+                  or not parsed.hostname or not parsed.hostname.endswith(".neon.tech")
+                  or parsed.port not in (None, 5432) or parsed.path != "/neondb"
+                  or parsed.username != "neondb_owner" or not parsed.password or parsed.fragment):
+                  raise ValueError("uri")
+              parameters = urllib.parse.parse_qsl(parsed.query, strict_parsing=True)
+              if any(k not in ("sslmode", "channel_binding") for k, v in parameters):
+                  raise ValueError("uri_options")
+              if len({k for k, v in parameters}) != len(parameters):
+                  raise ValueError("uri_options")
+              parameters = dict(parameters)
+              parameters["sslmode"] = "verify-full"
+              uri = urllib.parse.urlunsplit(parsed._replace(query=urllib.parse.urlencode(parameters)))
+              print("::add-mask::" + uri.replace("%", "%25"), flush=True)
+              with open(os.environ["GITHUB_ENV"], "a") as output:
+                  output.write("DATABASE_URL=" + uri + "\n")
+
+          try:
+              resolve()
+          except Exception:
+              raise SystemExit("production_database_resolution_failed") from None
+          PYTHON
+
+      # Operator must first record current normal serving/projector evidence:
+      # docs/goal-archive-search-recovery.md. No release or cron invokes this job.
+      - name: Certify full Goal archive search recovery
+        working-directory: turbo/packages/db
+        env:
+          RECOVERY_MODE: ${{ inputs.mode }}
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_USER_STORAGES_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
+        run: node --import tsx scripts/goal-archive-search-recovery/run.ts "$RECOVERY_MODE"

--- a/docs/goal-archive-search-recovery.md
+++ b/docs/goal-archive-search-recovery.md
@@ -1,0 +1,160 @@
+# Temporary protected Goal search recovery (#32875)
+
+This is the production execution entry for the accepted, unchanged operation
+[014](../turbo/packages/db/scripts/migrations/014-goal-archive-search/README.md),
+under [EPIC #32653](https://github.com/vm0-ai/vm0/issues/32653). It repairs only
+receipt-addressed derived search documents. It does not change Goal lifecycle,
+1093/1094, raw history, snapshots, immutable public shares or search watermarks.
+
+The implementation owner stops at protected merge. The controller independently
+accepts the merged workflow and negative gates, then delegates execution to the
+existing sole recovery owner, chat `cacc99f2-1570-4e64-961c-40b3fe8db2cf`. Only that
+owner dispatches and handles actual `production` environment approvals. A merged
+entry is usable from `main` after controller acceptance; no API/App release is
+needed for this workflow. Its merge is not S2 production acceptance.
+
+## Serving and convergence prerequisite
+
+Before **each dispatch**, the recovery owner records current normal API serving
+identity and outgoing normal projector completion/convergence evidence in the
+EPIC. Verify the repaired reader remains serving and the S1 creation/reactivation
+and continuation fences remain effective. Do not create a Goal canary. A release
+record or the passage of time alone is insufficient if serving has changed.
+
+The actual accepted starting evidence is the
+[release owner's report](https://github.com/vm0-ai/vm0/issues/32653#issuecomment-5597708442):
+
+- Release #32841, merge `82d1a6ff154c9ca81fd8e08d6764290733eb324d`,
+  [workflow 34320369826](https://github.com/vm0-ai/vm0/actions/runs/34320369826),
+  all 21 jobs successful; API 1.575.0 and App 0.871.0. Normal API promotion
+  completed at **2026-09-09 07:00:03.2195524 UTC**. Runtime schema identity also
+  names that API version, SHA and workflow.
+- A non-partial Axiom read covering **05:37:16.9253904–07:03:09.885577 UTC**
+  accounted for 86 normal projector requests in 86 consecutive minute buckets,
+  all completed with HTTP 200. The final outgoing invocation completed at
+  **06:59:42.956 UTC**, before promotion. Repaired invocations starting at
+  07:00:41.309, 07:01:41.376 and 07:02:41.437 also completed. The route awaits
+  projection transactions/convergence before its completion log; the unchanged
+  old writer uses conflict-do-nothing inserts and cannot overwrite a repair.
+- Full metadata census at **07:03:09.882275–07:03:12.951423 UTC** still matched
+  all original 4,162 IDs, with 3,819 complete / 143 paused / 200 blocked.
+  Actual Goal-origin queued/pending/running was zero without a time filter.
+  These are publication-time observations, not recovery results.
+
+Recheck and record these normal-production prerequisites before execution. The
+workflow deliberately has no extra operator-assertion or source inputs. Its
+production approval and the controller's evidence ledger own this prerequisite;
+the workflow does not independently prove live serving identity. Historical
+Vercel/fixed-deployment inventory is outside the
+[user-approved scope](https://github.com/vm0-ai/vm0/issues/32653#issuecomment-5595137042).
+Cron 200 or elapsed time never substitutes for the full data certificate below;
+`not-indexed > 0` requires normal projector convergence and investigation.
+
+## Exact invocation
+
+From an authorized GitHub CLI session, after controller acceptance:
+
+```bash
+# Default/read-only preflight (mode can be omitted; its default is dry-run).
+gh workflow run temporary-goal-archive-search-recovery.yml \
+  --repo vm0-ai/vm0 --ref main -f mode=dry-run
+
+# Independently repeats preflight in the same job before any mutation.
+gh workflow run temporary-goal-archive-search-recovery.yml \
+  --repo vm0-ai/vm0 --ref main -f mode=apply
+```
+
+Use the returned GitHub run identity and its job summary as evidence. Only
+`workflow_dispatch` on `refs/heads/main` reaches the finite 90-minute protected
+job. Both modes share one concurrency group with cancellation disabled. No push,
+PR, release, schedule, arbitrary SQL, command, ref, bucket, cursor, count or hash
+override is available. Checkout uses the dispatched `github.sha`, with credentials
+not persisted. Before binding production secrets, the job validates the mode,
+accepted merge ancestry and unchanged engine/import source, then installs frozen
+DB dependencies with install scripts disabled. Actions are pinned to full SHAs.
+
+The resolver reuses existing `NEON_API_KEY`, the expected
+`NEON_PROJECT_ID=hidden-lab-39609750`, and a unique `production` branch. It rejects
+partial branch listings, redirects and invalid URIs, requires the expected DB/role
+and Neon host, enforces `sslmode=verify-full`, and masks the URI before transferring
+it inside the protected job. Existing R2 account/bucket variables and access
+secrets are mounted only for execution. There is no credential export, new secret
+store or sandbox credential requirement.
+
+## Certificate and output
+
+The small wrapper lives at
+[`scripts/goal-archive-search-recovery/run.ts`](../turbo/packages/db/scripts/goal-archive-search-recovery/run.ts),
+with the validation boundary in
+[`certificate.ts`](../turbo/packages/db/scripts/goal-archive-search-recovery/certificate.ts).
+Every invocation starts at the full inventory. A metadata-only, read-only SQL
+snapshot computes the complete ID hash, unique-thread count, complete receipts,
+statuses, actual Goal-origin nonterminal runs and unrevoked runless Goal inputs
+(including reservations). It does not select objective or snapshot content.
+
+Required fixed certificate:
+
+- Goals, distinct threads and complete receipts: **4,162 each**.
+- Status: **3,819 complete / 143 paused / 200 blocked / active 0**.
+- Actual `trigger_source='goal'` queued/pending/running: **0**, without a date
+  or `goal_id` filter. Unrevoked runless `input.goal`, including reserved: **0**.
+- SHA256 of UTF-8 `"\n".join(sorted(ids)) + "\n"`:
+  `aa033d67b27ff3fdbd30c945e482962b3e054cf4a1a4f74fce7edf74fed4e7f2`.
+  PostgreSQL orders canonical UUID text with the C collation and includes the
+  trailing LF. No receipt filter can silently remove an ID from this census.
+
+`dry-run` validates the cohort, runs the default 014 dry-run, then rechecks the
+cohort. The final report must have processed **4,162**, `complete: true`, exact
+known fields, nonnegative integer counts summing to processed, and zero
+not-indexed/deleted/revoked/repaired. `repairable > 0` is a successful **preflight
+finding**, not completed recovery.
+
+`apply` repeats its own fresh cohort and dry-run preflight, rechecks the cohort
+immediately before mutation, calls only 014 with `--migrate`, validates the entire
+apply report, runs a new full default dry-run, then rechecks the cohort. Apply
+requires repairable/not-indexed/deleted/revoked zero; final dry-run additionally
+requires repaired zero. Every phase requires consistent totals and the complete
+4,162 inventory. Earlier progress, child exit 0, an empty/smaller inventory,
+malformed/trailing output, stderr, missing final LF or an incomplete final report
+cannot establish success.
+
+Logs and the job summary retain only sanitized mode/phase, count/hash,
+completion/error class and exact source/run/attempt identity. The child's raw
+stdout/stderr is captured with a 1 MiB output cap and never echoed. No secret,
+provider/SQL error text, objective, snapshot or raw query artifact is retained.
+Per-phase `complete` describes that report only; recovery certification requires
+the successful **apply job**, its final verification and `after` cohort check,
+plus controller acceptance. A successful standalone dry-run can still report work.
+
+014 retains its 5,000-thread inventory ceiling, 100-thread candidate pages,
+1,000-event tail pages, one-second locks, ten-second statements and 30-second
+object request timeout. Its existing snapshot decompression/history accumulation
+is unchanged. The workflow timeout bounds the job; it is **not a per-thread
+memory bound**.
+
+## Failure, partial commits and disposal
+
+Each apply thread commits independently. Failure rolls back its current
+transaction; earlier safe committed repairs remain. A clear can legitimately
+delete a Goal receipt while retaining ordinary archive history. A count/hash
+change before, during or after the run stops certification. Operation failure
+also attempts a fresh metadata-only count/hash diagnostic, without rerunning
+the operation. If that read fails, the sanitized error says so; there is no
+certificate. Cancellation/timeout may prevent a final diagnostic or summary.
+
+Return the source/run identity, phase, observed counts/hash and sanitized error
+class to the controller. Never reconstruct Goals, shrink the cohort, reset a
+watermark, alter raw history, fabricate terminal success or retry apply blindly.
+The controller reconciles intentional deletion or commissions a separately
+bounded canonical-inventory repair. Only after the actual blocker is resolved
+may the owner rerun this same full entry; already-correct documents remain
+unchanged. A prior run's report or a resumed subset is never write authority or
+a completion certificate. The historical 014 README's low-level cursor example
+does not apply to this protected certification path.
+
+After successful recovery and independent S2 production acceptance, the
+controller assigns the next S3/S4 consumer-removal owner to delete the temporary
+workflow, wrapper and their dedicated tests. This must happen **before S5 drops
+receipt inventory**. Keep this dated operational record, the original numbered
+014 operation and immutable 1093/1094 history under repository migration policy.
+Retain the actual run and controller evidence on the EPIC before disposal.

--- a/docs/goal-retirement-archival.md
+++ b/docs/goal-retirement-archival.md
@@ -170,6 +170,12 @@ objective census/export. The separate release owner must run and verify recovery
 after the repaired API serves and outgoing projectors finish, before controller S2
 acceptance and before S5 removes the repair inventory.
 
+For the intact 4,162-Goal production cohort, use the temporary
+[protected execution entry and full certificate](goal-archive-search-recovery.md)
+added by #32875. Its main-only manual workflow enforces the complete original
+ID set around recovery. The controller owns S2 production acceptance and assigns
+removal of that temporary workflow/wrapper in S3/S4, before S5 deletes receipts.
+
 Public shares are intentionally immutable copies. A previously stripped copy is
 not automatically changed or republished. Its owner can explicitly create a new
 share. This repair establishes that limitation with synthetic fixtures; no affected

--- a/turbo/packages/db/scripts/goal-archive-search-recovery/certificate.test.ts
+++ b/turbo/packages/db/scripts/goal-archive-search-recovery/certificate.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from "vitest";
+import {
+  certifyRecovery,
+  expectedHash,
+  parseMode,
+  type Mode,
+  type RecoveryIO,
+} from "./certificate";
+
+function cohort() {
+  // Synthetic metadata from the DB boundary; no production IDs or connections.
+  return {
+    goals: "4162",
+    threads: "4162",
+    receipts: "4162",
+    active: "0",
+    complete: "3819",
+    paused: "143",
+    blocked: "200",
+    nonterminal: "0",
+    pending: "0",
+    hash: expectedHash,
+  };
+}
+
+function report(mode: Mode, repairable = 0, repaired = 0) {
+  return {
+    mode: mode === "apply" ? "migrate" : "dry-run",
+    processed: 4162,
+    counts: {
+      unchanged: 4162 - repairable - repaired,
+      repairable,
+      repaired,
+      "not-indexed": 0,
+      deleted: 0,
+      revoked: 0,
+    },
+    cursor: "00000000-0000-0000-0000-000000004162",
+    complete: true,
+  };
+}
+
+function output(value: unknown) {
+  return { stdout: JSON.stringify(value) + "\n", stderr: "", exitCode: 0 };
+}
+
+function fixture(
+  options: {
+    inventories?: unknown[];
+    outputs?: Awaited<ReturnType<RecoveryIO["runOperation"]>>[];
+  } = {},
+) {
+  const records: Record<string, unknown>[] = [];
+  const operations: Mode[] = [];
+  let repaired = false;
+  const inventories = [
+    ...(options.inventories ?? [cohort(), cohort(), cohort()]),
+  ];
+  const outputs = options.outputs ? [...options.outputs] : undefined;
+  const io: RecoveryIO = {
+    readCohort: async () => {
+      return inventories.shift();
+    },
+    runOperation: async (mode) => {
+      operations.push(mode);
+      if (mode === "apply") repaired = true;
+      if (outputs) {
+        const next = outputs.shift();
+        if (!next) throw new Error("unexpected operation");
+        return next;
+      }
+      return output(report(mode, repaired ? 0 : 2, mode === "apply" ? 2 : 0));
+    },
+    emit: (record) => {
+      return records.push(record);
+    },
+  };
+  return {
+    io,
+    records,
+    operations,
+    wasRepaired: () => {
+      return repaired;
+    },
+  };
+}
+
+describe("full-cohort production recovery certificate", () => {
+  it("defaults to dry-run and rejects execution overrides", () => {
+    expect(parseMode([])).toBe("dry-run");
+    expect(parseMode(["apply"])).toBe("apply");
+    for (const args of [
+      ["migrate"],
+      ["apply", "--after-thread", "id"],
+      [""],
+      ["--max-threads=1"],
+    ])
+      expect(() => {
+        return parseMode(args);
+      }).toThrow("invalid_mode");
+  });
+
+  it("reports repairable preflight findings without writing", async () => {
+    const f = fixture();
+    expect(await certifyRecovery("dry-run", f.io)).toBe(true);
+    expect(f.wasRepaired()).toBe(false);
+    expect(f.operations).toEqual(["dry-run"]);
+    expect(f.records).toContainEqual(
+      expect.objectContaining({
+        phase: "preflight",
+        counts: expect.objectContaining({ repairable: 2 }),
+      }),
+    );
+    expect(f.records.at(-1)).toEqual({
+      mode: "dry-run",
+      phase: "after",
+      complete: true,
+    });
+  });
+
+  it("requires fresh preflight, apply, fresh verification and final cohort", async () => {
+    const f = fixture();
+    expect(await certifyRecovery("apply", f.io)).toBe(true);
+    expect(f.operations).toEqual(["dry-run", "apply", "dry-run"]);
+    expect(
+      f.records
+        .filter((r) => {
+          return r.hash;
+        })
+        .map((r) => {
+          return r.phase;
+        }),
+    ).toEqual(["before", "before-apply", "after"]);
+    expect(f.records.at(-1)).toEqual({
+      mode: "apply",
+      phase: "after",
+      complete: true,
+    });
+  });
+
+  it.each([
+    ["missing inventory", undefined],
+    ["empty cohort", { ...cohort(), goals: "0", threads: "0", receipts: "0" }],
+    ["missing ID", { ...cohort(), goals: "4161" }],
+    ["extra ID", { ...cohort(), goals: "4163" }],
+    ["changed set at same count", { ...cohort(), hash: "0".repeat(64) }],
+    ["incomplete receipt", { ...cohort(), receipts: "4161" }],
+    ["active Goal", { ...cohort(), active: "1" }],
+    ["actual nonterminal", { ...cohort(), nonterminal: "1" }],
+    ["pending or reserved input", { ...cohort(), pending: "1" }],
+    ["malformed count", { ...cohort(), goals: "4162suffix" }],
+    ["unsafe count", { ...cohort(), goals: "9007199254740992" }],
+  ])("stops before any operation on %s", async (_name, inventory) => {
+    const f = fixture({ inventories: [inventory] });
+    expect(await certifyRecovery("apply", f.io)).toBe(false);
+    expect(f.wasRepaired()).toBe(false);
+    expect(f.operations).toEqual([]);
+    expect(f.records.at(-1)).toMatchObject({ complete: false });
+  });
+
+  const valid = report("dry-run");
+  const badOutputs = [
+    { stdout: "", stderr: "", exitCode: 0 },
+    { stdout: JSON.stringify(valid), stderr: "", exitCode: 0 },
+    { stdout: "not-json\n", stderr: "", exitCode: 0 },
+    {
+      ...output(valid),
+      stdout: output(valid).stdout.replace(
+        '"complete":true',
+        '"complete":false,"complete":true',
+      ),
+    },
+    { ...output(valid), stdout: output(valid).stdout + "partial garbage\n" },
+    { ...output(valid), stdout: "garbage\n" + output(valid).stdout },
+    output({ ...valid, complete: false }),
+    output({
+      ...valid,
+      processed: 0,
+      counts: { ...valid.counts, unchanged: 0 },
+      cursor: null,
+    }),
+    output({
+      ...valid,
+      processed: 4161,
+      counts: { ...valid.counts, unchanged: 4161 },
+    }),
+    output({ ...valid, counts: { ...valid.counts, unchanged: 4161 } }),
+    output({ ...valid, counts: { ...valid.counts, error: 1 } }),
+    output({ ...valid, counts: { ...valid.counts, unchanged: "4162" } }),
+    output({ ...valid, errors: [] }),
+    output({ ...valid, complete: "true" }),
+    output({ ...valid, mode: "migrate" }),
+    { ...output(valid), exitCode: 1 },
+    { ...output(valid), exitCode: null },
+    { ...output(valid), stderr: "SECRET SQL objective\n" },
+    ...["not-indexed", "deleted", "revoked", "repaired"].map((key) => {
+      return output({
+        ...valid,
+        counts: { ...valid.counts, unchanged: 4161, [key]: 1 },
+      });
+    }),
+  ];
+  it.each(
+    badOutputs.map((value, i) => {
+      return [i, value] as const;
+    }),
+  )("failed preflight %i never applies", async (_i, bad) => {
+    const f = fixture({ outputs: [bad] });
+    expect(await certifyRecovery("apply", f.io)).toBe(false);
+    expect(f.wasRepaired()).toBe(false);
+    expect(f.operations).toEqual(["dry-run"]);
+    expect(f.records.at(-1)).toMatchObject({
+      phase: "preflight",
+      complete: false,
+    });
+    expect(JSON.stringify(f.records)).not.toContain("SECRET");
+    expect(JSON.stringify(f.records)).not.toContain("garbage");
+  });
+
+  it("accepts ordered progress only with the actual full final report", async () => {
+    const progress = {
+      ...valid,
+      processed: 100,
+      counts: { ...valid.counts, unchanged: 100 },
+      complete: false,
+      cursor: "00000000-0000-0000-0000-000000000100",
+    };
+    const f = fixture({
+      outputs: [
+        {
+          ...output(valid),
+          stdout:
+            output(progress).stdout +
+            output({ ...valid, complete: false }).stdout +
+            output(valid).stdout,
+        },
+      ],
+    });
+    expect(await certifyRecovery("dry-run", f.io)).toBe(true);
+  });
+
+  it("rejects a trailing report after complete, even if both claim success", async () => {
+    const f = fixture({
+      outputs: [{ ...output(valid), stdout: output(valid).stdout.repeat(2) }],
+    });
+    expect(await certifyRecovery("apply", f.io)).toBe(false);
+    expect(f.wasRepaired()).toBe(false);
+  });
+
+  it("detects a clear during preflight before applying", async () => {
+    const f = fixture({
+      inventories: [cohort(), { ...cohort(), receipts: "4161" }],
+    });
+    expect(await certifyRecovery("apply", f.io)).toBe(false);
+    expect(f.wasRepaired()).toBe(false);
+    expect(f.records.at(-1)).toMatchObject({
+      phase: "before-apply",
+      errorClass: "cohort_mismatch",
+    });
+  });
+
+  it.each([report("apply", 1), { ...report("apply"), complete: false }])(
+    "rejects invalid apply completion and never retries",
+    async (bad) => {
+      const f = fixture({ outputs: [output(valid), output(bad)] });
+      expect(await certifyRecovery("apply", f.io)).toBe(false);
+      expect(f.operations).toEqual(["dry-run", "apply"]);
+      expect(f.records.at(-1)).toMatchObject({
+        phase: "apply",
+        complete: false,
+      });
+    },
+  );
+
+  it.each([
+    report("dry-run", 1),
+    {
+      ...valid,
+      counts: { ...valid.counts, unchanged: 4161, "not-indexed": 1 },
+    },
+  ])("cannot certify remaining work after committed repairs", async (bad) => {
+    const f = fixture({
+      outputs: [output(valid), output(report("apply", 0, 2)), output(bad)],
+    });
+    expect(await certifyRecovery("apply", f.io)).toBe(false);
+    expect(f.wasRepaired()).toBe(true);
+    expect(f.operations).toEqual(["dry-run", "apply", "dry-run"]);
+    expect(f.records.at(-1)).toMatchObject({
+      phase: "verify",
+      complete: false,
+    });
+  });
+
+  it("fails final certification on changed cohort while preserving committed repairs", async () => {
+    const changed = {
+      ...cohort(),
+      goals: "4161",
+      receipts: "4161",
+      hash: "a".repeat(64),
+    };
+    const f = fixture({ inventories: [cohort(), cohort(), changed] });
+    expect(await certifyRecovery("apply", f.io)).toBe(false);
+    expect(f.wasRepaired()).toBe(true);
+    expect(f.records).toContainEqual(
+      expect.objectContaining({
+        phase: "after",
+        hash: changed.hash,
+        counts: expect.objectContaining({ goals: 4161 }),
+      }),
+    );
+    expect(f.records.at(-1)).toMatchObject({
+      phase: "after",
+      errorClass: "cohort_mismatch",
+      complete: false,
+    });
+  });
+
+  it("sanitizes dependency exceptions", async () => {
+    const f = fixture();
+    f.io.runOperation = async () => {
+      throw new Error("SECRET provider response");
+    };
+    expect(await certifyRecovery("apply", f.io)).toBe(false);
+    expect(JSON.stringify(f.records)).not.toContain("SECRET");
+    expect(f.wasRepaired()).toBe(false);
+  });
+});

--- a/turbo/packages/db/scripts/goal-archive-search-recovery/certificate.ts
+++ b/turbo/packages/db/scripts/goal-archive-search-recovery/certificate.ts
@@ -1,0 +1,273 @@
+// Temporary #32875 execution boundary. Remove in S3/S4 before S5 drops receipts.
+export const expectedCount = 4162;
+export const expectedHash =
+  "aa033d67b27ff3fdbd30c945e482962b3e054cf4a1a4f74fce7edf74fed4e7f2";
+
+export type Mode = "dry-run" | "apply";
+type Phase =
+  | "before"
+  | "preflight"
+  | "before-apply"
+  | "apply"
+  | "verify"
+  | "after";
+
+export class CertificateError extends Error {
+  constructor(
+    readonly errorClass:
+      | "invalid_mode"
+      | "invalid_cohort"
+      | "cohort_mismatch"
+      | "invalid_report"
+      | "incomplete_report"
+      | "disallowed_outcome"
+      | "operation_failed",
+  ) {
+    super(errorClass);
+  }
+}
+
+export function parseMode(args: readonly string[]): Mode {
+  if (args.length === 0) return "dry-run";
+  if (args.length === 1 && (args[0] === "dry-run" || args[0] === "apply"))
+    return args[0];
+  throw new CertificateError("invalid_mode");
+}
+
+function object(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    throw new CertificateError("invalid_report");
+  return value as Record<string, unknown>;
+}
+
+function count(value: unknown): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0)
+    throw new CertificateError("invalid_report");
+  return value;
+}
+
+const cohortKeys = [
+  "goals",
+  "threads",
+  "receipts",
+  "active",
+  "complete",
+  "paused",
+  "blocked",
+  "nonterminal",
+  "pending",
+] as const;
+
+function decodeCohort(value: unknown) {
+  const raw = object(value);
+  const counts: Record<string, number> = {};
+  for (const key of cohortKeys) {
+    const field = raw[key];
+    if (typeof field !== "string" || !/^(0|[1-9][0-9]*)$/u.test(field))
+      throw new CertificateError("invalid_cohort");
+    counts[key] = count(Number(field));
+  }
+  if (typeof raw.hash !== "string" || !/^[0-9a-f]{64}$/u.test(raw.hash))
+    throw new CertificateError("invalid_cohort");
+  return { counts, hash: raw.hash };
+}
+
+const outcomes = [
+  "unchanged",
+  "repairable",
+  "repaired",
+  "not-indexed",
+  "deleted",
+  "revoked",
+] as const;
+
+function decodeReport(value: unknown, mode: Mode) {
+  const raw = object(value);
+  if (
+    Object.keys(raw).sort().join(",") !==
+      "complete,counts,cursor,mode,processed" ||
+    raw.mode !== (mode === "apply" ? "migrate" : "dry-run") ||
+    typeof raw.complete !== "boolean" ||
+    typeof raw.cursor !== "string" ||
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u.test(
+      raw.cursor,
+    )
+  )
+    throw new CertificateError("invalid_report");
+  const rawCounts = object(raw.counts);
+  if (
+    Object.keys(rawCounts).sort().join(",") !== [...outcomes].sort().join(",")
+  )
+    throw new CertificateError("invalid_report");
+  const counts = {
+    unchanged: count(rawCounts.unchanged),
+    repairable: count(rawCounts.repairable),
+    repaired: count(rawCounts.repaired),
+    "not-indexed": count(rawCounts["not-indexed"]),
+    deleted: count(rawCounts.deleted),
+    revoked: count(rawCounts.revoked),
+  };
+  const processed = count(raw.processed);
+  if (
+    processed < 1 ||
+    processed > expectedCount ||
+    Object.values(counts).reduce((sum, n) => {
+      return sum + n;
+    }, 0) !== processed
+  )
+    throw new CertificateError("invalid_report");
+  return { processed, counts, cursor: raw.cursor, complete: raw.complete };
+}
+
+function validateProgress(
+  prior: ReturnType<typeof decodeReport>,
+  report: ReturnType<typeof decodeReport>,
+): void {
+  if (
+    prior.complete ||
+    report.processed < prior.processed ||
+    report.cursor < prior.cursor ||
+    (report.processed > prior.processed && report.cursor === prior.cursor) ||
+    outcomes.some((key) => {
+      return report.counts[key] < prior.counts[key];
+    }) ||
+    (report.processed === prior.processed &&
+      (!report.complete || report.cursor !== prior.cursor))
+  )
+    throw new CertificateError("invalid_report");
+}
+
+// Every nonempty stdout line is part of the protocol. Never search backwards
+// for a success-looking line or ignore malformed output/stderr.
+export function validateReport(
+  output: { stdout: string; stderr: string; exitCode: number | null },
+  mode: Mode,
+) {
+  if (output.exitCode !== 0 || output.stderr !== "")
+    throw new CertificateError("operation_failed");
+  if (!output.stdout.endsWith("\n"))
+    throw new CertificateError("incomplete_report");
+  const lines = output.stdout.slice(0, -1).split("\n");
+  let previous: ReturnType<typeof decodeReport> | undefined;
+  for (const [index, line] of lines.entries()) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      throw new CertificateError("invalid_report");
+    }
+    // The pinned engine emits JSON.stringify records. Require that encoding
+    // too, so duplicate keys cannot overwrite a failure-looking field.
+    if (JSON.stringify(parsed) !== line)
+      throw new CertificateError("invalid_report");
+    const report = decodeReport(parsed, mode);
+    if (previous) validateProgress(previous, report);
+    if (index < lines.length - 1 && report.complete)
+      throw new CertificateError("invalid_report");
+    previous = report;
+  }
+  if (!previous?.complete || previous.processed !== expectedCount)
+    throw new CertificateError("incomplete_report");
+  // Deliberately omit the child cursor from retained output.
+  return {
+    processed: previous.processed,
+    counts: previous.counts,
+    complete: true,
+  };
+}
+
+export interface RecoveryIO {
+  readCohort: () => Promise<unknown>;
+  runOperation: (mode: Mode) => Promise<{
+    stdout: string;
+    stderr: string;
+    exitCode: number | null;
+  }>;
+  emit: (record: Record<string, unknown>) => void;
+}
+
+export async function certifyRecovery(
+  mode: Mode,
+  io: RecoveryIO,
+): Promise<boolean> {
+  let phase: Phase = "before";
+  const cohort = async () => {
+    const { counts, hash } = decodeCohort(await io.readCohort());
+    io.emit({ mode, phase, counts, hash });
+    if (
+      hash !== expectedHash ||
+      counts.goals !== expectedCount ||
+      counts.threads !== expectedCount ||
+      counts.receipts !== expectedCount ||
+      counts.active !== 0 ||
+      counts.complete !== 3819 ||
+      counts.paused !== 143 ||
+      counts.blocked !== 200 ||
+      counts.nonterminal !== 0 ||
+      counts.pending !== 0
+    )
+      throw new CertificateError("cohort_mismatch");
+  };
+  const operation = async (operationMode: Mode, requireRepaired: boolean) => {
+    io.emit({ mode, phase, complete: false });
+    const report = validateReport(
+      await io.runOperation(operationMode),
+      operationMode,
+    );
+    io.emit({ mode, phase, ...report });
+    if (
+      report.counts["not-indexed"] !== 0 ||
+      report.counts.deleted !== 0 ||
+      report.counts.revoked !== 0 ||
+      (operationMode === "dry-run" && report.counts.repaired !== 0) ||
+      ((operationMode === "apply" || requireRepaired) &&
+        report.counts.repairable !== 0)
+    )
+      throw new CertificateError("disallowed_outcome");
+  };
+  try {
+    await cohort();
+    phase = "preflight";
+    await operation("dry-run", false);
+    if (mode === "apply") {
+      // Close the inventory window opened by a potentially long preflight.
+      phase = "before-apply";
+      await cohort();
+      phase = "apply";
+      await operation("apply", true);
+      phase = "verify";
+      await operation("dry-run", true);
+    }
+    phase = "after";
+    await cohort();
+    io.emit({ mode, phase, complete: true });
+    return true;
+  } catch (error) {
+    // A clear can make the engine fail before reaching final verification.
+    // Collect fresh count/hash evidence, without retrying the operation or
+    // converting this best-effort diagnostic into a completion certificate.
+    if (phase === "preflight" || phase === "apply" || phase === "verify") {
+      try {
+        const evidence = decodeCohort(await io.readCohort());
+        io.emit({ mode, phase: "after-failure", ...evidence, complete: false });
+      } catch {
+        io.emit({
+          mode,
+          phase: "after-failure",
+          complete: false,
+          errorClass: "cohort_read_failed",
+        });
+      }
+    }
+    io.emit({
+      mode,
+      phase,
+      complete: false,
+      errorClass:
+        error instanceof CertificateError
+          ? error.errorClass
+          : "dependency_failed",
+    });
+    return false;
+  }
+}

--- a/turbo/packages/db/scripts/goal-archive-search-recovery/run.ts
+++ b/turbo/packages/db/scripts/goal-archive-search-recovery/run.ts
@@ -1,0 +1,141 @@
+#!/usr/bin/env tsx
+import { execFile } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { Client } from "pg";
+import {
+  CertificateError,
+  certifyRecovery,
+  parseMode,
+  type Mode,
+} from "./certificate";
+
+// One metadata-only statement gives the complete inventory and retirement
+// prerequisites one PostgreSQL snapshot. No receipt filter or cursor can shrink it.
+export const inventorySql = `
+SELECT count(*)::text AS goals,
+  count(DISTINCT chat_thread_id)::text AS threads,
+  count(*) FILTER (WHERE retirement_archive_event_id IS NOT NULL
+    AND retirement_archive_seq_id > 0
+    AND retirement_archive_seq_id <= 9007199254740991)::text AS receipts,
+  count(*) FILTER (WHERE status = 'active')::text AS active,
+  count(*) FILTER (WHERE status = 'complete')::text AS complete,
+  count(*) FILTER (WHERE status = 'paused')::text AS paused,
+  count(*) FILTER (WHERE status = 'blocked')::text AS blocked,
+  encode(sha256(convert_to(coalesce(string_agg(id::text, E'\\n'
+    ORDER BY id::text COLLATE "C"), '') || E'\\n', 'UTF8')), 'hex') AS hash,
+  (SELECT count(*)::text FROM agent_runs
+    WHERE trigger_source = 'goal' AND status IN ('queued', 'pending', 'running')) AS nonterminal,
+  (SELECT count(*)::text FROM chat_events event
+    WHERE event.event_type = 'input.goal' AND event.run_id IS NULL
+      AND NOT EXISTS (SELECT 1 FROM chat_events revoker
+        WHERE revoker.revokes_event_id = event.id)) AS pending
+FROM thread_goals`;
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error("missing_configuration");
+  return value;
+}
+
+async function readCohort(): Promise<unknown> {
+  const client = new Client({
+    connectionString: required("DATABASE_URL"),
+    connectionTimeoutMillis: 30_000,
+  });
+  // Never allow pg notice/error payloads into runner logs.
+  let connectionFailed = false;
+  client.on("notice", () => {});
+  client.on("error", () => {
+    connectionFailed = true;
+  });
+  try {
+    await client.connect();
+    await client.query("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY");
+    await client.query("SET LOCAL statement_timeout = '10s'");
+    await client.query("SET LOCAL lock_timeout = '1s'");
+    const result = await client.query<Record<string, unknown>>(inventorySql);
+    if (result.rows.length !== 1) throw new CertificateError("invalid_cohort");
+    await client.query("COMMIT");
+    if (connectionFailed) throw new CertificateError("invalid_cohort");
+    return result.rows[0];
+  } finally {
+    await client.end();
+  }
+}
+
+function runOperation(mode: Mode) {
+  const script = fileURLToPath(
+    new URL(
+      "../migrations/014-goal-archive-search/backfill.ts",
+      import.meta.url,
+    ),
+  );
+  // No shell, resume arguments, or source override. A fresh process always
+  // starts the unchanged engine at its default complete inventory.
+  return new Promise<{
+    stdout: string;
+    stderr: string;
+    exitCode: number | null;
+  }>((resolve) => {
+    execFile(
+      process.execPath,
+      ["--import", "tsx", script, ...(mode === "apply" ? ["--migrate"] : [])],
+      {
+        maxBuffer: 1024 * 1024,
+        env: {
+          DATABASE_URL: required("DATABASE_URL"),
+          R2_ACCOUNT_ID: required("R2_ACCOUNT_ID"),
+          R2_ACCESS_KEY_ID: required("R2_ACCESS_KEY_ID"),
+          R2_SECRET_ACCESS_KEY: required("R2_SECRET_ACCESS_KEY"),
+          R2_USER_STORAGES_BUCKET_NAME: required(
+            "R2_USER_STORAGES_BUCKET_NAME",
+          ),
+        },
+      },
+      (error, stdout, stderr) => {
+        // execFile errors embed captured provider output: never return them.
+        resolve({ stdout, stderr, exitCode: error ? 1 : 0 });
+      },
+    );
+  });
+}
+
+async function main(): Promise<void> {
+  const mode = parseMode(process.argv.slice(2));
+  const source = required("GITHUB_SHA");
+  const runId = required("GITHUB_RUN_ID");
+  const attempt = required("GITHUB_RUN_ATTEMPT");
+  if (
+    required("GITHUB_EVENT_NAME") !== "workflow_dispatch" ||
+    required("GITHUB_REF") !== "refs/heads/main" ||
+    required("GITHUB_REPOSITORY") !== "vm0-ai/vm0" ||
+    !/^[0-9a-f]{40}$/u.test(source) ||
+    !/^[0-9]+$/u.test(runId) ||
+    !/^[0-9]+$/u.test(attempt)
+  )
+    throw new Error("invalid_run_identity");
+  const uri = new URL(required("DATABASE_URL"));
+  if (uri.searchParams.get("sslmode") !== "verify-full")
+    throw new Error("invalid_database_tls");
+  const success = await certifyRecovery(mode, {
+    readCohort,
+    runOperation,
+    emit: (record) => {
+      const line = JSON.stringify({ source, runId, attempt, ...record });
+      console.log(line);
+      appendFileSync(required("GITHUB_STEP_SUMMARY"), `\n\`${line}\`\n`);
+    },
+  });
+  if (!success) process.exitCode = 1;
+}
+
+// Imports used by synthetic tests do not execute the protected entry point.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch(() => {
+    console.error(
+      JSON.stringify({ complete: false, errorClass: "entry_failed" }),
+    );
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

Operation 014 has no reviewed production execution path despite its accepted reader already serving. Add one temporary, main-only `workflow_dispatch` job using the existing protected Neon/R2 configuration, pinned Actions and dispatched source, frozen dependencies before credentials, a finite timeout, and one non-cancelling concurrency group. The only input is `dry-run` (default) or `apply`.

The wrapper invokes the accepted 014 engine unchanged and requires the fixed 4,162-Goal ID hash, complete receipts and zero retirement residuals. Apply performs its own fresh preflight, rechecks the cohort before writing, validates the apply report, then runs a fresh full dry-run and final cohort check. It rejects partial/malformed/duplicate-key reports, disallowed outcomes, child failures and cohort changes while preserving already committed safe repairs. Logs and summaries contain only sanitized metadata.

The runbook records actual serving/projector evidence, exact dispatch commands, interpretation and retry limits, and controller-owned S3/S4 removal before S5 drops receipts. No production dispatch, environment approval, operation 014 execution, API/App release or promotion is performed by this PR's owner. Controller acceptance and execution by the existing recovery owner remain separate gates.

Closes #32875. Parent: #32653.

## Verification

- 45 focused synthetic certificate tests: `pnpm -F @okouai/db exec vitest run scripts/goal-archive-search-recovery/certificate.test.ts`.
- Executable workflow resolver/source tests: `bash .github/scripts/tests/goal-archive-search-recovery-workflow-test.sh`; this is included by the existing Workflow Lint fixture loop.
- Isolated local PostgreSQL 18: the unchanged inventory SQL matched Node SHA256 for 4,162 synthetic sorted UUIDs with a final LF; incomplete receipts, actual Goal nonterminal runs, unrevoked/revoked inputs, deleted and empty cohorts were checked.
- DB type check, scoped Knip/ESLint, Oxlint/type-aware Oxlint and Prettier passed; actionlint 1.7.12 passed for the new workflow. Accepted engine/import closure and 1093/1094 source equality were verified.
- Required PR and merge-group CI remain mandatory. No full local Vitest suite or application development server.
