### PR TITLE
feat(app): put the connector shelves on cards and drop the yours tab

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1968,7 +1968,6 @@
       "directory": {
         "allCategories": "Alle",
         "askAdmin": "Lassen Sie diese Integration von einem Admin freischalten",
-        "browse": "Integrationen durchsuchen",
         "configure": "Konfigurieren",
         "connected": "Verbunden",
         "createCustom": "Eigene erstellen",
@@ -1980,8 +1979,6 @@
         "detailPermissions": "Berechtigungen",
         "emptyCustomBody": "Erstellen Sie eine aus einer HTTP-API oder einem MCP-Server, und Okou nutzt sie wie jede andere Integration.",
         "emptyCustomTitle": "Noch keine eigenen Integrationen",
-        "emptyYoursBody": "Verbinden Sie eine App, damit Okou darin für Sie lesen und handeln kann.",
-        "emptyYoursTitle": "Sie haben noch nichts verbunden",
         "matchCount_one": "{{count}} Treffer",
         "matchCount_other": "{{count}} Treffer",
         "moreAccounts_one": "+{{count}}",
@@ -1993,12 +1990,10 @@
         "otherCategory": "Sonstige",
         "permissionCount_one": "{{count}} Berechtigung",
         "permissionCount_other": "{{count}} Berechtigungen",
-        "searchYours": "Ihre Integrationen durchsuchen",
         "showAll_one": "Alle {{count}} anzeigen",
         "showAll_other": "Alle {{count}} anzeigen",
         "tabCustom": "Eigene",
-        "tabDiscover": "Entdecken",
-        "tabYours": "Ihre Integrationen"
+        "tabDiscover": "Entdecken"
       },
       "fallsBackTo": "Wechselt zu {{account}} zurück",
       "find": "Integrationen suchen...",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1968,7 +1968,6 @@
       "directory": {
         "allCategories": "All",
         "askAdmin": "Ask an admin to enable",
-        "browse": "Browse connectors",
         "configure": "Configure",
         "connected": "Connected",
         "createCustom": "Create custom",
@@ -1980,8 +1979,6 @@
         "detailPermissions": "Permissions",
         "emptyCustomBody": "Build one from any HTTP API or MCP server, and Okou can use it like any other connector.",
         "emptyCustomTitle": "No custom connectors yet",
-        "emptyYoursBody": "Connect an app and Okou can read and act in it for you.",
-        "emptyYoursTitle": "You haven't connected anything yet",
         "matchCount_one": "{{count}} match",
         "matchCount_other": "{{count}} matches",
         "moreAccounts_one": "+{{count}}",
@@ -1993,12 +1990,10 @@
         "otherCategory": "Other",
         "permissionCount_one": "{{count}} permission",
         "permissionCount_other": "{{count}} permissions",
-        "searchYours": "Search your connectors",
         "showAll_one": "Show all {{count}}",
         "showAll_other": "Show all {{count}}",
         "tabCustom": "Custom",
-        "tabDiscover": "Discover",
-        "tabYours": "Your connectors"
+        "tabDiscover": "Discover"
       },
       "fallsBackTo": "Falls back to {{account}}",
       "find": "Find connectors...",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1998,7 +1998,6 @@
       "directory": {
         "allCategories": "Todos",
         "askAdmin": "Pide a un administrador que lo habilite",
-        "browse": "Explorar conectores",
         "configure": "Configurar",
         "connected": "Conectado",
         "createCustom": "Crear personalizado",
@@ -2010,8 +2009,6 @@
         "detailPermissions": "Permisos",
         "emptyCustomBody": "Crea uno a partir de cualquier API HTTP o servidor MCP y Okou podrá usarlo como cualquier otro conector.",
         "emptyCustomTitle": "Aún no hay conectores personalizados",
-        "emptyYoursBody": "Conecta una aplicación y Okou podrá leer y actuar en ella por ti.",
-        "emptyYoursTitle": "Aún no has conectado nada",
         "matchCount_one": "{{count}} resultado",
         "matchCount_many": "{{count}} resultados",
         "matchCount_other": "{{count}} resultados",
@@ -2026,13 +2023,11 @@
         "permissionCount_one": "{{count}} permiso",
         "permissionCount_many": "{{count}} permisos",
         "permissionCount_other": "{{count}} permisos",
-        "searchYours": "Buscar tus conectores",
         "showAll_one": "Ver los {{count}}",
         "showAll_many": "Ver los {{count}}",
         "showAll_other": "Ver los {{count}}",
         "tabCustom": "Personalizados",
-        "tabDiscover": "Descubrir",
-        "tabYours": "Tus conectores"
+        "tabDiscover": "Descubrir"
       },
       "fallsBackTo": "Usa {{account}} como alternativa",
       "find": "Buscar conectores...",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1998,7 +1998,6 @@
       "directory": {
         "allCategories": "Tous",
         "askAdmin": "Demandez à un administrateur de l'activer",
-        "browse": "Parcourir les connecteurs",
         "configure": "Configurer",
         "connected": "Connecté",
         "createCustom": "Créer un connecteur",
@@ -2010,8 +2009,6 @@
         "detailPermissions": "Autorisations",
         "emptyCustomBody": "Créez-en un à partir de n'importe quelle API HTTP ou serveur MCP, et Okou l'utilisera comme les autres.",
         "emptyCustomTitle": "Aucun connecteur personnalisé",
-        "emptyYoursBody": "Connectez une application et Okou pourra y lire et y agir pour vous.",
-        "emptyYoursTitle": "Vous n'avez encore rien connecté",
         "matchCount_one": "{{count}} résultat",
         "matchCount_many": "{{count}} résultats",
         "matchCount_other": "{{count}} résultats",
@@ -2026,13 +2023,11 @@
         "permissionCount_one": "{{count}} autorisation",
         "permissionCount_many": "{{count}} autorisations",
         "permissionCount_other": "{{count}} autorisations",
-        "searchYours": "Rechercher vos connecteurs",
         "showAll_one": "Afficher les {{count}}",
         "showAll_many": "Afficher les {{count}}",
         "showAll_other": "Afficher les {{count}}",
         "tabCustom": "Personnalisés",
-        "tabDiscover": "Découvrir",
-        "tabYours": "Vos connecteurs"
+        "tabDiscover": "Découvrir"
       },
       "fallsBackTo": "Utilise {{account}} en repli",
       "find": "Rechercher des connecteurs...",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1968,7 +1968,6 @@
       "directory": {
         "allCategories": "सभी",
         "askAdmin": "इसे चालू करने के लिए एडमिन से कहें",
-        "browse": "कनेक्टर्स देखें",
         "configure": "कॉन्फ़िगर करें",
         "connected": "कनेक्टेड",
         "createCustom": "कस्टम बनाएँ",
@@ -1980,8 +1979,6 @@
         "detailPermissions": "अनुमतियाँ",
         "emptyCustomBody": "किसी भी HTTP API या MCP सर्वर से एक बनाएँ, और Okou उसे बाकी कनेक्टर्स की तरह इस्तेमाल कर सकेगा।",
         "emptyCustomTitle": "अभी कोई कस्टम कनेक्टर नहीं है",
-        "emptyYoursBody": "कोई ऐप कनेक्ट करें और Okou आपके लिए उसमें पढ़ और काम कर सकेगा।",
-        "emptyYoursTitle": "आपने अभी तक कुछ नहीं जोड़ा है",
         "matchCount_one": "{{count}} परिणाम",
         "matchCount_other": "{{count}} परिणाम",
         "moreAccounts_one": "+{{count}}",
@@ -1993,12 +1990,10 @@
         "otherCategory": "अन्य",
         "permissionCount_one": "{{count}} अनुमति",
         "permissionCount_other": "{{count}} अनुमतियाँ",
-        "searchYours": "अपने कनेक्टर्स खोजें",
         "showAll_one": "सभी {{count}} देखें",
         "showAll_other": "सभी {{count}} देखें",
         "tabCustom": "कस्टम",
-        "tabDiscover": "खोजें",
-        "tabYours": "आपके कनेक्टर्स"
+        "tabDiscover": "खोजें"
       },
       "fallsBackTo": "{{account}} पर वापस जाता है",
       "find": "कनेक्टर ढूंढें...",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1965,7 +1965,6 @@
       "directory": {
         "allCategories": "Semua",
         "askAdmin": "Minta admin untuk mengaktifkan",
-        "browse": "Jelajahi konektor",
         "configure": "Konfigurasi",
         "connected": "Terhubung",
         "createCustom": "Buat kustom",
@@ -1977,8 +1976,6 @@
         "detailPermissions": "Izin",
         "emptyCustomBody": "Buat satu dari API HTTP atau server MCP mana pun, dan Okou dapat menggunakannya seperti konektor lain.",
         "emptyCustomTitle": "Belum ada konektor kustom",
-        "emptyYoursBody": "Hubungkan aplikasi dan Okou dapat membaca serta bertindak di dalamnya untuk Anda.",
-        "emptyYoursTitle": "Anda belum menghubungkan apa pun",
         "matchCount_other": "{{count}} hasil",
         "moreAccounts_other": "+{{count}}",
         "needsAttention": "Perlu perhatian",
@@ -1987,11 +1984,9 @@
         "openDetailAria": "Buka detail {{connector}}",
         "otherCategory": "Lainnya",
         "permissionCount_other": "{{count}} izin",
-        "searchYours": "Cari konektor Anda",
         "showAll_other": "Lihat semua {{count}}",
         "tabCustom": "Kustom",
-        "tabDiscover": "Temukan",
-        "tabYours": "Konektor Anda"
+        "tabDiscover": "Temukan"
       },
       "fallsBackTo": "Beralih kembali ke {{account}}",
       "find": "Cari konektor...",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1998,7 +1998,6 @@
       "directory": {
         "allCategories": "Tutti",
         "askAdmin": "Chiedi a un amministratore di abilitarlo",
-        "browse": "Esplora i connettori",
         "configure": "Configura",
         "connected": "Connesso",
         "createCustom": "Crea personalizzato",
@@ -2010,8 +2009,6 @@
         "detailPermissions": "Autorizzazioni",
         "emptyCustomBody": "Creane uno da qualsiasi API HTTP o server MCP e Okou potrà usarlo come ogni altro connettore.",
         "emptyCustomTitle": "Nessun connettore personalizzato",
-        "emptyYoursBody": "Connetti un'app e Okou potrà leggerla e agire al posto tuo.",
-        "emptyYoursTitle": "Non hai ancora connesso nulla",
         "matchCount_one": "{{count}} risultato",
         "matchCount_many": "{{count}} risultati",
         "matchCount_other": "{{count}} risultati",
@@ -2026,13 +2023,11 @@
         "permissionCount_one": "{{count}} autorizzazione",
         "permissionCount_many": "{{count}} autorizzazioni",
         "permissionCount_other": "{{count}} autorizzazioni",
-        "searchYours": "Cerca tra i tuoi connettori",
         "showAll_one": "Mostra tutti ({{count}})",
         "showAll_many": "Mostra tutti ({{count}})",
         "showAll_other": "Mostra tutti ({{count}})",
         "tabCustom": "Personalizzati",
-        "tabDiscover": "Scopri",
-        "tabYours": "I tuoi connettori"
+        "tabDiscover": "Scopri"
       },
       "fallsBackTo": "Passa a {{account}} come alternativa",
       "find": "Trova connettori...",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1965,7 +1965,6 @@
       "directory": {
         "allCategories": "すべて",
         "askAdmin": "管理者に有効化を依頼してください",
-        "browse": "コネクターを見る",
         "configure": "設定",
         "connected": "接続済み",
         "createCustom": "カスタムを作成",
@@ -1977,8 +1976,6 @@
         "detailPermissions": "権限",
         "emptyCustomBody": "HTTP API や MCP サーバーから作成すると、Okou は他のコネクターと同じように使えます。",
         "emptyCustomTitle": "カスタムコネクターはまだありません",
-        "emptyYoursBody": "アプリを接続すると、Okou が代わりに読み取り、操作できます。",
-        "emptyYoursTitle": "まだ何も接続していません",
         "matchCount_other": "{{count}} 件の一致",
         "moreAccounts_other": "+{{count}}",
         "needsAttention": "対応が必要",
@@ -1987,11 +1984,9 @@
         "openDetailAria": "{{connector}} の詳細を開く",
         "otherCategory": "その他",
         "permissionCount_other": "{{count}} 件の権限",
-        "searchYours": "接続済みのコネクターを検索",
         "showAll_other": "すべて表示 ({{count}})",
         "tabCustom": "カスタム",
-        "tabDiscover": "見つける",
-        "tabYours": "接続済み"
+        "tabDiscover": "見つける"
       },
       "fallsBackTo": "{{account}} にフォールバック",
       "find": "コネクタを検索...",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1965,7 +1965,6 @@
       "directory": {
         "allCategories": "전체",
         "askAdmin": "관리자에게 활성화를 요청하세요",
-        "browse": "커넥터 둘러보기",
         "configure": "설정",
         "connected": "연결됨",
         "createCustom": "커스텀 만들기",
@@ -1977,8 +1976,6 @@
         "detailPermissions": "권한",
         "emptyCustomBody": "HTTP API나 MCP 서버로 만들면 Okou가 다른 커넥터와 똑같이 사용할 수 있습니다.",
         "emptyCustomTitle": "아직 커스텀 커넥터가 없습니다",
-        "emptyYoursBody": "앱을 연결하면 Okou가 대신 읽고 작업할 수 있습니다.",
-        "emptyYoursTitle": "아직 아무것도 연결하지 않았습니다",
         "matchCount_other": "{{count}}개 일치",
         "moreAccounts_other": "+{{count}}",
         "needsAttention": "확인 필요",
@@ -1987,11 +1984,9 @@
         "openDetailAria": "{{connector}} 세부 정보 열기",
         "otherCategory": "기타",
         "permissionCount_other": "권한 {{count}}개",
-        "searchYours": "내 커넥터 검색",
         "showAll_other": "전체 {{count}}개 보기",
         "tabCustom": "커스텀",
-        "tabDiscover": "탐색",
-        "tabYours": "내 커넥터"
+        "tabDiscover": "탐색"
       },
       "fallsBackTo": "{{account}} 계정으로 대체",
       "find": "커넥터 찾기...",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1998,7 +1998,6 @@
       "directory": {
         "allCategories": "Todos",
         "askAdmin": "Peça a um administrador para habilitar",
-        "browse": "Explorar conectores",
         "configure": "Configurar",
         "connected": "Conectado",
         "createCustom": "Criar personalizado",
@@ -2010,8 +2009,6 @@
         "detailPermissions": "Permissões",
         "emptyCustomBody": "Crie um a partir de qualquer API HTTP ou servidor MCP, e o Okou poderá usá-lo como qualquer outro conector.",
         "emptyCustomTitle": "Nenhum conector personalizado ainda",
-        "emptyYoursBody": "Conecte um aplicativo e o Okou poderá ler e agir nele por você.",
-        "emptyYoursTitle": "Você ainda não conectou nada",
         "matchCount_one": "{{count}} resultado",
         "matchCount_many": "{{count}} resultados",
         "matchCount_other": "{{count}} resultados",
@@ -2026,13 +2023,11 @@
         "permissionCount_one": "{{count}} permissão",
         "permissionCount_many": "{{count}} permissões",
         "permissionCount_other": "{{count}} permissões",
-        "searchYours": "Buscar seus conectores",
         "showAll_one": "Ver todos os {{count}}",
         "showAll_many": "Ver todos os {{count}}",
         "showAll_other": "Ver todos os {{count}}",
         "tabCustom": "Personalizados",
-        "tabDiscover": "Descobrir",
-        "tabYours": "Seus conectores"
+        "tabDiscover": "Descobrir"
       },
       "fallsBackTo": "Usa {{account}} como alternativa",
       "find": "Buscar conectores...",

