### PR TITLE
ci: run production kms backfill through protected actions

### DIFF
--- a/.github/kms-migration-32264/README.md
+++ b/.github/kms-migration-32264/README.md
@@ -1,0 +1,89 @@
+# GitHub Actions KMS migration identity
+
+The production application remains the existing `vm0-kms-prod` IAM user.
+GitHub Actions uses a separate OIDC role for ciphertext rewrap. No new access
+keys or static operator credentials are required.
+
+## One-time IAM prerequisite
+
+An AWS administrator must provision or reconcile this exact role in account
+`251964670836` through the approved IAM change process:
+
+`arn:aws:iam::251964670836:role/vm0-kms-migration-github-32264`
+
+- Reuse the account's `token.actions.githubusercontent.com` OIDC provider if it
+  already exists. Its URL is `https://token.actions.githubusercontent.com` and
+  its client ID is `sts.amazonaws.com`; create it only if absent.
+- Apply [role-trust.json](role-trust.json). Trust is restricted to
+  `vm0-ai/vm0` jobs in the protected `production` environment and the STS
+  audience. Keep that environment's protected-branch and human-reviewer rules.
+  Both migration workflow jobs also require `refs/heads/main`.
+- Set the role's maximum session duration to 7,200 seconds and attach
+  [role-permissions.json](role-permissions.json) as an inline policy. This
+  allows decrypt and bidirectional rewrap only on the two production keys, and
+  data-key generation only on the target key for nested queue payloads. Every
+  operation requires `purpose=vm0-stored-secret`.
+- After the role exists, the owners of the source and target accounts add the
+  respective [source](source-key-policy-statement.json) and
+  [target](target-key-policy-statement.json) statements to the existing key
+  policies. These files are **individual additive statements**, not replacement
+  policies. Preserve all current administration, runtime, and rollback grants.
+- Set the GitHub `production` environment variable `KMS_MIGRATION_ROLE_ARN` to
+  the role ARN above. It is configuration, not a secret.
+
+The IAM setup identity needs role administration only for this named role,
+OIDC-provider administration only if the GitHub provider is missing, and
+`kms:GetKeyPolicy` / `kms:PutKeyPolicy` on the corresponding production key in
+each account. These setup permissions are not granted to the migration role.
+The workflows never bootstrap IAM using application credentials and never
+add `ReEncrypt` to runtime users.
+
+The currently recorded personal `AWSReservedSSO_KMSMigrationAccess` session is
+not a GitHub OIDC identity. Its existence does not prove this role is ready.
+Role provisioning is a prerequisite, not an operation performed by these
+workflow files. Verify it live before dispatching a production migration.
+
+## Protected execution
+
+1. Run **KMS Production Preflight** on `main` with the current production API
+   Vercel deployment ID. Approve its `production` job. It checks the exact
+   current target IAM user, loads the old user only from the verified rollback
+   backup, proves synthetic forward and rollback reads, and authenticates all
+   stored ciphertext using the target runtime user. It creates no role and
+   writes no database rows.
+2. Verify the deployed API's secret create/read/update and legacy-read business
+   flows before approving a mutation. The runtime canary and database scan do
+   not by themselves certify deployed application behavior. Retain the evidence
+   and exact deployment ID with the operational record.
+3. Run **KMS Production Migrate** with that deployment ID, initially with the
+   default 1,000-field limit. Each dispatch repeats the full target-runtime
+   scan, then obtains a temporary operator session using GitHub OIDC. It
+   verifies the exact role with STS and exercises the real migration tool's
+   forward and reverse `ReEncrypt` paths on synthetic envelope and legacy
+   ciphertext before changing database rows.
+4. Review `operation.json`, `verification.json`, and `migration.json` in the
+   run's artifact. `complete: false` is a bounded partial migration; the next
+   dispatch can use its `cursor`. Conditional writes preserve concurrent user
+   changes. Check `concurrentChanges` and scan from the beginning to recover
+   rows changed or deleted during a prior batch. A failed or cancelled run can
+   have partial writes: inspect its retained checkpoint before resuming.
+5. Run **KMS Production Preflight** again without a cursor. Only a fresh,
+   complete target-runtime report with `databaseVerifiedOnTarget: true` is the
+   final database certificate. A successful bounded migration is not that
+   certificate.
+
+The two workflows share a concurrency group and require manual production
+approval. Each dispatch uses the existing GitHub production Neon credentials,
+the exact `production` branch of `hidden-lab-39609750`, an unpooled connection,
+and TLS certificate verification. No agent-side Neon connection is necessary.
+The backup digest is pinned in the workflow and the backup's original run/head
+provenance is checked before using its configuration. Plaintext credentials,
+database URIs, OIDC tokens, and data keys remain in process memory and child
+environments; only sanitized metadata and checkpoints enter artifacts.
+
+The expected deployment is checked before verification, before mutation, and
+after the operation. A concurrent deployment stops successful certification;
+it does not automatically undo completed rows. Keep both keys and both runtime
+users' cross-account read access throughout the rollout. These workflows do
+not modify deployments, restore stale database snapshots, touch shared staging,
+or retire keys, users, retained sandbox state, or backup recovery access.

--- a/.github/kms-migration-32264/role-permissions.json
+++ b/.github/kms-migration-32264/role-permissions.json
@@ -1,0 +1,30 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "RewrapAndVerifyOnlyProductionKeys",
+      "Effect": "Allow",
+      "Action": ["kms:Decrypt", "kms:ReEncryptFrom", "kms:ReEncryptTo"],
+      "Resource": [
+        "arn:aws:kms:us-west-2:072707626411:key/a1b3922b-fab1-4ed3-aa9e-40f86f92a7a8",
+        "arn:aws:kms:us-west-2:251964670836:key/e68917e2-5541-4597-b6ef-7e9eb5670947"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "kms:EncryptionContext:purpose": "vm0-stored-secret"
+        }
+      }
+    },
+    {
+      "Sid": "ReencryptNestedProductionPayloads",
+      "Effect": "Allow",
+      "Action": ["kms:GenerateDataKey"],
+      "Resource": "arn:aws:kms:us-west-2:251964670836:key/e68917e2-5541-4597-b6ef-7e9eb5670947",
+      "Condition": {
+        "StringEquals": {
+          "kms:EncryptionContext:purpose": "vm0-stored-secret"
+        }
+      }
+    }
+  ]
+}

--- a/.github/kms-migration-32264/role-trust.json
+++ b/.github/kms-migration-32264/role-trust.json
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::251964670836:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:vm0-ai/vm0:environment:production"
+        }
+      }
+    }
+  ]
+}

