### PR TITLE
fix(api): skip intro video session polling after video id assignment

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/intro-video-agent.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/intro-video-agent.test.ts
@@ -751,6 +751,158 @@ describe("Managed Intro Video Agent", () => {
     expect(provider.submissions).toHaveLength(1);
   });
 
+  it.each(["missing", "network error"])(
+    "recovers a completed video with one charge when its session has a %s response",
+    async (sessionFailure) => {
+      const f = await fixture();
+      const provider = mockProvider();
+      provider.videoId = VIDEO_ID;
+      const body = request();
+      expect((await submit(f, body)).status).toBe(202);
+      server.use(
+        http.get(`${HEYGEN_CREATE_URL}/${SESSION_ID}`, () => {
+          return sessionFailure === "missing"
+            ? HttpResponse.json(
+                { error: { message: "Session not found" } },
+                { status: 404 },
+              )
+            : HttpResponse.error();
+        }),
+      );
+
+      await expect(status(f, body.requestId)).resolves.toMatchObject({
+        status: "running",
+        sessionId: SESSION_ID,
+        videoId: VIDEO_ID,
+        notice: expect.stringContaining("Resume this generation"),
+      });
+      await expect(credits(f)).resolves.toBe(10_000);
+
+      provider.videoStatus = "completed";
+      const completed = await status(f, body.requestId);
+      expect(completed).toMatchObject({
+        generationId: body.requestId,
+        status: "completed",
+        sessionId: SESSION_ID,
+        videoId: VIDEO_ID,
+        providerStatus: "completed",
+        contentType: "video/mp4",
+        durationSeconds: 61,
+        creditsCharged: 610,
+      });
+      expect(completed.url).toBeDefined();
+      expect(completed.url).not.toBe(VIDEO_URL);
+      await expect(status(f, body.requestId)).resolves.toStrictEqual(completed);
+      expect(provider.submissions).toHaveLength(1);
+      await expect(credits(f)).resolves.toBe(9390);
+    },
+  );
+
+  it("reports a failed video when its session is missing", async () => {
+    const f = await fixture();
+    const provider = mockProvider();
+    provider.videoId = VIDEO_ID;
+    const body = request();
+    expect((await submit(f, body)).status).toBe(202);
+    server.use(
+      http.get(`${HEYGEN_CREATE_URL}/${SESSION_ID}`, () => {
+        return HttpResponse.json(
+          { error: { message: "Session not found" } },
+          { status: 404 },
+        );
+      }),
+    );
+    provider.videoStatus = "failed";
+
+    await expect(status(f, body.requestId)).resolves.toMatchObject({
+      status: "failed",
+      sessionId: SESSION_ID,
+      videoId: VIDEO_ID,
+      providerStatus: "failed",
+      error: { code: "HEYGEN_GENERATION_FAILED" },
+    });
+    expect(provider.submissions).toHaveLength(1);
+    await expect(credits(f)).resolves.toBe(10_000);
+  });
+
+  it("keeps a missing session resumable until a video ID becomes available", async () => {
+    const f = await fixture();
+    const provider = mockProvider();
+    const body = request();
+    expect((await submit(f, body)).status).toBe(202);
+    server.use(
+      http.get(
+        `${HEYGEN_CREATE_URL}/${SESSION_ID}`,
+        () => {
+          return HttpResponse.json(
+            { error: { message: "Session not found" } },
+            { status: 404 },
+          );
+        },
+        { once: true },
+      ),
+    );
+
+    await expect(status(f, body.requestId)).resolves.toMatchObject({
+      status: "running",
+      sessionId: SESSION_ID,
+      videoId: null,
+      notice: expect.stringContaining("Session not found"),
+    });
+    await expect(credits(f)).resolves.toBe(10_000);
+
+    provider.sessionStatus = "completed";
+    provider.videoId = VIDEO_ID;
+    provider.videoStatus = "completed";
+    await expect(status(f, body.requestId)).resolves.toMatchObject({
+      status: "completed",
+      videoId: VIDEO_ID,
+      creditsCharged: 610,
+    });
+    expect(provider.submissions).toHaveLength(1);
+    await expect(credits(f)).resolves.toBe(9390);
+  });
+
+  it("keeps a conflicting session video blocked until its identity matches", async () => {
+    const f = await fixture();
+    const provider = mockProvider();
+    provider.videoId = VIDEO_ID;
+    const body = request();
+    expect((await submit(f, body)).status).toBe(202);
+    provider.videoStatus = "completed";
+    server.use(
+      http.get(
+        `${HEYGEN_CREATE_URL}/${SESSION_ID}`,
+        () => {
+          return HttpResponse.json({
+            data: {
+              session_id: SESSION_ID,
+              status: "completed",
+              video_id: "different-video",
+            },
+          });
+        },
+        { once: true },
+      ),
+    );
+
+    await expect(status(f, body.requestId)).resolves.toMatchObject({
+      status: "running",
+      sessionId: SESSION_ID,
+      videoId: VIDEO_ID,
+      notice: expect.stringContaining("different video"),
+    });
+    await expect(credits(f)).resolves.toBe(10_000);
+
+    await expect(status(f, body.requestId)).resolves.toMatchObject({
+      status: "completed",
+      videoId: VIDEO_ID,
+      creditsCharged: 610,
+    });
+    expect(provider.submissions).toHaveLength(1);
+    await expect(credits(f)).resolves.toBe(9390);
+  });
+
   it.each([false, true])(
     "keeps a slow session resumable and converges callback/status completion with one MP4 and charge (private=%s)",
     async (privateArtifacts) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/intro-video-agent.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/intro-video-agent.test.ts
@@ -87,8 +87,10 @@ interface ProviderState {
   voiceCatalogType: "public" | "private";
   submitStatus: number;
   sessionStatus: string;
+  sessionRequests: number;
   videoId: string | null;
   videoStatus: string;
+  videoRequests: number;
   videoContentType: string | null;
   videoDownloads: number;
   beforeDownload?: () => Promise<void>;
@@ -197,8 +199,10 @@ function mockProvider(): ProviderState {
     voiceCatalogType: "public",
     submitStatus: 200,
     sessionStatus: "thinking",
+    sessionRequests: 0,
     videoId: null,
     videoStatus: "processing",
+    videoRequests: 0,
     videoContentType: "video/mp4",
     videoDownloads: 0,
     submissions: [],
@@ -311,6 +315,7 @@ function mockProvider(): ProviderState {
       });
     }),
     http.get(`${HEYGEN_CREATE_URL}/${SESSION_ID}`, () => {
+      state.sessionRequests += 1;
       return HttpResponse.json({
         data: {
           session_id: SESSION_ID,
@@ -320,6 +325,7 @@ function mockProvider(): ProviderState {
       });
     }),
     http.get(`${HEYGEN_BASE}/videos/${VIDEO_ID}`, () => {
+      state.videoRequests += 1;
       return HttpResponse.json({
         data: {
           id: VIDEO_ID,
@@ -726,6 +732,8 @@ describe("Managed Intro Video Agent", () => {
       videoId: VIDEO_ID,
       contentType: "video/mp4",
     });
+    expect(provider.sessionRequests).toBe(0);
+    expect(provider.videoRequests).toBe(1);
     expect(provider.submissions).toHaveLength(1);
     await expect(credits(f)).resolves.toBe(9390);
   });
@@ -751,30 +759,39 @@ describe("Managed Intro Video Agent", () => {
     expect(provider.submissions).toHaveLength(1);
   });
 
-  it.each(["missing", "network error"])(
-    "recovers a completed video with one charge when its session has a %s response",
-    async (sessionFailure) => {
+  it.each(["submission", "session"])(
+    "polls only the recorded video after its ID arrives from the %s",
+    async (identitySource) => {
       const f = await fixture();
       const provider = mockProvider();
-      provider.videoId = VIDEO_ID;
+      provider.videoId = identitySource === "submission" ? VIDEO_ID : null;
       const body = request();
       expect((await submit(f, body)).status).toBe(202);
-      server.use(
-        http.get(`${HEYGEN_CREATE_URL}/${SESSION_ID}`, () => {
-          return sessionFailure === "missing"
-            ? HttpResponse.json(
-                { error: { message: "Session not found" } },
-                { status: 404 },
-              )
-            : HttpResponse.error();
-        }),
-      );
+      if (identitySource === "session") {
+        await expect(status(f, body.requestId)).resolves.toMatchObject({
+          status: "running",
+          videoId: null,
+        });
+        expect(provider.sessionRequests).toBe(1);
+        expect(provider.videoRequests).toBe(0);
+        provider.sessionStatus = "generating";
+        provider.videoId = VIDEO_ID;
+      }
 
       await expect(status(f, body.requestId)).resolves.toMatchObject({
         status: "running",
         sessionId: SESSION_ID,
         videoId: VIDEO_ID,
-        notice: expect.stringContaining("Resume this generation"),
+      });
+      expect(provider.sessionRequests).toBe(
+        identitySource === "session" ? 2 : 0,
+      );
+      expect(provider.videoRequests).toBe(1);
+      provider.sessionStatus = "failed";
+      provider.videoId = "different-video";
+      await expect(status(f, body.requestId)).resolves.toMatchObject({
+        status: "running",
+        videoId: VIDEO_ID,
       });
       await expect(credits(f)).resolves.toBe(10_000);
 
@@ -793,25 +810,22 @@ describe("Managed Intro Video Agent", () => {
       expect(completed.url).toBeDefined();
       expect(completed.url).not.toBe(VIDEO_URL);
       await expect(status(f, body.requestId)).resolves.toStrictEqual(completed);
+      expect(provider.sessionRequests).toBe(
+        identitySource === "session" ? 2 : 0,
+      );
+      expect(provider.videoRequests).toBe(3);
       expect(provider.submissions).toHaveLength(1);
+      expect(provider.videoDownloads).toBe(1);
       await expect(credits(f)).resolves.toBe(9390);
     },
   );
 
-  it("reports a failed video when its session is missing", async () => {
+  it("reports a recorded video's render failure without querying its session", async () => {
     const f = await fixture();
     const provider = mockProvider();
     provider.videoId = VIDEO_ID;
     const body = request();
     expect((await submit(f, body)).status).toBe(202);
-    server.use(
-      http.get(`${HEYGEN_CREATE_URL}/${SESSION_ID}`, () => {
-        return HttpResponse.json(
-          { error: { message: "Session not found" } },
-          { status: 404 },
-        );
-      }),
-    );
     provider.videoStatus = "failed";
 
     await expect(status(f, body.requestId)).resolves.toMatchObject({
@@ -821,64 +835,77 @@ describe("Managed Intro Video Agent", () => {
       providerStatus: "failed",
       error: { code: "HEYGEN_GENERATION_FAILED" },
     });
+    expect(provider.sessionRequests).toBe(0);
+    expect(provider.videoRequests).toBe(1);
     expect(provider.submissions).toHaveLength(1);
     await expect(credits(f)).resolves.toBe(10_000);
   });
 
-  it("keeps a missing session resumable until a video ID becomes available", async () => {
+  it.each(["missing", "network error"])(
+    "resumes a session with a %s response until a video ID is available",
+    async (sessionFailure) => {
+      const f = await fixture();
+      const provider = mockProvider();
+      const body = request();
+      expect((await submit(f, body)).status).toBe(202);
+      server.use(
+        http.get(
+          `${HEYGEN_CREATE_URL}/${SESSION_ID}`,
+          () => {
+            provider.sessionRequests += 1;
+            return sessionFailure === "missing"
+              ? HttpResponse.json(
+                  { error: { message: "Session not found" } },
+                  { status: 404 },
+                )
+              : HttpResponse.error();
+          },
+          { once: true },
+        ),
+      );
+
+      await expect(status(f, body.requestId)).resolves.toMatchObject({
+        status: "running",
+        sessionId: SESSION_ID,
+        videoId: null,
+        notice: expect.stringContaining("Resume this generation"),
+      });
+      expect(provider.sessionRequests).toBe(1);
+      expect(provider.videoRequests).toBe(0);
+      await expect(credits(f)).resolves.toBe(10_000);
+
+      provider.sessionStatus = "completed";
+      provider.videoId = VIDEO_ID;
+      provider.videoStatus = "completed";
+      await expect(status(f, body.requestId)).resolves.toMatchObject({
+        status: "completed",
+        videoId: VIDEO_ID,
+        creditsCharged: 610,
+      });
+      expect(provider.sessionRequests).toBe(2);
+      expect(provider.videoRequests).toBe(1);
+      expect(provider.submissions).toHaveLength(1);
+      await expect(credits(f)).resolves.toBe(9390);
+    },
+  );
+
+  it("keeps a conflicting video response blocked until its identity matches", async () => {
     const f = await fixture();
     const provider = mockProvider();
-    const body = request();
-    expect((await submit(f, body)).status).toBe(202);
-    server.use(
-      http.get(
-        `${HEYGEN_CREATE_URL}/${SESSION_ID}`,
-        () => {
-          return HttpResponse.json(
-            { error: { message: "Session not found" } },
-            { status: 404 },
-          );
-        },
-        { once: true },
-      ),
-    );
-
-    await expect(status(f, body.requestId)).resolves.toMatchObject({
-      status: "running",
-      sessionId: SESSION_ID,
-      videoId: null,
-      notice: expect.stringContaining("Session not found"),
-    });
-    await expect(credits(f)).resolves.toBe(10_000);
-
-    provider.sessionStatus = "completed";
-    provider.videoId = VIDEO_ID;
-    provider.videoStatus = "completed";
-    await expect(status(f, body.requestId)).resolves.toMatchObject({
-      status: "completed",
-      videoId: VIDEO_ID,
-      creditsCharged: 610,
-    });
-    expect(provider.submissions).toHaveLength(1);
-    await expect(credits(f)).resolves.toBe(9390);
-  });
-
-  it("keeps a conflicting session video blocked until its identity matches", async () => {
-    const f = await fixture();
-    const provider = mockProvider();
     provider.videoId = VIDEO_ID;
     const body = request();
     expect((await submit(f, body)).status).toBe(202);
     provider.videoStatus = "completed";
     server.use(
       http.get(
-        `${HEYGEN_CREATE_URL}/${SESSION_ID}`,
+        `${HEYGEN_BASE}/videos/${VIDEO_ID}`,
         () => {
           return HttpResponse.json({
             data: {
-              session_id: SESSION_ID,
+              id: "different-video",
               status: "completed",
-              video_id: "different-video",
+              video_url: VIDEO_URL,
+              duration: 61,
             },
           });
         },
@@ -890,7 +917,7 @@ describe("Managed Intro Video Agent", () => {
       status: "running",
       sessionId: SESSION_ID,
       videoId: VIDEO_ID,
-      notice: expect.stringContaining("different video"),
+      notice: expect.stringContaining("invalid video response"),
     });
     await expect(credits(f)).resolves.toBe(10_000);
 
@@ -899,6 +926,7 @@ describe("Managed Intro Video Agent", () => {
       videoId: VIDEO_ID,
       creditsCharged: 610,
     });
+    expect(provider.sessionRequests).toBe(0);
     expect(provider.submissions).toHaveLength(1);
     await expect(credits(f)).resolves.toBe(9390);
   });

--- a/turbo/apps/api/src/signals/services/intro-video-agent.service.ts
+++ b/turbo/apps/api/src/signals/services/intro-video-agent.service.ts
@@ -752,7 +752,8 @@ const reconcileAgentSession$ = command(
         },
         signal,
       );
-      return null;
+      // A recorded video can still finish when its session is unavailable.
+      return videoId ?? null;
     }
     const session = sessionResult.value;
     if (session.videoId && videoId && session.videoId !== videoId) {

--- a/turbo/apps/api/src/signals/services/intro-video-agent.service.ts
+++ b/turbo/apps/api/src/signals/services/intro-video-agent.service.ts
@@ -668,10 +668,10 @@ const persistAgentCompletion$ = command(
   },
 );
 
-function agentSessionProgress(
-  session: HeyGenVideoAgentSession,
-  videoId: string | undefined,
-): { readonly known: boolean; readonly notice: string } {
+function agentSessionProgress(session: HeyGenVideoAgentSession): {
+  readonly known: boolean;
+  readonly notice: string;
+} {
   const known = [
     "thinking",
     "waiting_for_input",
@@ -686,7 +686,7 @@ function agentSessionProgress(
   } else if (session.status === "waiting_for_input") {
     notice =
       "HeyGen requires input in this generate-mode session. Keep this generation ID and report the blocked session; do not resubmit or switch routes.";
-  } else if (session.status === "completed" && !session.videoId && !videoId) {
+  } else if (session.status === "completed" && !session.videoId) {
     notice =
       "HeyGen reports a completed session without a video ID. Resume this generation to reconcile; do not resubmit.";
   }
@@ -730,8 +730,12 @@ const reconcileAgentSession$ = command(
     const generationId = job.id;
     const internal = readBuiltInGenerationRequestInternal(job.request);
     const videoId = internal.providerJobId;
+    // Once assigned, the video endpoint owns rendering progress.
+    if (videoId) {
+      return videoId;
+    }
     if (!internal.providerSessionId) {
-      return videoId ?? null;
+      return null;
     }
     const sessionResult = await settle(
       getHeyGenVideoAgentSession(internal.providerSessionId, apiKey, signal),
@@ -752,25 +756,10 @@ const reconcileAgentSession$ = command(
         },
         signal,
       );
-      // A recorded video can still finish when its session is unavailable.
-      return videoId ?? null;
-    }
-    const session = sessionResult.value;
-    if (session.videoId && videoId && session.videoId !== videoId) {
-      await set(
-        mergeBuiltInGenerationJobInternal$,
-        {
-          generationId,
-          internal: {
-            providerNotice:
-              "HeyGen returned a different video for this session. Keep this generation ID and report the mismatch; do not resubmit.",
-          },
-        },
-        signal,
-      );
       return null;
     }
-    const { known, notice } = agentSessionProgress(session, videoId);
+    const session = sessionResult.value;
+    const { known, notice } = agentSessionProgress(session);
     if (session.videoId) {
       const recorded = await set(
         recordIntroVideoAgentIdentity$,
@@ -803,7 +792,7 @@ const reconcileAgentSession$ = command(
       );
       return null;
     }
-    return known ? (session.videoId ?? videoId ?? null) : null;
+    return known ? session.videoId : null;
   },
 );
 


### PR DESCRIPTION
Intro videos can remain `running` when HeyGen's session endpoint becomes unavailable even though the assigned video finishes successfully. Follow [HeyGen's documented polling flow](https://developers.heygen.com/docs/video-agent#poll-for-completion): query the session until a video ID is assigned, then query that video directly for its final render status and URL.

Once a video ID is recorded from submission, session lookup, or a callback, subsequent reconciliation skips the session endpoint entirely. Remove the redundant session checks for an already-recorded video. Identity binding during submission/session discovery/callbacks and video-response ID validation remain enforced, and completion retains its existing artifact and billing idempotency. Session errors remain resumable while no video ID is available.

## Validation

- Focused API route suite: 23 tests passed against an isolated local PostgreSQL database. Tests verify the session-to-video transition, direct polling for IDs returned by submission or callbacks, no further session requests after assignment, rendering failure, recovery from session 404/network errors before assignment, video-response identity validation, and one artifact/charge across repeated polls.
- Changed-file Prettier, Oxlint (including type-aware checks), and ESLint passed.
- Repository commit hooks passed: style policy, Knip, TypeScript checks, file-size check, and commitlint.
- Full local Vitest and a local app server were not run; broader tests run in the PR pipeline.
