### PR TITLE
fix(runner): preserve websocket pricing after tier-cache eviction

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -207,9 +207,10 @@ def report_model_provider_usage_source(
     in a later frame. Callers can drop the source from flow metadata after this
     returns. Tiered models retain only their bounded concrete
     tier decision. Evicted decisions are recovered from bounded source-key
-    admission history when possible so later or duplicate output-only frames
-    derive the same billable category; otherwise positive usage receives a
-    conservative billable fallback.
+    admission history when possible so later or duplicate snapshots derive
+    the same billable category even when they repeat input tokens or change
+    service-tier metadata. Without retained history or a classifiable input
+    partition, positive usage receives a conservative billable fallback.
     """
     usage_events: list[UsageEvent] = []
     source_id = f"{flow.id}:{message_id}"
@@ -591,39 +592,32 @@ def _source_model_usage_pricing(
         )
         tiers.move_to_end(message_id)
         return tier, fast
-    if billing_tier is None:
+    # Admitted source keys remain authoritative after the tier cache evicts
+    # a response, even if this snapshot contains a different input partition.
+    fast = observed_fast is True
+    recovered_pricing = _recover_source_model_usage_pricing(run_id, source_id)
+    if recovered_pricing is not None:
+        billing_tier, fast = recovered_pricing
+    elif billing_tier is None:
         if not has_positive_model_provider_usage(usage):
             return None
-        recovered_pricing = _recover_source_model_usage_pricing(run_id, source_id)
-        billing_tier, fast = recovered_pricing or (
-            _MODEL_USAGE_TIER_LONG_CONTEXT,
-            observed_fast is True,
+        billing_tier = _MODEL_USAGE_TIER_LONG_CONTEXT
+        _log_model_usage_tier_fallback(
+            flow,
+            run_id,
+            provider,
+            billing_tier,
+            fast,
         )
-        if recovered_pricing is None:
-            _log_model_usage_tier_fallback(
-                flow,
-                run_id,
-                provider,
-                billing_tier,
-                fast,
-            )
-        tiers[message_id] = _ModelUsageTierDecision(
-            tier=billing_tier,
-            fast=fast,
-            committed=True,
-        )
-        if len(tiers) > _MODEL_PROVIDER_USAGE_TIER_SOURCE_LIMIT:
-            tiers.popitem(last=False)
-        return billing_tier, fast
 
     tiers[message_id] = _ModelUsageTierDecision(
         tier=billing_tier,
-        fast=observed_fast is True,
-        committed=has_positive_model_provider_usage(usage),
+        fast=fast,
+        committed=recovered_pricing is not None or has_positive_model_provider_usage(usage),
     )
     if len(tiers) > _MODEL_PROVIDER_USAGE_TIER_SOURCE_LIMIT:
         tiers.popitem(last=False)
-    return billing_tier, observed_fast is True
+    return billing_tier, fast
 
 
 def _recover_source_model_usage_pricing(

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage_aggregation.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage_aggregation.py
@@ -47,8 +47,8 @@ def _openai_websocket_zero_usage_frame(response_id: str, *, model: str | None = 
     ).encode()
 
 
-def _pressure_model_usage_tier_state(flow: http.HTTPFlow) -> None:
-    for index in range(100):
+def _pressure_model_usage_tier_state(flow: http.HTTPFlow, *, response_count: int = 100) -> None:
+    for index in range(response_count):
         feed_websocket_server_message(
             flow,
             _openai_websocket_zero_usage_frame(f"resp_ws_pressure_{index}"),
@@ -367,6 +367,155 @@ class TestModelProviderWebSocketUsageAggregation:
         [duplicate_event] = duplicate_entry["usage_events"]
         assert duplicate_event["category"] == "tokens.output"
         assert duplicate_event["buffer_accepted"] is False
+
+    @pytest.mark.parametrize("intervening_responses", [99, 100])
+    @pytest.mark.parametrize(
+        "initial_output_tokens", [0, 12], ids=["late-output", "duplicate-output"]
+    )
+    @pytest.mark.parametrize(
+        (
+            "input_tokens",
+            "service_tier",
+            "replay_input_tokens",
+            "replay_service_tier",
+            "category_suffix",
+        ),
+        [
+            pytest.param(20, "priority", 20, None, ".fast", id="fast-omitted-tier"),
+            pytest.param(
+                272_001,
+                "priority",
+                272_001,
+                None,
+                ".long_context.fast",
+                id="long-context-fast-omitted-tier",
+            ),
+            pytest.param(20, "priority", 272_001, "default", ".fast", id="fast-changed-pricing"),
+            pytest.param(
+                272_001,
+                "priority",
+                20,
+                "default",
+                ".long_context.fast",
+                id="long-context-fast-changed-pricing",
+            ),
+            pytest.param(20, "default", 272_001, "priority", "", id="base-changed-pricing"),
+            pytest.param(
+                272_001,
+                "default",
+                20,
+                "priority",
+                ".long_context",
+                id="long-context-changed-pricing",
+            ),
+        ],
+    )
+    def test_model_websocket_input_replay_preserves_committed_pricing_at_eviction_boundary(
+        self,
+        tmp_path,
+        real_flow,
+        intervening_responses,
+        initial_output_tokens,
+        input_tokens,
+        service_tier,
+        replay_input_tokens,
+        replay_service_tier,
+        category_suffix,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+        replay_response = {
+            "id": "resp_ws_input_replay",
+            "model": "gpt-5.5",
+            "usage": {"input_tokens": replay_input_tokens, "output_tokens": 12},
+        }
+        if replay_service_tier is not None:
+            replay_response["service_tier"] = replay_service_tier
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_server_message(
+                flow,
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_ws_input_replay",
+                            "model": "gpt-5.5",
+                            "service_tier": service_tier,
+                            "usage": {
+                                "input_tokens": input_tokens,
+                                "output_tokens": initial_output_tokens,
+                            },
+                        },
+                    }
+                ).encode(),
+            )
+            usage.flush_usage_events(trigger="test")
+            _pressure_model_usage_tier_state(flow, response_count=intervening_responses)
+            feed_websocket_server_message(
+                flow,
+                json.dumps({"type": "response.done", "response": replay_response}).encode(),
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        assert_usage_event_rows(
+            webhook.usage_events(),
+            "provider",
+            [
+                ("gpt-5.5", f"tokens.input{category_suffix}", input_tokens),
+                ("gpt-5.5", f"tokens.output{category_suffix}", 12),
+            ],
+        )
+
+    def test_model_websocket_zero_replay_keeps_recovered_pricing_committed(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_server_message(
+                flow,
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_ws_zero_replay",
+                            "model": "gpt-5.5",
+                            "service_tier": "priority",
+                            "usage": {"input_tokens": 272_001},
+                        },
+                    }
+                ).encode(),
+            )
+            usage.flush_usage_events(trigger="test")
+            _pressure_model_usage_tier_state(flow)
+            feed_websocket_server_message(
+                flow,
+                _openai_websocket_zero_usage_frame("resp_ws_zero_replay"),
+            )
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame(
+                    "resp_ws_zero_replay",
+                    input_tokens=20,
+                    output_tokens=12,
+                ),
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        assert_usage_event_rows(
+            webhook.usage_events(),
+            "provider",
+            [
+                ("gpt-5.5", "tokens.input.long_context.fast", 272_001),
+                ("gpt-5.5", "tokens.output.long_context.fast", 12),
+            ],
+        )
 
     def test_model_websocket_explicit_zero_input_selects_base_tier_for_late_output(
         self,


### PR DESCRIPTION
## Summary

A late input-bearing Responses WebSocket snapshot could change committed pricing after the 100-response tier cache evicted it, producing a different output idempotency key and duplicate billing. Recover pricing from retained admission history before accepting snapshot-derived pricing on a cache miss, and keep recovered decisions committed even when a replay reports zero usage.

Add production-hook regressions for the 99/100-response boundary, late and duplicate output, omitted or conflicting service tiers, base/long-context pricing, and a zero-usage replay followed by late output. Existing memory bounds, category/key formats, input admission, and terminal cleanup remain intact. Recovery remains limited to retained admission history; historical billing remediation is outside this change.

Closes #32886

## Validation

Locked environment: uv 0.11.32, Python 3.14.0, mitmproxy 12.2.3, wsproto 1.3.2.

- Baseline new regressions: 13 failures (all 100-response eviction cases and zero-usage replay), 12 passing 99-response controls.
- WebSocket aggregation suite after the fix: 50 passed.
- Related reporting, buffer, error, shutdown, and lifecycle suites: 966 passed.
- Ruff format/check, BasedPyright, `git diff --check`, and staged-file size check passed.

Commands from `crates/runner/mitm-addon`:

```sh
uv lock --check
uv sync --locked
uv run --no-sync python -m pytest tests/test_model_provider_websocket_usage_aggregation.py -q
uv run --no-sync python -m pytest tests/test_model_provider_*.py tests/test_usage_*.py tests/test_error_handler.py tests/test_done_hook.py tests/test_request_handler_usage_tracking.py -q
uv run --no-sync ruff format --check .
uv run --no-sync ruff check .
uv run --no-sync basedpyright -p .
```