--- a/.github/kms-migration-32264/source-key-policy-statement.json
+++ b/.github/kms-migration-32264/source-key-policy-statement.json
@@ -1,0 +1,14 @@
+{
+  "Sid": "AllowGithubProductionKmsMigration32264",
+  "Effect": "Allow",
+  "Principal": {
+    "AWS": "arn:aws:iam::251964670836:role/vm0-kms-migration-github-32264"
+  },
+  "Action": ["kms:Decrypt", "kms:ReEncryptFrom", "kms:ReEncryptTo"],
+  "Resource": "*",
+  "Condition": {
+    "StringEquals": {
+      "kms:EncryptionContext:purpose": "vm0-stored-secret"
+    }
+  }
+}

--- a/.github/kms-migration-32264/target-key-policy-statement.json
+++ b/.github/kms-migration-32264/target-key-policy-statement.json
@@ -1,0 +1,19 @@
+{
+  "Sid": "AllowGithubProductionKmsMigration32264",
+  "Effect": "Allow",
+  "Principal": {
+    "AWS": "arn:aws:iam::251964670836:role/vm0-kms-migration-github-32264"
+  },
+  "Action": [
+    "kms:Decrypt",
+    "kms:ReEncryptFrom",
+    "kms:ReEncryptTo",
+    "kms:GenerateDataKey"
+  ],
+  "Resource": "*",
+  "Condition": {
+    "StringEquals": {
+      "kms:EncryptionContext:purpose": "vm0-stored-secret"
+    }
+  }
+}

