### PR TITLE
fix(runner): preserve jsonl framing after partial append failures

### DIFF
--- a/crates/runner/mitm-addon/src/jsonl_writer.py
+++ b/crates/runner/mitm-addon/src/jsonl_writer.py
@@ -46,7 +46,9 @@ def write_jsonl_line(log_path: str, line: bytes, log_name: str) -> None:
 
     When accepted, ``line`` is passed to the append worker without transformation.
     The caller owns JSON serialization and the terminating newline; this function
-    validates neither JSON nor record boundaries.
+    validates neither JSON nor record boundaries. Before a nonempty batch, the
+    worker adds a newline if the existing file tail is unterminated, isolating
+    subsequent records from a previous incomplete append.
 
     The call returns no admission or durability result. An empty ``log_path``,
     writer shutdown, pending-write or pending-byte saturation, or failure to start
@@ -304,8 +306,15 @@ def _report_append_recovery() -> None:
 
 
 def _append_lines(log_path: str, lines: list[bytes]) -> None:
-    fd = os.open(log_path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o644)
+    fd = os.open(log_path, os.O_CREAT | os.O_APPEND | os.O_RDWR, 0o644)
     try:
+        if any(lines):
+            size = os.fstat(fd).st_size
+            if size and os.pread(fd, 1, size - 1) != b"\n":
+                # Only append: Rust can also write to the shared network log,
+                # so rolling back to an earlier offset could delete its records.
+                lines = [b"\n", *lines]
+
         line_index = 0
         line_offset = 0
         while line_index < len(lines):

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer_recovery.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer_recovery.py
@@ -1,0 +1,221 @@
+"""Recovery framing through the production JSONL logging entry point."""
+
+import errno
+import json
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import jsonl_writer
+import logging_utils
+
+
+def _write_and_flush(path: Path, record_id: str) -> None:
+    logging_utils.log_network_entry(str(path), {"id": record_id})
+    assert logging_utils.flush_log_path(str(path), timeout=2)
+
+
+def _record_ids(path: Path) -> list[str]:
+    # The Runner uploader skips malformed physical lines independently.
+    records = []
+    for line in path.read_bytes().splitlines():
+        try:
+            records.append(json.loads(line)["id"])
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+    return records
+
+
+def _assert_drained() -> None:
+    assert jsonl_writer._pending_bytes == 0
+    assert jsonl_writer._queued_writes == 0
+    assert not jsonl_writer._accepted_by_path
+    assert not jsonl_writer._completed_by_path
+    assert not jsonl_writer._flush_waiters_by_path
+
+
+@pytest.mark.parametrize("failure_errno", [errno.ENOSPC, errno.EIO, None])
+@pytest.mark.parametrize("failure_position", ["first-record", "record-boundary", "second-record"])
+def test_partial_batch_failure_preserves_recovered_records(
+    tmp_path, mitm_ctx, failure_errno, failure_position
+):
+    path = tmp_path / "network.jsonl"
+    gate_started = threading.Event()
+    release_gate = threading.Event()
+    original_writev = jsonl_writer.os.writev
+    calls = 0
+
+    def writev(fd: int, buffers: list[bytes | memoryview]) -> int:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            gate_started.set()
+            release_gate.wait()
+            return original_writev(fd, buffers)
+        if calls == 2:
+            complete_count = 0 if failure_position == "first-record" else 1
+            partial_buffers = list(buffers[:complete_count])
+            if failure_position != "record-boundary":
+                partial_buffers.append(memoryview(buffers[complete_count])[:7])
+            return original_writev(fd, partial_buffers)
+        if failure_errno is None:
+            return 0
+        raise OSError(failure_errno, "injected after partial progress")
+
+    with patch.object(jsonl_writer.os, "writev", side_effect=writev), mitm_ctx() as log:
+        try:
+            logging_utils.log_network_entry(str(path), {"id": "before"})
+            assert gate_started.wait(timeout=2)
+            for record_id in ("complete", "failed", "unattempted"):
+                logging_utils.log_network_entry(str(path), {"id": record_id})
+        finally:
+            release_gate.set()
+
+        assert logging_utils.flush_log_path(str(path), timeout=2)
+
+    assert calls == 3
+    log.warn.assert_called_once()
+    _assert_drained()
+    failed_bytes = path.read_bytes()
+    expected = ["before"]
+    if failure_position != "first-record":
+        expected.append("complete")
+    assert _record_ids(path) == expected
+
+    _write_and_flush(path, "recovered")
+    _write_and_flush(path, "later")
+
+    assert path.read_bytes().startswith(failed_bytes)
+    assert b"\n\n" not in path.read_bytes()
+    assert _record_ids(path) == [*expected, "recovered", "later"]
+    _assert_drained()
+    assert jsonl_writer.shutdown_writer(timeout=2)
+    assert jsonl_writer._worker is None
+
+
+@pytest.mark.parametrize("failure_errno", [errno.ENOSPC, errno.EIO, None])
+def test_repeated_recovery_failure_after_restart_keeps_new_records_out_of_partial_tail(
+    tmp_path, mitm_ctx, failure_errno
+):
+    path = tmp_path / "network.jsonl"
+    _write_and_flush(path, "before")
+    # A prior process can leave a partial tail without any in-memory writer state.
+    with path.open("ab") as file:
+        file.write(b'{"id":')
+    jsonl_writer.reset_for_tests()
+    failed_bytes = path.read_bytes()
+
+    def writev(_fd: int, _buffers: list[bytes | memoryview]) -> int:
+        if failure_errno is None:
+            return 0
+        raise OSError(failure_errno, "injected during recovery")
+
+    with patch.object(jsonl_writer.os, "writev", side_effect=writev), mitm_ctx() as log:
+        _write_and_flush(path, "failed-retry-1")
+        _write_and_flush(path, "failed-retry-2")
+
+    log.warn.assert_called_once()
+    assert path.read_bytes() == failed_bytes
+    _assert_drained()
+
+    _write_and_flush(path, "recovered")
+    assert path.read_bytes().startswith(failed_bytes + b"\n")
+    assert _record_ids(path) == ["before", "recovered"]
+    _assert_drained()
+    assert jsonl_writer.shutdown_writer(timeout=2)
+
+
+def test_written_separator_survives_subsequent_payload_failure(tmp_path, mitm_ctx):
+    path = tmp_path / "network.jsonl"
+    _write_and_flush(path, "before")
+    with path.open("ab") as file:
+        file.write(b'{"id":')
+    failed_bytes = path.read_bytes()
+    original_writev = jsonl_writer.os.writev
+    calls = 0
+
+    def writev(fd: int, buffers: list[bytes | memoryview]) -> int:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return original_writev(fd, buffers)
+        raise OSError(errno.EIO, "injected after the separator")
+
+    with (
+        patch.object(jsonl_writer, "MAX_JSONL_IOVECS", 1),
+        patch.object(jsonl_writer.os, "writev", side_effect=writev),
+        mitm_ctx() as log,
+    ):
+        _write_and_flush(path, "failed-retry")
+
+    assert calls == 2
+    log.warn.assert_called_once()
+    assert path.read_bytes() == failed_bytes + b"\n"
+    _assert_drained()
+
+    _write_and_flush(path, "recovered")
+    assert b"\n\n" not in path.read_bytes()
+    assert _record_ids(path) == ["before", "recovered"]
+    assert jsonl_writer.shutdown_writer(timeout=2)
+
+
+def test_recovery_preserves_complete_records_from_another_appender(tmp_path, mitm_ctx):
+    path = tmp_path / "network.jsonl"
+    _write_and_flush(path, "before")
+    original_writev = jsonl_writer.os.writev
+    calls = 0
+
+    def writev(fd: int, buffers: list[bytes | memoryview]) -> int:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return original_writev(fd, [memoryview(buffers[0])[:7]])
+        raise OSError(errno.ENOSPC, "injected after a partial record")
+
+    with patch.object(jsonl_writer.os, "writev", side_effect=writev), mitm_ctx():
+        _write_and_flush(path, "failed")
+
+    assert calls == 2
+    # Like the Rust producer, an independent descriptor appends complete JSONL.
+    # Its first record joins the damaged line; the next record is already intact.
+    with path.open("ab") as file:
+        file.write(b'{"id":"embedded"}\n{"id":"external"}\n')
+    existing_bytes = path.read_bytes()
+    assert _record_ids(path) == ["before", "external"]
+
+    _write_and_flush(path, "recovered")
+
+    assert path.read_bytes().startswith(existing_bytes)
+    assert b"\n\n" not in path.read_bytes()
+    assert _record_ids(path) == ["before", "external", "recovered"]
+    _assert_drained()
+    assert jsonl_writer.shutdown_writer(timeout=2)
+
+
+@pytest.mark.parametrize("operation", ["fstat", "pread"])
+def test_tail_inspection_failure_retires_batch_without_appending(tmp_path, mitm_ctx, operation):
+    path = tmp_path / "network.jsonl"
+    _write_and_flush(path, "before")
+    existing_bytes = path.read_bytes()
+    failed_fds = []
+
+    def fail_inspection(fd: int, *_args):
+        failed_fds.append(fd)
+        raise OSError(errno.EIO, "injected while inspecting the tail")
+
+    with patch.object(jsonl_writer.os, operation, side_effect=fail_inspection), mitm_ctx() as log:
+        _write_and_flush(path, "failed")
+
+    assert len(failed_fds) == 1
+    with pytest.raises(OSError, match=rf"\[Errno {errno.EBADF}\]") as error:
+        jsonl_writer.os.fstat(failed_fds[0])
+    assert error.value.errno == errno.EBADF
+    log.warn.assert_called_once()
+    assert path.read_bytes() == existing_bytes
+    _assert_drained()
+
+    _write_and_flush(path, "recovered")
+    assert _record_ids(path) == ["before", "recovered"]
+    assert jsonl_writer.shutdown_writer(timeout=2)

