### PR TITLE
fix(platform): remove floating pinned agent drag handles

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -208,42 +208,6 @@ interface PinnedGridAgent {
 type PinnedDropSide = "before" | "after";
 
 /**
- * The drag handle shown above a pinned tile while a reorder drag is in flight.
- * Hovering a tile leaves it untouched — the handle marks the reorderable slots
- * once dragging starts, so browsing pinned agents stays quiet. It is absolutely
- * positioned so it costs no layout: the tile keeps its size and the avatar
- * never moves.
- *
- * Every inset is a whole pixel. The tile is a `1fr` grid column, so the handle
- * is centred on a fractional x; a half-pixel padding would round up on one edge
- * and down on the other and visibly push the dots off-centre.
- */
-function PinnedAgentDragHandle() {
-  return (
-    <span
-      aria-hidden="true"
-      data-testid="pinned-agent-drag-handle"
-      className="pointer-events-none absolute -top-[8px] left-1/2 z-10 flex -translate-x-1/2 flex-col gap-[2px] rounded border border-border bg-popover p-[3px]"
-    >
-      {[0, 1].map((row) => {
-        return (
-          <span key={row} className="flex gap-[2px]">
-            {[0, 1, 2].map((dot) => {
-              return (
-                <span
-                  key={dot}
-                  className="h-[2px] w-[2px] rounded-full bg-[hsl(var(--gray-500))]"
-                />
-              );
-            })}
-          </span>
-        );
-      })}
-    </span>
-  );
-}
-
-/**
  * A grid tile is only a fifth of the sidebar wide, so almost every agent name
  * is truncated down to a few characters. The tile carries a hover tooltip with
  * the full name — a native `title` is too slow and too easy to miss for a label
@@ -339,9 +303,6 @@ function PinnedAgentGridCard({
           : "text-sidebar-foreground hover:bg-state-hover"
       } ${isReorderable ? "cursor-grab active:cursor-grabbing" : ""}`}
     >
-      {isReorderable && isDragInFlight && !isDragging && (
-        <PinnedAgentDragHandle />
-      )}
       {dropSide && (
         <span
           aria-hidden="true"


### PR DESCRIPTION
Dragging a pinned agent currently adds floating six-dot grips above the other avatars, cluttering the sidebar. Remove those decorative grips and keep the existing grab/grabbing cursor as the drag affordance. Full-name tooltips, whole-tile dragging, insertion carets, and the fixed lead agent are preserved.

Verification: changed-file formatting, Oxlint, ESLint and style lint, repository style policy, App type checks, and App Knip passed. The existing page test `Reorder pinned agents while keeping Zero first` passed (1 selected test). Full tests run in the PR pipeline.

Browser QA passed in Chromium at 1440 x 1000 on deployment `b9d5b55c8dc964f1058501750c7a3586ef7d06f1`, which includes PR head `2d1d578eb44acec967f562f47e1162b84bcc4006`. Verified the grab/grabbing cursor, full-name tooltip, native drag/drop with an insertion caret and no floating grips, and the reordered list after reload. The lead agent remains first and non-draggable. Setup used a fresh Clerk test account, bypassed unrelated onboarding, and created two pinned fixture agents through the preview API. All PR checks passed.

Acceptance: pin at least two additional agents. Hover a pinned avatar to see its hand cursor and full-name tooltip; drag it over another avatar to see the insertion caret without floating grips. Drop and reload to confirm the new order, with the lead agent still first.
