### PR TITLE
fix(artifacts): use a.okou.io for public file sharing

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -246,7 +246,7 @@ runs:
         add_env PUBLIC_ARTIFACTS_BASE_URL "$public_artifacts_base_url"
         add_var OKOU_PUBLIC_ARTIFACTS_BASE_URL OKOU_PUBLIC_ARTIFACTS_BASE_URL
         if [[ "$INPUT_ENVIRONMENT" == "production" ]]; then
-          add_env PUBLIC_ARTIFACT_SHARES_BASE_URL "https://f.okou.io"
+          add_env PUBLIC_ARTIFACT_SHARES_BASE_URL "https://a.okou.io"
         else
           add_env PUBLIC_ARTIFACT_SHARES_BASE_URL "https://files.sites.vm7.io"
         fi

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -470,7 +470,7 @@ api_backend_url_absent_output="$(
 api_backend_url_absent_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${api_backend_url_absent_dir}/github-output")"
 assert_contains "$api_backend_url_absent_output" "Rendered"
 assert_api_backend_url_absent "$api_backend_url_absent_env_file"
-assert_env_value "$api_backend_url_absent_env_file" PUBLIC_ARTIFACT_SHARES_BASE_URL "https://f.okou.io"
+assert_env_value "$api_backend_url_absent_env_file" PUBLIC_ARTIFACT_SHARES_BASE_URL "https://a.okou.io"
 assert_env_value "$api_backend_url_absent_env_file" FEISHU_CALLBACK_BASE_URL ""
 assert_env_value "$api_backend_url_absent_env_file" FINICITY_WEBHOOK_BASE_URL ""
 

--- a/turbo/apps/api/src/__tests__/env-stub.ts
+++ b/turbo/apps/api/src/__tests__/env-stub.ts
@@ -58,7 +58,7 @@ vi.stubEnv("R2_USER_ARTIFACTS_ACCESS_KEY_ID", "test-artifacts-access-key");
 vi.stubEnv("R2_USER_ARTIFACTS_SECRET_ACCESS_KEY", "test-artifacts-secret-key");
 vi.stubEnv("PUBLIC_ARTIFACTS_BASE_URL", "https://cdn.vm7.io");
 vi.stubEnv("OKOU_PUBLIC_ARTIFACTS_BASE_URL", "https://a.okou.io");
-vi.stubEnv("PUBLIC_ARTIFACT_SHARES_BASE_URL", "https://f.okou.io");
+vi.stubEnv("PUBLIC_ARTIFACT_SHARES_BASE_URL", "https://a.okou.io");
 vi.stubEnv("R2_HOSTED_SITES_BUCKET_NAME", "test-hosted-sites");
 vi.stubEnv("R2_HOSTED_SITES_ACCESS_KEY_ID", "test-hosted-sites-access-key");
 vi.stubEnv("R2_HOSTED_SITES_SECRET_ACCESS_KEY", "test-hosted-sites-secret-key");

--- a/turbo/apps/api/src/lib/file-url.ts
+++ b/turbo/apps/api/src/lib/file-url.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { isArtifactPublicationFilePath } from "@okouai/api-contracts/contracts/artifact-delivery";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 
 import { env } from "./env";
@@ -109,6 +110,9 @@ export function artifactKeyFromShortOkouUrl(url: URL): string | null {
   }
 
   const shortPath = pathname.replace(/^\/+/, "");
