### PR TITLE
fix(app): keep the image annotation editor the size of the preview it replaces

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/flatten-annotated-image.ts
+++ b/turbo/apps/platform/src/signals/okou-page/flatten-annotated-image.ts
@@ -9,6 +9,8 @@ import {
   markOrdinal,
   NOTE_GROUND,
   noteOnImage,
+  PIN_INSET_PX,
+  PIN_RADIUS_PX,
   REDACT_FILL,
   STROKE_HALO_INNER,
 } from "./image-annotation.ts";
@@ -23,7 +25,6 @@ import { createDeferredPromise, withCleanup } from "../utils.ts";
 const REFERENCE_EDGE_PX = 1000;
 const STROKE_WIDTH_UNITS = 3;
 const HALO_WIDTH_UNITS = 1;
-const PIN_RADIUS_UNITS = 11;
 const PIN_FONT_UNITS = 13;
 const TEXT_FONT_UNITS = 18;
 const NOTE_FONT_UNITS = 15;
@@ -208,7 +209,7 @@ function drawPin(
 ): void {
   const { x, y } = at;
   const { ink, ordinal } = pin;
-  const radius = px(scale, PIN_RADIUS_UNITS);
+  const radius = px(scale, PIN_RADIUS_PX);
   context.beginPath();
   context.arc(x, y, radius, 0, Math.PI * 2);
   context.fillStyle = ink;
@@ -348,7 +349,14 @@ function drawMark(
         px(scale, CORNER_RADIUS_UNITS),
       );
     });
-    drawPin(context, scale, { x, y }, { ink: mark.ink, ordinal });
+    // Inset to match the editor, where the corner belongs to the resize grip.
+    const inset = px(scale, PIN_INSET_PX);
+    drawPin(
+      context,
+      scale,
+      { x: x + inset, y: y + inset },
+      { ink: mark.ink, ordinal },
+    );
     return;
   }
 

--- a/turbo/apps/platform/src/signals/okou-page/image-annotation.ts
+++ b/turbo/apps/platform/src/signals/okou-page/image-annotation.ts
@@ -51,6 +51,21 @@ export const STROKE_HALO_INNER = "rgba(255, 255, 255, 0.90)";
  */
 export const NOTE_GROUND = "rgba(255, 255, 255, 0.94)";
 
