### PR TITLE
feat(guest-control): attribute storage apply resource usage

### DIFF
--- a/crates/guest-agent/tests/integration_cases/telemetry.rs
+++ b/crates/guest-agent/tests/integration_cases/telemetry.rs
@@ -1057,6 +1057,8 @@ async fn urgent_oom_retries_transient_failure_and_retains_unacknowledged_old_rec
 #[tokio::test]
 async fn urgent_oom_arrives_while_normal_http_response_is_held_open() {
     use tokio::io::AsyncWriteExt;
+    // The private HTTP listener still shares process-global telemetry paths.
+    let _api = SharedApiMock::new().await;
     let files = ExplicitTelemetryFiles::new("urgent-inflight").unwrap();
     guest_agent::paths::write_private(files.paths.system_log_file(), "normal backlog\n").unwrap();
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1136,6 +1138,7 @@ async fn urgent_oom_arrives_while_normal_http_response_is_held_open() {
 
 #[tokio::test]
 async fn urgent_oom_stalled_http_has_two_bounded_attempts_and_retains_evidence() {
+    let _api = SharedApiMock::new().await;
     let files = ExplicitTelemetryFiles::new("urgent-stalled").unwrap();
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let http = guest_agent::http::HttpClient::with_api_config(

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -29,4 +29,5 @@ pub mod session_history;
 pub mod session_history_identity;
 pub mod stdout_framing;
 pub mod storage_manifest;
+pub mod storage_resources;
 pub mod workspace_mount;

--- a/crates/guest-contracts/src/storage_resources.rs
+++ b/crates/guest-contracts/src/storage_resources.rs
@@ -1,0 +1,129 @@
+//! Bounded storage-apply completion evidence shared by the guest and Runner.
+
+use serde::{Deserialize, Serialize};
+
+/// Configured leaf resource limit, distinct from an unavailable reading.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum StorageResourceLimit {
+    /// Finite quota or byte limit.
+    Value(u64),
+    /// Kernel unlimited marker.
+    Unlimited(StorageUnlimited),
+}
+
+/// Literal unlimited marker accepted from a cgroup limit file.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum StorageUnlimited {
+    /// The kernel reports no finite limit.
+    #[serde(rename = "max")]
+    Max,
+}
+
+/// Cleanup decision, not the helper's terminal status.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum StorageCleanupMode {
+    /// The helper exited normally.
+    Graceful,
+    /// Timeout, cancellation or startup failure requires forced cleanup.
+    Forced,
+}
+
+/// One pre-cleanup snapshot of a fresh storage workload cgroup.
+///
+/// Unknown kernel readings remain null. Fields are deliberately allowlisted;
+/// deserializing then serializing drops unknown peer fields before logging.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct StorageResourceUsage {
+    /// UUID-shaped operation identity; arbitrary request text is not logged.
+    pub run_id: Option<String>,
+    /// Storage request sequence on the guest-control connection.
+    pub request_seq: u32,
+    /// Generated exec cgroup name, validated before host logging.
+    pub group: String,
+    /// Cleanup decision at the snapshot boundary.
+    pub cleanup_mode: StorageCleanupMode,
+    /// Time from fresh containment activation to snapshot start.
+    pub containment_wall_us: u64,
+    /// Snapshot reads/assembly, excluding serialization and transport.
+    pub collection_us: u64,
+    /// Cgroup cpu.stat usage_usec counter, when available.
+    pub cpu_usage_usec: Option<u64>,
+    /// Cgroup cpu.stat user_usec counter, when available.
+    pub cpu_user_usec: Option<u64>,
+    /// Cgroup cpu.stat system_usec counter, when available.
+    pub cpu_system_usec: Option<u64>,
+    /// Cgroup cpu.stat nr_periods counter, when available.
+    pub cpu_nr_periods: Option<u64>,
+    /// Cgroup cpu.stat nr_throttled counter, when available.
+    pub cpu_nr_throttled: Option<u64>,
+    /// Cgroup cpu.stat throttled_usec counter, when available.
+    pub cpu_throttled_usec: Option<u64>,
+    /// Cgroup memory.events high counter, when available.
+    pub memory_events_high: Option<u64>,
+    /// Cgroup memory.events max counter, when available.
+    pub memory_events_max: Option<u64>,
+    /// Cgroup memory.events oom counter, when available.
+    pub memory_events_oom: Option<u64>,
+    /// Cgroup memory.events oom_kill counter, when available.
+    pub memory_events_oom_kill: Option<u64>,
+    /// Cgroup memory.events oom_group_kill counter, when available.
+    pub memory_events_oom_group_kill: Option<u64>,
+    /// Cgroup pids.events max counter, when available.
+    pub pids_events_max: Option<u64>,
+    /// Cgroup memory.stat pgfault counter, when available.
+    pub memory_pgfault: Option<u64>,
+    /// Cgroup memory.stat pgmajfault counter, when available.
+    pub memory_pgmajfault: Option<u64>,
+    /// Cgroup memory.stat pgscan counter, when available.
+    pub memory_pgscan: Option<u64>,
+    /// Cgroup memory.stat pgsteal counter, when available.
+    pub memory_pgsteal: Option<u64>,
+    /// Cgroup memory.stat pgscan_kswapd counter, when available.
+    pub memory_pgscan_kswapd: Option<u64>,
+    /// Cgroup memory.stat pgscan_direct counter, when available.
+    pub memory_pgscan_direct: Option<u64>,
+    /// Cgroup memory.stat pgsteal_kswapd counter, when available.
+    pub memory_pgsteal_kswapd: Option<u64>,
+    /// Cgroup memory.stat pgsteal_direct counter, when available.
+    pub memory_pgsteal_direct: Option<u64>,
+    /// Cgroup memory.stat workingset_refault_anon counter, when available.
+    pub memory_workingset_refault_anon: Option<u64>,
+    /// Cgroup memory.stat workingset_refault_file counter, when available.
+    pub memory_workingset_refault_file: Option<u64>,
+    /// Current bytes charged to the workload cgroup.
+    pub memory_current_bytes: Option<u64>,
+    /// Peak charged bytes since cgroup creation.
+    pub memory_peak_bytes: Option<u64>,
+    /// Configured leaf memory.high, not an effective ancestor limit.
+    pub memory_high_limit_bytes: Option<StorageResourceLimit>,
+    /// Configured leaf memory.max, not an effective ancestor limit.
+    pub memory_max_limit_bytes: Option<StorageResourceLimit>,
+    /// Configured leaf cpu.max quota, not an effective ancestor limit.
+    pub cpu_quota_us: Option<StorageResourceLimit>,
+    /// Configured cpu.max period in microseconds.
+    pub cpu_period_us: Option<u64>,
+}
+
+impl StorageResourceUsage {
+    /// Verify safe identity and bind optional evidence to its actual RPC.
+    pub fn matches_request(&self, run_id: &str, sequence: u32) -> bool {
+        let expected_run_id =
+            (run_id.len() == 36 && uuid::Uuid::parse_str(run_id).is_ok()).then_some(run_id);
+        let mut group = self.group.split('-');
+        self.run_id.as_deref() == expected_run_id
+            && self.request_seq == sequence
+            && self.group.len() <= 64
+            && group.next() == Some("exec")
+            && group
+                .next()
+                .and_then(|value| value.parse::<u32>().ok())
+                .is_some()
+            && group.next().and_then(|value| value.parse::<u32>().ok()) == Some(sequence)
+            && group
+                .next()
+                .and_then(|value| value.parse::<u64>().ok())
+                .is_some()
+            && group.next().is_none()
+    }
+}

--- a/crates/guest-control-client/src/guest_storage_manifest.rs
+++ b/crates/guest-control-client/src/guest_storage_manifest.rs
@@ -1,3 +1,4 @@
+use guest_contracts::storage_resources::StorageResourceUsage;
 use std::io;
 use std::time::Duration;
 