--- a/docs/mitm-addon-contracts.md
+++ b/docs/mitm-addon-contracts.md
@@ -27,6 +27,23 @@ nested fields map. Runner-owned Axiom metadata (`_time`, `context`, `service`,
 `runner_hostname`, and `runner_version`) remains authoritative. Callers remain
 responsible for redaction and bounded values.
 
+### JSONL append recovery
+
+The asynchronous writer accepts caller-framed JSONL bytes and opens the
+Runner-owned regular log files for reading and appending. Before a nonempty
+batch, it inspects only the final byte and appends a newline if the existing
+tail is unterminated. The separator uses the same bounded short-write loop as
+the records. Inspection or write failures retire the batch through the existing
+warning and accounting path; flush completion still means processed, not
+persisted. Healthy files gain no extra separators.
+
+Recovery never truncates or rewrites existing bytes: Rust also appends to the
+per-run network file. This isolates subsequent addon records from a failed
+prefix, including after a writer restart, but cannot recover another producer's
+record already embedded in a malformed line or serialize independently
+interleaved short-write sequences. The existing Runner uploader continues to
+skip malformed physical lines and upload independently parseable records.
+
 ## WebSocket Framing Contract
 
 [`websocket_framing.py`](../crates/runner/mitm-addon/src/websocket_framing.py)


