### PR TITLE
fix(pi): hand off failed api model turns to sandbox

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -9390,7 +9390,7 @@ describe("CHAT-02: model-first provider policies", () => {
       });
     }),
   )(
-    "surfaces custom $selectedModel Fast rejection $status without downgrade, replay, or billing",
+    "preserves custom $selectedModel Fast rejection $status without downgrade or an API retry",
     async ({ selectedModel, status }) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
       const gateway = await configureCustomPiModel(actor, selectedModel);
@@ -9439,6 +9439,30 @@ describe("CHAT-02: model-first provider policies", () => {
         prompt: "surface the custom Fast rejection",
         runOptions: { codexServiceTier: "fast" },
       });
+      if (status === 400) {
+        await flushWaitUntilForTest();
+        const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
+        const manifest = piApiFirstTurnManifestSchema.parse(
+          JSON.parse(objects.get(manifestKey)?.toString("utf8") ?? "{}"),
+        );
+        expect(manifest).toMatchObject({
+          outcome: "ownership-transfer",
+          mode: "sandbox-first",
+        });
+        expect(warningCallsForRun(run.runId)).toStrictEqual([]);
+        const claimed = await api.claimRunnerJob(run.runId, {
+          capabilities: { piModelConfigGenerations: [1, 2, 3] },
+        });
+        expect(claimed.piModelConfig).toMatchObject({
+          serviceTier: "priority",
+          model: gateway.upstreamModel,
+        });
+        await failChatRun(
+          run.runId,
+          { authorization: `Bearer ${claimed.sandboxToken}` },
+          "Sandbox rejected priority",
+        );
+      }
       await waitForRunStatus(actor, run.runId, "failed");
       await flushWaitUntilForTest();
       expect(requests).toStrictEqual([
@@ -9456,13 +9480,19 @@ describe("CHAT-02: model-first provider policies", () => {
       const failed = await api.readRun(actor, run.runId);
       expect(failed).toMatchObject({
         status: "failed",
-        error: expect.stringContaining("[PI_API_MODEL_FAILED]"),
+        error: expect.stringContaining(
+          status === 401
+            ? "[PI_API_MODEL_FAILED]"
+            : "Sandbox rejected priority",
+        ),
       });
       await api.heartbeatRunner(runnerGroup);
       const claim = await api.requestClaimRunnerJob(true, run.runId, [404]);
       expectApiError(claim.body);
       await expectNoBuiltInModelUsage(run.runId);
-      expectNoPiApiFirstTurnArtifacts(run.runId, objects);
+      if (status === 401) {
+        expectNoPiApiFirstTurnArtifacts(run.runId, objects);
+      }
       expect(
         JSON.stringify({
           failed,
@@ -10117,7 +10147,7 @@ describe("CHAT-02: model-first provider policies", () => {
         { [FeatureSwitchKey.PiLoop]: true },
       );
       mockPiResourceArchiveDownloads();
-      mockPiCheckpointObjectStore();
+      const checkpointObjects = mockPiCheckpointObjectStore();
 
       const providerEntered = createDeferredPromise<void>(context.signal);
       const releaseProvider = createDeferredPromise<void>(context.signal);
@@ -10187,6 +10217,15 @@ describe("CHAT-02: model-first provider policies", () => {
       await flushWaitUntilForTest();
 
       expect(modelCalls).toBe(1);
+      expectNoPiApiFirstTurnArtifacts(run.runId, checkpointObjects);
+      expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+        "Pi API first-turn outcome",
+        expect.objectContaining({
+          runId: run.runId,
+          outcome: "terminal_failure",
+          reason: "PI_API_MODEL_FAILED",
+        }),
+      );
       await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
         status: "failed",
         error: expect.stringContaining("[PI_API_MODEL_FAILED]"),
@@ -12338,159 +12377,204 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(warningCallsForRun(run.runId)).toStrictEqual([]);
   }, 90_000);
 
-  it("fails once when deadline handoff cannot settle by the coordination cap", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    mockPiResourceArchiveDownloads();
-    const providerEntered = createDeferredPromise<void>(context.signal);
-    const releaseProvider = createDeferredPromise<void>(context.signal);
-    let modelCalls = 0;
-    server.use(
-      http.post("https://api.openai.com/v1/responses", async () => {
-        modelCalls += 1;
-        providerEntered.resolve(undefined);
-        await releaseProvider.promise;
-        return nativeCodexSseResponse(
-          piResponsesTextSse("late result before handoff expiry", modelCalls),
-        );
-      }),
-    );
-    const checkpointObjects = mockPiCheckpointObjectStore();
-    const { anchor, anchorClaim, run, usagePricingResolution } =
-      await queueCapabilityProvenPiRun({
-        actor,
-        agentId,
-        runnerGroup,
-        prompt: "expire the bounded handoff publication",
+  it.each(["deadline", "model failure"] as const)(
+    "fails once when deadline handoff cannot settle by the coordination cap after %s",
+    async (trigger) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      mockPiResourceArchiveDownloads();
+      const providerEntered = createDeferredPromise<void>(context.signal);
+      const releaseProvider = createDeferredPromise<void>(context.signal);
+      let modelCalls = 0;
+      server.use(
+        http.post("https://api.openai.com/v1/responses", async () => {
+          modelCalls += 1;
+          providerEntered.resolve(undefined);
+          await releaseProvider.promise;
+          if (trigger === "model failure") {
+            return HttpResponse.json(
+              { error: "private-model-failure-sentinel" },
+              { status: 525 },
+            );
+          }
+          return nativeCodexSseResponse(
+            piResponsesTextSse("late result before handoff expiry", modelCalls),
+          );
+        }),
+      );
+      const checkpointObjects = mockPiCheckpointObjectStore();
+      const { anchor, anchorClaim, run, usagePricingResolution } =
+        await queueCapabilityProvenPiRun({
+          actor,
+          agentId,
+          runnerGroup,
+          prompt: "expire the bounded handoff publication",
+        });
+      const apiStartedAt = now();
+      mockNow(apiStartedAt);
+      onTestFinished(() => {
+        clearMockNow();
       });
-    const apiStartedAt = now();
-    mockNow(apiStartedAt);
-    onTestFinished(() => {
-      clearMockNow();
-    });
-    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
-      usagePricingResolution,
-    });
-    await providerEntered.promise;
-    // No public API can deterministically hold this lifecycle transaction
-    // across the coordination cap; this run-owned fixture isolates that race.
-    const lifecycleLock = await holdPiApiFirstTurnLifecycleLockFixture({
-      runId: run.runId,
-      signal: context.signal,
-    });
-    onTestFinished(async () => {
+      await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+        usagePricingResolution,
+      });
+      await providerEntered.promise;
+      // No public API can deterministically hold this lifecycle transaction
+      // across the coordination cap; this run-owned fixture isolates that race.
+      const lifecycleLock = await holdPiApiFirstTurnLifecycleLockFixture({
+        runId: run.runId,
+        signal: context.signal,
+      });
+      onTestFinished(async () => {
+        lifecycleLock.release();
+        await lifecycleLock.done;
+      });
+
+      if (trigger === "deadline") {
+        mockNow(apiStartedAt + API_FIRST_TURN_OWNERSHIP_BUDGET_MS - 2000);
+      }
+      releaseProvider.resolve(undefined);
+      await expect.poll(lifecycleLock.waiterCount).toBe(1);
+      mockNow(apiStartedAt + API_FIRST_TURN_COORDINATION_BUDGET_MS);
       lifecycleLock.release();
       await lifecycleLock.done;
-    });
+      await waitForRunStatus(actor, run.runId, "failed", 5000);
+      await flushWaitUntilForTest();
 
-    mockNow(apiStartedAt + API_FIRST_TURN_OWNERSHIP_BUDGET_MS - 2000);
-    releaseProvider.resolve(undefined);
-    await expect.poll(lifecycleLock.waiterCount).toBe(1);
-    mockNow(apiStartedAt + API_FIRST_TURN_COORDINATION_BUDGET_MS);
-    lifecycleLock.release();
-    await lifecycleLock.done;
-    await waitForRunStatus(actor, run.runId, "failed", 5000);
-    await flushWaitUntilForTest();
-
-    expect(modelCalls).toBe(1);
-    expectNoPiApiFirstTurnArtifacts(run.runId, checkpointObjects);
-    await expectTerraApiFollowUpUsage(run.runId);
-    expect(warningCallsForRun(run.runId)).toHaveLength(1);
-    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
-      "Pi API first-turn outcome",
-      expect.objectContaining({
-        runId: run.runId,
-        outcome: "terminal_failure",
-        recoveryReason: "api_attempt_timed_out",
-      }),
-    );
-    const events = (await chat.listThreadEvents(actor, run.threadId)).events;
-    expect(
-      events.filter((event) => {
-        return (
-          event.runId === run.runId &&
-          isChatRunTerminalEventType(event.eventType)
+      expect(modelCalls).toBe(1);
+      if (trigger === "model failure") {
+        expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+          "Pi API first-turn outcome",
+          expect.objectContaining({
+            runId: run.runId,
+            modelFailureCategory: "http_error",
+            modelFailureHttpStatus: 525,
+          }),
         );
-      }),
-    ).toMatchObject([{ eventType: "run.failed" }]);
-  }, 90_000);
+      }
+      expectNoPiApiFirstTurnArtifacts(run.runId, checkpointObjects);
+      if (trigger === "deadline") {
+        await expectTerraApiFollowUpUsage(run.runId);
+      } else {
+        await expectNoBuiltInModelUsage(run.runId);
+      }
+      expect(warningCallsForRun(run.runId)).toHaveLength(1);
+      expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+        "Pi API first-turn outcome",
+        expect.objectContaining({
+          runId: run.runId,
+          outcome: "terminal_failure",
+          recoveryReason:
+            trigger === "deadline"
+              ? "api_attempt_timed_out"
+              : "api_model_failed",
+        }),
+      );
+      const events = (await chat.listThreadEvents(actor, run.threadId)).events;
+      expect(
+        events.filter((event) => {
+          return (
+            event.runId === run.runId &&
+            isChatRunTerminalEventType(event.eventType)
+          );
+        }),
+      ).toMatchObject([{ eventType: "run.failed" }]);
+    },
+    90_000,
+  );
 
-  it("emits one canonical warning when the sandbox retry fails", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    mockPiResourceArchiveDownloads();
-    const providerEntered = createDeferredPromise<void>(context.signal);
-    const releaseProvider = createDeferredPromise<void>(context.signal);
-    let modelCalls = 0;
-    server.use(
-      http.post("https://api.openai.com/v1/responses", async () => {
-        modelCalls += 1;
-        providerEntered.resolve(undefined);
-        await releaseProvider.promise;
-        return nativeCodexSseResponse(
-          piResponsesTextSse("discarded before Sandbox failure", modelCalls),
-        );
-      }),
-    );
-    const checkpointObjects = mockPiCheckpointObjectStore();
-    const { anchor, anchorClaim, run, usagePricingResolution } =
-      await queueCapabilityProvenPiRun({
-        actor,
-        agentId,
-        runnerGroup,
-        prompt: "let the single Sandbox recovery fail",
+  it.each(["deadline", "model failure"] as const)(
+    "emits one canonical warning when the sandbox retry fails after %s",
+    async (trigger) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      mockPiResourceArchiveDownloads();
+      const providerEntered = createDeferredPromise<void>(context.signal);
+      const releaseProvider = createDeferredPromise<void>(context.signal);
+      let modelCalls = 0;
+      server.use(
+        http.post("https://api.openai.com/v1/responses", async () => {
+          modelCalls += 1;
+          providerEntered.resolve(undefined);
+          await releaseProvider.promise;
+          if (trigger === "model failure") {
+            return HttpResponse.json(
+              { error: "private-model-failure-sentinel" },
+              { status: 525 },
+            );
+          }
+          return nativeCodexSseResponse(
+            piResponsesTextSse("discarded before Sandbox failure", modelCalls),
+          );
+        }),
+      );
+      const checkpointObjects = mockPiCheckpointObjectStore();
+      const { anchor, anchorClaim, run, usagePricingResolution } =
+        await queueCapabilityProvenPiRun({
+          actor,
+          agentId,
+          runnerGroup,
+          prompt: "let the single Sandbox recovery fail",
+        });
+      const apiStartedAt = now();
+      mockNow(apiStartedAt);
+      onTestFinished(() => {
+        clearMockNow();
       });
-    const apiStartedAt = now();
-    mockNow(apiStartedAt);
-    onTestFinished(() => {
-      clearMockNow();
-    });
-    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
-      usagePricingResolution,
-    });
-    await providerEntered.promise;
-    mockNow(apiStartedAt + API_FIRST_TURN_OWNERSHIP_BUDGET_MS - 2000);
-    releaseProvider.resolve(undefined);
-    const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
-    await expect
-      .poll(() => {
-        return checkpointObjects.get(manifestKey);
-      })
-      .toBeInstanceOf(Buffer);
-    const claimed = await claimChatRun(runnerGroup, run.runId);
+      await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+        usagePricingResolution,
+      });
+      await providerEntered.promise;
+      if (trigger === "deadline") {
+        mockNow(apiStartedAt + API_FIRST_TURN_OWNERSHIP_BUDGET_MS - 2000);
+      }
+      releaseProvider.resolve(undefined);
+      const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
+      await expect
+        .poll(() => {
+          return checkpointObjects.get(manifestKey);
+        })
+        .toBeInstanceOf(Buffer);
+      const claimed = await claimChatRun(runnerGroup, run.runId);
 
-    await webhooks.requestAgentComplete(
-      {
-        runId: run.runId,
-        exitCode: 1,
-        error: "Sandbox retry failed",
-      },
-      claimed.sandboxHeaders,
-      [200],
-      undefined,
-      usagePricingResolution,
-    );
-    await waitForRunStatus(actor, run.runId, "failed", 5000);
-    await flushWaitUntilForTest();
+      await webhooks.requestAgentComplete(
+        {
+          runId: run.runId,
+          exitCode: 1,
+          error: "Sandbox retry failed",
+        },
+        claimed.sandboxHeaders,
+        [200],
+        undefined,
+        usagePricingResolution,
+      );
+      await waitForRunStatus(actor, run.runId, "failed", 5000);
+      await flushWaitUntilForTest();
 
-    expect(modelCalls).toBe(1);
-    await expectTerraApiFollowUpUsage(run.runId);
-    expect(warningCallsForRun(run.runId)).toHaveLength(1);
-    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
-      "Run failed",
-      expect.objectContaining({
-        runId: run.runId,
-        error: "Sandbox retry failed",
-      }),
-    );
-    const events = (await chat.listThreadEvents(actor, run.threadId)).events;
-    expect(
-      events.filter((event) => {
-        return (
-          event.runId === run.runId &&
-          isChatRunTerminalEventType(event.eventType)
-        );
-      }),
-    ).toMatchObject([{ eventType: "run.failed" }]);
-  }, 90_000);
+      expect(modelCalls).toBe(1);
+      if (trigger === "deadline") {
+        await expectTerraApiFollowUpUsage(run.runId);
+      } else {
+        await expectNoBuiltInModelUsage(run.runId);
+      }
+      expect(warningCallsForRun(run.runId)).toHaveLength(1);
+      expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+        "Run failed",
+        expect.objectContaining({
+          runId: run.runId,
+          error: "Sandbox retry failed",
+        }),
+      );
+      const events = (await chat.listThreadEvents(actor, run.threadId)).events;
+      expect(
+        events.filter((event) => {
+          return (
+            event.runId === run.runId &&
+            isChatRunTerminalEventType(event.eventType)
+          );
+        }),
+      ).toMatchObject([{ eventType: "run.failed" }]);
+    },
+    90_000,
+  );
 
   it("transfers pre-provider active input through one stable sandbox-first delivery", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
@@ -13883,49 +13967,580 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(requests).toHaveLength(3);
   }, 90_000);
 
