### PR TITLE
fix(api): classify fal downstream service errors

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -2088,6 +2088,21 @@ describe("POST /api/image-io/generate", () => {
       },
       expected: false,
     },
+    {
+      caseName: "downstream provider error",
+      providerErrorType: "downstream_service_error",
+      providerMessage: "Downstream service error",
+      location: ["body"],
+      providerHttpStatus: 500,
+      failureKind: "provider_unavailable",
+      failureStage: "provider",
+      retryPolicy: "retry_once",
+      publicError: {
+        message: "The image generation provider is temporarily unavailable.",
+        code: "GENERATION_PROVIDER_UNAVAILABLE",
+      },
+      expected: false,
+    },
   ])(
     "maps Fal $caseName through realtime and status without recording artifacts or usage",
     async ({
@@ -2283,6 +2298,32 @@ describe("POST /api/image-io/generate", () => {
       },
       providerErrorType: "file_download_error",
       providerHttpStatus: 422,
+    },
+    {
+      caseName: "downstream error with changed message",
+      status: "ERROR",
+      wrapper: "payload",
+      error: "Invalid status code: 500",
+      detail: {
+        type: "downstream_service_error",
+        loc: ["body"],
+        msg: "private-provider-message",
+      },
+      providerErrorType: "downstream_service_error",
+      providerHttpStatus: 500,
+    },
+    {
+      caseName: "downstream error at an unrecognized location",
+      status: "ERROR",
+      wrapper: "payload",
+      error: "Invalid status code: 500",
+      detail: {
+        type: "downstream_service_error",
+        loc: ["body", "private-provider-location"],
+        msg: "Downstream service error",
+      },
+      providerErrorType: "downstream_service_error",
+      providerHttpStatus: 500,
     },
     {
       caseName: "missing messages and an unknown first type",

--- a/turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts
@@ -313,6 +313,7 @@ const FAL_INVALID_ASPECT_RATIO_MESSAGE =
 const FAL_MISSING_FIELD_MESSAGE = "Field required";
 const FAL_PROMPT_TOO_SHORT_MESSAGE = "String should have at least 3 characters";
 const FAL_DOWNSTREAM_UNAVAILABLE_MESSAGE = "Downstream service unavailable";
+const FAL_DOWNSTREAM_ERROR_MESSAGE = "Downstream service error";
 
 type FalGenerationFailureKind =
   | "output_safety_blocked"
@@ -528,6 +529,19 @@ const FAL_STRUCTURED_FAILURE_RULES: readonly FalStructuredFailureRule[] = [
   {
     providerErrorType: "downstream_service_unavailable",
     message: FAL_DOWNSTREAM_UNAVAILABLE_MESSAGE,
+    locations: ["body"],
+    kind: "provider_unavailable",
+    stage: "provider",
+    retryPolicy: "retry_once",
+    error: {
+      message: "The image generation provider is temporarily unavailable.",
+      code: "GENERATION_PROVIDER_UNAVAILABLE",
+    },
+    expected: false,
+  },
+  {
+    providerErrorType: "downstream_service_error",
+    message: FAL_DOWNSTREAM_ERROR_MESSAGE,
     locations: ["body"],
     kind: "provider_unavailable",
     stage: "provider",


### PR DESCRIPTION
Fal's structured `downstream_service_error` responses currently become `unknown` even though the provider supplies a safe diagnostic. Recognize the observed `downstream_service_error` / `Downstream service error` / `loc: ["body"]` tuple as the existing `provider_unavailable` category, and persist/publish `GENERATION_PROVIDER_UNAVAILABLE` through the generation status API and realtime updates.

Keep these failures at warn with `retry_once` and the existing no-charge settlement. The diagnostic type is also retained when the message or location does not match; those cases continue to use the generic public failure. Add route regression cases for the exact HTTP 500 payload, changed messages, and unrecognized locations, including privacy and billing assertions.

## Verification

- Formatting, API lint, API type checks, scoped Knip, and commitlint passed.
- Image/video route integration: 109 passed, including all three new cases; one existing allowance test failed (`uses allowance for a legacy runless generation under shared debt`, expected short/weekly usage 50, received 0). The same assertion fails with the webhook source restored to main at `6e3669108941cbc17fbeb41865d82fd4d8454029`; that test is unchanged by this PR.

Post-deployment verification remains tracked in #32127.

Refs #32127
