### PR TITLE
fix(ads): route browser conversions by verified account ownership

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -30,6 +30,8 @@ surface; the index does not replace their detailed rules.
 
 ## Specialized Guidance
 
+- [Google Ads browser routing](./google-ads-browser-routing.md): verified account
+  ownership, conversion actions, rollout compatibility, and historical recovery.
 - [Connector inspection JSON](./connector-inspection-json.md): command output
   contracts, current versus run evidence, account identity, and next actions.
 - [Platform lint boundaries](./platform-lint.md): current transport and lifecycle

--- a/docs/google-ads-browser-routing.md
+++ b/docs/google-ads-browser-routing.md
@@ -1,0 +1,46 @@
+# Google Ads browser conversion routing
+
+Browser conversions use the captured campaign's verified Google Ads customer.
+`@okouai/core/google-ads-account` mirrors the campaign registry in
+`vm0-marketing/vite-ssr/app/lib/googleAdsAccounts.ts`, verified against Google Ads
+on 2026-09-09. Register a newly verified campaign in both repositories before
+expecting its conversions. Campaign names, UTM names and product domains do not
+establish ownership; missing, unknown or conflicting IDs remain unresolved.
+
+Signed-in onboarding and checkout events resolve ownership through
+`POST /api/attribution/google-ads-account`. A saved Clerk first touch is
+authoritative, including an unresolved or malformed saved touch. The request's
+captured attribution is used only when no first touch has been saved. Signup
+uses the account returned by the existing signup attribution endpoint.
+
+| Event                                    | Customer 1001302527                   | Customer 7935750692                                  |
+| ---------------------------------------- | ------------------------------------- | ---------------------------------------------------- |
+| Signup, onboarding start, checkout start | Its own website action                | Its own website action                               |
+| Paid invoice, product milestone          | Existing offline UPLOAD_CLICKS action | Its own website action and existing offline fallback |
+
+Paid responses resolve the invoice's attribution snapshot as a whole. Only an
+invoice without advertising attribution can use the organization's saved
+acquisition campaign. An invoice click without a campaign cannot borrow the
+organization's campaign. The API omits the optional browser paid payload unless
+the resolved customer is 7935750692; milestone responses likewise return no
+browser milestones for other or unresolved customers. This also prevents
+already-open older clients from firing those new-account actions.
+
+New clients require the account decision before firing a website conversion.
+Unresolved attempts do not advance delivery markers. The existing milestone
+baseline policy remains: events already earned on a browser's first resolved
+sync are historical, and historical recovery uses the offline path. Existing
+transaction IDs and per-action browser deduplication keys are preserved.
+
+The new response fields are optional so older API responses remain readable.
+A new client receiving an old response or a 404 from the new resolver withholds
+the conversion. Old clients still accept the existing request and response
+shapes. Already-open older clients retain their old signup/onboarding/checkout
+JavaScript until refreshed; no force-upgrade floor is changed in this patch.
+
+Historical recovery is a separate controlled operation. Reconcile original
+clicks, event times and prior delivery evidence; preserve the original transaction
+ID and send only to its confirmed account/action. API acceptance is not proof
+that Google ultimately attributed the conversion. Persist the request receipt
+and check the Data Manager processing status. Neither this code change nor a
+browser refresh replays historical conversions automatically.

--- a/turbo/apps/api/src/signals/routes/__tests__/acquisition-attribution.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/acquisition-attribution.test.ts
@@ -96,12 +96,23 @@ async function readGoogleAdsMilestones(
   actor: ApiTestUser,
 ): Promise<readonly GoogleAdsConversionMilestone[]> {
   mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+  context.mocks.clerk.users.getUserList.mockResolvedValue({
+    data: [
+      {
+        id: actor.userId,
+        privateMetadata: {
+          signup_attribution: { vm0_campaign_id: "24220469665" },
+        },
+      },
+    ],
+  });
   const response = await accept(
     client().googleAdsMilestones({
       headers: { authorization: "Bearer clerk-session" },
     }),
     [200],
   );
+  expect(response.body.googleAdsAccountId).toBe("7935750692");
   return response.body.milestones;
 }
 
