### PR TITLE
test(runner): synchronize deferred upload shutdown coverage

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1221,6 +1221,7 @@ enum StartLoopEvent {
     RoutineHeartbeatRequested { mode: RunnerMode },
     WorkspaceCacheChangeObserved,
     MaintenanceDrainEntered,
+    RunningJobsDrainEntered,
     DestroyTasksDrainEntered,
     DestroyTasksDrainCompleted,
     FinalizingCapacityWaitEntered { run_id: RunId },
@@ -2656,6 +2657,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 
     let remaining = jobs.len();
     let phase = teardown.phase_start("running_jobs_drain");
+    #[cfg(test)]
+    test_hooks
+        .test_observer
+        .record(StartLoopEvent::RunningJobsDrainEntered);
     if remaining > 0 {
         info!(remaining, "waiting for running jobs to finish");
         while !jobs.is_empty() {

--- a/crates/runner/src/cmd/start/tests/main_loop/usage_flush.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/usage_flush.rs
@@ -140,33 +140,51 @@ async fn job_completion_requests_proxy_usage_flush_without_waiting() {
 /// `tokio::spawn` fire-and-forget refactor that would silently lose the
 /// upload on runtime drop.
 ///
-/// The mock responds with a 400 ms delay. Since the job completes almost
-/// immediately under `MockSandboxRuntime`, `shutdown()` is invoked while
-/// the deferred `tokio::join!(flush, upload)` is still in-flight, so a
-/// well-behaved drain returns AFTER the mock delay elapses. A detached
-/// upload would let shutdown return immediately — the elapsed-time
-/// assertion below is what catches that.
+/// Hold the response to an observed upload until the runner reaches its
+/// running-job drain. The runner must not pass that drain until the test
+/// releases the response, regardless of scheduling before shutdown.
 #[tokio::test]
 async fn deferred_network_log_upload_drains_on_graceful_shutdown() {
-    use httpmock::prelude::*;
+    use crate::test_fixtures::raw_http::{json_response, read_http_request};
+    use futures_util::FutureExt;
+    use tokio::io::AsyncWriteExt;
 
-    const MOCK_DELAY: Duration = Duration::from_millis(400);
+    const WAIT: Duration = Duration::from_secs(5);
+    const RESPONSE_BODY: &str = r#"{"success":true,"id":"ok"}"#;
 
-    let server = MockServer::start_async().await;
-    let network_log_mock = server
-        .mock_async(|when, then| {
-            when.method(POST)
-                .path("/api/webhooks/agent/telemetry")
-                .body_includes("pending.example");
-            then.delay(MOCK_DELAY)
-                .status(200)
-                .header("content-type", "application/json")
-                .body(r#"{"success":true,"id":"ok"}"#);
-        })
-        .await;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let api_url = format!("http://{}", listener.local_addr().unwrap());
+    let (upload_tx, mut uploads) = tokio::sync::mpsc::unbounded_channel();
+    let (stop_server, mut server_stopped) = tokio::sync::oneshot::channel();
+    // JoinSet owns the server even when an assertion fails. Handing the
+    // unanswered socket to the test leaves other telemetry free to finish.
+    let mut server_tasks = tokio::task::JoinSet::new();
+    server_tasks.spawn(async move {
+        loop {
+            let (mut socket, _) = tokio::select! {
+                _ = &mut server_stopped => break,
+                accepted = listener.accept() => accepted.unwrap(),
+            };
+            let request = read_http_request(&mut socket).await.unwrap();
+            assert!(request.starts_with("POST /api/webhooks/agent/telemetry "));
+            let (_, body) = request.split_once("\r\n\r\n").unwrap();
+            let payload: serde_json::Value = serde_json::from_str(body).unwrap();
+            if payload.get("networkLogs").is_some() {
+                upload_tx.send((socket, payload)).unwrap();
+            } else {
+                assert!(payload["sandboxOperations"].is_array());
+                tokio::time::timeout(
+                    WAIT,
+                    socket.write_all(&json_response("200 OK", RESPONSE_BODY)),
+                )
+                .await
+                .unwrap()
+                .unwrap();
+            }
+        }
+    });
 
-    let (mut config, env) =
-        mock_run_config_with_api_url(test_profiles(), 8, 32768, 4, &server.base_url());
+    let (mut config, env) = mock_run_config_with_api_url(test_profiles(), 8, 32768, 4, &api_url);
     install_usage_flush_child(&mut config).await;
     let addon_dir = config.paths.base_dir.join("mitm-addon");
     config.proxy.mitm.set_addon_dir_for_test(addon_dir.clone());
@@ -181,8 +199,7 @@ async fn deferred_network_log_upload_drains_on_graceful_shutdown() {
     exec_config.mitm_jsonl_flush = Some(mitm_jsonl_flush);
 
     // Seed a network log file so `upload_network_logs` has a payload to POST
-    // (otherwise it early-returns on NotFound and the assertion below would
-    // measure nothing).
+    // (otherwise it early-returns on NotFound).
     let run_id = RunId::new_v4();
     let network_log_path = config.exec_config.log_paths.network_log(run_id);
     std::fs::create_dir_all(network_log_path.parent().unwrap()).unwrap();
@@ -210,9 +227,13 @@ async fn deferred_network_log_upload_drains_on_graceful_shutdown() {
             )
             .await
     );
-    write_started.notified().await;
+    tokio::time::timeout(WAIT, write_started.notified())
+        .await
+        .expect("accepted network-log write should reach its gate");
 
-    let run_handle = tokio::spawn(run(config));
+    // Poll the real runner directly, without cooperative-budget yields that
+    // could make a ready job completion look like an unfinished drain.
+    let mut runner = Box::pin(tokio::task::unconstrained(run(config)));
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
 
     // The finalizer now closes Rust-side network-log attribution before
@@ -220,19 +241,74 @@ async fn deferred_network_log_upload_drains_on_graceful_shutdown() {
     // completion. The upload itself is still deferred until after the
     // completion request below.
     release_write.add_permits(1);
-    let completion = env
-        .handle
-        .wait_completion(run_id, Duration::from_secs(5))
-        .await;
-    assert!(completion.is_some(), "job should complete");
+    tokio::select! {
+        result = &mut runner => panic!("runner exited before job completion: {result:?}"),
+        completion = env.handle.wait_completion(run_id, WAIT) => {
+            assert!(completion.is_some(), "job should complete");
+        }
+    }
+
+    let (mut upload_socket, payload) = tokio::select! {
+        result = &mut runner => panic!("runner exited before the upload request: {result:?}"),
+        upload = tokio::time::timeout(WAIT, uploads.recv()) => {
+            upload.expect("network-log upload should start")
+                .expect("HTTP server should retain the upload response")
+        }
+    };
+    assert_eq!(payload["runId"], run_id.to_string());
+    let logs = payload["networkLogs"].as_array().unwrap();
+    assert_eq!(logs.len(), 2);
+    assert_eq!(logs[0]["host"], "example.com");
+    assert_eq!(logs[1]["host"], "pending.example");
 
     // Drain shutdown — must block on each `spawn_job` closure's deferred
-    // `tokio::join!(flush, upload)` via the outer `jobs` JoinSet.
-    let shutdown_start = tokio::time::Instant::now();
-    shutdown(&env, run_handle).await;
-    let shutdown_elapsed = shutdown_start.elapsed();
+    // `tokio::join!(flush, upload)` via the outer `jobs` JoinSet. Match the
+    // shutdown helper's signals while retaining control of the response.
+    env.drain();
+    env.cancel.cancel();
+    tokio::select! {
+        // Consume ready runner work before checking the retained entry event.
+        biased;
+        result = &mut runner => panic!("runner exited with the upload response held: {result:?}"),
+        () = env.start_observer.wait_for(WAIT, "running-job drain", |event| {
+            matches!(event, StartLoopEvent::RunningJobsDrainEntered).then_some(())
+        }) => {}
+    }
+    assert!(
+        env.start_observer
+            .wait_destroy_tasks_drain_entered(WAIT)
+            .now_or_never()
+            .is_none(),
+        "runner must not pass the running-job drain while the upload response is held",
+    );
 
-    network_log_mock.assert_calls_async(1).await;
+    tokio::time::timeout(
+        WAIT,
+        upload_socket.write_all(&json_response("200 OK", RESPONSE_BODY)),
+    )
+    .await
+    .expect("held upload response should be writable")
+    .unwrap();
+    drop(upload_socket);
+    tokio::time::timeout(Duration::from_secs(10), runner)
+        .await
+        .expect("runner should finish after the upload response is released")
+        .unwrap();
+
+    assert!(
+        matches!(
+            uploads.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ),
+        "network logs should be uploaded exactly once",
+    );
+    stop_server.send(()).unwrap();
+    tokio::time::timeout(WAIT, server_tasks.join_next())
+        .await
+        .expect("HTTP server should stop")
+        .unwrap()
+        .unwrap();
+
     let jsonl_request: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(addon_dir.join("jsonl-flush-request")).unwrap(),
     )
@@ -249,13 +325,4 @@ async fn deferred_network_log_upload_drains_on_graceful_shutdown() {
     );
     assert_eq!(jsonl_state["path"], network_log_path_string);
     assert_eq!(jsonl_state["pending"], 0);
-
-    // Stronger invariant: drain must actually WAIT for the deferred work.
-    // With a 400 ms mock delay, a well-behaved drain takes ≥ the delay;
-    // a detached (fire-and-forget) upload would let shutdown return in
-    // tens of ms, dropping the in-flight request on runtime teardown.
-    assert!(
-        shutdown_elapsed >= MOCK_DELAY - Duration::from_millis(50),
-        "drain must block on deferred upload (≥{MOCK_DELAY:?}); took only {shutdown_elapsed:?}",
-    );
 }


### PR DESCRIPTION
The deferred network-log upload can progress before its shutdown test resumes after completion notification, consuming the mock's response delay before the shutdown timer starts. Replace that elapsed-time lower bound with an observed HTTP request whose response stays held until the runner reaches its running-job drain, and assert that the drain cannot finish before release.

Preserve the JSONL flush checks and verify the run ID, both log entries, and exactly one upload. Ordinary telemetry responses remain unblocked. The runner change is a `cfg(test)` drain-entry observation; production behavior and dependencies are unchanged.

Closes #32915.

Validation:

- Affected-crate formatting and `git diff --check` passed.
- Runner Clippy with `--all-targets --all-features` passed.
- Runner docs with `--all-features --no-deps` passed.
- The focused regression passed five runs; the usage-flush group and shutdown-deadlock regression passed. Both usage-flush tests passed again after restoring the mutations.
- Detaching the whole deferred flush was rejected at the held-response/drain assertion. Detaching only network upload was rejected at the same assertion in five runs. All mutations were reverted.

Local Cargo checks use `--profile local --jobs 1 --config profile.local.package.runner.debug=0` to reduce memory pressure in the 4 GiB sandbox.
