### PR TITLE
fix(ci): budget full goal search recovery

### DIFF
--- a/.github/scripts/tests/goal-archive-search-recovery-workflow-test.sh
+++ b/.github/scripts/tests/goal-archive-search-recovery-workflow-test.sh
@@ -78,37 +78,90 @@ for uri in [
 
 # Mock only the external Git source boundary, so these executable checks also
 # run in the PR pipeline's shallow checkout without fetching production history.
+# The runbook additionally requires this exact shell step against real Git at
+# the reviewed HEAD; synthetic success cannot certify the accepted source bytes.
+ancestors = [
+    "3e1544d55ac0dc54a1cdb21d6aee72d651a6808d",
+    "cede9cbfb62872ddabb705de852dc6fd81a3cc6d",
+    "04531239c7e796799f1dca20ab36f7af1d075f85",
+]
+protected_paths = {
+    ancestors[1]: [
+        "turbo/packages/db/scripts/migrations/014-goal-archive-search",
+        "turbo/packages/db/src/migrations/1093_goal_retirement_receipt.sql",
+        "turbo/packages/db/src/migrations/1094_archive_retired_goals.sql",
+        "turbo/apps/api/src/lib/chat-search-bigram.ts",
+        "turbo/packages/api-contracts/src/contracts/chat-event-rows.ts",
+        "turbo/packages/api-contracts/src/contracts/chat-events.ts",
+        "turbo/packages/api-contracts/src/contracts/run-failure-reasons.ts",
+        "turbo/packages/api-contracts/src/contracts/retired-goal-archive.ts",
+        "turbo/packages/api-contracts/src/contracts/pi-memory-citation-literals.ts",
+    ],
+    ancestors[2]: ["turbo/packages/api-contracts/src/contracts/pi-memory-citations.ts"],
+}
+expected_commands = [
+    ["rev-parse", "HEAD"],
+    *[["merge-base", "--is-ancestor", sha, "HEAD"] for sha in ancestors],
+    *[["diff", "--quiet", sha, "HEAD", "--", *paths] for sha, paths in protected_paths.items()],
+]
 with tempfile.TemporaryDirectory() as directory:
     git = Path(directory) / "git"
+    expectations = Path(directory) / "expectations.json"
+    expectations.write_text(json.dumps(expected_commands))
+    calls = Path(directory) / "calls.jsonl"
     git.write_text('''#!/usr/bin/env python3
-import os, sys
+import json, os, sys
+from pathlib import Path
 args = sys.argv[1:]
+assert args in json.loads(Path(os.environ["SOURCE_EXPECTATIONS"]).read_text())
+with open(os.environ["SOURCE_CALLS"], "a") as output:
+    output.write(json.dumps(args) + "\\n")
+failure = os.environ["SOURCE_FAILURE"]
 if args == ["rev-parse", "HEAD"]:
     print("a" * 40)
 elif args[:2] == ["merge-base", "--is-ancestor"]:
-    assert args[2] in ("3e1544d55ac0dc54a1cdb21d6aee72d651a6808d", "cede9cbfb62872ddabb705de852dc6fd81a3cc6d")
-    sys.exit(1 if os.environ.get("SOURCE_FAILURE") == "ancestor" else 0)
+    sys.exit(1 if failure == "ancestor:" + args[2] else 0)
 elif args[:2] == ["diff", "--quiet"]:
-    assert args[2] == "cede9cbfb62872ddabb705de852dc6fd81a3cc6d"
-    assert "turbo/packages/db/scripts/migrations/014-goal-archive-search" in args
-    sys.exit(1 if os.environ.get("SOURCE_FAILURE") == "changed" else 0)
+    sys.exit(1 if any(failure == "changed:" + path for path in args[5:]) else 0)
 else:
     sys.exit(1)
 ''')
     git.chmod(0o700)
     def check_source(mode, failure="", sha="a" * 40):
-        return subprocess.run(["bash", "-c", source_check], cwd=root,
+        calls.write_text("")
+        result = subprocess.run(["bash", "-c", source_check], cwd=root,
             env={**os.environ, "PATH": directory + os.pathsep + os.environ["PATH"],
-                 "RECOVERY_MODE": mode, "GITHUB_SHA": sha, "SOURCE_FAILURE": failure},
-            capture_output=True, text=True).returncode
+                 "RECOVERY_MODE": mode, "GITHUB_SHA": sha, "SOURCE_FAILURE": failure,
+                 "SOURCE_EXPECTATIONS": str(expectations), "SOURCE_CALLS": str(calls)},
+            capture_output=True, text=True)
+        actual_commands = [json.loads(line) for line in calls.read_text().splitlines()]
+        if mode not in ("dry-run", "apply"):
+            assert actual_commands == []
+        elif sha != "a" * 40:
+            assert actual_commands == expected_commands[:1]
+        elif not failure:
+            assert actual_commands == expected_commands
+        else:
+            # A failed ancestor/path must terminate the step, not continue to
+            # another baseline and accidentally turn its success into approval.
+            failed_command = next(command for command in expected_commands
+                if (failure.startswith("ancestor:") and command[:2] == ["merge-base", "--is-ancestor"] and failure[9:] == command[2])
+                or (failure.startswith("changed:") and command[:2] == ["diff", "--quiet"] and failure[8:] in command[5:]))
+            assert actual_commands == expected_commands[:expected_commands.index(failed_command) + 1]
+        return result.returncode
     for mode in ["dry-run", "apply", "", "migrate", "apply --after-thread=x", "$(touch forbidden)"]:
         assert (check_source(mode) == 0) == (mode in ("dry-run", "apply"))
