### PR TITLE
feat(app): make the connectors page a directory with a category filter

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -2866,6 +2866,7 @@
         "notConnected": "Keine weiteren Integrationen verfügbar",
         "search": "Keine Integrationen passend zu „{{search}}“"
       },
+      "filterCategory": "Kategorie",
       "filters": {
         "agents": "Agenten",
         "all": "Alle",
@@ -2874,17 +2875,18 @@
         "notConnected": "Nicht verbunden",
         "status": "Status"
       },
+      "filterWith": "Filter: {{category}}",
       "iconUnavailable": "Integrationssymbol nicht verfügbar",
       "newConnector": "Neue Integration",
       "noConnectorsAlt": "Keine Integrationen",
       "otherCategory": "Andere",
       "search": "Finden Sie Integrationen",
       "shelf": {
-        "browseAll": "Alle",
         "moreCategories": "Weitere Kategorien",
         "popular": "Beliebt",
         "seeMore_one": "{{names}} und {{count}} weiteren ansehen",
         "seeMore_other": "{{names}} und {{count}} weitere ansehen",
+        "top": "Top-Konnektoren",
         "yours": "Deine Konnektoren"
       },
       "tabs": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -2858,6 +2858,7 @@
         "notConnected": "No connectors left to connect",
         "search": "No connectors matching \"{{search}}\""
       },
+      "filterCategory": "Category",
       "filters": {
         "agents": "Agents",
         "all": "All",
@@ -2866,17 +2867,18 @@
         "notConnected": "Not connected",
         "status": "Status"
       },
+      "filterWith": "Filter: {{category}}",
       "iconUnavailable": "Connector icon unavailable",
       "newConnector": "New connector",
       "noConnectorsAlt": "No connectors",
       "otherCategory": "Other",
       "search": "Find connectors",
       "shelf": {
-        "browseAll": "All",
         "moreCategories": "More categories",
         "popular": "Popular",
         "seeMore_one": "See {{names}} and {{count}} more",
         "seeMore_other": "See {{names}} and {{count}} more",
+        "top": "Top connectors",
         "yours": "Your connectors"
       },
       "tabs": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -2915,6 +2915,7 @@
         "notConnected": "No quedan conectores para conectar",
         "search": "No hay conectores que coincidan con \"{{search}}\""
       },
+      "filterCategory": "Categoría",
       "filters": {
         "agents": "Agentes",
         "all": "Todos",
@@ -2923,18 +2924,19 @@
         "notConnected": "No conectado",
         "status": "Estado"
       },
+      "filterWith": "Filtro: {{category}}",
       "iconUnavailable": "Icono del conector no disponible",
       "newConnector": "Nuevo conector",
       "noConnectorsAlt": "Sin conectores",
       "otherCategory": "Otro",
       "search": "Buscar conectores",
       "shelf": {
-        "browseAll": "Todos",
         "moreCategories": "Más categorías",
         "popular": "Populares",
         "seeMore_one": "Ver {{names}} y {{count}} más",
         "seeMore_many": "Ver {{names}} y {{count}} más",
         "seeMore_other": "Ver {{names}} y {{count}} más",
+        "top": "Conectores principales",
         "yours": "Tus conectores"
       },
       "tabs": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -2915,6 +2915,7 @@
         "notConnected": "Aucun connecteur restant à connecter",
         "search": "Aucun connecteur correspondant à \"{{search}}\""
       },
+      "filterCategory": "Catégorie",
       "filters": {
         "agents": "Agents",
         "all": "Tous",
@@ -2923,18 +2924,19 @@
         "notConnected": "Non connecté",
         "status": "Statut"
       },
+      "filterWith": "Filtre : {{category}}",
       "iconUnavailable": "Icône du connecteur indisponible",
       "newConnector": "Nouveau connecteur",
       "noConnectorsAlt": "Aucun connecteur",
       "otherCategory": "Autre",
       "search": "Trouver des connecteurs",
       "shelf": {
-        "browseAll": "Tous",
         "moreCategories": "Autres catégories",
         "popular": "Populaires",
         "seeMore_one": "Voir {{names}} et {{count}} autre",
         "seeMore_many": "Voir {{names}} et {{count}} autres",
         "seeMore_other": "Voir {{names}} et {{count}} autres",
+        "top": "Connecteurs principaux",
         "yours": "Vos connecteurs"
       },
       "tabs": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -2866,6 +2866,7 @@
         "notConnected": "कनेक्ट करने के लिए कोई कनेक्टर नहीं बचा",
         "search": "\"{{search}}\" से मेल खाने वाला कोई कनेक्टर नहीं"
       },
