### PR TITLE
refactor(naming): correct residual retired-brand copy and internal names

### DIFF
--- a/crates/guest-agent/tests/cli_stderr_logging.rs
+++ b/crates/guest-agent/tests/cli_stderr_logging.rs
@@ -18,10 +18,10 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     let tmp = tempfile::tempdir()?;
     let secret = "super-secret-value";
     let multiline_secret = concat!(
-        "-----BEGIN VM0 TEST KEY-----\n",
+        "-----BEGIN TEST KEY-----\n",
         "alpha-multiline-secret-fragment\n",
         "beta-multiline-secret-fragment\n",
-        "-----END VM0 TEST KEY-----\n",
+        "-----END TEST KEY-----\n",
     );
     let short_unicode_multiline_secret = "密ab\n钥cd\n";
     let tail_only_secret = [
@@ -68,10 +68,10 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     stderr_payload.push_str(&format!("\n{overlong_secret_line}"));
     stderr_payload.push_str("\nafter-overlong-line");
     stderr_payload.push_str("\ncrlf multiline secret begins");
-    stderr_payload.push_str("\n-----BEGIN VM0 TEST KEY-----\r");
+    stderr_payload.push_str("\n-----BEGIN TEST KEY-----\r");
     stderr_payload.push_str("\nalpha-multiline-secret-fragment\r");
     stderr_payload.push_str("\nbeta-multiline-secret-fragment\r");
-    stderr_payload.push_str("\n-----END VM0 TEST KEY-----");
+    stderr_payload.push_str("\n-----END TEST KEY-----");
     stderr_payload.push_str("\nafter-multiline-secret");
     stderr_payload.push_str("\nshort unicode multiline fragments begin");
     stderr_payload.push_str("\n密ab");

--- a/crates/runner/mitm-addon/tests/test_request_handler_api_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_api_admission.py
@@ -19,7 +19,7 @@ from tests.upstream_connection_helpers import (
 )
 
 
-async def test_matching_sni_and_host_blocks_connected_vm0_api_edge_when_unbound(
+async def test_matching_sni_and_host_blocks_connected_platform_api_edge_when_unbound(
     registry_file, real_flow, mitm_ctx, headers
 ):
     flow = real_flow(
@@ -42,7 +42,7 @@ async def test_matching_sni_and_host_blocks_connected_vm0_api_edge_when_unbound(
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
 
 
-async def test_matching_sni_and_host_allows_authenticated_connected_vm0_api_edge(
+async def test_matching_sni_and_host_allows_authenticated_connected_platform_api_edge(
     registry_file, real_flow, mitm_ctx, headers
 ):
     flow = real_flow(
@@ -74,7 +74,7 @@ async def test_matching_sni_and_host_allows_authenticated_connected_vm0_api_edge
     assert binding.original_address == ("203.0.113.10", 443)
 
 
-async def test_matching_sni_and_host_retargets_unconnected_vm0_api_auto_allow(
+async def test_matching_sni_and_host_retargets_unconnected_platform_api_auto_allow(
     registry_file, real_flow, mitm_ctx, headers
 ):
     flow = real_flow(
@@ -97,7 +97,7 @@ async def test_matching_sni_and_host_retargets_unconnected_vm0_api_auto_allow(
     assert binding.original_address == ("203.0.113.10", 443)
 
 
-async def test_vm0_api_auto_allow_injects_runner_preview_bypass(
+async def test_platform_api_auto_allow_injects_runner_preview_bypass(
     registry_file, real_flow, mitm_ctx, monkeypatch
 ):
     flow = real_flow(
@@ -129,7 +129,7 @@ async def test_vm0_api_auto_allow_injects_runner_preview_bypass(
         pytest.param("/api/ordinary/%zz/test/example", id="malformed-escape"),
     ],
 )
-async def test_vm0_api_unsafe_paths_fail_closed_before_binding_or_bypass(
+async def test_platform_api_unsafe_paths_fail_closed_before_binding_or_bypass(
     registry_file, real_flow, mitm_ctx, monkeypatch, path
 ):
     flow = real_flow(
@@ -157,7 +157,7 @@ async def test_vm0_api_unsafe_paths_fail_closed_before_binding_or_bypass(
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
 
-async def test_vm0_api_unsafe_browser_path_does_not_fall_through_to_browser_allow(
+async def test_platform_api_unsafe_browser_path_does_not_fall_through_to_browser_allow(
     registry_file, real_flow, mitm_ctx, headers, monkeypatch
 ):
     flow = real_flow(
@@ -185,7 +185,7 @@ async def test_vm0_api_unsafe_browser_path_does_not_fall_through_to_browser_allo
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
 
-async def test_vm0_api_safe_repeated_separator_path_remains_auto_allowed(
+async def test_platform_api_safe_repeated_separator_path_remains_auto_allowed(
     registry_file, real_flow, mitm_ctx, monkeypatch
 ):
     flow = real_flow(
@@ -223,7 +223,7 @@ async def test_non_api_request_does_not_receive_runner_preview_bypass(
     assert "x-vercel-protection-bypass" not in flow.request.headers
 
 
-async def test_matching_sni_and_host_allows_bound_vm0_api_auto_allow(
+async def test_matching_sni_and_host_allows_bound_platform_api_auto_allow(
     registry_file, real_flow, mitm_ctx, headers
 ):
     flow = real_flow(
@@ -327,7 +327,7 @@ async def test_matching_sni_and_host_allows_bound_vm0_api_auto_allow(
         ),
     ],
 )
-async def test_vm0_api_auto_allow_respects_authority_boundary(
+async def test_platform_api_auto_allow_respects_authority_boundary(
     registry_file,
     real_flow,
     mitm_ctx,
@@ -364,7 +364,7 @@ async def test_vm0_api_auto_allow_respects_authority_boundary(
         assert "x-vercel-protection-bypass" not in flow.request.headers
 
 
-async def test_malformed_vm0_api_url_is_cached_as_non_match(
+async def test_malformed_platform_api_url_is_cached_as_non_match(
     registry_file,
     real_flow,
     mitm_ctx,
@@ -411,7 +411,7 @@ async def test_malformed_vm0_api_url_is_cached_as_non_match(
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
 
-async def test_vm0_api_wrong_port_uses_matching_firewall_deny_policy(
+async def test_platform_api_wrong_port_uses_matching_firewall_deny_policy(
     tmp_path,
     real_flow,
     mitm_ctx,
@@ -455,7 +455,7 @@ async def test_vm0_api_wrong_port_uses_matching_firewall_deny_policy(
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
 
-async def test_vm0_api_wrong_scheme_uses_matching_firewall_deny_policy(
+async def test_platform_api_wrong_scheme_uses_matching_firewall_deny_policy(
     tmp_path,
     real_flow,
     mitm_ctx,
@@ -500,7 +500,7 @@ async def test_vm0_api_wrong_scheme_uses_matching_firewall_deny_policy(
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
 
-async def test_vm0_api_wrong_port_uses_normal_connector_auth(
+async def test_platform_api_wrong_port_uses_normal_connector_auth(
     tmp_path,
     real_flow,
     mitm_ctx,
@@ -558,7 +558,9 @@ async def test_vm0_api_wrong_port_uses_normal_connector_auth(
     assert flow.request.headers["Authorization"] == "Bearer resolved-api-token"
 
 
-async def test_registry_unavailable_blocks_vm0_api_auto_allow(registry_file, real_flow, mitm_ctx):
+async def test_registry_unavailable_blocks_platform_api_auto_allow(
+    registry_file, real_flow, mitm_ctx
+):
     registry.load_registry(str(registry_file))
     registry_file.write_text("{ broken registry")
     flow = real_flow(with_response=False, host="api.okou.ai")
@@ -608,7 +610,7 @@ async def test_unknown_cached_classification_does_not_bypass_registry_gate(
         ),
     ],
 )
-async def test_vm0_api_test_paths_skip_auto_allow(
+async def test_platform_api_test_paths_skip_auto_allow(
     tmp_path,
     real_flow,
     mitm_ctx,
@@ -675,7 +677,7 @@ async def test_vm0_api_test_paths_skip_auto_allow(
     assert binding.kinds == frozenset(("connector_auth",))
 
 
-async def test_vm0_api_non_test_paths_auto_allow_before_firewall_auth(
+async def test_platform_api_non_test_paths_auto_allow_before_firewall_auth(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers
 ):
     reg_path = _write_registry(

--- a/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
@@ -135,7 +135,7 @@ function providerBrowser(
         ? "https://live.browser-use.com/?wss=provider-live-token"
         : null,
     cdpUrl: status === "active" ? `https://${id}.cdp.browser-use.com/` : null,
-    // Zero buys the provider's longest lifetime and reclaims idle browsers
+    // The API buys the provider's longest lifetime and reclaims idle browsers
     // itself, so the provider deadline stays far away in these tests.
     timeoutAt: isoAt(240 * MINUTE_MS),
     startedAt: isoAt(0),

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -770,7 +770,7 @@ describe("RUN-03: cancel through the run cancel route", () => {
     expectApiError(crossOrg.body);
     expect(crossOrg.body.error.code).toBe("NOT_FOUND");
 
-    // A queued agent run cancelled through the Zero route disappears from
+    // A queued agent run cancelled through the agent route disappears from
     // the visible queue.
     await api.ensureOrgModelProvider(actor);
     const agent = await bdd.createAgent(actor, {

--- a/turbo/apps/api/src/signals/routes/org-delete.ts
+++ b/turbo/apps/api/src/signals/routes/org-delete.ts
@@ -41,7 +41,7 @@ export const orgDeleteRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        // Deleting a workspace is a session-only action. Sandbox and zero
+        // Deleting a workspace is a session-only action. Sandbox and agent
         // tokens are already refused because this route declares no
         // requiredCapability, so this closes the remaining hole: a CLI PAT.
         accept: ["session"],

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -616,7 +616,7 @@ final class CommandResponseBox: @unchecked Sendable {
 
 final class ComputerUseCommandExecutor: @unchecked Sendable {
     private let queue = DispatchQueue(
-        label: "ai.vm0.computer-use-helper.command",
+        label: "ai.okou.computer-use-helper.command",
         qos: .userInitiated
     )
 

--- a/turbo/apps/desktop/src/renderer/setup-wizard/index.tsx
+++ b/turbo/apps/desktop/src/renderer/setup-wizard/index.tsx
@@ -384,8 +384,9 @@ export function PermissionsStepCard({
           <h2>Allow Computer Use permissions</h2>
           <p>
             {identity.brandName} needs macOS permission to inspect the screen
-            and control UI elements on this Mac. Okou is a separate app from
-            Zero, so these permissions must be granted again.
+            and control UI elements on this Mac. macOS grants these permissions
+            to each app separately, so approve {identity.brandName} in System
+            Settings.
           </p>
         </div>
         <div className="permission-list">


### PR DESCRIPTION
## Summary

Closes #32939. Corrects the seven authored occurrences of retired product vocabulary that the #32157 audit left in current source. None of them is a deployed identity, protocol field, persisted value, or compatibility reader, so every change here is a wording or internal-name fix with no external consumer.

## Changes

1. **Desktop permission copy** (`setup-wizard/index.tsx`) — the second sentence explained a cross-app migration to every user, including users who never installed the old app, and hardcoded the brand twice while the rest of the card renders `identity.brandName`. It now explains macOS per-app approval through `identity.brandName`, with no hardcoded brand literal. Card structure, heading, and permission rows are unchanged.
2. **Native helper dispatch queue label** (`main.swift:619`) — `ai.vm0.computer-use-helper.command` → `ai.okou.computer-use-helper.command`, matching its sibling recorder queues (`ai.okou.recorder.*`). This is process-local `DispatchQueue` debugging metadata: no plist, entitlement, mach service, or launchd label references it.
3. **Test comments** — `browser.test.ts` and `run-reads.bdd.test.ts` now describe the current surfaces. The second matches the adjacent `description: "Queued cancellation through the agent route."`. Comment text only.
4. **Rust PEM fixture label** (`cli_stderr_logging.rs`) — `VM0 TEST KEY` → `TEST KEY` on all four lines. The `-----BEGIN ... -----` / `-----END ... -----` delimiter framing, the `\r`/`\n` placement at lines 71 and 74, and every redaction assertion are byte-identical.
5. **Python test function names** (`test_request_handler_api_admission.py`) — the test identifiers containing `vm0_api` now name the platform API surface (`platform_api`). Bodies, fixtures, parametrization, and assertions are unchanged apart from the identifier; one signature is wrapped to stay under the 100-column ruff limit. **The `vm0_api_url` addon option is untouched** — it is a cross-process contract between the Rust Runner (`crates/runner/src/proxy/process.rs`, `--set vm0_api_url={url}`) and the Python addon, so `conftest.py` and every `vm0_api_url=` keyword argument are left alone.
6. **Workspace-delete auth comment** (`org-delete.ts`) — the `zero` token scope was retired under #32191, so the comment reasoned about a token kind that no longer exists. It now names what the route actually refuses today: sandbox and agent tokens are rejected at resolution because this route declares neither `requiredCapability` nor `acceptAnySandboxCapability`, leaving `accept: ["session"]` to close the CLI PAT hole. `accept: ["session"]` and all auth behavior are unchanged.

No assertion, auth decision, redaction rule, permission flow, or UI structure changes. No repository-wide substitution, and no residual-name scanner, baseline, or ratchet is added.

## Scope note

Two test identifiers containing `vm0_api` remain in a different module, `tests/test_request_handler_authority_validation.py` (lines 508 and 852). Issue #32939 item 5 enumerates only `test_request_handler_api_admission.py` and its exact line list, so they are deliberately left out of this focused PR rather than pulled in as unscoped drive-by renames.

The issue text says "fourteen test functions" but its line list and the module itself contain sixteen matching identifiers; all sixteen are renamed. The module's eighteen test functions and their bodies are otherwise unchanged.

## Verification

- `prettier --check` and package ESLint/oxlint on the changed TS/TSX files — pass
- `apps/api` and `apps/desktop` `check-types` — pass
- `cargo fmt --check` and `cargo clippy --tests` for `guest-agent` — pass
- `cargo test --test cli_stderr_logging` — 1 passed, confirming the redaction assertions still hold with the neutral label
- `uv run ruff check` / `ruff format --check` and `uv run pytest tests/test_request_handler_api_admission.py` — 35 passed
- The two API Vitest files need a local Postgres and are comment-only here; left to PR CI. The Swift target builds on the macOS CI runner.

## Overlap

`#32278` also touches `browser.test.ts`. Inventory only, not a dependency — normal merge precedence applies and whichever PR merges later resolves its own conflict.
