### PR TITLE
feat(platform): report ios keyboard viewport sessions to posthog

### DIFF
--- a/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment-options {"url":"https://app.okou.ai/"}
+
 import { expect, test, vi, type Mock } from "vitest";
 
 import { testContext } from "../../signals/__tests__/test-helpers.ts";
@@ -361,4 +363,130 @@ test("Browsers without visual-viewport support keep the normal layout", () => {
   focusTextEntry();
 
   expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
+});
+
+const IPHONE_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 26_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Mobile/15E148 Safari/604.1";
+const KEYBOARD_SESSION_EVENT = "keyboard_viewport_session";
+
+function setIPhoneUserAgent(): void {
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    value: IPHONE_USER_AGENT,
+  });
+  context.signal.addEventListener(
+    "abort",
+    () => {
+      Reflect.deleteProperty(navigator, "userAgent");
+    },
+    { once: true },
+  );
+}
+
+function keyboardSessionEvents(): Record<string, unknown>[] {
+  return context.mocks
+    .posthog()
+    .events.filter(({ name }) => {
+      return name === KEYBOARD_SESSION_EVENT;
+    })
+    .map(({ properties }) => {
+      return { ...properties };
+    });
+}
+
+// The close window samples the viewport on animation frames for 1.5s of
+// platform time; advancing the clock and flushing a frame ends it.
+async function finishCloseWindow(
+  clock: ControlledViewportClock,
+): Promise<void> {
+  await vi.advanceTimersByTimeAsync(1500);
+  await clock.flushUpdate();
+}
+
+test("An iOS keyboard session reports the visual viewport after the keyboard closes", async () => {
+  context.mocks.posthog();
+  const viewport = new MockVisualViewport(844);
+  setInnerHeight(844);
+  setStandalone(false);
+  setIPhoneUserAgent();
+  installVisualViewport(viewport);
+  const { editor } = focusComposer(true);
+  const clock = startViewportKeyboardState();
+
+  await resizeAndSettle(viewport, clock, 520, 310);
+  expect(document.documentElement.dataset.keyboardOpen).toBe("true");
+  expect(keyboardSessionEvents()).toHaveLength(0);
+
+  editor.blur();
+  await resizeAndSettle(viewport, clock, 844, 310);
+  await finishCloseWindow(clock);
+
+  const events = keyboardSessionEvents();
+  expect(events).toHaveLength(1);
+  expect(events[0]).toMatchObject({
+    focused_at_close: false,
+    inner_height: 844,
+    ios_version: "26.0",
+    keyboard_occlusion: 324,
+    max_offset_top_after_close: 310,
+    offset_top_after_close: 310,
+    offset_top_at_close: 310,
+    offset_top_open: 310,
+    page: "other",
+    residue_ms: null,
+    standalone: false,
+    viewport_height_after_close: 844,
+    viewport_height_open: 520,
+  });
+  expect(events[0]?.close_samples).toHaveLength(2);
+});
+
+test("A pan that clears after the keyboard closes reports how long it lasted", async () => {
+  context.mocks.posthog();
+  const viewport = new MockVisualViewport(844);
+  setInnerHeight(844);
+  setStandalone(false);
+  setIPhoneUserAgent();
+  installVisualViewport(viewport);
+  const entry = focusTextEntry();
+  const clock = startViewportKeyboardState();
+
+  await resizeAndSettle(viewport, clock, 520, 310);
+  entry.blur();
+  await resizeAndSettle(viewport, clock, 844, 310);
+  await vi.advanceTimersByTimeAsync(300);
+  await clock.flushUpdate();
+
+  // The pan ends without any viewport event.
+  viewport.offsetTop = 0;
+  await vi.advanceTimersByTimeAsync(100);
+  await clock.flushUpdate();
+  await finishCloseWindow(clock);
+
+  const events = keyboardSessionEvents();
+  expect(events).toHaveLength(1);
+  // The close settles 50ms after its event, so the pan was last seen at 350ms
+  // and first seen gone at 450ms.
+  expect(events[0]).toMatchObject({
+    max_offset_top_after_close: 310,
+    offset_top_after_close: 0,
+    offset_top_at_close: 310,
+    residue_ms: 450,
+  });
+});
+
+test("Keyboard sessions outside iOS are not reported", async () => {
+  context.mocks.posthog();
+  const viewport = new MockVisualViewport(844);
+  setInnerHeight(844);
+  installVisualViewport(viewport);
+  const entry = focusTextEntry();
+  const clock = startViewportKeyboardState();
+
+  await resizeAndSettle(viewport, clock, 520, 310);
+  entry.blur();
+  await resizeAndSettle(viewport, clock, 844, 0);
+  await finishCloseWindow(clock);
+
+  expect(keyboardSessionEvents()).toHaveLength(0);
 });

