### PR TITLE
perf(api): scope catalog reads for thread connector selections

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -133,9 +133,13 @@ import {
   API_TEST_CONNECTOR_CATALOG,
   apiTestConnectorCatalogValidationAuthority,
   clearApiTestConnectorCatalogExternalReaderIdentityReplacements,
+  clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements,
+  deleteApiTestConnectorCatalogRuntimeProjectionRow,
+  deleteApiTestConnectorCatalogRuntimeProjectionSet,
   installApiTestConnectorCatalog,
   replaceApiTestConnectorCatalogStoredBytes,
   setApiTestConnectorCatalogExternalReaderIdentityReadHook,
+  setApiTestConnectorCatalogRuntimeProjectionIdentityReadHook,
 } from "../../../test-fixtures/connector-catalog";
 import { setOrgModelPolicyProviderTypeFixture } from "../../../test-fixtures/org-model-policies";
 import {
@@ -1867,14 +1871,163 @@ async function configureRuntimeContextGateway(
   ]);
 }
 
+function setThreadConnectorCatalogReadHook(hook: () => Promise<void>): void {
+  // Admission first reads the run scope's projection and passes that result
+  // into preparation. Inject the failure/barrier only on the subsequent
+  // current-authority read for the stored thread account.
+  let admissionRead = true;
+  setApiTestConnectorCatalogRuntimeProjectionIdentityReadHook(() => {
+    if (admissionRead) {
+      admissionRead = false;
+      return Promise.resolve();
+    }
+    return hook();
+  });
+}
+
 describe("CHAT-02: thread connector account selection", () => {
+  it.each(["missing", "incomplete"] as const)(
+    "reads the selected account when the catalog projection is %s",
+    async (projectionState) => {
+      const fixture = await selectedThreadConnectorFixture(
+        "Thread catalog projection fallback",
+      );
+      // Advance authority so setup's cached selection cannot hide a missing row.
+      await installApiTestConnectorCatalog({
+        catalogVersion: `api-test-thread-fallback-${randomUUID()}`,
+        runtimeProjection: true,
+      });
+      // Model an older/incomplete persisted projection through the external
+      // database fixture; public APIs cannot create these rollout states.
+      if (projectionState === "missing") {
+        await deleteApiTestConnectorCatalogRuntimeProjectionSet();
+      } else {
+        await deleteApiTestConnectorCatalogRuntimeProjectionRow("openai");
+      }
+      const selections = await accept(
+        chatThreadConnectorSelectionsClient().get({
+          headers: sessionHeaders(fixture.actor),
+          params: { id: fixture.threadId },
+        }),
+        [200],
+      );
+      expect(selections.body.selectedConnections).toMatchObject([
+        {
+          id: fixture.connectionId,
+          target: { kind: "builtin", connectorSlug: "openai" },
+          connectionStatus: "connected",
+        },
+      ]);
+    },
+  );
+
+  it("uses a selected builtin account without reading the full catalog", async () => {
+    const fixture = await selectedThreadConnectorFixture(
+      "Scoped thread catalog selection",
+    );
+    onTestFinished(() => {
+      clearApiTestConnectorCatalogExternalReaderIdentityReplacements();
+    });
+    // Reject the external full-snapshot read while leaving real scoped
+    // PostgreSQL projections available to this API request.
+    setApiTestConnectorCatalogExternalReaderIdentityReadHook(() => {
+      return Promise.reject(new Error("Full catalog read is unavailable"));
+    });
+
+    const selections = await accept(
+      chatThreadConnectorSelectionsClient().get({
+        headers: sessionHeaders(fixture.actor),
+        params: { id: fixture.threadId },
+      }),
+      [200],
+    );
+    expect(selections.body.selections).toStrictEqual([
+      {
+        connectionId: fixture.connectionId,
+        target: { kind: "builtin", connectorSlug: "openai" },
+      },
+    ]);
+    const run = await sendChatRun(fixture.actor, {
+      agentId: fixture.agentId,
+      threadId: fixture.threadId,
+      prompt: "Use the selected account from its current projection",
+    });
+    const claimed = await claimChatRun(fixture.runnerGroup, run.runId);
+    expect(
+      claimed.claim.secretConnectorMetadataMap?.OPENAI_TOKEN,
+    ).toMatchObject({ sourceId: fixture.connectionId });
+    await cancelChatRun(fixture.actor, run.runId, claimed.sandboxHeaders);
+  });
+
+  it("preserves an out-of-scope choice without requiring its catalog", async () => {
+    const fixture = await selectedThreadConnectorFixture(
+      "Out-of-scope thread catalog selection",
+    );
+    await api.enableAgentConnectors(fixture.actor, fixture.agentId, []);
+    onTestFinished(() => {
+      clearApiTestConnectorCatalogExternalReaderIdentityReplacements();
+      clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements();
+    });
+    const rejectCatalogRead = () => {
+      return Promise.reject(new Error("Connector catalog is unavailable"));
+    };
+    setApiTestConnectorCatalogExternalReaderIdentityReadHook(rejectCatalogRead);
+    setApiTestConnectorCatalogRuntimeProjectionIdentityReadHook(
+      rejectCatalogRead,
+    );
+    const run = await sendChatRun(fixture.actor, {
+      agentId: fixture.agentId,
+      threadId: fixture.threadId,
+      prompt: "Do not use the connector removed from the agent scope",
+    });
+    const claimed = await claimChatRun(fixture.runnerGroup, run.runId);
+    expect(
+      claimed.claim.secretConnectorMetadataMap?.OPENAI_TOKEN,
+    ).toBeUndefined();
+    await cancelChatRun(fixture.actor, run.runId, claimed.sandboxHeaders);
+
+    clearApiTestConnectorCatalogExternalReaderIdentityReplacements();
+    clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements();
+    await api.enableAgentConnectors(fixture.actor, fixture.agentId, ["openai"]);
+    const selections = await accept(
+      chatThreadConnectorSelectionsClient().get({
+        headers: sessionHeaders(fixture.actor),
+        params: { id: fixture.threadId },
+      }),
+      [200],
+    );
+    expect(selections.body.selections).toStrictEqual([
+      {
+        connectionId: fixture.connectionId,
+        target: { kind: "builtin", connectorSlug: "openai" },
+      },
+    ]);
+    const reauthorized = await sendChatRun(fixture.actor, {
+      agentId: fixture.agentId,
+      threadId: fixture.threadId,
+      prompt: "Use the preserved account after reauthorization",
+    });
+    const reauthorizedClaim = await claimChatRun(
+      fixture.runnerGroup,
+      reauthorized.runId,
+    );
+    expect(
+      reauthorizedClaim.claim.secretConnectorMetadataMap?.OPENAI_TOKEN,
+    ).toMatchObject({ sourceId: fixture.connectionId });
+    await cancelChatRun(
+      fixture.actor,
+      reauthorized.runId,
+      reauthorizedClaim.sandboxHeaders,
+    );
+  });
+
   it("overlaps stored thread selection with model-provider resolution", async () => {
     const fixture = await selectedThreadConnectorFixture(
       "Runtime context overlap thread",
     );
     await configureRuntimeContextGateway(fixture.actor);
     onTestFinished(() => {
-      clearApiTestConnectorCatalogExternalReaderIdentityReplacements();
+      clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements();
     });
     const threadCatalogReadStarted = createDeferredPromise<void>(
       context.signal,
@@ -1884,7 +2037,7 @@ describe("CHAT-02: thread connector account selection", () => {
         threadCatalogReadStarted.resolve(undefined);
       }
     });
-    setApiTestConnectorCatalogExternalReaderIdentityReadHook(() => {
+    setThreadConnectorCatalogReadHook(() => {
       if (!threadCatalogReadStarted.settled()) {
         threadCatalogReadStarted.resolve(undefined);
       }
@@ -1924,7 +2077,7 @@ describe("CHAT-02: thread connector account selection", () => {
       "Overlap stored thread selection with runtime context",
       "runtime-context-priority-secret",
     ]);
-    clearApiTestConnectorCatalogExternalReaderIdentityReplacements();
+    clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements();
     const claimed = await claimChatRun(fixture.runnerGroup, run.runId);
     expect(kms.decryptCalls).toBeGreaterThan(0);
     expect(claimed.claim.environment).toMatchObject({
@@ -1943,13 +2096,13 @@ describe("CHAT-02: thread connector account selection", () => {
       "Runtime context abort priority thread",
     );
     onTestFinished(() => {
-      clearApiTestConnectorCatalogExternalReaderIdentityReplacements();
+      clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements();
     });
     const abortError = new Error("runtime context priority abort");
     abortError.name = "AbortError";
     const abortThreadError = new Error("thread selection below abort");
     const abortController = new AbortController();
-    setApiTestConnectorCatalogExternalReaderIdentityReadHook(() => {
+    setThreadConnectorCatalogReadHook(() => {
       abortController.abort(abortError);
       return Promise.reject(abortThreadError);
     });
@@ -1978,7 +2131,7 @@ describe("CHAT-02: thread connector account selection", () => {
     );
     await configureRuntimeContextGateway(fixture.actor);
     onTestFinished(() => {
-      clearApiTestConnectorCatalogExternalReaderIdentityReplacements();
+      clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements();
     });
     const providerFailureStarted = createDeferredPromise<void>(context.signal);
     onTestFinished(() => {
@@ -1988,7 +2141,7 @@ describe("CHAT-02: thread connector account selection", () => {
     });
     const threadError = new Error("runtime thread selection priority failure");
     const providerError = new Error("model provider below thread failure");
-    setApiTestConnectorCatalogExternalReaderIdentityReadHook(async () => {
+    setThreadConnectorCatalogReadHook(async () => {
       await providerFailureStarted.promise;
       throw threadError;
     });
@@ -2355,6 +2508,19 @@ describe("CHAT-02: thread connector account selection", () => {
       agentId,
       prompt: "Use my default custom connector account",
     });
+    onTestFinished(() => {
+      clearApiTestConnectorCatalogExternalReaderIdentityReplacements();
+      clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements();
+    });
+    const rejectBuiltinCatalogRead = () => {
+      return Promise.reject(new Error("Builtin catalog is unavailable"));
+    };
+    setApiTestConnectorCatalogExternalReaderIdentityReadHook(
+      rejectBuiltinCatalogRead,
+    );
+    setApiTestConnectorCatalogRuntimeProjectionIdentityReadHook(
+      rejectBuiltinCatalogRead,
+    );
     await accept(
       chatThreadConnectorSelectionsClient().update({
         headers: sessionHeaders(actor),
@@ -2369,6 +2535,22 @@ describe("CHAT-02: thread connector account selection", () => {
       }),
       [200],
     );
+    const availableSelection = await accept(
+      chatThreadConnectorSelectionsClient().get({
+        headers: sessionHeaders(actor),
+        params: { id: first.threadId },
+      }),
+      [200],
+    );
+    expect(availableSelection.body.selectedConnections).toMatchObject([
+      {
+        id: connectorId,
+        target: { kind: "custom", customConnectorId: customConnector.id },
+        connectionStatus: "connected",
+      },
+    ]);
+    clearApiTestConnectorCatalogExternalReaderIdentityReplacements();
+    clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacements();
     await cancelChatRun(actor, first.runId);
     await setCustomConnectorCredentialStorageState(context, {
       orgId,

--- a/turbo/apps/api/src/signals/services/chat-thread-connector-selection.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-connector-selection.service.ts
@@ -586,18 +586,18 @@ export async function resolveChatThreadConnectorSelections(
   const storedSelections = await projectStoredSelections(db, {
     orgId: args.orgId,
     userId: args.userId,
-    selections: rows.map(selectionFromRow),
+    selections: rows.map(selectionFromRow).filter((selection) => {
+      return targetIsAuthorized(args.scope, selection.target);
+    }),
   });
   const selectionCandidates = new Map<
     string,
     readonly ConnectorAccountSelection[]
   >();
   for (const selection of storedSelections) {
-    if (targetIsAuthorized(args.scope, selection.target)) {
-      selectionCandidates.set(connectorAccountTargetKey(selection.target), [
-        selection,
-      ]);
-    }
+    selectionCandidates.set(connectorAccountTargetKey(selection.target), [
+      selection,
+    ]);
   }
   if (args.connectorSourceId !== undefined) {
     const target = await loadConnectorTarget(db, {

--- a/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
@@ -62,7 +62,9 @@ import {
   connectorCredentialStatusWithMethod,
 } from "./connector-credential-status.service";
 import {
+  loadConnectorRuntimeSelection,
   loadConnectorRuntimeSnapshot,
+  type ConnectorRuntimeSelection,
   type ConnectorRuntimeSnapshot,
 } from "./connector-catalog-runtime.service";
 
@@ -423,7 +425,7 @@ async function customTargetIsVisible(
 
 function builtinConnection(
   row: ConnectorAccountRow,
-  snapshot: ConnectorRuntimeSnapshot,
+  snapshot: ConnectorRuntimeSelection,
   now: Date,
   includeScopeMismatch = false,
 ): ConnectorAccountConnection | null {
@@ -568,7 +570,7 @@ function customConnection(
 
 function projectConnection(
   row: ConnectorAccountRow,
-  snapshot: ConnectorRuntimeSnapshot | null,
+  snapshot: ConnectorRuntimeSelection | null,
   now: Date,
   includeBuiltinScopeMismatch = false,
 ): ConnectorAccountConnection | null {
@@ -821,6 +823,34 @@ export async function getConnectorAccount(
   return projectConnection(row, snapshot, nowDate());
 }
 
+async function loadConnectorAccountRuntimeSelection(
+  db: ReadonlyDb,
+  rows: readonly ConnectorAccountRow[],
+): Promise<ConnectorRuntimeSelection | null> {
+  const connectorSlugs = rows.flatMap((row) => {
+    const slug = connectorSlugSchema.safeParse(row.connectorSlug);
+    return slug.success ? [slug.data] : [];
+  });
+  if (connectorSlugs.length === 0) {
+    return null;
+  }
+  const result = await settle(
+    loadConnectorRuntimeSelection(db, {
+      requestedConnectorSlugs: connectorSlugs,
+    }),
+  );
+  if (result.ok) {
+    return result.value;
+  }
+  if (!isConnectorCatalogUnavailableError(result.error)) {
+    throw result.error;
+  }
+  log.warn("Connector catalog unavailable while resolving account lifecycle", {
+    error: result.error,
+  });
+  return null;
+}
+
 export async function listConnectorAccountsByIds(
   db: ReadonlyDb,
   args: {
@@ -837,7 +867,7 @@ export async function listConnectorAccountsByIds(
     ...args,
     connectionIds,
   });
-  const snapshot = await loadCurrentConnectorRuntimeSnapshot(db);
+  const snapshot = await loadConnectorAccountRuntimeSelection(db, rows);
   const now = nowDate();
   return rows.flatMap((row) => {
     const connection = projectConnection(row, snapshot, now);


### PR DESCRIPTION
## Summary

- Filter parsed stored thread connector selections against the effective run scope before loading their accounts. Keep thread ownership checks, local-row validation and source-account priority unchanged.
- Resolve ID-scoped account projections through the existing current runtime-selection loader, requesting only owned builtin account slugs. Empty/custom-only results do not read the builtin catalog; custom account availability remains independent.
- Add real API regressions for selected builtin delivery without a full-catalog read, out-of-scope preservation and reauthorization, custom selection without builtin catalog access, and missing/incomplete projection fallback. Preserve concurrency and abort/thread/provider error precedence.

## Why

#32943 records a repeated first-dispatch thread-selection tail and the verified full-catalog dependency. The run's separately prepared catalog did not remove the full accepted-snapshot/all-connector materialization used by stored account selection.

This is a production optimization, not experimental configuration. It does not claim that all measured thread-selection time came from catalog loading or promise a production speedup percentage. Mixed-day Goal traffic changes remain separate from this issue.

## Compatibility and risk

No API, database schema, persisted selection, queue or Runner protocol changes; no new cache, feature flag, KMS decryption, or deferred required work. Existing current-authority validation and projection fallback remain intact. Catalog-unavailable account handling is preserved; other database/invariant failures propagate.

The shared ID-scoped account inspection and thread-selection callers use the narrower projection. Unrelated full account list/summary readers are unchanged. Production latency improvement still needs a post-deploy matched-cohort comparison.

## Validation

All commands passed from `turbo/`:

- Prettier check on the three changed files.
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts src/signals/routes/__tests__/chat-threads.bdd.test.ts src/signals/routes/__tests__/chat-threads-create.test.ts src/signals/routes/__tests__/connector-accounts.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only` — 793 tests passed.
- After strengthening fallback setup to use a fresh catalog identity, reran the complete `chat-events.bdd.test.ts` file — 476 tests passed.
- `pnpm -F api lint`
- `TSC_CHECKERS=2 pnpm -F api check-types`
- `pnpm exec knip --workspace apps/api`
- `git diff --check`

Closes #32943
Related to #24203
