### PR TITLE
fix: preserve utf-8 for generated text artifacts

### DIFF
--- a/turbo/apps/api/src/lib/uploads-constants.ts
+++ b/turbo/apps/api/src/lib/uploads-constants.ts
@@ -1,3 +1,6 @@
+import { MIMEType } from "node:util";
+import { safeSync } from "../signals/utils";
+
 /**
  * Upload limits shared by the presigned-URL prepare endpoint and its callers.
  *
@@ -108,12 +111,26 @@ export function isAllowedUploadType(contentType: string): boolean {
 }
 
 /**
- * Keep recognized metadata and represent every other web upload as opaque
- * bytes. Slack canonical assets use isAllowedUploadType as a separate gate.
+ * Keep recognized MIME types and declared text charsets without inferring the
+ * encoding of bytes uploaded directly to storage. Other web uploads remain
+ * opaque bytes. Slack canonical assets use isAllowedUploadType as a separate gate.
  */
 export function normalizeWebUploadContentType(contentType: string): string {
   const normalized = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
-  return isAllowedUploadType(normalized)
-    ? normalized
-    : GENERIC_UPLOAD_CONTENT_TYPE;
+  if (!isAllowedUploadType(normalized)) {
+    return GENERIC_UPLOAD_CONTENT_TYPE;
+  }
+  if (!normalized.startsWith("text/")) {
+    return normalized;
+  }
+
+  const result = safeSync(() => {
+    const charset = new MIMEType(contentType).params.get("charset");
+    if (!charset) {
+      return normalized;
+    }
+    return `${normalized}; charset=${new TextDecoder(charset).encoding}`;
+  });
+  // Unrecognized parameters retain the existing base-MIME behavior.
+  return "ok" in result ? result.ok : normalized;
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
@@ -783,6 +783,9 @@ describe("FILE-01 uploads, storage, and host APIs", () => {
   it("prepares and completes an upload through S3 boundary state", async () => {
     const actor = bdd.user();
 
+    context.mocks.s3.getSignedUrl.mockResolvedValue(
+      "https://r2.example.com/upload?sig=test",
+    );
     api.mockEmptyObjectStorage();
     const prepared = await api.prepareUpload(actor, {
       filename: "notes.txt",
@@ -791,7 +794,7 @@ describe("FILE-01 uploads, storage, and host APIs", () => {
     });
     expect(prepared).toMatchObject({
       filename: "notes.txt",
-      contentType: "text/plain",
+      contentType: "text/plain; charset=utf-8",
       size: 12,
     });
     expect("uploadUrl" in prepared ? prepared.uploadUrl : "").toMatch(
@@ -801,11 +804,14 @@ describe("FILE-01 uploads, storage, and host APIs", () => {
     expect(prepared.url).not.toContain(actor.userId);
 
     api.mockCompletedUploadObject(actor, prepared.id, "notes.txt", 12);
-    const completed = await api.completeUpload(actor, { id: prepared.id });
+    const completed = await api.completeUpload(actor, {
+      id: prepared.id,
+      contentType: prepared.contentType,
+    });
     expect(completed).toMatchObject({
       id: prepared.id,
       filename: "notes.txt",
-      contentType: "text/plain",
+      contentType: "text/plain; charset=utf-8",
       size: 12,
     });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/uploads-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/uploads-complete.test.ts
@@ -179,8 +179,8 @@ describe("POST /api/uploads/complete", () => {
       ).prepare({
         headers: { authorization: fixture.bearer },
         body: {
-          filename: "private-report.pdf",
-          contentType: "application/pdf",
+          filename: "private-report.md",
+          contentType: "text/markdown; charset=utf-8",
           size: 1234,
           purpose: "artifact",
         },
@@ -191,7 +191,7 @@ describe("POST /api/uploads/complete", () => {
       expect(command).toBeInstanceOf(HeadObjectCommand);
       return Promise.resolve({
         ContentLength: 1234,
-        ContentType: "application/pdf",
+        ContentType: "text/markdown; charset=utf-8",
       });
     });
     const response = await chat.completeUploadWithBearer(
@@ -200,13 +200,14 @@ describe("POST /api/uploads/complete", () => {
       [200],
     );
     expect(response.body).toMatchObject({
-      url: artifactReferencePath(prepared.body.id, "private-report.pdf"),
+      url: artifactReferencePath(prepared.body.id, "private-report.md"),
+      contentType: "text/markdown; charset=utf-8",
     });
     const catalog = await chat.listArtifactCatalog(fixture.actor, {
       kind: "file",
     });
     const artifact = catalog.artifacts.find((entry) => {
-      return entry.title === "private-report.pdf";
+      return entry.title === "private-report.md";
     });
     expect(artifact).toBeDefined();
     if (!artifact) {
@@ -217,7 +218,11 @@ describe("POST /api/uploads/complete", () => {
       artifact.id,
     );
     expect(detail).toMatchObject({
-      file: { url: prepared.body.url, filename: "private-report.pdf" },
+      file: {
+        url: prepared.body.url,
+        filename: "private-report.md",
+        contentType: "text/markdown; charset=utf-8",
+      },
     });
   });
 
@@ -435,23 +440,29 @@ describe("POST /api/uploads/complete", () => {
     expect(response.body).toStrictEqual({ error: "Internal server error" });
   });
 
-  it("uses a recognized complete content type when provided", async () => {
-    const fixture = await createRunUploadFixture();
-    const fileId = randomUUID();
-    addUploadObject(fixture, fileId, "data.bin", 9);
+  it.each([
+    ["text/csv", "text/csv"],
+    ['Text/Markdown; Charset="UTF-8"', "text/markdown; charset=utf-8"],
+  ])(
+    "preserves recognized complete content type %s",
+    async (contentType, expected) => {
+      const fixture = await createRunUploadFixture();
+      const fileId = randomUUID();
+      addUploadObject(fixture, fileId, "data.bin", 9);
 
-    const response = await chat.completeUploadWithBearer(
-      fixture.bearer,
-      { id: fileId, contentType: "text/csv" },
-      [200],
-    );
+      const response = await chat.completeUploadWithBearer(
+        fixture.bearer,
+        { id: fileId, contentType },
+        [200],
+      );
 
-    expect(response.body).toMatchObject({
-      id: fileId,
-      filename: "data.bin",
-      contentType: "text/csv",
-    });
-  });
+      expect(response.body).toMatchObject({
+        id: fileId,
+        filename: "data.bin",
+        contentType: expected,
+      });
+    },
+  );
 
   it("infers audio content type from uploaded filename", async () => {
     const fixture = await createRunUploadFixture();

--- a/turbo/apps/api/src/signals/routes/__tests__/uploads-multipart.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/uploads-multipart.test.ts
@@ -152,6 +152,39 @@ describe("multipart user artifact uploads", () => {
     });
   });
 
+  it("stores the declared text charset when preparing a multipart artifact", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+    context.mocks.s3.send.mockImplementation((command) => {
+      if (command instanceof ListObjectsV2Command) {
+        return Promise.resolve({ Contents: [] });
+      }
+      if (command instanceof CreateMultipartUploadCommand) {
+        expect(command.input.ContentType).toBe("text/csv; charset=utf-8");
+        return Promise.resolve({ UploadId: "text-multipart-upload" });
+      }
+      throw new Error("Unexpected storage command");
+    });
+
+    const response = await accept(
+      apiClient().prepare({
+        headers: authHeaders(),
+        body: {
+          filename: "report.csv",
+          contentType: 'Text/CSV; Charset="UTF-8"',
+          size: 6 * 1024 * 1024,
+          purpose: "artifact",
+          multipart: true,
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      contentType: "text/csv; charset=utf-8",
+      multipart: { uploadId: "text-multipart-upload" },
+    });
+  });
+
   it("keeps the legacy single PUT response for small multipart requests", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/uploads-prepare.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/uploads-prepare.test.ts
@@ -223,6 +223,33 @@ describe("POST /api/uploads/prepare", () => {
     });
   });
 
+  it.each([
+    ['Text/Markdown; Charset="UTF-8"', "text/markdown; charset=utf-8"],
+    ["Text/Plain; Charset=UTF-8", "text/plain; charset=utf-8"],
+    ["text/plain; charset=GB18030", "text/plain; charset=gb18030"],
+    ["text/markdown", "text/markdown"],
+    ["text/markdown; charset=unsupported-label", "text/markdown"],
+    ["image/png; charset=utf-8", "image/png"],
+  ])(
+    "prepares %s with compatible upload metadata",
+    async (contentType, expected) => {
+      mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+      const response = await accept(
+        setupApp({ context, routes: uploadsTestRoutes })(
+          uploadsContract,
+        ).prepare({
+          body: { filename: "artifact.bin", contentType, size: 32 },
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      );
+      expect(response.body.contentType).toBe(expected);
+      expect(context.mocks.s3.getSignedUrl.mock.calls[0]?.[1]).toMatchObject({
+        input: { ContentType: expected },
+      });
+    },
+  );
+
   it("returns presigned upload URL and final CDN URL with full body shape", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
@@ -440,34 +467,6 @@ describe("POST /api/uploads/prepare", () => {
     );
 
     expect(response.body.error.code).toBe("INSUFFICIENT_CREDITS");
-  });
-
-  it("normalizes parameterized content types before signing", async () => {
-    const userId = `user_${randomUUID()}`;
-    const orgId = `org_${randomUUID()}`;
-    mocks.clerk.session(userId, orgId);
-
-    const client = setupApp({ context, routes: uploadsTestRoutes })(
-      uploadsContract,
-    );
-    const response = await client.prepare({
-      body: {
-        filename: "notes.txt",
-        contentType: "Text/Plain; Charset=UTF-8",
-        size: 13,
-      },
-      headers: { authorization: "Bearer clerk-session" },
-    });
-    expect(response.status).toBe(200);
-    if (response.status !== 200) {
-      return;
-    }
-    expect(response.body.contentType).toBe("text/plain");
-
-    const command = context.mocks.s3.getSignedUrl.mock.calls[0]?.[1] as {
-      input: { ContentType: string };
-    };
-    expect(command.input.ContentType).toBe("text/plain");
   });
 
   it("uses the public S3 endpoint for externally consumed upload URLs", async () => {

--- a/turbo/apps/cli/src/commands/web/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/web/__tests__/upload-file.test.ts
@@ -74,7 +74,7 @@ describe("okou web upload-file command", () => {
     ])(
       "delivers %s with UTF-8 metadata and original bytes",
       async (filename, contentType) => {
-        const filePath = join(tmpDir, filename);
+        const filePath = join(tmpDir, basename(filename));
         const bytes = Buffer.from("中文 / 日本語 / 한글 / emoji 😀\n", "utf8");
         writeFileSync(filePath, bytes);
         const file = {

--- a/turbo/apps/cli/src/commands/web/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/web/__tests__/upload-file.test.ts
@@ -67,14 +67,35 @@ describe("okou web upload-file command", () => {
 
   describe("successful upload", () => {
     it.each([
-      ["report.md", "text/markdown; charset=utf-8"],
-      ["note.txt", "text/plain; charset=utf-8"],
-      ["table.csv", "text/csv; charset=utf-8"],
-      ["table.tsv", "text/tab-separated-values; charset=utf-8"],
+      {
+        createPath: () => {
+          return join(tmpDir, "report.md");
+        },
+        contentType: "text/markdown; charset=utf-8",
+      },
+      {
+        createPath: () => {
+          return join(tmpDir, "note.txt");
+        },
+        contentType: "text/plain; charset=utf-8",
+      },
+      {
+        createPath: () => {
+          return join(tmpDir, "table.csv");
+        },
+        contentType: "text/csv; charset=utf-8",
+      },
+      {
+        createPath: () => {
+          return join(tmpDir, "table.tsv");
+        },
+        contentType: "text/tab-separated-values; charset=utf-8",
+      },
     ])(
-      "delivers %s with UTF-8 metadata and original bytes",
-      async (filename, contentType) => {
-        const filePath = join(tmpDir, basename(filename));
+      "delivers $contentType with original bytes",
+      async ({ createPath, contentType }) => {
+        const filePath = createPath();
+        const filename = basename(filePath);
         const bytes = Buffer.from("中文 / 日本語 / 한글 / emoji 😀\n", "utf8");
         writeFileSync(filePath, bytes);
         const file = {

--- a/turbo/apps/cli/src/commands/web/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/web/__tests__/upload-file.test.ts
@@ -51,6 +51,7 @@ describe("okou web upload-file command", () => {
   beforeEach(() => {
     chalk.level = 0;
     uploadFileCommand.setOptionValue("json", undefined);
+    uploadFileCommand.setOptionValue("contentType", undefined);
     vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
@@ -65,6 +66,107 @@ describe("okou web upload-file command", () => {
   });
 
   describe("successful upload", () => {
+    it.each([
+      ["report.md", "text/markdown; charset=utf-8"],
+      ["note.txt", "text/plain; charset=utf-8"],
+      ["table.csv", "text/csv; charset=utf-8"],
+      ["table.tsv", "text/tab-separated-values; charset=utf-8"],
+    ])(
+      "delivers %s with UTF-8 metadata and original bytes",
+      async (filename, contentType) => {
+        const filePath = join(tmpDir, filename);
+        const bytes = Buffer.from("中文 / 日本語 / 한글 / emoji 😀\n", "utf8");
+        writeFileSync(filePath, bytes);
+        const file = {
+          id: "00000000-0000-4000-8000-000000000028",
+          filename,
+          contentType,
+          size: bytes.length,
+          url: `https://cdn.example.test/${filename}`,
+        };
+        let uploadedBytes: ArrayBuffer | undefined;
+
+        server.use(
+          http.post(PREPARE_URL, async ({ request }) => {
+            expect(await request.json()).toMatchObject({
+              filename,
+              contentType,
+              size: bytes.length,
+              purpose: "artifact",
+            });
+            return HttpResponse.json({ ...file, uploadUrl: PUT_URL });
+          }),
+          http.put(PUT_URL, async ({ request }) => {
+            expect(request.headers.get("content-type")).toBe(contentType);
+            uploadedBytes = await request.arrayBuffer();
+            return new HttpResponse(null, { status: 200 });
+          }),
+          http.post(COMPLETE_URL, async ({ request }) => {
+            expect(await request.json()).toEqual({ id: file.id, contentType });
+            return HttpResponse.json(file);
+          }),
+        );
+
+        await uploadFileCommand.parseAsync([
+          "node",
+          "cli",
+          "-f",
+          filePath,
+          "--json",
+        ]);
+
+        expect(uploadedBytes).toEqual(new Uint8Array(bytes).buffer);
+        expect(
+          JSON.parse(mockConsoleLog.mock.calls.flat().join("\n")),
+        ).toMatchObject(file);
+      },
+    );
+
+    it("preserves an explicitly declared non-UTF-8 text artifact", async () => {
+      const filePath = join(tmpDir, "legacy.txt");
+      const bytes = Buffer.from([0xd6, 0xd0, 0xce, 0xc4]);
+      writeFileSync(filePath, bytes);
+      const file = {
+        id: "00000000-0000-4000-8000-000000000029",
+        filename: "legacy.txt",
+        contentType: "text/plain; charset=gb18030",
+        size: bytes.length,
+        url: "https://cdn.example.test/legacy.txt",
+      };
+      server.use(
+        http.post(PREPARE_URL, async ({ request }) => {
+          expect(await request.json()).toMatchObject({
+            contentType: file.contentType,
+          });
+          return HttpResponse.json({ ...file, uploadUrl: PUT_URL });
+        }),
+        http.put(PUT_URL, async ({ request }) => {
+          expect(request.headers.get("content-type")).toBe(file.contentType);
+          expect(await request.arrayBuffer()).toEqual(
+            new Uint8Array(bytes).buffer,
+          );
+          return new HttpResponse(null, { status: 200 });
+        }),
+        http.post(COMPLETE_URL, () => {
+          return HttpResponse.json(file);
+        }),
+      );
+
+      await uploadFileCommand.parseAsync([
+        "node",
+        "cli",
+        "-f",
+        filePath,
+        "--content-type",
+        file.contentType,
+        "--json",
+      ]);
+
+      expect(
+        JSON.parse(mockConsoleLog.mock.calls.flat().join("\n")),
+      ).toMatchObject(file);
+    });
+
     it("should prepare + PUT + complete and print artifact presentation context", async () => {
       const filePath = join(tmpDir, "report.pdf");
       writeFileSync(filePath, Buffer.from("%PDF-1.4 fake"));
@@ -484,7 +586,10 @@ describe("okou web upload-file command", () => {
         },
         { filename: "data.xml", contentType: "application/xml" },
         { filename: "config.yaml", contentType: "application/yaml" },
-        { filename: "table.tsv", contentType: "text/tab-separated-values" },
+        {
+          filename: "table.tsv",
+          contentType: "text/tab-separated-values; charset=utf-8",
+        },
         {
           filename: "events.parquet",
           contentType: "application/vnd.apache.parquet",
@@ -566,6 +671,32 @@ describe("okou web upload-file command", () => {
   });
 
   describe("validation errors", () => {
+    it("rejects non-UTF-8 generated text before storing mislabeled bytes", async () => {
+      const filePath = join(tmpDir, "report.md");
+      writeFileSync(filePath, Buffer.from([0xd6, 0xd0, 0xce, 0xc4]));
+      server.use(
+        http.post(PREPARE_URL, () => {
+          return HttpResponse.json({
+            id: "00000000-0000-4000-8000-000000000030",
+            filename: "report.md",
+            contentType: "text/markdown; charset=utf-8",
+            size: 4,
+            uploadUrl: PUT_URL,
+            url: "https://cdn.example.test/report.md",
+          });
+        }),
+      );
+
+      await expect(
+        uploadFileCommand.parseAsync(["node", "cli", "-f", filePath]),
+      ).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Text artifacts must use UTF-8"),
+      );
+      expect(mockConsoleLog).not.toHaveBeenCalled();
+    });
+
     it("should throw when the file does not exist", async () => {
       await expect(async () => {
         await uploadFileCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/web/upload-file.ts
+++ b/turbo/apps/cli/src/commands/web/upload-file.ts
@@ -36,6 +36,7 @@ Notes:
   - Private file URLs require the owner's authentication; they do not grant public access
   - Use okou web download-file <id> to retrieve a private file
   - Max file size: 1 GB
+  - Markdown, TXT, CSV and TSV files use UTF-8 unless --content-type declares a charset
   - Allowed image types: png / jpeg / gif / webp / avif / svg / bmp / heic / heif / tiff / psd
   - Allowed video types: mp4 / webm / mov
   - Allowed audio types: aac / flac / m4a / mp3 / mp4 / mpga / ogg / opus / wav / webm

--- a/turbo/apps/cli/src/lib/api/domains/web.ts
+++ b/turbo/apps/cli/src/lib/api/domains/web.ts
@@ -1,9 +1,11 @@
 import { parseArtifactReference } from "@okouai/api-contracts/contracts/artifact-references";
+import { isUtf8 } from "node:buffer";
 import { createWriteStream, readFileSync, statSync } from "node:fs";
 import { basename, extname } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { setTimeout as delay } from "node:timers/promises";
+import { MIMEType } from "node:util";
 import { Realtime, type AuthOptions, type InboundMessage } from "ably";
 import type {
   BuiltInGenerationAcceptedResponse,
@@ -149,6 +151,31 @@ const MIME_BY_EXTENSION: Record<string, string> = {
 export function inferWebUploadContentType(localPath: string): string {
   const ext = extname(localPath).toLowerCase();
   return MIME_BY_EXTENSION[ext] ?? "application/octet-stream";
+}
+
+const UTF8_TEXT_ARTIFACT_TYPES = new Set([
+  "text/markdown",
+  "text/plain",
+  "text/csv",
+  "text/tab-separated-values",
+]);
+
+function textArtifactContentType(contentType: string): {
+  readonly contentType: string;
+  readonly validateUtf8: boolean;
+} {
+  const base = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+  if (!UTF8_TEXT_ARTIFACT_TYPES.has(base)) {
+    return { contentType, validateUtf8: false };
+  }
+  const parsed = new MIMEType(contentType);
+  if (parsed.params.has("charset")) {
+    return { contentType, validateUtf8: false };
+  }
+  return {
+    contentType: `${parsed.essence}; charset=utf-8`,
+    validateUtf8: true,
+  };
 }
 
 interface DownloadWebFileResult {
@@ -806,8 +833,12 @@ export async function uploadWebFile(
   }
 
   const filename = basename(localPath);
-  const contentType =
+  const requestedContentType =
     options?.contentType ?? inferWebUploadContentType(localPath);
+  const { contentType, validateUtf8 } =
+    options?.purpose === "artifact"
+      ? textArtifactContentType(requestedContentType)
+      : { contentType: requestedContentType, validateUtf8: false };
 
   const prepareHeaders: Record<string, string> = {
     Authorization: `Bearer ${token}`,
@@ -837,6 +868,13 @@ export async function uploadWebFile(
   const prepared = (await prepareRes.json()) as PrepareUploadResponse;
 
   const bytes = readFileSync(localPath);
+  if (validateUtf8 && !isUtf8(bytes)) {
+    throw new ApiRequestError(
+      "Text artifacts must use UTF-8. Save the file as UTF-8 or specify its actual charset with --content-type.",
+      "BAD_REQUEST",
+      400,
+    );
+  }
   const putRes = await fetch(prepared.uploadUrl, {
     method: "PUT",
     headers: {


### PR DESCRIPTION
## Summary

AI-generated Markdown could contain valid UTF-8 bytes yet display Chinese as mojibake when opened from its artifact URL: the CLI sent a bare MIME type, and the upload API also removed an explicitly supplied charset.

- Default CLI artifact delivery of Markdown, TXT, CSV and TSV to `charset=utf-8`, validating the existing byte buffer before writing to storage. Preserve the bytes without transcoding or adding a BOM, and respect an explicitly supplied charset.
- Preserve supported declared charsets for recognized `text/*` MIME types through upload preparation and completion. Cover signed PUT metadata, multipart storage metadata, and private artifact catalog records.

## Compatibility and scope

Older clients can still send a bare MIME type. The CLI continues to use the content type returned by preparation, so it remains compatible with older API deployments; automatic UTF-8 delivery requires both the CLI and API changes to ship. Unknown MIME types, binary formats, and unsupported optional charset parameters retain their existing normalization behavior.

This change addresses the agent's file delivery command and its shared API boundary. Browser file selection and upload encoding detection are handled separately. Existing artifact objects and cached responses are not rewritten by this PR; their metadata/cache repair is separate operational work.

## Verification

- Targeted CLI upload command tests: 21 passed, including non-ASCII text without a BOM, byte preservation, explicit GB18030, invalid UTF-8, and older API normalization.
- Targeted API prepare, complete, and multipart tests: 50 passed against an isolated local test database. The existing upload lifecycle BDD scenario also passed independently after updating its charset expectation and initializing its external storage signer.
- API and CLI type checks passed. The API check used one TypeScript checker after a two-checker attempt exceeded this sandbox's 4 GiB memory limit.
- Affected-file lint and formatting, and API/CLI Knip checks passed. A local Semgrep 1.175.1 comparison against the base confirmed no introduced path-traversal findings in the upload fixture.
- Live verification passed on head `45ec750652b09af970eb116127f957ac44b85336`, using its published CLI package and `https://pr-32954-api.vm6.ai`. The App/API deployment jobs and CLI readiness manifest were verified against that head.
- [Live Markdown file (open in a separate browser tab)](https://cdn.vm7.io/artifacts/mtfqqsnjd0.md): HTTP `text/markdown; charset=utf-8`, unchanged source/download SHA-256, no BOM, and correct Chinese/Japanese/Korean/emoji rendering in Chromium 152. Invalid UTF-8 was rejected before the storage PUT. The test used a fresh Clerk test account and organization; onboarding was not bypassed.

- The latest `ci-gate-turbo` check and App/API/CLI deployment checks all passed on the verified head.

## Acceptance

**Status: direct-file and HTTP metadata checks passed; native in-chat preview acceptance is still blocked.**

The [diagnostic file viewer](https://ai-text-utf8-pr32954-check.okou.app) embeds the original Markdown object from the verified commit without copying or transcoding it. It verifies direct document rendering only. Its iframe does not exercise the chat viewer's cross-origin text fetch and is neither a product fix nor evidence that in-chat preview works.

The dev CDN omits the required CORS response headers for the production App and the actual PR App origin. Verify and correct the test storage/CDN policy for the intended preview origin, then test a Markdown artifact inside the real PR chat UI. This environment blocker is independent of charset normalization; this PR does not change CDN CORS policy.

Use this commit's CLI against its API preview to deliver a UTF-8 Markdown file containing Chinese and emoji with `okou web upload-file -f report.md`. The artifact response and downloaded HTTP headers should contain `text/markdown; charset=utf-8`; the downloaded bytes should match the source and the browser should display the text correctly. A non-UTF-8 file without an explicit charset should fail before the storage PUT.