### PR TITLE
fix(app): name and count connector category chips from discovery

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/connectors.ts
@@ -1,6 +1,7 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
 import type { CustomConnectorResponse } from "@okouai/api-contracts/contracts/custom-connectors";
+import type { PublicConnectorCatalogCategoryMetadata } from "@okouai/api-contracts/contracts/connector-catalog";
 import { userConnectorsContract } from "@okouai/api-contracts/contracts/user-connectors";
 import {
   agentCustomConnectorsContract,
@@ -84,6 +85,12 @@ interface ComposerConnectorData {
   readonly categoryConnectorCounts:
     | Readonly<Record<string, number>>
     | undefined;
+  /**
+   * The catalog's own category names. They ride on the same discovery response
+   * as the connectors, so the directory never has to name a category before it
+   * knows what that category is called.
+   */
+  readonly categoryMetadata: PublicConnectorCatalogCategoryMetadata | undefined;
 }
 
 export interface ComposerConnectorSignals {
@@ -391,6 +398,7 @@ export function createComposerConnectorSignals(
       customConnectors,
       authorization,
       categoryConnectorCounts: catalog.categoryConnectorCounts,
+      categoryMetadata: catalog.categoryMetadata,
     };
   });
   const addDialogKeyword$ = computed((get) => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connectors-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connectors-test-helpers.ts
@@ -14,6 +14,7 @@ import {
 import {
   connectorCatalogContract,
   type PublicConnectorCatalogAuthMethodDetail,
+  type PublicConnectorCatalogCategoryMetadata,
   type PublicConnectorCatalogPermissionDetail,
   type PublicConnectorCatalogStatusItem,
 } from "@okouai/api-contracts/contracts/connector-catalog";
@@ -72,6 +73,8 @@ interface ConnectorFixtureOptions {
   readonly featuredConnectorSlugs?: readonly ConnectorSlug[];
   /** Category totals discovery reports, so a shelf can close on a real count. */
   readonly categoryConnectorCounts?: Readonly<Record<string, number>>;
+  /** The catalog's own category names, as discovery returns them. */
+  readonly categoryMetadata?: PublicConnectorCatalogCategoryMetadata;
   readonly customConnectors?: readonly CustomConnectorResponse[];
   readonly builtinAuthorizations?: Readonly<
     Record<string, readonly ConnectorSlug[]>
@@ -327,6 +330,9 @@ export function installComposerConnectorFixture(
         ...(options.categoryConnectorCounts === undefined
           ? {}
           : { categoryConnectorCounts: options.categoryConnectorCounts }),
+        ...(options.categoryMetadata === undefined
+          ? {}
+          : { categoryMetadata: options.categoryMetadata }),
       });
     },
   );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connector-directory.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connector-directory.test.tsx
@@ -342,3 +342,48 @@ test("List the catalog when it is too small for any category to fill a shelf", a
   expect(dialog.querySelector("[data-testid^='connector-shelf-']")).toBeNull();
   expect(within(dialog).getByText("Gmail")).toBeVisible();
 });
