### PR TITLE
fix(artifacts): classify uploaded image outputs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/uploads-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/uploads-complete.test.ts
@@ -156,8 +156,63 @@ function addUploadObject(
   });
 }
 
+function publicArtifactStorageKey(url: string): string {
+  const pathname = new URL(url).pathname.replace(/^\/+/u, "");
+  return pathname.startsWith("artifacts/") ? pathname : `artifacts/${pathname}`;
+}
+
+function uploadObjectMetadata(
+  headers: Readonly<Record<string, string>>,
+): Readonly<Record<string, string>> {
+  const prefix = "x-amz-meta-";
+  return Object.fromEntries(
+    Object.entries(headers).map(([name, value]) => {
+      if (!name.startsWith(prefix)) {
+        throw new Error(`Expected an S3 metadata header, received ${name}`);
+      }
+      return [name.slice(prefix.length), value];
+    }),
+  );
+}
+
+async function stagePreparedRunUpload(
+  fixture: RunUploadFixture,
+  args: {
+    readonly filename: string;
+    readonly contentType: string;
+    readonly size: number;
+    readonly purpose?: "artifact";
+  },
+) {
+  const prepared = await accept(
+    setupApp({ context, routes: uploadsPrepareRoutes })(
+      uploadsContract,
+    ).prepare({
+      headers: { authorization: fixture.bearer },
+      body: {
+        filename: args.filename,
+        contentType: args.contentType,
+        size: args.size,
+        ...(args.purpose ? { purpose: args.purpose } : {}),
+      },
+    }),
+    [200],
+  );
+  if (!("uploadHeaders" in prepared.body)) {
+    throw new Error("Expected a single-part artifact upload");
+  }
+  fixture.objectStore.addObject({
+    bucket: "test-user-artifacts",
+    key: publicArtifactStorageKey(prepared.body.url),
+    size: args.size,
+    contentType: prepared.body.contentType,
+    metadata: uploadObjectMetadata(prepared.body.uploadHeaders),
+  });
+  return prepared.body;
+}
+
 describe("POST /api/uploads/complete", () => {
-  it("records a private artifact from an agent run in the catalog with its authenticated URL", async () => {
+  it("records a private image artifact from an agent run in the image catalog", async () => {
     const fixture = await createRunUploadFixture({ chatThread: true });
     mockEnv("OKOU_API_BACKEND_URL", "https://api.okou.ai");
     createRouteMocks(context).clerk.session(
@@ -179,8 +234,8 @@ describe("POST /api/uploads/complete", () => {
       ).prepare({
         headers: { authorization: fixture.bearer },
         body: {
-          filename: "private-report.pdf",
-          contentType: "application/pdf",
+          filename: "private-render.png",
+          contentType: "image/png",
           size: 1234,
           purpose: "artifact",
         },
@@ -191,7 +246,7 @@ describe("POST /api/uploads/complete", () => {
       expect(command).toBeInstanceOf(HeadObjectCommand);
       return Promise.resolve({
         ContentLength: 1234,
-        ContentType: "application/pdf",
+        ContentType: "image/png",
       });
     });
     const response = await chat.completeUploadWithBearer(
@@ -200,13 +255,13 @@ describe("POST /api/uploads/complete", () => {
       [200],
     );
     expect(response.body).toMatchObject({
-      url: artifactReferencePath(prepared.body.id, "private-report.pdf"),
+      url: artifactReferencePath(prepared.body.id, "private-render.png"),
     });
     const catalog = await chat.listArtifactCatalog(fixture.actor, {
-      kind: "file",
+      kind: "image",
     });
     const artifact = catalog.artifacts.find((entry) => {
-      return entry.title === "private-report.pdf";
+      return entry.title === "private-render.png";
     });
     expect(artifact).toBeDefined();
     if (!artifact) {
@@ -217,7 +272,95 @@ describe("POST /api/uploads/complete", () => {
       artifact.id,
     );
     expect(detail).toMatchObject({
-      file: { url: prepared.body.url, filename: "private-report.pdf" },
+      kind: "image",
+      file: { url: prepared.body.url, filename: "private-render.png" },
+      model: null,
+      provider: null,
+    });
+  });
+
+  it("lists public image artifact outputs as images without reclassifying image inputs", async () => {
+    const fixture = await createRunUploadFixture({ chatThread: true });
+    const outputUrls = new Map<string, string>();
+    const imageOutputs = [
+      { filename: "render.jpg", contentType: "image/jpeg" },
+      { filename: "diagram.png", contentType: "image/png" },
+      { filename: "logo.svg", contentType: "image/svg+xml" },
+    ] as const;
+    for (const image of imageOutputs) {
+      const prepared = await stagePreparedRunUpload(fixture, {
+        ...image,
+        size: 128,
+        purpose: "artifact",
+      });
+      const completed = await chat.completeUploadWithBearer(
+        fixture.bearer,
+        { id: prepared.id },
+        [200],
+      );
+      if (completed.status !== 200) {
+        throw new Error("Expected image artifact upload to complete");
+      }
+      outputUrls.set(image.filename, completed.body.url);
+    }
+
+    const input = await stagePreparedRunUpload(fixture, {
+      filename: "reference.png",
+      contentType: "image/png",
+      size: 128,
+    });
+    await chat.completeUploadWithBearer(
+      fixture.bearer,
+      { id: input.id },
+      [200],
+    );
+
+    const images = await chat.listArtifactCatalog(fixture.actor, {
+      kind: "image",
+    });
+    expect(images.artifacts).toHaveLength(imageOutputs.length);
+    for (const output of imageOutputs) {
+      const url = outputUrls.get(output.filename);
+      if (!url) {
+        throw new Error(`Expected output URL for ${output.filename}`);
+      }
+      expect(images.artifacts).toContainEqual(
+        expect.objectContaining({
+          kind: "image",
+          title: output.filename,
+          thumbnail: { url },
+        }),
+      );
+    }
+
+    const files = await chat.listArtifactCatalog(fixture.actor, {
+      kind: "file",
+    });
+    expect(files.artifacts).toStrictEqual([
+      expect.objectContaining({ kind: "file", title: "reference.png" }),
+    ]);
+
+    const svg = images.artifacts.find((artifact) => {
+      return artifact.title === "logo.svg";
+    });
+    if (!svg) {
+      throw new Error("Expected the SVG output in the image catalog");
+    }
+    const svgUrl = outputUrls.get("logo.svg");
+    if (!svgUrl) {
+      throw new Error("Expected the SVG output URL");
+    }
+    await expect(
+      chat.getArtifactCatalogEntry(fixture.actor, svg.id),
+    ).resolves.toMatchObject({
+      kind: "image",
+      file: {
+        filename: "logo.svg",
+        contentType: "image/svg+xml",
+        url: svgUrl,
+      },
+      model: null,
+      provider: null,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/uploads-prepare.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/uploads-prepare.test.ts
@@ -171,7 +171,7 @@ describe("POST /api/uploads/prepare", () => {
     const response = await setupApp({ context, routes: uploadsTestRoutes })(
       uploadsContract,
     ).prepare({
-      body: validBody(),
+      body: { ...validBody(), purpose: "artifact" },
       headers: { authorization: `Bearer ${token}` },
       extraHeaders: { origin: "https://app.okou.ai" },
     });
@@ -184,7 +184,10 @@ describe("POST /api/uploads/prepare", () => {
       /^https:\/\/a\.okou\.io\/[0-9a-z]{10}\.txt$/u,
     );
     expect(response.body).toMatchObject({
-      uploadHeaders: { "x-amz-meta-public-brand": "okou" },
+      uploadHeaders: {
+        "x-amz-meta-artifact-purpose": "artifact",
+        "x-amz-meta-public-brand": "okou",
+      },
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/uploads-complete.ts
+++ b/turbo/apps/api/src/signals/routes/uploads-complete.ts
@@ -87,7 +87,10 @@ const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       url,
       s3Key: s3Object.key,
       publicBrand: s3Object.publicBrand,
-      metadata: lastModified ? { lastModified } : {},
+      metadata: {
+        ...(lastModified ? { lastModified } : {}),
+        ...(s3Object.purpose ? { uploadPurpose: s3Object.purpose } : {}),
+      },
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/services/artifact-catalog.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-catalog.service.ts
@@ -57,9 +57,9 @@ import { runOwnedChatEventForRunCondition } from "./chat-event-type.service";
 const ARTIFACT_CATALOG_DEFAULT_LIMIT = 60;
 
 /**
- * `generatedBy` markers written by the built-in generation pipelines. They are
- * the only signal that separates an officially generated image or video from an
- * ordinary upload that happens to share a content type.
+ * `generatedBy` markers written by the built-in generation pipelines. Explicit
+ * artifact uploads carry a separate purpose marker so output images can be
+ * distinguished from ordinary uploads that happen to share a content type.
  */
 const OFFICIAL_IMAGE_MARKER = "zero-official-image";
 const OFFICIAL_VIDEO_MARKER = "zero-official-video";
@@ -108,12 +108,17 @@ function metadataString(
 }
 
 /**
- * The catalog kind a stored file maps to. Ordinary uploads of every media type
- * stay `file`; only the official generation pipelines produce `image`/`video`.
+ * The catalog kind a stored file maps to. Ordinary media uploads stay `file`;
+ * built-in media generation and explicit image artifact outputs receive their
+ * dedicated kinds.
  */
 function fileArtifactKind(row: CatalogFileRow): "file" | "image" | "video" {
   const generatedBy = metadataString(row.metadata, "generatedBy");
-  if (generatedBy === OFFICIAL_IMAGE_MARKER) {
+  if (
+    generatedBy === OFFICIAL_IMAGE_MARKER ||
+    (metadataString(row.metadata, "uploadPurpose") === "artifact" &&
+      fileContentType(row).startsWith("image/"))
+  ) {
     return "image";
   }
   if (
@@ -123,6 +128,11 @@ function fileArtifactKind(row: CatalogFileRow): "file" | "image" | "video" {
     return "video";
   }
   return "file";
+}
+
+function fileContentType(row: CatalogFileRow): string {
+  const filename = row.filename ?? row.externalId;
+  return row.contentType ?? inferMimetype(filename);
 }
 
 /**
@@ -197,8 +207,7 @@ function fileThumbnail(row: CatalogFileRow): ArtifactThumbnail | null {
   if (row.previewImageUrl) {
     return { url: row.previewImageUrl };
   }
-  const filename = row.filename ?? row.externalId;
-  const contentType = row.contentType ?? inferMimetype(filename);
+  const contentType = fileContentType(row);
   if (row.url && contentType.startsWith("image/")) {
     return { url: row.url };
   }
@@ -342,7 +351,7 @@ async function upsertArtifact(args: UpsertArtifactArgs): Promise<void> {
     });
 }
 
-async function upsertGeneratedMediaEntity(
+async function upsertMediaEntity(
   args: {
     readonly db: Db;
     readonly kind: "image" | "video";
@@ -669,7 +678,7 @@ async function syncArtifactCatalogFile(
   const entityId =
     kind === "file"
       ? row.id
-      : await upsertGeneratedMediaEntity({ db, kind, row }, signal);
+      : await upsertMediaEntity({ db, kind, row }, signal);
   if (!entityId) {
     return;
   }

--- a/turbo/apps/api/src/signals/services/artifact-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-storage.service.ts
@@ -37,6 +37,7 @@ const ARTIFACT_ID_METADATA_KEY = "artifact-id";
 const ARTIFACT_FILENAME_METADATA_KEY = "filename";
 const ARTIFACT_USER_ID_METADATA_KEY = "user-id";
 const ARTIFACT_PUBLIC_BRAND_METADATA_KEY = "public-brand";
+const ARTIFACT_PURPOSE_METADATA_KEY = "artifact-purpose";
 const CLOUDFLARE_IMAGE_RESIZE_PATH_PREFIX = "/cdn-cgi/image/";
 const PUBLIC_ARTIFACT_PATH_PREFIX = "/artifacts/";
 
@@ -65,6 +66,7 @@ export interface ResolvedArtifactObject {
   readonly contentType: string;
   readonly size: number;
   readonly lastModified: Date | undefined;
+  readonly purpose?: "artifact";
 }
 
 function publicArtifactPath(pathname: string): string | null {
@@ -154,13 +156,25 @@ export function artifactObjectMetadata(
   id: string,
   filename: string,
   publicBrand: PublicBrand,
+  purpose?: "artifact",
 ): Readonly<Record<string, string>> {
   return {
     [ARTIFACT_ID_METADATA_KEY]: id,
     [ARTIFACT_FILENAME_METADATA_KEY]: encodeURIComponent(filename),
     [ARTIFACT_USER_ID_METADATA_KEY]: encodeURIComponent(userId),
     [ARTIFACT_PUBLIC_BRAND_METADATA_KEY]: publicBrand,
+    ...(purpose ? { [ARTIFACT_PURPOSE_METADATA_KEY]: purpose } : {}),
   };
+}
+
+function artifactPurposeFromMetadata(
+  metadata: Readonly<Record<string, string>>,
+): "artifact" | undefined {
+  const purpose = metadata[ARTIFACT_PURPOSE_METADATA_KEY];
+  if (purpose === undefined || purpose === "artifact") {
+    return purpose;
+  }
+  throw new Error(`Invalid artifact purpose: ${purpose}`);
 }
 
 function publicBrandFromMetadata(
@@ -204,6 +218,7 @@ export const allocateArtifactObject$ = command(
       readonly userId: string;
       readonly filename: string;
       readonly publicBrand: PublicBrand;
+      readonly purpose?: "artifact";
       readonly id?: string;
       readonly variant?: string;
     },
@@ -236,6 +251,7 @@ export const allocateArtifactObject$ = command(
             id,
             args.filename,
             args.publicBrand,
+            args.purpose,
           ),
         };
       }
@@ -252,7 +268,8 @@ export const allocateArtifactObject$ = command(
             head.metadata[ARTIFACT_ID_METADATA_KEY] === id &&
             head.metadata[ARTIFACT_USER_ID_METADATA_KEY] ===
               encodeURIComponent(args.userId) &&
-            filenameFromMetadata(head.metadata) === args.filename
+            filenameFromMetadata(head.metadata) === args.filename &&
+            artifactPurposeFromMetadata(head.metadata) === args.purpose
           ) {
             const publicBrand = publicBrandFromMetadata(head.metadata);
             return {
@@ -265,6 +282,7 @@ export const allocateArtifactObject$ = command(
                 id,
                 args.filename,
                 publicBrand,
+                args.purpose,
               ),
             };
           }
@@ -405,6 +423,7 @@ function resolvedV2ArtifactObjectFromHead(args: {
   const filename =
     filenameFromMetadata(args.head.metadata) ?? filenameFromLegacyKey(args.key);
   const publicBrand = publicBrandFromMetadata(args.head.metadata);
+  const purpose = artifactPurposeFromMetadata(args.head.metadata);
   return {
     key: args.key,
     url: buildFileUrlFromKey(args.key, publicBrand),
@@ -413,6 +432,7 @@ function resolvedV2ArtifactObjectFromHead(args: {
     contentType: args.head.contentType ?? inferMimetype(filename),
     size,
     lastModified,
+    ...(purpose ? { purpose } : {}),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/uploaded-artifact.service.ts
+++ b/turbo/apps/api/src/signals/services/uploaded-artifact.service.ts
@@ -80,6 +80,7 @@ export function uploadedArtifactObject(args: UploadedArtifactIdentity) {
         contentType: record.contentType,
         size: head.contentLength,
         lastModified: head.lastModified,
+        purpose: "artifact" as const,
         isPrivate: true,
       };
     }

--- a/turbo/packages/db/src/schema/artifact.ts
+++ b/turbo/packages/db/src/schema/artifact.ts
@@ -125,8 +125,8 @@ export const artifactCatalogPendingFiles = pgTable(
 );
 
 /**
- * Kind entity for officially generated images. References the stored file
- * instead of copying its URL or storage state.
+ * Kind entity for cataloged images. References the stored file instead of
+ * copying its URL or storage state.
  */
 export const imageArtifacts = pgTable(
   "image_artifacts",


### PR DESCRIPTION
## Summary

- persist the existing `purpose: "artifact"` upload intent in public object metadata and carry it into the run file projection
- classify explicit image artifact outputs as `image` while leaving ordinary image uploads and processing inputs as `file`
- cover public JPG, PNG, and SVG outputs as well as private image artifacts

## Rationale

The earlier MIME-only approach in #24175 could not distinguish generated outputs from ordinary image uploads, which was the concern behind #24035. The upload contract now has an explicit artifact purpose used by `okou web upload-file`, so the catalog can make that distinction without broad MIME-based reclassification.

Previously uploaded public objects do not contain this purpose marker. This change intentionally avoids a heuristic backfill because it would also reclassify image-recognition and presentation-processing inputs. Built-in image generation continues to use its existing `generatedBy` marker.

## Test plan

- `pnpm exec vitest run apps/api/src/signals/routes/__tests__/uploads-complete.test.ts` (19 passed)
- `pnpm exec vitest run apps/api/src/signals/routes/__tests__/uploads-prepare.test.ts` (19 passed)
- `pnpm -F api check-types:core`
- `pnpm -F api check-types:tests`
- `pnpm -F @okouai/db check-types`
- `pnpm -F api lint`
- `pnpm -F @okouai/db lint`
- `pnpm knip --workspace api`
- `pnpm knip --workspace @okouai/db`

Fixes #33019

Please use rebase merge and delete the source branch after merging.

Co-Authored-By: Zero <zero@vm0.ai>
