### PR TITLE
feat(cli): extend artifact presentation guidance to generation results

### DIFF
--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -106,6 +106,20 @@ can appear as a link and a preview in one event while sharing its resource URL
 and load state. Artifacts carried out of folded work history retain their
 original nodes, so folding does not change links into cards.
 
+CLI artifact producers return `inlineMarkdownLink`, `previewMarkdownBlock`, and
+`artifactPresentationContext` alongside successful JSON results. Text output
+shows the same forms and explains their presentation. This applies to file
+uploads, hosting, built-in image/video/voice/avatar generation, completed social
+downloads, and internal Intro Video media. The forms use the stable artifact
+reference; an image's HTML embed URL has a separate authoring purpose. Pending
+Intro Video jobs return continuation guidance until a completed artifact exists.
+
+Image batches keep their authoring assets in `results.tsv` and record stable
+chat references plus both Markdown forms in `artifacts.json`, outside the
+authored bundle. `okou generate image-batch wait --json` returns this metadata.
+Persisted batches without that optional metadata remain readable through their
+TSV and provide upload guidance for selected local files.
+
 A path such as `/chats/:threadId` can use the same design when a chat-thread
 card is introduced: add an exact parser for the path, derive a canonical
 resource key, define the card's signals and registry, and add its render case.

--- a/turbo/apps/cli/src/commands/__intro-video-agent.ts
+++ b/turbo/apps/cli/src/commands/__intro-video-agent.ts
@@ -12,6 +12,7 @@ import {
   getWebIntroVideoAgent,
 } from "../lib/api/domains/web";
 import { withErrorHandler } from "../lib/command/with-error-handler";
