### PR TITLE
fix(artifacts): recover recorder metadata during public backfill

### DIFF
--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/README.md
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/README.md
@@ -97,14 +97,23 @@ after complete production coverage and the old-writer drain are verified.
 The 2026-09-09 public inventory also contains legacy `html-edit-drafts/<uuid>.html`
 objects and 29 Desktop recording sidecars without R2 Content-Type. Drafts undergo
 the same private-metadata and authoritative-database checks as all public files.
-Missing HTTP metadata requires either an exact existing public registration or a
-unique non-null `run_uploaded_files.content_type`; absent/conflicting evidence
-still blocks registration. Pre-registration also covers an uploaded object whose
+Missing HTTP metadata first uses an exact existing public registration or a
+unique non-null `run_uploaded_files.content_type`. Desktop recorder uploads can
+have neither: the old Blob PUT omitted Content-Type, and the DB row is created
+only when the recording is attached to chat. For the recorder's exact filename
+and storage-key patterns, the migration can recover `application/json` by reading
+at most 1 MiB with the HEAD ETag as an `If-Match` condition and verifying the byte
+length, UTF-8 JSON and frozen v1 recording signature. A changed object, invalid
+JSON, unknown format or oversized body blocks the pass before any registration.
+This is limited to the migration; ordinary missing MIME types still fail.
+Pre-registration also covers an uploaded object whose
 client has not called completion yet. Existing upload headers/signature semantics
 remain compatible with already-deployed App, CLI and Desktop clients. This
 persisted-data compatibility is owned by #32492 and can be retired when historical
 delivery no longer requires this migration. No MIME type is inferred from a file
-extension, and no source object is rewritten.
+extension alone, and no source object is rewritten. The read-only audit of all 29
+historical sidecars found matching v1 JSON bodies (269–54,078 bytes); both older
+click-only records and later optional pointer/typing fields are recognized.
 
 ## Production phases
 

--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/backfill.test.ts
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/backfill.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   GetObjectCommand,
   HeadObjectCommand,
@@ -22,6 +23,7 @@ function fixture() {
   const metadata = new Map<string, Record<string, string>>();
   const contentTypes = new Map<string, string | undefined>();
   const writes: string[] = [];
+  const beforeGet = vi.fn((_key: string) => {});
   const multipart: { Key: string; UploadId: string }[] = [];
   const id = "00000000-0000-4000-8000-000000000001";
   const prefix = `sites/demo/deployments/${id}`;
@@ -46,6 +48,29 @@ function fixture() {
   });
   objects.set("hosted/sites/demo/active.json", pointer);
   objects.set(`hosted/sites/deployments/${id}.json`, pointer);
