### PR TITLE
fix(pi-memory): preserve unchanged files and safe failure diagnostics

### DIFF
--- a/crates/guest-agent/src/cli/diagnostics.rs
+++ b/crates/guest-agent/src/cli/diagnostics.rs
@@ -92,3 +92,25 @@ where
 
     lines.into_iter().collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn pi_memory_phase2_terminal_lines_survive_stderr_collection() {
+        let fixtures: Vec<serde_json::Value> = serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../fixtures/pi-memory-phase2-terminal.json"
+        )))
+        .unwrap();
+        for fixture in fixtures {
+            let stderr = fixture["stderr"].as_str().unwrap();
+            assert!(stderr.len() < CLI_STDERR_RESULT_MAX_LINE_BYTES);
+            for suffix in ["\n", ""] {
+                let wire = format!("{stderr}{suffix}");
+                assert_eq!(collect_stderr_result_tail(wire.as_bytes()).await, [stderr]);
+            }
+        }
+    }
+}

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -1707,3 +1707,46 @@ fn cli_observed_exit_is_attached_without_changing_failure_reason() {
     assert_eq!(with_observed_exit.cli_observed_exit, Some(observed_exit));
     assert_eq!(unchanged, diagnostic);
 }
+
+#[test]
+fn pi_memory_phase2_terminal_diagnostics_survive_guest_error_persistence() {
+    let _system_log_state_guard = crate::lock_system_log_test_state();
+    let tmp = tempfile::tempdir().unwrap();
+    let system_log_path = tmp.path().join("system.log");
+    let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
+    let fixtures: Vec<Value> = serde_json::from_str(include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../fixtures/pi-memory-phase2-terminal.json"
+    )))
+    .unwrap();
+    for fixture in fixtures {
+        let stderr = fixture["stderr"].as_str().unwrap();
+        let failure = cli_failure_message(1, &[stderr.to_owned()], None);
+        assert_eq!(failure.message, stderr);
+        assert_eq!(failure.source, FailureDetailSource::Stderr);
+        assert_eq!(
+            classify_cli_failure_reason(AgentFramework::Pi, &failure.message),
+            None
+        );
+        let diagnostic = with_cli_failure_reason(
+            FailureDiagnostic::new(
+                FailureClass::CliNonzero,
+                AgentFramework::Pi,
+                PromptMetadata::from_prompt(""),
+            )
+            .with_cli_exit_code(1)
+            .with_failure_detail_source(failure.source),
+            &failure,
+        );
+        let encoded = serde_json::to_string(&diagnostic).unwrap();
+        let decoded: FailureDiagnostic = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded.failure_class, FailureClass::CliNonzero);
+        assert_eq!(decoded.failure_reason, None);
+        let error_path = tmp.path().join("guest-error.txt");
+        write_guest_error_file(error_path.to_str().unwrap(), &failure.message);
+        assert_eq!(std::fs::read_to_string(error_path).unwrap(), stderr);
+        let log = std::fs::read_to_string(&system_log_path).unwrap();
+        assert!(log.contains(stderr));
+        assert!(!log.contains("PRIVATE_"));
+    }
+}

--- a/crates/runner/src/cmd/start/job_terminal_log.rs
+++ b/crates/runner/src/cmd/start/job_terminal_log.rs
@@ -519,6 +519,35 @@ mod tests {
         diagnostic
     }
 
+    #[test]
+    fn pi_memory_phase2_terminal_diagnostics_remain_actionable() {
+        let fixtures: Vec<serde_json::Value> = serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../fixtures/pi-memory-phase2-terminal.json"
+        )))
+        .unwrap();
+        for fixture in fixtures {
+            let message = fixture["stderr"].as_str().unwrap();
+            let diagnostic = FailureDiagnostic::new(
+                FailureClass::CliNonzero,
+                AgentFramework::Pi,
+                PromptMetadata::from_prompt(""),
+            )
+            .with_cli_exit_code(1)
+            .with_failure_detail_source(FailureDetailSource::Stderr);
+            let wire = serde_json::to_vec(&diagnostic).unwrap();
+            let decoded: FailureDiagnostic = serde_json::from_slice(&wire).unwrap();
+            let failure = executor::ExecutionFailure::new(1, message, Some(decoded));
+            let event = capture_job_failure_log(&failure);
+            assert_eq!(event.level, Level::ERROR);
+            assert_field_eq(&event, "message", "job execution failed");
+            assert_field_eq(&event, "error", message);
+            assert_field_eq(&event, "failure_framework", "pi");
+            assert_field_eq(&event, "failure_class", "cli_nonzero");
+            assert_field_eq(&event, "failure_detail_source", "stderr");
+        }
+    }
+
     fn post_result_cli_termination() -> CliTerminationDiagnostic {
         CliTerminationDiagnostic::new(CliTerminationReason::PostResultReap)
             .record_signal(CliTerminationSignal::Sigterm, Some(1401), Some(10_000))

--- a/fixtures/pi-memory-phase2-terminal.json
+++ b/fixtures/pi-memory-phase2-terminal.json
@@ -1,0 +1,56 @@
+[
+  {
+    "name": "legacy",
+    "stderr": "Pi memory Phase 2 agent output was invalid."
+  },
+  {
+    "name": "summary_tokens",
+    "diagnostic": {
+      "stage": "output_validation",
+      "reason": "summary_tokens",
+      "fileClass": "summary",
+      "actual": 2608,
+      "limit": 2500
+    },
+    "stderr": "Pi memory Phase 2 agent output was invalid. pi_memory_phase2={\"stage\":\"output_validation\",\"reason\":\"summary_tokens\",\"fileClass\":\"summary\",\"actual\":2608,\"limit\":2500}"
+  },
+  {
+    "name": "summary_header",
+    "diagnostic": {
+      "stage": "output_validation",
+      "reason": "summary_header",
+      "fileClass": "summary"
+    },
+    "stderr": "Pi memory Phase 2 agent output was invalid. pi_memory_phase2={\"stage\":\"output_validation\",\"reason\":\"summary_header\",\"fileClass\":\"summary\"}"
+  },
+  {
+    "name": "apply_eacces",
+    "diagnostic": {
+      "stage": "mounted_apply",
+      "reason": "filesystem",
+      "fileClass": "immutable",
+      "errno": "EACCES"
+    },
+    "stderr": "Pi memory Phase 2 agent output was invalid. pi_memory_phase2={\"stage\":\"mounted_apply\",\"reason\":\"filesystem\",\"fileClass\":\"immutable\",\"errno\":\"EACCES\"}"
+  },
+  {
+    "name": "apply_enospc",
+    "diagnostic": {
+      "stage": "mounted_apply",
+      "reason": "filesystem",
+      "fileClass": "immutable",
+      "errno": "ENOSPC"
+    },
+    "stderr": "Pi memory Phase 2 agent output was invalid. pi_memory_phase2={\"stage\":\"mounted_apply\",\"reason\":\"filesystem\",\"fileClass\":\"immutable\",\"errno\":\"ENOSPC\"}"
+  },
+  {
+    "name": "apply_unknown",
+    "diagnostic": {
+      "stage": "mounted_apply",
+      "reason": "unknown",
+      "fileClass": "immutable",
+      "errno": "unknown"
+    },
+    "stderr": "Pi memory Phase 2 agent output was invalid. pi_memory_phase2={\"stage\":\"mounted_apply\",\"reason\":\"unknown\",\"fileClass\":\"immutable\",\"errno\":\"unknown\"}"
+  }
+]

--- a/turbo/apps/cli/src/commands/__agent-loop.ts
+++ b/turbo/apps/cli/src/commands/__agent-loop.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import {
   piSandboxAgentConfigFromEnv,
   runPiSandboxAgentLoop,
+  reportPiSandboxAgentLoopFailure,
 } from "../lib/pi-agent-loop";
 
 export const agentLoopCommand = new Command()
@@ -14,7 +15,6 @@ export const agentLoopCommand = new Command()
         config: await piSandboxAgentConfigFromEnv(),
       });
     } catch (error) {
-      console.error(error instanceof Error ? error.message : String(error));
-      process.exitCode = 1;
+      reportPiSandboxAgentLoopFailure(error);
     }
   });

