### PR TITLE
docs(rust): correct balloon memory-pressure rationale

### DIFF
--- a/crates/sandbox-firecracker/src/balloon.rs
+++ b/crates/sandbox-firecracker/src/balloon.rs
@@ -303,10 +303,11 @@ async fn wait_for_crash_or_stop(state_rx: &mut watch::Receiver<SandboxState>) {
 /// - **Inflate** uses `free_memory` (kernel `MemFree`) — only truly unused pages,
 ///   excluding reclaimable page cache. This prevents the balloon from evicting
 ///   file cache that improves guest I/O performance.
-/// - **Deflate** uses `available_memory` (kernel `MemAvailable`) — includes
-///   reclaimable cache, providing a more sensitive signal for memory pressure.
-///   When apps allocate memory, the kernel reclaims cache first, so `available`
-///   drops before `free` does, giving earlier deflate response.
+/// - **Deflate** uses `available_memory` (kernel `MemAvailable`) — an estimate
+///   of memory available for new applications without swapping, accounting for
+///   free memory and reclaimable cache. Low `MemFree` alone need not indicate
+///   memory pressure when reclaimable cache provides sufficient headroom;
+///   deflation responds to low estimated available headroom.
 ///
 /// Thresholds:
 /// - Inflate when `free_memory > TARGET_FREE + INFLATE_HYSTERESIS`


### PR DESCRIPTION
The balloon controller comment claimed that `MemAvailable` always drops before `MemFree`. Explain it as estimated memory available for new applications without swapping, including reclaimable capacity, and clarify why low free memory alone need not indicate pressure.

This changes only the deflation rationale in `tick`; thresholds, control flow, and existing tests remain unchanged.

Closes #32972

Validation:
- `cargo +stable fmt --manifest-path crates/sandbox-firecracker/Cargo.toml -- --check`
- `cargo +stable doc --locked --manifest-path crates/Cargo.toml --profile local -p sandbox-firecracker --no-deps --document-private-items`
- `git diff --check`; verified non-doc content and the complete test module are byte-identical to the base, and checked the rendered private-item documentation.
- Checked the wording against the [Linux kernel /proc documentation](https://docs.kernel.org/filesystems/proc.html). Runtime tests were not rerun for this documentation-only change.
