### PR TITLE
feat(platform): add model picker flyout layout behind a switch

### DIFF
--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -133,6 +133,11 @@ export const modelPickerMenuEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.ModelPickerMenu] ?? false;
 });
 
+/** The flyout replaces the drill-in menu's pages with two detached panels. */
+export const modelPickerFlyoutEnabled$ = computed((get): boolean => {
+  return get(featureSwitch$)[FeatureSwitchKey.ModelPickerFlyout] ?? false;
+});
+
 export const codexFastModeEnabled$ = computed((get): boolean => {
   return isCodexFastModeEnabled({ overrides: get(featureSwitch$) });
 });

--- a/turbo/apps/platform/src/signals/okou-page/model-picker-menu.ts
+++ b/turbo/apps/platform/src/signals/okou-page/model-picker-menu.ts
@@ -8,6 +8,11 @@ type ModelPickerMenuPage =
   | { readonly kind: "models"; readonly category: ModelPickerCategory }
   | { readonly kind: "settings" };
 
+/** Which side of the root panel the flyout has room to open towards. */
+type ModelPickerFlyoutSide = "left" | "right";
+
+const FLYOUT_PANEL_WIDTH = 258;
+
 /** One navigation state per composer, including split chats. */
 export function createModelPickerMenuSignals() {
   const internalPage$ = state<ModelPickerMenuPage>({ kind: "overview" });
@@ -16,6 +21,7 @@ export function createModelPickerMenuSignals() {
   });
   const reset$ = command(({ set }) => {
     set(internalPage$, { kind: "overview" });
+    set(internalFlyoutCategory$, "chat");
   });
   const showModels$ = command(({ set }, category: ModelPickerCategory) => {
     set(internalPage$, { kind: "models", category });
@@ -30,12 +36,72 @@ export function createModelPickerMenuSignals() {
         ?.focus();
     }),
   );
+
+  // The flyout keeps its own category rather than reusing the drill-in page:
+  // hovering a type must not push a navigation entry the user has to unwind.
+  const internalFlyoutCategory$ = state<ModelPickerCategory>("chat");
+  const flyoutCategory$ = computed((get) => {
+    return get(internalFlyoutCategory$);
+  });
+  const setFlyoutCategory$ = command(
+    ({ set }, category: ModelPickerCategory) => {
+      set(internalFlyoutCategory$, category);
+    },
+  );
+
+  const internalFlyoutSide$ = state<ModelPickerFlyoutSide>("left");
+  const flyoutSide$ = computed((get) => {
+    return get(internalFlyoutSide$);
+  });
+  /**
+   * Open the panel towards whichever side actually has room. Measured from the
+   * anchored root, so the root itself never moves when the panel flips.
+   */
+  const flyoutRootRef$ = onRef(
+    command(({ set }, element: HTMLElement, signal: AbortSignal) => {
+      const measure = () => {
+        const box = element.getBoundingClientRect();
+        const roomRight = window.innerWidth - box.right;
+        const roomLeft = box.left;
+        set(
+          internalFlyoutSide$,
+          roomRight >= FLYOUT_PANEL_WIDTH || roomRight >= roomLeft
+            ? "right"
+            : "left",
+        );
+      };
+      measure();
+      window.addEventListener("resize", measure);
+      signal.addEventListener("abort", () => {
+        window.removeEventListener("resize", measure);
+      });
+    }),
+  );
+
+  /** Land on the current model, not on whatever renders first. */
+  const focusFlyoutPanelRef$ = onRef(
+    command((_context, element: HTMLElement, _signal: AbortSignal) => {
+      const selected = element.querySelector<HTMLButtonElement>(
+        '[role="option"][aria-selected="true"]',
+      );
+      (
+        selected ??
+        element.querySelector<HTMLButtonElement>('[role="option"]')
+      )?.focus();
+    }),
+  );
+
   return {
     page$,
     reset$,
     showModels$,
     editSettings$,
     focusPanelRef$,
+    flyoutCategory$,
+    setFlyoutCategory$,
+    flyoutSide$,
+    flyoutRootRef$,
+    focusFlyoutPanelRef$,
   };
 }
 