--- a/.github/scripts/kms-production-migration.py
+++ b/.github/scripts/kms-production-migration.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""Run protected production KMS verification or a bounded ciphertext migration."""
+
+import datetime
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import urllib.parse
+
+
+SOURCE = "arn:aws:kms:us-west-2:072707626411:key/a1b3922b-fab1-4ed3-aa9e-40f86f92a7a8"
+TARGET = "arn:aws:kms:us-west-2:251964670836:key/e68917e2-5541-4597-b6ef-7e9eb5670947"
+OPERATOR = "arn:aws:iam::251964670836:role/vm0-kms-migration-github-32264"
+IDENTITY = "c0c87790-e651-45dd-b7fa-c5ed07bb990f"
+VERCEL_PROJECT = "prj_6mw0CgYjECVrJV57VJ47VN03B4UR"
+VERCEL_TEAM = "team_WRqI0kCoX5KcRInRWgZ1nBF0"
+DB_PROJECT = "hidden-lab-39609750"
+MIGRATION = "scripts/migrations/013-kms-account-rotation"
+CONFIG_NAMES = {
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "SECRETS_KMS_KEY_ID",
+    "AWS_REGION",
+}
+
+
+class MigrationError(Exception):
+    """Only fixed failure codes may reach logs; provider bodies stay in memory."""
+
+
+def require(condition, code):
+    if not condition:
+        raise MigrationError(code)
+
+
+def required_env(name):
+    value = os.environ.get(name, "")
+    require(bool(value), "missing_required_environment")
+    return value
+
+
+def request_json(url, bearer=None, body=None):
+    command = [
+        "curl",
+        "--silent",
+        "--show-error",
+        "--max-time",
+        "30",
+        "--request",
+        "POST" if body is not None else "GET",
+        "--header",
+        "Accept: application/json",
+        "--write-out",
+        "\n%{http_code}",
+        url,
+    ]
+    if bearer is not None:
+        command.extend(["--header", "Authorization: Bearer " + bearer])
+    if body is not None:
+        command.extend(
+            ["--header", "Content-Type: application/json", "--data-binary", "@-"]
+        )
+    result = subprocess.run(
+        command,
+        input=None if body is None else json.dumps(body),
+        text=True,
+        capture_output=True,
+        timeout=45,
+        check=False,
+    )
+    require(result.returncode == 0, "provider_transport_failed")
+    payload, status = result.stdout.rsplit("\n", 1)
+    require(status.startswith("2"), "provider_request_rejected")
+    value = json.loads(payload)
+    require(
+        isinstance(value, dict) and value.get("success") is not False,
+        "invalid_provider_response",
+    )
+    return value
+
+
+def oidc(audience):
+    url = urllib.parse.urlsplit(required_env("ACTIONS_ID_TOKEN_REQUEST_URL"))
+    require(
+        url.scheme == "https"
+        and url.hostname.endswith(".actions.githubusercontent.com"),
+        "invalid_oidc_origin",
+    )
+    query = dict(urllib.parse.parse_qsl(url.query))
+    query["audience"] = audience
+    return request_json(
+        urllib.parse.urlunsplit(url._replace(query=urllib.parse.urlencode(query))),
+        required_env("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
+    )["value"]
+
+
+def aws(arguments, environment, payload=None):
+    result = subprocess.run(
+        ["aws", *arguments, "--region", "us-west-2", "--output", "json"],
+        input=None if payload is None else json.dumps(payload),
+        env=environment,
+        text=True,
+        capture_output=True,
+        timeout=45,
+        check=False,
+    )
+    require(result.returncode == 0, "aws_operation_failed")
+    return json.loads(result.stdout)
+
+
+def runtime_environment(configuration):
+    require(set(configuration) == CONFIG_NAMES, "invalid_runtime_configuration")
+    require(
+        all(isinstance(value, str) and value for value in configuration.values()),
+        "missing_runtime_configuration",
+    )
+    require(configuration["AWS_REGION"] == "us-west-2", "runtime_region_mismatch")
+    # Do not propagate provider control-plane tokens into the KMS/DB subprocess.
+    environment = {
+        name: value
+        for name, value in os.environ.items()
+        if name
+        in {
+            "PATH",
+            "HOME",
+            "NODE_EXTRA_CA_CERTS",
+            "CI",
+            "PNPM_HOME",
+            "COREPACK_HOME",
+            "npm_config_audit",
+        }
+    }
+    return {
+        **environment,
+        **configuration,
+        "AWS_SESSION_TOKEN": "",
+        "AWS_DEFAULT_REGION": "us-west-2",
+        "AWS_EC2_METADATA_DISABLED": "true",
+    }
+
+
+def backup_configuration():
+    require(
+        required_env("DOPPLER_SERVICE_IDENTITY_ID") == IDENTITY,
+        "wrong_production_doppler_identity",
+    )
+    token = request_json(
+        "https://api.doppler.com/v3/auth/oidc",
+        body={"identity": IDENTITY, "token": oidc("https://github.com/vm0-ai")},
+    )["token"]
+    secrets = request_json(
+        "https://api.doppler.com/v3/configs/config/secrets?project=vm0-kms-rollback-32264&config=prd&include_managed_secrets=false",
+        token,
+    )["secrets"]
+    require(set(secrets) == {"KMS_BACKUP_JSON"}, "backup_secret_set_changed")
+    stored = secrets["KMS_BACKUP_JSON"]
+    require(
+        stored["raw"] == stored["computed"]
+        and stored["rawVisibility"] == stored["computedVisibility"] == "masked",
+        "backup_visibility_or_reference_changed",
+    )
+    require(
+        hashlib.sha256(stored["raw"].encode()).hexdigest()
+        == required_env("EXPECTED_BACKUP_SHA256"),
+        "backup_digest_changed",
+    )
+    snapshot = json.loads(stored["raw"])
+    require(
+        snapshot["version"] == 1
+        and snapshot["sourceKeyArn"] == SOURCE
+        and snapshot["sourcePrincipal"]
+        == "arn:aws:iam::072707626411:user/vm0-kms-prod",
+        "backup_identity_mismatch",
+    )
+    require(
+        snapshot["workflow"]
+        == {
+            "repository": "vm0-ai/vm0",
+            "commit": "594d907ca844e845f674c04640a58ae8cebcdc8a",
+            "runId": "34324494642",
+        },
+        "backup_provenance_mismatch",
+    )
+    return snapshot["configuration"]
+
+
+def production_deployment(expected):
+    project = request_json(
+        f"https://api.vercel.com/v9/projects/{VERCEL_PROJECT}?teamId={VERCEL_TEAM}",
+        required_env("VERCEL_TOKEN"),
+    )
+    require(
+        project["id"] == VERCEL_PROJECT and project["accountId"] == VERCEL_TEAM,
+        "deployment_project_mismatch",
+    )
+    deployment = project["targets"]["production"]
+    require(
+        deployment["id"] == expected
+        and deployment["readyState"] == "READY"
+        and deployment["target"] == "production"
+        and "api.okou.ai" in deployment["alias"],
+        "production_deployment_changed",
+    )
+    commit = deployment["meta"]["githubCommitSha"]
+    require(re.fullmatch(r"[0-9a-f]{40}", commit), "invalid_deployment_commit")
+    return {"id": deployment["id"], "url": deployment["url"], "commit": commit}
+
+
+def database_url():
+    require(required_env("NEON_PROJECT_ID") == DB_PROJECT, "database_project_mismatch")
+    base = f"https://console.neon.tech/api/v2/projects/{DB_PROJECT}"
+    token = required_env("NEON_API_KEY")
+    branches = request_json(base + "/branches", token)["branches"]
+    matches = [branch for branch in branches if branch["name"] == "production"]
+    require(len(matches) == 1, "production_branch_not_unique")
+    query = urllib.parse.urlencode(
+        {
+            "branch_id": matches[0]["id"],
+            "database_name": "neondb",
+            "role_name": "neondb_owner",
+            "pooled": "false",
+        }
+    )
+    parsed = urllib.parse.urlsplit(
+        request_json(base + "/connection_uri?" + query, token)["uri"]
+    )
+    require(
+        parsed.scheme in {"postgres", "postgresql"}
+        and parsed.hostname
+        and parsed.hostname.endswith(".neon.tech")
+        and "-pooler" not in parsed.hostname
+        and parsed.path == "/neondb"
+        and parsed.username == "neondb_owner"
+        and parsed.password,
+        "invalid_production_database_uri",
+    )
+    parameters = dict(urllib.parse.parse_qsl(parsed.query))
+    parameters["sslmode"] = "verify-full"
+    uri = urllib.parse.urlunsplit(
+        parsed._replace(query=urllib.parse.urlencode(parameters))
+    )
+    require("\r" not in uri and "\n" not in uri, "invalid_database_uri_delimiter")
+    return uri
+
+
+def run_tool(arguments, environment):
+    # The subprocess emits only sanitized reports, but suppress both streams to
+    # also contain dependency/SDK failure diagnostics. Checkpoints are retained.
+    result = subprocess.run(
+        ["pnpm", "exec", "tsx", *arguments],
+        env=environment,
+        text=True,
+        capture_output=True,
+        timeout=6000,
+        check=False,
+    )
+    require(
+        result.returncode == 0, "migration_tool_failed_inspect_sanitized_checkpoint"
+    )
+
+
+def canary(phase, environment, directory):
+    identity = aws(["sts", "get-caller-identity"], environment)
+    (directory / "identity.json").write_text(
+        json.dumps({"Account": identity["Account"], "Arn": identity["Arn"]})
+    )
+    run_tool([MIGRATION + "/runtime-canary.ts", phase, str(directory)], environment)
+    return identity["Arn"]
+
+
+def assume_operator(environment):
+    require(
+        required_env("KMS_MIGRATION_ROLE_ARN") == OPERATOR,
+        "migration_role_not_configured",
+    )
+    session_name = "github-kms-" + required_env("GITHUB_RUN_ID")
+    response = aws(
+        [
+            "sts",
+            "assume-role-with-web-identity",
+            "--cli-input-json",
+            "file:///dev/stdin",
+        ],
+        environment,
+        {
+            "RoleArn": OPERATOR,
+            "RoleSessionName": session_name,
+            "WebIdentityToken": oidc("sts.amazonaws.com"),
+            "DurationSeconds": 7200,
+        },
+    )
+    credentials = response["Credentials"]
+    operator = {
+        **environment,
+        "AWS_ACCESS_KEY_ID": credentials["AccessKeyId"],
+        "AWS_SECRET_ACCESS_KEY": credentials["SecretAccessKey"],
+        "AWS_SESSION_TOKEN": credentials["SessionToken"],
+    }
+    identity = aws(["sts", "get-caller-identity"], operator)
+    require(
+        identity["Account"] == "251964670836"
+        and identity["Arn"]
+        == "arn:aws:sts::251964670836:assumed-role/vm0-kms-migration-github-32264/"
+        + session_name,
+        "migration_operator_identity_mismatch",
+    )
+    return operator
+
+
+def read_verification(path):
+    report = json.loads(path.read_text())
+    require(
+        report["mode"] == "verify"
+        and report["complete"] is True
+        and report["resumed"] is False
+        and report["failure"] is None
+        and report["cursor"] is None,
+        "full_verification_required",
+    )
+    require(
+        report["source"] == SOURCE and report["target"] == TARGET,
+        "verification_key_scope_mismatch",
+    )
+    require(
+        all(
+            report["totals"][name] == 0
+            for name in [
+                "nonArn",
+                "invalid",
+                "unknownKey",
+                "nestedUninspected",
+                "updated",
+                "concurrentChanges",
+            ]
+        ),
+        "verification_has_unresolved_ciphertext",
+    )
+    require(
+        report["totals"]["rows"] == report["totals"]["verified"],
+        "verification_count_mismatch",
+    )
+    return report
+
+
+def main():
+    mode = required_env("KMS_OPERATION")
+    require(mode in {"verify", "migrate"}, "invalid_operation")
+    workflow = (
+        "kms-production-preflight.yml"
+        if mode == "verify"
+        else "kms-production-migrate.yml"
+    )
+    require(
+        required_env("GITHUB_REPOSITORY") == "vm0-ai/vm0"
+        and required_env("GITHUB_REF") == "refs/heads/main"
+        and required_env("GITHUB_EVENT_NAME") == "workflow_dispatch",
+        "protected_manual_main_required",
+    )
+    require(
+        required_env("GITHUB_WORKFLOW_REF")
+        == "vm0-ai/vm0/.github/workflows/" + workflow + "@refs/heads/main",
+        "workflow_scope_mismatch",
+    )
+    require(
+        required_env("GITHUB_RUN_ID").isdigit()
+        and re.fullmatch(r"[0-9a-f]{40}", required_env("GITHUB_SHA")),
+        "invalid_workflow_provenance",
+    )
+    require(
+        re.fullmatch(r"[0-9a-f]{64}", required_env("EXPECTED_BACKUP_SHA256")),
+        "invalid_backup_digest",
+    )
+    expected = required_env("EXPECTED_DEPLOYMENT_ID")
+    require(re.fullmatch(r"dpl_[A-Za-z0-9]+", expected), "invalid_expected_deployment")
+    cursor = os.environ.get("CURSOR", "")
+    require(len(cursor) <= 16384, "invalid_cursor_length")
+    require(mode == "migrate" or not cursor, "final_verification_must_not_resume")
+    limit = os.environ.get("MAX_ROWS", "1000")
+    require(
+        re.fullmatch(r"[0-9]{1,6}", limit) and 1 <= int(limit) <= 100000,
+        "invalid_migration_limit",
+    )
+    if mode == "migrate":
+        require(
+            required_env("KMS_MIGRATION_ROLE_ARN") == OPERATOR,
+            "migration_role_not_configured",
+        )
+    configuration = {name: required_env(name) for name in CONFIG_NAMES}
+    require(
+        configuration["SECRETS_KMS_KEY_ID"] == TARGET
+        and not os.environ.get("AWS_SESSION_TOKEN"),
+        "target_runtime_configuration_required",
+    )
+    target_environment = runtime_environment(configuration)
+    source_environment = runtime_environment(backup_configuration())
+    deployment = production_deployment(expected)
+    temporary = Path(required_env("RUNNER_TEMP"))
+    output = temporary / "kms-production-reports"
+    output.mkdir(mode=0o700)
+    fixture = temporary / "kms-production-canary"
+    fixture.mkdir(mode=0o700)
+    metadata = {
+        "version": 1,
+        "operation": mode,
+        "runId": required_env("GITHUB_RUN_ID"),
+        "commit": required_env("GITHUB_SHA"),
+        "startedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "deployment": deployment,
+        "backupSnapshotSha256": required_env("EXPECTED_BACKUP_SHA256"),
+        "result": "running",
+        "productionConfigurationChanged": False,
+        "staticCredentialsCreated": False,
+    }
+    try:
+        metadata["sourceRuntimePrincipal"] = canary(
+            "prepare-old", source_environment, fixture
+        )
+        metadata["targetRuntimePrincipal"] = canary(
+            "verify-new", target_environment, fixture
+        )
+        canary("verify-rollback", source_environment, fixture)
+        metadata["runtimeCanaryAndRollback"] = "passed"
+        target_environment["DATABASE_URL"] = database_url()
+        verification_path = output / "verification.json"
+        common = ["--source-key", SOURCE, "--target-key", TARGET, "--batch-size", "100"]
+        run_tool(
+            [
+                MIGRATION + "/backfill.ts",
+                *common,
+                "--verify",
+                "--verify-concurrency",
+                "8",
+                "--max-rows",
+                "1000000",
+                "--report-path",
+                str(verification_path),
+            ],
+            target_environment,
+        )
+        verified = read_verification(verification_path)
+        metadata["targetRuntimeVerification"] = {
+            "databaseVerifiedOnTarget": verified["databaseVerifiedOnTarget"],
+            "totals": verified["totals"],
+            "database": verified["database"],
+            "manifest": verified["manifest"],
+        }
+        require(
+            production_deployment(expected) == deployment,
+            "deployment_changed_during_verification",
+        )
+        if mode == "migrate":
+            operator = assume_operator(target_environment)
+            metadata["migrationOperator"] = canary("verify-operator", operator, fixture)
+            metadata["operatorReencryptAndRollback"] = "passed"
+            require(
+                production_deployment(expected) == deployment,
+                "deployment_changed_before_migration",
+            )
+            args = [
+                MIGRATION + "/backfill.ts",
+                *common,
+                "--migrate",
+                "--preflight",
+                str(verification_path),
+                "--max-rows",
+                limit,
+                "--report-path",
+                str(output / "migration.json"),
+            ]
+            if cursor:
+                args.extend(["--cursor", cursor])
+            run_tool(args, operator)
+            migrated = json.loads((output / "migration.json").read_text())
+            require(
+                migrated["mode"] == "migrate"
+                and migrated["failure"] is None
+                and migrated["source"] == SOURCE
+                and migrated["target"] == TARGET,
+                "migration_report_failed",
+            )
+            metadata["migration"] = {
+                "complete": migrated["complete"],
+                "cursor": migrated["cursor"],
+                "totals": migrated["totals"],
+            }
+            metadata["freshFinalTargetVerificationRequired"] = True
+        require(
+            production_deployment(expected) == deployment,
+            "deployment_changed_during_operation",
+        )
+        metadata["result"] = "passed"
+    except BaseException:
+        metadata["result"] = "failed"
+        raise
+    finally:
+        metadata["finishedAt"] = datetime.datetime.now(
+            datetime.timezone.utc
+        ).isoformat()
+        (output / "operation.json").write_text(json.dumps(metadata, indent=2) + "\n")
+        shutil.rmtree(fixture)
+    print(json.dumps(metadata))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except BaseException as error:
+        print(
+            "KMS production operation failed: "
+            + (str(error) if isinstance(error, MigrationError) else "unexpected_error"),
+            file=sys.stderr,
+        )
+        sys.exit(1)

--- a/.github/scripts/tests/fixtures/kms-production-migration-tools.py
+++ b/.github/scripts/tests/fixtures/kms-production-migration-tools.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Isolated provider/transport boundaries for the real KMS workflow CLI test."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+binary = Path(sys.argv[0])
+state_path = binary.parent.parent / "provider.json"
+state = json.loads(state_path.read_text())
+name = binary.name
+arguments = sys.argv[1:]
+scenario = state["scenario"]
+source = "arn:aws:kms:us-west-2:072707626411:key/a1b3922b-fab1-4ed3-aa9e-40f86f92a7a8"
+target = "arn:aws:kms:us-west-2:251964670836:key/e68917e2-5541-4597-b6ef-7e9eb5670947"
+
+if name == "pnpm":
+    # Delegate to the actual migration and canary TypeScript entry points.
+    # Only the external KMS endpoint and database connection are redirected.
+    env = {**os.environ, "AWS_ENDPOINT_URL_KMS": state["kmsEndpoint"]}
+    if "DATABASE_URL" in env:
+        env["DATABASE_URL"] = state["databaseUrl"]
+    result = subprocess.run([state["pnpm"], *arguments], env=env, check=False)
+    sys.exit(result.returncode)
+
+if name == "aws":
+    if arguments[:2] == ["sts", "assume-role-with-web-identity"]:
+        payload = json.load(sys.stdin)
+        assert (
+            payload["RoleArn"]
+            == "arn:aws:iam::251964670836:role/vm0-kms-migration-github-32264"
+        )
+        assert payload["WebIdentityToken"] == "synthetic-oidc-token"
+        state["assumeCalls"] += 1
+        result = {
+            "Credentials": {
+                "AccessKeyId": "operator",
+                "SecretAccessKey": "synthetic-operator-secret",
+                "SessionToken": "synthetic-operator-session",
+            }
+        }
+    else:
+        assert arguments[:2] == ["sts", "get-caller-identity"]
+        principal = os.environ["AWS_ACCESS_KEY_ID"]
+        account = "072707626411" if principal == "source" else "251964670836"
+        arn = f"arn:aws:iam::{account}:user/vm0-kms-prod"
+        if principal == "operator":
+            arn = "arn:aws:sts::251964670836:assumed-role/vm0-kms-migration-github-32264/github-kms-12345"
+            if scenario == "wrong-operator":
+                arn = "arn:aws:iam::251964670836:user/vm0-kms-prod"
+        result = {"Account": account, "Arn": arn}
+    state_path.write_text(json.dumps(state))
+    print(json.dumps(result))
+    sys.exit(0)
+
+assert name == "curl"
+url = next(value for value in arguments if value.startswith("https://"))
+status = 200
+if ".actions.githubusercontent.com/" in url:
+    result = {"value": "synthetic-oidc-token"}
+elif url == "https://api.doppler.com/v3/auth/oidc":
+    result = {"token": "synthetic-doppler-token"}
+elif "api.doppler.com/v3/configs/config/secrets" in url:
+    raw = json.dumps(state["snapshot"], separators=(",", ":"))
+    if scenario == "backup-changed":
+        raw += " "
+    result = {
+        "secrets": {
+            "KMS_BACKUP_JSON": {
+                "raw": raw,
+                "computed": raw,
+                "rawVisibility": "masked",
+                "computedVisibility": "masked",
+            }
+        }
+    }
+elif "api.vercel.com/v9/projects/" in url:
+    state["deploymentReads"] += 1
+    deployment = "dpl_fixture"
+    if scenario == "deployment-changed" and state["deploymentReads"] >= 2:
+        deployment = "dpl_changed"
+    result = {
+        "id": "prj_6mw0CgYjECVrJV57VJ47VN03B4UR",
+        "accountId": "team_WRqI0kCoX5KcRInRWgZ1nBF0",
+        "targets": {
+            "production": {
+                "id": deployment,
+                "url": "fixture.vm6.ai",
+                "readyState": "READY",
+                "target": "production",
+                "alias": ["api.okou.ai"],
+                "meta": {"githubCommitSha": "b" * 40},
+            }
+        },
+    }
+elif "console.neon.tech/api/v2/projects/hidden-lab-39609750/branches" in url:
+    result = {"branches": [{"id": "br-fixture", "name": "production"}]}
+elif "console.neon.tech/api/v2/projects/hidden-lab-39609750/connection_uri?" in url:
+    result = {
+        "uri": "postgresql://neondb_owner:synthetic-database-secret@fixture.neon.tech/neondb"
+    }
+else:
+    raise AssertionError("unhandled provider boundary")
+if scenario == "provider-error":
+    status = 403
+    result = {"error": "synthetic-provider-secret-must-not-be-logged"}
+state_path.write_text(json.dumps(state))
+print(json.dumps(result) + "\n" + str(status), end="")

--- a/.github/workflows/kms-production-migrate.yml
+++ b/.github/workflows/kms-production-migrate.yml
@@ -1,4 +1,4 @@
-name: KMS Production Preflight
+name: KMS Production Migrate
 
 env:
   npm_config_audit: "false"
@@ -10,6 +10,15 @@ on:
         description: "Current production API deployment ID, recorded before approval"
         required: true
         type: string
+      max_rows:
+        description: "Maximum field values to scan in this bounded migration (1-100000)"
+        required: true
+        type: string
+        default: "1000"
+      cursor:
+        description: "Optional migration cursor from the previous sanitized migration.json"
+        type: string
+        default: ""
 
 concurrency:
   group: kms-production-operation-32264
@@ -19,10 +28,10 @@ permissions:
   contents: read
 
 jobs:
-  preflight:
+  migrate:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     environment: production
     permissions:
       contents: read
@@ -40,12 +49,15 @@ jobs:
           corepack enable pnpm
           pnpm install --frozen-lockfile --ignore-scripts --filter @okouai/db...
           command -v aws
-      - name: Verify target runtime, rollback reads, and all production ciphertext
+      - name: Verify runtime and rewrap a bounded production batch with the operator role
         working-directory: turbo/packages/db
         env:
-          KMS_OPERATION: verify
+          KMS_OPERATION: migrate
           EXPECTED_BACKUP_SHA256: 60d1500d90c83a8b40996c3e9e6fbb9453ffbf598a9ae1c670d38f60b340e9f8
           EXPECTED_DEPLOYMENT_ID: ${{ inputs.expected_deployment_id }}
+          MAX_ROWS: ${{ inputs.max_rows }}
+          CURSOR: ${{ inputs.cursor }}
+          KMS_MIGRATION_ROLE_ARN: ${{ vars.KMS_MIGRATION_ROLE_ARN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ""
@@ -60,7 +72,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: kms-production-verification-${{ github.run_id }}-${{ github.run_attempt }}
+          name: kms-production-migration-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/kms-production-reports/*.json
           if-no-files-found: warn
           retention-days: 7

--- a/turbo/packages/db/scripts/migrations/013-kms-account-rotation/README.md
+++ b/turbo/packages/db/scripts/migrations/013-kms-account-rotation/README.md
@@ -13,12 +13,15 @@ changes no deployment configuration, and disables no keys.
 
 ## Production preflight
 
-After this PR merges, manually run **KMS Production Preflight** on `main`.
+After production configuration has switched to the existing target user,
+manually run **KMS Production Preflight** on `main` with the expected current
+production API Vercel deployment ID.
 It uses the existing GitHub `production` environment's protected-branch and
 required-reviewer gates. PR branches cannot access that job.
 
-The job first uses the actual old production IAM user, the existing target
-credentials from Doppler `vm0/prd_kms_migration_32264`, and the old user again to
+The job first loads the actual old production IAM user from the independently
+verified Doppler rollback snapshot, uses the current GitHub production target
+credentials, and then the old user again to
 verify synthetic envelope/legacy reads, target writes, rollback reads, and denial
 of old-key writes, test-key access, and the wrong encryption context. STS must
 identify the exact `vm0-kms-prod` user in each expected account. Only synthetic
@@ -34,16 +37,31 @@ used only in process memory for authentication checks and nested queue parsing;
 it is never logged, written to a report, or uploaded. JavaScript strings cannot
 be explicitly zeroed; plaintext byte buffers are cleared after use.
 
-The workflow has no deployment, secret-update, or database-mutation step. It
-does not grant runtime users `ReEncrypt`. A migrate command must run separately
-under the existing migration operator's permissions and with an authorized
-production database connection.
+The preflight workflow has no deployment, secret-update, or database-mutation
+step. After checking deployed application business flows, **KMS Production
+Migrate** executes the bounded mutation through the separate production OIDC
+migration role. It uses GitHub's existing Neon credentials, repeats a fresh full
+target-runtime scan, and verifies synthetic operator re-encryption and rollback
+before writing. It does not grant runtime users `ReEncrypt`.
 
-## Preserve the effective production configuration
+See the [Actions execution and IAM prerequisite](../../../../../../.github/kms-migration-32264/README.md).
+The workflows share a concurrency group. Verification always starts from the
+beginning; migration accepts a checkpoint cursor and defaults to a 1,000-field
+limit. After all batches, run the preflight again and require a fresh complete
+`databaseVerifiedOnTarget: true` report. These post-cutover workflows must not
+be used to repeat the already-completed backup step below.
 
-After preflight succeeds, run **KMS Production Backup** on `main`. Supply the
-current production API Vercel deployment ID as `expected_deployment_id` and
-approve its protected GitHub `production` environment job. This backup is a
+## Completed pre-cutover configuration backup
+
+The pre-cutover verification ([run 34314877468](https://github.com/vm0-ai/vm0/actions/runs/34314877468))
+and configuration backup ([run 34324494642](https://github.com/vm0-ai/vm0/actions/runs/34324494642))
+completed before the GitHub production secrets changed. The backup workflow
+below documents that completed operation; it requires the old configuration
+and refuses the now-existing destination. Do not repeat it after cutover.
+
+For that operation, **KMS Production Backup** ran on `main` with the
+then-current production API Vercel deployment ID as `expected_deployment_id`
+and an approved protected GitHub `production` environment job. This backup is a
 separate operation from deployment or ciphertext migration.
 
 The job verifies the exact old production IAM user and resolves the configured

--- a/turbo/packages/db/scripts/migrations/013-kms-account-rotation/runtime-canary.ts
+++ b/turbo/packages/db/scripts/migrations/013-kms-account-rotation/runtime-canary.ts
@@ -18,6 +18,7 @@ import {
   encrypt,
   encryptionContext,
   object,
+  rewrap,
   string,
 } from "./kms";
 
@@ -32,16 +33,33 @@ const plaintext = Buffer.from("kms-32264-production-synthetic-only");
 async function main(): Promise<void> {
   const phase = string(process.argv[2]);
   const directory = string(process.argv[3]);
-  assert.ok(["prepare-old", "verify-new", "verify-rollback"].includes(phase));
-  const account = phase === "verify-new" ? "251964670836" : "072707626411";
+  assert.ok(
+    [
+      "prepare-old",
+      "verify-new",
+      "verify-rollback",
+      "verify-operator",
+    ].includes(phase),
+  );
+  const account =
+    phase === "verify-new" || phase === "verify-operator"
+      ? "251964670836"
+      : "072707626411";
   const identity = object(
     JSON.parse(await readFile(join(directory, "identity.json"), "utf8")),
   );
   assert.equal(identity.Account, account);
-  assert.equal(identity.Arn, `arn:aws:iam::${account}:user/vm0-kms-prod`);
+  if (phase === "verify-operator") {
+    assert.match(
+      string(identity.Arn),
+      /^arn:aws:sts::251964670836:assumed-role\/vm0-kms-migration-github-32264\/github-kms-[0-9]+$/u,
+    );
+  } else {
+    assert.equal(identity.Arn, `arn:aws:iam::${account}:user/vm0-kms-prod`);
+  }
   const configuredKey = process.env.SECRETS_KMS_KEY_ID;
   assert.ok(
-    phase === "verify-new"
+    phase === "verify-new" || phase === "verify-operator"
       ? configuredKey === target
       : [
           source,
@@ -123,12 +141,32 @@ async function main(): Promise<void> {
           },
         );
       }
-    } else {
+    } else if (phase === "verify-rollback") {
       const fresh = object(
         JSON.parse(await readFile(join(directory, "new.json"), "utf8")),
       );
       assert.equal(decode(string(fresh.envelope)).kms.keyId, target);
       await verify(string(fresh.envelope));
+    } else {
+      const old = object(
+        JSON.parse(await readFile(join(directory, "old.json"), "utf8")),
+      );
+      for (const value of [old.envelope, old.legacy]) {
+        const original = decode(string(value));
+        const moved = await rewrap(kms, original, source, target);
+        assert.equal(moved.kms.keyId, target);
+        await verify(encode(moved));
+        const restored = await rewrap(kms, moved, target, source);
+        assert.equal(restored.kms.keyId, source);
+        await verify(encode(restored));
+        if (original.kms.encryptedDataKey) {
+          for (const envelope of [moved, restored]) {
+            assert.equal(envelope.kms.ciphertext, original.kms.ciphertext);
+            assert.equal(envelope.kms.iv, original.kms.iv);
+            assert.equal(envelope.kms.authTag, original.kms.authTag);
+          }
+        }
+      }
     }
     process.stdout.write(
       JSON.stringify({

--- a/turbo/packages/db/scripts/migrations/013-kms-account-rotation/test.ts
+++ b/turbo/packages/db/scripts/migrations/013-kms-account-rotation/test.ts
@@ -3,11 +3,18 @@
 // CLI integration: a real, isolated Postgres database and an HTTP KMS boundary.
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { randomBytes, randomUUID } from "node:crypto";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join, resolve } from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
 
@@ -68,6 +75,17 @@ const server = createServer((request, response) => {
         ? body.SourceEncryptionContext
         : body.EncryptionContext,
     );
+    if (
+      operation === "GenerateDataKey" &&
+      string(request.headers.authorization).includes("Credential=target/") &&
+      (body.KeyId !== target || context.purpose !== encryptionContext.purpose)
+    ) {
+      response.writeHead(400, {
+        "content-type": "application/x-amz-json-1.1",
+      });
+      response.end(JSON.stringify({ __type: "AccessDeniedException" }));
+      return;
+    }
     assert.deepEqual(context, encryptionContext);
     let result: Record<string, unknown>;
     if (operation === "GenerateDataKey" || operation === "Encrypt") {
@@ -211,6 +229,144 @@ async function stored(
   ).rows;
   return string(object(rows[0]).value);
 }
+
+async function workflowCli(
+  name: string,
+  operation: "verify" | "migrate",
+  scenario = "success",
+  overrides: Record<string, string> = {},
+): Promise<Record<string, unknown> | null> {
+  const root = join(directory, name);
+  const binary = join(root, "bin");
+  await mkdir(binary, { recursive: true });
+  const wrapper = await readFile(
+    "../../../.github/scripts/tests/fixtures/kms-production-migration-tools.py",
+    "utf8",
+  );
+  for (const command of ["aws", "curl", "pnpm"]) {
+    const path = join(binary, command);
+    await writeFile(path, wrapper);
+    await chmod(path, 0o700);
+  }
+  const snapshot = {
+    version: 1,
+    sourceKeyArn: source,
+    sourcePrincipal: "arn:aws:iam::072707626411:user/vm0-kms-prod",
+    configuration: {
+      AWS_ACCESS_KEY_ID: "source",
+      AWS_SECRET_ACCESS_KEY: "synthetic-source-secret",
+      SECRETS_KMS_KEY_ID: source,
+      AWS_REGION: "us-west-2",
+    },
+    workflow: {
+      repository: "vm0-ai/vm0",
+      commit: "594d907ca844e845f674c04640a58ae8cebcdc8a",
+      runId: "34324494642",
+    },
+  };
+  const pnpm = (await execute("which", ["pnpm"])).stdout.trim();
+  await writeFile(
+    join(root, "provider.json"),
+    JSON.stringify({
+      scenario,
+      snapshot,
+      pnpm,
+      kmsEndpoint: endpoint,
+      databaseUrl: input.toString(),
+      assumeCalls: 0,
+      deploymentReads: 0,
+    }),
+  );
+  const environment = {
+    ...process.env,
+    PATH: binary + delimiter + string(process.env.PATH),
+    RUNNER_TEMP: root,
+    GITHUB_REPOSITORY: "vm0-ai/vm0",
+    GITHUB_REF: "refs/heads/main",
+    GITHUB_EVENT_NAME: "workflow_dispatch",
+    GITHUB_RUN_ID: "12345",
+    GITHUB_SHA: "a".repeat(40),
+    GITHUB_WORKFLOW_REF: `vm0-ai/vm0/.github/workflows/kms-production-${operation === "verify" ? "preflight" : "migrate"}.yml@refs/heads/main`,
+    ACTIONS_ID_TOKEN_REQUEST_URL:
+      "https://pipelines.actions.githubusercontent.com/oidc",
+    ACTIONS_ID_TOKEN_REQUEST_TOKEN: "synthetic-github-token",
+    DOPPLER_SERVICE_IDENTITY_ID: "c0c87790-e651-45dd-b7fa-c5ed07bb990f",
+    EXPECTED_BACKUP_SHA256: createHash("sha256")
+      .update(JSON.stringify(snapshot))
+      .digest("hex"),
+    EXPECTED_DEPLOYMENT_ID: "dpl_fixture",
+    VERCEL_TOKEN: "synthetic-vercel-secret",
+    NEON_PROJECT_ID: "hidden-lab-39609750",
+    NEON_API_KEY: "synthetic-neon-secret",
+    AWS_ACCESS_KEY_ID: "target",
+    AWS_SECRET_ACCESS_KEY: "synthetic-target-secret",
+    AWS_SESSION_TOKEN: "",
+    AWS_REGION: "us-west-2",
+    SECRETS_KMS_KEY_ID: target,
+    KMS_OPERATION: operation,
+    KMS_MIGRATION_ROLE_ARN:
+      "arn:aws:iam::251964670836:role/vm0-kms-migration-github-32264",
+    MAX_ROWS: "1",
+    ...overrides,
+  };
+  let failed = false;
+  let output = "";
+  try {
+    const result = await execute(
+      "python3",
+      [resolve("../../../.github/scripts/kms-production-migration.py")],
+      { env: environment, timeout: 60_000 },
+    );
+    output = result.stdout + result.stderr;
+  } catch (error) {
+    const result = object(error);
+    output = string(result.stdout) + string(result.stderr);
+    failed = true;
+  }
+  assert.equal(failed, scenario !== "success", output);
+  let report: Record<string, unknown> | null = null;
+  try {
+    report = object(
+      JSON.parse(
+        await readFile(
+          join(root, "kms-production-reports/operation.json"),
+          "utf8",
+        ),
+      ),
+    );
+  } catch (error) {
+    assert.equal(object(error).code, "ENOENT");
+  }
+  const reportDirectory = join(root, "kms-production-reports");
+  let reportText = "";
+  for (const name of [
+    "operation.json",
+    "verification.json",
+    "migration.json",
+  ]) {
+    try {
+      reportText += await readFile(join(reportDirectory, name), "utf8");
+    } catch (error) {
+      assert.equal(object(error).code, "ENOENT");
+    }
+  }
+  for (const value of [
+    secret,
+    "synthetic-source-secret",
+    "synthetic-target-secret",
+    "synthetic-operator-secret",
+    "synthetic-operator-session",
+    "synthetic-database-secret",
+    "synthetic-doppler-token",
+    "synthetic-provider-secret-must-not-be-logged",
+  ]) {
+    assert.ok(!(output + reportText).includes(value));
+  }
+  if (operation === "verify" || scenario !== "success") {
+    assert.equal(report?.migration, undefined);
+  }
+  return report;
+}
 try {
   const tables = new Map<string, string[]>();
   for (const field of fields) {
@@ -226,6 +382,82 @@ try {
   for (const [table, columns] of tables) {
     await db.query(`CREATE TABLE "${table}" (${columns.join(", ")})`);
   }
+  const workflowCiphertext = encode(
+    await encrypt(kms, Buffer.from(secret), source),
+  );
+  await db.query(
+    "INSERT INTO secrets VALUES ('workflow-1', $1), ('workflow-2', $1)",
+    [workflowCiphertext],
+  );
+  const workflowVerify = await workflowCli("workflow-verify", "verify");
+  assert.equal(
+    object(workflowVerify?.targetRuntimeVerification).databaseVerifiedOnTarget,
+    false,
+  );
+  assert.equal(
+    await stored("secrets", "encrypted_value", "workflow-1"),
+    workflowCiphertext,
+  );
+  for (const scenario of [
+    "backup-changed",
+    "wrong-operator",
+    "deployment-changed",
+    "provider-error",
+  ]) {
+    await workflowCli("workflow-" + scenario, "migrate", scenario);
+    assert.equal(
+      await stored("secrets", "encrypted_value", "workflow-1"),
+      workflowCiphertext,
+    );
+    assert.equal(
+      await stored("secrets", "encrypted_value", "workflow-2"),
+      workflowCiphertext,
+    );
+  }
+  for (const [name, overrides] of [
+    ["unprotected-branch", { GITHUB_REF: "refs/heads/unprotected" }],
+    ["missing-role", { KMS_MIGRATION_ROLE_ARN: "" }],
+    ["invalid-limit", { MAX_ROWS: "100001" }],
+    ["wrong-runtime-key", { SECRETS_KMS_KEY_ID: source }],
+  ] satisfies [string, Record<string, string>][]) {
+    await workflowCli("workflow-" + name, "migrate", "rejected", overrides);
+    assert.equal(
+      await stored("secrets", "encrypted_value", "workflow-1"),
+      workflowCiphertext,
+    );
+  }
+  failRewrap = true;
+  try {
+    await workflowCli("workflow-operator-denied", "migrate", "operator-denied");
+    assert.equal(
+      await stored("secrets", "encrypted_value", "workflow-1"),
+      workflowCiphertext,
+    );
+  } finally {
+    failRewrap = false;
+  }
+  const workflowMigration = await workflowCli("workflow-bounded", "migrate");
+  const migration = object(workflowMigration?.migration);
+  assert.equal(migration.complete, false);
+  assert.equal(object(migration.totals).updated, 1);
+  assert.equal(
+    decode(await stored("secrets", "encrypted_value", "workflow-1")).kms.keyId,
+    target,
+  );
+  assert.equal(
+    await stored("secrets", "encrypted_value", "workflow-2"),
+    workflowCiphertext,
+  );
+  await workflowCli("workflow-resume", "migrate", "success", {
+    CURSOR: string(migration.cursor),
+    MAX_ROWS: "100",
+  });
+  const workflowFinal = await workflowCli("workflow-final", "verify");
+  assert.equal(
+    object(workflowFinal?.targetRuntimeVerification).databaseVerifiedOnTarget,
+    true,
+  );
+  await db.query("DELETE FROM secrets");
   const concurrentFixtures: { id: string; ciphertext: string }[] = [];
   for (let index = 0; index < 9; index++) {
     const envelope = await encrypt(kms, Buffer.from(secret), source);
@@ -542,7 +774,7 @@ try {
   assert.equal(object(invalid.totals).invalid, 1);
   assert.equal(invalid.databaseVerifiedOnTarget, false);
   process.stdout.write(
-    "KMS rotation CLI integration passed: read-only inventory, concurrent verification and failure checkpoints, nested verification, bounded resume, concurrent writes, KMS failure recovery, rewrap preservation, reverse migration, and malformed ciphertext.\n",
+    "KMS rotation CLI integration passed: protected workflow entry, runtime and operator canaries, failure-before-write guards, secret-safe artifacts, read-only inventory, concurrent verification and failure checkpoints, nested verification, bounded resume, concurrent writes, KMS failure recovery, rewrap preservation, reverse migration, and malformed ciphertext.\n",
   );
 } finally {
   kms.destroy();


### PR DESCRIPTION
After production switches to the target AWS account, the old preflight treats the new credentials as the old user, and historical ciphertext has no protected GitHub Actions migration entry point. This change loads the independently verified old configuration from its Doppler backup, verifies the current target runtime and rollback reads, and adds a separate bounded production migration workflow.

Both workflows run only on `main`, require the existing `production` environment approval, share a concurrency group, and use the existing GitHub Neon credentials. Every migration first authenticates the complete database under the target runtime user, then assumes a dedicated GitHub OIDC operator role and verifies synthetic forward/reverse re-encryption before conditional database writes. The default limit is 1,000 field values; sanitized artifacts retain checkpoints for resume, and a separate fresh verification certifies completion. No static credentials, deployment settings, staging resources, or key retirement are changed by these jobs.

The PR includes the exact role trust, production-key IAM permissions, and additive source/target key-policy statements. That role and the `KMS_MIGRATION_ROLE_ARN` production variable must be configured before migration; the workflows do not bootstrap IAM with runtime credentials. The production API's business create/read/update and legacy-read evidence remains a pre-mutation operational prerequisite; runtime canaries alone do not certify it.

Validation: the real Python workflow entry point and TypeScript canary/backfill run against isolated PostgreSQL and external AWS/Neon/Doppler/Vercel fixtures. Coverage includes bounded writes, resume, final target verification, wrong operator, modified backup, deployment drift, provider failure, invalid scope/limits, denied re-encryption, and secret-safe logs/artifacts. Strict TypeScript, ESLint, type-aware Oxlint, Prettier, Python Ruff, and actionlint pass. Production ciphertext has not been changed by this PR.

Refs #32264.
