### PR TITLE
feat(platform): show chat menu shortcuts

### DIFF
--- a/turbo/apps/platform/src/lib/global-keyboard-shortcuts.ts
+++ b/turbo/apps/platform/src/lib/global-keyboard-shortcuts.ts
@@ -11,4 +11,12 @@ export const GLOBAL_KEYBOARD_SHORTCUTS = {
     binding: "mod+b",
     ariaKeyShortcuts: "Meta+B Control+B",
   },
+  renameChat: {
+    binding: "f2",
+    ariaKeyShortcuts: "F2",
+  },
+  toggleChatPin: {
+    binding: "mod+shift+d",
+    ariaKeyShortcuts: "Meta+Shift+D Control+Shift+D",
+  },
 } as const;

--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -29,6 +29,7 @@ import {
   type GlobalShortcutBindings,
 } from "../../lib/setup-global-shortcut.ts";
 import { COMPOSER_VOICE_INPUT_SHORTCUT } from "../../lib/composer-voice-input-shortcut.ts";
+import { GLOBAL_KEYBOARD_SHORTCUTS } from "../../lib/global-keyboard-shortcuts.ts";
 import { scrollToThread$ } from "./sidebar-chat-thread-scroll.ts";
 
 type ChatThreadPane = "main" | "side";
