### PR TITLE
fix(api): record browser screenshot outcome metrics without warnings

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
@@ -68,6 +68,36 @@ function commandInput(command: unknown): Record<string, unknown> {
   return command.input as Record<string, unknown>;
 }
 
+function browserScreenshotResults() {
+  const schema = z.strictObject({
+    _time: z.iso.datetime(),
+    type: z.literal("managed_browser_screenshot"),
+    source: z.literal("api"),
+    outcome: z.enum(["success", "failure"]),
+    duration_ms: z.number().finite().nonnegative(),
+    failure_stage: z.enum(["prepare", "capture", "upload", "save"]).optional(),
+    failure_kind: z.string().optional(),
+  });
+  return context.mocks.axiom.sdkIngest.mock.calls.flatMap(
+    ([dataset, events]) => {
+      if (dataset !== "vm0-web-logs-dev" || !Array.isArray(events)) {
+        return [];
+      }
+      return events.flatMap((event: unknown) => {
+        if (
+          typeof event !== "object" ||
+          event === null ||
+          !("type" in event) ||
+          event.type !== "managed_browser_screenshot"
+        ) {
+          return [];
+        }
+        return [schema.parse(event)];
+      });
+    },
+  );
+}
+
 aroundEach(async (runTest) => {
   await withMockNowForTest(STARTED_AT_MS, runTest);
 });
@@ -2077,93 +2107,146 @@ describe("okou browser route", () => {
     await flushWaitUntilForTest();
   }, 120_000);
 