+
+test("Count the whole category on a chip, not the slice discovery returned", async () => {
+  const user = userEvent.setup({ delay: null });
+  installComposerConnectorFixture({
+    catalog: rankedCatalog(),
+    categoryConnectorCounts: { mail: 329, voice: 50 },
+    categoryMetadata: {
+      categories: [
+        {
+          id: "mail",
+          label: "Communication and Collaboration",
+          menuLabel: "Communication",
+          groupId: null,
+        },
+      ],
+      groups: [],
+    },
+  });
+
+  await setupPage({
+    context,
+    path: `/agents/${SCOUT_AGENT_ID}/chat`,
+    featureSwitches: { [FeatureSwitchKey.ConnectorDirectory]: true },
+  });
+
+  const dialog = await openDirectory(user);
+  await waitFor(() => {
+    expect(within(dialog).getByTestId("connector-shelf-mail")).toBeVisible();
+  });
+
+  // The chip stands for the category, so it has to carry the catalog's own
+  // name and the server's total -- not a name derived from the id and the ten
+  // connectors this response happened to include.
+  const chips = Array.from(
+    dialog.querySelectorAll<HTMLElement>("[data-connector-category-chip]"),
+  ).map((element) => {
+    return element.textContent;
+  });
+  expect(chips).toContain("Communication329");
+  expect(
+    within(dialog).getByRole("heading", {
+      name: "Communication and Collaboration",
+    }),
+  ).toBeVisible();
+});

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -10564,6 +10564,8 @@ function ComposerConnectorsSlot({
             state={connectorUi}
             onUpdateState={updateConnectorUi}
             categoryCounts={connectorData?.categoryConnectorCounts}
+            categoryMetadata={connectorData?.categoryMetadata}
+            loading={connectorData === undefined}
             connected={agentConnectors}
             unconnected={unconnectedConnectors}
             connectedCustom={agentCustomConnectors}

--- a/turbo/apps/platform/src/views/okou-page/connector-directory-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connector-directory-dialog.tsx
@@ -16,8 +16,8 @@ import {
   SegmentControlItem,
 } from "@okouai/ui/components/ui/segment-control";
 import { Button, cn } from "@okouai/ui";
+import type { PublicConnectorCatalogCategoryMetadata } from "@okouai/api-contracts/contracts/connector-catalog";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
-import { connectorCatalogStatus$ } from "../../signals/external/connectors.ts";
 import { connectorAccountSummaryByTarget$ } from "../../signals/okou-page/connector-accounts.ts";
 import type {
   ComposerConnectorUiState,
@@ -273,10 +273,12 @@ function CustomConnectorDirectoryCard({
 
 function DirectoryCategoryChips({
   sections,
+  categoryCounts,
   selected,
   onSelect,
 }: {
   readonly sections: readonly ConnectorCategorySection<PlatformConnectorCatalogStatusItem>[];
+  readonly categoryCounts: Readonly<Record<string, number>> | undefined;
   readonly selected: string | null;
   readonly onSelect: (category: string | null) => void;
 }) {
@@ -320,9 +322,14 @@ function DirectoryCategoryChips({
               }}
             >
               {section.menuLabel}
-              <span className="text-[11px] text-muted-foreground/70 tabular-nums">
-                {section.connectors.length}
-              </span>
+              {/* The chip stands for the whole category, not the slice
+                  discovery returned, so it counts only what the server
+                  reported and shows nothing when it reported nothing. */}
+              {categoryCounts?.[section.category] !== undefined && (
+                <span className="text-[11px] text-muted-foreground/70 tabular-nums">
+                  {categoryCounts[section.category]}
+                </span>
+              )}
             </button>
           );
         })}
@@ -602,6 +609,7 @@ function DirectoryBrowseView({
   tab,
   search,
   category,
+  categoryCounts,
   loading,
   model,
   renderCard,
@@ -611,6 +619,7 @@ function DirectoryBrowseView({
   readonly tab: ConnectorDirectoryTab;
   readonly search: string;
   readonly category: string | null;
+  readonly categoryCounts: Readonly<Record<string, number>> | undefined;
   readonly loading: boolean;
   readonly model: ConnectorDirectoryModel;
   readonly renderCard: RenderConnectorCard;
@@ -635,6 +644,7 @@ function DirectoryBrowseView({
       {tab === "discover" && (
         <DirectoryCategoryChips
           sections={model.categorySections}
+          categoryCounts={categoryCounts}
           selected={category}
           onSelect={(next) => {
             onUpdateState({
@@ -808,6 +818,14 @@ interface ConnectorDirectoryDialogProps {
   readonly onUpdateState: UpdateDirectoryState;
   /** Category totals from discovery; a shelf's closing cell stands for these. */
   readonly categoryCounts: Readonly<Record<string, number>> | undefined;
+  /**
+   * The catalog's category names, from the same discovery response as the
+   * connectors. Reading them from the full-catalog status endpoint instead
+   * made every chip wait on a 6.7 MB response and show an id-derived name
+   * until it arrived.
+   */
+  readonly categoryMetadata: PublicConnectorCatalogCategoryMetadata | undefined;
+  readonly loading: boolean;
   readonly connected: readonly PlatformConnectorCatalogStatusItem[];
   readonly unconnected: readonly PlatformConnectorCatalogStatusItem[];
   readonly connectedCustom: readonly CustomConnectorResponse[];
@@ -846,6 +864,8 @@ export function ConnectorDirectoryDialog({
   state,
   onUpdateState,
   categoryCounts,
+  categoryMetadata,
+  loading,
   connected,
   unconnected,
   connectedCustom,
@@ -858,7 +878,6 @@ export function ConnectorDirectoryDialog({
 }: ConnectorDirectoryDialogProps) {
   const { t } = useTranslation();
   const accountLabelOf = useConnectorAccountLabel();
-  const catalogLoadable = useLastLoadable(connectorCatalogStatus$);
   const accountsLoadable = useLastLoadable(connectorAccountSummaryByTarget$);
   const accountSummaries: ReadonlyMap<string, ConnectorAccountSummary> =
     accountsLoadable.state === "hasData"
@@ -875,10 +894,7 @@ export function ConnectorDirectoryDialog({
     unconnectedCustom,
     search,
     category,
-    categoryMetadata:
-      catalogLoadable.state === "hasData"
-        ? catalogLoadable.data.categoryMetadata
-        : undefined,
+    categoryMetadata,
     otherCategoryLabel: t(($) => {
       return $.chat.connectors.directory.otherCategory;
     }),
@@ -887,7 +903,6 @@ export function ConnectorDirectoryDialog({
       return $.connectors.catalog.shelf.popular;
     }),
   });
-  const loading = catalogLoadable.state === "loading" && connected.length === 0;
   const navigableSlugs = navigableDirectorySlugs(tab, model);
   const activeSlug = navigableSlugs[state.directoryActiveIndex];
   const detailConnector = state.directoryDetailSlug
@@ -954,6 +969,7 @@ export function ConnectorDirectoryDialog({
             tab={tab}
             search={search}
             category={category}
+            categoryCounts={categoryCounts}
             loading={loading}
             model={model}
             renderCard={renderCard}


### PR DESCRIPTION
Caught in acceptance: the chips read **"Communication Collaboration 11"** where the catalog says **"Communication and Collaboration"** and holds **329**.

## The name

The dialog took its category metadata from `/api/connector-catalog/status` — 4 048 connectors, **6.7 MB** — while rendering its connectors from the discovery response it already had. Until that much larger request resolved, `groupConnectorsByCategory` had no metadata and fell back to a name derived from the category id, so every chip *and* every shelf heading showed `Communication Collaboration` instead of the catalog's own label.

Discovery returns the same `categoryMetadata` (198 KB, 144 connectors), so the dialog now takes it from the response its connectors came from and **no longer subscribes to the full-catalog status endpoint at all**.

## The count

The number was `section.connectors.length` — the slice discovery returned for that category, at most twelve, and smaller once connectors are connected. A chip stands for the whole category, so it now uses `categoryConnectorCounts`, the same total the shelf's closing cell already used, and shows **no number** when the server reported none rather than a number that means something else.

## Verification

- `@okouai/app` `check-types`, `lint`, `pnpm knip` — clean
- 40 tests across `connector-directory`, `chat-composer-connectors`, `chat-composer-connector-accounts`, `chat-composer-connector-loading`
- New case "Count the whole category on a chip, not the slice discovery returned" asserts both halves through the dialog. Verified it fails without the fix: with `categoryMetadata` withheld the heading reads `Mail` and the chip reads `Communication9`.