### PR TITLE
perf(connectors): precompute catalog leakage match values

### DIFF
--- a/turbo/packages/connectors/src/__tests__/connector-catalog-public-leak.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connector-catalog-public-leak.test.ts
@@ -17,7 +17,11 @@ const STORAGE_VERSION_PREFIX = `__system__/volume/${STORAGE_NAME}/${VERSION_ID}`
 const PRIVATE_NAME = "TOKEN_SECURITY_API_TOKEN";
 const VALUE_REF = `$secrets.${PRIVATE_NAME}`;
 
-function catalogArtifact(description: string): ConnectorCatalogArtifact {
+function catalogArtifact(
+  description: string,
+  privateName = PRIVATE_NAME,
+  placeholder: string | null = null,
+): ConnectorCatalogArtifact {
   return {
     artifactSchemaVersion: SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
     catalogVersion: CATALOG_VERSION,
@@ -48,25 +52,25 @@ function catalogArtifact(description: string): ConnectorCatalogArtifact {
             visible: true,
             storage: {
               version: 1,
-              secrets: [PRIVATE_NAME],
+              secrets: [privateName],
               variables: [],
             },
             grant: {
               kind: "manual",
               fields: [
                 {
-                  privateName: PRIVATE_NAME,
+                  privateName,
                   publicId: "credential",
                   label: "API token",
                   required: true,
-                  placeholder: null,
+                  placeholder,
                   storage: "secret",
                 },
               ],
             },
             access: {
               kind: "static",
-              envBindings: { SERVICE_TOKEN: VALUE_REF },
+              envBindings: { SERVICE_TOKEN: `$secrets.${privateName}` },
             },
             revoke: { kind: "none" },
           },
@@ -90,10 +94,10 @@ function catalogArtifact(description: string): ConnectorCatalogArtifact {
   };
 }
 
-function decodeCatalog(description: string): ConnectorCatalogArtifact {
-  const rawBytes = Buffer.from(
-    `${JSON.stringify(catalogArtifact(description))}\n`,
-  );
+function decodeCatalog(
+  artifact: ConnectorCatalogArtifact,
+): ConnectorCatalogArtifact {
+  const rawBytes = Buffer.from(`${JSON.stringify(artifact)}\n`);
   return decodeConnectorCatalogSnapshot({
     catalogGzip: encodeConnectorCatalogSnapshot(rawBytes),
     catalogRawSize: rawBytes.byteLength,
@@ -104,7 +108,9 @@ function decodeCatalog(description: string): ConnectorCatalogArtifact {
 
 describe("connector catalog public projection", () => {
   it("accepts the exact public slug derived from bundled skill storage", () => {
-    const artifact = decodeCatalog("Public connector description");
+    const artifact = decodeCatalog(
+      catalogArtifact("Public connector description"),
+    );
 
     expect(artifact.connectors[0]?.slug).toBe(CONNECTOR_SLUG);
   });
@@ -117,7 +123,114 @@ describe("connector catalog public projection", () => {
     ["private value reference", VALUE_REF],
   ])("rejects a leaked %s", (_name, privateValue) => {
     expect(() => {
-      decodeCatalog(privateValue);
+      decodeCatalog(catalogArtifact(privateValue));
     }).toThrow("public-leakage");
+  });
+
+  it.each([
+    ["ABCD_EFGH", "prefix-abcd-efgh-suffix"],
+    [PRIVATE_NAME, "Your token security api token"],
+  ])("rejects a placeholder derived from %s", (privateName, placeholder) => {
+    expect(() => {
+      decodeCatalog(
+        catalogArtifact("Public description", privateName, placeholder),
+      );
+    }).toThrow("public-leakage");
+  });
+
+  it.each([
+    ["ABC_DEFG", "abc-defg"],
+    ["ABCDEFGH", "abcd-efgh"],
+    [PRIVATE_NAME, "Enter your credential"],
+  ])(
+    "accepts an unrelated placeholder for %s: %s",
+    (privateName, placeholder) => {
+      const artifact = catalogArtifact(
+        "Public description",
+        privateName,
+        placeholder,
+      );
+      expect(decodeCatalog(artifact)).toEqual(artifact);
+    },
+  );
+
+  it("keeps normalized private names public outside derived-value paths", () => {
+    const artifact = catalogArtifact("Token security api token");
+    for (const connector of artifact.connectors) {
+      connector.tags = ["token-security-api-token"];
+    }
+    expect(decodeCatalog(artifact)).toEqual(artifact);
+  });
+
+  it("rejects exact private values inside public arrays", () => {
+    const artifact = catalogArtifact("Public description");
+    for (const connector of artifact.connectors) {
+      connector.tags = [PRIVATE_NAME];
+    }
+    expect(() => {
+      decodeCatalog(artifact);
+    }).toThrow("public-leakage");
+  });
+
+  it.each(["defaultValue", "value", "neither"])(
+    "checks derived private names in device fields: %s",
+    (field) => {
+      const artifact = catalogArtifact("Public description");
+      for (const connector of artifact.connectors) {
+        for (const method of connector.authMethods) {
+          method.client = {
+            clientType: "public",
+            clientRegistration: "static",
+            clientId: "fixture-device-client",
+          };
+          method.grant = {
+            kind: "device-auth",
+            scopes: [],
+            outputs: { token: VALUE_REF },
+            startOptions: [
+              {
+                privateName: "environment",
+                publicId: "environment",
+                kind: "select",
+                label: "Environment",
+                required: true,
+                defaultValue:
+                  field === "defaultValue" ? "token-security-api-token" : null,
+                options: [
+                  {
+                    // Keep the default-value case independent: missing its
+                    // leakage check must reach relationship-mismatch, not
+                    // pass because the option value also leaks.
+                    value:
+                      field === "value"
+                        ? "token-security-api-token"
+                        : "production",
+                    label: "Production",
+                  },
+                ],
+              },
+            ],
+          };
+        }
+      }
+      if (field === "neither") {
+        expect(decodeCatalog(artifact)).toEqual(artifact);
+      } else {
+        expect(() => {
+          decodeCatalog(artifact);
+        }).toThrow("public-leakage");
+      }
+    },
+  );
+
+  it("keeps sensitive matching scoped to its connector", () => {
+    const first = catalogArtifact("Public description");
+    const second = catalogArtifact(PRIVATE_NAME, "OTHER_CREDENTIAL");
+    for (const connector of second.connectors) {
+      connector.slug = "another-connector";
+      connector.skill = { kind: "none" };
+      first.connectors.push(connector);
+    }
+    expect(decodeCatalog(first)).toEqual(first);
   });
 });

--- a/turbo/packages/connectors/src/__tests__/connector-catalog-public-leak.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connector-catalog-public-leak.test.ts
@@ -224,8 +224,9 @@ describe("connector catalog public projection", () => {
   );
 
   it("keeps sensitive matching scoped to its connector", () => {
-    const first = catalogArtifact("Public description");
-    const second = catalogArtifact(PRIVATE_NAME, "OTHER_CREDENTIAL");
+    const firstPrivateName = "FIRST_PRIVATE_FIELD";
+    const first = catalogArtifact("Public description", firstPrivateName);
+    const second = catalogArtifact(firstPrivateName, "SECOND_PRIVATE_FIELD");
     for (const connector of second.connectors) {
       connector.slug = "another-connector";
       connector.skill = { kind: "none" };

--- a/turbo/packages/connectors/src/connector-catalog/artifacts/public-leak.ts
+++ b/turbo/packages/connectors/src/connector-catalog/artifacts/public-leak.ts
@@ -111,13 +111,30 @@ function connectorCatalogSensitiveValues(
   return values;
 }
 
+interface SensitiveValues {
+  readonly exact: ReadonlySet<string>;
+  readonly derived: readonly string[];
+}
+
+function prepareSensitiveValues(exact: ReadonlySet<string>): SensitiveValues {
+  const derived: string[] = [];
+  for (const value of exact) {
+    if (value.includes("_")) {
+      const normalized = normalizeSensitiveString(value);
+      if (normalized.length >= 8) {
+        derived.push(normalized);
+      }
+    }
+  }
+  return { exact, derived };
+}
+
 function assertNoSensitiveString(args: {
   readonly value: string;
   readonly path: string;
-  readonly sensitiveValues: ReadonlySet<string>;
+  readonly sensitiveValues: SensitiveValues;
 }): void {
-  const normalizedValue = normalizeSensitiveString(args.value);
-  for (const sensitiveValue of args.sensitiveValues) {
+  for (const sensitiveValue of args.sensitiveValues.exact) {
     if (sensitiveValue.length === 0) {
       continue;
     }
@@ -126,23 +143,25 @@ function assertNoSensitiveString(args: {
         `Public connector catalog projection leaked private value at ${args.path}`,
       );
     }
-    const normalizedSensitiveValue = normalizeSensitiveString(sensitiveValue);
-    if (
-      shouldCheckDerivedSensitiveValue(args.path) &&
-      sensitiveValue.includes("_") &&
-      normalizedSensitiveValue.length >= 8 &&
-      normalizedValue.includes(normalizedSensitiveValue)
-    ) {
-      throw new Error(
-        `Public connector catalog projection leaked private value at ${args.path}`,
-      );
+  }
+  if (
+    args.sensitiveValues.derived.length > 0 &&
+    shouldCheckDerivedSensitiveValue(args.path)
+  ) {
+    const normalizedValue = normalizeSensitiveString(args.value);
+    for (const sensitiveValue of args.sensitiveValues.derived) {
+      if (normalizedValue.includes(sensitiveValue)) {
+        throw new Error(
+          `Public connector catalog projection leaked private value at ${args.path}`,
+        );
+      }
     }
   }
 }
 
 function assertPublicValueHasNoPrivateFields(
   value: unknown,
-  sensitiveValues: ReadonlySet<string>,
+  sensitiveValues: SensitiveValues,
   path = "$",
 ): void {
   if (typeof value === "string") {
@@ -268,7 +287,7 @@ export function validateConnectorCatalogPublicProjection(
       catalogVersion: artifact.catalogVersion,
       categoryMetadata: artifact.categoryMetadata,
     },
-    new Set(),
+    { exact: new Set(), derived: [] },
   );
   for (const connector of artifact.connectors) {
     // A connector slug is public identity even when a private storage name
@@ -277,7 +296,7 @@ export function validateConnectorCatalogPublicProjection(
     sensitiveValues.delete(connector.slug);
     assertPublicValueHasNoPrivateFields(
       publicConnector(connector),
-      sensitiveValues,
+      prepareSensitiveValues(sensitiveValues),
       `$.connectors[${connector.slug}]`,
     );
   }


### PR DESCRIPTION
## Summary

- Prepare underscore-containing normalized sensitive values once per connector, after the existing exact-public-slug exclusion.
- Preserve exact substring checks on every public string; normalize public strings only on the existing derived-match paths (`placeholder`, `defaultValue`, `value`). Keep the original normalized-length threshold, forbidden-key traversal, failure classification and connector-local scope.
- Add full compressed-snapshot decoder regression coverage for normalized boundaries, ordinary public text, nested/array values, device defaults/options and cross-connector isolation.

Closes #32981. Parent context: #24203 (not closed by this PR).

## Measurements

Full exported `decodeConnectorCatalogSnapshot`, baseline `5802f5ba59d8d47865139dccd1f49acdf50a2a02`, same prebuilt baseline/candidate harness. Linux arm64 / Node 22.23.2 / 12 logical CPUs, shared local development host, no CPU/memory cgroup cap. Valid input encoding/compression/digest construction is outside timing. Each independent process measures its first decoder call and 24 repeats without timing callbacks; five later instrumented calls diagnose phases. Process order alternates by arm.

Durations are milliseconds. Repeat columns are p50 of per-process medians, not independent cold samples.

| Fixture / round | Fresh processes per arm | First-call p50 baseline → candidate | Repeated median p50 baseline → candidate |
| --- | ---: | ---: | ---: |
| Existing API fixture, 71 connectors | 12 | 29.951 → 27.123 | 7.570 → 6.238 (**17.6% lower**) |
| API confirmation, separate later window | 32 | 34.127 → 30.716 | 9.139 → 7.330 (**19.8% lower**) |
| Synthetic 1,024 manual connectors, eight fields each | 12 | 320.238 → 162.258 | 272.704 → 112.626 (**58.7% lower**) |

API initial/confirmation public-projection median p50: 3.734 → 2.508 ms / 4.124 → 2.766 ms; synthetic 237.232 → 80.010 ms. Initial median peak RSS changes: +52 KiB (API), +224 KiB (synthetic); API confirmation -132 KiB. Post-GC retained heap increases approximately 5 KiB / 11 KiB, respectively. These are resource guards, not total-allocation measurements.

No outliers excluded. The initial API candidate had one 47.695 ms first call above baseline's 36.880 ms maximum, prompting 32 more process pairs. Confirmation first-call p90 improved 42.904 → 35.992 ms; maxima were 68.990 / 67.876 ms. No consistent cold-tail regression observed, but production p99 remains unverified. Synthetic fixtures are not a production catalog clone; first invocation excludes process/module startup. Do not extrapolate these results to the production 2.2-second stage or to `api_to_spawn` savings.

[Full methodology, variance and resource results](https://github.com/vm0-ai/vm0/issues/32981#issuecomment-5601203451). Reproducible local harness and raw measurements are retained under ignored `codex-work/research/issue-32981-catalog-public-leak/`.

## Scope and risks

- Main risk is accidentally suppressing an exact/derived leakage condition; positive and negative decoder-entry-point tests exercise those conditions. Default-value and option-value rejection cases are independent.
- Prepared strings are transient and bounded by one connector's sensitive values. No process-global/request cache, dependency, configuration, or benchmark code enters production.
- No schema, digest, relationship, protocol, database, authority identity mechanism, rollout behavior, or Runner change. Existing full fallback remains required when authority differs; no validation is skipped. The existing connectors package version/release-please mechanism remains responsible for version changes, with no manual bump.
- Production verification after a containing release remains pending. Compare exact API/Runner and authority/fallback cohorts, not mixed-version daily aggregates. Team-concurrency queue wait remains excluded; post-admission durable Runner queue wait remains included.

## Fallbacks

None introduced or removed.

## Validation

Commands run from `turbo`:

- `pnpm exec prettier --check packages/connectors/src/connector-catalog/artifacts/public-leak.ts packages/connectors/src/__tests__/connector-catalog-public-leak.test.ts`
- `pnpm -F @okouai/connectors lint`
- `pnpm -F @okouai/connectors check-types`
- `pnpm exec knip --workspace packages/connectors`
- `pnpm -F @okouai/connectors exec vitest run --maxWorkers=4 --silent=passed-only` — 51 files, 1,149 tests passed.
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts src/signals/routes/__tests__/connector-catalog.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/__tests__/release-please-config.test.ts --maxWorkers=4 --silent=passed-only` — 4 files, 400 tests passed.
- `git diff --check` and repository commit hooks; no checks bypassed.

No deployment or merge is included.
