### PR TITLE
fix(api): apply morning brief email design

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/official-automation-result-email.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-automation-result-email.test.ts
@@ -397,7 +397,7 @@ describe.sequential("Official Automation result email callbacks", () => {
         ? send.html
         : "";
     expect(html).toContain(
-      '<img src="https://static.okou.io/public/okou-agent-email-avatar-5c997967b68e.png" width="36" height="36" alt="" role="presentation" style="display:block;width:36px;height:36px;border:0;border-radius:50%;outline:none;text-decoration:none">',
+      'alt="Wake up to what matters. Your morning brief is ready."',
     );
     expect(html).toContain(
       'href="https://app.okou.ai/agents?settings=preference&amp;focus=morning-brief"',

--- a/turbo/apps/api/src/signals/services/official-automation-result-email-renderer.ts
+++ b/turbo/apps/api/src/signals/services/official-automation-result-email-renderer.ts
@@ -5,33 +5,32 @@ import { PUBLIC_BRAND_PRESENTATION } from "@okouai/core/public-brand";
 import { safeSync, safeUrlParse } from "../utils";
 
 const OFFICIAL_AUTOMATION_RESULT_EMAIL_HTML_MAX_BYTES = 96 * 1024;
-const OKOU_AUTOMATION_EMAIL_AVATAR_URL =
-  "https://static.okou.io/public/okou-agent-email-avatar-5c997967b68e.png";
+const MORNING_BRIEF_HERO_URL = "https://a.okou.io/vfv041yxil.png";
 
 const SAFE_LINK_INFO = "official-email-safe-link";
 const UNSAFE_LINK_INFO = "official-email-unsafe-link";
 const LINK_STYLE =
-  "color:#d94801;text-decoration:underline;text-underline-offset:2px";
-const FOOTER_LINK_STYLE = "color:#6f7378;text-decoration:underline";
+  "color:#171717;text-decoration:underline;text-decoration-color:#f5d90a;text-underline-offset:3px";
+const FOOTER_LINK_STYLE = "color:#171717;text-decoration:underline";
 const BODY_WRAP_STYLE =
   "margin:0;max-width:100%;overflow-wrap:anywhere;word-break:break-word";
 const PARAGRAPH_STYLE =
-  "margin:0 0 14px;overflow-wrap:anywhere;word-break:break-word";
+  "margin:0 0 20px;overflow-wrap:anywhere;word-break:break-word";
 const LIST_STYLE =
-  "margin:0 0 16px;padding-left:22px;overflow-wrap:anywhere;word-break:break-word";
+  "margin:0 0 24px;padding-left:20px;overflow-wrap:anywhere;word-break:break-word";
 const LIST_ITEM_STYLE =
-  "margin:0 0 8px;padding-left:1px;overflow-wrap:anywhere;word-break:break-word";
+  "margin:0 0 10px;padding-left:0;overflow-wrap:anywhere;word-break:break-word";
 const INLINE_CODE_STYLE =
-  "padding:1px 4px;border-radius:4px;background-color:#f3f4f6;font-family:SFMono-Regular,Consolas,'Liberation Mono',monospace;font-size:0.92em;white-space:normal;overflow-wrap:anywhere;word-break:break-word";
+  "padding:1px 4px;border-radius:4px;background-color:#faf5f3;font-family:SFMono-Regular,Consolas,'Liberation Mono',monospace;font-size:0.92em;white-space:normal;overflow-wrap:anywhere;word-break:break-word";
 const CODE_BLOCK_STYLE =
-  "margin:0 0 16px;padding:12px 14px;border:1px solid #e4e6e8;border-radius:6px;background-color:#f7f7f8;font-family:SFMono-Regular,Consolas,'Liberation Mono',monospace;font-size:12px;line-height:1.5;white-space:pre-wrap;overflow-wrap:anywhere;word-break:break-word";
+  "margin:0 0 24px;padding:12px 14px;border:1px solid #dbcdc6;border-radius:6px;background-color:#faf5f3;font-family:SFMono-Regular,Consolas,'Liberation Mono',monospace;font-size:13px;line-height:1.5;white-space:pre-wrap;overflow-wrap:anywhere;word-break:break-word";
 const TABLE_CELL_STYLE =
-  "padding:8px 10px;border:1px solid #d9dde1;text-align:left;vertical-align:top;overflow-wrap:anywhere;word-break:break-word";
+  "padding:8px 10px;border:1px solid #dbcdc6;text-align:left;vertical-align:top;overflow-wrap:anywhere;word-break:break-word";
 
 const HEADING_STYLES: Readonly<Record<string, string>> = {
-  h1: "margin:0 0 25px;font-size:23px;line-height:1.3;letter-spacing:-0.025em",
-  h2: "margin:24px 0 9px;font-size:16px;line-height:1.35;letter-spacing:-0.01em",
-  h3: "margin:20px 0 8px;font-size:15px;line-height:1.4",
+  h1: "margin:0 0 24px;font-size:24px;line-height:1.3;letter-spacing:-0.025em",
+  h2: "margin:28px 0 10px;font-size:16px;line-height:1.5",
+  h3: "margin:24px 0 10px;font-size:15px;line-height:1.5",
   h4: "margin:18px 0 8px;font-size:14px;line-height:1.4",
   h5: "margin:16px 0 8px;font-size:13px;line-height:1.45",
   h6: "margin:16px 0 8px;font-size:12px;line-height:1.45",
@@ -164,7 +163,7 @@ function createMarkdownRenderer(): MarkdownIt {
     return '<s style="text-decoration:line-through">';
   };
   markdown.renderer.rules.blockquote_open = () => {
-    return '<blockquote style="margin:0 0 16px;padding:2px 0 2px 14px;border-left:3px solid #d0d4d8;color:#4b5563;overflow-wrap:anywhere;word-break:break-word">';
+    return '<blockquote style="margin:0 0 24px;padding:2px 0 2px 14px;border-left:3px solid #dbcdc6;color:#555555;overflow-wrap:anywhere;word-break:break-word">';
   };
   markdown.renderer.rules.code_inline = (tokens, index) => {
     return `<code style="${INLINE_CODE_STYLE}">${escapeHtml(tokens[index]!.content)}</code>`;
@@ -178,13 +177,13 @@ function createMarkdownRenderer(): MarkdownIt {
   markdown.renderer.rules.fence = renderCodeBlock;
   markdown.renderer.rules.code_block = renderCodeBlock;
   markdown.renderer.rules.hr = () => {
-    return '<hr style="height:1px;margin:20px 0;border:0;background-color:#e4e6e8">\n';
+    return '<hr style="height:1px;margin:24px 0;border:0;background-color:#dbcdc6">\n';
   };
   markdown.renderer.rules.table_open = () => {
     return '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:100%;table-layout:fixed;border-collapse:collapse;margin:0 0 16px">';
   };
   markdown.renderer.rules.thead_open = () => {
-    return '<thead style="background-color:#f3f4f6">';
+    return '<thead style="background-color:#faf5f3">';
   };
   markdown.renderer.rules.th_open = () => {
     return `<th style="${TABLE_CELL_STYLE};font-weight:700">`;
@@ -217,29 +216,62 @@ function officialAutomationResultEmailHtml(
   resultBodyHtml: string,
   unsubscribeUrl: string,
 ): string {
-  const presentation = PUBLIC_BRAND_PRESENTATION;
-  const assistantIdentity = `<td width="36" height="36" align="center" valign="middle" style="width:36px;height:36px;line-height:0;mso-line-height-rule:exactly"><img src="${OKOU_AUTOMATION_EMAIL_AVATAR_URL}" width="36" height="36" alt="" role="presentation" style="display:block;width:36px;height:36px;border:0;border-radius:50%;outline:none;text-decoration:none"></td>`;
-  const footer = `Sent by an ${escapeHtml(
-    presentation.assistantName,
-  )} automation &middot; <a href="${escapeHtml(
+  const assistantName = escapeHtml(PUBLIC_BRAND_PRESENTATION.assistantName);
+  const footer = `Sent by an ${assistantName} automation &middot; <a href="${escapeHtml(
     props.manageUrl,
   )}" style="${FOOTER_LINK_STYLE}">Manage</a> &middot; <a href="${escapeHtml(
     unsubscribeUrl,
   )}" style="${FOOTER_LINK_STYLE}">Unsubscribe</a>`;
 
-  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="color-scheme" content="light"><meta name="supported-color-schemes" content="light"><title>${escapeHtml(
-    props.title,
-  )}</title></head><body style="margin:0;padding:0;background-color:#f7f7f5;color:#202124;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:1.58;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%"><table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f7f7f5" style="width:100%;border-collapse:collapse;background-color:#f7f7f5"><tr><td align="center" style="padding:24px 20px 40px"><table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#ffffff" style="width:100%;max-width:650px;border:1px solid #e5e6e4;border-radius:16px;border-collapse:separate;background-color:#ffffff;text-align:left"><tr><td style="padding:30px 38px 24px"><table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;margin:0 0 18px"><tr>${assistantIdentity}<td valign="middle" style="padding-left:10px;color:#303235;font-size:13px;font-weight:600;line-height:1.4">${escapeHtml(
-    presentation.assistantName,
-  )}</td></tr></table><div style="${BODY_WRAP_STYLE}">${resultBodyHtml}</div><p style="margin:24px 0 22px;font-size:13px;line-height:1.5"><a href="${escapeHtml(
-    props.runUrl,
-  )}" style="${LINK_STYLE};font-weight:600">Open in ${escapeHtml(
-    presentation.assistantName,
-  )} &rarr;</a></p><p style="margin:0;padding-top:17px;border-top:1px solid #e5e6e4;color:#8c9094;font-size:11px;line-height:1.5">${footer}</p></td></tr></table></td></tr></table></body></html>`;
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="color-scheme" content="light">
+    <meta name="supported-color-schemes" content="light">
+    <title>${escapeHtml(props.title)}</title>
+  </head>
+  <body style="margin:0;padding:0;background-color:#ffffff;color:#171717;font-family:Helvetica,Arial,sans-serif;font-size:15px;line-height:1.6;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#ffffff" style="width:100%;border-collapse:collapse;background-color:#ffffff">
+      <tr>
+        <td align="center" style="padding:24px 20px 48px">
+          <!--[if mso]><table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0"><tr><td><![endif]-->
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:600px;border-collapse:collapse;text-align:left">
+            <tr>
+              <td style="padding:0 0 36px">
+                <img src="${MORNING_BRIEF_HERO_URL}" width="600" alt="Wake up to what matters. Your morning brief is ready." style="display:block;width:100%;max-width:600px;height:auto;border:0;outline:none;text-decoration:none;color:#171717;font-size:24px;font-weight:700;line-height:1.3">
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:0">
+                <div style="${BODY_WRAP_STYLE}">${resultBodyHtml}</div>
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse:separate;margin:24px 0 36px">
+                  <tr>
+                    <td align="center" bgcolor="#3462da" style="background-color:#3462da;border-radius:999px;mso-padding-alt:12px 32px">
+                      <a href="${escapeHtml(props.runUrl)}" style="display:inline-block;padding:12px 32px;border-radius:999px;color:#ffffff;font-size:13px;font-weight:700;line-height:16px;text-decoration:none">Open in ${assistantName} &rarr;</a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:24px 0 0;border-top:1px solid #dbcdc6;color:#8c9094;font-size:12px;line-height:1.6">${footer}</td>
+            </tr>
+          </table>
+          <!--[if mso]></td></tr></table><![endif]-->
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
 }
 
 function plainTextFromHtml(html: string): string {
-  return convert(html, { wordwrap: false }).trim();
+  return convert(html, {
+    wordwrap: false,
+    selectors: [{ selector: "img", format: "skip" }],
+  }).trim();
 }
 
 export function renderOfficialAutomationResultEmail(


### PR DESCRIPTION
## Summary

Morning Brief still uses a small avatar inside a bordered notification card. Rebuild its result-email presentation from current `main` to match the supplied design: the morning illustration, a fluid 600px white layout, warm dividers, yellow link underlines, and a blue pill-shaped “Open in Okou” action.

The implementation uses the supplied artwork at https://a.okou.io/vfv041yxil.png and the desktop/mobile screenshots as visual references. It does not reuse either closed PR's code and does not depend on their branches or an unpublished static asset. Supersedes #32906 and vm0-ai/static-files#198, both closed at the user's request.

The existing Markdown safety policy, result content, subject, run/manage/unsubscribe destinations, persisted email props, retry behavior, plain-text alternative, and 96KB HTML bound remain in place. The decorative header is excluded from plain text. The layout uses inline email styles and an Outlook fixed-width wrapper.

## Verification

- PASS: `pnpm -F api lint`
- PASS: `pnpm -F api check-types`
- PASS: `pnpm exec knip --workspace apps/api --no-progress`
- PASS: formatting and `git diff --check`
- PASS: direct production-renderer smoke check with synthetic Markdown: 7,435-byte regular email, safe links and escaped raw HTML, and a size-limit fallback from 411,548 bytes to 10,218 bytes.
- PASS: staging-browser's local `agent-browser`/Chromium at 760px desktop and 390px mobile; the live hero loads at 600px/350px, links retain their expected destinations, and content stays within the viewport. Long table cells and code also fit at 320px.
- Existing API route integration assertion updated for the accessible header. No local Vitest suite or dev server was started; integration tests run in the PR pipeline.

## Visual evidence

Screenshots show synthetic briefing content rendered by the changed production email renderer, not a separately authored mockup or a delivered inbox message.

| Desktop, 760px | Mobile, 390px |
| --- | --- |
| ![Desktop email](https://a.okou.io/yl0iv4dvp6.png) | ![Mobile email](https://a.okou.io/oym7sn5ycl.png) |

[Hosted HTML preview](https://morning-brief-email-20260909.okou.app) · [Immutable preview version](https://dpl-227f3db3-c615-4d69-b77e-141b3aff611d.okou.app)

The hosted URLs returned a Cloudflare verification page to headless Chromium. Visual checks therefore opened the same HTML files locally, with the real remote hero; the screenshots above are the verified result. Gmail/Outlook inbox rendering has not been exercised.
