### PR TITLE
test(rust): synchronize storage timeout tests with helper readiness

### DIFF
--- a/crates/guest-control-server/src/connection.rs
+++ b/crates/guest-control-server/src/connection.rs
@@ -998,6 +998,35 @@ pub fn handle_connection_with_test_storage_resources(
     )
 }
 
+/// Holds each test storage helper before starting its real request timeout.
+///
+/// Use a zero-capacity channel. Receiving the owned child's PID starts the timer,
+/// allowing tests to establish helper readiness first. Receive or drop the
+/// receiver before joining the connection so cleanup can proceed on test failure.
+/// An optional resource path selects owned diagnostic files instead of cgroups.
+#[doc(hidden)]
+pub fn handle_connection_with_test_storage_manifest_timeout_gate(
+    stream: UnixStream,
+    program: std::path::PathBuf,
+    resource_path: Option<std::path::PathBuf>,
+    timeout_gate: std::sync::mpsc::SyncSender<u32>,
+) -> io::Result<()> {
+    handle_connection_with_mode_and_program(
+        stream,
+        ProcessContainmentMode::TestNoop,
+        EXEC_OUTPUT_DRAIN_DEADLINE,
+        ConnectionPrograms {
+            guest_storage_manifest: GuestStorageManifestProgram::for_test_timeout(
+                program,
+                resource_path,
+                timeout_gate,
+            ),
+            ..ConnectionPrograms::production()
+        },
+        MeminfoSource::production(),
+    )
+}
+
 /// Handles a host-side test connection with a test workspace mount executable
 /// and child timeout.
 #[doc(hidden)]

