### PR TITLE
refactor(runner): delete retired mitmdump runtime marker tombstone tests

### DIFF
--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -1213,10 +1213,6 @@ PY
         std::fs::set_permissions(path, perms).unwrap();
     }
 
-    fn retired_runtime_marker_env() -> String {
-        ["VM0", "MITMDUMP", "RUNTIME", "DIR"].join("_")
-    }
-
     #[test]
     fn embedded_addon_reads_runner_token_environment() {
         let source = ADDON_FILES
@@ -2290,40 +2286,6 @@ exit 42
         assert!(!stale_launch.exists(), "stale launch directory remains");
         assert!(unrelated_sibling.is_dir());
         assert!(unrelated_shared.path().is_dir());
-    }
-
-    #[tokio::test]
-    async fn proxy_startup_ignores_retired_legacy_marker() {
-        let dir = tempfile::tempdir().unwrap();
-        let home = HomePaths::with_root(dir.path().join("home"));
-        let config = test_proxy_config(dir.path(), &home, dir.path().join("mitmdump"));
-        let runtime = acquire_test_runtime(&config).await;
-        let stale_launch = config.runtime_dir.join("launch-retired");
-        std::fs::create_dir(&stale_launch).unwrap();
-        let retired_marker = retired_runtime_marker_env();
-        drop(runtime);
-
-        let mut retired_process = tokio::process::Command::new("sleep")
-            .arg("60")
-            .env_remove(CANONICAL_RUNTIME_MARKER_ENV)
-            .env("TMPDIR", &stale_launch)
-            .env(retired_marker, &stale_launch)
-            .process_group(0)
-            .kill_on_drop(true)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .unwrap();
-
-        let (_proxy, _crash_rx) = MitmProxy::new(config).await.unwrap();
-
-        assert!(
-            retired_process.try_wait().unwrap().is_none(),
-            "retired legacy-only marker made the process eligible for signalling"
-        );
-        assert!(!stale_launch.exists(), "stale launch directory remains");
-        retired_process.kill().await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/runner/src/proxy/runtime.rs
+++ b/crates/runner/src/proxy/runtime.rs
@@ -685,8 +685,7 @@ mod tests {
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::null())
-                .env_remove(CANONICAL_RUNTIME_MARKER_ENV)
-                .env_remove(retired_runtime_marker_env());
+                .env_remove(CANONICAL_RUNTIME_MARKER_ENV);
             if let Some((name, value)) = marker {
                 command.env(name, value);
             }
@@ -713,20 +712,10 @@ mod tests {
         }
     }
 