-  it("fails Pi after one model request without claiming Sandbox or replaying the model", async () => {
-    const { actor, agentId } = await entitledChatActor();
-    if (!actor.orgId) {
-      throw new Error("Expected entitled chat actor to have an org");
-    }
-    await configureBuiltInPiModel(actor, "deepseek-v4-flash");
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.PiLoop]: true },
-    );
+  it.each([
+    { name: "HTTP 522", status: 522, category: "http_error" },
+    { name: "HTTP 525", status: 525, category: "http_error" },
+    { name: "unknown model failure", status: 200, category: "unknown" },
+    { name: "terminated stream", status: 200, category: "stream_terminated" },
+    { name: "failed result with usage", status: 200, category: "unknown" },
+  ])(
+    "hands $name directly to Sandbox and completes the same run once",
+    async (scenario) => {
+      mockOptionalEnv("OKOU_DEBUG", "pi-api-first-turn");
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      mockPiResourceArchiveDownloads();
+      const privateMarker = "private-provider-sentinel-32751";
+      const partial = "partial assistant output must not become H1";
+      let modelCalls = 0;
+      server.use(
+        http.post("https://api.openai.com/v1/responses", () => {
+          modelCalls += 1;
+          if (scenario.status !== 200) {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: `${privateMarker} https://private.example/?token=secret ${"x".repeat(10_000)}`,
+                },
+              },
+              { status: scenario.status },
+            );
+          }
+          const body = piResponsesTextSse(partial, 1);
+          if (scenario.name === "failed result with usage") {
+            return nativeCodexSseResponse(
+              body
+                .replace(
+                  '"type":"response.completed"',
+                  '"type":"response.incomplete"',
+                )
+                .replace(
+                  '"status":"completed","output"',
+                  '"status":"incomplete","output"',
+                ),
+            );
+          }
+          const prefix = body.slice(0, body.lastIndexOf("data: "));
+          if (scenario.name === "terminated stream") {
+            let emitted = false;
+            return new HttpResponse(
+              new ReadableStream<Uint8Array>({
+                pull(controller) {
+                  if (!emitted) {
+                    emitted = true;
+                    controller.enqueue(new TextEncoder().encode(prefix));
+                  } else {
+                    controller.error(new TypeError("terminated"));
+                  }
+                },
+              }),
+              { headers: { "content-type": "text/event-stream" } },
+            );
+          }
+          return nativeCodexSseResponse(
+            `${prefix}data: ${JSON.stringify({ type: "error", code: "unknown", message: privateMarker })}\n\n`,
+          );
+        }),
+      );
+      const checkpointObjects = mockPiCheckpointObjectStore();
+      const prompt = "keep the original input for one Sandbox handoff";
+      const { anchor, anchorClaim, run, usagePricingResolution } =
+        await queueCapabilityProvenPiRun({
+          actor,
+          agentId,
+          runnerGroup,
+          prompt,
+        });
+      await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+        usagePricingResolution,
+      });
+      await flushWaitUntilForTest();
+      const prefix = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/`;
+      const manifest = piApiFirstTurnManifestSchema.parse(
+        JSON.parse(
+          checkpointObjects.get(`${prefix}manifest.json`)?.toString("utf8") ??
+            "{}",
+        ),
+      );
+      expect(manifest).toMatchObject({
+        schemaVersion: 3,
+        outcome: "ownership-transfer",
+        mode: "sandbox-first",
+        baseSession: { sessionId: run.threadId, sha256: null },
+        sandboxEventSequenceStart: 1,
+      });
+      const h0 = checkpointObjects.get(`${prefix}session.jsonl`);
+      if (!h0) {
+        throw new Error("Expected original H0 after model failure");
+      }
+      expect(
+        MemoryPiSession.fromJsonl(h0.toString("utf8")).buildSessionContext()
+          .messages,
+      ).toStrictEqual([]);
+      expect(manifest.session).toMatchObject({
+        sessionId: run.threadId,
+        rawSize: h0.length,
+        sha256: createHash("sha256").update(h0).digest("hex"),
+      });
+      expect(modelCalls).toBe(1);
+      const before = (await chat.listThreadEvents(actor, run.threadId)).events;
+      expect(eventBackedContents(before, run.runId)).toStrictEqual([]);
+      expect(
+        before.filter((event) => {
+          return (
+            event.runId === run.runId &&
+            isChatRunTerminalEventType(event.eventType)
+          );
+        }),
+      ).toStrictEqual([]);
+      expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
+        "cancel",
+        expect.objectContaining({ runId: run.runId }),
+      );
+      expect(warningCallsForRun(run.runId)).toStrictEqual([]);
+      expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+      expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+        "Pi API first-turn outcome",
+        expect.objectContaining({
+          runId: run.runId,
+          outcome: "sandbox_retry_started",
+          reason: "api_model_failed",
+          modelFailureCategory: scenario.category,
+          modelFailureHttpStatus: scenario.status,
+        }),
+      );
+      for (const log of Object.values(context.mocks.axiomLogging)) {
+        expect(JSON.stringify(log.mock.calls)).not.toContain(privateMarker);
+      }
+      const claimed = await claimChatRun(runnerGroup, run.runId);
+      expect(claimed.claim.prompt).toBe(prompt);
+      const answer = "Sandbox recovered the failed model turn";
+      await completeSandboxFirstPiRun({
+        actor,
+        answer,
+        checkpointObjects,
+        claim: claimed,
+        prompt,
+        run,
+        usagePricingResolution,
+      });
+      if (scenario.name === "failed result with usage") {
+        await expectTerraApiFollowUpUsage(run.runId);
+      } else {
+        await expectNoBuiltInModelUsage(run.runId);
+      }
+      const events = (await chat.listThreadEvents(actor, run.threadId)).events;
+      expect(
+        events.filter((event) => {
+          return (
+            event.runId === run.runId &&
+            isChatRunTerminalEventType(event.eventType)
+          );
+        }),
+      ).toMatchObject([{ eventType: "run.completed" }]);
+      expect(
+        eventBackedContents(events, run.runId).filter((event) => {
+          return event.content === answer;
+        }),
+      ).toHaveLength(1);
+      expect(JSON.stringify(events)).not.toContain(partial);
+      expect(modelCalls).toBe(1);
+      expect(warningCallsForRun(run.runId)).toStrictEqual([]);
+    },
+    90_000,
+  );
+
+  it("preserves subscription H0 and active input after a failed resumed model turn", async () => {
+    mockOptionalEnv("OKOU_DEBUG", "pi-api-first-turn");
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    await configureSubscriptionPiModel(actor, {
+      accountId: "model-handoff-account",
+    });
     mockPiResourceArchiveDownloads();
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const entered = createDeferredPromise<void>(context.signal);
+    const release = createDeferredPromise<void>(context.signal);
     let modelCalls = 0;
     server.use(
-      http.post("https://api.deepseek.com/responses", () => {
+      http.post("https://chatgpt.com/backend-api/codex/responses", async () => {
         modelCalls += 1;
+        if (modelCalls === 1) {
+          return nativeCodexSseResponse(
+            piResponsesTextSse("previous settled subscription answer", 0),
+          );
+        }
+        entered.resolve(undefined);
+        await release.promise;
         return HttpResponse.json(
-          { error: "provider unavailable" },
-          { status: 503 },
+          { error: "private subscription provider failure" },
+          { status: 525 },
+        );
+      }),
+    );
+    const first = await sendChatRun(actor, {
+      agentId,
+      model: "gpt-5.6-terra",
+      prompt: "establish original subscription history",
+    });
+    await waitForRunStatus(actor, first.runId, "completed");
+    await flushWaitUntilForTest();
+    const prompt = "resume from the settled subscription H0";
+    const run = await sendChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      model: "gpt-5.6-terra",
+      prompt,
+    });
+    await entered.promise;
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await claimGptPiSandbox(actor, run.runId, undefined);
+    const activeInputEventId = randomUUID();
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: run.threadId,
+        prompt: "preserve this in-flight active input",
+        clientEventId: activeInputEventId,
+      },
+      [201],
+    );
+    const reserved = await api.reserveRunnerActiveInputs(
+      claim.sandboxToken,
+      run.runId,
+    );
+    if (reserved.outcome !== "reserved") {
+      throw new Error("Expected one reserved active input");
+    }
+    release.resolve(undefined);
+    await flushWaitUntilForTest();
+    const prefix = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/`;
+    const manifest = piApiFirstTurnManifestSchema.parse(
+      JSON.parse(
+        checkpointObjects.get(`${prefix}manifest.json`)?.toString("utf8") ??
+          "{}",
+      ),
+    );
+    expect(manifest).toMatchObject({
+      outcome: "ownership-transfer",
+      mode: "sandbox-first",
+      sandboxEventSequenceStart: 1,
+      baseSession: { sessionId: first.threadId, sha256: expect.any(String) },
+    });
+    expect(claim.prompt).toBe(prompt);
+    expect(claim.resumeSession).toMatchObject({
+      sessionId: first.threadId,
+      historyRef: { hash: manifest.baseSession.sha256 },
+    });
+    const h0 = checkpointObjects.get(`${prefix}session.jsonl`);
+    expect(h0).toStrictEqual(
+      checkpointObjects.get(
+        `${env("R2_USER_STORAGES_BUCKET_NAME")}/blobs/${manifest.baseSession.sha256}.blob`,
+      ),
+    );
+    expect(h0?.toString("utf8")).toContain(
+      "previous settled subscription answer",
+    );
+    expect(h0?.toString("utf8")).not.toContain(prompt);
+    await expect(
+      api.reserveRunnerActiveInputs(claim.sandboxToken, run.runId),
+    ).resolves.toStrictEqual(reserved);
+    await expect(
+      api.recordRunnerActiveInputDelivery(
+        claim.sandboxToken,
+        run.runId,
+        reserved.deliveryId,
+      ),
+    ).resolves.toStrictEqual({ outcome: "delivered" });
+    const events = (await chat.listThreadEvents(actor, run.threadId)).events;
+    expect(
+      events.filter((event) => {
+        return event.revokesEventId === activeInputEventId;
+      }),
+    ).toHaveLength(1);
+    expect(
+      events.filter((event) => {
+        return (
+          event.runId === run.runId &&
+          isChatRunTerminalEventType(event.eventType)
+        );
+      }),
+    ).toStrictEqual([]);
+    expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+      "Pi API first-turn outcome",
+      expect.objectContaining({
+        runId: run.runId,
+        dialect: "openai-codex-responses",
+        reason: "api_model_failed",
+        modelFailureCategory: "http_error",
+        modelFailureHttpStatus: 525,
+      }),
+    );
+    expect(modelCalls).toBe(2);
+    expect(warningCallsForRun(run.runId)).toStrictEqual([]);
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+    await expectNoBuiltInModelUsage(run.runId);
+    await cancelChatRun(actor, run.runId, {
+      authorization: `Bearer ${claim.sandboxToken}`,
+    });
+  }, 90_000);
+
+  it.each(["H1 commit", "H1 deadline", "handoff publication"] as const)(
+    "keeps a genuine %s failure terminal without replaying H0",
+    async (stage) => {
+      mockOptionalEnv("OKOU_DEBUG", "pi-api-first-turn");
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      mockPiResourceArchiveDownloads();
+      let modelCalls = 0;
+      server.use(
+        http.post("https://api.openai.com/v1/responses", () => {
+          modelCalls += 1;
+          return stage !== "handoff publication"
+            ? nativeCodexSseResponse(
+                piResponsesTextSse("uncommitted API answer", 1),
+              )
+            : HttpResponse.json(
+                { error: "private model sentinel" },
+                { status: 522 },
+              );
+        }),
+      );
+      const checkpointObjects = mockPiCheckpointObjectStore();
+      const { anchor, anchorClaim, run, usagePricingResolution } =
+        await queueCapabilityProvenPiRun({
+          actor,
+          agentId,
+          runnerGroup,
+          prompt: "surface the real publication failure",
+        });
+      const deadline = new AbortController();
+      onTestFinished(() => {
+        deadline.abort();
+      });
+      if (stage === "H1 deadline") {
+        // The public API cannot expire an OS timer at the H1 write boundary.
+        // Keep real AbortSignal propagation with this test-owned deadline.
+        context.mocks.abortSignal.timeout.mockImplementation((milliseconds) => {
+          return milliseconds > API_FIRST_TURN_OWNERSHIP_BUDGET_MS - 1000 &&
+            milliseconds <= API_FIRST_TURN_OWNERSHIP_BUDGET_MS
+            ? deadline.signal
+            : undefined;
+        });
+      }
+      const store = context.mocks.s3.send.getMockImplementation();
+      const sessionWrites: Buffer[] = [];
+      let manifestWrites = 0;
+      context.mocks.s3.send.mockImplementation((command: unknown) => {
+        const candidate = command as PiCheckpointS3Command;
+        const key = piS3ObjectKey(candidate);
+        if (
+          candidate.constructor?.name === "PutObjectCommand" &&
+          key?.includes(`/pi-api-first-turn/${run.runId}/`)
+        ) {
+          if (key.endsWith("session.jsonl")) {
+            if (!(candidate.input?.Body instanceof Uint8Array)) {
+              throw new Error("Expected session bytes");
+            }
+            sessionWrites.push(Buffer.from(candidate.input.Body));
+            if (stage === "H1 deadline") {
+              deadline.abort(
+                new DOMException(
+                  "API ownership expired during H1 write",
+                  "TimeoutError",
+                ),
+              );
+              return Promise.reject(deadline.signal.reason);
+            }
+            if (stage !== "handoff publication") {
+              return Promise.reject(new Error("private storage sentinel"));
+            }
+          }
+          if (key.endsWith("manifest.json")) {
+            manifestWrites += 1;
+            return Promise.reject(new Error("private storage sentinel"));
+          }
+        }
+        return store?.(command) ?? Promise.resolve({});
+      });
+      await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+        usagePricingResolution,
+      });
+      await waitForRunStatus(actor, run.runId, "failed");
+      await flushWaitUntilForTest();
+      expect(modelCalls).toBe(1);
+      expect(sessionWrites).toHaveLength(1);
+      expect(manifestWrites).toBe(stage !== "handoff publication" ? 0 : 1);
+      if (stage !== "handoff publication") {
+        expect(sessionWrites[0]?.toString("utf8")).toContain(
+          "uncommitted API answer",
+        );
+        await expectTerraApiFollowUpUsage(run.runId);
+      } else {
+        expect(
+          MemoryPiSession.fromJsonl(
+            sessionWrites[0]?.toString("utf8") ?? "",
+          ).buildSessionContext().messages,
+        ).toStrictEqual([]);
+        expect(warningCallsForRun(run.runId)).toHaveLength(1);
+      }
+      const errorCode =
+        stage === "H1 deadline"
+          ? "PI_API_FIRST_TURN_DEADLINE_EXCEEDED"
+          : stage === "H1 commit"
+            ? "PI_API_COMMIT_FAILED"
+            : "PI_API_SANDBOX_FALLBACK_FAILED";
+      await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+        status: "failed",
+        error: expect.stringContaining(`[${errorCode}]`),
+      });
+      expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+        "Pi API first-turn outcome",
+        expect.objectContaining({
+          runId: run.runId,
+          outcome: "terminal_failure",
+          reason: errorCode,
+          ...(stage === "handoff publication"
+            ? {
+                recoveryReason: "api_model_failed",
+                modelFailureCategory: "http_error",
+                modelFailureHttpStatus: 522,
+              }
+            : {}),
+        }),
+      );
+      for (const log of Object.values(context.mocks.axiomLogging)) {
+        expect(JSON.stringify(log.mock.calls)).not.toContain(
+          "private storage sentinel",
+        );
+        expect(JSON.stringify(log.mock.calls)).not.toContain(
+          "private model sentinel",
+        );
+      }
+      const events = (await chat.listThreadEvents(actor, run.threadId)).events;
+      expect(eventBackedContents(events, run.runId)).toStrictEqual([]);
+      expect(
+        events.filter((event) => {
+          return (
+            event.runId === run.runId &&
+            isChatRunTerminalEventType(event.eventType)
+          );
+        }),
+      ).toMatchObject([{ eventType: "run.failed" }]);
+      expect(
+        checkpointObjects.has(
+          `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`,
+        ),
+      ).toBeFalsy();
+      await api.requestClaimRunnerJob(true, run.runId, [404]);
+    },
+    90_000,
+  );
+
+  it("lets canonical cancellation win a failed model handoff", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    mockPiResourceArchiveDownloads();
+    const entered = createDeferredPromise<void>(context.signal);
+    const release = createDeferredPromise<void>(context.signal);
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.openai.com/v1/responses", async () => {
+        modelCalls += 1;
+        entered.resolve(undefined);
+        await release.promise;
+        return HttpResponse.json(
+          { error: "private cancelled model failure" },
+          { status: 522 },
         );
       }),
     );
     const checkpointObjects = mockPiCheckpointObjectStore();
