### PR TITLE
refactor(api): rename residual emitted observability identifiers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9534,7 +9534,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     );
     expect(loadSnapshotEvent).toStrictEqual(
       expect.objectContaining({
-        connector_scope_source: "zero_agent",
+        connector_scope_source: "stored_agent",
         stored_connector_candidate_count_bucket: "1",
       }),
     );
@@ -9544,7 +9544,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     );
     expect(materializeSnapshotEvent).toStrictEqual(
       expect.objectContaining({
-        connector_scope_source: "zero_agent",
+        connector_scope_source: "stored_agent",
         stored_connector_candidate_count_bucket: "1",
         stored_connector_count_bucket: "1",
         stored_connector_secret_count_bucket: "1",

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -634,7 +634,7 @@ type TestOnlyDirectRunResolver = (args: {
   readonly timing?: ApiDispatchTimingCollector;
 }) => Promise<ResolvedAgentExecution | CreateRunErrorResult>;
 
-type ConnectorScopeSource = "explicit" | "zero_agent" | "empty";
+type ConnectorScopeSource = "explicit" | "stored_agent" | "empty";
 
 interface EffectiveConnectorScope {
   readonly allowedConnectorSlugs: readonly ConnectorSlug[];

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -1020,7 +1020,7 @@ function buildCreateAgentRunArgs(args: {
       allowedConnectorSlugs: args.allowedConnectorSlugs,
       allowedCustomConnectorIds: args.allowedCustomConnectorIds,
       customConnectorGrants: args.customConnectorGrants,
-      source: "zero_agent",
+      source: "stored_agent",
     },
     validateEnvironmentReferences: false,
     agentRunMetadata: {

--- a/turbo/apps/api/src/signals/services/email-common.service.ts
+++ b/turbo/apps/api/src/signals/services/email-common.service.ts
@@ -33,7 +33,7 @@ interface EmailOutboxItemsContext extends EmailOutboxDrainContext {
   readonly itemIds: readonly string[];
 }
 
-const log = logger("zero:email");
+const log = logger("EmailCommon");
 const USER_CACHE_TTL_MS = 900_000;
 const MAX_ATTEMPTS = 3;
 const BACKOFF_BASE_MS = 1000;


### PR DESCRIPTION
## Summary

Renames the two remaining externally emitted observability values that still carry retired product vocabulary. Behavior is otherwise unchanged.

Part B of #32941. Part of #32157. This follows the atomic-cutover precedent established by #32242 / #32328. Part A (the Teams `zero` command prefix retirement) merged separately as #32947; there is no dependency between them.

## Query migration mapping

| Old emitted value | New emitted value |
|---|---|
| `zero:email` | `EmailCommon` |
| `zero_agent` | `stored_agent` |

## What changed

Four files, five lines:

- `services/email-common.service.ts:36` — the logger context literal. `zero:email` was the only colon-prefixed context left in `signals/services/`; every sibling (`AgentRunCreate`, `Browser`, `CreditUsage`, …) is un-prefixed PascalCase, so `EmailCommon` also resolves the convention outlier.
- `services/agent-run-create.service.ts:637` — the `ConnectorScopeSource` union member.
- `services/agent-runs-create.service.ts:1023` — the producer that sets `source` on the stored-agent connector scope.
- `routes/__tests__/run-lifecycle.bdd.test.ts:9537,9547` — the two existing assertions for the `connector_scope_source` dispatch timing dimension.

Preserved byte-for-byte apart from the mapped literals: the logger's level, message text, structured fields, and error handling; the dispatch span kind, nesting, and timing ownership; the `connector_scope_source` field name; the sibling `stored_connector_count_bucket` dimension and all bucketing logic; and the existing `"explicit"` and `"empty"` union members with their assertions at lines 2041, 3801, 9681, 9920, and 9930.

## Operational disposition

Renamed once. **No dual emission, no old-name tombstone, no compatibility branch.** Retained Axiom events keep their historical values. `vm0-web-logs-prod` retains 3 days and `vm0-sandbox-op-log-prod` retains 7 days, so the mixed-data window is bounded to 7 days. If an unenumerable saved chart or monitor filters `connector_scope_source == "zero_agent"`, it will go quiet after deployment; the table above is the query migration reference.

From the pre-dispatch check recorded on #32941 for the windows ending `2026-09-09T09:38Z` / `09:39Z`:

- `context == "zero:email"` emitted **0 events** in `vm0-web-logs-prod`. This logger runs only on exceptional email paths, so zero recent events does not make the source dead.
- `connector_scope_source` in `vm0-sandbox-op-log-prod` was `zero_agent` **251,031 events** (first `2026-09-02T09:26:40Z`, last `2026-09-09T09:38:01Z`) and `empty` 2,320 events. **This is a live, high-volume dimension value**, which is why it gets an explicit disposition rather than a silent rename.
- Both replacements emitted 0 events in the same windows and have zero matches in current tracked source, so the cutover does not collide with an existing series.
- The available Axiom provider token can query datasets but returns provider-level 403 for monitors, dashboards, starred queries, and views, so saved consumers cannot be enumerated. This is a token scope limit, not an Okou policy denial, and is the same residual visibility limit accepted under #31842 and #32242. No external Axiom object was modified.

## Live caller and overlap audit

Refreshed immediately before implementation and recorded on #32941; re-verified after branching from `origin/main` at `c5e6ef9`:

- `zero:email` — 1 occurrence, the emitter itself. No consumer in the repository or anywhere in the organization.
- `zero_agent` as `connector_scope_source` — exactly the 3 files above. `ConnectorScopeSource` has six references, all inside `agent-run-create.service.ts` (`637`, `645`, `681`, `3945`, `4262`, `6930`); the type is not exported and has no cross-module consumer. The dimension is emitted at `agent-run-create.service.ts:6934` through `storedConnectorTimingDimensions`.
- GitHub organization code search for `zero_agent` returns 9 hits. The other 6 are the unrelated **`zero_agents` / `zero_agent_schedules` database table names** in historical one-off migration scripts (`packages/db/scripts/migrations/005`, `006`, `010`), two changelogs, and `vm0-ai/prd-db-mask-refresh` (which applies masking labels to `zero_agent_schedules` columns). **All are byte-identical here** — `git diff --name-only` returns exactly the four files above and zero paths under `packages/db/scripts/migrations` or any `CHANGELOG.md`. A whole-word substitution would have corrupted historical migration SQL; this was applied per-site instead.
- Paginated the file list of all open PRs. #32926 (bingjiez666) overlaps `agent-run-create.service.ts` and `agent-runs-create.service.ts`; #32722 (seven332) overlaps `agent-runs-create.service.ts` and `run-lifecycle.bdd.test.ts`. Neither is a functional dependency and each touches unrelated lines. Treated as inventory only — normal merge precedence applies; whichever merges later rebases and resolves its own overlap.

## Verification

- Prettier check on all four changed files: passed.
- `pnpm -F api lint`: passed (oxlint, oxlint type-aware for `src` and `__tests__`, ESLint `--max-warnings 0`).
- `pnpm -F api check-types`: passed all six API TypeScript programs.
- `TZ=UTC pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1`: **244 passed**, full file. This covers both renamed assertions and every preserved `"empty"` and `"explicit"` assertion.
- `TZ=UTC pnpm -F api exec vitest run email.test.ts cron-drain-email-outbox-scoped.test.ts email-subscription.test.ts official-automation-result-email.test.ts --maxWorkers=1`: 31 passed, covering the email outbox drain paths that own the renamed logger.
- Residual check: `zero:email` and the `zero_agent` scope-source value have zero matches in tracked source; each replacement appears exactly at its intended site.
- `git diff --check`: passed.

No full local Vitest suite and no local development server was run; the remaining coverage is left to PR CI.

## Boundaries honored

- No Axiom dataset name, service name, `vm0.db.*` telemetry attribute, dashboard, monitor, or other deployed observability identity changed.
- The `connector_scope_source` **field name** is unchanged; only one of its three dimension values is renamed.
- No `zero_agents` / `zero_agent_schedules` database table name, historical migration, or changelog touched. No repository-wide `zero`/`vm0` substitution.
- No change to admission, credit resolution, connector-scope resolution, email delivery, or Teams behavior.
- No classifier, manifest, baseline, compatibility branch, dual emit, residual-name scanner, or old-name absence test added.
- No production release, deployment, or post-deploy verification is part of this PR. This part only takes effect once deployed; the controller decides and coordinates any release after independent acceptance.

Closes part B of #32941.
