### PR TITLE
fix(voice): recover transient provider capacity failures

### DIFF
--- a/turbo/apps/api/src/signals/external/openrouter-voice.ts
+++ b/turbo/apps/api/src/signals/external/openrouter-voice.ts
@@ -12,6 +12,7 @@ import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { OpenRouterRequestError, type OpenRouterTextPart } from "./openrouter";
 import { readBoundedResponseText, safeJsonParse } from "../utils";
+import { requestVoiceProvider } from "./voice-provider-request";
 
 const L = logger("OpenRouterVoice");
 
@@ -322,64 +323,80 @@ async function generateStructuredVoiceResponse<T>(
     ? args.systemPrompt
     : `${args.systemPrompt}\nJSON schema: ${JSON.stringify(args.jsonSchema.schema)}`;
 
-  const response = await fetch(OPENROUTER_CHAT_COMPLETIONS_URL, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      model: args.model,
-      messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: args.content },
-      ],
-      max_tokens: isGemini ? (isGemini25 ? 65_535 : 65_536) : 16_384,
-      ...(isGemini
-        ? { reasoning: { effort: isGemini25 ? "none" : "minimal" } }
-        : { modalities: ["text"] }),
-      temperature: 0,
-      store: false,
-      ...(isGemini && {
-        response_format: {
-          type: "json_schema",
-          json_schema: args.jsonSchema,
+  return await requestVoiceProvider(
+    (requestSignal) => {
+      return fetch(OPENROUTER_CHAT_COMPLETIONS_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
         },
-      }),
-    }),
-    signal,
-  });
-  const responseBody = await readBoundedResponseText(
-    response,
-    OPENROUTER_VOICE_RESPONSE_MAX_BYTES,
-  );
-  signal.throwIfAborted();
-  const parsedBody =
-    responseBody.kind === "text" ? safeJsonParse(responseBody.text) : undefined;
-  if (!response.ok) {
-    const error = requestError(
-      "OpenRouter voice request failed",
-      response.status,
-      parsedBody,
-    );
-    L.warn("OpenRouter voice request rejected", {
+        body: JSON.stringify({
+          model: args.model,
+          messages: [
+            { role: "system", content: systemPrompt },
+            { role: "user", content: args.content },
+          ],
+          max_tokens: isGemini ? (isGemini25 ? 65_535 : 65_536) : 16_384,
+          ...(isGemini
+            ? { reasoning: { effort: isGemini25 ? "none" : "minimal" } }
+            : { modalities: ["text"] }),
+          temperature: 0,
+          store: false,
+          ...(isGemini && {
+            response_format: {
+              type: "json_schema",
+              json_schema: args.jsonSchema,
+            },
+          }),
+        }),
+        signal: requestSignal,
+      });
+    },
+    async (response) => {
+      const responseBody = await readBoundedResponseText(
+        response,
+        OPENROUTER_VOICE_RESPONSE_MAX_BYTES,
+      );
+      signal.throwIfAborted();
+      const parsedBody =
+        responseBody.kind === "text"
+          ? safeJsonParse(responseBody.text)
+          : undefined;
+      if (!response.ok) {
+        const error = requestError(
+          "OpenRouter voice request failed",
+          response.status,
+          parsedBody,
+        );
+        L.warn("OpenRouter voice request rejected", {
+          model: args.model,
+          responseSchema: args.jsonSchema.name,
+          status: error.status,
+          errorType: error.errorType,
+        });
+        throw error;
+      }
+      if (parsedBody === undefined) {
+        throw new Error("OpenRouter voice response was not valid JSON");
+      }
+
+      const content = parseCompletionText(parsedBody);
+      const generated = args.schema.safeParse(safeJsonParse(content));
+      if (!generated.success) {
+        throw new Error(
+          "OpenRouter voice response did not match its JSON schema",
+        );
+      }
+      return generated.data;
+    },
+    {
+      provider: "openrouter",
       model: args.model,
       responseSchema: args.jsonSchema.name,
-      status: error.status,
-      errorType: error.errorType,
-    });
-    throw error;
-  }
-  if (parsedBody === undefined) {
-    throw new Error("OpenRouter voice response was not valid JSON");
-  }
-
-  const content = parseCompletionText(parsedBody);
-  const generated = args.schema.safeParse(safeJsonParse(content));
-  if (!generated.success) {
-    throw new Error("OpenRouter voice response did not match its JSON schema");
-  }
-  return generated.data;
+    },
+    signal,
+  );
 }
 
 /** The saved prefix is spoken content; editor/chat context remains reference only. */