--- a/turbo/apps/platform/src/signals/okou-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/connectors.ts
@@ -65,8 +65,12 @@ export interface ComposerConnectorUiState {
   readonly directoryActiveIndex: number;
 }
 
-/** Which half of the directory is showing: what is connected, or what is not. */
-export type ConnectorDirectoryTab = "yours" | "discover" | "custom";
+/**
+ * Which half of the directory is showing. There is no "yours": the composer's
+ * connector popover already lists every connected connector with its accounts
+ * and permissions, so the directory is the surface for adding one.
+ */
+export type ConnectorDirectoryTab = "discover" | "custom";
 
 interface ComposerConnectorData {
   readonly relatedCatalogItems: readonly PlatformConnectorCatalogStatusItem[];
@@ -206,7 +210,7 @@ function initialComposerConnectorUiState(): ComposerConnectorUiState {
     popoverSearch: "",
     popoverSortOrder: null,
     permissionConnectorSlug: null,
-    directoryTab: "yours",
+    directoryTab: "discover",
     directoryCategory: null,
     directoryDetailSlug: null,
     directoryActiveIndex: 0,

--- a/turbo/apps/platform/src/signals/okou-page/settings/connector-shelves.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connector-shelves.ts
@@ -1,10 +1,11 @@
 import type { ConnectorCategorySection } from "./connector-categories.ts";
 
 /**
- * A shelf is one category shown six deep, closed by a cell that names what is
- * behind it. It exists because a catalog of four thousand connectors cannot be
- * browsed by a filter: the person opening it does not know the product's name,
- * so the surface has to say "Lark, Zendesk and 321 more" rather than "327".
+ * A shelf is one category shown a few cards deep, closed by a cell that names
+ * what is behind it. It exists because a catalog of four thousand connectors
+ * cannot be browsed by a filter: the person opening it does not know the
+ * product's name, so the surface has to say "Lark, Zendesk and 321 more"
+ * rather than "327".
  */
 export interface ConnectorShelf<T> {
   /** The category this shelf opens, or null for the cross-category head. */
@@ -39,7 +40,11 @@ interface ShelfConnector {
   readonly popularityRank?: number;
 }
 
-/** How many a shelf shows before it closes. */
+/**
+ * How many a shelf shows before it closes, when the caller does not say. Each
+ * surface passes the number that fills whole rows of its own card grid, so a
+ * shelf never ends on a ragged row.
+ */
 const CONNECTOR_SHELF_PREVIEW = 6;
 
 /**

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connector-directory.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connector-directory.test.tsx
@@ -75,7 +75,7 @@ async function openDirectory(
   return dialog;
 }
 
-test("Separate connected connectors from the catalog", async () => {
+test("Offer the catalog for adding, and find a connected connector by name", async () => {
   const user = userEvent.setup({ delay: null });
   installComposerConnectorFixture({ catalog: directoryCatalog() });
 
@@ -85,20 +85,26 @@ test("Separate connected connectors from the catalog", async () => {
     featureSwitches: { [FeatureSwitchKey.ConnectorDirectory]: true },
   });
 
+  // The composer's connector popover already lists what is connected, so the
+  // directory opens on what can be added and does not repeat GitHub.
   const dialog = await openDirectory(user);
-  expect(
-    within(dialog).getByRole("heading", { name: "Connected" }),
-  ).toBeVisible();
-  expect(within(dialog).getByText("GitHub")).toBeVisible();
-  // Discovery lives behind its own tab, so the catalog never mixes into the
-  // list of what is already connected.
-  expect(within(dialog).queryByText("Notion")).not.toBeInTheDocument();
-
-  await user.click(within(dialog).getByRole("radio", { name: "Discover" }));
   await waitFor(() => {
     expect(within(dialog).getByText("Notion")).toBeVisible();
   });
   expect(within(dialog).queryByText("GitHub")).not.toBeInTheDocument();
+
+  // Searching for it must still answer, or the search reads as "we do not have
+  // GitHub" for a connector the user already connected.
+  await fill(
+    within(dialog).getByPlaceholderText("Find connectors..."),
+    "github",
+  );
+  await waitFor(() => {
+    expect(within(dialog).getByText("GitHub")).toBeVisible();
+  });
+  expect(
+    within(dialog).getByRole("heading", { name: "Connected" }),
+  ).toBeVisible();
 });
 
 test("Find a connector by a tag that is not in its name", async () => {
@@ -112,7 +118,6 @@ test("Find a connector by a tag that is not in its name", async () => {
   });
 
   const dialog = await openDirectory(user);
-  await user.click(within(dialog).getByRole("radio", { name: "Discover" }));
   await fill(
     within(dialog).getByPlaceholderText("Find connectors..."),
     "email",
@@ -145,6 +150,13 @@ test("Open connector detail and step back to the list", async () => {
   });
 
   const dialog = await openDirectory(user);
+  await fill(
+    within(dialog).getByPlaceholderText("Find connectors..."),
+    "github",
+  );
+  await waitFor(() => {
+    expect(within(dialog).getByText("GitHub")).toBeVisible();
+  });
   await user.click(dialogButton(dialog, "Open GitHub details"));
 
   await waitFor(() => {
@@ -188,7 +200,6 @@ test("Keep the category chips the same width when the selection moves", async ()
   });
 
   const dialog = await openDirectory(user);
-  await user.click(within(dialog).getByRole("radio", { name: "Discover" }));
   await waitFor(() => {
     expect(within(dialog).getByText("Notion")).toBeVisible();
   });
@@ -266,14 +277,13 @@ test("Close a shelf with the products behind it, and open that category", async 
   });
 
   const dialog = await openDirectory(user);
-  await user.click(within(dialog).getByRole("radio", { name: "Discover" }));
   await waitFor(() => {
     expect(within(dialog).getByTestId("connector-shelf-mail")).toBeVisible();
   });
 
   // A count alone says nothing to someone who does not know the product names,
   // so the closing cell has to name what it stands for.
-  const tail = dialogButton(dialog, "See Zendesk, Intercom and 321 more");
+  const tail = dialogButton(dialog, "See Telegram, Lark and 323 more");
   expect(tail).toBeVisible();
 
   // A category with one ranked connector cannot fill a shelf and is offered as
@@ -302,7 +312,6 @@ test("Show a connector on one shelf only", async () => {
   });
 
   const dialog = await openDirectory(user);
-  await user.click(within(dialog).getByRole("radio", { name: "Discover" }));
   await waitFor(() => {
     expect(within(dialog).getByTestId("connector-shelf-head")).toBeVisible();
   });
@@ -323,7 +332,6 @@ test("List the catalog when it is too small for any category to fill a shelf", a
   });
 
   const dialog = await openDirectory(user);
-  await user.click(within(dialog).getByRole("radio", { name: "Discover" }));
   await waitFor(() => {
     expect(within(dialog).getByText("Notion")).toBeVisible();
   });

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-shelf.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-shelf.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
-import { ChevronRight, Loader2, Plus } from "lucide-react";
-import { cn, surfaceVariants } from "@okouai/ui";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@okouai/ui";
 import type { PlatformConnectorCatalogStatusItem } from "../../../../signals/connector-domain.ts";
 import type {
   ConnectorShelf,
@@ -8,104 +8,6 @@ import type {
 } from "../../../../signals/okou-page/settings/connector-shelves.ts";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import { DIRECTORY_HAIRLINE } from "./connector-card.tsx";
-
-/**
- * A shelf cell. The description card is three rows deep per category, so six
- * of them push the next category off the first screen; this is the same six
- * products in two rows. Descriptions come back inside a category and on search
- * results, where the reader is comparing rather than scanning.
- */
-export function ConnectorShelfRow({
-  connector,
-  connected,
-  busy,
-  active = false,
-  onActivate,
-}: {
-  readonly connector: PlatformConnectorCatalogStatusItem;
-  readonly connected: boolean;
-  readonly busy: boolean;
-  readonly active?: boolean;
-  readonly onActivate: () => void;
-}) {
-  const { t } = useTranslation();
-  return (
-    <div
-      role="button"
-      tabIndex={busy ? -1 : 0}
-      data-connector-slug={connector.slug}
-      data-active={active ? "true" : undefined}
-      aria-label={
-        connected
-          ? t(
-              ($) => {
-                return $.chat.connectors.directory.openDetailAria;
-              },
-              { connector: connector.label },
-            )
-          : t(
-              ($) => {
-                return $.connectors.card.connectAria;
-              },
-              { connector: connector.label },
-            )
-      }
-      aria-disabled={busy}
-      className={surfaceVariants({
-        radius: "compact",
-        interactive: !busy,
-        className: cn(
-          "flex items-center gap-2.5 px-2.5 py-1.5",
-          busy && "cursor-default",
-          active && "bg-state-selected",
-        ),
-      })}
-      onClick={() => {
-        if (!busy) {
-          onActivate();
-        }
-      }}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          if (!busy) {
-            onActivate();
-          }
-        }
-      }}
-    >
-      <span
-        className={cn(
-          "flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-gray-50",
-          DIRECTORY_HAIRLINE,
-        )}
-      >
-        <ConnectorIcon icon={connector.icon} size={18} />
-      </span>
-      <span
-        data-testid="connector-card-label"
-        className="min-w-0 flex-1 truncate text-sm font-medium text-foreground"
-      >
-        {connector.label}
-      </span>
-      <span
-        className={cn(
-          "flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground",
-          !busy && !connected && "border border-border/60",
-        )}
-        aria-hidden="true"
-      >
-        {busy ? (
-          <Loader2 size={14} className="animate-spin" />
-        ) : connected ? (
-          <ChevronRight size={14} />
-        ) : (
-          <Plus size={13} />
-        )}
-      </span>
-    </div>
-  );
-}
 
 /**
  * The closing cell. "See all 327" names nothing a reader can act on, so this
@@ -185,7 +87,7 @@ export function ConnectorShelfSection({
       </h3>
       <div
         className={cn(
-          "grid gap-2",
+          "grid gap-3",
           columns === 3
             ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
             : "grid-cols-1 sm:grid-cols-2",

--- a/turbo/apps/platform/src/views/okou-page/connector-directory-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connector-directory-dialog.tsx
@@ -31,7 +31,6 @@ import {
 } from "./components/settings/connector-card.tsx";
 import {
   ConnectorShelfChips,
-  ConnectorShelfRow,
   ConnectorShelfSection,
 } from "./components/settings/connector-shelf.tsx";
 import { CustomConnectorIcon } from "./components/settings/custom-connector-icon.tsx";
@@ -60,10 +59,6 @@ type UpdateDirectoryState = (patch: Partial<ComposerConnectorUiState>) => void;
 type RenderConnectorCard = (
   connector: PlatformConnectorCatalogStatusItem,
   connected: boolean,
-) => React.ReactNode;
-
-type RenderShelfRow = (
-  connector: PlatformConnectorCatalogStatusItem,
 ) => React.ReactNode;
 
 function DirectorySection({
@@ -336,74 +331,9 @@ function DirectoryCategoryChips({
   );
 }
 
-function DirectoryYoursPanel({
-  model,
-  renderCard,
-  onBrowse,
-  search,
-}: {
-  readonly model: ConnectorDirectoryModel;
-  readonly renderCard: RenderConnectorCard;
-  readonly onBrowse: () => void;
-  readonly search: string;
-}) {
-  const { t } = useTranslation();
-  if (model.connectedCount === 0) {
-    return (
-      <DirectoryEmptyState
-        icon={<Plus size={24} aria-hidden="true" />}
-        title={t(($) => {
-          return $.chat.connectors.directory.emptyYoursTitle;
-        })}
-        body={t(($) => {
-          return $.chat.connectors.directory.emptyYoursBody;
-        })}
-        action={
-          <Button type="button" onClick={onBrowse}>
-            {t(($) => {
-              return $.chat.connectors.directory.browse;
-            })}
-          </Button>
-        }
-      />
-    );
-  }
-  if (model.attention.length === 0 && model.healthy.length === 0) {
-    return <DirectoryNoResults query={search} />;
-  }
-  return (
-    <>
-      {model.attention.length > 0 && (
-        <DirectorySection
-          tone="warning"
-          title={t(($) => {
-            return $.chat.connectors.directory.needsAttention;
-          })}
-        >
-          {model.attention.map((item) => {
-            return renderCard(item, true);
-          })}
-        </DirectorySection>
-      )}
-      {model.healthy.length > 0 && (
-        <DirectorySection
-          title={t(($) => {
-            return $.chat.connectors.directory.connected;
-          })}
-        >
-          {model.healthy.map((item) => {
-            return renderCard(item, true);
-          })}
-        </DirectorySection>
-      )}
-    </>
-  );
-}
-
 function DirectoryDiscoverPanel({
   model,
   renderCard,
-  renderShelfRow,
   search,
   category,
   onSelectCategory,
@@ -411,25 +341,42 @@ function DirectoryDiscoverPanel({
 }: {
   readonly model: ConnectorDirectoryModel;
   readonly renderCard: RenderConnectorCard;
-  readonly renderShelfRow: RenderShelfRow;
   readonly search: string;
   readonly category: string | null;
   readonly onSelectCategory: (category: string) => void;
   readonly onCreateCustom: () => void;
 }) {
   const { t } = useTranslation();
-  if (model.discover.length === 0) {
+  // Connection health has no other home in the composer: the connector popover
+  // lists what is connected but not whether it still works.
+  const attention =
+    model.attention.length > 0 ? (
+      <DirectorySection
+        tone="warning"
+        title={t(($) => {
+          return $.chat.connectors.directory.needsAttention;
+        })}
+      >
+        {model.attention.map((item) => {
+          return renderCard(item, true);
+        })}
+      </DirectorySection>
+    ) : null;
+  if (model.discover.length === 0 && model.matchedConnected.length === 0) {
     return (
-      <DirectoryNoResults
-        query={search}
-        action={
-          <Button type="button" variant="outline" onClick={onCreateCustom}>
-            {t(($) => {
-              return $.chat.connectors.directory.createCustom;
-            })}
-          </Button>
-        }
-      />
+      <>
+        {attention}
+        <DirectoryNoResults
+          query={search}
+          action={
+            <Button type="button" variant="outline" onClick={onCreateCustom}>
+              {t(($) => {
+                return $.chat.connectors.directory.createCustom;
+              })}
+            </Button>
+          }
+        />
+      </>
     );
   }
   // A query or a chosen category is already a filter: show what matched as one
@@ -442,22 +389,39 @@ function DirectoryDiscoverPanel({
     model.shelfLayout.shelves.length === 0
   ) {
     return (
-      <DirectorySection
-        title={t(
-          ($) => {
-            return $.chat.connectors.directory.matchCount;
-          },
-          { count: model.discover.length },
+      <>
+        {attention}
+        {model.matchedConnected.length > 0 && (
+          <DirectorySection
+            title={t(($) => {
+              return $.chat.connectors.directory.connected;
+            })}
+          >
+            {model.matchedConnected.map((item) => {
+              return renderCard(item, true);
+            })}
+          </DirectorySection>
         )}
-      >
-        {model.discover.map((item) => {
-          return renderCard(item, false);
-        })}
-      </DirectorySection>
+        {model.discover.length > 0 && (
+          <DirectorySection
+            title={t(
+              ($) => {
+                return $.chat.connectors.directory.matchCount;
+              },
+              { count: model.discover.length },
+            )}
+          >
+            {model.discover.map((item) => {
+              return renderCard(item, false);
+            })}
+          </DirectorySection>
+        )}
+      </>
     );
   }
   return (
     <>
+      {attention}
       {model.shelfLayout.shelves.map((shelf) => {
         return (
           <ConnectorShelfSection
@@ -467,7 +431,7 @@ function DirectoryDiscoverPanel({
             onOpenCategory={onSelectCategory}
           >
             {shelf.connectors.map((item) => {
-              return renderShelfRow(item);
+              return renderCard(item, false);
             })}
           </ConnectorShelfSection>
         );
@@ -553,11 +517,6 @@ function DirectoryToolbar({
             return $.chat.connectors.title;
           })}
         >
-          <SegmentControlItem value="yours">
-            {t(($) => {
-              return $.chat.connectors.directory.tabYours;
-            })}
-          </SegmentControlItem>
           <SegmentControlItem value="discover">
             {t(($) => {
               return $.chat.connectors.directory.tabDiscover;
@@ -579,15 +538,9 @@ function DirectoryToolbar({
         <Input
           type="text"
           className="pl-9"
-          placeholder={
-            tab === "yours"
-              ? t(($) => {
-                  return $.chat.connectors.directory.searchYours;
-                })
-              : t(($) => {
-                  return $.chat.connectors.find;
-                })
-          }
+          placeholder={t(($) => {
+            return $.chat.connectors.find;
+          })}
           value={search}
           onChange={(event) => {
             onSearchChange(event.target.value);
@@ -604,7 +557,6 @@ function DirectoryBody({
   loading,
   model,
   renderCard,
-  renderShelfRow,
   search,
   category,
   onUpdateState,
@@ -614,7 +566,6 @@ function DirectoryBody({
   readonly loading: boolean;
   readonly model: ConnectorDirectoryModel;
   readonly renderCard: RenderConnectorCard;
-  readonly renderShelfRow: RenderShelfRow;
   readonly search: string;
   readonly category: string | null;
   readonly onUpdateState: UpdateDirectoryState;
@@ -623,24 +574,11 @@ function DirectoryBody({
   if (loading) {
     return <DirectorySkeleton />;
   }
-  if (tab === "yours") {
-    return (
-      <DirectoryYoursPanel
-        model={model}
-        renderCard={renderCard}
-        search={search}
-        onBrowse={() => {
-          onUpdateState({ directoryTab: "discover", directoryActiveIndex: 0 });
-        }}
-      />
-    );
-  }
   if (tab === "discover") {
     return (
       <DirectoryDiscoverPanel
         model={model}
         renderCard={renderCard}
-        renderShelfRow={renderShelfRow}
         search={search}
         category={category}
         onSelectCategory={(next) => {
@@ -667,7 +605,6 @@ function DirectoryBrowseView({
   loading,
   model,
   renderCard,
-  renderShelfRow,
   onUpdateState,
   onConnectCustom,
 }: {
@@ -677,7 +614,6 @@ function DirectoryBrowseView({
   readonly loading: boolean;
   readonly model: ConnectorDirectoryModel;
   readonly renderCard: RenderConnectorCard;
-  readonly renderShelfRow: RenderShelfRow;
   readonly onUpdateState: UpdateDirectoryState;
   readonly onConnectCustom: (connector: CustomConnectorResponse) => void;
 }) {
@@ -719,7 +655,6 @@ function DirectoryBrowseView({
           loading={loading}
           model={model}
           renderCard={renderCard}
-          renderShelfRow={renderShelfRow}
           search={search}
           category={category}
           onUpdateState={onUpdateState}
@@ -775,13 +710,7 @@ function navigableDirectorySlugs(
   tab: ConnectorDirectoryTab,
   model: ConnectorDirectoryModel,
 ): readonly ConnectorSlug[] {
-  if (tab === "yours") {
-    return model.yoursSlugs;
-  }
-  if (tab === "discover") {
-    return model.discoverSlugs;
-  }
-  return [];
+  return tab === "discover" ? model.discoverSlugs : [];
 }
 
 function createDirectoryKeyDownHandler({
@@ -835,47 +764,6 @@ function createDirectoryKeyDownHandler({
     } else if (!connecting) {
       launchConnectorConnect({ connector: target, ...connectHandlers(target) });
     }
-  };
-}
-
-/**
- * A shelf cell opens what the reader already has and connects what they don't,
- * which is the same split the card grid makes; keeping it here leaves the
- * dialog holding state rather than behaviour.
- */
-function createDirectoryShelfRowRenderer({
-  connecting,
-  activeSlug,
-  connectHandlers,
-  onUpdateState,
-}: {
-  readonly connecting: boolean;
-  readonly activeSlug: ConnectorSlug | undefined;
-  readonly connectHandlers: (
-    connector: PlatformConnectorCatalogStatusItem,
-  ) => ConnectorConnectHandlers;
-  readonly onUpdateState: UpdateDirectoryState;
-}): RenderShelfRow {
-  return (connector) => {
-    return (
-      <ConnectorShelfRow
-        key={connector.slug}
-        connector={connector}
-        connected={connector.connected}
-        busy={connecting}
-        active={activeSlug === connector.slug}
-        onActivate={() => {
-          if (connector.connected) {
-            onUpdateState({ directoryDetailSlug: connector.slug });
-            return;
-          }
-          launchConnectorConnect({
-            connector,
-            ...connectHandlers(connector),
-          });
-        }}
-      />
-    );
   };
 }
 
