### PR TITLE
fix(platform): open the default agent from home

### DIFF
--- a/turbo/apps/platform/src/signals/agent.ts
+++ b/turbo/apps/platform/src/signals/agent.ts
@@ -16,18 +16,9 @@ import { activeRoute$ } from "./active-route.ts";
 import { onboardingStatus$ } from "./okou-page/onboarding.ts";
 import { apiClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
-import { localStorageSignals } from "./external/local-storage.ts";
 import { retryTransientLoad } from "./utils.ts";
 import { rootSignal$ } from "./root-signal.ts";
 import { assistantName$ } from "./branding.ts";
-
-const LAST_USED_AGENT_STORAGE_KEY = "zero.lastUsedAgentId";
-
-const {
-  get$: lastUsedAgentIdRaw$,
-  set$: setLastUsedAgentIdRaw$,
-  clear$: clearLastUsedAgentIdRaw$,
-} = localStorageSignals(LAST_USED_AGENT_STORAGE_KEY);
 
 export const defaultAgentId$ = computed(async (get) => {
   const status = await get(onboardingStatus$);
@@ -93,24 +84,6 @@ export const currentAgent$ = computed((get) => {
   return get(agentById(agentId));
 });
 
-const lastUsedAgentId$ = computed((get) => {
-  const value = get(lastUsedAgentIdRaw$);
-  if (typeof value !== "string") {
-    return null;
-  }
-
-  const parsed = agentsByIdContract.get.pathParams.safeParse({ id: value });
-  return parsed.success ? parsed.data.id : null;
-});
-
-export const rememberLastUsedAgentId$ = command(({ set }, agentId: string) => {
-  set(setLastUsedAgentIdRaw$, agentId);
-});
-
-export const clearLastUsedAgentId$ = command(({ set }) => {
-  set(clearLastUsedAgentIdRaw$);
-});
-
 const internalReloadAgents$ = state(0);
 
 /** All visible agents in the user's active organization. */
@@ -119,17 +92,6 @@ export const agents$ = computed(async (get) => {
   const apiClient = get(apiClient$)(agentsMainContract);
   const result = await accept(apiClient.list(), [200]);
   return result.body;
-});
-
-export const homeAgentId$ = computed(async (get) => {
-  const lastUsedAgentId = get(lastUsedAgentId$);
-  if (lastUsedAgentId) {
-    return lastUsedAgentId;
-  }
-
-  // Onboarding status already identifies the default agent, so the home route
-  // can hand off directly.
-  return await get(defaultAgentId$);
 });
 
 export const sortedAgents$ = computed(async (get) => {

--- a/turbo/apps/platform/src/signals/agents-page/agent-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/agents-page/agent-detail-page-setup.ts
@@ -4,12 +4,7 @@ import { JobDetailPage } from "../../views/team-page/job-detail-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
-import {
-  currentAgentId$,
-  agents$,
-  defaultAgentId$,
-  rememberLastUsedAgentId$,
-} from "../agent.ts";
+import { currentAgentId$, agents$, defaultAgentId$ } from "../agent.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { setActiveAgent$ } from "../okou-page/job-detail";
 import { setChatAgentId$ } from "../agent-chat.ts";
@@ -53,7 +48,6 @@ export const setupAgentDetailPage$ = command(
     // Activate the agent to trigger dependent signals (detail, automation, etc.)
     set(setActiveAgent$, agentId);
     set(setChatAgentId$, agentId);
-    set(rememberLastUsedAgentId$, agentId);
     const displayName =
       agent.displayName ??
       i18n.t(

--- a/turbo/apps/platform/src/signals/okou-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/okou-page/agent-chat-page-setup.ts
@@ -9,12 +9,7 @@ import {
   updateSearchParams$,
   detachedNavigateTo$,
 } from "../route.ts";
-import {
-  currentAgentId$,
-  defaultAgentId$,
-  agents$,
-  rememberLastUsedAgentId$,
-} from "../agent.ts";
+import { currentAgentId$, defaultAgentId$, agents$ } from "../agent.ts";
 import { setChatAgentId$ } from "../agent-chat.ts";
 import { setTalkDraft$, talkDraft$ } from "./chat-draft.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
@@ -74,7 +69,6 @@ export const setupAgentChatPage$ = command(
       return;
     }
 
-    set(rememberLastUsedAgentId$, agentId);
     set(
       updateDocumentTitle$,
       agent.displayName ??

--- a/turbo/apps/platform/src/signals/okou-page/home-page-setup.ts
+++ b/turbo/apps/platform/src/signals/okou-page/home-page-setup.ts
@@ -1,7 +1,7 @@
 import { command } from "ccstate";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
-import { homeAgentId$ } from "../agent.ts";
+import { defaultAgentId$ } from "../agent.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { setupAgentsPage$ } from "../agents-page/agents-page-setup.ts";
 import { parseTemplatePickerEntryCategory } from "./template-picker-entry.ts";
@@ -12,12 +12,12 @@ import {
 
 export const setupHomePage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    // Redirect bare / to /agents/:id/chat. Keep prompt deep links intact so
-    // paid-onboarding handoffs can prefill the chat composer on arrival.
+    // Redirect bare / to the default agent's chat. Keep prompt deep links intact
+    // so paid-onboarding handoffs can prefill the chat composer on arrival.
     // ?queue= is also forwarded so the queue drawer opens on arrival.
-    const homeAgentId = await get(homeAgentId$);
+    const defaultAgentId = await get(defaultAgentId$);
     signal.throwIfAborted();
-    if (!homeAgentId) {
+    if (!defaultAgentId) {
       await set(setupAgentsPage$, signal);
       return;
     }
@@ -55,7 +55,7 @@ export const setupHomePage$ = command(
       }
     }
     set(detachedNavigateTo$, "/agents/:agentId/chat", {
-      pathParams: { agentId: homeAgentId },
+      pathParams: { agentId: defaultAgentId },
       searchParams: forwardParams.size > 0 ? forwardParams : undefined,
       replace: true,
     });

--- a/turbo/apps/platform/src/signals/okou-page/ideation-page-setup.ts
+++ b/turbo/apps/platform/src/signals/okou-page/ideation-page-setup.ts
@@ -4,11 +4,10 @@ import { IdeationPage } from "../../views/okou-page/ideation-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
-import { currentAgentId$, rememberLastUsedAgentId$ } from "../agent.ts";
 import { i18n } from "../../i18n/index.ts";
 
 export const setupIdeationPage$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
+  async ({ set }, signal: AbortSignal) => {
     set(updatePage$, createElement(IdeationPage), "sidebar");
     set(
       updateDocumentTitle$,
@@ -19,11 +18,6 @@ export const setupIdeationPage$ = command(
         { ns: "agents" },
       ),
     );
-
-    const agentId = get(currentAgentId$);
-    if (agentId) {
-      set(rememberLastUsedAgentId$, agentId);
-    }
 
     await set(hideAppSkeleton$, signal);
   },

--- a/turbo/apps/platform/src/signals/okou-page/welcome-thread-page-setup.ts
+++ b/turbo/apps/platform/src/signals/okou-page/welcome-thread-page-setup.ts
@@ -4,7 +4,7 @@ import { createElement } from "react";
 
 import { i18n } from "../../i18n/index.ts";
 import { WelcomeThreadPage } from "../../views/okou-page/welcome-thread-page.tsx";
-import { agents$, defaultAgentId$, homeAgentId$ } from "../agent.ts";
+import { defaultAgentId$ } from "../agent.ts";
 import { setChatAgentId$ } from "../agent-chat.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { assistantName$ } from "../branding.ts";
@@ -36,17 +36,8 @@ export const setupWelcomeThreadPage$ = command(
       return;
     }
 
-    const preferredAgentId = await get(homeAgentId$);
+    const agentId = await get(defaultAgentId$);
     signal.throwIfAborted();
-    const agents = await get(agents$);
-    signal.throwIfAborted();
-    const fallbackAgentId = await get(defaultAgentId$);
-    signal.throwIfAborted();
-    const agentId = agents.some((agent) => {
-      return agent.agentId === preferredAgentId;
-    })
-      ? preferredAgentId
-      : fallbackAgentId;
 
     if (!agentId) {
       set(detachedNavigateTo$, ROUTES.agents, { replace: true });

--- a/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
@@ -6,7 +6,6 @@ import {
   billingUsagePackCheckoutContract,
 } from "@okouai/api-contracts/contracts/billing";
 import { accept } from "../../lib/accept.ts";
-import { clearLastUsedAgentId$ } from "../agent.ts";
 import { apiClient$ } from "../api-client.ts";
 import { authenticatedIdentity$ } from "../auth.ts";
 import { ROUTES } from "../route-paths.ts";
@@ -61,7 +60,6 @@ export const completeOnboarding$ = command(
     if (role) {
       set(capturePaidOnboardingRoleConfirmed$, role);
     }
-    set(clearLastUsedAgentId$);
     set(reloadOnboardingStatus$);
     set(resetOnboardingDraft$);
   },

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-page-setup.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-page-setup.ts
@@ -4,11 +4,10 @@ import { i18n } from "../../i18n/index.ts";
 import { PermissionAllowPage } from "../../views/permission-allow/permission-allow-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
-import { currentAgentId$, rememberLastUsedAgentId$ } from "../agent.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 
 export const setupPermissionAllowPage$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
+  async ({ set }, signal: AbortSignal) => {
     set(updatePage$, createElement(PermissionAllowPage), "minimal");
     set(
       updateDocumentTitle$,
@@ -16,11 +15,6 @@ export const setupPermissionAllowPage$ = command(
         return $.connectors.permissions.permissions;
       }),
     );
-
-    const agentId = get(currentAgentId$);
-    if (agentId) {
-      set(rememberLastUsedAgentId$, agentId);
-    }
 
     await set(hideAppSkeleton$, signal);
   },

--- a/turbo/apps/platform/src/views/okou-page/__tests__/home-route.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/home-route.test.tsx
@@ -1,5 +1,5 @@
-import { agentDraftContract } from "@okouai/api-contracts/contracts/agent-draft";
 import {
+  agentsByIdContract,
   agentsMainContract,
   type AgentResponse,
 } from "@okouai/api-contracts/contracts/agents";
@@ -8,43 +8,16 @@ import { expect, test } from "vitest";
 
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { localStorageSignals } from "../../../signals/external/local-storage.ts";
 import { pathname } from "../../../signals/location.ts";
 
 const context = testContext();
-const LAST_USED_AGENT_STORAGE_KEY = "zero.lastUsedAgentId";
-const { set$: setLastUsedAgentId$ } = localStorageSignals(
-  LAST_USED_AGENT_STORAGE_KEY,
-);
-
-const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
-
-const OTHER_ORG_AGENT_ID = "c0000000-0000-4000-a000-000000000004";
 const CURRENT_ORG_AGENT_ID = "c0000000-0000-4000-a000-000000000005";
-const STALE_AGENT_ID = "c0000000-0000-4000-a000-000000000006";
 
-const UNVALIDATED_AGENT_CASES = [
-  {
-    candidateId: STALE_AGENT_ID,
-    label: "stale",
-    recoveryAgentId: DEFAULT_AGENT_ID,
-    recoveryAgentName: "Default agent",
-    switchedOrganization: false,
-  },
-  {
-    candidateId: OTHER_ORG_AGENT_ID,
-    label: "cross-organization",
-    recoveryAgentId: CURRENT_ORG_AGENT_ID,
-    recoveryAgentName: "Current organization agent",
-    switchedOrganization: true,
-  },
-] as const;
-
-function agentResponse(id: string, displayName: string): AgentResponse {
-  return {
-    agentId: id,
-    ownerId: "user_mock",
-    displayName,
+function mockCurrentOrganizationAgents() {
+  const agent: AgentResponse = {
+    agentId: CURRENT_ORG_AGENT_ID,
+    ownerId: "test-user-123",
+    displayName: "Current organization agent",
     description: null,
     sound: null,
     avatarUrl: null,
@@ -53,95 +26,70 @@ function agentResponse(id: string, displayName: string): AgentResponse {
     preferPersonalProvider: false,
     visibility: "private",
   };
-}
-
-function deferAgentsResponse(agents: AgentResponse[]) {
-  const started = context.mocks.deferred<void>();
-  const release = context.mocks.deferred<void>();
-  const responded = context.mocks.deferred<void>();
-  context.mocks.api(agentsMainContract.list, async ({ respond }) => {
-    started.resolve(undefined);
-    await release.promise;
-    const response = respond(200, agents);
-    responded.resolve(undefined);
-    return response;
+  const agents: AgentResponse[] = [
+    {
+      ...agent,
+      agentId: "c0000000-0000-4000-a000-000000000004",
+      displayName: "Research agent",
+    },
+    agent,
+  ];
+  context.mocks.data.onboardingStatus({
+    defaultAgentId: CURRENT_ORG_AGENT_ID,
   });
-  return { release, responded, started };
-}
-
-function recordAgentDraftLoads(): () => readonly string[] {
-  const agentIds: string[] = [];
-  context.mocks.api(agentDraftContract.get, ({ params, respond }) => {
-    agentIds.push(params.id);
-    return respond(200, {
-      draftUserMessage: null,
-      draftAttachments: null,
+  context.mocks.api(agentsMainContract.list, ({ respond }) => {
+    return respond(200, agents);
+  });
+  context.mocks.api(agentsByIdContract.get, ({ params, respond }) => {
+    const requestedAgent = agents.find((candidate) => {
+      return candidate.agentId === params.id;
     });
+    return requestedAgent
+      ? respond(200, requestedAgent)
+      : respond(404, {
+          error: {
+            code: "NOT_FOUND",
+            message: `Agent not found: ${params.id}`,
+          },
+        });
   });
-  return () => {
-    return agentIds;
-  };
 }
 
-function setupCandidateHomeRoute(
-  candidate: (typeof UNVALIDATED_AGENT_CASES)[number],
-): Promise<void> {
-  return setupPage({
+test("Home opens the current organization's default agent", async () => {
+  mockCurrentOrganizationAgents();
+
+  await setupPage({
     context,
     path: "/",
-    ...(candidate.switchedOrganization
-      ? {
-          auth: {
-            user: { id: "test-user-123", fullName: "Test User" },
-            organization: {
-              activeOrg: {
-                id: "org_current",
-                name: "Current organization",
-              },
-              memberships: [{ id: "org_current" }, { id: "org_previous" }],
-            },
-          },
-        }
-      : {}),
+    auth: {
+      user: { id: "test-user-123", fullName: "Test User" },
+      organization: {
+        activeOrg: { id: "org_current", name: "Current organization" },
+        memberships: [{ id: "org_current" }, { id: "org_previous" }],
+      },
+    },
   });
-}
 
-async function expectCandidateRecovery(
-  candidate: (typeof UNVALIDATED_AGENT_CASES)[number],
-): Promise<void> {
-  context.store.set(setLastUsedAgentId$, candidate.candidateId);
-  context.mocks.data.onboardingStatus({
-    defaultAgentId: candidate.recoveryAgentId,
-  });
-  const draftLoads = recordAgentDraftLoads();
-  const team = deferAgentsResponse([
-    agentResponse(candidate.recoveryAgentId, candidate.recoveryAgentName),
-  ]);
-
-  await setupCandidateHomeRoute(candidate);
-
-  await team.started.promise;
-  expect(pathname()).toBe(`/agents/${candidate.candidateId}/chat`);
-  await expect(
-    screen.findByRole("textbox", { name: "Message" }),
-  ).resolves.toBeInTheDocument();
-  expect(draftLoads()).not.toContain(candidate.candidateId);
-
-  team.release.resolve(undefined);
+  await screen.findByRole("textbox", { name: "Message" });
   await waitFor(() => {
-    expect(pathname()).toBe(`/agents/${candidate.recoveryAgentId}/chat`);
-    expect(document.title).toContain(candidate.recoveryAgentName);
+    expect(pathname()).toBe(`/agents/${CURRENT_ORG_AGENT_ID}/chat`);
+    expect(document.title).toContain("Current organization agent");
   });
-  expect(screen.getByRole("textbox", { name: "Message" })).toBeInTheDocument();
-  expect(draftLoads()).not.toContain(candidate.candidateId);
-}
-
-test("An unavailable last-used agent recovers to an available agent", async () => {
-  await expectCandidateRecovery(UNVALIDATED_AGENT_CASES[0]);
-  expect(pathname()).toBe(`/agents/${DEFAULT_AGENT_ID}/chat`);
 });
 
-test("A last-used agent from another organization recovers within the active organization", async () => {
-  await expectCandidateRecovery(UNVALIDATED_AGENT_CASES[1]);
-  expect(pathname()).toBe(`/agents/${CURRENT_ORG_AGENT_ID}/chat`);
+test("Home preserves a prompt handoff when opening the default agent", async () => {
+  mockCurrentOrganizationAgents();
+
+  await setupPage({
+    context,
+    path: "/?prompt=Draft%20a%20launch%20plan",
+  });
+
+  await screen.findByRole("textbox", { name: "Message" });
+  await waitFor(() => {
+    expect(pathname()).toBe(`/agents/${CURRENT_ORG_AGENT_ID}/chat`);
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveTextContent(
+      "Draft a launch plan",
+    );
+  });
 });

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -43,8 +43,6 @@ import { mockOAuthCompletions } from "../../okou-page/__tests__/connector-page-t
 
 const context = testContext();
 const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
-const STALE_AGENT_ID = "c0000000-0000-4000-a000-000000000099";
-const LAST_USED_AGENT_STORAGE_KEY = "zero.lastUsedAgentId";
 
 function onboardingAgent(agentId: string): AgentResponse {
   return {
@@ -393,24 +391,7 @@ test("Website creation opens its template gallery", async () => {
 });
 
 test("Creative onboarding uses the current workspace's default agent", async () => {
-  const browserStorage = Reflect.get(window, "localStorage");
-  if (!(browserStorage instanceof Storage)) {
-    throw new Error("Expected browser local storage");
-  }
-  browserStorage.setItem(LAST_USED_AGENT_STORAGE_KEY, STALE_AGENT_ID);
-  context.signal.addEventListener(
-    "abort",
-    () => {
-      browserStorage.removeItem(LAST_USED_AGENT_STORAGE_KEY);
-    },
-    { once: true },
-  );
-  let firstAgentRoute: string | null = null;
   context.mocks.api(agentsMainContract.list, ({ respond }) => {
-    const currentPath = pathname();
-    if (firstAgentRoute === null && currentPath.startsWith("/agents/")) {
-      firstAgentRoute = currentPath;
-    }
     return respond(200, [onboardingAgent(DEFAULT_AGENT_ID)]);
   });
 
@@ -418,7 +399,7 @@ test("Creative onboarding uses the current workspace's default agent", async () 
   chooseMakeOption("Generate a presentation");
 
   await waitFor(() => {
-    expect(firstAgentRoute).toBe(`/agents/${DEFAULT_AGENT_ID}/chat`);
+    expect(pathname()).toBe(`/agents/${DEFAULT_AGENT_ID}/chat`);
   });
   await waitFor(() => {
     const presentationTab = queryAllByRoleFast("tab").find((candidate) => {

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -22,10 +22,6 @@ import {
   connectorManualGrantContract,
   connectorOauthStartContract,
 } from "@okouai/api-contracts/contracts/connectors";
-import {
-  agentsMainContract,
-  type AgentResponse,
-} from "@okouai/api-contracts/contracts/agents";
 import { onboardingCompleteContract } from "@okouai/api-contracts/contracts/onboarding";
 
 import {
@@ -42,22 +38,6 @@ import { mockChatLifecycle } from "../../okou-page/__tests__/chat-test-helpers.t
 import { mockOAuthCompletions } from "../../okou-page/__tests__/connector-page-test-helpers.ts";
 
 const context = testContext();
-const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
-
-function onboardingAgent(agentId: string): AgentResponse {
-  return {
-    agentId,
-    ownerId: "user_mock",
-    displayName: "Default agent",
-    description: null,
-    sound: null,
-    avatarUrl: null,
-    modelProviderId: null,
-    selectedModel: null,
-    preferPersonalProvider: false,
-    visibility: "private",
-  };
-}
 
 const MARKETING_PRESENTATION_PROMPT = [
   "/gen presentation with template `html-ppt-playful-launch`, create a 15-slide launch deck for SproutPop, a playful habit-building app for remote teams introducing a shared 30-day wellness challenge.",
@@ -361,6 +341,7 @@ test("Presentation creation opens its template gallery", async () => {
     tab: "Presentation",
   });
   expect(selectedTab).toHaveAttribute("aria-selected", "true");
+  expect(pathname()).toBe("/agents/c0000000-0000-4000-a000-000000000001/chat");
 });
 
 test("Image creation opens its template gallery", async () => {
@@ -388,28 +369,6 @@ test("Website creation opens its template gallery", async () => {
     tab: "Website",
   });
   expect(selectedTab).toHaveAttribute("aria-selected", "true");
-});
-
-test("Creative onboarding uses the current workspace's default agent", async () => {
-  context.mocks.api(agentsMainContract.list, ({ respond }) => {
-    return respond(200, [onboardingAgent(DEFAULT_AGENT_ID)]);
-  });
-
-  await openMakePage();
-  chooseMakeOption("Generate a presentation");
-
-  await waitFor(() => {
-    expect(pathname()).toBe(`/agents/${DEFAULT_AGENT_ID}/chat`);
-  });
-  await waitFor(() => {
-    const presentationTab = queryAllByRoleFast("tab").find((candidate) => {
-      return (
-        candidate.textContent === "Presentation" &&
-        candidate.getAttribute("aria-selected") === "true"
-      );
-    });
-    expect(presentationTab).toBeInTheDocument();
-  });
 });
 
 test("A user can identify and switch workspace during onboarding", async () => {


### PR DESCRIPTION
Opening `/` now goes directly to the current organization's default agent. This removes the browser-wide last-used agent preference that could briefly open the previous account's agent and show an "Agent not found" toast during account switching. The welcome thread also uses the default agent, and existing home deep-link parameters remain supported.

## Cleanup scope

Compared the introducing PR and follow-up diffs against the current implementation:

| Historical change | Cleanup |
| --- | --- |
| #10846: remember the last-used agent | Remove the storage key, signals, home selection, and writers in agent detail, chat, ideation, and permission pages. The old talk page and signal tests were already removed by #14814 and #16865. |
| #29599 / #29691: move validation around the stored home candidate | Remove the stored-candidate home tests. Confirm that the dedicated validation page and retry command no longer exist. |
| #29726: clear the preference after onboarding | Remove the clear command, onboarding call, dedicated recovery test, and fixture. Keep the default-agent navigation assertion in the existing presentation-template onboarding test. |

Home page tests cover the current organization's configured default agent, even when it is not first in the agent list, and prompt handoff. General recovery for unavailable agents in explicit URLs predates #10846 and still serves those links.

## Verification

- Changed-file Prettier, ESLint, and Oxlint, including type-aware lint, passed.
- Platform type checks, scoped Knip, and style policy passed. The test type check and Knip also passed after the final test cleanup.
- All 8 `test-app` shards and all lint/type/format/Knip checks passed in [GitHub Actions](https://github.com/vm0-ai/vm0/actions/runs/34389092515) for `e57c017e4cf9941f386242bae2c862836dd2cba7`. Other pipeline jobs are still running. Vitest ran in CI, per repository instructions.