+import { createArtifactPresentation } from "./shared/artifact-return";
 
 interface IntroVideoAgentCommandOptions {
   readonly prompt?: string;
@@ -44,8 +45,22 @@ function resumeCommand(generationId: string): string {
 }
 
 function printResult(result: IntroVideoAgentResponse, json?: boolean): void {
+  const presentation =
+    result.status === "completed" && result.url
+      ? createArtifactPresentation(result.filename ?? "Intro video", result.url)
+      : undefined;
+  const continuation =
+    result.status === "queued" || result.status === "running"
+      ? {
+          resumeCommand: resumeCommand(result.generationId),
+          continuationContext:
+            "This job is still running. Check its status using resumeCommand; do not submit another video. Artifact presentation fields become available after completion.",
+        }
+      : undefined;
   if (json) {
-    console.log(JSON.stringify(result));
+    console.log(
+      JSON.stringify({ ...result, ...presentation?.json, ...continuation }),
+    );
     return;
   }
   console.log(`Intro Video Agent: ${result.status}`);
@@ -71,6 +86,9 @@ function printResult(result: IntroVideoAgentResponse, json?: boolean): void {
     console.log(
       chalk.dim("  Continue checking this job; do not submit another video."),
     );
+  }
+  if (presentation) {
+    console.log(`\n${presentation.text}`);
   }
 }
 

--- a/turbo/apps/cli/src/commands/__intro-video-presenter.ts
+++ b/turbo/apps/cli/src/commands/__intro-video-presenter.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 
 import { generateWebIntroVideoPresenter } from "../lib/api/domains/web";
 import { withErrorHandler } from "../lib/command/with-error-handler";
+import { createArtifactPresentation } from "./shared/artifact-return";
 
 interface IntroVideoPresenterCommandOptions {
   readonly avatarId: string;
@@ -29,8 +30,13 @@ async function runIntroVideoPresenterCommand(
     audioUrl: options.audioUrl,
     ...(options.videoName ? { videoName: options.videoName } : {}),
   });
+  const presentation = createArtifactPresentation(
+    result.filename,
+    result.url,
+    "This result is a presenter clip that can be used in subsequent video composition.",
+  );
   if (options.json) {
-    console.log(JSON.stringify(result));
+    console.log(JSON.stringify({ ...result, ...presentation.json }));
     return;
   }
   console.log(chalk.green(`✓ Intro Video presenter generated: ${result.url}`));
@@ -38,6 +44,7 @@ async function runIntroVideoPresenterCommand(
   console.log(chalk.dim(`  Duration: ${result.durationSeconds}s`));
   console.log(chalk.dim(`  Avatar: ${result.avatarId}`));
   console.log(chalk.dim(`  Credits charged: ${result.creditsCharged}`));
+  console.log(`\n${presentation.text}`);
 }
 
 export const introVideoPresenterCommand = new Command()

--- a/turbo/apps/cli/src/commands/__intro-video-voice.ts
+++ b/turbo/apps/cli/src/commands/__intro-video-voice.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 
 import { generateWebIntroVideoVoice } from "../lib/api/domains/web";
 import { withErrorHandler } from "../lib/command/with-error-handler";
+import { createArtifactPresentation } from "./shared/artifact-return";
 
 interface IntroVideoVoiceCommandOptions {
   readonly voiceId: string;
@@ -38,8 +39,13 @@ async function runIntroVideoVoiceCommand(
     voiceId: options.voiceId,
     text: options.text,
   });
+  const presentation = createArtifactPresentation(
+    result.filename,
+    result.url,
+    "This result is narration audio that can be used in subsequent video composition.",
+  );
   if (options.json) {
-    console.log(JSON.stringify(result));
+    console.log(JSON.stringify({ ...result, ...presentation.json }));
     return;
   }
   console.log(chalk.green(`✓ Intro Video narration generated: ${result.url}`));
@@ -47,6 +53,7 @@ async function runIntroVideoVoiceCommand(
   console.log(chalk.dim(`  Duration: ${result.durationSeconds}s`));
   console.log(chalk.dim(`  Voice: ${result.voiceId}`));
   console.log(chalk.dim(`  Credits charged: ${result.creditsCharged}`));
+  console.log(`\n${presentation.text}`);
 }
 
 export const introVideoVoiceCommand = new Command()

--- a/turbo/apps/cli/src/commands/__tests__/intro-video-agent.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/intro-video-agent.test.ts
@@ -36,6 +36,18 @@ const COMPLETED_RESULT: IntroVideoAgentResponse = {
   orientation: "landscape",
 };
 
+const PENDING_OUTPUT = {
+  ...PENDING_RESULT,
+  resumeCommand: `okou __intro-video-agent status ${REQUEST_ID} --json`,
+  continuationContext: expect.stringContaining("do not submit another video"),
+};
+const COMPLETED_OUTPUT = {
+  ...COMPLETED_RESULT,
+  inlineMarkdownLink: `[intro.mp4](<${COMPLETED_RESULT.url}>)`,
+  previewMarkdownBlock: `![intro.mp4](<${COMPLETED_RESULT.url}>)`,
+  artifactPresentationContext: expect.stringContaining("outside code fences"),
+};
+
 function submitArgs(...extra: string[]): string[] {
   return [
     "node",
@@ -142,9 +154,10 @@ describe("internal Intro Video Agent command", () => {
       );
 
       expect(submissions).toBe(1);
-      expect(mockConsoleLog.mock.calls).toEqual([
-        [JSON.stringify(PENDING_RESULT)],
-      ]);
+      expect(mockConsoleLog.mock.calls).toHaveLength(1);
+      expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toEqual(
+        PENDING_OUTPUT,
+      );
     },
   );
 
@@ -192,7 +205,7 @@ describe("internal Intro Video Agent command", () => {
       mockConsoleLog.mock.calls.map(([output]) => {
         return JSON.parse(String(output));
       }),
-    ).toEqual([PENDING_RESULT, COMPLETED_RESULT]);
+    ).toEqual([PENDING_OUTPUT, COMPLETED_OUTPUT]);
   });
 
   it.each([
@@ -228,10 +241,53 @@ describe("internal Intro Video Agent command", () => {
       expect(statusRequests).toBe(1);
       expect(mockConsoleLog).toHaveBeenCalledTimes(1);
       expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toEqual(
-        result,
+        result.status === "completed"
+          ? COMPLETED_OUTPUT
+          : { ...PENDING_OUTPUT, ...result },
       );
     },
   );
+
+  it("prints the completed video preview forms from a status query", async () => {
+    server.use(
+      http.get(STATUS_URL, () => {
+        return HttpResponse.json(COMPLETED_RESULT);
+      }),
+    );
+    await introVideoAgentCommand.parseAsync([
+      "node",
+      "okou",
+      "status",
+      REQUEST_ID,
+    ]);
+    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(stdout).toContain(`[intro.mp4](<${COMPLETED_RESULT.url}>)`);
+    expect(stdout).toContain(`\n\n![intro.mp4](<${COMPLETED_RESULT.url}>)\n\n`);
+    expect(stdout).toContain("outside a code fence");
+  });
+
+  it("keeps a failed job's error available without claiming a preview", async () => {
+    const failed = {
+      ...PENDING_RESULT,
+      status: "failed",
+      error: { code: "PROVIDER_ERROR", message: "Generation failed" },
+    };
+    server.use(
+      http.get(STATUS_URL, () => {
+        return HttpResponse.json(failed);
+      }),
+    );
+    await introVideoAgentCommand.parseAsync([
+      "node",
+      "okou",
+      "status",
+      REQUEST_ID,
+      "--json",
+    ]);
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toEqual(
+      failed,
+    );
+  });
 
   it.each([false, true])(
     "prints a new recovery ID before submitting (JSON: %s)",

--- a/turbo/apps/cli/src/commands/__tests__/intro-video-presenter.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/intro-video-presenter.test.ts
@@ -78,9 +78,43 @@ describe("internal Intro Video presenter command", () => {
         "--json",
       ]);
 
-      expect(mockConsoleLog.mock.calls).toEqual([[JSON.stringify(result)]]);
+      expect(mockConsoleLog.mock.calls).toHaveLength(1);
+      expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toEqual({
+        ...result,
+        inlineMarkdownLink: `[${result.filename}](<${result.url}>)`,
+        previewMarkdownBlock: `![${result.filename}](<${result.url}>)`,
+        artifactPresentationContext: expect.stringContaining(
+          "outside code fences",
+        ),
+      });
     },
   );
+
+  it("prints preview forms with the presenter clip context", async () => {
+    server.use(
+      http.post(GENERATE_URL, () => {
+        return HttpResponse.json(PRESENTER_RESULT);
+      }),
+    );
+    introVideoPresenterCommand.setOptionValue("json", false);
+    await introVideoPresenterCommand.parseAsync([
+      "node",
+      "okou",
+      "--avatar-id",
+      PRESENTER_RESULT.avatarId,
+      "--audio-url",
+      "https://example.com/voice.mp3",
+    ]);
+    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(stdout).toContain(
+      `[${PRESENTER_RESULT.filename}](<${PRESENTER_RESULT.url}>)`,
+    );
+    expect(stdout).toContain(
+      `\n\n![${PRESENTER_RESULT.filename}](<${PRESENTER_RESULT.url}>)\n\n`,
+    );
+    expect(stdout).toContain("presenter clip");
+    expect(stdout).toContain("outside a code fence");
+  });
 
   it("rejects malformed avatar IDs before calling the API", async () => {
     const generate = vi.fn();

--- a/turbo/apps/cli/src/commands/__tests__/intro-video-voice.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/intro-video-voice.test.ts
@@ -62,7 +62,41 @@ describe("internal Intro Video voice command", () => {
       "--json",
     ]);
 
-    expect(mockConsoleLog.mock.calls).toEqual([[JSON.stringify(VOICE_RESULT)]]);
+    expect(mockConsoleLog.mock.calls).toHaveLength(1);
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toEqual({
+      ...VOICE_RESULT,
+      inlineMarkdownLink: `[${VOICE_RESULT.filename}](<${VOICE_RESULT.url}>)`,
+      previewMarkdownBlock: `![${VOICE_RESULT.filename}](<${VOICE_RESULT.url}>)`,
+      artifactPresentationContext: expect.stringContaining(
+        "outside code fences",
+      ),
+    });
+  });
+
+  it("prints preview forms with the narration audio context", async () => {
+    server.use(
+      http.post(GENERATE_URL, () => {
+        return HttpResponse.json(VOICE_RESULT);
+      }),
+    );
+    introVideoVoiceCommand.setOptionValue("json", false);
+    await introVideoVoiceCommand.parseAsync([
+      "node",
+      "okou",
+      "--voice-id",
+      VOICE_RESULT.voiceId,
+      "--text",
+      "Welcome to Okou",
+    ]);
+    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(stdout).toContain(
+      `[${VOICE_RESULT.filename}](<${VOICE_RESULT.url}>)`,
+    );
+    expect(stdout).toContain(
+      `\n\n![${VOICE_RESULT.filename}](<${VOICE_RESULT.url}>)\n\n`,
+    );
+    expect(stdout).toContain("narration audio");
+    expect(stdout).toContain("outside a code fence");
   });
 
   it("rejects malformed voice IDs before calling the API", async () => {

--- a/turbo/apps/cli/src/commands/generate/__tests__/avatar-video.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/avatar-video.test.ts
@@ -235,6 +235,13 @@ describe("okou generate avatar-video command", () => {
       `Avatar video generated: ${AVATAR_VIDEO_RESULT.url}`,
     );
     expect(stdout).toContain(`File: ${AVATAR_VIDEO_RESULT.filename}`);
+    expect(stdout).toContain(
+      `[${AVATAR_VIDEO_RESULT.filename}](<${AVATAR_VIDEO_RESULT.url}>)`,
+    );
+    expect(stdout).toContain(
+      `\n\n![${AVATAR_VIDEO_RESULT.filename}](<${AVATAR_VIDEO_RESULT.url}>)\n\n`,
+    );
+    expect(stdout).toContain("creates two user-facing references");
     expect(stdout).toContain("Duration: 42s");
     expect(stdout).toContain("Credits charged: 623");
   });
@@ -259,9 +266,15 @@ describe("okou generate avatar-video command", () => {
       "--json",
     ]);
 
-    expect(mockConsoleLog.mock.calls).toEqual([
-      [JSON.stringify(AVATAR_VIDEO_RESULT)],
-    ]);
+    expect(mockConsoleLog.mock.calls).toHaveLength(1);
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toEqual({
+      ...AVATAR_VIDEO_RESULT,
+      inlineMarkdownLink: `[${AVATAR_VIDEO_RESULT.filename}](<${AVATAR_VIDEO_RESULT.url}>)`,
+      previewMarkdownBlock: `![${AVATAR_VIDEO_RESULT.filename}](<${AVATAR_VIDEO_RESULT.url}>)`,
+      artifactPresentationContext: expect.stringContaining(
+        "outside code fences",
+      ),
+    });
   });
 
   it("rejects mixed script and audio input before calling the API", async () => {

--- a/turbo/apps/cli/src/commands/generate/__tests__/image-batch.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/image-batch.test.ts
@@ -8,6 +8,7 @@ import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { server } from "../../../mocks/server";
 import { generateCommand } from "../index";
+import { imageBatchCommand } from "../image-batch";
 
 vi.mock("node:child_process", async (importOriginal) => {
   const original = await importOriginal<typeof import("node:child_process")>();
@@ -67,6 +68,11 @@ describe("okou generate image-batch command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
+    imageBatchCommand.commands
+      .find((command) => {
+        return command.name() === "wait";
+      })
+      ?.setOptionValue("json", false);
     vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
   });
@@ -194,9 +200,48 @@ describe("okou generate image-batch command", () => {
         "",
       ].join("\n"),
     );
+    const metadata = JSON.parse(
+      await readFile(join(stateDirectory, "artifacts.json"), "utf8"),
+    );
+    expect(metadata).toMatchObject({
+      resultsPath: join(stateDirectory, "results.tsv"),
+      artifacts: [
+        {
+          assetId: "hero",
+          asset: "https://embed.example/hero-dog-portrait.png",
+          url: "https://cdn.example/hero-dog-portrait.png",
+          inlineMarkdownLink:
+            "[hero](<https://cdn.example/hero-dog-portrait.png>)",
+          previewMarkdownBlock:
+            "![hero](<https://cdn.example/hero-dog-portrait.png>)",
+        },
+        { assetId: "detail" },
+        { assetId: "retry" },
+        { assetId: "team" },
+        { assetId: "fifth" },
+      ],
+      artifactPresentationContext: expect.stringContaining(
+        "outside code fences",
+      ),
+    });
+    await writeFile(join(stateDirectory, "pid"), String(process.pid));
+    mockConsoleLog.mockClear();
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "image-batch",
+      "wait",
+      stateDirectory,
+      "--json",
+    ]);
+    expect(mockConsoleLog.mock.calls).toHaveLength(1);
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toEqual(
+      metadata,
+    );
+    expect(attempts.get("Hero dog portrait")).toBe(1);
   });
 