-  it("keeps the browser usable without retrying a failed screenshot capture", async () => {
-    const { routeMocks, runs, chat, actor, agent } =
-      await setupBrowserScenario();
-    const current = await createClaimedChatRun(
-      chat,
-      runs,
-      actor,
-      agent.agentId,
-      "Open a browser without a screenshot",
-    );
-    const providerId = randomUUID();
-    acceptBrowserUseCdpSessions([providerId]);
-    server.use(
-      http.post(`${BROWSER_USE_API_URL}/profiles`, async ({ request }) => {
-        const body = z
-          .strictObject({ name: z.string() })
-          .parse(await request.json());
-        return HttpResponse.json(providerProfile(randomUUID(), body.name), {
-          status: 201,
+  it.each(["no_page_target", "target_disappeared", "other", "timeout"])(
+    "records a %s screenshot failure once without warnings and keeps the browser usable",
+    async (failureKind) => {
+      context.mocks.axiom.useRealTelemetry.mockReturnValue(true);
+      const { routeMocks, runs, chat, actor, agent } =
+        await setupBrowserScenario();
+      const current = await createClaimedChatRun(
+        chat,
+        runs,
+        actor,
+        agent.agentId,
+        "Open a browser without a screenshot",
+      );
+      const providerId = randomUUID();
+      acceptBrowserUseCdpSessions([providerId]);
+      server.use(
+        http.post(`${BROWSER_USE_API_URL}/profiles`, async ({ request }) => {
+          const body = z
+            .strictObject({ name: z.string() })
+            .parse(await request.json());
+          return HttpResponse.json(providerProfile(randomUUID(), body.name), {
+            status: 201,
+          });
+        }),
+        http.post(`${BROWSER_USE_API_URL}/browsers`, () => {
+          return HttpResponse.json(providerBrowser(providerId), {
+            status: 201,
+          });
+        }),
+        http.get(`${BROWSER_USE_API_URL}/browsers/:id`, ({ params }) => {
+          return HttpResponse.json(providerBrowser(String(params.id)));
+        }),
+      );
+      await accept(
+        client().use({ headers: current.claim.browserHeaders, body: {} }),
+        [200],
+      );
+      await flushWaitUntilForTest();
+      context.mocks.browserUseCdp.command.mockImplementation((command) => {
+        if (
+          command.method === "Target.getTargets" &&
+          failureKind === "no_page_target"
+        ) {
+          return { targetInfos: [] };
+        }
+        if (command.method === "Target.attachToTarget") {
+          if (failureKind === "target_disappeared") {
+            return new Error("No target with given id found");
+          }
+          return { sessionId: "foreground-session" };
+        }
+        if (command.method === "Runtime.evaluate") {
+          return { result: { type: "boolean", value: true } };
+        }
+        if (command.method === "Page.getLayoutMetrics") {
+          return {
+            cssVisualViewport: {
+              pageX: 0,
+              pageY: 0,
+              clientWidth: 1280,
+              clientHeight: 720,
+            },
+          };
+        }
+        if (command.method === "Page.captureScreenshot") {
+          return failureKind === "other"
+            ? new Error("Screenshot capture unavailable")
+            : { data: Buffer.from("screenshot").toString("base64") };
+        }
+        return undefined;
+      });
+      if (failureKind === "timeout") {
+        // Node storage transports can wrap the deadline in an AbortError.
+        const timeout = new Error("The operation was aborted", {
+          cause: new DOMException(
+            "Screenshot deadline exceeded",
+            "TimeoutError",
+          ),
         });
-      }),
-      http.post(`${BROWSER_USE_API_URL}/browsers`, () => {
-        return HttpResponse.json(providerBrowser(providerId), { status: 201 });
-      }),
-      http.get(`${BROWSER_USE_API_URL}/browsers/:id`, ({ params }) => {
-        return HttpResponse.json(providerBrowser(String(params.id)));
-      }),
-    );
-    context.mocks.browserUseCdp.command.mockImplementation((command) => {
-      if (command.method === "Target.attachToTarget") {
-        return { sessionId: "foreground-session" };
+        timeout.name = "AbortError";
+        context.mocks.s3.send.mockImplementation((command: unknown) => {
+          return commandInput(command).ContentType === "image/webp"
+            ? Promise.reject(timeout)
+            : Promise.resolve({});
+        });
       }
-      if (command.method === "Runtime.evaluate") {
-        return { result: { type: "boolean", value: true } };
-      }
-      if (command.method === "Page.getLayoutMetrics") {
-        return {
-          cssVisualViewport: {
-            pageX: 0,
-            pageY: 0,
-            clientWidth: 1280,
-            clientHeight: 720,
-          },
-        };
-      }
-      if (command.method === "Page.captureScreenshot") {
-        return new Error("Screenshot capture unavailable");
-      }
-      return undefined;
-    });
 
-    await accept(
-      client().use({ headers: current.claim.browserHeaders, body: {} }),
-      [200],
-    );
-    const reconciled = await reconcileBrowsers(current.threadId);
-    expect(reconciled.body).toMatchObject({ healthy: 1, errors: 0 });
-    await flushWaitUntilForTest();
+      const reconciled = await reconcileBrowsers(current.threadId);
+      expect(reconciled.body).toMatchObject({ healthy: 1, errors: 0 });
+      await flushWaitUntilForTest();
 
-    routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
-    const lease = await accept(
-      client().leaseByThread({
-        headers: { authorization: "Bearer clerk-session" },
-        params: { threadId: current.threadId },
-        body: {},
-      }),
-      [200],
-    );
-    expect(lease.body.browser).toMatchObject({
-      status: "active",
-      screenshotUrl: null,
-    });
-    await flushWaitUntilForTest();
-    expect(
-      context.mocks.browserUseCdp.command.mock.calls.filter(([command]) => {
-        return command.method === "Page.captureScreenshot";
-      }),
-    ).toHaveLength(1);
-    expect(
-      context.mocks.s3.send.mock.calls.filter(([command]) => {
-        const input = commandInput(command);
-        return input.ContentType === "image/webp" || "Delete" in input;
-      }),
-    ).toHaveLength(0);
-  }, 120_000);
+      routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+      const lease = await accept(
+        client().leaseByThread({
+          headers: { authorization: "Bearer clerk-session" },
+          params: { threadId: current.threadId },
+          body: {},
+        }),
+        [200],
+      );
+      expect(lease.body.browser).toMatchObject({
+        status: "active",
+        screenshotUrl: null,
+      });
+      await flushWaitUntilForTest();
+      expect(
+        context.mocks.browserUseCdp.command.mock.calls.filter(([command]) => {
+          return command.method === "Page.captureScreenshot";
+        }),
+      ).toHaveLength(
+        failureKind === "other" || failureKind === "timeout" ? 1 : 0,
+      );
+      expect(
+        context.mocks.s3.send.mock.calls.filter(([command]) => {
+          const input = commandInput(command);
+          return input.ContentType === "image/webp" || "Delete" in input;
+        }),
+      ).toHaveLength(failureKind === "timeout" ? 1 : 0);
+      expect(browserScreenshotResults()).toStrictEqual([
+        {
+          _time: isoAt(0),
+          type: "managed_browser_screenshot",
+          source: "api",
+          outcome: "failure",
+          duration_ms: 0,
+          failure_stage: failureKind === "timeout" ? "upload" : "capture",
+          failure_kind: failureKind,
+        },
+      ]);
+      expect(context.mocks.axiomLogging.warn.mock.calls).toStrictEqual([]);
+      expect(context.mocks.axiomLogging.error.mock.calls).toStrictEqual([]);
+      expect(context.mocks.sentry.captureException.mock.calls).toStrictEqual(
+        [],
+      );
+    },
+    120_000,
+  );
 
   it("captures the foreground tab and keeps previous screenshot objects when updating or deleting a thread", async () => {
+    context.mocks.axiom.useRealTelemetry.mockReturnValue(true);
     const { routeMocks, runs, chat, actor, agent } =
       await setupBrowserScenario();
     const current = await createClaimedChatRun(
@@ -2217,6 +2300,7 @@ describe("okou browser route", () => {
       return Promise.resolve({});
     });
     let captureCount = 0;
+    let failNextCapture = false;
     context.mocks.browserUseCdp.command.mockImplementation((command) => {
       if (command.method === "Target.getTargets") {
         return {
@@ -2261,6 +2345,9 @@ describe("okou browser route", () => {
         };
       }
       if (command.method === "Page.captureScreenshot") {
+        if (failNextCapture) {
+          return new Error("Screenshot capture unavailable");
+        }
         captureCount += 1;
         return {
           data: Buffer.from(`screenshot-${String(captureCount)}`).toString(
@@ -2288,6 +2375,7 @@ describe("okou browser route", () => {
     expect(firstLease.body.browser.screenshotUrl).toBeNull();
     await flushWaitUntilForTest();
     expect(captureCount).toBe(0);
+    expect(browserScreenshotResults()).toStrictEqual([]);
 
     const afterViewerLease = await accept(
       client().get({
@@ -2344,8 +2432,16 @@ describe("okou browser route", () => {
     expect(secondReconcile.body).toMatchObject({
       errors: 0,
     });
+    let flushedScreenshotResults = browserScreenshotResults();
+    context.mocks.axiom.flush.mockImplementation(() => {
+      flushedScreenshotResults = browserScreenshotResults();
+      return Promise.resolve();
+    });
     releaseSecondScreenshotUpload.resolve(undefined);
     await flushWaitUntilForTest();
+    // The response already completed while upload was blocked. Its flush
+    // cannot deliver the screenshot result; the background task must flush it.
+    expect(flushedScreenshotResults).toHaveLength(2);
 
     const afterSecondCapture = await accept(
       client().get({
@@ -2445,6 +2541,41 @@ describe("okou browser route", () => {
     }
     const finalScreenshotKey = `artifacts/${new URL(finalScreenshotUrl).pathname.slice(1)}`;
     expect(captureCount).toBe(3);
+    expect(browserScreenshotResults()).toStrictEqual(
+      Array.from({ length: 3 }, () => {
+        return {
+          _time: isoAt(0),
+          type: "managed_browser_screenshot",
+          source: "api",
+          outcome: "success",
+          duration_ms: 0,
+        };
+      }),
+    );
+    failNextCapture = true;
+    const failedCapture = await reconcileBrowsers(current.threadId);
+    expect(failedCapture.body).toMatchObject({ healthy: 1, errors: 0 });
+    await flushWaitUntilForTest();
+    const retainedPreview = await accept(
+      client().get({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { threadId: current.threadId },
+      }),
+      [200],
+    );
+    expect(retainedPreview.body.browser).toMatchObject({
+      status: "active",
+      screenshotUrl: finalScreenshotUrl,
+    });
+    expect(browserScreenshotResults()).toHaveLength(4);
+    expect(browserScreenshotResults().at(-1)).toMatchObject({
+      outcome: "failure",
+      failure_stage: "capture",
+      failure_kind: "other",
+    });
+    expect(context.mocks.axiomLogging.warn.mock.calls).toStrictEqual([]);
+    expect(context.mocks.axiomLogging.error.mock.calls).toStrictEqual([]);
+    expect(context.mocks.sentry.captureException.mock.calls).toStrictEqual([]);
     expect(
       context.mocks.s3.send.mock.calls.filter(([command]) => {
         const input = commandInput(command);

--- a/turbo/apps/api/src/signals/services/browser.service.ts
+++ b/turbo/apps/api/src/signals/services/browser.service.ts
@@ -44,9 +44,10 @@ import {
   publishBrowserSessionChangedSafely,
   publishChatThreadMessageCreatedSafely,
 } from "../external/realtime";
-import { nowDate } from "../../lib/time";
+import { now, nowDate } from "../../lib/time";
+import { flushAxiom, getDatasetName, ingestToAxiom } from "../external/axiom";
 import { putImmutableS3Object } from "../external/s3";
-import { settle, settleIncludingAbort, tapError } from "../utils";
+import { settle, settleIncludingAbort } from "../utils";
 import {
   BrowserUseProviderError,
   captureBrowserUseScreenshot,
@@ -815,97 +816,171 @@ async function lockBrowserThread(
   );
 }
 
+type BrowserScreenshotStage = "prepare" | "capture" | "upload" | "save";
+
+function browserScreenshotFailureKind(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return "other";
+  }
+  if (
+    error.name === "TimeoutError" ||
+    (error.name === "AbortError" &&
+      error.cause instanceof Error &&
+      error.cause.name === "TimeoutError")
+  ) {
+    return "timeout";
+  }
+  switch (error.message) {
+    case "Browser Use CDP returned no page target": {
+      return "no_page_target";
+    }
+    case "No target with given id found": {
+      return "target_disappeared";
+    }
+    case "Browser Use CDP connection failed": {
+      return "connection_failed";
+    }
+    case "Browser Use CDP connection closed": {
+      return "connection_closed";
+    }
+    default: {
+      return error.name === "AbortError" ? "aborted" : "other";
+    }
+  }
+}
+
+async function recordBrowserScreenshotResult(result: {
+  readonly startedAt: number;
+  readonly outcome: "success" | "failure";
+  readonly failureStage?: BrowserScreenshotStage;
+  readonly failureKind?: string;
+}): Promise<void> {
+  const ingested = ingestToAxiom(getDatasetName("web-logs"), [
+    {
+      _time: nowDate().toISOString(),
+      type: "managed_browser_screenshot",
+      source: "api",
+      outcome: result.outcome,
+      duration_ms: Math.max(0, now() - result.startedAt),
+      ...(result.failureStage === undefined
+        ? {}
+        : { failure_stage: result.failureStage }),
+      ...(result.failureKind === undefined
+        ? {}
+        : { failure_kind: result.failureKind }),
+    },
+  ]);
+  if (ingested) {
+    await flushAxiom({ client: "telemetry" });
+  }
+}
+
 const captureAndStoreBrowserScreenshot$ = command(
-  async (
-    { get, set },
-    browser: BrowserSessionRow,
-    signal: AbortSignal,
-  ): Promise<void> => {
-    const db = set(writeDb$);
-    if (!(await browserScreenshotSchemaAvailable(db))) {
-      signal.throwIfAborted();
-      return;
-    }
-    const instance = await loadActiveInstance(db, browser.chatThreadId);
-    signal.throwIfAborted();
-    if (!instance) {
-      return;
-    }
-    const provider = await getBrowserUseSession(
-      instance.providerSessionId,
-      signal,
-    );
-    signal.throwIfAborted();
-    if (provider.status !== "active" || !provider.cdpUrl) {
-      return;
-    }
-    const image = await captureBrowserUseScreenshot(provider.cdpUrl, signal);
-    signal.throwIfAborted();
-    const artifact = await set(
-      allocateArtifactObject$,
-      {
-        userId: browser.userId,
-        filename: BROWSER_SCREENSHOT_FILENAME,
-        publicBrand: browser.publicBrand,
-      },
-      signal,
-    );
-    const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
-    await get(
-      putImmutableS3Object(
-        bucket,
-        artifact.key,
-        image,
-        BROWSER_SCREENSHOT_CONTENT_TYPE,
-        { signal, metadata: artifact.metadata },
-      ),
-    );
-    signal.throwIfAborted();
-
-    await db.transaction(async (tx) => {
-      await lockBrowserThread(tx, browser.chatThreadId);
-      await tx
-        .insert(browserSessionScreenshots)
-        .values({
-          chatThreadId: browser.chatThreadId,
-          objectKey: artifact.key,
-          url: artifact.url,
-        })
-        .onConflictDoUpdate({
-          target: browserSessionScreenshots.chatThreadId,
-          set: {
-            objectKey: artifact.key,
-            url: artifact.url,
-            updatedAt: nowDate(),
+  async ({ get, set }, browser: BrowserSessionRow): Promise<void> => {
+    const startedAt = now();
+    const signal = AbortSignal.timeout(BROWSER_SCREENSHOT_CAPTURE_TIMEOUT_MS);
+    let stage: BrowserScreenshotStage = "prepare";
+    // This task owns its timeout. Include aborts in the final outcome instead
+    // of losing timed-out attempts through tapError's cancellation path.
+    const [result] = await Promise.allSettled([
+      (async () => {
+        const db = set(writeDb$);
+        if (!(await browserScreenshotSchemaAvailable(db))) {
+          signal.throwIfAborted();
+          return;
+        }
+        const instance = await loadActiveInstance(db, browser.chatThreadId);
+        signal.throwIfAborted();
+        if (!instance) {
+          return;
+        }
+        const provider = await getBrowserUseSession(
+          instance.providerSessionId,
+          signal,
+        );
+        signal.throwIfAborted();
+        if (provider.status !== "active" || !provider.cdpUrl) {
+          return;
+        }
+        stage = "capture";
+        const image = await captureBrowserUseScreenshot(
+          provider.cdpUrl,
+          signal,
+        );
+        signal.throwIfAborted();
+        stage = "upload";
+        const artifact = await set(
+          allocateArtifactObject$,
+          {
+            userId: browser.userId,
+            filename: BROWSER_SCREENSHOT_FILENAME,
+            publicBrand: browser.publicBrand,
           },
-        });
-    });
-    signal.throwIfAborted();
+          signal,
+        );
+        const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
+        await get(
+          putImmutableS3Object(
+            bucket,
+            artifact.key,
+            image,
+            BROWSER_SCREENSHOT_CONTENT_TYPE,
+            { signal, metadata: artifact.metadata },
+          ),
+        );
+        signal.throwIfAborted();
 
-    await publishBrowserSessionChangedSafely(browser.userId, {
-      threadId: browser.chatThreadId,
-    });
-    signal.throwIfAborted();
+        stage = "save";
+        await db.transaction(async (tx) => {
+          await lockBrowserThread(tx, browser.chatThreadId);
+          await tx
+            .insert(browserSessionScreenshots)
+            .values({
+              chatThreadId: browser.chatThreadId,
+              objectKey: artifact.key,
+              url: artifact.url,
+            })
+            .onConflictDoUpdate({
+              target: browserSessionScreenshots.chatThreadId,
+              set: {
+                objectKey: artifact.key,
+                url: artifact.url,
+                updatedAt: nowDate(),
+              },
+            });
+        });
+
+        // Persistence is the success boundary; a deadline after commit must
+        // not turn an available preview into a failed capture metric.
+        await publishBrowserSessionChangedSafely(browser.userId, {
+          threadId: browser.chatThreadId,
+        });
+        return true;
+      })(),
+    ]);
+    if (result.status === "fulfilled" && !result.value) {
+      return;
+    }
+    // Flush after the background result exists, within the same waitUntil.
+    // Telemetry delivery must not reject the screenshot task.
+    await Promise.allSettled([
+      recordBrowserScreenshotResult({
+        startedAt,
+        ...(result.status === "fulfilled"
+          ? { outcome: "success" }
+          : {
+              outcome: "failure",
+              failureStage: stage,
+              failureKind: browserScreenshotFailureKind(result.reason),
+            }),
+      }),
+    ]);
   },
 );
 
 const scheduleBrowserScreenshotCapture$ = command(
   ({ set }, browser: BrowserSessionRow): void => {
-    waitUntil(
-      tapError(
-        set(
-          captureAndStoreBrowserScreenshot$,
-          browser,
-          AbortSignal.timeout(BROWSER_SCREENSHOT_CAPTURE_TIMEOUT_MS),
-        ),
-        (error) => {
-          L.warn("Managed browser screenshot capture failed", {
-            chatThreadId: browser.chatThreadId,
-            error,
-          });
-        },
-      ),
-    );
+    waitUntil(set(captureAndStoreBrowserScreenshot$, browser));
   },
 );
 


### PR DESCRIPTION
Managed-browser screenshot failures currently produce warnings without a success denominator. Record one `managed_browser_screenshot` outcome event in the existing Axiom telemetry dataset for each completed attempt, including missing/disappeared CDP targets and timeout errors. Successful attempts are counted after the new preview is persisted; ineligible captures are skipped.

The background task flushes telemetry after recording its result. Failed captures retain the previous preview and produce no screenshot warning/error or Sentry report. The event includes outcome, duration, and bounded failure stage/kind, without raw errors or browser/session identifiers.

Fixes #32747.

## Verification

- Browser route and rollout integration tests: 20 passed. Coverage includes success/failure counts, missing/disappeared targets, wrapped timeout errors, retaining an earlier preview, and telemetry flush after the response completes.
- Changed-file Prettier, Oxlint, type-aware Oxlint, and ESLint passed.
- All repository commit hooks passed, including Knip, full-workspace type checks, style policy, file size, and commitlint. Type checks ran with `GOMEMLIMIT=2GiB` and `GOGC=50` to fit the 4 GB local environment.

## Success-rate query

```kusto
['vm0-web-logs-prod']
| where type == "managed_browser_screenshot"
| summarize successes = countif(outcome == "success"), attempts = count(), p95_ms = percentile(duration_ms, 95) by bin(_time, 1h)
| extend success_rate_pct = 100.0 * successes / attempts
```

This query measures attempts emitted by the new API version; older releases have no success events.