-    const prompt = "strict PI_API_MODEL_FAILED prompt";
-    const run = await sendChatRun(actor, {
-      agentId,
-      prompt,
-      model: "deepseek-v4-flash",
+    const { anchor, anchorClaim, run, usagePricingResolution } =
+      await queueCapabilityProvenPiRun({
+        actor,
+        agentId,
+        runnerGroup,
+        prompt: "cancel instead of reviving the run",
+      });
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+      usagePricingResolution,
     });
-
-    await waitForRunStatus(actor, run.runId, "failed");
+    await entered.promise;
+    await cancelBeforeLatePiResult(
+      actor,
+      run.runId,
+      () => {
+        return release.resolve(undefined);
+      },
+      usagePricingResolution,
+    );
     await flushWaitUntilForTest();
-    const failed = await api.readRun(actor, run.runId);
-    expect(failed.error).toContain("[PI_API_MODEL_FAILED]");
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "cancelled",
+    });
+    expectNoPiApiFirstTurnArtifacts(run.runId, checkpointObjects);
     expect(modelCalls).toBe(1);
+    const events = (await chat.listThreadEvents(actor, run.threadId)).events;
     expect(
-      checkpointObjects.has(
-        `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`,
-      ),
-    ).toBeFalsy();
-    const claim = await api.requestClaimRunnerJob(true, run.runId, [404]);
-    expect(claim.status).toBe(404);
+      events.filter((event) => {
+        return (
+          event.runId === run.runId &&
+          isChatRunTerminalEventType(event.eventType)
+        );
+      }),
+    ).toMatchObject([{ eventType: "run.cancelled" }]);
+    expect(warningCallsForRun(run.runId)).toStrictEqual([]);
+    await api.requestClaimRunnerJob(true, run.runId, [404]);
   }, 90_000);
