### PR TITLE
docs(python): clarify process-event size and error contract

### DIFF
--- a/crates/runner/mitm-addon/src/addon_process_logging.py
+++ b/crates/runner/mitm-addon/src/addon_process_logging.py
@@ -68,8 +68,18 @@ def emit_addon_process_event(
     transport ``version`` and logger-owned ``level`` and ``message``, fields
     are passed through without an event-specific schema. Values must be JSON
     serializable. Runner-owned Axiom metadata such as time, context, service,
-    hostname, and Runner version remains authoritative. The write is best
-    effort because observability failure must not interrupt proxy traffic.
+    hostname, and Runner version remains authoritative.
+
+    The complete UTF-8 encoded record, including the prefix, JSON envelope,
+    and trailing newline, is limited to ``MAX_ADDON_PROCESS_EVENT_BYTES``
+    (4096 bytes). Only ``message`` is automatically shortened; structured
+    fields are never truncated. Callers must keep those fields within the
+    remaining encoded-record budget. If the record still exceeds the limit
+    with an empty message, ``ValueError`` is raised before any write.
+
+    The stderr write is best effort: ``OSError`` is suppressed so a write
+    failure does not interrupt proxy traffic. Input validation, serialization,
+    and record-size errors propagate to the caller.
     """
     if level not in ("warn", "error"):
         raise ValueError(f"invalid addon process event level: {level!r}")


### PR DESCRIPTION
The public `emit_addon_process_event()` docstring describes best-effort logging without explaining that oversized structured fields can raise before writing. Document the complete 4096-byte UTF-8 record budget, message-only truncation, caller responsibility for bounding structured fields, and the `ValueError` raised when the envelope cannot fit with an empty message. Clarify that only stderr write `OSError` is suppressed; validation, serialization, and size errors propagate.

This changes only the docstring. Runtime behavior, constants, dependencies, and existing tests are unchanged.

Closes #32968

## Validation

From `crates/runner/mitm-addon/`, using the locked environment:

- `uv lock --check` and `uv sync --locked`
- `uv run --no-sync ruff format --check src/addon_process_logging.py`
- `uv run --no-sync ruff check src/addon_process_logging.py`
- `uv run --no-sync python -m pytest tests/test_addon_process_logging.py` — 5 passed

`git diff --check` passed. An AST comparison against the base, excluding docstrings, confirmed identical executable code. Full local Vitest and a local dev server were not run; PR CI is separate verification.
