### PR TITLE
test(api): mock video previews on the short artifact origin

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
@@ -68,7 +68,7 @@ const KLING_RESPONSE_URL =
   "https://queue.fal.run/fal-ai/kling-video/v3/4k/text-to-video/requests/kling-video-request/response";
 const KLING_VIDEO_URL = "https://v3b.fal.media/files/kling-output.mp4";
 const CLOUDFLARE_MEDIA_FRAME_URL =
-  /^https:\/\/cdn\.(?:vm7|okou)\.io\/cdn-cgi\/media\/mode=frame,time=1s,width=640,format=jpg\//u;
+  /^https:\/\/(?:a\.okou|cdn\.(?:vm7|okou))\.io\/cdn-cgi\/media\/mode=frame,time=1s,width=640,format=jpg\//u;
 const WEB_ORIGIN = "https://www.okou.test";
 
 const VIDEO_PRICING_DEFAULTS = [


### PR DESCRIPTION
The video-generation route fixture only intercepts Cloudflare frame requests on the CDN origins, while the shared test environment now uses `https://a.okou.io` for Okou artifacts. Requests to the short origin escape the fixture and reach the real CDN. In [this merge-group job](https://github.com/vm0-ai/vm0/actions/runs/34359049136/job/102491160656), a Dreamina test exceeded its five-second timeout and logged Cloudflare's real `MEDIA_TRANSFORMATION_ERROR 9404` response instead of the fixture response. The unchanged test passed in 764 ms in the preceding merge-group job.

Include `a.okou.io` in the existing media-frame handler while retaining both supported CDN origins. This keeps preview generation at the mocked external boundary; production code, timeouts, and every business assertion are unchanged.

Validation: the affected test passed five consecutive runs; all 46 tests in `video-io-generate.test.ts` passed against an isolated local PostgreSQL database. Prettier, targeted ESLint, Oxlint, type-aware Oxlint, and API Knip passed. Full API type checking passed in [CI](https://github.com/vm0-ai/vm0/actions/runs/34360801433/job/102497081031).
