### PR TITLE
fix(platform): use the popover surface and keep the flyout panel on screen

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/model-picker-menu.ts
+++ b/turbo/apps/platform/src/signals/okou-page/model-picker-menu.ts
@@ -12,6 +12,7 @@ type ModelPickerMenuPage =
 type ModelPickerFlyoutSide = "left" | "right";
 
 const FLYOUT_PANEL_WIDTH = 258;
+const FLYOUT_VIEWPORT_MARGIN = 8;
 
 /** One navigation state per composer, including split chats. */
 export function createModelPickerMenuSignals() {
@@ -54,25 +55,38 @@ export function createModelPickerMenuSignals() {
     return get(internalFlyoutSide$);
   });
   /**
-   * Open the panel towards whichever side actually has room. Measured from the
-   * anchored root, so the root itself never moves when the panel flips.
+   * Open the panel towards a side it actually fits on. Measured from the
+   * anchored root, so the root itself never moves when the panel flips, and
+   * measured after the popover has been positioned -- on mount the root is
+   * still at its pre-collision position and would pick the wrong side.
    */
   const flyoutRootRef$ = onRef(
     command(({ set }, element: HTMLElement, signal: AbortSignal) => {
+      let frame = 0;
       const measure = () => {
         const box = element.getBoundingClientRect();
-        const roomRight = window.innerWidth - box.right;
-        const roomLeft = box.left;
+        const roomRight =
+          window.innerWidth - box.right - FLYOUT_VIEWPORT_MARGIN;
+        const roomLeft = box.left - FLYOUT_VIEWPORT_MARGIN;
         set(
           internalFlyoutSide$,
-          roomRight >= FLYOUT_PANEL_WIDTH || roomRight >= roomLeft
+          roomRight >= FLYOUT_PANEL_WIDTH
             ? "right"
-            : "left",
+            : roomLeft >= FLYOUT_PANEL_WIDTH
+              ? "left"
+              : roomRight >= roomLeft
+                ? "right"
+                : "left",
         );
       };
-      measure();
+      // Two frames: the first lets the popover commit its collision-adjusted
+      // position, the second measures the box it settled on.
+      frame = window.requestAnimationFrame(() => {
+        frame = window.requestAnimationFrame(measure);
+      });
       window.addEventListener("resize", measure);
       signal.addEventListener("abort", () => {
+        window.cancelAnimationFrame(frame);
         window.removeEventListener("resize", measure);
       });
     }),

--- a/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
@@ -438,6 +438,14 @@ function MediaModelList({
 }
 
 /**
+ * Both flyout panels wear the shared popover surface rather than a hand-rolled
+ * card: same 0.7px gray-400 hairline, same radius, and no drop shadow, which
+ * the design system does not use for popovers.
+ */
+const FLYOUT_PANEL_CLASS =
+  "rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-1 text-foreground outline-none";
+
+/**
  * Flyout layout: model types on the left, that type's models in a panel beside
  * it. The two panels are separate cards -- joining them would make the root
  * resize whenever a longer list opened, and the type rows would move out from
@@ -668,7 +676,7 @@ export function ModelPickerFlyoutContent({
           aria-label={t(($) => {
             return $.settings.models.picker.models;
           })}
-          className="flex flex-col gap-0.5 rounded-xl border border-border bg-popover p-1 shadow-md"
+          className={cn("flex flex-col gap-0.5", FLYOUT_PANEL_CLASS)}
         >
           {types.map((type, index) => {
             return (
@@ -694,7 +702,7 @@ export function ModelPickerFlyoutContent({
         aria-label={panelLabel}
         className={cn(
           "flex max-h-[284px] w-[252px] flex-col gap-0.5 overflow-y-auto overscroll-contain",
-          "rounded-xl border border-border bg-popover p-1 shadow-md",
+          FLYOUT_PANEL_CLASS,
           types.length > 1
             ? cn(
                 "absolute bottom-0",


### PR DESCRIPTION
## What

Two fixes to the model picker flyout added in #32955, both found on the live
Lab build.

**Surface.** The two panels were hand-rolled cards — `border-border`,
`rounded-xl`, `shadow-md` — instead of the treatment the shared
`PopoverContent` uses (`rounded-[12px] border-[0.7px]
border-[hsl(var(--gray-400))] bg-card`, no shadow). The heavy drop shadow was
the most visible symptom. Both panels now take that surface from one constant.

**Placement.** The side measurement ran on mount, before the popover had
committed its collision-adjusted position, so it measured a stale box and could
open the panel past the right edge of the viewport (models' trailing badges were
cut off). It now measures after two animation frames, requires the panel to
actually fit on the chosen side, and only falls back to the roomier side when
neither side fits.

## Verification

- `chat-composer-model-selection.test.tsx` + `chat-composer-media-models.test.tsx`
  — 35 passed
- `pnpm check-types` in `turbo/apps/platform` — clean
- `eslint --max-warnings 0` on the changed files, `prettier`, and
  `node scripts/style-policy.mjs` — clean

Both behaviours are geometry and computed styles that jsdom does not lay out,
so they are verified against the live Lab build rather than by new assertions.

## Fallbacks

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)