### PR DESCRIPTION
## Summary

A short JSONL write followed by an I/O error leaves an incomplete record at EOF. The next healthy addon record was appended to that prefix and discarded by the Runner uploader as part of a malformed line. Inspect the final byte before each nonempty batch and append a separator through the existing short-write loop when needed.

Recovery preserves existing bytes, including records from the independent Rust appender, and keeps failed-batch accounting and flush semantics unchanged. It uses bounded EOF inspection without retaining failed paths. The log schema is unchanged; this does not add crash durability or serialize concurrent producers' short-write sequences, and cannot salvage records already embedded in malformed lines.

Closes #32920.

## Validation

- Added 16 deterministic cases through `logging_utils.log_network_entry`, using real temporary files and OS-boundary fault injection. Covers ENOSPC/EIO/zero after partial progress, record boundaries, repeated recovery failures, restart, a written separator followed by failure, another appender, and failed EOF inspection/descriptor cleanup. The six mid-record cases reproduced loss of the recovered record before the fix.
- `uv run --no-sync python -m pytest tests/test_jsonl_writer_recovery.py tests/test_jsonl_writer.py tests/test_logging_utils.py tests/test_runner_jsonl_flush.py -q` — 87 passed. The 16 new cases were rechecked after tightening an exception matcher for lint.
- `uv run --no-sync ruff format --check .`, `uv run --no-sync ruff check .`, and `uv run --no-sync basedpyright -p .` — passed in the locked Python 3.14.0 environment.
- Prettier 3.8.1 check for the updated logging contract, file-size check, and `git diff --cached --check` — passed.
