### PR TITLE
fix(auth): restore v1 email code styling

### DIFF
--- a/e2e/playwright/tests/auth-v1.spec.ts
+++ b/e2e/playwright/tests/auth-v1.spec.ts
@@ -328,12 +328,24 @@ for (const device of [
       const error = page.locator(".cl-otpCodeFieldErrorText:visible");
       const resend = page.locator(".cl-formResendCodeLink");
       await expect(inputs).toBeVisible();
+      const slots = page.locator(".cl-otpCodeFieldInput");
+      await expect(slots).toHaveCount(6);
+      const expectedBorderColor =
+        device.theme === "light" ? "rgb(207, 204, 203)" : "rgb(86, 84, 84)";
+      for (const slot of await slots.all()) {
+        await expect(slot).toHaveCSS("border-color", expectedBorderColor);
+      }
       const code = page.getByRole("textbox", {
         name: "Enter verification code",
       });
       await code.fill("1");
       await expect(code).toBeFocused();
       await expect(code).toHaveValue("1");
+      const activeSlot = page.locator(
+        '.cl-otpCodeFieldInput[data-focus-within="true"]',
+      );
+      await expect(activeSlot).toHaveCount(1);
+      await expect(activeSlot).toHaveCSS("box-shadow", /3px/u);
       await code.clear();
       await enterInvalidCode(page, "000000");
       await expect(error).not.toBeEmpty();

--- a/e2e/playwright/tests/auth-v1.spec.ts
+++ b/e2e/playwright/tests/auth-v1.spec.ts
@@ -328,6 +328,15 @@ for (const device of [
       const error = page.locator(".cl-otpCodeFieldErrorText:visible");
       const resend = page.locator(".cl-formResendCodeLink");
       await expect(inputs).toBeVisible();
+      const primaryAction = page.getByRole("button", {
+        exact: true,
+        name: "Continue",
+      });
+      await expect(primaryAction).toHaveCSS(
+        "background-color",
+        "rgb(255, 165, 0)",
+      );
+      await expect(primaryAction).toHaveCSS("color", "rgb(36, 35, 33)");
       const slots = page.locator(".cl-otpCodeFieldInput");
       await expect(slots).toHaveCount(6);
       const expectedBorderColor =

--- a/turbo/apps/platform/src/views/auth-v1/component-appearance.ts
+++ b/turbo/apps/platform/src/views/auth-v1/component-appearance.ts
@@ -3,6 +3,7 @@ import type { SignIn } from "@clerk/react";
 import type { ComponentProps } from "react";
 import { platformOkouWordmarkLightImg } from "../../lib/static-assets.ts";
 import type { AuthBrandContext } from "../../signals/auth.ts";
+import { AUTH_V2_PRIMARY_ACTION_CLASS } from "../auth-v2/auth-v2-action-styles.ts";
 
 type ClerkAppearance = NonNullable<ComponentProps<typeof SignIn>["appearance"]>;
 
@@ -33,6 +34,10 @@ export function getAuthV1ComponentAppearance(
       card: "m-0 w-full rounded-none border-0 bg-card px-[var(--okou-auth-card-padding-inline)] py-[var(--okou-auth-card-padding-block)] shadow-none",
       // Clerk owns the header rhythm; only the wordmark keeps its brand width.
       logoImage: "h-auto w-[76px]",
+      // Clerk shares colorPrimary between links and filled controls. Keep the
+      // accessible link color at provider level, then give only the CTA the
+      // same filled treatment as Auth V2.
+      formButtonPrimary: cn(AUTH_V2_PRIMARY_ACTION_CLASS, "border-transparent"),
       otpCodeFieldInput: AUTH_V1_OTP_INPUT_CLASS,
     },
   };

--- a/turbo/apps/platform/src/views/auth-v1/component-appearance.ts
+++ b/turbo/apps/platform/src/views/auth-v1/component-appearance.ts
@@ -6,6 +6,12 @@ import type { AuthBrandContext } from "../../signals/auth.ts";
 
 type ClerkAppearance = NonNullable<ComponentProps<typeof SignIn>["appearance"]>;
 
+// Clerk's OTP slots are visual divs; its accessible textbox owns focus. Match
+// the shared Input boundary while adapting focus and error states through the
+// public attributes that Clerk exposes on each slot.
+const AUTH_V1_OTP_INPUT_CLASS =
+  "border-[0.7px] border-[hsl(var(--gray-400))] bg-input shadow-none data-[focus-within=true]:border-primary data-[focus-within=true]:ring-[3px] data-[focus-within=true]:ring-primary/10 aria-invalid:border-destructive data-[focus-within=true]:aria-invalid:border-destructive";
+
 /** Keep branding and the page shell; Clerk owns control styles and states. */
 export function getAuthV1ComponentAppearance(
   authBrand: AuthBrandContext,
@@ -27,6 +33,7 @@ export function getAuthV1ComponentAppearance(
       card: "m-0 w-full rounded-none border-0 bg-card px-[var(--okou-auth-card-padding-inline)] py-[var(--okou-auth-card-padding-block)] shadow-none",
       // Clerk owns the header rhythm; only the wordmark keeps its brand width.
       logoImage: "h-auto w-[76px]",
+      otpCodeFieldInput: AUTH_V1_OTP_INPUT_CLASS,
     },
   };
 }


### PR DESCRIPTION
## Summary

- restore visible borders on Clerk V1 email verification code slots
- align the V1 primary CTA fill and foreground with Auth V2 while preserving the accessible light-theme link color
- use Clerk public appearance element keys and keep Auth V2 behavior unchanged

## Verification

- `git diff --check`
- Prettier 3.6.2 on the changed files
- PR pipeline passed
- App Preview: V1 sign-in → Use another method → Email code, verified in light and dark themes
- App Preview: compared the same Email code state against Auth V2