### PR TITLE
fix(platform): preserve pinned agent drag feedback

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -25,7 +25,10 @@ import {
   agentsByIdContract,
   type AgentResponse,
 } from "@okouai/api-contracts/contracts/agents";
-import { avatarComposerUrl } from "@okouai/core/agent-avatar";
+import {
+  avatarComposerUrl,
+  DEFAULT_AGENT_AVATAR_URL,
+} from "@okouai/core/agent-avatar";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { artifactCatalogContract } from "@okouai/api-contracts/contracts/artifact-catalog";
 import { userPreferencesContract } from "@okouai/api-contracts/contracts/user-preferences";
@@ -95,7 +98,10 @@ interface SidebarThread {
   readonly sortAt?: string;
 }
 
-function prepareDefaultAgent(targetContext = context): void {
+function prepareDefaultAgent(
+  targetContext = context,
+  avatarUrl: string | null = null,
+): void {
   targetContext.mocks.data.agents([
     {
       agentId: AGENT_ID,
@@ -103,7 +109,7 @@ function prepareDefaultAgent(targetContext = context): void {
       displayName: "Zero",
       description: null,
       sound: null,
-      avatarUrl: null,
+      avatarUrl,
       visibility: "public",
     },
   ]);
@@ -2452,7 +2458,23 @@ test("Reorder pinned agents while keeping Zero first", async () => {
   expect(pinnedAgentLink(grid, "Zero")).toBeInTheDocument();
 });
 
-test("Keep pinned agent drag feedback on the dragged agent", async () => {
+test("Keep the default Okou sweater outside a circular mask", async () => {
+  prepareDefaultAgent(context, DEFAULT_AGENT_AVATAR_URL);
+
+  await setupSidebarPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+  });
+
+  const grid = await screen.findByTestId("pinned-agents-grid");
+  const avatar = grid.querySelector(`img[src="${DEFAULT_AGENT_AVATAR_URL}"]`);
+  if (!(avatar instanceof HTMLImageElement)) {
+    throw new Error("Default Okou avatar not found");
+  }
+  expect(avatar).not.toHaveClass("rounded-full");
+});
+
+test("Use the complete layered avatar without a drag handle", async () => {
   const pinnedAgentIds = prepareOverflowingPinnedAgents(
     context,
     LAYERED_AVATAR_URL,
@@ -2473,7 +2495,6 @@ test("Keep pinned agent drag feedback on the dragged agent", async () => {
   });
 
   const dragged = pinnedAgentLink(grid, "Support Agent");
-  const target = pinnedAgentLink(grid, "Operations Agent");
   const avatar = dragged.querySelector('[data-slot="pinned-agent-avatar"]');
   if (!(avatar instanceof HTMLElement)) {
     throw new Error("Pinned-agent avatar not found");
@@ -2486,11 +2507,8 @@ test("Keep pinned agent drag feedback on the dragged agent", async () => {
   const dataTransfer = createDataTransferStub();
 
   expect(
-    within(dragged).getByTestId("pinned-agent-drag-handle"),
-  ).toBeInTheDocument();
-  expect(
-    within(target).getByTestId("pinned-agent-drag-handle"),
-  ).toBeInTheDocument();
+    within(grid).queryByTestId("pinned-agent-drag-handle"),
+  ).not.toBeInTheDocument();
 
   fireEvent.dragStart(topAvatarLayer, { dataTransfer });
 
@@ -2498,10 +2516,7 @@ test("Keep pinned agent drag feedback on the dragged agent", async () => {
   // boundary that proves the complete composite was selected as its image.
   expect(dataTransfer.dragImage).toBe(avatar);
   expect(
-    within(dragged).getByTestId("pinned-agent-drag-handle"),
-  ).toBeInTheDocument();
-  expect(
-    within(target).queryByTestId("pinned-agent-drag-handle"),
+    within(grid).queryByTestId("pinned-agent-drag-handle"),
   ).not.toBeInTheDocument();
 });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -25,6 +25,7 @@ import {
   agentsByIdContract,
   type AgentResponse,
 } from "@okouai/api-contracts/contracts/agents";
+import { avatarComposerUrl } from "@okouai/core/agent-avatar";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { artifactCatalogContract } from "@okouai/api-contracts/contracts/artifact-catalog";
 import { userPreferencesContract } from "@okouai/api-contracts/contracts/user-preferences";
@@ -73,6 +74,14 @@ const INCIDENT_THREAD_ID = "b0000000-0000-4000-a000-000000000002";
 const AUTOMATION_THREAD_ID = "b0000000-0000-4000-a000-000000000003";
 const ARCHIVED_THREAD_ID = "b0000000-0000-4000-a000-000000000004";
 const RESEARCH_THREAD_ID = "b0000000-0000-4000-a000-000000000005";
+const LAYERED_AVATAR_URL = avatarComposerUrl({
+  face: "round",
+  hair: "curly-cap",
+  expression: "calm",
+  skin: "light",
+  hairColor: "blue",
+  sweater: "lime",
+});
 
 interface SidebarThread {
   readonly id: string;
@@ -181,14 +190,22 @@ const OVERFLOW_PINNED_AGENTS = [
  * Pins five agents so the grid holds six cards plus Pin, which overflows the
  * five-column row and puts cards on both sides of the Pin button.
  */
-function prepareOverflowingPinnedAgents(targetContext = context): string[] {
+function prepareOverflowingPinnedAgents(
+  targetContext = context,
+  supportAvatarUrl: string | null = null,
+): string[] {
   const agents = prepareAgents(targetContext);
+  const agentsWithAvatar = agents.map((agent) => {
+    return agent.agentId === SUPPORT_AGENT_ID
+      ? { ...agent, avatarUrl: supportAvatarUrl }
+      : agent;
+  });
   const templateAgent = agents[1];
   if (!templateAgent) {
     throw new Error("Pinned-agent template is unavailable");
   }
   targetContext.mocks.data.agents([
-    ...agents,
+    ...agentsWithAvatar,
     ...OVERFLOW_PINNED_AGENTS.map((agent) => {
       return {
         ...templateAgent,
@@ -426,11 +443,19 @@ function commandItemByText(container: HTMLElement, text: string): HTMLElement {
  * jsdom does not implement DataTransfer, so drag events need a stub that keeps
  * the payload the pinned grid writes on drag start.
  */
+interface DataTransferStub extends DataTransfer {
+  readonly dragImage: Element | null;
+}
+
 function createDataTransferStub(
   initialValues: Readonly<Record<string, string>> = {},
-): DataTransfer {
+): DataTransferStub {
   let values = new Map<string, string>(Object.entries(initialValues));
+  let dragImage: Element | null = null;
   return {
+    get dragImage() {
+      return dragImage;
+    },
     effectAllowed: "none",
     dropEffect: "none",
     clearData: (format?: string) => {
@@ -446,7 +471,10 @@ function createDataTransferStub(
     getData: (format: string) => {
       return values.get(format) ?? "";
     },
-  } as unknown as DataTransfer;
+    setDragImage: (image: Element) => {
+      dragImage = image;
+    },
+  } as unknown as DataTransferStub;
 }
 
 const SIDEBAR_TITLE_BOX_WIDTH = 160;
@@ -2422,6 +2450,59 @@ test("Reorder pinned agents while keeping Zero first", async () => {
   });
   expect(pinnedAgentNames(grid)).toStrictEqual(orderAfterReorder);
   expect(pinnedAgentLink(grid, "Zero")).toBeInTheDocument();
+});
+
+test("Keep pinned agent drag feedback on the dragged agent", async () => {
+  const pinnedAgentIds = prepareOverflowingPinnedAgents(
+    context,
+    LAYERED_AVATAR_URL,
+  );
+  context.mocks.data.userPreferences({ pinnedAgentIds });
+
+  await setupSidebarPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+    featureSwitches: {
+      [FeatureSwitchKey.AvatarNeckSweater]: true,
+    },
+  });
+
+  const grid = await screen.findByTestId("pinned-agents-grid");
+  await waitFor(() => {
+    expect(within(grid).getAllByTestId("pinned-agent-card")).toHaveLength(6);
+  });
+
+  const dragged = pinnedAgentLink(grid, "Support Agent");
+  const target = pinnedAgentLink(grid, "Operations Agent");
+  const avatar = dragged.querySelector('[data-slot="pinned-agent-avatar"]');
+  if (!(avatar instanceof HTMLElement)) {
+    throw new Error("Pinned-agent avatar not found");
+  }
+  const avatarLayers = avatar.querySelectorAll("img");
+  const topAvatarLayer = avatarLayers.item(avatarLayers.length - 1);
+  if (!(topAvatarLayer instanceof HTMLImageElement)) {
+    throw new Error("Layered pinned-agent avatar not found");
+  }
+  const dataTransfer = createDataTransferStub();
+
+  expect(
+    within(dragged).getByTestId("pinned-agent-drag-handle"),
+  ).toBeInTheDocument();
+  expect(
+    within(target).getByTestId("pinned-agent-drag-handle"),
+  ).toBeInTheDocument();
+
+  fireEvent.dragStart(topAvatarLayer, { dataTransfer });
+
+  // jsdom cannot paint native drag feedback, so DataTransfer is the browser
+  // boundary that proves the complete composite was selected as its image.
+  expect(dataTransfer.dragImage).toBe(avatar);
+  expect(
+    within(dragged).getByTestId("pinned-agent-drag-handle"),
+  ).toBeInTheDocument();
+  expect(
+    within(target).queryByTestId("pinned-agent-drag-handle"),
+  ).not.toBeInTheDocument();
 });
 
 test("Search, pin, and open an agent from the pin manager", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -5,6 +5,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import { compile } from "tailwindcss";
 import { expect, test, vi } from "vitest";
 
 import {
@@ -449,15 +450,21 @@ function commandItemByText(container: HTMLElement, text: string): HTMLElement {
  * jsdom does not implement DataTransfer, so drag events need a stub that keeps
  * the payload the pinned grid writes on drag start.
  */
+interface DragImageSnapshot {
+  readonly width: string;
+  readonly height: string;
+  readonly renderedImageLayerCount: number;
+}
+
 interface DataTransferStub extends DataTransfer {
-  readonly dragImage: Element | null;
+  readonly dragImage: DragImageSnapshot | null;
 }
 
 function createDataTransferStub(
   initialValues: Readonly<Record<string, string>> = {},
 ): DataTransferStub {
   let values = new Map<string, string>(Object.entries(initialValues));
-  let dragImage: Element | null = null;
+  let dragImage: DragImageSnapshot | null = null;
   return {
     get dragImage() {
       return dragImage;
@@ -478,9 +485,63 @@ function createDataTransferStub(
       return values.get(format) ?? "";
     },
     setDragImage: (image: Element) => {
-      dragImage = image;
+      if (!(image instanceof HTMLElement)) {
+        throw new Error("Drag image must be an HTML element");
+      }
+      const style = getComputedStyle(image);
+      const renderedImageLayerCount = Array.from(
+        image.querySelectorAll("img"),
+      ).filter((layer) => {
+        const layerStyle = getComputedStyle(layer);
+        return (
+          layerStyle.display !== "none" &&
+          layerStyle.visibility !== "hidden" &&
+          layerStyle.opacity !== "0"
+        );
+      }).length;
+      dragImage = {
+        width: style.width,
+        height: style.height,
+        renderedImageLayerCount,
+      };
     },
   } as unknown as DataTransferStub;
+}
+
+async function renderTailwindUtilities(
+  signal: AbortSignal,
+  ...elements: readonly HTMLElement[]
+): Promise<void> {
+  const compiler = await compile(`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `);
+  const classNames = new Set<string>();
+  for (const element of elements) {
+    for (const candidate of [
+      element,
+      ...element.querySelectorAll<HTMLElement>("[class]"),
+    ]) {
+      for (const className of candidate.classList) {
+        classNames.add(className);
+      }
+    }
+  }
+  const styleElement = document.createElement("style");
+  styleElement.textContent = compiler
+    .build([...classNames])
+    .replaceAll("calc(var(--spacing) * 9)", "36px")
+    .replaceAll("calc(infinity * 1px)", "9999px");
+  document.head.append(styleElement);
+  signal.addEventListener(
+    "abort",
+    () => {
+      styleElement.remove();
+    },
+    { once: true },
+  );
 }
 
 const SIDEBAR_TITLE_BOX_WIDTH = 160;
@@ -2471,10 +2532,11 @@ test("Keep the default Okou sweater outside a circular mask", async () => {
   if (!(avatar instanceof HTMLImageElement)) {
     throw new Error("Default Okou avatar not found");
   }
-  expect(avatar).not.toHaveClass("rounded-full");
+  await renderTailwindUtilities(context.signal, avatar);
+  expect(getComputedStyle(avatar).borderRadius).toBe("");
 });
 
-test("Use the complete layered avatar without a drag handle", async () => {
+test("Render the complete layered drag image with grab feedback", async () => {
   const pinnedAgentIds = prepareOverflowingPinnedAgents(
     context,
     LAYERED_AVATAR_URL,
@@ -2504,20 +2566,19 @@ test("Use the complete layered avatar without a drag handle", async () => {
   if (!(topAvatarLayer instanceof HTMLImageElement)) {
     throw new Error("Layered pinned-agent avatar not found");
   }
+  await renderTailwindUtilities(context.signal, dragged, avatar);
   const dataTransfer = createDataTransferStub();
 
-  expect(
-    within(grid).queryByTestId("pinned-agent-drag-handle"),
-  ).not.toBeInTheDocument();
+  expect(getComputedStyle(dragged).cursor).toBe("grab");
 
   fireEvent.dragStart(topAvatarLayer, { dataTransfer });
 
-  // jsdom cannot paint native drag feedback, so DataTransfer is the browser
-  // boundary that proves the complete composite was selected as its image.
-  expect(dataTransfer.dragImage).toBe(avatar);
-  expect(
-    within(grid).queryByTestId("pinned-agent-drag-handle"),
-  ).not.toBeInTheDocument();
+  expect(dataTransfer.dragImage).toStrictEqual({
+    width: "36px",
+    height: "36px",
+    renderedImageLayerCount: avatarLayers.length,
+  });
+  expect(dataTransfer.dragImage?.renderedImageLayerCount).toBeGreaterThan(1);
 });
 
 test("Search, pin, and open an agent from the pin manager", async () => {

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -208,22 +208,25 @@ interface PinnedGridAgent {
 type PinnedDropSide = "before" | "after";
 
 /**
- * The drag handle shown above a pinned tile while a reorder drag is in flight.
- * Hovering a tile leaves it untouched — the handle marks the reorderable slots
- * once dragging starts, so browsing pinned agents stays quiet. It is absolutely
- * positioned so it costs no layout: the tile keeps its size and the avatar
- * never moves.
+ * The drag handle shown above a reorderable pinned tile on hover or focus. It
+ * stays visible on the source tile while dragging, without appearing on the
+ * other drop targets. It is absolutely positioned so it costs no layout: the
+ * tile keeps its size and the avatar never moves.
  *
  * Every inset is a whole pixel. The tile is a `1fr` grid column, so the handle
  * is centred on a fractional x; a half-pixel padding would round up on one edge
  * and down on the other and visibly push the dots off-centre.
  */
-function PinnedAgentDragHandle() {
+function PinnedAgentDragHandle({ isActive }: { readonly isActive: boolean }) {
   return (
     <span
       aria-hidden="true"
       data-testid="pinned-agent-drag-handle"
-      className="pointer-events-none absolute -top-[8px] left-1/2 z-10 flex -translate-x-1/2 flex-col gap-[2px] rounded border border-border bg-popover p-[3px]"
+      className={`pointer-events-none absolute -top-[8px] left-1/2 z-10 flex -translate-x-1/2 flex-col gap-[2px] rounded border border-border bg-popover p-[3px] transition-opacity ${
+        isActive
+          ? "opacity-100"
+          : "opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100"
+      }`}
     >
       {[0, 1].map((row) => {
         return (
@@ -295,6 +298,16 @@ function PinnedAgentGridCard({
           "application/x-okou-pinned-agent",
           agent.agentId,
         );
+        const dragImage = e.currentTarget.querySelector<HTMLElement>(
+          '[data-slot="pinned-agent-avatar"]',
+        );
+        if (dragImage) {
+          e.dataTransfer.setDragImage(
+            dragImage,
+            dragImage.offsetWidth / 2,
+            dragImage.offsetHeight / 2,
+          );
+        }
         startDrag(agent.agentId);
       }}
       onDragEnd={() => {
@@ -339,8 +352,8 @@ function PinnedAgentGridCard({
           : "text-sidebar-foreground hover:bg-state-hover"
       } ${isReorderable ? "cursor-grab active:cursor-grabbing" : ""}`}
     >
-      {isReorderable && isDragInFlight && !isDragging && (
-        <PinnedAgentDragHandle />
+      {isReorderable && (!isDragInFlight || isDragging) && (
+        <PinnedAgentDragHandle isActive={isDragging} />
       )}
       {dropSide && (
         <span
@@ -358,7 +371,8 @@ function PinnedAgentGridCard({
         />
       )}
       <span
-        className={`relative flex h-9 w-9 shrink-0 ${
+        data-slot="pinned-agent-avatar"
+        className={`pointer-events-none relative flex h-9 w-9 shrink-0 ${
           isDragging ? "opacity-0" : ""
         }`}
       >

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -309,7 +309,7 @@ function PinnedAgentGridCard({
         );
         endDrag();
       }}
-      className={`relative ${pinnedAgentGridCardFrameClassName} no-underline transition-colors duration-200 ${
+      className={`group relative ${pinnedAgentGridCardFrameClassName} no-underline transition-colors duration-200 ${
         isPrimarySelected
           ? "bg-state-selected text-sidebar-foreground"
           : "text-sidebar-foreground hover:bg-state-hover"

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -208,45 +208,6 @@ interface PinnedGridAgent {
 type PinnedDropSide = "before" | "after";
 
 /**
- * The drag handle shown above a reorderable pinned tile on hover or focus. It
- * stays visible on the source tile while dragging, without appearing on the
- * other drop targets. It is absolutely positioned so it costs no layout: the
- * tile keeps its size and the avatar never moves.
- *
- * Every inset is a whole pixel. The tile is a `1fr` grid column, so the handle
- * is centred on a fractional x; a half-pixel padding would round up on one edge
- * and down on the other and visibly push the dots off-centre.
- */
-function PinnedAgentDragHandle({ isActive }: { readonly isActive: boolean }) {
-  return (
-    <span
-      aria-hidden="true"
-      data-testid="pinned-agent-drag-handle"
-      className={`pointer-events-none absolute -top-[8px] left-1/2 z-10 flex -translate-x-1/2 flex-col gap-[2px] rounded border border-border bg-popover p-[3px] transition-opacity ${
-        isActive
-          ? "opacity-100"
-          : "opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100"
-      }`}
-    >
-      {[0, 1].map((row) => {
-        return (
-          <span key={row} className="flex gap-[2px]">
-            {[0, 1, 2].map((dot) => {
-              return (
-                <span
-                  key={dot}
-                  className="h-[2px] w-[2px] rounded-full bg-[hsl(var(--gray-500))]"
-                />
-              );
-            })}
-          </span>
-        );
-      })}
-    </span>
-  );
-}
-
-/**
  * A grid tile is only a fifth of the sidebar wide, so almost every agent name
  * is truncated down to a few characters. The tile carries a hover tooltip with
  * the full name — a native `title` is too slow and too easy to miss for a label
@@ -257,12 +218,14 @@ function PinnedAgentGridCard({
   agent,
   isPrimarySelected,
   hasUnread,
+  isDefaultAgent,
   isReorderable,
   dropSide,
 }: {
   readonly agent: PinnedGridAgent;
   readonly isPrimarySelected: boolean;
   readonly hasUnread: boolean;
+  readonly isDefaultAgent: boolean;
   readonly isReorderable: boolean;
   readonly dropSide: PinnedDropSide | null;
 }) {
@@ -346,15 +309,12 @@ function PinnedAgentGridCard({
         );
         endDrag();
       }}
-      className={`group relative ${pinnedAgentGridCardFrameClassName} no-underline transition-colors duration-200 ${
+      className={`relative ${pinnedAgentGridCardFrameClassName} no-underline transition-colors duration-200 ${
         isPrimarySelected
           ? "bg-state-selected text-sidebar-foreground"
           : "text-sidebar-foreground hover:bg-state-hover"
       } ${isReorderable ? "cursor-grab active:cursor-grabbing" : ""}`}
     >
-      {isReorderable && (!isDragInFlight || isDragging) && (
-        <PinnedAgentDragHandle isActive={isDragging} />
-      )}
       {dropSide && (
         <span
           aria-hidden="true"
@@ -379,7 +339,9 @@ function PinnedAgentGridCard({
         <AgentAvatarImg
           name={agent.agentId}
           alt=""
-          className="block h-full w-full rounded-full object-cover object-top"
+          className={`block h-full w-full object-cover object-top ${
+            isDefaultAgent ? "" : "rounded-full"
+          }`}
         />
         {hasUnread && (
           <span className="absolute -right-0.5 -top-0.5 flex">
@@ -528,6 +490,7 @@ export function PinnedAgentListSection({
                   agent={agent}
                   isPrimarySelected={isPrimarySelected}
                   hasUnread={hasUnread}
+                  isDefaultAgent={isDefaultAgent}
                   isReorderable={isPinned && !isDefaultAgent}
                   dropSide={resolveDropSide({
                     agents: horizontalPinnedAgents,


### PR DESCRIPTION
## Summary

- use the complete composite avatar as the pinned-agent drag image instead of the topmost SVG layer
- keep the existing hand/grab cursor and hover tooltip while removing the obsolete six-dot drag handle entirely
- leave the canonical Okou avatar outside the circular mask so its sweater stays visible
- cover the rendered layered drag preview, grab cursor, and Okou avatar framing regressions

Closes #32923

## Verification

- `pnpm exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx -t 'Reorder pinned agents|Keep the default Okou sweater|Render the complete layered drag image' --maxWorkers=1` (3 passed)
- `pnpm exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx -t 'Move to the next relevant agent with a shortcut' --maxWorkers=1` (1 passed)
- `pnpm --filter @okouai/app check-types`
- `pnpm exec oxlint --deny-warnings src/views/okou-page/sidebar-pinned.tsx src/views/okou-page/__tests__/sidebar.test.tsx`
- `pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings src/views/okou-page/sidebar-pinned.tsx src/views/okou-page/__tests__/sidebar.test.tsx`
- `pnpm exec eslint src/views/okou-page/sidebar-pinned.tsx src/views/okou-page/__tests__/sidebar.test.tsx --max-warnings 0 --cache --cache-strategy content --cache-location .eslintcache`
- `pnpm lint:style`
- `pnpm exec prettier --check src/views/okou-page/sidebar-pinned.tsx src/views/okou-page/__tests__/sidebar.test.tsx`

## Browser verification

- verified the unchanged production behavior on the PR App/API Preview at `a74703e41487cfb2a1b3ad176f23caddd1878e16`; the later `757bd5849e380c2c29aa3fc2da40955ef157375e` commit only strengthens test assertions
- canonical Okou avatar renders with `border-radius: 0px`; its sweater is no longer circularly clipped
- hovering a reorderable pinned agent keeps the tooltip and `grab` cursor with zero drag-handle elements
- native drag/drop selects the complete 36px, six-layer avatar as the drag image and reorders successfully with zero drag-handle elements throughout