+/** Radius of the disc a box's ordinal is printed in. */
+export const PIN_RADIUS_PX = 11;
+
+/**
+ * How far the pin's centre sits inside the box's own top-left corner.
+ *
+ * The pin used to be centred *on* that corner, which is precisely where the
+ * selection grip lands — so selecting a box hid its number under the white dot
+ * and the note that says "1" had nothing left to point at. Tucking the pin
+ * inside clears the grip by a whole radius, and unlike a pin parked outside the
+ * box it survives a mark drawn against the top or left edge of the image, which
+ * is what matters in the flattened copy the model actually reads.
+ */
+export const PIN_INSET_PX = PIN_RADIUS_PX + 3;
+
 /**
  * `highlight`, `crop` and `redact` were dropped, and `select` with them: a
  * mark is clicked directly, so a mode for "not drawing" has nothing left to do,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-annotation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-annotation.test.tsx
@@ -86,6 +86,35 @@ test("A selected annotation mark can be resized directly", async () => {
   expect(screen.getByTestId("annotation-handle-br")).toBeVisible();
 });
 
+test("Pressing outside the editor keeps the session and every mark drawn in it", async () => {
+  // The editor used to be an inert overlay, so there was no dismissal to lose.
+  // It now rides on a dialog that closes on an outside press by default, and
+  // closing discards the whole session: marks live nowhere but here until
+  // "Attach marks", and there is no undo across that boundary.
+  const user = userEvent.setup({ pointerEventsCheck: 0 });
+  const image = draftAttachment("stray-press.png");
+  mockAttachmentChat(context, { draft: draftForAttachment(image, "") });
+
+  await setupPage({
+    context,
+    path: `/chats/${ATTACHMENT_THREAD_ID}`,
+    featureSwitches: { [FeatureSwitchKey.ComposerImageAnnotation]: true },
+  });
+
+  const surface = await openAnnotationEditor("stray-press.png");
+  drawBox(surface);
+  await screen.findByTestId("annotation-mark-1");
+
+  const backdrop = document.querySelector('[data-slot="dialog-overlay"]');
+  if (!backdrop) {
+    throw new Error("Expected the annotation editor's dialog backdrop");
+  }
+  await user.click(backdrop);
+
+  expect(screen.getByTestId("image-annotation-editor")).toBeVisible();
+  expect(screen.getByTestId("annotation-mark-1")).toBeVisible();
+});
+
 test("A user can click an annotation note, edit it, and close only the note", async () => {
   const user = userEvent.setup();
   const image = draftAttachment("annotated-plan.png", {

--- a/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
+++ b/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
@@ -1211,6 +1211,16 @@ function useGrabEndpoint(
   };
 }
 
+/**
+ * Makes the scrolling stage a size query container, so the image can be bounded
+ * by the box it is actually in.
+ *
+ * The fit used to be written as fractions of the *viewport* — `min(880px, 88vw)`
+ * by `min(520px, 62vh)` — which is a guess at the stage that stops being true
+ * the moment anything around it changes size. `100cqw`/`100cqh` are that box.
+ */
+const STAGE_QUERY_CONTAINER = { containerType: "size" } as const;
+
 function EditorStage({
   filename,
   signals,
@@ -1289,7 +1299,10 @@ function EditorStage({
 
   return (
     <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-muted/30">
-      <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-5">
+      <div
+        className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-5"
+        style={STAGE_QUERY_CONTAINER}
+      >
         <div
           ref={bindSurface}
           onPointerDown={handlers.onPointerDown}
@@ -1308,8 +1321,8 @@ function EditorStage({
             // The fit bounds are the stage's own box, so 100% zoom shows the
             // whole image and zooming grows the layout box the stage scrolls.
             style={{
-              maxWidth: `calc(min(880px, 88vw) * ${zoom})`,
-              maxHeight: `calc(min(520px, 62vh) * ${zoom})`,
+              maxWidth: `calc(100cqw * ${zoom})`,
+              maxHeight: `calc(100cqh * ${zoom})`,
             }}
             className="block rounded-lg object-contain"
           />
@@ -1385,7 +1398,11 @@ function AnnotationSurface({
       >
         <KeyboardShortcuts signals={signals} />
         <div
-          className="flex h-[min(700px,90vh)] w-[min(980px,94vw)] min-h-0 flex-col overflow-hidden rounded-xl bg-background text-foreground shadow-[0_24px_70px_hsl(var(--overlay)/0.30)]"
+          // The same envelope the preview dialog uses (`DialogContent`
+          // maxWidth={1440} height={1000}, 1.5rem of viewport padding). Edit
+          // replaces that window in place, so anything narrower reads as the
+          // picture shrinking the moment the pencil is pressed.
+          className="flex h-[1000px] max-h-full w-full max-w-[1440px] min-h-0 flex-col overflow-hidden rounded-xl bg-background text-foreground shadow-[0_24px_70px_hsl(var(--overlay)/0.30)]"
           data-testid="image-annotation-panel"
         >
           <EditorHeader filename={target.filename} signals={signals} />

--- a/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
+++ b/turbo/apps/platform/src/views/okou-page/image-annotation-editor.tsx
@@ -14,6 +14,7 @@ import {
   X,
 } from "lucide-react";
 import { Button } from "@okouai/ui/components/ui/button";
+import { Dialog, DialogContent } from "@okouai/ui/components/ui/dialog";
 import { Input } from "@okouai/ui/components/ui/input";
 import {
   Tooltip,
@@ -1377,6 +1378,18 @@ export function ImageAnnotationEditor({
   return <AnnotationSurface signals={signals} target={target} />;
 }
 
+/**
+ * The editor is the same window as the preview it replaces.
+ *
+ * It used to be a hand-rolled `fixed z-50` overlay, which lost twice. Its size
+ * was a second set of numbers that had to be kept level with the preview's by
+ * hand, and it drifted — `min(980px, 94vw)` against the preview's 1440, so the
+ * picture shrank the moment the pencil was pressed. And `z-50` only orders it
+ * inside the app's own stacking context, so anything portalled to `body` after
+ * it — the composer's slash-command menu, left open behind the preview — kept
+ * painting on top of the editor and stayed clickable. Both are the dialog
+ * primitive's job, and the preview next door was already using it.
+ */
 function AnnotationSurface({
   signals,
   target,
@@ -1384,6 +1397,8 @@ function AnnotationSurface({
   readonly signals: ImageAnnotationSignals;
   readonly target: AnnotationTarget;
 }) {
+  const { t } = useTranslation();
+  const close = useSet(signals.closeAnnotationEditor$);
   const resolvedUrl = useResolvedAttachmentUrl(target.url);
 
   if (resolvedUrl === null) {
@@ -1392,28 +1407,48 @@ function AnnotationSurface({
 
   return (
     <TooltipProvider delayDuration={300}>
-      <div
-        className="okou-app fixed inset-0 z-50 flex items-center justify-center bg-gray-900/45 p-6"
-        data-testid="image-annotation-editor"
+      <Dialog
+        open
+        // A press outside must not throw the session away: the marks live
+        // nowhere else until "Attach marks", so a stray click on the backdrop
+        // would discard every one of them with no undo.
+        disablePointerDismissal
+        onOpenChange={(next, details) => {
+          // Escape belongs to `KeyboardShortcuts`, which backs out one layer at
+          // a time — the open note, then the selection, then the session.
+          // Closing here as well would collapse all three into the first press.
+          if (!next && details.reason !== "escape-key") {
+            close();
+          }
+        }}
       >
-        <KeyboardShortcuts signals={signals} />
-        <div
-          // The same envelope the preview dialog uses (`DialogContent`
-          // maxWidth={1440} height={1000}, 1.5rem of viewport padding). Edit
-          // replaces that window in place, so anything narrower reads as the
-          // picture shrinking the moment the pencil is pressed.
-          className="flex h-[1000px] max-h-full w-full max-w-[1440px] min-h-0 flex-col overflow-hidden rounded-xl bg-background text-foreground shadow-[0_24px_70px_hsl(var(--overlay)/0.30)]"
-          data-testid="image-annotation-panel"
+        <DialogContent
+          showCloseButton={false}
+          maxWidth={1440}
+          height={1000}
+          surface="canvas"
+          overlayClassName="bg-gray-900/45 dark:bg-gray-900/45"
+          contentClassName="okou-app flex flex-col gap-0 overflow-hidden bg-background p-0"
+          aria-label={t(($) => {
+            return $.artifacts.annotation.open;
+          })}
+          data-testid="image-annotation-editor"
         >
-          <EditorHeader filename={target.filename} signals={signals} />
-          <EditorStage
-            filename={target.filename}
-            signals={signals}
-            url={resolvedUrl}
-          />
-          <EditorFooter signals={signals} />
-        </div>
-      </div>
+          <KeyboardShortcuts signals={signals} />
+          <div
+            className="relative flex min-h-0 flex-1 flex-col overflow-hidden text-foreground"
+            data-testid="image-annotation-panel"
+          >
+            <EditorHeader filename={target.filename} signals={signals} />
+            <EditorStage
+              filename={target.filename}
+              signals={signals}
+              url={resolvedUrl}
+            />
+            <EditorFooter signals={signals} />
+          </div>
+        </DialogContent>
+      </Dialog>
     </TooltipProvider>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/image-annotation-marks.tsx
+++ b/turbo/apps/platform/src/views/okou-page/image-annotation-marks.tsx
@@ -8,6 +8,8 @@ import {
   markOrdinal,
   NOTE_GROUND,
   noteOnImage,
+  PIN_INSET_PX,
+  PIN_RADIUS_PX,
   REDACT_FILL,
   STROKE_HALO_INNER,
 } from "../../signals/okou-page/image-annotation.ts";
@@ -257,9 +259,18 @@ export function MarkShape({
       }}
     >
       {mark.shape === "box" && (
+        // Inside the corner, not on it — the selection grip owns the corner
+        // itself. `flatten-annotated-image` prints the same disc at the same
+        // offset, so what is picked here is what gets sent.
         <span
-          style={{ background: mark.ink }}
-          className="absolute -left-[11px] -top-[11px] flex h-[22px] w-[22px] items-center justify-center rounded-full border-[1.5px] border-on-filled text-[11px] font-bold text-on-filled"
+          style={{
+            background: mark.ink,
+            left: PIN_INSET_PX - PIN_RADIUS_PX,
+            top: PIN_INSET_PX - PIN_RADIUS_PX,
+            height: PIN_RADIUS_PX * 2,
+            width: PIN_RADIUS_PX * 2,
+          }}
+          className="absolute flex items-center justify-center rounded-full border-[1.5px] border-on-filled text-[11px] font-bold text-on-filled"
         >
           {ordinal}
         </span>


### PR DESCRIPTION
Closes #32964.

Three symptoms in the report, two causes behind them, and both causes turn out
to be the same thing: the annotation editor was a hand-rolled `fixed inset-0
z-50` overlay when the preview it replaces is a `DialogContent`.

## 1. Edit shrank the window

The preview is `DialogContent maxWidth={1440} height={1000}`. The editor was
pinned at `w-[min(980px,94vw)] h-[min(700px,90vh)]` — a second copy of the
preview's numbers, kept level by hand, and already drifted. The image inside it
was fitted to a *guess* at that stage, `min(880px, 88vw)` by `min(520px, 62vh)`,
so the picture shrank while the zoom readout still said 100%.

The panel now renders through the shared `Dialog`/`DialogContent` with the same
`maxWidth={1440} height={1000} surface="canvas"`, which deletes the duplicated
size classes with it, and the stage is a size query container so the image fit
is `100cqw`/`100cqh` — the box the image is actually in.

Measured on the preview at a 1680×1050 viewport:

| | panel | image |
| --- | --- | --- |
| Preview lightbox | 1440×1000 | 1371×896 |
| Editor, before | 980×700 | 796×520 |
| Editor, after | 1440×1000 | 1357×848 |

## 2. The number was under the drag handle

A box mark's ordinal disc was centred on the box's own top-left corner, which is
exactly where the selection grip lands. Selecting a box hid its number under the
white dot, and a note that reads "1" had nothing left to point at.

The pin now sits a radius *inside* the corner. Inside rather than outside
because a mark drawn against the top or left edge of a screenshot would push an
outside pin off the image entirely, and the flattened copy is what the vision
model reads. `flatten-annotated-image` draws the disc at the same offset from
the same shared constants.

## 3. The white menu over the editor

Not a stray sidebar control — the composer's own slash-command menu. `z-50`
only orders the editor inside the app's own stacking context, so a menu
portalled to `body` kept painting on top of it and stayed clickable. Reproduced
by opening `/` in the composer, then the image preview, then Edit. Going
through the dialog primitive fixes this too.

Two dismissals are held back deliberately:

- **Pointer dismissal is off.** The marks live nowhere but this session until
  "Attach marks", so a press on the backdrop would discard all of them with no
  undo.
- **Escape stays with `KeyboardShortcuts`**, which backs out one layer at a
  time — the open note, then the selection, then the session. Letting the
  primitive close on the same key collapses all three into the first press;
  removing the `escape-key` guard fails the existing note-escape regression,
  so it is load-bearing rather than defensive.

## Verification

- `vitest run` on `chat-attachment-annotation` (11), `chat-attachment-composer`,
  `chat-attachment-message-previews`, `chat-attachment-artifact-viewer` — 33 passed.
  The new case presses the backdrop and asserts the editor and its mark survive;
  it fails if `disablePointerDismissal` is dropped, which is what makes the
  no-discard property a guarded contract rather than a default
- `tsc` on the production and test projects, `oxlint` (incl. type-aware),
  `eslint`, the style config, and `lint:localized-ui`
- End to end on this PR's preview: attach an image, open the preview, Edit,
  draw and select a box, backdrop-click (session survives), Escape (deselects),
  Escape again (closes), Attach marks, then download the flattened PNG and
  confirm the pin lands inside the corner there too

🤖 Generated with [Claude Code](https://claude.com/claude-code)