@@ -1024,13 +912,6 @@ export function ConnectorDirectoryDialog({
     );
   };
 
-  const renderShelfRow = createDirectoryShelfRowRenderer({
-    connecting,
-    activeSlug,
-    connectHandlers,
-    onUpdateState,
-  });
-
   const handleKeyDown = createDirectoryKeyDownHandler({
     activeIndex: state.directoryActiveIndex,
     navigableSlugs,
@@ -1076,7 +957,6 @@ export function ConnectorDirectoryDialog({
             loading={loading}
             model={model}
             renderCard={renderCard}
-            renderShelfRow={renderShelfRow}
             onUpdateState={onUpdateState}
             onConnectCustom={onConnectCustom}
           />

--- a/turbo/apps/platform/src/views/okou-page/connector-directory-model.ts
+++ b/turbo/apps/platform/src/views/okou-page/connector-directory-model.ts
@@ -21,15 +21,17 @@ import { localizeConnectorCategoryMetadata } from "./components/settings/connect
 export interface ConnectorDirectoryModel {
   /** Connected connectors whose connection or permissions need a fix. */
   readonly attention: readonly PlatformConnectorCatalogStatusItem[];
-  /** Connected connectors that are working. */
-  readonly healthy: readonly PlatformConnectorCatalogStatusItem[];
+  /**
+   * Connected connectors matching the current search. Discovery only offers
+   * what can be added, so without these a search for something already
+   * connected would answer "no match".
+   */
+  readonly matchedConnected: readonly PlatformConnectorCatalogStatusItem[];
   readonly discover: readonly PlatformConnectorCatalogStatusItem[];
   readonly custom: readonly CustomConnectorResponse[];
   readonly categorySections: readonly ConnectorCategorySection<PlatformConnectorCatalogStatusItem>[];
   /** Shelves for the default browse view: no search, no chosen category. */
   readonly shelfLayout: ConnectorShelfLayout<PlatformConnectorCatalogStatusItem>;
-  readonly connectedCount: number;
-  readonly yoursSlugs: readonly ConnectorSlug[];
   readonly discoverSlugs: readonly ConnectorSlug[];
   readonly bySlug: ReadonlyMap<
     ConnectorSlug,
@@ -101,8 +103,8 @@ export function buildConnectorDirectoryModel({
   const matchedConnected = connected.filter((connector) => {
     return matchesConnectorDirectorySearch(search, connector);
   });
-  const attention = matchedConnected.filter(needsAttention);
-  const healthy = matchedConnected.filter((connector) => {
+  const attention = connected.filter(needsAttention);
+  const searchedConnected = matchedConnected.filter((connector) => {
     return !needsAttention(connector);
   });
   const discover = unconnected.filter((connector) => {
@@ -127,6 +129,8 @@ export function buildConnectorDirectoryModel({
     sections: categorySections,
     categoryCounts,
     headLabel: headShelfLabel,
+    // The dialog's card grid is two wide, so four is two whole rows.
+    previewSize: 4,
   });
   const categoryLabels = new Map(
     categorySections.map((section) => {
@@ -136,13 +140,11 @@ export function buildConnectorDirectoryModel({
 
   return {
     attention,
-    healthy,
+    matchedConnected: search.trim() ? searchedConnected : [],
     discover,
     custom,
     categorySections,
     shelfLayout,
-    connectedCount: connected.length,
-    yoursSlugs: [...slugsOf(attention), ...slugsOf(healthy)],
     discoverSlugs:
       search.trim() || category !== null || shelfLayout.shelves.length === 0
         ? slugsOf(discover)

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -80,7 +80,6 @@ import {
 } from "./components/settings/connector-card.tsx";
 import {
   ConnectorShelfChips,
-  ConnectorShelfRow,
   ConnectorShelfSection,
 } from "./components/settings/connector-shelf.tsx";
 import {
@@ -712,23 +711,15 @@ function ConnectorCategoryGroupSection({
 function ConnectorShelfBrowse({
   connected,
   layout,
-  busySlugs,
   renderCard,
   onOpenCategory,
-  onConnect,
-  onOpenConnected,
 }: {
   readonly connected: readonly PlatformConnectorCatalogStatusItem[];
   readonly layout: ConnectorShelfLayout<PlatformConnectorCatalogStatusItem>;
-  readonly busySlugs: ReadonlySet<ConnectorSlug>;
   readonly renderCard: (
     connector: PlatformConnectorCatalogStatusItem,
   ) => ReactNode;
   readonly onOpenCategory: (category: string) => void;
-  readonly onConnect: (connector: PlatformConnectorCatalogStatusItem) => void;
-  readonly onOpenConnected: (
-    connector: PlatformConnectorCatalogStatusItem,
-  ) => void;
 }) {
   const { t } = useTranslation();
   return (
@@ -757,23 +748,7 @@ function ConnectorShelfBrowse({
               columns={3}
               onOpenCategory={onOpenCategory}
             >
-              {shelf.connectors.map((connector) => {
-                return (
-                  <ConnectorShelfRow
-                    key={connector.slug}
-                    connector={connector}
-                    connected={connector.connected}
-                    busy={busySlugs.has(connector.slug)}
-                    onActivate={() => {
-                      if (connector.connected) {
-                        onOpenConnected(connector);
-                        return;
-                      }
-                      onConnect(connector);
-                    }}
-                  />
-                );
-              })}
+              {shelf.connectors.map(renderCard)}
             </ConnectorShelfSection>
           );
         })}
@@ -790,17 +765,6 @@ function discoveryCategoryCounts(
   return catalogStatusLoadable.state === "hasData"
     ? catalogStatusLoadable.data.categoryConnectorCounts
     : undefined;
-}
-
-/** The connectors a connect flow is currently in flight for. */
-function connectorBusySlugs(
-  slugs: readonly (ConnectorSlug | null)[],
-): ReadonlySet<ConnectorSlug> {
-  return new Set(
-    slugs.filter((slug): slug is ConnectorSlug => {
-      return slug !== null;
-    }),
-  );
 }
 
 interface ConnectorsBrowseModel {
@@ -863,6 +827,8 @@ function buildConnectorsBrowseModel({
     ),
     categoryCounts,
     headLabel,
+    // The page's card grid is three wide, so six is two whole rows.
+    previewSize: 6,
   });
   return {
     // Shelves need something to shelve: a catalog too small for any category to
@@ -889,25 +855,17 @@ function ConnectorsBuiltinPanel({
   shelfEnabled,
   categoryFilter,
   setCategoryFilter,
-  busySlugs,
   renderCard,
   fallback,
-  onConnect,
-  onOpenConnected,
 }: {
   readonly browse: ConnectorsBrowseModel;
   readonly shelfEnabled: boolean;
   readonly categoryFilter: string | null;
   readonly setCategoryFilter: (category: string | null) => void;
-  readonly busySlugs: ReadonlySet<ConnectorSlug>;
   readonly renderCard: (
     connector: PlatformConnectorCatalogStatusItem,
   ) => ReactNode;
   readonly fallback: ReactNode;
-  readonly onConnect: (connector: PlatformConnectorCatalogStatusItem) => void;
-  readonly onOpenConnected: (
-    connector: PlatformConnectorCatalogStatusItem,
-  ) => void;
 }) {
   return (
     <>
@@ -923,11 +881,8 @@ function ConnectorsBuiltinPanel({
         <ConnectorShelfBrowse
           connected={browse.connected}
           layout={browse.layout}
-          busySlugs={busySlugs}
           renderCard={renderCard}
           onOpenCategory={setCategoryFilter}
-          onConnect={onConnect}
-          onOpenConnected={onOpenConnected}
         />
       ) : (
         fallback
@@ -1389,11 +1344,6 @@ export function ConnectorsPage() {
     connectionFilter,
     ready: shelfEnabled && filteredCatalogItemsLoadable.state === "hasData",
   });
-  const busySlugs = connectorBusySlugs([
-    pollingAuthCodeSlug,
-    pollingDeviceAuthSlug,
-    connectFlowSlug,
-  ]);
 
   const builtinList = renderBuiltinList({
     loadingState: filteredCatalogItemsLoadable.state,
@@ -1466,18 +1416,8 @@ export function ConnectorsPage() {
                 shelfEnabled={shelfEnabled}
                 categoryFilter={categoryFilter}
                 setCategoryFilter={setCategoryFilter}
-                busySlugs={busySlugs}
                 renderCard={renderCard}
                 fallback={builtinList}
-                onConnect={(connector) => {
-                  launchConnectorConnect({
-                    connector,
-                    ...accountConnectHandlers(connector),
-                  });
-                }}
-                onOpenConnected={(connector) => {
-                  return openAccountManager(connector, signal);
-                }}
               />
             )}
 


### PR DESCRIPTION
Follow-up to #32997, from acceptance on staging.

## Card shelves

The shelf cell goes back to the description card the product already ships — **four to a shelf** in the composer dialog, **six** on the connectors page, which is two whole rows of each surface's own card grid so a shelf never ends on a ragged row. The one-line cell fitted more products per screen but gave up the description, and the description is what tells someone who does not know a product's name whether it is the one they want. That is the reader the shelves exist for.

## No "Yours" tab

The composer's connector popover already lists every connected connector with its accounts and permissions, so the tab repeated it one click further away. The directory is now simply where a connector gets added, and its segment control is `Discover | Custom`.

Two things the tab uniquely carried move into discovery rather than disappearing:

- A connected connector that needs reconnecting or a permission update still appears at the top of Discover under **Needs attention** — the popover lists what is connected but not whether it still works.
- **Search now answers with connected connectors too.** Discovery only offers what can be added, so without this a search for something already connected would report "no match" for a connector the user is currently using. Its detail panel is reached from that result.

The strings the tab owned (`tabYours`, `searchYours`, `emptyYoursTitle`, `emptyYoursBody`, `browse`) are deleted from all ten locales with it.

## Feature switch

Unchanged: everything stays behind `connectorDirectory`, one toggle for both surfaces.

## Verification

- `@okouai/app` `check-types` and `lint`, `pnpm lint:style`, `pnpm knip` — clean
- 66 tests across `connector-directory`, `connectors-catalog`, `chat-composer-connectors`, `chat-composer-connector-accounts`, `connectors-accounts`
- `connector-directory.test.tsx` covers the new search-finds-a-connected-connector path and detail-from-search; the shelf tail count moves with the four-card preview