### PR TITLE
test(app): await page readiness before activity switch assertion

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-activity-summary.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-activity-summary.test.tsx
@@ -217,16 +217,13 @@ test("Authoritative switch activation replaces the legacy fallback in the mounte
       return respond(200, summary({ status: "pending", phrase: null }));
     },
   );
-  const page = startPage({
+  await setupPage({
     context,
     path: RUN_PATH,
     cachedFeatureSwitches: { [FeatureSwitchKey.ThreadActivitySummary]: false },
   });
   await expect(screen.findByText(LEGACY_FALLBACK)).resolves.toBeVisible();
   featureResponse.resolve(undefined);
-  await (
-    await page
-  ).ready;
   await expect(screen.findByText("Thinking...")).resolves.toBeVisible();
   expect(screen.queryByText(LEGACY_FALLBACK)).not.toBeInTheDocument();
   events.push(


### PR DESCRIPTION
The activity-summary switch activation test starts querying for the cached legacy fallback before the chat page is ready. It failed in [the merge queue](https://github.com/vm0-ai/vm0/actions/runs/34354817280/job/102476800551) after #33000, and the same assertion fails locally on the unchanged test.

Await the existing `setupPage` helper before the first assertion. This waits for initial page content while the authoritative feature-switch response remains deferred, so the test still verifies the cached fallback changing to `Thinking...` in the mounted thread and subsequent commentary updates. All assertions and the controlled response are preserved.

Validation: the unchanged targeted test reproduced the failure; the fixed test passed five consecutive runs; all 23 tests in `chat-activity-summary.test.tsx` passed. Targeted lint, formatting, test type checking, and platform Knip checks passed.