--- a/turbo/apps/cli/src/commands/__tests__/__agent-loop.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/__agent-loop.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { agentLoopCommand } from "../__agent-loop";
+
+const previousExit = process.exitCode;
+
+afterEach(() => {
+  process.exitCode = previousExit;
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+it("keeps a failed command terminal when its stderr sink throws", async () => {
+  vi.stubEnv("OKOU_RUN_ID", "");
+  const log = vi.spyOn(console, "error").mockImplementation(() => {
+    throw new Error("PRIVATE_SINK_SENTINEL");
+  });
+  await expect(
+    agentLoopCommand.parseAsync(["node", "okou"]),
+  ).resolves.toBeDefined();
+  expect(log).toHaveBeenCalledWith("OKOU_RUN_ID is required for Pi execution");
+  expect(process.exitCode).toBe(1);
+});

--- a/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
@@ -1,3 +1,7 @@
+import { http, HttpResponse } from "msw";
+import { promises as fs } from "node:fs";
+import { server } from "../mocks/server";
+import terminalFixtures from "../../../../../fixtures/pi-memory-phase2-terminal.json";
 import nativePiFixtures from "../../../../packages/api-contracts/src/contracts/__tests__/fixtures/pi-native.json";
 import { PI_NATIVE_CREDENTIAL_PLACEHOLDER } from "@okouai/api-contracts/contracts/pi-native";
 import { zstdDecompressSync } from "node:zlib";
@@ -19,12 +23,16 @@ import { createInterface, type Interface } from "node:readline";
 import { fileURLToPath } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { MemoryPiSession } from "@okouai/pi-agent-runtime/node";
+import {
+  MemoryPiSession,
+  PiMemoryPhase2EngineError,
+} from "@okouai/pi-agent-runtime/node";
 
 import {
   piSandboxAgentConfigFromEnv,
   recordPiMemoryToolSourceUse,
   runPiSandboxAgentLoop,
+  reportPiSandboxAgentLoopFailure,
   type PiSandboxAgentConfig,
 } from "./pi-agent-loop";
 
@@ -370,6 +378,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await rm(launchPayloadDirectory, { recursive: true, force: true });
 });
 