--- a/turbo/apps/platform/src/lib/browser-support.ts
+++ b/turbo/apps/platform/src/lib/browser-support.ts
@@ -10,16 +10,28 @@ export interface BrowserUpgrade {
   readonly target: BrowserUpgradeTarget;
 }
 
+const IOS_VERSION_PATTERN = /\b(?:iPhone|iPad|iPod)\b.*\bOS (\d+)(?:_(\d+))?/;
+
 function supportsAppleVersion(match: RegExpExecArray): boolean {
   const major = Number(match[1]);
   const minor = Number(match[2] ?? 0);
   return major > 16 || (major === 16 && minor >= 4);
 }
 
+/**
+ * The iOS major.minor version advertised by a WebKit user agent, or null when
+ * the user agent is not an iOS device.
+ */
+export function iosVersionFromUserAgent(userAgent: string): string | null {
+  const match = IOS_VERSION_PATTERN.exec(userAgent);
+  if (!match) {
+    return null;
+  }
+  return `${match[1]}.${match[2] ?? "0"}`;
+}
+
 function browserUpgradeForUserAgent(userAgent: string): BrowserUpgrade | null {
-  const iosMatch = /\b(?:iPhone|iPad|iPod)\b.*\bOS (\d+)(?:_(\d+))?/.exec(
-    userAgent,
-  );
+  const iosMatch = IOS_VERSION_PATTERN.exec(userAgent);
   if (iosMatch) {
     return supportsAppleVersion(iosMatch)
       ? null

--- a/turbo/apps/platform/src/lib/keyboard-viewport-telemetry.ts
+++ b/turbo/apps/platform/src/lib/keyboard-viewport-telemetry.ts
@@ -1,0 +1,208 @@
+import { iosVersionFromUserAgent } from "./browser-support.ts";
+import { isStandalonePwa } from "./keyboard-dismiss-gesture.ts";
+import {
+  captureKeyboardViewportSession,
+  type KeyboardViewportCloseSample,
+  type KeyboardViewportPage,
+} from "./posthog.ts";
+import { now } from "./time.ts";
+
+const CLOSE_WINDOW_MS = 1500;
+const CLOSE_SAMPLE_INTERVAL_MS = 100;
+const CLOSE_SAMPLE_LIMIT = 40;
+const RESIDUE_MIN_PX = 24;
+const CHAT_COMPOSER_SELECTOR = "[data-chat-composer]";
+
+type KeyboardViewportRecorder = {
+  /** The visual viewport settled on an open software keyboard. */
+  opened(): void;
+  /** The keyboard session ended; sample the visual viewport for a short window. */
+  closed(focused: boolean): void;
+  /** Drop the current session, for example on orientation change or teardown. */
+  clear(): void;
+};
+
+interface OpenSession {
+  readonly innerHeight: number;
+  readonly offsetTop: number;
+  readonly openedAt: number;
+  readonly viewportHeight: number;
+}
+
+interface CloseSession {
+  readonly closedAt: number;
+  readonly focused: boolean;
+  readonly opened: OpenSession;
+  readonly scaleAtClose: number;
+}
+
+function readPage(): KeyboardViewportPage {
+  const path = window.location.pathname;
+  if (path.startsWith("/chats/")) {
+    return "thread";
+  }
+  if (/^\/agents\/[^/]+\/chat$/.test(path)) {
+    return "home";
+  }
+  return "other";
+}
+
+function readRootPixels(name: string): number {
+  const value = Number.parseFloat(
+    getComputedStyle(document.documentElement).getPropertyValue(name),
+  );
+  return Number.isFinite(value) ? Math.round(value) : 0;
+}
+
+function readCloseSample(
+  viewport: VisualViewport,
+  t: number,
+): KeyboardViewportCloseSample {
+  const root = document.getElementById("root");
+  const composer = document.querySelector(CHAT_COMPOSER_SELECTOR);
+  return {
+    gap:
+      composer instanceof HTMLElement
+        ? Math.round(viewport.height - composer.getBoundingClientRect().bottom)
+        : null,
+    height: Math.round(viewport.height),
+    offset: Math.round(viewport.offsetTop),
+    root_top: root ? Math.round(root.getBoundingClientRect().top) : null,
+    scroll_y: Math.round(window.scrollY),
+    t,
+  };
+}
+
+function sampleChanged(
+  sample: KeyboardViewportCloseSample,
+  previous: KeyboardViewportCloseSample,
+): boolean {
+  return (
+    sample.offset !== previous.offset ||
+    sample.height !== previous.height ||
+    sample.scroll_y !== previous.scroll_y ||
+    sample.root_top !== previous.root_top
+  );
+}
+
+/**
+ * Records one software-keyboard session on iOS and reports the visual viewport
+ * geometry sampled for 1.5s after the keyboard closed. A viewport that stays
+ * panned after the close (#32420) shows up as a non-zero offset that never
+ * settles inside the window, together with the iOS version, surface, and page
+ * it happened on. Sampling runs on animation frames because some builds keep
+ * panning the visual viewport after the close without publishing any event.
+ */
+export function createKeyboardViewportRecorder(
+  viewport: VisualViewport,
+): KeyboardViewportRecorder {
+  let session: OpenSession | null = null;
+  let frameId: number | null = null;
+
+  const cancelClose = () => {
+    if (frameId !== null) {
+      window.cancelAnimationFrame(frameId);
+      frameId = null;
+    }
+  };
+
+  const report = (
+    close: CloseSession,
+    samples: KeyboardViewportCloseSample[],
+    last: KeyboardViewportCloseSample,
+  ) => {
+    const { closedAt, focused, opened, scaleAtClose } = close;
+    const settled = samples.find((sample) => {
+      return sample.offset < RESIDUE_MIN_PX;
+    });
+    captureKeyboardViewportSession({
+      close_samples: samples,
+      composer_gap_after_close: last.gap,
+      focused_at_close: focused,
+      inner_height: window.innerHeight,
+      ios_version: iosVersionFromUserAgent(navigator.userAgent) ?? "unknown",
+      keyboard_occlusion: opened.innerHeight - opened.viewportHeight,
+      max_offset_top_after_close: Math.max(
+        ...samples.map((sample) => {
+          return sample.offset;
+        }),
+      ),
+      offset_top_after_close: last.offset,
+      offset_top_at_close: samples[0]?.offset ?? 0,
+      offset_top_open: opened.offsetTop,
+      page: readPage(),
+      referrer_origin: document.referrer
+        ? new URL(document.referrer).origin
+        : "",
+      residue_ms: settled ? settled.t : null,
+      root_top_after_close: last.root_top,
+      safe_area_bottom: readRootPixels("--sab"),
+      safe_area_top: readRootPixels("--sat"),
+      scale_at_close: Number(scaleAtClose.toFixed(2)),
+      screen_height: window.screen.height,
+      session_ms: Math.max(0, Math.round(closedAt - opened.openedAt)),
+      standalone: isStandalonePwa(),
+      viewport_height_after_close: last.height,
+      viewport_height_open: opened.viewportHeight,
+    });
+  };
+
+  const sampleClose = (opened: OpenSession, focused: boolean) => {
+    const close: CloseSession = {
+      closedAt: now(),
+      focused,
+      opened,
+      scaleAtClose: viewport.scale,
+    };
+    let last = readCloseSample(viewport, 0);
+    let lastRecordedAt = 0;
+    const samples = [last];
+    const scheduleSample = () => {
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        const t = Math.max(0, Math.round(now() - close.closedAt));
+        const sample = readCloseSample(viewport, t);
+        if (
+          samples.length < CLOSE_SAMPLE_LIMIT &&
+          (sampleChanged(sample, last) ||
+            t - lastRecordedAt >= CLOSE_SAMPLE_INTERVAL_MS)
+        ) {
+          samples.push(sample);
+          lastRecordedAt = t;
+        }
+        last = sample;
+        if (t >= CLOSE_WINDOW_MS) {
+          report(close, samples, last);
+          return;
+        }
+        scheduleSample();
+      });
+    };
+    scheduleSample();
+  };
+
+  return {
+    opened() {
+      cancelClose();
+      session = {
+        innerHeight: window.innerHeight,
+        offsetTop: Math.round(viewport.offsetTop),
+        openedAt: now(),
+        viewportHeight: Math.round(viewport.height),
+      };
+    },
+    closed(focused) {
+      if (!session) {
+        return;
+      }
+      const opened = session;
+      session = null;
+      cancelClose();
+      sampleClose(opened, focused);
+    },
+    clear() {
+      session = null;
+      cancelClose();
+    },
+  };
+}

