### PR TITLE
fix: recommend deepseek v4 pro for new users

### DIFF
--- a/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
@@ -157,7 +157,7 @@ run_real_claude_steer() {
     assert_success
     run jq -e '
         any(.policies[]?;
-            .model == "deepseek-v4-flash" and
+            .model == "deepseek-v4-pro" and
             .defaultProviderType == "built-in" and
             .credentialScope == "org" and
             .modelProviderId == null
@@ -168,7 +168,7 @@ run_real_claude_steer() {
     run run_real_chat \
         "123+456. Reply only RESULT=<answer>." \
         "RESULT=579" \
-        "deepseek-v4-flash"
+        "deepseek-v4-pro"
 
     assert_success
     assert_output --partial '"status":"completed"'
@@ -185,7 +185,7 @@ run_real_claude_steer() {
     run jq -e '
         .cliAgentType == "pi" and
         .environment.OPENAI_BASE_URL == "https://api.deepseek.com/" and
-        .environment.OPENAI_MODEL == "deepseek-v4-flash" and
+        .environment.OPENAI_MODEL == "deepseek-v4-pro" and
         any(
             .firewalls[];
             .kind == "builtin" and

--- a/e2e/tests/03-runner/run-t11-real-codex-billing.bats
+++ b/e2e/tests/03-runner/run-t11-real-codex-billing.bats
@@ -32,14 +32,14 @@ teardown() {
     assert_success
 
     # The same dedicated Codex organization uses gpt-5.6-luna for BYOK steer
-    # coverage. Its independent gpt-5.6-sol policy remains built-in, so the
+    # coverage. Its independent gpt-6-astra policy remains built-in, so the
     # two real-agent shards can run concurrently without changing org state.
     run runner_api_curl "/api/model-policies"
     echo "$output"
     assert_success
     run jq -e '
         any(.policies[]?;
-            .model == "gpt-5.6-sol" and
+            .model == "gpt-6-astra" and
             .defaultProviderType == "built-in" and
             .credentialScope == "org" and
             .modelProviderId == null
@@ -49,7 +49,7 @@ teardown() {
     assert_success
 
     local prompt="Briefly confirm that the real Codex runner is responding."
-    run runner_chat_send "$AGENT_ID" "$prompt" "" "gpt-5.6-sol"
+    run runner_chat_send "$AGENT_ID" "$prompt" "" "gpt-6-astra"
     echo "$output"
     assert_success
     RUN_ID=$(jq -er '.runId | select(type == "string" and length > 0)' <<<"$output")
@@ -104,11 +104,11 @@ teardown() {
     run runner_e2e_wait_for_usage_event \
         "$THREAD_ID" \
         "$RUN_ID" \
-        "gpt-5.6-sol"
+        "gpt-6-astra"
     echo "$output"
     assert_success
 
-    run runner_e2e_wait_for_usage_record "$THREAD_ID" "gpt-5.6-sol"
+    run runner_e2e_wait_for_usage_record "$THREAD_ID" "gpt-6-astra"
     echo "$output"
     assert_success
     local usage_record="$output"
@@ -120,7 +120,7 @@ teardown() {
             any(.breakdown[]?;
                 .kind == "model" and
                 any(.providers[]?;
-                    .provider == "gpt-5.6-sol" and .credits > 0
+                    .provider == "gpt-6-astra" and .credits > 0
                 )
             )
         )

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -7238,7 +7238,7 @@ describe("CHAT-02: model-first provider policies", () => {
       supportByok: false,
       restrictedVm0Models: false,
     });
-    await seedBuiltInModelKey("deepseek-v4-flash");
+    await seedBuiltInModelKey("deepseek-v4-pro");
     const byokDisabled = await chat.requestSendEvent(
       actor,
       {
@@ -7257,7 +7257,7 @@ describe("CHAT-02: model-first provider policies", () => {
     const byokDisabledPolicies = await misc.listModelPolicies(actor);
     expect(byokDisabledPolicies.policies).toContainEqual(
       expect.objectContaining({
-        model: "deepseek-v4-flash",
+        model: "deepseek-v4-pro",
         isDefault: true,
         defaultProviderType: "built-in",
         modelProviderId: null,
@@ -7306,7 +7306,7 @@ describe("CHAT-02: model-first provider policies", () => {
     const restrictedPolicies = await misc.listModelPolicies(actor);
     expect(restrictedPolicies.policies).toContainEqual(
       expect.objectContaining({
-        model: "deepseek-v4-flash",
+        model: "deepseek-v4-pro",
         isDefault: true,
         defaultProviderType: "built-in",
         modelProviderId: null,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -4483,7 +4483,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       expect.stringContaining("Use org default"),
     );
 
-    await integrations.updateUserModelPreference(actor, "gpt-5.6-sol");
+    await integrations.updateUserModelPreference(actor, "gpt-5.6-luna");
     const modelResponse = await integrations.postSlackCommand({
       teamId,
       userId: slackUserId,
@@ -4501,7 +4501,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     expect(modelModal.optionLabels).toContainEqual(
       expect.stringContaining("(workspace default)"),
     );
-    expect(modelModal.initialOptionValue).toBe("gpt-5.6-sol");
+    expect(modelModal.initialOptionValue).toBe("gpt-5.6-luna");
 
     const disconnected = await integrations.postSlackCommand({
       teamId,
@@ -4737,7 +4737,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       integrations.modelPickerSubmission({
         workspaceId: teamId,
         slackUserId,
-        selectedValue: "claude-fable-5-1",
+        selectedValue: "deepseek-v4-pro",
         channelId: "C_BDD_PICK",
       }),
     );
@@ -4746,20 +4746,20 @@ describe("INT-01: Slack app deep webhook flows", () => {
       expect.objectContaining({
         channel: "C_BDD_PICK",
         user: slackUserId,
-        text: "Switched to *Claude Fable 5.1* for new Slack threads.",
+        text: "Switched to *DeepSeek V4 Pro* for new Slack threads.",
       }),
     );
     await expect(
       integrations.readUserModelPreference(actor),
     ).resolves.toMatchObject({
-      selectedModel: "claude-fable-5-1",
+      selectedModel: "deepseek-v4-pro",
     });
 
     const replaceModel = await integrations.postSlackInteractive(
       integrations.modelPickerSubmission({
         workspaceId: teamId,
         slackUserId,
-        selectedValue: "gpt-5.6-sol",
+        selectedValue: "gpt-5.6-luna",
         channelId: "C_BDD_PICK",
       }),
     );
@@ -4767,7 +4767,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     await expect(
       integrations.readUserModelPreference(actor),
     ).resolves.toMatchObject({
-      selectedModel: "gpt-5.6-sol",
+      selectedModel: "gpt-5.6-luna",
     });
 
     const rejectedModel = await integrations.postSlackInteractive(
@@ -4785,7 +4785,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     await expect(
       integrations.readUserModelPreference(actor),
     ).resolves.toMatchObject({
-      selectedModel: "gpt-5.6-sol",
+      selectedModel: "gpt-5.6-luna",
     });
 
     context.mocks.slack.views.open.mockClear();

--- a/turbo/apps/api/src/signals/routes/__tests__/model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-policies.test.ts
@@ -186,6 +186,18 @@ describe("GET/PUT /api/model-policies", () => {
       [400],
     );
     expect(oldPreference.body.error.message).toBe(retired.body.error.message);
+    await accept(
+      client.update({
+        headers: authHeaders(),
+        body: {
+          policies: [
+            ...toUpdate(existing.body),
+            makeBuiltInPolicy("claude-fable-5-1"),
+          ],
+        },
+      }),
+      [200],
+    );
     const successor = await accept(
       preferences.update({
         headers: authHeaders(),
@@ -371,40 +383,35 @@ describe("GET/PUT /api/model-policies", () => {
     ).toBe(LIMITED_FREE1_DEFAULT_RUN_MODEL);
   });
 
-  it("keeps an existing allowed default for limited-free-1 workspaces", async () => {
-    const fixture = await seedFixture();
-    useSession(fixture);
-    const client = apiClient();
-    const listed = await accept(client.list({ headers: authHeaders() }), [200]);
-    const previousDefaultModel = "gpt-5.6-luna";
-    const updates = toUpdate(listed.body).map((policy) => {
-      return {
-        ...policy,
-        isDefault: policy.model === previousDefaultModel,
-      };
-    });
-    await accept(
-      client.update({
-        headers: authHeaders(),
-        body: { policies: updates },
-      }),
-      [200],
-    );
+  it.each(["deepseek-v4-flash", "gpt-5.6-luna"] as const)(
+    "keeps an existing %s default for limited-free-1 workspaces",
+    async (previousDefaultModel) => {
+      const fixture = seedFixture();
+      useSession(fixture);
+      const client = apiClient();
+      await accept(
+        client.update({
+          headers: authHeaders(),
+          body: {
+            policies: [makeBuiltInPolicy(previousDefaultModel, true)],
+          },
+        }),
+        [200],
+      );
 
-    await makeLimitedFreeWorkspace(fixture);
-    useSession(fixture);
-    const response = await accept(
-      client.list({ headers: authHeaders() }),
-      [200],
-    );
+      await makeLimitedFreeWorkspace(fixture);
+      useSession(fixture);
+      const response = await accept(
+        client.list({ headers: authHeaders() }),
+        [200],
+      );
 
-    expect(response.body.workspaceDefaultModel).toBe(previousDefaultModel);
-    expect(
-      response.body.policies.find((policy) => {
-        return policy.isDefault;
-      })?.model,
-    ).toBe(previousDefaultModel);
-  });
+      expect(response.body.workspaceDefaultModel).toBe(previousDefaultModel);
+      expect(response.body.policies).toMatchObject([
+        { model: previousDefaultModel, isDefault: true },
+      ]);
+    },
+  );
 
   it("allows members to read policy controls", async () => {
     const fixture = await seedFixture();
@@ -659,7 +666,7 @@ describe("GET/PUT /api/model-policies", () => {
     const updates = [
       ...toUpdate(listResponse.body),
       makeBuiltInPolicy("claude-opus-5"),
-      makeBuiltInPolicy("deepseek-v4-pro"),
+      makeBuiltInPolicy("deepseek-v4-flash"),
     ];
     const configuredModels = new Set(
       updates.map((policy) => {
@@ -695,8 +702,8 @@ describe("GET/PUT /api/model-policies", () => {
       headers: authHeaders(),
       body: {
         policies: [
-          makeBuiltInPolicy("deepseek-v4-flash", true),
-          makeBuiltInPolicy("deepseek-v4-pro"),
+          makeBuiltInPolicy("deepseek-v4-pro", true),
+          makeBuiltInPolicy("gpt-6-astra"),
         ],
       },
     });
@@ -804,7 +811,10 @@ describe("GET/PUT /api/model-policies", () => {
       client.list({ headers: authHeaders() }),
       [200],
     );
-    const updates = toUpdate(listResponse.body).map((policy) => {
+    const updates = [
+      ...toUpdate(listResponse.body),
+      makeBuiltInPolicy("gpt-5.6-sol"),
+    ].map((policy) => {
       if (policy.model !== "gpt-5.6-sol") {
         return policy;
       }
@@ -979,7 +989,10 @@ describe("GET/PUT /api/model-policies", () => {
         client.list({ headers: authHeaders() }),
         [200],
       );
-      const updates = toUpdate(listResponse.body).map((policy) => {
+      const updates = [
+        ...toUpdate(listResponse.body),
+        makeBuiltInPolicy("gpt-5.6-sol"),
+      ].map((policy) => {
         if (policy.model !== "gpt-5.6-sol") {
           return policy;
         }
@@ -1019,7 +1032,10 @@ describe("GET/PUT /api/model-policies", () => {
       client.list({ headers: authHeaders() }),
       [200],
     );
-    const updates = toUpdate(listResponse.body).map((policy) => {
+    const updates = [
+      ...toUpdate(listResponse.body),
+      makeBuiltInPolicy("gpt-5.6-sol"),
+    ].map((policy) => {
       if (policy.model !== "gpt-5.6-sol") {
         return policy;
       }
@@ -1064,16 +1080,10 @@ describe("GET/PUT /api/model-policies", () => {
         client.list({ headers: authHeaders() }),
         [200],
       );
-      const updates = toUpdate(listResponse.body).map((policy) => {
-        return policy.model === "gpt-5.6-sol"
-          ? {
-              ...policy,
-              defaultProviderType: "built-in" as const,
-              credentialScope: "org" as const,
-              modelProviderId: null,
-            }
-          : policy;
-      });
+      const updates = [
+        ...toUpdate(listResponse.body),
+        makeBuiltInPolicy("gpt-5.6-sol"),
+      ];
       await accept(
         client.update({
           headers: authHeaders(),
@@ -1504,7 +1514,7 @@ describe("GET/PUT /api/model-policies", () => {
       [200],
     );
     const updates = toUpdate(listResponse.body).map((policy) => {
-      if (policy.model !== "deepseek-v4-flash") {
+      if (policy.model !== "deepseek-v4-pro") {
         return policy;
       }
       return {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8486,7 +8486,7 @@ describe("RUN-02: model provider selection and built-in admission", () => {
     expect(queue.body.concurrency.active).toBe(0);
   });
 
-  it("defaults limited-free runs to Flash and rejects paid models", async () => {
+  it("defaults limited-free runs to DeepSeek V4 Pro and rejects paid models", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
     const chat = createChatFilesBddApi(context);
@@ -8542,7 +8542,7 @@ describe("RUN-02: model provider selection and built-in admission", () => {
       await api.requestCancelRun(actor, sent.body.runId, [200]);
     }
 
-    for (const model of ["gpt-5.6-sol", "deepseek-v4-pro"] as const) {
+    for (const model of ["gpt-5.6-sol", "gpt-6-astra"] as const) {
       const rejectedThreadId = randomUUID();
       const rejected = await chat.requestSendEvent(
         actor,

--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -539,9 +539,9 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
           upstream_model: primary.upstream_model,
         });
 
-        await seedBuiltInModelCandidateKeys(context, "deepseek-v4-pro");
+        await seedBuiltInModelCandidateKeys(context, "deepseek-v4-flash");
         await expect(
-          resolveBuiltInModelRouteFixture(context, "deepseek-v4-pro"),
+          resolveBuiltInModelRouteFixture(context, "deepseek-v4-flash"),
         ).resolves.toMatchObject({ provider_type: "deepseek" });
 
         await withMockNowForTest(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-core-behavior.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-core-behavior.test.tsx
@@ -108,7 +108,7 @@ test("A new message keeps its attachment, text, and selected model together", as
     readonly userMessage?: UserMessageDocument;
   }[] = [];
   context.mocks.data.userModelPreference({
-    selectedModel: "deepseek-v4-flash",
+    selectedModel: "deepseek-v4-pro",
     serviceTier: null,
     selectedImageModel: null,
     selectedVideoModel: null,
@@ -139,7 +139,7 @@ test("A new message keeps its attachment, text, and selected model together", as
   await waitFor(() => {
     expect(buttonsNamed("Attach").length).toBeGreaterThan(0);
   });
-  await screen.findByText("DeepSeek V4 Flash");
+  await screen.findByText("DeepSeek V4 Pro");
   const fileInput = document.querySelector('input[type="file"]');
   if (!(fileInput instanceof HTMLInputElement)) {
     throw new Error("Composer file input is not mounted");
@@ -172,7 +172,7 @@ test("A new message keeps its attachment, text, and selected model together", as
           contentType: "text/plain",
         },
         { type: "text", text: "Review the launch brief." },
-        { type: "model", selectedModel: "deepseek-v4-flash" },
+        { type: "model", selectedModel: "deepseek-v4-pro" },
       ],
     },
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-composer.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-composer.test.tsx
@@ -233,7 +233,7 @@ test("Send a large image with a fallback-enabled text model", async () => {
 
   await readyChat();
   await expect(
-    screen.findByRole("combobox", { name: "DeepSeek V4 Flash" }),
+    screen.findByRole("combobox", { name: "DeepSeek V4 Pro" }),
   ).resolves.toBeVisible();
   await uploadFile(
     user,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx
@@ -730,23 +730,24 @@ test("Limit free workspaces to eligible built-in models", async () => {
   click(buttonByText("Add model"));
   const dialog = screen.getByRole("dialog", { name: "Add model" });
   click(within(dialog).getByRole("combobox"));
-  const deepSeekFlashOption = await screen.findByRole("option", {
-    name: "DeepSeek V4 Flash",
+  const deepSeekProOption = await screen.findByRole("option", {
+    name: "DeepSeek V4 Pro",
   });
   expect(
-    screen.queryByRole("option", { name: "DeepSeek V4 Pro" }),
+    screen.getByRole("option", { name: "DeepSeek V4 Flash" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByRole("option", { name: "GPT 6 Astra" }),
   ).not.toBeInTheDocument();
-  click(deepSeekFlashOption);
+  click(deepSeekProOption);
 
   expect(within(dialog).queryByText("Upgrade to Pro")).toBeNull();
   click(buttonByText("Add model", dialog));
 
   const deepseekRow = await screen.findByTestId(
-    "org-model-policy-row-deepseek-v4-flash",
+    "org-model-policy-row-deepseek-v4-pro",
   );
-  expect(
-    within(deepseekRow).getByText("DeepSeek V4 Flash"),
-  ).toBeInTheDocument();
+  expect(within(deepseekRow).getByText("DeepSeek V4 Pro")).toBeInTheDocument();
 });
 
 test("Connect a workspace API key to a model route", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/preferences-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/preferences-page.test.tsx
@@ -264,7 +264,7 @@ test("Chat settings fall back to Preference while the capability is disabled", a
 test("Chat settings keep the agreed row order and save chat defaults", async () => {
   const updates = mockPreferences({ cloudBrowserEnabledByDefault: false });
   context.mocks.data.userModelPreference({
-    selectedModel: "gpt-5.6-sol",
+    selectedModel: "gpt-6-astra",
     serviceTier: null,
     selectedVideoModel: null,
     selectedImageModel: null,
@@ -313,18 +313,18 @@ test("Chat settings keep the agreed row order and save chat defaults", async () 
       Node.DOCUMENT_POSITION_FOLLOWING,
   ).toBeTruthy();
 
-  click(await within(dialog).findByRole("combobox", { name: "GPT 5.6 Sol" }));
-  click(await screen.findByRole("option", { name: "GPT 5.6 Sol Fast" }));
+  click(await within(dialog).findByRole("combobox", { name: "GPT 6 Astra" }));
+  click(await screen.findByRole("option", { name: "GPT 6 Astra Fast" }));
   await waitFor(() => {
     expect(modelUpdates).toContainEqual({
-      selectedModel: "gpt-5.6-sol",
+      selectedModel: "gpt-6-astra",
       serviceTier: "priority",
     });
     expect(
-      within(dialog).getByRole("combobox", { name: "GPT 5.6 Sol Fast" }),
+      within(dialog).getByRole("combobox", { name: "GPT 6 Astra Fast" }),
     ).toBeVisible();
   });
-  click(within(dialog).getByRole("combobox", { name: "GPT 5.6 Sol Fast" }));
+  click(within(dialog).getByRole("combobox", { name: "GPT 6 Astra Fast" }));
   click(
     await screen.findByRole("option", { name: "Inherit from org default" }),
   );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/prompt-link.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/prompt-link.test.tsx
@@ -152,7 +152,7 @@ test("A prompt route starts a chat with its selected model", async () => {
   const capture = capturePromptLaunch();
   await setupPage({
     context,
-    path: "/prompt?prompt=Compare%20the%20launch%20options&model=deepseek-v4-flash&connector=github",
+    path: "/prompt?prompt=Compare%20the%20launch%20options&model=gpt-5.6-luna&connector=github",
   });
 
   const send = await waitForPromptLaunch("Compare the launch options", capture);
@@ -160,7 +160,7 @@ test("A prompt route starts a chat with its selected model", async () => {
 
   expect(capture.createdThreads[0]).toStrictEqual({
     connectorSelections: undefined,
-    model: "deepseek-v4-flash",
+    model: "gpt-5.6-luna",
   });
   expect(send.prompt).toBe("Compare the launch options");
   expect(parts).toContainEqual({
@@ -169,7 +169,7 @@ test("A prompt route starts a chat with its selected model", async () => {
   });
   expect(parts).toContainEqual({
     type: "model",
-    selectedModel: "deepseek-v4-flash",
+    selectedModel: "gpt-5.6-luna",
   });
   expect(JSON.stringify(parts)).not.toContain("github");
   expect(search()).toBe("");
@@ -220,10 +220,10 @@ test("A prompt link starts a presentation chat with its selected template", asyn
       },
     },
   });
-  expect(capture.createdThreads[0]?.model).toBe("deepseek-v4-flash");
+  expect(capture.createdThreads[0]?.model).toBe("deepseek-v4-pro");
   expect(userMessageParts(send)).toContainEqual({
     type: "model",
-    selectedModel: "deepseek-v4-flash",
+    selectedModel: "deepseek-v4-pro",
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -190,7 +190,10 @@ describe("model-first canonical catalog", () => {
     expect(isLimitedFree1RestrictedRunModel("deepseek/deepseek-v4-flash")).toBe(
       false,
     );
-    expect(isLimitedFree1RestrictedRunModel("deepseek-v4-pro")).toBe(true);
+    expect(isLimitedFree1RestrictedRunModel("deepseek-v4-pro")).toBe(false);
+    expect(isLimitedFree1RestrictedRunModel("deepseek/deepseek-v4-pro")).toBe(
+      false,
+    );
     expect(isLimitedFree1RestrictedRunModel("gpt-5.5")).toBe(true);
     expect(isLimitedFree1RestrictedRunModel("openai/gpt-5.5")).toBe(true);
     expect(isLimitedFree1RestrictedRunModel("claude-fable-5-1")).toBe(true);
@@ -635,15 +638,12 @@ describe("model-first canonical catalog", () => {
 
   it("builds the default org policy seed from the workspace defaults", () => {
     expect(DEFAULT_ORG_MODEL_POLICY_MODELS).toEqual([
-      "claude-fable-5-1",
       "gpt-6-astra",
-      "gpt-5.6-sol",
       "gpt-5.6-luna",
-      "deepseek-v4-flash",
+      "deepseek-v4-pro",
     ]);
-    expect(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL).toBe("deepseek-v4-flash");
-    expect(LIMITED_FREE1_DEFAULT_RUN_MODEL).toBe("deepseek-v4-flash");
-    expect(DEFAULT_ORG_MODEL_POLICY_MODELS).not.toContain("deepseek-v4-pro");
+    expect(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL).toBe("deepseek-v4-pro");
+    expect(LIMITED_FREE1_DEFAULT_RUN_MODEL).toBe("deepseek-v4-pro");
     expect(getDefaultModel("built-in")).toBe(
       DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
     );

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -130,18 +130,16 @@ const MODEL_PROVIDER_CODEX_RUNTIME_CONFIGS: Partial<
 };
 
 export const DEFAULT_ORG_MODEL_POLICY_MODELS = [
-  "claude-fable-5-1",
   "gpt-6-astra",
-  "gpt-5.6-sol",
   "gpt-5.6-luna",
-  "deepseek-v4-flash",
+  "deepseek-v4-pro",
 ] as const satisfies readonly SupportedRunModel[];
 
 export const DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL =
-  "deepseek-v4-flash" as const satisfies SupportedRunModel;
+  "deepseek-v4-pro" as const satisfies SupportedRunModel;
 
 export const LIMITED_FREE1_DEFAULT_RUN_MODEL =
-  "deepseek-v4-flash" as const satisfies SupportedRunModel;
+  "deepseek-v4-pro" as const satisfies SupportedRunModel;
 
 export const supportedRunModelSchema = z.enum(SUPPORTED_RUN_MODELS);
 
@@ -467,6 +465,7 @@ const BUILT_IN_MODEL_ALIAS_LOOKUP: Readonly<Record<string, string>> =
 const LIMITED_FREE1_ALLOWED_RUN_MODELS: ReadonlySet<string> = new Set([
   "gpt-5.6-luna",
   "deepseek-v4-flash",
+  "deepseek-v4-pro",
 ]);
 
 export function normalizeBuiltInModelId(model: string): string {


### PR DESCRIPTION
## Summary

New workspaces currently start with five curated models and recommend DeepSeek V4 Flash. Seed only DeepSeek V4 Pro, GPT 5.6 Luna, and GPT 6 Astra, with DeepSeek V4 Pro as the default for both regular and restricted free workspaces.

Allow restricted free workspaces to use DeepSeek V4 Pro so their new default can run. Preserve existing workspace policies and valid defaults, including Flash eligibility; GPT 6 Astra retains its paid-plan restriction. No data migration is required.

Update settings, Slack, and deployed Runner scenarios to use the new seed while preserving Fast-tier selection/reset, model preference persistence and rejection, real Pi execution, and built-in Codex usage attribution. The billing scenario uses Astra independently of the existing Luna BYOK route.

Prompt-link coverage distinguishes an explicit Luna selection from the Pro workspace default. Provider cooldown coverage keeps Flash as the separate unaffected model when the claimed default is Pro. Existing sessions whose BYOK route becomes disallowed are verified to select the Pro built-in default.

## Verification

- 269 focused tests passed: model contracts (148), model policy endpoints (45), free-workspace run admission and runner claim (1), Platform page scenarios (45), Slack model-selection scenarios (2), runtime/cooldown scenarios (27), and persisted model plan transitions (1).
- Type checks for API contracts, API, and Platform passed; affected-file ESLint/Oxlint (including type-aware lint) and scoped Knip checks passed.
- Formatting, whitespace, and Runner workflow static checks passed. The deployed Pro execution and Astra billing scenarios passed in PR CI; all required checks also run on the final head.