+      "filterCategory": "श्रेणी",
       "filters": {
         "agents": "एजेंटों",
         "all": "सभी",
@@ -2874,17 +2875,18 @@
         "notConnected": "जुड़े नहीं हैं",
         "status": "स्थिति"
       },
+      "filterWith": "फ़िल्टर: {{category}}",
       "iconUnavailable": "कनेक्टर आइकन अनुपलब्ध",
       "newConnector": "नया कनेक्टर",
       "noConnectorsAlt": "कोई कनेक्टर नहीं",
       "otherCategory": "अन्य",
       "search": "कनेक्टर खोजें",
       "shelf": {
-        "browseAll": "सभी",
         "moreCategories": "और श्रेणियाँ",
         "popular": "लोकप्रिय",
         "seeMore_one": "{{names}} और {{count}} अन्य देखें",
         "seeMore_other": "{{names}} और {{count}} अन्य देखें",
+        "top": "शीर्ष कनेक्टर",
         "yours": "आपके कनेक्टर"
       },
       "tabs": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -2854,6 +2854,7 @@
         "notConnected": "Tidak ada konektor lagi untuk dihubungkan",
         "search": "Tidak ada konektor yang cocok dengan \"{{search}}\""
       },
+      "filterCategory": "Kategori",
       "filters": {
         "agents": "Agen",
         "all": "Semua",
@@ -2862,17 +2863,18 @@
         "notConnected": "Tidak terhubung",
         "status": "Status"
       },
+      "filterWith": "Filter: {{category}}",
       "iconUnavailable": "Ikon konektor tidak tersedia",
       "newConnector": "Konektor baru",
       "noConnectorsAlt": "Tidak ada konektor",
       "otherCategory": "Lainnya",
       "search": "Cari konektor",
       "shelf": {
-        "browseAll": "Semua",
         "moreCategories": "Kategori lainnya",
         "popular": "Populer",
         "seeMore_one": "Lihat {{names}} dan {{count}} lainnya",
         "seeMore_other": "Lihat {{names}} dan {{count}} lainnya",
+        "top": "Konektor teratas",
         "yours": "Konektor Anda"
       },
       "tabs": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -2915,6 +2915,7 @@
         "notConnected": "Nessun connettore rimasto da collegare",
         "search": "Nessun connettore corrispondente a \"{{search}}\""
       },
+      "filterCategory": "Categoria",
       "filters": {
         "agents": "Agenti",
         "all": "Tutto",
@@ -2923,18 +2924,19 @@
         "notConnected": "Non connesso",
         "status": "Stato"
       },
+      "filterWith": "Filtro: {{category}}",
       "iconUnavailable": "Icona del connettore non disponibile",
       "newConnector": "Nuovo connettore",
       "noConnectorsAlt": "Nessun connettore",
       "otherCategory": "Altro",
       "search": "Trova connettori",
       "shelf": {
-        "browseAll": "Tutti",
         "moreCategories": "Altre categorie",
         "popular": "Popolari",
         "seeMore_one": "Vedi {{names}} e altro {{count}}",
         "seeMore_many": "Vedi {{names}} e altri {{count}}",
         "seeMore_other": "Vedi {{names}} e altri {{count}}",
+        "top": "Connettori principali",
         "yours": "I tuoi connettori"
       },
       "tabs": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -2854,6 +2854,7 @@
         "notConnected": "接続するコネクタが残っていない",
         "search": "「{{search}}」に一致するコネクタはありません"
       },
+      "filterCategory": "カテゴリ",
       "filters": {
         "agents": "エージェント",
         "all": "すべて",
@@ -2862,17 +2863,18 @@
         "notConnected": "接続されていません",
         "status": "ステータス"
       },