-    assert check_source("apply", "ancestor") != 0
-    assert check_source("apply", "changed") != 0
+    for ancestor in ancestors:
+        assert check_source("apply", "ancestor:" + ancestor) != 0
+    for paths in protected_paths.values():
+        for path in paths:
+            assert check_source("apply", "changed:" + path) != 0
     assert check_source("apply", sha="b" * 40) != 0
 
 assert workflow.count("  workflow_dispatch:") == 1
 assert "github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'" in workflow
+assert workflow.count("timeout-minutes:") == 1 and "timeout-minutes: 240\n" in workflow
+assert workflow.index("Validate mode and accepted operation source") < workflow.index("pnpm install --frozen-lockfile --ignore-scripts")
 assert workflow.index("pnpm install --frozen-lockfile --ignore-scripts") < workflow.index("${{ secrets.NEON_API_KEY }}")
 assert workflow.index("pnpm install --frozen-lockfile --ignore-scripts") < workflow.index("${{ secrets.R2_ACCESS_KEY_ID }}")
 assert "environment: production" in workflow and "cancel-in-progress: false" in workflow

--- a/.github/workflows/temporary-goal-archive-search-recovery.yml
+++ b/.github/workflows/temporary-goal-archive-search-recovery.yml
@@ -28,7 +28,8 @@ jobs:
   recovery:
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # Three full scans at the observed 58m39s need ~176m, plus setup/variance.
+    timeout-minutes: 240
     environment: production
     steps:
       - name: Check out dispatched source
@@ -51,6 +52,7 @@ jobs:
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
           git merge-base --is-ancestor 3e1544d55ac0dc54a1cdb21d6aee72d651a6808d HEAD
           git merge-base --is-ancestor cede9cbfb62872ddabb705de852dc6fd81a3cc6d HEAD
+          git merge-base --is-ancestor 04531239c7e796799f1dca20ab36f7af1d075f85 HEAD
           # Include the engine's local import closure and original SQL. A later
           # source change requires controller review, never an override input.
           git diff --quiet cede9cbfb62872ddabb705de852dc6fd81a3cc6d HEAD -- \
@@ -62,8 +64,11 @@ jobs:
             turbo/packages/api-contracts/src/contracts/chat-events.ts \
             turbo/packages/api-contracts/src/contracts/run-failure-reasons.ts \
             turbo/packages/api-contracts/src/contracts/retired-goal-archive.ts \
-            turbo/packages/api-contracts/src/contracts/pi-memory-citations.ts \
             turbo/packages/api-contracts/src/contracts/pi-memory-citation-literals.ts
