### PR TITLE
fix(api): keep auxiliary generations from starving on a shared token budget

### DIFF
--- a/turbo/apps/api/src/signals/external/openrouter-failure.ts
+++ b/turbo/apps/api/src/signals/external/openrouter-failure.ts
@@ -8,11 +8,27 @@ export type OpenRouterFailureReason =
   | "provider_unavailable"
   | "invalid_request"
   | "auth"
+  // The model stopped at the token budget. Reasoning models draw thinking and
+  // visible output from one budget, so this is an expected capacity outcome
+  // rather than a defect in the request or the provider.
+  | "output_truncated"
+  // The completion terminated as a tool call although no tools were offered.
+  | "unexpected_tool_calls"
   | "invalid_output"
   | "unknown";
 
+/** Provider-reported token counts, bounded to integers; never payload data. */
+export interface OpenRouterTokenCounts {
+  readonly completionTokens?: number;
+  readonly reasoningTokens?: number;
+}
+
 const failureReasons = singleton(() => {
   return new WeakMap<object, OpenRouterFailureReason>();
+});
+
+const failureTokenCounts = singleton(() => {
+  return new WeakMap<object, OpenRouterTokenCounts>();
 });
 
 export function openRouterFailureReason(
@@ -30,6 +46,28 @@ export function recordOpenRouterFailure(
   if (typeof error === "object" && error !== null) {
     failureReasons().set(error, reason);
   }
+}
+
+/**
+ * Token counts belonging to the completion that produced this failure. A
+ * truncated completion still reports usage, and that usage is the only direct
+ * evidence of how much of the shared budget the model spent on thinking.
+ */
+export function recordOpenRouterFailureTokenCounts(
+  error: unknown,
+  counts: OpenRouterTokenCounts,
+): void {
+  if (typeof error === "object" && error !== null) {
+    failureTokenCounts().set(error, counts);
+  }
+}
+
+export function openRouterFailureTokenCounts(
+  error: unknown,
+): OpenRouterTokenCounts {
+  return typeof error === "object" && error !== null
+    ? (failureTokenCounts().get(error) ?? {})
+    : {};
 }
 
 function property(value: unknown, key: string): unknown {

--- a/turbo/apps/api/src/signals/external/openrouter.ts
+++ b/turbo/apps/api/src/signals/external/openrouter.ts
@@ -7,9 +7,13 @@ import {
   safeSync,
 } from "../utils";
 import {
+  openRouterFailureReason,
   recordOpenRouterFailure,
+  recordOpenRouterFailureTokenCounts,
   recordOpenRouterRequestFailure,
   recordOpenRouterTransportFailure,
+  type OpenRouterFailureReason,
+  type OpenRouterTokenCounts,
 } from "./openrouter-failure";
 
 const OPENROUTER_CHAT_COMPLETIONS_URL =
@@ -24,6 +28,21 @@ const OPENROUTER_ERROR_RESPONSE_MAX_BYTES = 64 * 1024;
  * single model rather than one constant per service.
  */
 export const FAST_PATH_MODEL = "google/gemini-3.8-flash";
+
+/**
+ * Token budget for the short auxiliary text generations (chat and shared-thread
+ * titles, notification summaries, run summaries, recommended follow-ups).
+ *
+ * `FAST_PATH_MODEL` reports `reasoning.mandatory: true` with
+ * `supported_efforts: ["high", "medium", "low"]` and no independent reasoning
+ * budget, and Gemini 3 spends thinking and visible output from one combined
+ * `max_output_tokens`. `effort: "low"` is already the model's floor, so the
+ * only remaining lever is the ceiling: a budget sized for the answer alone lets
+ * model-chosen thinking starve the answer to nothing. A ceiling is not billed —
+ * only generated tokens are — and length stays governed by the prompts, so
+ * raising it removes the starvation without buying longer answers.
+ */
+export const AUXILIARY_TEXT_MAX_TOKENS = 2048;
 
 export interface OpenRouterTextPart {
   readonly type: "text";
@@ -58,6 +77,8 @@ export interface OpenRouterUsage {
 interface OpenRouterTextGeneration {
   readonly text: string;
   readonly usage?: OpenRouterUsage;
+  /** The completion stopped at the token budget and the text may be partial. */
+  readonly truncated?: boolean;
 }
 
 interface OpenRouterChoice {
@@ -80,6 +101,12 @@ type OpenRouterReasoningEffort = "none" | "minimal" | "low" | "medium" | "high";
 interface OpenRouterGenerateTextOptions {
   readonly reasoning?: { readonly effort: OpenRouterReasoningEffort };
   readonly temperature?: number;
+  /**
+   * Return a non-empty completion that stopped at the token budget instead of
+   * throwing. Only callers whose output stays useful when shortened may opt in;
+   * anything persisted immutably or parsed as JSON must keep rejecting it.
+   */
+  readonly acceptTruncatedText?: boolean;
 }
 
 export class OpenRouterRequestError extends Error {
@@ -247,8 +274,43 @@ async function ensureOpenRouterResponseOk(response: Response): Promise<void> {
   });
 }
 
+/** Provider counts are untrusted numbers; retain only bounded integers. */
+export function openRouterTokenCounts(
+  usage: OpenRouterUsage | undefined,
+): OpenRouterTokenCounts {
+  const completionTokens = tokenCount(usage?.completion_tokens);
+  const reasoningTokens = tokenCount(
+    usage?.completion_tokens_details?.reasoning_tokens,
+  );
+  return {
+    ...(completionTokens === undefined ? {} : { completionTokens }),
+    ...(reasoningTokens === undefined ? {} : { reasoningTokens }),
+  };
+}
+
+function tokenCount(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.min(Number.MAX_SAFE_INTEGER, Math.max(0, Math.trunc(value)))
+    : undefined;
+}
+
+/**
+ * An incomplete completion is a capacity outcome, not invalid provider output.
+ * Keeping the distinction finite lets telemetry separate the expected budget
+ * ceiling from content the caller genuinely cannot interpret.
+ */
+function incompleteFinishReason(
+  finishReason: string | undefined,
+): OpenRouterFailureReason | undefined {
+  if (finishReason === "length") {
+    return "output_truncated";
+  }
+  return finishReason === "tool_calls" ? "unexpected_tool_calls" : undefined;
+}
+
 function parseOpenRouterGeneration(
   data: OpenRouterResponse,
+  acceptTruncatedText: boolean,
 ): OpenRouterTextGeneration {
   const choice = data.choices?.[0];
   if (!choice) {
@@ -270,6 +332,7 @@ function parseOpenRouterGeneration(
       value: choice.error ?? data.error,
     });
   }
+  const rawContent = choice.message?.content;
   if (choice.finish_reason !== "stop") {
     const nativeFinishReason = safeDiagnosticString(
       choice.native_finish_reason,
@@ -280,15 +343,27 @@ function parseOpenRouterGeneration(
       "content_filter",
       "tool_calls",
     ]);
+    const partial = typeof rawContent === "string" ? rawContent.trim() : "";
+    if (acceptTruncatedText && finishReason === "length" && partial) {
+      return generation(partial, data.usage, true);
+    }
     const nativeReason = nativeFinishReason
       ? ` (native: ${nativeFinishReason})`
       : "";
-    throw new Error(
+    const error = new Error(
       `OpenRouter completion finished with ${finishReason ?? "unknown"}${nativeReason}`,
     );
+    const reason = incompleteFinishReason(finishReason);
+    if (reason) {
+      recordOpenRouterFailure(error, reason);
+      recordOpenRouterFailureTokenCounts(
+        error,
+        openRouterTokenCounts(data.usage),
+      );
+    }
+    throw error;
   }
 
-  const rawContent = choice.message?.content;
   if (typeof rawContent !== "string") {
     throw new Error("OpenRouter returned invalid content");
   }
@@ -296,9 +371,19 @@ function parseOpenRouterGeneration(
   if (!content) {
     throw new Error("OpenRouter returned empty content");
   }
-  return data.usage === undefined
-    ? { text: content }
-    : { text: content, usage: data.usage };
+  return generation(content, data.usage, false);
+}
+
+function generation(
+  text: string,
+  usage: OpenRouterUsage | undefined,
+  truncated: boolean,
+): OpenRouterTextGeneration {
+  return {
+    text,
+    ...(usage === undefined ? {} : { usage }),
+    ...(truncated ? { truncated } : {}),
+  };
 }
 
 /**
@@ -383,10 +468,19 @@ export async function generateTextWithUsage(
     if (typeof data !== "object" || data === null) {
       throw new Error("OpenRouter returned invalid JSON");
     }
-    return parseOpenRouterGeneration(data as OpenRouterResponse);
+    return parseOpenRouterGeneration(
+      data as OpenRouterResponse,
+      options?.acceptTruncatedText === true,
+    );
   });
   if ("error" in parsed) {
-    if (!(parsed.error instanceof OpenRouterRequestError)) {
+    // Only classify what nothing else has. A reason recorded at the throw site
+    // is more specific than this fallback, and overwriting it would erase the
+    // one signal that separates an expected outcome from a defect.
+    if (
+      !(parsed.error instanceof OpenRouterRequestError) &&
+      openRouterFailureReason(parsed.error) === "unknown"
+    ) {
       recordOpenRouterFailure(parsed.error, "invalid_output");
     }
     throw parsed.error;

--- a/turbo/apps/api/src/signals/routes/__tests__/auxiliary-generation.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auxiliary-generation.test.ts
@@ -33,11 +33,35 @@ const secret = "private-provider-payload";
 function completion(
   content: unknown = "A usable summary",
   finishReason = "stop",
+  usage?: Readonly<Record<string, unknown>>,
 ) {
   return HttpResponse.json({
-    choices: [{ finish_reason: finishReason, message: { content } }],
+    choices: [
+      {
+        finish_reason: finishReason,
+        ...(finishReason === "length"
+          ? { native_finish_reason: "MAX_TOKENS" }
+          : {}),
+        message: { content },
+      },
+    ],
+    ...(usage === undefined ? {} : { usage }),
   });
 }
+
+const successUsage = Object.freeze({
+  prompt_tokens: 640,
+  completion_tokens: 118,
+  completion_tokens_details: { reasoning_tokens: 96 },
+});
+
+// The provider reports usage on a truncated completion too, and the reasoning
+// count is the only direct evidence of how the combined budget was spent.
+const exhaustedUsage = Object.freeze({
+  prompt_tokens: 640,
+  completion_tokens: 2048,
+  completion_tokens_details: { reasoning_tokens: 2041 },
+});
 
 function responseFailure(code?: string) {
   return HttpResponse.json({
@@ -60,12 +84,12 @@ function brokenBody(error: Error) {
   );
 }
 
-function summaryCancellationRequest(signal: AbortSignal) {
+function saveRunSummaryRequest(signal: AbortSignal) {
   // Infrastructure-only exception: a public callback acknowledges before its
   // background work finishes and cannot inject an independently owned task
-  // AbortSignal. The existing runtime harness lets cancellation reach the real
-  // summary boundary; every case aborts before persistence. Normal output and
-  // fallback cases below use the production chat API and readback instead.
+  // AbortSignal. The existing runtime harness lets cancellation and the real
+  // persistence attempt reach the summary boundary. Normal output and fallback
+  // cases below use the production chat API and readback instead.
   return setupApp({
     context,
     routes: testRuntimeStateRoutes,
@@ -302,17 +326,33 @@ const cases = Object.freeze([
     reason: "invalid_output",
   },
   {
-    name: "length terminal outcome",
+    name: "token budget exhausted with partial text",
     response: () => {
       return completion(secret, "length");
     },
-    outcome: "error",
-    reason: "invalid_output",
+    outcome: "degraded",
+    reason: "output_truncated",
+  },
+  {
+    name: "token budget exhausted with empty text",
+    response: () => {
+      return completion("", "length");
+    },
+    outcome: "degraded",
+    reason: "output_truncated",
   },
   {
     name: "tool terminal outcome",
     response: () => {
       return completion(secret, "tool_calls");
+    },
+    outcome: "degraded",
+    reason: "unexpected_tool_calls",
+  },
+  {
+    name: "content filtered outcome",
+    response: () => {
+      return completion(secret, "content_filter");
     },
     outcome: "error",
     reason: "invalid_output",
@@ -323,7 +363,7 @@ const cases = Object.freeze([
       return completion("---");
     },
     outcome: "error",
-    reason: "invalid_output",
+    reason: "unusable_output",
   },
   {
     name: "success",
@@ -364,6 +404,7 @@ describe("auxiliary generation outcomes", () => {
         outcome === "error" ? 1 : 0,
       );
       expect(JSON.stringify(auxiliaryWarnings(context))).not.toContain(secret);
+      expect(JSON.stringify(auxiliaryResults(context))).not.toContain(secret);
       expect(
         context.mocks.axiomLogging.warn.mock.calls.map(([message]) => {
           return message;
@@ -374,6 +415,77 @@ describe("auxiliary generation outcomes", () => {
       expect(context.mocks.axiomLogging.error.mock.calls).toStrictEqual([]);
     },
   );
+
+  it.each([
+    {
+      name: "success",
+      response: () => {
+        return completion("A usable summary", "stop", successUsage);
+      },
+      outcome: "success",
+      reason: "none",
+      completion_tokens: 118,
+      reasoning_tokens: 96,
+    },
+    {
+      name: "an exhausted token budget",
+      response: () => {
+        return completion(secret, "length", exhaustedUsage);
+      },
+      outcome: "degraded",
+      reason: "output_truncated",
+      completion_tokens: 2048,
+      reasoning_tokens: 2041,
+    },
+  ])(
+    "records provider token counts on $name",
+    async ({ response, ...expected }) => {
+      const title = await prepareChatTitle();
+      mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
+      createChatCallbacksApi(context).mockOpenRouterCompletions((body) => {
+        return body.messages[0]?.content.includes(
+          "Generate a short, descriptive title",
+        )
+          ? response()
+          : "Thinking";
+      });
+      await title.create();
+      await flushWaitUntilForTest();
+      expect(auxiliaryResults(context)).toStrictEqual([
+        expect.objectContaining({ feature: "chat_title", ...expected }),
+      ]);
+      expect(auxiliaryWarnings(context)).toStrictEqual([]);
+    },
+  );
+
+  it("keeps shortened summary text for a caller that can use it", async () => {
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
+    server.use(
+      http.post(endpoint, () => {
+        // PostgreSQL rejects NUL in text, so a persistence attempt is
+        // observable. A rejected generation returns nothing and never writes,
+        // which makes the storage warning the proof the text was accepted.
+        return completion("Unstorable\u0000summary", "length", exhaustedUsage);
+      }),
+    );
+    await saveRunSummaryRequest(context.signal);
+    await flushWaitUntilForTest();
+    expect(
+      context.mocks.axiomLogging.warn.mock.calls.map(([message]) => {
+        return message;
+      }),
+    ).toStrictEqual(["Failed to save run summary"]);
+    expect(auxiliaryWarnings(context)).toStrictEqual([]);
+    expect(auxiliaryResults(context)).toStrictEqual([
+      expect.objectContaining({
+        feature: "run_summary",
+        outcome: "degraded",
+        reason: "output_truncated",
+        completion_tokens: 2048,
+        reasoning_tokens: 2041,
+      }),
+    ]);
+  });
 
   it("skips optional title generation when configuration is missing", async () => {
     const title = await prepareChatTitle();
@@ -453,7 +565,7 @@ describe("auxiliary generation outcomes", () => {
           return completion();
         }),
       );
-      const request = summaryCancellationRequest(controller.signal);
+      const request = saveRunSummaryRequest(controller.signal);
       const outcome = (async () => {
         await expect(request).rejects.toBe(reason);
       })();
@@ -495,7 +607,7 @@ describe("auxiliary generation outcomes", () => {
         );
       }),
     );
-    const request = summaryCancellationRequest(controller.signal);
+    const request = saveRunSummaryRequest(controller.signal);
     const rejected = (async () => {
       await expect(request).rejects.toMatchObject({ name: "AbortError" });
     })();

--- a/turbo/apps/api/src/signals/routes/__tests__/auxiliary-generation.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auxiliary-generation.test.ts
@@ -422,24 +422,28 @@ describe("auxiliary generation outcomes", () => {
       response: () => {
         return completion("A usable summary", "stop", successUsage);
       },
-      outcome: "success",
-      reason: "none",
-      completion_tokens: 118,
-      reasoning_tokens: 96,
+      expected: {
+        outcome: "success",
+        reason: "none",
+        completion_tokens: 118,
+        reasoning_tokens: 96,
+      },
     },
     {
       name: "an exhausted token budget",
       response: () => {
         return completion(secret, "length", exhaustedUsage);
       },
-      outcome: "degraded",
-      reason: "output_truncated",
-      completion_tokens: 2048,
-      reasoning_tokens: 2041,
+      expected: {
+        outcome: "degraded",
+        reason: "output_truncated",
+        completion_tokens: 2048,
+        reasoning_tokens: 2041,
+      },
     },
   ])(
     "records provider token counts on $name",
-    async ({ response, ...expected }) => {
+    async ({ response, expected }) => {
       const title = await prepareChatTitle();
       mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
       createChatCallbacksApi(context).mockOpenRouterCompletions((body) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1736,30 +1736,19 @@ describe("CHAT-02: completed chat callback", () => {
     ]);
 
     // Reasoning tokens are drawn from the same budget as the answer, so a
-    // budget sized for a non-reasoning model starves the answer entirely.
-    expect(requestsBySite.get("title")).toStrictEqual({
-      model: "google/gemini-3.8-flash",
-      max_tokens: 512,
-      reasoning: { effort: "low" },
-    });
-    expect(requestsBySite.get("followups")).toStrictEqual({
-      model: "google/gemini-3.8-flash",
-      max_tokens: 1024,
-      reasoning: { effort: "low" },
-    });
-    expect(requestsBySite.get("notification")).toStrictEqual({
-      model: "google/gemini-3.8-flash",
-      max_tokens: 512,
-      reasoning: { effort: "low" },
-    });
-    expect(requestsBySite.get("runSummary")).toStrictEqual({
-      model: "google/gemini-3.8-flash",
-      max_tokens: 768,
-      reasoning: { effort: "low" },
-    });
+    // budget sized for a non-reasoning model starves the answer entirely. This
+    // model cannot disable thinking and "low" is already its floor, so the
+    // shared ceiling is the only lever that keeps the answer from being lost.
+    for (const site of ["title", "followups", "notification", "runSummary"]) {
+      expect(requestsBySite.get(site)).toStrictEqual({
+        model: "google/gemini-3.8-flash",
+        max_tokens: 2048,
+        reasoning: { effort: "low" },
+      });
+    }
   });
 
-  it("discards a token-limited notification summary instead of pushing truncated text", async () => {
+  it("pushes a token-limited notification summary instead of discarding it", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
@@ -1796,6 +1785,8 @@ describe("CHAT-02: completed chat callback", () => {
     await flushWaitUntilForTest();
 
     expect(notificationRequests).toBe(1);
+    // A shortened sentence still tells the user what finished, and the only
+    // alternative is the generic fallback, so this caller keeps the text.
     await expect
       .poll(() => {
         return context.mocks.webpush.sendNotification.mock.calls.some(
@@ -1803,18 +1794,22 @@ describe("CHAT-02: completed chat callback", () => {
             const payload = pushPayload(call) as Record<string, unknown>;
             return (
               payload.title === prompt.slice(0, 60) &&
-              payload.body === "Your task is complete"
+              payload.body === truncatedSummary
             );
           },
         );
       })
       .toBe(true);
-    expect(
-      context.mocks.webpush.sendNotification.mock.calls.some((call) => {
-        const payload = pushPayload(call) as Record<string, unknown>;
-        return payload.body === truncatedSummary;
+    // An exhausted shared budget is expected and non-actionable: counted, and
+    // never a production warning.
+    expect(auxiliaryResults(context)).toContainEqual(
+      expect.objectContaining({
+        feature: "notification_summary",
+        outcome: "degraded",
+        reason: "output_truncated",
       }),
-    ).toBeFalsy();
+    );
+    expect(auxiliaryWarnings(context)).toStrictEqual([]);
   });
 
   it("leaves the thread untitled when the title completion is token-limited", async () => {
@@ -1847,6 +1842,14 @@ describe("CHAT-02: completed chat callback", () => {
     await expect(
       readThreadTitleFromEvents(actor, run.threadId),
     ).resolves.toBeNull();
+    expect(auxiliaryResults(context)).toContainEqual(
+      expect.objectContaining({
+        feature: "chat_title",
+        outcome: "degraded",
+        reason: "output_truncated",
+      }),
+    );
+    expect(auxiliaryWarnings(context)).toStrictEqual([]);
 
     await api.requestCancelRun(actor, run.runId, [200]);
     await waitForRunStatus(actor, run.runId, "cancelled");
@@ -1895,6 +1898,14 @@ describe("CHAT-02: completed chat callback", () => {
       throw new Error("Expected a completed lifecycle marker");
     }
     expect(marker).not.toHaveProperty("recommendedFollowups");
+    expect(auxiliaryResults(context)).toContainEqual(
+      expect.objectContaining({
+        feature: "recommended_followups",
+        outcome: "degraded",
+        reason: "output_truncated",
+      }),
+    );
+    expect(auxiliaryWarnings(context)).toStrictEqual([]);
   });
 
   it("auto-sends the queued message before completed-run LLM side effects finish", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1812,6 +1812,62 @@ describe("CHAT-02: completed chat callback", () => {
     expect(auxiliaryWarnings(context)).toStrictEqual([]);
   });
 
+  it("falls back to the fixed notification copy when the token-limited summary strips to nothing", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
+    chatCallbacks.mockOpenRouterCompletions((body) => {
+      const systemContent = body.messages[0]?.content ?? "";
+      if (systemContent.includes("one short notification sentence")) {
+        // Non-empty for the provider, nothing once the Markdown rule is
+        // stripped. Accepting truncated text made this state reachable.
+        return { content: "---", finishReason: "length" };
+      }
+      if (systemContent.includes("Generate a short, descriptive title")) {
+        return "Emptied Notification";
+      }
+      if (systemContent.includes("recommended follow-up messages")) {
+        return JSON.stringify([{ prompt: "Keep going", kind: "talk" }]);
+      }
+      return "Generated summary";
+    });
+
+    const prompt = "Summarize the emptied notification";
+    const run = await startChatRun(actor, { agentId, prompt });
+    await chatCallbacks.registerPushSubscription(actor);
+    chatCallbacks.enableVapid();
+
+    const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "The final assistant answer"),
+    ]);
+    await completeChatRunOk(run.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+    await flushWaitUntilForTest();
+
+    await expect
+      .poll(() => {
+        return context.mocks.webpush.sendNotification.mock.calls.some(
+          (call) => {
+            const payload = pushPayload(call) as Record<string, unknown>;
+            return (
+              payload.title === prompt.slice(0, 60) &&
+              payload.body === "Your task is complete"
+            );
+          },
+        );
+      })
+      .toBe(true);
+    expect(
+      context.mocks.webpush.sendNotification.mock.calls.every((call) => {
+        const payload = pushPayload(call) as Record<string, unknown>;
+        return payload.body !== "";
+      }),
+    ).toBeTruthy();
+  });
+
   it("leaves the thread untitled when the title completion is token-limited", async () => {
     const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -22155,7 +22155,7 @@ describe("CHAT-02: prior rounds and thread titles", () => {
     expect(upstreamAuthorization).toBe("Bearer title-key");
     expect(titleRequestBody).toMatchObject({
       model: "google/gemini-3.8-flash",
-      max_tokens: 512,
+      max_tokens: 2048,
       reasoning: { effort: "low" },
     });
 
@@ -22188,7 +22188,7 @@ describe("CHAT-02: prior rounds and thread titles", () => {
     expect(recommender.eventType).toBe("output.followups");
     expect(followupRequestBody).toMatchObject({
       model: "google/gemini-3.8-flash",
-      max_tokens: 1024,
+      max_tokens: 2048,
       reasoning: { effort: "low" },
     });
     const futureFollowups = resolveChatEventRecommendedFollowups(recommender);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
@@ -36,9 +36,9 @@ const openRouterCompletionBodySchema = z.object({
 type OpenRouterCompletionBody = z.infer<typeof openRouterCompletionBodySchema>;
 
 /**
- * A completion the upstream cut short. `generateTextWithUsage` rejects any
- * `finish_reason` other than `"stop"`, so tests use this to prove a starved
- * token budget discards the partial text instead of persisting it.
+ * A completion the upstream cut short. Whether the partial text survives is a
+ * per-caller decision: prose summaries keep it, while immutably persisted
+ * titles and JSON output reject it. Tests use this to prove both halves.
  */
 interface TruncatedOpenRouterCompletion {
   readonly content: string;

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/auxiliary-generation.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/auxiliary-generation.ts
@@ -24,11 +24,27 @@ const resultSchema = z
       "caller_cancelled",
       "invalid_request",
       "auth",
+      "output_truncated",
+      "unexpected_tool_calls",
+      "unusable_output",
       "invalid_output",
       "unknown",
       "not_applicable",
     ]),
     duration_ms: z.number().finite().nonnegative().max(Number.MAX_SAFE_INTEGER),
+    // Present only when the provider reported usage. Integers, never payload.
+    completion_tokens: z
+      .number()
+      .int()
+      .nonnegative()
+      .max(Number.MAX_SAFE_INTEGER)
+      .optional(),
+    reasoning_tokens: z
+      .number()
+      .int()
+      .nonnegative()
+      .max(Number.MAX_SAFE_INTEGER)
+      .optional(),
   })
   .strict();
 

--- a/turbo/apps/api/src/signals/routes/__tests__/shared-threads.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/shared-threads.test.ts
@@ -51,9 +51,17 @@ function authenticate(actor: ApiTestUser) {
   return { authorization: "Bearer clerk-session" };
 }
 
-function completion(content = "**Launch checklist**") {
+function completion(content = "**Launch checklist**", finishReason = "stop") {
   return HttpResponse.json({
-    choices: [{ finish_reason: "stop", message: { content } }],
+    choices: [
+      {
+        finish_reason: finishReason,
+        ...(finishReason === "length"
+          ? { native_finish_reason: "MAX_TOKENS" }
+          : {}),
+        message: { content },
+      },
+    ],
   });
 }
 
@@ -319,7 +327,17 @@ describe("optional shared-thread titles", () => {
         return completion("---");
       },
       outcome: "error",
-      reason: "invalid_output",
+      reason: "unusable_output",
+    },
+    {
+      // A public snapshot keeps its title forever, so a partial one is worse
+      // than the fixed fallback. The exhausted budget is still only counted.
+      name: "exhausted token budget",
+      response: () => {
+        return completion("A Truncated Shared Title That Must", "length");
+      },
+      outcome: "degraded",
+      reason: "output_truncated",
     },
     {
       name: "invalid JSON",

--- a/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
@@ -8,7 +8,9 @@ import {
 } from "../external/openrouter";
 import {
   openRouterFailureReason,
+  openRouterFailureTokenCounts,
   type OpenRouterFailureReason,
+  type OpenRouterTokenCounts,
 } from "../external/openrouter-failure";
 import { onRejection, safeSync, settle } from "../utils";
 
@@ -24,28 +26,67 @@ type Reason =
   | OpenRouterFailureReason
   | "none"
   | "caller_cancelled"
-  | "not_applicable";
+  | "not_applicable"
+  // The provider returned well-formed text the feature itself cannot use.
+  | "unusable_output";
+
+/**
+ * Provider-outcome detail the generation closure observes and the boundary
+ * cannot infer from the returned value. Token counts are integers, so they
+ * carry no payload risk while showing how much of the shared thinking-plus-
+ * output budget a generation actually spent.
+ */
+interface AuxiliaryGenerationDetail {
+  readonly truncated: boolean;
+  readonly tokens: OpenRouterTokenCounts;
+}
+
+export type RecordAuxiliaryGenerationDetail = (
+  detail: AuxiliaryGenerationDetail,
+) => void;
+
+interface AuxiliaryResult {
+  readonly feature: AuxiliaryFeature;
+  readonly outcome: Outcome;
+  readonly reason: Reason;
+  readonly tokens: OpenRouterTokenCounts;
+  readonly startedAt: number;
+}
+
+/** Reasons the caller can do nothing about: counted, never warned. */
+function isDegradedReason(reason: Reason): boolean {
+  return (
+    reason === "rate_limited" ||
+    reason === "upstream_timeout" ||
+    reason === "network" ||
+    reason === "provider_unavailable" ||
+    reason === "output_truncated" ||
+    reason === "unexpected_tool_calls"
+  );
+}
+
 const log = logger("api:auxiliary-generation");
 
-async function deliverResult(
-  feature: AuxiliaryFeature,
-  outcome: Outcome,
-  reason: Reason,
-  startedAt: number,
-): Promise<void> {
-  const elapsed = now() - startedAt;
+async function deliverResult(result: AuxiliaryResult): Promise<void> {
+  const elapsed = now() - result.startedAt;
   const ingested = safeSync(() => {
     return ingestToAxiom(getDatasetName("web-logs"), [
       {
         _time: nowDate().toISOString(),
         type: "auxiliary_generation_result",
         source: "api",
-        feature,
-        outcome,
-        reason,
+        feature: result.feature,
+        outcome: result.outcome,
+        reason: result.reason,
         duration_ms: Number.isFinite(elapsed)
           ? Math.min(Number.MAX_SAFE_INTEGER, Math.max(0, elapsed))
           : 0,
+        ...(result.tokens.completionTokens === undefined
+          ? {}
+          : { completion_tokens: result.tokens.completionTokens }),
+        ...(result.tokens.reasoningTokens === undefined
+          ? {}
+          : { reasoning_tokens: result.tokens.reasoningTokens }),
       },
     ]);
   });
@@ -54,43 +95,19 @@ async function deliverResult(
   }
 }
 
-function recordResult(
-  feature: AuxiliaryFeature,
-  outcome: Outcome,
-  reason: Reason,
-  startedAt: number,
-): void {
+function recordResult(result: AuxiliaryResult): void {
   // A title/callback may finish after the response's flush. Register its own
   // flush with the same request lifetime; exporter failure is never business failure.
-  waitUntil(
-    Promise.allSettled([deliverResult(feature, outcome, reason, startedAt)]),
-  );
+  waitUntil(Promise.allSettled([deliverResult(result)]));
 }
 
-function diagnosticLocations(error: unknown): readonly string[] {
-  if (!(error instanceof Error)) {
-    return [];
-  }
-  const header = `${error.name}: ${error.message}`;
-  const stack = error.stack;
-  if (!stack?.startsWith(header)) {
-    return [];
-  }
-  // Remove the complete message, including any injected newlines, before
-  // accepting bounded first-party frames from the engine-generated stack.
-  return stack
-    .slice(header.length)
-    .split("\n")
-    .flatMap((frame) => {
-      const location =
-        /^\s+at .+\/src\/((?:signals|lib)\/[a-zA-Z0-9_./-]+\.ts:\d+:\d+)\)?$/u.exec(
-          frame,
-        )?.[1];
-      return location ? [location.slice(0, 240)] : [];
-    })
-    .slice(0, 5);
-}
-
+/**
+ * The finite reason and error kind carry the whole signal. This deliberately
+ * reports no source locations: production runs a bundle whose frames are
+ * `file:///var/task/index.js:...`, so a first-party stack filter matched
+ * nothing there while remaining a standing risk of admitting a provider
+ * message or a file path into the diagnostic.
+ */
 function diagnose(
   feature: AuxiliaryFeature,
   reason: Reason,
@@ -117,9 +134,6 @@ function diagnose(
           errorType: error.errorType,
         }
       : {}),
-    // Keep first-party source locations, without the error message, provider
-    // payload, arbitrary file paths, or a raw stack in the diagnostic.
-    locations: diagnosticLocations(error),
   });
 }
 
@@ -127,7 +141,7 @@ function diagnose(
 export async function generateAuxiliary<T>(
   args: {
     readonly feature: AuxiliaryFeature;
-    readonly generate: () => Promise<T>;
+    readonly generate: (record: RecordAuxiliaryGenerationDetail) => Promise<T>;
     readonly usable: (value: T) => boolean;
     readonly diagnosticContext?: Readonly<{
       runId?: string;
@@ -137,31 +151,50 @@ export async function generateAuxiliary<T>(
   signal?: AbortSignal,
 ): Promise<T | undefined> {
   const startedAt = now();
+  let detail: AuxiliaryGenerationDetail | undefined;
   const result = await settle(
     onRejection(
       (async () => {
         signal?.throwIfAborted();
         if (!isLlmConfigured()) {
-          recordResult(args.feature, "skipped", "not_applicable", startedAt);
+          recordResult({
+            feature: args.feature,
+            outcome: "skipped",
+            reason: "not_applicable",
+            tokens: {},
+            startedAt,
+          });
           return undefined;
         }
-        const value = await args.generate();
+        const value = await args.generate((reported) => {
+          detail = reported;
+        });
         signal?.throwIfAborted();
         const usable = args.usable(value);
-        if (!usable) {
+        // Truncation classifies first even when the shortened text turns out to
+        // be unusable: the token ceiling is the known, non-actionable cause, and
+        // reporting it as a defect would restore the noise this replaces.
+        const truncated = detail?.truncated === true;
+        const outcome = truncated ? "degraded" : usable ? "success" : "error";
+        if (outcome === "error") {
           diagnose(
             args.feature,
-            "invalid_output",
+            "unusable_output",
             undefined,
             args.diagnosticContext,
           );
         }
-        recordResult(
-          args.feature,
-          usable ? "success" : "error",
-          usable ? "none" : "invalid_output",
+        recordResult({
+          feature: args.feature,
+          outcome,
+          reason: truncated
+            ? "output_truncated"
+            : usable
+              ? "none"
+              : "unusable_output",
+          tokens: detail?.tokens ?? {},
           startedAt,
-        );
+        });
         return value;
       })(),
       (error) => {
@@ -173,18 +206,19 @@ export async function generateAuxiliary<T>(
           : openRouterFailureReason(error);
         const outcome = cancelled
           ? "cancelled"
-          : [
-                "rate_limited",
-                "upstream_timeout",
-                "network",
-                "provider_unavailable",
-              ].includes(reason)
+          : isDegradedReason(reason)
             ? "degraded"
             : "error";
         if (outcome === "error") {
           diagnose(args.feature, reason, error, args.diagnosticContext);
         }
-        recordResult(args.feature, outcome, reason, startedAt);
+        recordResult({
+          feature: args.feature,
+          outcome,
+          reason,
+          tokens: openRouterFailureTokenCounts(error),
+          startedAt,
+        });
       },
     ),
   );

--- a/turbo/apps/api/src/signals/services/chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-title.service.ts
@@ -476,6 +476,10 @@ export async function generateChatNotificationSummary(
   },
   signal?: AbortSignal,
 ): Promise<string | null> {
+  // Accepting truncated text makes an empty result reachable here: a partial
+  // completion can be non-empty for the provider and still strip to nothing.
+  // The caller reads `null` as "no summary" and shows its own copy, so the
+  // empty string must never reach it as a notification body.
   return (
     (await generateAuxiliary(
       {
@@ -506,7 +510,7 @@ export async function generateChatNotificationSummary(
         },
       },
       signal,
-    )) ?? null
+    )) || null
   );
 }
 

--- a/turbo/apps/api/src/signals/services/chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-title.service.ts
@@ -25,15 +25,20 @@ import { logger } from "../../lib/log";
 import { stripMarkdown } from "../../lib/strip-markdown";
 import { waitUntil } from "../context/wait-until";
 import {
+  AUXILIARY_TEXT_MAX_TOKENS,
   FAST_PATH_MODEL,
-  generateText,
+  generateTextWithUsage,
   isLlmConfigured,
+  openRouterTokenCounts,
 } from "../external/openrouter";
 import { publishThreadListChanged } from "../external/realtime";
 import type { Db } from "../external/db";
 import { nowDate } from "../../lib/time";
 import { safeJsonParse, tapError } from "../utils";
-import { generateAuxiliary } from "./auxiliary-generation.service";
+import {
+  generateAuxiliary,
+  type RecordAuxiliaryGenerationDetail,
+} from "./auxiliary-generation.service";
 import { chatEventTextCondition } from "./chat-event-type.service";
 import { visibleChatEventCondition } from "./chat-event-shared.service";
 import {
@@ -186,29 +191,43 @@ function chatCompletionContextMessage(
 
 async function generateFastPathText(
   messages: readonly ChatMessageForGeneration[],
-  maxTokens = 512,
+  maxTokens = AUXILIARY_TEXT_MAX_TOKENS,
   options?: {
     readonly stripMarkdown?: boolean;
+    readonly acceptTruncatedText?: boolean;
+    readonly record?: RecordAuxiliaryGenerationDetail;
   },
   signal?: AbortSignal,
 ): Promise<string | null> {
-  const content = await generateText(
+  const generation = await generateTextWithUsage(
     FAST_PATH_MODEL,
     messages,
     maxTokens,
     {
       reasoning: { effort: "low" },
       temperature: 0.3,
+      ...(options?.acceptTruncatedText === true
+        ? { acceptTruncatedText: true }
+        : {}),
     },
     signal,
   );
-  if (content === null) {
+  if (generation === null) {
     return null;
   }
-  return options?.stripMarkdown === false ? content : stripMarkdown(content);
+  options?.record?.({
+    truncated: generation.truncated === true,
+    tokens: openRouterTokenCounts(generation.usage),
+  });
+  return options?.stripMarkdown === false
+    ? generation.text
+    : stripMarkdown(generation.text);
 }
 
-function generateChatTitle(input: ChatTitleInput): Promise<string | null> {
+function generateChatTitle(
+  input: ChatTitleInput,
+  record: RecordAuxiliaryGenerationDetail,
+): Promise<string | null> {
   const sections: string[] = [];
 
   if (input.priorRounds && input.priorRounds.length > 0) {
@@ -227,17 +246,23 @@ function generateChatTitle(input: ChatTitleInput): Promise<string | null> {
     `Most recent user message:\n${input.currentUserMessage.slice(0, TITLE_CONTEXT_CHAR_CAP)}`,
   );
 
-  return generateFastPathText([
-    {
-      role: "system",
-      content:
-        "Generate a short, descriptive title (max 60 chars) for a chat conversation. Weight the most recent exchange highest, but use the earlier rounds to keep the title consistent as the thread evolves. Return only the title as plain text. Do not use any markdown syntax such as #, *, **, _, ---, ``` or quotes. Just plain text.",
-    },
-    {
-      role: "user",
-      content: sections.join("\n\n"),
-    },
-  ]);
+  // A title is persisted immutably onto the thread, so a mid-word fragment is
+  // worse than leaving the thread untitled: truncation stays rejected here.
+  return generateFastPathText(
+    [
+      {
+        role: "system",
+        content:
+          "Generate a short, descriptive title (max 60 chars) for a chat conversation. Weight the most recent exchange highest, but use the earlier rounds to keep the title consistent as the thread evolves. Return only the title as plain text. Do not use any markdown syntax such as #, *, **, _, ---, ``` or quotes. Just plain text.",
+      },
+      {
+        role: "user",
+        content: sections.join("\n\n"),
+      },
+    ],
+    AUXILIARY_TEXT_MAX_TOKENS,
+    { record },
+  );
 }
 
 /** Generate the immutable title stored with a public shared-thread snapshot. */
@@ -254,7 +279,9 @@ export async function generateSharedThreadTitle(
   const title = await generateAuxiliary(
     {
       feature: "shared_thread_title",
-      generate: () => {
+      generate: (record) => {
+        // Public snapshots keep this title forever; a partial one is worse
+        // than the fixed fallback, so truncation stays rejected.
         return generateFastPathText(
           [
             {
@@ -267,8 +294,8 @@ export async function generateSharedThreadTitle(
               content: conversation,
             },
           ],
-          512,
-          undefined,
+          AUXILIARY_TEXT_MAX_TOKENS,
+          { record },
           signal,
         );
       },
@@ -388,11 +415,14 @@ async function generateAndPersistChatThreadTitle(args: {
         : [];
       const title = await generateAuxiliary({
         feature: "chat_title",
-        generate: () => {
-          return generateChatTitle({
-            currentUserMessage: args.prompt,
-            priorRounds: priorRounds.length > 0 ? priorRounds : undefined,
-          });
+        generate: (record) => {
+          return generateChatTitle(
+            {
+              currentUserMessage: args.prompt,
+              priorRounds: priorRounds.length > 0 ? priorRounds : undefined,
+            },
+            record,
+          );
         },
         usable: (value) => {
           return Boolean(value);
@@ -454,7 +484,9 @@ export async function generateChatNotificationSummary(
         usable: (value) => {
           return Boolean(value);
         },
-        generate: () => {
+        generate: (record) => {
+          // A shortened notification sentence still tells the user their task
+          // finished; the alternative is a notification with no summary at all.
           return generateFastPathText(
             [
               {
@@ -467,8 +499,8 @@ export async function generateChatNotificationSummary(
                 content: `User request:\n${args.prompt.slice(0, TITLE_CONTEXT_CHAR_CAP)}\n\nAssistant reply:\n${args.resultText.slice(0, TITLE_CONTEXT_CHAR_CAP)}`,
               },
             ],
-            512,
-            undefined,
+            AUXILIARY_TEXT_MAX_TOKENS,
+            { acceptTruncatedText: true, record },
             signal,
           );
         },
@@ -519,6 +551,7 @@ async function getLatestFollowupContextMessages(
 
 async function generateRecommendedFollowups(
   messages: readonly ChatCompletionContextMessage[],
+  record: RecordAuxiliaryGenerationDetail,
   signal?: AbortSignal,
 ): Promise<ChatRecommendedFollowup[]> {
   const context = messages
@@ -527,6 +560,8 @@ async function generateRecommendedFollowups(
     })
     .join("\n\n");
 
+  // The output must parse as JSON, so a truncated array is unusable by
+  // construction and stays rejected.
   const text = await generateFastPathText(
     [
       {
@@ -538,8 +573,8 @@ async function generateRecommendedFollowups(
         content: `Recent conversation:\n${context}`,
       },
     ],
-    1024,
-    { stripMarkdown: false },
+    AUXILIARY_TEXT_MAX_TOKENS,
+    { stripMarkdown: false, record },
     signal,
   );
 
@@ -568,8 +603,8 @@ export async function generateChatThreadRecommendedFollowupsFromContext(
     (await generateAuxiliary(
       {
         feature: "recommended_followups",
-        generate: () => {
-          return generateRecommendedFollowups(args.messages, signal);
+        generate: (record) => {
+          return generateRecommendedFollowups(args.messages, record, signal);
         },
         usable: (value) => {
           return value.length > 0;

--- a/turbo/apps/api/src/signals/services/run-summary.service.ts
+++ b/turbo/apps/api/src/signals/services/run-summary.service.ts
@@ -5,9 +5,17 @@ import { agentRuns } from "@okouai/db/schema/agent-run";
 import { logger } from "../../lib/log";
 import { stripMarkdown } from "../../lib/strip-markdown";
 import { writeDb$, type Db } from "../external/db";
-import { FAST_PATH_MODEL, generateText } from "../external/openrouter";
+import {
+  AUXILIARY_TEXT_MAX_TOKENS,
+  FAST_PATH_MODEL,
+  generateTextWithUsage,
+  openRouterTokenCounts,
+} from "../external/openrouter";
 import { tapError } from "../utils";
-import { generateAuxiliary } from "./auxiliary-generation.service";
+import {
+  generateAuxiliary,
+  type RecordAuxiliaryGenerationDetail,
+} from "./auxiliary-generation.service";
 import { writeRunMetadata } from "./agent-run-metadata-write.service";
 
 const log = logger("run-summary");
@@ -32,12 +40,15 @@ async function generateRunSummary(
   triggerSource: string,
   prompt: string,
   resultText: string,
+  record: RecordAuxiliaryGenerationDetail,
   signal?: AbortSignal,
 ): Promise<string | null> {
   const promptSnippet = truncateSnippet(prompt);
   const resultSnippet = truncateSnippet(resultText);
 
-  const content = await generateText(
+  // A shortened summary still describes what the run produced, and the
+  // alternative is a run with no summary at all.
+  const generation = await generateTextWithUsage(
     FAST_PATH_MODEL,
     [
       {
@@ -49,11 +60,22 @@ async function generateRunSummary(
         content: `Context (user request):\n${promptSnippet}\n\nResult:\n${resultSnippet}`,
       },
     ],
-    768,
-    { reasoning: { effort: "low" }, temperature: 0.3 },
+    AUXILIARY_TEXT_MAX_TOKENS,
+    {
+      reasoning: { effort: "low" },
+      temperature: 0.3,
+      acceptTruncatedText: true,
+    },
     signal,
   );
-  return content === null ? null : stripMarkdown(content);
+  if (generation === null) {
+    return null;
+  }
+  record({
+    truncated: generation.truncated === true,
+    tokens: openRouterTokenCounts(generation.usage),
+  });
+  return stripMarkdown(generation.text);
 }
 
 export async function saveRunSummary(
@@ -69,11 +91,12 @@ export async function saveRunSummary(
   const summary = await generateAuxiliary(
     {
       feature: "run_summary",
-      generate: () => {
+      generate: (record) => {
         return generateRunSummary(
           args.triggerSource,
           args.prompt,
           args.resultText,
+          record,
           signal,
         );
       },


### PR DESCRIPTION
Closes #32118. Implements the [approved contract](https://github.com/vm0-ai/vm0/issues/32118#issuecomment-5600393190); layers 1, 2 and 3 ship together.

## Root cause

`FAST_PATH_MODEL` (`google/gemini-3.8-flash`) reports `reasoning.mandatory: true` with `supported_efforts: ["high", "medium", "low"]` and no independent reasoning budget, and Gemini 3 spends thinking and visible output from one combined `max_output_tokens`. `effort: "low"` is already this model's floor, so model-chosen thinking could consume the whole budget: `finish_reason` became `length`, the visible content was empty, `parseOpenRouterGeneration` threw, and the auxiliary generation warned with no summary. #31715 raised the ceilings but the budgets it chose are the ones still failing.

## Layer 1 — remove the truncation condition

One documented constant, `AUXILIARY_TEXT_MAX_TOKENS = 2048`, applied to the five auxiliary text sites:

| call site | from | to |
| --- | --- | --- |
| `generateFastPathText` default (chat title) | 512 | 2048 |
| shared-thread title | 512 | 2048 |
| notification summary | 512 | 2048 |
| recommended follow-ups | 1024 | 2048 |
| run summary | 768 | 2048 |

A ceiling is not billed, only generated tokens are, and this model picks its own thinking length, so a higher ceiling does not buy more thinking — it stops the answer from being starved. Output length stays governed by the prompts ("max 60 chars", "max 90 chars", "at most 50 words"). Every measured call site at or above 1024 recorded zero failures; 2048 clears the observed 1024 failures with margin and stays far below the model's 65536 completion limit.

Not in scope and unchanged: `FAST_PATH_MODEL`, every `reasoning.effort` value, `voice_io_polish` (65536), `chat_initial_thinking` (1024), `chat_activity_summary` (1024), `people-search.service.ts` (a different provider). No retry on truncation was added, and #32117 rate-limit backoff and deduplication are untouched.

## Layer 2 — do not discard usable partial text

`OpenRouterGenerateTextOptions` gains `acceptTruncatedText`, and the generation surfaces `truncated`. The decision is per caller, deliberately not uniform:

- **Accept** — `notification_summary`, `run_summary`: a shortened sentence still informs the user, and the alternative is nothing.
- **Reject** — `chat_title`, `shared_thread_title`: a title is persisted immutably onto the thread and into public shared snapshots.
- **Reject** — `recommended_followups`: truncated JSON cannot parse.

Because the budget is combined, a real `MAX_TOKENS` event usually leaves content empty and still falls through to the empty-content rejection. Layer 1 is what removes the failures.

## Layer 3 — classify, quiet the expected condition, restore diagnosability

- `OpenRouterFailureReason` gains `output_truncated` and `unexpected_tool_calls`, recorded at the `parseOpenRouterGeneration` throw site.
- The `usable() === false` path now reports `unusable_output` instead of impersonating provider-side invalid output. That path still passes `error: undefined`, and `diagnose` still tolerates it.
- Both new reasons map to `degraded`, so they stop emitting `Auxiliary generation failed` while staying fully counted in `auxiliary_generation_result`.
- `auxiliary_generation_result` carries `completion_tokens` and `reasoning_tokens` on success and on truncation. These are integers with no payload risk and are the direct evidence of how much of the combined budget thinking consumes.

**Trap 1 fixed first.** `generateTextWithUsage` unconditionally called `recordOpenRouterFailure(parsed.error, "invalid_output")` for anything that was not an `OpenRouterRequestError`, which would have clobbered every reason recorded at the throw site and made the new classification silently inert. It now only classifies an error nothing else has classified.

`safeDiagnosticString` keeps its allowlist discipline: no arbitrary provider string is retained, and no prompt, completion, provider payload or raw stack enters any log or Axiom field.

### `diagnosticLocations` removed

Its regex matched `/src/(signals|lib)/**.ts:line:col`, but production runs a bundle whose frames are `file:///var/task/index.js:5153:36148` — the sanitized production stack quoted in the issue. It therefore returned `[]` on every production invocation while remaining a standing risk of admitting a message or a path into the diagnostic. All eight post-#32636 warnings show `locations: []`, which is the evidence. The finite reason now carries that signal, so the helper is deleted rather than reworked against the bundle.

## Acceptance

Each criterion is proved by a test.

| # | Criterion | Where |
| --- | --- | --- |
| 1 | `length` / `MAX_TOKENS` with empty content → truncation reason, `degraded`, no warning | `auxiliary-generation.test.ts` case "token budget exhausted with empty text" |
| 2 | Same completion with content is kept by `notification_summary` and `run_summary`, rejected by `chat_title`, `shared_thread_title`, `recommended_followups` | `chat-callbacks.bdd.test.ts` (push body, thread title, follow-ups marker), `shared-threads.test.ts` case "exhausted token budget", `auxiliary-generation.test.ts` "keeps shortened summary text for a caller that can use it" |
| 3 | `tool_calls` → own finite reason, `degraded`, no warning | `auxiliary-generation.test.ts` case "tool terminal outcome" |
| 4 | `usable() === false` reports a reason distinct from provider-side invalid output | `auxiliary-generation.test.ts` case "empty interpreted output" (`unusable_output`), `shared-threads.test.ts` "empty interpreted title" |
| 5 | Control — HTTP 401 and a malformed JSON body still produce `error` and still warn | `auxiliary-generation.test.ts` cases "broken credentials" and "malformed JSON", unchanged |
| 6 | Events carry numeric completion and reasoning token counts on success and on truncation | `auxiliary-generation.test.ts` "records provider token counts on success / on an exhausted token budget", plus the run-summary case |
| 7 | The five Layer 1 sites send `max_tokens: 2048` | Updated exact-budget assertions in `chat-callbacks.bdd.test.ts` and `chat-events.bdd.test.ts`; shared-thread title covered by `shared-threads.test.ts` |
| 8 | No prompt, completion, provider payload or raw stack in any log or Axiom field | The outcome loop asserts the provider secret appears in neither `auxiliaryWarnings` nor `auxiliaryResults` |

Accepting a truncated summary makes one more state reachable: content that is non-empty for the provider but empty after `stripMarkdown` (`---`, `**`, `### `). `generateChatNotificationSummary` maps that to `null` so the push notification keeps its fixed "Your task is complete" copy instead of an empty body, covered by "falls back to the fixed notification copy when the token-limited summary strips to nothing". The other four callers already treated an empty value as absent.

The `run_summary` acceptance case proves the shortened text is used rather than dropped: it reaches persistence, where a NUL byte makes PostgreSQL reject the write and produce `Failed to save run summary`. A rejected generation returns nothing and never writes.

Two behavioural tests from #31715 are inverted deliberately, because Layer 2 reverses their decision for one caller: the notification-summary test now asserts the shortened text **is** pushed. The title and follow-up rejection tests keep their original outcome and additionally assert `degraded` / `output_truncated` with no warning.

### One deviation from the contract's trap list

Trap 4 enumerates `chat-events.bdd.test.ts:20887` among the exact-budget assertions to update. At the analysed base that line is `thinkingRequestBody` with `max_tokens: 1024` — the `chat_initial_thinking` site, which the contract's own non-goals exclude from scope. It is left unchanged. The two in-scope assertions in that file (title, follow-ups) are updated to 2048; none were deleted or weakened to `expect.any(Number)`.

## Verification

`pnpm --filter api check-types` and `pnpm --filter api lint` pass on the rebased branch, and `pnpm knip` is clean. The API integration suites need Postgres and 1Password-provisioned secrets that are unavailable in this environment, so they run in the PR pipeline.

## Post-deployment

Per the contract, a bounded window of at least 24 hours after production promotion should confirm: truncation-reason `Auxiliary generation failed` warnings reach zero; `auxiliary_generation_result` still counts the truncations; `rate_limited` degraded volume is materially unchanged; and reported reasoning-token counts are compared against the 2048 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
