### PR TITLE
feat: display automation times in agent and browser timezones

### DIFF
--- a/turbo/apps/cli/src/commands/workflow/automation/__tests__/automation.test.ts
+++ b/turbo/apps/cli/src/commands/workflow/automation/__tests__/automation.test.ts
@@ -459,6 +459,7 @@ describe("okou workflow automation commands", () => {
 
   describe("add", () => {
     it("should add a cron automation to a workflow id", async () => {
+      vi.stubEnv("TZ", "Asia/Shanghai");
       const captured = captureCreateAutomation(cronAutomation);
 
       await automationCommand.parseAsync([
@@ -488,6 +489,18 @@ describe("okou workflow automation commands", () => {
       );
       expect(logCalls).toContain(AUTOMATION_ID);
       expect(logCalls).toContain("0 9 * * *");
+      expect(logCalls).toContain("Next run:     2026-06-12T17:00:00+08:00");
+      expect(logCalls).toContain("Last run:     -");
+      expect(logCalls).toContain("Time display guidance:");
+      expect(logCalls).toContain(
+        '<time datetime="2026-06-12T17:00:00+08:00">2026-06-12T17:00:00+08:00</time>',
+      );
+      expect(logCalls).toContain(
+        "current environment timezone (Asia/Shanghai)",
+      );
+      expect(logCalls).toContain(
+        "Do not wrap the tag in inline code or a code block.",
+      );
       expect(logCalls).toContain(`Thread model: GPT 5.6 Sol (${MODEL_ID})`);
       expect(logCalls).toContain("Thread priority:  enabled");
       expect(logCalls).toContain("Manage with Okou CLI:");
@@ -1877,6 +1890,7 @@ describe("okou workflow automation commands", () => {
     });
 
     it("should switch to a cron schedule", async () => {
+      vi.stubEnv("TZ", "America/New_York");
       const captured = captureUpdateAutomation(cronAutomation);
 
       await automationCommand.parseAsync([
@@ -1902,6 +1916,10 @@ describe("okou workflow automation commands", () => {
         `Automation ${AUTOMATION_ID} updated`,
       );
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Next run:     2026-06-12T05:00:00-04:00");
+      expect(logCalls).toContain(
+        '<time datetime="2026-06-12T05:00:00-04:00">2026-06-12T05:00:00-04:00</time>',
+      );
       expect(logCalls).toContain(`Thread model: GPT 5.6 Sol (${MODEL_ID})`);
       expect(logCalls).not.toContain("Manage with Okou CLI:");
     });
@@ -2193,6 +2211,7 @@ describe("okou workflow automation commands", () => {
 
   describe("list", () => {
     it("should display workflow automations", async () => {
+      vi.stubEnv("TZ", "Asia/Shanghai");
       server.use(
         http.get(
           "http://localhost:3000/api/workflows/:workflowId/automations",
@@ -2217,6 +2236,8 @@ describe("okou workflow automation commands", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain(AUTOMATION_ID);
       expect(logCalls).toContain("0 9 * * *");
+      expect(logCalls).toContain("2026-06-12T17:00:00+08:00");
+      expect(logCalls).toContain("Time display guidance:");
       expect(logCalls).toContain("every 15m");
       expect(logCalls).toContain("Gmail new message");
       expect(logCalls).toContain('from contains "@acme.com"');
@@ -2298,6 +2319,59 @@ describe("okou workflow automation commands", () => {
   });
 
   describe("show", () => {
+    it.each([
+      {
+        timezone: "America/Los_Angeles",
+        nextRun: "2026-09-09T00:00:00-07:00",
+        lastRun: "2026-01-08T23:00:00.123-08:00",
+      },
+      {
+        timezone: "Asia/Kathmandu",
+        nextRun: "2026-09-09T12:45:00+05:45",
+        lastRun: "2026-01-09T12:45:00.123+05:45",
+      },
+      {
+        timezone: "UTC",
+        nextRun: "2026-09-09T07:00:00+00:00",
+        lastRun: "2026-01-09T07:00:00.123+00:00",
+      },
+    ])(
+      "should display precise run timestamps in the environment timezone $timezone",
+      async ({ timezone, nextRun, lastRun }) => {
+        vi.stubEnv("TZ", timezone);
+        const automation = {
+          ...cronAutomation,
+          nextRunAt: "2026-09-09T07:00:00Z",
+          lastRunAt: "2026-01-09T07:00:00.123Z",
+        };
+        server.use(
+          http.get("http://localhost:3000/api/workflow-automations/:id", () => {
+            return HttpResponse.json(automation);
+          }),
+          http.get("http://localhost:3000/api/workflow-automations", () => {
+            return HttpResponse.json([
+              { workflow: workflowSummary, automation },
+            ]);
+          }),
+        );
+
+        await automationCommand.parseAsync([
+          "node",
+          "cli",
+          "show",
+          AUTOMATION_ID,
+        ]);
+
+        const output = mockConsoleLog.mock.calls.flat().join("\n");
+        expect(output).toContain(`Next run:     ${nextRun}`);
+        expect(output).toContain(`Last run:     ${lastRun}`);
+        expect(output).toContain("Automation:   0 9 * * * (UTC)");
+        expect(output).toContain(
+          `<time datetime="${nextRun}">${nextRun}</time>`,
+        );
+      },
+    );
+
     it("should display automation details", async () => {
       server.use(
         http.get("http://localhost:3000/api/workflow-automations/:id", () => {

--- a/turbo/apps/cli/src/commands/workflow/automation/display.ts
+++ b/turbo/apps/cli/src/commands/workflow/automation/display.ts
@@ -385,6 +385,46 @@ function formatRunTime(value: string | null): string {
   return value ? formatRelativeTime(value) : chalk.dim("-");
 }
 
+function formatRunTimestamp(value: string | null): string {
+  if (value === null) {
+    return chalk.dim("-");
+  }
+
+  const timestamp = new Date(value);
+  const offsetMinutes = -timestamp.getTimezoneOffset();
+  const localTimestamp = new Date(timestamp.getTime() + offsetMinutes * 60_000)
+    .toISOString()
+    .replace(/(?:\.000)?Z$/, "");
+  const sign = offsetMinutes < 0 ? "-" : "+";
+  const hours = String(Math.floor(Math.abs(offsetMinutes) / 60)).padStart(
+    2,
+    "0",
+  );
+  const minutes = String(Math.abs(offsetMinutes) % 60).padStart(2, "0");
+  return `${localTimestamp}${sign}${hours}:${minutes}`;
+}
+
+function printRunTimeGuidance(value: string | null): void {
+  if (value === null) {
+    return;
+  }
+  const timestamp = formatRunTimestamp(value);
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  console.log("");
+  console.log(chalk.bold("Time display guidance:"));
+  console.log(
+    "  If you show a run time to the user, use a <time> tag directly in prose:",
+  );
+  console.log(`    <time datetime="${timestamp}">${timestamp}</time>`);
+  console.log(
+    `  Use the current environment timezone (${timezone}) for datetime and`,
+  );
+  console.log(
+    "  visible text, retaining the numeric UTC offset for that date.",
+  );
+  console.log("  Do not wrap the tag in inline code or a code block.");
+}
+
 function workflowAutomationKindLabel(
   automation: WorkflowAutomationSummary,
 ): string {
@@ -503,10 +543,15 @@ export function printWorkflowAutomationsTable(
         formatWorkflowAutomationEntry(automation, options).padEnd(
           scheduleWidth,
         ),
-        formatRunTime(automation.nextRunAt),
+        formatRunTimestamp(automation.nextRunAt),
       ].join("  "),
     );
   }
+  printRunTimeGuidance(
+    automations.find((automation) => {
+      return automation.nextRunAt !== null;
+    })?.nextRunAt ?? null,
+  );
   if (!options.showStripeDetails) {
     return;
   }
@@ -892,10 +937,11 @@ export function printWorkflowAutomationDetails(
   );
   printWorkflowAutomationThreadModel(options.threadModel);
   console.log(
-    `${"Next run:".padEnd(14)}${formatRunTime(automation.nextRunAt)}`,
+    `${"Next run:".padEnd(14)}${formatRunTimestamp(automation.nextRunAt)}`,
   );
   console.log(
-    `${"Last run:".padEnd(14)}${formatRunTime(automation.lastRunAt)}`,
+    `${"Last run:".padEnd(14)}${formatRunTimestamp(automation.lastRunAt)}`,
   );
+  printRunTimeGuidance(automation.nextRunAt ?? automation.lastRunAt);
   printManagementCommands(automation, options);
 }

--- a/turbo/apps/platform/src/views/components/rich-markdown.tsx
+++ b/turbo/apps/platform/src/views/components/rich-markdown.tsx
@@ -1,12 +1,14 @@
 import { withChatScrollLayout } from "./chat-scroll-layout.tsx";
 import "../css/vendor/uiw-react-markdown-preview-5.2.0.css";
 import { CopyButton } from "@okouai/ui";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { useGet, useLastResolved, useSet } from "ccstate-react";
 import type { Element, Root } from "hast";
 import { toJsxRuntime } from "hast-util-to-jsx-runtime";
 import { File, Image, Loader2, Video } from "lucide-react";
 import type { ComponentPropsWithoutRef, CSSProperties, ReactNode } from "react";
 import { Fragment, jsx, jsxs } from "react/jsx-runtime";
+import { z } from "zod";
 
 import {
   escapeHtmlTags,
@@ -20,6 +22,8 @@ import type {
 } from "../../signals/chat-page/artifact-card-signals.ts";
 import type { ImageLoadSignals } from "../../signals/image-load.ts";
 import { isImageUrl, isSafeMediaUrl } from "../../lib/media-url.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import { locale$ } from "../../signals/locale.ts";
 import { MarkdownCardView } from "../okou-page/chat-body-cards.tsx";
 import { MarkdownColorPreview } from "./markdown-color-preview.tsx";
 import { MarkdownFrame } from "./markdown-frame.tsx";
@@ -30,6 +34,7 @@ type MarkdownNodeProp = { node?: Element };
 type MarkdownAnchorProps = ComponentPropsWithoutRef<"a"> & MarkdownNodeProp;
 type MarkdownImageProps = ComponentPropsWithoutRef<"img"> & MarkdownNodeProp;
 type MarkdownSpanProps = ComponentPropsWithoutRef<"span"> & MarkdownNodeProp;
+type MarkdownTimeProps = ComponentPropsWithoutRef<"time"> & MarkdownNodeProp;
 type MarkdownDivProps = ComponentPropsWithoutRef<"div"> & {
   node?: Element;
 };
@@ -332,6 +337,32 @@ function MarkdownSpanRenderer(props: MarkdownSpanProps) {
   return <span {...omitMarkdownNodeProp(rest)}>{children}</span>;
 }
 
+const markdownDateTimeSchema = z.iso.datetime({ offset: true });
+
+function MarkdownTimeRenderer({
+  children,
+  dateTime,
+  ...rest
+}: MarkdownTimeProps) {
+  const features = useLastResolved(featureSwitch$);
+  const locale = useGet(locale$);
+  const timestamp = features?.[FeatureSwitchKey.MarkdownTime]
+    ? markdownDateTimeSchema.safeParse(dateTime)
+    : undefined;
+  const content = timestamp?.success
+    ? new Intl.DateTimeFormat(locale, {
+        dateStyle: "medium",
+        timeStyle: "long",
+      }).format(new Date(timestamp.data))
+    : children;
+
+  return (
+    <time {...omitMarkdownNodeProp(rest)} dateTime={dateTime}>
+      {content}
+    </time>
+  );
+}
+
 // `rehypeMermaid` turns mermaid fences into `<div data-mermaid-code>`; every
 // other div renders as-is.
 // The pipeline marks copy buttons and mermaid diagrams on the node's `data`,
@@ -375,6 +406,7 @@ const PLAIN_MARKDOWN_COMPONENTS = {
   a: PlainLinkRenderer,
   img: PlainImageRenderer,
   span: MarkdownSpanRenderer,
+  time: MarkdownTimeRenderer,
   div: MarkdownDivRenderer,
 } as const;
 
@@ -384,6 +416,7 @@ const MEDIA_MARKDOWN_COMPONENTS = {
   a: MediaLinkRenderer,
   img: MediaImageRenderer,
   span: MarkdownSpanRenderer,
+  time: MarkdownTimeRenderer,
   div: MarkdownDivRenderer,
 } as const;
 

--- a/turbo/apps/platform/src/views/components/rich-markdown.tsx
+++ b/turbo/apps/platform/src/views/components/rich-markdown.tsx
@@ -23,7 +23,6 @@ import type {
 import type { ImageLoadSignals } from "../../signals/image-load.ts";
 import { isImageUrl, isSafeMediaUrl } from "../../lib/media-url.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
-import { locale$ } from "../../signals/locale.ts";
 import { MarkdownCardView } from "../okou-page/chat-body-cards.tsx";
 import { MarkdownColorPreview } from "./markdown-color-preview.tsx";
 import { MarkdownFrame } from "./markdown-frame.tsx";
@@ -345,12 +344,13 @@ function MarkdownTimeRenderer({
   ...rest
 }: MarkdownTimeProps) {
   const features = useLastResolved(featureSwitch$);
-  const locale = useGet(locale$);
+  const browserLocales =
+    navigator.languages.length > 0 ? navigator.languages : [navigator.language];
   const timestamp = features?.[FeatureSwitchKey.MarkdownTime]
     ? markdownDateTimeSchema.safeParse(dateTime)
     : undefined;
   const content = timestamp?.success
-    ? new Intl.DateTimeFormat(locale, {
+    ? new Intl.DateTimeFormat(browserLocales, {
         dateStyle: "medium",
         timeStyle: "long",
       }).format(new Date(timestamp.data))

--- a/turbo/apps/platform/src/views/okou-page/__tests__/markdown-time.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/markdown-time.test.tsx
@@ -41,6 +41,7 @@ test.each([
 ])(
   "Markdown times use the browser timezone $timezone for each instant",
   async ({ timezone, summer, winter }) => {
+    context.mocks.browser.language("en-US");
     context.mocks.data.userPreferences({ timezone: "Pacific/Auckland" });
     const chat = installMessage(
       'Summer meeting: **<time datetime="2026-09-09T15:00:00+08:00">source summer time</time>**. ' +
@@ -71,7 +72,46 @@ test.each([
   },
 );
 
+test.each([
+  {
+    scenario: "British English uses day-first dates and a 24-hour clock",
+    languages: ["en-GB", "en-US"],
+    expected: "9 Sept 2026, 15:00:00 GMT+8",
+  },
+  {
+    scenario: "Chinese works even when the application UI is in English",
+    languages: ["zh-CN", "en-US"],
+    expected: "2026年9月9日 GMT+8 15:00:00",
+  },
+  {
+    scenario: "the single browser language is used when its list is empty",
+    languages: [],
+    expected: "9 Sept 2026, 15:00:00 GMT+8",
+  },
+])("Markdown times follow browser locale: $scenario", async (scenario) => {
+  context.mocks.browser.language("en-GB");
+  context.mocks.browser.languages(scenario.languages);
+  const chat = installMessage(
+    '<time datetime="2026-09-09T15:00:00+08:00">source time</time>',
+  );
+
+  await setupPage({
+    context,
+    path: chat.path,
+    host: "app.okou.ai",
+    locale: "en-US",
+    env: { TZ: "Asia/Shanghai" },
+    featureSwitches: { [FeatureSwitchKey.MarkdownTime]: true },
+  });
+
+  const time = await screen.findByText(scenario.expected);
+  expect(time).toBeVisible();
+  expect(time).toHaveAttribute("datetime", "2026-09-09T15:00:00+08:00");
+  expect(document.documentElement).toHaveAttribute("lang", "en-US");
+});
+
 test("A time tag can render from datetime without a text label", async () => {
+  context.mocks.browser.language("en-US");
   const chat = installMessage(
     '<time datetime="2026-09-09T07:00:00.123Z"></time>',
   );
@@ -124,6 +164,7 @@ test("Missing, invalid, and timezone-free datetimes retain their original text",
 });
 
 test("Time tags in inline and fenced code remain literal code", async () => {
+  context.mocks.browser.language("en-US");
   const inline =
     '<time datetime="2026-09-09T15:00:00+08:00">inline example</time>';
   const fenced =

--- a/turbo/apps/platform/src/views/okou-page/__tests__/markdown-time.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/markdown-time.test.tsx
@@ -1,0 +1,175 @@
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { createMarkdownChatFixture } from "./markdown-page-test-helpers.ts";
+
+const context = testContext();
+
+function installMessage(content: string) {
+  const chat = createMarkdownChatFixture(context);
+  const rows = [
+    chat.outputMessage(content, { seqId: 1 }),
+    chat.runCompleted({ seqId: 2 }),
+  ];
+  chat.install({
+    rows: () => {
+      return rows;
+    },
+  });
+  return chat;
+}
+
+test.each([
+  {
+    timezone: "America/Los_Angeles",
+    summer: "Sep 9, 2026, 12:00:00 AM PDT",
+    winter: "Jan 8, 2026, 11:00:00 PM PST",
+  },
+  {
+    timezone: "Asia/Kathmandu",
+    summer: "Sep 9, 2026, 12:45:00 PM GMT+5:45",
+    winter: "Jan 9, 2026, 12:45:00 PM GMT+5:45",
+  },
+  {
+    timezone: "UTC",
+    summer: "Sep 9, 2026, 7:00:00 AM UTC",
+    winter: "Jan 9, 2026, 7:00:00 AM UTC",
+  },
+])(
+  "Markdown times use the browser timezone $timezone for each instant",
+  async ({ timezone, summer, winter }) => {
+    context.mocks.data.userPreferences({ timezone: "Pacific/Auckland" });
+    const chat = installMessage(
+      'Summer meeting: **<time datetime="2026-09-09T15:00:00+08:00">source summer time</time>**. ' +
+        'Winter meeting: <time datetime="2026-01-09T07:00:00Z">source winter time</time>.',
+    );
+
+    await setupPage({
+      context,
+      path: chat.path,
+      host: "app.okou.ai",
+      locale: "en-US",
+      env: { TZ: timezone },
+      cachedFeatureSwitches: { [FeatureSwitchKey.MarkdownTime]: false },
+      featureSwitches: { [FeatureSwitchKey.MarkdownTime]: true },
+    });
+
+    const summerTime = await screen.findByText(summer);
+    expect(summerTime.tagName).toBe("TIME");
+    expect(summerTime).toHaveAttribute("datetime", "2026-09-09T15:00:00+08:00");
+    expect(summerTime.closest("strong")).not.toBeNull();
+    expect(summerTime.closest("p")).toHaveTextContent(
+      `Summer meeting: ${summer}. Winter meeting: ${winter}.`,
+    );
+    expect(screen.getByText(winter)).toHaveAttribute(
+      "datetime",
+      "2026-01-09T07:00:00Z",
+    );
+  },
+);
+
+test("A time tag can render from datetime without a text label", async () => {
+  const chat = installMessage(
+    '<time datetime="2026-09-09T07:00:00.123Z"></time>',
+  );
+  await setupPage({
+    context,
+    path: chat.path,
+    host: "app.okou.ai",
+    locale: "en-US",
+    env: { TZ: "Asia/Shanghai" },
+    featureSwitches: { [FeatureSwitchKey.MarkdownTime]: true },
+  });
+
+  const time = await screen.findByText("Sep 9, 2026, 3:00:00 PM GMT+8");
+  expect(time).toHaveAttribute("datetime", "2026-09-09T07:00:00.123Z");
+});
+
+test("Missing, invalid, and timezone-free datetimes retain their original text", async () => {
+  const chat = installMessage(
+    [
+      "<time>No datetime provided</time>",
+      '<time datetime="">Empty datetime</time>',
+      '<time datetime="not-a-date">Invalid datetime</time>',
+      '<time datetime="2026-02-30T07:00:00Z">Invalid calendar date</time>',
+      '<time datetime="2026-09-09">Date only</time>',
+      '<time datetime="2026-09-09T07:00:00">No timezone offset</time>',
+      '<time datetime="PT1H">Duration</time>',
+    ].join("\n\n"),
+  );
+  await setupPage({
+    context,
+    path: chat.path,
+    host: "app.okou.ai",
+    env: { TZ: "America/Los_Angeles" },
+    featureSwitches: { [FeatureSwitchKey.MarkdownTime]: true },
+  });
+
+  await expect(
+    screen.findByText("No datetime provided"),
+  ).resolves.toBeVisible();
+  for (const text of [
+    "Empty datetime",
+    "Invalid datetime",
+    "Invalid calendar date",
+    "Date only",
+    "No timezone offset",
+    "Duration",
+  ]) {
+    expect(screen.getByText(text)).toBeVisible();
+  }
+});
+
+test("Time tags in inline and fenced code remain literal code", async () => {
+  const inline =
+    '<time datetime="2026-09-09T15:00:00+08:00">inline example</time>';
+  const fenced =
+    '<time datetime="2026-09-09T15:00:00+08:00">fenced example</time>';
+  const chat = installMessage(
+    [
+      `Inline code: \`${inline}\``,
+      "",
+      "```html",
+      fenced,
+      "```",
+      "",
+      '<time datetime="2026-09-09T15:00:00+08:00">actual meeting</time>',
+    ].join("\n"),
+  );
+  await setupPage({
+    context,
+    path: chat.path,
+    host: "app.okou.ai",
+    locale: "en-US",
+    env: { TZ: "America/Los_Angeles" },
+    featureSwitches: { [FeatureSwitchKey.MarkdownTime]: true },
+  });
+
+  const time = await screen.findByText("Sep 9, 2026, 12:00:00 AM PDT");
+  const frame = time.closest(".wmde-markdown");
+  expect(frame).not.toBeNull();
+  expect(frame?.querySelectorAll("time")).toHaveLength(1);
+  expect(screen.getByText(inline).closest("code")).not.toBeNull();
+  expect(frame?.querySelector("pre code.language-html")?.textContent).toBe(
+    `${fenced}\n`,
+  );
+});
+
+test("Time tags retain their original text while localization is disabled", async () => {
+  const chat = installMessage(
+    '<time datetime="2026-09-09T15:00:00+08:00">2026-09-09T15:00:00+08:00</time>',
+  );
+  await setupPage({
+    context,
+    path: chat.path,
+    host: "app.okou.ai",
+    env: { TZ: "America/Los_Angeles" },
+    featureSwitches: { [FeatureSwitchKey.MarkdownTime]: false },
+  });
+
+  const time = await screen.findByText("2026-09-09T15:00:00+08:00");
+  expect(time).toHaveAttribute("datetime", "2026-09-09T15:00:00+08:00");
+});

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -54,6 +54,7 @@ export enum FeatureSwitchKey {
   ChatErrorRecovery = "chatErrorRecovery",
   PrivateArtifacts = "privateArtifacts",
   AgentMessageMath = "agentMessageMath",
+  MarkdownTime = "markdownTime",
   ProgressiveArtifactPreview = "progressiveArtifactPreview",
   ChatThinkingSpinner = "chatThinkingSpinner",
   ResponsiveFollowupCards = "responsiveFollowupCards",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -380,6 +380,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.MarkdownTime]: {
+    maintainer: "ethan@okou.ai",
+    description:
+      "Render Markdown time tags with explicit datetime offsets in the browser timezone.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ProgressiveArtifactPreview]: {
     maintainer: "bingjie@okou.ai",
     description:


### PR DESCRIPTION
Automation next/last run times currently use rounded relative text such as `in 15h`, so agents cannot recover precise timestamps from CLI output. Print ISO 8601 timestamps in the CLI environment timezone, retaining each instant's numeric UTC offset and nonzero fractional seconds. Append guidance asking agents to emit `<time datetime="...">...</time>` directly in prose, with both the attribute and fallback text in the environment timezone.

The shared Markdown renderer now displays valid, offset-qualified `datetime` values in the browser timezone and browser language preferences, independently of the application UI language. For example, `<time datetime="2026-09-09T15:00:00+08:00">...</time>` displays as `2026年9月9日 GMT+8 15:00:00` with a Chinese browser locale in Shanghai, or `Sep 9, 2026, 12:00:00 AM PDT` with a US English browser locale in Los Angeles. Locale selection follows `navigator.languages`, falling back to `navigator.language` when the list is empty; Intl supplies the date order, month names, and 12/24-hour convention. The original `datetime` attribute is preserved. Missing, invalid, date-only, and timezone-free values retain their original text; tags inside inline and fenced code remain literal.

The `markdownTime` feature switch enables browser localization for staff organizations initially.

## Fallbacks

- **Browser language preferences** — `turbo/apps/platform/src/views/components/rich-markdown.tsx:MarkdownTimeRenderer` uses `navigator.language` when the external browser input `navigator.languages` is empty. This presentational default keeps formatting in the browser's preferred language, independently of the app UI language. It is used by the Markdown time presentation surface under `markdownTime`. There is no cross-version rollout window; retain this behavior while an empty browser language list is supported. Removal requires a browser-input contract that guarantees a nonempty list, so no temporary-rollout cleanup issue applies.
- **Original time label** — In the same renderer, a disabled or unavailable `markdownTime` switch, or a missing, invalid, date-only, timezone-free, or duration `datetime`, preserves the supplied children. This protects existing Markdown content without inventing an instant or timezone. The switch is non-GA and initially staff-enabled; no cross-version compatibility window is introduced. Remove the disabled-switch branch during terminal switch cleanup. Preservation of non-convertible input is a permanent presentational contract and has no rollout cleanup follow-up; revisit it only if the supported Markdown input contract changes.

## Verification

- Automation and workflow-copy command integration tests: 91 passed, covering environment/schedule timezone differences, DST transitions, fractional-hour offsets, UTC, and response guidance.
- Markdown time and existing Markdown content page integration tests: 21 passed, covering browser timezone versus saved preferences, browser locale versus UI language (Chinese and British English), an empty language-list fallback, DST, day rollover, fractional-hour offsets, preserved attributes, code, invalid values, and disabled or cached feature switches.
- Core feature-switch tests: 30 passed.
- CLI lint, type checks, scoped Knip, formatting, and production build passed.
- Platform and core lint/type checks, platform-scoped Knip, and formatting passed. All applicable PR CI checks passed for head `fe944bcf9e3e9c112282bfa5cb884dc185481b78` (79 successful checks, 22 skipped).
- Read-only smoke checks of the built CLI's automation `show` and `list` commands confirmed exact `+08:00` timestamps and matching `<time>` guidance.
- Deployed browser verification passed on the preview build `2829631b430499a7b5816aa75f0f9e3e63456be8` containing this PR head. With the UI kept in English and browser timezone set to Shanghai, Chinese and British English browser preferences render the same assistant message in their respective formats; attributes, invalid values, and code remain intact. No page errors or horizontal overflow.
- Preview: https://pr-32899-app-okou-app-preview.vm0.workers.dev
- Screenshots: [Chinese browser locale](https://a.okou.io/31qmsblefx.png), [British English browser locale](https://a.okou.io/801ykdd7ot.png).
