### PR TITLE
feat(web-chat): lay out mobile follow-ups as a horizontal quick reply rail

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-message-followups.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-message-followups.test.tsx
@@ -333,7 +333,7 @@ test("A recommended follow-up edits the draft without sending it", async () => {
   expect(onSendRequest).not.toHaveBeenCalled();
 });
 
-test("A touch device renders the recommended follow-ups as quick replies", async () => {
+test("A touch device renders the recommended follow-ups as a quick reply rail", async () => {
   context.mocks.browser.matchMedia((query) => {
     return query === "(pointer: coarse)";
   });
@@ -349,7 +349,7 @@ test("A touch device renders the recommended follow-ups as quick replies", async
   });
 
   const group = await keepGoingGroup();
-  expect(group).toHaveAttribute("data-followup-layout", "quick-replies");
+  expect(group).toHaveAttribute("data-followup-layout", "quick-reply-rail");
   expect(followupButtons(group)).toHaveLength(variedFollowups().length);
 });
 

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -3982,13 +3982,15 @@ function RecommendedFollowupList({
       // The layout is decided by the device, not by width, so it is not
       // observable through a media query. Tests and e2e read this instead of
       // the styling classes.
-      data-followup-layout={showFollowupCards ? "quick-replies" : "rows"}
+      data-followup-layout={showFollowupCards ? "quick-reply-rail" : "rows"}
       className={cn(
         // The flat list pulls out by the row buttons' own px-2 so its text
-        // aligns with the message column. Quick replies carry a deeper inner
-        // offset of their own, so the stack stays flush with the column and
-        // the composer instead of pulling out to meet it.
-        showFollowupCards ? "flex flex-col items-start gap-1.5" : "-mx-2",
+        // aligns with the message column. The rail carries a deeper inner
+        // offset of its own, so it stays flush with the column and the
+        // composer instead of pulling out to meet them.
+        showFollowupCards
+          ? "flex items-stretch gap-2 overflow-x-auto overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          : "-mx-2",
       )}
     >
       {source.followups.map((followup, followupIndex) => {
@@ -3999,14 +4001,18 @@ function RecommendedFollowupList({
             title={followup.prompt}
             className={cn(
               "group flex text-left transition-colors",
-              // A quick reply hugs its own text so three suggestions read as
-              // one glanceable stack. `active:` rather than `hover:` carries
-              // the press: Tailwind gates `hover:` behind `(hover: hover)`,
-              // which is exactly the devices this branch never runs on. Rest
-              // already sits on the hover layer, so hover and press each take
-              // the next step up the ladder rather than starting from it.
+              // A quick reply sizes to its own text, so a short suggestion
+              // stays small and more than one fits on screen. The rail equalises
+              // their heights, which is why the contents align to the top: a
+              // one-line reply has to start on the same line as its two-line
+              // neighbour rather than float in the middle of the taller box.
+              //
+              // `active:` rather than `hover:` carries the press: Tailwind gates
+              // `hover:` behind `(hover: hover)`, which is exactly the devices
+              // this branch never runs on. Rest already sits on the hover layer,
+              // so hover and press each take the next step up the ladder.
               showFollowupCards
-                ? "min-h-11 w-fit max-w-full items-center gap-1.5 rounded-[var(--okou-card-radius)] bg-state-hover px-4 py-2.5 hover:bg-state-selected active:bg-state-pressed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                ? "w-auto max-w-[min(17rem,72%)] shrink-0 self-stretch items-start gap-1.5 rounded-[var(--okou-card-radius)] bg-state-hover px-4 py-3 hover:bg-state-selected active:bg-state-pressed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                 : "min-h-8 w-full items-center gap-0 rounded-lg px-2 py-1 hover:bg-state-hover",
             )}
             onClick={() => {
@@ -4018,9 +4024,11 @@ function RecommendedFollowupList({
                 "text-muted-foreground/70 transition-colors group-hover:text-foreground",
                 // A quick reply drops the 28px response rail, but keeps the
                 // icon for `generate`: mispicking one there costs a real
-                // generation rather than another message.
+                // generation rather than another message. `h-6` is one line
+                // box, so the glyph centres on the first line of a wrapped
+                // suggestion instead of on the whole text block.
                 showFollowupCards
-                  ? "inline-flex shrink-0 items-center justify-center"
+                  ? "inline-flex h-6 shrink-0 items-center justify-center"
                   : CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS,
                 showFollowupCards && followup.kind !== "generate" && "hidden",
               )}
@@ -4031,8 +4039,10 @@ function RecommendedFollowupList({
               className={cn(
                 "min-w-0 flex-1 break-words text-[0.9375rem] font-medium leading-6 text-muted-foreground group-hover:text-foreground",
                 // Prompt length is unbounded server-side, so a runaway
-                // suggestion is clamped rather than allowed to grow the stack.
-                showFollowupCards && "line-clamp-3",
+                // suggestion is clamped rather than allowed to grow the rail.
+                // Two lines is also the rail's ceiling: every card matches the
+                // tallest one, so this bounds the whole block.
+                showFollowupCards && "line-clamp-2",
               )}
             >
               {followup.prompt}

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -4012,7 +4012,7 @@ function RecommendedFollowupList({
               // this branch never runs on. Rest already sits on the hover layer,
               // so hover and press each take the next step up the ladder.
               showFollowupCards
-                ? "w-auto max-w-[min(17rem,72%)] shrink-0 self-stretch items-start gap-1.5 rounded-[var(--okou-card-radius)] bg-state-hover px-4 py-3 hover:bg-state-selected active:bg-state-pressed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                ? "max-w-[min(17rem,72%)] shrink-0 items-start gap-1.5 rounded-surface bg-state-hover px-4 py-3 hover:bg-state-selected active:bg-state-pressed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                 : "min-h-8 w-full items-center gap-0 rounded-lg px-2 py-1 hover:bg-state-hover",
             )}
             onClick={() => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -406,7 +406,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ResponsiveFollowupCards]: {
     maintainer: "ethan@okou.ai",
     description:
-      "Render recommended follow-ups as a stack of tappable quick replies on touch devices.",
+      "Render recommended follow-ups as a horizontally scrollable rail of tappable quick replies on touch devices.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },


### PR DESCRIPTION
## Summary

Returns the mobile recommended follow-ups to a **horizontal rail**, keeping every visual token `#32817` established. The vertical stack read well but took the most vertical space of any layout, and that space belongs to the answer above it.

Unchanged from `#32817`: the `bg-state-hover` fill, `--okou-card-radius`, `text-[0.9375rem]/leading-6`, `text-muted-foreground`, the `hover:bg-state-selected` / `active:bg-state-pressed` ladder, no border, no shadow. The switch (`FeatureSwitchKey.ResponsiveFollowupCards`) keeps its gate: `isMobileTextInputDevice()` only, never viewport width. Desktop rows are untouched.

## This is not a revert

The two defects that made the original card rail expensive are both absent:

- **No `min-h-24`.** Card height follows content. Three short suggestions occupy **48px** instead of the original rail's 96px, and `line-clamp-2` caps the worst case at **72px**.
- **No `snap-mandatory` + `snap-center`.** Under that combination only the middle of three cards could reach the centre; the first and last rested 32px off it. The rail now scrolls freely.

Measured against one fixture at 390x844, height of the follow-up block and the visible height of the answer above it:

| Layout | Block | Answer visible | Suggestions on screen |
| --- | --- | --- | --- |
| Original card rail (pre-`#32817`) | 96px | 314px | 1 of 3 |
| Vertical stack (`#32817`, current `main`) | 144px | 266px | 3 of 3 |
| This rail, short suggestions | **48px** | **362px** | 2–3 of 3 |
| This rail, worst case | 72px | — | 1–2 of 3 |

## Changes

`chat-thread-page.tsx` — `RecommendedFollowupList`:

- **Container** — `flex items-stretch gap-2 overflow-x-auto overscroll-x-contain` with the scrollbar hidden.
- **Button** — `w-auto max-w-[min(17rem,72%)] shrink-0 self-stretch`. Cards size to their own text rather than taking a fixed share of the width, so a short suggestion stays small and more than one is usually on screen. `py-3` replaces `py-2.5`; `min-h-11` is dropped because two lines already exceed the 44px target and one line plus padding meets it.
- **Alignment** — `items-start`. The rail equalises card heights, so a one-line reply must start on the same line as its two-line neighbour instead of floating in the middle of the taller box.
- **Icon** — `h-6`, one line box, so the glyph centres on the **first line** of a wrapped suggestion rather than on the whole text block. Without this it drifts to the gap between lines.
- **Text** — `line-clamp-2` replaces `line-clamp-3`. Two lines is also the rail's ceiling, since every card matches the tallest.
- **`data-followup-layout`** — `"quick-replies"` becomes `"quick-reply-rail"`.

`feature-switch.ts` — the registered description said "a stack of tappable quick replies"; it is a rail now, and that string is rendered to staff at `lab-page.tsx:134-136`.

## Tests

`chat-message-followups.test.tsx` — the three device-gate cases from `#32817` carry over unchanged in intent; the coarse-pointer case now asserts `quick-reply-rail`, and its name follows. The fine-pointer and switch-off cases still assert `rows` and needed no edit, which is the point of asserting the attribute rather than styling classes.

## Verification

- All three changed files parse clean under `esbuild`.
- `max-w-[min(17rem,72%)]` was compiled with `tailwindcss@4.3.3`, the version this repo pins, and emits `max-width: min(17rem, 72%)`.
- Geometry, the visible-answer gain, and the two alignment corrections were measured on a class-for-class reproduction before implementing; first-line offset and icon-to-first-line offset both go from 12px to 0px.
- Per repository policy the remaining checks (types, lint, style ratchet, vitest) run in the PR pipeline rather than locally.

Design review, including light/dark, the alignment before/after and the long-prompt case: https://okou-followup-rail.okou.app

## Fallbacks

Fallbacks: none. This is a client-side layout decision behind the non-GA staff-only `ResponsiveFollowupCards` switch, so no cross-version compatibility path is introduced, kept, or removed.