+          # Only this import accepts #32891's reviewed vm0 -> Okou license
+          # comment. Every byte, including comments, remains protected.
+          git diff --quiet 04531239c7e796799f1dca20ab36f7af1d075f85 HEAD -- \
+            turbo/packages/api-contracts/src/contracts/pi-memory-citations.ts
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/docs/goal-archive-search-recovery.md
+++ b/docs/goal-archive-search-recovery.md
@@ -65,13 +65,38 @@ gh workflow run temporary-goal-archive-search-recovery.yml \
 ```
 
 Use the returned GitHub run identity and its job summary as evidence. Only
-`workflow_dispatch` on `refs/heads/main` reaches the finite 90-minute protected
+`workflow_dispatch` on `refs/heads/main` reaches the finite 240-minute protected
 job. Both modes share one concurrency group with cancellation disabled. No push,
 PR, release, schedule, arbitrary SQL, command, ref, bucket, cursor, count or hash
 override is available. Checkout uses the dispatched `github.sha`, with credentials
 not persisted. Before binding production secrets, the job validates the mode,
 accepted merge ancestry and unchanged engine/import source, then installs frozen
 DB dependencies with install scripts disabled. Actions are pinned to full SHAs.
+
+### Exact accepted source
+
+The original archive merge `3e1544d55ac0dc54a1cdb21d6aee72d651a6808d` and repair
+merge `cede9cbfb62872ddabb705de852dc6fd81a3cc6d` must remain ancestors of the
+dispatched source. Every guarded path in the 014 engine/import closure and
+1093/1094 retains exact byte comparison to the repair merge, except one file:
+`turbo/packages/api-contracts/src/contracts/pi-memory-citations.ts` is compared
+only to reviewed branding merge `04531239c7e796799f1dca20ab36f7af1d075f85`
+([#32891](https://github.com/vm0-ai/vm0/pull/32891)), which must also be an ancestor.
+The single accepted difference is line 7's license comment, `vm0` to `Okou`.
+No runtime logic changed. Any further difference, including another comment
+edit, must fail before production secrets are bound. Do not advance the whole
+closure to a newer main, ignore comments, omit paths or add a source override.
+
+Implementation and controller acceptance must execute the workflow's actual
+`Validate mode and accepted operation source` shell step against real Git history
+at the exact reviewed HEAD, with `GITHUB_SHA` set to that HEAD, for both modes.
+This check needs all three ancestor commits locally and no production credentials.
+Record that full SHA and the byte/ancestry results alongside the executable
+workflow fixture's independent missing-ancestor, changed-path, invalid-mode and
+dispatch-SHA rejection results. Shallow-checkout synthetic fixtures alone cannot
+prove that the reviewed source matches either accepted baseline. Before each
+production approval, the operator validates the actual dispatched main source
+and accepted execution files again if main has advanced.
 
 The resolver reuses existing `NEON_API_KEY`, the expected
 `NEON_PROJECT_ID=hidden-lab-39609750`, and a unique `production` branch. It rejects
@@ -131,6 +156,54 @@ plus controller acceptance. A successful standalone dry-run can still report wor
 object request timeout. Its existing snapshot decompression/history accumulation
 is unchanged. The workflow timeout bounds the job; it is **not a per-thread
 memory bound**.
+
+## Measured job budget and operator continuation (#32978)
+
+The first apply [run 34333317500 / job 102406764659](https://github.com/vm0-ai/vm0/actions/runs/34333317500/job/102406764659),
+attempt 1, dispatched source `99bd2254849a4890c0bf7dc12c151b6463b34726`, was
+cancelled by GitHub at **2026-09-09 10:42:30 UTC**. Its annotation states
+`The job has exceeded the maximum execution time of 1h30m0s`. The
+[terminal evidence](https://github.com/vm0-ai/vm0/issues/32653#issuecomment-5600632181)
+contains a complete preflight from **09:13:00 to 10:11:39 UTC** (**58m39s**):
+4,162 processed, 4,153 unchanged, nine repairable and all other outcomes zero.
+Both before and immediately-before-apply cohorts matched all 4,162 Goals,
+distinct threads and complete receipts, the fixed hash and every prerequisite.
+Apply started **10:11:41 UTC**. No complete apply report, fresh final verification
+or after cohort was emitted. The committed repair count is **unknown**; nine
+repairable threads do not mean nine repaired threads or zero committed repairs.
+
+Apply requires three complete scans: fresh preflight, full apply and fresh full
+verification. Three scans at 58m39s take **175m57s**, about 176 minutes before
+setup/cohort reads. The finite **240-minute** budget adds about **64 minutes**
+for setup and timing variability; the earlier standalone dry-run took about
+41m15s. This is a measured allocation, not a completion guarantee. Preserve all
+three scans, the full cohort and all existing transaction, lock, statement,
+object-request and inventory bounds. There is no operator timeout override.
+
+A GitHub job can outlive an operator's **two-hour assistant run**. Before that
+assistant limit, the sole operator records a continuation checkpoint on the EPIC:
+
+1. Exact run and job URLs/IDs, attempt, dispatched full source SHA, mode,
+   observation UTC, actual job/check status and approval state.
+2. Only completed source/run/attempt-bound phase reports and count/hash records;
+   identify the last started phase and every absent report. The wrapper captures
+   child output until a complete phase validates, so a quiet active phase does
+   not expose a committed repair count.
+3. Stop the assistant run while leaving the GitHub job intact. Controller
+   `9faa0333-002f-418a-b47d-185aa32afa4a` continues the same sole operator,
+   `cacc99f2-1570-4e64-961c-40b3fe8db2cf`, to read the same run/job and attempt.
+   Resume observation of that job whether it is still active or became terminal
+   between assistant runs. Do not dispatch, rerun, cancel or add an executor to
+   cross the assistant runtime boundary.
+
+An assistant continuation is not a GitHub retry or a completion certificate.
+If the GitHub job actually times out or fails again, preserve safe per-thread
+commits, report only observed counts and missing evidence, and return to the
+controller before any retry. After this repair is merged and independently
+accepted, the existing operator first rechecks the terminal two-run inventory
+(dry-run `34329154556`, apply `34333317500`), the actual accepted dispatch source
+and current normal serving/projector prerequisites, then follows the full fresh
+dry-run and apply certification path. Prior reports never replace these scans.
 
 ## Failure, partial commits and disposal
 


### PR DESCRIPTION
## Summary

The recovery apply job was cancelled at its 90-minute limit after a 58m39s full preflight; full apply and a fresh full verification still had to run. Set a finite 240-minute budget for the unchanged three-scan certificate (about 176 minutes at the observed rate, plus 64 minutes for setup and variability).

Keep every original guarded path pinned to accepted repair `cede9cbfb62872ddabb705de852dc6fd81a3cc6d`, except `pi-memory-citations.ts`, which is checked byte-for-byte against reviewed branding merge `04531239c7e796799f1dca20ab36f7af1d075f85`. Require that additional ancestor and retain both original ancestry requirements. This accepts only the reviewed license-comment branding change; further changes, including comments, still fail before credentials.

Extend the executable guard fixtures for both exact path groups, each missing ancestor, each changed protected path, invalid modes and mismatched dispatch SHA. The runbook records the actual failed job, unknown committed repair count, and controller continuation of the same operator observing the same GitHub job across the two-hour assistant limit.

Closes #32978. Parent: #32653. Follows accepted #32875 / #32885.

## Validation

- Started from freshly fetched `origin/main` at `fb0765d15816bacbcb7c086cd6806ab7e450cde1`, rebased the independent branch, and inspected all 39 open PR file inventories: no relevant overlap.
- At full HEAD `202bc2f3edd0bed99d34d0346cd75b826bac8d92`, executed the actual workflow source-check shell against real Git for both `dry-run` and `apply`: passed. All three ancestors and all 12 guarded files matched the two exact baselines.
- In an isolated local Git fixture, 22 negative cases passed: an additional comment change in every guarded file, added/deleted engine files, each missing required ancestor, invalid modes and a mismatched dispatch SHA. These invoke the same actual shell step and do not bind production credentials.
- `bash .github/scripts/tests/goal-archive-search-recovery-workflow-test.sh`: passed, including existing synthetic production-resolver safety checks and the expanded source/dispatch gates.
- `pnpm -F @okouai/db exec vitest run scripts/goal-archive-search-recovery/certificate.test.ts`: all 45 tests passed after frozen-lockfile installation with scripts disabled.
- Actionlint 1.7.12, Bash syntax, scoped Prettier, runbook relative links, commitlint and `git diff --check`: passed.
- Required PR and protected merge-group checks remain mandatory. No full local Vitest suite or development server.

Only the temporary workflow, its existing workflow fixture and its runbook change. The certificate/parser/SQL/wrapper, 014, 1093/1094, full 4,162 cohort and hash, all three scans, credentials/TLS, pinned dispatch identity and shared non-cancelling concurrency remain intact. No source, timeout, command or cohort override is added.

This implementation stops at protected merge. No production dispatch, rerun, approval, API/App release, promotion or other production action was performed. Independent controller acceptance and recovery certification by the existing sole operator remain separate gates; S2 is still unaccepted.
