### PR TITLE
fix(host-worker): stop restoring the retired file route

### DIFF
--- a/turbo/apps/host-worker/wrangler.jsonc
+++ b/turbo/apps/host-worker/wrangler.jsonc
@@ -4,7 +4,6 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-05-13",
   "routes": [
-    { "pattern": "f.okou.io/*", "zone_name": "okou.io" },
     {
       "pattern": "*.sites.vm0.io/*",
       "zone_name": "vm0.io",


### PR DESCRIPTION
A normal `zero-host-worker` production deployment recreated `f.okou.io/*` from `wrangler.jsonc` after the unlaunched domain was retired. Remove that route entry so subsequent deployments do not recreate it.

The shared Worker keeps its hosted-site routes and existing bindings. The separate `a.okou.io` delivery cutover remains in draft #32959, after historical registration coverage is verified. The current `f.okou.io` DNS remains absent; deleting the recreated live route still needs the Cloudflare connector's `workers-routes.write` grant.

Validation: the complete diff is one route deletion; JSONC formatting, file-size checks and commitlint passed. Runtime code and existing test coverage are unchanged; CI validates the Worker configuration.

Relates to #32492.
