### PR TITLE
fix(python): prevent sigv4 body retention on worker-start failure

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -15,6 +15,7 @@ from enum import Enum
 
 from mitmproxy import http
 
+import aws_sigv4_hash_executor
 import flow_metadata
 import flow_metadata_keys as metadata_keys
 import http_local_responses
@@ -826,7 +827,7 @@ async def _precompute_aws_sigv4_body_hash(
         return None
 
     hash_future = asyncio.get_running_loop().run_in_executor(
-        None,
+        aws_sigv4_hash_executor.get_executor(),
         hash_request_body,
         flow.request.raw_content,
     )

--- a/crates/runner/mitm-addon/src/aws_sigv4_hash_executor.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4_hash_executor.py
@@ -1,0 +1,69 @@
+"""Own bounded off-loop SigV4 hashing without orphaning request bodies.
+
+The first payload-dependent request starts the pool's workers on body-free
+jobs. Only a fully started pool can accept bodies: ThreadPoolExecutor queues
+before starting workers, and failed startup otherwise leaves inaccessible work.
+The worker ceiling matches body admission, preserving parallel hashing. Idle
+workers are reused until addon shutdown; flow admission owns queued/running
+bodies, and request cancellation waits for hash completion before cleanup.
+"""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from aws_sigv4_body_admission import MAX_ADMITTED_AWS_SIGV4_REQUESTS
+
+_lock = threading.Lock()
+_executor: ThreadPoolExecutor | None = None
+_shut_down = False
+
+
+def get_executor() -> ThreadPoolExecutor:
+    """Return a pool whose future submissions cannot need another worker."""
+    global _executor
+    with _lock:
+        if _shut_down:
+            raise RuntimeError("AWS SigV4 hashing is shut down")
+        if _executor is None:
+            _executor = _start_executor()
+        return _executor
+
+
+def _start_executor() -> ThreadPoolExecutor:
+    executor = ThreadPoolExecutor(
+        max_workers=MAX_ADMITTED_AWS_SIGV4_REQUESTS,
+        thread_name_prefix="aws-sigv4-hash",
+    )
+    release_workers = threading.Event()
+    try:
+        # Keep startup jobs busy so every submit starts a worker. No body enters
+        # this queue until all worker starts have succeeded.
+        for _ in range(MAX_ADMITTED_AWS_SIGV4_REQUESTS):
+            executor.submit(release_workers.wait)
+    except BaseException:
+        release_workers.set()
+        executor.shutdown(wait=True, cancel_futures=True)
+        raise
+    release_workers.set()
+    return executor
+
+
+def shutdown() -> None:
+    """Close hashing admission and join accepted work before addon exit."""
+    global _executor, _shut_down
+    with _lock:
+        _shut_down = True
+        executor = _executor
+        _executor = None
+    if executor is not None:
+        # Complete accepted futures so awaiting requests keep their existing
+        # cancellation and flow-admission cleanup contract.
+        executor.shutdown(wait=True)
+
+
+def reset_for_tests() -> None:
+    """Join owned workers before reopening hashing for the next test."""
+    global _shut_down
+    shutdown()
+    with _lock:
+        _shut_down = False

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -51,6 +51,7 @@ import addon_process_logging
 #      callers — no mock-placement pitfalls from copied function bindings.
 import auth_base_forwarder
 import aws_sigv4_body_admission
+import aws_sigv4_hash_executor
 import body_capture
 import builtin_host_policy
 import codex_model_catalog_cache
@@ -2007,7 +2008,8 @@ def done():
     pending. After joining the usage executor, retained billing and diagnostic
     work is drained through synchronous delivery. Model-provider
     failure delivery stops admission and receives one bounded drain window.
-    Catalog validation closes admission and joins its bounded off-loop work.
+    Catalog validation and SigV4 hashing close admission and join their bounded
+    off-loop work.
     """
     try:
         runner_flush_lifecycle.drain_and_close()
@@ -2025,7 +2027,10 @@ def done():
                 try:
                     codex_model_catalog_cache.shutdown()
                 finally:
-                    shutdown_log_writer()
+                    try:
+                        aws_sigv4_hash_executor.shutdown()
+                    finally:
+                        shutdown_log_writer()
 
 
 # ============================================================================

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -30,6 +30,7 @@ import auth
 import auth_base_forwarder
 import auth_base_transport
 import aws_sigv4_body_admission
+import aws_sigv4_hash_executor
 import builtin_connector_diagnostics
 import claude_output_timing
 import codex_model_catalog_cache
@@ -66,6 +67,7 @@ def _reset_module_state() -> Iterator[None]:
     auth_base_forwarder.reset_forward_request_state_for_tests()
     auth_base_transport.reset_transport_state_for_tests()
     firewall_auth_client.reset_transport_state_for_tests()
+    aws_sigv4_hash_executor.reset_for_tests()
     aws_sigv4_body_admission.reset_for_tests()
     builtin_connector_diagnostics.reset_cache_for_tests()
     registry.reset_cache_for_tests()
@@ -97,6 +99,7 @@ def _reset_module_state() -> Iterator[None]:
     auth_base_forwarder.reset_forward_request_state_for_tests()
     auth_base_transport.reset_transport_state_for_tests()
     firewall_auth_client.reset_transport_state_for_tests()
+    aws_sigv4_hash_executor.reset_for_tests()
     aws_sigv4_body_admission.reset_for_tests()
     builtin_connector_diagnostics.reset_cache_for_tests()
     upstream_destination_binding.reset_for_tests()

--- a/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_hash_executor.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_hash_executor.py
@@ -1,0 +1,315 @@
+"""Real worker-start, admission, and shutdown regressions for SigV4 hashing."""
+
+import asyncio
+import gc
+import json
+import threading
+import weakref
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from mitmproxy import http
+
+import auth
+import aws_sigv4_body_admission as admission
+import aws_sigv4_hash_executor
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+from aws_sigv4 import AwsSigV4BodyHash, hash_request_body
+from tests.aws_sigv4_helpers import RESOLVED_AWS_ACCESS_KEY_ID
+from tests.test_request_handler_aws_sigv4_body import (
+    _header_auth_flow,
+    _resolved_token_meta,
+    _write_aws_registry,
+)
+
+
+class _TrackedBody(bytes):
+    """Observe release of real bytes without retaining them in the test."""
+
+    identifier: int
+    released: list[int]
+
+    def __new__(cls, identifier: int, size: int, released: list[int]):
+        body = super().__new__(cls, bytes([identifier]) * size)
+        body.identifier = identifier
+        body.released = released
+        return body
+
+    def __del__(self) -> None:
+        self.released.append(self.identifier)
+
+
+class _ControlledHashes:
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self.started: asyncio.Queue[threading.Thread] = asyncio.Queue()
+        self.release = threading.Event()
+        self._loop = loop
+
+    def __call__(self, body: bytes | None) -> AwsSigV4BodyHash:
+        self._loop.call_soon_threadsafe(self.started.put_nowait, threading.current_thread())
+        if not self.release.wait(timeout=2):
+            raise AssertionError("controlled SigV4 hash was not released")
+        return hash_request_body(body)
+
+
+@pytest.mark.parametrize("capture_body", [False, True])
+@pytest.mark.parametrize("failed_worker", [0, 3], ids=["first-worker", "partial-start"])
+async def test_worker_start_failures_release_bodies_and_recover(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+    capture_body: bool,
+    failed_worker: int,
+) -> None:
+    loop = asyncio.get_running_loop()
+    default_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="sigv4-test-default")
+    loop.set_default_executor(default_executor)
+    registry_path = _write_aws_registry(tmp_path, capture_body=capture_body)
+    original_start = threading.Thread.start
+    owned_threads: list[threading.Thread] = []
+    executors: list[ThreadPoolExecutor] = []
+    released: list[int] = []
+    flows: list[weakref.ReferenceType[http.HTTPFlow]] = []
+    hashed: list[int] = []
+    size = admission.MAX_AWS_SIGV4_REQUEST_BODY_BYTES
+
+    def create_executor(*, max_workers: int, thread_name_prefix: str) -> ThreadPoolExecutor:
+        executor = ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix=thread_name_prefix
+        )
+        executors.append(executor)
+        return executor
+
+    def fail_start(thread: threading.Thread) -> None:
+        if thread.name.startswith(("aws-sigv4-hash_", "sigv4-test-default_")):
+            owned_threads.append(thread)
+            if thread.name.endswith(f"_{failed_worker}"):
+                raise RuntimeError("can't start new thread")
+        original_start(thread)
+
+    def observe_hash(body: bytes | None) -> AwsSigV4BodyHash:
+        if isinstance(body, _TrackedBody):
+            hashed.append(body.identifier)
+        return hash_request_body(body)
+
+    try:
+        with (
+            mitm_ctx(registry_path=str(registry_path)),
+            patch.object(
+                auth, "get_firewall_headers", AsyncMock(return_value=_resolved_token_meta())
+            ),
+            patch.object(auth, "hash_request_body", observe_hash),
+            patch.object(
+                aws_sigv4_hash_executor, "ThreadPoolExecutor", side_effect=create_executor
+            ),
+        ):
+            with patch.object(threading.Thread, "start", fail_start):
+                # Five distinct maximum-size bodies exceed the aggregate 128 MiB bound.
+                for identifier in range(5):
+                    flow = _header_auth_flow(
+                        real_flow,
+                        headers,
+                        body=_TrackedBody(identifier, size, released),
+                        content_length=str(size),
+                    )
+                    flows.append(weakref.ref(flow))
+                    assert mitm_addon.requestheaders(flow) is None
+                    assert admission.state_for_tests() == (1, size)
+                    with pytest.raises(RuntimeError, match="can't start new thread"):
+                        await mitm_addon.request(flow)
+                    assert flow.response is not None
+                    assert flow.response.status_code == 500
+                    assert json.loads(flow.response.content)["error"] == "request_processing_failed"
+                    mitm_addon.response(flow)
+                    assert admission.state_for_tests() == (0, 0)
+                    del flow
+
+            gc.collect()
+            assert all(flow_ref() is None for flow_ref in flows)
+            assert sorted(released) == list(range(5))
+            assert hashed == []
+            assert all(not thread.is_alive() for thread in owned_threads)
+            for executor in executors:
+                with pytest.raises(RuntimeError, match="shutdown"):
+                    executor.submit(lambda: None)
+
+            healthy = _header_auth_flow(real_flow, headers, body=b"healthy", content_length="7")
+            assert mitm_addon.requestheaders(healthy) is None
+            await mitm_addon.request(healthy)
+            assert healthy.response is None
+            assert (
+                f"Credential={RESOLVED_AWS_ACCESS_KEY_ID}/"
+                in healthy.request.headers["authorization"]
+            )
+            healthy.response = http.Response.make(200, b"ok")
+            mitm_addon.response(healthy)
+            assert admission.state_for_tests() == (0, 0)
+            assert hashed == []
+            assert await loop.run_in_executor(None, lambda: "unrelated work") == "unrelated work"
+    finally:
+        aws_sigv4_hash_executor.reset_for_tests()
+        default_executor.shutdown(wait=True, cancel_futures=True)
+        for executor in executors:
+            executor.shutdown(wait=True, cancel_futures=True)
+
+
+@pytest.mark.parametrize(
+    ("body_size", "accepted_count"),
+    [(1, 16), (32 * 1024 * 1024, 4)],
+    ids=["request-count", "body-bytes"],
+)
+async def test_active_hashes_remain_bounded_without_starting_more_workers(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+    body_size: int,
+    accepted_count: int,
+) -> None:
+    loop = asyncio.get_running_loop()
+    hasher = _ControlledHashes(loop)
+    registry_path = _write_aws_registry(tmp_path)
+    tasks: list[asyncio.Task[None]] = []
+    flows: list[http.HTTPFlow] = []
+    worker_threads: set[threading.Thread] = set()
+    original_start = threading.Thread.start
+
+    def fail_hash_worker_start(thread: threading.Thread) -> None:
+        if thread.name.startswith("aws-sigv4-hash_"):
+            raise RuntimeError("can't start new thread")
+        original_start(thread)
+
+    with (
+        mitm_ctx(registry_path=str(registry_path)),
+        patch.object(auth, "get_firewall_headers", AsyncMock(return_value=_resolved_token_meta())),
+        patch.object(auth, "hash_request_body", hasher),
+    ):
+        try:
+            first = _header_auth_flow(
+                real_flow, headers, body=b"a" * body_size, content_length=str(body_size)
+            )
+            flows.append(first)
+            assert mitm_addon.requestheaders(first) is None
+            tasks.append(asyncio.create_task(mitm_addon.request(first)))
+            worker_threads.add(await asyncio.wait_for(hasher.started.get(), timeout=2))
+
+            # An active hash owns capacity while new worker creation is unavailable.
+            with patch.object(threading.Thread, "start", fail_hash_worker_start):
+                for identifier in range(1, accepted_count):
+                    flow = _header_auth_flow(
+                        real_flow,
+                        headers,
+                        body=bytes([identifier]) * body_size,
+                        content_length=str(body_size),
+                    )
+                    flows.append(flow)
+                    assert mitm_addon.requestheaders(flow) is None
+                    tasks.append(asyncio.create_task(mitm_addon.request(flow)))
+                    worker_threads.add(await asyncio.wait_for(hasher.started.get(), timeout=2))
+
+                assert len(worker_threads) == accepted_count
+                assert admission.state_for_tests() == (accepted_count, accepted_count * body_size)
+                overflow = _header_auth_flow(real_flow, headers, content_length=str(body_size))
+                assert mitm_addon.requestheaders(overflow) is None
+                assert overflow.error is not None
+                assert (
+                    overflow.metadata[metadata_keys.FIREWALL_ERROR]
+                    == auth.AWS_SIGV4_REQUEST_BODY_ADMISSION_SATURATED_ERROR
+                )
+                tasks[0].cancel()
+                await asyncio.sleep(0)
+                assert not tasks[0].done()
+                assert admission.state_for_tests() == (accepted_count, accepted_count * body_size)
+                assert await loop.run_in_executor(None, lambda: "progress") == "progress"
+
+                hasher.release.set()
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+                assert isinstance(results[0], asyncio.CancelledError)
+                assert results[1:] == [None] * (accepted_count - 1)
+                for flow in flows[1:]:
+                    assert flow.response is None
+                    assert (
+                        f"Credential={RESOLVED_AWS_ACCESS_KEY_ID}/"
+                        in flow.request.headers["authorization"]
+                    )
+                    flow.response = http.Response.make(200, b"ok")
+                    mitm_addon.response(flow)
+                assert admission.state_for_tests() == (0, 0)
+        finally:
+            hasher.release.set()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.parametrize("catalog_shutdown_fails", [False, True])
+async def test_done_joins_hashes_and_closes_hashing(
+    tmp_path,
+    real_flow,
+    headers,
+    mitm_ctx,
+    catalog_shutdown_fails: bool,
+) -> None:
+    hasher = _ControlledHashes(asyncio.get_running_loop())
+    registry_path = _write_aws_registry(tmp_path)
+    tasks: list[asyncio.Task[None]] = []
+    flows: list[http.HTTPFlow] = []
+
+    with (
+        mitm_ctx(registry_path=str(registry_path)),
+        patch.object(auth, "get_firewall_headers", AsyncMock(return_value=_resolved_token_meta())),
+        patch.object(auth, "hash_request_body", hasher),
+    ):
+        try:
+            for _ in range(2):
+                flow = _header_auth_flow(real_flow, headers, body=b"body", content_length="4")
+                flows.append(flow)
+                assert mitm_addon.requestheaders(flow) is None
+                tasks.append(asyncio.create_task(mitm_addon.request(flow)))
+                await asyncio.wait_for(hasher.started.get(), timeout=2)
+            workers = [
+                thread
+                for thread in threading.enumerate()
+                if thread.name.startswith("aws-sigv4-hash_")
+            ]
+            assert workers
+            tasks[0].cancel()
+            await asyncio.sleep(0)
+            assert not tasks[0].done()
+            hasher.release.set()
+
+            if catalog_shutdown_fails:
+                with (
+                    patch.object(
+                        mitm_addon.codex_model_catalog_cache,
+                        "shutdown",
+                        side_effect=RuntimeError("catalog shutdown failed"),
+                    ),
+                    pytest.raises(RuntimeError, match="catalog shutdown failed"),
+                ):
+                    mitm_addon.done()
+            else:
+                mitm_addon.done()
+
+            assert all(not worker.is_alive() for worker in workers)
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            assert isinstance(results[0], asyncio.CancelledError)
+            assert results[1] is None
+            assert (
+                f"Credential={RESOLVED_AWS_ACCESS_KEY_ID}/"
+                in flows[1].request.headers["authorization"]
+            )
+            flows[1].response = http.Response.make(200, b"ok")
+            mitm_addon.response(flows[1])
+
+            rejected = _header_auth_flow(real_flow, headers, body=b"body", content_length="4")
+            assert mitm_addon.requestheaders(rejected) is None
+            with pytest.raises(RuntimeError, match="AWS SigV4 hashing is shut down"):
+                await mitm_addon.request(rejected)
+            assert rejected.response is not None
+            assert rejected.response.status_code == 500
+            assert admission.state_for_tests() == (0, 0)
+        finally:
+            hasher.release.set()
+            await asyncio.gather(*tasks, return_exceptions=True)


### PR DESCRIPTION
Closes #32969

Failed executor worker startup could leave complete SigV4 request bodies queued after request cleanup released their memory reservations. Five failed 32 MiB requests retained 160 MiB in the regression before this fix.

Start a lazy SigV4-owned pool on payload-free gated jobs before accepting any body. Failed initialization cancels and joins only that pool; successful initialization reuses at most 16 workers, with the existing count/byte admission, parallel hashing, cancellation, signing, and streaming behavior. Add explicit addon shutdown and test-reset ownership. The first payload-dependent request pays for bounded pool startup, and idle workers remain until shutdown. The shared default executor and external contracts are unchanged.

Validation in the locked Python 3.14.0 / mitmproxy 12.2.3 environment:

- The real `Thread.start` regression failed on the original hashing path with all five bodies retained after flow cleanup.
- Eight new integration cases cover both capture modes, first/partial startup failure, recovery, count/byte saturation with parallel active hashes, cancellation, unrelated executor progress, and normal/failing shutdown.
- `python -m pytest tests/ -q`: **7,488 passed** (43 dependency/existing-fixture warnings).
- `ruff check .`, `ruff format --check .`, `basedpyright -p .`, and `PYTHONPATH=src python scripts/check-flow-metadata-keys.py`: passed.

No dependency, API, persisted-data, or fallback changes. Production cold-start latency has not been measured.