@@ -613,6 +622,8 @@ async function closeServer(server: Server): Promise<void> {
 
 describe("sandbox Pi agent loop", () => {
   it("writes the private maintenance attestation only after mounted validation", async () => {
+    const errors = vi.spyOn(console, "error");
+    const exitCode = process.exitCode;
     const validationFile = join(
       launchPayloadDirectory,
       "maintenance-validation.json",
@@ -693,6 +704,154 @@ describe("sandbox Pi agent loop", () => {
       }),
     );
     expect((await stat(validationFile)).mode & 0o777).toBe(0o600);
+    expect(errors).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(exitCode);
+  });
+
+  it.each(
+    terminalFixtures.filter((fixture) => {
+      return fixture.diagnostic;
+    }),
+  )(
+    "carries $name through the real mounted runtime and CLI terminal serializer",
+    async (fixture) => {
+      server.use(
+        http.post("https://phase2-fixture.example/responses", () => {
+          return HttpResponse.text(
+            responsesTextSse("Synthetic model leaves files unchanged", 1),
+            { headers: { "content-type": "text/event-stream" } },
+          );
+        }),
+      );
+      const memoryRoot = join(launchPayloadDirectory, "terminal-memory");
+      const validationFile = join(
+        launchPayloadDirectory,
+        "maintenance-validation.json",
+      );
+      const memory = "# PRIVATE_MEMORY_SENTINEL\n";
+      const isApply = fixture.diagnostic?.stage === "mounted_apply";
+      const summary = isApply
+        ? "v1\nValid summary"
+        : fixture.name === "summary_tokens"
+          ? `v1\n${" token".repeat(2605)}`
+          : "V1\nPRIVATE_SUMMARY_SENTINEL";
+      await mkdir(memoryRoot);
+      await writeFile(join(memoryRoot, "MEMORY.md"), memory);
+      await writeFile(join(memoryRoot, "memory_summary.md"), summary);
+      await writeFile(validationFile, "stale-attestation");
+      const memoryStorageId = "1d09f0c9-a5c6-4f21-9664-d80a3ca3ae63";
+      const stalePath = join(
+        memoryRoot,
+        "rollout_summaries/pi/PRIVATE_PATH_SENTINEL.md",
+      );
+      const staleContent = "PRIVATE_EVIDENCE_SENTINEL";
+      if (isApply) {
+        await mkdir(join(memoryRoot, "rollout_summaries/pi"), {
+          recursive: true,
+        });
+        await writeFile(stalePath, staleContent);
+      }
+      const contentIdentity = createHash("sha256")
+        .update(
+          `storage:${memoryStorageId}\n${[
+            `MEMORY.md:${createHash("sha256").update(memory).digest("hex")}`,
+            `memory_summary.md:${createHash("sha256").update(summary).digest("hex")}`,
+            ...(isApply
+              ? [
+                  `rollout_summaries/pi/PRIVATE_PATH_SENTINEL.md:${createHash("sha256").update(staleContent).digest("hex")}`,
+                ]
+              : []),
+          ]
+            .sort()
+            .join("\n")}`,
+        )
+        .digest("hex");
+      const originalUnlink = fs.unlink;
+      const remove = vi.spyOn(fs, "unlink").mockImplementation(async (path) => {
+        if (isApply && path === stalePath)
+          throw Object.assign(new Error("PRIVATE_ERROR_SENTINEL"), {
+            code:
+              fixture.diagnostic?.errno === "unknown"
+                ? "PRIVATE_ERRNO_SENTINEL"
+                : fixture.diagnostic?.errno,
+            path: stalePath,
+          });
+        await originalUnlink(path);
+      });
+      const log = vi.spyOn(console, "error").mockImplementation(() => {});
+      const previousExit = process.exitCode;
+      try {
+        const run = runPiSandboxAgentLoop({
+          config: {
+            ...CONFIG,
+            model: {
+              provider: "openai",
+              baseUrl: "https://phase2-fixture.example/",
+              apiKey: "SYNTHETIC_KEY",
+              model: "gpt-5.6-terra",
+              dialect: "openai-responses",
+            },
+            launchPayload: {
+              ...CONFIG.launchPayload,
+              launchConfig: {
+                ...CONFIG.launchPayload.launchConfig,
+                maintenance: {
+                  schemaVersion: 1,
+                  memoryStorageId,
+                  claimedRevision: 7,
+                  claimedBaseVersionId: contentIdentity,
+                  leaseToken: "44754115-d375-4c46-aea7-a55bd1b61ec7",
+                  selectionDigest:
+                    "f95c6835f8a93234e88b26bc2162bd3cf8defd709037f6eefb14ee6ae3d56e48",
+                  selected: [],
+                },
+              },
+            },
+          },
+          memoryRoot,
+          maintenanceValidationFile: validationFile,
+        }).catch(reportPiSandboxAgentLoopFailure);
+        await run;
+        expect(process.exitCode).toBe(1);
+        expect(log.mock.calls).toEqual([[fixture.stderr]]);
+        expect(fixture.stderr.length).toBeLessThan(512);
+        expect(fixture.stderr).not.toMatch(
+          /PRIVATE_|SYNTHETIC_KEY|terminal-memory/,
+        );
+        await expect(readFile(validationFile)).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+        expect(await readFile(join(memoryRoot, "MEMORY.md"), "utf8")).toBe(
+          memory,
+        );
+      } finally {
+        process.exitCode = previousExit;
+        log.mockRestore();
+        remove.mockRestore();
+      }
+    },
+  );
+
+  it("preserves failure status when the terminal log sink throws", () => {
+    const previousExit = process.exitCode;
+    const log = vi.spyOn(console, "error").mockImplementation(() => {
+      throw new Error("PRIVATE_SINK_SENTINEL");
+    });
+    try {
+      const failure = new PiMemoryPhase2EngineError("agent_output_invalid", {
+        candidateCount: 0,
+        fileCount: 0,
+        totalBytes: 0,
+        heartbeatCount: 0,
+      });
+      expect(() => {
+        return reportPiSandboxAgentLoopFailure(failure);
+      }).not.toThrow();
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = previousExit;
+      log.mockRestore();
+    }
   });
 
   it("removes a stale maintenance attestation when validation fails", async () => {

--- a/turbo/apps/cli/src/lib/pi-agent-loop.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.ts
@@ -10,6 +10,7 @@ import {
   type PiLaunchPayload,
 } from "@okouai/api-contracts/contracts/runners";
 import {
+  PiMemoryPhase2EngineError,
   materializePiAgentModelConfig,
   runPiOfficialRpcMode,
   runPiMemoryPhase2MountedConsolidation,
@@ -238,4 +239,20 @@ export async function runPiSandboxAgentLoop(args: {
     sessionFile: handoff.sessionFile,
     ownershipTransferMode: handoff.ownershipTransferMode,
   });
+}
+
+/** Preserve terminal status even if the best-effort stderr sink throws. */
+export function reportPiSandboxAgentLoopFailure(error: unknown): void {
+  process.exitCode = 1;
+  try {
+    console.error(
+      error instanceof PiMemoryPhase2EngineError
+        ? error.terminalMessage()
+        : error instanceof Error
+          ? error.message
+          : String(error),
+    );
+  } catch {
+    // The diagnostic sink cannot turn a failed maintenance run into success.
+  }
 }

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-diagnostics.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-diagnostics.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import fixtures from "../../../../fixtures/pi-memory-phase2-terminal.json";
+import {
+  Phase2OutputInvalidError,
+  phase2DiagnosticForError,
+  sanitizePiMemoryPhase2Diagnostic,
+} from "./phase2-memory-diagnostics";
+import { PiMemoryPhase2EngineError } from "./phase2-memory-types";
+
+const counts = {
+  candidateCount: 0,
+  fileCount: 0,
+  totalBytes: 0,
+  heartbeatCount: 0,
+};
+
+describe("Pi Phase 2 terminal diagnostic boundary", () => {
+  it.each(fixtures)(
+    "serializes the cross-language $name fixture",
+    (fixture) => {
+      const error = new PiMemoryPhase2EngineError(
+        "agent_output_invalid",
+        counts,
+        fixture.diagnostic
+          ? sanitizePiMemoryPhase2Diagnostic(fixture.diagnostic)
+          : undefined,
+      );
+      error.message = "PRIVATE_MESSAGE_SENTINEL";
+      error.stack = "PRIVATE_STACK_SENTINEL";
+      error.cause = new Error("PRIVATE_CAUSE_SENTINEL");
+      expect(error.terminalMessage()).toBe(fixture.stderr);
+      expect(error.terminalMessage().length).toBeLessThan(512);
+    },
+  );
+
+  it("drops unknown fields, maps unknown enums and bounds numeric fields", () => {
+    const secret = "/private/memory/PRIVATE_SENTINEL?token=secret";
+    const diagnostic = sanitizePiMemoryPhase2Diagnostic({
+      stage: secret,
+      reason: secret.repeat(1000),
+      fileClass: secret,
+      errno: secret,
+      actual: Number.MAX_SAFE_INTEGER,
+      limit: -1,
+      path: secret,
+      message: secret,
+      stack: secret,
+      cause: secret,
+      prompt: secret,
+      output: secret,
+    });
+    expect(diagnostic).toEqual({
+      stage: "unknown",
+      reason: "unknown",
+      fileClass: "unknown",
+      errno: "unknown",
+      actual: 2147483647,
+    });
+    expect(JSON.stringify(diagnostic)).not.toContain("PRIVATE_SENTINEL");
+    for (const invalid of [Infinity, NaN, -1, 1.5, "123", null]) {
+      expect(
+        sanitizePiMemoryPhase2Diagnostic({ actual: invalid, limit: invalid }),
+      ).toEqual({ stage: "unknown", reason: "unknown" });
+    }
+    expect(
+      sanitizePiMemoryPhase2Diagnostic({ actual: 0, limit: 65536 }),
+    ).toEqual({ stage: "unknown", reason: "unknown", actual: 0, limit: 65536 });
+  });
+
+  it("revalidates untrusted diagnostic fields at terminal serialization", () => {
+    const error = new PiMemoryPhase2EngineError("agent_output_invalid", counts);
+    Object.defineProperty(error, "diagnostic", {
+      value: {
+        stage: "PRIVATE_STAGE_SENTINEL".repeat(1000),
+        reason: "/private/path",
+        fileClass: "PRIVATE_FILE_SENTINEL",
+        errno: "PRIVATE_ERRNO_SENTINEL",
+        actual: Number.MAX_SAFE_INTEGER,
+        limit: Number.MAX_SAFE_INTEGER,
+        toJSON() {
+          throw new Error("PRIVATE_SERIALIZATION_SENTINEL");
+        },
+      },
+    });
+    const terminal = error.terminalMessage();
+    expect(terminal).toBe(
+      'Pi memory Phase 2 agent output was invalid. pi_memory_phase2={"stage":"unknown","reason":"unknown","fileClass":"unknown","errno":"unknown","actual":2147483647,"limit":2147483647}',
+    );
+    expect(terminal.length).toBeLessThan(512);
+  });
+
+  it("keeps unknown failures bounded and ignores throwing diagnostic accessors", () => {
+    const secret = "PRIVATE_ERROR_SENTINEL";
+    expect(
+      phase2DiagnosticForError(
+        Object.assign(new Error(secret), { code: secret }),
+        "mounted_apply",
+        "memory",
+      ),
+    ).toEqual({
+      stage: "mounted_apply",
+      reason: "unknown",
+      fileClass: "memory",
+      errno: "unknown",
+    });
+    expect(
+      sanitizePiMemoryPhase2Diagnostic({
+        get stage() {
+          throw new Error(secret);
+        },
+      }),
+    ).toEqual({ stage: "unknown", reason: "unknown" });
+    expect(
+      phase2DiagnosticForError(
+        {
+          get code() {
+            throw new Error(secret);
+          },
+        },
+        "mounted_apply",
+      ),
+    ).toEqual({
+      stage: "mounted_apply",
+      reason: "unknown",
+      fileClass: "tree",
+      errno: "unknown",
+    });
+    const failure = new Phase2OutputInvalidError("summary_header", {
+      fileClass: "summary",
+    });
+    expect(phase2DiagnosticForError(failure, "output_validation")).toEqual({
+      stage: "output_validation",
+      reason: "summary_header",
+      fileClass: "summary",
+    });
+  });
+});

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-diagnostics.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-diagnostics.ts
@@ -1,0 +1,165 @@
+/** Content-free diagnostics carried by the existing terminal error string. */
+const STAGES = ["output_validation", "mounted_apply", "unknown"] as const;
+const REASONS = [
+  "unknown",
+  "filesystem",
+  "unsafe_path",
+  "unsafe_tree",
+  "file_size",
+  "inventory_files",
+  "inventory_paths",
+  "inventory_bytes",
+  "file_integrity",
+  "base_mismatch",
+  "final_identity",
+  "immutable_changed",
+  "required_artifact",
+  "memory_invalid",
+  "memory_bytes",
+  "summary_encoding",
+  "summary_header",
+  "summary_bytes",
+  "summary_tokens",
+  "skill_path",
+  "skill_encoding",
+  "skill_file_bytes",
+  "skill_files",
+  "skill_bytes",
+  "skill_manifest",
+] as const;
+const FILE_CLASSES = [
+  "memory",
+  "summary",
+  "skill",
+  "git",
+  "immutable",
+  "tree",
+  "unknown",
+] as const;
+const ERRNOS = [
+  "EACCES",
+  "EPERM",
+  "ENOSPC",
+  "EROFS",
+  "ENOENT",
+  "EIO",
+  "EMFILE",
+  "ENFILE",
+  "EISDIR",
+  "ENOTDIR",
+  "ELOOP",
+  "unknown",
+] as const;
+const MAX_COUNT = 2_147_483_647;
+
+export interface PiMemoryPhase2Diagnostic {
+  readonly stage: (typeof STAGES)[number];
+  readonly reason: (typeof REASONS)[number];
+  readonly fileClass?: (typeof FILE_CLASSES)[number];
+  readonly errno?: (typeof ERRNOS)[number];
+  readonly actual?: number;
+  readonly limit?: number;
+}
+
+function allowed<T extends string>(
+  values: readonly T[],
+  value: unknown,
+): T | undefined {
+  return values.find((candidate) => {
+    return candidate === value;
+  });
+}
+
+function boundedCount(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? Math.min(value, MAX_COUNT)
+    : undefined;
+}
+
+/** Re-project at the log boundary; never serialize arbitrary properties or text. */
+export function sanitizePiMemoryPhase2Diagnostic(
+  value: unknown,
+): PiMemoryPhase2Diagnostic {
+  try {
+    const fields =
+      value !== null && typeof value === "object"
+        ? (value as Record<string, unknown>)
+        : {};
+    const fileClass =
+      fields.fileClass === undefined
+        ? undefined
+        : (allowed(FILE_CLASSES, fields.fileClass) ?? "unknown");
+    const errno =
+      fields.errno === undefined
+        ? undefined
+        : (allowed(ERRNOS, fields.errno) ?? "unknown");
+    const actual = boundedCount(fields.actual);
+    const limit = boundedCount(fields.limit);
+    return Object.freeze({
+      stage: allowed(STAGES, fields.stage) ?? "unknown",
+      reason: allowed(REASONS, fields.reason) ?? "unknown",
+      ...(fileClass === undefined ? {} : { fileClass }),
+      ...(errno === undefined ? {} : { errno }),
+      ...(actual === undefined ? {} : { actual }),
+      ...(limit === undefined ? {} : { limit }),
+    });
+  } catch {
+    // A hostile diagnostic accessor must not replace the primary failure.
+    return Object.freeze({ stage: "unknown", reason: "unknown" });
+  }
+}
+
+export function phase2FileClass(
+  path: string,
+): NonNullable<PiMemoryPhase2Diagnostic["fileClass"]> {
+  if (path === "MEMORY.md") return "memory";
+  if (path === "memory_summary.md") return "summary";
+  if (path.startsWith("skills/")) return "skill";
+  if (path === ".git" || path.startsWith(".git/")) return "git";
+  return path === "" ? "tree" : "immutable";
+}
+
+export class Phase2OutputInvalidError extends Error {
+  readonly diagnostic: PiMemoryPhase2Diagnostic;
+
+  constructor(
+    reason: PiMemoryPhase2Diagnostic["reason"] = "unknown",
+    details: Omit<PiMemoryPhase2Diagnostic, "stage" | "reason"> = {},
+    stage: PiMemoryPhase2Diagnostic["stage"] = "output_validation",
+  ) {
+    super("Pi memory Phase 2 agent output was invalid.");
+    this.diagnostic = sanitizePiMemoryPhase2Diagnostic({
+      ...details,
+      stage,
+      reason,
+    });
+  }
+}
+
+export function phase2DiagnosticForError(
+  error: unknown,
+  stage: PiMemoryPhase2Diagnostic["stage"],
+  fileClass: PiMemoryPhase2Diagnostic["fileClass"] = "tree",
+): PiMemoryPhase2Diagnostic {
+  if (error instanceof Phase2OutputInvalidError) {
+    return sanitizePiMemoryPhase2Diagnostic({ ...error.diagnostic, stage });
+  }
+  // Read only a data property: raw text and arbitrary getters stay outside
+  // this best-effort diagnostic boundary.
+  let errno: PiMemoryPhase2Diagnostic["errno"];
+  try {
+    const value: unknown =
+      error !== null && typeof error === "object"
+        ? Object.getOwnPropertyDescriptor(error, "code")?.value
+        : undefined;
+    errno = allowed(ERRNOS, value);
+  } catch {
+    errno = undefined;
+  }
+  return sanitizePiMemoryPhase2Diagnostic({
+    stage,
+    reason: errno && errno !== "unknown" ? "filesystem" : "unknown",
+    fileClass,
+    errno: errno ?? "unknown",
+  });
+}

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-filesystem.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-filesystem.test.ts
@@ -1,5 +1,8 @@
+import { promises as fs } from "node:fs";
 import { createHash } from "node:crypto";
 import {
+  chmod,
+  stat,
   link,
   mkdir,
   mkdtemp,
@@ -23,13 +26,13 @@ import {
   STORAGE_MANIFEST_MAX_PATH_BYTES,
 } from "@okouai/api-contracts/contracts/storages";
 import { encode } from "gpt-tokenizer/encoding/o200k_base";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { Phase2OutputInvalidError } from "./phase2-memory-diagnostics";
 import {
   applyValidatedPiMemoryPhase2Result,
   createPiMemoryPhase2Workspace,
   Phase2InputInvalidError,
-  Phase2OutputInvalidError,
   PI_MEMORY_PHASE2_EVIDENCE_SLUG_MAX_BYTES,
   PI_MEMORY_PHASE2_MAX_SELECTED_CANDIDATES,
   PI_MEMORY_PHASE2_MAX_SELECTED_UTF8_BYTES,
@@ -58,6 +61,7 @@ const temporaryDirectories: string[] = [];
 const EMPTY_HASH = createHash("sha256").update("").digest("hex");
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await Promise.all(
     temporaryDirectories.splice(0).map(async (directory) => {
       await removePiMemoryPhase2Workspace(directory);
@@ -156,6 +160,221 @@ const VALID_BASE = [
 ] as const;
 
 describe("Pi memory Phase 2 filesystem", () => {
+  it.each([0o444, 0o600])(
+    "applies changes without rewriting unchanged immutable files (mode %s), including no-diff",
+    async (mode) => {
+      const original = [
+        ...VALID_BASE,
+        baseFile(
+          ".git/objects/ab/synthetic-object",
+          "synthetic immutable bytes",
+        ),
+        baseFile("skills/existing/old.md", "delete me"),
+      ];
+      const memoryRoot = await mkdtemp(join(tmpdir(), "pi-memory-writeback-"));
+      temporaryDirectories.push(memoryRoot);
+      for (const file of original) {
+        const path = join(memoryRoot, file.path);
+        await mkdir(dirname(path), { recursive: true });
+        await writeFile(path, file.bytes);
+      }
+      const objectPath = join(memoryRoot, ".git/objects/ab/synthetic-object");
+      await chmod(objectPath, mode);
+      const baseFiles = await snapshotMountedPiMemoryPhase2Base(memoryRoot);
+      const workspace = await freshWorkspace(baseFiles);
+      await put(workspace, "MEMORY.md", "# Changed memory\n");
+      await put(workspace, "skills/existing/new.md", "new reference");
+      await unlink(join(workspace.memoryRoot, "skills/existing/old.md"));
+      const prepared = await validatePiMemoryPhase2Output(
+        workspace,
+        "storage-phase2",
+      );
+      const writes = vi.spyOn(fs, "writeFile");
+      await applyValidatedPiMemoryPhase2Result({
+        memoryRoot,
+        memoryStorageId: "storage-phase2",
+        baseFiles,
+        ...prepared,
+      });
+      expect(
+        writes.mock.calls
+          .map(([path]) => {
+            return String(path);
+          })
+          .sort(),
+      ).toEqual([
+        join(memoryRoot, "MEMORY.md"),
+        join(memoryRoot, "skills/existing/new.md"),
+      ]);
+      expect(await readFile(objectPath, "utf8")).toBe(
+        "synthetic immutable bytes",
+      );
+      expect((await stat(objectPath)).mode & 0o777).toBe(mode);
+      await expect(
+        readFile(join(memoryRoot, "skills/existing/old.md")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      const mounted = await snapshotMountedPiMemoryPhase2Base(memoryRoot);
+      expect(
+        mounted.map(({ path, bytes }) => {
+          return [path, bytes.toString()];
+        }),
+      ).toEqual(
+        prepared.files.map(({ path, contentBase64 }) => {
+          return [path, Buffer.from(contentBase64, "base64").toString()];
+        }),
+      );
+      expect(
+        preparedSetFromSnapshot(
+          "storage-phase2",
+          new Map(
+            mounted.map(({ path, bytes }) => {
+              return [path, Buffer.from(bytes)];
+            }),
+          ),
+        ),
+      ).toEqual(prepared);
+      writes.mockClear();
+      await applyValidatedPiMemoryPhase2Result({
+        memoryRoot,
+        memoryStorageId: "storage-phase2",
+        baseFiles: mounted,
+        ...prepared,
+      });
+      expect(writes).not.toHaveBeenCalled();
+      expect((await stat(objectPath)).mode & 0o777).toBe(mode);
+    },
+  );
+
+  it.each(["EACCES", "ENOSPC"])(
+    "retains %s for a changed read-only target without chmod or publication",
+    async (code) => {
+      const workspace = await freshWorkspace(VALID_BASE);
+      const target = join(workspace.memoryRoot, "MEMORY.md");
+      await chmod(target, 0o444);
+      const baseFiles = await snapshotMountedPiMemoryPhase2Base(
+        workspace.memoryRoot,
+      );
+      const files = new Map(
+        baseFiles.map((file) => {
+          return [file.path, Buffer.from(file.bytes)];
+        }),
+      );
+      files.set("MEMORY.md", Buffer.from("changed"));
+      const prepared = preparedSetFromSnapshot("storage-phase2", files);
+      const originalWrite = fs.writeFile;
+      vi.spyOn(fs, "writeFile").mockImplementation(
+        async (path, data, options) => {
+          if (path === target)
+            throw Object.assign(new Error("SECRET /private/path"), {
+              code,
+              path: "/private/path",
+            });
+          return await originalWrite(path, data, options);
+        },
+      );
+      await expect(
+        applyValidatedPiMemoryPhase2Result({
+          memoryRoot: workspace.memoryRoot,
+          memoryStorageId: "storage-phase2",
+          baseFiles,
+          ...prepared,
+        }),
+      ).rejects.toMatchObject({
+        diagnostic: {
+          stage: "mounted_apply",
+          reason: "filesystem",
+          errno: code,
+          fileClass: "memory",
+        },
+      });
+      expect(await readFile(target, "utf8")).toBe("# Task Group: existing\n");
+      expect((await stat(target)).mode & 0o777).toBe(0o444);
+    },
+  );
+
+  it("distinguishes exact-base and final identity rejection", async () => {
+    const workspace = await freshWorkspace(VALID_BASE);
+    const baseFiles = await snapshotMountedPiMemoryPhase2Base(
+      workspace.memoryRoot,
+    );
+    const prepared = await validatePiMemoryPhase2Output(
+      workspace,
+      "storage-phase2",
+    );
+    const applyArgs = {
+      memoryRoot: workspace.memoryRoot,
+      memoryStorageId: "storage-phase2",
+      baseFiles,
+      ...prepared,
+    };
+    await expect(
+      applyValidatedPiMemoryPhase2Result({
+        ...applyArgs,
+        contentIdentity: "0".repeat(64),
+      }),
+    ).rejects.toMatchObject({
+      diagnostic: { stage: "mounted_apply", reason: "final_identity" },
+    });
+    await put(workspace, "MEMORY.md", "changed mount epoch");
+    await expect(
+      applyValidatedPiMemoryPhase2Result(applyArgs),
+    ).rejects.toMatchObject({
+      diagnostic: { stage: "mounted_apply", reason: "base_mismatch" },
+    });
+    expect(
+      await readFile(join(workspace.memoryRoot, "MEMORY.md"), "utf8"),
+    ).toBe("changed mount epoch");
+  });
+
+  it.each([
+    ["summary_header", "V1\nPRIVATE_SUMMARY_SENTINEL"],
+    ["summary_tokens", `v1\n${" token".repeat(2605)}`],
+    ["summary_bytes", `v1\n${" ".repeat(PI_MEMORY_SUMMARY_MAX_BYTES - 2)}`],
+  ])(
+    "classifies %s without exposing generated content",
+    async (reason, content) => {
+      const workspace = await freshWorkspace(VALID_BASE);
+      await put(workspace, "memory_summary.md", content);
+      try {
+        await validatePiMemoryPhase2Output(workspace, "storage-phase2");
+        expect.fail("invalid summary accepted");
+      } catch (error) {
+        expect(error).toMatchObject({
+          diagnostic: {
+            stage: "output_validation",
+            reason,
+            fileClass: "summary",
+          },
+        });
+        if (reason === "summary_tokens") {
+          expect(Buffer.byteLength(content)).toBeLessThan(
+            PI_MEMORY_SUMMARY_MAX_BYTES,
+          );
+          expect(error).toMatchObject({
+            diagnostic: { actual: encode(content).length, limit: 2500 },
+          });
+        }
+        if (reason === "summary_bytes")
+          expect(error).toMatchObject({
+            diagnostic: { actual: 65537, limit: 65536 },
+          });
+        expect(JSON.stringify(error)).not.toContain("PRIVATE_SUMMARY_SENTINEL");
+      }
+    },
+  );
+
+  it("keeps inclusive summary token and byte boundaries", async () => {
+    const workspace = await freshWorkspace(VALID_BASE);
+    const tokenBoundary = `v1\n${" token".repeat(2497)}`;
+    expect(encode(tokenBoundary).length).toBe(2500);
+    for (const content of [tokenBoundary, `v1\n${" ".repeat(65533)}`]) {
+      await put(workspace, "memory_summary.md", content);
+      await expect(
+        validatePiMemoryPhase2Output(workspace, "storage-phase2"),
+      ).resolves.toBeDefined();
+    }
+  });
+
   it("pins every frozen size and count boundary", () => {
     expect(PI_MEMORY_PHASE2_WORKSPACE_DIFF_MAX_BYTES).toBe(4 * 1024 * 1024);
     expect(PI_MEMORY_SUMMARY_MAX_BYTES).toBe(64 * 1024);

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-filesystem.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-filesystem.ts
@@ -29,6 +29,12 @@ import {
   type PiMemoryPhase2SelectedSnapshot,
 } from "./phase2-memory-types";
 
+import {
+  Phase2OutputInvalidError,
+  phase2DiagnosticForError,
+  phase2FileClass,
+} from "./phase2-memory-diagnostics";
+
 export const PI_MEMORY_PHASE2_MAX_SELECTED_CANDIDATES = 256;
 export const PI_MEMORY_PHASE2_MAX_SELECTED_UTF8_BYTES = 21_036_800;
 export const PI_MEMORY_PHASE2_EVIDENCE_SLUG_MAX_BYTES = 48;
@@ -94,7 +100,6 @@ interface ValidatedPreparedSet {
 }
 
 export class Phase2InputInvalidError extends Error {}
-export class Phase2OutputInvalidError extends Error {}
 
 function byteLength(value: string): number {
   return Buffer.byteLength(value, "utf8");
@@ -693,14 +698,33 @@ function validMemory(content: Buffer): boolean {
   );
 }
 
-function validSummary(content: Buffer): boolean {
+function summaryFailure(content: Buffer) {
+  const details = { fileClass: "summary" as const };
   const decoded = decodeUtf8(content);
-  return (
-    decoded !== null &&
-    decoded.split(/\r?\n/u)[0] === "v1" &&
-    content.length <= PI_MEMORY_SUMMARY_MAX_BYTES &&
-    encode(decoded).length <= PI_MEMORY_SUMMARY_MAX_TOKENS
-  );
+  if (decoded === null)
+    return new Phase2OutputInvalidError("summary_encoding", details);
+  if (decoded.split(/\r?\n/u)[0] !== "v1")
+    return new Phase2OutputInvalidError("summary_header", details);
+  if (content.length > PI_MEMORY_SUMMARY_MAX_BYTES) {
+    return new Phase2OutputInvalidError("summary_bytes", {
+      ...details,
+      actual: content.length,
+      limit: PI_MEMORY_SUMMARY_MAX_BYTES,
+    });
+  }
+  const tokens = encode(decoded).length;
+  if (tokens > PI_MEMORY_SUMMARY_MAX_TOKENS) {
+    return new Phase2OutputInvalidError("summary_tokens", {
+      ...details,
+      actual: tokens,
+      limit: PI_MEMORY_SUMMARY_MAX_TOKENS,
+    });
+  }
+  return undefined;
+}
+
+function validSummary(content: Buffer): boolean {
+  return summaryFailure(content) === undefined;
 }
 
 export function baseHasValidConsolidatedArtifacts(
@@ -783,7 +807,7 @@ async function inventoryFiles(
     }
     const directoryStat = await fs.lstat(directory.path, { bigint: true });
     if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
-      throw new Phase2OutputInvalidError();
+      throw new Phase2OutputInvalidError("unsafe_tree", { fileClass: "tree" });
     }
     const entries = await fs.readdir(directory.path, { withFileTypes: true });
     entries.sort((left, right) => {
@@ -796,36 +820,58 @@ async function inventoryFiles(
       try {
         assertSafeFilePath(relative);
       } catch {
-        throw new Phase2OutputInvalidError();
+        throw new Phase2OutputInvalidError("unsafe_path", {
+          fileClass: phase2FileClass(relative),
+        });
       }
       const path = join(directory.path, entry.name);
       const stat = await fs.lstat(path, { bigint: true });
       if (stat.isSymbolicLink()) {
-        throw new Phase2OutputInvalidError();
+        throw new Phase2OutputInvalidError("unsafe_tree", {
+          fileClass: phase2FileClass(relative),
+        });
       }
       if (stat.isDirectory()) {
         pending.push({ path, relative });
         continue;
       }
-      if (
-        !stat.isFile() ||
-        stat.nlink !== 1n ||
-        stat.size > BigInt(MAX_FILE_SIZE_BYTES)
-      ) {
-        throw new Phase2OutputInvalidError();
+      if (!stat.isFile() || stat.nlink !== 1n) {
+        throw new Phase2OutputInvalidError("unsafe_tree", {
+          fileClass: phase2FileClass(relative),
+        });
+      }
+      if (stat.size > BigInt(MAX_FILE_SIZE_BYTES)) {
+        throw new Phase2OutputInvalidError("file_size", {
+          fileClass: phase2FileClass(relative),
+          actual: Number(stat.size),
+          limit: MAX_FILE_SIZE_BYTES,
+        });
       }
       const content = await fs.readFile(path);
       if (BigInt(content.length) !== stat.size) {
-        throw new Phase2OutputInvalidError();
+        throw new Phase2OutputInvalidError("file_integrity", {
+          fileClass: phase2FileClass(relative),
+        });
       }
       pathBytes += byteLength(relative);
       totalBytes += content.length;
-      if (
-        result.size >= STORAGE_MANIFEST_MAX_FILES ||
-        pathBytes > STORAGE_MANIFEST_MAX_PATH_BYTES ||
-        totalBytes > PI_MEMORY_PHASE2_PREPARED_MAX_BYTES
-      ) {
-        throw new Phase2OutputInvalidError();
+      if (result.size >= STORAGE_MANIFEST_MAX_FILES) {
+        throw new Phase2OutputInvalidError("inventory_files", {
+          actual: result.size + 1,
+          limit: STORAGE_MANIFEST_MAX_FILES,
+        });
+      }
+      if (pathBytes > STORAGE_MANIFEST_MAX_PATH_BYTES) {
+        throw new Phase2OutputInvalidError("inventory_paths", {
+          actual: pathBytes,
+          limit: STORAGE_MANIFEST_MAX_PATH_BYTES,
+        });
+      }
+      if (totalBytes > PI_MEMORY_PHASE2_PREPARED_MAX_BYTES) {
+        throw new Phase2OutputInvalidError("inventory_bytes", {
+          actual: totalBytes,
+          limit: PI_MEMORY_PHASE2_PREPARED_MAX_BYTES,
+        });
       }
       result.set(relative, content);
     }
@@ -833,7 +879,7 @@ async function inventoryFiles(
   try {
     validatePathCollection([...result.keys()]);
   } catch {
-    throw new Phase2OutputInvalidError();
+    throw new Phase2OutputInvalidError("unsafe_path", { fileClass: "tree" });
   }
   return result;
 }
@@ -891,47 +937,87 @@ export async function applyValidatedPiMemoryPhase2Result(args: {
   readonly files: readonly PiMemoryPhase2PreparedFile[];
   readonly contentIdentity: string;
 }): Promise<void> {
-  const expectedBase = snapshotBaseFiles(args.baseFiles).files;
-  const mountedBefore = await inventoryFiles(args.memoryRoot);
-  const expectedBaseMap = new Map(
-    expectedBase.map((file) => {
-      return [file.path, file.bytes] as const;
-    }),
-  );
-  if (!mapsEqual(mountedBefore, expectedBaseMap)) {
-    throw new Phase2OutputInvalidError();
-  }
+  try {
+    const expectedBase = snapshotBaseFiles(args.baseFiles).files;
+    const mountedBefore = await inventoryFiles(args.memoryRoot);
+    const expectedBaseMap = new Map(
+      expectedBase.map((file) => {
+        return [file.path, file.bytes] as const;
+      }),
+    );
+    if (!mapsEqual(mountedBefore, expectedBaseMap)) {
+      throw new Phase2OutputInvalidError("base_mismatch");
+    }
 
-  const prepared = new Map<string, Buffer>();
-  for (const file of args.files) {
-    const bytes = Buffer.from(file.contentBase64, "base64");
+    const prepared = new Map<string, Buffer>();
+    for (const file of args.files) {
+      const bytes = Buffer.from(file.contentBase64, "base64");
+      if (
+        bytes.length !== file.size ||
+        hashBytes(bytes) !== file.hash ||
+        prepared.has(file.path)
+      ) {
+        throw new Phase2OutputInvalidError("file_integrity", {
+          fileClass: phase2FileClass(file.path),
+        });
+      }
+      prepared.set(file.path, bytes);
+    }
+
+    for (const path of mountedBefore.keys()) {
+      if (!prepared.has(path)) {
+        try {
+          await fs.unlink(join(args.memoryRoot, ...path.split("/")));
+        } catch (error) {
+          const diagnostic = phase2DiagnosticForError(
+            error,
+            "mounted_apply",
+            phase2FileClass(path),
+          );
+          throw new Phase2OutputInvalidError(
+            diagnostic.reason,
+            diagnostic,
+            "mounted_apply",
+          );
+        }
+      }
+    }
+    for (const [path, bytes] of prepared) {
+      // Exact-base verification above makes these bytes authoritative. Preserve
+      // unchanged files (including read-only Git objects) and their permissions.
+      if (mountedBefore.get(path)?.equals(bytes)) continue;
+      try {
+        await writeWorkspaceFile(args.memoryRoot, path, bytes);
+      } catch (error) {
+        const diagnostic = phase2DiagnosticForError(
+          error,
+          "mounted_apply",
+          phase2FileClass(path),
+        );
+        throw new Phase2OutputInvalidError(
+          diagnostic.reason,
+          diagnostic,
+          "mounted_apply",
+        );
+      }
+    }
+    await removeEmptyDirectories(args.memoryRoot);
+
+    const mountedAfter = await inventoryFiles(args.memoryRoot);
+    const committed = manifestForFiles(args.memoryStorageId, mountedAfter);
     if (
-      bytes.length !== file.size ||
-      hashBytes(bytes) !== file.hash ||
-      prepared.has(file.path)
+      !mapsEqual(mountedAfter, prepared) ||
+      committed.contentIdentity !== args.contentIdentity
     ) {
-      throw new Phase2OutputInvalidError();
+      throw new Phase2OutputInvalidError("final_identity");
     }
-    prepared.set(file.path, bytes);
-  }
-
-  for (const path of mountedBefore.keys()) {
-    if (!prepared.has(path)) {
-      await fs.unlink(join(args.memoryRoot, ...path.split("/")));
-    }
-  }
-  for (const [path, bytes] of prepared) {
-    await writeWorkspaceFile(args.memoryRoot, path, bytes);
-  }
-  await removeEmptyDirectories(args.memoryRoot);
-
-  const mountedAfter = await inventoryFiles(args.memoryRoot);
-  const committed = manifestForFiles(args.memoryStorageId, mountedAfter);
-  if (
-    !mapsEqual(mountedAfter, prepared) ||
-    committed.contentIdentity !== args.contentIdentity
-  ) {
-    throw new Phase2OutputInvalidError();
+  } catch (error) {
+    const diagnostic = phase2DiagnosticForError(error, "mounted_apply");
+    throw new Phase2OutputInvalidError(
+      diagnostic.reason,
+      diagnostic,
+      "mounted_apply",
+    );
   }
 }
 
@@ -947,7 +1033,9 @@ function validateImmutablePaths(
     const before = baseline.get(path);
     const after = finalFiles.get(path);
     if (!before || !after || !before.equals(after)) {
-      throw new Phase2OutputInvalidError();
+      throw new Phase2OutputInvalidError("immutable_changed", {
+        fileClass: phase2FileClass(path),
+      });
     }
   }
 }
@@ -966,22 +1054,32 @@ function validateChangedSkills(
       return !before || !after || !before.equals(after);
     });
   if (changed.length > PI_MEMORY_PHASE2_MAX_CHANGED_SKILL_FILES) {
-    throw new Phase2OutputInvalidError();
+    throw new Phase2OutputInvalidError("skill_files", {
+      fileClass: "skill",
+      actual: changed.length,
+      limit: PI_MEMORY_PHASE2_MAX_CHANGED_SKILL_FILES,
+    });
   }
   let totalBytes = 0;
   const newSkillNames = new Set<string>();
   const changedSkillManifests = new Set<string>();
   for (const path of changed) {
     if (!validChangedSkillPath(path)) {
-      throw new Phase2OutputInvalidError();
+      throw new Phase2OutputInvalidError("skill_path", { fileClass: "skill" });
     }
     const content = finalFiles.get(path);
     if (content) {
-      if (
-        content.length > PI_MEMORY_PHASE2_MAX_CHANGED_SKILL_FILE_BYTES ||
-        decodeUtf8(content) === null
-      ) {
-        throw new Phase2OutputInvalidError();
+      if (content.length > PI_MEMORY_PHASE2_MAX_CHANGED_SKILL_FILE_BYTES) {
+        throw new Phase2OutputInvalidError("skill_file_bytes", {
+          fileClass: "skill",
+          actual: content.length,
+          limit: PI_MEMORY_PHASE2_MAX_CHANGED_SKILL_FILE_BYTES,
+        });
+      }
+      if (decodeUtf8(content) === null) {
+        throw new Phase2OutputInvalidError("skill_encoding", {
+          fileClass: "skill",
+        });
       }
       totalBytes += content.length;
       const skillName = path.split("/")[1];
@@ -999,18 +1097,26 @@ function validateChangedSkills(
     }
   }
   if (totalBytes > PI_MEMORY_PHASE2_MAX_CHANGED_SKILL_BYTES) {
-    throw new Phase2OutputInvalidError();
+    throw new Phase2OutputInvalidError("skill_bytes", {
+      fileClass: "skill",
+      actual: totalBytes,
+      limit: PI_MEMORY_PHASE2_MAX_CHANGED_SKILL_BYTES,
+    });
   }
   for (const skillName of changedSkillManifests) {
     const manifest = finalFiles.get(`skills/${skillName}/SKILL.md`);
     if (!manifest || !validSkillManifest(manifest, skillName)) {
-      throw new Phase2OutputInvalidError();
+      throw new Phase2OutputInvalidError("skill_manifest", {
+        fileClass: "skill",
+      });
     }
   }
   for (const skillName of newSkillNames) {
     const manifest = finalFiles.get(`skills/${skillName}/SKILL.md`);
     if (!manifest || !validSkillManifest(manifest, skillName)) {
-      throw new Phase2OutputInvalidError();
+      throw new Phase2OutputInvalidError("skill_manifest", {
+        fileClass: "skill",
+      });
     }
   }
 }
@@ -1083,20 +1189,36 @@ export async function validatePiMemoryPhase2Output(
   workspace: Phase2PrivateWorkspace,
   storageId: string,
 ): Promise<ValidatedPreparedSet> {
-  const finalFiles = await inventoryFiles(workspace.memoryRoot);
-  validateImmutablePaths(finalFiles, workspace.agentBaseline);
-  const memory = finalFiles.get(MEMORY_FILE);
-  const summary = finalFiles.get(SUMMARY_FILE);
-  if (
-    memory === undefined ||
-    summary === undefined ||
-    !validMemory(memory) ||
-    !validSummary(summary)
-  ) {
-    throw new Phase2OutputInvalidError();
+  try {
+    const finalFiles = await inventoryFiles(workspace.memoryRoot);
+    validateImmutablePaths(finalFiles, workspace.agentBaseline);
+    const memory = finalFiles.get(MEMORY_FILE);
+    const summary = finalFiles.get(SUMMARY_FILE);
+    if (memory === undefined || summary === undefined) {
+      throw new Phase2OutputInvalidError("required_artifact", {
+        fileClass: memory === undefined ? "memory" : "summary",
+      });
+    }
+    if (memory.length > PI_MEMORY_PHASE2_MEMORY_MAX_BYTES) {
+      throw new Phase2OutputInvalidError("memory_bytes", {
+        fileClass: "memory",
+        actual: memory.length,
+        limit: PI_MEMORY_PHASE2_MEMORY_MAX_BYTES,
+      });
+    }
+    if (!validMemory(memory))
+      throw new Phase2OutputInvalidError("memory_invalid", {
+        fileClass: "memory",
+      });
+    const invalidSummary = summaryFailure(summary);
+    if (invalidSummary) throw invalidSummary;
+    validateChangedSkills(finalFiles, workspace.agentBaseline);
+    return manifestForFiles(storageId, finalFiles);
+  } catch (error) {
+    if (error instanceof Phase2OutputInvalidError) throw error;
+    const diagnostic = phase2DiagnosticForError(error, "output_validation");
+    throw new Phase2OutputInvalidError(diagnostic.reason, diagnostic);
   }
-  validateChangedSkills(finalFiles, workspace.agentBaseline);
-  return manifestForFiles(storageId, finalFiles);
 }
 
 export function preparedSetFromSnapshot(

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-types.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-types.ts
@@ -1,3 +1,7 @@
+import {
+  sanitizePiMemoryPhase2Diagnostic,
+  type PiMemoryPhase2Diagnostic,
+} from "./phase2-memory-diagnostics";
 import type { PiAgentModelConfig } from "./types";
 
 export const PI_MEMORY_PHASE2_MAINTENANCE_REASONING = "max" as const;
@@ -165,14 +169,26 @@ const FAILURE_MESSAGES: Readonly<Record<PiMemoryPhase2FailureClass, string>> = {
 export class PiMemoryPhase2EngineError extends Error {
   readonly errorClass: PiMemoryPhase2FailureClass;
   readonly counts: PiMemoryPhase2FailureCounts;
+  readonly diagnostic?: PiMemoryPhase2Diagnostic;
 
   constructor(
     errorClass: PiMemoryPhase2FailureClass,
     counts: PiMemoryPhase2FailureCounts,
+    diagnostic?: PiMemoryPhase2Diagnostic,
   ) {
     super(FAILURE_MESSAGES[errorClass]);
     this.name = "PiMemoryPhase2EngineError";
     this.errorClass = errorClass;
     this.counts = Object.freeze({ ...counts });
+    if (diagnostic)
+      this.diagnostic = sanitizePiMemoryPhase2Diagnostic(diagnostic);
+  }
+
+  /** The existing Guest stderr consumer forwards this bounded line to terminal logs. */
+  terminalMessage(): string {
+    const message = FAILURE_MESSAGES[this.errorClass];
+    return this.diagnostic
+      ? `${message} pi_memory_phase2=${JSON.stringify(sanitizePiMemoryPhase2Diagnostic(this.diagnostic))}`
+      : message;
   }
 }

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
@@ -835,6 +835,33 @@ describe("Pi memory Phase 2 consolidation engine", () => {
     ).toContain("rollout_summaries/codex.md");
   });
 
+  it("preserves output diagnostics when failure lifecycle observation throws", async () => {
+    const provider = await startProvider([{ type: "text", text: "done" }]);
+    const input = args(provider.baseUrl, {
+      baseFiles: [
+        baseFile("MEMORY.md", "# Memory\n"),
+        baseFile("memory_summary.md", `v1\n${" token".repeat(2605)}`),
+      ],
+      selected: [],
+      onLifecycle(event) {
+        if (event.stage === "failed")
+          throw new Error("PRIVATE_OBSERVER_SENTINEL");
+      },
+    });
+    await expect(
+      runPiMemoryPhase2Consolidation(input, new AbortController().signal),
+    ).rejects.toMatchObject({
+      errorClass: "agent_output_invalid",
+      diagnostic: {
+        stage: "output_validation",
+        reason: "summary_tokens",
+        fileClass: "summary",
+        actual: 2608,
+        limit: 2500,
+      },
+    });
+  });
+
   it("returns bounded failures with no partial result and always cleans staging", async () => {
     const cases: ReadonlyArray<{
       readonly steps: readonly ProviderStep[];

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory.ts
@@ -24,7 +24,6 @@ import {
   createPiMemoryPhase2Workspace,
   mapsEqual,
   Phase2InputInvalidError,
-  Phase2OutputInvalidError,
   preparedSetFromSnapshot,
   removePiMemoryPhase2Workspace,
   snapshotPiMemoryPhase2Input,
@@ -33,6 +32,10 @@ import {
   type SnapshotPhase2Input,
   validatePiMemoryPhase2Output,
 } from "./phase2-memory-filesystem";
+import {
+  Phase2OutputInvalidError,
+  phase2DiagnosticForError,
+} from "./phase2-memory-diagnostics";
 import { renderPiMemoryPhase2Prompt } from "./phase2-memory-prompt";
 import {
   createPiMemoryPhase2Tools,
@@ -678,7 +681,11 @@ function normalizeFailure(
     return engineError("input_invalid", input, state);
   }
   if (error instanceof Phase2OutputInvalidError) {
-    return engineError("agent_output_invalid", input, state);
+    return new PiMemoryPhase2EngineError(
+      "agent_output_invalid",
+      failureCounts(input, state),
+      error.diagnostic,
+    );
   }
   if (input === null) {
     return engineError("input_invalid", input, state);
@@ -974,13 +981,17 @@ export async function runPiMemoryPhase2MountedConsolidation(
       files: result.files,
       contentIdentity: result.contentIdentity,
     });
-  } catch {
-    throw new PiMemoryPhase2EngineError("agent_output_invalid", {
-      candidateCount: args.selected.length,
-      fileCount: result.manifest.fileCount,
-      totalBytes: result.manifest.totalBytes,
-      heartbeatCount: 0,
-    });
+  } catch (error) {
+    throw new PiMemoryPhase2EngineError(
+      "agent_output_invalid",
+      {
+        candidateCount: args.selected.length,
+        fileCount: result.manifest.fileCount,
+        totalBytes: result.manifest.totalBytes,
+        heartbeatCount: 0,
+      },
+      phase2DiagnosticForError(error, "mounted_apply"),
+    );
   }
   signal.throwIfAborted();
   return {


### PR DESCRIPTION
An unchanged immutable Git object can legitimately be read-only. Mounted Pi memory apply currently rewrites it and fails with EACCES even after accepting valid generated output. Skip byte-identical files after exact-base verification, while preserving differential writes/deletes, immutable validation, filesystem guards, final identity verification, and the existing publication fence.

Preserve bounded failure diagnostics from output validation and mounted apply through the actual CLI terminal error string. The existing public error class/message prefix stays stable; a single-line `pi_memory_phase2=` JSON suffix carries allowlisted stage/reason, file category, errno, and applicable integer actual/limit counts. Unknown data is reduced to `unknown`, never raw exception text or private content.

Refs #32744. Implements the [approved contract](https://github.com/vm0-ai/vm0/issues/32744#issuecomment-5597968341), criteria 1–9; controller acceptance (10) remains separate.

### Compatibility and terminal consumers

The existing CLI stderr → Guest tail/selection → guest error file → Runner terminal log path preserves the bounded line. Guest checkpoint recovery forwards the same failure message to the existing completion API; Runner `error` and API warning `fields.error` can carry this suffix in the existing Axiom stream. No new top-level Axiom field, wire schema, consumer parser, log collection setting, deployment ordering requirement, or checkpoint architecture is introduced. Shared synthetic fixtures exercise old messages and new diagnostics across TypeScript serialization and Rust consumers.

### Acceptance evidence

| Criterion | Implementation and evidence |
| --- | --- |
| 1 | Real filesystem regression uses unchanged `.git/objects/ab/synthetic-object` at both 0444 and 0600. A pass-through filesystem spy verifies exactly the changed/new files are written; bytes and permission bits are preserved. Reapplying no-diff performs zero writes. |
| 2 | The same regression changes MEMORY.md, adds a skill reference and deletes another; it checks exact resulting bytes, manifest and content identity. Injected errors on a genuinely changed 0444 target remain failures, with bytes/mode preserved. |
| 3 | Existing immutable/path/symlink/hardlink/size/inventory and interrupted-apply regressions are retained; explicit base/final-identity failures remain fail-closed. Guest maintenance checkpoint tests preserve parent recovery and reject missing/invalid success attestations. |
| 4 | Summary token/header/byte rejection, inclusive 2,500-token/65,536-byte boundaries, mounted base/final identity, and injected EACCES/ENOSPC have distinct safe diagnostics. Limits, prompt/tools, model/provider/Pi versions and generation/retry policies are unchanged. |
| 5 | Real mounted runtime failures pass through the production CLI reporter and match cross-language fixtures. Guest consumes the stderr line with/without a newline, selects/persists it and round-trips the failure diagnostic; Runner captures the actual ERROR event. Strict enum projection, bounded integer counts, hostile accessors, unknown errno, oversized fields and private sentinels are tested. |
| 6 | No-diff emits no terminal error and preserves status. Genuine Pi failures retain `cli_nonzero` and ERROR severity. Failed lifecycle observation preserves the primary validation error; a throwing stderr sink preserves exit 1. Failure removes stale success attestation. Existing cancellation, cleanup and checkpoint tests remain in scope. |
| 7 | Temporarily restoring the old unconditional writer makes both regression cases fail; restoring the fix makes the identical command pass. Details below. |
| 8 | Scoped local checks and required PR/merge-group CI evidence are recorded below and in the final tracked review. No full local Vitest or dev server. |
| 9 | Same-owner `/pr-auto` starts immediately after PR creation; independent exact-head review and normal protected merge queue are required before completion. Final head/merge/review/gate evidence will be reported after GitHub confirms MERGED. |
| 10 | Pending controller acceptance after merge. Release and natural production verification remain unauthorized and unperformed. |

### Validation

- Runtime: 52 tests passed across `phase2-memory-filesystem.test.ts`, `phase2-memory-diagnostics.test.ts`, `phase2-memory.test.ts`, `phase2-memory-tools.test.ts`, and `phase2-memory-scope.test.ts`.
- CLI: 45 tests passed in `src/lib/pi-agent-loop.test.ts` and `src/commands/__tests__/__agent-loop.test.ts`.
- Guest: 2 new terminal-consumer tests and 4 existing maintenance checkpoint tests passed.
- Runtime and CLI package lint (Oxlint, type-aware Oxlint, ESLint), type checks, public declaration build, scoped Knip for both workspaces, Prettier, Rust formatting and `git diff --check` passed.
- All normal pre-commit and commit-msg hooks passed, including full Knip, 15 workspace type-check tasks, Rust all-target/all-feature Clippy, workspace Rust docs, formatting, file sizes and commitlint. No hooks or CI protections were bypassed.
- Runner: 25 targeted `job_terminal_log::tests::` tests passed, including `pi_memory_phase2_terminal_diagnostics_remain_actionable`. Initial compilation attempts were constrained by the approximately 4 GiB local container, not counted as passes. After compiler memory limits and temporary 4 GiB local swap, all normal hooks and the identical targeted Runner command completed successfully. The swap was disabled and removed. No repository rules or production configuration changed.
- PR Rust coverage also passed the new Guest/Runner diagnostic consumers and existing partial-apply recovery/publication regressions: [coverage job](https://github.com/vm0-ai/vm0/actions/runs/34331642301/job/102401440682).

Negative control, UID 1000, all synthetic data: temporarily remove only the byte-equality guard in `applyValidatedPiMemoryPhase2Result`, restoring the complete source bytes in `finally`. From `turbo`, run:

```sh
npx --yes pnpm@10.33.4 --filter @okouai/pi-agent-runtime exec vitest run src/phase2-memory-filesystem.test.ts -t 'without rewriting unchanged immutable'
```

Old writer: exit 1, both tests fail. The 0444 case fails during apply; the writable 0600 control deterministically detects nine attempted writes instead of two, including the unchanged Git object. Restored fix, identical command: exit 0, both pass, including no-diff and exact identity assertions. Root execution was not performed; the 0600 control proves the write assertion does not depend on permission enforcement.

### Fallbacks

- Permanent privacy boundary in `turbo/packages/pi-agent-runtime/src/phase2-memory-diagnostics.ts` (`sanitizePiMemoryPhase2Diagnostic`, `phase2DiagnosticForError`, `boundedCount`): untrusted diagnostic enums become bounded `unknown`; invalid counts are omitted. Valid nonnegative safe integers above 2,147,483,647 are clamped to that value; nonfinite, negative, fractional, nonnumeric or unsafe integers are omitted. This handles external filesystem exceptions and diagnostic serialization, not an old-producer rollout. No removal window applies while unknown external failures remain possible. It never substitutes a successful outcome.
- Permanent best-effort terminal logging in `turbo/apps/cli/src/lib/pi-agent-loop.ts` (`reportPiSandboxAgentLoopFailure`): set exit 1 before the stderr write and catch only diagnostic sink failure. A broken sink must not change the primary run outcome. No rollout window/removal dependency applies; failure remains terminal even when diagnostics cannot be delivered.

All fixtures and provider responses are synthetic. No private production outputs, real-provider generation or production replay were used. The unchanged-file defect is independently demonstrated; this PR does not establish that any/all 48 historical maintenance failures (96 terminal records) had this cause. No production release, deployment approval or production verification is part of this PR.