@@ -188,7 +199,10 @@ describe("POST /api/attribution/signup", () => {
       [200],
     );
 
-    expect(response.body).toStrictEqual({ recorded: true });
+    expect(response.body).toStrictEqual({
+      recorded: true,
+      googleAdsAccountId: null,
+    });
     expect(context.mocks.clerk.users.updateUserMetadata).toHaveBeenCalledWith(
       userId,
       {
@@ -234,7 +248,10 @@ describe("POST /api/attribution/signup", () => {
       [200],
     );
 
-    expect(response.body).toStrictEqual({ recorded: true });
+    expect(response.body).toStrictEqual({
+      recorded: true,
+      googleAdsAccountId: null,
+    });
     expect(context.mocks.clerk.users.getUserList).toHaveBeenCalledTimes(2);
     expect(context.mocks.signalTimers.delay).toHaveBeenCalledTimes(1);
     expect(context.mocks.clerk.users.updateUserMetadata).toHaveBeenCalledTimes(
@@ -270,7 +287,10 @@ describe("POST /api/attribution/signup", () => {
       [200],
     );
 
-    expect(response.body).toStrictEqual({ recorded: false });
+    expect(response.body).toStrictEqual({
+      recorded: false,
+      googleAdsAccountId: null,
+    });
     expect(context.mocks.clerk.users.updateUserMetadata).not.toHaveBeenCalled();
   });
 
@@ -309,7 +329,10 @@ describe("POST /api/attribution/signup", () => {
       }),
       [200],
     );
-    expect(first.body).toStrictEqual({ recorded: true });
+    expect(first.body).toStrictEqual({
+      recorded: true,
+      googleAdsAccountId: null,
+    });
 
     // There is no public org-attribution read API, so the focused fixture
     // verifies the persisted first-touch boundary exercised by this route.
@@ -333,7 +356,10 @@ describe("POST /api/attribution/signup", () => {
       }),
       [200],
     );
-    expect(replay.body).toStrictEqual({ recorded: false });
+    expect(replay.body).toStrictEqual({
+      recorded: false,
+      googleAdsAccountId: null,
+    });
     await expect(
       readOrgAcquisitionAttributionFixture(fixture.org_id),
     ).resolves.toMatchObject({
@@ -353,6 +379,9 @@ describe("GET /api/attribution/google-ads-milestones", () => {
   it("returns no milestones for a user without acquisition activity", async () => {
     const userId = `user_${randomUUID()}`;
     mocks.clerk.session(userId, null);
+    context.mocks.clerk.users.getUserList.mockResolvedValue({
+      data: [{ id: userId, privateMetadata: {} }],
+    });
 
     const response = await accept(
       client().googleAdsMilestones({
@@ -361,7 +390,10 @@ describe("GET /api/attribution/google-ads-milestones", () => {
       [200],
     );
 
-    expect(response.body).toStrictEqual({ milestones: [] });
+    expect(response.body).toStrictEqual({
+      milestones: [],
+      googleAdsAccountId: null,
+    });
   });
 
   it("returns stable run and connector milestones through the public route", async () => {
@@ -536,5 +568,85 @@ describe("GET /api/attribution/google-ads-milestones", () => {
     await expect(
       readGoogleAdsMilestones(actorForFixture(fixture)),
     ).resolves.toStrictEqual([]);
+  });
+});
+
+describe("POST /api/attribution/google-ads-account", () => {
+  it("requires authentication before resolving attribution", async () => {
+    const response = await client().resolveGoogleAdsAccount({
+      body: { attribution: { vm0_campaign_id: "24220469665" } },
+    });
+    expect(response.status).toBe(401);
+  });
+  it.each([
+    {
+      saved: { vm0_campaign_id: "24154967178" },
+      supplied: "24220469665",
+      expected: "1001302527",
+    },
+    {
+      saved: { vm0_campaign_id: "24220469665" },
+      supplied: "24154967178",
+      expected: "7935750692",
+    },
+    {
+      saved: { gclid: "original-click" },
+      supplied: "24220469665",
+      expected: null,
+    },
+    { saved: null, supplied: "24220469665", expected: null },
+    {
+      saved: { vm0_campaign_id: "24220469665,24154967178" },
+      supplied: "24220469665",
+      expected: null,
+    },
+    {
+      saved: { vm0_campaign_id: "99999999999" },
+      supplied: "24220469665",
+      expected: null,
+    },
+  ])(
+    "preserves the saved first touch: $saved",
+    async ({ saved, supplied, expected }) => {
+      const userId = `user_${randomUUID()}`;
+      mocks.clerk.session(userId, null);
+      context.mocks.clerk.users.getUserList.mockResolvedValue({
+        data: [{ id: userId, privateMetadata: { signup_attribution: saved } }],
+      });
+      const response = await accept(
+        client().resolveGoogleAdsAccount({
+          headers: { authorization: "Bearer clerk-session" },
+          body: { attribution: { vm0_campaign_id: supplied } },
+        }),
+        [200],
+      );
+      expect(response.body).toStrictEqual({ googleAdsAccountId: expected });
+      const milestones = await accept(
+        client().googleAdsMilestones({
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      );
+      if (expected !== "7935750692")
+        expect(milestones.body).toStrictEqual({
+          googleAdsAccountId: expected,
+          milestones: [],
+        });
+    },
+  );
+  it("resolves the captured campaign only before a first touch has been saved", async () => {
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+    context.mocks.clerk.users.getUserList.mockResolvedValue({
+      data: [{ id: userId, privateMetadata: {} }],
+    });
+    const response = await accept(
+      client().resolveGoogleAdsAccount({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { attribution: { vm0_campaign_id: "24220469665" } },
+      }),
+      [200],
+    );
+    expect(response.body).toStrictEqual({ googleAdsAccountId: "7935750692" });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/acquisition-attribution.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/acquisition-attribution.test.ts
@@ -627,11 +627,12 @@ describe("POST /api/attribution/google-ads-account", () => {
         }),
         [200],
       );
-      if (expected !== "7935750692")
+      if (expected !== "7935750692") {
         expect(milestones.body).toStrictEqual({
           googleAdsAccountId: expected,
           milestones: [],
         });
+      }
     },
   );
   it("resolves the captured campaign only before a first touch has been saved", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -15352,13 +15352,14 @@ describe("POST /api/billing/checkout/complete", () => {
   });
 
   it.each([
-    { campaignId: "24220469665", accountId: "7935750692" },
-    { campaignId: "24154967178", accountId: null },
-    { campaignId: undefined, accountId: null },
-    { campaignId: "99999999999", accountId: null },
+    { campaignId: "24220469665", accountId: "7935750692", amountPaid: 20_000 },
+    { campaignId: "24154967178", accountId: null, amountPaid: 20_000 },
+    { campaignId: undefined, accountId: null, amountPaid: 20_000 },
+    { campaignId: "99999999999", accountId: null, amountPaid: 20_000 },
+    { campaignId: "24220469665", accountId: null, amountPaid: undefined },
   ])(
-    "returns a website paid conversion only for the owning account: $campaignId",
-    async ({ campaignId, accountId }) => {
+    "returns a website paid conversion only for the owning account: $campaignId, amount $amountPaid",
+    async ({ campaignId, accountId, amountPaid }) => {
       const customerId = `cus_${randomUUID().slice(0, 8)}`;
       const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
       const fixture = await trackedSeed({
@@ -15388,7 +15389,7 @@ describe("POST /api/billing/checkout/complete", () => {
           },
           status: "paid",
           currency: "usd",
-          amount_paid: 20_000,
+          amount_paid: amountPaid,
         },
         items: {
           data: [

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -2756,10 +2756,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
     expect(confirmation.body).toStrictEqual({
       status: "completed",
       hostedInvoiceUrl: null,
-      googleAdsConversion: {
-        transactionId: invoiceId,
-        valueUsd: 20,
-      },
     });
     if (!usagePackSubscriptionId) {
       throw new Error("Expected the confirmed usage pack subscription ID");
@@ -15158,10 +15154,6 @@ describe("POST /api/billing/checkout/complete", () => {
       const responses = await Promise.all([complete(), complete()]);
       const completedBody = {
         completed: true,
-        googleAdsConversion: {
-          transactionId: paidInvoice.id,
-          valueUsd: 20,
-        },
       };
       for (const response of responses) {
         expect(response.body).toStrictEqual(completedBody);
@@ -15359,64 +15351,81 @@ describe("POST /api/billing/checkout/complete", () => {
     expect(status.currentPeriodEnd).toBeNull();
   });
 
-  it("returns the paid invoice conversion when the subscription is already stored", async () => {
-    const customerId = `cus_${randomUUID().slice(0, 8)}`;
-    const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
-    const fixture = await trackedSeed({
-      stripeCustomerId: customerId,
-      stripeSubscriptionId: subscriptionId,
-      subscriptionStatus: "active",
-      tier: "team",
-    });
-    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+  it.each([
+    { campaignId: "24220469665", accountId: "7935750692" },
+    { campaignId: "24154967178", accountId: null },
+    { campaignId: undefined, accountId: null },
+    { campaignId: "99999999999", accountId: null },
+  ])(
+    "returns a website paid conversion only for the owning account: $campaignId",
+    async ({ campaignId, accountId }) => {
+      const customerId = `cus_${randomUUID().slice(0, 8)}`;
+      const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
+      const fixture = await trackedSeed({
+        stripeCustomerId: customerId,
+        stripeSubscriptionId: subscriptionId,
+        subscriptionStatus: "active",
+        tier: "team",
+      });
+      mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
-      id: "cs_test_completed",
-      mode: "subscription",
-      status: "complete",
-      customer: customerId,
-      subscription: subscriptionId,
-    });
-    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
-      id: subscriptionId,
-      status: "active",
-      cancel_at_period_end: false,
-      latest_invoice: {
-        id: "in_checkout_paid",
-        status: "paid",
-        currency: "usd",
-        amount_paid: 20_000,
-      },
-      items: {
-        data: [
-          {
-            price: { id: TEST_PRICE_TEAM },
-            current_period_end: 1_800_000_000,
+      context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+        id: "cs_test_completed",
+        mode: "subscription",
+        status: "complete",
+        customer: customerId,
+        subscription: subscriptionId,
+      });
+      context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+        id: subscriptionId,
+        status: "active",
+        cancel_at_period_end: false,
+        latest_invoice: {
+          id: "in_checkout_paid",
+          metadata: {
+            gclid: "original-paid-click",
+            ...(campaignId ? { vm0_campaign_id: campaignId } : {}),
           },
-        ],
-      },
-    });
+          status: "paid",
+          currency: "usd",
+          amount_paid: 20_000,
+        },
+        items: {
+          data: [
+            {
+              price: { id: TEST_PRICE_TEAM },
+              current_period_end: 1_800_000_000,
+            },
+          ],
+        },
+      });
 
-    const client = setupApp({ context, routes: billingCheckoutRoutes })(
-      billingCheckoutContract,
-    );
+      const client = setupApp({ context, routes: billingCheckoutRoutes })(
+        billingCheckoutContract,
+      );
 
-    const response = await accept(
-      client.complete({
-        body: { sessionId: "cs_test_completed" },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
+      const response = await accept(
+        client.complete({
+          body: { sessionId: "cs_test_completed" },
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      );
 
-    expect(response.body).toStrictEqual({
-      completed: true,
-      googleAdsConversion: {
-        transactionId: "in_checkout_paid",
-        valueUsd: 200,
-      },
-    });
-  });
+      expect(response.body).toStrictEqual({
+        completed: true,
+        ...(accountId
+          ? {
+              googleAdsConversion: {
+                transactionId: "in_checkout_paid",
+                valueUsd: 200,
+                googleAdsAccountId: accountId,
+              },
+            }
+          : {}),
+      });
+    },
+  );
 
   it("returns 400 when completed checkout would downgrade the current tier", async () => {
     const customerId = `cus_${randomUUID().slice(0, 8)}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-usage-media.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-usage-media.bdd.test.ts
@@ -513,7 +513,10 @@ describe("BILL-02: usage and attribution reads", () => {
 
     context.mocks.clerk.users.updateUserMetadata.mockResolvedValue({});
     const attribution = await api.recordSignupAttribution(admin);
-    expect(attribution.body).toStrictEqual({ recorded: true });
+    expect(attribution.body).toStrictEqual({
+      recorded: true,
+      googleAdsAccountId: null,
+    });
     expect(context.mocks.clerk.users.updateUserMetadata).toHaveBeenCalledWith(
       admin.userId,
       expect.objectContaining({

--- a/turbo/apps/api/src/signals/routes/acquisition-attribution.ts
+++ b/turbo/apps/api/src/signals/routes/acquisition-attribution.ts
@@ -1,5 +1,9 @@
 import { command } from "ccstate";
 import {
+  googleAdsAccountForAttribution,
+  GOOGLE_ADS_ADSMARCH_ACCOUNT_ID,
+} from "@okouai/core/google-ads-account";
+import {
   acquisitionAttributionContract,
   type AdAttributionMetadata,
 } from "@okouai/api-contracts/contracts/acquisition-attribution";
@@ -10,6 +14,7 @@ import { bodyResultOf } from "../context/request";
 import { clerk$ } from "../external/clerk";
 import { nowDate } from "../../lib/time";
 import {
+  googleAdsAccountForUser$,
   parseStoredSignupAttribution,
   persistOrgAcquisitionAttribution$,
 } from "../services/acquisition-attribution.service";
@@ -26,16 +31,45 @@ const recordSignupBody$ = bodyResultOf(
   acquisitionAttributionContract.recordSignup,
 );
 
+const resolveGoogleAdsAccountInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const body = await get(
+      bodyResultOf(acquisitionAttributionContract.resolveGoogleAdsAccount),
+    );
+    signal.throwIfAborted();
+    if (!body.ok) return body.response;
+    const googleAdsAccountId = await set(
+      googleAdsAccountForUser$,
+      get(authContext$).userId,
+      body.data.attribution,
+      signal,
+    );
+    return { status: 200 as const, body: { googleAdsAccountId } };
+  },
+);
+
 const googleAdsMilestonesInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(authContext$);
+    const googleAdsAccountId = await set(
+      googleAdsAccountForUser$,
+      auth.userId,
+      undefined,
+      signal,
+    );
+    if (googleAdsAccountId !== GOOGLE_ADS_ADSMARCH_ACCOUNT_ID) {
+      return {
+        status: 200 as const,
+        body: { milestones: [], googleAdsAccountId },
+      };
+    }
     const milestones = await set(
       googleAdsConversionMilestonesForUser$,
       auth.userId,
       signal,
     );
     signal.throwIfAborted();
-    return { status: 200 as const, body: { milestones } };
+    return { status: 200 as const, body: { milestones, googleAdsAccountId } };
   },
 );
 
@@ -84,7 +118,14 @@ const recordSignupInner$ = command(
           signal,
         );
       }
-      return { status: 200 as const, body: { recorded: false } };
+      return {
+        status: 200 as const,
+        body: {
+          recorded: false,
+          googleAdsAccountId:
+            googleAdsAccountForAttribution(existingAttribution),
+        },
+      };
     }
 
     const attribution: AdAttributionMetadata = bodyResult.data.attribution;
@@ -107,11 +148,21 @@ const recordSignupInner$ = command(
       );
     }
 
-    return { status: 200 as const, body: { recorded: true } };
+    return {
+      status: 200 as const,
+      body: {
+        recorded: true,
+        googleAdsAccountId: googleAdsAccountForAttribution(attribution),
+      },
+    };
   },
 );
 
 export const acquisitionAttributionRoutes: readonly RouteEntry[] = [
+  {
+    route: acquisitionAttributionContract.resolveGoogleAdsAccount,
+    handler: authRoute({ accept: ["session"] }, resolveGoogleAdsAccountInner$),
+  },
   {
     route: acquisitionAttributionContract.googleAdsMilestones,
     handler: authRoute({ accept: ["session"] }, googleAdsMilestonesInner$),

--- a/turbo/apps/api/src/signals/routes/acquisition-attribution.ts
+++ b/turbo/apps/api/src/signals/routes/acquisition-attribution.ts
@@ -37,7 +37,9 @@ const resolveGoogleAdsAccountInner$ = command(
       bodyResultOf(acquisitionAttributionContract.resolveGoogleAdsAccount),
     );
     signal.throwIfAborted();
-    if (!body.ok) return body.response;
+    if (!body.ok) {
+      return body.response;
+    }
     const googleAdsAccountId = await set(
       googleAdsAccountForUser$,
       get(authContext$).userId,

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -1,3 +1,7 @@
+import {
+  googleAdsAccountForAttribution,
+  GOOGLE_ADS_ADSMARCH_ACCOUNT_ID,
+} from "@okouai/core/google-ads-account";
 import { command } from "ccstate";
 import {
   billingCheckoutContract,
@@ -454,25 +458,62 @@ function usagePackCheckoutTierConflicts(
   );
 }
 
-function googleAdsPaidConversion(invoice: StripeInvoice | null):
-  | {
-      readonly transactionId: string;
-      readonly valueUsd: number;
+const googleAdsPaidConversion$ = command(
+  async (
+    { get },
+    invoice: StripeInvoice | null,
+    orgId: string,
+    signal: AbortSignal,
+  ) => {
+    if (
+      invoice?.status !== "paid" ||
+      invoice.currency.toLowerCase() !== "usd" ||
+      invoice.amount_paid <= 0
+    )
+      return undefined;
+
+    // Invoice attribution is a frozen checkout snapshot. Never fill an unknown
+    // invoice click with a campaign from a different touch or organization.
+    const snapshots = [
+      invoice.metadata,
+      invoice.parent?.subscription_details?.metadata,
+    ];
+    const attribution = snapshots.find((metadata) => {
+      return (
+        metadata &&
+        ["gclid", "gbraid", "wbraid", "vm0_campaign_id"].some((key) => {
+          return metadata[key];
+        })
+      );
+    });
+    let googleAdsAccountId: string | null;
+    if (attribution) {
+      googleAdsAccountId = googleAdsAccountForAttribution(attribution);
+    } else {
+      const [org] = await get(db$)
+        .select({
+          campaignId: orgMetadata.acquisitionCampaignId,
+          adGroupId: orgMetadata.acquisitionAdGroupId,
+        })
+        .from(orgMetadata)
+        .where(eq(orgMetadata.orgId, orgId))
+        .limit(1);
+      signal.throwIfAborted();
+      googleAdsAccountId = googleAdsAccountForAttribution({
+        vm0_campaign_id: org?.campaignId ?? undefined,
+        vm0_ad_group_id: org?.adGroupId ?? undefined,
+      });
     }
-  | undefined {
-  const amountPaidCents = invoice?.amount_paid ?? 0;
-  if (
-    invoice?.status !== "paid" ||
-    invoice.currency.toLowerCase() !== "usd" ||
-    amountPaidCents <= 0
-  ) {
-    return undefined;
-  }
-  return {
-    transactionId: invoice.id,
-    valueUsd: amountPaidCents / 100,
-  };
-}
+    // Legacy paid conversions are UPLOAD_CLICKS and remain on the offline path.
+    // Omitting this optional payload also protects already-open old clients.
+    if (googleAdsAccountId !== GOOGLE_ADS_ADSMARCH_ACCOUNT_ID) return undefined;
+    return {
+      transactionId: invoice.id,
+      valueUsd: invoice.amount_paid / 100,
+      googleAdsAccountId,
+    };
+  },
+);
 
 const confirmPlanPurchaseForOrg$ = command(
   async ({ set }, orgId: string, previewToken: string, signal: AbortSignal) => {
@@ -494,7 +535,12 @@ const confirmPlanPurchaseForOrg$ = command(
         );
       }
     }
-    const conversion = googleAdsPaidConversion(result.paidInvoice);
+    const conversion = await set(
+      googleAdsPaidConversion$,
+      result.paidInvoice,
+      orgId,
+      signal,
+    );
     return {
       status: 200 as const,
       body:
@@ -698,7 +744,12 @@ const confirmUsagePackPurchaseForOrg$ = command(
         );
       }
     }
-    const conversion = googleAdsPaidConversion(result.paidInvoice);
+    const conversion = await set(
+      googleAdsPaidConversion$,
+      result.paidInvoice,
+      orgId,
+      signal,
+    );
     return {
       status: 200 as const,
       body:
@@ -1810,7 +1861,12 @@ const checkoutCompleteAuthed$ = command(
       }
     }
 
-    const conversion = googleAdsPaidConversion(result.paidInvoice);
+    const conversion = await set(
+      googleAdsPaidConversion$,
+      result.paidInvoice,
+      auth.orgId,
+      signal,
+    );
     return {
       status: 200 as const,
       body: {

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -465,12 +465,14 @@ const googleAdsPaidConversion$ = command(
     orgId: string,
     signal: AbortSignal,
   ) => {
+    const amountPaidCents = invoice?.amount_paid ?? 0;
     if (
       invoice?.status !== "paid" ||
       invoice.currency.toLowerCase() !== "usd" ||
-      invoice.amount_paid <= 0
-    )
+      amountPaidCents <= 0
+    ) {
       return undefined;
+    }
 
     // Invoice attribution is a frozen checkout snapshot. Never fill an unknown
     // invoice click with a campaign from a different touch or organization.
@@ -506,10 +508,12 @@ const googleAdsPaidConversion$ = command(
     }
     // Legacy paid conversions are UPLOAD_CLICKS and remain on the offline path.
     // Omitting this optional payload also protects already-open old clients.
-    if (googleAdsAccountId !== GOOGLE_ADS_ADSMARCH_ACCOUNT_ID) return undefined;
+    if (googleAdsAccountId !== GOOGLE_ADS_ADSMARCH_ACCOUNT_ID) {
+      return undefined;
+    }
     return {
       transactionId: invoice.id,
-      valueUsd: invoice.amount_paid / 100,
+      valueUsd: amountPaidCents / 100,
       googleAdsAccountId,
     };
   },

--- a/turbo/apps/api/src/signals/services/acquisition-attribution.service.ts
+++ b/turbo/apps/api/src/signals/services/acquisition-attribution.service.ts
@@ -7,6 +7,9 @@ import { orgMetadata } from "@okouai/db/schema/org-metadata";
 import { and, eq, isNull } from "drizzle-orm";
 import { command } from "ccstate";
 
+import { googleAdsAccountForAttribution } from "@okouai/core/google-ads-account";
+import { clerk$ } from "../external/clerk";
+
 import { nowDate } from "../../lib/time";
 import { writeDb$ } from "../external/db";
 
@@ -51,6 +54,36 @@ export function parseStoredSignupAttribution(
   const parsed = adAttributionMetadataSchema.safeParse(metadata);
   return parsed.success ? parsed.data : undefined;
 }
+
+export const googleAdsAccountForUser$ = command(
+  async (
+    { get },
+    userId: string,
+    provided: AdAttributionMetadata | undefined,
+    signal: AbortSignal,
+  ) => {
+    const users = await get(clerk$).users.getUserList(
+      { userId: [userId], limit: 1 },
+      undefined,
+      signal,
+    );
+    signal.throwIfAborted();
+    const user = users.data.find((candidate) => {
+      return candidate.id === userId;
+    });
+    if (!user) throw new Error(`No Clerk user found for user ${userId}`);
+    const metadata = user.privateMetadata;
+    // An existing unresolved or malformed first touch cannot borrow a later
+    // visit's campaign. Only users with no saved touch may use the captured one.
+    const attribution = Object.prototype.hasOwnProperty.call(
+      metadata,
+      "signup_attribution",
+    )
+      ? parseStoredSignupAttribution(metadata.signup_attribution)
+      : provided;
+    return googleAdsAccountForAttribution(attribution);
+  },
+);
 
 function orgAttributionValues(
   attribution: Readonly<Record<string, string | undefined>> | undefined,

--- a/turbo/apps/api/src/signals/services/acquisition-attribution.service.ts
+++ b/turbo/apps/api/src/signals/services/acquisition-attribution.service.ts
@@ -71,7 +71,9 @@ export const googleAdsAccountForUser$ = command(
     const user = users.data.find((candidate) => {
       return candidate.id === userId;
     });
-    if (!user) throw new Error(`No Clerk user found for user ${userId}`);
+    if (!user) {
+      throw new Error(`No Clerk user found for user ${userId}`);
+    }
     const metadata = user.privateMetadata;
     // An existing unresolved or malformed first touch cannot borrow a later
     // visit's campaign. Only users with no saved touch may use the captured one.

--- a/turbo/apps/platform/src/mocks/handlers/api-attribution.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-attribution.ts
@@ -2,6 +2,12 @@ import { acquisitionAttributionContract } from "@okouai/api-contracts/contracts/
 import { mockApi } from "../msw-contract.ts";
 
 export const apiAttributionHandlers = [
+  mockApi(
+    acquisitionAttributionContract.resolveGoogleAdsAccount,
+    ({ respond }) => {
+      return respond(200, { googleAdsAccountId: null });
+    },
+  ),
   mockApi(acquisitionAttributionContract.googleAdsMilestones, ({ respond }) => {
     return respond(200, { milestones: [] });
   }),

--- a/turbo/apps/platform/src/signals/bootstrap/__tests__/google-ads-conversion-milestones.test.tsx
+++ b/turbo/apps/platform/src/signals/bootstrap/__tests__/google-ads-conversion-milestones.test.tsx
@@ -78,7 +78,10 @@ test("Each product milestone uses its defined conversion action", async () => {
     acquisitionAttributionContract.googleAdsMilestones,
     ({ respond }) => {
       milestoneReads += 1;
-      return respond(200, { milestones: [...milestones] });
+      return respond(200, {
+        milestones: [...milestones],
+        googleAdsAccountId: "7935750692",
+      });
     },
   );
 
@@ -143,7 +146,10 @@ test("Only newly earned conversion milestones are reported", async () => {
     acquisitionAttributionContract.googleAdsMilestones,
     ({ respond }) => {
       milestoneReads += 1;
-      return respond(200, { milestones: [...milestones] });
+      return respond(200, {
+        milestones: [...milestones],
+        googleAdsAccountId: "7935750692",
+      });
     },
   );
 
@@ -172,4 +178,36 @@ test("Only newly earned conversion milestones are reported", async () => {
   await context.store.set(syncGoogleAdsConversionMilestones$, context.signal);
 
   expect(reportedMilestoneEvents(googleTag, ALL_MILESTONES)).toHaveLength(1);
+});
+
+// Milestone polling has no page-visible control; this bootstrap test drives the
+// existing background synchronization boundary with external API responses.
+test("Unknown ownership leaves earned milestones eligible for later delivery", async () => {
+  const googleTag = vi.fn<GoogleTag>();
+  vi.stubGlobal("gtag", googleTag);
+  let accountId: string | null = "7935750692";
+  let milestones: readonly GoogleAdsConversionMilestone[] = [];
+  context.mocks.api(
+    acquisitionAttributionContract.googleAdsMilestones,
+    ({ respond }) => {
+      return respond(200, {
+        milestones: [...milestones],
+        googleAdsAccountId: accountId,
+      });
+    },
+  );
+  await setupPage({ context, path: "/agents", host: "app.okou.ai" });
+  await expect(
+    screen.findByRole("heading", { name: "Agents" }),
+  ).resolves.toBeVisible();
+  accountId = null;
+  milestones = ALL_MILESTONES;
+  await context.store.set(syncGoogleAdsConversionMilestones$, context.signal);
+  expect(reportedMilestoneEvents(googleTag, ALL_MILESTONES)).toHaveLength(0);
+  accountId = "1001302527";
+  await context.store.set(syncGoogleAdsConversionMilestones$, context.signal);
+  expect(reportedMilestoneEvents(googleTag, ALL_MILESTONES)).toHaveLength(0);
+  accountId = "7935750692";
+  await context.store.set(syncGoogleAdsConversionMilestones$, context.signal);
+  expect(reportedMilestoneEvents(googleTag, ALL_MILESTONES)).toHaveLength(6);
 });

--- a/turbo/apps/platform/src/signals/bootstrap/google-ads-account.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/google-ads-account.ts
@@ -11,7 +11,9 @@ export const resolveGoogleAdsAccount$ = command(
     const user = await get(user$);
     signal.throwIfAborted();
     const attribution = set(readStoredAdAttributionMetadata$);
-    if (!user) return googleAdsAccountForAttribution(attribution);
+    if (!user) {
+      return googleAdsAccountForAttribution(attribution);
+    }
     const client = get(apiClient$)(acquisitionAttributionContract);
     const result = await accept(
       client.resolveGoogleAdsAccount({

--- a/turbo/apps/platform/src/signals/bootstrap/google-ads-account.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/google-ads-account.ts
@@ -1,0 +1,27 @@
+import { command } from "ccstate";
+import { acquisitionAttributionContract } from "@okouai/api-contracts/contracts/acquisition-attribution";
+import { googleAdsAccountForAttribution } from "@okouai/core/google-ads-account";
+import { accept } from "../../lib/accept.ts";
+import { apiClient$ } from "../api-client.ts";
+import { user$ } from "../auth.ts";
+import { readStoredAdAttributionMetadata$ } from "./ad-attribution.ts";
+
+export const resolveGoogleAdsAccount$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<string | null> => {
+    const user = await get(user$);
+    signal.throwIfAborted();
+    const attribution = set(readStoredAdAttributionMetadata$);
+    if (!user) return googleAdsAccountForAttribution(attribution);
+    const client = get(apiClient$)(acquisitionAttributionContract);
+    const result = await accept(
+      client.resolveGoogleAdsAccount({
+        body: { attribution },
+        fetchOptions: { signal },
+      }),
+      [200, 404],
+    );
+    signal.throwIfAborted();
+    // During mixed-version rollout an older API cannot prove ownership.
+    return result.status === 200 ? result.body.googleAdsAccountId : null;
+  },
+);

--- a/turbo/apps/platform/src/signals/bootstrap/google-ads-conversion-milestones.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/google-ads-conversion-milestones.ts
@@ -120,8 +120,9 @@ export const syncGoogleAdsConversionMilestones$ = command(
 
     // Old-account milestones use UPLOAD_CLICKS, not these website actions.
     // Unresolved ownership must not initialize or advance the delivery state.
-    if (response.body.googleAdsAccountId !== GOOGLE_ADS_ADSMARCH_ACCOUNT_ID)
+    if (response.body.googleAdsAccountId !== GOOGLE_ADS_ADSMARCH_ACCOUNT_ID) {
       return false;
+    }
 
     const stored = storedMilestonesByUser(get(milestoneStorage.get$));
     const previous = stored[user.id];
@@ -178,7 +179,9 @@ export const bootstrapGoogleAdsConversionMilestones$ = command(
     }
     const resolved = await set(syncGoogleAdsConversionMilestones$, signal);
     signal.throwIfAborted();
-    if (!resolved) return;
+    if (!resolved) {
+      return;
+    }
     set(bootstrappedUserIds$, (previous) => {
       return new Set([...previous, user.id]);
     });

--- a/turbo/apps/platform/src/signals/bootstrap/google-ads-conversion-milestones.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/google-ads-conversion-milestones.ts
@@ -1,3 +1,4 @@
+import { GOOGLE_ADS_ADSMARCH_ACCOUNT_ID } from "@okouai/core/google-ads-account";
 import { command, state } from "ccstate";
 import {
   acquisitionAttributionContract,
@@ -103,11 +104,11 @@ function writeUserMilestoneState(
 }
 
 export const syncGoogleAdsConversionMilestones$ = command(
-  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+  async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
     const user = await get(user$);
     signal.throwIfAborted();
     if (!user) {
-      return;
+      return false;
     }
 
     const client = get(apiClient$)(acquisitionAttributionContract);
@@ -116,6 +117,11 @@ export const syncGoogleAdsConversionMilestones$ = command(
       [200],
     );
     signal.throwIfAborted();
+
+    // Old-account milestones use UPLOAD_CLICKS, not these website actions.
+    // Unresolved ownership must not initialize or advance the delivery state.
+    if (response.body.googleAdsAccountId !== GOOGLE_ADS_ADSMARCH_ACCOUNT_ID)
+      return false;
 
     const stored = storedMilestonesByUser(get(milestoneStorage.get$));
     const previous = stored[user.id];
@@ -130,7 +136,7 @@ export const syncGoogleAdsConversionMilestones$ = command(
           }),
         ),
       );
-      return;
+      return true;
     }
 
     const deliveredTransactionIds = new Set(previous.transactionIds);
@@ -141,6 +147,7 @@ export const syncGoogleAdsConversionMilestones$ = command(
       }
       const config = MILESTONE_CONFIG[item.kind];
       const fired = fireGoogleAdsConversion({
+        accountId: response.body.googleAdsAccountId,
         sendTo: config.sendTo,
         dedupeValue: item.transactionId,
         value: config.value,
@@ -158,6 +165,7 @@ export const syncGoogleAdsConversionMilestones$ = command(
         writeUserMilestoneState(stored, user.id, deliveredTransactionIds),
       );
     }
+    return true;
   },
 );
 
@@ -168,8 +176,9 @@ export const bootstrapGoogleAdsConversionMilestones$ = command(
     if (!user || get(bootstrappedUserIds$).has(user.id)) {
       return;
     }
-    await set(syncGoogleAdsConversionMilestones$, signal);
+    const resolved = await set(syncGoogleAdsConversionMilestones$, signal);
     signal.throwIfAborted();
+    if (!resolved) return;
     set(bootstrappedUserIds$, (previous) => {
       return new Set([...previous, user.id]);
     });

--- a/turbo/apps/platform/src/signals/bootstrap/google-ads-conversion.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/google-ads-conversion.ts
@@ -70,7 +70,9 @@ export function fireGoogleAdsConversion(args: {
       : args.accountId === GOOGLE_ADS_ADSMARCH_ACCOUNT_ID
         ? "AW-18407336975"
         : null;
-  if (!tagId || !args.sendTo.startsWith(`${tagId}/`)) return false;
+  if (!tagId || !args.sendTo.startsWith(`${tagId}/`)) {
+    return false;
+  }
   if (args.storedDedupeValue === args.dedupeValue) {
     return false;
   }

--- a/turbo/apps/platform/src/signals/bootstrap/google-ads-conversion.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/google-ads-conversion.ts
@@ -1,3 +1,8 @@
+import {
+  GOOGLE_ADS_ADSMARCH_ACCOUNT_ID,
+  GOOGLE_ADS_LEGACY_ACCOUNT_ID,
+} from "@okouai/core/google-ads-account";
+
 // Google Ads website-tag conversions. The gtag base snippet lives in
 // `apps/platform/src/lib/google-ads.ts`; these are the event snippets for the
 // conversion actions that Google Ads uses as bidding signals. Legacy
@@ -52,12 +57,20 @@ type WindowWithGoogleTag = Window & {
  * dedupe value. Returns whether the event fired so the caller can persist it.
  */
 export function fireGoogleAdsConversion(args: {
+  readonly accountId: string | null;
   readonly sendTo: string;
   readonly dedupeValue: string;
   readonly value: number;
   readonly storedDedupeValue: string | null;
   readonly transactionId?: string;
 }): boolean {
+  const tagId =
+    args.accountId === GOOGLE_ADS_LEGACY_ACCOUNT_ID
+      ? "AW-18144854014"
+      : args.accountId === GOOGLE_ADS_ADSMARCH_ACCOUNT_ID
+        ? "AW-18407336975"
+        : null;
+  if (!tagId || !args.sendTo.startsWith(`${tagId}/`)) return false;
   if (args.storedDedupeValue === args.dedupeValue) {
     return false;
   }

--- a/turbo/apps/platform/src/signals/bootstrap/google-ads-paid-conversion.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/google-ads-paid-conversion.ts
@@ -48,6 +48,7 @@ export const fireGoogleAdsPaidConversion$ = command(
         ? GOOGLE_ADS_ADSMARCH_PAID_IN_ONBOARDING_SEND_TO
         : GOOGLE_ADS_ADSMARCH_PAID_AFTER_ONBOARDING_SEND_TO;
     const fired = fireGoogleAdsConversion({
+      accountId: conversion.googleAdsAccountId ?? null,
       sendTo,
       dedupeValue: conversion.transactionId,
       value: kind === "paid_in_onboarding" ? conversion.valueUsd : 40,

--- a/turbo/apps/platform/src/signals/bootstrap/paid-funnel-telemetry.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/paid-funnel-telemetry.ts
@@ -4,6 +4,10 @@
 // Ads bids on (`Onboarding Start`, `Checkout Start`) fire from the same call
 // sites as their PostHog counterparts.
 
+import {
+  GOOGLE_ADS_ADSMARCH_ACCOUNT_ID,
+  GOOGLE_ADS_LEGACY_ACCOUNT_ID,
+} from "@okouai/core/google-ads-account";
 import type { AdAttributionMetadata } from "@okouai/api-contracts/contracts/acquisition-attribution";
 import { command } from "ccstate";
 import { capturePaidOnboardingEvent } from "../../lib/posthog.ts";
@@ -16,6 +20,7 @@ import {
 } from "./google-ads-conversion.ts";
 import { readStoredAdAttributionMetadata$ } from "./ad-attribution.ts";
 import { sessionStorageSignals } from "../external/session-storage.ts";
+import { resolveGoogleAdsAccount$ } from "./google-ads-account.ts";
 import type { OnboardingRouteStep } from "../onboarding/onboarding-state.ts";
 
 const ONBOARDING_START_CONVERSION_KEY =
@@ -78,7 +83,11 @@ function attributionProperties(
 }
 
 export const capturePaidOnboardingStepViewed$ = command(
-  ({ get, set }, step: OnboardingRouteStep): void => {
+  async (
+    { get, set },
+    step: OnboardingRouteStep,
+    signal: AbortSignal,
+  ): Promise<void> => {
     const stepIndex = ONBOARDING_STEP_ORDER.indexOf(step);
     capturePaidOnboardingEvent("StepViewed", {
       ...attributionProperties(set(readStoredAdAttributionMetadata$)),
@@ -89,31 +98,30 @@ export const capturePaidOnboardingStepViewed$ = command(
 
     // `Onboarding Start` counts one entry into the onboarding flow, so it is
     // deduped per session rather than fired on every step view.
+    const accountId = await set(resolveGoogleAdsAccount$, signal);
+    const config =
+      accountId === GOOGLE_ADS_LEGACY_ACCOUNT_ID
+        ? {
+            sendTo: GOOGLE_ADS_ONBOARDING_START_SEND_TO,
+            storage: onboardingStartConversionStorage,
+            value: ONBOARDING_START_CONVERSION_VALUE_USD,
+          }
+        : accountId === GOOGLE_ADS_ADSMARCH_ACCOUNT_ID
+          ? {
+              sendTo: GOOGLE_ADS_ADSMARCH_ONBOARDING_START_SEND_TO,
+              storage: adsmarchOnboardingStartConversionStorage,
+              value: ONBOARDING_START_CONVERSION_VALUE_USD,
+            }
+          : null;
+    if (!config) return;
     const conversionFired = fireGoogleAdsConversion({
-      sendTo: GOOGLE_ADS_ONBOARDING_START_SEND_TO,
-      dedupeValue: GOOGLE_ADS_ONBOARDING_START_SEND_TO,
-      value: ONBOARDING_START_CONVERSION_VALUE_USD,
-      storedDedupeValue: get(onboardingStartConversionStorage.get$),
+      accountId,
+      sendTo: config.sendTo,
+      dedupeValue: config.sendTo,
+      value: config.value,
+      storedDedupeValue: get(config.storage.get$),
     });
-    if (conversionFired) {
-      set(
-        onboardingStartConversionStorage.set$,
-        GOOGLE_ADS_ONBOARDING_START_SEND_TO,
-      );
-    }
-
-    const adsmarchConversionFired = fireGoogleAdsConversion({
-      sendTo: GOOGLE_ADS_ADSMARCH_ONBOARDING_START_SEND_TO,
-      dedupeValue: GOOGLE_ADS_ADSMARCH_ONBOARDING_START_SEND_TO,
-      value: ONBOARDING_START_CONVERSION_VALUE_USD,
-      storedDedupeValue: get(adsmarchOnboardingStartConversionStorage.get$),
-    });
-    if (adsmarchConversionFired) {
-      set(
-        adsmarchOnboardingStartConversionStorage.set$,
-        GOOGLE_ADS_ADSMARCH_ONBOARDING_START_SEND_TO,
-      );
-    }
+    if (conversionFired) set(config.storage.set$, config.sendTo);
   },
 );
 
@@ -136,37 +144,40 @@ export const capturePaidOnboardingRoleConfirmed$ = command(
 );
 
 export const capturePaidOnboardingRedirectToStripe$ = command(
-  ({ get, set }, checkoutSource: string): void => {
+  async (
+    { get, set },
+    checkoutSource: string,
+    signal: AbortSignal,
+  ): Promise<void> => {
     capturePaidOnboardingEvent("RedirectToStripe", {
       ...attributionProperties(set(readStoredAdAttributionMetadata$)),
       checkout_source: checkoutSource,
     });
 
+    const accountId = await set(resolveGoogleAdsAccount$, signal);
+    const config =
+      accountId === GOOGLE_ADS_LEGACY_ACCOUNT_ID
+        ? {
+            sendTo: GOOGLE_ADS_CHECKOUT_START_SEND_TO,
+            storage: checkoutStartConversionStorage,
+            value: CHECKOUT_START_CONVERSION_VALUE_USD,
+          }
+        : accountId === GOOGLE_ADS_ADSMARCH_ACCOUNT_ID
+          ? {
+              sendTo: GOOGLE_ADS_ADSMARCH_CHECKOUT_START_SEND_TO,
+              storage: adsmarchCheckoutStartConversionStorage,
+              value: ADSMARCH_CHECKOUT_START_CONVERSION_VALUE_USD,
+            }
+          : null;
+    if (!config) return;
     const conversionFired = fireGoogleAdsConversion({
-      sendTo: GOOGLE_ADS_CHECKOUT_START_SEND_TO,
-      dedupeValue: GOOGLE_ADS_CHECKOUT_START_SEND_TO,
-      value: CHECKOUT_START_CONVERSION_VALUE_USD,
-      storedDedupeValue: get(checkoutStartConversionStorage.get$),
+      accountId,
+      sendTo: config.sendTo,
+      dedupeValue: config.sendTo,
+      value: config.value,
+      storedDedupeValue: get(config.storage.get$),
     });
-    if (conversionFired) {
-      set(
-        checkoutStartConversionStorage.set$,
-        GOOGLE_ADS_CHECKOUT_START_SEND_TO,
-      );
-    }
-
-    const adsmarchConversionFired = fireGoogleAdsConversion({
-      sendTo: GOOGLE_ADS_ADSMARCH_CHECKOUT_START_SEND_TO,
-      dedupeValue: GOOGLE_ADS_ADSMARCH_CHECKOUT_START_SEND_TO,
-      value: ADSMARCH_CHECKOUT_START_CONVERSION_VALUE_USD,
-      storedDedupeValue: get(adsmarchCheckoutStartConversionStorage.get$),
-    });
-    if (adsmarchConversionFired) {
-      set(
-        adsmarchCheckoutStartConversionStorage.set$,
-        GOOGLE_ADS_ADSMARCH_CHECKOUT_START_SEND_TO,
-      );
-    }
+    if (conversionFired) set(config.storage.set$, config.sendTo);
   },
 );
 

--- a/turbo/apps/platform/src/signals/bootstrap/paid-funnel-telemetry.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/paid-funnel-telemetry.ts
@@ -113,7 +113,9 @@ export const capturePaidOnboardingStepViewed$ = command(
               value: ONBOARDING_START_CONVERSION_VALUE_USD,
             }
           : null;
-    if (!config) return;
+    if (!config) {
+      return;
+    }
     const conversionFired = fireGoogleAdsConversion({
       accountId,
       sendTo: config.sendTo,
@@ -121,7 +123,9 @@ export const capturePaidOnboardingStepViewed$ = command(
       value: config.value,
       storedDedupeValue: get(config.storage.get$),
     });
-    if (conversionFired) set(config.storage.set$, config.sendTo);
+    if (conversionFired) {
+      set(config.storage.set$, config.sendTo);
+    }
   },
 );
 
@@ -169,7 +173,9 @@ export const capturePaidOnboardingRedirectToStripe$ = command(
               value: ADSMARCH_CHECKOUT_START_CONVERSION_VALUE_USD,
             }
           : null;
-    if (!config) return;
+    if (!config) {
+      return;
+    }
     const conversionFired = fireGoogleAdsConversion({
       accountId,
       sendTo: config.sendTo,
@@ -177,7 +183,9 @@ export const capturePaidOnboardingRedirectToStripe$ = command(
       value: config.value,
       storedDedupeValue: get(config.storage.get$),
     });
-    if (conversionFired) set(config.storage.set$, config.sendTo);
+    if (conversionFired) {
+      set(config.storage.set$, config.sendTo);
+    }
   },
 );
 

--- a/turbo/apps/platform/src/signals/bootstrap/signup-attribution.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/signup-attribution.ts
@@ -132,7 +132,9 @@ export const recordSignupAttribution$ = command(
                 transactionId: user.id,
               }
             : null;
-      if (!config) return;
+      if (!config) {
+        return;
+      }
       const conversionFired = fireGoogleAdsConversion({
         accountId: googleAdsAccountId,
         sendTo: config.sendTo,
@@ -141,7 +143,9 @@ export const recordSignupAttribution$ = command(
         storedDedupeValue: get(config.storage.get$),
         transactionId: config.transactionId,
       });
-      if (conversionFired) set(config.storage.set$, user.id);
+      if (conversionFired) {
+        set(config.storage.set$, user.id);
+      }
     }
   },
 );

--- a/turbo/apps/platform/src/signals/bootstrap/signup-attribution.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/signup-attribution.ts
@@ -1,3 +1,7 @@
+import {
+  GOOGLE_ADS_ADSMARCH_ACCOUNT_ID,
+  GOOGLE_ADS_LEGACY_ACCOUNT_ID,
+} from "@okouai/core/google-ads-account";
 import { command } from "ccstate";
 import {
   acquisitionAttributionContract,
@@ -16,6 +20,8 @@ import {
   GOOGLE_ADS_ADSMARCH_SIGNUP_SEND_TO,
   GOOGLE_ADS_SIGNUP_SEND_TO,
 } from "./google-ads-conversion.ts";
+
+import { resolveGoogleAdsAccount$ } from "./google-ads-account.ts";
 
 const SIGNUP_ATTRIBUTION_RECORDED_KEY = "vm0.signupAttributionRecorded";
 const SIGNUP_CONVERSION_RECORDED_KEY = "vm0.googleAdsSignupConversionRecorded";
@@ -80,6 +86,7 @@ export const recordSignupAttribution$ = command(
     let recorded =
       get(signupAttributionRecordedStorage.get$) === attributionFingerprint;
 
+    let googleAdsAccountId: string | null = null;
     if (!recorded) {
       const createClient = get(apiClient$);
       const client = createClient(acquisitionAttributionContract);
@@ -92,6 +99,7 @@ export const recordSignupAttribution$ = command(
       );
       signal.throwIfAborted();
       recorded = result.body.recorded;
+      googleAdsAccountId = result.body.googleAdsAccountId ?? null;
       if (recorded) {
         set(signupAttributionRecordedStorage.set$, attributionFingerprint);
         capturePaidOnboardingEvent("SignupAttributionRecorded", {
@@ -109,26 +117,31 @@ export const recordSignupAttribution$ = command(
     }
 
     if (recorded && recentlyCreatedUser) {
+      googleAdsAccountId ??= await set(resolveGoogleAdsAccount$, signal);
+      const config =
+        googleAdsAccountId === GOOGLE_ADS_LEGACY_ACCOUNT_ID
+          ? {
+              sendTo: GOOGLE_ADS_SIGNUP_SEND_TO,
+              storage: signupConversionRecordedStorage,
+              transactionId: undefined,
+            }
+          : googleAdsAccountId === GOOGLE_ADS_ADSMARCH_ACCOUNT_ID
+            ? {
+                sendTo: GOOGLE_ADS_ADSMARCH_SIGNUP_SEND_TO,
+                storage: adsmarchSignupConversionRecordedStorage,
+                transactionId: user.id,
+              }
+            : null;
+      if (!config) return;
       const conversionFired = fireGoogleAdsConversion({
-        sendTo: GOOGLE_ADS_SIGNUP_SEND_TO,
+        accountId: googleAdsAccountId,
+        sendTo: config.sendTo,
         dedupeValue: user.id,
         value: SIGNUP_CONVERSION_VALUE_USD,
-        storedDedupeValue: get(signupConversionRecordedStorage.get$),
+        storedDedupeValue: get(config.storage.get$),
+        transactionId: config.transactionId,
       });
-      if (conversionFired) {
-        set(signupConversionRecordedStorage.set$, user.id);
-      }
-
-      const adsmarchConversionFired = fireGoogleAdsConversion({
-        sendTo: GOOGLE_ADS_ADSMARCH_SIGNUP_SEND_TO,
-        dedupeValue: user.id,
-        value: SIGNUP_CONVERSION_VALUE_USD,
-        storedDedupeValue: get(adsmarchSignupConversionRecordedStorage.get$),
-        transactionId: user.id,
-      });
-      if (adsmarchConversionFired) {
-        set(adsmarchSignupConversionRecordedStorage.set$, user.id);
-      }
+      if (conversionFired) set(config.storage.set$, user.id);
     }
   },
 );

--- a/turbo/apps/platform/src/signals/okou-page/billing.ts
+++ b/turbo/apps/platform/src/signals/okou-page/billing.ts
@@ -34,7 +34,7 @@ import { reloadUsageRecords$ } from "./settings/personal-usage-record.ts";
 import { setAblyLoop$, subscribeRealtimeReadyCatchUp$ } from "../realtime.ts";
 import { foregroundReady$ } from "../foreground-catch-up.ts";
 import { isOrgAdmin$ } from "../org.ts";
-import { settle, tapError, withCleanup } from "../utils.ts";
+import { bestEffort, settle, tapError, withCleanup } from "../utils.ts";
 import { accept } from "../../lib/accept.ts";
 import {
   applyStoredAdAttribution$,
@@ -823,7 +823,10 @@ export const startCheckout$ = command(
     if (!("url" in result.body)) {
       throw new Error("Plan checkout returned an unexpected confirmation");
     }
-    set(capturePaidOnboardingRedirectToStripe$, "paywall");
+    await bestEffort(
+      set(capturePaidOnboardingRedirectToStripe$, "paywall", signal),
+      signal,
+    );
     if (newTab) {
       window.open(result.body.url, "_blank");
     } else {
@@ -950,7 +953,10 @@ export const confirmSubscriptionPurchase$ = command(
       );
       signal.throwIfAborted();
       if ("url" in refreshed.body) {
-        set(capturePaidOnboardingRedirectToStripe$, "paywall");
+        await bestEffort(
+          set(capturePaidOnboardingRedirectToStripe$, "paywall", signal),
+          signal,
+        );
         if (state.newTab) {
           window.open(refreshed.body.url, "_blank");
         } else {

--- a/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
@@ -1,3 +1,4 @@
+import { bestEffort } from "../utils.ts";
 import { command } from "ccstate";
 import { onboardingCompleteContract } from "@okouai/api-contracts/contracts/onboarding";
 import {
@@ -142,7 +143,10 @@ export const prepareOnboardingVideoRun$ = command(
     }
     const checkoutUrl = result.body.url;
     set(capturePaidOnboardingCheckoutCreated$, "onboarding_video");
-    set(capturePaidOnboardingRedirectToStripe$, "onboarding_video");
+    await bestEffort(
+      set(capturePaidOnboardingRedirectToStripe$, "onboarding_video", signal),
+      signal,
+    );
     window.location.href = checkoutUrl;
     return "checkout";
   },

--- a/turbo/apps/platform/src/signals/onboarding/onboarding-page-setup.ts
+++ b/turbo/apps/platform/src/signals/onboarding/onboarding-page-setup.ts
@@ -1,3 +1,4 @@
+import { bestEffort } from "../utils.ts";
 import { command, type Command } from "ccstate";
 import { createElement, type ComponentType } from "react";
 import { ILLUSTRATION_TEMPLATE_ITEMS } from "@okouai/core/illustration-template-items";
@@ -158,8 +159,11 @@ function createOnboardingPageSetup(
     const title = config.title(get(brandName$));
     set(updatePage$, createElement(config.Page), "none");
     set(updateDocumentTitle$, title);
-    set(capturePaidOnboardingStepViewed$, config.step);
     await set(hideAppSkeleton$, signal);
+    await bestEffort(
+      set(capturePaidOnboardingStepViewed$, config.step, signal),
+      signal,
+    );
   });
 }
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/billing-conversions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/billing-conversions.test.tsx
@@ -57,43 +57,50 @@ test("Returning from concurrency checkout confirms purchased capacity", async ()
   );
 });
 
-test("A confirmed subscription reports the paid conversion", async () => {
-  const googleTag = vi.fn<GoogleTag>();
-  vi.stubGlobal("gtag", googleTag);
-  context.mocks.api(billingCheckoutContract.complete, ({ respond }) => {
-    return respond(200, {
-      completed: true,
-      googleAdsConversion: {
-        transactionId: "invoice_subscription_123",
-        valueUsd: 160,
-      },
+test.each(["7935750692", "1001302527", undefined])(
+  "A confirmed subscription reports a browser conversion only for the new account: %s",
+  async (accountId) => {
+    const googleTag = vi.fn<GoogleTag>();
+    vi.stubGlobal("gtag", googleTag);
+    context.mocks.api(billingCheckoutContract.complete, ({ respond }) => {
+      return respond(200, {
+        completed: true,
+        googleAdsConversion: {
+          googleAdsAccountId: accountId,
+          transactionId: "invoice_subscription_123",
+          valueUsd: 160,
+        },
+      });
     });
-  });
 
-  await setupPage({
-    context,
-    path: "/agents?billing=team&billing_session_id=cs_paid_subscription",
-    host: "app.okou.ai",
-  });
+    await setupPage({
+      context,
+      path: "/agents?billing=team&billing_session_id=cs_paid_subscription",
+      host: "app.okou.ai",
+    });
 
-  await expect(
-    screen.findByRole("heading", { name: "Agents" }),
-  ).resolves.toBeVisible();
-  await waitFor(() => {
-    expect(window.history.replaceState).toHaveBeenLastCalledWith(
-      {},
-      "",
-      "/agents",
-    );
-    expect(googleTag).toHaveBeenCalledTimes(1);
-  });
-  expect(googleTag).toHaveBeenCalledWith("event", "conversion", {
-    send_to: "AW-18407336975/ePWuCPuRrOccEI_YpslE",
-    value: 40,
-    currency: "USD",
-    transaction_id: "invoice_subscription_123",
-  });
-});
+    await expect(
+      screen.findByRole("heading", { name: "Agents" }),
+    ).resolves.toBeVisible();
+    await waitFor(() => {
+      expect(window.history.replaceState).toHaveBeenLastCalledWith(
+        {},
+        "",
+        "/agents",
+      );
+      expect(googleTag).toHaveBeenCalledTimes(
+        accountId === "7935750692" ? 1 : 0,
+      );
+    });
+    if (accountId !== "7935750692") return;
+    expect(googleTag).toHaveBeenCalledWith("event", "conversion", {
+      send_to: "AW-18407336975/ePWuCPuRrOccEI_YpslE",
+      value: 40,
+      currency: "USD",
+      transaction_id: "invoice_subscription_123",
+    });
+  },
+);
 
 test("A confirmed usage-pack purchase reports the paid conversion", async () => {
   const googleTag = vi.fn<GoogleTag>();
@@ -165,6 +172,7 @@ test("A confirmed usage-pack purchase reports the paid conversion", async () => 
         status: "completed",
         hostedInvoiceUrl: null,
         googleAdsConversion: {
+          googleAdsAccountId: "7935750692",
           transactionId: "invoice_usage_pack_123",
           valueUsd: 40,
         },

--- a/turbo/apps/platform/src/views/okou-page/__tests__/billing-conversions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/billing-conversions.test.tsx
@@ -92,7 +92,9 @@ test.each(["7935750692", "1001302527", undefined])(
         accountId === "7935750692" ? 1 : 0,
       );
     });
-    if (accountId !== "7935750692") return;
+    if (accountId !== "7935750692") {
+      return;
+    }
     expect(googleTag).toHaveBeenCalledWith("event", "conversion", {
       send_to: "AW-18407336975/ePWuCPuRrOccEI_YpslE",
       value: 40,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/signup-attribution.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/signup-attribution.test.tsx
@@ -126,29 +126,43 @@ async function openWorksPage(): Promise<void> {
   ).resolves.toBeInTheDocument();
 }
 
-test("A first-time sign-up conversion can queue before marketing scripts load", async () => {
-  const marketingWindow = installQueuedGtag();
-  context.mocks.api(
-    acquisitionAttributionContract.recordSignup,
-    ({ respond }) => {
-      return respond(200, { recorded: true });
-    },
-  );
+test.each([
+  {
+    accountId: "1001302527",
+    sendTo: SIGNUP_SEND_TO,
+    otherSendTo: ADSMARCH_SIGNUP_SEND_TO,
+  },
+  {
+    accountId: "7935750692",
+    sendTo: ADSMARCH_SIGNUP_SEND_TO,
+    otherSendTo: SIGNUP_SEND_TO,
+  },
+])(
+  "A first-time sign-up queues only the verified $accountId action",
+  async ({ accountId, sendTo, otherSendTo }) => {
+    const marketingWindow = installQueuedGtag();
+    context.mocks.api(
+      acquisitionAttributionContract.recordSignup,
+      ({ respond }) => {
+        return respond(200, { recorded: true, googleAdsAccountId: accountId });
+      },
+    );
 
-  await setupAttributionPage(new Date(NOW), true);
-  await waitForAgentsPage();
+    await setupAttributionPage(new Date(NOW), true);
+    await waitForAgentsPage();
 
-  expect(marketingWindow.dataLayer).toContainEqual([
-    "event",
-    "conversion",
-    expect.objectContaining({ send_to: SIGNUP_SEND_TO }),
-  ]);
-  expect(marketingWindow.dataLayer).toContainEqual([
-    "event",
-    "conversion",
-    expect.objectContaining({ send_to: ADSMARCH_SIGNUP_SEND_TO }),
-  ]);
-});
+    expect(marketingWindow.dataLayer).toContainEqual([
+      "event",
+      "conversion",
+      expect.objectContaining({ send_to: sendTo }),
+    ]);
+    expect(marketingWindow.dataLayer).not.toContainEqual([
+      "event",
+      "conversion",
+      expect.objectContaining({ send_to: otherSendTo }),
+    ]);
+  },
+);
 
 test("A malformed analytics cookie is ignored", async () => {
   const gtag = installGtagMock();
@@ -197,7 +211,7 @@ test("A paid sign-up is attributed and converted once", async () => {
     ({ body, respond }) => {
       attributionRequests += 1;
       recordedAttribution = body.attribution;
-      return respond(200, { recorded: true });
+      return respond(200, { recorded: true, googleAdsAccountId: "7935750692" });
     },
   );
 
@@ -217,15 +231,6 @@ test("A paid sign-up is attributed and converted once", async () => {
     "event",
     "conversion",
     expect.objectContaining({
-      send_to: SIGNUP_SEND_TO,
-      value: 1,
-      currency: "USD",
-    }),
-  );
-  expect(gtag).toHaveBeenCalledWith(
-    "event",
-    "conversion",
-    expect.objectContaining({
       send_to: ADSMARCH_SIGNUP_SEND_TO,
       value: 1,
       currency: "USD",
@@ -235,7 +240,7 @@ test("A paid sign-up is attributed and converted once", async () => {
 
   await openWorksPage();
   expect(attributionRequests).toBe(1);
-  expect(gtag).toHaveBeenCalledTimes(2);
+  expect(gtag).toHaveBeenCalledTimes(1);
 });
 
 test("A recent organic sign-up records its analytics client identifier", async () => {
@@ -256,15 +261,7 @@ test("A recent organic sign-up records its analytics client identifier", async (
   expect(recordedAttribution).toStrictEqual({
     ga_client_id: "123456789.987654321",
   });
-  expect(gtag).toHaveBeenCalledWith(
-    "event",
-    "conversion",
-    expect.objectContaining({
-      send_to: SIGNUP_SEND_TO,
-      value: 1,
-      currency: "USD",
-    }),
-  );
+  expect(gtag).not.toHaveBeenCalled();
 });
 
 test("Previously recorded server attribution prevents a duplicate conversion", async () => {
@@ -350,3 +347,36 @@ test.each(["url", "cookie"])(
     });
   },
 );
+
+test("An unresolved signup can be sent after its account is verified", async () => {
+  const gtag = installGtagMock();
+  let accountId: string | null = null;
+  context.mocks.api(
+    acquisitionAttributionContract.recordSignup,
+    ({ respond }) => {
+      return respond(200, { recorded: true, googleAdsAccountId: null });
+    },
+  );
+  context.mocks.api(
+    acquisitionAttributionContract.resolveGoogleAdsAccount,
+    ({ respond }) => {
+      return respond(200, { googleAdsAccountId: accountId });
+    },
+  );
+  await setupAttributionPage(new Date(NOW), true);
+  await waitForAgentsPage();
+  expect(gtag).not.toHaveBeenCalled();
+  accountId = "7935750692";
+  await openWorksPage();
+  await waitFor(() => {
+    return expect(gtag).toHaveBeenCalledTimes(1);
+  });
+  expect(gtag).toHaveBeenCalledWith(
+    "event",
+    "conversion",
+    expect.objectContaining({
+      send_to: ADSMARCH_SIGNUP_SEND_TO,
+      transaction_id: "test-user-123",
+    }),
+  );
+});

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -1,3 +1,4 @@
+import { acquisitionAttributionContract } from "@okouai/api-contracts/contracts/acquisition-attribution";
 import { screen, waitFor, within } from "@testing-library/react";
 import { expect, test, vi } from "vitest";
 import {
@@ -1253,6 +1254,7 @@ test("A completed video checkout resumes onboarding and the run", async () => {
         ? {
             completed: true,
             googleAdsConversion: {
+              googleAdsAccountId: "7935750692",
               transactionId: "in_onboarding_paid",
               valueUsd: 49,
             },
@@ -1326,53 +1328,69 @@ test("An invalid template link returns to the matching picker", async () => {
   expect(pathname()).toBe("/onboarding/image-template");
 });
 
-test("Onboarding and checkout starts report their conversions", async () => {
-  const gtag = installGtagMock();
-  const template = firstItem(VIDEO_TEMPLATE_ITEMS);
-  mockChatLifecycle(context);
-  context.mocks.api(billingCheckoutContract.create, ({ respond }) => {
-    return respond(200, {
-      url: "https://checkout.stripe.com/test/onboarding-video",
+test.each([
+  {
+    accountId: "1001302527",
+    onboarding: [ONBOARDING_START_SEND_TO],
+    checkout: [CHECKOUT_START_SEND_TO],
+  },
+  {
+    accountId: "7935750692",
+    onboarding: [ADSMARCH_ONBOARDING_START_SEND_TO],
+    checkout: [ADSMARCH_CHECKOUT_START_SEND_TO],
+  },
+  { accountId: null, onboarding: [], checkout: [] },
+])(
+  "Onboarding and checkout route only to $accountId",
+  async ({ accountId, onboarding, checkout }) => {
+    context.mocks.api(
+      acquisitionAttributionContract.resolveGoogleAdsAccount,
+      ({ respond }) => {
+        return respond(200, { googleAdsAccountId: accountId });
+      },
+    );
+    const gtag = installGtagMock();
+    const template = firstItem(VIDEO_TEMPLATE_ITEMS);
+    mockChatLifecycle(context);
+    context.mocks.api(billingCheckoutContract.create, ({ respond }) => {
+      return respond(200, {
+        url: "https://checkout.stripe.com/test/onboarding-video",
+      });
     });
-  });
 
-  mockOnboardingNeeded();
-  await setupPage({
-    context,
-    path: "/onboarding/video-template?choice=video",
-  });
+    mockOnboardingNeeded();
+    await setupPage({
+      context,
+      path: "/onboarding/video-template?choice=video",
+    });
 
-  await expect(
-    screen.findByRole("heading", {
-      name: "Pick a video template to start from",
-    }),
-  ).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByRole("heading", {
+        name: "Pick a video template to start from",
+      }),
+    ).resolves.toBeInTheDocument();
 
-  expect(sentConversions(gtag)).toStrictEqual([
-    ONBOARDING_START_SEND_TO,
-    ADSMARCH_ONBOARDING_START_SEND_TO,
-  ]);
-  chooseTemplate(template.title, "video");
-
-  await expect(
-    screen.findByRole("heading", { name: "Customize your video" }),
-  ).resolves.toBeInTheDocument();
-  await fill(
-    screen.getByLabelText("Custom video prompt"),
-    "A 20-second launch teaser for a habit-tracking app.",
-  );
-  click(
     await waitFor(() => {
-      return buttonByText("Upgrade Pro to run");
-    }),
-  );
+      return expect(sentConversions(gtag)).toStrictEqual(onboarding);
+    });
+    chooseTemplate(template.title, "video");
 
-  await waitFor(() => {
-    expect(sentConversions(gtag)).toStrictEqual([
-      ONBOARDING_START_SEND_TO,
-      ADSMARCH_ONBOARDING_START_SEND_TO,
-      CHECKOUT_START_SEND_TO,
-      ADSMARCH_CHECKOUT_START_SEND_TO,
-    ]);
-  });
-});
+    await expect(
+      screen.findByRole("heading", { name: "Customize your video" }),
+    ).resolves.toBeInTheDocument();
+    await fill(
+      screen.getByLabelText("Custom video prompt"),
+      "A 20-second launch teaser for a habit-tracking app.",
+    );
+    click(
+      await waitFor(() => {
+        return buttonByText("Upgrade Pro to run");
+      }),
+    );
+
+    await waitFor(() => {
+      expect(window.location.href).toContain("checkout.stripe.com");
+      expect(sentConversions(gtag)).toStrictEqual([...onboarding, ...checkout]);
+    });
+  },
+);

--- a/turbo/packages/api-contracts/src/contracts/acquisition-attribution.ts
+++ b/turbo/packages/api-contracts/src/contracts/acquisition-attribution.ts
@@ -62,6 +62,7 @@ const recordSignupAttributionRequestSchema = z.object({
 
 const recordSignupAttributionResponseSchema = z.object({
   recorded: z.boolean(),
+  googleAdsAccountId: z.string().nullable().optional(),
 });
 
 export const GOOGLE_ADS_CONVERSION_MILESTONE_KINDS = [
@@ -80,9 +81,25 @@ const googleAdsConversionMilestoneSchema = z.object({
 
 const googleAdsConversionMilestonesResponseSchema = z.object({
   milestones: z.array(googleAdsConversionMilestoneSchema),
+  googleAdsAccountId: z.string().nullable().optional(),
 });
 
 export const acquisitionAttributionContract = c.router({
+  resolveGoogleAdsAccount: {
+    method: "POST",
+    path: "/api/attribution/google-ads-account",
+    headers: authHeadersSchema,
+    body: z.object({ attribution: adAttributionMetadataSchema.optional() }),
+    responses: {
+      200: z.object({ googleAdsAccountId: z.string().nullable() }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary:
+      "Resolve the Google Ads account from authoritative first-touch attribution",
+  },
   googleAdsMilestones: {
     method: "GET",
     path: "/api/attribution/google-ads-milestones",

--- a/turbo/packages/api-contracts/src/contracts/billing.ts
+++ b/turbo/packages/api-contracts/src/contracts/billing.ts
@@ -139,6 +139,7 @@ const usagePackPurchasePreviewResponseSchema =
   });
 
 const googleAdsPaidConversionSchema = z.object({
+  googleAdsAccountId: z.string().optional(),
   transactionId: z.string().min(1),
   valueUsd: z.number().positive(),
 });

--- a/turbo/packages/core/src/google-ads-account.ts
+++ b/turbo/packages/core/src/google-ads-account.ts
@@ -1,0 +1,45 @@
+// Campaign ownership verified against Google Ads on 2026-09-09. Keep in sync
+// with vm0-marketing/vite-ssr/app/lib/googleAdsAccounts.ts. Provider IDs are
+// attribution identifiers, so do not rename them with the product brand.
+export const GOOGLE_ADS_LEGACY_ACCOUNT_ID = "1001302527";
+export const GOOGLE_ADS_ADSMARCH_ACCOUNT_ID = "7935750692";
+
+const CAMPAIGN_ACCOUNTS: Readonly<Record<string, string>> = {
+  "23843514859": "1001302527",
+  "23843604937": "1001302527",
+  "23888527671": "1001302527",
+  "23890207845": "1001302527",
+  "23895240410": "1001302527",
+  "23897724622": "1001302527",
+  "23898746151": "1001302527",
+  "23898746154": "1001302527",
+  "23898746157": "1001302527",
+  "23898746280": "1001302527",
+  "23899030780": "1001302527",
+  "24006983243": "1001302527",
+  "24061743341": "1001302527",
+  "24064707516": "1001302527",
+  "24088318259": "1001302527",
+  "24154967178": "1001302527",
+  "24160551742": "1001302527",
+  "24160760528": "1001302527",
+  "24165608095": "1001302527",
+  "24185301545": "1001302527",
+  "24220469665": "7935750692",
+  "24220530631": "7935750692",
+};
+
+export function googleAdsAccountForAttribution(
+  metadata: Readonly<Record<string, string | undefined>> | undefined,
+): string | null {
+  const campaignId = metadata?.vm0_campaign_id;
+  const adGroupId = metadata?.vm0_ad_group_id;
+  if (
+    !campaignId ||
+    !/^\d+$/.test(campaignId) ||
+    (adGroupId && !/^\d+$/.test(adGroupId))
+  ) {
+    return null;
+  }
+  return CAMPAIGN_ACCOUNTS[campaignId] ?? null;
+}


### PR DESCRIPTION
## Summary

Signup, onboarding-start and checkout-start conversions currently fire into both Google Ads accounts, while paid and milestone website conversions always fire into the new account. Resolve each conversion against verified campaign ownership and emit only the matching website action. Saved Clerk first-touch attribution takes precedence over a later browser visit; unresolved ownership withholds the conversion without recording it as delivered.

The API withholds paid/milestone website payloads for legacy or unresolved attribution. Legacy paid/milestone actions retain their offline `UPLOAD_CLICKS` path. Invoice attribution stays together as a snapshot, existing transaction IDs and deduplication keys are retained, and the campaign registry and recovery rules are documented in `docs/google-ads-browser-routing.md`.

Related PR: https://github.com/vm0-ai/vm0/pull/32833

## Fallbacks

- `platform/signals/bootstrap/google-ads-account.ts:resolveGoogleAdsAccount$` and the optional `googleAdsAccountId` fields in the acquisition/billing response contracts protect **new App → old API**. A resolver 404 or absent account field withholds the browser conversion while allowing onboarding/checkout to continue. Exposure lasts while API versions lacking account routing serve production or remain rollback targets. Once deployment evidence proves both conditions closed, remove the tolerant branches, optional account fields, resolver 404 contract entry, helper types and temporary tests together in #32924. Retain nullable unresolved-account results and the optional paid payload itself. No elapsed-time or merge-only gate is assumed.
- `api/signals/services/acquisition-attribution.service.ts:googleAdsAccountForUser$` uses supplied capture only if Clerk has **no** saved first touch. This handles genuinely optional external metadata; an existing saved object remains authoritative even when unresolved or malformed. This is an ongoing input contract, not a rollout reader; no timed retirement applies.
- `api/signals/routes/billing-checkout.ts:googleAdsPaidConversion$` uses saved organization acquisition only when Stripe's invoice/subscription snapshot has **no advertising attribution**. This handles genuinely optional external data and nullable persisted attribution. A partial invoice click snapshot cannot borrow the organization's campaign. This is an ongoing input contract, not a rollout reader; no timed retirement applies.

## Validation

- Focused Platform page coverage includes both accounts, unresolved ownership, old API responses, a resolver 404, continued Stripe checkout, and conversion suppression when ownership is unavailable.
- Prior focused runs passed 52 Platform tests, 219 billing checkout API tests, and 19 acquisition attribution API cases. The previous head passed all required PR checks, including App/API shards, types, lint, formatting and E2E. CI must pass again on the final head.
- No full local Vitest suite or development server was run.

## Rollout

Older open clients retain their signup/onboarding/checkout JavaScript until refreshed. Paid and milestone responses are filtered server-side. This PR does not raise the force-upgrade floor or replay historical conversions; recovery preserves original event times and transaction IDs and is handled separately.
