### PR TITLE
feat: enable intro video for the team

### DIFF
--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -88,7 +88,7 @@ test("Lab groups every feature by rollout stage with a switch", async () => {
     within(released).getByText(FeatureSwitchKey.AvatarNeckSweater),
   ).toBeVisible();
   expect(within(beta).getByText(FeatureSwitchKey.Banking)).toBeVisible();
-  expect(within(alpha).getByText(FeatureSwitchKey.IntroVideo)).toBeVisible();
+  expect(within(beta).getByText(FeatureSwitchKey.IntroVideo)).toBeVisible();
   expect(
     within(alpha).getByText(FeatureSwitchKey.AhrefsConnector),
   ).toBeVisible();

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -199,7 +199,7 @@ describe("getAllFeatureStates", () => {
     );
     expect(staffOrgStates[FeatureSwitchKey.ChatTranslation]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.VoiceInputV2]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.IntroVideo]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.MorningBrief]).toBe(true);
@@ -334,7 +334,7 @@ describe("getFeatureSwitchMetadata", () => {
       "released",
     );
     expect(metadata[FeatureSwitchKey.Banking].rolloutStage).toBe("beta");
-    expect(metadata[FeatureSwitchKey.IntroVideo].rolloutStage).toBe("alpha");
+    expect(metadata[FeatureSwitchKey.IntroVideo].rolloutStage).toBe("beta");
     expect(metadata[FeatureSwitchKey.AhrefsConnector].rolloutStage).toBe(
       "alpha",
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -319,6 +319,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Enable explainer videos with style, avatar, and voice selection in the template picker.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.AvatarNeckSweater]: {
     maintainer: "ming@okou.ai",


### PR DESCRIPTION
## Summary

Intro Video is currently disabled by default for the internal team. Enable it for the existing staff organization allowlist so team members get the creation entry point and managed API access by default. Existing per-user overrides retain precedence, and other organizations remain default-off.

Update the existing rollout and Lab page tests for Intro Video's move from Alpha to Beta.

## Verification

- Focused tests: 29 feature-switch tests and 6 Lab page tests passed.
- Prettier check passed for all changed files.
- Core lint, Platform lint for the changed test, and both packages' type checks passed.
- Knip passed for the core and Platform workspaces.
- Full Vitest suites are left to the PR pipeline.
