### PR TITLE
feat(chat): summarize activity for visible threads on demand

### DIFF
--- a/docs/chat-thread-activity-summary.md
+++ b/docs/chat-thread-activity-summary.md
@@ -2,8 +2,9 @@
 
 `threadActivitySummary` is disabled by default, with no rollout audience. Both
 accepted-event capture and direct summary requests resolve the canonical
-owner's organization/user database overrides. This backend slice leaves the
-existing initial-thinking producer and all frontend behavior intact.
+owner's organization/user database overrides. The same switch hands off the
+initial-thinking producer to demand from the visible main thread. Disabled
+accounts retain the existing producer, display and historical behavior.
 
 ## API contract
 
@@ -78,7 +79,41 @@ Debug diagnostics record capture outcomes, cache states, attempt/completion
 counts, latency, cooldown, and cleanup counts. They never contain prompts,
 arguments, results, or provider response bodies.
 
-## Deployment and the next slice
+## Visible viewer lifecycle
+
+The committed main-thread container owns summary demand through its local
+callback-ref AbortSignal and page lifecycle. Sidebar panels and unmounted routes
+do not request summaries. A visible, enabled viewer requests immediately for the
+latest eligible live run from the canonical event fold; the API independently
+verifies the admitted-run pointer and authorization. Subsequent requests use a
+15-second baseline and never precede `retryAfterMs`. Cooldown deadlines survive
+visibility changes. Each viewer serializes requests, including an aborted
+transport still settling after a ref change.
+
+Hiding, navigating away, unmounting, switching off, losing thread access, queuing,
+ending or replacing a run cancels demand and rejects late responses. An
+`ineligible`, 401, 403 or 404 response clears dynamic copy and stops retries for
+that run identity. An unavailable, malformed or failed optional response keeps
+the current run's last usable phrase (or the existing generic indicator) and
+backs off at least 60 seconds, stopping after three consecutive failures.
+
+Cached `pending`, `cooldown` and `stale` phrases keep their actual
+`summaryRevision`, sequence, message cursor and completion time. Hashes are
+opaque; only monotonic summary provenance may replace current copy. Identical
+text preserves the mounted typewriter; changed text restarts it even after
+commentary or a completed animation. Run status remains the existing programmatic
+projection. All dynamic copy stays in transient page state, outside chat events,
+browser persistence, history and model context.
+
+Normal-send preparation suppresses automatic initial thinking for enabled
+owners through the shared gate used by both retained scheduling branches. The
+producer rechecks canonical overrides before starting a model request, covering
+work scheduled before activation. Already-started provider calls cannot be
+recalled. Thread-title generation and the main model are independent and remain
+unchanged. Current normal sends all enter queue-first; the retained
+associated-message scheduling branch has no reachable normal-send caller.
+
+## Deployment and rollout
 
 The migration only creates an empty table and index; it changes no existing
 persisted contract and backfills no historical rows. Existing API/Runner/App
@@ -86,8 +121,11 @@ versions continue their current paths. Apply the additive migration before
 activating readers/writers; normal API production promotion already enforces
 that ordering. This PR does not perform a release or enable production users.
 