@@ -175,7 +176,7 @@ interface ChatPageShortcutActions {
   canToggleThreadPin: (event: KeyboardEvent) => boolean;
   clearEmoji: () => void | Promise<void>;
   openEmojiMenu: () => void | Promise<void>;
-  renameThread: () => void | Promise<void>;
+  renameThread: (event: KeyboardEvent) => void | Promise<void>;
   navigateNext: () => void | Promise<void>;
   navigatePrev: () => void | Promise<void>;
   scrollBottom: () => void | Promise<void>;
@@ -189,6 +190,16 @@ interface ChatPageShortcutSetup {
   doc: Document;
   focusedThread: () => ChatPanelSignals | null;
   navigateFocusedThread: (direction: "prev" | "next") => void | Promise<void>;
+}
+
+function menuThreadId(target: EventTarget | null): string | null {
+  if (!(target instanceof Element)) {
+    return null;
+  }
+  return (
+    target.closest<HTMLElement>("[data-chat-thread-menu-thread-id]")?.dataset
+      .chatThreadMenuThreadId ?? null
+  );
 }
 
 function setupChatPageGlobalShortcutListener(
@@ -262,13 +273,16 @@ const setupChatPageShortcutActions$ = command(
               await set(openFocusedThreadEmojiMenu$, { thread }, signal);
             }
           },
-          renameThread: async () => {
+          renameThread: async (event) => {
             const thread = focusedThread();
-            const threadId = thread?.threadId ?? get(currentChatThreadId$);
+            const threadId =
+              menuThreadId(event.target) ??
+              thread?.threadId ??
+              get(currentChatThreadId$);
             if (threadId) {
               const request = await set(
                 renameDialogRequestForThread$,
-                thread,
+                thread?.threadId === threadId ? thread : null,
                 threadId,
                 signal,
               );
@@ -317,12 +331,13 @@ const setupChatPageShortcutActions$ = command(
               return;
             }
             const thread = focusedThread();
-            if (thread) {
+            const threadId = menuThreadId(event.target) ?? thread?.threadId;
+            if (threadId) {
               await set(
-                get(thread.threadMeta$)?.pinnedAt
+                get(chatThreadMetaMap$).get(threadId)?.pinnedAt
                   ? unpinChatThread$
                   : pinChatThread$,
-                thread.threadId,
+                threadId,
                 signal,
               );
             }
@@ -409,7 +424,7 @@ function createChatPageShortcutBindings({
       allowInEditableTarget: true,
       run: openEmojiMenu,
     },
-    f2: {
+    [GLOBAL_KEYBOARD_SHORTCUTS.renameChat.binding]: {
       allowInEditableTarget: true,
       run: renameThread,
     },
@@ -421,7 +436,7 @@ function createChatPageShortcutBindings({
       allowInEditableTarget: true,
       run: navigateNext,
     },
-    "mod+shift+d": {
+    [GLOBAL_KEYBOARD_SHORTCUTS.toggleChatPin.binding]: {
       allowInEditableTarget: true,
       shouldHandle: canToggleThreadPin,
       run: toggleThreadPin,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-keyboard.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-keyboard.test.tsx
@@ -61,7 +61,7 @@ function openThreadMenu(threadId: string): void {
   if (!row) {
     throw new Error(`Expected sidebar row for ${threadId}`);
   }
-  click(within(row).getByTestId("chat-thread-menu-trigger"));
+  click(within(row).getByLabelText("Open chat menu"));
 }
 
 function menuItemNamedOrNull(name: string): HTMLElement | null {
@@ -425,7 +425,9 @@ test("Apply displayed shortcuts to the chat whose menu is open", async () => {
 
   openThreadMenu(menuTarget.id);
   const pinItem = menuItemNamed("Pin chat");
-  pinItem.focus();
+  await waitFor(() => {
+    expect(pinItem).toHaveFocus();
+  });
   await userEvent.keyboard("{Control>}{Shift>}D{/Shift}{/Control}");
 
   await waitFor(() => {
@@ -439,8 +441,10 @@ test("Apply displayed shortcuts to the chat whose menu is open", async () => {
   });
 
   openThreadMenu(menuTarget.id);
-  const renameItem = menuItemNamed("Rename chat");
-  renameItem.focus();
+  const unpinItem = menuItemNamed("Unpin chat");
+  await waitFor(() => {
+    expect(unpinItem).toHaveFocus();
+  });
   await userEvent.keyboard("{F2}");
 
   const dialog = await screen.findByRole("dialog", { name: "Rename chat" });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-keyboard.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-keyboard.test.tsx
@@ -56,6 +56,30 @@ function pinnedIndicator(threadId: string): HTMLElement | null {
   return within(row).queryByLabelText("Pinned");
 }
 
+function openThreadMenu(threadId: string): void {
+  const row = continuitySidebarLink(threadId).parentElement;
+  if (!row) {
+    throw new Error(`Expected sidebar row for ${threadId}`);
+  }
+  click(within(row).getByTestId("chat-thread-menu-trigger"));
+}
+
+function menuItemNamedOrNull(name: string): HTMLElement | null {
+  return (
+    queryAllByRoleFast("menuitem").find((candidate) => {
+      return candidate.getAttribute("aria-label") === name;
+    }) ?? null
+  );
+}
+
+function menuItemNamed(name: string): HTMLElement {
+  const item = menuItemNamedOrNull(name);
+  if (!item) {
+    throw new Error(`Expected ${name} menu item`);
+  }
+  return item;
+}
+
 function dispatchPinShortcut(
   target: HTMLElement,
   options: KeyboardEventInit = {},
@@ -375,6 +399,54 @@ test("Pin the main chat when neither pane owns keyboard focus", async () => {
     expect(pinnedIndicator(main.id)).toBeVisible();
   });
   expect(pinnedIndicator(side.id)).toBeNull();
+});
+
+test("Apply displayed shortcuts to the chat whose menu is open", async () => {
+  const main = continuityThread(72, 1, "Focused shortcut chat");
+  const menuTarget = continuityThread(72, 2, "Menu shortcut chat");
+  const workspace = installContinuityWorkspace(context, {
+    caseId: 72,
+    threads: [main, menuTarget],
+  });
+  context.mocks.api(chatThreadPinContract.pin, ({ respond }) => {
+    return respond(204);
+  });
+
+  await setupPage({
+    context,
+    path: `/chats/${main.id}`,
+    ...workspace.pageOptions,
+  });
+  await waitFor(() => {
+    expect(composerIn(main.id)).toBeVisible();
+    expect(continuitySidebarLink(menuTarget.id)).toBeVisible();
+  });
+  composerIn(main.id).focus();
+
+  openThreadMenu(menuTarget.id);
+  const pinItem = menuItemNamed("Pin chat");
+  pinItem.focus();
+  await userEvent.keyboard("{Control>}{Shift>}D{/Shift}{/Control}");
+
+  await waitFor(() => {
+    expect(pinnedIndicator(menuTarget.id)).toBeVisible();
+  });
+  expect(pinnedIndicator(main.id)).toBeNull();
+
+  await userEvent.keyboard("{Escape}");
+  await waitFor(() => {
+    expect(menuItemNamedOrNull("Unpin chat")).toBeNull();
+  });
+
+  openThreadMenu(menuTarget.id);
+  const renameItem = menuItemNamed("Rename chat");
+  renameItem.focus();
+  await userEvent.keyboard("{F2}");
+
+  const dialog = await screen.findByRole("dialog", { name: "Rename chat" });
+  expect(within(dialog).getByPlaceholderText("Chat title")).toHaveValue(
+    "Menu shortcut chat",
+  );
 });
 
 test("Respect composition, held keys, dialogs, and navigation for pin shortcuts", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-pin-order.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-pin-order.test.tsx
@@ -86,7 +86,10 @@ function menuButton(title: string) {
 
 function menuItem(title: string) {
   const item = queryAllByRoleFast("menuitem").find((element) => {
-    return element.textContent?.trim() === title;
+    return (
+      element.getAttribute("aria-label") === title ||
+      element.textContent?.trim() === title
+    );
   });
   if (!item) {
     throw new Error(`Missing menu item: ${title}`);
@@ -187,13 +190,7 @@ test("new pins receive a rank ahead of all existing pins", async () => {
     throw new Error("Missing thread menu");
   }
   click(menuButton);
-  const pinItem = queryAllByRoleFast("menuitem").find((item) => {
-    return item.textContent?.trim() === "Pin chat";
-  });
-  if (!pinItem) {
-    throw new Error("Missing pin menu item");
-  }
-  click(pinItem);
+  click(menuItem("Pin chat"));
   expect((await requested.promise)! < "a0").toBeTruthy();
   await waitFor(() => {
     return expect(sidebarThreadTitles()).toStrictEqual([

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -336,7 +336,10 @@ function menuItemByText(text: string): HTMLElement {
 function queryMenuItemByText(text: string): HTMLElement | null {
   return (
     queryAllByRoleFast("menuitem").find((candidate) => {
-      return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
+      return (
+        candidate.getAttribute("aria-label") === text ||
+        candidate.textContent?.replace(/\s+/g, " ").trim() === text
+      );
     }) ?? null
   );
 }
@@ -2273,7 +2276,13 @@ test("Recognize and pin sidebar conversation states", async () => {
   }
 
   openThreadMenu("Release plan");
-  click(menuItemByText("Pin chat"));
+  const pinItem = menuItemByText("Pin chat");
+  expect(pinItem).toHaveTextContent("Ctrl+Shift+D");
+  expect(pinItem).toHaveAttribute(
+    "aria-keyshortcuts",
+    "Meta+Shift+D Control+Shift+D",
+  );
+  click(pinItem);
 
   await waitFor(() => {
     expect(
@@ -2288,7 +2297,9 @@ test("Recognize and pin sidebar conversation states", async () => {
       "chat-thread-pinned-indicator",
     ),
   );
-  click(menuItemByText("Unpin chat"));
+  const unpinItem = menuItemByText("Unpin chat");
+  expect(unpinItem).toHaveTextContent("Ctrl+Shift+D");
+  click(unpinItem);
 
   await waitFor(() => {
     expect(
@@ -2299,7 +2310,9 @@ test("Recognize and pin sidebar conversation states", async () => {
   });
 
   openThreadMenu("Running analysis");
-  expect(menuItemByText("Rename chat")).toBeInTheDocument();
+  const renameItem = menuItemByText("Rename chat");
+  expect(renameItem).toHaveTextContent("F2");
+  expect(renameItem).toHaveAttribute("aria-keyshortcuts", "F2");
   expect(menuItemByText("Delete chat")).toBeInTheDocument();
 });
 

--- a/turbo/apps/platform/src/views/okou-page/chat-shortcut-help-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-shortcut-help-dialog.tsx
@@ -74,8 +74,14 @@ const CHAT_THREAD_SHORTCUT_SECTIONS = [
     titleId: "global",
     shortcuts: [
       ...GLOBAL_NAVIGATION_SHORTCUTS,
-      { key: "f2", labelId: "renameChat" },
-      { key: "mod+shift+d", labelId: "togglePin" },
+      {
+        key: GLOBAL_KEYBOARD_SHORTCUTS.renameChat.binding,
+        labelId: "renameChat",
+      },
+      {
+        key: GLOBAL_KEYBOARD_SHORTCUTS.toggleChatPin.binding,
+        labelId: "togglePin",
+      },
       { key: "shift+f2", labelId: "changeIcon" },
       { key: "ctrl+shift+1", labelId: "setIcon" },
       { key: "ctrl+shift+0", labelId: "clearIcon" },

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -29,6 +29,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  getShortcutLabel,
 } from "@okouai/ui";
 import {
   Dialog,
@@ -96,11 +97,23 @@ import { equalArrays } from "../../lib/equality.ts";
 import { activeRoute$ } from "../../signals/active-route.ts";
 import { assistantName$ } from "../../signals/branding.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import { GLOBAL_KEYBOARD_SHORTCUTS } from "../../lib/global-keyboard-shortcuts.ts";
 
 // The row glyphs draw at 17px, which the shared button base (`[&_svg]:size-4`)
 // would otherwise clamp to 16px. Dimming stays on the individual glyphs so the
 // state indicators keep their own contrast.
 const CHAT_THREAD_ROW_ICON_CLASS = "[&_svg]:size-[17px]";
+
+function ChatThreadMenuShortcut({ shortcut }: { readonly shortcut: string }) {
+  return (
+    <kbd
+      aria-hidden="true"
+      className="ml-auto shrink-0 whitespace-nowrap pl-4 font-sans text-xs opacity-70"
+    >
+      {getShortcutLabel(shortcut)}
+    </kbd>
+  );
+}
 
 function equalSidebarChatThreadWindows(
   previous: SidebarChatThreadWindow,
@@ -209,28 +222,33 @@ function ChatThreadPinMenuItems({
   const isPinned = useGet(signals.pinned$);
   const togglePinned = useSet(signals.togglePinned$);
   const pageSignal = useGet(pageSignal$);
+  const label = isPinned
+    ? t(($) => {
+        return $.chat.sidebar.unpin;
+      })
+    : t(($) => {
+        return $.chat.sidebar.pin;
+      });
   return (
     <>
       <DropdownMenuItem
+        aria-label={label}
+        aria-keyshortcuts={
+          GLOBAL_KEYBOARD_SHORTCUTS.toggleChatPin.ariaKeyShortcuts
+        }
         onSelect={() => {
           detach(togglePinned(pageSignal), Reason.DomCallback);
         }}
       >
         {isPinned ? (
-          <>
-            <PinOff size={16} className="mr-2" />
-            {t(($) => {
-              return $.chat.sidebar.unpin;
-            })}
-          </>
+          <PinOff size={16} className="mr-2" />
         ) : (
-          <>
-            <Pin size={16} className="mr-2" />
-            {t(($) => {
-              return $.chat.sidebar.pin;
-            })}
-          </>
+          <Pin size={16} className="mr-2" />
         )}
+        {label}
+        <ChatThreadMenuShortcut
+          shortcut={GLOBAL_KEYBOARD_SHORTCUTS.toggleChatPin.binding}
+        />
       </DropdownMenuItem>
       <ThreadPinMoveMenuItems signals={signals} />
     </>
@@ -248,6 +266,9 @@ function ChatThreadMenu({
   const openRename = useSet(signals.openRename$);
   const requestDelete = useSet(signals.requestDelete$);
   const pageSignal = useGet(pageSignal$);
+  const renameLabel = t(($) => {
+    return $.chat.sidebar.rename;
+  });
 
   function openRenameDialog() {
     detach(openRename(pageSignal), Reason.DomCallback);
@@ -323,14 +344,25 @@ function ChatThreadMenu({
             </Tooltip>
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-40">
+        <DropdownMenuContent
+          align="end"
+          className="w-56"
+          data-chat-thread-menu-thread-id={signals.threadId}
+        >
           <ChatThreadPinMenuItems signals={signals} />
           <ChatThreadMarkUnreadMenuItem signals={signals} />
-          <DropdownMenuModalItem onModalSelect={openRenameDialog}>
+          <DropdownMenuModalItem
+            aria-label={renameLabel}
+            aria-keyshortcuts={
+              GLOBAL_KEYBOARD_SHORTCUTS.renameChat.ariaKeyShortcuts
+            }
+            onModalSelect={openRenameDialog}
+          >
             <Pencil size={16} className="mr-2" />
-            {t(($) => {
-              return $.chat.sidebar.rename;
-            })}
+            {renameLabel}
+            <ChatThreadMenuShortcut
+              shortcut={GLOBAL_KEYBOARD_SHORTCUTS.renameChat.binding}
+            />
           </DropdownMenuModalItem>
           <DropdownMenuModalItem
             onModalSelect={() => {


### PR DESCRIPTION
## Summary

- show platform-aware pin/unpin and rename shortcuts at the end of sidebar chat menu rows
- share shortcut definitions between bindings, the keyboard help dialog, and menu hints
- apply a shortcut pressed from an open chat menu to that menu's chat

## Verification

- `pnpm exec prettier --check ...` on all changed files
- scoped Oxlint, type-aware Oxlint, ESLint, and UI style lint
- `pnpm check-types` in `turbo/apps/platform`
- targeted Vitest coverage for menu hints and menu-owned shortcut behavior
