### PR TITLE
docs(platform): record the merged page-surface card batch

### DIFF
--- a/docs/style-migration.md
+++ b/docs/style-migration.md
@@ -113,6 +113,27 @@ Investigate that finding before using this runner as an unattended gate;
 `verified` records the successful bounded acceptance, not flake-free automation
 or completion of the issue-wide migration.
 
+## Batches migrated outside the repeatable suite
+
+The `page-surface-cards` batch, [PR #32604](https://github.com/vm0-ai/vm0/pull/32604),
+cleared `okou-card` from 28 consumers before `cases.json` covered any page
+surface. It was captured under its own archived protocol of 98 cases, so it
+cannot borrow the preference-dialog case ids, and recording nothing at all
+would leave the manifest unable to answer which batches were accepted.
+
+Such a batch declares `externalProtocol` with the reason, its own case count,
+and its passed/failed split, and leaves `cases` empty. The check then requires
+durable evidence and a consistent result count, and refuses the `verified`
+status, so the repeatable suite remains the only route to acceptance. This
+state records what actually ran; it does not authorize skipping the suite.
+
+`page-surface-cards` merged at 96 passed and 2 failed
+(`official-settings-complete-dark`, `ready-home-template-focus-dark`), each
+bounded to a few unclassified pixels at rounded and focus edges with comparable
+unchanged-code fluctuation. It is recorded as `merged`, never `verified`. Add
+page-surface cases to `cases.json` before the next `page-surfaces` batch takes
+`dialog-scrollable`, so that family finishes inside the repeatable suite.
+
 ## Evidence and merge gate
 
 Before changing styles, upload the frozen baseline archive to Okou file storage

--- a/turbo/scripts/style-migration.mjs
+++ b/turbo/scripts/style-migration.mjs
@@ -18,6 +18,34 @@ function nonempty(value, label) {
   assert(value.trim(), `${label} must not be empty`);
 }
 
+/**
+ * A batch migrated before the repeatable case suite covered its surfaces
+ * records the protocol that actually ran instead of borrowing another batch's
+ * case ids. Such a batch can never claim `verified`, so the repeatable suite
+ * stays the only route to that state.
+ */
+function validateExternalProtocol(batch) {
+  const external = batch.externalProtocol;
+  nonempty(external.reason, `${batch.id} external protocol reason`);
+  assert(
+    Number.isInteger(external.cases) && external.cases > 0,
+    `${batch.id} external protocol needs a case count`,
+  );
+  assert(
+    Number.isInteger(external.passed) &&
+      Number.isInteger(external.failed) &&
+      external.passed >= 0 &&
+      external.failed >= 0 &&
+      external.passed + external.failed <= external.cases,
+    `${batch.id} external protocol needs a consistent result count`,
+  );
+  assert(
+    batch.status !== "verified",
+    `${batch.id} cannot claim verified outside the repeatable case suite`,
+  );
+  assert(batch.evidence.length > 0, `${batch.id} needs durable evidence`);
+}
+
 export function validateMigration(manifest, baseline, cases) {
   assert.equal(manifest.version, 1, "Unsupported migration manifest version");
   assert.equal(cases.version, 1, "Unsupported visual case version");
@@ -55,7 +83,12 @@ export function validateMigration(manifest, baseline, cases) {
     assert(!batches.has(batch.id), `Duplicate batch ${batch.id}`);
     batches.add(batch.id);
     assert(families.has(batch.family), `Unknown family ${batch.family}`);
-    assert(batch.consumers.length > 0 && batch.cases.length > 0);
+    assert(batch.consumers.length > 0, `${batch.id} needs consumers`);
+    if (batch.externalProtocol) {
+      validateExternalProtocol(batch);
+    } else {
+      assert(batch.cases.length > 0, `${batch.id} needs visual cases`);
+    }
     for (const token of batch.tokens) {
       assert(tokens.has(token), `Unknown batch token ${token}`);
     }

--- a/turbo/scripts/style-migration.test.mjs
+++ b/turbo/scripts/style-migration.test.mjs
@@ -121,6 +121,52 @@ test("the command rejects missing replay coverage and missing consumer files", (
   assert.equal(check(root).status, 1);
 });
 
+test("a batch outside the repeatable suite records its own protocol", (t) => {
+  const { root, manifest } = workspace(t);
+  const batch = manifest.batches[0];
+  batch.cases = [];
+  const write = () =>
+    writeFileSync(
+      resolve(root, "style-migration-manifest.json"),
+      JSON.stringify(manifest),
+    );
+  write();
+  assert.match(check(root).stderr, /one needs visual cases/);
+
+  batch.externalProtocol = {
+    reason: "Migrated before the suite covered this surface",
+    cases: 98,
+    passed: 96,
+    failed: 2,
+  };
+  batch.status = "merged";
+  batch.evidence = [
+    {
+      kind: "after",
+      url: "https://example.invalid/after.zip",
+      sha256: "a".repeat(64),
+      commit: "b".repeat(40),
+    },
+  ];
+  write();
+  assert.equal(check(root).status, 0);
+
+  batch.status = "verified";
+  write();
+  assert.match(
+    check(root).stderr,
+    /one cannot claim verified outside the repeatable case suite/,
+  );
+
+  batch.status = "merged";
+  batch.externalProtocol.passed = 97;
+  write();
+  assert.match(
+    check(root).stderr,
+    /one external protocol needs a consistent result count/,
+  );
+});
+
 test("an acceptance state requires a durable commit-bound evidence record", (t) => {
   const { root, manifest } = workspace(t);
   manifest.batches[0].status = "verified";

--- a/turbo/style-migration-manifest.json
+++ b/turbo/style-migration-manifest.json
@@ -180,6 +180,70 @@
         }
       ],
       "pullRequest": "https://github.com/vm0-ai/vm0/pull/32843"
+    },
+    {
+      "id": "page-surface-cards",
+      "family": "page-surfaces",
+      "tokens": ["okou-card"],
+      "consumers": [
+        "apps/platform/src/views/agents-page/agents-page-tabs.tsx",
+        "apps/platform/src/views/artifacts-page/artifact-catalog-page.tsx",
+        "apps/platform/src/views/export-page/export-page.tsx",
+        "apps/platform/src/views/lab-page/lab-page.tsx",
+        "apps/platform/src/views/okou-page/activity-detail-page.tsx",
+        "apps/platform/src/views/okou-page/agentphone-card.tsx",
+        "apps/platform/src/views/okou-page/chat-composer.tsx",
+        "apps/platform/src/views/okou-page/components/delete-agent-dialog.tsx",
+        "apps/platform/src/views/okou-page/components/org-manage/unsaved-bar.tsx",
+        "apps/platform/src/views/okou-page/components/settings/connector-card.tsx",
+        "apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx",
+        "apps/platform/src/views/okou-page/connect-page-shell.tsx",
+        "apps/platform/src/views/okou-page/connectors-page.tsx",
+        "apps/platform/src/views/okou-page/feishu-card.tsx",
+        "apps/platform/src/views/okou-page/ideation-page.tsx",
+        "apps/platform/src/views/okou-page/settings-tab.tsx",
+        "apps/platform/src/views/okou-page/sidebar-upgrade.tsx",
+        "apps/platform/src/views/okou-page/start-cards.tsx",
+        "apps/platform/src/views/okou-page/telegram-settings-page.tsx",
+        "apps/platform/src/views/okou-page/tiptap-instructions-editor.tsx",
+        "apps/platform/src/views/okou-page/unsaved-bar.tsx",
+        "apps/platform/src/views/okou-page/works-page.tsx",
+        "apps/platform/src/views/team-page/job-custom-connectors-section.tsx",
+        "apps/platform/src/views/team-page/job-detail-page.tsx",
+        "apps/platform/src/views/workflows-page/official-workflows-page.tsx",
+        "apps/platform/src/views/workflows-page/workflow-automation-card.tsx",
+        "apps/platform/src/views/workflows-page/workflow-detail-page.tsx",
+        "apps/platform/src/views/workflows-page/workflows-page.tsx"
+      ],
+      "cases": [],
+      "externalProtocol": {
+        "reason": "Implemented and captured before the repeatable case suite covered page surfaces; cases.json still only covers the settings preference dialog.",
+        "cases": 98,
+        "passed": 96,
+        "failed": 2,
+        "failedCases": [
+          "official-settings-complete-dark",
+          "ready-home-template-focus-dark"
+        ]
+      },
+      "status": "merged",
+      "evidence": [
+        {
+          "kind": "frozen-main-baseline",
+          "url": "https://a.okou.io/412522jwib.zip",
+          "sha256": "62c882e041987cf8f3cd346834f189c1d92932fe90cbe6e947d1b67f60e47a4b",
+          "commit": "afe297e93dea741a95527536db8f9c16a36110e6"
+        },
+        {
+          "kind": "after-with-raw-diffs-and-case-manifest",
+          "url": "https://a.okou.io/bgqvk9vjev.zip",
+          "sha256": "a89e7b8655f2a8827d6f37ba9cfc72804c8583d9cdbe024ca758c3463cd647bd",
+          "commit": "6f0bd81d429fdd8d99355b3ced144b347f707922"
+        }
+      ],
+      "pullRequest": "https://github.com/vm0-ai/vm0/pull/32604",
+      "mergeCommit": "a4abff8ecd382a0051d5ccaace5de4d76ed899f9",
+      "note": "Evidence was captured at 6f0bd81; the merged head 25c296be only replaced a duplicate hover-overlay token with the shared bg-state-hover-overlay and generates identical CSS."
     }
   ]
 }