+
+  it.each([401, 403])(
+    "keeps an explicit HTTP %s credential failure terminal",
+    async (status) => {
+      mockOptionalEnv("OKOU_DEBUG", "pi-api-first-turn");
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      mockPiResourceArchiveDownloads();
+      let modelCalls = 0;
+      server.use(
+        http.post("https://api.openai.com/v1/responses", () => {
+          modelCalls += 1;
+          return HttpResponse.json(
+            {
+              error: {
+                code: "invalid_api_key",
+                message: "private-credential-sentinel",
+              },
+            },
+            { status },
+          );
+        }),
+      );
+      const checkpointObjects = mockPiCheckpointObjectStore();
+      const { anchor, anchorClaim, run, usagePricingResolution } =
+        await queueCapabilityProvenPiRun({
+          actor,
+          agentId,
+          runnerGroup,
+          prompt: "preserve explicit credential failure",
+        });
+      await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+        usagePricingResolution,
+      });
+      await waitForRunStatus(actor, run.runId, "failed");
+      await flushWaitUntilForTest();
+      expectNoPiApiFirstTurnArtifacts(run.runId, checkpointObjects);
+      expect(modelCalls).toBe(1);
+      expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+        "Pi API first-turn outcome",
+        expect.objectContaining({
+          runId: run.runId,
+          outcome: "terminal_failure",
+          reason: "PI_API_MODEL_FAILED",
+          modelFailureCategory: "http_error",
+          modelFailureHttpStatus: status,
+        }),
+      );
+      const failed = await api.readRun(actor, run.runId);
+      expect(failed.error).toContain("[PI_API_MODEL_FAILED]");
+      expect(JSON.stringify(failed)).not.toContain(
+        "private-credential-sentinel",
+      );
+      for (const log of Object.values(context.mocks.axiomLogging)) {
+        expect(JSON.stringify(log.mock.calls)).not.toContain(
+          "private-credential-sentinel",
+        );
+      }
+      await api.requestClaimRunnerJob(true, run.runId, [404]);
+    },
+    90_000,
+  );
 
   it.each(["identity", "gzip", "zstd"] as const)(
     "saves large Pi %s history and transfers the next turn without API history or resource IO",
@@ -14587,7 +15202,7 @@ describe("CHAT-02: model-first provider policies", () => {
     90_000,
   );
 
-  it("hands a Terra resource failure to Sandbox without replaying a later provider failure", async () => {
+  it("hands a Terra resource failure to Sandbox without replaying a later credential failure", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     if (!actor.orgId) {
       throw new Error("Expected entitled chat actor to have an org");
@@ -14621,8 +15236,10 @@ describe("CHAT-02: model-first provider policies", () => {
       http.post("https://api.openai.com/v1/responses", () => {
         modelCalls += 1;
         return HttpResponse.json(
-          { error: "provider unavailable" },
-          { status: 503 },
+          {
+            error: { code: "invalid_api_key", message: "credential rejected" },
+          },
+          { status: 401 },
         );
       }),
     );
@@ -14682,7 +15299,8 @@ describe("CHAT-02: model-first provider policies", () => {
         },
       },
     });
-    const postProviderPrompt = "must fail after one provider request";
+    const postProviderPrompt =
+      "fail a credential rejection after one provider request";
     const postProvider = await sendChatRun(actor, {
       agentId,
       prompt: postProviderPrompt,

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-native-usage.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-native-usage.bdd.test.ts
@@ -106,7 +106,12 @@ function turn(
       responseId: randomUUID(),
       timestamp: 1,
       content: [],
-      stopReason,
+      ...(stopReason === "error" || stopReason === "aborted"
+        ? {
+            stopReason,
+            failureDiagnostic: { category: "unknown" as const },
+          }
+        : { stopReason }),
       usage: {
         input: 11,
         output: 3,

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -29,7 +29,8 @@ import {
 import {
   createPiApiFirstTurnOwnership,
   createPiSessionJsonl,
-  classifyPiApiProviderFailure,
+  PiApiModelRequestError,
+  type PiApiModelFailureDiagnostic,
   inspectPiSessionJsonl,
   PiApiFirstTurnCompactionRequiredError,
   runPiApiFirstTurn,
@@ -165,6 +166,17 @@ class PiApiFirstTurnCodexReconnectRequiredError extends PiApiFirstTurnError {
       "Pi API first-turn subscription access token is unavailable",
       { failureReason: "reconnect_required" },
     );
+  }
+}
+
+class PiApiFirstTurnModelFailureError extends PiApiFirstTurnError {
+  constructor(
+    readonly diagnostic: PiApiModelFailureDiagnostic,
+    failureReason?: RunFailureReasonToken,
+  ) {
+    super("PI_API_MODEL_FAILED", "Pi API first-turn model request failed", {
+      failureReason,
+    });
   }
 }
 
@@ -1284,10 +1296,8 @@ function validateApiModelTurnOutcome(turn: PiApiFirstTurnResult): void {
     turn.assistantMessage.stopReason === "error" ||
     turn.assistantMessage.stopReason === "aborted"
   ) {
-    throw piApiFirstTurnError(
-      "PI_API_MODEL_FAILED",
-      `Pi API first-turn model stopped with ${turn.assistantMessage.stopReason}`,
-      undefined,
+    throw new PiApiFirstTurnModelFailureError(
+      turn.assistantMessage.failureDiagnostic ?? { category: "unknown" },
       turn.assistantMessage.failureReason,
     );
   }
@@ -1398,6 +1408,15 @@ async function executeApiModelTurn(
         executed.error,
       );
     }
+    if (
+      !modelSignal.aborted &&
+      executed.error instanceof PiApiModelRequestError
+    ) {
+      throw new PiApiFirstTurnModelFailureError(
+        executed.error.diagnostic,
+        executed.error.failureReason,
+      );
+    }
     throw piApiFirstTurnError(
       modelSignal.aborted
         ? "PI_API_FIRST_TURN_DEADLINE_EXCEEDED"
@@ -1406,9 +1425,6 @@ async function executeApiModelTurn(
         ? "Pi API first-turn model deadline elapsed"
         : "Pi API first-turn model request failed",
       executed.error,
-      modelSignal.aborted || args.model.provider !== "openai-codex"
-        ? undefined
-        : classifyPiApiProviderFailure(executed.error),
     );
   }
   const turn = executed.value;
@@ -1498,6 +1514,7 @@ type PiSandboxFallbackReason =
 type PiSandboxFirstReason =
   | PiSandboxFallbackReason
   | "active_input"
+  | "api_model_failed"
   | "api_attempt_timed_out";
 
 function eligibleSandboxFallbackReason(
@@ -1572,9 +1589,8 @@ function materializeApiFirstTurnH0(args: {
 }
 
 /**
- * Intentional runtime ownership fallback for a real preparation failure. This
- * remains necessary while API preparation happens after durable activation;
- * parent issue #30564 owns that lifecycle boundary.
+ * Runtime ownership recovery for pre-commit preparation, model or deadline
+ * failure. Reconstruct validated H0; never publish a failed/partial API turn.
  */
 const publishSandboxFallback$ = command(async function publishSandboxFallback(
   { get, set },
@@ -2161,7 +2177,20 @@ async function canonicalApiFirstTurnCancellationWon(
 function logCanonicalApiFirstTurnCancellation(
   args: ApiFirstTurnContext,
   ownership: PiApiFirstTurnOwnership,
+  failure?: unknown,
 ): void {
+  if (
+    failure instanceof PiApiFirstTurnCanonicalCancellationError &&
+    ownership.stage === "provider-may-have-started"
+  ) {
+    L.debug("Pi API first-turn outcome", {
+      runId: args.activation.runId,
+      ...piApiFirstTurnOutcomeTelemetry(args.activation.executionContext),
+      outcome: "discarded_late_provider_result",
+      reason: "canonical_cancellation",
+      ownershipStage: ownership.stage,
+    });
+  }
   L.debug("Pi API first-turn outcome", {
     runId: args.activation.runId,
     ...piApiFirstTurnOutcomeTelemetry(args.activation.executionContext),
@@ -2196,10 +2225,11 @@ function sandboxFirstPublicationOutcome(reason: PiSandboxFirstReason): {
   readonly reason: string;
 } {
   switch (reason) {
+    case "api_model_failed":
     case "api_attempt_timed_out": {
       return {
         outcome: "sandbox_retry_started",
-        reason: "api_attempt_timed_out",
+        reason,
       };
     }
     case "active_input": {
@@ -2227,6 +2257,7 @@ function logSandboxFirstPublication(
   activation: PiApiFirstTurnActivation,
   ownership: PiApiFirstTurnOwnership,
   reason: PiSandboxFirstReason,
+  modelFailure: PiApiModelFailureDiagnostic | undefined,
 ): void {
   L.debug("Pi API first-turn outcome", {
     runId: activation.runId,
@@ -2234,6 +2265,67 @@ function logSandboxFirstPublication(
     handoffOwner: "sandbox",
     ...sandboxFirstPublicationOutcome(reason),
     ownershipStage: ownership.stage,
+    ...modelFailureTelemetry(modelFailure),
+  });
+}
+
+function modelFailureTelemetry(
+  diagnostic: PiApiModelFailureDiagnostic | undefined,
+) {
+  return diagnostic
+    ? {
+        modelFailureCategory: diagnostic.category,
+        ...(diagnostic.httpStatus === undefined
+          ? {}
+          : { modelFailureHttpStatus: diagnostic.httpStatus }),
+      }
+    : {};
+}
+
+function eligibleApiModelFailure(
+  failure: PiApiFirstTurnError,
+  commitStarted: boolean,
+  coordinationDeadlineAt: number,
+  signal: AbortSignal,
+): boolean {
+  return (
+    failure instanceof PiApiFirstTurnModelFailureError &&
+    !failure.failureReason &&
+    failure.diagnostic.httpStatus !== 401 &&
+    failure.diagnostic.httpStatus !== 403 &&
+    !commitStarted &&
+    !signal.aborted &&
+    now() < coordinationDeadlineAt
+  );
+}
+
+function logApiFirstTurnTerminalFailure(args: {
+  readonly activation: PiApiFirstTurnActivation;
+  readonly ownership: PiApiFirstTurnOwnership;
+  readonly failure: PiApiFirstTurnError;
+  readonly modelFailure: PiApiModelFailureDiagnostic | undefined;
+  readonly resourceFallbackReason: PiSandboxFallbackReason | null;
+  readonly sandboxFirstReason: PiSandboxFirstReason | null;
+}): void {
+  if (args.failure instanceof PiApiFirstTurnCodexReconnectRequiredError) {
+    return;
+  }
+  const recoveryReason =
+    args.sandboxFirstReason === "api_attempt_timed_out" ||
+    args.sandboxFirstReason === "api_model_failed"
+      ? args.sandboxFirstReason
+      : undefined;
+  L.warn("Pi API first-turn outcome", {
+    runId: args.activation.runId,
+    ...piApiFirstTurnOutcomeTelemetry(args.activation.executionContext),
+    outcome: "terminal_failure",
+    reason: args.failure.code,
+    ownershipStage: args.ownership.stage,
+    ...modelFailureTelemetry(args.modelFailure),
+    ...(args.resourceFallbackReason
+      ? { fallbackReason: args.resourceFallbackReason }
+      : {}),
+    ...(recoveryReason ? { recoveryReason } : {}),
   });
 }
 
@@ -2338,7 +2430,10 @@ const runPiApiFirstTurnCore$ = command(
     // Classify the failure before closing any residual attempt work. Aborting
     // the private controller first would misclassify every raw API failure as
     // an ownership deadline and incorrectly replay it in Sandbox.
-    apiAttemptController.abort(executed.error);
+    const modelFailure =
+      failure instanceof PiApiFirstTurnModelFailureError
+        ? failure.diagnostic
+        : undefined;
     const resourceFallbackReason = activeInputBeforeProvider
       ? null
       : eligibleSandboxFallbackReason(
@@ -2356,12 +2451,21 @@ const runPiApiFirstTurnCore$ = command(
       !signal.aborted;
     const apiAttemptTimedOut =
       apiOwnershipExpired && now() < coordinationDeadlineAt;
+    const apiModelFailed = eligibleApiModelFailure(
+      failure,
+      commitProgress.started,
+      coordinationDeadlineAt,
+      signal,
+    );
     const sandboxFirstReason: PiSandboxFirstReason | null =
       activeInputBeforeProvider
         ? "active_input"
         : apiAttemptTimedOut
           ? "api_attempt_timed_out"
-          : resourceFallbackReason;
+          : apiModelFailed
+            ? "api_model_failed"
+            : resourceFallbackReason;
+    apiAttemptController.abort(executed.error);
     if (sandboxFirstReason) {
       if (apiAttemptTimedOut) {
         logApiFirstTurnAttemptTimedOut(activation, ownership, failure);
@@ -2378,48 +2482,34 @@ const runPiApiFirstTurnCore$ = command(
         signal,
       );
       if (fallback.ok) {
-        logSandboxFirstPublication(activation, ownership, sandboxFirstReason);
+        logSandboxFirstPublication(
+          activation,
+          ownership,
+          sandboxFirstReason,
+          modelFailure,
+        );
         return undefined;
       }
       failure = normalizedSandboxFallbackFailure(fallback.error, handoffSignal);
     }
     if (await canonicalApiFirstTurnCancellationWon(context)) {
-      if (
-        executed.error instanceof PiApiFirstTurnCanonicalCancellationError &&
-        ownership.stage === "provider-may-have-started"
-      ) {
-        L.debug("Pi API first-turn outcome", {
-          runId: activation.runId,
-          ...piApiFirstTurnOutcomeTelemetry(activation.executionContext),
-          outcome: "discarded_late_provider_result",
-          reason: "canonical_cancellation",
-          ownershipStage: ownership.stage,
-        });
-      }
-      logCanonicalApiFirstTurnCancellation(context, ownership);
+      logCanonicalApiFirstTurnCancellation(context, ownership, executed.error);
       return undefined;
     }
-    if (!(failure instanceof PiApiFirstTurnCodexReconnectRequiredError)) {
-      L.warn("Pi API first-turn outcome", {
-        runId: activation.runId,
-        ...piApiFirstTurnOutcomeTelemetry(activation.executionContext),
-        outcome: "terminal_failure",
-        reason: failure.code,
-        ownershipStage: ownership.stage,
-        ...(resourceFallbackReason
-          ? { fallbackReason: resourceFallbackReason }
-          : {}),
-        ...(apiAttemptTimedOut
-          ? { recoveryReason: "api_attempt_timed_out" }
-          : {}),
-      });
-    }
+    logApiFirstTurnTerminalFailure({
+      activation,
+      ownership,
+      failure,
+      modelFailure,
+      resourceFallbackReason,
+      sandboxFirstReason,
+    });
     return set(
       failApiFirstTurn$,
       context,
       failure,
       ownership,
-      apiOwnershipExpired,
+      apiOwnershipExpired || apiModelFailed,
     );
   },
 );

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -1297,7 +1297,7 @@ function validateApiModelTurnOutcome(turn: PiApiFirstTurnResult): void {
     turn.assistantMessage.stopReason === "aborted"
   ) {
     throw new PiApiFirstTurnModelFailureError(
-      turn.assistantMessage.failureDiagnostic ?? { category: "unknown" },
+      turn.assistantMessage.failureDiagnostic,
       turn.assistantMessage.failureReason,
     );
   }

--- a/turbo/packages/pi-agent-runtime/src/api-failure.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/api-failure.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import {
+  PiApiModelRequestError,
+  projectPiApiModelFailure,
+} from "./api-failure";
+import { projectPiApiAssistantMessage } from "./api-turn";
+
+describe("Pi API model failure diagnostics", () => {
+  it.each([522, 525, 401, 403])(
+    "retains observed HTTP %s without provider content",
+    (status) => {
+      const raw =
+        "private-token https://private.example/?secret=sentinel " +
+        "x".repeat(100_000);
+      const projected = projectPiApiAssistantMessage(
+        {
+          ...fauxAssistantMessage("partial output"),
+          stopReason: "error",
+          errorMessage: raw,
+        },
+        status,
+      );
+      expect(projected.failureDiagnostic).toStrictEqual({
+        category: "http_error",
+        httpStatus: status,
+      });
+      expect(JSON.stringify(projected)).not.toContain("private-token");
+      expect(projected).not.toHaveProperty("errorMessage");
+      const thrown = new PiApiModelRequestError(
+        new Error(raw),
+        "openai",
+        status,
+      );
+      expect(thrown.diagnostic).toStrictEqual(projected.failureDiagnostic);
+      expect(thrown.message).toBe("Pi API model request failed");
+      expect(thrown).not.toHaveProperty("cause");
+    },
+  );
+
+  it.each([
+    {
+      error: new TypeError("terminated"),
+      expected: { category: "stream_terminated", httpStatus: 200 },
+    },
+    {
+      error: new Error("terminated private prompt"),
+      expected: { category: "unknown", httpStatus: 200 },
+    },
+    {
+      error: "OpenAI API error (525): forged status and secret",
+      expected: { category: "unknown", httpStatus: 200 },
+    },
+    {
+      error: { status: 525, code: "private", message: "secret" },
+      expected: { category: "unknown", httpStatus: 200 },
+    },
+  ])("projects only allowlisted evidence for $error", ({ error, expected }) => {
+    expect(projectPiApiModelFailure(error, 200)).toStrictEqual(expected);
+  });
+
+  it.each([undefined, NaN, Infinity, 99, 600, 522.5])(
+    "rejects untrustworthy status %s",
+    (status) => {
+      expect(projectPiApiModelFailure("private 522", status)).toStrictEqual({
+        category: "unknown",
+      });
+    },
+  );
+
+  it("keeps known product failures on the thrown request boundary", () => {
+    const error = new PiApiModelRequestError(
+      new Error("usage_limit private sentinel"),
+      "openai-codex",
+      429,
+    );
+    expect(error.failureReason).toBe("usage_limit");
+    expect(error.diagnostic).toStrictEqual({
+      category: "http_error",
+      httpStatus: 429,
+    });
+    expect(JSON.stringify(error)).not.toContain("sentinel");
+  });
+});

--- a/turbo/packages/pi-agent-runtime/src/api-failure.ts
+++ b/turbo/packages/pi-agent-runtime/src/api-failure.ts
@@ -5,6 +5,56 @@ const CODEX_USAGE_LIMIT_SNIPPETS = [
   "usagelimit",
 ] as const;
 
+/** Content-free evidence; never infer an HTTP status from provider prose. */
+export interface PiApiModelFailureDiagnostic {
+  readonly category: "http_error" | "stream_terminated" | "aborted" | "unknown";
+  readonly httpStatus?: number;
+}
+
+export function projectPiApiModelFailure(
+  error: unknown,
+  responseStatus?: number,
+): PiApiModelFailureDiagnostic {
+  const httpStatus =
+    responseStatus !== undefined &&
+    Number.isInteger(responseStatus) &&
+    responseStatus >= 100 &&
+    responseStatus <= 599
+      ? responseStatus
+      : undefined;
+  const message =
+    typeof error === "string"
+      ? error
+      : error instanceof Error
+        ? error.message
+        : undefined;
+  const category =
+    httpStatus !== undefined && httpStatus >= 400
+      ? "http_error"
+      : message === "terminated"
+        ? "stream_terminated"
+        : error instanceof Error && error.name === "AbortError"
+          ? "aborted"
+          : "unknown";
+  return { category, ...(httpStatus === undefined ? {} : { httpStatus }) };
+}
+
+/** Only the request/stream boundary may create this recovery provenance. */
+export class PiApiModelRequestError extends Error {
+  readonly diagnostic: PiApiModelFailureDiagnostic;
+  readonly failureReason: "reconnect_required" | "usage_limit" | undefined;
+
+  constructor(error: unknown, provider: string, responseStatus?: number) {
+    super("Pi API model request failed");
+    this.name = "PiApiModelRequestError";
+    this.diagnostic = projectPiApiModelFailure(error, responseStatus);
+    this.failureReason =
+      provider === "openai-codex"
+        ? classifyPiApiProviderFailure(error)
+        : undefined;
+  }
+}
+
 /** Reduce native provider diagnostics to the only subscription product states. */
 export function classifyPiApiProviderFailure(
   error: unknown,

--- a/turbo/packages/pi-agent-runtime/src/api-turn.ts
+++ b/turbo/packages/pi-agent-runtime/src/api-turn.ts
@@ -14,7 +14,10 @@ import type {
   PiObservedServiceTier,
 } from "./api-types";
 import { UnsupportedPiResourceSnapshotError } from "./errors";
-import { classifyPiApiProviderFailure } from "./api-failure";
+import {
+  classifyPiApiProviderFailure,
+  projectPiApiModelFailure,
+} from "./api-failure";
 
 function projectAssistantContent(message: AssistantMessage): {
   readonly content: PiApiAssistantContent[];
@@ -61,6 +64,7 @@ function projectAssistantContent(message: AssistantMessage): {
 
 export function projectPiApiAssistantMessage(
   message: AssistantMessage,
+  responseStatus?: number,
 ): PiApiAssistantMessage {
   const projection = projectAssistantContent(message);
   const failureReason =
@@ -78,6 +82,14 @@ export function projectPiApiAssistantMessage(
     responseId: message.responseId,
     stopReason: message.stopReason,
     ...(failureReason ? { failureReason } : {}),
+    ...(message.stopReason === "error" || message.stopReason === "aborted"
+      ? {
+          failureDiagnostic: projectPiApiModelFailure(
+            message.errorMessage,
+            responseStatus,
+          ),
+        }
+      : {}),
     timestamp: message.timestamp,
     usage: {
       input: message.usage.input,
@@ -157,7 +169,10 @@ export async function runPiApiFirstTurn(
       providerRequestBoundary: args.providerRequestBoundary,
     });
     return {
-      assistantMessage: projectPiApiAssistantMessage(turn.assistantMessage),
+      assistantMessage: projectPiApiAssistantMessage(
+        turn.assistantMessage,
+        turn.responseStatus,
+      ),
       handoffRequired: turn.handoffRequired,
       observedServiceTier,
       sessionJsonl: memorySession.toJsonl(),

--- a/turbo/packages/pi-agent-runtime/src/api-turn.ts
+++ b/turbo/packages/pi-agent-runtime/src/api-turn.ts
@@ -73,23 +73,14 @@ export function projectPiApiAssistantMessage(
     message.provider === "openai-codex"
       ? classifyPiApiProviderFailure(message.errorMessage)
       : undefined;
-  return {
+  const projected = {
     content: projection.content,
     ...(projection.memoryCitation
       ? { memoryCitation: projection.memoryCitation }
       : {}),
     model: message.model,
     responseId: message.responseId,
-    stopReason: message.stopReason,
     ...(failureReason ? { failureReason } : {}),
-    ...(message.stopReason === "error" || message.stopReason === "aborted"
-      ? {
-          failureDiagnostic: projectPiApiModelFailure(
-            message.errorMessage,
-            responseStatus,
-          ),
-        }
-      : {}),
     timestamp: message.timestamp,
     usage: {
       input: message.usage.input,
@@ -101,6 +92,17 @@ export function projectPiApiAssistantMessage(
         : { cacheWrite1h: message.usage.cacheWrite1h }),
     },
   };
+  if (message.stopReason === "error" || message.stopReason === "aborted") {
+    return {
+      ...projected,
+      stopReason: message.stopReason,
+      failureDiagnostic: projectPiApiModelFailure(
+        message.errorMessage,
+        responseStatus,
+      ),
+    };
+  }
+  return { ...projected, stopReason: message.stopReason };
 }
 
 /** Run exactly one provider request using Pi's official prompt and tool schemas. */

--- a/turbo/packages/pi-agent-runtime/src/api-types.ts
+++ b/turbo/packages/pi-agent-runtime/src/api-types.ts
@@ -145,16 +145,14 @@ export type PiApiAssistantStopReason =
   | "aborted"
   | "deferred";
 
-export interface PiApiAssistantMessage {
+interface PiApiAssistantMessageFields {
   readonly content: readonly PiApiAssistantContent[];
   /** Private, bounded provenance removed from every user-visible text field. */
   readonly memoryCitation?: PiMemoryCitation;
   readonly model: string;
   readonly responseId?: string;
-  readonly stopReason: PiApiAssistantStopReason;
   /** Content-free product classification; native provider diagnostics stay private. */
   readonly failureReason?: "reconnect_required" | "usage_limit";
-  readonly failureDiagnostic?: PiApiModelFailureDiagnostic;
   readonly timestamp: number;
   readonly usage: {
     readonly input: number;
@@ -165,6 +163,21 @@ export interface PiApiAssistantMessage {
     readonly cacheWrite1h?: number;
   };
 }
+
+export type PiApiAssistantMessage = PiApiAssistantMessageFields &
+  (
+    | {
+        readonly stopReason: "error" | "aborted";
+        readonly failureDiagnostic: PiApiModelFailureDiagnostic;
+      }
+    | {
+        readonly stopReason: Exclude<
+          PiApiAssistantStopReason,
+          "error" | "aborted"
+        >;
+        readonly failureDiagnostic?: never;
+      }
+  );
 
 /** Terminal Responses payload service tier, kept outside persisted Pi state. */
 export type PiObservedServiceTier = string | null | undefined;

--- a/turbo/packages/pi-agent-runtime/src/api-types.ts
+++ b/turbo/packages/pi-agent-runtime/src/api-types.ts
@@ -1,4 +1,5 @@
 import type { PiAgentModelConfig } from "./types";
+import type { PiApiModelFailureDiagnostic } from "./api-failure";
 import type { PiApiFirstTurnOwnership } from "./provider-ownership";
 import type { PiMemoryCitation } from "@okouai/api-contracts/contracts/pi-memory-citations";
 
@@ -153,6 +154,7 @@ export interface PiApiAssistantMessage {
   readonly stopReason: PiApiAssistantStopReason;
   /** Content-free product classification; native provider diagnostics stay private. */
   readonly failureReason?: "reconnect_required" | "usage_limit";
+  readonly failureDiagnostic?: PiApiModelFailureDiagnostic;
   readonly timestamp: number;
   readonly usage: {
     readonly input: number;

--- a/turbo/packages/pi-agent-runtime/src/api.ts
+++ b/turbo/packages/pi-agent-runtime/src/api.ts
@@ -1,4 +1,8 @@
-import { classifyPiApiProviderFailure } from "./api-failure";
+import {
+  classifyPiApiProviderFailure,
+  PiApiModelRequestError,
+  type PiApiModelFailureDiagnostic,
+} from "./api-failure";
 import { runPiApiFirstTurn as runPiApiFirstTurnImpl } from "./api-turn";
 import { MemoryPiSession } from "./session-memory";
 import type {
@@ -71,6 +75,7 @@ import type {
 } from "./stage1-memory";
 export {
   classifyPiApiProviderFailure,
+  PiApiModelRequestError,
   PI_MEMORY_STAGE1_RESPONSE_SCHEMA,
   PiMemoryStage1ProviderError,
   projectPiMemoryStage1History,
@@ -93,6 +98,7 @@ export {
 };
 export { createPiApiFirstTurnOwnership };
 export type {
+  PiApiModelFailureDiagnostic,
   PiApiAssistantContent,
   PiApiAssistantMessage,
   PiApiAssistantStopReason,

--- a/turbo/packages/pi-agent-runtime/src/model.ts
+++ b/turbo/packages/pi-agent-runtime/src/model.ts
@@ -20,7 +20,10 @@ import type {
 import { clampThinkingLevel } from "@earendil-works/pi-ai";
 
 import type { PiAgentModelConfig } from "./types";
-import type { PiAgentStreamOptions } from "./stream-options";
+import {
+  observePiResponseStatus,
+  type PiAgentStreamOptions,
+} from "./stream-options";
 
 const PI_AGENT_USER_AGENT = "okou-pi-agent/1.0";
 
@@ -312,13 +315,22 @@ export function piAgentStreamForConfig(
     ) {
       return streamPiNative(config, model, context, configuredOptions);
     }
+    const responseOptions = configuredOptions.onObservedResponseStatus
+      ? {
+          ...configuredOptions,
+          fetch: observePiResponseStatus(
+            configuredOptions.fetch ?? globalThis.fetch,
+            configuredOptions.onObservedResponseStatus,
+          ),
+        }
+      : configuredOptions;
     if (config.dialect === "openai-responses") {
       if (!isResponsesModel(model)) {
         throw new Error(
           `Pi public Responses route received unexpected ${model.api} model`,
         );
       }
-      return piAgentStream(model, context, configuredOptions);
+      return piAgentStream(model, context, responseOptions);
     }
     if (!isCodexResponsesModel(model)) {
       throw new Error(
@@ -335,7 +347,7 @@ export function piAgentStreamForConfig(
       model,
       context,
       config.accountId,
-      configuredOptions,
+      responseOptions,
     );
   };
 }

--- a/turbo/packages/pi-agent-runtime/src/native-stream.ts
+++ b/turbo/packages/pi-agent-runtime/src/native-stream.ts
@@ -11,7 +11,10 @@ import { HttpsProxyAgent } from "https-proxy-agent";
 
 import { assertPiNativeCredential } from "./credential";
 import type { PiAgentModelConfig } from "./types";
-import type { PiAgentStreamOptions } from "./stream-options";
+import {
+  observePiResponseStatus,
+  type PiAgentStreamOptions,
+} from "./stream-options";
 
 function isMessages(model: Model<Api>): model is Model<"anthropic-messages"> {
   return model.api === "anthropic-messages";
@@ -48,7 +51,10 @@ export function streamPiNative(
   const nativeOptions = {
     ...options,
     maxRetries: 0,
-    fetch: options.fetch ?? nativePublicFetch,
+    fetch: observePiResponseStatus(
+      options.fetch ?? nativePublicFetch,
+      options.onObservedResponseStatus,
+    ),
     // Neither ambient cache policy nor provider authentication is inherited.
     cacheRetention: "short" as const,
     env: {},

--- a/turbo/packages/pi-agent-runtime/src/native.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/native.test.ts
@@ -277,6 +277,11 @@ describe("native Pi execution edges", () => {
       }[] = [];
       server.use(
         http.post(piNativeInferenceUrl(config), async ({ request }) => {
+          // API failure diagnostics must retain the native credential-safe
+          // fetch policy, including refusal to follow redirects.
+          if (config.dialect === "anthropic-messages") {
+            expect(request.redirect).toBe("error");
+          }
           requests.push({
             url: request.url,
             headers: request.headers,

--- a/turbo/packages/pi-agent-runtime/src/session-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-memory.test.ts
@@ -18,6 +18,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { MemoryPiSession, runPiFirstModelTurn } from "./session-memory";
 import { UnsupportedPiSessionVersionError } from "./errors";
+import { PiApiModelRequestError } from "./api-failure";
 import { createPiApiFirstTurnOwnership } from "./provider-ownership";
 
 const SESSION_ID = "00000000-0000-4000-8000-000000000123";
@@ -398,8 +399,42 @@ describe("MemoryPiSession", () => {
         tools: [],
         ownership,
       }),
-    ).rejects.toThrow("provider transport failed");
+    ).rejects.toMatchObject({
+      name: "PiApiModelRequestError",
+      message: "Pi API model request failed",
+      diagnostic: { category: "unknown" },
+    });
     expect(ownership.stage).toBe("provider-may-have-started");
+  });
+
+  it("does not turn a durable ownership failure into a model request failure", async () => {
+    const memory = MemoryPiSession.create({
+      cwd: "/workspace",
+      id: SESSION_ID,
+    });
+    const faux = createFauxCore({
+      api: "boundary-failure",
+      provider: "boundary-failure",
+    });
+    const failure = new Error(
+      "durable transaction failed after marking ownership",
+    );
+    const turn = runPiFirstModelTurn({
+      model: faux.getModel(),
+      session: memory,
+      stream: faux.streamSimple,
+      systemPrompt: "system",
+      prompt: "keep the original invariant",
+      tools: [],
+      ownership: createPiApiFirstTurnOwnership(),
+      providerRequestBoundary: async (mark) => {
+        mark();
+        throw failure;
+      },
+    });
+    await expect(turn).rejects.toBe(failure);
+    await expect(turn).rejects.not.toBeInstanceOf(PiApiModelRequestError);
+    expect(faux.state.callCount).toBe(0);
   });
 
   it("uses Pi migrations and compacted-context projection", async () => {

--- a/turbo/packages/pi-agent-runtime/src/session-memory.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-memory.ts
@@ -29,6 +29,7 @@ import {
 } from "@okouai/api-contracts/contracts/pi-memory-citations";
 import type { PiApiFirstTurnOwnership } from "./provider-ownership";
 import type { PiAgentStreamOptions } from "./stream-options";
+import { PiApiModelRequestError } from "./api-failure";
 
 interface CreateMemoryPiSessionOptions {
   readonly cwd: string;
@@ -56,6 +57,7 @@ interface RunPiFirstModelTurnOptions<TApi extends Api = Api> {
 interface PiModelTurnResult {
   readonly assistantMessage: AssistantMessage;
   readonly handoffRequired: boolean;
+  readonly responseStatus?: number;
 }
 
 type NewMemorySessionEntry =
@@ -332,16 +334,38 @@ export async function runPiFirstModelTurn<TApi extends Api>(
   } else {
     options.ownership.markProviderRequestMayHaveStarted();
   }
-  const responseStream = options.stream(options.model, context, {
+  let responseStatus: number | undefined;
+  let assistantMessage: AssistantMessage;
+  const streamOptions: PiAgentStreamOptions = {
     ...options.streamOptions,
+    onObservedResponseStatus(status) {
+      responseStatus = status;
+      options.streamOptions?.onObservedResponseStatus?.(status);
+    },
     reasoning:
       options.streamOptions?.reasoning ?? piReasoningLevel(sessionContext),
     sessionId: options.session.getSessionId(),
-  });
-  const assistantMessage = await consumeAssistantMessage(responseStream);
+  };
+  // Preparation, durable ownership and session writes are outside this catch:
+  // their failures must never authorize replay of the original H0.
+  try {
+    const responseStream = options.stream(
+      options.model,
+      context,
+      streamOptions,
+    );
+    assistantMessage = await consumeAssistantMessage(responseStream);
+  } catch (error) {
+    throw new PiApiModelRequestError(
+      error,
+      options.model.provider,
+      responseStatus,
+    );
+  }
   options.session.appendMessage(assistantMessage);
   return {
     assistantMessage,
     handoffRequired: piAssistantRequiresHandoff(assistantMessage),
+    responseStatus,
   };
 }

--- a/turbo/packages/pi-agent-runtime/src/stream-options.ts
+++ b/turbo/packages/pi-agent-runtime/src/stream-options.ts
@@ -6,5 +6,19 @@ import type { PiObservedServiceTier } from "./api-types";
 /** Internal extension consumed by Pi's native OpenAI Responses adapter. */
 export interface PiAgentStreamOptions extends SimpleStreamOptions {
   readonly onObservedServiceTier?: (serviceTier: PiObservedServiceTier) => void;
+  readonly onObservedResponseStatus?: (status: number) => void;
   readonly serviceTier?: PiAgentServiceTier;
+}
+
+/** Observe only status; preserve the adapter's own fetch and network policy. */
+export function observePiResponseStatus(
+  fetchImpl: NonNullable<SimpleStreamOptions["fetch"]>,
+  observe: PiAgentStreamOptions["onObservedResponseStatus"],
+): NonNullable<SimpleStreamOptions["fetch"]> {
+  if (!observe) return fetchImpl;
+  return async (input, init) => {
+    const response = await fetchImpl(input, init);
+    observe(response.status);
+    return response;
+  };
 }


### PR DESCRIPTION
## Summary

An ordinary Pi API first-model-turn failure now transfers the same run and original H0/input to the existing Sandbox path before commit. The API makes one attempt; Sandbox owns subsequent recovery. Known credential/reconnect and usage-limit failures retain their product handling.

A narrow request/stream boundary carries actual model-stage provenance, so the generic `PI_API_MODEL_FAILED` wrapper cannot turn storage, usage-recording or invariant failures into replay. Recovery is classified before retiring the API attempt and preserves the H1 commit fence, canonical cancellation, remaining coordination budget, durable ownership, active input, event sequence and usage idempotency.

Diagnostics contain only a fixed category and an observed, bounded HTTP status. Response observation preserves each adapter's existing fetch/network policy. Successful handoff emits debug telemetry without API terminal completion or warning/Sentry error; genuine terminal and handoff-publication failures retain actionable reporting.

## Fallbacks

- `turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts:eligibleApiModelFailure`, `runPiApiFirstTurnCore$` and `publishSandboxFallback$` — permanent same-run recovery from an actual pre-commit model failure. Surface: API first-turn owner to the existing Sandbox V3 `sandbox-first` manifest consumer, under existing Pi execution eligibility and lifecycle gates. It adds no protocol, feature flag, API retry loop, timeout extension or Sandbox retry change. This protects a reachable runtime failure, not an old/new deployment interaction; there is no rollout window. Retain while API first-turn ownership exists; removal requires retiring that ownership or replacing its recovery contract. Owner: #32751.
- `turbo/packages/pi-agent-runtime/src/api-failure.ts:projectPiApiModelFailure` — use `unknown` when bounded external diagnostic evidence is insufficient. Surface: provider evidence to safe telemetry; diagnostic-only, without changing recovery eligibility or reading an old producer. The internal failed-result type requires this projected diagnostic, and its consumer does not default missing fields. There is no rollout window or separate capability gate. Retain while external model failure evidence can be unknown. Owner: #32751.

## Verification

- Pi runtime: 131 targeted tests passed across `api-failure`, `api`, `session-memory`, `model` and `native`.
- API orchestration: 59 selected behavioral regressions passed in `chat-events.bdd.test.ts`, covering 522/525, interrupted/unknown/failed model results, original H0 and active input, cancellation and commit races, credential/product exclusions, coordination exhaustion, non-model usage failure, privacy, usage accounting and truthful final Sandbox failure.
- Native API billing: all 7 tests in `pi-native-usage.bdd.test.ts` passed with the required failed-result diagnostic contract, including cancelled/late usage and identity-collision controls.
- CLI: all 39 tests in `pi-api-first-turn-handoff.test.ts` passed.
- API/runtime lint and normal commit hooks validate formatting, static checks and types.
- Local API tests used a dedicated PostgreSQL database with existing migrations and UTC timezone. No full local Vitest suite or local dev server was run. Required PR and merge-group CI remain the integration gates.

No schema or memory-maintenance changes. Production release and independent controller acceptance are outside this implementation PR.

Refs #32751