--- a/crates/guest-control-server/src/guest_storage_manifest.rs
+++ b/crates/guest-control-server/src/guest_storage_manifest.rs
@@ -18,7 +18,7 @@ use crate::contained_command::{
 use crate::drain::{BoundedDrainResult, DrainCancellation, drain_bounded_cancellable};
 use crate::error::to_io_error;
 use crate::log::log;
-use crate::process::{extract_exit_code, kill_and_reap_child};
+use crate::process::{ChildProcess, extract_exit_code, kill_and_reap_child};
 use crate::process_containment::{
     ExecProcessContainment, ProcessContainmentCleanupMode, ProcessContainmentError,
     ProcessContainmentMode,
@@ -45,6 +45,11 @@ pub(crate) enum GuestStorageManifestProgram {
         program: PathBuf,
         resource_path: PathBuf,
     },
+    TestTimeout {
+        program: PathBuf,
+        resource_path: Option<PathBuf>,
+        timeout_gate: mpsc::SyncSender<u32>,
+    },
 }
 
 impl GuestStorageManifestProgram {
@@ -63,11 +68,31 @@ impl GuestStorageManifestProgram {
         }
     }
 
+    pub(crate) fn for_test_timeout(
+        program: PathBuf,
+        resource_path: Option<PathBuf>,
+        timeout_gate: mpsc::SyncSender<u32>,
+    ) -> Self {
+        Self::TestTimeout {
+            program,
+            resource_path,
+            timeout_gate,
+        }
+    }
+
     fn path(&self) -> &Path {
         match self {
             Self::Production => Path::new(guest_contracts::guest_binary::STORAGE_APPLY_PATH),
             Self::Test(path) => path,
-            Self::TestResources { program, .. } => program,
+            Self::TestResources { program, .. } | Self::TestTimeout { program, .. } => program,
+        }
+    }
+
+    fn await_test_timeout_gate(&self, child_id: u32) {
+        if let Self::TestTimeout { timeout_gate, .. } = self {
+            // The test receives on a zero-capacity channel after helper readiness.
+            // If it panics and drops the receiver, continue into normal cleanup.
+            let _ = timeout_gate.send(child_id);
         }
     }
 
@@ -77,7 +102,12 @@ impl GuestStorageManifestProgram {
         mode: ProcessContainmentMode,
         run_id: &str,
     ) -> Result<ExecProcessContainment, ProcessContainmentError> {
-        if let Self::TestResources { resource_path, .. } = self {
+        if let Self::TestResources { resource_path, .. }
+        | Self::TestTimeout {
+            resource_path: Some(resource_path),
+            ..
+        } = self
+        {
             return Ok(ExecProcessContainment::for_test_storage_resources(
                 resource_path.clone(),
                 run_id,
@@ -425,6 +455,7 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
     };
     drop(drain_done_tx);
 
+    program.await_test_timeout_gate(child.id());
     let outcome = wait_with_kill_timeout_or_connection_cancelled(
         child,
         timeout_ms,

--- a/crates/guest-control-server/src/lib.rs
+++ b/crates/guest-control-server/src/lib.rs
@@ -41,6 +41,7 @@ pub use connection::handle_connection_with_test_guest_agent_program;
 pub use connection::handle_connection_with_test_guest_state_restore_program;
 pub use connection::handle_connection_with_test_memory_snapshot_path;
 pub use connection::handle_connection_with_test_storage_manifest_program;
+pub use connection::handle_connection_with_test_storage_manifest_timeout_gate;
 pub use connection::handle_connection_with_test_storage_resources;
 pub use connection::handle_connection_with_test_workspace_drive_mount_program;
 pub use connection::{

--- a/crates/guest-control-server/tests/connection/guest_storage_manifest.rs
+++ b/crates/guest-control-server/tests/connection/guest_storage_manifest.rs
@@ -1,6 +1,10 @@
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
 
 use guest_control_proto::{
     ExecCapturedOutput, ExecTermination, GUEST_STORAGE_MANIFEST_OUTPUT_LIMIT_BYTES,
@@ -78,9 +82,34 @@ fn captured(output: ExecCapturedOutput<'_>) -> (Vec<u8>, bool) {
 
 fn slow_program(pid_path: &Path) -> String {
     format!(
-        "printf '%s' \"$$\" > '{}'; cat >/dev/null; sleep 60",
+        "cat >/dev/null; sleep 60 & printf '%s' \"$$\" > '{}'; wait",
         pid_path.display()
     )
+}
+
+fn start_with_timeout_gate(
+    program: PathBuf,
+    resource_path: Option<PathBuf>,
+) -> (
+    thread::JoinHandle<std::io::Result<()>>,
+    UnixStream,
+    mpsc::Receiver<u32>,
+) {
+    // The protocol cannot order helper readiness before its timeout. Gate only
+    // the test executable; assertions still exercise the real timed wait and RPC.
+    let (timeout_tx, timeout_rx) = mpsc::sync_channel(0);
+    let (guest, mut host) = UnixStream::pair().unwrap();
+    host.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    let handle = thread::spawn(move || {
+        guest_control_server::handle_connection_with_test_storage_manifest_timeout_gate(
+            guest,
+            program,
+            resource_path,
+            timeout_tx,
+        )
+    });
+    read_guest_ready(&mut host);
+    (handle, host, timeout_rx)
 }
 
 #[test]
@@ -169,16 +198,58 @@ fn guest_storage_manifest_timeout_kills_and_reaps_process_group() {
     let pid_path = unique_pid_path("storage-manifest-timeout");
     let mut process_guard = ProcessGroupFileGuard::new(pid_path.as_str());
     let (_directory, program) = create_program(&slow_program(Path::new(pid_path.as_str())));
-    let (handle, mut host_stream) = start_guest_connection_with_storage_manifest_program(program);
+    let (handle, mut host_stream, timeout_gate) = start_with_timeout_gate(program, None);
 
     send_request(&mut host_stream, 403, 20, "run", "/run", b"{}");
     let pid = process_guard.read_pid();
+    assert_eq!(
+        timeout_gate.recv_timeout(Duration::from_secs(3)).unwrap(),
+        pid
+    );
     let result = read_result(&mut host_stream, 403);
 
     assert_eq!(result.termination, ExecTermination::TimedOut);
     wait_for_pid_exit(pid, "guest storage manifest timeout");
     process_guard.disarm();
     finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn guest_storage_manifest_can_timeout_before_helper_readiness() {
+    let fifo = unique_tmp_path("storage-manifest-not-ready", ".fifo");
+    let (_directory, program) = create_program(&format!(
+        "mkfifo '{}'; read -r ready < '{}'; printf ready",
+        fifo.as_str(),
+        fifo.as_str(),
+    ));
+    let (handle, mut host, timeout_gate) = start_with_timeout_gate(program, None);
+
+    send_request(&mut host, 412, 20, "run", "/run", b"{}");
+    // No FIFO writer exists: readiness is impossible even if the shell starts.
+    // Observe the server-owned identity without relying on a helper PID file.
+    let pid = timeout_gate.recv_timeout(Duration::from_secs(3)).unwrap();
+    let result = read_result(&mut host, 412);
+    wait_for_pid_exit(pid, "storage timeout before helper readiness");
+    assert_eq!(result.termination, ExecTermination::TimedOut);
+    assert!(result.stdout.is_empty());
+    finish_guest_connection(handle, host);
+}
+
+#[test]
+fn guest_storage_manifest_abandoned_timeout_gate_allows_connection_cleanup() {
+    let pid_path = unique_pid_path("storage-manifest-abandoned-gate");
+    let mut process_guard = ProcessGroupFileGuard::new(pid_path.as_str());
+    let (_directory, program) = create_program(&slow_program(Path::new(pid_path.as_str())));
+    let (handle, mut host, timeout_gate) = start_with_timeout_gate(program, None);
+
+    send_request(&mut host, 413, 60_000, "run", "/run", b"{}");
+    let pid = process_guard.read_pid();
+    drop(timeout_gate);
+    drop(host);
+    join_guest_connection(handle);
+
+    wait_for_pid_exit(pid, "abandoned storage timeout gate");
+    process_guard.disarm();
 }
 
 #[test]

--- a/crates/guest-control-server/tests/connection/guest_storage_manifest/resources.rs
+++ b/crates/guest-control-server/tests/connection/guest_storage_manifest/resources.rs
@@ -170,7 +170,8 @@ fn forced_storage_cleanup_retains_diagnostics_with_missing_kernel_files() {
         let mut process_guard = ProcessGroupFileGuard::new(pid_path.as_str());
         let (directory, program) = create_program(&slow_program(Path::new(pid_path.as_str())));
         fs::write(directory.path().join("cpu.max"), "max 100000\n").unwrap();
-        let (handle, mut host) = start_with_resources(program, directory.path());
+        let (handle, mut host, timeout_gate) =
+            start_with_timeout_gate(program, Some(directory.path().to_owned()));
         send_request(
             &mut host,
             504,
@@ -180,6 +181,10 @@ fn forced_storage_cleanup_retains_diagnostics_with_missing_kernel_files() {
             b"{}",
         );
         let pid = process_guard.read_pid();
+        assert_eq!(
+            timeout_gate.recv_timeout(Duration::from_secs(3)).unwrap(),
+            pid
+        );
         let resources = if disconnect {
             drop(host);
             join_guest_connection(handle);


### PR DESCRIPTION
The storage timeout tests could kill a slowly starting helper before it wrote its PID, then fail on fixture readiness instead of checking timeout cleanup. Add a connection-local test rendezvous so the helper launches a descendant and publishes its PID before the unchanged 20 ms timer starts.

Both affected cases retain their real protocol, process-group, and resource assertions. Additional cases cover timeout before helper readiness and connection cleanup after abandoning the rendezvous. The hook is selected only by an explicit test connection entry point; production timeout policy and wire/resource formats are unchanged.

Closes #32974.

## Validation

- Reproduced on unmodified `main`: storage module **12/12 passed** normally; **10/12 passed** with a 100 ms external helper-startup delay, failing exactly the two reported PID assertions.
- Fixed storage module **14/14 passed**; the same delayed-start probe passed **5 rounds, 70/70 tests**.
- Temporary behavioral mutations were rejected: missing timely timeout, surviving descendant after leader termination, and discarded resource diagnostics. All mutations were restored before final checks.
- `cargo test --manifest-path crates/Cargo.toml --locked --profile local -p guest-control-server --all-targets --all-features`
- `cargo fmt --manifest-path crates/guest-control-server/Cargo.toml -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --locked --profile local -p guest-control-server --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml --locked --release -p guest-control-server --no-default-features --all-targets`
- `cargo doc --manifest-path crates/Cargo.toml --locked --profile local -p guest-control-server --all-features --no-deps`

The three existing production-identity integration tests require the dedicated root/sandbox-user CI fixture and remain ignored locally. Host-side tests exercise process-group containment with owned resource files.
