### PR TITLE
fix(auth): keep signup background visible while scrolling

### DIFF
--- a/e2e/playwright/tests/auth-v1.spec.ts
+++ b/e2e/playwright/tests/auth-v1.spec.ts
@@ -94,6 +94,24 @@ async function expectPasswordControlFits(
     .toBeGreaterThanOrEqual(0);
 }
 
+async function expectAuthBackgroundCoversViewport(page: Page): Promise<void> {
+  const background = page.getByTestId("app-auth-background");
+  await expect(background).toBeVisible();
+  await expect
+    .poll(async () => {
+      return background.evaluate((element) => {
+        const box = element.getBoundingClientRect();
+        return (
+          box.top <= 0 &&
+          box.right >= window.innerWidth &&
+          box.bottom >= window.innerHeight &&
+          box.left <= 0
+        );
+      });
+    })
+    .toBe(true);
+}
+
 /**
  * Clerk prepares the verification after the code card mounts. A code entered
  * before that response lands is rejected with a card-level error instead of
@@ -274,6 +292,19 @@ for (const device of [
       await page.setViewportSize({ width: 375, height: 812 });
       await expectSeparated(password, error);
       await expectSeparated(error, legalConsent);
+
+      await page.setViewportSize({ width: 375, height: 568 });
+      await page
+        .getByRole("link", { exact: true, name: "Sign in" })
+        .scrollIntoViewIfNeeded();
+      await expect
+        .poll(() => {
+          return page
+            .getByTestId("app-auth-layout")
+            .evaluate((element) => element.scrollTop);
+        })
+        .toBeGreaterThan(0);
+      await expectAuthBackgroundCoversViewport(page);
 
       const longPassword = "A-Long-Password-For-Reveal-Layout!2026";
       await password.fill(longPassword);

--- a/turbo/apps/platform/src/views/auth/auth-shell.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-shell.tsx
@@ -25,7 +25,7 @@ export function AuthShell({ authBrand, children }: AuthShellProps) {
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 overflow-hidden"
+        className="pointer-events-none fixed inset-0 overflow-hidden"
         data-testid="app-auth-background"
       >
         <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--primary)/0.06)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--primary)/0.06)_1px,transparent_1px)] bg-[size:3rem_3rem]" />


### PR DESCRIPTION
## Summary

- pin the shared authentication background to the viewport so long Clerk V1 sign-up states cannot scroll past it
- extend the existing Clerk V1 Playwright coverage to verify the background still covers a scrolled, constrained viewport

## Testing

- `pnpm -F @okouai/app exec vitest run src/views/auth-v1/__tests__/auth-v1-page.test.tsx --maxWorkers=2 --silent=passed-only` (12 passed)
- `pnpm -F @okouai/app check-types`
- `pnpm lint:style`
- targeted Prettier, Oxlint, and ESLint checks
- `pnpm check-types` from `e2e/`

The deployed Playwright scenario is left to the PR pipeline, per repository workflow.