+  if (isArtifactPublicationFilePath(`/${shortPath}`)) {
+    return null;
+  }
   return shortPath === "" ? null : `${ARTIFACTS_PATH_PREFIX}${shortPath}`;
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/artifact-shares.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifact-shares.test.ts
@@ -552,7 +552,7 @@ test("audience changes revoke old public tokens; rollback preserves grants and p
     [200],
   );
   expect(publicShare.body.url).toMatch(
-    /^https:\/\/f\.okou\.io\/[a-f0-9]{24}\.pdf$/u,
+    /^https:\/\/a\.okou\.io\/[a-f0-9]{24}\.pdf$/u,
   );
   const first = publicShare.body;
   const organization = await accept(

--- a/turbo/apps/host-worker/src/artifact-sharing.test.ts
+++ b/turbo/apps/host-worker/src/artifact-sharing.test.ts
@@ -13,7 +13,7 @@ const fileId = "00000000-0000-4000-8000-000000000011";
 const snapshotId = "00000000-0000-4000-8000-000000000012";
 const siteId = "00000000-0000-4000-8000-000000000013";
 const publicToken = "a".repeat(24);
-const origin = `https://f.okou.io/${publicToken}.pdf`;
+const origin = `https://a.okou.io/${publicToken}.pdf`;
 const siteOrigin = `https://${publicToken}.okou.app`;
 const policyKey = `artifact-shares/okou/${id}.json`;
 
@@ -149,7 +149,7 @@ function fixture(html = false) {
     OKOU_HOST_DOMAIN: "okou.app",
     HOSTED_SITES_BUCKET: bucket,
     PRIVATE_ARTIFACTS_BUCKET: bucket,
-    PUBLIC_ARTIFACT_HOST: "f.okou.io",
+    PUBLIC_ARTIFACT_HOST: "a.okou.io",
   };
   const bytes = new Map<string, Response>();
   const cache = {
@@ -387,7 +387,7 @@ test("an unregistered public hash cannot use a private object or bypass a revoke
   expect(
     (
       await fetchWorker(
-        new Request(`https://f.okou.io/private-artifacts/${fileId}/report.pdf`),
+        new Request(`https://a.okou.io/private-artifacts/${fileId}/report.pdf`),
         f.env,
       )
     ).status,
@@ -409,7 +409,7 @@ test("a publication registry cannot change a policy's delivery type", async () =
     }),
   );
   const response = await fetchWorker(
-    new Request(`https://f.okou.io/${publicToken}.html`),
+    new Request(`https://a.okou.io/${publicToken}.html`),
     f.env,
   );
   expect(response.status).toBe(404);
@@ -430,34 +430,89 @@ test("malformed alias and registration state fails closed", async () => {
   expect(f.cache.match).not.toHaveBeenCalled();
 });
 
-test("explicit historical Public file registration preserves bytes without enabling unknown aliases", async () => {
+test.each([
+  "0123456789.pdf",
+  "user_historical/00000000-0000-4000-8000-000000000014/report.pdf",
+])(
+  "historical Public file %s keeps its URL, bytes, cache and range access",
+  async (legacy) => {
+    const f = fixture();
+    const key = `artifacts/${legacy}`;
+    f.objects.set(key, "Historical public PDF");
+    f.objects.set(
+      artifactDeliveryKey("okou", "file", legacy),
+      JSON.stringify({
+        version: 1,
+        kind: "legacy-file",
+        publicBrand: "okou",
+        audience: "public",
+        key,
+        filename: "old.pdf",
+        contentType: "application/pdf",
+      }),
+    );
+    const env = {
+      ...f.env,
+      PUBLIC_ARTIFACTS_BUCKET: f.env.HOSTED_SITES_BUCKET,
+    };
+    const response = await fetchWorker(
+      new Request(`https://a.okou.io/${legacy}`),
+      env,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("Historical public PDF");
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=31536000, immutable",
+    );
+    const head = await fetchWorker(
+      new Request(`https://a.okou.io/${legacy}`, { method: "HEAD" }),
+      env,
+    );
+    expect(head.status).toBe(200);
+    expect(await head.text()).toBe("");
+    const ranged = await fetchWorker(
+      new Request(`https://a.okou.io/${legacy}`, {
+        headers: { Range: "bytes=0-9" },
+      }),
+      env,
+    );
+    expect(ranged.status).toBe(206);
+    expect(await ranged.text()).toBe("Historical");
+    // Cloudflare's existing rewrite can still be active during the route cutover.
+    const rewritten = await fetchWorker(
+      new Request(`https://a.okou.io/artifacts/${legacy}`),
+      env,
+    );
+    expect(rewritten.status).toBe(200);
+    expect(await rewritten.text()).toBe("Historical public PDF");
+    const imageSource = await fetchWorker(
+      new Request(`https://a.okou.io/${legacy}`, {
+        headers: { Via: "image-resizing" },
+      }),
+      env,
+    );
+    expect(imageSource.status).toBe(200);
+    expect(
+      (
+        await fetchWorker(
+          new Request("https://a.okou.io/unregistered.pdf"),
+          env,
+        )
+      ).status,
+    ).toBe(404);
+  },
+);
+
+test("public file shares cannot feed an image cache outside their revocation checks", async () => {
   const f = fixture();
-  const legacy = "0123456789.pdf";
-  const key = `artifacts/${legacy}`;
-  f.objects.set(key, "Historical public PDF");
-  f.objects.set(
-    artifactDeliveryKey("okou", "file", legacy),
-    JSON.stringify({
-      version: 1,
-      kind: "legacy-file",
-      publicBrand: "okou",
-      audience: "public",
-      key,
-      filename: "old.pdf",
-      contentType: "application/pdf",
-    }),
+  expect((await fetchWorker(new Request(origin), f.env)).status).toBe(200);
+  const resized = await fetchWorker(
+    new Request(origin, { headers: { Via: "1.1 image-resizing" } }),
+    f.env,
   );
-  const env = { ...f.env, PUBLIC_ARTIFACTS_BUCKET: f.env.HOSTED_SITES_BUCKET };
-  const response = await fetchWorker(
-    new Request(`https://f.okou.io/${legacy}`),
-    env,
-  );
-  expect(response.status).toBe(200);
-  expect(await response.text()).toBe("Historical public PDF");
-  expect(
-    (await fetchWorker(new Request("https://f.okou.io/unregistered.pdf"), env))
-      .status,
-  ).toBe(404);
+  expect(resized.status).toBe(404);
+  expect(resized.headers.get("Cache-Control")).toBe("private, no-store");
+  expect(await resized.text()).not.toContain("Private PDF");
 });
 
 test("media byte ranges remain authorized after a full response warms the cache", async () => {

--- a/turbo/apps/host-worker/src/artifact-sharing.test.ts
+++ b/turbo/apps/host-worker/src/artifact-sharing.test.ts
@@ -17,7 +17,7 @@ const origin = `https://a.okou.io/${publicToken}.pdf`;
 const siteOrigin = `https://${publicToken}.okou.app`;
 const policyKey = `artifact-shares/okou/${id}.json`;
 
-function fixture(html = false) {
+function fixture(html = false, extension = "pdf") {
   const files = {
     "/index.html": {
       path: "/index.html",
@@ -82,8 +82,8 @@ function fixture(html = false) {
       : {
           kind: "file",
           id: fileId,
-          key: `private-artifacts/${fileId}/shares/${snapshotId}/report.pdf`,
-          filename: "report.pdf",
+          key: `private-artifacts/${fileId}/shares/${snapshotId}/report.${extension}`,
+          filename: `report.${extension}`,
           contentType: "application/pdf",
         },
   };
@@ -94,7 +94,7 @@ function fixture(html = false) {
       artifactDeliveryKey(
         "okou",
         html ? "html" : "file",
-        html ? publicToken : `${publicToken}.pdf`,
+        html ? publicToken : `${publicToken}.${extension}`,
       ),
       JSON.stringify({
         version: 1,
@@ -500,6 +500,46 @@ test.each([
         )
       ).status,
     ).toBe(404);
+  },
+);
+
+test.each(["", "artifacts/"])(
+  "public file shares reject noncanonical %s paths outside cache exclusions",
+  async (prefix) => {
+    const extension = "presentation";
+    const f = fixture(false, extension);
+    const path = `${publicToken}.${extension}`;
+    const url = `https://a.okou.io/${prefix}${path}`;
+    const canonical = await fetchWorker(new Request(url), f.env);
+    expect(canonical.status).toBe(200);
+    expect(await canonical.text()).toBe("Private PDF bytes");
+    expect(canonical.headers.get("Cache-Control")).toBe("private, no-store");
+    for (const variant of [
+      `${path}/`,
+      `${publicToken}%2E${extension}`,
+      `%61${publicToken.slice(1)}.${extension}`,
+    ]) {
+      const response = await fetchWorker(
+        new Request(`https://a.okou.io/${prefix}${variant}`),
+        f.env,
+      );
+      expect(response.status).toBe(404);
+      expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+      expect(await response.text()).not.toContain("Private PDF");
+    }
+    f.objects.set(
+      policyKey,
+      JSON.stringify({
+        ...f.policy,
+        audience: "private",
+        status: "revoked",
+        publicToken: null,
+      }),
+    );
+    const revoked = await fetchWorker(new Request(url), f.env);
+    expect(revoked.status).toBe(404);
+    expect(revoked.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(await revoked.text()).not.toContain("Private PDF");
   },
 );
 

--- a/turbo/apps/host-worker/src/index.ts
+++ b/turbo/apps/host-worker/src/index.ts
@@ -475,6 +475,19 @@ async function readDeliveryRecord(
   return record;
 }
 
+function artifactFileAlias(
+  pathname: string,
+  hostname: string | undefined,
+): string {
+  // The live a.okou.io rewrite adds /artifacts before Workers run. Keep old
+  // links available while routing moves to this Worker; #32492 can remove this
+  // normalization once that Cloudflare rule is disabled and rollback excludes it.
+  const prefix = "/artifacts/";
+  if (hostname === "a.okou.io" && pathname.startsWith(prefix))
+    return pathname.slice(prefix.length);
+  return pathname.slice(1);
+}
+
 async function serveArtifactDelivery(
   request: Request,
   env: Env,
@@ -484,7 +497,9 @@ async function serveArtifactDelivery(
   execution: ExecutionContext,
 ): Promise<Response> {
   const brands = fileHost ? [null] : target!.publicBrands;
-  const alias = fileHost ? pathname.slice(1) : target!.publicSlug;
+  const alias = fileHost
+    ? artifactFileAlias(pathname, env.PUBLIC_ARTIFACT_HOST)
+    : target!.publicSlug;
   const records = await Promise.all(
     brands.map(async (brand) => {
       const record = await readDeliveryRecord(
@@ -529,13 +544,39 @@ async function serveArtifactDelivery(
   if (fileHost) {
     if (record?.kind !== "legacy-file" || !env.PUBLIC_ARTIFACTS_BUCKET)
       return privateResponse(notFoundResponse());
-    return serveArtifactFile(request, env.PUBLIC_ARTIFACTS_BUCKET, record);
+    return serveLegacyArtifactFile(
+      request,
+      env.PUBLIC_ARTIFACTS_BUCKET,
+      record,
+      execution,
+    );
   }
   if (!target) return notFoundResponse();
   if (record && record.kind !== "legacy-site")
     return privateResponse(notFoundResponse());
 
   return serveLegacyHostedSite(request, env, pathname, target, record);
+}
+
+async function serveLegacyArtifactFile(
+  request: Request,
+  bucket: R2Bucket,
+  file: Extract<ArtifactDeliveryRecord, { kind: "legacy-file" }>,
+  execution: ExecutionContext,
+): Promise<Response> {
+  const cache = (caches as CacheStorage & { readonly default: Cache }).default;
+  const key = new Request(request.url);
+  const ranged = request.headers.has("Range");
+  const cached = ranged ? undefined : await cache.match(key);
+  if (cached)
+    return new Response(request.method === "HEAD" ? null : cached.body, cached);
+
+  const response = await serveArtifactFile(request, bucket, file);
+  if (!response.ok) return privateResponse(response);
+  response.headers.set("Cache-Control", "public, max-age=31536000, immutable");
+  if (request.method === "GET" && response.status === 200 && !ranged)
+    execution.waitUntil(cache.put(key, response.clone()));
+  return response;
 }
 
 async function registrationComplete(
@@ -942,7 +983,13 @@ async function serveAuthorizedArtifact(
     return privateResponse(notFoundResponse());
   };
   const target = policy.target;
-  if (target.kind === "file" && pathname !== "/") return denied();
+  // Image Resizing caches derivatives outside this Worker's policy checks.
+  // Public files must re-enter authorization even when their bytes are warm.
+  if (
+    target.kind === "file" &&
+    (pathname !== "/" || request.headers.get("Via")?.includes("image-resizing"))
+  )
+    return denied();
   const cacheUrl = new URL(request.url);
   cacheUrl.pathname = `/__artifact-content/${policy.publicBrand}/${target.kind === "html" ? target.snapshotId : encodeURIComponent(target.key)}${pathname}`;
   cacheUrl.search = `?html=${acceptsHtml(request)}`;

--- a/turbo/apps/host-worker/src/index.ts
+++ b/turbo/apps/host-worker/src/index.ts
@@ -2,6 +2,7 @@ import {
   artifactDeliveryKey,
   artifactDeliveryRecordSchema,
   artifactDeliveryRegistrationKey,
+  isArtifactPublicationFilePath,
   type ArtifactDeliveryRecord,
 } from "@okouai/api-contracts/contracts/artifact-delivery";
 import {
@@ -523,6 +524,15 @@ async function serveArtifactDelivery(
   const record = registered[0];
   if (record?.kind === "publication") {
     if ((record.targetKind === "file") !== fileHost)
+      return privateResponse(notFoundResponse());
+    // The legacy one-year cache rule excludes only canonical share paths.
+    // Decoding or trimming a different path must not expose share bytes there.
+    if (
+      fileHost &&
+      !isArtifactPublicationFilePath(
+        `/${artifactFileAlias(new URL(request.url).pathname, env.PUBLIC_ARTIFACT_HOST)}`,
+      )
+    )
       return privateResponse(notFoundResponse());
     const policy = await readPublicShare(
       env,

--- a/turbo/apps/host-worker/wrangler.jsonc
+++ b/turbo/apps/host-worker/wrangler.jsonc
@@ -4,6 +4,7 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-05-13",
   "routes": [
+    { "pattern": "a.okou.io/*", "zone_name": "okou.io" },
     {
       "pattern": "*.sites.vm0.io/*",
       "zone_name": "vm0.io",
@@ -16,7 +17,7 @@
   "vars": {
     "HOST_DOMAIN": "sites.vm0.io",
     "OKOU_HOST_DOMAIN": "okou.app",
-    "PUBLIC_ARTIFACT_HOST": "f.okou.io",
+    "PUBLIC_ARTIFACT_HOST": "a.okou.io",
   },
   "r2_buckets": [
     {

--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -1,5 +1,6 @@
 import { resolveApiBase } from "../api-base.ts";
 import { parseArtifactReference } from "@okouai/api-contracts/contracts/artifact-references";
+import { isArtifactPublicationFilePath } from "@okouai/api-contracts/contracts/artifact-delivery";
 import { privateHostedDeploymentId } from "@okouai/core/private-hosted-artifact";
 import {
   parseConnectorAuthorizeUrl,
@@ -132,7 +133,6 @@ const SHORT_ARTIFACT_FILE_PATH_PATTERN = /^\/artifacts\/[0-9a-z]{10}\.[^/]+$/;
 const OKOU_SHORT_ARTIFACT_FILE_PATH_PATTERN = /^\/[0-9a-z]{10}\.[^/]+$/;
 const OKOU_SHORT_ARTIFACT_ORIGINS: readonly string[] = Object.freeze([
   "https://a.okou.io",
-  "https://f.okou.io",
   "https://files.sites.vm7.io",
 ]);
 const PLATFORM_FILE_CDN_HOSTS = [
@@ -449,8 +449,7 @@ function isPlatformFileUrl(url: string): boolean {
     parsed.username === "" &&
     parsed.password === "" &&
     (OKOU_SHORT_ARTIFACT_FILE_PATH_PATTERN.test(parsed.pathname) ||
-      (parsed.origin !== "https://a.okou.io" &&
-        /^\/[a-f0-9]{24}\.[a-z0-9]{1,12}$/u.test(parsed.pathname)));
+      isArtifactPublicationFilePath(parsed.pathname));
   if (!isLegacyPath && !isShortArtifactPath && !isOkouShortArtifactPath) {
     return false;
   }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-artifact-sidebar.test.tsx
@@ -448,7 +448,7 @@ test("Render a generated private image from the authenticated file reference", a
   expect(within(dialog).queryByLabelText(/^share$/i)).not.toBeInTheDocument();
 });
 
-test.each(["https://f.okou.io", "https://files.sites.vm7.io"])(
+test.each(["https://a.okou.io", "https://files.sites.vm7.io"])(
   "public CDN images use the file viewer on %s",
   async (origin) => {
     const filename = "shared-image.png";

--- a/turbo/packages/api-contracts/src/contracts/artifact-delivery.ts
+++ b/turbo/packages/api-contracts/src/contracts/artifact-delivery.ts
@@ -48,6 +48,11 @@ export function artifactFilenameExtension(filename: string): string {
   return filename.toLowerCase().match(/\.[a-z0-9]{1,12}$/u)?.[0] ?? ".bin";
 }
 
+/** Public share aliases are separate from the historical public object keys. */
+export function isArtifactPublicationFilePath(pathname: string): boolean {
+  return /^\/[a-f0-9]{24}\.[a-z0-9]{1,12}$/u.test(pathname);
+}
+
 /** The marker certifies completed registration, not a feature rollout flag. */
 export function artifactDeliveryRegistrationKey(brand: "vm0" | "okou"): string {
   return `artifact-delivery/${brand}/registration.json`;

--- a/turbo/packages/core/src/__tests__/r2-image-transform.spec.ts
+++ b/turbo/packages/core/src/__tests__/r2-image-transform.spec.ts
@@ -2,6 +2,19 @@ import { describe, expect, it } from "vitest";
 import { r2ImageTransformUrl } from "../r2-image-transform";
 
 describe("r2ImageTransformUrl", () => {
+  it("keeps public shares on their policy-checked URL", () => {
+    const url = `https://a.okou.io/${"a".repeat(24)}.png?download=1#preview`;
+    expect(r2ImageTransformUrl(url, { width: 400, height: 300 })).toBe(url);
+  });
+
+  it("continues resizing historical short artifact URLs", () => {
+    expect(
+      r2ImageTransformUrl("https://a.okou.io/0123456789.png", { width: 400 }),
+    ).toBe(
+      "https://a.okou.io/cdn-cgi/image/width=400,fit=scale-down,format=auto,quality=85,metadata=none/0123456789.png",
+    );
+  });
+
   it("adds image transform directives for vm0 CDN artifact URLs", () => {
     expect(
       r2ImageTransformUrl("https://cdn.vm0.io/artifacts/user/id/image.png", {

--- a/turbo/packages/core/src/r2-image-transform.ts
+++ b/turbo/packages/core/src/r2-image-transform.ts
@@ -1,3 +1,5 @@
+import { isArtifactPublicationFilePath } from "@okouai/api-contracts/contracts/artifact-delivery";
+
 const R2_IMAGE_TRANSFORM_HOSTS = new Set([
   "cdn.vm0.io",
   "a.okou.io",
@@ -74,6 +76,9 @@ export function r2ImageTransformUrl(
 
   if (
     !R2_IMAGE_TRANSFORM_HOSTS.has(parsed.hostname) ||
+    // Cloudflare's image cache cannot enforce a share's current permissions.
+    (parsed.hostname === "a.okou.io" &&
+      isArtifactPublicationFilePath(parsed.pathname)) ||
     parsed.pathname.startsWith(R2_IMAGE_TRANSFORM_PREFIX)
   ) {
     return url;

--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/README.md
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/README.md
@@ -162,12 +162,12 @@ click-only records and later optional pointer/typing fields are recognized.
    Neon queries. No workflow mode passes `--finalize`. Accept coverage only
    with zero missing, conflicting or unclassified records and zero unregistered
    pending multipart uploads.
-3. Review the separate `a.okou.io` delivery cutover (#32959) after coverage is
-   complete. The planned unified host serves old registered public files and new
-   opaque public-share aliases through `zero-host-worker`. Existing URLs and old
-   public thumbnail behavior must remain compatible. New shares require policy
-   checks before any byte-cache hit; global public cache overrides and prefix
-   rewrites must be scoped for those routes as part of that later cutover.
+3. Prepare the cache policy and review the separate `a.okou.io` delivery cutover
+   (#32959). It serves registered public files and opaque public-share aliases
+   through `zero-host-worker`. Preserve old URLs, one-year caching and public
+   image transformations; new shares require policy checks before byte-cache
+   reads. Follow the cutover order and the explicitly accepted production
+   exception below. That exception does not certify full registration coverage.
 4. Finalize registration and enable new private artifact behavior only as separate
    rollout decisions. Completion markers close the legacy site fallback, so they
    are intentionally excluded from the first production phase.
@@ -177,3 +177,94 @@ The current API/Worker file-share host configuration is changed by #32959, not b
 this registration rollout. Private preview URL lifetime and renewal are tracked
 separately in #32977; image derivatives and private video/HTML previews remain
 follow-ups in #32492.
+
+## Unified public file domain
+
+Both historical public files and new Public file shares use `a.okou.io`.
+Historical aliases resolve their `legacy-file` record to the same object in the
+public bucket. This also covers new flag-off writes, whose exact registration
+precedes upload. GET/HEAD/Range and the one-year cache policy depend on that
+registration kind, not the object's creation date. Existing `cdn.*` endpoints
+keep their direct public storage behavior.
+
+New shares resolve a `publication` record and read the current R2 share policy
+before private snapshot bytes or any content-cache hit. Their browser response
+is `private, no-store`. Only canonical file-share paths are accepted, including
+the temporary `/artifacts/` rewrite form; encoded or trailing-slash variants
+must not expose share bytes through the legacy cache rule.
+
+The unlaunched `f.okou.io` DNS and route were removed on 2026-09-09; #33017
+already removed its deployment route. Retain the shared `zero-host-worker`,
+`*.okou.app/*` and `*.sites.vm0.io/*` routes. Staging continues to use
+`files.sites.vm7.io` on its existing wildcard. Never attach a public domain to
+the private bucket, move public bytes or delete historical objects.
+
+### Accepted production state on 2026-09-10
+
+Incremental registration is deployed. Backfill wrote the missing registrations;
+independent run [34422606017](https://github.com/vm0-ai/vm0/actions/runs/34422606017)
+passed its completed-object missing/unclassified assertions but failed on three
+old unregistered multipart sessions. The subsequent
+[preflight](https://github.com/vm0-ai/vm0/actions/runs/34453611593) confirmed those
+sessions still blocked full acceptance. Under the
+[maintainer decision in #32492](https://github.com/vm0-ai/vm0/issues/32492#issuecomment-5599918851),
+these three sessions no longer block advancing #32959. They are not registered,
+verified or finalized by this decision. Preserve their parts and lifecycle; do
+not bypass the verifier or write completion markers. A late completion of one
+of those old sessions can still require reconciliation.
+
+Cache preparation was applied and independently read back on 2026-09-10. The
+existing one-year override excludes the prospective public-share filename
+shape on both short and `/artifacts/` paths. A full 145,548-object public-bucket
+listing found no existing paths excluded. Cold requests for a post-change
+upload and recent generated/completed-multipart samples showed MISS then HIT
+with a one-year cache header; old image resizing, HEAD and Range remained
+usable. This cache inventory does not replace database/registry verification.
+
+### Production cutover order
+
+Releasing the Worker configuration attaches `a.okou.io/*` even while
+`privateArtifacts` is off. A code merge alone does not deploy that route.
+
+1. Retain the deployed incremental registration hooks and the completed-object
+   backfill. Carry the three-session exception above explicitly; final coverage
+   and completion markers remain separate decisions.
+2. Preserve the applied one-year cache rule for legacy paths and its exclusions
+   for a 24-character basename plus a 1-12 character extension, both with and
+   without the `/artifacts/` prefix. Preserve error-response no-cache behavior
+   and unrelated `cdn.*`/static rules. Do not change the entire host to
+   `respect_origin` while direct R2 delivery is active: most historical objects
+   have no origin Cache-Control, so that would shorten their cache lifetime.
+3. Keep the R2-managed `a.okou.io` DNS/custom-domain binding. Deploy the reviewed
+   Worker with `a.okou.io/*`, `PUBLIC_ARTIFACT_HOST=a.okou.io` and its existing
+   public/private bucket bindings. The file reader accepts the live rewrite's
+   `/artifacts/` prefix, preserving registered links across this transition.
+4. Verify legacy GET/HEAD/Range and resized-image requests through the Worker.
+   Disable the rewrite named
+   `Serve a.okou.io short artifact paths from /artifacts in R2` after this
+   verification. Verify the original short paths again. Once the Worker
+   supplies the one-year legacy response headers, the entire host's browser
+   and edge TTLs can separately move to `respect_origin`. That optional rule
+   cleanup was not performed by the cache preparation above. Restore the R2
+   rewrite and legacy one-year rule before any rollback to direct R2 delivery.
+5. Deploy the matching API configuration
+   `PUBLIC_ARTIFACT_SHARES_BASE_URL=https://a.okou.io` and App URL recognition.
+   Keep `privateArtifacts` off; the hostname change does not enable it or add a
+   second switch. Before later activation, use an authorized test cohort to
+   verify Public access, warm-cache access, revocation, organization audience
+   and republishing on the exact production origin, including rejection of
+   noncanonical paths. Confirm new shares remain `private, no-store`.
+
+Image Resizing has a separate derivative cache that cannot enforce current
+share permissions. New Public file previews keep their original URL and the
+Worker rejects Image Resizing source requests for publication records.
+Historical public images retain resizing. A future private-thumbnail path must
+authorize before every derivative-cache read.
+
+Immutable alias metadata has its own cache; the mutable policy remains an R2
+read on every share request. Missing aliases are not cached. File aliases use
+one global namespace across both brands. Measure regional cold/warm latency
+before feature activation. Under #32492, remove the temporary prefix
+normalization after the rewrite is disabled and supported infrastructure
+rollback no longer depends on it. Finalization and private-preview lifetime
+work remain independent of the domain cutover.


### PR DESCRIPTION
Public file shares use `https://a.okou.io/<publicHash>.ext`, alongside existing Okou artifact URLs. The Worker resolves registered legacy files to their existing public R2 objects with GET/HEAD/Range, one-year caching and image-resizing support. New flag-off uploads keep that same behavior because incremental registration precedes upload and the registry kind selects the delivery policy.

New Public shares use private snapshots and recheck the current R2 policy before every content-cache read. Browser responses stay `private, no-store`. API catalog normalization and App image transforms exclude these aliases; chat previews recognize them on `a.okou.io`. The Worker rejects Image Resizing source requests and noncanonical share paths (including trailing slashes and percent-encoded variants), preventing those responses from entering the legacy one-year cache rule.

## Rollout state and deployment

- Incremental registration is deployed, and the completed-object backfill has run. The independent verification and subsequent preflight still failed on three old unregistered multipart sessions. The maintainer explicitly accepted those sessions as exceptions for advancing this replacement PR; this does **not** claim full verification or authorize finalization, aborting parts or changing retention.
- Cache preparation was applied and verified on 2026-09-10: the existing one-year override now excludes the prospective share filename shape, both bare and under `/artifacts/`. A complete 145,548-object listing found zero existing paths excluded. Post-change upload and recent generation/completed-multipart samples verified cold MISS → HIT with one-year cache headers. Historical thumbnails, HEAD and Range remained usable. Evidence and the accepted exception are in [the original #32492 rollout comment](https://github.com/vm0-ai/vm0/issues/32492#issuecomment-5599918851).
- Read-only verification at **2026-09-10 12:07:32 UTC** confirmed that the `a.okou.io` DNS binding still points to public R2 and the zone has no Worker route; prepared cache ruleset v5 and prefix rewrite v3 remain unchanged. Merging this code does not deploy it; the subsequent normal production release attaches `a.okou.io/*` to `zero-host-worker` **regardless of the feature switch**. `privateArtifacts` stays off. Its later activation and registration completion markers remain separate decisions.

The migration README now preserves the preflight/MIME-recovery work on main and gives the current cutover order: preserve registration and the prepared cache exclusions → release the Worker with the existing R2 DNS binding → verify old files and thumbnails → disable the prefix rewrite and verify again → complete matching API/App deployment. Only after the Worker supplies legacy one-year response headers may a separate cache cleanup change the entire host to `respect_origin`; doing that while direct R2 serves metadata-less objects would shorten their cache lifetime.

The unlaunched `f.okou.io` DNS/route were already removed, and #33017 removed the deployment route. This PR replaces the remaining file-host configuration with `a.okou.io`; it preserves the shared Worker, its site routes, public objects and `cdn.*` endpoints. Regional latency and exact-production-origin Public/revocation checks remain required before feature activation.

## Fallbacks

- `turbo/apps/host-worker/src/index.ts` — `artifactFileAlias` accepts the live Cloudflare rewrite's `/artifacts/` prefix while the already-public `a.okou.io` origin moves from direct R2 to the Worker. Surface: independently changed Worker routing and zone rewrite configuration, observed live on 2026-09-10. Remove after the rewrite is disabled and supported infrastructure rollback no longer depends on it; tracked by #32492. The acceptance check applies to canonical new share paths as well. No compatibility alias is retained for the retired file hostname.

## Validation

- 73 focused tests passed: Host Worker and shared image URL behavior (57), real chat page artifact viewer (16).
- API environment-rendering shell tests passed; the production-origin assertion in the Public sharing API test is covered by PR CI.
- Worker, contracts, core and connector-dependency lint passed.
- ESLint passed for changed API/App files; Worker production bundle passed `wrangler deploy --dry-run`.
- Final normal commit hooks passed: formatting, style policy, Knip, all 14 repository TypeScript workspace checks, file size and commit-message validation.
- PR CI passed on `2040d2a5180b79465825412985f17081ea4147f8`: 102 successful checks and 3 skipped checks, including all three required gates. The normal protected merge queue completed, and this PR merged into `main` at **2026-09-10 11:28:37 UTC**, merge commit `50663a2f204f55d9fe296c7767fdf7c63c4b61c7`. This is a code merge, not a production release.
- No full local Vitest suite, local app server, direct Worker deployment, feature activation or completion-marker write.

Refs #32492.
