### PR TITLE
fix(artifacts): register legacy writes before publishing files

### DIFF
--- a/.github/workflows/public-artifact-registration.yml
+++ b/.github/workflows/public-artifact-registration.yml
@@ -1,0 +1,162 @@
+name: Public Artifact Registration
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Inventory only, register and verify, or independently verify"
+        type: choice
+        options: [dry-run, migrate, verify]
+        default: dry-run
+        required: true
+      max_objects:
+        description: "Maximum objects per bucket (production exceeds 100,000)"
+        type: string
+        default: "1000000"
+        required: true
+      concurrency:
+        description: "Concurrent R2 operations (1 to 64)"
+        type: string
+        default: "32"
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-artifact-registration-production
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  registration:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    environment: production
+    steps:
+      - name: Check out dispatched source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24.19.0
+
+      - name: Install frozen migration dependencies before credentials
+        working-directory: turbo
+        run: |
+          corepack enable pnpm
+          pnpm install --frozen-lockfile --ignore-scripts --filter @okouai/db...
+
+      - name: Resolve protected production database
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+        run: |
+          python3 - <<'PYTHON'
+          import json
+          import os
+          import urllib.parse
+          import urllib.request
+
+          # Same HTTP resolver boundary as kms-production-preflight; fail closed
+          # without exposing provider responses, exception text or credentials.
+          class NoRedirect(urllib.request.HTTPRedirectHandler):
+              def redirect_request(self, *args, **kwargs):
+                  raise ValueError("redirect")
+
+          def resolve():
+              project = os.environ["NEON_PROJECT_ID"]
+              if project != "hidden-lab-39609750":
+                  raise ValueError("project")
+              base = f"https://console.neon.tech/api/v2/projects/{project}"
+              headers = {"Authorization": "Bearer " + os.environ["NEON_API_KEY"]}
+              opener = urllib.request.build_opener(NoRedirect())
+
+              def read(url):
+                  with opener.open(urllib.request.Request(url, headers=headers), timeout=30) as response:
+                      return json.load(response)
+
+              result = read(base + "/branches")
+              # Never infer uniqueness from an explicitly truncated listing.
+              if result.get("pagination", {}).get("cursor"):
+                  raise ValueError("partial_branches")
+              production = [b for b in result["branches"] if b["name"] == "production"]
+              if len(production) != 1 or not production[0]["id"]:
+                  raise ValueError("branch")
+              query = urllib.parse.urlencode({"branch_id": production[0]["id"], "database_name": "neondb", "role_name": "neondb_owner", "pooled": "false"})
+              uri = read(base + "/connection_uri?" + query)["uri"]
+              if not isinstance(uri, str) or any(ord(c) <= 32 or ord(c) == 127 for c in uri):
+                  raise ValueError("uri")
+              parsed = urllib.parse.urlsplit(uri)
+              if (parsed.scheme not in ("postgres", "postgresql")
+                  or not parsed.hostname or not parsed.hostname.endswith(".neon.tech")
+                  or parsed.port not in (None, 5432) or parsed.path != "/neondb"
+                  or parsed.username != "neondb_owner" or not parsed.password or parsed.fragment):
+                  raise ValueError("uri")
+              parameters = urllib.parse.parse_qsl(parsed.query, strict_parsing=True)
+              if any(k not in ("sslmode", "channel_binding") for k, v in parameters):
+                  raise ValueError("uri_options")
+              if len({k for k, v in parameters}) != len(parameters):
+                  raise ValueError("uri_options")
+              parameters = dict(parameters)
+              parameters["sslmode"] = "verify-full"
+              uri = urllib.parse.urlunsplit(parsed._replace(query=urllib.parse.urlencode(parameters)))
+              print("::add-mask::" + uri.replace("%", "%25"), flush=True)
+              with open(os.environ["GITHUB_ENV"], "a") as output:
+                  output.write("DATABASE_URL=" + uri + "\n")
+
+          try:
+              resolve()
+          except Exception:
+              raise SystemExit("production_database_resolution_failed") from None
+          PYTHON
+
+      # Run after the incremental writers are serving production. This phase
+      # creates metadata only; it cannot write completion markers or change
+      # privateArtifacts, DNS, Worker routes, cache rules or artifact bytes.
+      - name: Register or verify historical public artifacts
+        working-directory: turbo/packages/db
+        env:
+          REGISTRATION_MODE: ${{ inputs.mode }}
+          REGISTRATION_LIMIT: ${{ inputs.max_objects }}
+          REGISTRATION_CONCURRENCY: ${{ inputs.concurrency }}
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
+          R2_USER_ARTIFACTS_BUCKET_NAME: ${{ vars.R2_USER_ARTIFACTS_BUCKET_NAME }}
+          R2_USER_ARTIFACTS_ACCESS_KEY_ID: ${{ secrets.R2_USER_ARTIFACTS_ACCESS_KEY_ID }}
+          R2_USER_ARTIFACTS_SECRET_ACCESS_KEY: ${{ secrets.R2_USER_ARTIFACTS_SECRET_ACCESS_KEY }}
+          R2_HOSTED_SITES_BUCKET_NAME: ${{ vars.R2_HOSTED_SITES_BUCKET_NAME }}
+          R2_HOSTED_SITES_ACCESS_KEY_ID: ${{ secrets.R2_HOSTED_SITES_ACCESS_KEY_ID }}
+          R2_HOSTED_SITES_SECRET_ACCESS_KEY: ${{ secrets.R2_HOSTED_SITES_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          test "$R2_USER_ARTIFACTS_BUCKET_NAME" = "user-artifact-prod"
+          test "$R2_HOSTED_SITES_BUCKET_NAME" = "vm0-hosted-sites"
+          registration_args=()
+          case "$REGISTRATION_MODE" in
+            dry-run) ;;
+            migrate) registration_args+=(--migrate --verify) ;;
+            verify) registration_args+=(--verify) ;;
+            *) echo '::error::invalid_mode'; exit 1 ;;
+          esac
+          pnpm exec tsx scripts/migrations/014-public-artifact-registration/backfill.ts \
+            "${registration_args[@]}" \
+            --max-objects "$REGISTRATION_LIMIT" \
+            --concurrency "$REGISTRATION_CONCURRENCY" \
+            --report public-artifact-registration.json
+
+      - name: Preserve registration evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: public-artifact-registration-${{ github.run_id }}
+          path: turbo/packages/db/public-artifact-registration.json
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/public-artifact-registration.yml
+++ b/.github/workflows/public-artifact-registration.yml
@@ -1,5 +1,8 @@
 name: Public Artifact Registration
 
+env:
+  npm_config_audit: "false"
+
 on:
   workflow_dispatch:
     inputs:

