### PR TITLE
refactor: remove chat desktop selection feature switch

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
@@ -168,15 +168,12 @@ function closestExpandedFeedbackSource(node: Node | null): Element | null {
   );
 }
 
-function shouldExpandSelectionToAssistantReply(enabled: boolean): boolean {
-  return enabled && !window.matchMedia(COARSE_POINTER_QUERY).matches;
+function shouldExpandSelectionToAssistantReply(): boolean {
+  return !window.matchMedia(COARSE_POINTER_QUERY).matches;
 }
 
-function resolveSelectionSource(
-  range: Range,
-  expandToAssistantReply: boolean,
-): Element | null {
-  if (expandToAssistantReply) {
+function resolveSelectionSource(range: Range): Element | null {
+  if (shouldExpandSelectionToAssistantReply()) {
     const startSource = closestExpandedFeedbackSource(range.startContainer);
     const endSource = closestExpandedFeedbackSource(range.endContainer);
     return startSource !== null && startSource === endSource
@@ -324,9 +321,7 @@ function rectFromRange(range: Range): ChatThreadFeedbackSelection["rect"] {
   return { top, left, width: right - left, height: bottom - top };
 }
 
-function readFeedbackSelection(
-  expandToAssistantReply: boolean,
-): CapturedFeedbackSelection | null {
+function readFeedbackSelection(): CapturedFeedbackSelection | null {
   const selection = window.getSelection();
   if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
     return null;
@@ -336,7 +331,7 @@ function readFeedbackSelection(
     return null;
   }
   const range = selection.getRangeAt(0);
-  const sourceElement = resolveSelectionSource(range, expandToAssistantReply);
+  const sourceElement = resolveSelectionSource(range);
   if (!sourceElement) {
     return null;
   }
@@ -404,11 +399,7 @@ function createSelectionState(threadId: string) {
   });
   const capture$ = command(({ get, set }, signal: AbortSignal) => {
     signal.throwIfAborted();
-    const selection = readFeedbackSelection(
-      shouldExpandSelectionToAssistantReply(
-        get(featureSwitch$)[FeatureSwitchKey.ChatDesktopSelection],
-      ),
-    );
+    const selection = readFeedbackSelection();
     if (!selection || selection.threadId !== threadId) {
       set(close$);
       return;
@@ -430,11 +421,7 @@ function createSelectionState(threadId: string) {
     if (!currentSelection) {
       return;
     }
-    const selection = readFeedbackSelection(
-      shouldExpandSelectionToAssistantReply(
-        get(featureSwitch$)[FeatureSwitchKey.ChatDesktopSelection],
-      ),
-    );
+    const selection = readFeedbackSelection();
     if (
       !selection ||
       selection.threadId !== threadId ||
@@ -824,9 +811,7 @@ function createListenersRef({
           mouseSelectionInProgress =
             event.button === 0 &&
             event.target instanceof Node &&
-            (shouldExpandSelectionToAssistantReply(
-              get(featureSwitch$)[FeatureSwitchKey.ChatDesktopSelection],
-            )
+            (shouldExpandSelectionToAssistantReply()
               ? closestExpandedFeedbackSource(event.target)
               : closestFeedbackSource(event.target)) !== null;
           const activeElement = doc.activeElement;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-feedback.test.tsx
@@ -1,5 +1,4 @@
 import type { UserMessageDocument } from "@okouai/api-contracts/contracts/chat-threads";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, test } from "vitest";
@@ -116,11 +115,7 @@ test("Expand desktop passage actions to the boundary of one AI reply", async () 
     events: completedConversation(FIRST_PASSAGE, SECOND_PASSAGE),
   });
 
-  await setupPage({
-    context,
-    path: RUN_PATH,
-    featureSwitches: { [FeatureSwitchKey.ChatDesktopSelection]: true },
-  });
+  await setupPage({ context, path: RUN_PATH });
 
   await readyChat();
   const firstResponse = await screen.findByText(FIRST_PASSAGE);
@@ -181,13 +176,7 @@ test("Hide passage actions for a run summary inside an AI reply", async () => {
     ],
   });
 
-  await setupPage({
-    context,
-    path: RUN_PATH,
-    featureSwitches: {
-      [FeatureSwitchKey.ChatDesktopSelection]: true,
-    },
-  });
+  await setupPage({ context, path: RUN_PATH });
 
   await readyChat();
   await expect(screen.findByText("Worked for 1m")).resolves.toBeVisible();
@@ -199,36 +188,7 @@ test("Hide passage actions for a run summary inside an AI reply", async () => {
   expect(queryToolbarButton("Forward")).not.toBeInTheDocument();
 });
 
-test("Keep the legacy Markdown selection boundary when expansion is disabled", async () => {
-  installCapabilityChat({
-    events: completedConversation(FIRST_PASSAGE),
-  });
-
-  await setupPage({
-    context,
-    path: RUN_PATH,
-    featureSwitches: { [FeatureSwitchKey.ChatDesktopSelection]: false },
-  });
-
-  await readyChat();
-  const firstResponse = await screen.findByText(FIRST_PASSAGE);
-  const assistantReply = firstResponse.closest('[data-role="assistant"]');
-  if (!assistantReply) {
-    throw new Error("AI reply boundary was not rendered");
-  }
-  const renderedDetail = document.createElement("div");
-  renderedDetail.textContent = "A rendered detail outside Markdown.";
-  assistantReply.append(renderedDetail);
-
-  await selectPassage("launch plan has three careful stages");
-  await selectPassageWithoutActions("rendered detail outside Markdown");
-
-  expect(queryToolbarButton("Copy")).not.toBeInTheDocument();
-  expect(queryToolbarButton("Quote")).not.toBeInTheDocument();
-  expect(queryToolbarButton("Forward")).not.toBeInTheDocument();
-});
-
-test("Keep touch passage actions on the legacy Markdown boundary", async () => {
+test("Keep touch passage actions within the Markdown boundary", async () => {
   context.mocks.browser.matchMedia((query) => {
     return query === "(pointer: coarse)";
   });
@@ -236,11 +196,7 @@ test("Keep touch passage actions on the legacy Markdown boundary", async () => {
     events: completedConversation(FIRST_PASSAGE),
   });
 
-  await setupPage({
-    context,
-    path: RUN_PATH,
-    featureSwitches: { [FeatureSwitchKey.ChatDesktopSelection]: true },
-  });
+  await setupPage({ context, path: RUN_PATH });
 
   await readyChat();
   const firstResponse = await screen.findByText(FIRST_PASSAGE);

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -198,7 +198,6 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.ChatTranslation]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.ChatDesktopSelection]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.VoiceInputV2]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
@@ -224,7 +223,6 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.ChatTranslation]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ChatDesktopSelection]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.VoiceInputV2]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -65,7 +65,6 @@ export enum FeatureSwitchKey {
   PiLoop = "piLoop",
   IntroVideo = "introVideo",
   ChatTranslation = "chatTranslation",
-  ChatDesktopSelection = "chatDesktopSelection",
   VoiceInputV2 = "voiceInputV2",
   ComposerCreateCommands = "composerCreateCommands",
   ComposerTaskChips = "composerTaskChips",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -327,12 +327,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Translate selected assistant text into a remembered target language.",
     enabled: false,
   },
-  [FeatureSwitchKey.ChatDesktopSelection]: {
-    maintainer: "bingjie@okou.ai",
-    description:
-      "Offer desktop passage actions for selections anywhere within one assistant reply.",
-    enabled: true,
-  },
   [FeatureSwitchKey.VoiceInputV2]: {
     maintainer: "ethan@okou.ai",
     description:


### PR DESCRIPTION
## Summary

Retire the fully rolled out `chatDesktopSelection` switch and permanently enable passage actions for desktop text selections contained within one assistant reply. Preserve the touch Markdown boundary, cross-reply rejection, linked-mail feedback sources, and run-summary exclusions.

## Terminal state and history

- Terminal state: `fully-rolled-out`, established by merged PR #32661 (`18268a496641345dfcb7613ecb08a97ffb0a1c3e`), which enabled the switch for every organization and removed its staff allowlist. The starting `main` revision, `22af62b889e097ed05c3be9d95a723ccb44c8e69`, still has `enabled: true`.
- Introduction: PR #32338, commit `c9f6e05544a950b9df4e7734a32f7335cd210512`. Compared its patch and parent versions of the selection logic, registry, key enum, and tests: the old desktop path restricted selections to Markdown, while the enabled path expands to a single assistant reply. The Markdown resolver remains necessary for coarse pointers.
- Checked the subsequent run-summary exclusion in #32508 (`4831b6c1429fa595b59ce1cfd684e14e43eb2141`) and folding-switch cleanup in #32727 (`1357f20a71a4ddfad029682d776826593492f0cc`); both behaviors are retained.

## Cleanup and coverage

- Remove the enum member, registry entry and description, three switch reads, and the obsolete boolean arguments through selection capture and source resolution.
- Delete the disabled-desktop test and the two rollout-matrix assertions. Update the existing desktop, touch, and summary tests to exercise product behavior without switch overrides; remove their unused enum import.
- Checked the generic override contract and readers: requests and responses use string-keyed records, the service filters unregistered overrides, and older clients retain their built-in enabled default when the API omits the key. No schema migration is needed.
- The second repository-wide search covered `chatDesktopSelection`, `ChatDesktopSelection`, kebab/snake/uppercase variants, the removed description and disabled-test title, `expandToAssistantReply`, `closestExpandedFeedbackSource`, `shouldExpandSelectionToAssistantReply`, `COARSE_POINTER_QUERY`, `setPassageSelection`, `selectPassageWithoutActions`, and selection-source/summary selectors. No retired key or argument remains. Surviving helpers and selectors support permanent desktop/touch behavior, linked mail, or summary exclusions; unrelated coarse-pointer helpers remain in use.

## Validation

- Core feature-switch tests: 30 passed.
- Five Platform test files covering passage actions, linked-mail feedback, feedback submission, forwarding, and scrolling: 40 passed, with at most two workers.
- Prettier for all five changed files: passed.
- Core package lint and types: passed.
- Targeted Platform Oxlint, type-aware Oxlint, and ESLint: passed.
- Platform production, test, and build-configuration type checks: passed.
- Knip for Core and Platform: passed.
- Full diff review and repository-wide residual searches: passed.
- Full-suite and broader cross-workspace validation are left to the PR pipeline.