--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -303,6 +303,57 @@ export function captureTaskCompletedSuccessfully(): void {
   });
 }
 
+export type KeyboardViewportPage = "home" | "other" | "thread";
+
+export interface KeyboardViewportCloseSample {
+  /** Composer bottom to visual viewport bottom, null without a composer. */
+  readonly gap: number | null;
+  readonly height: number;
+  readonly offset: number;
+  readonly root_top: number | null;
+  readonly scroll_y: number;
+  /** Milliseconds after the keyboard closed. */
+  readonly t: number;
+}
+
+interface KeyboardViewportSessionProperties {
+  readonly close_samples: readonly KeyboardViewportCloseSample[];
+  readonly composer_gap_after_close: number | null;
+  readonly focused_at_close: boolean;
+  readonly inner_height: number;
+  readonly ios_version: string;
+  readonly keyboard_occlusion: number;
+  readonly max_offset_top_after_close: number;
+  readonly offset_top_after_close: number;
+  readonly offset_top_at_close: number;
+  readonly offset_top_open: number;
+  readonly page: KeyboardViewportPage;
+  readonly referrer_origin: string;
+  readonly residue_ms: number | null;
+  readonly root_top_after_close: number | null;
+  readonly safe_area_bottom: number;
+  readonly safe_area_top: number;
+  readonly scale_at_close: number;
+  readonly screen_height: number;
+  readonly session_ms: number;
+  readonly standalone: boolean;
+  readonly viewport_height_after_close: number;
+  readonly viewport_height_open: number;
+}
+
+/**
+ * One software-keyboard session on iOS, with the visual viewport sampled for
+ * 1.5s after the keyboard closed. Used to attribute a viewport that stays
+ * panned after the close (#32420) to iOS versions, surfaces, and pages.
+ */
+export function captureKeyboardViewportSession(
+  properties: KeyboardViewportSessionProperties,
+): void {
+  runPostHog(() => {
+    posthog.capture("keyboard_viewport_session", { ...properties });
+  });
+}
+
 export type ChatThreadMetadataShortcutOutcome =
   | "hit"
   | "not-found"

