### PR TITLE
feat(core): roll out chat thread header actions to staff

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -229,7 +229,9 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.MorningBrief]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ChatThreadHeaderActions]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ChatThreadHeaderActions]).toBe(
+      false,
+    );
   });
 
   it("should enable the model picker menu for Bingjie by email outside the staff org", () => {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -204,6 +204,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.MorningBrief]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.SshAccess]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.ChatThreadHeaderActions]).toBe(true);
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",
@@ -228,6 +229,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.MorningBrief]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ChatThreadHeaderActions]).toBe(false);
   });
 
   it("should enable the model picker menu for Bingjie by email outside the staff org", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -485,6 +485,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Pin chats from the desktop title and keep Pin, Share, and More visible in the mobile thread header.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
 };
 


### PR DESCRIPTION
## Summary

Enable the `chatThreadHeaderActions` feature switch for the Okou staff org so the team can try the chat thread header Pin control in production.

The switch stays `enabled: false` by default; only the staff org hashes turn it on.

## Changes

- `turbo/packages/core/src/feature-switch.ts`: add `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` to the `ChatThreadHeaderActions` entry.
- `turbo/packages/core/src/__tests__/feature-switch.test.ts`: extend the staff org rollout matrix test — on for the staff org, off for other orgs.

## Verification

- `npx vitest run src/__tests__/feature-switch.test.ts` in `turbo/packages/core` — 29 passed.

## Rollout

Staff can still turn it off per user from Lab; graduating to everyone is a separate change.
