### PR TITLE
test(runner): enter teardown explicitly for deferred upload

### DIFF
--- a/crates/runner/src/cmd/start/tests/main_loop/usage_flush.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/usage_flush.rs
@@ -144,7 +144,7 @@ async fn job_completion_requests_proxy_usage_flush_without_waiting() {
 /// running-job drain. The runner must not pass that drain until the test
 /// releases the response, regardless of scheduling before shutdown.
 #[tokio::test]
-async fn deferred_network_log_upload_drains_on_graceful_shutdown() {
+async fn deferred_network_log_upload_drains_after_stopping_signal() {
     use crate::test_fixtures::raw_http::{json_response, read_http_request};
     use futures_util::FutureExt;
     use tokio::io::AsyncWriteExt;
@@ -261,11 +261,11 @@ async fn deferred_network_log_upload_drains_on_graceful_shutdown() {
     assert_eq!(logs[0]["host"], "example.com");
     assert_eq!(logs[1]["host"], "pending.example");
 
-    // Drain shutdown — must block on each `spawn_job` closure's deferred
-    // `tokio::join!(flush, upload)` via the outer `jobs` JoinSet. Match the
-    // shutdown helper's signals while retaining control of the response.
-    env.drain();
-    env.cancel.cancel();
+    // The job has reported completion; teardown must still join its deferred
+    // upload. Enter Stopping through the real signal handler. Combining natural
+    // drain with discovery cancellation races: a Draining reactor disables
+    // discovery and cannot reach teardown until this held upload is released.
+    env.trigger_stopping().await;
     tokio::select! {
         // Consume ready runner work before checking the retained entry event.
         biased;


### PR DESCRIPTION
The deferred-upload shutdown regression can deadlock while its HTTP response is deliberately held. It sends both natural-drain and discovery-cancellation signals, then waits for a teardown-only observation. If the reactor observes Draining first, it disables discovery and waits for the held upload before entering teardown; if cancelled discovery wins first, it enters teardown and the test passes.

After the job has already reported completion, use the existing real stopping-signal handler to enter teardown explicitly. Keep the held response, running-job/destroy-drain assertions, exact upload payload/count, and JSONL flush checks. Rename the test to state the stopping-signal contract. No timeout increase, delay, retry, or production behavior change is introduced.

This reproduced twice while merging #32980:
- https://github.com/vm0-ai/vm0/actions/runs/34344352189/job/102442390277
- https://github.com/vm0-ai/vm0/actions/runs/34345673410/job/102446657619

Both failed with `runner did not observe running-job drain within 5s`. The implicated Rust files match the earlier passing PR-head run. Related to #32915 and follows #32957.

Validation: affected-crate formatting and diff checks passed. The full Rust coverage suite passed on this PR: https://github.com/vm0-ai/vm0/actions/runs/34346833348/job/102450384567. The local focused regression could not reach execution: compiling the runner exhausted the 4 GiB sandbox (kernel OOM, exit 137), including one single-job retry. Validation therefore relies on the passing CI coverage run for execution.