--- a/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
+++ b/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
@@ -1,5 +1,6 @@
 import { delay } from "signal-timers";
 import { detach, Reason } from "../signals/utils.ts";
+import { createKeyboardViewportRecorder } from "./keyboard-viewport-telemetry.ts";
 
 const KEYBOARD_SHRINK_RATIO = 0.15;
 const MIN_KEYBOARD_SHRINK_PX = 120;
@@ -175,6 +176,73 @@ function revealFocusedComposer(): void {
   });
 }
 
+type FrameTask = {
+  /** Run once on the next animation frame; a pending frame is reused. */
+  schedule(): void;
+  cancel(): void;
+};
+
+function createFrameTask(run: () => void): FrameTask {
+  let frameId: number | null = null;
+  return {
+    schedule() {
+      if (frameId !== null) {
+        return;
+      }
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        run();
+      });
+    },
+    cancel() {
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+        frameId = null;
+      }
+    },
+  };
+}
+
+type SettledCommit = {
+  /** Commit once the viewport has been quiet for the settle delay. */
+  schedule(): void;
+  cancel(): void;
+};
+
+function createSettledCommit(
+  resetSettledSignal: () => AbortSignal,
+  commit: () => void,
+): SettledCommit {
+  let timerSignal: AbortSignal | null = null;
+
+  const cancel = () => {
+    if (timerSignal) {
+      resetSettledSignal();
+      timerSignal = null;
+    }
+  };
+
+  const run = async (settledSignal: AbortSignal) => {
+    await delay(VIEWPORT_SETTLE_DELAY_MS, { signal: settledSignal });
+    settledSignal.throwIfAborted();
+    if (timerSignal !== settledSignal) {
+      return;
+    }
+    timerSignal = null;
+    commit();
+  };
+
+  return {
+    cancel,
+    schedule() {
+      cancel();
+      const settledSignal = resetSettledSignal();
+      timerSignal = settledSignal;
+      detach(run(settledSignal), Reason.DomCallback, "visual viewport settle");
+    },
+  };
+}
+
 type KeyboardViewportState = {
   baselineHeight: number;
   keyboardOpen: boolean;
@@ -242,77 +310,58 @@ export function setupVisualViewportKeyboardState(
     keyboardOpen: false,
     resetBaselineOnSettle: false,
   };
-  let scheduledFrameId: number | null = null;
-  let revealFrameId: number | null = null;
-  let settledTimerSignal: AbortSignal | null = null;
-
-  const cancelSettledUpdate = () => {
-    if (settledTimerSignal) {
-      resetSettledSignal();
-      settledTimerSignal = null;
+  const recorder = isIOSDevice()
+    ? createKeyboardViewportRecorder(viewport)
+    : null;
+  // The scroll reserve is a pseudo-element driven by the keyboard-open style.
+  // Give WebKit one layout frame to publish the new scrollHeight before asking
+  // it to reveal the composer.
+  const revealFrame = createFrameTask(() => {
+    if (state.keyboardOpen) {
+      revealFocusedComposer();
     }
-  };
-
-  const commitSettledUpdate = async (settledSignal: AbortSignal) => {
-    await delay(VIEWPORT_SETTLE_DELAY_MS, { signal: settledSignal });
-    settledSignal.throwIfAborted();
-    if (settledTimerSignal !== settledSignal) {
-      return;
-    }
-    settledTimerSignal = null;
-    update(true);
-  };
+  });
 
   const update = (commitOpening: boolean) => {
     const keyboardWasOpen = state.keyboardOpen;
     updateKeyboardViewportState(state, viewport, commitOpening);
-    if (!keyboardWasOpen && state.keyboardOpen) {
-      if (revealFrameId !== null) {
-        window.cancelAnimationFrame(revealFrameId);
+    if (!state.keyboardOpen) {
+      if (keyboardWasOpen) {
+        recorder?.closed(isTextEntryElement(document.activeElement));
       }
-      // The scroll reserve is a pseudo-element driven by the keyboard-open
-      // style. Give WebKit one layout frame to publish the new scrollHeight
-      // before asking it to reveal the composer.
-      revealFrameId = window.requestAnimationFrame(() => {
-        revealFrameId = null;
-        if (state.keyboardOpen) {
-          revealFocusedComposer();
-        }
-      });
-    } else if (!state.keyboardOpen && revealFrameId !== null) {
-      window.cancelAnimationFrame(revealFrameId);
-      revealFrameId = null;
+      revealFrame.cancel();
+      return;
+    }
+    if (!keyboardWasOpen) {
+      recorder?.opened();
+      revealFrame.cancel();
+      revealFrame.schedule();
     }
   };
 
-  const scheduleUpdate = () => {
-    // Keep committed keyboard geometry live during animation and caret-driven
-    // viewport panning.
-    if (scheduledFrameId === null) {
-      scheduledFrameId = window.requestAnimationFrame(() => {
-        scheduledFrameId = null;
-        update(false);
-      });
-    }
+  // Keep committed keyboard geometry live during animation and caret-driven
+  // viewport panning.
+  const updateFrame = createFrameTask(() => {
+    update(false);
+  });
+  // Standalone WebKit can publish its final offsetTop without another event.
+  // The short trailing read also prevents the first stale resize sample from
+  // moving the page before the native focus pan has settled.
+  const settledCommit = createSettledCommit(resetSettledSignal, () => {
+    update(true);
+  });
 
-    // Standalone WebKit can publish its final offsetTop without another event.
-    // The short trailing read also prevents the first stale resize sample from
-    // moving the page before the native focus pan has settled.
-    cancelSettledUpdate();
-    const settledSignal = resetSettledSignal();
-    settledTimerSignal = settledSignal;
-    detach(
-      commitSettledUpdate(settledSignal),
-      Reason.DomCallback,
-      "visual viewport settle",
-    );
+  const scheduleUpdate = () => {
+    updateFrame.schedule();
+    settledCommit.schedule();
   };
 
   const scheduleBaselineReset = () => {
     state.resetBaselineOnSettle = true;
     state.keyboardOpen = false;
-    cancelSettledUpdate();
+    settledCommit.cancel();
     setKeyboardClosed();
+    recorder?.clear();
 
     // Some WebKit versions emit orientationchange before the new viewport
     // metrics and others emit it afterwards. Commit immediately only for the
@@ -344,14 +393,11 @@ export function setupVisualViewportKeyboardState(
     window.removeEventListener("orientationchange", scheduleBaselineReset);
     document.removeEventListener("focusin", scheduleUpdate);
     document.removeEventListener("focusout", scheduleUpdate);
-    if (scheduledFrameId !== null) {
-      window.cancelAnimationFrame(scheduledFrameId);
-    }
-    if (revealFrameId !== null) {
-      window.cancelAnimationFrame(revealFrameId);
-    }
-    cancelSettledUpdate();
+    updateFrame.cancel();
+    revealFrame.cancel();
+    settledCommit.cancel();
     setKeyboardClosed();
+    recorder?.clear();
   };
   signal.addEventListener("abort", cleanup, { once: true });
   return cleanup;


### PR DESCRIPTION
## Summary

- Capture a `keyboard_viewport_session` PostHog event on iOS (Safari, in-app browsers, and the installed PWA) after every software-keyboard session. At open it records the visual viewport pan and height; after close it samples the visual viewport on animation frames for 1.5s (a sample whenever offset, height, scrollY, or the root position changes, or at least every 100ms, capped at 40) with the `#root` top and the chat composer's bottom gap. The event also carries `ios_version`, `standalone`, `page` (home / thread / other), `safe_area_top` / `safe_area_bottom`, `screen_height`, `inner_height`, `referrer_origin`, `focused_at_close`, `session_ms`, `keyboard_occlusion`, `scale_at_close`, and `residue_ms` (time until the pan dropped below 24px, `null` when it never did inside the window).
- No layout or interaction change. `visual-viewport-keyboard.ts` gains two small factories (animation-frame task and settled commit) so the setup function stays within the lint size limit, and `browser-support.ts` exports `iosVersionFromUserAgent`.
- Refs #32420. PR #32621 (closed) tried to correct the geometry from `visualViewport.offsetTop`; on an iPhone 16 Pro running iOS 26 that value stays stale after a normal keyboard close while the screen is already at rest, so every correction based on it misplaced the page. This PR only measures.

## How to read the data

- The reported bug (composer left mid-screen with a white band below) is a session with `residue_ms = null` and `max_offset_top_after_close` in the hundreds of pixels; `composer_gap_after_close` is the visible band in CSS px and `root_top_after_close` the root displacement.
- Group those sessions by `ios_version`, `standalone`, `referrer_origin`, `page`, and the surface fingerprint (`screen_height`, `inner_height`, `safe_area_top`, `safe_area_bottom`) to tell Safari from in-app browsers, and by `focused_at_close` to tell blur-based dismissals from the accessory-bar Done key.
- `close_samples` gives the close animation timeline per build: BrowserStack iPhone 15 / 17 Pro on iOS 26.6 restore height and offset in one step, while the iPhone 16 Pro above reports intermediate offsets for hundreds of milliseconds.

## Verification

- `pnpm exec prettier --write` on the five changed files
- `pnpm --filter @okouai/app run lint` (oxlint + eslint, as CI runs it)
- `pnpm --filter @okouai/app run check-types`
- `pnpm knip --workspace apps/platform`
- `pnpm --filter @okouai/app exec vitest run src/lib/__tests__/visual-viewport-keyboard.test.ts` (14 passed, 3 new: an iOS session reports its geometry after the keyboard closes, a pan that clears reports how long it lasted, sessions outside iOS are not reported)
- Not run: on-device. PostHog is only initialised for the production hostname, so the event can be checked in PostHog after the production deploy, not on the PR preview.