--- a/turbo/apps/platform/src/signals/okou-page/model-picker-menu.ts
+++ b/turbo/apps/platform/src/signals/okou-page/model-picker-menu.ts
@@ -85,8 +85,7 @@ export function createModelPickerMenuSignals() {
         '[role="option"][aria-selected="true"]',
       );
       (
-        selected ??
-        element.querySelector<HTMLButtonElement>('[role="option"]')
+        selected ?? element.querySelector<HTMLButtonElement>('[role="option"]')
       )?.focus();
     }),
   );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-media-models.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-media-models.test.tsx
@@ -918,3 +918,61 @@ test.each(["desktop", "mobile"])(
     expect(mediaModelRow("Change Chat model, Claude Fable 5.1")).toBeVisible();
   },
 );
+
+test("Switch model type in the flyout without leaving the panel", async () => {
+  installModelEnvironment();
+  setDesktopViewport();
+  mockThread({
+    selectedModel: DEFAULT_RUN_MODEL,
+    selectedImageModel: null,
+  });
+
+  await setupPage({
+    context,
+    path: `/chats/${THREAD_ID}`,
+    featureSwitches: { [FeatureSwitchKey.ModelPickerFlyout]: true },
+  });
+
+  // The flyout trigger is a popover button inside the composer, not the
+  // Select combobox the menu layout renders.
+  const flyoutTrigger = await waitFor(() => {
+    const trigger = composerFor()
+      .querySelector('[data-slot="select-value"]')
+      ?.closest("button");
+    if (!(trigger instanceof HTMLElement)) {
+      throw new Error("Composer model picker not found");
+    }
+    return trigger;
+  });
+  click(flyoutTrigger);
+
+  // Types live in their own panel; the models sit in a second one beside it.
+  const types = await screen.findByRole("tablist", { name: "Models" });
+  const typeNames = queryAllByRoleFast("tab", types).map((tab) => {
+    return tab.textContent;
+  });
+  expect(typeNames).toHaveLength(3);
+  await screen.findByRole("listbox", { name: "Chat models" });
+
+  const imageType = queryAllByRoleFast("tab", types).find((tab) => {
+    return tab.textContent?.includes("Image");
+  });
+  if (!imageType) {
+    throw new Error("Image type row not found");
+  }
+  click(imageType);
+
+  // The panel swapped in place: no page was pushed, so nothing to go back from.
+  const imageList = await screen.findByRole("listbox", {
+    name: "Image models",
+  });
+  expect(screen.queryByLabelText("Back to models")).not.toBeInTheDocument();
+  expect(imageType).toHaveAttribute("aria-selected", "true");
+  const banana = queryAllByRoleFast("option", imageList).find((option) => {
+    return option.textContent?.includes("Nano Banana 2");
+  });
+  if (!banana) {
+    throw new Error("Nano Banana 2 option not found");
+  }
+  expect(banana).toHaveAttribute("aria-selected", "true");
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
@@ -731,9 +731,7 @@ test("Choose a model from the flyout without leaving the type list", async () =>
   click(await findButton("GPT 5.6 Sol"));
   // One panel, no pages: every model is reachable without a drill-in step.
   const list = await screen.findByRole("listbox", { name: "Chat models" });
-  expect(
-    screen.queryByRole("button", { name: "Back to models" }),
-  ).not.toBeInTheDocument();
+  expect(screen.queryByLabelText("Back to models")).not.toBeInTheDocument();
   const current = within(list).getByRole("option", { name: /GPT 5.6 Sol/u });
   expect(current).toHaveAttribute("aria-selected", "true");
   expect(current).toHaveFocus();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
@@ -16,7 +16,7 @@ import {
   userModelPreferenceContract,
 } from "@okouai/api-contracts/contracts/user-model-preference";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, test } from "vitest";
 
@@ -711,4 +711,35 @@ test("Navigate the compact menu by keyboard and retain Fast after dismissal", as
   click(buttonNamed("Adjust GPT 5.6 Sol settings", reopened));
   await screen.findByRole("region", { name: "Chat settings" });
   expect(screen.getByRole("switch", { name: "Fast" })).toBeChecked();
+});
+
+test("Choose a model from the flyout without leaving the type list", async () => {
+  const user = userEvent.setup({ delay: null });
+  context.mocks.browser.matchMedia((query) => {
+    return query === "(min-width: 640px)";
+  });
+  installNewChat(["gpt-5.6-sol", "gpt-5.6-luna"], "gpt-5.6-sol");
+  await setupPage({
+    context,
+    path: NEW_CHAT_PATH,
+    featureSwitches: {
+      [FeatureSwitchKey.ModelPickerFlyout]: true,
+      [FeatureSwitchKey.CodexFastMode]: false,
+    },
+  });
+  await readyComposer();
+  click(await findButton("GPT 5.6 Sol"));
+  // One panel, no pages: every model is reachable without a drill-in step.
+  const list = await screen.findByRole("listbox", { name: "Chat models" });
+  expect(
+    screen.queryByRole("button", { name: "Back to models" }),
+  ).not.toBeInTheDocument();
+  const current = within(list).getByRole("option", { name: /GPT 5.6 Sol/u });
+  expect(current).toHaveAttribute("aria-selected", "true");
+  expect(current).toHaveFocus();
+  await user.keyboard("{ArrowDown}");
+  const next = within(list).getByRole("option", { name: /GPT 5.6 Luna/u });
+  expect(next).toHaveFocus();
+  click(next);
+  await expect(findButton("GPT 5.6 Luna")).resolves.toBeVisible();
 });

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -252,6 +252,7 @@ import {
 } from "../../signals/external/user-model-preference.ts";
 import {
   codexFastModeEnabled$,
+  modelPickerFlyoutEnabled$,
   modelPickerMenuEnabled$,
   customConnectorMcpEnabled$,
   voiceInputV2Enabled$,
@@ -9478,6 +9479,10 @@ function ComposerRunModelPickerControl({
 }) {
   const { t } = useTranslation();
   const modelMenuEnabled = useGet(modelPickerMenuEnabled$);
+  // The flyout needs the room a phone does not have; narrow viewports keep the
+  // menu's pages until the sheet layout lands.
+  const modelFlyoutEnabled =
+    useGet(modelPickerFlyoutEnabled$) && desktopLayout;
   const modelPickerOpen = useGet(signals.model.modelPickerOpen$);
   const setModelPickerOpen = useSet(signals.model.setModelPickerOpen$);
   const setLifecycleRef = useSet(signals.model.desktopModelPickerLifecycleRef$);
@@ -9490,7 +9495,10 @@ function ComposerRunModelPickerControl({
           return $.chat.composer.selectModel;
         })}
         triggerClassName={composerModelPickerTriggerClassName()}
-        menuSignals={modelMenuEnabled ? signals.model.menu : undefined}
+        menuSignals={
+          modelMenuEnabled || modelFlyoutEnabled ? signals.model.menu : undefined
+        }
+        flyoutLayout={modelFlyoutEnabled}
         compactTrigger
         mobileIconTrigger
         open={modelPickerOpen}

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -9481,8 +9481,7 @@ function ComposerRunModelPickerControl({
   const modelMenuEnabled = useGet(modelPickerMenuEnabled$);
   // The flyout needs the room a phone does not have; narrow viewports keep the
   // menu's pages until the sheet layout lands.
-  const modelFlyoutEnabled =
-    useGet(modelPickerFlyoutEnabled$) && desktopLayout;
+  const modelFlyoutEnabled = useGet(modelPickerFlyoutEnabled$) && desktopLayout;
   const modelPickerOpen = useGet(signals.model.modelPickerOpen$);
   const setModelPickerOpen = useSet(signals.model.setModelPickerOpen$);
   const setLifecycleRef = useSet(signals.model.desktopModelPickerLifecycleRef$);
@@ -9496,7 +9495,9 @@ function ComposerRunModelPickerControl({
         })}
         triggerClassName={composerModelPickerTriggerClassName()}
         menuSignals={
-          modelMenuEnabled || modelFlyoutEnabled ? signals.model.menu : undefined
+          modelMenuEnabled || modelFlyoutEnabled
+            ? signals.model.menu
+            : undefined
         }
         flyoutLayout={modelFlyoutEnabled}
         compactTrigger

--- a/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
@@ -695,11 +695,12 @@ export function ModelPickerFlyoutContent({
         className={cn(
           "flex max-h-[284px] w-[252px] flex-col gap-0.5 overflow-y-auto overscroll-contain",
           "rounded-xl border border-border bg-popover p-1 shadow-md",
-          "motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150",
           types.length > 1
             ? cn(
                 "absolute bottom-0",
-                side === "right" ? "left-[calc(100%+6px)]" : "right-[calc(100%+6px)]",
+                side === "right"
+                  ? "left-[calc(100%+6px)]"
+                  : "right-[calc(100%+6px)]",
               )
             : "w-[252px]",
         )}
@@ -762,7 +763,8 @@ function moveFlyoutFocus(
   }
   event.preventDefault();
   const next =
-    (current + (event.key === "ArrowDown" ? 1 : -1) + ring.length) % ring.length;
+    (current + (event.key === "ArrowDown" ? 1 : -1) + ring.length) %
+    ring.length;
   ring[next]?.focus();
 }
 

--- a/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
@@ -5,6 +5,7 @@ import {
   Check,
   ChevronRight,
   Cpu,
+  MessageCircle,
   SlidersHorizontal,
 } from "lucide-react";
 import { Button, Switch, cn } from "@okouai/ui";
@@ -434,6 +435,335 @@ function MediaModelList({
       </div>
     </>
   );
+}
+
+/**
+ * Flyout layout: model types on the left, that type's models in a panel beside
+ * it. The two panels are separate cards -- joining them would make the root
+ * resize whenever a longer list opened, and the type rows would move out from
+ * under the pointer.
+ */
+function ModelPickerFlyoutTypeRow({
+  icon,
+  label,
+  current,
+  active,
+  index,
+  total,
+  onActivate,
+}: {
+  icon: ReactNode;
+  label: string;
+  current: string;
+  active: boolean;
+  index: number;
+  total: number;
+  onActivate: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      aria-posinset={index + 1}
+      aria-setsize={total}
+      tabIndex={active ? 0 : -1}
+      className={cn(
+        "flex h-11 w-full items-center gap-2 rounded-lg px-2 text-left transition-colors",
+        "hover:bg-state-hover focus-visible:ring-inset",
+        active && "bg-state-hover",
+      )}
+      onMouseEnter={onActivate}
+      onFocus={onActivate}
+      onClick={onActivate}
+    >
+      <span className="flex w-4 shrink-0 items-center justify-center text-muted-foreground">
+        {icon}
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-px">
+        <span className="truncate text-[13px] leading-[17px] text-foreground">
+          {label}
+        </span>
+        <span className="truncate text-[11px] leading-[14px] text-muted-foreground">
+          {current}
+        </span>
+      </span>
+      <ChevronRight
+        size={13}
+        aria-hidden="true"
+        className="shrink-0 text-muted-foreground"
+      />
+    </button>
+  );
+}
+
+function ModelPickerFlyoutOption({
+  content,
+  selected,
+  disabled,
+  index,
+  total,
+  onSelect,
+}: {
+  content: ReactNode;
+  selected: boolean;
+  disabled: boolean;
+  index: number;
+  total: number;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={selected}
+      aria-posinset={index + 1}
+      aria-setsize={total}
+      // Unavailable routes stay in the list and stay reachable: a native
+      // disabled row is invisible to keyboard and screen reader users.
+      aria-disabled={disabled || undefined}
+      tabIndex={-1}
+      className={cn(
+        "relative flex h-9 w-full items-center gap-2 rounded-lg py-0 pl-2 pr-8 text-left",
+        "text-[13px] font-normal text-foreground transition-colors",
+        "focus-visible:ring-inset",
+        disabled ? "opacity-55" : "hover:bg-state-hover",
+      )}
+      onClick={() => {
+        if (!disabled) {
+          onSelect();
+        }
+      }}
+    >
+      {content}
+      {selected && (
+        <Check size={15} aria-hidden="true" className="absolute right-2" />
+      )}
+    </button>
+  );
+}
+
+function ModelPickerFlyoutOptions({
+  activeMedia,
+  options,
+  value,
+  onChange,
+}: {
+  activeMedia: MediaModelPanelState["categories"][number] | undefined;
+  options: readonly ModelPickerMenuOption[];
+  value: ModelProviderSelection | null;
+  onChange: (selection: ModelProviderSelection) => void;
+}) {
+  if (activeMedia) {
+    return activeMedia.options.map((option, index) => {
+      return (
+        <ModelPickerFlyoutOption
+          key={option.key}
+          content={
+            <>
+              {option.icon}
+              <span className="min-w-0 flex-1 truncate">{option.label}</span>
+              <PriceTierBadge
+                tier={option.priceTier}
+                description={getMediaModelPriceTierLabel(option.priceTier)}
+              />
+            </>
+          }
+          selected={option.selected}
+          disabled={false}
+          index={index}
+          total={activeMedia.options.length}
+          onSelect={option.onSelect}
+        />
+      );
+    });
+  }
+  return options.map((option, index) => {
+    return (
+      <ModelPickerFlyoutOption
+        key={option.model}
+        content={option.content}
+        selected={value?.selectedModel === option.model}
+        disabled={option.disabled}
+        index={index}
+        total={options.length}
+        onSelect={() => {
+          onChange(
+            value?.selectedModel === option.model
+              ? value
+              : { selectedModel: option.model },
+          );
+        }}
+      />
+    );
+  });
+}
+
+export function ModelPickerFlyoutContent({
+  signals,
+  value,
+  placeholder,
+  options,
+  mediaModelPanel,
+  onChange,
+}: ModelPickerMenuContentProps) {
+  const { t } = useTranslation();
+  const category = useGet(signals.flyoutCategory$);
+  const side = useGet(signals.flyoutSide$);
+  const setCategory = useSet(signals.setFlyoutCategory$);
+  const rootRef = useSet(signals.flyoutRootRef$);
+  const panelRef = useSet(signals.focusFlyoutPanelRef$);
+  const selectedOption = options.find((option) => {
+    return option.model === value?.selectedModel;
+  });
+  const chatLabel =
+    selectedOption?.label ??
+    (value ? getCanonicalModelDisplayName(value.selectedModel) : placeholder);
+  const types = [
+    {
+      id: "chat" as const,
+      label: t(($) => {
+        return $.settings.models.picker.categoryChat;
+      }),
+      current: chatLabel,
+      icon: <MessageCircle size={15} aria-hidden="true" />,
+    },
+    ...(mediaModelPanel?.categories ?? []).map((mediaCategory) => {
+      const selected = mediaCategory.options.find((option) => {
+        return option.selected;
+      });
+      return {
+        id: mediaCategory.id,
+        label: mediaCategory.tabLabel,
+        current: selected?.label ?? mediaCategory.label,
+        icon: selected?.icon ?? null,
+      };
+    }),
+  ];
+  const activeType = types.some((type) => {
+    return type.id === category;
+  })
+    ? category
+    : "chat";
+  const activeMedia = mediaModelPanel?.categories.find((mediaCategory) => {
+    return mediaCategory.id === activeType;
+  });
+  const panelLabel =
+    activeMedia?.label ??
+    t(($) => {
+      return $.settings.models.picker.chatModels;
+    });
+  return (
+    <div
+      ref={rootRef}
+      className="relative w-[188px]"
+      onKeyDown={(event) => {
+        moveFlyoutFocus(event, types.length);
+      }}
+    >
+      {types.length > 1 && (
+        <div
+          role="tablist"
+          aria-orientation="vertical"
+          aria-label={t(($) => {
+            return $.settings.models.picker.models;
+          })}
+          className="flex flex-col gap-0.5 rounded-xl border border-border bg-popover p-1 shadow-md"
+        >
+          {types.map((type, index) => {
+            return (
+              <ModelPickerFlyoutTypeRow
+                key={type.id}
+                icon={type.icon}
+                label={type.label}
+                current={type.current}
+                active={type.id === activeType}
+                index={index}
+                total={types.length}
+                onActivate={() => {
+                  setCategory(type.id);
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
+      <div
+        ref={panelRef}
+        role="listbox"
+        aria-label={panelLabel}
+        className={cn(
+          "flex max-h-[284px] w-[252px] flex-col gap-0.5 overflow-y-auto overscroll-contain",
+          "rounded-xl border border-border bg-popover p-1 shadow-md",
+          "motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150",
+          types.length > 1
+            ? cn(
+                "absolute bottom-0",
+                side === "right" ? "left-[calc(100%+6px)]" : "right-[calc(100%+6px)]",
+              )
+            : "w-[252px]",
+        )}
+      >
+        <ModelPickerFlyoutOptions
+          activeMedia={activeMedia}
+          options={options}
+          value={value}
+          onChange={onChange}
+        />
+        {options.length === 0 && !activeMedia && (
+          <p className="px-2 py-2 text-sm text-muted-foreground">
+            {t(($) => {
+              return $.settings.models.picker.noConfiguredModels;
+            })}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Vertical tablist paired with a listbox: up/down inside each, arrows across. */
+function moveFlyoutFocus(
+  event: KeyboardEvent<HTMLDivElement>,
+  typeCount: number,
+): void {
+  const target = event.target as HTMLElement;
+  const root = event.currentTarget;
+  const onType = target.getAttribute("role") === "tab";
+  const options = Array.from(
+    root.querySelectorAll<HTMLElement>('[role="option"]'),
+  );
+  const tabs = Array.from(root.querySelectorAll<HTMLElement>('[role="tab"]'));
+  if (onType && (event.key === "ArrowRight" || event.key === "Enter")) {
+    event.preventDefault();
+    (
+      options.find((option) => {
+        return option.getAttribute("aria-selected") === "true";
+      }) ?? options[0]
+    )?.focus();
+    return;
+  }
+  if (!onType && event.key === "ArrowLeft" && typeCount > 1) {
+    event.preventDefault();
+    tabs
+      .find((tab) => {
+        return tab.getAttribute("aria-selected") === "true";
+      })
+      ?.focus();
+    return;
+  }
+  if (event.key !== "ArrowDown" && event.key !== "ArrowUp") {
+    return;
+  }
+  const ring = onType ? tabs : options;
+  const current = ring.indexOf(target);
+  if (current === -1 || ring.length === 0) {
+    return;
+  }
+  event.preventDefault();
+  const next =
+    (current + (event.key === "ArrowDown" ? 1 : -1) + ring.length) % ring.length;
+  ring[next]?.focus();
 }
 
 export function ModelPickerMenuContent(props: ModelPickerMenuContentProps) {

--- a/turbo/apps/platform/src/views/okou-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-provider-picker.tsx
@@ -79,7 +79,10 @@ import { settingsIconAssetUrl } from "./settings/settings-icon-assets";
 
 import type { ModelPickerMenuSignals } from "../../../signals/okou-page/model-picker-menu.ts";
 import { PriceTierBadge } from "./model-picker-price-tier.tsx";
-import { ModelPickerMenuContent } from "./model-picker-menu.tsx";
+import {
+  ModelPickerFlyoutContent,
+  ModelPickerMenuContent,
+} from "./model-picker-menu.tsx";
 
 export interface ModelProviderSelection {
   selectedModel: SupportedRunModel;
@@ -158,6 +161,8 @@ interface ModelProviderPickerProps {
   mediaModelPanel?: MediaModelPanelState;
   /** Composer-owned navigation for the compact model menu rollout. */
   menuSignals?: ModelPickerMenuSignals;
+  /** Replaces the menu's pages with the detached type/model flyout. */
+  flyoutLayout?: boolean;
   /** Model omitted from this caller's list of available choices. */
   excludedModel?: SupportedRunModel;
 }
@@ -1344,6 +1349,7 @@ function SubscribedExplicitModelFirstModelPickerContent({
   excludedModel,
   showInheritOption,
   menuSignals,
+  flyoutLayout,
   onMenuChange,
 }: {
   value: ModelProviderSelection | null;
@@ -1354,6 +1360,7 @@ function SubscribedExplicitModelFirstModelPickerContent({
   excludedModel: SupportedRunModel | undefined;
   showInheritOption: boolean;
   menuSignals: ModelPickerMenuSignals | undefined;
+  flyoutLayout: boolean;
   onMenuChange: (selection: ModelProviderSelection) => void;
 }) {
   const { t } = useTranslation();
@@ -1402,8 +1409,11 @@ function SubscribedExplicitModelFirstModelPickerContent({
     excludedModel,
   });
   if (menuSignals) {
+    const MenuContent = flyoutLayout
+      ? ModelPickerFlyoutContent
+      : ModelPickerMenuContent;
     return (
-      <ModelPickerMenuContent
+      <MenuContent
         signals={menuSignals}
         value={state.selection}
         placeholder={placeholder}
@@ -1501,6 +1511,7 @@ function EnabledExplicitModelFirstModelPicker(
       excludedModel={props.excludedModel}
       showInheritOption={props.showInheritOption ?? false}
       menuSignals={props.menuSignals}
+      flyoutLayout={props.flyoutLayout ?? false}
       onMenuChange={handleSelectionChange}
     />
   );
@@ -1543,7 +1554,13 @@ function EnabledExplicitModelFirstModelPicker(
           align="end"
           collisionPadding={8}
           aria-label={props.placeholder}
-          className="w-[304px] max-w-[calc(100vw-16px)] max-h-[var(--available-height)] overflow-y-auto overscroll-contain p-1"
+          className={cn(
+            props.flyoutLayout
+              ? // Each flyout panel carries its own card, so the popover itself
+                // must not paint one -- otherwise they read as a single box.
+                "w-auto border-0 bg-transparent p-0 shadow-none"
+              : "w-[304px] max-w-[calc(100vw-16px)] max-h-[var(--available-height)] overflow-y-auto overscroll-contain p-1",
+          )}
         >
           {content}
         </PopoverContent>
@@ -1581,6 +1598,7 @@ export function ModelProviderPicker({
   showInheritOption = false,
   mediaModelPanel,
   menuSignals,
+  flyoutLayout = false,
   excludedModel,
 }: ModelProviderPickerProps) {
   const { t } = useTranslation();
@@ -1619,6 +1637,7 @@ export function ModelProviderPicker({
       fastLabel={fastLabel}
       excludedModel={excludedModel}
       menuSignals={menuSignals}
+      flyoutLayout={flyoutLayout}
       {...(mediaModelPanel ? { mediaModelPanel } : {})}
     />
   );

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -47,6 +47,7 @@ export enum FeatureSwitchKey {
   WorkdayConnector = "workdayConnector",
   CodexFastMode = "_fastModel",
   ModelPickerMenu = "modelPickerMenu",
+  ModelPickerFlyout = "modelPickerFlyout",
   ChatPreference = "chatPreference",
   RealAgentInPreview = "_realAgentInPreview",
   ZapierConnector = "zapierConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -287,6 +287,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabledEmailHashes: ["6490c77f"], // bingjie@okou.ai
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ModelPickerFlyout]: {
+    maintainer: "tongx@okou.ai",
+    description:
+      "Pick a model from a detached flyout: model types on the left, that type's models in a panel beside it.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ChatPreference]: {
     maintainer: "lancy@okou.ai",
     description:


### PR DESCRIPTION
## What

Adds `modelPickerFlyout` (staff-visible in Lab, off by default) and, when it is
on, replaces the compact menu's drill-in pages with **two detached panels**:
model types on the left, that type's models in a panel beside it.

Design was reviewed end to end for DES-43; the interactive prototype the
decisions were taken against is at https://des43-model-picker-review.okou.app

## Why detached rather than one panel

Joining the two columns makes the whole popover resize whenever a longer list
opens. Because it is bottom-anchored, the type rows then move out from under the
pointer and the mouse has to chase them. Separate cards keep the root a constant
size; only the floating panel resizes.

## What it fixes from the review

- The current model is reachable in one step instead of a drill-in plus a Back.
- Focus lands on the current model, not on the Back button.
- Rows are a real `listbox` with `aria-selected` / `aria-posinset`, so a screen
  reader announces "3 of 7, selected" rather than "toggle button, pressed".
- Unavailable routes keep `aria-disabled` and stay in the keyboard order; a
  native `disabled` row is invisible to keyboard and screen reader users.
- The panel opens towards whichever side has room, measured from the anchored
  root, so it never runs off the viewport.

## Scope

Desktop only for now — narrow viewports keep the existing menu until the bottom
sheet layout lands in a follow-up. The thinking-effort entry and moving Fast out
of the picker are separate changes; `thinkingLevel` has no path from the
composer to the runner yet.

## Verification

- `pnpm check-types` in `turbo/apps/platform` — clean
- `chat-composer-model-selection.test.tsx` — 13 passed, including a new case
  covering the flyout's single-panel structure, focus landing and selection
- `oxlint --deny-warnings` on the changed files — clean

## Try it

Lab → turn on **modelPickerFlyout**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)