### PR TITLE
perf(runner): bound codex catalog accept-encoding inspection

### DIFF
--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -104,6 +104,10 @@ MAX_CATALOG_QUERY_BYTES = (
     * (len(_CLIENT_VERSION_QUERY_NAME.encode()) + _MAX_CLIENT_VERSION_BYTES)
     + 1
 )
+_RAW_ACCEPT_ENCODING = b"accept-encoding"
+# Match the normalizer's inclusive 64 KiB aggregate raw-value budget. Oversized
+# requests bypass this optional cache without decoding or rewriting their values.
+_MAX_ACCEPT_ENCODING_VALUE_BYTES = 64 * 1024
 _MAX_ETAG_BYTES = 512
 _MAX_CONTENT_TYPE_BYTES = 256
 _MAX_JSON_NESTING = 128
@@ -422,13 +426,37 @@ def _single_content_encoding(headers: http.Headers) -> str | None:
 
 
 def _request_accepts_encoded_response(headers: http.Headers) -> bool:
-    values = headers.get_all("Accept-Encoding")
-    if not values:
+    remaining_bytes = _MAX_ACCEPT_ENCODING_VALUE_BYTES
+    has_header = False
+    for raw_name, raw_value in headers.fields:
+        if raw_name.lower() != _RAW_ACCEPT_ENCODING:
+            continue
+        has_header = True
+        if len(raw_value) > remaining_bytes:
+            return True
+        remaining_bytes -= len(raw_value)
+    if not has_header:
         return False
-    tokens = [
-        token.strip().lower() for value in values for token in value.split(",") if token.strip()
-    ]
-    return tokens != [_IDENTITY_ENCODING]
+
+    has_identity = False
+    for raw_name, raw_value in headers.fields:
+        if raw_name.lower() != _RAW_ACCEPT_ENCODING:
+            continue
+        # Preserve mitmproxy's decoding and the existing string whitespace rules,
+        # but stop before decoding later fields once a token requires bypassing.
+        value = raw_value.decode("utf-8", "surrogateescape")
+        start = 0
+        while start < len(value):
+            end = value.find(",", start)
+            if end == -1:
+                end = len(value)
+            token = value[start:end].strip()
+            if token:
+                if has_identity or token.lower() != _IDENTITY_ENCODING:
+                    return True
+                has_identity = True
+            start = end + 1
+    return not has_identity
 
 
 def _cache_control_directive_names(headers: http.Headers) -> set[str]:

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
@@ -41,6 +41,11 @@ class _DecodeGuardPrefetchMarker(bytes):
         raise AssertionError("Codex prefetch marker must not be decoded")
 
 
+class _DecodeGuardAcceptEncoding(bytes):
+    def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
+        raise AssertionError("bypassed Accept-Encoding must not be decoded")
+
+
 def _set_catalog_query(flow: http.HTTPFlow, raw_query: str) -> None:
     path = f"/backend-api/codex/models?{raw_query}"
     flow.request.path = path
