### PR TITLE
fix(api): retain activity diagnostics in production

### DIFF
--- a/docs/chat-thread-activity-summary.md
+++ b/docs/chat-thread-activity-summary.md
@@ -79,9 +79,42 @@ credential-shaped argument keys are additionally redacted.
   one cleanup batch of at most 500 rows with `FOR UPDATE SKIP LOCKED`, attached
   to existing sandbox maintenance and available with the switch off.
 
-Debug diagnostics record capture outcomes, cache states, attempt/completion
-counts, latency, cooldown, and cleanup counts. They never contain prompts,
-arguments, results, or provider response bodies.
+## Production diagnostics
+
+The existing activity records use `info` for normal outcomes and `warn` for
+failed operations so they survive the default Axiom transport's `info` threshold.
+The shared logger and unrelated debug filtering are unchanged. Axiom events
+retain `source: api`, the stable message, and the following nested `fields`:
+
+| Message                        | Context                | Level                                             | Safe fields besides context                                                                                |
+| ------------------------------ | ---------------------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `Activity summary cache`       | `api:activity-summary` | info                                              | `runId`, `outcome` (existing response status)                                                              |
+| `Activity summary attempt`     | `api:activity-summary` | info                                              | `runId`                                                                                                    |
+| `Activity summary completion`  | `api:activity-summary` | info on success; warn otherwise                   | `runId`, `outcome`, `durationMs`, `cooldownMs`; numeric `providerStatus` only for `OpenRouterRequestError` |
+| `Activity summary unavailable` | `api:activity-summary` | warn                                              | `runId`, `outcome: storage_failed`                                                                         |
+| `Activity snapshot capture`    | `api:run-activity`     | info for written/unchanged; warn for write_failed | `runId`, `outcome`, `eventCount`                                                                           |
+| `Activity snapshot cleanup`    | `api:run-activity`     | info on success; warn on failure                  | `outcome`, `removed`, `retentionMs`                                                                        |
+
+Completion outcomes remain `success`, `timeout`, `provider_failure`, and
+`invalid_or_unconfigured`. A provider HTTP 429 is distinguishable by
+`fields.providerStatus: 429`; no error object or provider body is attached.
+
+Granularity is unchanged: one cache record for a request resolved without a
+claim, one attempt/completion pair per generation attempt, one unavailable
+record for an optional summary storage failure, one capture record per relevant
+batch (including unchanged duplicates), and one cleanup record per maintenance
+operation (including zero removals). Disabled, irrelevant, and ineligible
+captures remain silent. `eventCount` counts the submitted batch, not new retained
+entries. Failed cleanup reports `removed: 0` with `outcome: failed`; that is not a
+successful empty cleanup.
+
+These records never contain prompts, phrases, messages, arguments, evidence,
+credentials, database-driver errors, or provider response bodies. The tests call
+real endpoints and exercise the production logger and real Axiom SDK/transport,
+with ingestion captured by MSW and unrelated debug records verified as filtered.
+No test logs go to production. Attempt records measure this service's generation
+attempts; they do not establish provider billing, token usage, or cost savings.
+Production verification remains controller-owned after release.
 
 ## Visible viewer lifecycle
 

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -256,6 +256,37 @@ export default [
     },
   },
   {
+    files: ["src/signals/services/chat-activity-summary.service.ts"],
+    rules: {
+      // Existing content-free operation records must survive Axiom's info default.
+      "api/no-logger-info": [
+        "error",
+        {
+          allowedMessages: [
+            "Activity summary cache",
+            "Activity summary attempt",
+            "Activity summary completion",
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ["src/signals/services/run-activity-snapshot.service.ts"],
+    rules: {
+      // One record per relevant batch or cleanup; suppressed captures stay silent.
+      "api/no-logger-info": [
+        "error",
+        {
+          allowedMessages: [
+            "Activity snapshot capture",
+            "Activity snapshot cleanup",
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ["src/signals/services/onboarding.service.ts"],
     rules: {
       "api/no-logger-info": [

--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -108,6 +108,7 @@ export interface ApiTestMocks {
     readonly sdkIngest: UnknownMock;
   };
   readonly axiomLogging: {
+    readonly useRealTransport: Mock<() => boolean>;
     readonly debug: SyncMock;
     readonly info: SyncMock;
     readonly warn: SyncMock;
@@ -331,7 +332,7 @@ interface ResendClientMock {
   };
 }
 type SlackWebClientMock = Omit<ApiTestMocks["slack"], "fetchFile">;
-type AxiomLoggerMock = ApiTestMocks["axiomLogging"];
+type AxiomLoggerMock = Omit<ApiTestMocks["axiomLogging"], "useRealTransport">;
 type AxiomJSTransportMock = Readonly<Record<string, never>>;
 
 const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
@@ -525,6 +526,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   };
 
   const axiomLogging = {
+    useRealTransport: vi.fn<() => boolean>(),
     debug: vi.fn<(...args: unknown[]) => void>(),
     info: vi.fn<(...args: unknown[]) => void>(),
     warn: vi.fn<(...args: unknown[]) => void>(),
@@ -1234,40 +1236,56 @@ vi.mock("../signals/external/axiom", async () => {
   };
 });
 
-function createAxiomSdkMock() {
+async function createAxiomSdkMock() {
+  const actual =
+    await vi.importActual<typeof import("@axiomhq/js")>("@axiomhq/js");
   return {
-    Axiom: vi.fn<(...args: AxiomSdkConstructorArguments) => AxiomSdkClientMock>(
-      function (options) {
-        apiTestMocks.axiom.clientError.mockImplementation((error: Error) => {
-          options.onError?.(error);
-        });
-        const client: AxiomSdkClientMock = {
-          options,
-          flush: vi.fn<AxiomSdkClient["flush"]>(async (...args) => {
-            await apiTestMocks.axiom.flush(...args);
-          }),
-          ingest: vi.fn<AxiomSdkClient["ingest"]>((...args) => {
-            apiTestMocks.axiom.sdkIngest(...args);
-          }),
-          query: vi.fn<AxiomSdkQueryBridge>((...args) => {
-            return apiTestMocks.axiom.query(...args);
-          }),
-        };
-        apiTestMocks.axiom.clients.push(client);
-        return client;
-      },
-    ),
+    Axiom: vi.fn<
+      (
+        ...args: AxiomSdkConstructorArguments
+      ) => AxiomSdkClientMock | AxiomSdkClient
+    >(function (options) {
+      if (apiTestMocks.axiomLogging.useRealTransport()) {
+        return new actual.Axiom(options);
+      }
+      apiTestMocks.axiom.clientError.mockImplementation((error: Error) => {
+        options.onError?.(error);
+      });
+      const client: AxiomSdkClientMock = {
+        options,
+        flush: vi.fn<AxiomSdkClient["flush"]>(async (...args) => {
+          await apiTestMocks.axiom.flush(...args);
+        }),
+        ingest: vi.fn<AxiomSdkClient["ingest"]>((...args) => {
+          apiTestMocks.axiom.sdkIngest(...args);
+        }),
+        query: vi.fn<AxiomSdkQueryBridge>((...args) => {
+          return apiTestMocks.axiom.query(...args);
+        }),
+      };
+      apiTestMocks.axiom.clients.push(client);
+      return client;
+    }),
   };
 }
 
 vi.mock("@axiomhq/js", createAxiomSdkMock);
 
-function createAxiomLoggingMock() {
+async function createAxiomLoggingMock() {
+  const actual =
+    await vi.importActual<typeof import("@axiomhq/logging")>(
+      "@axiomhq/logging",
+    );
   return {
-    EVENT: Symbol("EVENT"),
+    EVENT: actual.EVENT,
     Logger: vi.fn<
-      (...args: AxiomLoggerConstructorArguments) => AxiomLoggerMock
-    >(function () {
+      (
+        ...args: AxiomLoggerConstructorArguments
+      ) => AxiomLoggerMock | InstanceType<typeof actual.Logger>
+    >(function (...args) {
+      if (apiTestMocks.axiomLogging.useRealTransport()) {
+        return new actual.Logger(...args);
+      }
       const logger: AxiomLoggerMock = {
         debug: apiTestMocks.axiomLogging.debug,
         info: apiTestMocks.axiomLogging.info,
@@ -1278,8 +1296,13 @@ function createAxiomLoggingMock() {
       return logger;
     }),
     AxiomJSTransport: vi.fn<
-      (...args: AxiomJSTransportConstructorArguments) => AxiomJSTransportMock
-    >(function () {
+      (
+        ...args: AxiomJSTransportConstructorArguments
+      ) => AxiomJSTransportMock | InstanceType<typeof actual.AxiomJSTransport>
+    >(function (...args) {
+      if (apiTestMocks.axiomLogging.useRealTransport()) {
+        return new actual.AxiomJSTransport(...args);
+      }
       const transport: AxiomJSTransportMock = {};
       return transport;
     }),
@@ -1349,6 +1372,8 @@ export function resetApiTestMocks(): void {
   apiTestMocks.axiom.ingest.mockReturnValue(true);
   apiTestMocks.axiom.query.mockReset();
   apiTestMocks.axiom.sdkIngest.mockReset();
+  apiTestMocks.axiomLogging.useRealTransport.mockReset();
+  apiTestMocks.axiomLogging.useRealTransport.mockReturnValue(false);
   apiTestMocks.axiomLogging.debug.mockReset();
   apiTestMocks.axiomLogging.info.mockReset();
   apiTestMocks.axiomLogging.warn.mockReset();

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
@@ -12,6 +12,11 @@ import { setupApp } from "../../../__tests__/test-helpers";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import {
+  flushLogs,
+  logger,
+  __resetForTest as resetLogs,
+} from "../../../lib/log";
+import {
   advanceRunActivityClockFixture,
   holdRunActivityFixture,
 } from "../../../test-fixtures/run-activity";
@@ -197,13 +202,77 @@ async function deliver(
   await flushWaitUntilForTest();
 }
 
+// Exercise the production logger and both real SDK constructors. Only the
+// outbound ingestion HTTP request is captured; no application logger is spied on.
+function captureDiagnostics() {
+  const eventSchema = z
+    .object({
+      level: z.string(),
+      message: z.string(),
+      source: z.literal("api"),
+      fields: z.record(z.string(), z.unknown()),
+    })
+    .passthrough();
+  const events: z.infer<typeof eventSchema>[] = [];
+  context.mocks.axiomLogging.useRealTransport.mockReturnValue(true);
+  mockEnv("AXIOM_TOKEN_TELEMETRY", "xaat-activity-logging-test");
+  mockEnv("AXIOM_DATASET_SUFFIX", "dev");
+  mockEnv("OKOU_DEBUG", "");
+  resetLogs();
+  server.use(
+    http.post(
+      "https://api.axiom.co/v1/datasets/vm0-web-logs-dev/ingest",
+      async ({ request: ingestion }) => {
+        expect(ingestion.headers.get("content-type")).toBe(
+          "application/x-ndjson",
+        );
+        const body = await ingestion.text();
+        const batch = body
+          .trim()
+          .split("\n")
+          .map((line) => {
+            return eventSchema.parse(JSON.parse(line));
+          });
+        events.push(...batch);
+        return HttpResponse.json({
+          ingested: batch.length,
+          failed: 0,
+          failures: [],
+          processedBytes: body.length,
+          blocksCreated: 1,
+          walLength: 0,
+        });
+      },
+    ),
+  );
+  onTestFinished(async () => {
+    await flushLogs();
+    resetLogs();
+  });
+  logger("api:unrelated").debug("Unrelated activity transport debug");
+  return async () => {
+    await flushLogs();
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ level: "debug" }),
+    );
+    return events.filter((event) => {
+      return (
+        event.fields.context === "api:activity-summary" ||
+        event.fields.context === "api:run-activity"
+      );
+    });
+  };
+}
+
 describe("thread activity summary", () => {
   it("enforces feature availability and ownership before cache or model exposure", async () => {
     const f = await fixture(false);
+    const diagnostics = captureDiagnostics();
     const inputs = provider();
     await deliver(f, [tool(0, "must not be captured")]);
     await accept(request(f.actor, f.run), [403]);
     expect(inputs).toHaveLength(0);
+    await expect(diagnostics()).resolves.toStrictEqual([]);
     await enable(f.actor);
     const first = await summarize(f.actor, f.run);
     expect(first).toMatchObject({
@@ -220,6 +289,85 @@ describe("thread activity summary", () => {
     await accept(request(f.actor, { ...f.run, runId: randomUUID() }), [404]);
     await enable(f.actor, false);
     await accept(request(f.actor, f.run), [403]);
+    expect(inputs).toHaveLength(1);
+  });
+
+  it("ingests content-free activity records through the default production transport at operation granularity", async () => {
+    const f = await fixture(true, "PRIVATE_PROMPT");
+    const diagnostics = captureDiagnostics();
+    const inputs = provider(() => {
+      return "PRIVATE PHRASE";
+    });
+    const batch = [tool(0, "PRIVATE_ARGUMENT"), tool(1, "PRIVATE_EVIDENCE")];
+    await deliver(f, batch);
+    expect(inputs).toHaveLength(0);
+    await expect(summarize(f.actor, f.run)).resolves.toMatchObject({
+      status: "fresh",
+      phrase: "PRIVATE PHRASE",
+    });
+    await summarize(f.actor, f.run);
+    await deliver(f, batch);
+    await deliver(f, [
+      { type: "usage", sequenceNumber: 2, usage: { input_tokens: 300 } },
+    ]);
+    expect(inputs).toHaveLength(1);
+    const logs = await diagnostics();
+    expect(logs).toStrictEqual([
+      expect.objectContaining({
+        level: "info",
+        message: "Activity snapshot capture",
+        fields: {
+          context: "api:run-activity",
+          runId: f.run.runId,
+          outcome: "written",
+          eventCount: 2,
+        },
+      }),
+      expect.objectContaining({
+        level: "info",
+        message: "Activity summary attempt",
+        fields: { context: "api:activity-summary", runId: f.run.runId },
+      }),
+      expect.objectContaining({
+        level: "info",
+        message: "Activity summary completion",
+        fields: {
+          context: "api:activity-summary",
+          runId: f.run.runId,
+          outcome: "success",
+          durationMs: expect.any(Number),
+          cooldownMs: 0,
+        },
+      }),
+      expect.objectContaining({
+        level: "info",
+        message: "Activity summary cache",
+        fields: {
+          context: "api:activity-summary",
+          runId: f.run.runId,
+          outcome: "fresh",
+        },
+      }),
+      expect.objectContaining({
+        level: "info",
+        message: "Activity snapshot capture",
+        fields: {
+          context: "api:run-activity",
+          runId: f.run.runId,
+          outcome: "unchanged",
+          eventCount: 2,
+        },
+      }),
+    ]);
+    expect(JSON.stringify(logs)).not.toContain("PRIVATE");
+    await webhooks.requestAgentComplete(
+      { runId: f.run.runId, exitCode: 0 },
+      f.headers,
+      [200],
+    );
+    await flushWaitUntilForTest();
+    await deliver(f, [tool(3, "PRIVATE_TERMINAL_ARGUMENT")]);
+    await expect(diagnostics()).resolves.toStrictEqual(logs);
     expect(inputs).toHaveLength(1);
   });
 
@@ -716,11 +864,12 @@ describe("thread activity summary", () => {
 
   it("honors bounded Retry-After and keeps the last known summary", async () => {
     const f = await fixture();
+    const diagnostics = captureDiagnostics();
     const inputs = provider((_input, index) => {
       return index === 1
         ? "Preparing the launch checklist"
         : HttpResponse.json(
-            { error: { code: 429 } },
+            { error: { code: 429, message: "PRIVATE_PROVIDER_BODY" } },
             { status: 429, headers: { "Retry-After": "120" } },
           );
     });
@@ -734,12 +883,45 @@ describe("thread activity summary", () => {
     expect(failed.retryAfterMs).toBeLessThanOrEqual(120_000);
     await summarize(f.actor, f.run);
     expect(inputs).toHaveLength(2);
+    const logs = await diagnostics();
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        message: "Activity summary completion",
+        fields: {
+          context: "api:activity-summary",
+          runId: f.run.runId,
+          outcome: "provider_failure",
+          providerStatus: 429,
+          durationMs: expect.any(Number),
+          cooldownMs: 120_000,
+        },
+      }),
+    );
+    expect(
+      logs.filter((event) => {
+        return event.message === "Activity summary attempt";
+      }),
+    ).toHaveLength(2);
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        level: "info",
+        message: "Activity summary cache",
+        fields: {
+          context: "api:activity-summary",
+          runId: f.run.runId,
+          outcome: "cooldown",
+        },
+      }),
+    );
+    expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
   });
 
   it("keeps normal publication working when snapshot writes fail and excludes expired evidence", async () => {
     const f = await fixture();
     const inputs = provider();
     await summarize(f.actor, f.run);
+    const diagnostics = captureDiagnostics();
     // A stalled Postgres writer is an infrastructure condition, not a user API.
     const held = await holdRunActivityFixture(f.run.runId, context.signal);
     onTestFinished(async () => {
@@ -760,6 +942,31 @@ describe("thread activity summary", () => {
         },
       },
     ]);
+    await expect(summarize(f.actor, f.run)).resolves.toMatchObject({
+      status: "unavailable",
+      phrase: null,
+    });
+    await expect(diagnostics()).resolves.toStrictEqual([
+      expect.objectContaining({
+        level: "warn",
+        message: "Activity snapshot capture",
+        fields: {
+          context: "api:run-activity",
+          runId: f.run.runId,
+          outcome: "write_failed",
+          eventCount: 1,
+        },
+      }),
+      expect.objectContaining({
+        level: "warn",
+        message: "Activity summary unavailable",
+        fields: {
+          context: "api:activity-summary",
+          runId: f.run.runId,
+          outcome: "storage_failed",
+        },
+      }),
+    ]);
     held.release();
     await held.done;
     const page = await chat.listThreadEvents(f.actor, f.run.threadId);
@@ -774,6 +981,7 @@ describe("thread activity summary", () => {
   });
   it("cleans expired snapshots through scoped maintenance even while disabled", async () => {
     const f = await fixture();
+    const diagnostics = captureDiagnostics();
     const inputs = provider();
     await deliver(f, [tool(0, "old evidence")]);
     await summarize(f.actor, f.run);
@@ -803,5 +1011,17 @@ describe("thread activity summary", () => {
       sourceSequence: null,
     });
     expect(inputs[1]!.activity).toStrictEqual([]);
+    await expect(diagnostics()).resolves.toContainEqual(
+      expect.objectContaining({
+        level: "info",
+        message: "Activity snapshot cleanup",
+        fields: {
+          context: "api:run-activity",
+          outcome: "success",
+          removed: 1,
+          retentionMs: 86_400_000,
+        },
+      }),
+    );
   });
 });

--- a/turbo/apps/api/src/signals/services/chat-activity-summary.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-activity-summary.service.ts
@@ -318,7 +318,7 @@ async function generateSummary(
 ): Promise<ActivitySummaryResponse> {
   const claimed = await claimSummary(db, identity);
   if (claimed.kind === "response") {
-    log.debug("Activity summary cache", {
+    log.info("Activity summary cache", {
       runId: identity.runId,
       outcome: claimed.response.status,
     });
@@ -329,7 +329,7 @@ async function generateSummary(
     return emptyResponse(identity.runId, "ineligible");
   }
   signal.throwIfAborted();
-  log.debug("Activity summary attempt", { runId: identity.runId });
+  log.info("Activity summary attempt", { runId: identity.runId });
   const started = performance.now();
   const deadline = AbortSignal.timeout(SUMMARY_DEADLINE_MS);
   const result = await settleIncludingAbort(
@@ -359,7 +359,7 @@ async function generateSummary(
     MAX_COOLDOWN_MS,
     Math.max(FAILURE_COOLDOWN_MS, retryAfterMs ?? 0),
   );
-  log.debug("Activity summary completion", {
+  const completion = {
     runId: identity.runId,
     outcome: phrase
       ? "success"
@@ -370,7 +370,15 @@ async function generateSummary(
           : "invalid_or_unconfigured",
     durationMs: Math.round(performance.now() - started),
     cooldownMs: phrase ? 0 : cooldown,
-  });
+    ...(!result.ok && result.error instanceof OpenRouterRequestError
+      ? { providerStatus: result.error.status }
+      : {}),
+  };
+  if (phrase) {
+    log.info("Activity summary completion", completion);
+  } else {
+    log.warn("Activity summary completion", completion);
+  }
   const enabled = await activityEnabled(db, identity.orgId, identity.userId);
   if (!enabled) {
     return emptyResponse(identity.runId, "unavailable");
@@ -454,7 +462,7 @@ export async function requestActivitySummary(
   );
   signal.throwIfAborted();
   if (!result.ok) {
-    log.debug("Activity summary unavailable", {
+    log.warn("Activity summary unavailable", {
       runId: identity.runId,
       outcome: "storage_failed",
     });

--- a/turbo/apps/api/src/signals/services/run-activity-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/run-activity-snapshot.service.ts
@@ -167,11 +167,16 @@ export const captureRunActivity$ = command(
       return { status: 200 };
     }
     // Never attach a database error: driver messages can include bound evidence.
-    log.debug("Activity snapshot capture", {
+    const capture = {
       runId: payload.runId,
       outcome: outcome.ok ? outcome.value : "write_failed",
       eventCount: payload.events.length,
-    });
+    };
+    if (outcome.ok) {
+      log.info("Activity snapshot capture", capture);
+    } else {
+      log.warn("Activity snapshot capture", capture);
+    }
     return { status: 200 };
   },
 );
@@ -218,10 +223,15 @@ export const cleanupExpiredRunActivity$ = command(
       }),
     );
     signal.throwIfAborted();
-    log.debug("Activity snapshot cleanup", {
+    const cleanup = {
       outcome: outcome.ok ? "success" : "failed",
       removed: outcome.ok ? outcome.value : 0,
       retentionMs: ACTIVITY_RETENTION_MS,
-    });
+    };
+    if (outcome.ok) {
+      log.info("Activity snapshot cleanup", cleanup);
+    } else {
+      log.warn("Activity snapshot cleanup", cleanup);
+    }
   },
 );


### PR DESCRIPTION
Activity summary and snapshot diagnostics reached the logger at debug but were discarded by AxiomJSTransport's production-default info threshold. Promote the six existing content-free records to info for normal outcomes and warn for failures, retaining their messages, contexts, metadata and operation/batch granularity. Add only numeric `providerStatus` from `OpenRouterRequestError` to distinguish HTTP 429.

The two service-specific static-message allowlists retain the API's info-log restriction. Route tests opt into the real Axiom SDK constructors and production logger, capture ingestion with MSW, and verify safe fields, unrelated debug filtering, capture suppression, shared cooldown, optional storage failure, and no extra summary calls. The diagnostics reference documents the final levels and measurement limits. Shared production logging, gates, model budgets, API/UI contracts, persistence and release settings are unchanged.

### Validation

- 23 focused activity route tests and 51 logger/transport tests pass against local PostgreSQL with UTC configuration.
- Regression sensitivity: restoring both original debug services makes the new transport test fail with zero ingested activity records; the fixed implementation passes.
- API lint, formatting, and normal commit hooks (including Knip and type checks).
- No production test ingestion, full local Vitest suite, or development server.

### Fallbacks

None added or removed. Existing optional-failure and cooldown behavior remains intact.

Fixes #32986
Refs #32819