-  it("bundles authenticated private images as local optimized assets without persisting URLs", async () => {
+  it("bundles private images locally and retains their stable chat references", async () => {
     const root = await makeTemporaryDirectory();
     const manifestPath = join(root, "images.tsv");
     const stateDirectory = join(root, "state");
@@ -262,6 +307,96 @@ describe("okou generate image-batch command", () => {
       ]),
     );
     expect(vi.mocked(execFile).mock.calls.at(-1)?.[1]).not.toContain("-vf");
+    expect(
+      JSON.parse(
+        await readFile(join(stateDirectory, "artifacts.json"), "utf8"),
+      ),
+    ).toMatchObject({
+      artifacts: [
+        {
+          assetId: "hero",
+          asset: "assets/image-hero.webp",
+          url: reference,
+          inlineMarkdownLink: `[hero](<${reference}>)`,
+          previewMarkdownBlock: `![hero](<${reference}>)`,
+        },
+      ],
+    });
+    await writeFile(join(stateDirectory, "pid"), String(process.pid));
+    mockConsoleLog.mockClear();
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "image-batch",
+      "wait",
+      stateDirectory,
+    ]);
+    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(stdout).toContain("hero\tassets/image-hero.webp");
+    expect(stdout).toContain(join(stateDirectory, "artifacts.json"));
+    expect(stdout).toContain("only available inside the agent runtime");
+  });
+
+  it.each([false, true])(
+    "reads a stored TSV-only batch with upload guidance (JSON: %s)",
+    async (json) => {
+      const stateDirectory = await makeTemporaryDirectory();
+      await writeFile(join(stateDirectory, "pid"), String(process.pid));
+      await writeFile(join(stateDirectory, "done"), "0\n");
+      await writeFile(
+        join(stateDirectory, "results.tsv"),
+        "hero\tassets/image-hero.webp\n",
+      );
+      await generateCommand.parseAsync([
+        "node",
+        "cli",
+        "image-batch",
+        "wait",
+        stateDirectory,
+        ...(json ? ["--json"] : []),
+      ]);
+      const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+      if (json) {
+        expect(JSON.parse(stdout)).toEqual({
+          resultsPath: join(stateDirectory, "results.tsv"),
+          artifactPresentationContext: expect.stringContaining(
+            "okou web upload-file",
+          ),
+        });
+      } else {
+        expect(stdout).toContain("hero\tassets/image-hero.webp");
+        expect(stdout).toContain("no artifact presentation metadata");
+        expect(stdout).toContain("okou web upload-file");
+      }
+    },
+  );
+
+  it("reports malformed presentation metadata instead of accepting it as a TSV-only batch", async () => {
+    const stateDirectory = await makeTemporaryDirectory();
+    await writeFile(join(stateDirectory, "pid"), String(process.pid));
+    await writeFile(join(stateDirectory, "done"), "0\n");
+    await writeFile(
+      join(stateDirectory, "results.tsv"),
+      "hero\tassets/image-hero.webp\n",
+    );
+    await writeFile(
+      join(stateDirectory, "artifacts.json"),
+      '{"artifacts": "invalid"}',
+    );
+    await expect(
+      generateCommand.parseAsync([
+        "node",
+        "cli",
+        "image-batch",
+        "wait",
+        stateDirectory,
+        "--json",
+      ]),
+    ).rejects.toThrow("process.exit called");
+    expect(mockConsoleLog.mock.calls).toHaveLength(0);
+    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
+      "artifacts",
+    );
   });
 
   it("does not automatically retry an async output safety block", async () => {
@@ -554,6 +689,12 @@ await writeFile(join(stateDirectory, "done"), "0\\n", "utf8");
 
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
     expect(stdout).toContain(`Image batch started: ${stateDirectory}`);
+    expect(stdout).toContain(
+      `okou generate image-batch wait '${stateDirectory}'`,
+    );
+    expect(stdout).toContain(
+      "reuse this batch instead of starting another one",
+    );
     expect(stdout).toContain("hero\thttps://cdn.example/dog.png");
     expect(stdout).toContain(
       `Image batch joined: ${join(stateDirectory, "results.tsv")}`,

--- a/turbo/apps/cli/src/commands/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/image.test.ts
@@ -133,6 +133,13 @@ describe("okou generate image command", () => {
     expect(stdout).toContain("Credits charged: 65");
     expect(stdout).toContain("Model: gpt-image-1");
     expect(stdout).toContain("Provider: fal");
+    expect(stdout).toContain(
+      `[${IMAGE_RESULT.filename}](<${IMAGE_RESULT.url}>)`,
+    );
+    expect(stdout).toContain(
+      `\n\n![${IMAGE_RESULT.filename}](<${IMAGE_RESULT.url}>)\n\n`,
+    );
+    expect(stdout).toContain("creates two user-facing references");
   });
 
   it.each([
@@ -308,6 +315,12 @@ describe("okou generate image command", () => {
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
     expect(stdout).toContain(`Image generated: ${IMAGE_RESULT.url}`);
     expect(stdout).toContain(`Embed this URL in HTML: ${embedUrl}`);
+    expect(stdout).toContain(
+      `[${IMAGE_RESULT.filename}](<${IMAGE_RESULT.url}>)`,
+    );
+    expect(stdout).toContain(
+      `${embedUrl} is for embedding the image in authored HTML`,
+    );
   });
 
   it("should omit the embed line when the API does not return one", async () => {
@@ -346,8 +359,51 @@ describe("okou generate image command", () => {
       "--json",
     ]);
 
-    expect(mockConsoleLog.mock.calls).toEqual([[JSON.stringify(IMAGE_RESULT)]]);
+    expect(mockConsoleLog.mock.calls).toHaveLength(1);
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toEqual({
+      ...IMAGE_RESULT,
+      inlineMarkdownLink: `[${IMAGE_RESULT.filename}](<${IMAGE_RESULT.url}>)`,
+      previewMarkdownBlock: `![${IMAGE_RESULT.filename}](<${IMAGE_RESULT.url}>)`,
+      artifactPresentationContext: expect.stringContaining(
+        "outside code fences",
+      ),
+    });
   });
+
+  it.each([
+    "/artifacts/00000000000040008000000000000021.png",
+    "http://localhost:3000/api/web/download-file?file_id=00000000-0000-4000-8000-000000000021&filename=Launch%20v2.png",
+  ])(
+    "preserves the private artifact reference %s and escapes its label",
+    async (url) => {
+      const filename = String.raw`Launch [v2]\image.png`;
+      const label = String.raw`Launch \[v2\]\\image.png`;
+      server.use(
+        http.post(IMAGE_URL, () => {
+          return HttpResponse.json({ ...IMAGE_RESULT, filename, url });
+        }),
+      );
+      await generateCommand.parseAsync([
+        "node",
+        "cli",
+        "image",
+        "--raw-prompt",
+        "A product image",
+        "--json",
+      ]);
+      expect(
+        JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0])),
+      ).toMatchObject({
+        filename,
+        url,
+        inlineMarkdownLink: `[${label}](<${url}>)`,
+        previewMarkdownBlock: `![${label}](<${url}>)`,
+        artifactPresentationContext: expect.stringContaining(
+          "own Markdown paragraph",
+        ),
+      });
+    },
+  );
 
   it.each([
     ["provider listing", ["image", "--json"]],

--- a/turbo/apps/cli/src/commands/generate/__tests__/video.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/video.test.ts
@@ -239,6 +239,13 @@ describe("okou generate video command", () => {
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
     expect(stdout).toContain(`Video generated: ${VIDEO_RESULT.url}`);
     expect(stdout).toContain(`File: ${VIDEO_RESULT.filename}`);
+    expect(stdout).toContain(
+      `[${VIDEO_RESULT.filename}](<${VIDEO_RESULT.url}>)`,
+    );
+    expect(stdout).toContain(
+      `\n\n![${VIDEO_RESULT.filename}](<${VIDEO_RESULT.url}>)\n\n`,
+    );
+    expect(stdout).toContain("creates two user-facing references");
     expect(stdout).toContain("Duration: 6s");
     expect(stdout).toContain("Resolution: 1080p");
     expect(stdout).toContain("Aspect ratio: 9:16");
@@ -262,7 +269,15 @@ describe("okou generate video command", () => {
       "--json",
     ]);
 
-    expect(mockConsoleLog.mock.calls).toEqual([[JSON.stringify(VIDEO_RESULT)]]);
+    expect(mockConsoleLog.mock.calls).toHaveLength(1);
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toEqual({
+      ...VIDEO_RESULT,
+      inlineMarkdownLink: `[${VIDEO_RESULT.filename}](<${VIDEO_RESULT.url}>)`,
+      previewMarkdownBlock: `![${VIDEO_RESULT.filename}](<${VIDEO_RESULT.url}>)`,
+      artifactPresentationContext: expect.stringContaining(
+        "outside code fences",
+      ),
+    });
   });
 
   it.each([

--- a/turbo/apps/cli/src/commands/generate/__tests__/voice.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/voice.test.ts
@@ -91,6 +91,13 @@ describe("okou generate voice command", () => {
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
     expect(stdout).toContain(`Voice generated: ${VOICE_RESULT.url}`);
     expect(stdout).toContain(`File: ${VOICE_RESULT.filename}`);
+    expect(stdout).toContain(
+      `[${VOICE_RESULT.filename}](<${VOICE_RESULT.url}>)`,
+    );
+    expect(stdout).toContain(
+      `\n\n![${VOICE_RESULT.filename}](<${VOICE_RESULT.url}>)\n\n`,
+    );
+    expect(stdout).toContain("creates two user-facing references");
     expect(stdout).toContain("Duration: 3s");
     expect(stdout).toContain("Credits charged: 1");
   });
@@ -111,7 +118,15 @@ describe("okou generate voice command", () => {
       "--json",
     ]);
 
-    expect(mockConsoleLog.mock.calls).toEqual([[JSON.stringify(VOICE_RESULT)]]);
+    expect(mockConsoleLog.mock.calls).toHaveLength(1);
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toEqual({
+      ...VOICE_RESULT,
+      inlineMarkdownLink: `[${VOICE_RESULT.filename}](<${VOICE_RESULT.url}>)`,
+      previewMarkdownBlock: `![${VOICE_RESULT.filename}](<${VOICE_RESULT.url}>)`,
+      artifactPresentationContext: expect.stringContaining(
+        "outside code fences",
+      ),
+    });
   });
 
   it.each([

--- a/turbo/apps/cli/src/commands/generate/avatar-video.ts
+++ b/turbo/apps/cli/src/commands/generate/avatar-video.ts
@@ -9,6 +9,7 @@ import {
 } from "../../lib/api/domains/web";
 import { getBillingStatus } from "../../lib/api/domains/billing";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { createArtifactPresentation } from "../shared/artifact-return";
 import {
   currentPlanAllowsVideo,
   currentTokenCanReadBilling,
@@ -356,8 +357,9 @@ function printAvatarVideoResult(
   result: Awaited<ReturnType<typeof generateWebAvatarVideo>>,
   json: boolean,
 ): void {
+  const presentation = createArtifactPresentation(result.filename, result.url);
   if (json) {
-    console.log(JSON.stringify(result));
+    console.log(JSON.stringify({ ...result, ...presentation.json }));
     return;
   }
   console.log(chalk.green(`✓ Avatar video generated: ${result.url}`));
@@ -367,6 +369,7 @@ function printAvatarVideoResult(
   console.log(chalk.dim(`  Avatar: ${result.avatarId}`));
   console.log(chalk.dim(`  Voice: ${result.voiceId}`));
   console.log(chalk.dim(`  Credits charged: ${result.creditsCharged}`));
+  console.log(`\n${presentation.text}`);
 }
 
 async function generateAvatarVideo(

--- a/turbo/apps/cli/src/commands/generate/image-batch.ts
+++ b/turbo/apps/cli/src/commands/generate/image-batch.ts
@@ -12,15 +12,41 @@ import {
 import { join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { Command, InvalidArgumentError } from "commander";
+import { z } from "zod";
+import { artifactUrlSchema } from "@okouai/api-contracts/contracts/artifact-references";
 import { ApiRequestError } from "../../lib/api/core/client-factory";
 import { generateWebImage } from "../../lib/api/domains/web";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { generatedImageAsset } from "../shared/generated-image-asset";
+import {
+  ARTIFACT_PRESENTATION_CONTEXT,
+  createArtifactPresentation,
+} from "../shared/artifact-return";
 
 const MAX_CONCURRENCY = 3;
 const DEFAULT_SIZE = "816x816";
 const POLL_INTERVAL_MS = 500;
 const RETRY_DELAY_MS = 1_000;
+const BATCH_PRESENTATION_CONTEXT =
+  "asset identifies the material for authored HTML; local paths are relative to the batch directory and are only available inside the agent runtime. Use each item's stable artifact reference for chat. " +
+  ARTIFACT_PRESENTATION_CONTEXT;
+
+const imageBatchArtifactsSchema = z.object({
+  resultsPath: z.string(),
+  artifacts: z.array(
+    z.object({
+      assetId: z.string(),
+      asset: z.string(),
+      url: artifactUrlSchema,
+      inlineMarkdownLink: z.string(),
+      previewMarkdownBlock: z.string(),
+    }),
+  ),
+  artifactPresentationContext: z.string(),
+});
+type ImageBatchArtifact = z.infer<
+  typeof imageBatchArtifactsSchema
+>["artifacts"][number];
 
 interface ImageBatchJob {
   readonly id: string;
@@ -30,6 +56,11 @@ interface ImageBatchJob {
 
 interface ImageBatchWaitOptions {
   readonly timeout: number;
+  readonly json?: boolean;
+}
+
+function shellQuoteArg(value: string): string {
+  return `'${value.replaceAll("'", "'\"'\"'")}'`;
 }
 
 function isMissingPathError(error: unknown): boolean {
@@ -156,7 +187,7 @@ async function runBatch(
   stateDirectory: string,
 ): Promise<void> {
   const jobs = await readManifest(manifestPath);
-  const results: Array<string | undefined> = Array.from({
+  const results: Array<ImageBatchArtifact | undefined> = Array.from({
     length: jobs.length,
   });
   const failures: string[] = [];
@@ -172,11 +203,15 @@ async function runBatch(
       }
       try {
         const result = await generateOne(job);
-        results[index] = await generatedImageAsset(
-          result,
-          job.id,
-          stateDirectory,
-        );
+        const asset = await generatedImageAsset(result, job.id, stateDirectory);
+        const presentation = createArtifactPresentation(job.id, result.url);
+        results[index] = {
+          assetId: job.id,
+          asset,
+          url: result.url,
+          inlineMarkdownLink: presentation.json.inlineMarkdownLink,
+          previewMarkdownBlock: presentation.json.previewMarkdownBlock,
+        };
       } catch (error) {
         failures.push(`${job.id}: ${errorMessage(error)}`);
       }
@@ -192,16 +227,33 @@ async function runBatch(
     throw new Error(`Image batch failed: ${failures.join("; ")}`);
   }
 
-  const rows = jobs.map((job, index) => {
+  const artifacts = jobs.map((job, index) => {
     const result = results[index];
     if (result === undefined) {
       throw new Error(`Image batch job ${job.id} has no result`);
     }
-    return `${job.id}\t${result}`;
+    return result;
   });
+  const resultsPath = join(stateDirectory, "results.tsv");
   await writeAtomic(
-    join(stateDirectory, "results.tsv"),
-    `${rows.join("\n")}\n`,
+    resultsPath,
+    `${artifacts
+      .map((artifact) => {
+        return `${artifact.assetId}\t${artifact.asset}`;
+      })
+      .join("\n")}\n`,
+  );
+  await writeAtomic(
+    join(stateDirectory, "artifacts.json"),
+    JSON.stringify(
+      {
+        resultsPath,
+        artifacts,
+        artifactPresentationContext: BATCH_PRESENTATION_CONTEXT,
+      },
+      null,
+      2,
+    ) + "\n",
   );
 }
 
@@ -291,6 +343,38 @@ async function startBatch(
   }
   await logHandle.close();
   console.log(`Image batch started: ${stateDirectory}`);
+  console.log(
+    [
+      "The images are being generated in the background.",
+      "Wait for this batch before using its results:",
+      `okou generate image-batch wait ${shellQuoteArg(stateDirectory)}`,
+      "Continue authoring while it runs; reuse this batch instead of starting another one.",
+    ].join("\n"),
+  );
+}
+
+async function readBatchArtifacts(stateDirectory: string) {
+  try {
+    return imageBatchArtifactsSchema.parse(
+      JSON.parse(
+        await readFile(join(stateDirectory, "artifacts.json"), "utf8"),
+      ),
+    );
+  } catch (error) {
+    // Persisted batches created before presentation metadata still contain usable
+    // TSV assets. Retain until support for those stored batch directories is retired.
+    if (isMissingPathError(error)) return undefined;
+    throw error;
+  }
+}
+
+function missingBatchArtifactsContext(stateDirectory: string): string {
+  return [
+    "This batch has no artifact presentation metadata.",
+    `Local asset paths in results.tsv are relative to ${stateDirectory}.`,
+    "To present a selected local image in chat, upload it with okou web upload-file -f <selected-local-file>.",
+    "The upload result provides inline-link and rich-preview Markdown forms.",
+  ].join("\n");
 }
 
 function isProcessAlive(pid: number): boolean {
@@ -344,8 +428,34 @@ async function waitForBatch(
   }
   const resultsPath = join(stateDirectory, "results.tsv");
   const results = await readFile(resultsPath, "utf8");
+  const metadata = await readBatchArtifacts(stateDirectory);
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        metadata
+          ? { ...metadata, resultsPath }
+          : {
+              resultsPath,
+              artifactPresentationContext:
+                missingBatchArtifactsContext(stateDirectory),
+            },
+      ),
+    );
+    return;
+  }
   console.log(results.trimEnd());
   console.log(`Image batch joined: ${resultsPath}`);
+  console.log(
+    metadata
+      ? [
+          "",
+          "Artifact presentation context:",
+          `results.tsv lists assets for authored HTML. Resolve local paths against ${stateDirectory} and copy those files into the authored bundle.`,
+          `For chat presentation, read ${join(stateDirectory, "artifacts.json")}. Each image includes its stable artifact reference, inlineMarkdownLink, and previewMarkdownBlock.`,
+          metadata.artifactPresentationContext,
+        ].join("\n")
+      : `\n${missingBatchArtifactsContext(stateDirectory)}`,
+  );
 }
 
 const startCommand = new Command("start")
@@ -358,6 +468,7 @@ const waitCommand = new Command("wait")
   .description("Wait for an image batch and print its results")
   .argument("<state-dir>", "State directory returned by start")
   .option("--timeout <seconds>", "Maximum wait time", parseTimeout, 300)
+  .option("--json", "Print batch artifacts and presentation guidance as JSON")
   .action(withErrorHandler(waitForBatch));
 
 const runCommand = new Command("__run")
@@ -374,5 +485,5 @@ export const imageBatchCommand = new Command("image-batch")
   .addCommand(runCommand, { hidden: true })
   .addHelpText(
     "after",
-    `\nManifest format:\n  asset-id<TAB>raw prompt[<TAB>size]\n  Size is optional per image and defaults to ${DEFAULT_SIZE}; the image API validates it.\n\nResult format:\n  asset-id<TAB>image URL or relative asset path\n  Private images are downloaded to <state-dir>/assets/ and optimized as WebP without resizing. Requires ffmpeg with libwebp on PATH. Resolve relative paths against <state-dir>, then copy assets into the authored bundle. Never embed preview signatures in HTML.\n\nExamples:\n  okou generate image-batch start images.tsv .image-batch\n  okou generate image-batch wait .image-batch`,
+    `\nManifest format:\n  asset-id<TAB>raw prompt[<TAB>size]\n  Size is optional per image and defaults to ${DEFAULT_SIZE}; the image API validates it.\n\nResult format:\n  asset-id<TAB>image URL or relative asset path\n  results.tsv retains the asset index; artifacts.json adds stable chat references and Markdown forms.\n  Use wait --json for the presentation metadata as one JSON object.\n  Private images are downloaded to <state-dir>/assets/ and optimized as WebP without resizing. Requires ffmpeg with libwebp on PATH. Resolve relative paths against <state-dir>, then copy assets into the authored bundle. Never embed preview signatures in HTML.\n\nExamples:\n  okou generate image-batch start images.tsv .image-batch\n  okou generate image-batch wait .image-batch`,
   );

--- a/turbo/apps/cli/src/commands/host/__tests__/publish.test.ts
+++ b/turbo/apps/cli/src/commands/host/__tests__/publish.test.ts
@@ -213,6 +213,9 @@ describe("okou host publish command", () => {
           Buffer.byteLength(DEFAULT_HOSTED_SITE_ROBOTS_TXT),
         inlineMarkdownLink: `[demo-site](<${url}>)`,
         previewMarkdownBlock: `![demo-site](<${url}>)`,
+        artifactPresentationContext: expect.stringContaining(
+          "outside code fences",
+        ),
       });
       if (privateArtifact) {
         expect(parsed.aliasUrl).toBeUndefined();
@@ -280,6 +283,9 @@ describe("okou host publish command", () => {
       url: legacyUrl,
       inlineMarkdownLink: `[demo-site](<${legacyUrl}>)`,
       previewMarkdownBlock: `![demo-site](<${legacyUrl}>)`,
+      artifactPresentationContext: expect.stringContaining(
+        "outside code fences",
+      ),
     });
     expect(parsed.deploymentVersion).toBeUndefined();
     expect(parsed.artifactUrl).toBeUndefined();

--- a/turbo/apps/cli/src/commands/host/index.ts
+++ b/turbo/apps/cli/src/commands/host/index.ts
@@ -6,10 +6,7 @@ import {
 } from "@okouai/api-contracts/contracts/host";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { publishStaticSite } from "../../lib/host/publish-static-site";
-import {
-  createArtifactMarkdownOutput,
-  formatArtifactPresentationContext,
-} from "../shared/artifact-return";
+import { createArtifactPresentation } from "../shared/artifact-return";
 import { cloneHostedSiteCommand } from "./clone";
 import { versionsHostedSiteCommand } from "./versions";
 
@@ -90,12 +87,12 @@ Notes:
             },
       });
 
-      const markdown = createArtifactMarkdownOutput(
+      const presentation = createArtifactPresentation(
         options.site,
         result.aliasUrl ?? result.url,
       );
       if (options.json) {
-        console.log(JSON.stringify({ ...result, ...markdown }));
+        console.log(JSON.stringify({ ...result, ...presentation.json }));
         return;
       }
 
@@ -122,6 +119,6 @@ Notes:
         console.log(`  URL: ${result.url}`);
       }
       console.log("");
-      console.log(formatArtifactPresentationContext(markdown));
+      console.log(presentation.text);
     }),
   );

--- a/turbo/apps/cli/src/commands/shared/artifact-return.ts
+++ b/turbo/apps/cli/src/commands/shared/artifact-return.ts
@@ -1,7 +1,5 @@
-type ArtifactMarkdownOutput = {
-  readonly inlineMarkdownLink: string;
-  readonly previewMarkdownBlock: string;
-};
+export const ARTIFACT_PRESENTATION_CONTEXT =
+  "inlineMarkdownLink remains a link in normal prose. previewMarkdownBlock displays a standalone preview when placed in its own Markdown paragraph, with a blank line before and after it, outside code fences. Both forms reference the same artifact; including both creates two user-facing references.";
 
 function escapeMarkdownLabel(label: string): string {
   return label
@@ -12,33 +10,34 @@ function escapeMarkdownLabel(label: string): string {
     .replace(/\]/gu, String.raw`\]`);
 }
 
-export function createArtifactMarkdownOutput(
+export function createArtifactPresentation(
   label: string,
   url: string,
-): ArtifactMarkdownOutput {
+  usageContext?: string,
+) {
   const escapedLabel = escapeMarkdownLabel(label);
-  return {
+  const json = {
     inlineMarkdownLink: `[${escapedLabel}](<${url}>)`,
     previewMarkdownBlock: `![${escapedLabel}](<${url}>)`,
+    artifactPresentationContext: usageContext
+      ? `${usageContext} ${ARTIFACT_PRESENTATION_CONTEXT}`
+      : ARTIFACT_PRESENTATION_CONTEXT,
   };
-}
-
-export function formatArtifactPresentationContext(
-  output: ArtifactMarkdownOutput,
-): string {
-  return [
+  const text = [
     "Artifact presentation context:",
     "",
     "Inline Markdown link:",
-    output.inlineMarkdownLink,
+    json.inlineMarkdownLink,
     "This form remains a link in normal prose.",
     "",
     "Rich preview Markdown:",
     "",
-    output.previewMarkdownBlock,
+    json.previewMarkdownBlock,
     "",
     "The rich-preview form is displayed as a standalone preview when it occupies its own Markdown paragraph, with a blank line before and after it, and is outside a code fence.",
     "",
     "Both forms reference the same artifact. Including both in one response creates two user-facing references.",
+    ...(usageContext ? [usageContext] : []),
   ].join("\n");
+  return { json, text };
 }

--- a/turbo/apps/cli/src/commands/shared/image-generate.ts
+++ b/turbo/apps/cli/src/commands/shared/image-generate.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { generateWebImage } from "../../lib/api/domains/web";
 import { decodeSandboxTokenPayload } from "../../lib/api/sandbox-token";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { createArtifactPresentation } from "./artifact-return";
 import { createStyledImageCompilationPacket } from "./image-style-authoring";
 import { runDefaultImageModelFromEnvironment } from "./run-default-image-model";
 import {
@@ -332,6 +333,9 @@ Output:
   --style <id> --prompt "..." --compile, prints a prompt-compilation packet
   for the current agent.
 
+  Successful results include inline-link and rich-preview Markdown guidance.
+  --json includes inlineMarkdownLink, previewMarkdownBlock, and artifactPresentationContext.
+
 Notes:
   - Authenticates via OKOU_TOKEN (requires file:write capability)
   - Charges org credits after successful image generation
@@ -472,8 +476,15 @@ ${formatRegistryListing(styles, "image styles")}`;
           imagePromptStrength,
         });
 
+        const presentation = createArtifactPresentation(
+          result.filename,
+          result.url,
+          result.embedUrl !== undefined && result.embedUrl !== result.url
+            ? `${result.url} is the artifact reference for chat. ${result.embedUrl} is for embedding the image in authored HTML.`
+            : undefined,
+        );
         if (options.json) {
-          console.log(JSON.stringify(result));
+          console.log(JSON.stringify({ ...result, ...presentation.json }));
           return;
         }
 
@@ -504,6 +515,7 @@ ${formatRegistryListing(styles, "image styles")}`;
         console.log(chalk.dim(`  Credits charged: ${result.creditsCharged}`));
         console.log(chalk.dim(`  Model: ${result.model}`));
         console.log(chalk.dim(`  Provider: ${result.provider}`));
+        console.log(`\n${presentation.text}`);
       }),
     );
 }

--- a/turbo/apps/cli/src/commands/shared/video-generate.ts
+++ b/turbo/apps/cli/src/commands/shared/video-generate.ts
@@ -8,6 +8,7 @@ import {
 } from "../../lib/api/domains/web";
 import { getBillingStatus } from "../../lib/api/domains/billing";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { createArtifactPresentation } from "./artifact-return";
 import {
   findVideoTemplate,
   listVideoTemplates,
@@ -453,6 +454,9 @@ Output:
   Prints the generated /f/ video file URL and metadata. Use --json for the
   complete result object.
 
+  Successful results include inline-link and rich-preview Markdown guidance.
+  --json includes inlineMarkdownLink, previewMarkdownBlock, and artifactPresentationContext.
+
 Notes:
   - Authenticates via OKOU_TOKEN (requires file:write capability)
   - Charges org credits after successful video generation
@@ -544,8 +548,12 @@ Models:
           lastFrameImageUrl: options.lastFrameImageUrl,
         });
 
+        const presentation = createArtifactPresentation(
+          result.filename,
+          result.url,
+        );
         if (options.json) {
-          console.log(JSON.stringify(result));
+          console.log(JSON.stringify({ ...result, ...presentation.json }));
           return;
         }
 
@@ -559,6 +567,7 @@ Models:
         );
         console.log(chalk.dim(`  Credits charged: ${result.creditsCharged}`));
         console.log(chalk.dim(`  Model: ${result.model}`));
+        console.log(`\n${presentation.text}`);
       }),
     );
 }

--- a/turbo/apps/cli/src/commands/shared/voice-generate.ts
+++ b/turbo/apps/cli/src/commands/shared/voice-generate.ts
@@ -2,6 +2,7 @@ import { Command, Option } from "commander";
 import chalk from "chalk";
 import { generateWebVoice } from "../../lib/api/domains/web";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { createArtifactPresentation } from "./artifact-return";
 import { dispatchGenerate } from "../generate/lib/dispatch";
 import type { GenerationType } from "../generate/lib/lister";
 
@@ -52,6 +53,9 @@ Output:
   complete result object. With no --prompt and no piped input, prints the
   provider menu instead.
 
+  Successful results include inline-link and rich-preview Markdown guidance.
+  --json includes inlineMarkdownLink, previewMarkdownBlock, and artifactPresentationContext.
+
 Notes:
   - Authenticates via OKOU_TOKEN (requires file:write capability)
   - Charges org credits after successful audio generation
@@ -75,8 +79,12 @@ Notes:
           instructions: options.instructions,
         });
 
+        const presentation = createArtifactPresentation(
+          result.filename,
+          result.url,
+        );
         if (options.json) {
-          console.log(JSON.stringify(result));
+          console.log(JSON.stringify({ ...result, ...presentation.json }));
           return;
         }
 
@@ -86,6 +94,7 @@ Notes:
         console.log(chalk.dim(`  Credits charged: ${result.creditsCharged}`));
         console.log(chalk.dim(`  Model: ${result.model}`));
         console.log(chalk.dim(`  Voice: ${result.voice}`));
+        console.log(`\n${presentation.text}`);
       }),
     );
 }