+  function readObject(command: GetObjectCommand) {
+    beforeGet(`${command.input.Bucket}/${command.input.Key}`);
+    const body = objects.get(`${command.input.Bucket}/${command.input.Key}`);
+    if (body === undefined)
+      throw Object.assign(new Error("Missing"), { name: "NoSuchKey" });
+    const etag = `"${createHash("md5").update(body).digest("hex")}"`;
+    if (command.input.IfMatch && command.input.IfMatch !== etag)
+      throw Object.assign(new Error("Object changed"), {
+        name: "PreconditionFailed",
+      });
+    return {
+      ContentLength: Buffer.byteLength(body),
+      ETag: etag,
+      Body: {
+        transformToString: async () => {
+          return body;
+        },
+        transformToByteArray: async () => {
+          return Buffer.from(body);
+        },
+      },
+    };
+  }
   const sender: {
     send(
       command:
@@ -93,25 +118,19 @@ function fixture() {
           offset + 1 < keys.length ? String(offset + 1) : undefined,
       };
     }
-    if (command instanceof HeadObjectCommand)
+    if (command instanceof HeadObjectCommand) {
+      const body = objects.get(`${command.input.Bucket}/${command.input.Key}`);
+      if (body === undefined) throw new Error("Missing fixture object");
       return {
+        ContentLength: Buffer.byteLength(body),
+        ETag: `"${createHash("md5").update(body).digest("hex")}"`,
         ContentType: contentTypes.has(command.input.Key!)
           ? contentTypes.get(command.input.Key!)
           : "application/pdf",
         Metadata: metadata.get(command.input.Key!) ?? {},
       };
-    if (command instanceof GetObjectCommand) {
-      const body = objects.get(`${command.input.Bucket}/${command.input.Key}`);
-      if (body === undefined)
-        throw Object.assign(new Error("Missing"), { name: "NoSuchKey" });
-      return {
-        Body: {
-          transformToString: async () => {
-            return body;
-          },
-        },
-      };
     }
+    if (command instanceof GetObjectCommand) return readObject(command);
     if (command instanceof PutObjectCommand) {
       const key = `${command.input.Bucket}/${command.input.Key}`;
       if (command.input.IfNoneMatch === "*" && objects.has(key))
@@ -144,6 +163,7 @@ function fixture() {
     metadata,
     contentTypes,
     writes,
+    beforeGet,
     multipart,
     options,
     reconcile,
@@ -431,6 +451,180 @@ test("missing R2 content types require authoritative upload metadata", async () 
     missing: 0,
     resolvedContentTypes: 1,
   });
+});
+
+function clickTrackFixture(f: ReturnType<typeof fixture>, extended = false) {
+  const key = "artifacts/abcdefghij.json";
+  const filename = "screen-recording-1788354885159.clicks.json";
+  const track = {
+    version: 1,
+    recording: {
+      startedAtUnixMs: 1788354885159,
+      durationMs: 1000,
+      video: { width: 1920, height: 1080, frameRate: 30 },
+      capture: {
+        originX: 0,
+        originY: 0,
+        widthPoints: 1920,
+        heightPoints: 1080,
+        scale: 1,
+      },
+    },
+    clicks: [],
+    droppedOutOfFrameClicks: 0,
+    warnings: [],
+    ...(extended ? { pointerEvents: [], typingBursts: [] } : {}),
+  };
+  const body = JSON.stringify(track);
+  f.objects.set(`public/${key}`, body);
+  f.metadata.set(key, { filename });
+  f.contentTypes.set(key, undefined);
+  return { key, filename, body, track };
+}
+
+test.each([false, true])(
+  "recovers verified recorder JSON without rewriting source bytes (extended=%s)",
+  async (extended) => {
+    const f = fixture();
+    const track = clickTrackFixture(f, extended);
+    const dryRun = await registerHistoricalPublicArtifacts(
+      f.client,
+      f.client,
+      f.options,
+      async () => {},
+    );
+    expect(dryRun).toMatchObject({ resolvedContentTypes: 1, missing: 4 });
+    expect(f.writes).toHaveLength(0);
+
+    const result = await registerHistoricalPublicArtifacts(
+      f.client,
+      f.client,
+      { ...f.options, migrate: true },
+      async () => {},
+    );
+    expect(result).toMatchObject({
+      finalFiles: 2,
+      missing: 0,
+      verified: true,
+      finalized: false,
+    });
+    expect(
+      JSON.parse(
+        f.objects.get(
+          `hosted/${artifactDeliveryKey("vm0", "file", "abcdefghij.json")}`,
+        )!,
+      ),
+    ).toStrictEqual({
+      version: 1,
+      kind: "legacy-file",
+      audience: "public",
+      publicBrand: "vm0",
+      key: track.key,
+      filename: track.filename,
+      contentType: "application/json",
+    });
+    expect(f.objects.get(`public/${track.key}`)).toBe(track.body);
+    expect(f.contentTypes.get(track.key)).toBeUndefined();
+
+    await expect(
+      registerHistoricalPublicArtifacts(
+        f.client,
+        f.client,
+        { ...f.options, verify: true },
+        async () => {},
+      ),
+    ).resolves.toMatchObject({ existing: 4, missing: 0, verified: true });
+  },
+);
+
+test.each([
+  { label: "invalid JSON", body: "<html>not a recording</html>" },
+  { label: "unrelated JSON", body: '{"version":1,"data":[]}' },
+  { label: "oversized content", body: "x".repeat(1024 * 1024 + 1) },
+])("blocks $label before registration", async ({ body }) => {
+  const f = fixture();
+  const track = clickTrackFixture(f);
+  f.objects.set(`public/${track.key}`, body);
+  await expect(
+    registerHistoricalPublicArtifacts(
+      f.client,
+      f.client,
+      { ...f.options, migrate: true },
+      async () => {},
+    ),
+  ).rejects.toThrow("Historical click track");
+  expect(f.writes).toHaveLength(0);
+});
+
+test("does not classify another filename from its JSON contents", async () => {
+  const f = fixture();
+  const track = clickTrackFixture(f);
+  f.metadata.set(track.key, { filename: "report.json" });
+  await expect(
+    registerHistoricalPublicArtifacts(
+      f.client,
+      f.client,
+      { ...f.options, migrate: true },
+      async () => {},
+    ),
+  ).rejects.toThrow("has no content type");
+  expect(f.writes).toHaveLength(0);
+});
+
+test("blocks an unsupported recorder version before registration", async () => {
+  const f = fixture();
+  const track = clickTrackFixture(f);
+  f.objects.set(
+    `public/${track.key}`,
+    JSON.stringify({ ...track.track, version: 2 }),
+  );
+  await expect(
+    registerHistoricalPublicArtifacts(
+      f.client,
+      f.client,
+      { ...f.options, migrate: true },
+      async () => {},
+    ),
+  ).rejects.toThrow("unrecognized format");
+  expect(f.writes).toHaveLength(0);
+});
+
+test("blocks a recording replaced between HEAD and content inspection", async () => {
+  const f = fixture();
+  const track = clickTrackFixture(f);
+  f.beforeGet.mockImplementation((key) => {
+    if (key === `public/${track.key}`)
+      f.objects.set(key, JSON.stringify({ ...track.track, version: 2 }));
+  });
+  await expect(
+    registerHistoricalPublicArtifacts(
+      f.client,
+      f.client,
+      { ...f.options, migrate: true },
+      async () => {},
+    ),
+  ).rejects.toMatchObject({ name: "PreconditionFailed" });
+  expect(f.writes).toHaveLength(0);
+});
+
+test("content inspection cannot hide an authoritative metadata conflict", async () => {
+  const f = fixture();
+  clickTrackFixture(f);
+  await expect(
+    registerHistoricalPublicArtifacts(
+      f.client,
+      f.client,
+      {
+        ...f.options,
+        migrate: true,
+        resolveMissingContentType: async () => {
+          throw new Error("Conflicting authoritative MIME metadata");
+        },
+      },
+      async () => {},
+    ),
+  ).rejects.toThrow("Conflicting authoritative MIME metadata");
+  expect(f.writes).toHaveLength(0);
 });
 
 test("historical public HTML drafts are included in verified coverage", async () => {

--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/backfill.ts
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/backfill.ts
@@ -12,6 +12,7 @@ import {
 } from "@aws-sdk/client-s3";
 import postgres from "postgres";
 import { forEachConcurrent } from "./concurrent";
+import { resolveLegacyClickTrackContentType } from "./legacy-click-track";
 // Frozen v1 format: numbered data migrations must remain runnable after app
 // contracts evolve. Only confirmed historical Public records are constructed.
 type PublicBrand = "vm0" | "okou";
@@ -342,7 +343,14 @@ async function inventory(
           brand,
           filename,
         )) ??
-        (await options.resolveMissingContentType?.(key));
+        (await options.resolveMissingContentType?.(key)) ??
+        (await resolveLegacyClickTrackContentType(
+          publicClient,
+          options.publicBucket,
+          key,
+          filename,
+          head,
+        ));
       if (!contentType)
         throw new Error(`Historical artifact has no content type: ${key}`);
       if (!head.ContentType) resolvedContentTypes++;
@@ -666,6 +674,10 @@ async function main() {
         resolveMissingContentType: async (key) => {
           const rows =
             await db`select distinct content_type from run_uploaded_files where storage_key = ${key} and content_type is not null`;
+          if (rows.length > 1)
+            throw new Error(
+              `Historical artifact has conflicting database content types: ${key}`,
+            );
           if (rows.length !== 1 || typeof rows[0]?.content_type !== "string")
             return undefined;
           return rows[0].content_type;

--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/legacy-click-track.ts
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/legacy-click-track.ts
@@ -1,0 +1,109 @@
+import {
+  GetObjectCommand,
+  type HeadObjectCommandOutput,
+  type S3Client,
+} from "@aws-sdk/client-s3";
+
+const MAX_CLICK_TRACK_BYTES = 1024 * 1024;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasNumbers(value: unknown, fields: readonly string[]): boolean {
+  return (
+    isRecord(value) &&
+    fields.every((field) => {
+      return typeof value[field] === "number" && Number.isFinite(value[field]);
+    })
+  );
+}
+
+// Frozen signature shared by the historical v1 recorder variants. Newer v1
+// tracks add content, pointerEvents and typingBursts; these are not required to
+// identify the JSON format. This does not validate playback behavior.
+function isClickTrack(value: unknown): boolean {
+  if (!isRecord(value) || !isRecord(value.recording)) return false;
+  const recording = value.recording;
+  return (
+    value.version === 1 &&
+    hasNumbers(recording, ["startedAtUnixMs", "durationMs"]) &&
+    hasNumbers(recording.video, ["width", "height", "frameRate"]) &&
+    hasNumbers(recording.capture, [
+      "originX",
+      "originY",
+      "widthPoints",
+      "heightPoints",
+      "scale",
+    ]) &&
+    Array.isArray(value.clicks) &&
+    typeof value.droppedOutOfFrameClicks === "number" &&
+    Number.isSafeInteger(value.droppedOutOfFrameClicks) &&
+    value.droppedOutOfFrameClicks >= 0 &&
+    Array.isArray(value.warnings) &&
+    value.warnings.every((warning) => {
+      return typeof warning === "string";
+    })
+  );
+}
+
+/**
+ * Old Desktop uploads supplied application/json to prepare/complete, but their
+ * Blob PUT could omit Content-Type and no DB row exists before chat attachment.
+ * Recover only a bounded, verified recorder JSON body. Keep this frozen with
+ * migration 014 until historical delivery is retired under #32492.
+ */
+export async function resolveLegacyClickTrackContentType(
+  client: S3Client,
+  bucket: string,
+  key: string,
+  filename: string,
+  head: HeadObjectCommandOutput,
+): Promise<string | undefined> {
+  if (
+    !/^artifacts\/[a-z0-9]{10}\.json$/u.test(key) ||
+    !/^screen-recording-\d+\.clicks\.json$/u.test(filename)
+  )
+    return undefined;
+
+  const size = head.ContentLength;
+  if (
+    size === undefined ||
+    !Number.isSafeInteger(size) ||
+    size < 1 ||
+    size > MAX_CLICK_TRACK_BYTES ||
+    !head.ETag
+  )
+    throw new Error(`Historical click track has no bounded identity: ${key}`);
+
+  const result = await client.send(
+    new GetObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      IfMatch: head.ETag,
+      Range: `bytes=0-${size - 1}`,
+    }),
+  );
+  if (
+    !result.Body ||
+    result.ContentLength !== size ||
+    result.ETag !== head.ETag
+  )
+    throw new Error(`Historical click track changed during inventory: ${key}`);
+  const bytes = await result.Body.transformToByteArray();
+  if (bytes.byteLength !== size)
+    throw new Error(`Historical click track body length mismatch: ${key}`);
+
+  let value: unknown;
+  try {
+    value = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+  } catch {
+    // Do not expose artifact contents through JSON parser errors in job logs.
+    throw new Error(`Historical click track is not valid UTF-8 JSON: ${key}`);
+  }
+  if (!isClickTrack(value))
+    throw new Error(
+      `Historical click track has an unrecognized format: ${key}`,
+    );
+  return "application/json";
+}


### PR DESCRIPTION
The production dry-run of public artifact registration stopped on a Desktop recorder click-track file without R2 Content-Type or an authoritative registry/DB MIME value. The full inventory identified 29 recorder sidecars without R2 Content-Type. Historical recorder uploads declared `application/json` to prepare/complete, but the Blob PUT could omit the HTTP metadata and unattached recordings have no upload row to reconcile.

Migration 014 now recognizes only the recorder's filename/storage-key patterns, reads at most 1 MiB with the inventoried ETag as an `If-Match` condition, and verifies byte length, UTF-8 JSON and the frozen v1 recording signature before registering `application/json`. Existing registration/DB evidence remains authoritative; conflicting DB types, unknown formats, invalid JSON, changed objects and oversized bodies stop the pass. Source bytes, URLs, permissions, feature switches, Worker routing and Cloudflare cache/thumbnail behavior are unchanged.

Production evidence: [read-only preflight failure](https://github.com/vm0-ai/vm0/actions/runs/34361749684). A subsequent read-only audit verified all 29 original bodies (269–54,078 bytes) against their inventoried MD5 values and successfully classified each with the new migration helper. No production registration writes have run.

## Fallbacks

- `legacy-click-track.ts:resolveLegacyClickTrackContentType` — recovers missing metadata only for bounded, content-verified historical Desktop recorder JSON. Surface: genuinely absent persisted/external metadata from the legacy public upload producer, not an application request compatibility branch. Stop using this recovery after historical coverage and old-writer drain are verified under #32492; keep the numbered migration as a permanent historical record. No generic MIME default or extension-only inference is added.

## Verification

- 20 focused migration tests pass, including dry-run, exact registration/read-back, independent verification, source-byte preservation, malformed/oversized/unknown input, changed-object rejection and authoritative metadata conflicts.
- DB workspace lint passes, including JSONB contract lint, oxlint, type-aware oxlint and ESLint.
- Normal repository commit checks pass: formatting, style policy, Knip, all workspace type checks, file-size checks and commitlint.

Relates to #32492; follows #32990.