-The next slice should use the same switch to stop automatic initial-thinking
-creation for enabled runs and request this endpoint only from the visible active
-thread. It must discard responses for a changed/ended run or disabled switch,
-keep phrases transient, and honor retry metadata without overlapping requests.
-Dynamic phrases must never be appended to durable chat history or agent context.
+New App against an older API without this endpoint receives 404 and retains the
+generic indicator without repeated requests. Older Apps against a new API retain
+their generic indicator for enabled runs because opening-copy generation is
+suppressed. Switch rollback restores the legacy path for subsequent runs; it
+does not backfill opening copy into an already-created run. The feature has no
+GA audience and stays default-off with no production allowlist. Epic #32819 owns
+release, controlled activation, production billing verification and the removal
+of the mixed-version fallback once older API rollback targets are retired.

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -20703,6 +20703,108 @@ describe("CHAT-02: incomplete-round context", () => {
 });
 
 describe("CHAT-02: initial thinking indicator", () => {
+  it.each([
+    { enabled: false, existingThread: false },
+    { enabled: true, existingThread: false },
+    { enabled: false, existingThread: true },
+    { enabled: true, existingThread: true },
+  ])(
+    "hands opening copy to visible demand only when enabled=$enabled (existing thread=$existingThread)",
+    async ({ enabled, existingThread }) => {
+      const { actor, agentId } = await entitledChatActor();
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId: requireOrgId(actor) },
+        { [FeatureSwitchKey.ThreadActivitySummary]: enabled },
+      );
+      const thread = existingThread
+        ? await chat.createThread(actor, { agentId })
+        : null;
+      mockOptionalEnv("OPENROUTER_API_KEY", "thinking-handover-key");
+      const indicatorCalls: string[] = [];
+      let titleCalls = 0;
+      server.use(
+        http.post(
+          "https://openrouter.ai/api/v1/chat/completions",
+          async ({ request }) => {
+            const payload = openRouterBodySchema.parse(await request.json());
+            const system = payload.messages[0]?.content ?? "";
+            const isInitial = system.includes(
+              "Write user-visible progress copy",
+            );
+            const isSummary = system.includes("Write one short");
+            if (isInitial || isSummary) {
+              indicatorCalls.push(isInitial ? "initial" : "summary");
+            } else if (system.includes("Generate a short, descriptive title")) {
+              titleCalls++;
+            }
+            return HttpResponse.json({
+              choices: [
+                {
+                  finish_reason: "stop",
+                  message: {
+                    content: isInitial
+                      ? "Preparing the original checklist"
+                      : isSummary
+                        ? "Preparing the visible checklist"
+                        : "Launch Checklist",
+                  },
+                },
+              ],
+            });
+          },
+        ),
+      );
+      const run = await sendChatRun(actor, {
+        agentId,
+        prompt: "Prepare the launch checklist",
+        ...(thread ? { threadId: thread.id } : {}),
+      });
+      await flushWaitUntilForTest();
+      const beforeDemand = await chat.listThreadEvents(actor, run.threadId);
+      const initial = beforeDemand.events.filter((event) => {
+        return event.runEventId === "thinking:initial";
+      });
+      expect(indicatorCalls).toStrictEqual(enabled ? [] : ["initial"]);
+      expect(initial).toHaveLength(enabled ? 0 : 1);
+      if (!enabled) {
+        expect(initial[0]).toMatchObject({
+          eventType: "output.thinking",
+          thinking: "Preparing the original checklist",
+          runId: run.runId,
+        });
+      }
+      expect(titleCalls).toBeGreaterThan(0);
+      expect((await api.readRun(actor, run.runId)).status).toBe("pending");
+
+      const requested = await accept(
+        setupApp({ context, routes: chatThreadActivitySummaryRoutes })(
+          chatThreadActivitySummaryContract,
+        ).summarize({
+          headers: sessionHeaders(actor),
+          params: { id: run.threadId },
+          body: { runId: run.runId },
+        }),
+        [200, 403],
+      );
+      if (enabled) {
+        expect(requested.status).toBe(200);
+        expect(requested.body).toMatchObject({
+          phrase: "Preparing the visible checklist",
+          status: "fresh",
+          runId: run.runId,
+        });
+        expect(indicatorCalls).toStrictEqual(["summary"]);
+      } else {
+        expect(requested.status).toBe(403);
+        expect(indicatorCalls).toStrictEqual(["initial"]);
+      }
+      const afterDemand = await chat.listThreadEvents(actor, run.threadId);
+      expect(afterDemand.events).toStrictEqual(beforeDemand.events);
+      await cancelChatRun(actor, run.runId);
+    },
+  );
+
   it("persists a fast assistant thinking marker with paragraphs for active web chat runs", async () => {
     const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();

--- a/turbo/apps/api/src/signals/services/chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/chat-events.command.ts
@@ -465,6 +465,19 @@ interface NormalSendFeatureSwitches {
   readonly featureSwitchContext: FeatureSwitchContext;
 }
 
+function initialThinkingForSend(
+  args: NormalSendArgs,
+  switches: NormalSendFeatureSwitches,
+): boolean {
+  return (
+    args.agentRunPreCreateSource === undefined &&
+    !isFeatureEnabled(
+      FeatureSwitchKey.ThreadActivitySummary,
+      switches.featureSwitchContext,
+    )
+  );
+}
+
 interface RuntimeNormalSendBody extends Omit<
   CanonicalNormalSendBody,
   "userMessage"
@@ -2809,7 +2822,7 @@ const prepareNormalSend$ = command(
       videoRunOptions: templateContext.videoRunOptions,
       computerUseHostGrant: computerAccess.computerUseHostGrant,
       persistedExplicitSelection,
-      initialThinkingEnabled: args.agentRunPreCreateSource === undefined,
+      initialThinkingEnabled: initialThinkingForSend(args, featureSwitches),
       attachFileMetadata,
       runConfiguration,
       clientEventPrechecked: preflight.prechecked,

--- a/turbo/apps/api/src/signals/services/chat-initial-thinking.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-initial-thinking.service.ts
@@ -1,4 +1,5 @@
 import { agentRuns } from "@okouai/db/schema/agent-run";
+import { FeatureSwitchKey, isFeatureEnabled } from "@okouai/core";
 import { chatEventCompatibilityRole } from "@okouai/api-contracts/contracts/chat-events";
 import { chatEvents } from "@okouai/db/schema/chat-event";
 import {
@@ -25,6 +26,7 @@ import {
   visibleChatEventCondition,
 } from "./chat-event-shared.service";
 import { insertChatEvent } from "./chat-event.service";
+import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { chatEventTypeIn } from "./chat-event-type.service";
 import { queuedUserMessageExists } from "./chat-queued-event.service";
 import {
@@ -249,6 +251,18 @@ export async function generateAndPersistInitialThinkingMessage(args: {
   }
 
   const history = await loadThinkingContextMessages(args);
+  // Scheduling can precede a switch update. Recheck both queue-first and
+  // associated-message work immediately before starting another model attempt.
+  const featureContext = await loadUserFeatureSwitchContext(
+    args.db,
+    args.orgId,
+    args.userId,
+  );
+  if (
+    isFeatureEnabled(FeatureSwitchKey.ThreadActivitySummary, featureContext)
+  ) {
+    return false;
+  }
   const thinking = await tapError(
     generateInitialThinkingText({
       currentPrompt: args.currentPrompt,

--- a/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
@@ -180,9 +180,8 @@ export interface ChatPanelSignals {
     (() => void) | undefined,
     [HTMLElement | null]
   >;
-  readonly setMainContainerRef$: Command<
-    (() => void) | undefined,
-    [HTMLElement | null]
+  readonly mainContainerRef$: Computed<
+    Command<(() => void) | undefined, [HTMLElement | null]>
   >;
   // True when the event list is scrolled away from the bottom - drives the
   // feature-gated scroll-to-bottom button. Read-only outside scroll signals.

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-container.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-container.ts
@@ -1,4 +1,4 @@
-import { command, computed, state } from "ccstate";
+import { command, computed, state, type Command, type Computed } from "ccstate";
 import { onRef } from "../utils.ts";
 
 function isDocumentScrollTarget(
@@ -56,7 +56,12 @@ const attachMainThreadFocusFallback$ = command(
   },
 );
 
-export function createChatThreadContainerSignals() {
+export function createChatThreadContainerSignals(
+  attachActivitySummary$: Computed<
+    Command<Promise<void>, [HTMLElement, AbortSignal]>
+  >,
+  pageSignal: AbortSignal,
+) {
   const internalContainerEl$ = state<HTMLElement | null>(null);
   const containerEl$ = computed((get) => {
     return get(internalContainerEl$);
@@ -70,11 +75,17 @@ export function createChatThreadContainerSignals() {
     },
   );
   const setContainerRef$ = onRef(attachContainer$);
-  const setMainContainerRef$ = onRef(
-    command(({ set }, el: HTMLElement, signal: AbortSignal) => {
-      set(attachContainer$, el, signal);
-      set(attachMainThreadFocusFallback$, el, signal);
-    }),
-  );
-  return { containerEl$, setContainerRef$, setMainContainerRef$ };
+  const mainContainerRef$ = computed((get) => {
+    const attachActivity$ = get(attachActivitySummary$);
+    return onRef(
+      command(async ({ set }, el: HTMLElement, mountSignal: AbortSignal) => {
+        const signal = AbortSignal.any([mountSignal, pageSignal]);
+        signal.throwIfAborted();
+        set(attachContainer$, el, signal);
+        set(attachMainThreadFocusFallback$, el, signal);
+        await set(attachActivity$, el, signal);
+      }),
+    );
+  });
+  return { containerEl$, setContainerRef$, mainContainerRef$ };
 }

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -212,6 +212,7 @@ import {
   type BrowserLifecycleOptimisticEvents,
 } from "./browser-session-block.ts";
 import { createChatThreadContainerSignals } from "./chat-thread-container.ts";
+import { createThreadActivitySummarySignals } from "./thread-activity-summary.ts";
 import { createAssistantErrorRecoverySignals } from "./assistant-error-recovery.ts";
 import {
   messageDocumentToPrompt,
@@ -4317,7 +4318,12 @@ function createChatPanelSignalsWithDraft(
   const threadDraft$ = createRemoteChatThreadDraft(threadId);
   const threadMeta$ = createThreadMeta(threadId);
   const threadTitle = createThreadTitleParts(threadMeta$);
-  const container = createChatThreadContainerSignals();
+  const activity = createThreadActivitySummarySignals(
+    threadId,
+    chatEvents.chatEvents$,
+    threadMeta$,
+  );
+  const container = createChatThreadContainerSignals(activity.attach$, signal);
   const threadOwned = createThreadOwnedSignals(threadId);
   const cancellationRecovery = createCancellationRecoverySignals(threadId);
   const composer = createThreadComposerSignalsWithContext(
@@ -4372,6 +4378,16 @@ function createChatPanelSignalsWithDraft(
     reloadConnectorAccountPreference$:
       composer.connector.accounts.reloadPreference$,
   });
+  const thinkingText$ = computed(async (get) => {
+    return get(activity.enabled$)
+      ? get(activity.thinkingText$)
+      : await get(messages.thinkingText$);
+  });
+  const thinkingEventId$ = computed(async (get) => {
+    return get(activity.enabled$)
+      ? get(activity.thinkingId$)
+      : await get(messages.thinkingEventId$);
+  });
   return {
     threadId,
     agentId,
@@ -4403,11 +4419,10 @@ function createChatPanelSignalsWithDraft(
     ...threadOwned,
     sidebar: messages.sidebar,
     ...publicChatThreadEventSignals(messages),
+    thinkingText$,
+    thinkingEventId$,
     subscribeChatThread$: runTracking.subscribeChatThread$,
-    ...createThinkingIndicatorSignals(
-      messages.thinkingText$,
-      messages.thinkingEventId$,
-    ),
+    ...createThinkingIndicatorSignals(thinkingText$, thinkingEventId$),
     artifacts$: messages.artifacts$,
     reloadArtifacts$: messages.reloadArtifacts$,
   };

--- a/turbo/apps/platform/src/signals/chat-page/thread-activity-summary.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-activity-summary.ts
@@ -1,0 +1,249 @@
+import { command, computed, state, type Computed, type State } from "ccstate";
+import {
+  activitySummaryResponseSchema,
+  chatThreadActivitySummaryContract,
+  type ActivitySummaryResponse,
+} from "@okouai/api-contracts/contracts/chat-thread-activity-summary";
+import { foldChatRunStates } from "@okouai/api-contracts/contracts/chat-events";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { accept } from "../../lib/accept.ts";
+import { now } from "../../lib/time.ts";
+import { currentChatThreadId$ } from "../agent-chat.ts";
+import { apiClient$ } from "../api-client.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import { createChildAbortController, setLoop, settle } from "../utils.ts";
+import { liveRunIdsFromChatEvents } from "./chat-event-state.ts";
+import type { ChatEvent } from "./chat-event-types.ts";
+import type { ThreadMeta } from "./chat-thread-event-sourcing.ts";
+
+const REQUEST_INTERVAL_MS = 15_000;
+const FAILURE_RETRY_MS = 60_000;
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+type Summary = Pick<
+  ActivitySummaryResponse,
+  | "runId"
+  | "phrase"
+  | "summaryRevision"
+  | "summarySequence"
+  | "summaryMessageCursor"
+  | "summarizedAt"
+>;
+
+function canReplaceSummary(previous: Summary | null, next: Summary): boolean {
+  if (previous === null || previous.runId !== next.runId) {
+    return true;
+  }
+  // Hashes are opaque. Compare the actual summary's provenance, never the
+  // potentially newer sourceRevision carried alongside a cached phrase.
+  return (
+    next.summarizedAt !== null &&
+    (previous.summarizedAt === null ||
+      next.summarizedAt >= previous.summarizedAt) &&
+    (next.summarySequence ?? -1) >= (previous.summarySequence ?? -1) &&
+    (next.summaryMessageCursor ?? -1) >= (previous.summaryMessageCursor ?? -1)
+  );
+}
+
+function createSummaryRequestSignals(
+  threadId: string,
+  runId$: Computed<string | null>,
+  visible$: State<boolean>,
+) {
+  const summary$ = state<Summary | null>(null);
+  const blockedRun$ = state<string | null>(null);
+  const requestCompletion$ = state<Promise<unknown>>(Promise.resolve());
+  const request$ = command(
+    async ({ get, set }, runId: string, signal: AbortSignal) => {
+      // A detached ref may still be settling an aborted transport. Serialize
+      // across ref/visibility/run replacement as well as inside each loop.
+      await Promise.allSettled([get(requestCompletion$)]);
+      signal.throwIfAborted();
+      if (get(runId$) !== runId || !get(visible$)) {
+        return { stop: true, failed: false, retryAfterMs: 0 };
+      }
+      const completion = settle(
+        accept(
+          get(apiClient$)(chatThreadActivitySummaryContract).summarize({
+            params: { id: threadId },
+            body: { runId },
+            fetchOptions: { signal },
+          }),
+          [200, 401, 403, 404, 500],
+          signal,
+          { showErrorToast: false },
+        ),
+        signal,
+      );
+      set(requestCompletion$, completion);
+      const result = await completion;
+      signal.throwIfAborted();
+      if (get(runId$) !== runId || !get(visible$)) {
+        return { stop: true, failed: false, retryAfterMs: 0 };
+      }
+      if (!result.ok || result.value.status === 500) {
+        return { stop: false, failed: true, retryAfterMs: FAILURE_RETRY_MS };
+      }
+      const response = result.value;
+      if (response.status !== 200) {
+        // Includes an older API without the additive endpoint. No cache is
+        // exposed and no retry occurs for this identity. #32819 owns verifying
+        // API rollback targets before retiring the mixed-version fallback.
+        set(summary$, null);
+        set(blockedRun$, runId);
+        return { stop: true, failed: false, retryAfterMs: 0 };
+      }
+      const parsed = activitySummaryResponseSchema.safeParse(response.body);
+      if (!parsed.success || parsed.data.runId !== runId) {
+        return { stop: false, failed: true, retryAfterMs: FAILURE_RETRY_MS };
+      }
+      const data = parsed.data;
+      if (data.status === "ineligible") {
+        set(summary$, null);
+        set(blockedRun$, runId);
+        return { stop: true, failed: false, retryAfterMs: 0 };
+      }
+      if (
+        data.phrase &&
+        data.summaryRevision !== null &&
+        data.summarizedAt !== null &&
+        canReplaceSummary(get(summary$), data)
+      ) {
+        set(summary$, {
+          runId,
+          phrase: data.phrase,
+          summaryRevision: data.summaryRevision,
+          summarySequence: data.summarySequence,
+          summaryMessageCursor: data.summaryMessageCursor,
+          summarizedAt: data.summarizedAt,
+        });
+      }
+      return {
+        stop: false,
+        failed: data.status === "unavailable",
+        retryAfterMs: Math.max(
+          data.retryAfterMs,
+          data.status === "unavailable"
+            ? FAILURE_RETRY_MS
+            : REQUEST_INTERVAL_MS,
+        ),
+      };
+    },
+  );
+
+  return { summary$, blockedRun$, request$ };
+}
+
+export function createThreadActivitySummarySignals(
+  threadId: string,
+  chatEvents$: Computed<ChatEvent[]>,
+  threadMeta$: Computed<ThreadMeta | null>,
+) {
+  const visible$ = state(false);
+  const retry$ = state<{
+    runId: string | null;
+    nextRequestAt: number;
+    failures: number;
+  }>({ runId: null, nextRequestAt: 0, failures: 0 });
+  const enabled$ = computed((get) => {
+    return get(featureSwitch$)[FeatureSwitchKey.ThreadActivitySummary] === true;
+  });
+  const runId$ = computed((get): string | null => {
+    if (
+      !get(enabled$) ||
+      get(currentChatThreadId$) !== threadId ||
+      get(threadMeta$) === null
+    ) {
+      return null;
+    }
+    const events = get(chatEvents$);
+    const states = foldChatRunStates(events);
+    // Reuse the run lifecycle fold: optimistic unassociated sends, queue
+    // markers, interrupted/terminal runs and historical rounds aren't demand.
+    return (
+      liveRunIdsFromChatEvents(events)
+        .filter((id) => {
+          return states.get(id) !== "queued";
+        })
+        .at(-1) ?? null
+    );
+  });
+  const { summary$, blockedRun$, request$ } = createSummaryRequestSignals(
+    threadId,
+    runId$,
+    visible$,
+  );
+  const currentSummary$ = computed((get) => {
+    const summary = get(summary$);
+    return summary?.runId === get(runId$) ? summary : null;
+  });
+  const thinkingText$ = computed((get) => {
+    return get(currentSummary$)?.phrase ?? null;
+  });
+  const thinkingId$ = computed((get) => {
+    const summary = get(currentSummary$);
+    // Text equality keeps the existing typewriter mounted even when a newer
+    // summary revision produces the same phrase. A changed phrase remounts it.
+    return summary?.phrase ? `${summary.runId}:${summary.phrase}` : null;
+  });
+
+  const attach$ = computed((get) => {
+    const runId = get(runId$);
+    const visible = get(visible$);
+    return command(
+      async ({ get, set }, el: HTMLElement, signal: AbortSignal) => {
+        const doc = el.ownerDocument;
+        const demand = createChildAbortController(signal);
+        const updateVisibility = () => {
+          if (doc.visibilityState !== "visible") {
+            demand.abort();
+          }
+          set(visible$, doc.visibilityState === "visible");
+        };
+        doc.addEventListener("visibilitychange", updateVisibility, { signal });
+        updateVisibility();
+        if (get(summary$)?.runId !== runId) {
+          set(summary$, null);
+        }
+        if (get(blockedRun$) !== runId) {
+          set(blockedRun$, null);
+        }
+        if (get(retry$).runId !== runId) {
+          set(retry$, { runId, nextRequestAt: 0, failures: 0 });
+        }
+        if (!runId || !visible || get(blockedRun$) === runId) {
+          return;
+        }
+        await setLoop(
+          async () => {
+            const retry = get(retry$);
+            if (now() < retry.nextRequestAt) {
+              return false;
+            }
+            const outcome = await set(request$, runId, demand.signal);
+            const failures = outcome.failed ? retry.failures + 1 : 0;
+            if (outcome.stop) {
+              return true;
+            }
+            if (failures >= MAX_CONSECUTIVE_FAILURES) {
+              set(blockedRun$, runId);
+              return true;
+            }
+            set(retry$, {
+              runId,
+              failures,
+              nextRequestAt:
+                now() + Math.max(REQUEST_INTERVAL_MS, outcome.retryAfterMs),
+            });
+            return false;
+          },
+          REQUEST_INTERVAL_MS,
+          demand.signal,
+          { retryTransientErrors: false },
+        );
+      },
+    );
+  });
+
+  return { attach$, enabled$, thinkingText$, thinkingId$ };
+}

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-activity-summary.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-activity-summary.test.tsx
@@ -1,0 +1,586 @@
+import { act, screen, waitFor } from "@testing-library/react";
+import { expect, test } from "vitest";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import {
+  chatThreadActivitySummaryContract,
+  type ActivitySummaryResponse,
+} from "@okouai/api-contracts/contracts/chat-thread-activity-summary";
+import { featureSwitchesContract } from "@okouai/api-contracts/contracts/feature-switches";
+import { HttpResponse } from "msw";
+import { click, setupPage, startPage } from "../../../__tests__/page-helper.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
+import { mockNow, now } from "../../../lib/time.ts";
+import {
+  assistantEvent,
+  cancelledEvent,
+  completedEvent,
+  context,
+  findLink,
+  installRunChat,
+  promptEvent,
+  publishRunUpdate,
+  readyChat,
+  RUN_PATH,
+  RUN_THREAD_ID,
+  thinkingEvent,
+} from "./chat-run-test-fixtures.ts";
+
+const RUN_ID = "d0000000-0000-4000-a000-000000000841";
+const NEXT_RUN_ID = "d0000000-0000-4000-a000-000000000842";
+const PREPARATION = "Preparing the launch checklist";
+const ACTIVITY = "Checking the release evidence";
+const featureSwitches = Object.freeze({
+  [FeatureSwitchKey.ThreadActivitySummary]: true,
+});
+
+function summary(
+  overrides: Partial<ActivitySummaryResponse> = {},
+): ActivitySummaryResponse {
+  return {
+    runId: RUN_ID,
+    phrase: PREPARATION,
+    status: "fresh",
+    sourceRevision: "source-z",
+    summaryRevision: "summary-z",
+    sourceSequence: 2,
+    summarySequence: 2,
+    messageCursor: 1,
+    summaryMessageCursor: 1,
+    summarizedAt: "2026-09-09T08:00:00.000Z",
+    retryAfterMs: 15_000,
+    ...overrides,
+  };
+}
+
+function installActiveRun() {
+  mockNow(new Date("2026-09-09T08:00:00.000Z"), context.signal);
+  const events = [
+    promptEvent({
+      id: "activity-prompt",
+      runId: RUN_ID,
+      seqId: 1,
+      text: "Prepare a launch checklist",
+    }),
+  ];
+  installRunChat({ chatEvents: events, activeRunIds: [RUN_ID, NEXT_RUN_ID] });
+  return events;
+}
+
+function advanceTime(milliseconds: number) {
+  mockNow(now() + milliseconds, context.signal);
+}
+
+function changeVisibility(
+  visibility: ReturnType<typeof context.mocks.browser.visibilityState>,
+  state: DocumentVisibilityState,
+) {
+  act(() => {
+    visibility.changeTo(state);
+  });
+}
+
+test("Feature off retains initial thinking and makes no summary demand", async () => {
+  const events = installActiveRun();
+  events.push(
+    thinkingEvent({
+      id: "old-thinking",
+      runId: RUN_ID,
+      seqId: 2,
+      text: "Preparing the original response",
+    }),
+  );
+  let requests = 0;
+  context.mocks.api(
+    chatThreadActivitySummaryContract.summarize,
+    ({ respond }) => {
+      requests++;
+      return respond(200, summary());
+    },
+  );
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ThreadActivitySummary]: false },
+  });
+  await expect(
+    screen.findByLabelText("Preparing the original response"),
+  ).resolves.toBeVisible();
+  expect(requests).toBe(0);
+});
+
+test("Only a visible main thread requests and later copy survives commentary and a completed animation", async () => {
+  const initialTime = new Date("2026-09-09T08:00:00.000Z").getTime();
+  mockNow(initialTime, context.signal);
+  const visibility = context.mocks.browser.visibilityState("hidden");
+  const events = installActiveRun();
+  const requests: { threadId: string; body: unknown }[] = [];
+  context.mocks.api(
+    chatThreadActivitySummaryContract.summarize,
+    ({ params, body, respond }) => {
+      requests.push({ threadId: params.id, body });
+      return respond(
+        200,
+        summary(
+          requests.length > 1
+            ? {
+                phrase: ACTIVITY,
+                // Hash order decreases while the actual summary advances.
+                summaryRevision: "summary-a",
+                summarySequence: 3,
+                summaryMessageCursor: 3,
+                summarizedAt: "2026-09-09T08:00:15.000Z",
+              }
+            : {},
+        ),
+      );
+    },
+  );
+  await setupPage({ context, path: RUN_PATH, featureSwitches });
+  await readyChat();
+  expect(requests).toHaveLength(0);
+  changeVisibility(visibility, "visible");
+  await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
+  expect(requests).toStrictEqual([
+    { threadId: RUN_THREAD_ID, body: { runId: RUN_ID } },
+  ]);
+  mockNow(initialTime + 14_999, context.signal);
+  events.push(
+    assistantEvent({
+      id: "activity-commentary",
+      runId: RUN_ID,
+      seqId: 2,
+      text: "I have started checking the release.",
+    }),
+  );
+  publishRunUpdate();
+  await expect(
+    screen.findByText("I have started checking the release."),
+  ).resolves.toBeVisible();
+  expect(requests).toHaveLength(1);
+  // Advance the production clock; keep real timers and the viewer mounted.
+  mockNow(initialTime + 15_001, context.signal);
+  await expect(screen.findByText(ACTIVITY)).resolves.toBeVisible();
+  expect(requests).toHaveLength(2);
+  expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
+});
+
+test.each(["pending", "cooldown", "stale"] as const)(
+  "A cached %s phrase keeps its actual provenance and identical text stays readable",
+  async (status) => {
+    const visibility = context.mocks.browser.visibilityState("visible");
+    installActiveRun();
+    let result = summary({
+      status,
+      sourceRevision: "new-source",
+      sourceSequence: 100,
+      messageCursor: 100,
+    });
+    const refreshed = createDeferredPromise<void>(context.signal);
+    let requests = 0;
+    context.mocks.api(
+      chatThreadActivitySummaryContract.summarize,
+      ({ respond }) => {
+        requests++;
+        if (requests === 2) {
+          refreshed.resolve(undefined);
+        }
+        return respond(200, result);
+      },
+    );
+    await setupPage({ context, path: RUN_PATH, featureSwitches });
+    await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
+    const mutations: MutationRecord[] = [];
+    const observer = new MutationObserver((records) => {
+      mutations.push(...records);
+    });
+    const label = screen.getByLabelText(PREPARATION);
+    observer.observe(label, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+    context.signal.addEventListener(
+      "abort",
+      () => {
+        observer.disconnect();
+      },
+      { once: true },
+    );
+    result = summary({
+      status,
+      sourceRevision: "new-source",
+      sourceSequence: 100,
+      messageCursor: 100,
+      retryAfterMs: 60_000,
+    });
+    changeVisibility(visibility, "hidden");
+    advanceTime(15_001);
+    changeVisibility(visibility, "visible");
+    await act(async () => {
+      await refreshed.promise;
+    });
+    expect(screen.getByText(PREPARATION)).toBeVisible();
+    expect(screen.getByLabelText(PREPARATION)).toBe(label);
+    // A newer current source must not relabel old copy as a new summary.
+    result = summary({
+      phrase: ACTIVITY,
+      summaryRevision: "summary-a",
+      summarySequence: 3,
+      summaryMessageCursor: 3,
+      summarizedAt: "2026-09-09T08:00:15.000Z",
+    });
+    changeVisibility(visibility, "hidden");
+    advanceTime(60_001);
+    changeVisibility(visibility, "visible");
+    await expect(screen.findByText(ACTIVITY)).resolves.toBeVisible();
+    expect(mutations).toHaveLength(0);
+  },
+);
+
+test("Hide and reopen aborts old demand and ignores its late response", async () => {
+  const visibility = context.mocks.browser.visibilityState("visible");
+  installActiveRun();
+  const started = createDeferredPromise<AbortSignal>(context.signal);
+  const oldResponse = createDeferredPromise<void>(context.signal);
+  let requests = 0;
+  context.mocks.api(
+    chatThreadActivitySummaryContract.summarize,
+    async ({ signal, respond }) => {
+      requests++;
+      if (requests === 1) {
+        started.resolve(signal);
+        await oldResponse.promise;
+        return respond(200, summary());
+      }
+      return respond(
+        200,
+        summary({
+          phrase: ACTIVITY,
+          summaryRevision: "a",
+          summarySequence: 4,
+          summarizedAt: "2026-09-09T08:00:15.000Z",
+        }),
+      );
+    },
+  );
+  await setupPage({ context, path: RUN_PATH, featureSwitches });
+  const requestSignal = await started.promise;
+  changeVisibility(visibility, "hidden");
+  await waitFor(() => {
+    expect(requestSignal.aborted).toBeTruthy();
+  });
+  expect(requests).toBe(1);
+  changeVisibility(visibility, "visible");
+  await expect(screen.findByText(ACTIVITY)).resolves.toBeVisible();
+  oldResponse.resolve(undefined);
+  expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
+  expect(screen.getByText(ACTIVITY)).toBeVisible();
+});
+
+test("An outstanding request cannot overlap another interval or survive navigation", async () => {
+  const visibility = context.mocks.browser.visibilityState("visible");
+  const events = installActiveRun();
+  const started = createDeferredPromise<AbortSignal>(context.signal);
+  const response = createDeferredPromise<void>(context.signal);
+  let requests = 0;
+  context.mocks.api(
+    chatThreadActivitySummaryContract.summarize,
+    async ({ signal, respond }) => {
+      requests++;
+      started.resolve(signal);
+      await response.promise;
+      return respond(200, summary());
+    },
+  );
+  await setupPage({ context, path: RUN_PATH, featureSwitches });
+  const requestSignal = await started.promise;
+  advanceTime(120_000);
+  events.push(
+    assistantEvent({
+      id: "while-summary-pending",
+      runId: RUN_ID,
+      seqId: 2,
+      text: "The main run continues while summary is pending.",
+    }),
+  );
+  publishRunUpdate();
+  await expect(
+    screen.findByText("The main run continues while summary is pending."),
+  ).resolves.toBeVisible();
+  expect(requests).toBe(1);
+  expect(requestSignal.aborted).toBeFalsy();
+  click(await findLink("Agents"));
+  await waitFor(() => {
+    expect(requestSignal.aborted).toBeTruthy();
+  });
+  response.resolve(undefined);
+  changeVisibility(visibility, "hidden");
+  changeVisibility(visibility, "visible");
+  expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
+  expect(requests).toBe(1);
+});
+
+test("Server cooldown survives hide and reopen before demand can refresh", async () => {
+  const visibility = context.mocks.browser.visibilityState("visible");
+  const events = installActiveRun();
+  let requests = 0;
+  context.mocks.api(
+    chatThreadActivitySummaryContract.summarize,
+    ({ respond }) => {
+      requests++;
+      return respond(
+        200,
+        summary({
+          status: "cooldown",
+          phrase: requests === 1 ? PREPARATION : ACTIVITY,
+          retryAfterMs: 60_000,
+        }),
+      );
+    },
+  );
+  await setupPage({ context, path: RUN_PATH, featureSwitches });
+  await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
+  changeVisibility(visibility, "hidden");
+  advanceTime(15_001);
+  changeVisibility(visibility, "visible");
+  events.push(
+    assistantEvent({
+      id: "during-cooldown",
+      runId: RUN_ID,
+      seqId: 2,
+      text: "Progress is available during cooldown.",
+    }),
+  );
+  publishRunUpdate();
+  await expect(
+    screen.findByText("Progress is available during cooldown."),
+  ).resolves.toBeVisible();
+  expect(requests).toBe(1);
+  advanceTime(45_000);
+  await expect(screen.findByLabelText(ACTIVITY)).resolves.toBeVisible();
+  expect(requests).toBe(2);
+});
+
+test("Optional service failures have a bounded retry budget across visibility changes", async () => {
+  const visibility = context.mocks.browser.visibilityState("visible");
+  const events = installActiveRun();
+  let requests = 0;
+  context.mocks.api(
+    chatThreadActivitySummaryContract.summarize,
+    ({ respond }) => {
+      requests++;
+      return respond(200, summary({ status: "unavailable", phrase: null }));
+    },
+  );
+  await setupPage({ context, path: RUN_PATH, featureSwitches });
+  for (const attempt of [1, 2, 3]) {
+    await waitFor(() => {
+      expect(requests).toBe(attempt);
+    });
+    events.push(
+      assistantEvent({
+        id: `during-failure-${attempt}`,
+        runId: RUN_ID,
+        seqId: attempt + 1,
+        text: `Main run progress ${attempt}`,
+      }),
+    );
+    publishRunUpdate();
+    await expect(
+      screen.findByText(`Main run progress ${attempt}`),
+    ).resolves.toBeVisible();
+    changeVisibility(visibility, "hidden");
+    advanceTime(60_001);
+    changeVisibility(visibility, "visible");
+  }
+  await readyChat();
+  expect(requests).toBe(3);
+  expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
+});
+
+test.each(["completed", "cancelled", "replaced", "queued"] as const)(
+  "A %s run cancels outstanding work and cannot revive its indicator",
+  async (outcome) => {
+    context.mocks.browser.visibilityState("visible");
+    const events = installActiveRun();
+    const started = createDeferredPromise<AbortSignal>(context.signal);
+    const response = createDeferredPromise<void>(context.signal);
+    const requestedRuns: string[] = [];
+    context.mocks.api(
+      chatThreadActivitySummaryContract.summarize,
+      async ({ body, signal, respond }) => {
+        requestedRuns.push(body.runId);
+        if (body.runId === RUN_ID) {
+          started.resolve(signal);
+          await response.promise;
+        }
+        return respond(
+          200,
+          summary({
+            runId: body.runId,
+            phrase: body.runId === RUN_ID ? PREPARATION : ACTIVITY,
+          }),
+        );
+      },
+    );
+    await setupPage({ context, path: RUN_PATH, featureSwitches });
+    const requestSignal = await started.promise;
+    if (outcome === "replaced") {
+      events.push(
+        promptEvent({
+          id: "replacement",
+          runId: NEXT_RUN_ID,
+          seqId: 3,
+          text: "Prepare another checklist",
+        }),
+      );
+    } else if (outcome === "queued") {
+      events.push({
+        id: "queued-run",
+        role: "assistant",
+        content: null,
+        eventType: "run.queued",
+        runEventId: "queue:queued",
+        runId: RUN_ID,
+        seqId: 3,
+        createdAt: "2026-08-01T10:00:03.000Z",
+      });
+    } else {
+      events.push(
+        outcome === "completed"
+          ? completedEvent({ id: "completed", runId: RUN_ID, seqId: 3 })
+          : cancelledEvent({ id: "cancelled", runId: RUN_ID, seqId: 3 }),
+      );
+    }
+    publishRunUpdate();
+    await waitFor(() => {
+      expect(requestSignal.aborted).toBeTruthy();
+    });
+    response.resolve(undefined);
+    const activityLabel =
+      outcome === "replaced"
+        ? await screen.findByLabelText(ACTIVITY)
+        : screen.queryByLabelText(ACTIVITY);
+    expect(activityLabel !== null).toBe(outcome === "replaced");
+    expect(requestedRuns).toStrictEqual(
+      outcome === "replaced" ? [RUN_ID, NEXT_RUN_ID] : [RUN_ID],
+    );
+    expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
+  },
+);
+
+test.each([403, 404, "ineligible"] as const)(
+  "A %s response clears copy and stops retries across visibility changes",
+  async (status) => {
+    const visibility = context.mocks.browser.visibilityState("visible");
+    installActiveRun();
+    let requests = 0;
+    context.mocks.api(
+      chatThreadActivitySummaryContract.summarize,
+      ({ respond }) => {
+        requests++;
+        if (requests === 1) {
+          return respond(200, summary());
+        }
+        return status === "ineligible"
+          ? respond(
+              200,
+              summary({ status, phrase: null, summaryRevision: null }),
+            )
+          : respond(status, {
+              error: { message: "Unavailable", code: "FORBIDDEN" },
+            });
+      },
+    );
+    await setupPage({ context, path: RUN_PATH, featureSwitches });
+    await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
+    changeVisibility(visibility, "hidden");
+    advanceTime(15_001);
+    changeVisibility(visibility, "visible");
+    await waitFor(() => {
+      expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
+    });
+    changeVisibility(visibility, "hidden");
+    changeVisibility(visibility, "visible");
+    await readyChat();
+    expect(requests).toBe(2);
+  },
+);
+
+test("A new app with an unavailable or malformed API retains a usable current-run phrase", async () => {
+  const visibility = context.mocks.browser.visibilityState("visible");
+  installActiveRun();
+  let requests = 0;
+  context.mocks.api(
+    chatThreadActivitySummaryContract.summarize,
+    ({ respond }) => {
+      requests++;
+      return respond(
+        200,
+        summary(
+          requests === 1
+            ? {}
+            : { phrase: null, status: "unavailable", retryAfterMs: 60_000 },
+        ),
+      );
+    },
+  );
+  await setupPage({ context, path: RUN_PATH, featureSwitches });
+  await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
+  changeVisibility(visibility, "hidden");
+  advanceTime(15_001);
+  changeVisibility(visibility, "visible");
+  await waitFor(() => {
+    expect(requests).toBe(2);
+  });
+  expect(screen.getByText(PREPARATION)).toBeVisible();
+  const malformed = createDeferredPromise<void>(context.signal);
+  context.mocks.http.post("*/api/chat-threads/:id/activity-summary", () => {
+    malformed.resolve(undefined);
+    return HttpResponse.json({ oldApi: true });
+  });
+  changeVisibility(visibility, "hidden");
+  advanceTime(60_001);
+  changeVisibility(visibility, "visible");
+  await malformed.promise;
+  expect(screen.getByText(PREPARATION)).toBeVisible();
+});
+
+test("Authoritative switch rollback aborts a request started from cached feature state", async () => {
+  context.mocks.browser.visibilityState("visible");
+  installActiveRun();
+  const featureResponse = createDeferredPromise<void>(context.signal);
+  const summaryResponse = createDeferredPromise<void>(context.signal);
+  const started = createDeferredPromise<AbortSignal>(context.signal);
+  context.mocks.api(featureSwitchesContract.get, async ({ respond }) => {
+    await featureResponse.promise;
+    return respond(200, {
+      switches: { [FeatureSwitchKey.ThreadActivitySummary]: false },
+      effectiveSwitches: { [FeatureSwitchKey.ThreadActivitySummary]: false },
+    });
+  });
+  context.mocks.api(
+    chatThreadActivitySummaryContract.summarize,
+    async ({ signal, respond }) => {
+      started.resolve(signal);
+      await summaryResponse.promise;
+      return respond(200, summary());
+    },
+  );
+  const page = startPage({
+    context,
+    path: RUN_PATH,
+    cachedFeatureSwitches: featureSwitches,
+  });
+  const requestSignal = await started.promise;
+  featureResponse.resolve(undefined);
+  await (
+    await page
+  ).ready;
+  await readyChat();
+  await waitFor(() => {
+    expect(requestSignal.aborted).toBeTruthy();
+  });
+  summaryResponse.resolve(undefined);
+  expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
+});

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -2813,8 +2813,9 @@ function ChatThread({
   thread: ChatPanelSignals;
 }) {
   const { t } = useTranslation();
+  const mainContainerRef = useGet(thread.mainContainerRef$);
   const setContainerRef = useSet(
-    isMain ? thread.setMainContainerRef$ : thread.setContainerRef$,
+    isMain ? mainContainerRef : thread.setContainerRef$,
   );
 
   return (


### PR DESCRIPTION
Visible running threads now request short activity summaries in the existing indicator. The same `threadActivitySummary` switch suppresses automatic opening-copy generation, so enabled runs incur no indicator model calls until a viewer requests a summary.

- Own demand in the committed main-thread container, independently of thinking events and typewriter completion. Request immediately when eligible and visible, then at a 15-second baseline while respecting server cooldown across visibility changes. Serialize requests, cancel on lifecycle changes, and reject obsolete responses.
- Keep actual summary provenance in transient page state. Cached pending/cooldown/stale phrases remain useful, opaque hashes are never ordered, and identical text preserves its DOM/typewriter. Run status, historical messages, title generation and the main model retain their existing paths.
- Apply canonical user/org overrides at the shared initial-thinking scheduling gate and recheck before a producer model attempt. The switch remains default-off without a production allowlist.

### Validation

- 19 Platform page/legacy-indicator tests: visibility, navigation, no overlap, deferred cancellation, run replacement/end/queue, rollback, commentary, completed animation, identical text, cached provenance, cooldown and bounded failures.
- 59 focused API tests: initial thinking, backend activity-summary contracts, Pi API-first resume and the enabled/disabled tool-handoff scenarios. New/existing-thread integration cases verify zero indicator calls before demand for enabled owners, preserved opening copy when off, independent title calls, and no dynamic history writes.
- API and App type checks; affected-file ESLint and Oxlint (including type-aware rules); affected-workspace Knip; Prettier; style policy; diff checks. No full local Vitest suite or development server.
- Local PostgreSQL needed UTC configuration for existing queue-expiry checks. The original tests remain unchanged; no assertions or protections were weakened.

### Coverage boundary

Current normal sends always pass `queueFirstClaim`. The retained associated-message scheduling branch has no reachable normal-send caller. Both branches consume the same gated `appendInitialThinking` value and invoke the same guarded producer; executable coverage exercises real new/existing-thread queue-first entry points. No test-only production bypass was introduced to manufacture reachability.

### Fallbacks

- **Optional summary service:** unavailable, malformed or failed responses retain only the current run's last usable phrase, otherwise the existing generic indicator. Retry at least 60 seconds apart and stop after three consecutive failures. This is permanent best-effort indicator behavior, justified by an optional auxiliary service; normal execution is unaffected.
- **Eligibility/access:** ineligible and 401/403/404 responses clear dynamic copy and stop requests for that run identity. This is the endpoint's normal fail-closed contract, with no cached output exposed after rejection.
- **Mixed App/API rollout:** an older API's missing endpoint reaches the same bounded 404 path; an older App with an enabled new API keeps its generic indicator. There is no GA audience or new legacy protocol. The exposure window is the controlled #32819 rollout and supported API rollback targets; already-open older Apps can remain until refresh/the existing version floor. #32819 owns verifying those targets and retiring compatibility-specific documentation/tests when that window closes. Switch-off restores legacy behavior for subsequent runs without backfilling an existing run.

### Rollout

This PR ends at protected merge. Release, production verification, billing reconciliation and controlled activation remain with the Epic controller. No release, production deployment approval or real-user feature switch change is included.

Fixes #32898
Refs #32819
