### PR TITLE
chore(api): refresh private artifact preview qa marker

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createProductionApp } from "./production-bootstrap";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed for sidebar touch preview QA on 2026-09-08)
+// (no-op API release marker refreshed for private artifact QA on 2026-09-09)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
This disposable preview fixes the App/API revision and isolates test data for browser acceptance of merged PR #32977 (private artifact preview lifetime, browser caching, and demand-driven renewal).

Shared staging resets its Neon preview branch when main deploys, which removed the first acceptance fixtures during testing. This PR changes only the existing no-op API deployment marker, based on main `4a1e9e1a7c67de3d47ef0de86601f26819003d71`, which includes #32977.

This is a QA deployment fixture and must not be merged as a product change. Reuse it for related validation. Production feature switches, Workers, buckets and historical data are outside this fixture.

Validation: inspected the one-line comment-only diff. No local dev server or full local test suite. The PR deployment pipeline provisions the isolated App/API environment; browser evidence will be recorded against its deployed commit.

Refs #32977, #32492.
