### PR TITLE
docs(rust): correct memory_max_events counter semantics

### DIFF
--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -232,7 +232,14 @@ impl HeartbeatAttemptFailureKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkloadResourceLimitDiagnostic {
-    /// Number of workload allocations rejected by `memory.max`.
+    /// Number of times the workload cgroup's memory usage was about to exceed
+    /// `memory.max` (the `max` counter in `memory.events`).
+    ///
+    /// Direct reclaim may allow the allocation to succeed. This is not a count
+    /// of failed allocations and does not by itself imply an OOM event or kill.
+    /// See the [kernel definition] for details.
+    ///
+    /// [kernel definition]: https://docs.kernel.org/admin-guide/cgroup-v2.html#memory-interface-files
     pub memory_max_events: u64,
     /// Number of workload OOM events.
     pub memory_oom_events: u64,


### PR DESCRIPTION
`memory_max_events` was documented as rejected allocations, which could mislead failure triage when direct reclaim succeeds. Clarify that it is the workload cgroup's `memory.events` / `max` counter, distinguish it from failed allocations and OOM events or kills, and link the Linux kernel definition.

This changes only the public field's Rust documentation. Field identity, serialization, counter mapping, and OOM classification are unchanged.

Closes #32884.

Validation:

- `cargo fmt --manifest-path crates/guest-contracts/Cargo.toml --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml --profile local -p guest-contracts --no-deps --locked`
- Inspected the generated field documentation and verified the linked kernel page and anchor.
- `git diff --check`

No new runtime tests are needed for this documentation-only correction.
