### PR TITLE
fix(kms): keep oidc input readable for aws cli

### DIFF
--- a/.github/kms-migration-32264/README.md
+++ b/.github/kms-migration-32264/README.md
@@ -85,6 +85,13 @@ provenance is checked before using its configuration. Plaintext credentials,
 database URIs, OIDC tokens, and data keys remain in process memory and child
 environments; only sanitized metadata and checkpoints enter artifacts.
 
+The Linux workflow passes STS input through an anonymous memory file so AWS CLI
+can read its JSON more than once without consuming a pipe or persisting the OIDC
+token. On an AWS CLI failure, `operation.json` retains `awsFailure` with an
+allowlisted operation name, error code, and exit status. Unknown error names and
+raw stdout/stderr remain suppressed; inspect this checkpoint before changing IAM
+permissions or retrying the production job.
+
 The expected deployment is checked before verification, before mutation, and
 after the operation. A concurrent deployment stops successful certification;
 it does not automatically undo completed rows. Keep both keys and both runtime

--- a/.github/scripts/kms-production-migration.py
+++ b/.github/scripts/kms-production-migration.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Run protected production KMS verification or a bounded ciphertext migration."""
 
+from contextlib import ExitStack
 import datetime
 import hashlib
 import json
@@ -31,6 +32,45 @@ CONFIG_NAMES = {
 
 class MigrationError(Exception):
     """Only fixed failure codes may reach logs; provider bodies stay in memory."""
+
+
+class AwsOperationError(MigrationError):
+    """Retain only an allowlisted operation/error and the CLI exit status."""
+
+    def __init__(self, operation, result):
+        match = re.search(r"An error occurred \(([A-Za-z0-9]+)\)", result.stderr)
+        error_code = "UnclassifiedAwsCliFailure"
+        if match and match[1] in {
+            "AccessDenied", "AccessDeniedException", "ExpiredToken",
+            "ExpiredTokenException", "IDPCommunicationError", "IDPRejectedClaim",
+            "InvalidClientTokenId", "InvalidIdentityToken", "MalformedPolicyDocument",
+            "PackedPolicyTooLarge", "RegionDisabledException", "RequestExpired",
+            "ServiceUnavailable", "SignatureDoesNotMatch", "Throttling",
+            "ThrottlingException", "ValidationError",
+        }:
+            error_code = match[1]
+        elif any(
+            prefix in result.stderr
+            for prefix in (
+                "Error parsing parameter '--cli-input-json':",
+                "Error parsing parameter 'cli-input-json':",
+            )
+        ):
+            error_code = "CliInputError"
+        elif "Parameter validation failed:" in result.stderr:
+            error_code = "ParameterValidationFailed"
+        elif "SSL validation failed" in result.stderr:
+            error_code = "TlsValidationFailed"
+        elif "Could not connect to the endpoint URL" in result.stderr:
+            error_code = "EndpointConnectionFailed"
+        elif "Unable to locate credentials" in result.stderr:
+            error_code = "CredentialsUnavailable"
+        self.details = {
+            "operation": operation,
+            "errorCode": error_code,
+            "exitCode": result.returncode,
+        }
+        super().__init__("aws_operation_failed:" + operation + ":" + error_code)
 
 
 def require(condition, code):
@@ -100,16 +140,38 @@ def oidc(audience):
 
 
 def aws(arguments, environment, payload=None):
-    result = subprocess.run(
-        ["aws", *arguments, "--region", "us-west-2", "--output", "json"],
-        input=None if payload is None else json.dumps(payload),
-        env=environment,
-        text=True,
-        capture_output=True,
-        timeout=45,
-        check=False,
-    )
-    require(result.returncode == 0, "aws_operation_failed")
+    operation = {
+        ("sts", "get-caller-identity"): "sts:GetCallerIdentity",
+        ("sts", "assume-role-with-web-identity"): "sts:AssumeRoleWithWebIdentity",
+    }[tuple(arguments[:2])]
+    with ExitStack() as resources:
+        descriptors = ()
+        if payload is not None:
+            # AWS CLI can read JSON input more than once. A pipe is consumed on
+            # its first read; this anonymous Linux memory file is seekable and
+            # keeps the OIDC token out of disk files and process arguments.
+            input_file = resources.enter_context(
+                os.fdopen(os.memfd_create("kms-migration-input"), "w+")
+            )
+            json.dump(payload, input_file)
+            input_file.flush()
+            descriptors = (input_file.fileno(),)
+            arguments = [
+                *arguments,
+                "--cli-input-json",
+                "file:///proc/self/fd/" + str(input_file.fileno()),
+            ]
+        result = subprocess.run(
+            ["aws", *arguments, "--region", "us-west-2", "--output", "json"],
+            pass_fds=descriptors,
+            env=environment,
+            text=True,
+            capture_output=True,
+            timeout=45,
+            check=False,
+        )
+    if result.returncode != 0:
+        raise AwsOperationError(operation, result)
     return json.loads(result.stdout)
 
 
@@ -283,8 +345,6 @@ def assume_operator(environment):
         [
             "sts",
             "assume-role-with-web-identity",
-            "--cli-input-json",
-            "file:///dev/stdin",
         ],
         environment,
         {
@@ -544,8 +604,13 @@ def main():
             "deployment_changed_during_operation",
         )
         metadata["result"] = "passed"
-    except BaseException:
+    except BaseException as error:
         metadata["result"] = "failed"
+        metadata["failure"] = (
+            str(error) if isinstance(error, MigrationError) else "unexpected_error"
+        )
+        if isinstance(error, AwsOperationError):
+            metadata["awsFailure"] = error.details
         raise
     finally:
         metadata["finishedAt"] = datetime.datetime.now(

--- a/.github/scripts/tests/fixtures/kms-production-migration-tools.py
+++ b/.github/scripts/tests/fixtures/kms-production-migration-tools.py
@@ -50,13 +50,30 @@ if name == "pnpm":
 
 if name == "aws":
     if arguments[:2] == ["sts", "assume-role-with-web-identity"]:
-        payload = json.load(sys.stdin)
+        # Honor the real CLI's file argument and repeated reads instead of
+        # assuming a single stdin read. A consumed pipe cannot satisfy this.
+        input_path = arguments[arguments.index("--cli-input-json") + 1]
+        assert input_path.startswith("file://")
+        input_file = Path(input_path.removeprefix("file://"))
+        payload = json.loads(input_file.read_text())
+        assert json.loads(input_file.read_text()) == payload
         assert (
             payload["RoleArn"]
             == "arn:aws:iam::251964670836:role/vm0-kms-migration-github-32264"
         )
         assert payload["WebIdentityToken"] == "synthetic-oidc-token"
         state["assumeCalls"] += 1
+        if scenario.startswith("aws-"):
+            errors = {
+                "aws-access-denied": "An error occurred (AccessDenied) when calling the AssumeRoleWithWebIdentity operation: synthetic-provider-secret-must-not-be-logged",
+                "aws-invalid-identity-token": "An error occurred (InvalidIdentityToken) when calling the AssumeRoleWithWebIdentity operation: synthetic-oidc-token",
+                "aws-cli-input-error": "Error parsing parameter 'cli-input-json': Invalid JSON: synthetic-oidc-token",
+                "aws-unclassified": "An error occurred (syntheticOperatorSecret) when calling the AssumeRoleWithWebIdentity operation: synthetic-provider-secret-must-not-be-logged",
+            }
+            state_path.write_text(json.dumps(state))
+            print("synthetic-operator-session")
+            print(errors[scenario], file=sys.stderr)
+            sys.exit(255)
         result = {
             "Credentials": {
                 "AccessKeyId": "operator",

--- a/turbo/packages/db/scripts/migrations/013-kms-account-rotation/test.ts
+++ b/turbo/packages/db/scripts/migrations/013-kms-account-rotation/test.ts
@@ -361,9 +361,11 @@ async function workflowCli(
     "synthetic-source-secret",
     "synthetic-target-secret",
     "synthetic-operator-secret",
+    "syntheticOperatorSecret",
     "synthetic-operator-session",
     "synthetic-database-secret",
     "synthetic-doppler-token",
+    "synthetic-oidc-token",
     "synthetic-provider-secret-must-not-be-logged",
     "synthetic-clerk-secret",
   ]) {
@@ -409,6 +411,30 @@ try {
   assert.equal(business?.businessVerification, "passed");
   assert.equal(business.operatorReencryptAndRollback, "passed");
   assert.equal(business.targetRuntimeVerification, undefined);
+  for (const [scenario, errorCode] of [
+    ["aws-access-denied", "AccessDenied"],
+    ["aws-invalid-identity-token", "InvalidIdentityToken"],
+    ["aws-cli-input-error", "CliInputError"],
+    ["aws-unclassified", "UnclassifiedAwsCliFailure"],
+  ]) {
+    const rejected = await workflowCli(
+      "workflow-business-" + scenario,
+      "verify-business",
+      scenario,
+    );
+    assert.equal(rejected?.result, "failed");
+    assert.deepEqual(rejected.awsFailure, {
+      operation: "sts:AssumeRoleWithWebIdentity",
+      errorCode,
+      exitCode: 255,
+    });
+    assert.equal(
+      rejected.failure,
+      "aws_operation_failed:sts:AssumeRoleWithWebIdentity:" + errorCode,
+    );
+    assert.equal(rejected.businessVerification, undefined);
+    assert.equal(rejected.operatorReencryptAndRollback, undefined);
+  }
   for (const scenario of [
     "business-incomplete",
     "wrong-operator",


### PR DESCRIPTION
Production business verification [34349931246](https://github.com/vm0-ai/vm0/actions/runs/34349931246) stopped during migration-role setup after the runtime canary and rollback passed. Its STS JSON was supplied through a one-shot stdin pipe, and the report retained only `aws_operation_failed`.

Pass the STS input through an anonymous Linux memory file that AWS CLI can reopen without consuming the token. The descriptor is closed after the subprocess; the token stays out of disk files and process arguments. Retain an allowlisted AWS operation, error code, and CLI exit status in the failure checkpoint while suppressing unknown error names and raw stdout/stderr. Extend the real workflow-driver integration to exercise repeated input reads, classified failures, and secret-free failure artifacts.

Validation:
- A real AWS CLI 1.46.1 reproduction read 167 bytes and then zero bytes from the pipe and failed with invalid JSON; the memory-file request succeeded against a local synthetic STS endpoint. The production runner uses AWS CLI 2.36.35, so production verification must still be rerun after merge.
- `test:kms-rotation` passed, including driver failure guards and all eight business-canary scenarios; database-package types, ESLint, Oxlint, type-aware Oxlint, Knip, formatting, and Python compilation passed.

Related to #32264. Production business-flow verification and cleanup remain required before any historical backfill.