-    fn retired_runtime_marker_env() -> String {
-        ["VM0", "MITMDUMP", "RUNTIME", "DIR"].join("_")
-    }
-
-    fn marker_environment(canonical: Option<&[u8]>, retired: Option<&[u8]>) -> Vec<u8> {
+    fn marker_environment(canonical: Option<&[u8]>) -> Vec<u8> {
         let mut environ = b"UNRELATED=value\0".to_vec();
         if let Some(value) = canonical {
             environ.extend_from_slice(CANONICAL_RUNTIME_MARKER_PREFIX);
-            environ.extend_from_slice(value);
-            environ.push(0);
-        }
-        if let Some(value) = retired {
-            environ.extend_from_slice(retired_runtime_marker_env().as_bytes());
-            environ.push(b'=');
             environ.extend_from_slice(value);
             environ.push(0);
         }
@@ -758,45 +747,22 @@ mod tests {
         drop(runtime);
     }
 
-    #[tokio::test]
-    async fn acquisition_ignores_retired_legacy_only_process() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path().join("runtime");
-        let lock_path = dir.path().join("runtime.lock");
-        crate::private_fs::ensure_private_dir(&root).await.unwrap();
-        let launch = root.join("launch-retired");
-        std::fs::create_dir(&launch).unwrap();
-        let retired_marker = retired_runtime_marker_env();
-        let mut child = ProbeChild::spawn(Some((&retired_marker, &launch)));
-
-        let runtime = MitmdumpRuntime::acquire(root, lock_path).await.unwrap();
-
-        child.assert_responds();
-        assert!(!launch.exists(), "stale launch directory was not removed");
-        drop(runtime);
-    }
-
     #[test]
-    fn runtime_marker_resolver_reads_canonical_bytes_only() {
+    fn runtime_marker_resolver_reads_canonical_marker_as_raw_bytes() {
         let canonical = b"/runtime/launch-canonical";
-        let retired = b"/runtime/launch-retired";
         let non_unicode = b"/runtime/launch-\xff";
 
-        assert!(resolve_runtime_marker(&marker_environment(None, None)).is_none());
+        assert!(resolve_runtime_marker(&marker_environment(None)).is_none());
         assert_eq!(
-            resolve_runtime_marker(&marker_environment(None, Some(retired))),
-            None,
-        );
-        assert_eq!(
-            resolve_runtime_marker(&marker_environment(Some(b""), None)),
+            resolve_runtime_marker(&marker_environment(Some(b""))),
             Some(b"".as_slice()),
         );
         assert_eq!(
-            resolve_runtime_marker(&marker_environment(Some(non_unicode), None)),
+            resolve_runtime_marker(&marker_environment(Some(non_unicode))),
             Some(non_unicode.as_slice()),
         );
         assert_eq!(
-            resolve_runtime_marker(&marker_environment(Some(canonical), Some(retired))),
+            resolve_runtime_marker(&marker_environment(Some(canonical))),
             Some(canonical.as_slice()),
         );
     }
@@ -852,23 +818,6 @@ mod tests {
         let launch = root.path().join("launch-removed-marker");
         std::fs::create_dir(&launch).unwrap();
         let mut replacement = ProbeChild::spawn(None);
-        let current = process_identity(replacement.pid()).await;
-
-        signal_stable_process(&runtime, Some(&launch), current)
-            .await
-            .unwrap();
-
-        replacement.assert_responds();
-    }
-
-    #[tokio::test]
-    async fn pidfd_signal_ignores_retired_legacy_marker() {
-        let root = tempfile::tempdir().unwrap();
-        let runtime = test_runtime(root.path()).await;
-        let launch = root.path().join("launch-retired-marker");
-        std::fs::create_dir(&launch).unwrap();
-        let retired_marker = retired_runtime_marker_env();
-        let mut replacement = ProbeChild::spawn(Some((&retired_marker, &launch)));
         let current = process_identity(replacement.pid()).await;
 
         signal_stable_process(&runtime, Some(&launch), current)


### PR DESCRIPTION
Closes #32937

## Problem

`OKOU_MITMDUMP_RUNTIME_DIR` is the current canonical Runner proxy runtime marker (`crates/runner/src/proxy/runtime.rs:19-20`). The retired `VM0_MITMDUMP_RUNTIME_DIR` marker has **no producer anywhere in tracked source** — the only remaining occurrences were test scaffolding that reconstructed the old name via `["VM0","MITMDUMP","RUNTIME","DIR"].join("_")` so it could assert the old name no longer works.

EPIC #32157 ("Tests describe the current system, not deleted history") and `docs/fallback.md` §1 both reject this shape. Migration proof belongs in merged PR and issue history, not in the test suite.

## What this changes

Test-only deletion. **No runtime behavior changes.**

- Deleted both copies of `retired_runtime_marker_env()` (`runtime.rs`, `process.rs`).
- Deleted the three tombstone tests whose entire assertion was that the retired marker is inert:
  - `runtime.rs` `acquisition_ignores_retired_legacy_only_process`
  - `runtime.rs` `pidfd_signal_ignores_retired_legacy_marker`
  - `process.rs` `proxy_startup_ignores_retired_legacy_marker`
- Dropped `.env_remove(retired_runtime_marker_env())` from `ProbeChild::spawn`. `.env_remove(CANONICAL_RUNTIME_MARKER_ENV)` is retained — that is what actually makes the probe child's marker state deterministic.
- Reduced `marker_environment(canonical, retired)` to the canonical-only shape it still needs.
- **Kept** `runtime_marker_resolver_reads_canonical_bytes_only`, removing only its retired-marker assertions. It still proves the resolver's current contract: absent marker → `None`, empty canonical value → `Some(b"")`, non-UTF-8 canonical value → raw byte passthrough, and canonical value read among unrelated entries. Renamed to `runtime_marker_resolver_reads_canonical_marker_as_raw_bytes` since "canonical bytes **only**" no longer describes what remains.

## Preserved on purpose

- `CANONICAL_RUNTIME_MARKER_ENV` / `CANONICAL_RUNTIME_MARKER_PREFIX` and every producer and reader of `OKOU_MITMDUMP_RUNTIME_DIR` are untouched.
- `acquisition_reconciles_canonical_process`, `pidfd_signal_rejects_replacement_process_generation`, `pidfd_signal_rechecks_runtime_marker`, `close_launch_accepts_environment_error_after_process_becomes_zombie`.
- `proxy_startup_reconciles_canonical_marker_and_only_private_launches`, including its anti-kill guarantees for unrelated sibling and unrelated shared `/tmp` directories.

## Non-goals honored

No replacement negative test, residual-name scanner, baseline, or ratchet. No marker renames. No changes to `vm0_api_url`, `x-vm0-*` headers, or any cross-process option or protocol identifier. No repository-wide `zero`/`vm0` substitution.

## Verification

- `VM0_MITMDUMP_RUNTIME_DIR` and every `join`-based reconstruction of it are absent from tracked source (grep-verified).
- `cargo fmt -p runner --check` — clean.
- `cargo clippy -p runner --all-targets` — clean.
- Full `runner` proxy test execution is left to CI: a debug build of this workspace exceeds the implementation sandbox's memory and disk budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)