+      "filterWith": "フィルタ: {{category}}",
       "iconUnavailable": "コネクタアイコンが使用不可",
       "newConnector": "新しいコネクタ",
       "noConnectorsAlt": "コネクターなし",
       "otherCategory": "その他",
       "search": "コネクターを検索",
       "shelf": {
-        "browseAll": "すべて",
         "moreCategories": "その他のカテゴリ",
         "popular": "人気",
         "seeMore_one": "{{names}} ほか {{count}} 件を見る",
         "seeMore_other": "{{names}} ほか {{count}} 件を見る",
+        "top": "人気のコネクタ",
         "yours": "あなたのコネクタ"
       },
       "tabs": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -2854,6 +2854,7 @@
         "notConnected": "연결할 커넥터가 남아 있지 않습니다",
         "search": "\"{{search}}\"와(과) 일치하는 커넥터가 없습니다"
       },
+      "filterCategory": "카테고리",
       "filters": {
         "agents": "에이전트",
         "all": "전체",
@@ -2862,17 +2863,18 @@
         "notConnected": "연결 안 됨",
         "status": "상태"
       },
+      "filterWith": "필터: {{category}}",
       "iconUnavailable": "커넥터 아이콘을 사용할 수 없습니다",
       "newConnector": "새 커넥터",
       "noConnectorsAlt": "커넥터 없음",
       "otherCategory": "기타",
       "search": "커넥터 찾기",
       "shelf": {
-        "browseAll": "전체",
         "moreCategories": "다른 카테고리",
         "popular": "인기",
         "seeMore_one": "{{names}} 외 {{count}}개 보기",
         "seeMore_other": "{{names}} 외 {{count}}개 보기",
+        "top": "인기 커넥터",
         "yours": "내 커넥터"
       },
       "tabs": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -2915,6 +2915,7 @@
         "notConnected": "Não há mais conectores para conectar",
         "search": "Nenhum conector correspondente a \"{{search}}\""
       },
+      "filterCategory": "Categoria",
       "filters": {
         "agents": "Agentes",
         "all": "Todos",
@@ -2923,18 +2924,19 @@
         "notConnected": "Não conectados",
         "status": "Status"
       },
+      "filterWith": "Filtro: {{category}}",
       "iconUnavailable": "Ícone do conector indisponível",
       "newConnector": "Novo conector",
       "noConnectorsAlt": "Nenhum conector",
       "otherCategory": "Outros",
       "search": "Buscar conectores",
       "shelf": {
-        "browseAll": "Todos",
         "moreCategories": "Mais categorias",
         "popular": "Populares",
         "seeMore_one": "Ver {{names}} e mais {{count}}",
         "seeMore_many": "Ver {{names}} e mais {{count}}",
         "seeMore_other": "Ver {{names}} e mais {{count}}",
+        "top": "Principais conectores",
         "yours": "Seus conectores"
       },
       "tabs": {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
@@ -475,7 +475,7 @@ function shelfCatalog() {
   ];
 }
 