--- a/turbo/apps/cli/src/commands/social/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/social/__tests__/index.test.ts
@@ -1135,6 +1135,13 @@ describe("okou social command", () => {
       platform: "youtube",
       billing: { quantity: 2, creditsCharged: 6 },
       data: { status: "completed", artifact: { filename: "example.mp4" } },
+      inlineMarkdownLink:
+        "[example.mp4](<https://artifacts.example/video.mp4>)",
+      previewMarkdownBlock:
+        "![example.mp4](<https://artifacts.example/video.mp4>)",
+      artifactPresentationContext: expect.stringContaining(
+        "media file saved to Okou",
+      ),
     });
     expect(outputRequest()).toStrictEqual({
       resume: false,
@@ -1232,6 +1239,13 @@ describe("okou social command", () => {
 
     expect(creates).toBe(0);
     expect(JSON.parse(output()) as unknown).toMatchObject({
+      inlineMarkdownLink:
+        "[example.mp4](<https://artifacts.example/video.mp4>)",
+      previewMarkdownBlock:
+        "![example.mp4](<https://artifacts.example/video.mp4>)",
+      artifactPresentationContext: expect.stringContaining(
+        "outside code fences",
+      ),
       target: {
         kind: "download",
         downloadId: "6bdc3449-41ef-4624-a525-45bce09c67f0",

--- a/turbo/apps/cli/src/commands/social/index.ts
+++ b/turbo/apps/cli/src/commands/social/index.ts
@@ -19,6 +19,7 @@ import {
 } from "../../lib/api/domains/social";
 import { ApiRequestError } from "../../lib/api/core/client-factory";
 import { getOkouToken } from "../../lib/okou-env";
+import { createArtifactPresentation } from "../shared/artifact-return";
 import {
   commentsIntent,
   downloadPlatform,
@@ -918,7 +919,9 @@ function downloadOutput(
     | SocialTarget
     | { readonly kind: "download"; readonly downloadId: string },
   request: SocialRequestMetadata,
-): SocialOutput {
+): SocialResultOutput &
+  Partial<ReturnType<typeof createArtifactPresentation>["json"]> {
+  const artifact = response.status === "completed" ? response.artifact : null;
   return {
     kind: "result",
     status: "complete",
@@ -927,6 +930,13 @@ function downloadOutput(
     target,
     request,
     data: response,
+    ...(artifact
+      ? createArtifactPresentation(
+          artifact.filename,
+          artifact.url,
+          "These forms reference the media file saved to Okou. The source post URL identifies the original social post.",
+        ).json
+      : {}),
     collection: null,
     billing: response.billing
       ? {

--- a/turbo/apps/cli/src/commands/web/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/web/__tests__/upload-file.test.ts
@@ -241,6 +241,9 @@ describe("okou web upload-file command", () => {
           "[data.bin](<https://presigned.example.com/csv-uuid/data.bin?sig=xyz>)",
         previewMarkdownBlock:
           "![data.bin](<https://presigned.example.com/csv-uuid/data.bin?sig=xyz>)",
+        artifactPresentationContext: expect.stringContaining(
+          "outside code fences",
+        ),
       });
     });
 

--- a/turbo/apps/cli/src/commands/web/upload-file.ts
+++ b/turbo/apps/cli/src/commands/web/upload-file.ts
@@ -1,10 +1,7 @@
 import { Command } from "commander";
 import { uploadWebFile } from "../../lib/api/domains/web";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
-import {
-  createArtifactMarkdownOutput,
-  formatArtifactPresentationContext,
-} from "../shared/artifact-return";
+import { createArtifactPresentation } from "../shared/artifact-return";
 
 interface UploadFileOptions {
   readonly file: string;
@@ -28,7 +25,7 @@ Examples:
 
 Output:
   By default, prints artifact presentation context with inline-link and rich-preview Markdown forms.
-  With --json, prints metadata plus inlineMarkdownLink and previewMarkdownBlock.
+  With --json, prints metadata plus inlineMarkdownLink, previewMarkdownBlock, and artifactPresentationContext.
 
 Notes:
   - Authenticates via OKOU_TOKEN (requires file:write capability)
@@ -49,19 +46,19 @@ Notes:
         contentType: options.contentType,
         purpose: "artifact",
       });
-      const markdown = createArtifactMarkdownOutput(
+      const presentation = createArtifactPresentation(
         result.filename,
         result.url,
       );
       if (options.json) {
-        console.log(JSON.stringify({ ...result, ...markdown }));
+        console.log(JSON.stringify({ ...result, ...presentation.json }));
         return;
       }
       console.log(
         [
           "The artifact upload completed successfully.",
           "",
-          formatArtifactPresentationContext(markdown),
+          presentation.text,
         ].join("\n"),
       );
     }),


### PR DESCRIPTION
Generated and downloaded media return URLs and metadata without the link-versus-preview guidance already provided by file uploads and hosting. This extends that guidance to built-in image, video, voice and avatar-video generation, completed social downloads, and internal Intro Video results.

- Successful results add `inlineMarkdownLink`, `previewMarkdownBlock`, and `artifactPresentationContext`. Text output explains paragraph placement, code fences, and duplicate references. Existing upload and host JSON now includes the same context.
- Preserve the returned artifact URL, including private references and query parameters. Image results distinguish the chat reference from the HTML embed URL; internal presenter and voice results explain their composition purpose.
- Pending Intro Video JSON includes `resumeCommand` and `continuationContext`; preview fields appear only after completion with an artifact URL.
- Image batches retain the existing `results.tsv` format and local asset behavior. A manifest-ordered `artifacts.json` and `wait --json` provide chat references and Markdown forms. Start and wait output explain how to reuse the existing batch and consume its results.

## Validation

- 11 focused CLI command test files, 231 tests passed, covering successful text/JSON output, private references, escaped labels, batch ordering and local assets, saved batches, malformed metadata, and pending/completed/failed jobs. The image test file was rerun with `OKOU_DEFAULT_IMAGE_MODEL` unset to isolate it from the agent runtime's model selection.
- CLI `pnpm lint`, `pnpm check-types`, and `pnpm build` passed.
- `pnpm exec knip --workspace apps/cli` and `git diff --cached --check` passed.
- Full repository tests remain with the PR pipeline.

## Fallbacks

- `generate/image-batch.ts:readBatchArtifacts` / `waitForBatch` accepts only missing `artifacts.json` for persisted batches created by the existing TSV-only writer, retaining usable TSV output and providing upload guidance. Invalid JSON or schema errors still fail. Surface: new CLI reading existing local batch state; service deployment and rollback gates do not establish when user-owned directories disappear. Removal condition: explicit retirement or migration of these stored batch directories. This compatibility is part of the requested behavior; no timed removal follow-up is scheduled.
- `__intro-video-agent.ts:printResult` uses the display label `Intro video` when the response's optional filename is absent. This is a presentation default under `docs/fallback.md` section 6, with no identity substitution or deployment gate. Remove it if the response contract makes the filename required; no separate follow-up is scheduled.
