### PR TITLE
fix(app): lighten the composer stroke so it stops out-weighing every border

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -734,12 +734,11 @@ body {
   border: none;
 }
 
-/* Composer / input card (white, light border — “Just ask” / chat input).
-   Surfaces that borrow this class are read as siblings of the real composer, so
-   the resting and focused strokes both track the `ComposerCard` class list. */
+/* Composer / input card (white, light border — “Just ask” / chat input) */
 .okou-app .okou-composer {
+  --okou-composer-ring: var(--gray-500);
   background-color: hsl(var(--card));
-  border: 0.7px solid hsl(var(--gray-300));
+  border: 0.7px solid hsl(var(--gray-400));
   border-radius: var(--okou-composer-radius);
   box-shadow: var(--okou-card-shadow);
 }
@@ -750,7 +749,7 @@ body {
   content: "";
   position: absolute;
   inset: -0.7px;
-  border: 0.7px solid hsl(var(--surface-focus));
+  border: 0.7px solid hsl(var(--okou-composer-ring));
   border-radius: inherit;
   box-shadow: var(--okou-composer-focus-veil);
   opacity: 0;
@@ -1851,6 +1850,17 @@ details > summary {
   text-overflow: ellipsis;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+}
+
+/* Dark carries the brand hue instead of a lighter neutral. The light ring can
+   stay neutral because there it darkens, and
+   darker-than-the-border already reads as emphasis. Lifting a neutral against a
+   dark card does not: it lands on a bright grey that reads as a white outline
+   rather than as focus, which is what `--ring` means on every other control.
+   Saturation, not lightness, does the work, so the ring stays quieter than the
+   full Amber stop. */
+:where([data-theme="dark"]) .okou-app .okou-composer {
+  --okou-composer-ring: 38.8 38% 38%;
 }
 
 /* Colour themes realigned to the permanent palette's lightness steps. */

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -734,11 +734,12 @@ body {
   border: none;
 }
 
-/* Composer / input card (white, light border — “Just ask” / chat input) */
+/* Composer / input card (white, light border — “Just ask” / chat input).
+   Surfaces that borrow this class are read as siblings of the real composer, so
+   the resting and focused strokes both track the `ComposerCard` class list. */
 .okou-app .okou-composer {
-  --okou-composer-ring: var(--gray-500);
   background-color: hsl(var(--card));
-  border: 0.7px solid hsl(var(--gray-400));
+  border: 0.7px solid hsl(var(--gray-300));
   border-radius: var(--okou-composer-radius);
   box-shadow: var(--okou-card-shadow);
 }
@@ -749,7 +750,7 @@ body {
   content: "";
   position: absolute;
   inset: -0.7px;
-  border: 0.7px solid hsl(var(--okou-composer-ring));
+  border: 0.7px solid hsl(var(--surface-focus));
   border-radius: inherit;
   box-shadow: var(--okou-composer-focus-veil);
   opacity: 0;
@@ -1850,17 +1851,6 @@ details > summary {
   text-overflow: ellipsis;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
-}
-
-/* Dark carries the brand hue instead of a lighter neutral. The light ring can
-   stay neutral because there it darkens, and
-   darker-than-the-border already reads as emphasis. Lifting a neutral against a
-   dark card does not: it lands on a bright grey that reads as a white outline
-   rather than as focus, which is what `--ring` means on every other control.
-   Saturation, not lightness, does the work, so the ring stays quieter than the
-   full Amber stop. */
-:where([data-theme="dark"]) .okou-app .okou-composer {
-  --okou-composer-ring: 38.8 38% 38%;
 }
 
 /* Colour themes realigned to the permanent palette's lightness steps. */

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -10709,7 +10709,7 @@ function ComposerCard({ signals }: { signals: ComposerSignals }) {
       className={cn(
         // Paint focus on the existing border. A separately promoted border
         // with a negative inset can snap differently from the card and SVGs.
-        "@container/composer relative z-10 overflow-visible rounded-3xl border-[0.7px] border-gray-300 bg-card shadow-[var(--okou-card-shadow)] transition-[border-color] duration-[220ms] ease-[cubic-bezier(0.4,0,0.2,1)] focus-within:border-surface-focus motion-reduce:transition-none",
+        "@container/composer relative z-10 overflow-visible rounded-3xl border-gray-300 bg-card shadow-[var(--okou-card-shadow)] transition-[border-color] duration-[220ms] ease-[cubic-bezier(0.4,0,0.2,1)] focus-within:border-surface-focus motion-reduce:transition-none",
         "after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-0 after:shadow-[var(--okou-composer-focus-veil)] after:transition-opacity after:duration-[220ms] after:ease-[cubic-bezier(0.4,0,0.2,1)] after:content-[''] focus-within:after:opacity-100 motion-reduce:after:transition-none",
         "[@media(display-mode:standalone)]:[[data-chat-composer]_&]:scroll-mb-4",
         dragOver && "outline outline-2 outline-blue-400/60",

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -10709,7 +10709,7 @@ function ComposerCard({ signals }: { signals: ComposerSignals }) {
       className={cn(
         // Paint focus on the existing border. A separately promoted border
         // with a negative inset can snap differently from the card and SVGs.
-        "@container/composer relative z-10 overflow-visible rounded-3xl border-gray-400 bg-card shadow-[var(--okou-card-shadow)] transition-[border-color] duration-[220ms] ease-[cubic-bezier(0.4,0,0.2,1)] focus-within:border-surface-focus motion-reduce:transition-none",
+        "@container/composer relative z-10 overflow-visible rounded-3xl border-[0.7px] border-gray-300 bg-card shadow-[var(--okou-card-shadow)] transition-[border-color] duration-[220ms] ease-[cubic-bezier(0.4,0,0.2,1)] focus-within:border-surface-focus motion-reduce:transition-none",
         "after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-0 after:shadow-[var(--okou-composer-focus-veil)] after:transition-opacity after:duration-[220ms] after:ease-[cubic-bezier(0.4,0,0.2,1)] after:content-[''] focus-within:after:opacity-100 motion-reduce:after:transition-none",
         "[@media(display-mode:standalone)]:[[data-chat-composer]_&]:scroll-mb-4",
         dragOver && "outline outline-2 outline-blue-400/60",

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -396,7 +396,7 @@
     --border: var(--gray-200); /* gray-200 - primary border color (lighter) */
     /* Large editable surfaces emphasize their existing edge on focus. One step
        is enough: the composer is the widest border on the page, so its stroke
-       carries far more ink than a control-sized one at the same colour. */
+       carries far more ink than a control-sized one at the same color. */
     --surface-focus: var(--gray-400);
     --input: var(--white); /* white - same as card */
     --ring: var(--primary-400); /* primary-400 - 6.73:1 on the canvas */
@@ -551,12 +551,8 @@
     --interrupt-foreground: var(--on-filled); /* white on Coral 500 */
 
     --border: var(--gray-200); /* gray-200 - primary border color */
-    /* Dark carries the brand hue instead of a lighter neutral. Light can stay
-       neutral because there the focused edge darkens, and darker-than-the-border
-       already reads as emphasis. Lifting a neutral against a dark card does not:
-       it lands on a bright grey that reads as a white outline rather than as
-       focus. Saturation, not lightness, does the work here, so the edge stays
-       quieter than the full Amber stop. */
+    /* Saturation, not lightness, carries focus here: lifting a neutral against a
+       dark card reads as a white outline rather than as emphasis. */
     --surface-focus: 38.8 38% 38%;
     --input: var(
       --gray-200

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -394,8 +394,10 @@
     --interrupt-foreground: var(--on-filled); /* white on Coral 500 */
 
     --border: var(--gray-200); /* gray-200 - primary border color (lighter) */
-    /* Large editable surfaces emphasize their existing edge on focus. */
-    --surface-focus: var(--gray-500);
+    /* Large editable surfaces emphasize their existing edge on focus. One step
+       is enough: the composer is the widest border on the page, so its stroke
+       carries far more ink than a control-sized one at the same colour. */
+    --surface-focus: var(--gray-400);
     --input: var(--white); /* white - same as card */
     --ring: var(--primary-400); /* primary-400 - 6.73:1 on the canvas */
 
@@ -549,6 +551,12 @@
     --interrupt-foreground: var(--on-filled); /* white on Coral 500 */
 
     --border: var(--gray-200); /* gray-200 - primary border color */
+    /* Dark carries the brand hue instead of a lighter neutral. Light can stay
+       neutral because there the focused edge darkens, and darker-than-the-border
+       already reads as emphasis. Lifting a neutral against a dark card does not:
+       it lands on a bright grey that reads as a white outline rather than as
+       focus. Saturation, not lightness, does the work here, so the edge stays
+       quieter than the full Amber stop. */
     --surface-focus: 38.8 38% 38%;
     --input: var(
       --gray-200


### PR DESCRIPTION
## What

The Okou home composer is the widest surface on the page, and it was drawing the heaviest line on it. Both of its stroke states drop one stop on the neutral ramp. Colour only — the border width is untouched.

| | before | after |
|---|---|---|
| rest | `border-gray-400` `#CFCCCB` | `border-gray-300` `#E0DDDC` |
| focus (light) | `--surface-focus` = `gray-500` `#A5A3A3` | `--surface-focus` = `gray-400` `#CFCCCB` |
| focus (dark) | `38.8 38% 38%` amber | unchanged |

For reference, every other card in the app borders on `--border` = `gray-200`. The composer sat two stops heavier than that at rest and three when focused.

Rest and focus stay a full stop apart, so the focused edge is still distinguishable — it just no longer lands near readable-text grey.

## Why dark is untouched

Dark's `--surface-focus` is already an amber-brown: it signals focus by hue, not by darkness, and lifting a neutral against a dark card reads as a white outline rather than as focus. Only the light value moves.

## Scope

`--surface-focus` has exactly one consumer in the repo (`ComposerCard` in `chat-composer.tsx`), so moving the token does not ripple into cards, inputs or dialogs. Both edits sit at the layer `docs/styles.md` names as the source of truth — `:root` / `[data-theme="dark"]` in `packages/ui/src/styles/globals.css`, and a Tailwind utility in the component.

Two things this PR deliberately does **not** do, after the review on `398ad747`:

- It does not retune `.okou-app .okou-composer` in `views/css/index.css`. That legacy selector is frozen by the shrink-only baseline (`docs/styles.md`: *"a changed declaration ... fails lint"*), and its atoms are recorded verbatim in `turbo/style-legacy-baseline.json`. As a result the shared-thread card and the Instatus notice, which borrow that class, stay one stop heavier than the real composer until that selector is migrated to utilities. Worth a follow-up; not worth a ratchet violation here.
- It does not change the border width. `docs/styles.md` states the chat composer *"uses the default `border` width for its surface and connector circles"*, and an earlier `border-[0.7px]` attempt was reverted. Measured at `devicePixelRatio: 2`, `0.7px` and `1px` rasterise identically to two device pixels, so the width bought nothing.

## Verification

Compiled the patched `globals.css` with the repo's pinned Tailwind (`4.3.3`) and read computed values off the real merged class list:

- rest → `rgb(224, 221, 220)` = `#E0DDDC` = `gray-300`
- focus → `rgb(207, 204, 203)` = `#CFCCCB` = `gray-400`
- radius unchanged at `24px`

Checked class merging against the repo's pinned `tailwind-merge@3.0.2`: `cn()` over `Card`'s base `border border-border` plus this class list keeps the default `border` width and resolves the colour to `border-gray-300`.

No tests: a token value and a utility class, with no behaviour change. `docs/testing.md` directs coverage at externally observable behaviour and warns against cases that restate static configuration, and `docs/styles.md` forbids locating surfaces through utility class names in tests. No feature switch: this restyles an existing element rather than adding user-facing surface area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
