### PR TITLE
fix(ssh): restore chat directory setup and keyboard activation

### DIFF
--- a/docs/ssh-access.md
+++ b/docs/ssh-access.md
@@ -72,6 +72,10 @@ then custom Connectors. The trigger keeps its three-icon limit and existing
 computer/browser slots; SSH no longer displaces built-in Connector icons.
 It always uses that composer's Agent, including split-pane chats. No hosts hides
 the SSH row; **Add connectors** offers the same zero-host setup entry.
+Both the legacy dialog and the Discover directory include this entry when
+SSH is enabled and no hosts are configured. In Discover, it appears after
+built-in shelves and under **Remote access**, participates in search, and stays
+out of the Custom tab. Its link also supports normal keyboard activation.
 Opening the popover refreshes SSH reads without dropping the last confirmed
 display for the same user/workspace. Its switch waits for the refreshed result.
 Changing owner discards that retained display, and each composer selects only

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-ssh.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-ssh.test.tsx
@@ -3,8 +3,9 @@ import { sshConnectionsContract } from "@okouai/api-contracts/contracts/ssh-conn
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { connectorSlugSchema } from "@okouai/api-contracts/contracts/connector-identity";
 import { act, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { expect, test } from "vitest";
-import { click, setupPage } from "../../../__tests__/page-helper.ts";
+import { click, fill, setupPage } from "../../../__tests__/page-helper.ts";
 import {
   context,
   findFastControl,
@@ -247,12 +248,21 @@ test.each([SCOUT_AGENT_ID, OTHER_AGENT_ID])(
   },
 );
 
-test.each([true, false])(
-  "Chat hides unconfigured SSH and exposes the zero-host setup entry only when enabled (%s)",
-  async (enabled) => {
+test.each([
+  { enabled: true, directory: false, configuredCount: 0 },
+  { enabled: false, directory: false, configuredCount: 0 },
+  { enabled: true, directory: true, configuredCount: 0 },
+  { enabled: false, directory: true, configuredCount: 0 },
+  { enabled: true, directory: true, configuredCount: 1 },
+])(
+  "Chat SSH setup respects SSH=$enabled, directory=$directory and hosts=$configuredCount",
+  async ({ enabled, directory, configuredCount }) => {
     installComposerConnectorFixture();
     context.mocks.api(sshConnectionsContract.summary, ({ respond }) => {
-      return respond(200, { configuredCount: 0 });
+      return respond(200, { configuredCount });
+    });
+    context.mocks.api(agentSshAccessContract.get, ({ respond }) => {
+      return respond(200, { enabled: false });
     });
     context.mocks.api(sshConnectionsContract.list, ({ respond }) => {
       return respond(200, { connections: [] });
@@ -260,7 +270,10 @@ test.each([true, false])(
     await setupPage({
       context,
       path: `/agents/${SCOUT_AGENT_ID}/chat`,
-      featureSwitches: { [FeatureSwitchKey.SshAccess]: enabled },
+      featureSwitches: {
+        [FeatureSwitchKey.SshAccess]: enabled,
+        [FeatureSwitchKey.ConnectorDirectory]: directory,
+      },
     });
     click(await findFastControl("button", "Connectors"));
     click(await findFastControl("button", "Add connectors"));
@@ -270,17 +283,73 @@ test.each([true, false])(
     if (!(dialog instanceof HTMLElement)) {
       throw new Error("Missing connector dialog");
     }
-    const entry = queryFastControl("link", "Manage SSH hosts", dialog);
-    expect(entry !== null).toBe(enabled);
-    if (enabled) {
-      click(entry!);
+    const showEntry = enabled && configuredCount === 0;
+    const initialEntry = showEntry
+      ? await findFastControl("link", "Manage SSH hosts", dialog)
+      : queryFastControl("link", "Manage SSH hosts", dialog);
+    expect(initialEntry !== null).toBe(showEntry);
+    if (showEntry) {
+      await fill(search, "ssh");
+      const entry = await findFastControl("link", "Manage SSH hosts", dialog);
+      click(entry);
       await screen.findByRole("dialog", { name: "Add host" });
     }
     await waitFor(() => {
       return expect(window.location.pathname).toBe(
-        enabled ? "/connectors/ssh" : `/agents/${SCOUT_AGENT_ID}/chat`,
+        showEntry ? "/connectors/ssh" : `/agents/${SCOUT_AGENT_ID}/chat`,
       );
     });
     expect(window.location.search).toBe("");
   },
 );
+
+test("Directory SSH setup follows shelves and categories and supports keyboard navigation", async () => {
+  const user = userEvent.setup({ delay: null });
+  installComposerConnectorFixture({
+    catalog: ["GitHub", "Slack", "Gmail", "Notion", "Jira"].map(
+      (label, popularityRank) => {
+        return builtinConnector({
+          slug: connectorSlugSchema.parse(label.toLowerCase()),
+          label,
+          connected: false,
+          popularityRank,
+        });
+      },
+    ),
+    categoryConnectorCounts: { productivity: 5 },
+  });
+  context.mocks.api(sshConnectionsContract.summary, ({ respond }) => {
+    return respond(200, { configuredCount: 0 });
+  });
+  context.mocks.api(sshConnectionsContract.list, ({ respond }) => {
+    return respond(200, { connections: [] });
+  });
+  await setupPage({
+    context,
+    path: `/agents/${SCOUT_AGENT_ID}/chat`,
+    featureSwitches: {
+      [FeatureSwitchKey.SshAccess]: true,
+      [FeatureSwitchKey.ConnectorDirectory]: true,
+    },
+  });
+  click(await findFastControl("button", "Connectors"));
+  click(await findFastControl("button", "Add connectors"));
+  const dialog = await screen.findByRole("dialog", { name: "Connectors" });
+  await within(dialog).findByTestId("connector-shelf-head");
+  await findFastControl("link", "Manage SSH hosts", dialog);
+  click(await findFastControl("button", "Remote access1", dialog));
+  await within(dialog).findByText("1 match");
+  expect(within(dialog).queryByText("GitHub")).toBeNull();
+  click(within(dialog).getByText("Custom", { exact: true }));
+  await within(dialog).findByText("No custom connectors yet");
+  expect(queryFastControl("link", "Manage SSH hosts", dialog)).toBeNull();
+  click(within(dialog).getByText("Discover", { exact: true }));
+  await findFastControl("link", "Manage SSH hosts", dialog);
+  click(await findFastControl("button", "All", dialog));
+  await within(dialog).findByTestId("connector-shelf-head");
+  const entry = await findFastControl("link", "Manage SSH hosts", dialog);
+  entry.focus();
+  await user.keyboard("{Enter}");
+  await screen.findByRole("dialog", { name: "Add host" });
+  expect(window.location.pathname).toBe("/connectors/ssh");
+});

--- a/turbo/apps/platform/src/views/okou-page/connector-directory-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connector-directory-dialog.tsx
@@ -1,4 +1,4 @@
-import { useLastLoadable } from "ccstate-react";
+import { useLastLoadable, useLoadable } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import { ArrowRight, Plus, Search, TriangleAlert } from "lucide-react";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
@@ -19,6 +19,8 @@ import { Button, cn } from "@okouai/ui";
 import type { PublicConnectorCatalogCategoryMetadata } from "@okouai/api-contracts/contracts/connector-catalog";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import { connectorAccountSummaryByTarget$ } from "../../signals/okou-page/connector-accounts.ts";
+import { sshSummary$ } from "../../signals/ssh.ts";
+import { REMOTE_ACCESS_CATEGORY } from "../../signals/okou-page/settings/ssh-connector.ts";
 import type {
   ComposerConnectorUiState,
   ConnectorDirectoryTab,
@@ -41,6 +43,7 @@ import {
 } from "./components/settings/launch-connector-connect.ts";
 import { useConnectorAccountLabel } from "./components/settings/use-connector-account-label.ts";
 import { ConnectorDetailPanel } from "./connector-directory-detail.tsx";
+import { SshConnectorCard } from "./components/settings/ssh-connector-card.tsx";
 import {
   buildConnectorDirectoryModel,
   type ConnectorDirectoryModel,
@@ -340,6 +343,7 @@ function DirectoryCategoryChips({
 
 function DirectoryDiscoverPanel({
   model,
+  showSsh,
   renderCard,
   search,
   category,
@@ -347,6 +351,7 @@ function DirectoryDiscoverPanel({
   onCreateCustom,
 }: {
   readonly model: ConnectorDirectoryModel;
+  readonly showSsh: boolean;
   readonly renderCard: RenderConnectorCard;
   readonly search: string;
   readonly category: string | null;
@@ -369,7 +374,11 @@ function DirectoryDiscoverPanel({
         })}
       </DirectorySection>
     ) : null;
-  if (model.discover.length === 0 && model.matchedConnected.length === 0) {
+  if (
+    model.discover.length === 0 &&
+    model.matchedConnected.length === 0 &&
+    !showSsh
+  ) {
     return (
       <>
         {attention}
@@ -409,18 +418,19 @@ function DirectoryDiscoverPanel({
             })}
           </DirectorySection>
         )}
-        {model.discover.length > 0 && (
+        {(model.discover.length > 0 || showSsh) && (
           <DirectorySection
             title={t(
               ($) => {
                 return $.chat.connectors.directory.matchCount;
               },
-              { count: model.discover.length },
+              { count: model.discover.length + Number(showSsh) },
             )}
           >
             {model.discover.map((item) => {
               return renderCard(item, false);
             })}
+            {showSsh && <SshConnectorCard configuredCount={0} />}
           </DirectorySection>
         )}
       </>
@@ -447,6 +457,15 @@ function DirectoryDiscoverPanel({
         chips={model.shelfLayout.chips}
         onSelect={onSelectCategory}
       />
+      {showSsh && (
+        <DirectorySection
+          title={t(($) => {
+            return $.connectors.catalog.remoteAccess;
+          })}
+        >
+          <SshConnectorCard configuredCount={0} />
+        </DirectorySection>
+      )}
     </>
   );
 }
@@ -561,6 +580,7 @@ function DirectoryToolbar({
 
 function DirectoryBody({
   tab,
+  showSsh,
   loading,
   model,
   renderCard,
@@ -570,6 +590,7 @@ function DirectoryBody({
   onConnectCustom,
 }: {
   readonly tab: ConnectorDirectoryTab;
+  readonly showSsh: boolean;
   readonly loading: boolean;
   readonly model: ConnectorDirectoryModel;
   readonly renderCard: RenderConnectorCard;
@@ -585,6 +606,7 @@ function DirectoryBody({
     return (
       <DirectoryDiscoverPanel
         model={model}
+        showSsh={showSsh}
         renderCard={renderCard}
         search={search}
         category={category}
@@ -626,6 +648,29 @@ function DirectoryBrowseView({
   readonly onUpdateState: UpdateDirectoryState;
   readonly onConnectCustom: (connector: CustomConnectorResponse) => void;
 }) {
+  const { t } = useTranslation();
+  const summary = useLoadable(sshSummary$);
+  const sshAvailable =
+    summary.state === "hasData" && summary.data?.configuredCount === 0;
+  const showSsh =
+    sshAvailable &&
+    (category === null || category === REMOTE_ACCESS_CATEGORY) &&
+    "ssh".includes(search.trim().toLowerCase());
+  const remoteAccessLabel = t(($) => {
+    return $.connectors.catalog.remoteAccess;
+  });
+  const sections = sshAvailable
+    ? [
+        ...model.categorySections,
+        {
+          category: REMOTE_ACCESS_CATEGORY,
+          label: remoteAccessLabel,
+          menuLabel: remoteAccessLabel,
+          groupId: null,
+          connectors: [],
+        },
+      ]
+    : model.categorySections;
   return (
     <>
       <DirectoryToolbar
@@ -643,8 +688,12 @@ function DirectoryBrowseView({
       />
       {tab === "discover" && (
         <DirectoryCategoryChips
-          sections={model.categorySections}
-          categoryCounts={categoryCounts}
+          sections={sections}
+          categoryCounts={
+            sshAvailable
+              ? { ...categoryCounts, [REMOTE_ACCESS_CATEGORY]: 1 }
+              : categoryCounts
+          }
           selected={category}
           onSelect={(next) => {
             onUpdateState({
@@ -662,6 +711,7 @@ function DirectoryBrowseView({
       >
         <DirectoryBody
           tab={tab}
+          showSsh={showSsh}
           loading={loading}
           model={model}
           renderCard={renderCard}
@@ -745,7 +795,10 @@ function createDirectoryKeyDownHandler({
   readonly onUpdateState: UpdateDirectoryState;
 }) {
   return (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (inDetail) {
+    if (
+      inDetail ||
+      (event.target instanceof HTMLElement && event.target.closest("a, button"))
+    ) {
       return;
     }
     const next = nextDirectoryIndex(


### PR DESCRIPTION
## Summary

Closes #33026. Follow-up to merged #32722 / #32014; related SSH delivery #31932 remains open.

- Restore the zero-host SSH setup card in Chat's new Connector directory, reusing the existing standalone SSH card and one-shot `/connectors/ssh` Add host flow.
- Include SSH in Discover browse, the Remote access category and matching search results/counts. Keep it out of Custom and hide the setup entry when SSH is disabled or hosts are already configured.
- Leave keyboard activation of focused links/buttons to those controls. Pressing Enter on the SSH link must not launch the currently selected builtin Connector.
- Extend Router regressions for both directory modes and SSH eligibility, category/tab navigation, shelves, search and keyboard activation; document the behavior.

## Evidence

The expanded flag-combination regression failed on the merged code because **Manage SSH hosts** was missing from the new directory. With the entry added but the keyboard fix removed, the focused-link regression started the GitHub redirect instead of opening **Add host**. Both pass with this change.

## Scope and risk

Frontend presentation, keyboard routing, tests and documentation only. The existing SSH identity, summary and management flow are reused; no Connector identity/account is fabricated.

The directory now displays one additional setup card/category for eligible zero-host users. Its global navigation shortcut no longer intercepts a focused link/button; search-driven selected-result navigation remains unchanged.

No new fallback, API/schema change, credentials exposure, Agent authorization change, Runner change, switch-default change or production activation. No merge is requested. The user's pre-existing SharedWorker stash is untouched.

## Validation

Based on `main` at `0c27252592810ab55baa97169773056a7453ab30`.

- **188 tests passed across 10 Platform Router suites**, with no selected tests skipped.
- Changed-file Prettier, full Platform lint (including i18n), Platform type checks, scoped Knip and `git diff --check` passed.
- Commit hooks also passed style policy, full workspace Knip and type checks, formatting and commitlint.
- No new deployed Run, browser screenshot or CI-green result is claimed.

Commands run from `turbo/`:

```sh
pnpm -F @okouai/app exec vitest run \
  src/views/okou-page/__tests__/connectors-ssh.test.tsx \
  src/views/okou-page/__tests__/connectors-catalog.test.tsx \
  src/views/okou-page/__tests__/connector-directory.test.tsx \
  src/views/okou-page/__tests__/chat-composer-ssh.test.tsx \
  src/views/okou-page/__tests__/ssh-settings.test.tsx \
  src/views/okou-page/__tests__/connectors-accounts.test.tsx \
  src/views/okou-page/__tests__/connectors-custom.test.tsx \
  src/views/okou-page/__tests__/connectors-auth-methods.test.tsx \
  src/views/okou-page/__tests__/chat-composer-connectors.test.tsx \
  src/views/okou-page/__tests__/onboarding.test.tsx \
  --maxWorkers=2 --silent=passed-only
pnpm -F @okouai/app lint
pnpm -F @okouai/app check-types
pnpm knip --workspace apps/platform
pnpm exec prettier --check \
  apps/platform/src/views/okou-page/connector-directory-dialog.tsx \
  apps/platform/src/views/okou-page/__tests__/chat-composer-ssh.test.tsx \
  ../docs/ssh-access.md
```