@@ -321,6 +326,163 @@ async def test_high_cardinality_catalog_query_bypasses_before_percent_decoding(r
     assert telemetry == {
         "model_catalog_cache_status": "model_catalog_bypass",
         "model_catalog_cache_bypass_reason": "request_url",
+    }
+
+
+@pytest.mark.parametrize(
+    ("raw_values", "eligible"),
+    [
+        pytest.param((), True, id="absent"),
+        pytest.param((b"identity",), True, id="identity"),
+        pytest.param((b" \tIdEnTiTy\t ",), True, id="case-and-whitespace"),
+        pytest.param((b"\xc2\xa0identity\xe2\x80\xa8",), True, id="unicode-whitespace"),
+        pytest.param((b"",), False, id="empty"),
+        pytest.param((b" \t",), False, id="whitespace"),
+        pytest.param((b", ,",), False, id="empty-items"),
+        pytest.param((b"", b""), False, id="repeated-empty"),
+        pytest.param((b", identity, ,",), True, id="identity-with-empty-items"),
+        pytest.param((b"", b"identity", b" , "), True, id="identity-in-repeated-fields"),
+        pytest.param((b"identity, identity",), False, id="duplicate-identity-items"),
+        pytest.param((b"identity", b"identity"), False, id="duplicate-identity-fields"),
+        pytest.param((b"gzip",), False, id="encoded"),
+        pytest.param((b"identity, br",), False, id="mixed-encodings"),
+        pytest.param((b"identity;q=1",), False, id="parameterized-identity"),
+        pytest.param((b"*;q=0",), False, id="wildcard"),
+        pytest.param((b"\xffidentity",), False, id="invalid-utf8"),
+        pytest.param((b" " * (64 * 1024 - 8) + b"identity",), True, id="exact-budget"),
+        pytest.param(
+            (b"," * (64 * 1024 - 8) + b"identity",), True, id="many-empty-items-at-budget"
+        ),
+        pytest.param(
+            (b" " * (32 * 1024), b" " * (32 * 1024 - 8) + b"identity"),
+            True,
+            id="aggregate-exact-budget",
+        ),
+        pytest.param((b" " * (64 * 1024 - 7) + b"identity",), False, id="first-over-budget"),
+    ],
+)
+async def test_accept_encoding_controls_fresh_catalog_reuse(real_flow, raw_values, eligible):
+    await install_catalog(catalog_flow(real_flow))
+    flow = catalog_flow(real_flow)
+    flow.request.headers.set_all("Accept-Encoding", [])
+    flow.request.headers.fields += tuple((b"aCcEpT-EnCoDiNg", value) for value in raw_values)
+    original_fields = flow.request.headers.fields
+
+    await catalog_cache.prepare_request(flow, request_end_stream=True)
+
+    assert flow.request.headers.fields == original_fields
+    if eligible:
+        assert flow.response is not None
+        assert flow.response.content == CATALOG_BODY
+    else:
+        assert flow.response is None
+        telemetry: dict[str, object] = {}
+        catalog_cache.add_network_log_fields(flow, telemetry)
+        assert telemetry == {
+            "model_catalog_cache_status": "model_catalog_bypass",
+            "model_catalog_cache_bypass_reason": "request_encoding",
+        }
+
+
+async def test_accept_encoding_budget_excludes_unrelated_values(real_flow):
+    await install_catalog(catalog_flow(real_flow))
+    flow = catalog_flow(real_flow)
+    flow.request.headers.fields += ((b"X-Unrelated", b"x" * (64 * 1024 + 1)),)
+    original_fields = flow.request.headers.fields
+
+    await catalog_cache.prepare_request(flow, request_end_stream=True)
+
+    assert flow.request.headers.fields == original_fields
+    assert flow.response is not None
+    assert flow.response.content == CATALOG_BODY
+
+
+@pytest.mark.parametrize("leading_value", [b"gzip", b"identity,identity"])
+async def test_accept_encoding_bypass_stops_before_decoding_later_fields(real_flow, leading_value):
+    flow = catalog_flow(real_flow)
+    flow.request.headers.set_all("Accept-Encoding", [])
+    flow.request.headers.fields += (
+        (b"Accept-Encoding", leading_value),
+        (b"accept-encoding", _DecodeGuardAcceptEncoding(b"identity")),
+    )
+    original_fields = flow.request.headers.fields
+
+    await catalog_cache.prepare_request(flow, request_end_stream=True)
+
+    assert flow.response is None
+    assert flow.request.headers.fields == original_fields
+    telemetry: dict[str, object] = {}
+    catalog_cache.add_network_log_fields(flow, telemetry)
+    assert telemetry == {
+        "model_catalog_cache_status": "model_catalog_bypass",
+        "model_catalog_cache_bypass_reason": "request_encoding",
+    }
+
+
+@pytest.mark.parametrize("entry_point", ["request", "requestheaders"])
+@pytest.mark.parametrize("billable", [False, True], ids=["non-billable", "billable"])
+@pytest.mark.parametrize("repeated", [False, True], ids=["single-field", "aggregate-overflow"])
+async def test_over_budget_accept_encoding_bypasses_catalog_without_decoding(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    entry_point: Literal["request", "requestheaders"],
+    billable: bool,
+    repeated: bool,
+):
+    if repeated:
+        encoding_fields = (
+            (b"Accept-Encoding", _DecodeGuardAcceptEncoding(b" " * (32 * 1024))),
+            (b"accept-encoding", _DecodeGuardAcceptEncoding(b" " * (32 * 1024 - 7) + b"identity")),
+        )
+    else:
+        encoding_fields = (
+            (b"aCcEpT-EnCoDiNg", _DecodeGuardAcceptEncoding(b"gzip," * (64 * 1024 // 5) + b"br")),
+        )
+    registry_path = _write_codex_registry(
+        tmp_path, capture=entry_point == "requestheaders", billable=billable
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="chatgpt.com",
+        method="GET",
+        path="/backend-api/codex/models?client_version=0.145.0",
+        request_headers=http.Headers(((b"Host", b"chatgpt.com"), *encoding_fields)),
+    )
+    flow.metadata["_request_end_stream"] = True
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(
+            headers={
+                "Authorization": "Bearer resolved-token",
+                "ChatGPT-Account-ID": "resolved-account",
+            }
+        ),
+    ):
+        if entry_point == "requestheaders":
+            await await_requestheaders_result(mitm_addon.requestheaders(flow))
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.request.headers["Authorization"] == "Bearer resolved-token"
+    assert (
+        tuple(
+            (name, value)
+            for name, value in flow.request.headers.fields
+            if name.lower() == b"accept-encoding"
+        )
+        == encoding_fields
+    )
+    if billable:
+        assert flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] == "preserved_work_budget"
+    telemetry: dict[str, object] = {}
+    catalog_cache.add_network_log_fields(flow, telemetry)
+    assert telemetry == {
+        "model_catalog_cache_status": "model_catalog_bypass",
+        "model_catalog_cache_bypass_reason": "request_encoding",
     }
 
 


### PR DESCRIPTION
## Summary

Codex catalog requests could fully decode and tokenize a large `Accept-Encoding` field before the optional cache rejected it. Check an inclusive 64 KiB aggregate raw-value budget before decoding, then inspect one field and token at a time and stop once bypass is certain. Oversized requests keep their original headers and continue through the existing `request_encoding` bypass path.

Preserve existing absent, identity, empty, repeated-field, case, and whitespace behavior within the budget. This change is limited to request-side cache eligibility; general encoding negotiation, global request admission, and response-side inspection are unchanged.

Closes #32888

## Validation

- Added 32 real-flow regression cases covering eligibility, exact/overflow budgets, no-decode guards, early exit, and both authenticated hooks for billable and non-billable requests. Confirmed the relevant failures against unchanged production code before applying the fix.
- `uv run --no-sync python -m pytest tests/test_codex_model_catalog_cache_*.py tests/test_response_encoding_negotiation.py tests/test_mitmproxy_codex_catalog_framing.py -q` — **242 passed**.
- `uv run --no-sync ruff format --check .`, `uv run --no-sync ruff check .`, and `uv run --no-sync basedpyright -p .` — passed.
- `uv lock --check` and `uv sync --locked` — passed using CPython 3.14.0 and mitmproxy 12.2.3 without lockfile changes.
- `git diff --check` — passed. No timing assertions, external provider calls, local dev server, or Vitest run.