--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -23,11 +23,116 @@ import {
 
 import { env } from "../../lib/env";
 import { detach, Mechanism, settle } from "../utils";
+import {
+  artifactDeliveryKey,
+  artifactDeliveryRecordSchema,
+} from "@okouai/api-contracts/contracts/artifact-delivery";
 
 export interface S3Object {
   readonly key: string;
   readonly size: number;
   readonly lastModified: Date;
+}
+
+interface LegacyArtifactWrite {
+  readonly key: string;
+  readonly contentType: string;
+  readonly metadata?: Readonly<Record<string, string>>;
+}
+
+/** Reserve public delivery before bytes or upload credentials can escape. */
+async function registerLegacyArtifactWrite(
+  client: S3Client,
+  bucket: string,
+  write: LegacyArtifactWrite,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (
+    write.metadata?.storage === "private-artifact-v1" ||
+    write.metadata?.access === "owner-private-v1"
+  ) {
+    throw new Error(
+      "Private artifacts cannot use public delivery registration",
+    );
+  }
+  // Historical public writers without brand/filename metadata use the same
+  // interpretation as migration 014; #32492 owns this persisted-data boundary.
+  const record = artifactDeliveryRecordSchema.parse({
+    version: 1,
+    kind: "legacy-file",
+    publicBrand: write.metadata?.["public-brand"] ?? "vm0",
+    audience: "public",
+    key: write.key,
+    filename: decodeURIComponent(
+      write.metadata?.filename ??
+        write.key.slice(write.key.lastIndexOf("/") + 1),
+    ),
+    contentType: write.contentType,
+  });
+  const key = artifactDeliveryKey(
+    null,
+    "file",
+    write.key.slice("artifacts/".length),
+  );
+  const body = JSON.stringify(record);
+  const written = await settle(
+    client.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        Body: body,
+        ContentType: "application/json",
+        IfNoneMatch: "*",
+      }),
+      { abortSignal: signal },
+    ),
+  );
+  signal?.throwIfAborted();
+  if (written.ok) {
+    return;
+  }
+  if (!isS3PreconditionFailedError(written.error)) {
+    throw written.error;
+  }
+  const existing = await client.send(
+    new GetObjectCommand({ Bucket: bucket, Key: key }),
+    { abortSignal: signal },
+  );
+  if (!existing.Body) {
+    throw new Error("Public artifact registration has no body");
+  }
+  const previous = artifactDeliveryRecordSchema.parse(
+    JSON.parse(await existing.Body.transformToString()),
+  );
+  if (JSON.stringify(previous) !== body) {
+    throw new Error("Artifact delivery alias is already allocated");
+  }
+  signal?.throwIfAborted();
+}
+
+function publicArtifactWriteRegistration(
+  bucket: string,
+  write: LegacyArtifactWrite,
+  signal?: AbortSignal,
+): Computed<Promise<void>> {
+  return computed(async (get) => {
+    if (
+      bucket !== env("R2_USER_ARTIFACTS_BUCKET_NAME") ||
+      !write.key.startsWith("artifacts/")
+    ) {
+      return;
+    }
+    const registryBucket = env("R2_HOSTED_SITES_BUCKET_NAME");
+    if (!registryBucket) {
+      throw new Error("Artifact delivery registry storage is not configured");
+    }
+    await registerLegacyArtifactWrite(
+      get(hostedSitesS3Client$),
+      registryBucket,
+      write,
+      signal,
+    );
+  });
 }
 
 interface S3ObjectPage {
@@ -548,25 +653,17 @@ export function generatePresignedPutUrl(
   bucket: string,
   key: string,
   contentType: string,
-  expiresIn: number,
-  options:
-    | boolean
-    | {
-        readonly usePublicEndpoint?: boolean;
-        readonly metadata?: Readonly<Record<string, string>>;
-      } = false,
+  options: {
+    readonly expiresIn: number;
+    readonly usePublicEndpoint?: boolean;
+    readonly metadata?: Readonly<Record<string, string>>;
+  },
+  signal?: AbortSignal,
 ): Computed<Promise<string>> {
-  const usePublicEndpoint =
-    typeof options === "boolean"
-      ? options
-      : (options.usePublicEndpoint ?? false);
-  const metadata = typeof options === "boolean" ? undefined : options.metadata;
   return generatePresignedPutUrlWithClient(
-    s3ClientForBucket(bucket, usePublicEndpoint),
-    bucket,
-    key,
-    contentType,
-    { expiresIn, metadata },
+    s3ClientForBucket(bucket, options.usePublicEndpoint ?? false),
+    { bucket, key, contentType, ...options },
+    signal,
   );
 }
 
@@ -589,6 +686,13 @@ export function createMultipartS3Upload(
 ): Computed<Promise<string>> {
   return computed(async (get): Promise<string> => {
     const client = get(s3ClientForBucket(bucket));
+    await get(
+      publicArtifactWriteRegistration(
+        bucket,
+        { key, contentType, metadata },
+        signal,
+      ),
+    );
     const response = await client.send(
       new CreateMultipartUploadCommand({
         Bucket: bucket,
@@ -734,16 +838,25 @@ export function abortMultipartS3Upload(
 
 function generatePresignedPutUrlWithClient(
   client$: Computed<S3Client>,
-  bucket: string,
-  key: string,
-  contentType: string,
   options: {
+    readonly bucket: string;
+    readonly key: string;
+    readonly contentType: string;
     readonly expiresIn: number;
     readonly metadata?: Readonly<Record<string, string>>;
   },
+  signal?: AbortSignal,
 ): Computed<Promise<string>> {
-  return computed((get): Promise<string> => {
+  return computed(async (get): Promise<string> => {
     const client = get(client$);
+    const { bucket, key, contentType } = options;
+    await get(
+      publicArtifactWriteRegistration(
+        bucket,
+        { key, contentType, metadata: options.metadata },
+        signal,
+      ),
+    );
     const metadataHeaders = options.metadata
       ? s3MetadataHeaders(options.metadata)
       : undefined;
@@ -773,10 +886,7 @@ export function generateHostedSitesPresignedPutUrl(
 ): Computed<Promise<string>> {
   return generatePresignedPutUrlWithClient(
     usePublicEndpoint ? hostedSitesPublicS3Client$ : hostedSitesS3Client$,
-    bucket,
-    key,
-    contentType,
-    { expiresIn },
+    { bucket, key, contentType, expiresIn },
   );
 }
 
@@ -894,6 +1004,7 @@ function putS3ObjectWithClient(
 ): Computed<Promise<void>> {
   return computed(async (get): Promise<void> => {
     const client = get(client$);
+    await get(publicArtifactWriteRegistration(args.bucket, args, signal));
     await client.send(
       new PutObjectCommand({
         Bucket: args.bucket,
@@ -940,6 +1051,13 @@ export function putImmutableS3Object(
   return computed(async (get): Promise<void> => {
     const writeOptions = isAbortSignal(options) ? { signal: options } : options;
     const client = get(s3ClientForBucket(bucket));
+    await get(
+      publicArtifactWriteRegistration(
+        bucket,
+        { key, contentType, metadata: writeOptions?.metadata },
+        writeOptions?.signal,
+      ),
+    );
     const uploaded = await settle(
       client.send(
         new PutObjectCommand({

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
@@ -16,7 +16,7 @@ import {
   holdRunActivityFixture,
 } from "../../../test-fixtures/run-activity";
 import { flushWaitUntilForTest } from "../../context/wait-until";
-import { createDeferredPromise } from "../../utils";
+import { createDeferredPromise, settleIncludingAbort } from "../../utils";
 import { chatThreadActivitySummaryRoutes } from "../chat-threads-activity-summary";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
@@ -382,7 +382,7 @@ describe("thread activity summary", () => {
       entered.resolve(undefined);
       return await release.promise;
     });
-    const first = summarize(f.actor, f.run);
+    const first = settleIncludingAbort(summarize(f.actor, f.run));
     await entered.promise;
     const concurrent = await Promise.all([
       summarize(f.actor, f.run),
@@ -390,12 +390,21 @@ describe("thread activity summary", () => {
     ]);
     expect(
       concurrent.every((value) => {
-        return value.status === "pending" && value.phrase === null;
+        // Concurrent followers may hit the production lock budget and degrade
+        // to unavailable. Neither outcome may publish a phrase or claim again.
+        return (
+          (value.status === "pending" || value.status === "unavailable") &&
+          value.phrase === null
+        );
       }),
     ).toBeTruthy();
     await deliver(f, [tool(0, "new activity while the provider is working")]);
     release.resolve("Preparing the requested checklist");
-    const finished = await first;
+    const outcome = await first;
+    if (!outcome.ok) {
+      throw outcome.error;
+    }
+    const finished = outcome.value;
     expect(finished.summarySequence).toBeNull();
     expect(finished.sourceSequence).toBe(0);
     expect(finished.summaryRevision).not.toBe(finished.sourceRevision);

--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -243,7 +243,11 @@ function putObjectInput(): PutObjectCommandInput {
       return candidate;
     })
     .find((candidate): candidate is PutObjectCommand => {
-      return candidate instanceof PutObjectCommand;
+      return (
+        candidate instanceof PutObjectCommand &&
+        (candidate.input.Key?.startsWith("artifacts/") === true ||
+          candidate.input.Key?.startsWith("private-artifacts/") === true)
+      );
     });
   if (!command) {
     throw new Error("Expected generated image to be uploaded to S3");

--- a/turbo/apps/api/src/signals/routes/__tests__/private-artifact-generation.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/private-artifact-generation.test.ts
@@ -411,6 +411,15 @@ describe("managed artifact privacy", () => {
           [401],
         );
       } else {
+        const writes = [...objects.keys()];
+        const contentWrite = writes.findIndex((key) => {
+          return key.startsWith(`${publicBucket}/artifacts/`);
+        });
+        const registrationWrite = writes.findIndex((key) => {
+          return key.startsWith("test-hosted-sites/artifact-delivery/files/");
+        });
+        expect(registrationWrite).toBeGreaterThanOrEqual(0);
+        expect(contentWrite).toBeGreaterThan(registrationWrite);
         expect(result.url).toMatch(/^https:\/\/a\.okou\.io\//u);
         expect(result.sourceUrl).toBe(sourceUrl);
         expect(result.embedUrl).toContain("cdn-cgi/image/");

--- a/turbo/apps/api/src/signals/routes/__tests__/uploads-multipart.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/uploads-multipart.test.ts
@@ -8,6 +8,7 @@ import {
   HeadObjectCommand,
   ListObjectsV2Command,
   ListPartsCommand,
+  PutObjectCommand,
 } from "@aws-sdk/client-s3";
 import { uploadsContract } from "@okouai/api-contracts/contracts/uploads";
 
@@ -74,11 +75,22 @@ describe("multipart user artifact uploads", () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
+    let publicRegistration: unknown;
     context.mocks.s3.send.mockImplementation((command: unknown) => {
       if (command instanceof ListObjectsV2Command) {
         return Promise.resolve({ Contents: [] });
       }
+      if (command instanceof PutObjectCommand) {
+        expect(command.input.Bucket).toBe("test-hosted-sites");
+        publicRegistration = JSON.parse(String(command.input.Body));
+      }
       if (command instanceof CreateMultipartUploadCommand) {
+        expect(publicRegistration).toMatchObject({
+          kind: "legacy-file",
+          filename: "recording.mp4",
+          contentType: "video/mp4",
+          audience: "public",
+        });
         return Promise.resolve({ UploadId: "multipart-upload-1" });
       }
       return Promise.resolve({});
@@ -221,7 +233,7 @@ describe("multipart user artifact uploads", () => {
     });
 
     expect(response.status).toBe(500);
-    expect(context.mocks.s3.send).toHaveBeenCalledTimes(3);
+    expect(context.mocks.s3.getSignedUrl).not.toHaveBeenCalled();
     const abortCommand = context.mocks.s3.send.mock.calls
       .map(([command]) => {
         return command;

--- a/turbo/apps/api/src/signals/routes/__tests__/uploads-prepare.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/uploads-prepare.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { createStore } from "ccstate";
 import { beforeEach, describe, expect, it, onTestFinished } from "vitest";
 
@@ -46,6 +47,63 @@ function validBody() {
 }
 
 describe("POST /api/uploads/prepare", () => {
+  it("registers the legacy public URL before issuing upload credentials", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+    const registrations: unknown[] = [];
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (command instanceof PutObjectCommand) {
+        expect(command.input.Bucket).toBe("test-hosted-sites");
+        expect(command.input.IfNoneMatch).toBe("*");
+        registrations.push(JSON.parse(String(command.input.Body)));
+      }
+      return Promise.resolve({});
+    });
+    context.mocks.s3.getSignedUrl.mockImplementation(() => {
+      expect(registrations).toHaveLength(1);
+      return Promise.resolve("https://r2.example.com/upload?sig=test");
+    });
+    const response = await setupApp({ context, routes: uploadsTestRoutes })(
+      uploadsContract,
+    ).prepare({
+      body: validBody(),
+      headers: { authorization: "Bearer clerk-session" },
+      extraHeaders: { origin: "https://app.okou.ai" },
+    });
+    expect(response.status).toBe(200);
+    expect(registrations).toStrictEqual([
+      {
+        version: 1,
+        kind: "legacy-file",
+        audience: "public",
+        publicBrand: "okou",
+        key: expect.stringMatching(/^artifacts\/[a-z0-9]{10}\.txt$/u),
+        filename: "hello.txt",
+        contentType: "text/plain",
+      },
+    ]);
+  });
+
+  it("does not issue upload credentials when public registration fails", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (command instanceof PutObjectCommand) {
+        return Promise.reject(new Error("Registry unavailable"));
+      }
+      return Promise.resolve({});
+    });
+    const response = await accept(
+      setupApp({ context, routes: uploadsTestRoutes })(uploadsContract).prepare(
+        {
+          body: validBody(),
+          headers: { authorization: "Bearer clerk-session" },
+        },
+      ),
+      [500],
+    );
+    expect(response.status).toBe(500);
+    expect(context.mocks.s3.getSignedUrl).not.toHaveBeenCalled();
+  });
+
   it("returns 401 when unauthenticated", async () => {
     const client = setupApp({ context, routes: uploadsTestRoutes })(
       uploadsContract,

--- a/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
@@ -277,7 +277,11 @@ function putObjectInput(): PutObjectCommandInput {
       return candidate;
     })
     .find((candidate): candidate is PutObjectCommand => {
-      return candidate instanceof PutObjectCommand;
+      return (
+        candidate instanceof PutObjectCommand &&
+        (candidate.input.Key?.startsWith("artifacts/") === true ||
+          candidate.input.Key?.startsWith("private-artifacts/") === true)
+      );
     });
   if (!command) {
     throw new Error("Expected generated video to be uploaded to S3");

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-post.test.ts
@@ -106,7 +106,10 @@ function putObjectInput(): PutObjectCommandInput {
       return candidate;
     })
     .find((candidate): candidate is PutObjectCommand => {
-      return candidate instanceof PutObjectCommand;
+      return (
+        candidate instanceof PutObjectCommand &&
+        candidate.input.Bucket === TEST_BUCKET
+      );
     });
   if (!command) {
     throw new Error("Expected generated speech to be uploaded to S3");

--- a/turbo/apps/api/src/signals/routes/integrations-feishu-files.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-feishu-files.ts
@@ -418,8 +418,12 @@ const initUpload$ = command(async ({ get, set }, signal: AbortSignal) => {
       bucket,
       artifact.key,
       bodyResult.data.contentType,
-      PUT_URL_TTL_SECONDS,
-      { usePublicEndpoint: true, metadata: artifact.metadata },
+      {
+        expiresIn: PUT_URL_TTL_SECONDS,
+        usePublicEndpoint: true,
+        metadata: artifact.metadata,
+      },
+      signal,
     ),
   );
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/integrations-github-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-github-upload-init.ts
@@ -41,8 +41,12 @@ const init$ = command(async ({ get, set }, signal: AbortSignal) => {
       bucket,
       artifact.key,
       body.contentType,
-      PUT_URL_TTL_SECONDS,
-      { usePublicEndpoint: true, metadata: artifact.metadata },
+      {
+        expiresIn: PUT_URL_TTL_SECONDS,
+        usePublicEndpoint: true,
+        metadata: artifact.metadata,
+      },
+      signal,
     ),
   );
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/integrations-phone-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-phone-upload-init.ts
@@ -41,8 +41,12 @@ const init$ = command(async ({ get, set }, signal: AbortSignal) => {
       bucket,
       artifact.key,
       body.contentType,
-      PUT_URL_TTL_SECONDS,
-      { usePublicEndpoint: true, metadata: artifact.metadata },
+      {
+        expiresIn: PUT_URL_TTL_SECONDS,
+        usePublicEndpoint: true,
+        metadata: artifact.metadata,
+      },
+      signal,
     ),
   );
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/integrations-teams-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-teams-upload-init.ts
@@ -41,8 +41,12 @@ const init$ = command(async ({ get, set }, signal: AbortSignal) => {
       bucket,
       artifact.key,
       body.contentType,
-      PUT_URL_TTL_SECONDS,
-      { usePublicEndpoint: true, metadata: artifact.metadata },
+      {
+        expiresIn: PUT_URL_TTL_SECONDS,
+        usePublicEndpoint: true,
+        metadata: artifact.metadata,
+      },
+      signal,
     ),
   );
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/integrations-telegram-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-telegram-upload-init.ts
@@ -42,8 +42,12 @@ const initInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       bucket,
       artifact.key,
       contentType,
-      PUT_URL_TTL_SECONDS,
-      { usePublicEndpoint: true, metadata: artifact.metadata },
+      {
+        expiresIn: PUT_URL_TTL_SECONDS,
+        usePublicEndpoint: true,
+        metadata: artifact.metadata,
+      },
+      signal,
     ),
   );
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/uploads-prepare.ts
+++ b/turbo/apps/api/src/signals/routes/uploads-prepare.ts
@@ -76,7 +76,13 @@ const prepareUploadInner$ = command(
       return await onRejection(
         (async () => {
           uploadId = await get(
-            createMultipartS3Upload(bucket, s3Key, contentType, metadata),
+            createMultipartS3Upload(
+              bucket,
+              s3Key,
+              contentType,
+              metadata,
+              signal,
+            ),
           );
           signal.throwIfAborted();
           const partCount = Math.ceil(size / MULTIPART_PART_SIZE_BYTES);
@@ -124,10 +130,13 @@ const prepareUploadInner$ = command(
     }
 
     const uploadUrl = await get(
-      generatePresignedPutUrl(bucket, s3Key, contentType, PUT_URL_TTL_SECONDS, {
-        usePublicEndpoint: true,
-        metadata,
-      }),
+      generatePresignedPutUrl(
+        bucket,
+        s3Key,
+        contentType,
+        { expiresIn: PUT_URL_TTL_SECONDS, usePublicEndpoint: true, metadata },
+        signal,
+      ),
     );
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -646,8 +646,8 @@ export const prepareCheckpointHistoryUpload$ = command(
         bucketName,
         s3Key,
         "application/octet-stream",
-        3600,
-        true,
+        { expiresIn: 3600, usePublicEndpoint: true },
+        signal,
       ),
     );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/canonical-asset.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-asset.service.ts
@@ -986,11 +986,12 @@ export const prepareCanonicalPublishedAsset$ = command(
         env("R2_USER_ARTIFACTS_BUCKET_NAME"),
         storageKey,
         args.contentType,
-        CANONICAL_UPLOAD_URL_TTL_SECONDS,
         {
+          expiresIn: CANONICAL_UPLOAD_URL_TTL_SECONDS,
           usePublicEndpoint: true,
           metadata,
         },
+        signal,
       ),
     );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/storage-write.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-write.service.ts
@@ -652,8 +652,8 @@ function createStorageUploadResponse(
           args.bucket,
           archiveKey,
           "application/gzip",
-          3600,
-          true,
+          { expiresIn: 3600, usePublicEndpoint: true },
+          signal,
         ),
       ),
       get(
@@ -661,8 +661,8 @@ function createStorageUploadResponse(
           args.bucket,
           manifestKey,
           "application/json",
-          3600,
-          true,
+          { expiresIn: 3600, usePublicEndpoint: true },
+          signal,
         ),
       ),
     ]);

--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/README.md
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/README.md
@@ -20,10 +20,18 @@ an explicit publication update adopts the registry format. These readers remain
 until #32492 accounts for every retained pre-registry share link. The historical
 Public inventory below does not rewrite existing share policies.
 
-Drain earlier API writers before finalizing registration. Registration hooks
-on existing public writes run regardless of the switch so rollback cannot create
-unregistered sites; they add a hosted-bucket metadata write without changing
-those public URLs or permissions. Use the same
+Deploy incremental registration first while `privateArtifacts` stays off. Every
+public file write, immutable write, presigned PUT and multipart initiation must
+successfully reserve its exact registry metadata before exposing bytes or upload
+credentials. Registration failure fails the upload/generation request. Upload
+completion registration remains a backstop for credentials issued by older API
+instances. Site aliases register before their public pointers are published.
+These hooks run regardless of the switch.
+
+Drain earlier API writers and their already-issued upload credentials before
+accepting final coverage; current public PUT credentials last up to one hour.
+Run an independent verification after this drain. API binary rollback must
+retain incremental registration. Use the same
 `privateArtifacts` rollout switch for new artifact behavior; there is no second
 feature switch. The R2 completion marker records a completed data migration.
 After finalization, API binary rollbacks must retain these registration writers;
@@ -59,10 +67,16 @@ pnpm exec tsx scripts/migrations/014-public-artifact-registration/backfill.ts --
 read-only verification.
 
 Every pass is paginated and limited to 100,000 objects per bucket by default;
-`--max-objects` can explicitly raise that bound. Truncation, changing inventories,
-missing manifests, deleted/unready DB deployments, conflicting aliases and
-private metadata block finalization. Rerun after concurrent writes settle; writes
-are conditional and restartable. Every existing alias is checked for conflicts
+`--max-objects` can explicitly raise that bound. Production already exceeds this
+default. R2 operations use bounded concurrency (default 16; `--concurrency` accepts
+1–64) and drain in-flight work before reporting failure.
+
+The final pass re-inventories storage, reconciles the database again, and reads
+every registry record. Concurrent additions are accepted only when their exact
+registration already exists. Missing registrations, unknown keys, incomplete
+pagination, missing manifests, deleted/unready DB deployments, conflicting aliases
+and private metadata block verification. Conditional writes are restartable; a
+retry fills missing records without overwriting existing ones. Every existing alias is checked for conflicts
 before the first write. A blocked `--report` includes the complete conflicting
 alias-key inventory; successful reports contain counts and an inventory digest.
 Reports never include credentials or artifact contents. Unclassified file keys must be
@@ -75,24 +89,40 @@ Keep it after feature-switch rollback: already-established permissions remain
 enforced. Follow-up #32492 removes the pre-registration compatibility reader
 after complete production coverage and the old-writer drain are verified.
 
-Old `a.okou.io` and `cdn.*` domains keep their direct public storage behavior.
-Registration does not revoke those URLs or already-cached bytes. New public file
-shares use `f.okou.io` and policy-checked private storage. New site shares use an
-opaque subdomain on `okou.app`, with no visible version prefix.
+The 2026-09-09 public inventory also contains legacy `html-edit-drafts/<uuid>.html`
+objects and 29 Desktop recording sidecars without R2 Content-Type. Drafts undergo
+the same private-metadata and authoritative-database checks as all public files.
+Missing HTTP metadata requires either an exact existing public registration or a
+unique non-null `run_uploaded_files.content_type`; absent/conflicting evidence
+still blocks registration. Pre-registration also covers an uploaded object whose
+client has not called completion yet. Existing upload headers/signature semantics
+remain compatible with already-deployed App, CLI and Desktop clients. This
+persisted-data compatibility is owned by #32492 and can be retired when historical
+delivery no longer requires this migration. No MIME type is inferred from a file
+extension, and no source object is rewritten.
 
-Before enabling Public file sharing, create a proxied DNS record for `f.okou.io`
-in the VM0 Cloudflare account and deploy the reviewed `f.okou.io/*` Worker route
-with both public/private bucket bindings. Do not repoint `a.okou.io` or attach a
-public domain to the private bucket. Staging uses `files.sites.vm7.io` on the
-existing test wildcard. API public-file URL configuration must match that Worker
-host. Immutable alias metadata uses a separate edge cache; the mutable share
-policy is read from R2 before every content-cache hit. The warm path adds no
-API/primary-DB hop or repeated alias lookup. Missing aliases are not cached, so
-a newly published URL is immediately discoverable. File aliases use one global
-namespace across both brands to prevent ownership collisions on `f.okou.io`.
-Measure regional cold/warm latency before production activation. Byte-range
-requests use R2 range reads after authorization. Previously issued signed
-previews expire within 15 minutes.
+## Production phases
 
-This PR does not execute production registration, deploy Workers/DNS or enable
-the production feature switch.
+1. Release incremental registration with `privateArtifacts` off. Keep `a.okou.io`
+   on its current public R2 path, including its existing Cloudflare cache and image
+   transformations. No Worker route or cache-rule changes belong to this phase.
+2. Run the protected **Public Artifact Registration** GitHub Action on `main`: first
+   `dry-run`, then `migrate`, then an independent `verify` after the old-writer and
+   upload-credential drain. It uses production R2 credentials and read-only Neon
+   queries, saves the report as a GitHub artifact, and never passes `--finalize`.
+   Accept coverage only with zero missing, conflicting or unclassified records.
+3. Review the separate `a.okou.io` delivery cutover (#32959) after coverage is
+   complete. The planned unified host serves old registered public files and new
+   opaque public-share aliases through `zero-host-worker`. Existing URLs and old
+   public thumbnail behavior must remain compatible. New shares require policy
+   checks before any byte-cache hit; global public cache overrides and prefix
+   rewrites must be scoped for those routes as part of that later cutover.
+4. Finalize registration and enable new private artifact behavior only as separate
+   rollout decisions. Completion markers close the legacy site fallback, so they
+   are intentionally excluded from the first production phase.
+
+The unlaunched `f.okou.io` domain is retired; it is not a rollout prerequisite.
+The current API/Worker file-share host configuration is changed by #32959, not by
+this registration rollout. Private preview URL lifetime and renewal are tracked
+separately in #32977; image derivatives and private video/HTML previews remain
+follow-ups in #32492.

--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/README.md
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/README.md
@@ -30,6 +30,11 @@ These hooks run regardless of the switch.
 
 Drain earlier API writers and their already-issued upload credentials before
 accepting final coverage; current public PUT credentials last up to one hour.
+Multipart completion can outlive those signatures. The migration also inventories
+all pending public multipart uploads, including their pagination, before its final
+object scan. An old session without a valid public registration blocks verified
+coverage until it completes or expires in storage; newly pre-registered sessions
+can continue. The report includes pending and unregistered multipart counts.
 Run an independent verification after this drain. API binary rollback must
 retain incremental registration. Use the same
 `privateArtifacts` rollout switch for new artifact behavior; there is no second
@@ -110,7 +115,8 @@ extension, and no source object is rewritten.
    `dry-run`, then `migrate`, then an independent `verify` after the old-writer and
    upload-credential drain. It uses production R2 credentials and read-only Neon
    queries, saves the report as a GitHub artifact, and never passes `--finalize`.
-   Accept coverage only with zero missing, conflicting or unclassified records.
+   Accept coverage only with zero missing, conflicting or unclassified records
+   and zero unregistered pending multipart uploads.
 3. Review the separate `a.okou.io` delivery cutover (#32959) after coverage is
    complete. The planned unified host serves old registered public files and new
    opaque public-share aliases through `zero-host-worker`. Existing URLs and old

--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/backfill.test.ts
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/backfill.test.ts
@@ -19,6 +19,7 @@ function fixture() {
   });
   const objects = new Map<string, string>();
   const metadata = new Map<string, Record<string, string>>();
+  const contentTypes = new Map<string, string | undefined>();
   const writes: string[] = [];
   const id = "00000000-0000-4000-8000-000000000001";
   const prefix = `sites/demo/deployments/${id}`;
@@ -73,7 +74,9 @@ function fixture() {
     }
     if (command instanceof HeadObjectCommand)
       return {
-        ContentType: "application/pdf",
+        ContentType: contentTypes.has(command.input.Key!)
+          ? contentTypes.get(command.input.Key!)
+          : "application/pdf",
         Metadata: metadata.get(command.input.Key!) ?? {},
       };
     if (command instanceof GetObjectCommand) {
@@ -114,7 +117,16 @@ function fixture() {
       expect([...deployments]).toStrictEqual([id]);
     },
   );
-  return { client, objects, metadata, writes, options, reconcile, send };
+  return {
+    client,
+    objects,
+    metadata,
+    contentTypes,
+    writes,
+    options,
+    reconcile,
+    send,
+  };
 }
 
 test("dry-run inventories all pages and reconciles twice without writing", async () => {
@@ -254,3 +266,134 @@ test("bounds and unclassified keys prevent a completion marker", async () => {
     }),
   ).toBe(false);
 });
+
+test("missing R2 content types require authoritative upload metadata", async () => {
+  const f = fixture();
+  f.contentTypes.set("artifacts/0123456789.pdf", undefined);
+  await expect(
+    registerHistoricalPublicArtifacts(
+      f.client,
+      f.client,
+      { ...f.options, migrate: true },
+      f.reconcile,
+    ),
+  ).rejects.toThrow("has no content type");
+  expect(f.writes).toHaveLength(0);
+  const resolveMissingContentType = vi.fn((key: string) => {
+    expect(key).toBe("artifacts/0123456789.pdf");
+    return Promise.resolve("application/pdf");
+  });
+  await expect(
+    registerHistoricalPublicArtifacts(
+      f.client,
+      f.client,
+      { ...f.options, migrate: true, resolveMissingContentType },
+      f.reconcile,
+    ),
+  ).resolves.toMatchObject({ missing: 0, verified: true });
+  expect(resolveMissingContentType).toHaveBeenCalledTimes(1);
+  // An issued upload can exist before its client completes the database write.
+  // Its exact pre-registration is sufficient for the independent verification.
+  await expect(
+    registerHistoricalPublicArtifacts(
+      f.client,
+      f.client,
+      { ...f.options, verify: true },
+      f.reconcile,
+    ),
+  ).resolves.toMatchObject({
+    existing: 3,
+    missing: 0,
+    resolvedContentTypes: 1,
+  });
+});
+
+test("historical public HTML drafts are included in verified coverage", async () => {
+  const f = fixture();
+  const key =
+    "artifacts/html-edit-drafts/00000000-0000-4000-8000-000000000002.html";
+  f.objects.set(`public/${key}`, "historical public HTML");
+  f.contentTypes.set(key, "text/html");
+  const result = await registerHistoricalPublicArtifacts(
+    f.client,
+    f.client,
+    { ...f.options, migrate: true },
+    async () => {},
+  );
+  expect(result).toMatchObject({
+    finalFiles: 2,
+    finalAliases: 4,
+    missing: 0,
+    skipped: 0,
+  });
+  expect(
+    JSON.parse(
+      f.objects.get(
+        `hosted/${artifactDeliveryKey("vm0", "file", key.slice("artifacts/".length))}`,
+      )!,
+    ),
+  ).toMatchObject({
+    kind: "legacy-file",
+    key,
+    contentType: "text/html",
+    audience: "public",
+  });
+});
+
+test.each([true, false])(
+  "concurrent public writes require exact registration (registered=%s)",
+  async (registered) => {
+    const f = fixture();
+    let passes = 0;
+    const reconcile = async () => {
+      if (++passes !== 1) return;
+      f.objects.set("public/artifacts/abcdefghij.pdf", "concurrent bytes");
+      if (registered) {
+        f.objects.set(
+          `hosted/${artifactDeliveryKey("vm0", "file", "abcdefghij.pdf")}`,
+          JSON.stringify({
+            version: 1,
+            kind: "legacy-file",
+            publicBrand: "vm0",
+            audience: "public",
+            key: "artifacts/abcdefghij.pdf",
+            filename: "abcdefghij.pdf",
+            contentType: "application/pdf",
+          }),
+        );
+      }
+    };
+    const operation = registerHistoricalPublicArtifacts(
+      f.client,
+      f.client,
+      { ...f.options, migrate: true, verify: true },
+      reconcile,
+    );
+    if (registered) {
+      await expect(operation).resolves.toMatchObject({
+        files: 1,
+        finalFiles: 2,
+        finalAliases: 4,
+        missing: 0,
+        verified: true,
+        finalized: false,
+      });
+    } else {
+      await expect(operation).rejects.toThrow("unregistered public artifacts");
+      // A partial pass is safe to rerun; it fills only the new missing record.
+      await expect(
+        registerHistoricalPublicArtifacts(
+          f.client,
+          f.client,
+          { ...f.options, migrate: true, verify: true },
+          async () => {},
+        ),
+      ).resolves.toMatchObject({ existing: 3, registered: 1, missing: 0 });
+    }
+    expect(
+      f.writes.some((key) => {
+        return key.endsWith("registration.json");
+      }),
+    ).toBe(false);
+  },
+);

--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/backfill.test.ts
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/backfill.test.ts
@@ -1,6 +1,7 @@
 import {
   GetObjectCommand,
   HeadObjectCommand,
+  ListMultipartUploadsCommand,
   ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
@@ -21,6 +22,7 @@ function fixture() {
   const metadata = new Map<string, Record<string, string>>();
   const contentTypes = new Map<string, string | undefined>();
   const writes: string[] = [];
+  const multipart: { Key: string; UploadId: string }[] = [];
   const id = "00000000-0000-4000-8000-000000000001";
   const prefix = `sites/demo/deployments/${id}`;
   objects.set("public/artifacts/0123456789.pdf", "historical bytes");
@@ -49,11 +51,30 @@ function fixture() {
       command:
         | GetObjectCommand
         | HeadObjectCommand
+        | ListMultipartUploadsCommand
         | ListObjectsV2Command
         | PutObjectCommand,
     ): Promise<unknown>;
   } = client;
   const send = vi.spyOn(sender, "send").mockImplementation(async (command) => {
+    if (command instanceof ListMultipartUploadsCommand) {
+      const offset = command.input.KeyMarker
+        ? multipart.findIndex((upload) => {
+            return (
+              upload.Key === command.input.KeyMarker &&
+              upload.UploadId === command.input.UploadIdMarker
+            );
+          }) + 1
+        : 0;
+      const last = multipart[offset];
+      const truncated = offset + 1 < multipart.length;
+      return {
+        Uploads: last ? [last] : [],
+        IsTruncated: truncated,
+        NextKeyMarker: truncated ? last?.Key : undefined,
+        NextUploadIdMarker: truncated ? last?.UploadId : undefined,
+      };
+    }
     if (command instanceof ListObjectsV2Command) {
       const root = `${command.input.Bucket}/`;
       const keys = [...objects.keys()]
@@ -123,6 +144,7 @@ function fixture() {
     metadata,
     contentTypes,
     writes,
+    multipart,
     options,
     reconcile,
     send,
@@ -147,6 +169,109 @@ test("dry-run inventories all pages and reconciles twice without writing", async
   });
   expect(f.writes).toStrictEqual([]);
   expect(f.reconcile).toHaveBeenCalledTimes(2);
+});
+
+test("old pending multipart uploads block coverage until their completed bytes are registered", async () => {
+  const f = fixture();
+  const key = "artifacts/abcdefghij.mp4";
+  f.multipart.push({ Key: key, UploadId: "old-upload" });
+  await expect(
+    registerHistoricalPublicArtifacts(
+      f.client,
+      f.client,
+      f.options,
+      f.reconcile,
+    ),
+  ).resolves.toMatchObject({
+    pendingMultipartUploads: 1,
+    unregisteredMultipartUploads: 1,
+    verified: false,
+  });
+  const options = { ...f.options, migrate: true, verify: true, finalize: true };
+  await expect(
+    registerHistoricalPublicArtifacts(f.client, f.client, options, f.reconcile),
+  ).rejects.toThrow("1 unregistered multipart uploads");
+  expect(
+    f.writes.some((path) => {
+      return path.endsWith("registration.json");
+    }),
+  ).toBe(false);
+
+  // A client can complete already-uploaded parts after its PUT URLs expire.
+  f.multipart.splice(0);
+  f.objects.set(`public/${key}`, "late completed bytes");
+  f.contentTypes.set(key, "video/mp4");
+  await expect(
+    registerHistoricalPublicArtifacts(
+      f.client,
+      f.client,
+      { ...options, finalize: false },
+      async () => {},
+    ),
+  ).resolves.toMatchObject({
+    registered: 1,
+    missing: 0,
+    finalFiles: 2,
+    pendingMultipartUploads: 0,
+    unregisteredMultipartUploads: 0,
+    verified: true,
+  });
+});
+
+test("pre-registered multipart uploads may continue across every inventory page", async () => {
+  const f = fixture();
+  const key = "artifacts/abcdefghij.mp4";
+  f.multipart.push(
+    { Key: key, UploadId: "new-upload-1" },
+    { Key: key, UploadId: "new-upload-2" },
+  );
+  f.objects.set(
+    `hosted/${artifactDeliveryKey("vm0", "file", "abcdefghij.mp4")}`,
+    JSON.stringify({
+      version: 1,
+      kind: "legacy-file",
+      key,
+      filename: "recording.mp4",
+      contentType: "video/mp4",
+      publicBrand: "okou",
+      audience: "public",
+    }),
+  );
+  await expect(
+    registerHistoricalPublicArtifacts(
+      f.client,
+      f.client,
+      { ...f.options, migrate: true },
+      f.reconcile,
+    ),
+  ).resolves.toMatchObject({
+    pendingMultipartUploads: 2,
+    unregisteredMultipartUploads: 0,
+    verified: true,
+  });
+});
+
+test("incomplete multipart pagination cannot produce a verified inventory", async () => {
+  const f = fixture();
+  const original = f.send.getMockImplementation()!;
+  f.send.mockImplementation((command) => {
+    if (command instanceof ListMultipartUploadsCommand)
+      return Promise.resolve({ Uploads: [], IsTruncated: true });
+    return original(command);
+  });
+  await expect(
+    registerHistoricalPublicArtifacts(
+      f.client,
+      f.client,
+      { ...f.options, migrate: true, verify: true, finalize: true },
+      f.reconcile,
+    ),
+  ).rejects.toThrow("multipart upload pagination is incomplete");
+  expect(
+    f.writes.some((path) => {
+      return path.endsWith("registration.json");
+    }),
+  ).toBe(false);
 });
 
 test("registration is idempotent, verifies exact metadata, and preserves bytes and pointers", async () => {

--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/backfill.ts
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/backfill.ts
@@ -10,6 +10,7 @@ import {
   S3Client,
 } from "@aws-sdk/client-s3";
 import postgres from "postgres";
+import { forEachConcurrent } from "./concurrent";
 // Frozen v1 format: numbered data migrations must remain runnable after app
 // contracts evolve. Only confirmed historical Public records are constructed.
 type PublicBrand = "vm0" | "okou";
@@ -47,6 +48,11 @@ interface Options {
   readonly verify: boolean;
   readonly finalize: boolean;
   readonly maxObjects: number;
+  readonly concurrency?: number;
+  readonly onProgress?: (phase: string, completed: number) => void;
+  readonly resolveMissingContentType?: (
+    key: string,
+  ) => Promise<string | undefined>;
 }
 interface Entry {
   readonly key: string;
@@ -174,6 +180,37 @@ async function historicalSiteEntry(
   };
 }
 
+async function registeredContentType(
+  hostedClient: S3Client,
+  options: Options,
+  key: string,
+  brand: PublicBrand,
+  filename: string,
+) {
+  const value = await readJson(
+    hostedClient,
+    options.hostedBucket,
+    artifactDeliveryKey(brand, "file", key.slice("artifacts/".length)),
+  );
+  if (value === undefined) return undefined;
+  const record = objectRecord(value);
+  if (
+    record.version !== 1 ||
+    record.kind !== "legacy-file" ||
+    record.audience !== "public" ||
+    record.key !== key ||
+    record.publicBrand !== brand ||
+    record.filename !== filename ||
+    typeof record.contentType !== "string" ||
+    !record.contentType
+  ) {
+    throw new Error(
+      "Existing registration cannot resolve missing public MIME metadata",
+    );
+  }
+  return record.contentType;
+}
+
 /** Enumerate only the historical public artifact namespace and public pointers. */
 async function inventory(
   publicClient: S3Client,
@@ -193,68 +230,93 @@ async function inventory(
       throw new Error("Conflicting historical aliases");
     entries.set(entry.key, entry);
   }
-  for await (const key of keys(
-    publicClient,
-    options.publicBucket,
-    "artifacts/",
-    options.maxObjects,
-  )) {
-    // These are the two key shapes emitted by historical artifact writers.
-    if (
-      !/^artifacts\/(?:[a-z0-9]{10}\.[^/]+|[^/]+\/[^/]+\/[^/]+)$/u.test(key)
-    ) {
-      skipped++;
-      continue;
-    }
-    const head = await publicClient.send(
-      new HeadObjectCommand({ Bucket: options.publicBucket, Key: key }),
-    );
-    if (
-      head.Metadata?.storage === "private-artifact-v1" ||
-      head.Metadata?.access === "owner-private-v1"
-    )
-      throw new Error(
-        "Private metadata found in historical public storage; investigate without publishing it",
+  let scannedFiles = 0;
+  let resolvedContentTypes = 0;
+  await forEachConcurrent(
+    keys(publicClient, options.publicBucket, "artifacts/", options.maxObjects),
+    options.concurrency ?? 16,
+    async (key) => {
+      // The draft namespace is also present in the existing public bucket.
+      // Private metadata and database ownership are checked before any write.
+      if (
+        !/^artifacts\/(?:[a-z0-9]{10}\.[^/]+|[^/]+\/[^/]+\/[^/]+|html-edit-drafts\/[0-9a-f-]{36}\.html)$/u.test(
+          key,
+        )
+      ) {
+        skipped++;
+        return;
+      }
+      const head = await publicClient.send(
+        new HeadObjectCommand({ Bucket: options.publicBucket, Key: key }),
       );
-    const brand = head.Metadata?.["public-brand"] ?? "vm0";
-    if (brand !== "okou" && brand !== "vm0")
-      throw new Error("Invalid historical artifact brand");
-    const filename = head.Metadata?.filename
-      ? decodeURIComponent(head.Metadata.filename)
-      : decodeURIComponent(key.slice(key.lastIndexOf("/") + 1));
-    if (!head.ContentType)
-      throw new Error(`Historical artifact has no content type: ${key}`);
-    const record: HistoricalPublicRecord = {
-      version: 1,
-      kind: "legacy-file",
-      publicBrand: brand,
-      audience: "public",
-      key,
-      filename,
-      contentType: head.ContentType,
-    };
-    sourceFiles.add(key);
-    add({
-      key: artifactDeliveryKey(brand, "file", key.slice("artifacts/".length)),
-      record,
-    });
-  }
-  for await (const key of keys(
-    hostedClient,
-    options.hostedBucket,
-    "sites/",
-    options.maxObjects,
-  )) {
-    const site = await historicalSiteEntry(hostedClient, options, key);
-    if (!site) continue;
-    if (site.skipped) {
-      skipped++;
-      continue;
-    }
-    sourceDeployments.add(site.deploymentId);
-    add(site.entry);
-  }
-  return { entries, sourceFiles, sourceDeployments, skipped };
+      if (
+        head.Metadata?.storage === "private-artifact-v1" ||
+        head.Metadata?.access === "owner-private-v1"
+      )
+        throw new Error(
+          "Private metadata found in historical public storage; investigate without publishing it",
+        );
+      const brand = head.Metadata?.["public-brand"] ?? "vm0";
+      if (brand !== "okou" && brand !== "vm0")
+        throw new Error("Invalid historical artifact brand");
+      const filename = head.Metadata?.filename
+        ? decodeURIComponent(head.Metadata.filename)
+        : decodeURIComponent(key.slice(key.lastIndexOf("/") + 1));
+      // Desktop click tracks can lack R2 HTTP metadata. A pre-registration
+      // remains authoritative even if an upload has not completed in the DB.
+      const contentType =
+        head.ContentType ??
+        (await registeredContentType(
+          hostedClient,
+          options,
+          key,
+          brand,
+          filename,
+        )) ??
+        (await options.resolveMissingContentType?.(key));
+      if (!contentType)
+        throw new Error(`Historical artifact has no content type: ${key}`);
+      if (!head.ContentType) resolvedContentTypes++;
+      const record: HistoricalPublicRecord = {
+        version: 1,
+        kind: "legacy-file",
+        publicBrand: brand,
+        audience: "public",
+        key,
+        filename,
+        contentType,
+      };
+      sourceFiles.add(key);
+      add({
+        key: artifactDeliveryKey(brand, "file", key.slice("artifacts/".length)),
+        record,
+      });
+      scannedFiles++;
+      if (scannedFiles % 1000 === 0)
+        options.onProgress?.("inventory-files", scannedFiles);
+    },
+  );
+  await forEachConcurrent(
+    keys(hostedClient, options.hostedBucket, "sites/", options.maxObjects),
+    options.concurrency ?? 16,
+    async (key) => {
+      const site = await historicalSiteEntry(hostedClient, options, key);
+      if (!site) return;
+      if (site.skipped) {
+        skipped++;
+        return;
+      }
+      sourceDeployments.add(site.deploymentId);
+      add(site.entry);
+    },
+  );
+  return {
+    entries,
+    sourceFiles,
+    sourceDeployments,
+    skipped,
+    resolvedContentTypes,
+  };
 }
 
 function digest(entries: ReadonlyMap<string, Entry>): string {
@@ -292,16 +354,23 @@ async function readExistingAliases(
 ) {
   const previousRecords = new Map<string, unknown>();
   const conflicts: string[] = [];
-  for (const entry of initial.entries.values()) {
-    const previous = await readJson(
-      hostedClient,
-      options.hostedBucket,
-      entry.key,
-    );
-    previousRecords.set(entry.key, previous);
-    if (previous !== undefined && !isDeepStrictEqual(previous, entry.record))
-      conflicts.push(entry.key);
-  }
+  let checked = 0;
+  await forEachConcurrent(
+    initial.entries.values(),
+    options.concurrency ?? 16,
+    async (entry) => {
+      const previous = await readJson(
+        hostedClient,
+        options.hostedBucket,
+        entry.key,
+      );
+      previousRecords.set(entry.key, previous);
+      if (previous !== undefined && !isDeepStrictEqual(previous, entry.record))
+        conflicts.push(entry.key);
+      if (++checked % 1000 === 0)
+        options.onProgress?.("check-existing-aliases", checked);
+    },
+  );
   if (conflicts.length)
     throw new RegistrationConflictError({
       status: "blocked",
@@ -314,6 +383,14 @@ async function readExistingAliases(
 }
 
 /** API/CLI-driven writes continue to register while this idempotent pass runs. */
+function validateOptions(options: Options) {
+  const concurrency = options.concurrency ?? 16;
+  if (!Number.isSafeInteger(concurrency) || concurrency < 1 || concurrency > 64)
+    throw new Error("Concurrency must be between 1 and 64");
+  if (options.finalize && (!options.migrate || !options.verify))
+    throw new Error("--finalize requires --migrate --verify");
+}
+
 export async function registerHistoricalPublicArtifacts(
   publicClient: S3Client,
   hostedClient: S3Client,
@@ -323,8 +400,7 @@ export async function registerHistoricalPublicArtifacts(
     deployments: ReadonlySet<string>,
   ) => Promise<void>,
 ) {
-  if (options.finalize && (!options.migrate || !options.verify))
-    throw new Error("--finalize requires --migrate --verify");
+  validateOptions(options);
   const initial = await inventory(publicClient, hostedClient, options);
   await reconcile(initial.sourceFiles, initial.sourceDeployments);
   const previousRecords = await readExistingAliases(
@@ -334,65 +410,80 @@ export async function registerHistoricalPublicArtifacts(
   );
   let existing = 0;
   let registered = 0;
-  for (const entry of initial.entries.values()) {
-    const previous = previousRecords.get(entry.key);
-    const body = JSON.stringify(entry.record);
-    if (previous !== undefined) {
-      existing++;
-    } else if (options.migrate) {
-      try {
-        await hostedClient.send(
-          new PutObjectCommand({
-            Bucket: options.hostedBucket,
-            Key: entry.key,
-            Body: body,
-            ContentType: "application/json",
-            IfNoneMatch: "*",
-          }),
-        );
-        registered++;
-      } catch (error) {
-        if (!(error instanceof Error) || error.name !== "PreconditionFailed")
-          throw error;
-        const concurrent = await readJson(
+  let processed = 0;
+  await forEachConcurrent(
+    initial.entries.values(),
+    options.concurrency ?? 16,
+    async (entry) => {
+      const previous = previousRecords.get(entry.key);
+      const body = JSON.stringify(entry.record);
+      if (previous !== undefined) {
+        existing++;
+      } else if (options.migrate) {
+        try {
+          await hostedClient.send(
+            new PutObjectCommand({
+              Bucket: options.hostedBucket,
+              Key: entry.key,
+              Body: body,
+              ContentType: "application/json",
+              IfNoneMatch: "*",
+            }),
+          );
+          registered++;
+        } catch (error) {
+          if (!(error instanceof Error) || error.name !== "PreconditionFailed")
+            throw error;
+          const concurrent = await readJson(
+            hostedClient,
+            options.hostedBucket,
+            entry.key,
+          );
+          if (!isDeepStrictEqual(concurrent, entry.record))
+            throw new Error(
+              "Concurrent alias registration conflicts with the inventory",
+            );
+          existing++;
+        }
+      }
+      if (options.verify || options.migrate) {
+        const actual = await readJson(
           hostedClient,
           options.hostedBucket,
           entry.key,
         );
-        if (!isDeepStrictEqual(concurrent, entry.record))
-          throw new Error(
-            "Concurrent alias registration conflicts with the inventory",
-          );
-        existing++;
+        if (!isDeepStrictEqual(actual, entry.record))
+          throw new Error("Public registration read-back failed");
       }
-    }
-    if (options.verify || options.migrate) {
-      const actual = await readJson(
-        hostedClient,
-        options.hostedBucket,
-        entry.key,
-      );
-      if (!isDeepStrictEqual(actual, entry.record))
-        throw new Error("Public registration read-back failed");
-    }
-  }
+      processed++;
+      if (processed % 1000 === 0)
+        options.onProgress?.("registration", processed);
+    },
+  );
   const final = await inventory(publicClient, hostedClient, options);
   await reconcile(final.sourceFiles, final.sourceDeployments);
-  const inventoryHash = digest(initial.entries);
-  if (inventoryHash !== digest(final.entries))
+  // Online writers register before exposing objects. Accept concurrent additions
+  // only after independently verifying their exact records in the final inventory.
+  const finalRecords = await readExistingAliases(hostedClient, options, final);
+  const missing = [...final.entries.keys()].filter((key) => {
+    return finalRecords.get(key) === undefined;
+  }).length;
+  if ((options.migrate || options.verify) && missing > 0) {
     throw new Error(
-      "Historical inventory changed during registration; rerun to include concurrent writes",
+      "Final inventory contains unregistered public artifacts; rerun to repair missing aliases",
     );
+  }
+  if ((options.migrate || options.verify) && final.skipped > 0)
+    throw new Error(
+      "Unclassified historical artifact objects require reconciliation before verification",
+    );
+  const inventoryHash = digest(final.entries);
   if (options.finalize) {
-    if (initial.skipped > 0)
-      throw new Error(
-        "Unclassified historical artifact objects require reconciliation before finalization",
-      );
     const marker = JSON.stringify({
       version: 1,
       complete: true,
       inventoryHash,
-      count: initial.entries.size,
+      count: final.entries.size,
       completedAt: new Date().toISOString(),
     });
     for (const brand of ["vm0", "okou"] as const) {
@@ -420,8 +511,11 @@ export async function registerHistoricalPublicArtifacts(
     aliases: initial.entries.size,
     existing,
     registered,
-    skipped: initial.skipped,
-    missing: initial.entries.size - existing - registered,
+    skipped: final.skipped,
+    missing,
+    finalFiles: final.sourceFiles.size,
+    finalAliases: final.entries.size,
+    resolvedContentTypes: final.resolvedContentTypes,
     verified: options.verify || options.migrate,
     finalized: options.finalize,
   };
@@ -440,6 +534,7 @@ async function main() {
       verify: { type: "boolean", default: false },
       finalize: { type: "boolean", default: false },
       "max-objects": { type: "string", default: "100000" },
+      concurrency: { type: "string", default: "16" },
       report: { type: "string" },
     },
   });
@@ -481,6 +576,17 @@ async function main() {
         verify: values.verify,
         finalize: values.finalize,
         maxObjects,
+        concurrency: Number(values.concurrency),
+        onProgress: (phase, completed) => {
+          console.error(JSON.stringify({ phase, completed }));
+        },
+        resolveMissingContentType: async (key) => {
+          const rows =
+            await db`select distinct content_type from run_uploaded_files where storage_key = ${key} and content_type is not null`;
+          if (rows.length !== 1 || typeof rows[0]?.content_type !== "string")
+            return undefined;
+          return rows[0].content_type;
+        },
       },
       async (files, deployments) => {
         const privateRows =

--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/backfill.ts
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/backfill.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 import {
   GetObjectCommand,
   HeadObjectCommand,
+  ListMultipartUploadsCommand,
   ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
@@ -116,6 +117,74 @@ function objectRecord(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value))
     throw new Error("Invalid historical pointer or manifest");
   return value as Record<string, unknown>;
+}
+
+async function pendingMultipartRegistrations(
+  publicClient: S3Client,
+  hostedClient: S3Client,
+  options: Options,
+) {
+  let keyMarker: string | undefined;
+  let uploadIdMarker: string | undefined;
+  let pending = 0;
+  let unregistered = 0;
+  do {
+    const page = await publicClient.send(
+      new ListMultipartUploadsCommand({
+        Bucket: options.publicBucket,
+        Prefix: "artifacts/",
+        MaxUploads: 1000,
+        KeyMarker: keyMarker,
+        UploadIdMarker: uploadIdMarker,
+      }),
+    );
+    await forEachConcurrent(
+      page.Uploads ?? [],
+      options.concurrency ?? 16,
+      async (upload) => {
+        const key = upload.Key;
+        if (!key?.startsWith("artifacts/") || !upload.UploadId)
+          throw new Error("Invalid pending multipart upload identity");
+        if (++pending > options.maxObjects)
+          throw new Error("Pending multipart upload inventory limit reached");
+        const value = await readJson(
+          hostedClient,
+          options.hostedBucket,
+          artifactDeliveryKey("vm0", "file", key.slice("artifacts/".length)),
+        );
+        if (value === undefined) {
+          unregistered++;
+          return;
+        }
+        const record = objectRecord(value);
+        if (
+          record.version !== 1 ||
+          record.kind !== "legacy-file" ||
+          record.audience !== "public" ||
+          record.key !== key ||
+          (record.publicBrand !== "vm0" && record.publicBrand !== "okou") ||
+          typeof record.filename !== "string" ||
+          !record.filename ||
+          typeof record.contentType !== "string" ||
+          !record.contentType
+        )
+          throw new Error("Pending multipart upload registration is invalid");
+      },
+    );
+    if (
+      page.IsTruncated &&
+      (!page.NextKeyMarker ||
+        !page.NextUploadIdMarker ||
+        (page.NextKeyMarker === keyMarker &&
+          page.NextUploadIdMarker === uploadIdMarker))
+    )
+      throw new Error("Pending multipart upload pagination is incomplete");
+    keyMarker = page.IsTruncated ? page.NextKeyMarker : undefined;
+    uploadIdMarker = page.IsTruncated ? page.NextUploadIdMarker : undefined;
+  } while (keyMarker);
+  options.onProgress?.("pending-multipart-uploads", pending);
+  options.onProgress?.("unregistered-multipart-uploads", unregistered);
+  return { pending, unregistered };
 }
 
 function stringField(value: Record<string, unknown>, key: string): string {
@@ -460,6 +529,14 @@ export async function registerHistoricalPublicArtifacts(
         options.onProgress?.("registration", processed);
     },
   );
+  // Parts can be completed long after their PUT signatures expire. Check them
+  // before the final object inventory so an old session completing during this
+  // boundary is either blocked here or included in the final object coverage.
+  const multipart = await pendingMultipartRegistrations(
+    publicClient,
+    hostedClient,
+    options,
+  );
   const final = await inventory(publicClient, hostedClient, options);
   await reconcile(final.sourceFiles, final.sourceDeployments);
   // Online writers register before exposing objects. Accept concurrent additions
@@ -476,6 +553,10 @@ export async function registerHistoricalPublicArtifacts(
   if ((options.migrate || options.verify) && final.skipped > 0)
     throw new Error(
       "Unclassified historical artifact objects require reconciliation before verification",
+    );
+  if ((options.migrate || options.verify) && multipart.unregistered > 0)
+    throw new Error(
+      `${multipart.unregistered} unregistered multipart uploads must finish or expire before coverage can be accepted`,
     );
   const inventoryHash = digest(final.entries);
   if (options.finalize) {
@@ -516,6 +597,8 @@ export async function registerHistoricalPublicArtifacts(
     finalFiles: final.sourceFiles.size,
     finalAliases: final.entries.size,
     resolvedContentTypes: final.resolvedContentTypes,
+    pendingMultipartUploads: multipart.pending,
+    unregisteredMultipartUploads: multipart.unregistered,
     verified: options.verify || options.migrate,
     finalized: options.finalize,
   };

--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/concurrent.ts
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/concurrent.ts
@@ -1,0 +1,26 @@
+/** Drain in-flight storage operations before propagating the first failure. */
+export async function forEachConcurrent<T>(
+  items: Iterable<T> | AsyncIterable<T>,
+  concurrency: number,
+  visit: (item: T) => Promise<void>,
+): Promise<void> {
+  async function* source() {
+    yield* items;
+  }
+  const iterator = source();
+  let failure: { readonly error: unknown } | undefined;
+  async function worker() {
+    while (!failure) {
+      try {
+        const next = await iterator.next();
+        if (next.done || failure) return;
+        await visit(next.value);
+      } catch (error) {
+        failure ??= { error };
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: concurrency }, worker));
+  await iterator.return(undefined);
+  if (failure) throw failure.error;
+}


### PR DESCRIPTION
Public files produced through the legacy path can currently reach R2 without an `artifact-delivery/` record. Register exact public metadata before direct/immutable writes, presigned PUTs and multipart initiation, regardless of `privateArtifacts`. Fail the operation if registration fails, preserve completion hooks for already-issued credentials.

The historical migration now uses bounded R2 concurrency, verifies a complete final inventory and accepts concurrent additions only when their exact registration already exists. A protected manual production job supports dry-run, conditional registration and independent verification. Its database access is read-only; it cannot finalize registration, enable the feature switch or change file bytes, DNS, Worker routes or cache rules. This is the first production phase of #32492; the `a.okou.io` cutover in #32959 stays separate and draft.

### Validation

- 162 focused API tests covering uploads and cancellation, private/public image and video generation, speech, Slack upload initiation and Telegram completion (local Postgres uses UTC, matching CI).
- 11 historical migration tests cover pagination, exact read-back, conflicts/private metadata, concurrent additions, restartability, historical drafts, authoritative MIME recovery and pending multipart uploads.
- Repository pre-commit checks: formatting, style policy, Knip and all workspace type checks.
- Merge-queue CI exposed an existing activity-summary test assumption: concurrent followers can legitimately return `unavailable` under the production database lock budget. Preserve its single-claim/version assertions and handle the owner promise immediately; the focused test passed five consecutive runs. [Failure evidence](https://github.com/vm0-ai/vm0/actions/runs/34350977482/job/102464006162).
- Live read-only inventory: 143,456 public objects; 29 missing R2 Content-Type and one historical HTML draft. Missing MIME metadata must resolve from an exact prior registration or one authoritative upload-row value; otherwise the migration blocks.

### Rollout

Deploy API registration first with `privateArtifacts` off. Run the manual migration on protected `main`, then independently verify after older API instances and their previously-issued upload credentials drain (current PUT lifetime: up to one hour). Require zero missing/conflicting/unclassified records and zero unregistered pending multipart uploads. Multipart completion can outlive PUT signatures, so the migration paginates pending sessions before its final object scan and blocks coverage until old unregistered sessions finish or expire in storage; newly pre-registered sessions can continue. Keep `a.okou.io` and its legacy thumbnail/cache behavior unchanged until the separate delivery cutover is reviewed.

### Fallbacks

Historical brandless/name-less public object metadata retains the existing VM0/basename interpretation used by migration 014. Missing R2 MIME metadata is resolved only from an exact existing registration or a unique persisted `run_uploaded_files.content_type`, never from an extension or fabricated default. These persisted-data boundaries cover existing public files, including 29 observed Desktop recording sidecars; #32492 owns removal once historical delivery no longer needs the migration and older writers have drained. Existing upload-completion registration remains a backstop for upload credentials issued before the new API release.
