### PR TITLE
feat: support fuzzy workflow command matching

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/workflow-composer-domain.ts
+++ b/turbo/apps/platform/src/signals/okou-page/workflow-composer-domain.ts
@@ -3,21 +3,71 @@ import type { WorkflowSummary } from "@okouai/api-contracts/contracts/workflows"
 export function findWorkflowQueryMatches(
   workflows: readonly ComposerSlashWorkflow[],
   query: string,
-): readonly ComposerSlashWorkflow[] {
+  fuzzy: boolean,
+): readonly ComposerSlashWorkflowMatch[] {
   const normalizedQuery = query.toLowerCase();
-  const prefixMatches: ComposerSlashWorkflow[] = [];
-  const substringMatches: ComposerSlashWorkflow[] = [];
+  const matches: {
+    workflow: ComposerSlashWorkflowMatch;
+    rank: number;
+  }[] = [];
 
   for (const workflow of workflows) {
     const normalizedName = workflow.name.toLowerCase();
-    if (normalizedName.startsWith(normalizedQuery)) {
-      prefixMatches.push(workflow);
-    } else if (normalizedName.includes(normalizedQuery)) {
-      substringMatches.push(workflow);
+    const start = normalizedName.indexOf(normalizedQuery);
+    if (start !== -1) {
+      matches.push({
+        workflow: {
+          ...workflow,
+          matchRanges: query ? [{ start, end: start + query.length }] : [],
+        },
+        rank:
+          fuzzy && normalizedName === normalizedQuery ? 0 : start === 0 ? 1 : 2,
+      });
+      continue;
+    }
+    if (fuzzy && normalizedQuery.length >= 3) {
+      const matchRanges = findWorkflowSubsequence(
+        normalizedName,
+        normalizedQuery,
+      );
+      if (matchRanges) {
+        matches.push({ workflow: { ...workflow, matchRanges }, rank: 3 });
+      }
     }
   }
 
-  return [...prefixMatches, ...substringMatches];
+  return matches
+    .sort((left, right) => {
+      return left.rank - right.rank;
+    })
+    .map((match) => {
+      return match.workflow;
+    });
+}
+
+function findWorkflowSubsequence(
+  name: string,
+  query: string,
+): readonly WorkflowMatchRange[] | null {
+  const ranges: WorkflowMatchRange[] = [];
+  let offset = 0;
+
+  // Keep numeric identifiers contiguous while allowing letters to skip ahead.
+  for (const [part] of query.matchAll(/\d+|\D/g)) {
+    const start = name.indexOf(part, offset);
+    if (start === -1) {
+      return null;
+    }
+    offset = start + part.length;
+    const previous = ranges.at(-1);
+    if (previous?.end === start) {
+      ranges[ranges.length - 1] = { start: previous.start, end: offset };
+    } else {
+      ranges.push({ start, end: offset });
+    }
+  }
+
+  return ranges;
 }
 
 export interface SlashWorkflowRange {
@@ -32,6 +82,15 @@ export interface ComposerSlashWorkflow {
   readonly displayName: string | null;
   readonly description: string | null;
   readonly token: string;
+}
+
+interface WorkflowMatchRange {
+  readonly start: number;
+  readonly end: number;
+}
+
+export interface ComposerSlashWorkflowMatch extends ComposerSlashWorkflow {
+  readonly matchRanges: readonly WorkflowMatchRange[];
 }
 
 export function findActiveSlashWorkflowRange(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-workflows.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-workflows.test.tsx
@@ -6,6 +6,7 @@ import {
   workflowsCollectionContract,
 } from "@okouai/api-contracts";
 import {
+  FeatureSwitchKey,
   PRESENTATION_TEMPLATE_PICKER_ITEMS,
   WORKFLOW_TEMPLATE_ITEMS,
 } from "@okouai/core";
@@ -13,6 +14,7 @@ import { expect, test } from "vitest";
 
 import {
   click,
+  fill,
   queryAllByRoleFast,
   setupPage,
 } from "../../../__tests__/page-helper.ts";
@@ -75,6 +77,15 @@ function slashMenu(): HTMLElement {
 
 function slashMenuButtons(): HTMLElement[] {
   return queryAllByRoleFast("button", slashMenu());
+}
+
+function slashWorkflowNames(): string[] {
+  return Array.from(
+    slashMenu().querySelectorAll('[data-slot="slash-workflow-name"]'),
+    (element) => {
+      return element.textContent ?? "";
+    },
+  );
 }
 
 function slashButton(name: string): HTMLElement {
@@ -465,7 +476,7 @@ test("Insert an attached workflow with slash suggestions", async () => {
       Node.DOCUMENT_POSITION_FOLLOWING,
   ).toBeTruthy();
   const emphasizedMatch = slashButton("/sales-research").querySelector(
-    String.raw`span.text-brand-text\/60`,
+    '[data-slot="workflow-query-match"]',
   );
   expect(emphasizedMatch).toHaveTextContent("research");
 
@@ -478,6 +489,147 @@ test("Insert an attached workflow with slash suggestions", async () => {
   });
   expect(window.visualViewport?.offsetTop).toBe(160);
 });
+
+test("Find and insert a workflow with an abbreviated name", async () => {
+  mockAgent();
+  mockThread();
+  installWorkflows(() => {
+    return [
+      workflow("pr-design-acceptance-url"),
+      workflow("pr-url-design-acceptance"),
+      workflow("pr-auto"),
+    ];
+  });
+
+  await setupPage({
+    context,
+    path: `/chats/${THREAD_ID}`,
+    featureSwitches: { [FeatureSwitchKey.ComposerWorkflowFuzzySearch]: true },
+  });
+
+  const user = userEvent.setup();
+  const editor = await findComposerEditor();
+  await user.click(editor);
+  await user.keyboard("Review /PdAu");
+
+  await waitFor(() => {
+    expect(slashWorkflowNames()).toStrictEqual(["/pr-design-acceptance-url"]);
+  });
+  const highlighted = Array.from(
+    slashButton("/pr-design-acceptance-url").querySelectorAll(
+      '[data-slot="workflow-query-match"]',
+    ),
+    (element) => {
+      return element.textContent;
+    },
+  );
+  expect(highlighted).toStrictEqual(["p", "d", "a", "u"]);
+
+  await user.keyboard("{Enter}");
+
+  await waitFor(() => {
+    expect(editor).toHaveTextContent("Review /pr-design-acceptance-url");
+    expect(workflowHighlights(editor)).toHaveLength(1);
+    expect(screen.queryByTestId("slash-workflow-menu")).toBeNull();
+  });
+});
+
+test("Rank exact workflow names before prefixes, substrings, and abbreviations", async () => {
+  mockAgent();
+  mockThread();
+  installWorkflows(() => {
+    return [
+      workflow("pr-audit-report"),
+      workflow("team-pr-auto"),
+      workflow("pr-auto-deploy"),
+      workflow("pr-auto"),
+    ];
+  });
+
+  await setupPage({
+    context,
+    path: `/chats/${THREAD_ID}`,
+    featureSwitches: { [FeatureSwitchKey.ComposerWorkflowFuzzySearch]: true },
+  });
+
+  const user = userEvent.setup();
+  const editor = await findComposerEditor();
+  await user.click(editor);
+  await user.keyboard("/pr-auto");
+
+  await waitFor(() => {
+    expect(slashWorkflowNames()).toStrictEqual([
+      "/pr-auto",
+      "/pr-auto-deploy",
+      "/team-pr-auto",
+      "/pr-audit-report",
+    ]);
+  });
+
+  await user.keyboard("{Enter}");
+
+  await waitFor(() => {
+    expect(workflowHighlights(editor)[0]).toHaveTextContent(/^\/pr-auto$/);
+    expect(screen.queryByTestId("slash-workflow-menu")).toBeNull();
+  });
+});
+
+test("Keep numeric workflow identifiers contiguous in abbreviated queries", async () => {
+  mockAgent();
+  mockThread();
+  installWorkflows(() => {
+    return [
+      workflow("pr-26-809-ship-watch"),
+      workflow("pr-26819-ship-watch"),
+      workflow("pr-26809-ship-watch"),
+    ];
+  });
+
+  await setupPage({
+    context,
+    path: `/chats/${THREAD_ID}`,
+    featureSwitches: { [FeatureSwitchKey.ComposerWorkflowFuzzySearch]: true },
+  });
+
+  const editor = await findComposerEditor();
+  await fill(editor, "/26809");
+  await waitFor(() => {
+    expect(slashWorkflowNames()).toStrictEqual(["/pr-26809-ship-watch"]);
+  });
+
+  await fill(editor, "/pr26809");
+  await waitFor(() => {
+    expect(slashWorkflowNames()).toStrictEqual(["/pr-26809-ship-watch"]);
+  });
+});
+
+test.each([
+  { enabled: false, query: "/pdau" },
+  { enabled: true, query: "/pd" },
+])(
+  "Keep strict workflow matching for $query when fuzzy search is $enabled",
+  async ({ enabled, query }) => {
+    mockAgent();
+    mockThread();
+    installWorkflows(() => {
+      return [workflow("pr-design-acceptance-url")];
+    });
+
+    await setupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerWorkflowFuzzySearch]: enabled,
+      },
+    });
+
+    const editor = await findComposerEditor();
+    await fill(editor, query);
+    await expect(
+      screen.findByText("No matching workflows"),
+    ).resolves.toBeVisible();
+  },
+);
 
 test("Suggest only the effective workflow when a private workflow shadows a public workflow", async () => {
   const privateWorkflow = workflow("pr-auto", {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-workflows.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-workflows.test.tsx
@@ -528,8 +528,7 @@ test("Find and insert a workflow with an abbreviated name", async () => {
   await user.keyboard("{Enter}");
 
   await waitFor(() => {
-    expect(editor).toHaveTextContent("Review /pr-design-acceptance-url");
-    expect(workflowHighlights(editor)).toHaveLength(1);
+    expect(editor).toHaveTextContent(/^Review \/pr-design-acceptance-url\s*$/);
     expect(screen.queryByTestId("slash-workflow-menu")).toBeNull();
   });
 });
@@ -569,7 +568,7 @@ test("Rank exact workflow names before prefixes, substrings, and abbreviations",
   await user.keyboard("{Enter}");
 
   await waitFor(() => {
-    expect(workflowHighlights(editor)[0]).toHaveTextContent(/^\/pr-auto$/);
+    expect(editor).toHaveTextContent(/^\/pr-auto\s*$/);
     expect(screen.queryByTestId("slash-workflow-menu")).toBeNull();
   });
 });

--- a/turbo/apps/platform/src/views/okou-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/okou-page/slash-workflow.tsx
@@ -14,7 +14,10 @@ import { cn, PopoverContent } from "@okouai/ui";
 import { useTranslation } from "react-i18next";
 import { ROUTES } from "../../signals/route-paths.ts";
 import { Link } from "../router/link.tsx";
-import type { ComposerSlashWorkflow } from "../../signals/okou-page/workflow-composer-domain.ts";
+import type {
+  ComposerSlashWorkflow,
+  ComposerSlashWorkflowMatch,
+} from "../../signals/okou-page/workflow-composer-domain.ts";
 
 import {
   composerCreateCommandLabel,
@@ -127,22 +130,51 @@ function SlashCreateGroup({
   );
 }
 
+function SlashWorkflowName({
+  workflow,
+}: {
+  readonly workflow: ComposerSlashWorkflowMatch;
+}) {
+  return (
+    <span
+      className="w-full truncate font-mono text-sm text-foreground"
+      data-slot="slash-workflow-name"
+    >
+      <span className="text-brand-text">/</span>
+      {workflow.matchRanges.flatMap((range, index) => {
+        return [
+          workflow.name.slice(
+            workflow.matchRanges[index - 1]?.end ?? 0,
+            range.start,
+          ),
+          <span
+            key={range.start}
+            className="text-brand-text/60"
+            data-slot="workflow-query-match"
+          >
+            {workflow.name.slice(range.start, range.end)}
+          </span>,
+        ];
+      })}
+      {workflow.name.slice(workflow.matchRanges.at(-1)?.end ?? 0)}
+    </span>
+  );
+}
+
 export function SlashWorkflowMenu({
   anchor,
   workflows,
   createModes,
   onSelectCreate,
-  query,
   loading,
   selectedIndex,
   showWorkflowsPageLink,
   onSelect,
 }: {
   readonly anchor?: ComponentProps<typeof PopoverContent>["anchor"];
-  readonly workflows: readonly ComposerSlashWorkflow[];
+  readonly workflows: readonly ComposerSlashWorkflowMatch[];
   readonly createModes: readonly ComposerCreateCommand[];
   readonly onSelectCreate: (mode: ComposerCreateCommand) => void;
-  readonly query: string;
   readonly loading: boolean;
   readonly selectedIndex: number;
   readonly showWorkflowsPageLink: boolean;
@@ -186,10 +218,6 @@ export function SlashWorkflowMenu({
           <div className="px-1.5 pb-1.5">
             {workflows.map((workflow, index) => {
               const selected = index + createModes.length === selectedIndex;
-              const matchStart = workflow.name
-                .toLowerCase()
-                .indexOf(query.toLowerCase());
-              const matchEnd = matchStart + query.length;
               return (
                 <button
                   id={slashWorkflowOptionId(workflow.id)}
@@ -204,16 +232,7 @@ export function SlashWorkflowMenu({
                     onSelect(workflow);
                   }}
                 >
-                  <span className="w-full truncate font-mono text-sm text-foreground">
-                    <span className="text-brand-text">/</span>
-                    {workflow.name.slice(0, matchStart)}
-                    {query && matchStart !== -1 && (
-                      <span className="text-brand-text/60">
-                        {workflow.name.slice(matchStart, matchEnd)}
-                      </span>
-                    )}
-                    {workflow.name.slice(query ? matchEnd : 0)}
-                  </span>
+                  <SlashWorkflowName workflow={workflow} />
                   {workflow.description && (
                     <span className="w-full truncate text-xs text-muted-foreground/70">
                       {workflow.description}

--- a/turbo/apps/platform/src/views/okou-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/tiptap-workflow-composer.tsx
@@ -9,7 +9,9 @@ import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { useEditorState } from "@tiptap/react";
 import { Popover, type KeyboardEventLike } from "@okouai/ui";
 import { useTranslation } from "react-i18next";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { i18n } from "../../i18n/index.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import type { ComposerAgentSuggestion } from "../../signals/okou-page/composer-agent-suggestion-domain.ts";
 import type { ComposerChatThreadSuggestion } from "../../signals/okou-page/chat-thread-suggestion-domain.ts";
 import type { ComposerSignals } from "../../signals/okou-page/composer-signals.ts";
@@ -18,6 +20,7 @@ import {
   buildComposerSlashWorkflows,
   findWorkflowQueryMatches,
   type ComposerSlashWorkflow,
+  type ComposerSlashWorkflowMatch,
 } from "../../signals/okou-page/workflow-composer-domain";
 import {
   scrollSlashWorkflowIntoView,
@@ -283,10 +286,9 @@ interface ComposerSuggestionMenuState {
   readonly range: ComposerSuggestionRange | null;
   readonly selectedIndex: number;
   readonly close: () => void;
-  readonly workflows: readonly ComposerSlashWorkflow[];
+  readonly workflows: readonly ComposerSlashWorkflowMatch[];
   readonly createModes: readonly ComposerCreateCommand[];
   readonly selectCreate: (mode: ComposerCreateCommand) => void;
-  readonly workflowQuery: string;
   readonly workflowsLoading: boolean;
   readonly showWorkflows: boolean;
   readonly agents: readonly ComposerAgentSuggestion[];
@@ -323,6 +325,28 @@ function useComposerCreateSuggestions(
   });
 }
 
+function useComposerWorkflowSuggestions(
+  composer: ComposerSignals,
+  query: string | undefined,
+) {
+  const workflowsLoadable = useLastLoadable(composer.workflow.workflows$);
+  const fuzzyWorkflows =
+    useGet(featureSwitch$)[FeatureSwitchKey.ComposerWorkflowFuzzySearch] ===
+    true;
+  const workflows = buildComposerSlashWorkflows({
+    agentId: composer.agentId,
+    workflows:
+      workflowsLoadable.state === "hasData" ? workflowsLoadable.data : [],
+  });
+  return {
+    workflows:
+      query === undefined
+        ? []
+        : findWorkflowQueryMatches(workflows, query, fuzzyWorkflows),
+    loading: workflowsLoadable.state === "loading",
+  };
+}
+
 function useComposerSuggestionMenu({
   composer,
   onKeyDown,
@@ -350,15 +374,11 @@ function useComposerSuggestionMenu({
   const insertAgent = useSet(composer.suggestion.insertAgent$);
   const insertChatThread = useSet(composer.suggestion.insertChatThread$);
   const currentAgentId = composer.agentId;
-  const workflowsLoadable = useLastLoadable(composer.workflow.workflows$);
-  const workflows = buildComposerSlashWorkflows({
-    agentId: currentAgentId,
-    workflows:
-      workflowsLoadable.state === "hasData" ? workflowsLoadable.data : [],
-  });
-  const workflowSuggestions = slashRange
-    ? findWorkflowQueryMatches(workflows, slashRange.query)
-    : [];
+  const workflowResult = useComposerWorkflowSuggestions(
+    composer,
+    slashRange?.query,
+  );
+  const workflowSuggestions = workflowResult.workflows;
   const showWorkflows = slashRange !== null;
   const mentionResult =
     chatThreadRange &&
@@ -443,8 +463,7 @@ function useComposerSuggestionMenu({
     workflows: workflowSuggestions,
     createModes,
     selectCreate,
-    workflowQuery: slashRange?.query ?? "",
-    workflowsLoading: workflowsLoadable.state === "loading",
+    workflowsLoading: workflowResult.loading,
     showWorkflows,
     agents,
     chatThreads,
@@ -562,7 +581,6 @@ export function TiptapWorkflowComposer({
           workflows={suggestionMenu.workflows}
           createModes={suggestionMenu.createModes}
           onSelectCreate={suggestionMenu.selectCreate}
-          query={suggestionMenu.workflowQuery}
           loading={suggestionMenu.workflowsLoading}
           selectedIndex={suggestionMenu.selectedIndex}
           showWorkflowsPageLink

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -70,6 +70,7 @@ export enum FeatureSwitchKey {
   VoiceInputV2 = "voiceInputV2",
   ComposerCreateCommands = "composerCreateCommands",
   ComposerTaskChips = "composerTaskChips",
+  ComposerWorkflowFuzzySearch = "composerWorkflowFuzzySearch",
   ComposerImageAnnotation = "composerImageAnnotation",
   GradientColorThemes = "gradientColorThemes",
   AvatarNeckSweater = "avatarNeckSweater",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -63,6 +63,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ComposerWorkflowFuzzySearch]: {
+    maintainer: "bingjie@okou.ai",
+    description: "Fuzzy workflow name matching in the chat composer",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.Dummy]: {
     maintainer: "ethan@okou.ai",
     description: "Test-only feature switch for flag system validation",


### PR DESCRIPTION
Typing `/pdau` currently returns no workflow suggestions even when `pr-design-acceptance-url` is available. Add a small, dependency-free matcher that accepts characters in order with gaps, highlights the actual matched ranges, and inserts the workflow's canonical command when selected.

Results rank by exact name, prefix, substring, then abbreviation. Queries shorter than three characters retain literal matching, and numeric runs must remain contiguous so PR identifiers cannot match across unrelated digits. The `composerWorkflowFuzzySearch` switch enables the new behavior for staff; existing prefix and substring behavior remains available when it is off.

## Verification

- All 16 workflow composer page tests pass, including abbreviation highlighting and insertion, ranking, numeric identifiers, short queries, and the disabled switch.
- Formatting, affected-file Oxlint/ESLint, Platform and Core type checks, scoped Knip, and style policy.
- Browser verification on the App/API previews for `57bec4398517f1c7df2068ec6b30f8525fc1cd04`: mixed-case abbreviation highlighting, full command insertion with preceding text preserved, exact/prefix/substring/abbreviation ordering, contiguous numeric matching, and the short-query limit all pass. Chromium 152, 1280 × 900, disposable test account with seven private workflow fixtures; onboarding bypassed and the Lab switch enabled.
- All applicable PR CI checks pass, including App/API tests, deployment, and the Turbo/security gates.

## Acceptance

1. Enable `composerWorkflowFuzzySearch` in Lab and open a chat with the relevant workflows available.
2. Type `/pdau` to find `pr-design-acceptance-url`; confirm the complete name is displayed with the matching letters highlighted and Enter inserts the full command.
3. Type `/pr-auto`; confirm the exact workflow precedes longer prefixes, substring matches, and abbreviations.
4. Type `/pr26809`; confirm `pr-26809-ship-watch` can match while `pr-26-809-ship-watch` cannot.