--- a/turbo/apps/api/src/signals/external/voice-input-transcription.ts
+++ b/turbo/apps/api/src/signals/external/voice-input-transcription.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { env, optionalEnv } from "../../lib/env";
 import { readBoundedResponseText, safeJsonParse } from "../utils";
 import type { OpenRouterVoiceAudio } from "./openrouter-voice";
+import { requestVoiceProvider } from "./voice-provider-request";
 
 type TranscriptionModel = Extract<VoiceInputModel, { kind: "transcription" }>;
 const ELEVENLABS_MODEL = "fal-ai/elevenlabs/speech-to-text/scribe-v2";
@@ -38,36 +39,48 @@ export async function transcribeVoiceInputAudio(
   if (!key) {
     throw new Error("Voice transcription provider is not configured");
   }
-  const response = await fetch(
-    elevenLabs
-      ? `https://fal.run/${ELEVENLABS_MODEL}`
-      : "https://openrouter.ai/api/v1/audio/transcriptions",
-    {
-      method: "POST",
-      headers: {
-        Authorization: `${elevenLabs ? "Key" : "Bearer"} ${key}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(
+  return await requestVoiceProvider(
+    (requestSignal) => {
+      return fetch(
         elevenLabs
-          ? {
-              audio_url: `data:audio/wav;base64,${audio.data}`,
-              tag_audio_events: false,
-              diarize: false,
-            }
-          : { model: model.id, input_audio: audio, response_format: "json" },
-      ),
-      signal,
+          ? `https://fal.run/${ELEVENLABS_MODEL}`
+          : "https://openrouter.ai/api/v1/audio/transcriptions",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `${elevenLabs ? "Key" : "Bearer"} ${key}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(
+            elevenLabs
+              ? {
+                  audio_url: `data:audio/wav;base64,${audio.data}`,
+                  tag_audio_events: false,
+                  diarize: false,
+                }
+              : {
+                  model: model.id,
+                  input_audio: audio,
+                  response_format: "json",
+                },
+          ),
+          signal: requestSignal,
+        },
+      );
     },
+    async (response) => {
+      if (!response.ok) {
+        await response.body?.cancel();
+        throw new VoiceTranscriptionRequestError(response.status);
+      }
+      const body = await readBoundedResponseText(response, MAX_RESPONSE_BYTES);
+      signal.throwIfAborted();
+      if (body.kind !== "text") {
+        throw new Error("Voice transcription response exceeds the size limit");
+      }
+      return transcriptionSchema.parse(safeJsonParse(body.text)).text;
+    },
+    { provider: elevenLabs ? "fal" : "openrouter", model: model.id },
+    signal,
   );
-  if (!response.ok) {
-    await response.body?.cancel();
-    throw new VoiceTranscriptionRequestError(response.status);
-  }
-  const body = await readBoundedResponseText(response, MAX_RESPONSE_BYTES);
-  signal.throwIfAborted();
-  if (body.kind !== "text") {
-    throw new Error("Voice transcription response exceeds the size limit");
-  }
-  return transcriptionSchema.parse(safeJsonParse(body.text)).text;
 }

--- a/turbo/apps/api/src/signals/external/voice-provider-request.ts
+++ b/turbo/apps/api/src/signals/external/voice-provider-request.ts
@@ -1,0 +1,117 @@
+import { delay } from "signal-timers";
+
+import { logger } from "../../lib/log";
+import { now } from "../../lib/time";
+import { onRejection } from "../utils";
+
+const L = logger("VoiceProvider");
+const MAX_ATTEMPTS = 3;
+// Recovery gets its own deadline after the first rejected request. Do not
+// impose this short budget on an otherwise healthy long transcription.
+const RECOVERY_BUDGET_MS = 15_000;
+const INITIAL_BACKOFF_MS = 1000;
+
+interface VoiceProviderContext {
+  readonly provider: "openrouter" | "fal";
+  readonly model: string;
+  readonly responseSchema?: string;
+}
+
+export class VoiceProviderUnavailableError extends Error {
+  constructor(readonly status: number) {
+    super("Voice provider recovery exhausted");
+    this.name = "VoiceProviderUnavailableError";
+  }
+}
+
+function isRetryableStatus(status: number): boolean {
+  return (
+    status === 429 ||
+    status === 500 ||
+    status === 502 ||
+    status === 503 ||
+    status === 504
+  );
+}
+
+function retryAfterMs(value: string | null): number | undefined {
+  if (!value?.trim()) {
+    return undefined;
+  }
+  const text = value.trim();
+  const milliseconds = /^\d+(?:\.\d+)?$/u.test(text)
+    ? Number(text) * 1000
+    : Date.parse(text) - now();
+  return Number.isFinite(milliseconds) && milliseconds >= 0
+    ? milliseconds
+    : undefined;
+}
+
+function exhausted(
+  context: VoiceProviderContext,
+  status: number,
+  attempts: number,
+): VoiceProviderUnavailableError {
+  L.warn("Voice provider recovery exhausted", {
+    ...context,
+    status,
+    attempts,
+  });
+  return new VoiceProviderUnavailableError(status);
+}
+
+/** Retry only explicit temporary HTTP failures, at the failed provider step. */
+export async function requestVoiceProvider<T>(
+  request: (signal: AbortSignal) => Promise<Response>,
+  readResponse: (response: Response) => Promise<T>,
+  context: VoiceProviderContext,
+  signal: AbortSignal,
+): Promise<T> {
+  signal.throwIfAborted();
+  let response = await request(signal);
+  signal.throwIfAborted();
+  const deadline = now() + RECOVERY_BUDGET_MS;
+  let attempts = 1;
+  let responseSignal = signal;
+  let status = response.status;
+  const checkSignal = () => {
+    signal.throwIfAborted();
+    if (attempts > 1 && (responseSignal.aborted || now() >= deadline)) {
+      throw exhausted(context, status, attempts);
+    }
+  };
+  while (isRetryableStatus(response.status)) {
+    status = response.status;
+    const wait = Math.max(
+      INITIAL_BACKOFF_MS * 2 ** (attempts - 1),
+      retryAfterMs(response.headers.get("Retry-After")) ?? 0,
+    );
+    await onRejection(
+      response.body?.cancel() ?? Promise.resolve(),
+      checkSignal,
+    );
+    checkSignal();
+    // A provider's long retry delay is not permission to retry earlier.
+    if (attempts >= MAX_ATTEMPTS || wait >= deadline - now()) {
+      throw exhausted(context, status, attempts);
+    }
+    await delay(wait, { signal });
+    signal.throwIfAborted();
+    const remaining = deadline - now();
+    if (remaining <= 0) {
+      throw exhausted(context, status, attempts);
+    }
+    responseSignal = AbortSignal.any([signal, AbortSignal.timeout(remaining)]);
+    attempts += 1;
+    response = await onRejection(request(responseSignal), checkSignal);
+    checkSignal();
+  }
+  // Keep body consumption inside the recovery deadline and report success only
+  // after the provider response has passed the caller's validation.
+  const result = await onRejection(readResponse(response), checkSignal);
+  checkSignal();
+  if (response.ok && attempts > 1) {
+    L.debug("Voice provider request recovered", { ...context, attempts });
+  }
+  return result;
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
@@ -14,6 +14,8 @@ import { HttpResponse, http } from "msw";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
+import { mockNow } from "../../../lib/time";
+import { createDeferredPromise } from "../../utils";
 import { server } from "../../../mocks/server";
 import { createUniqueStaffOrgIdFixture } from "../../../test-fixtures/staff-org";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
@@ -25,6 +27,23 @@ import { voiceIoTranscribeRoutes } from "../voice-io-transcribe";
 const context = testContext();
 const mocks = createRouteMocks(context);
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+
+function recoveredVoiceResponse() {
+  return HttpResponse.json({
+    choices: [
+      {
+        finish_reason: "stop",
+        message: {
+          content: JSON.stringify({
+            transcript: "Recorded speech.",
+            polishedText: "Recorded speech.",
+            language: "en",
+          }),
+        },
+      },
+    ],
+  });
+}
 
 interface OpenRouterRequest {
   readonly model: string;
@@ -1346,5 +1365,468 @@ describe("POST /api/voice-io/transcribe/segment", () => {
       ),
     });
     expect(result.status).toBe(502);
+  });
+});
+
+describe("voice provider capacity recovery", () => {
+  beforeEach(() => {
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    context.mocks.signalTimers.delay.mockResolvedValue(undefined);
+  });
+
+  it.each([429, 503])(
+    "recovers HTTP %i without error signals and counts the recording once",
+    async (status) => {
+      const actor = await enabledActor();
+      if (!actor.orgId) {
+        throw new Error("Expected an organization");
+      }
+      await seedOrgMetadata({
+        orgId: actor.orgId,
+        tier: "free",
+        credits: 10_000,
+      });
+      const requests: string[] = [];
+      server.use(
+        http.post(OPENROUTER_URL, async ({ request }) => {
+          requests.push(await request.text());
+          return requests.length === 1
+            ? new HttpResponse(null, { status })
+            : recoveredVoiceResponse();
+        }),
+      );
+      const headers = { authorization: "Bearer clerk-session" };
+      const result = await accept(
+        client().segment({ headers, body: form([audioFile(1)]) }),
+        [200],
+      );
+      expect(result.body.polishedText).toBe("Recorded speech.");
+      expect(requests).toHaveLength(2);
+      expect(requests[1]).toBe(requests[0]);
+      const quota = setupApp({ context, routes: voiceIoQuotaRoutes })(
+        voiceIoQuotaContract,
+      );
+      const usage = await accept(quota.get({ headers }), [200]);
+      expect(usage.body).toMatchObject({ count: 1, allowed: true });
+      expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+      expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+      expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+      expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+        "Voice provider request recovered",
+        expect.objectContaining({ attempts: 2, provider: "openrouter" }),
+      );
+    },
+  );
+
+  it("ends persistent capacity failures after three attempts with actionable reporting", async () => {
+    await enabledActor();
+    let attempts = 0;
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        attempts += 1;
+        return attempts <= 3
+          ? new HttpResponse(null, { status: 429 })
+          : recoveredVoiceResponse();
+      }),
+    );
+    const response = await accept(
+      client().segment({
+        headers: { authorization: "Bearer clerk-session" },
+        body: form([audioFile(1)]),
+      }),
+      [503],
+    );
+    expect(response.body.error).toStrictEqual({
+      code: "PROVIDER_UNAVAILABLE",
+      message:
+        "Speech recognition is temporarily busy. Please retry in a moment.",
+    });
+    expect(attempts).toBe(3);
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledExactlyOnceWith(
+      "Voice provider recovery exhausted",
+      expect.objectContaining({ status: 429, attempts: 3 }),
+    );
+  });
+
+  it.each([
+    { value: "2", wait: 2000 },
+    { value: "Wed, 09 Sep 2026 08:00:03 GMT", wait: 3000 },
+    { value: "invalid", wait: 1000 },
+  ])(
+    "honors Retry-After $value within the recovery budget",
+    async ({ value, wait }) => {
+      await enabledActor();
+      mockNow(new Date("2026-09-09T08:00:00Z"));
+      const waits: number[] = [];
+      context.mocks.signalTimers.delay.mockImplementation((ms) => {
+        waits.push(ms);
+        return Promise.resolve();
+      });
+      let available = false;
+      server.use(
+        http.post(OPENROUTER_URL, () => {
+          if (available) {
+            return recoveredVoiceResponse();
+          }
+          available = true;
+          return new HttpResponse(null, {
+            status: 429,
+            headers: { "Retry-After": value },
+          });
+        }),
+      );
+      const result = await accept(
+        client().segment({
+          headers: { authorization: "Bearer clerk-session" },
+          body: form([audioFile(1)]),
+        }),
+        [200],
+      );
+      expect(result.body.polishedText).toBe("Recorded speech.");
+      expect(waits).toStrictEqual([wait]);
+    },
+  );
+
+  it("does not retry earlier than a provider delay that exceeds the budget", async () => {
+    await enabledActor();
+    let attempts = 0;
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        attempts += 1;
+        return attempts === 1
+          ? new HttpResponse(null, {
+              status: 429,
+              headers: { "Retry-After": "60" },
+            })
+          : recoveredVoiceResponse();
+      }),
+    );
+    const response = await accept(
+      client().segment({
+        headers: { authorization: "Bearer clerk-session" },
+        body: form([audioFile(1)]),
+      }),
+      [503],
+    );
+    expect(response.body.error.code).toBe("PROVIDER_UNAVAILABLE");
+    expect(attempts).toBe(1);
+    expect(context.mocks.signalTimers.delay).not.toHaveBeenCalled();
+  });
+
+  it("stops recovery when the elapsed budget is exhausted", async () => {
+    await enabledActor();
+    const started = new Date("2026-09-09T08:00:00Z").getTime();
+    mockNow(started);
+    let attempts = 0;
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        attempts += 1;
+        if (attempts > 1) {
+          mockNow(started + 15_000);
+        }
+        return attempts <= 2
+          ? new HttpResponse(null, { status: 503 })
+          : recoveredVoiceResponse();
+      }),
+    );
+    const response = await accept(
+      client().segment({
+        headers: { authorization: "Bearer clerk-session" },
+        body: form([audioFile(1)]),
+      }),
+      [503],
+    );
+    expect(response.body.error.code).toBe("PROVIDER_UNAVAILABLE");
+    expect(attempts).toBe(2);
+  });
+
+  it("aborts an in-flight recovery request when its budget expires", async () => {
+    await enabledActor();
+    mockNow(new Date("2026-09-09T08:00:00Z"));
+    const deadline = new AbortController();
+    context.mocks.abortSignal.timeout.mockImplementation((milliseconds) => {
+      return milliseconds === 15_000 ? deadline.signal : undefined;
+    });
+    const retryStarted = createDeferredPromise<void>(context.signal);
+    let attempts = 0;
+    server.use(
+      http.post(OPENROUTER_URL, async ({ request }) => {
+        attempts += 1;
+        if (attempts === 1) {
+          return new HttpResponse(null, { status: 429 });
+        }
+        const aborted = createDeferredPromise<void>(context.signal);
+        request.signal.addEventListener(
+          "abort",
+          () => {
+            return aborted.resolve();
+          },
+          {
+            once: true,
+          },
+        );
+        retryStarted.resolve();
+        await aborted.promise;
+        return HttpResponse.error();
+      }),
+    );
+    const pending = client().segment({
+      headers: { authorization: "Bearer clerk-session" },
+      body: form([audioFile(1)]),
+    });
+    await retryStarted.promise;
+    deadline.abort(
+      new DOMException("Recovery deadline reached", "TimeoutError"),
+    );
+    const response = await accept(pending, [503]);
+    expect(response.body.error.code).toBe("PROVIDER_UNAVAILABLE");
+    expect(attempts).toBe(2);
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledExactlyOnceWith(
+      "Voice provider recovery exhausted",
+      expect.objectContaining({ status: 429, attempts: 2 }),
+    );
+  });
+
+  it("keeps the recovery deadline active while reading a successful response body", async () => {
+    await enabledActor();
+    mockNow(new Date("2026-09-09T08:00:00Z"));
+    const deadline = new AbortController();
+    context.mocks.abortSignal.timeout.mockImplementation((milliseconds) => {
+      return milliseconds === 15_000 ? deadline.signal : undefined;
+    });
+    const reading = createDeferredPromise<void>(context.signal);
+    let attempts = 0;
+    server.use(
+      http.post(OPENROUTER_URL, ({ request }) => {
+        attempts += 1;
+        if (attempts === 1) {
+          return new HttpResponse(null, { status: 429 });
+        }
+        const body = new ReadableStream<Uint8Array>(
+          {
+            start(controller) {
+              request.signal.addEventListener(
+                "abort",
+                () => {
+                  controller.error(
+                    new DOMException("Body aborted", "AbortError"),
+                  );
+                },
+                { once: true },
+              );
+            },
+            pull() {
+              reading.resolve();
+            },
+          },
+          { highWaterMark: 0 },
+        );
+        return new HttpResponse(body, {
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+    const pending = client().segment({
+      headers: { authorization: "Bearer clerk-session" },
+      body: form([audioFile(1)]),
+    });
+    await reading.promise;
+    deadline.abort(
+      new DOMException("Recovery deadline reached", "TimeoutError"),
+    );
+    const response = await accept(pending, [503]);
+    expect(response.body.error.code).toBe("PROVIDER_UNAVAILABLE");
+    expect(attempts).toBe(2);
+    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalledWith(
+      "Voice provider request recovered",
+      expect.anything(),
+    );
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledExactlyOnceWith(
+      "Voice provider recovery exhausted",
+      expect.objectContaining({ status: 429, attempts: 2 }),
+    );
+  });
+
+  it("keeps provider authentication errors non-retryable and actionable", async () => {
+    await enabledActor();
+    let attempts = 0;
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        attempts += 1;
+        return attempts === 1
+          ? new HttpResponse(null, { status: 401 })
+          : recoveredVoiceResponse();
+      }),
+    );
+    const response = await accept(
+      client().segment({
+        headers: { authorization: "Bearer clerk-session" },
+        body: form([audioFile(1)]),
+      }),
+      [502],
+    );
+    expect(response.body.error.code).toBe("VOICE_TRANSCRIPTION_FAILED");
+    expect(attempts).toBe(1);
+    expect(context.mocks.signalTimers.delay).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      "OpenRouter voice request rejected",
+      expect.objectContaining({ status: 401 }),
+    );
+  });
+
+  it("keeps an invalid successful response as a genuine transcription failure", async () => {
+    await enabledActor();
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json({ choices: [] });
+      }),
+    );
+    const response = await accept(
+      client().segment({
+        headers: { authorization: "Bearer clerk-session" },
+        body: form([audioFile(1)]),
+      }),
+      [502],
+    );
+    expect(response.body.error.code).toBe("VOICE_TRANSCRIPTION_FAILED");
+    expect(context.mocks.signalTimers.delay).not.toHaveBeenCalled();
+  });
+
+  it("cancels backoff with the request owner without reporting provider exhaustion", async () => {
+    await enabledActor();
+    const controller = new AbortController();
+    const waiting = createDeferredPromise<void>(context.signal);
+    context.mocks.signalTimers.delay.mockImplementation((_ms, options) => {
+      const signal = options?.signal;
+      if (!signal) {
+        throw new Error("Expected an owned voice recovery delay");
+      }
+      waiting.resolve();
+      return createDeferredPromise<void>(signal).promise;
+    });
+    let attempts = 0;
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        attempts += 1;
+        return new HttpResponse(null, { status: 429 });
+      }),
+    );
+    const scopedClient = setupApp({
+      context,
+      routes: voiceIoTranscribeRoutes,
+      signal: AbortSignal.any([context.signal, controller.signal]),
+      rethrowErrors: true,
+    })(voiceIoTranscribeContract);
+    const pending = scopedClient.segment({
+      headers: { authorization: "Bearer clerk-session" },
+      body: form([audioFile(1)]),
+    });
+    const outcome = Promise.allSettled([pending]);
+    await waiting.promise;
+    controller.abort(new DOMException("Request cancelled", "AbortError"));
+    const [result] = await outcome;
+    expect(result).toMatchObject({
+      status: "rejected",
+      reason: { name: "AbortError", message: "Request cancelled" },
+    });
+    expect(attempts).toBe(1);
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "qwen/qwen3-asr-1.7b",
+    "fal-ai/elevenlabs/speech-to-text/scribe-v2",
+  ] as const)(
+    "recovers capacity errors in the selected %s ASR step",
+    async (model) => {
+      await enabledActor();
+      const headers = { authorization: "Bearer clerk-session" };
+      await accept(
+        preferencesClient().update({
+          headers,
+          body: { voiceInputModel: model },
+        }),
+        [200],
+      );
+      const endpoint = model.startsWith("fal-ai/")
+        ? `https://fal.run/${model}`
+        : "https://openrouter.ai/api/v1/audio/transcriptions";
+      let attempts = 0;
+      server.use(
+        http.post(endpoint, () => {
+          attempts += 1;
+          return attempts === 1
+            ? new HttpResponse(null, { status: 429 })
+            : HttpResponse.json({ text: "Recorded speech." });
+        }),
+      );
+      const response = await accept(
+        client().segment({
+          headers,
+          body: segmentForm([audioFile(1)], "", false, 1),
+        }),
+        [200],
+      );
+      expect(response.body).toStrictEqual({
+        transcript: "Recorded speech.",
+        language: "und",
+      });
+      expect(attempts).toBe(2);
+      expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+    },
+  );
+
+  it("retries failed polish without repeating successful dedicated ASR", async () => {
+    await enabledActor();
+    const headers = { authorization: "Bearer clerk-session" };
+    await accept(
+      preferencesClient().update({
+        headers,
+        body: { voiceInputModel: "qwen/qwen3-asr-1.7b" },
+      }),
+      [200],
+    );
+    let asrAttempts = 0;
+    let polishAttempts = 0;
+    server.use(
+      http.post("https://openrouter.ai/api/v1/audio/transcriptions", () => {
+        asrAttempts += 1;
+        return asrAttempts === 1
+          ? HttpResponse.json({ text: "Recorded speech." })
+          : new HttpResponse(null, { status: 400 });
+      }),
+      http.post(OPENROUTER_URL, () => {
+        polishAttempts += 1;
+        return polishAttempts === 1
+          ? new HttpResponse(null, { status: 503 })
+          : HttpResponse.json({
+              choices: [
+                {
+                  finish_reason: "stop",
+                  message: {
+                    content: JSON.stringify({
+                      polishedText: "Recorded speech.",
+                      language: "en",
+                    }),
+                  },
+                },
+              ],
+            });
+      }),
+    );
+    const response = await accept(
+      client().segment({ headers, body: form([audioFile(1)]) }),
+      [200],
+    );
+    expect(response.body).toStrictEqual({
+      transcript: "Recorded speech.",
+      polishedText: "Recorded speech.",
+      language: "en",
+    });
+    expect(asrAttempts).toBe(1);
+    expect(polishAttempts).toBe(2);
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/api/src/signals/services/voice-io-transcribe.service.ts
+++ b/turbo/apps/api/src/signals/services/voice-io-transcribe.service.ts
@@ -31,6 +31,7 @@ import {
   VoiceTranscriptionRequestError,
 } from "../external/voice-input-transcription";
 import { settle } from "../utils";
+import { VoiceProviderUnavailableError } from "../external/voice-provider-request";
 
 // Character rate is noisy for short clips, so only context-sized output can
 // trigger the conservative upper bound for human speech.
@@ -70,6 +71,13 @@ function transcriptionError<Status extends number>(
 }
 
 function providerError(error: unknown) {
+  if (error instanceof VoiceProviderUnavailableError) {
+    return transcriptionError(
+      503,
+      "PROVIDER_UNAVAILABLE",
+      "Speech recognition is temporarily busy. Please retry in a moment.",
+    );
+  }
   if (
     (error instanceof OpenRouterRequestError ||
       error instanceof VoiceTranscriptionRequestError) &&
@@ -288,8 +296,9 @@ export const transcribeVoiceSegment$ = command(
     const startedAt = performance.now();
     const generated = await settle(
       transcribeIncrementalVoice(input, requestSignal),
+      signal,
     );
-    signal.throwIfAborted();
+    requestSignal.throwIfAborted();
     if (!generated.ok) {
       return providerError(generated.error);
     }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-incremental.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-incremental.test.tsx
@@ -5,6 +5,7 @@ import { expect, test, vi } from "vitest";
 import { click, setupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { createChildAbortController } from "../../../signals/utils.ts";
+import { initSentry } from "../../../lib/sentry.ts";
 import {
   context,
   findEnabledButton,
@@ -15,6 +16,37 @@ import {
 const refreshedContext = testContext();
 const flags = { [FeatureSwitchKey.VoiceInputV2]: true } as const;
 const endpoint = "*/api/voice-io/transcribe/segment";
+
+test("Keep transcription pending until server recovery succeeds without reporting an error", async () => {
+  const sentry = context.mocks.sentry();
+  initSentry();
+  const started = context.mocks.deferred<void>();
+  const recovered = context.mocks.deferred<void>();
+  context.mocks.browser.voiceInput({ rms: 0.1 });
+  installRunChat();
+  // The contract mock only parses JSON; voice segments use multipart bodies.
+  context.mocks.http.post(endpoint, async () => {
+    started.resolve();
+    await recovered.promise;
+    return HttpResponse.json({
+      transcript: "Recovered speech.",
+      polishedText: "Recovered speech.",
+      language: "en",
+    });
+  });
+  await setupPage({ context, path: RUN_PATH, featureSwitches: flags });
+  click(await findEnabledButton("Voice input"));
+  click(await findEnabledButton("Stop recording"));
+  await started.promise;
+  await expect(screen.findByText("Transcribing...")).resolves.toBeVisible();
+  recovered.resolve();
+  await waitFor(() => {
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveTextContent(
+      "Recovered speech.",
+    );
+  });
+  expect(sentry.reports).toStrictEqual([]);
+});
 
 test("Keep recording after an incremental segment fails and finish in order", async () => {
   const capture = context.mocks.deferred<(samples: Float32Array) => void>();
@@ -195,7 +227,11 @@ test("Stop during transcription and finalize the saved prefix without retranscri
   });
 });
 
-test("Preserve audio through a failed transcription request and retry the same audio", async () => {
+test("Preserve audio and actionable reporting after provider recovery is exhausted", async () => {
+  const sentry = context.mocks.sentry();
+  initSentry();
+  const message =
+    "Speech recognition is temporarily busy. Please retry in a moment.";
   context.mocks.browser.voiceInput({ rms: 0.1 });
   installRunChat();
   let available = false;
@@ -212,7 +248,7 @@ test("Preserve audio through a failed transcription request and retry the same a
         {
           error: {
             code: "PROVIDER_UNAVAILABLE",
-            message: "Transcription unavailable",
+            message,
           },
         },
         { status: 503 },
@@ -228,6 +264,19 @@ test("Preserve audio through a failed transcription request and retry the same a
   click(await findEnabledButton("Voice input"));
   click(await findEnabledButton("Stop recording"));
   await findEnabledButton("Retry");
+  await expect(screen.findByText(message)).resolves.toBeVisible();
+  expect(
+    screen.getByText("Your recording is kept. Retry transcription."),
+  ).toBeVisible();
+  expect(sentry.reports).toContainEqual(
+    expect.objectContaining({
+      type: "exception",
+      error: expect.objectContaining({
+        code: "PROVIDER_UNAVAILABLE",
+        status: 503,
+      }),
+    }),
+  );
   available = true;
   click(await findEnabledButton("Retry"));
   await waitFor(() => {


### PR DESCRIPTION
Transient voice-provider capacity responses currently fail the recording immediately and surface a generic transcription error. This change recovers the failed provider operation while the existing page stays in its transcription progress state.

- Retry HTTP 429/500/502/503/504 up to three total attempts, with exponential backoff, usable `Retry-After` values, and a 15-second recovery budget after the first rejection. The recovery deadline covers response consumption and remains cancellable.
- Apply recovery to OpenRouter voice completions and OpenRouter/fal ASR. Retrying polish preserves successful ASR work, while quota accounting and saved recording/checkpoint behavior remain intact.
- Record successful recovery at debug level. Exhaustion emits one capacity warning and returns `503 PROVIDER_UNAVAILABLE` with an actionable retry message; genuine authentication, invalid-output, transport, and cancellation failures retain their existing handling.

Closes #32904.

Parent context: #32743. Google Cloud migration is excluded; provider/model selection, authentication, API contracts, and persisted recording formats remain unchanged.

Validation passed:

- `pnpm -F api exec vitest run src/signals/routes/__tests__/voice-io-transcribe.test.ts --maxWorkers=1 --silent=passed-only` — 60 tests, using a migrated local PostgreSQL database.
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-capability-voice-incremental.test.tsx src/views/okou-page/__tests__/chat-capability-voice-quota.test.tsx --maxWorkers=1 --silent=passed-only` — 13 tests.
- `pnpm -F api check-types` and `pnpm -F @okouai/app check-types`.
- From `turbo/`: `pnpm exec knip --workspace apps/api --workspace apps/platform` and `node scripts/style-policy.mjs`.
- Prettier, ESLint, and Oxlint (including type-aware checks) for the affected files; staged diff and file-size checks.

Post-deployment production observation remains tracked in parent #32743. Merging this PR completes the implementation child; it does not establish that the production incident has stopped recurring.