-test("Browse the catalog as shelves and filter it with category chips", async () => {
+test("Browse the catalog as shelves, then enter a category and come back", async () => {
   mockConnectors(context, []);
   mockPublicConnectorStatus(context, shelfCatalog(), undefined, {
     "communication-collaboration": 327,
@@ -495,15 +495,14 @@ test("Browse the catalog as shelves and filter it with category chips", async ()
     screen.getByTestId("connector-shelf-communication-collaboration"),
   ).toBeInTheDocument();
 
-  // The status dimension is its own control now, and the agent list is gone
-  // from the filter: which agents may use a connector is answered on its card.
-  expect(screen.getByRole("radio", { name: "Not connected" })).toBeVisible();
-  expect(screen.queryByLabelText("Filter connectors")).toBeNull();
+  // Status has no control: the page already opens on what is connected. The
+  // agent list is gone from the filter too -- that question is answered on the
+  // connector's own card.
+  expect(screen.queryByRole("radio", { name: "Not connected" })).toBeNull();
+  expect(screen.queryByLabelText("Filter connectors")).toBeInTheDocument();
 
-  const communicationChip = queryAllByRoleFast("button").find((element) => {
-    return element.textContent?.startsWith("Communication");
-  });
-  await click(communicationChip!);
+  // A category is a place: entering it filters the page and leaves a way back.
+  await click(screen.getByText("See Zendesk and 321 more"));
   await waitFor(() => {
     expect(locationSearch()).toContain("category=communication-collaboration");
   });
@@ -511,4 +510,15 @@ test("Browse the catalog as shelves and filter it with category chips", async ()
     screen.queryByTestId("connector-shelf-communication-collaboration"),
   ).toBeNull();
   expect(getConnectorCard("Zendesk")).toBeInTheDocument();
+
+  const back = queryAllByRoleFast("button").find((element) => {
+    return element.textContent === "Connectors";
+  });
+  await click(back!);
+  await waitFor(() => {
+    expect(locationSearch()).not.toContain("category=");
+  });
+  expect(
+    screen.getByTestId("connector-shelf-communication-collaboration"),
+  ).toBeInTheDocument();
 });

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -20,10 +20,6 @@ import type {
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import type { AgentResponse } from "@okouai/api-contracts/contracts/agents";
 import { Tabs, TabsList, TabsTrigger } from "@okouai/ui/components/ui/tabs";
-import {
-  SegmentControl,
-  SegmentControlItem,
-} from "@okouai/ui/components/ui/segment-control";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { formatLocalizedNumber } from "../../i18n/format.ts";
@@ -75,7 +71,6 @@ import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import {
   ConnectorCard,
   connectorAccountSummaryStatus,
-  DIRECTORY_HAIRLINE,
   type ConnectorAccountSummaryStatus,
 } from "./components/settings/connector-card.tsx";
 import {
@@ -101,7 +96,6 @@ import {
 import { noConnectorImg } from "./platform-assets.ts";
 import { AvatarFromUrl } from "./sidebar-shared.tsx";
 import {
-  cn,
   surfaceVariants,
   Button,
   DropdownMenu,
@@ -450,121 +444,178 @@ function ConnectorFilterDropdown({
 }
 
 /**
- * Status as its own control. The dropdown it replaces mixed three unrelated
- * dimensions — everything, connection status, and one entry per agent — into a
- * single mutually exclusive list that grew without bound as the account aged,
- * while category, the only dimension that organises four thousand connectors,
- * was not offered at all. Which agents may use a connector is answered on the
- * connector's own card, where the question is actually asked.
+ * The directory toolbar. Category is the only dimension that organises four
+ * thousand connectors, so it owns the filter; connection status does not need
+ * a control because the page opens on what is already connected.
  */
-function ConnectorStatusSegment({
-  value,
-  onChange,
+function ConnectorsDirectoryToolbar({
+  search,
+  setSearch,
+  categories,
+  categoryCounts,
+  categoryFilter,
+  setCategoryFilter,
+  isAdmin,
+  onCreateCustom,
 }: {
-  readonly value: ConnectorsConnectionFilter;
-  readonly onChange: (value: ConnectorsConnectionFilter) => void;
+  readonly search: string;
+  readonly setSearch: (value: string) => void;
+  readonly categories: readonly ConnectorCategorySection<PlatformConnectorCatalogStatusItem>[];
+  readonly categoryCounts: Readonly<Record<string, number>> | undefined;
+  readonly categoryFilter: string | null;
+  readonly setCategoryFilter: (category: string | null) => void;
+  readonly isAdmin: boolean;
+  readonly onCreateCustom: () => void;
 }) {
   const { t } = useTranslation();
-  const selected =
-    value.kind === "connected" || value.kind === "not-connected"
-      ? value.kind
-      : "all";
+  const active = categories.find((section) => {
+    return section.category === categoryFilter;
+  });
   return (
-    <SegmentControl
-      size="sm"
-      value={selected}
-      onValueChange={(next: string) => {
-        onChange(
-          next === "connected"
-            ? { kind: "connected" }
-            : next === "not-connected"
-              ? { kind: "not-connected" }
-              : { kind: "all" },
-        );
-      }}
-      aria-label={t(($) => {
-        return $.connectors.catalog.filters.status;
-      })}
-    >
-      <SegmentControlItem value="all">
-        {t(($) => {
-          return $.connectors.catalog.filters.all;
-        })}
-      </SegmentControlItem>
-      <SegmentControlItem value="connected">
-        {t(($) => {
-          return $.connectors.catalog.filters.connected;
-        })}
-      </SegmentControlItem>
-      <SegmentControlItem value="not-connected">
-        {t(($) => {
-          return $.connectors.catalog.filters.notConnected;
-        })}
-      </SegmentControlItem>
-    </SegmentControl>
+    <div className="flex flex-col gap-3">
+      {active && (
+        <ConnectorsBreadcrumb
+          label={active.label}
+          onBack={() => {
+            setCategoryFilter(null);
+          }}
+        />
+      )}
+      <div className="flex items-center gap-2">
+        <div className="relative min-w-0 flex-1">
+          <Search
+            size={15}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
+            aria-hidden="true"
+          />
+          <Input
+            type="text"
+            placeholder={t(($) => {
+              return $.connectors.catalog.search;
+            })}
+            value={search}
+            onChange={(event) => {
+              return setSearch(event.target.value);
+            }}
+            className="pl-9 pr-3"
+          />
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-9 shrink-0 gap-1.5"
+              aria-label={t(($) => {
+                return $.connectors.catalog.filters.aria;
+              })}
+            >
+              <Filter size={14} aria-hidden="true" />
+              <span className="max-w-[160px] truncate">
+                {t(
+                  ($) => {
+                    return $.connectors.catalog.filterWith;
+                  },
+                  {
+                    category:
+                      active?.menuLabel ??
+                      t(($) => {
+                        return $.connectors.catalog.filters.all;
+                      }),
+                  },
+                )}
+              </span>
+              <ChevronDown size={14} aria-hidden="true" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            className="max-h-[min(420px,var(--available-height))] w-64 overflow-y-auto"
+          >
+            <ConnectorFilterSectionLabel>
+              {t(($) => {
+                return $.connectors.catalog.filterCategory;
+              })}
+            </ConnectorFilterSectionLabel>
+            <ConnectorFilterOption
+              active={categoryFilter === null}
+              onSelect={() => {
+                setCategoryFilter(null);
+              }}
+            >
+              {t(($) => {
+                return $.connectors.catalog.filters.all;
+              })}
+            </ConnectorFilterOption>
+            {categories.map((section) => {
+              const total = categoryCounts?.[section.category];
+              return (
+                <ConnectorFilterOption
+                  key={section.category}
+                  active={categoryFilter === section.category}
+                  onSelect={() => {
+                    setCategoryFilter(section.category);
+                  }}
+                >
+                  <span className="min-w-0 truncate">{section.menuLabel}</span>
+                  {total !== undefined && (
+                    <span className="shrink-0 text-xs tabular-nums text-muted-foreground/70">
+                      {total}
+                    </span>
+                  )}
+                </ConnectorFilterOption>
+              );
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        {isAdmin && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-9 shrink-0 gap-2"
+            onClick={onCreateCustom}
+          >
+            <Plus size={14} aria-hidden="true" />
+            {t(($) => {
+              return $.connectors.catalog.newConnector;
+            })}
+          </Button>
+        )}
+      </div>
+    </div>
   );
 }
 
-/** Category chips: the browse dimension the filter dropdown never offered. */
-function ConnectorCategoryChipRow({
-  sections,
-  categoryCounts,
-  selected,
-  onSelect,
+/**
+ * A category is a place, not a filter chip: entering one has to leave a way
+ * back to the directory it was entered from.
+ */
+function ConnectorsBreadcrumb({
+  label,
+  onBack,
 }: {
-  readonly sections: readonly ConnectorCategorySection<PlatformConnectorCatalogStatusItem>[];
-  readonly categoryCounts: Readonly<Record<string, number>> | undefined;
-  readonly selected: string | null;
-  readonly onSelect: (category: string | null) => void;
+  readonly label: string;
+  readonly onBack: () => void;
 }) {
   const { t } = useTranslation();
-  // Weight stays on the base class: the row is horizontal and every chip is
-  // auto-width, so a heavier selected label would shift every chip after it.
-  const chipClass = (active: boolean) => {
-    return cn(
-      "flex h-7 shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-lg bg-gray-50 px-2.5 text-xs font-medium transition-colors",
-      DIRECTORY_HAIRLINE,
-      active
-        ? "bg-state-selected text-foreground"
-        : "text-muted-foreground hover:text-foreground",
-    );
-  };
   return (
-    <div className="overflow-x-auto [scrollbar-width:none]">
-      <div className="flex w-max gap-1.5 pb-1">
-        <button
-          type="button"
-          data-connector-category-chip=""
-          className={chipClass(selected === null)}
-          onClick={() => {
-            onSelect(null);
-          }}
-        >
-          {t(($) => {
-            return $.connectors.catalog.shelf.browseAll;
-          })}
-        </button>
-        {sections.map((section) => {
-          return (
-            <button
-              key={section.category}
-              type="button"
-              data-connector-category-chip=""
-              className={chipClass(selected === section.category)}
-              onClick={() => {
-                onSelect(section.category);
-              }}
-            >
-              {section.menuLabel}
-              <span className="text-[11px] tabular-nums text-muted-foreground/70">
-                {categoryCounts?.[section.category] ??
-                  section.connectors.length}
-              </span>
-            </button>
-          );
+    <nav className="flex items-center gap-1.5 text-sm">
+      <button
+        type="button"
+        className="cursor-pointer rounded-md px-1 py-0.5 text-muted-foreground transition-colors hover:text-foreground"
+        onClick={onBack}
+      >
+        {t(($) => {
+          return $.connectors.catalog.title;
         })}
-      </div>
-    </div>
+      </button>
+      <span className="text-muted-foreground/50" aria-hidden="true">
+        /
+      </span>
+      <span aria-current="page" className="font-medium text-foreground">
+        {label}
+      </span>
+    </nav>
   );
 }
 
@@ -573,7 +624,6 @@ function ConnectorsToolbarActions({
   search,
   setSearch,
   showAccessManagement,
-  shelfEnabled,
   connectionFilter,
   agents,
   setConnectionFilter,
@@ -584,7 +634,6 @@ function ConnectorsToolbarActions({
   readonly search: string;
   readonly setSearch: (value: string) => void;
   readonly showAccessManagement: boolean;
-  readonly shelfEnabled: boolean;
   readonly connectionFilter: ConnectorsConnectionFilter;
   readonly agents: readonly AgentResponse[];
   readonly setConnectionFilter: (value: ConnectorsConnectionFilter) => void;
@@ -613,20 +662,13 @@ function ConnectorsToolbarActions({
           />
         </div>
       )}
-      {activeTab === "builtin" &&
-        showAccessManagement &&
-        (shelfEnabled ? (
-          <ConnectorStatusSegment
-            value={connectionFilter}
-            onChange={setConnectionFilter}
-          />
-        ) : (
-          <ConnectorFilterDropdown
-            value={connectionFilter}
-            agents={agents}
-            onChange={setConnectionFilter}
-          />
-        ))}
+      {activeTab === "builtin" && showAccessManagement && (
+        <ConnectorFilterDropdown
+          value={connectionFilter}
+          agents={agents}
+          onChange={setConnectionFilter}
+        />
+      )}
       {activeTab === "custom" && isAdmin && (
         <Button
           variant="outline"
@@ -712,15 +754,14 @@ function ConnectorShelfBrowse({
   connected,
   layout,
   renderCard,
-  onOpenCategory,
 }: {
   readonly connected: readonly PlatformConnectorCatalogStatusItem[];
   readonly layout: ConnectorShelfLayout<PlatformConnectorCatalogStatusItem>;
   readonly renderCard: (
     connector: PlatformConnectorCatalogStatusItem,
   ) => ReactNode;
-  readonly onOpenCategory: (category: string) => void;
 }) {
+  const onOpenCategory = useSet(setConnectorsCategoryFilter$);
   const { t } = useTranslation();
   return (
     <>
@@ -852,41 +893,35 @@ function buildConnectorsBrowseModel({
  */
 function ConnectorsBuiltinPanel({
   browse,
-  shelfEnabled,
   categoryFilter,
-  setCategoryFilter,
   renderCard,
   fallback,
+  customPanel,
 }: {
   readonly browse: ConnectorsBrowseModel;
-  readonly shelfEnabled: boolean;
   readonly categoryFilter: string | null;
-  readonly setCategoryFilter: (category: string | null) => void;
   readonly renderCard: (
     connector: PlatformConnectorCatalogStatusItem,
   ) => ReactNode;
   readonly fallback: ReactNode;
+  readonly customPanel: ReactNode;
 }) {
   return (
     <>
-      {shelfEnabled && (
-        <ConnectorCategoryChipRow
-          sections={browse.chipSections}
-          categoryCounts={browse.categoryCounts}
-          selected={categoryFilter}
-          onSelect={setCategoryFilter}
-        />
-      )}
       {browse.showShelves ? (
         <ConnectorShelfBrowse
           connected={browse.connected}
           layout={browse.layout}
           renderCard={renderCard}
-          onOpenCategory={setCategoryFilter}
         />
       ) : (
         fallback
       )}
+      {/* Custom connectors used to be a tab. They are one more thing the
+          directory offers, so they sit at the end of the directory rather
+          than behind a switch of surfaces -- but a chosen category is a
+          filtered view of the built-in catalog and does not include them. */}
+      {categoryFilter === null && customPanel}
     </>
   );
 }
@@ -1337,7 +1372,7 @@ export function ConnectorsPage() {
     categoryCounts: discoveryCategoryCounts(catalogStatusLoadable),
     otherCategoryLabel,
     headLabel: t(($) => {
-      return $.connectors.catalog.shelf.popular;
+      return $.connectors.catalog.shelf.top;
     }),
     search,
     categoryFilter,
@@ -1376,52 +1411,66 @@ export function ConnectorsPage() {
             )}
 
           <div className="min-w-0 flex w-full max-w-[900px] flex-col gap-6">
-            <div className="flex items-center justify-between gap-3">
-              <Tabs
-                value={activeTab}
-                onValueChange={(v) => {
-                  return setActiveTab(v === "custom" ? "custom" : "builtin");
-                }}
-              >
-                <TabsList>
-                  <TabsTrigger value="builtin">
-                    {t(($) => {
-                      return $.connectors.catalog.tabs.builtin;
-                    })}
-                  </TabsTrigger>
-                  <TabsTrigger value="custom">
-                    {t(($) => {
-                      return $.connectors.catalog.tabs.custom;
-                    })}
-                  </TabsTrigger>
-                </TabsList>
-              </Tabs>
-              <ConnectorsToolbarActions
-                activeTab={activeTab}
+            {shelfEnabled ? (
+              <ConnectorsDirectoryToolbar
                 search={search}
                 setSearch={setSearch}
-                shelfEnabled={shelfEnabled}
-                showAccessManagement
-                connectionFilter={connectionFilter}
-                agents={agents}
-                setConnectionFilter={setConnectionFilter}
+                categories={browse.chipSections}
+                categoryCounts={browse.categoryCounts}
+                categoryFilter={categoryFilter}
+                setCategoryFilter={setCategoryFilter}
                 isAdmin={isAdmin}
                 onCreateCustom={openCreateCustom}
               />
-            </div>
-
-            {activeTab === "builtin" && (
-              <ConnectorsBuiltinPanel
-                browse={browse}
-                shelfEnabled={shelfEnabled}
-                categoryFilter={categoryFilter}
-                setCategoryFilter={setCategoryFilter}
-                renderCard={renderCard}
-                fallback={builtinList}
-              />
+            ) : (
+              <div className="flex items-center justify-between gap-3">
+                <Tabs
+                  value={activeTab}
+                  onValueChange={(v) => {
+                    return setActiveTab(v === "custom" ? "custom" : "builtin");
+                  }}
+                >
+                  <TabsList>
+                    <TabsTrigger value="builtin">
+                      {t(($) => {
+                        return $.connectors.catalog.tabs.builtin;
+                      })}
+                    </TabsTrigger>
+                    <TabsTrigger value="custom">
+                      {t(($) => {
+                        return $.connectors.catalog.tabs.custom;
+                      })}
+                    </TabsTrigger>
+                  </TabsList>
+                </Tabs>
+                <ConnectorsToolbarActions
+                  activeTab={activeTab}
+                  search={search}
+                  setSearch={setSearch}
+                  showAccessManagement
+                  connectionFilter={connectionFilter}
+                  agents={agents}
+                  setConnectionFilter={setConnectionFilter}
+                  isAdmin={isAdmin}
+                  onCreateCustom={openCreateCustom}
+                />
+              </div>
             )}
 
-            {activeTab === "custom" && <CustomConnectorsPanel />}
+            {shelfEnabled ? (
+              <ConnectorsBuiltinPanel
+                browse={browse}
+                categoryFilter={categoryFilter}
+                renderCard={renderCard}
+                fallback={builtinList}
+                customPanel={<CustomConnectorsPanel />}
+              />
+            ) : (
+              <>
+                {activeTab === "builtin" && builtinList}
+                {activeTab === "custom" && <CustomConnectorsPanel />}
+              </>
+            )}
           </div>
         </div>
       </main>

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -893,13 +893,11 @@ function buildConnectorsBrowseModel({
  */
 function ConnectorsBuiltinPanel({
   browse,
-  categoryFilter,
   renderCard,
   fallback,
   customPanel,
 }: {
   readonly browse: ConnectorsBrowseModel;
-  readonly categoryFilter: string | null;
   readonly renderCard: (
     connector: PlatformConnectorCatalogStatusItem,
   ) => ReactNode;
@@ -918,10 +916,11 @@ function ConnectorsBuiltinPanel({
         fallback
       )}
       {/* Custom connectors used to be a tab. They are one more thing the
-          directory offers, so they sit at the end of the directory rather
-          than behind a switch of surfaces -- but a chosen category is a
-          filtered view of the built-in catalog and does not include them. */}
-      {categoryFilter === null && customPanel}
+          directory offers, so they sit at the end of it rather than behind a
+          switch of surfaces. They belong to the directory view only: the
+          panel does not read the page's keyword, so under a search or inside
+          a category it would answer a question nobody asked. */}
+      {browse.showShelves && customPanel}
     </>
   );
 }
@@ -1460,7 +1459,6 @@ export function ConnectorsPage() {
             {shelfEnabled ? (
               <ConnectorsBuiltinPanel
                 browse={browse}
-                categoryFilter={categoryFilter}
                 renderCard={renderCard}
                 fallback={builtinList}
                 customPanel={<CustomConnectorsPanel />}


### PR DESCRIPTION
Acceptance on the connectors page. All four asks point the same way: the page should read as one directory rather than a set of controls.

| Ask | Change |
| --- | --- |
| "不需要用 tab 来切换" | The built-in/custom tabs are gone. Custom connectors sit at the end of the directory, and "New connector" moves into the toolbar so an admin reaches it without switching surfaces. |
| "首页都显示了已连接的 connectors，那就不需要右上角那个 Segment" | The status segment is removed. It offered *all / connected / not connected* directly above a page whose first section is already **Your connectors**, so two of its three states were a slower way to read what was on screen. |
| "Segment control 的位置可以做成一个 filter" | A category filter takes its place — `Filter: <Category>` with every category and its total, the way the reference does it. The chip row goes with it, since the filter carries the same categories plus which one is active. |
| "进到详情页后需要让用户也可以返回" | Choosing a category **enters** it rather than quietly narrowing the page, and the toolbar shows a breadcrumb `Connectors / <Category>` back to the directory. |

The head shelf is titled **Top connectors** on this surface.

Cards already carry their description (#33003); the closing cell you liked — "See Groq, MiniMax and 65 more" — is unchanged and is now one of two ways into a category, the other being the filter.

## Not in this PR

**Trending connectors** needs a signal we do not have. Popularity today is a hand-curated seed (#32927), and "trending" means growth over time, which requires the connection history in MaskDB. Same blocked dependency as real popularity ranking; I did not want to label an arbitrary slice as trending.

## Feature switch

Everything stays behind `connectorDirectory`. With the switch off the page renders exactly as before — tabs, status/agent dropdown, category rail, category sections.

## Verification

- `@okouai/app` `check-types`, `lint`, `pnpm lint:style`, `pnpm knip` — clean
- 65 tests across `connectors-catalog`, `connectors-custom`, `connectors-accounts`, `connector-directory`
- `connectors-catalog.test.tsx` covers the new navigation end to end: shelves render, the status radio is absent, the closing cell enters the category and writes `category=` to the URL, and the breadcrumb returns to the directory with the shelves restored