### PR TITLE
feat: send presentation slide counts in additional info

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/composer-additional-info.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-additional-info.ts
@@ -1,15 +1,31 @@
 import type { ChatRunVideoOptionsRequest } from "@okouai/api-contracts/contracts/chat-threads";
 import { buildVideoRunOptionsPrompt } from "@okouai/core/video-run-options-prompt";
-import type { ComposerCreateMode } from "./composer-create.ts";
+import type {
+  ComposerCreateMode,
+  PresentationSlideCount,
+} from "./composer-create.ts";
 
 /** Freeze the composer's selections as agent-only context for this message. */
 export function buildComposerAdditionalInfo(
   mode: ComposerCreateMode | null,
   videoRunOptions: ChatRunVideoOptionsRequest | undefined,
+  presentationSlideCount: PresentationSlideCount,
 ): string | undefined {
   const text = [
     buildVideoRunOptionsPrompt(videoRunOptions ?? null),
     mode ? `Create ${mode === "image" ? "an" : "a"} ${mode}.` : "",
+    mode === "presentation"
+      ? [
+          "# Presentation Generation Defaults",
+          "The user set these for presentations generated in this run:",
+          `- Slide count: ${
+            presentationSlideCount === "auto"
+              ? "Auto (choose the number of slides based on the content)"
+              : presentationSlideCount
+          }`,
+          "Where this run's message asks for a different slide count, the message wins.",
+        ].join("\n")
+      : "",
   ]
     .filter((part) => {
       return part.length > 0;

--- a/turbo/apps/platform/src/signals/okou-page/composer-create.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-create.ts
@@ -16,7 +16,7 @@ export const PRESENTATION_SLIDE_COUNTS = [
   "20-24",
 ] as const;
 
-type PresentationSlideCount = (typeof PRESENTATION_SLIDE_COUNTS)[number];
+export type PresentationSlideCount = (typeof PRESENTATION_SLIDE_COUNTS)[number];
 
 export type ComposerCreateMode = (typeof COMPOSER_CREATE_MODES)[number];
 export type ComposerCreateCommand = ComposerCreateMode | "choose";

--- a/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
@@ -891,7 +891,11 @@ function createSubmitCurrentInput(
       signal.throwIfAborted();
       // Keep the new persisted part within the existing Create rollout.
       const additionalInfo = get(create.enabled$)
-        ? buildComposerAdditionalInfo(mode, videoRunOptions)
+        ? buildComposerAdditionalInfo(
+            mode,
+            videoRunOptions,
+            get(create.presentationSlideCount$),
+          )
         : undefined;
       const editorDocument = additionalInfo
         ? createEditorDocumentSnapshot(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
@@ -248,6 +248,13 @@ test("A queued Create message keeps its intent separate from user-authored text"
     `${prompt} /create presentation`,
     "Create presentation",
   );
+  click(screen.getByRole("combobox", { name: "Slide count" }));
+  click(await screen.findByRole("option", { name: "20–24 slides" }));
+  await waitFor(() => {
+    expect(
+      screen.getByRole("combobox", { name: "Slide count" }),
+    ).toHaveTextContent("20–24 slides");
+  });
   await waitFor(() => {
     expect(button("Send")).toBeEnabled();
   });
@@ -257,7 +264,11 @@ test("A queued Create message keeps its intent separate from user-authored text"
   });
   expect(queued[0]?.parts).toContainEqual({
     type: "additional_info",
-    text: "Create a presentation.",
+    text: expect.stringContaining("Create a presentation."),
+  });
+  expect(queued[0]?.parts).toContainEqual({
+    type: "additional_info",
+    text: expect.stringContaining("- Slide count: 20-24"),
   });
   expect(
     queued[0]?.parts
@@ -271,6 +282,27 @@ test("A queued Create message keeps its intent separate from user-authored text"
       .trim(),
   ).toBe(prompt);
   await expect(screen.findByText(prompt)).resolves.toBeVisible();
+  click(screen.getByRole("combobox", { name: "Slide count" }));
+  click(await screen.findByRole("option", { name: "4–8 slides" }));
+  await waitFor(() => {
+    expect(
+      screen.getByRole("combobox", { name: "Slide count" }),
+    ).toHaveTextContent("4–8 slides");
+  });
+  await fill(await findComposerEditor(), "A shorter follow-up");
+  click(button("Send"));
+  await waitFor(() => {
+    expect(queued).toHaveLength(2);
+  });
+  expect(queued[1]?.parts).toContainEqual({
+    type: "additional_info",
+    text: expect.stringContaining("- Slide count: 4-8"),
+  });
+  expect(queued[0]?.parts).toContainEqual({
+    type: "additional_info",
+    text: expect.stringContaining("- Slide count: 20-24"),
+  });
+  await expect(screen.findByText("A shorter follow-up")).resolves.toBeVisible();
 });
 
 test("Image mode combines styles and image models while preserving the prompt", async () => {
@@ -420,7 +452,9 @@ test.each([
     const parts = submissions[0]?.parts;
     expect(parts).toContainEqual({
       type: "additional_info",
-      text: `Create ${mode === "image" ? "an" : "a"} ${mode}.`,
+      text: expect.stringContaining(
+        `Create ${mode === "image" ? "an" : "a"} ${mode}.`,
+      ),
     });
     expect(
       parts?.flatMap((part) => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-presentation-options.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-presentation-options.test.tsx
@@ -81,7 +81,7 @@ function visibleText(message: SubmittedMessage | undefined): string {
   );
 }
 
-test("Presentation offers six lengths without changing the submitted message", async () => {
+test("Presentation sends Auto as hidden additional info while keeping the message unchanged", async () => {
   setupModels();
   const submissions: SubmittedMessage[] = [];
   mockChatLifecycle(context, {
@@ -121,12 +121,62 @@ test("Presentation offers six lengths without changing the submitted message", a
     expect(submissions).toHaveLength(1);
   });
   expect(submissions[0]?.runOptions).toBeUndefined();
-  expect(visibleText(submissions[0])).toBe("Our launch");
   expect(submissions[0]?.userMessage?.parts).toContainEqual({
     type: "additional_info",
-    text: "Create a presentation.",
+    text: expect.stringContaining("Create a presentation."),
   });
-  await expect(screen.findByText("Our launch")).resolves.toBeVisible();
+  expect(submissions[0]?.userMessage?.parts).toContainEqual({
+    type: "additional_info",
+    text: expect.stringContaining(
+      "- Slide count: Auto (choose the number of slides based on the content)",
+    ),
+  });
+  expect(visibleText(submissions[0])).toBe("Our launch");
+  const text = await screen.findByText("Our launch");
+  const message = text.closest<HTMLElement>('[data-role="user"]');
+  expect(message).toBeVisible();
+  expect(message).not.toHaveTextContent("Slide count");
+  expect(message).not.toHaveTextContent("Create a presentation.");
+});
+
+test.each([
+  ["8–12 slides", "8-12"],
+  ["4–8 slides", "4-8"],
+  ["12–16 slides", "12-16"],
+  ["16–20 slides", "16-20"],
+  ["20–24 slides", "20-24"],
+])("Presentation sends %s in additional info", async (label, range) => {
+  setupModels();
+  const submissions: SubmittedMessage[] = [];
+  mockChatLifecycle(context, {
+    onRunCreate: (body) => {
+      submissions.push(body);
+    },
+  });
+  const editor = await setupComposer();
+  const picker = await enterPresentation(editor);
+  if (range !== "8-12") {
+    click(picker);
+    click(await screen.findByRole("option", { name: label }));
+  }
+  await waitFor(() => {
+    expect(picker).toHaveTextContent(label);
+  });
+  click(button("Send"));
+  await waitFor(() => {
+    expect(submissions).toHaveLength(1);
+  });
+  expect(submissions[0]?.userMessage?.parts).toContainEqual({
+    type: "additional_info",
+    text: expect.stringContaining(`- Slide count: ${range}`),
+  });
+  expect(submissions[0]?.userMessage?.parts).toContainEqual({
+    type: "additional_info",
+    text: expect.stringContaining(
+      "Where this run's message asks for a different slide count, the message wins.",
+    ),
+  });
+  expect(visibleText(submissions[0])).toBe("Our launch");
 });
 
 test("Leaving presentation hides its picker and resets its length", async () => {
@@ -163,5 +213,8 @@ test("Leaving presentation hides its picker and resets its length", async () => 
     expect(submissions).toHaveLength(1);
   });
   expect(submissions[0]?.runOptions).toBeUndefined();
+  expect(submissions[0]?.userMessage?.parts).not.toContainEqual(
+    expect.objectContaining({ type: "additional_info" }),
+  );
   expect(visibleText(submissions[0])).toBe("Our launch");
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/composer-task-chips.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/composer-task-chips.test.tsx
@@ -86,7 +86,7 @@ test.each([
     expect(capture.runPrompts).toStrictEqual(["My launch next week"]);
     expect(capture.sentMessages[0]?.parts).toContainEqual({
       type: "additional_info",
-      text: instruction,
+      text: expect.stringContaining(instruction),
     });
     await expect(
       screen.findByText("My launch next week"),
@@ -255,6 +255,13 @@ test("A presentation suggestion inserts a canonical template and preserves the p
     expect(editor).toHaveTextContent(template.title);
   });
   expect(editor).toHaveTextContent("Explain our product launch");
+  const slideCount = screen.getByRole("combobox", { name: "Slide count" });
+  expect(slideCount).toHaveTextContent("8–12 slides");
+  click(slideCount);
+  click(await screen.findByRole("option", { name: "16–20 slides" }));
+  await waitFor(() => {
+    expect(slideCount).toHaveTextContent("16–20 slides");
+  });
   expect(capture.sentMessages).toHaveLength(0);
   click(button("Send"));
   await waitFor(() => {
@@ -266,6 +273,10 @@ test("A presentation suggestion inserts a canonical template and preserves the p
       templateId: template.templateId,
       previewUrl: template.embedUrl,
     },
+  });
+  expect(capture.sentMessages[0]?.parts).toContainEqual({
+    type: "additional_info",
+    text: expect.stringContaining("- Slide count: 16-20"),
   });
 });
 


### PR DESCRIPTION
Presentation mode's slide-count picker currently changes only the UI. Include its selected range (8–12 by default) or Auto in the existing `additional_info` message part so the agent receives the selection while the visible message stays unchanged.

This builds on #32782 and uses the same submission path as video context. Each submitted or queued message captures its own selection, and explicit slide-count instructions in the user's message take precedence. Both the Create menu and Slides shortcut are covered. The change is frontend-only and requires no database, API, or contract changes.

Validation: 42 focused composer tests passed across presentation options, Create, video options, and task shortcuts. Platform production/test type checks, scoped formatting and lint checks, and Platform Knip passed.

Acceptance:
- With Create or Slides shortcuts enabled, enter presentation mode and check that the default is 8–12; select another range or Auto.
- Send a message and inspect its `additional_info` part for the selected slide count. The chat bubble and copied user text should contain only the authored message.
- Queue two messages with different selections; each should retain the count selected when it was submitted.
