### PR TITLE
refactor(api): retire the legacy zero teams command prefix

### DIFF
--- a/turbo/apps/api/src/signals/services/teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/teams-dispatch.service.ts
@@ -254,7 +254,7 @@ function modelLabel(option: TeamsModelPickerOption): string {
 function parseTeamsBotCommand(prompt: string): TeamsBotCommand | null {
   const parts = prompt.trim().split(/\s+/u);
   const first = parts[0]?.toLowerCase().replace(/^\//u, "") ?? "";
-  const prefixed = first === "zero" || first === "okou";
+  const prefixed = first === "okou";
   const command = prefixed
     ? (parts[1]?.toLowerCase().replace(/^\//u, "") ?? "")
     : first;


### PR DESCRIPTION
## Summary

Retires the legacy `zero` Teams bot command prefix. `parseTeamsBotCommand` now accepts only the `okou` prefix and the bare command form.

Part A of #32941. Part of #32157. Part B (the emitted observability identifier rename) ships as a separate PR with a different blast radius and rollback story.

## What changed

`turbo/apps/api/src/signals/services/teams-dispatch.service.ts`, one line:

```diff
-  const prefixed = first === "zero" || first === "okou";
+  const prefixed = first === "okou";
```

Unchanged: the leading-`/` stripping, the `toLowerCase()` folding, the `parts.length === 1` bare-command path, the `isTeamsBotCommand` guard, and every other Teams dispatch behavior.

## Accepted behavior change

This is live input handling, not wording. `help`, `/help`, `okou help`, `okou switch`, and `okou model` all continue to work. A message beginning with `zero` is no longer parsed as a bot command and is dispatched to the agent as an ordinary prompt — a degraded but non-breaking outcome for a legacy input form that no current surface advertises.

## Pre-implementation evidence

Refreshed on 2026-09-09 against `origin/main` at `cd0012572ce91c992d330c1599961e4248207303` and recorded on #32941:

- `PUBLIC_BRANDS` is exactly `["vm0", "okou"]` (`packages/api-contracts/src/contracts/public-brand.ts`); `zero` is not a supported public brand.
- `teamsIdentity` (`teams-dispatch.service.ts:111-121`) hard-types `assistantName: "Okou"` and `brandName: "Okou"` from `PUBLIC_BRAND_PRESENTATION`, so no Teams tenant is presented as Zero today.
- No user-facing Teams string instructs the prefix. `commandHelpNotice` and `teamsWelcomeText` document bare commands only.
- `"zero"` at line 257 was its only occurrence in the file, and after this change the file contains no case-insensitive `zero` match at all.
- No test in `teams-bot.test.ts` or any sibling Teams test referenced the alias; the existing command tests use `help` and `/help`.
- **Visibility limit, accepted on the issue:** `teams_org_installations` is not exposed through the current MaskDB projection, so live per-tenant Teams bot naming is not directly observable. The brand and identity evidence above is what supports the disposition.

## Live overlap audit

Paginated the file list of all 41 open PRs. **No open PR touches `teams-dispatch.service.ts`**, so this PR has no overlap at all.

## Verification

- Prettier check on the changed file: passed.
- `pnpm -F api lint`: passed (oxlint, oxlint type-aware for `src` and `__tests__`, ESLint `--max-warnings 0`).
- `pnpm -F api check-types`: passed all six API TypeScript programs.
- `TZ=UTC pnpm -F api exec vitest run src/signals/routes/__tests__/teams-bot.test.ts --maxWorkers=1`: 24 passed, 6 failed — **byte-identical to the `origin/main` baseline run in the same sandbox** (same six test names, all failing in `claimRunnerJob` with `Job not found in queue`, an environment limitation of this sandbox rather than a code regression). Every command-parsing test passes. The full comparison was made by diffing the sorted failure sets of the baseline and patched runs.
- `git diff --check`: passed.

No full local Vitest suite and no local development server was run; the remaining coverage is left to PR CI.

## Boundaries honored

- No compatibility branch, deprecation warning, dual acceptance window, or negative test asserting the `zero` prefix is rejected.
- No change to Teams auth, attachment handling, agent/model switching, greetings, welcome text, help text, or any Teams dispatch behavior beyond the single removed prefix.
- No repository-wide `zero`/`vm0` substitution; no database table, historical migration, or changelog touched.
- No Axiom dataset, dashboard, monitor, service name, or other deployed observability identity changed.
- No production release, deployment, or post-deploy verification is part of this PR. This part only takes effect once deployed; the controller decides and coordinates any release after independent acceptance.

Closes part A of #32941.