@@ -16,6 +17,8 @@ const TERMINAL_MSG_TYPES: &[u8] = &[MSG_ERROR, MSG_GUEST_STORAGE_MANIFEST_RESULT
 /// Owned result of the fixed guest storage-manifest helper.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GuestStorageManifestResult {
+    /// Validated optional resource evidence, never helper output or an error.
+    pub resources: Option<StorageResourceUsage>,
     /// Terminal process state.
     pub termination: ExecTermination,
     /// Guest-observed helper duration in milliseconds.
@@ -30,6 +33,22 @@ pub struct GuestStorageManifestResult {
     pub stderr_truncated: bool,
     /// Bounded process or internal diagnostic.
     pub diagnostic: String,
+}
+
+impl GuestStorageManifestResult {
+    /// Record validated resource evidence with its host-owned sandbox identity.
+    /// Missing terminal evidence produces no fabricated zero-usage event.
+    pub fn log_resources(&self, sandbox_id: &str) {
+        if let Some(resources) = &self.resources
+            && let Ok(resources) = serde_json::to_string(resources)
+        {
+            tracing::info!(
+                id = %sandbox_id,
+                resources = %resources,
+                "storage apply resources"
+            );
+        }
+    }
 }
 
 impl GuestControlClient {
@@ -83,9 +102,27 @@ impl GuestControlClient {
 
         let decoded = decode_guest_storage_manifest_result(&response.payload)
             .map_err(protocol_invalid_data)?;
+        let resources = if decoded.resource_summary.is_empty() {
+            None
+        } else {
+            match serde_json::from_slice::<StorageResourceUsage>(decoded.resource_summary) {
+                Ok(resources) if resources.matches_request(run_id, response.seq) => Some(resources),
+                _ => {
+                    // Optional evidence cannot fail a valid core result. Never
+                    // log raw peer bytes or parser errors containing those bytes.
+                    tracing::warn!(
+                        request_seq = response.seq,
+                        "storage resource summary unavailable: invalid metadata"
+                    );
+                    None
+                }
+            }
+        };
+        let decoded = decoded.result;
         let (stdout, stdout_truncated) = owned_capture(decoded.stdout, "stdout")?;
         let (stderr, stderr_truncated) = owned_capture(decoded.stderr, "stderr")?;
         Ok(GuestStorageManifestResult {
+            resources,
             termination: decoded.termination,
             duration_ms: decoded.duration_ms,
             stdout,

--- a/crates/guest-control-client/src/tests/guest_storage_manifest.rs
+++ b/crates/guest-control-client/src/tests/guest_storage_manifest.rs
@@ -15,17 +15,20 @@ use crate::tests::support::{
 
 fn success_payload() -> Vec<u8> {
     guest_control_proto::encode_guest_storage_manifest_result(
-        ExecTermination::Exited { exit_code: 0 },
-        17,
-        ExecCapturedOutput::Captured {
-            bytes: b"out",
-            truncated: false,
+        guest_control_proto::DecodedExecResult {
+            termination: ExecTermination::Exited { exit_code: 0 },
+            duration_ms: 17,
+            stdout: ExecCapturedOutput::Captured {
+                bytes: b"out",
+                truncated: false,
+            },
+            stderr: ExecCapturedOutput::Captured {
+                bytes: b"err",
+                truncated: true,
+            },
+            diagnostic: "",
         },
-        ExecCapturedOutput::Captured {
-            bytes: b"err",
-            truncated: true,
-        },
-        "",
+        &[],
     )
     .unwrap()
 }
@@ -72,10 +75,93 @@ async fn guest_storage_manifest_sends_request_and_decodes_result() {
     assert_eq!(result.stderr, b"err");
     assert!(!result.stdout_truncated);
     assert!(result.stderr_truncated);
+    assert!(result.resources.is_none());
     assert_eq!(
         normal_operation_readiness(&host),
         NormalOperationReadiness::Idle
     );
+    release_tx.send(()).unwrap();
+    guest.await.unwrap();
+}
+
+#[tokio::test]
+async fn storage_resources_are_bound_to_the_request_without_changing_core_results() {
+    let (host_stream, guest_stream) = make_pair();
+    let (release_tx, release_rx) = oneshot::channel();
+    let guest = tokio::spawn(async move {
+        let mut guest = MockGuest::new(guest_stream);
+        guest.complete_handshake().await;
+        for case in 0..6 {
+            let request = guest.expect_message(MSG_GUEST_STORAGE_MANIFEST).await;
+            let mut resource = serde_json::json!({
+                "run_id": "8d7a07c8-15b2-446f-9f47-36d32028baa6",
+                "request_seq": request.seq,
+                "group": format!("exec-7-{}-1", request.seq),
+                "cleanup_mode": "Graceful",
+                "containment_wall_us": 1000,
+                "collection_us": 170,
+                "cpu_usage_usec": 0,
+                "unknown_peer_field": "never logged"
+            });
+            match case {
+                1 => resource["run_id"] = serde_json::json!("ffffffff-ffff-ffff-ffff-ffffffffffff"),
+                2 => resource["request_seq"] = serde_json::json!(request.seq + 1),
+                3 => resource["group"] = serde_json::json!("secret-group\nforged"),
+                4 => resource["cpu_usage_usec"] = serde_json::json!(-1),
+                _ => {}
+            }
+            let resources = if case == 5 {
+                vec![0xff]
+            } else {
+                serde_json::to_vec(&resource).unwrap()
+            };
+            let original = success_payload();
+            let result = guest_control_proto::decode_guest_storage_manifest_result(&original)
+                .unwrap()
+                .result;
+            let payload =
+                guest_control_proto::encode_guest_storage_manifest_result(result, &resources)
+                    .unwrap();
+            guest
+                .send_response(MSG_GUEST_STORAGE_MANIFEST_RESULT, request.seq, &payload)
+                .await;
+        }
+        release_rx.await.unwrap();
+    });
+    let host = host_from_stream(host_stream).await.unwrap();
+    for case in 0..6 {
+        let result = host
+            .guest_storage_manifest(
+                b"{}",
+                "8d7a07c8-15b2-446f-9f47-36d32028baa6",
+                "/run",
+                1000,
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+        assert_eq!(result.stdout, b"out");
+        assert_eq!(result.stderr, b"err");
+        assert!(result.stderr_truncated);
+        assert!(result.diagnostic.is_empty());
+        if case == 0 {
+            let resources = result.resources.unwrap();
+            assert_eq!(resources.cpu_usage_usec, Some(0));
+            assert_eq!(resources.memory_peak_bytes, None);
+            assert!(
+                !serde_json::to_string(&resources)
+                    .unwrap()
+                    .contains("never logged")
+            );
+        } else {
+            assert!(result.resources.is_none());
+        }
+        assert_eq!(
+            normal_operation_readiness(&host),
+            NormalOperationReadiness::Idle
+        );
+    }
     release_tx.send(()).unwrap();
     guest.await.unwrap();
 }

--- a/crates/guest-control-proto/src/lib.rs
+++ b/crates/guest-control-proto/src/lib.rs
@@ -55,7 +55,7 @@
 //! | 0x16 | H→G       | guest_dns_readiness | `[4B positive timeout_ms][2B hostname_len][hostname]` |
 //! | 0x17 | G→H       | guest_dns_readiness_result | `[termination][4B duration_ms][1B flags][2B answer_len][answer][2B diagnostic_len][diagnostic]` |
 //! | 0x18 | H→G       | guest_storage_manifest | `[4B positive timeout_ms][2B run_id_len][run_id][2B runtime_dir_len][runtime_dir][4B manifest_len][manifest]` |
-//! | 0x19 | G→H       | guest_storage_manifest_result | same payload as `exec_result`, with both streams captured and bounded to 1 MiB each |
+//! | 0x19 | G→H       | guest_storage_manifest_result | `[2B resource_json_len][resource_json][exec_result]`; optional resources bounded to 4 KiB, both streams captured and bounded to 1 MiB each |
 //! | 0x1A | H→G       | guest_state_restore | `[4B positive timeout_ms][8B unix_seconds][4B unix_nanoseconds][1B timezone_mode][2B timezone_len][timezone][256B entropy]` |
 //! | 0x1B | G→H       | guest_state_restore_result | same payload as `exec_result`, with empty stdout and stderr bounded to 64 KiB |
 //! | 0x1C | G→H       | exec_agent_ready | `[4B containment_create_us][4B placement_broker_setup_us][4B shell_spawn_us][4B bootstrap_ready_wait_us]` |
@@ -245,8 +245,9 @@ pub use payloads::guest_state_restore::{
     encode_guest_state_restore_result_frame_into,
 };
 pub use payloads::guest_storage_manifest::{
-    DecodedGuestStorageManifestRequest, GUEST_STORAGE_MANIFEST_MAX_RUN_ID_BYTES,
-    GUEST_STORAGE_MANIFEST_MAX_RUNTIME_DIR_BYTES, GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES,
+    DecodedGuestStorageManifestRequest, DecodedGuestStorageManifestResult,
+    GUEST_STORAGE_MANIFEST_MAX_RUN_ID_BYTES, GUEST_STORAGE_MANIFEST_MAX_RUNTIME_DIR_BYTES,
+    GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES, GUEST_STORAGE_RESOURCE_SUMMARY_LIMIT_BYTES,
     decode_guest_storage_manifest_request, decode_guest_storage_manifest_result,
     encode_guest_storage_manifest_request, encode_guest_storage_manifest_request_frame_into,
     encode_guest_storage_manifest_result, encode_guest_storage_manifest_result_frame_into,

--- a/crates/guest-control-proto/src/payloads/exec_operation.rs
+++ b/crates/guest-control-proto/src/payloads/exec_operation.rs
@@ -18,6 +18,7 @@ pub use output::{
     DecodedExecOutput, ExecOutputStream, decode_exec_output, encode_exec_output,
     encode_exec_output_frame_into,
 };
+pub(crate) use result::encode_exec_result_frame_into_with_prefix;
 pub(crate) use result::encode_exec_result_frame_into_with_type;
 pub use result::{
     DecodedExecResult, ExecCapturedOutput, decode_exec_result, encode_exec_result,

--- a/crates/guest-control-proto/src/payloads/exec_operation/result.rs
+++ b/crates/guest-control-proto/src/payloads/exec_operation/result.rs
@@ -189,9 +189,38 @@ pub(crate) fn encode_exec_result_frame_into_with_type<const MSG_TYPE: u8>(
     stderr: ExecCapturedOutput<'_>,
     diagnostic: &str,
 ) -> Result<(), ProtocolError> {
+    encode_exec_result_frame_into_with_prefix::<MSG_TYPE>(
+        frame,
+        seq,
+        DecodedExecResult {
+            termination,
+            duration_ms,
+            stdout,
+            stderr,
+            diagnostic,
+        },
+        &[],
+    )
+}
+
+pub(crate) fn encode_exec_result_frame_into_with_prefix<const MSG_TYPE: u8>(
+    frame: &mut Vec<u8>,
+    seq: u32,
+    result: DecodedExecResult<'_>,
+    prefix: &[u8],
+) -> Result<(), ProtocolError> {
+    let DecodedExecResult {
+        termination,
+        duration_ms,
+        stdout,
+        stderr,
+        diagnostic,
+    } = result;
     let (diagnostic_len, payload_len) =
         validate_exec_result_payload(termination, stdout, stderr, diagnostic)?;
+    let payload_len = checked_payload_len_add(prefix.len(), payload_len)?;
     encode_into(frame, MSG_TYPE, seq, payload_len, |frame| {
+        frame.extend_from_slice(prefix);
         append_exec_result_payload(
             frame,
             termination,

--- a/crates/guest-control-proto/src/payloads/guest_storage_manifest.rs
+++ b/crates/guest-control-proto/src/payloads/guest_storage_manifest.rs
@@ -2,13 +2,13 @@ use std::path::Path;
 
 use crate::ProtocolError;
 use crate::frame::encode_into;
-use crate::payloads::exec_operation::encode_exec_result_frame_into_with_type;
+use crate::payloads::exec_operation::encode_exec_result_frame_into_with_prefix;
 use crate::read::{
     checked_payload_len_add, ensure_payload_fits_message, ensure_u16_len, ensure_u32_len,
     expect_consumed, read_slice, read_str, read_u16, read_u32,
 };
 use crate::wire::{MSG_GUEST_STORAGE_MANIFEST, MSG_GUEST_STORAGE_MANIFEST_RESULT};
-use crate::{DecodedExecResult, ExecCapturedOutput, ExecTermination, MAX_EXEC_STDIN_BYTES};
+use crate::{DecodedExecResult, ExecCapturedOutput, MAX_EXEC_STDIN_BYTES};
 
 /// Maximum encoded run-id length accepted by the fixed storage operation.
 pub const GUEST_STORAGE_MANIFEST_MAX_RUN_ID_BYTES: usize = 256;
@@ -18,6 +18,19 @@ pub const GUEST_STORAGE_MANIFEST_MAX_RUNTIME_DIR_BYTES: usize = 4 * 1024;
 
 /// Fixed stdout/stderr capture bound for the storage helper.
 pub const GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES: usize = 1024 * 1024;
+
+/// Maximum optional JSON resource summary, separate from helper output/errors.
+pub const GUEST_STORAGE_RESOURCE_SUMMARY_LIMIT_BYTES: usize = 4 * 1024;
+
+/// Dedicated storage result with bounded optional resource evidence.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DecodedGuestStorageManifestResult<'a> {
+    /// Original terminal process metadata and captured helper output.
+    pub result: DecodedExecResult<'a>,
+    /// Optional resource JSON; empty means unavailable. Typed validation belongs
+    /// to the host consumer and cannot change the core operation outcome.
+    pub resource_summary: &'a [u8],
+}
 
 /// Decoded fixed guest storage-manifest request.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -166,15 +179,22 @@ pub fn decode_guest_storage_manifest_request(
 
 /// Encode a fixed guest storage-manifest terminal result payload.
 pub fn encode_guest_storage_manifest_result(
-    termination: ExecTermination,
-    duration_ms: u32,
-    stdout: ExecCapturedOutput<'_>,
-    stderr: ExecCapturedOutput<'_>,
-    diagnostic: &str,
+    result: DecodedExecResult<'_>,
+    resource_summary: &[u8],
 ) -> Result<Vec<u8>, ProtocolError> {
-    validate_result_output(stdout, "stdout")?;
-    validate_result_output(stderr, "stderr")?;
-    crate::encode_exec_result(termination, duration_ms, stdout, stderr, diagnostic)
+    validate_result_output(result.stdout, "stdout")?;
+    validate_result_output(result.stderr, "stderr")?;
+    let mut payload = resource_prefix(resource_summary)?;
+    let output = crate::encode_exec_result(
+        result.termination,
+        result.duration_ms,
+        result.stdout,
+        result.stderr,
+        result.diagnostic,
+    )?;
+    ensure_payload_fits_message(checked_payload_len_add(payload.len(), output.len())?)?;
+    payload.extend_from_slice(&output);
+    Ok(payload)
 }
 
 /// Encode a full fixed guest storage-manifest terminal result frame.
@@ -183,41 +203,64 @@ pub fn encode_guest_storage_manifest_result(
 ///
 /// Returns [`ProtocolError`] if stdout or stderr was discarded or exceeds
 /// [`GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES`] bytes; if `diagnostic` cannot
-/// fit its wire length field; or if the encoded payload exceeds the maximum
-/// message size.
+/// fit its wire length field; if resources exceed
+/// [`GUEST_STORAGE_RESOURCE_SUMMARY_LIMIT_BYTES`]; or if the encoded payload
+/// exceeds the maximum message size.
 ///
 /// Validation runs before the shared frame encoder clears `frame`, so a
 /// validation error leaves the destination unchanged.
 pub fn encode_guest_storage_manifest_result_frame_into(
     frame: &mut Vec<u8>,
     seq: u32,
-    termination: ExecTermination,
-    duration_ms: u32,
-    stdout: ExecCapturedOutput<'_>,
-    stderr: ExecCapturedOutput<'_>,
-    diagnostic: &str,
+    result: DecodedExecResult<'_>,
+    resource_summary: &[u8],
 ) -> Result<(), ProtocolError> {
-    validate_result_output(stdout, "stdout")?;
-    validate_result_output(stderr, "stderr")?;
-    encode_exec_result_frame_into_with_type::<MSG_GUEST_STORAGE_MANIFEST_RESULT>(
-        frame,
-        seq,
-        termination,
-        duration_ms,
-        stdout,
-        stderr,
-        diagnostic,
+    validate_result_output(result.stdout, "stdout")?;
+    validate_result_output(result.stderr, "stderr")?;
+    let prefix = resource_prefix(resource_summary)?;
+    encode_exec_result_frame_into_with_prefix::<MSG_GUEST_STORAGE_MANIFEST_RESULT>(
+        frame, seq, result, &prefix,
     )
+}
+
+fn resource_prefix(resources: &[u8]) -> Result<Vec<u8>, ProtocolError> {
+    if resources.len() > GUEST_STORAGE_RESOURCE_SUMMARY_LIMIT_BYTES {
+        return Err(ProtocolError::PayloadTooLarge(
+            "storage resources",
+            resources.len(),
+        ));
+    }
+    let length = ensure_u16_len("storage resources", resources.len())?;
+    let mut prefix = Vec::with_capacity(2 + resources.len());
+    prefix.extend_from_slice(&length.to_be_bytes());
+    prefix.extend_from_slice(resources);
+    Ok(prefix)
 }
 
 /// Decode a fixed guest storage-manifest terminal result payload.
 pub fn decode_guest_storage_manifest_result(
     payload: &[u8],
-) -> Result<DecodedExecResult<'_>, ProtocolError> {
-    let decoded = crate::decode_exec_result(payload)?;
+) -> Result<DecodedGuestStorageManifestResult<'_>, ProtocolError> {
+    let mut offset = 0;
+    let length = usize::from(read_u16(
+        payload,
+        &mut offset,
+        "storage resources length truncated",
+    )?);
+    if length > GUEST_STORAGE_RESOURCE_SUMMARY_LIMIT_BYTES {
+        return Err(ProtocolError::PayloadTooLarge("storage resources", length));
+    }
+    let resource_summary = read_slice(payload, &mut offset, length, "storage resources truncated")?;
+    let result = payload
+        .get(offset..)
+        .ok_or(ProtocolError::InvalidPayload("storage result truncated"))?;
+    let decoded = crate::decode_exec_result(result)?;
     validate_result_output(decoded.stdout, "stdout")?;
     validate_result_output(decoded.stderr, "stderr")?;
-    Ok(decoded)
+    Ok(DecodedGuestStorageManifestResult {
+        result: decoded,
+        resource_summary,
+    })
 }
 
 #[derive(Clone, Copy)]

--- a/crates/guest-control-proto/tests/guest_storage_manifest_properties.rs
+++ b/crates/guest-control-proto/tests/guest_storage_manifest_properties.rs
@@ -19,6 +19,53 @@ const MAX_GENERATED_MANIFEST_BYTES: usize = 64;
 const MAX_GENERATED_OUTPUT_BYTES: usize = 64;
 const MAX_ARBITRARY_PAYLOAD_BYTES: usize = 512;
 
+#[test]
+fn resource_field_is_bounded_and_independent_of_terminal_metadata() {
+    let result = DecodedExecResult {
+        termination: ExecTermination::TimedOut,
+        duration_ms: 17,
+        stdout: ExecCapturedOutput::Captured {
+            bytes: b"out",
+            truncated: true,
+        },
+        stderr: ExecCapturedOutput::Captured {
+            bytes: b"err",
+            truncated: false,
+        },
+        diagnostic: "original diagnostic",
+    };
+    for resources in [
+        &[][..],
+        b"{}",
+        &[0xff],
+        &vec![b'x'; guest_control_proto::GUEST_STORAGE_RESOURCE_SUMMARY_LIMIT_BYTES],
+    ] {
+        let payload = encode_guest_storage_manifest_result(result, resources).unwrap();
+        let decoded = decode_guest_storage_manifest_result(&payload).unwrap();
+        assert_eq!(decoded.result, result);
+        assert_eq!(decoded.resource_summary, resources);
+        let mut frame = Vec::new();
+        encode_guest_storage_manifest_result_frame_into(&mut frame, 7, result, resources).unwrap();
+        assert_eq!(
+            frame,
+            encode(MSG_GUEST_STORAGE_MANIFEST_RESULT, 7, &payload).unwrap()
+        );
+    }
+    let oversized = vec![0; guest_control_proto::GUEST_STORAGE_RESOURCE_SUMMARY_LIMIT_BYTES + 1];
+    assert!(encode_guest_storage_manifest_result(result, &oversized).is_err());
+    let mut frame = b"unchanged".to_vec();
+    assert!(
+        encode_guest_storage_manifest_result_frame_into(&mut frame, 7, result, &oversized).is_err()
+    );
+    assert_eq!(frame, b"unchanged");
+    let mut invalid = vec![0x10, 0x01];
+    invalid.extend_from_slice(&oversized);
+    assert!(decode_guest_storage_manifest_result(&invalid).is_err());
+    for invalid in [&[][..], &[0], &[0, 1], &[0, 0], &[0, 1, 0xff]] {
+        assert!(decode_guest_storage_manifest_result(invalid).is_err());
+    }
+}
+
 #[derive(Clone, Debug)]
 struct OwnedRequest {
     timeout_ms: u32,
@@ -140,11 +187,14 @@ impl OwnedResult {
 
     fn encode(&self) -> Result<Vec<u8>, ProtocolError> {
         encode_guest_storage_manifest_result(
-            self.termination,
-            self.duration_ms,
-            self.stdout(),
-            self.stderr(),
-            &self.diagnostic,
+            guest_control_proto::DecodedExecResult {
+                termination: self.termination,
+                duration_ms: self.duration_ms,
+                stdout: self.stdout(),
+                stderr: self.stderr(),
+                diagnostic: &self.diagnostic,
+            },
+            &[],
         )
     }
 
@@ -434,33 +484,19 @@ proptest! {
         prop_assert!(payload.is_ok(), "generated result failed to encode: {payload:?}");
         let payload = payload.unwrap();
 
-        let decoded = decode_guest_storage_manifest_result(&payload);
+        let decoded = decode_guest_storage_manifest_result(&payload).map(|value| value.result);
         prop_assert!(decoded.is_ok(), "encoded result failed to decode: {decoded:?}");
         let decoded = decoded.unwrap();
         result.assert_decoded(&decoded)?;
 
-        let reencoded = encode_guest_storage_manifest_result(
-            decoded.termination,
-            decoded.duration_ms,
-            decoded.stdout,
-            decoded.stderr,
-            decoded.diagnostic,
-        );
+        let reencoded = encode_guest_storage_manifest_result(guest_control_proto::DecodedExecResult { termination: decoded.termination, duration_ms: decoded.duration_ms, stdout: decoded.stdout, stderr: decoded.stderr, diagnostic: decoded.diagnostic }, &[]);
         prop_assert!(reencoded.is_ok(), "decoded result failed to re-encode: {reencoded:?}");
         prop_assert_eq!(reencoded.unwrap(), payload.as_slice());
 
         let expected_frame = encode(MSG_GUEST_STORAGE_MANIFEST_RESULT, seq, &payload);
         prop_assert!(expected_frame.is_ok(), "generic result frame failed: {expected_frame:?}");
         let mut direct_frame = Vec::new();
-        let direct_result = encode_guest_storage_manifest_result_frame_into(
-            &mut direct_frame,
-            seq,
-            result.termination,
-            result.duration_ms,
-            result.stdout(),
-            result.stderr(),
-            &result.diagnostic,
-        );
+        let direct_result = encode_guest_storage_manifest_result_frame_into(&mut direct_frame, seq, guest_control_proto::DecodedExecResult { termination: result.termination, duration_ms: result.duration_ms, stdout: result.stdout(), stderr: result.stderr(), diagnostic: &result.diagnostic }, &[]);
         prop_assert!(direct_result.is_ok(), "direct result frame failed: {direct_result:?}");
         prop_assert_eq!(direct_frame, expected_frame.unwrap());
     }
@@ -534,14 +570,19 @@ fn result_enforces_capture_contract_for_each_stream() {
         };
         let (stdout, stderr) = with_selected_output(stream, selected);
         let payload = encode_guest_storage_manifest_result(
-            ExecTermination::Exited { exit_code: 7 },
-            u32::MAX,
-            stdout,
-            stderr,
-            "boundary",
+            guest_control_proto::DecodedExecResult {
+                termination: ExecTermination::Exited { exit_code: 7 },
+                duration_ms: u32::MAX,
+                stdout,
+                stderr,
+                diagnostic: "boundary",
+            },
+            &[],
         )
         .unwrap();
-        let decoded = decode_guest_storage_manifest_result(&payload).unwrap();
+        let decoded = decode_guest_storage_manifest_result(&payload)
+            .unwrap()
+            .result;
         assert_eq!(decoded.stdout, stdout);
         assert_eq!(decoded.stderr, stderr);
         let expected_frame = encode(MSG_GUEST_STORAGE_MANIFEST_RESULT, 42, &payload).unwrap();
@@ -549,11 +590,14 @@ fn result_enforces_capture_contract_for_each_stream() {
         encode_guest_storage_manifest_result_frame_into(
             &mut frame,
             42,
-            ExecTermination::Exited { exit_code: 7 },
-            u32::MAX,
-            stdout,
-            stderr,
-            "boundary",
+            guest_control_proto::DecodedExecResult {
+                termination: ExecTermination::Exited { exit_code: 7 },
+                duration_ms: u32::MAX,
+                stdout,
+                stderr,
+                diagnostic: "boundary",
+            },
+            &[],
         )
         .unwrap();
         assert_eq!(frame, expected_frame);
@@ -565,11 +609,14 @@ fn result_enforces_capture_contract_for_each_stream() {
         };
         let (stdout, stderr) = with_selected_output(stream, selected);
         let encode_error = encode_guest_storage_manifest_result(
-            ExecTermination::WaitFailed,
-            0,
-            stdout,
-            stderr,
-            "",
+            guest_control_proto::DecodedExecResult {
+                termination: ExecTermination::WaitFailed,
+                duration_ms: 0,
+                stdout,
+                stderr,
+                diagnostic: "",
+            },
+            &[],
         )
         .unwrap_err();
         assert!(matches!(
@@ -582,11 +629,14 @@ fn result_enforces_capture_contract_for_each_stream() {
         let frame_error = encode_guest_storage_manifest_result_frame_into(
             &mut frame,
             42,
-            ExecTermination::WaitFailed,
-            0,
-            stdout,
-            stderr,
-            "",
+            guest_control_proto::DecodedExecResult {
+                termination: ExecTermination::WaitFailed,
+                duration_ms: 0,
+                stdout,
+                stderr,
+                diagnostic: "",
+            },
+            &[],
         )
         .unwrap_err();
         assert!(matches!(
@@ -598,7 +648,9 @@ fn result_enforces_capture_contract_for_each_stream() {
         assert_eq!(frame, b"stale frame bytes");
         let generic_payload =
             encode_exec_result(ExecTermination::WaitFailed, 0, stdout, stderr, "").unwrap();
-        let decode_error = decode_guest_storage_manifest_result(&generic_payload).unwrap_err();
+        let decode_error =
+            decode_guest_storage_manifest_result(&[&[0, 0][..], &generic_payload].concat())
+                .unwrap_err();
         assert!(matches!(
             decode_error,
             ProtocolError::PayloadTooLarge(field, size)
@@ -608,7 +660,16 @@ fn result_enforces_capture_contract_for_each_stream() {
 
         let (stdout, stderr) = with_selected_output(stream, ExecCapturedOutput::Discarded);
         assert!(matches!(
-            encode_guest_storage_manifest_result(ExecTermination::Cancelled, 0, stdout, stderr, "",),
+            encode_guest_storage_manifest_result(
+                guest_control_proto::DecodedExecResult {
+                    termination: ExecTermination::Cancelled,
+                    duration_ms: 0,
+                    stdout,
+                    stderr,
+                    diagnostic: ""
+                },
+                &[]
+            ),
             Err(ProtocolError::InvalidPayload(
                 "guest_storage_manifest_result output must be captured"
             ))
@@ -618,11 +679,14 @@ fn result_enforces_capture_contract_for_each_stream() {
             encode_guest_storage_manifest_result_frame_into(
                 &mut frame,
                 42,
-                ExecTermination::Cancelled,
-                0,
-                stdout,
-                stderr,
-                "",
+                guest_control_proto::DecodedExecResult {
+                    termination: ExecTermination::Cancelled,
+                    duration_ms: 0,
+                    stdout,
+                    stderr,
+                    diagnostic: ""
+                },
+                &[]
             ),
             Err(ProtocolError::InvalidPayload(
                 "guest_storage_manifest_result output must be captured"
@@ -632,7 +696,7 @@ fn result_enforces_capture_contract_for_each_stream() {
         let generic_payload =
             encode_exec_result(ExecTermination::Cancelled, 0, stdout, stderr, "").unwrap();
         assert!(matches!(
-            decode_guest_storage_manifest_result(&generic_payload),
+            decode_guest_storage_manifest_result(&[&[0, 0][..], &generic_payload].concat()),
             Err(ProtocolError::InvalidPayload(
                 "guest_storage_manifest_result output must be captured"
             ))
@@ -652,11 +716,14 @@ fn result_frame_enforces_diagnostic_boundary() {
     };
     let max_diagnostic = "x".repeat(u16::MAX as usize);
     let payload = encode_guest_storage_manifest_result(
-        ExecTermination::TimedOut,
-        u32::MAX,
-        stdout,
-        stderr,
-        &max_diagnostic,
+        guest_control_proto::DecodedExecResult {
+            termination: ExecTermination::TimedOut,
+            duration_ms: u32::MAX,
+            stdout,
+            stderr,
+            diagnostic: &max_diagnostic,
+        },
+        &[],
     )
     .unwrap();
     let expected_frame = encode(MSG_GUEST_STORAGE_MANIFEST_RESULT, 42, &payload).unwrap();
@@ -664,11 +731,14 @@ fn result_frame_enforces_diagnostic_boundary() {
     encode_guest_storage_manifest_result_frame_into(
         &mut frame,
         42,
-        ExecTermination::TimedOut,
-        u32::MAX,
-        stdout,
-        stderr,
-        &max_diagnostic,
+        guest_control_proto::DecodedExecResult {
+            termination: ExecTermination::TimedOut,
+            duration_ms: u32::MAX,
+            stdout,
+            stderr,
+            diagnostic: &max_diagnostic,
+        },
+        &[],
     )
     .unwrap();
     assert_eq!(frame, expected_frame);
@@ -678,11 +748,14 @@ fn result_frame_enforces_diagnostic_boundary() {
     let error = encode_guest_storage_manifest_result_frame_into(
         &mut frame,
         42,
-        ExecTermination::TimedOut,
-        u32::MAX,
-        stdout,
-        stderr,
-        &oversized_diagnostic,
+        guest_control_proto::DecodedExecResult {
+            termination: ExecTermination::TimedOut,
+            duration_ms: u32::MAX,
+            stdout,
+            stderr,
+            diagnostic: &oversized_diagnostic,
+        },
+        &[],
     )
     .unwrap_err();
     assert!(matches!(

--- a/crates/guest-control-server/src/connection.rs
+++ b/crates/guest-control-server/src/connection.rs
@@ -975,6 +975,29 @@ pub fn handle_connection_with_test_storage_manifest_program(
     )
 }
 
+/// Exercises storage RPC diagnostics using owned resource files.
+/// No real guest cgroup hierarchy is accessed by this integration-test hook.
+#[doc(hidden)]
+pub fn handle_connection_with_test_storage_resources(
+    stream: UnixStream,
+    program: std::path::PathBuf,
+    resource_path: std::path::PathBuf,
+) -> io::Result<()> {
+    handle_connection_with_mode_and_program(
+        stream,
+        ProcessContainmentMode::TestNoop,
+        EXEC_OUTPUT_DRAIN_DEADLINE,
+        ConnectionPrograms {
+            guest_storage_manifest: GuestStorageManifestProgram::for_test_resources(
+                program,
+                resource_path,
+            ),
+            ..ConnectionPrograms::production()
+        },
+        MeminfoSource::production(),
+    )
+}
+
 /// Handles a host-side test connection with a test workspace mount executable
 /// and child timeout.
 #[doc(hidden)]

--- a/crates/guest-control-server/src/guest_storage_manifest.rs
+++ b/crates/guest-control-server/src/guest_storage_manifest.rs
@@ -1,3 +1,4 @@
+use guest_contracts::storage_resources::StorageResourceUsage;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::ChildStdin;
@@ -40,6 +41,10 @@ const MAX_DIAGNOSTIC_BYTES: usize = u16::MAX as usize;
 pub(crate) enum GuestStorageManifestProgram {
     Production,
     Test(PathBuf),
+    TestResources {
+        program: PathBuf,
+        resource_path: PathBuf,
+    },
 }
 
 impl GuestStorageManifestProgram {
@@ -51,11 +56,36 @@ impl GuestStorageManifestProgram {
         Self::Test(path)
     }
 
+    pub(crate) fn for_test_resources(program: PathBuf, resource_path: PathBuf) -> Self {
+        Self::TestResources {
+            program,
+            resource_path,
+        }
+    }
+
     fn path(&self) -> &Path {
         match self {
             Self::Production => Path::new(guest_contracts::guest_binary::STORAGE_APPLY_PATH),
             Self::Test(path) => path,
+            Self::TestResources { program, .. } => program,
         }
+    }
+
+    fn create_containment(
+        &self,
+        seq: u32,
+        mode: ProcessContainmentMode,
+        run_id: &str,
+    ) -> Result<ExecProcessContainment, ProcessContainmentError> {
+        if let Self::TestResources { resource_path, .. } = self {
+            return Ok(ExecProcessContainment::for_test_storage_resources(
+                resource_path.clone(),
+                run_id,
+                seq,
+            ));
+        }
+        ExecProcessContainment::create(seq, mode, guest_control_proto::ExecProcessRole::Workload)
+            .map(|containment| containment.with_storage_resources(run_id, seq))
     }
 }
 
@@ -176,9 +206,10 @@ fn handle_request(
         operation_guard,
         admission,
     } = request;
+    let mut resources = None;
     let output = run_manifest(RunManifestInput {
         seq,
-        program: program.path(),
+        program,
         timeout_ms,
         run_id: &run_id,
         runtime_dir: &runtime_dir,
@@ -186,18 +217,29 @@ fn handle_request(
         connection_cancel,
         process_containment_mode,
         drain_deadline,
+        resources: &mut resources,
     });
     let stdout = captured_output(&output.stdout);
     let stderr = captured_output(&output.stderr);
+    let resource_summary = resources
+        .as_ref()
+        .and_then(|value| serde_json::to_vec(value).ok())
+        .filter(|value| {
+            value.len() <= guest_control_proto::GUEST_STORAGE_RESOURCE_SUMMARY_LIMIT_BYTES
+        })
+        .unwrap_or_default();
     let mut frame = Vec::new();
     guest_control_proto::encode_guest_storage_manifest_result_frame_into(
         &mut frame,
         seq,
-        output.termination,
-        output.duration_ms,
-        stdout,
-        stderr,
-        &output.diagnostic,
+        guest_control_proto::DecodedExecResult {
+            termination: output.termination,
+            duration_ms: output.duration_ms,
+            stdout,
+            stderr,
+            diagnostic: &output.diagnostic,
+        },
+        &resource_summary,
     )
     .map_err(to_io_error)?;
 
@@ -210,8 +252,9 @@ fn handle_request(
 }
 
 struct RunManifestInput<'a> {
+    resources: &'a mut Option<StorageResourceUsage>,
     seq: u32,
-    program: &'a Path,
+    program: &'a GuestStorageManifestProgram,
     timeout_ms: u32,
     run_id: &'a str,
     runtime_dir: &'a str,
@@ -232,6 +275,7 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
         connection_cancel,
         process_containment_mode,
         drain_deadline,
+        resources,
     } = input;
     let started = Instant::now();
     let drain_cancel = match DrainCancellation::new() {
@@ -244,21 +288,18 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
             );
         }
     };
-    let process_containment = match ExecProcessContainment::create(
-        seq,
-        process_containment_mode,
-        guest_control_proto::ExecProcessRole::Workload,
-    ) {
-        Ok(process_containment) => process_containment,
-        Err(error) => {
-            return failed_output(
-                ExecTermination::StartFailed,
-                started,
-                format!("Failed to initialize storage helper process containment: {error}"),
-            );
-        }
-    };
-    let mut command = Command::new(program);
+    let process_containment =
+        match program.create_containment(seq, process_containment_mode, run_id) {
+            Ok(process_containment) => process_containment,
+            Err(error) => {
+                return failed_output(
+                    ExecTermination::StartFailed,
+                    started,
+                    format!("Failed to initialize storage helper process containment: {error}"),
+                );
+            }
+        };
+    let mut command = Command::new(program.path());
     command
         .arg("--manifest-stdin")
         .env(guest_contracts::env::RUN_ID_ENV, run_id)
@@ -272,7 +313,8 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
     let mut child = match command.spawn(false, &process_containment) {
         Ok(child) => child,
         Err(error) => {
-            let _ = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
+            let _ = process_containment
+                .cleanup_with_storage_resources(ProcessContainmentCleanupMode::Forced, resources);
             return failed_output(
                 ExecTermination::StartFailed,
                 started,
@@ -285,6 +327,7 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
         return abort_spawned(
             child,
             process_containment,
+            resources,
             started,
             "storage helper stdin pipe missing",
         );
@@ -294,6 +337,7 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
         return abort_spawned(
             child,
             process_containment,
+            resources,
             started,
             "storage helper stdout pipe missing",
         );
@@ -304,6 +348,7 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
         return abort_spawned(
             child,
             process_containment,
+            resources,
             started,
             "storage helper stderr pipe missing",
         );
@@ -321,7 +366,8 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
             drop(stdin);
             drop(stderr);
             kill_and_reap_child(child);
-            let cleanup = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
+            let cleanup = process_containment
+                .cleanup_with_storage_resources(ProcessContainmentCleanupMode::Forced, resources);
             return failed_output(
                 ExecTermination::WaitFailed,
                 started,
@@ -343,7 +389,8 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
             drain_cancel.cancel();
             drop(stdin);
             kill_and_reap_child(child);
-            let cleanup = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
+            let cleanup = process_containment
+                .cleanup_with_storage_resources(ProcessContainmentCleanupMode::Forced, resources);
             drop(drain_done_tx);
             let _ = stdout_drain.join();
             return failed_output(
@@ -361,7 +408,8 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
         Err(error) => {
             drain_cancel.cancel();
             kill_and_reap_child(child);
-            let cleanup = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
+            let cleanup = process_containment
+                .cleanup_with_storage_resources(ProcessContainmentCleanupMode::Forced, resources);
             drop(drain_done_tx);
             let _ = stdout_drain.join();
             let _ = stderr_drain.join();
@@ -387,7 +435,8 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
     );
     let cancellation_observed = connection_cancel.load(Ordering::Acquire);
     let cleanup_mode = cleanup_mode_for_wait_outcome(&outcome, cancellation_observed);
-    let containment_result = process_containment.cleanup(cleanup_mode);
+    let containment_result =
+        process_containment.cleanup_with_storage_resources(cleanup_mode, resources);
     let stdin_result = stdin_writer.join();
     if !matches!(outcome, WaitOutcome::Exited(_))
         || cancellation_observed
@@ -451,11 +500,13 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
 fn abort_spawned(
     child: Child,
     process_containment: ExecProcessContainment,
+    resources: &mut Option<StorageResourceUsage>,
     started: Instant,
     diagnostic: &str,
 ) -> GuestStorageManifestOutput {
     kill_and_reap_child(child);
-    let cleanup = process_containment.cleanup(ProcessContainmentCleanupMode::Forced);
+    let cleanup = process_containment
+        .cleanup_with_storage_resources(ProcessContainmentCleanupMode::Forced, resources);
     failed_output(
         ExecTermination::WaitFailed,
         started,

--- a/crates/guest-control-server/src/lib.rs
+++ b/crates/guest-control-server/src/lib.rs
@@ -41,6 +41,7 @@ pub use connection::handle_connection_with_test_guest_agent_program;
 pub use connection::handle_connection_with_test_guest_state_restore_program;
 pub use connection::handle_connection_with_test_memory_snapshot_path;
 pub use connection::handle_connection_with_test_storage_manifest_program;
+pub use connection::handle_connection_with_test_storage_resources;
 pub use connection::handle_connection_with_test_workspace_drive_mount_program;
 pub use connection::{
     connect_unix, connect_vsock, handle_connection,

--- a/crates/guest-control-server/src/process_containment.rs
+++ b/crates/guest-control-server/src/process_containment.rs
@@ -24,9 +24,14 @@ use guest_contracts::process_containment::{
     WORKLOAD_CGROUP_NAME, WORKLOAD_MEMORY_OOM_GROUP, WorkloadResourceEvents,
     WorkloadResourcePolicy,
 };
+use guest_contracts::storage_resources::StorageResourceUsage;
 use guest_control_proto::ExecProcessRole;
 
 use crate::log::log;
+
+mod storage_resources;
+
+use storage_resources::{StorageOperation, read_resource_file};
 
 const CGROUP_EVENTS_FILE: &str = "cgroup.events";
 const CGROUP_KILL_FILE: &str = "cgroup.kill";
@@ -72,6 +77,10 @@ enum ContainmentBackend {
     Cgroup(CgroupGuard),
     ProcessGroup,
     TestNoop,
+    TestResourceFiles {
+        resource_path: PathBuf,
+        operation: StorageOperation,
+    },
     #[cfg(test)]
     TestDirectory(PathBuf),
 }
@@ -84,6 +93,7 @@ struct CgroupGuard {
     tools_path: Option<PathBuf>,
     create_elapsed: Duration,
     oom_evidence: Option<Arc<Mutex<crate::oom_evidence::EvidenceMonitor>>>,
+    storage_operation: Option<StorageOperation>,
 }
 
 pub(crate) struct PreparedProcessContainmentCommand<'a> {
@@ -242,6 +252,19 @@ impl ProcessContainmentError {
 }
 
 impl ExecProcessContainment {
+    pub(crate) fn for_test_storage_resources(
+        resource_path: PathBuf,
+        run_id: &str,
+        sequence: u32,
+    ) -> Self {
+        Self {
+            backend: ContainmentBackend::TestResourceFiles {
+                resource_path,
+                operation: StorageOperation::new(run_id, sequence, Instant::now()),
+            },
+        }
+    }
+
     pub(crate) fn create(
         sequence: u32,
         mode: ProcessContainmentMode,
@@ -272,12 +295,12 @@ impl ExecProcessContainment {
     pub(crate) fn prepare_command(&self) -> PreparedProcessContainmentCommand<'_> {
         match &self.backend {
             ContainmentBackend::Cgroup(guard) => guard.prepare_command(),
-            ContainmentBackend::ProcessGroup | ContainmentBackend::TestNoop => {
-                PreparedProcessContainmentCommand {
-                    directory: None,
-                    deny_process_inspection: false,
-                }
-            }
+            ContainmentBackend::ProcessGroup
+            | ContainmentBackend::TestNoop
+            | ContainmentBackend::TestResourceFiles { .. } => PreparedProcessContainmentCommand {
+                directory: None,
+                deny_process_inspection: false,
+            },
             #[cfg(test)]
             ContainmentBackend::TestDirectory(_) => PreparedProcessContainmentCommand {
                 directory: None,
@@ -286,10 +309,19 @@ impl ExecProcessContainment {
         }
     }
 
+    pub(crate) fn with_storage_resources(mut self, run_id: &str, sequence: u32) -> Self {
+        if let ContainmentBackend::Cgroup(guard) = &mut self.backend {
+            guard.storage_operation = Some(StorageOperation::new(run_id, sequence, Instant::now()));
+        }
+        self
+    }
+
     pub(crate) fn create_elapsed(&self) -> Duration {
         match &self.backend {
             ContainmentBackend::Cgroup(guard) => guard.create_elapsed,
-            ContainmentBackend::ProcessGroup | ContainmentBackend::TestNoop => Duration::ZERO,
+            ContainmentBackend::ProcessGroup
+            | ContainmentBackend::TestNoop
+            | ContainmentBackend::TestResourceFiles { .. } => Duration::ZERO,
             #[cfg(test)]
             ContainmentBackend::TestDirectory(_) => Duration::ZERO,
         }
@@ -308,7 +340,9 @@ impl ExecProcessContainment {
             ContainmentBackend::Cgroup(guard) => guard
                 .start_workload_placement_bootstrap(control_endpoint, expected_uid)
                 .map(Some),
-            ContainmentBackend::ProcessGroup | ContainmentBackend::TestNoop => Ok(None),
+            ContainmentBackend::ProcessGroup
+            | ContainmentBackend::TestNoop
+            | ContainmentBackend::TestResourceFiles { .. } => Ok(None),
             #[cfg(test)]
             ContainmentBackend::TestDirectory(_) => Ok(None),
         }
@@ -334,9 +368,40 @@ impl ExecProcessContainment {
         self,
         mode: ProcessContainmentCleanupMode,
     ) -> Result<Option<String>, ProcessContainmentError> {
+        self.cleanup_with_outputs(mode, &mut None)
+    }
+
+    pub(crate) fn cleanup_with_storage_resources(
+        self,
+        mode: ProcessContainmentCleanupMode,
+        resources: &mut Option<StorageResourceUsage>,
+    ) -> Result<(), ProcessContainmentError> {
+        self.cleanup_with_outputs(mode, resources).map(|_| ())
+    }
+
+    fn cleanup_with_outputs(
+        self,
+        mode: ProcessContainmentCleanupMode,
+        resources: &mut Option<StorageResourceUsage>,
+    ) -> Result<Option<String>, ProcessContainmentError> {
         match self.backend {
-            ContainmentBackend::Cgroup(guard) => guard.cleanup(mode),
+            ContainmentBackend::Cgroup(guard) => guard.cleanup(mode, resources),
             ContainmentBackend::ProcessGroup | ContainmentBackend::TestNoop => Ok(None),
+            ContainmentBackend::TestResourceFiles {
+                resource_path,
+                operation,
+            } => {
+                let snapshot_started = Instant::now();
+                let events = ResourceEventFiles::read(&resource_path);
+                *resources = Some(operation.collect(
+                    &format!("exec-1-{}-1", operation.sequence),
+                    &resource_path,
+                    mode,
+                    snapshot_started,
+                    &events,
+                ));
+                Ok(None)
+            }
             #[cfg(test)]
             ContainmentBackend::TestDirectory(group_path) => fs::remove_dir(group_path)
                 .map(|()| None)
@@ -514,6 +579,7 @@ impl CgroupGuard {
             workload_placement,
             tools_path,
             create_elapsed: started.elapsed(),
+            storage_operation: None,
         })
     }
 
@@ -648,6 +714,7 @@ impl CgroupGuard {
     fn cleanup(
         self,
         mode: ProcessContainmentCleanupMode,
+        resources: &mut Option<StorageResourceUsage>,
     ) -> Result<Option<String>, ProcessContainmentError> {
         let started = Instant::now();
         let CgroupGuard {
@@ -658,11 +725,18 @@ impl CgroupGuard {
             tools_path: _,
             create_elapsed,
             oom_evidence,
+            storage_operation,
         } = self;
         drop(outer_placement);
         drop(workload_placement);
 
-        log_resource_events(&group_name, &group_path.join(WORKLOAD_CGROUP_NAME));
+        log_resource_events(
+            &group_name,
+            &group_path.join(WORKLOAD_CGROUP_NAME),
+            storage_operation.as_ref(),
+            mode,
+            resources,
+        );
 
         // Capture before any cleanup enumeration, signal or removal. Placement
         // workers have joined, so this lock cannot wait behind socket IO.
@@ -824,8 +898,20 @@ fn open_placement(
         .map_err(|error| ProcessContainmentError::new(stage, error))
 }
 
-fn log_resource_events(group_name: &str, workload_path: &Path) {
-    let events = match read_resource_events(workload_path) {
+fn log_resource_events(
+    group_name: &str,
+    workload_path: &Path,
+    storage_operation: Option<&StorageOperation>,
+    mode: ProcessContainmentCleanupMode,
+    resources: &mut Option<StorageResourceUsage>,
+) {
+    let snapshot_started = Instant::now();
+    let files = ResourceEventFiles::read(workload_path);
+    if let Some(operation) = storage_operation {
+        *resources =
+            Some(operation.collect(group_name, workload_path, mode, snapshot_started, &files));
+    }
+    let events = match files.into_events() {
         Ok(events) => events,
         Err(error) => {
             log(
@@ -861,11 +947,24 @@ fn log_resource_events(group_name: &str, workload_path: &Path) {
     }
 }
 
-fn read_resource_events(workload_path: &Path) -> io::Result<WorkloadResourceEvents> {
-    let cpu = fs::read_to_string(workload_path.join(CPU_STAT_FILE))?;
-    let memory = fs::read_to_string(workload_path.join(MEMORY_EVENTS_FILE))?;
-    let pids = fs::read_to_string(workload_path.join(PIDS_EVENTS_FILE))?;
-    WorkloadResourceEvents::from_file_contents(&cpu, &memory, &pids)
+struct ResourceEventFiles {
+    cpu: io::Result<String>,
+    memory: io::Result<String>,
+    pids: io::Result<String>,
+}
+
+impl ResourceEventFiles {
+    fn read(workload_path: &Path) -> Self {
+        Self {
+            cpu: read_resource_file(workload_path, CPU_STAT_FILE),
+            memory: read_resource_file(workload_path, MEMORY_EVENTS_FILE),
+            pids: read_resource_file(workload_path, PIDS_EVENTS_FILE),
+        }
+    }
+
+    fn into_events(self) -> io::Result<WorkloadResourceEvents> {
+        WorkloadResourceEvents::from_file_contents(&self.cpu?, &self.memory?, &self.pids?)
+    }
 }
 
 #[derive(Debug)]
@@ -1787,12 +1886,15 @@ mod tests {
             tools_path: None,
             create_elapsed: Duration::ZERO,
             oom_evidence: Some(Arc::new(Mutex::new(monitor))),
+            storage_operation: None,
         };
+        let mut resources = None;
         let diagnostic = guard
-            .cleanup(ProcessContainmentCleanupMode::Forced)
+            .cleanup(ProcessContainmentCleanupMode::Forced, &mut resources)
             .unwrap()
             .unwrap();
         assert!(!root.exists());
+        assert!(resources.is_none());
         let evidence: guest_contracts::oom_evidence::OomEvidence = serde_json::from_str(
             diagnostic
                 .strip_prefix(guest_contracts::oom_evidence::EVIDENCE_PREFIX)

--- a/crates/guest-control-server/src/process_containment/storage_resources.rs
+++ b/crates/guest-control-server/src/process_containment/storage_resources.rs
@@ -1,0 +1,147 @@
+//! One bounded, pre-cleanup snapshot for a storage apply containment lifetime.
+
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::Path;
+use std::time::Instant;
+
+use guest_contracts::storage_resources::{
+    StorageCleanupMode, StorageResourceLimit, StorageResourceUsage, StorageUnlimited,
+};
+
+use super::{ProcessContainmentCleanupMode, ResourceEventFiles};
+
+const MAX_RESOURCE_FILE_BYTES: u64 = 16 * 1024;
+
+pub(super) struct StorageOperation {
+    run_id: Option<String>,
+    pub(super) sequence: u32,
+    started: Instant,
+}
+
+impl StorageOperation {
+    pub(super) fn new(run_id: &str, sequence: u32, started: Instant) -> Self {
+        // Validate only the diagnostic identity, not RPC admission or helper env.
+        let canonical_uuid = run_id.len() == 36
+            && run_id.bytes().enumerate().all(|(index, byte)| {
+                if matches!(index, 8 | 13 | 18 | 23) {
+                    byte == b'-'
+                } else {
+                    byte.is_ascii_hexdigit()
+                }
+            });
+        Self {
+            run_id: canonical_uuid.then(|| run_id.to_owned()),
+            sequence,
+            started,
+        }
+    }
+
+    pub(super) fn collect(
+        &self,
+        group_name: &str,
+        workload_path: &Path,
+        mode: ProcessContainmentCleanupMode,
+        snapshot_started: Instant,
+        events: &ResourceEventFiles,
+    ) -> StorageResourceUsage {
+        let memory_stat = read_resource_file(workload_path, "memory.stat");
+        let memory_current = read_resource_file(workload_path, "memory.current");
+        let memory_peak = read_resource_file(workload_path, "memory.peak");
+        let memory_high = read_resource_file(workload_path, "memory.high");
+        let memory_max = read_resource_file(workload_path, "memory.max");
+        let cpu_max = read_resource_file(workload_path, "cpu.max");
+        let mut cpu_words = cpu_max.as_deref().ok().map(str::split_ascii_whitespace);
+        let quota = cpu_words.as_mut().and_then(Iterator::next);
+        let period = cpu_words.as_mut().and_then(Iterator::next);
+        let valid_cpu_max = quota.is_some()
+            && period.is_some()
+            && cpu_words.as_mut().and_then(Iterator::next).is_none();
+        let mut resources = StorageResourceUsage {
+            run_id: self.run_id.clone(),
+            request_seq: self.sequence,
+            group: group_name.to_owned(),
+            cleanup_mode: match mode {
+                ProcessContainmentCleanupMode::Graceful => StorageCleanupMode::Graceful,
+                ProcessContainmentCleanupMode::Forced => StorageCleanupMode::Forced,
+            },
+            containment_wall_us: micros(snapshot_started.duration_since(self.started)),
+            collection_us: 0,
+            cpu_usage_usec: counter(events.cpu.as_deref().ok(), "usage_usec"),
+            cpu_user_usec: counter(events.cpu.as_deref().ok(), "user_usec"),
+            cpu_system_usec: counter(events.cpu.as_deref().ok(), "system_usec"),
+            cpu_nr_periods: counter(events.cpu.as_deref().ok(), "nr_periods"),
+            cpu_nr_throttled: counter(events.cpu.as_deref().ok(), "nr_throttled"),
+            cpu_throttled_usec: counter(events.cpu.as_deref().ok(), "throttled_usec"),
+            memory_events_high: counter(events.memory.as_deref().ok(), "high"),
+            memory_events_max: counter(events.memory.as_deref().ok(), "max"),
+            memory_events_oom: counter(events.memory.as_deref().ok(), "oom"),
+            memory_events_oom_kill: counter(events.memory.as_deref().ok(), "oom_kill"),
+            memory_events_oom_group_kill: counter(events.memory.as_deref().ok(), "oom_group_kill"),
+            pids_events_max: counter(events.pids.as_deref().ok(), "max"),
+            memory_pgfault: counter(memory_stat.as_deref().ok(), "pgfault"),
+            memory_pgmajfault: counter(memory_stat.as_deref().ok(), "pgmajfault"),
+            memory_pgscan: counter(memory_stat.as_deref().ok(), "pgscan"),
+            memory_pgsteal: counter(memory_stat.as_deref().ok(), "pgsteal"),
+            memory_pgscan_kswapd: counter(memory_stat.as_deref().ok(), "pgscan_kswapd"),
+            memory_pgscan_direct: counter(memory_stat.as_deref().ok(), "pgscan_direct"),
+            memory_pgsteal_kswapd: counter(memory_stat.as_deref().ok(), "pgsteal_kswapd"),
+            memory_pgsteal_direct: counter(memory_stat.as_deref().ok(), "pgsteal_direct"),
+            memory_workingset_refault_anon: counter(
+                memory_stat.as_deref().ok(),
+                "workingset_refault_anon",
+            ),
+            memory_workingset_refault_file: counter(
+                memory_stat.as_deref().ok(),
+                "workingset_refault_file",
+            ),
+            memory_current_bytes: memory_current
+                .ok()
+                .and_then(|value| value.trim().parse().ok()),
+            memory_peak_bytes: memory_peak.ok().and_then(|value| value.trim().parse().ok()),
+            memory_high_limit_bytes: limit_value(memory_high.as_deref().ok().map(str::trim)),
+            memory_max_limit_bytes: limit_value(memory_max.as_deref().ok().map(str::trim)),
+            cpu_quota_us: limit_value(quota.filter(|_| valid_cpu_max)),
+            cpu_period_us: period
+                .filter(|_| valid_cpu_max)
+                .and_then(|value| value.parse().ok()),
+        };
+        resources.collection_us = micros(snapshot_started.elapsed());
+        resources
+    }
+}
+
+fn micros(duration: std::time::Duration) -> u64 {
+    u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
+}
+
+fn counter(contents: Option<&str>, key: &str) -> Option<u64> {
+    let mut matches = contents?.lines().filter_map(|line| {
+        let mut words = line.split_ascii_whitespace();
+        (words.next() == Some(key)).then_some(words)
+    });
+    let mut words = matches.next()?;
+    let value = words.next()?.parse().ok()?;
+    (words.next().is_none() && matches.next().is_none()).then_some(value)
+}
+
+fn limit_value(value: Option<&str>) -> Option<StorageResourceLimit> {
+    match value? {
+        "max" => Some(StorageResourceLimit::Unlimited(StorageUnlimited::Max)),
+        value => value.parse().ok().map(StorageResourceLimit::Value),
+    }
+}
+
+pub(super) fn read_resource_file(workload_path: &Path, filename: &str) -> io::Result<String> {
+    let mut contents = String::new();
+    File::open(workload_path.join(filename))?
+        .take(MAX_RESOURCE_FILE_BYTES + 1)
+        .read_to_string(&mut contents)?;
+    if contents.len() as u64 > MAX_RESOURCE_FILE_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "resource file exceeds limit",
+        ));
+    }
+    Ok(contents)
+}

--- a/crates/guest-control-server/tests/connection/guest_storage_manifest.rs
+++ b/crates/guest-control-server/tests/connection/guest_storage_manifest.rs
@@ -9,6 +9,8 @@ use guest_control_proto::{
 
 use super::support::*;
 
+mod resources;
+
 fn create_program(body: &str) -> (tempfile::TempDir, PathBuf) {
     let directory = tempfile::tempdir().unwrap();
     let path = directory.path().join("guest-storage-apply-test");
@@ -37,6 +39,7 @@ fn send_request(
 }
 
 struct TestResult {
+    resources: Vec<u8>,
     termination: ExecTermination,
     stdout: Vec<u8>,
     stderr: Vec<u8>,
@@ -51,9 +54,12 @@ fn read_result(stream: &mut impl std::io::Read, seq: u32) -> TestResult {
     assert_eq!(message.seq, seq);
     let decoded =
         guest_control_proto::decode_guest_storage_manifest_result(&message.payload).unwrap();
+    let resources = decoded.resource_summary.to_vec();
+    let decoded = decoded.result;
     let (stdout, stdout_truncated) = captured(decoded.stdout);
     let (stderr, stderr_truncated) = captured(decoded.stderr);
     TestResult {
+        resources,
         termination: decoded.termination,
         stdout,
         stderr,

--- a/crates/guest-control-server/tests/connection/guest_storage_manifest/resources.rs
+++ b/crates/guest-control-server/tests/connection/guest_storage_manifest/resources.rs
@@ -1,0 +1,219 @@
+use std::fs;
+use std::os::unix::net::UnixStream;
+use std::thread;
+
+use serde_json::{Value, json};
+
+use super::*;
+
+const RUN_ID: &str = "8d7a07c8-15b2-446f-9f47-36d32028baa6";
+
+fn start_with_resources(
+    program: PathBuf,
+    resources: &Path,
+) -> (thread::JoinHandle<std::io::Result<()>>, UnixStream) {
+    let resource_path = resources.to_owned();
+    let (guest, mut host) = UnixStream::pair().unwrap();
+    let handle = thread::spawn(move || {
+        guest_control_server::handle_connection_with_test_storage_resources(
+            guest,
+            program,
+            resource_path,
+        )
+    });
+    read_guest_ready(&mut host);
+    (handle, host)
+}
+
+fn resource_summary(result: &TestResult) -> Value {
+    assert!(
+        result.resources.len() < guest_control_proto::GUEST_STORAGE_RESOURCE_SUMMARY_LIMIT_BYTES
+    );
+    serde_json::from_slice(&result.resources).unwrap()
+}
+
+#[test]
+fn successful_storage_rpc_records_one_resource_snapshot_per_request() {
+    let (directory, program) = create_program("cat >/dev/null; printf applied");
+    for (name, contents) in [
+        (
+            "cpu.stat",
+            "usage_usec 5100000\nuser_usec 4800000\nsystem_usec 300000\nnr_periods 31\nnr_throttled 29\nthrottled_usec 5014584\nfuture_counter 123\n",
+        ),
+        (
+            "memory.events",
+            "high 0\nmax 2\noom 1\noom_kill 1\noom_group_kill 0\n",
+        ),
+        ("pids.events", "max 0\n"),
+        (
+            "memory.stat",
+            "pgfault 210\npgmajfault 0\npgscan 16\npgsteal 8\npgscan_kswapd 16\npgscan_direct 0\npgsteal_kswapd 8\npgsteal_direct 0\nworkingset_refault_anon 1\nworkingset_refault_file 2\n",
+        ),
+        ("memory.current", "65536\n"),
+        ("memory.peak", "1048576\n"),
+        ("memory.high", "max\n"),
+        ("memory.max", "3997175808\n"),
+        ("cpu.max", "190000 100000\n"),
+    ] {
+        fs::write(directory.path().join(name), contents).unwrap();
+    }
+    let (handle, mut host) = start_with_resources(program, directory.path());
+    let mut summaries = Vec::new();
+    for seq in [501, 502] {
+        send_request(&mut host, seq, 1000, RUN_ID, "/run", b"{}");
+        let result = read_result(&mut host, seq);
+        assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+        assert_eq!(result.stdout, b"applied");
+        summaries.push(resource_summary(&result));
+        assert!(result.diagnostic.is_empty());
+    }
+    finish_guest_connection(handle, host);
+    assert_eq!(summaries.len(), 2);
+    for (summary, seq) in summaries.iter().zip([501, 502]) {
+        for (field, expected) in [
+            ("run_id", json!(RUN_ID)),
+            ("request_seq", json!(seq)),
+            ("cleanup_mode", json!("Graceful")),
+            ("cpu_usage_usec", json!(5_100_000)),
+            ("cpu_user_usec", json!(4_800_000)),
+            ("cpu_system_usec", json!(300_000)),
+            ("cpu_nr_periods", json!(31)),
+            ("cpu_nr_throttled", json!(29)),
+            ("cpu_throttled_usec", json!(5_014_584)),
+            ("cpu_quota_us", json!(190_000)),
+            ("cpu_period_us", json!(100_000)),
+            ("memory_current_bytes", json!(65_536)),
+            ("memory_peak_bytes", json!(1_048_576)),
+            ("memory_high_limit_bytes", json!("max")),
+            ("memory_max_limit_bytes", json!(3_997_175_808_u64)),
+            ("memory_events_high", json!(0)),
+            ("memory_events_max", json!(2)),
+            ("memory_pgmajfault", json!(0)),
+            ("memory_pgscan_direct", json!(0)),
+            ("memory_pgsteal_kswapd", json!(8)),
+        ] {
+            assert_eq!(summary.get(field), Some(&expected), "{field}");
+        }
+        assert!(summary.get("cpu_future_counter").is_none());
+        assert!(
+            summary
+                .get("containment_wall_us")
+                .and_then(Value::as_u64)
+                .is_some()
+        );
+        assert!(
+            summary
+                .get("collection_us")
+                .and_then(Value::as_u64)
+                .is_some()
+        );
+    }
+}
+
+#[test]
+fn unavailable_resources_do_not_fail_storage_or_leak_request_text() {
+    let (directory, program) = create_program("cat >/dev/null; exit 7");
+    fs::write(directory.path().join("cpu.stat"), "usage_usec -1\nuser_usec 10\nuser_usec 11\nsystem_usec secret-value\nnr_periods 0\nthrottled_usec 18446744073709551616\n").unwrap();
+    fs::write(
+        directory.path().join("memory.events"),
+        "high 0 extra\nmax 0\n",
+    )
+    .unwrap();
+    fs::write(directory.path().join("memory.peak"), "secret-value").unwrap();
+    fs::write(
+        directory.path().join("memory.stat"),
+        vec![b'x'; 16 * 1024 + 1],
+    )
+    .unwrap();
+    fs::write(directory.path().join("cpu.max"), "190000 100000 extra").unwrap();
+    let (handle, mut host) = start_with_resources(program, directory.path());
+    send_request(
+        &mut host,
+        503,
+        1000,
+        "secret-run\nforged log",
+        "/run",
+        b"{}",
+    );
+    let result = read_result(&mut host, 503);
+    let summary = resource_summary(&result);
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 7 });
+    assert!(result.diagnostic.is_empty());
+    finish_guest_connection(handle, host);
+
+    for field in [
+        "run_id",
+        "cpu_usage_usec",
+        "cpu_user_usec",
+        "cpu_system_usec",
+        "cpu_throttled_usec",
+        "cpu_quota_us",
+        "cpu_period_us",
+        "memory_events_high",
+        "memory_peak_bytes",
+        "memory_current_bytes",
+        "memory_pgscan",
+        "pids_events_max",
+    ] {
+        assert_eq!(summary.get(field), Some(&Value::Null), "{field}");
+    }
+    assert_eq!(summary.get("cpu_nr_periods"), Some(&json!(0)));
+    assert_eq!(summary.get("memory_events_max"), Some(&json!(0)));
+    assert!(!summary.to_string().contains("secret"));
+    assert!(!summary.to_string().contains("forged"));
+}
+
+#[test]
+fn forced_storage_cleanup_retains_diagnostics_with_missing_kernel_files() {
+    for disconnect in [false, true] {
+        let pid_path = unique_pid_path("storage-resources-forced");
+        let mut process_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+        let (directory, program) = create_program(&slow_program(Path::new(pid_path.as_str())));
+        fs::write(directory.path().join("cpu.max"), "max 100000\n").unwrap();
+        let (handle, mut host) = start_with_resources(program, directory.path());
+        send_request(
+            &mut host,
+            504,
+            if disconnect { 60_000 } else { 20 },
+            RUN_ID,
+            "/run",
+            b"{}",
+        );
+        let pid = process_guard.read_pid();
+        let resources = if disconnect {
+            drop(host);
+            join_guest_connection(handle);
+            None
+        } else {
+            let result = read_result(&mut host, 504);
+            assert_eq!(result.termination, ExecTermination::TimedOut);
+            let resources = resource_summary(&result);
+            finish_guest_connection(handle, host);
+            Some(resources)
+        };
+        wait_for_pid_exit(pid, "resource diagnostic cleanup");
+        process_guard.disarm();
+        if let Some(resources) = resources {
+            assert_eq!(resources.get("cleanup_mode"), Some(&json!("Forced")));
+            assert_eq!(resources.get("cpu_quota_us"), Some(&json!("max")));
+            assert_eq!(resources.get("cpu_period_us"), Some(&json!(100_000)));
+            assert_eq!(resources.get("memory_peak_bytes"), Some(&Value::Null));
+            assert_eq!(resources.get("cpu_usage_usec"), Some(&Value::Null));
+        }
+    }
+}
+
+#[test]
+fn storage_start_failure_retains_resource_evidence_without_changing_diagnostic() {
+    let (directory, program) = create_program("exit 0");
+    fs::remove_file(&program).unwrap();
+    let (handle, mut host) = start_with_resources(program, directory.path());
+    send_request(&mut host, 505, 1000, RUN_ID, "/run", b"{}");
+    let result = read_result(&mut host, 505);
+    assert_eq!(result.termination, ExecTermination::StartFailed);
+    assert!(result.diagnostic.contains("Failed to start storage helper"));
+    let resources = resource_summary(&result);
+    assert_eq!(resources["cleanup_mode"], "Forced");
+    assert_eq!(resources["request_seq"], 505);
+    finish_guest_connection(handle, host);
+}

--- a/crates/guest-control-tests/tests/integration/main.rs
+++ b/crates/guest-control-tests/tests/integration/main.rs
@@ -9,5 +9,6 @@
 mod exec;
 mod file_write_status;
 mod shutdown;
+mod storage_manifest;
 mod support;
 mod write_file;

--- a/crates/guest-control-tests/tests/integration/storage_manifest.rs
+++ b/crates/guest-control-tests/tests/integration/storage_manifest.rs
@@ -1,0 +1,71 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::time::Duration;
+
+use guest_control_client::GuestControlClient;
+use guest_control_proto::{ExecTermination, VSOCK_PORT};
+
+use crate::support::{join_raw_guest_connection, wait_for_path};
+
+#[tokio::test]
+async fn storage_resources_cross_the_real_client_server_boundary() {
+    let directory = tempfile::tempdir().unwrap();
+    let program = directory.path().join("helper");
+    fs::write(
+        &program,
+        "#!/bin/sh\ncat >/dev/null\nprintf applied\nprintf warning >&2\n",
+    )
+    .unwrap();
+    fs::set_permissions(&program, fs::Permissions::from_mode(0o700)).unwrap();
+    fs::write(
+        directory.path().join("cpu.stat"),
+        "usage_usec 5100000\nnr_throttled 27\n",
+    )
+    .unwrap();
+    fs::write(directory.path().join("memory.peak"), "268435456\n").unwrap();
+    fs::write(directory.path().join("memory.high"), "max\n").unwrap();
+    let vsock = directory.path().join("vsock");
+    let listener = format!("{}_{VSOCK_PORT}", vsock.display());
+    let resources = directory.path().to_owned();
+    let host =
+        GuestControlClient::wait_for_connection(vsock.to_str().unwrap(), Duration::from_secs(5));
+    let guest = async {
+        wait_for_path(std::path::Path::new(&listener), Duration::from_secs(5)).await;
+        std::thread::spawn(move || {
+            let stream = guest_control_server::connect_unix(&listener)?;
+            guest_control_server::handle_connection_with_test_storage_resources(
+                stream, program, resources,
+            )
+        })
+    };
+    let (host, guest) = tokio::join!(host, guest);
+    let host = host.unwrap();
+    for index in 0..2 {
+        if index == 1 {
+            fs::write(directory.path().join("cpu.stat"), "usage_usec malformed\n").unwrap();
+        }
+        let result = host
+            .guest_storage_manifest(
+                b"{}",
+                "8d7a07c8-15b2-446f-9f47-36d32028baa6",
+                "/run",
+                1000,
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+        assert_eq!(result.stdout, b"applied");
+        assert_eq!(result.stderr, b"warning");
+        assert!(result.diagnostic.is_empty());
+        let resources = result.resources.unwrap();
+        assert_eq!(
+            resources.cpu_usage_usec,
+            if index == 0 { Some(5_100_000) } else { None }
+        );
+        assert_eq!(resources.memory_peak_bytes, Some(268_435_456));
+        assert_eq!(resources.memory_current_bytes, None);
+    }
+    drop(host);
+    join_raw_guest_connection(guest);
+}

--- a/crates/sandbox-firecracker/src/sandbox.rs
+++ b/crates/sandbox-firecracker/src/sandbox.rs
@@ -2754,7 +2754,10 @@ impl Sandbox for FirecrackerSandbox {
                     Duration::from_millis(u64::from(timeout_ms) + 5_000),
                 )
                 .await
-                .map(storage_manifest_exec_result)
+                .map(|result| {
+                    result.log_resources(&self.id);
+                    storage_manifest_exec_result(result)
+                })
         })
         .await
     }

--- a/crates/sandbox-firecracker/src/sandbox/tests.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests.rs
@@ -2810,6 +2810,9 @@ fn exec_result_from_operation_result_preserves_terminal_metadata() {
 
 #[tokio::test]
 async fn apply_storage_manifest_preserves_terminal_metadata() {
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
     let sandbox = test_sandbox_with_state(SandboxState::Running);
     let mut guest = attach_mock_shutdown_guest(&sandbox).await;
     let request = StorageManifestRequest {
@@ -2833,18 +2836,35 @@ async fn apply_storage_manifest_preserves_terminal_metadata() {
         assert_eq!(decoded.runtime_dir, "/run/vm0/runs/run-1");
         assert_eq!(decoded.manifest_json, b"{\"storages\":[]}");
 
+        let resources = serde_json::to_vec(&serde_json::json!({
+            "run_id": null,
+            "request_seq": request.seq,
+            "group": format!("exec-7-{}-1", request.seq),
+            "cleanup_mode": "Forced",
+            "containment_wall_us": 19000,
+            "collection_us": 170,
+            "cpu_usage_usec": 16000,
+            "memory_peak_bytes": 1048576,
+            "memory_high_limit_bytes": "max",
+            "unknown_peer_field": "must-not-be-logged"
+        }))
+        .unwrap();
+
         let payload = guest_control_proto::encode_guest_storage_manifest_result(
-            guest_control_proto::ExecTermination::WaitFailed,
-            19,
-            guest_control_proto::ExecCapturedOutput::Captured {
-                bytes: b"out",
-                truncated: true,
+            guest_control_proto::DecodedExecResult {
+                termination: guest_control_proto::ExecTermination::WaitFailed,
+                duration_ms: 19,
+                stdout: guest_control_proto::ExecCapturedOutput::Captured {
+                    bytes: b"out",
+                    truncated: true,
+                },
+                stderr: guest_control_proto::ExecCapturedOutput::Captured {
+                    bytes: b"err",
+                    truncated: false,
+                },
+                diagnostic: "containment cleanup failed",
             },
-            guest_control_proto::ExecCapturedOutput::Captured {
-                bytes: b"err",
-                truncated: false,
-            },
-            "containment cleanup failed",
+            &resources,
         )
         .unwrap();
         let response = guest_control_proto::encode(
@@ -2865,6 +2885,21 @@ async fn apply_storage_manifest_preserves_terminal_metadata() {
     assert!(result.stdout_truncated);
     assert!(!result.stderr_truncated);
     assert_eq!(result.diagnostic, "containment cleanup failed");
+    let events = captured.entries();
+    let summaries: Vec<_> = events
+        .iter()
+        .filter(|event| {
+            event.fields.get("message").map(String::as_str) == Some("storage apply resources")
+        })
+        .collect();
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].fields["id"], sandbox.id.to_string());
+    let resources: serde_json::Value =
+        serde_json::from_str(&summaries[0].fields["resources"]).unwrap();
+    assert_eq!(resources["cpu_usage_usec"], 16000);
+    assert_eq!(resources["memory_high_limit_bytes"], "max");
+    assert!(resources["memory_pgscan"].is_null());
+    assert!(!summaries[0].fields["resources"].contains("must-not-be-logged"));
 }
 
 #[tokio::test]

--- a/docs/storage-apply-resource-diagnostics.md
+++ b/docs/storage-apply-resource-diagnostics.md
@@ -1,0 +1,79 @@
+# Storage apply resource diagnostics
+
+The guest control server takes one resource snapshot before cleaning an
+initialized storage-apply cgroup. It returns the snapshot in a dedicated bounded
+field of the storage terminal RPC. The Runner validates and logs it as an INFO
+`storage apply resources` event, with a JSON `resources` field and the sandbox
+`id`. Normal operations, nonzero exits and timeouts are included, not just
+CPU-pressure cases. Existing guest pressure and hard-limit warnings remain
+separate. Other exec, agent and tool operations do not acquire this snapshot.
+
+Find these events in Runner local logs. Routine INFO evidence is not guaranteed
+to be ingested into Axiom. Join the resource JSON `run_id`, `request_seq` and
+`group` with the sandbox identity. Group names include process, request and
+operation counters. The host binds the evidence to its actual request and only
+logs the typed allowlisted fields. Non-UUID-shaped run IDs are `null` without
+changing accepted inputs or helper environment.
+
+## Field meanings
+
+| Fields                                                                  | Meaning                                                                                                                                                                                     |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `containment_wall_us`                                                   | Time from enabling the summary on the fresh, empty containment (after cgroup creation, before placement/spawn) to starting the pre-cleanup snapshot.                                        |
+| `cleanup_mode`                                                          | `Graceful` or `Forced`; this is a cleanup decision, not the helper exit status.                                                                                                             |
+| `cpu_usage_usec`, `cpu_user_usec`, `cpu_system_usec`                    | Cumulative CPU time charged to this operation's workload.                                                                                                                                   |
+| `cpu_nr_periods`, `cpu_nr_throttled`, `cpu_throttled_usec`              | CPU bandwidth period and accumulated throttling counters.                                                                                                                                   |
+| `cpu_quota_us`, `cpu_period_us`                                         | The actual configured workload-leaf `cpu.max`, not effective ancestor limits. Quota `"max"` means unlimited.                                                                                |
+| `memory_current_bytes`, `memory_peak_bytes`                             | Charged current/peak cgroup memory. Peak is since creation; no counter is reset.                                                                                                            |
+| `memory_high_limit_bytes`, `memory_max_limit_bytes`                     | Actual configured leaf limits; `"max"` means unlimited.                                                                                                                                     |
+| `memory_pgfault`, `memory_pgmajfault`                                   | Workload fault counters, not fault durations.                                                                                                                                               |
+| `memory_pgscan*`, `memory_pgsteal*`                                     | Scanned/reclaimed page counters, including direct and kswapd variants when supported.                                                                                                       |
+| `memory_workingset_refault_anon`, `memory_workingset_refault_file`      | Workingset refault counters when supported.                                                                                                                                                 |
+| `memory_events_high/max/oom/oom_kill/oom_group_kill`, `pids_events_max` | The corresponding resource-limit events, shared with existing cleanup diagnostics.                                                                                                          |
+| `collection_us`                                                         | Reading and assembling this snapshot, including the three existing event reads; excludes serialization, RPC transport and host logging. Measure those costs separately or in the full call. |
+
+Missing, unreadable, oversized, malformed or unsupported readings are `null`,
+never invented zeros. Only allowlisted fields and parsed unsigned values or
+`"max"` limits are emitted. Each of nine fixed cgroup files is capped at 16 KiB;
+there is no sampling loop, ancestor walk or new background worker. The optional
+resource field is capped at 4 KiB and does not replace stdout, stderr or error
+diagnostics. The guest does not print this summary to its serial console.
+Collection, serialization, result transport and host logging still add
+synchronous pre-spawn work; this is not a claim of zero overhead.
+
+Unavailable or unencodable evidence is omitted. Bounded invalid JSON or mismatched
+identity is discarded by the host with a fixed warning, without logging raw peer
+data or changing an otherwise valid helper result. Invalid core RPC framing still
+fails normally. Real containment/cleanup failures retain their existing semantics
+and do not discard an already collected snapshot.
+
+## Interpretation limits
+
+- The wall interval includes placement, helper execution and waiting, but not
+  cgroup creation, output-drain completion, cleanup or result transport. It is
+  wider than `archive_scheduler`; do not divide operation CPU by scheduler time.
+  It is not `api_to_spawn` or team-concurrency queue time.
+- Reads are sequential, not an atomic kernel snapshot. Forced cleanup can still
+  have live descendants at this boundary; those counters are not final lifetime
+  accounting. A disconnected or crashed guest cannot deliver a terminal summary;
+  cleanup still runs on disconnect, but this evidence is unavailable. There is
+  no serial fallback, retry, durable outbox or delayed logger. Missing summaries
+  are not zero usage.
+- Accumulated throttled time can exceed elapsed wall time. Do not subtract it
+  from latency or advertise it as a removable saving.
+- Configured leaf limits do not establish unconstrained ancestors or explain
+  scheduler/accounting stalls. A later snapshot cannot reconstruct per-period
+  CPU execution or a historical pause/resume trace.
+- With `memory.high=max`, zero high events do not exclude guest-global reclaim.
+  Peak/charged memory omits the timing of pressure and does not represent all
+  shared pages accessed. Cgroup reclaim and fault counts do not measure all
+  global allocation, writeback, host paging or balloon-related stalls.
+- Compare exact Runner/API artifacts when analyzing frequently released,
+  mixed-version production windows. Older versions have no summary. These
+  internal storage-result format changes together with the bundled Runner/guest
+  binaries, which are one deployed artifact. It changes no externally deployed
+  API, queue, persisted state or resource policy. Do not pair a new Runner with
+  old guest binaries; see [deployment compatibility](deployment-compatibility.md).
+
+See the authoritative [cgroup v2 interface](https://docs.kernel.org/admin-guide/cgroup-v2.html)
+and [CPU bandwidth control](https://docs.kernel.org/scheduler/sched-bwc.html).


### PR DESCRIPTION
## Summary

Closes #32607.
Relates to #32414 and #24203; the historical production root-cause investigation remains open.

Storage-apply latency currently lacks per-operation CPU/memory evidence. Collect one bounded pre-cleanup snapshot and deliver it through the dedicated terminal RPC to a typed, identity-bound Runner INFO event.

- Reuse three existing cgroup event reads and add six fixed resource files (16 KiB/file), covering CPU usage/quota/throttling and memory usage/peak/limits/reclaim/faults.
- Carry optional <=4 KiB resource JSON separately from process outcome, stdout/stderr and error diagnostics; retain an available snapshot across startup, timeout and cleanup failures.
- Validate actual run/request/generated-cgroup identity, discard unknown peer fields and log once with the host-owned sandbox identity. Missing/malformed optional evidence is unavailable, not invented zero; malformed core framing still fails normally.
- Document field meanings and limitations, and cover the public codec, real client/server boundary, timeout/disconnect and provider host-log consumer.

This is permanent bounded observability, **not an experiment, startup optimization or zero-overhead claim**. No archive-concurrency, CPU/memory quota, balloon, team queue, launcher/clone3, drain policy, async worker, API, deployment or CI changes. Ignored benchmark scripts and raw data are not included.

## Compatibility and risks

Runner and guest binaries are already one bundled artifact; the storage terminal wire layout changes together. Do not combine a new host with old guest binaries. Independently deployed API/queue/persisted-state boundaries are unchanged.

Collection and logging add synchronous work and about 1 KiB of host log volume per result. Sequential pre-cleanup counters are not atomic/final accounting; leaf limits do not establish ancestor/global constraints. Disconnect/crash can lose the terminal summary. Routine INFO ingestion into Axiom is not guaranteed. These data help future attribution, not retrospective proof of #32414's cause.

## Native local-11 acceptance (pre-rebase head)

The [prospectively fixed protocol](https://github.com/vm0-ai/vm0/issues/32607#issuecomment-5595454437) qualified its precision with same-binary A/A before **three independently accepted native A/B cohorts**. Each contains 8,192 archive pairs and 512 empty pairs, separate warmups and full restored-file checks. Total: **52,248 A/B calls; 26,124 validated summaries**.

| Batch | Empty p90 increment | Empty 95% upper bound | 114-archive p90 increment | Archive 95% upper bound |
| --- | ---: | ---: | ---: | ---: |
| 102 | +0.318 ms | +0.551 ms | +0.132 ms (+0.135%) | +0.396 ms |
| 103 | +0.320 ms | +0.770 ms | +0.302 ms (+0.308%) | +0.518 ms |
| 104 | +0.235 ms | +0.435 ms | +0.019 ms (+0.019%) | +0.374 ms |

Every batch passes empty <=1 ms and archive <=1 ms AND <=5% empirical p90 increments, plus the predeclared conservative confidence-upper-bound requirements. Full-call timers include actual native RPC, helper/containment, collection/serialization, typed host decoding and the exact INFO stderr/nonblocking rolling-file call. All content, identity, bounds, sink-equivalence, logger-drop and cleanup checks pass; all warmups, tails and host-pressure fluctuations are retained.

Shared local-11, x86_64-musl, 2 vCPU/4096 MiB; archive concurrency four and resource policy unchanged. Old surrounding Runner/image is disclosed benchmark infrastructure, not production Blank/API replay. No fleet speedup claim. The prior low-resolution +1.965 ms archive failure remains historical evidence; no retrospective pooling, relabeling or retry-until-green. All owned VMs are cleaned up and the exclusive base recoverably archived; both unrelated services remain active.

[Full final evidence and limits](https://github.com/vm0-ai/vm0/issues/32607#issuecomment-5598852866); [exact-source Rust and real-guest control evidence](https://github.com/vm0-ai/vm0/issues/32607#issuecomment-5595288607). These native measurements and real-guest controls apply to the pre-rebase commit `fa9a3b770d679a4549c48395fed82c2c6bc42b1b`. They have **not** been rerun on the rebased head and are not exact-head performance certification for it.

## Rebase and test-isolation follow-up

Current head: `a356f32b7575f230507f40470aa2bca8c0222c0c`, rebased onto `main` at `eaf0fbfa49920d5eda5f9c86bb2c72c8f758b1a7`.

- Preserve main's bounded OOM evidence capture and its terminal diagnostic precedence alongside the separate storage-resource output. Both still capture before containment cleanup removes their sources.
- Adapt main's OOM cleanup regression to the new resource-output argument and assert that a non-storage operation produces no storage summary.
- The first expanded Guest Agent integration run failed `flush_is_incremental_between_calls` and `urgent_oom_stalled_http_has_two_bounded_attempts_and_retains_evidence`. The tests passed individually, but two newly merged OOM tests changed the process-global telemetry destination without taking the integration suite's shared lock.
- With user approval, those two private-listener tests now hold the existing `SharedApiMock` guard before installing telemetry paths and through teardown. No production telemetry behavior, timeout, assertion, test selection, or CI setting changed.

## Validation

Passed for the resolved tree. Protocol/client/server checks from the immediately preceding rebase step are reused because the only subsequent edit was the Guest Agent test-isolation fix. The full Guest Agent/Runner test command that previously failed was rerun after that fix and passed.

```sh
# From crates/, heavy checks executed sequentially
cargo fmt --all -- --check
cargo test --profile local -p guest-control-server --all-targets --all-features --quiet
cargo test --profile local -p guest-contracts -p guest-control-proto -p guest-control-client -p guest-control-tests --all-targets --all-features --quiet
cargo test --profile local -p guest-agent --test integration
cargo test --profile local -p guest-agent -p guest-init -p sandbox-firecracker -p runner --all-targets --all-features --quiet
cargo clippy --profile local -p guest-contracts -p guest-control-proto -p guest-control-server -p guest-control-client -p guest-control-tests -p guest-agent -p guest-init -p sandbox-firecracker -p runner --all-targets --all-features -- -D warnings
RUSTDOCFLAGS=-Dwarnings cargo doc --profile local -p guest-contracts -p guest-control-proto -p guest-control-server -p guest-control-client -p guest-control-tests -p guest-agent -p guest-init -p sandbox-firecracker -p runner --all-features --no-deps
cargo xtask check-rust-path-attributes

# From turbo/
pnpm exec prettier --check ../docs/storage-apply-resource-diagnostics.md

# From repository root
git diff --check
```

Guest Agent integration: **140 passed**, both standalone and within the full multi-crate run, using default test concurrency. Runner: **3,623 passed**; sandbox-firecracker: **879 passed**. Existing privileged/CI-only ignored tests are unchanged and **not claimed as local passes**. Environment preparation also completed successfully.

Range-diff confirms that the original feature patch is preserved, with only the OOM conflict integration/test adaptation and the approved three-line telemetry test fix. The update was pushed with an explicit expected-head lease.

Local-11 native benchmarks were not rerun after rebase. PR CI and deployment are not certified by these local checks. No merge requested.
