### PR TITLE
ci: independently verify public artifacts after backfill

### DIFF
--- a/.github/workflows/public-artifact-registration.yml
+++ b/.github/workflows/public-artifact-registration.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: "Inventory only, register and verify, or independently verify"
+        description: "Inventory, backfill then independently verify, or verify only"
         type: choice
         options: [dry-run, migrate, verify]
         default: dry-run
@@ -155,11 +155,23 @@ jobs:
             --concurrency "$REGISTRATION_CONCURRENCY" \
             --report public-artifact-registration.json
 
+          # A separate read-only process verifies fresh storage and DB state.
+          # Preserve the backfill report even if this independent pass fails.
+          if [ "$REGISTRATION_MODE" = migrate ]; then
+            pnpm exec tsx scripts/migrations/014-public-artifact-registration/backfill.ts \
+              --verify \
+              --max-objects "$REGISTRATION_LIMIT" \
+              --concurrency "$REGISTRATION_CONCURRENCY" \
+              --report public-artifact-registration-verification.json
+          fi
+
       - name: Preserve registration evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: public-artifact-registration-${{ github.run_id }}
-          path: turbo/packages/db/public-artifact-registration.json
+          path: |
+            turbo/packages/db/public-artifact-registration.json
+            turbo/packages/db/public-artifact-registration-verification.json
           if-no-files-found: ignore
           retention-days: 30

--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/README.md
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/README.md
@@ -121,11 +121,17 @@ click-only records and later optional pointer/typing fields are recognized.
    on its current public R2 path, including its existing Cloudflare cache and image
    transformations. No Worker route or cache-rule changes belong to this phase.
 2. Run the protected **Public Artifact Registration** GitHub Action on `main`: first
-   `dry-run`, then `migrate`, then an independent `verify` after the old-writer and
-   upload-credential drain. It uses production R2 credentials and read-only Neon
-   queries, saves the report as a GitHub artifact, and never passes `--finalize`.
-   Accept coverage only with zero missing, conflicting or unclassified records
-   and zero unregistered pending multipart uploads.
+   `dry-run`, then `migrate` after the old-writer and upload-credential drain.
+   After a successful backfill, `migrate` starts a separate read-only `--verify`
+   process with fresh storage inventories and database reconciliation. The same
+   protected job continues through both passes and succeeds only if both succeed.
+   Its artifact preserves `public-artifact-registration.json` for the backfill
+   and `public-artifact-registration-verification.json` for the independent pass,
+   including the first report if the second pass fails. The `verify` mode remains
+   available for a standalone read-only run. All modes use production R2 credentials
+   and read-only Neon queries and never pass `--finalize`. Accept coverage only
+   with zero missing, conflicting or unclassified records and zero unregistered
+   pending multipart uploads.
 3. Review the separate `a.okou.io` delivery cutover (#32959) after coverage is
    complete. The planned unified host serves old registered public files and new
    opaque public-share aliases through `zero-host-worker`. Existing URLs and old


### PR DESCRIPTION
The production backfill can outlive the interactive rollout session, leaving its independent coverage check waiting for a second dispatch. In `migrate` mode, the protected production job now starts a separate read-only `--verify` process after a successful backfill, saves distinct JSON reports for both passes, and succeeds only if both pass. If independent verification fails, the completed backfill report is still uploaded.

Dispatch after the old-writer/upload-credential drain documented in #32492. The main-only production gate, serialized concurrency, dependency installation before credentials, bucket guards and frozen migration are retained. Standalone `dry-run` and `verify` modes remain available; this does not finalize registration or activate private artifact delivery.

Validation: pinned actionlint 1.7.12 and Prettier passed. Seven execution probes ran the extracted Bash step with a local stand-in for the unchanged migration command: all three modes, failure of either pass, report preservation, invalid mode and wrong-bucket rejection. Normal commit checks passed. No full local Vitest run or development server was used.

Relates to #32492.