### PR DESCRIPTION
Records the merged card batch in the style migration manifest.

[PR #32604](https://github.com/vm0-ai/vm0/pull/32604) cleared `okou-card` from 28 consumers and merged as `a4abff8`, but added no `batches` entry. The manifest therefore lists only the pilot batch and can no longer answer which batches have been accepted, even though the baseline shows the token is gone.

It could not be recorded as-is either. `validateMigration` requires every batch to reference an id in `e2e/playwright/style-migration/cases.json`, and that suite still covers only the settings preference dialog — its own file is scoped `"batch": "settings-choice-controls"`. The card batch predates that suite and was captured under a separate archived protocol of 98 cases across home, template, settings, connectors and workflow surfaces. Borrowing the preference-dialog ids would have claimed coverage that never ran.

### Change

- A batch may declare `externalProtocol` (`reason`, `cases`, `passed`, `failed`) and leave `cases` empty. The check then requires durable evidence and a consistent result count, and **refuses the `verified` status**, so the repeatable suite remains the only route to acceptance. The state records what actually ran; it does not authorize skipping the suite.
- `page-surface-cards` is recorded as `merged` — never `verified` — with 96 passed / 2 failed, its 28 consumers, the frozen main baseline and after archives with their SHA-256 and commits, the merge commit, and a note that evidence was captured at `6f0bd81` while the merged head `25c296be` only swapped a duplicate hover token for the shared `bg-state-hover-overlay` and generates identical CSS.
- `docs/style-migration.md` documents the state and the follow-up: page-surface cases must join `cases.json` before the next `page-surfaces` batch takes `dialog-scrollable`, so that family finishes inside the repeatable suite.

No production code, styles, tokens or baseline entries change.

### Verification

- `pnpm lint:style` passes in full from `turbo`: 18 style-policy tests, the `@eslint/css` layer, the Tailwind unknown-class layer, and 4 style-migration tests. The manifest check reads every one of the 28 recorded consumer paths, which confirms they all exist.
- New test `a batch outside the repeatable suite records its own protocol` covers all four branches: empty `cases` without `externalProtocol` still fails, a declared external protocol with evidence passes, `verified` under an external protocol fails, and an inconsistent passed/failed split fails.
- Prettier reports all four changed files unchanged; `git diff --check` is clean.
