### PR TITLE
chore(platform): enforce clerk customization boundary

### DIFF
--- a/docs/clerk-customize.md
+++ b/docs/clerk-customize.md
@@ -1,0 +1,188 @@
+# Clerk customization
+
+This guide defines the styling boundary for the hosted Clerk authentication UI
+under `turbo/apps/platform/src/views/auth-v1`. The goal is not to reproduce
+Auth V2 inside Clerk. The goal is a branded, legible, accessible auth surface
+that continues to use Clerk's public customization contract.
+
+## Ownership
+
+The maintenance rule is simple: the code that owns the DOM also owns its
+control styling and states.
+
+| Surface             | Owner       | Application responsibility                                                                                    |
+| ------------------- | ----------- | ------------------------------------------------------------------------------------------------------------- |
+| Auth V1 page canvas | Application | Background, safe areas, centering, theme toggle, and brand navigation through `AuthShell`                     |
+| Auth V1 hosted card | Clerk       | Internal DOM, controls, spacing, validation, focus behavior, and authentication states                        |
+| Auth V1 adaptation  | Application | Semantic variables, official Clerk options, card frame, wordmark, and narrowly justified public element slots |
+| Auth V2             | Application | Its own DOM, styles, state presentation, accessibility, and tests                                             |
+
+Auth V1 and Auth V2 share `AuthShell` and semantic design values such as
+`--card`, `--foreground`, `--primary`, and `--radius-lg`. They do not share
+button, input, OTP, checkbox, passkey, or other DOM-level Tailwind recipes.
+Their card dimensions currently use equivalent values from independent
+definitions. Do not couple them only to deduplicate those values; share a new
+token only after both versions intentionally adopt the same product contract.
+
+## Sources of truth
+
+| Concern                                                   | Source                                                                 |
+| --------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Provider-level semantic variables and Clerk cascade layer | `turbo/apps/platform/src/views/auth-v1/provider-appearance.ts`         |
+| Auth component options and public element slots           | `turbo/apps/platform/src/views/auth-v1/component-appearance.ts`        |
+| Shared page canvas and brand shell                        | `turbo/apps/platform/src/views/auth/auth-shell.tsx`                    |
+| Clerk layer order and V1 card geometry                    | `turbo/apps/platform/src/views/css/index.css`                          |
+| Exact browser artifact versions                           | `turbo/apps/platform/src/lib/clerk-versions.ts` and its `package.json` |
+| Real hosted UI coverage                                   | `e2e/playwright/tests/auth-v1.spec.ts`                                 |
+
+The current contract has two appearance levels. Provider appearance maps
+application semantics into Clerk and assigns Clerk's stylesheet to its own
+cascade layer:
+
+```ts
+return {
+  cssLayerName: "clerk",
+  variables: {
+    colorBackground: "hsl(var(--card))",
+    colorForeground: "hsl(var(--foreground))",
+    colorPrimary: "hsl(var(--brand-text))",
+    colorBorder: "hsl(var(--border))",
+    colorRing: "hsl(var(--ring))",
+    colorDanger: "hsl(var(--destructive))",
+  },
+};
+```
+
+Provider appearance must not contain `elements`. Authentication-specific
+element overrides belong on `SignIn` and `SignUp`, so unrelated Clerk surfaces
+cannot inherit them.
+
+Component appearance selects an official Clerk theme and options, then adapts
+only public slots:
+
+```ts
+return {
+  theme: "simple",
+  options: {
+    elevation: "raised",
+    logoLinkUrl: authBrand.homeUrl,
+    socialButtonsPlacement: "top",
+    socialButtonsVariant: "blockButton",
+  },
+  elements: {
+    rootBox: "...",
+    cardBox: "...",
+    card: "...",
+    logoImage: "...",
+  },
+};
+```
+
+This abbreviated example describes the shape, not a permanent element-key
+allowlist. A public slot such as `otpCodeFieldInput` may be added for an
+observed legibility or interaction defect. That does not authorize styling all
+Clerk controls for visual parity with Auth V2.
+
+Clerk's styles sit between base styles and application components/utilities:
+
+```css
+@layer theme, base, clerk, components, utilities;
+```
+
+This layer order lets Tailwind classes supplied through public Clerk slots win
+through the normal cascade. It removes any need for specificity escalation.
+
+## Allowed customization
+
+Use the smallest public contract that resolves the observed problem:
+
+1. Fix page background, scrolling, safe-area, or brand navigation in
+   `AuthShell` or the V1 page wrapper, because the application owns that DOM.
+2. Change a provider variable when a semantic color, font, or radius mapping is
+   wrong for every hosted auth state.
+3. Prefer an official Clerk `theme` or `options` setting when it expresses the
+   requirement.
+4. Add one component-level `appearance.elements` slot when the real Clerk UI
+   has a concrete contrast, focus, overflow, visibility, or accessibility
+   defect. Use Tailwind classes and existing semantic tokens.
+5. Keep the override on the public slot itself. Do not reach into descendants
+   that Clerk owns.
+
+The stopping condition is that every required flow is usable, readable,
+keyboard-focusable, and free of overflow, while the page shell, brand, and card
+frame remain coherent with the application. Differences in Clerk's internal
+spacing or control treatment are acceptable after that condition is met.
+
+## Prohibited customization
+
+Do not recreate the legacy Clerk DOM adapter. In Auth V1 production code:
+
+- Do not inject `<style>`, import a route-owned stylesheet, use inline styles,
+  or add CSS-in-JS element objects.
+- Do not use `!important`.
+- Do not target `.cl-*`, generated `cl-internal-*` classes, `[class*=...]`,
+  `data-localization-key`, element structure, or `:has()`.
+- Do not query or mutate Clerk's rendered DOM to apply styling.
+- Do not import Auth V2 components or its control-level class recipes.
+- Do not add overrides only to make Clerk's inputs, OTP, checkbox, passkey, or
+  internal spacing look exactly like Auth V2.
+
+If a product requirement needs broad control over Clerk's internal layout or
+states and its public slots cannot express it, that requirement belongs in an
+application-owned UI such as Auth V2. It is not a reason to expand Auth V1 into
+an internal-DOM adapter.
+
+## Lint
+
+Run the focused check from `turbo/apps/platform`:
+
+```bash
+pnpm lint:clerk-customize
+```
+
+The check scans production TypeScript under `src/views/auth-v1` and rejects the
+legacy patterns above. Its failure output directs contributors back to this
+guide. It intentionally excludes tests: deployed E2E may locate `.cl-*`
+elements to observe the real third-party UI, but production styling must not
+depend on those selectors.
+
+Passing lint proves only that the known unsafe mechanisms are absent. A new
+public element override still needs a concrete defect, the narrowest affected
+slot, semantic tokens, and relevant UI verification.
+
+## Verification and upgrades
+
+Platform Vitest replaces `@clerk/react` at the external package boundary. Those
+tests verify application routing, props, loading, redirects, and lifecycle;
+they are not visual evidence for hosted Clerk markup.
+
+`e2e/playwright/tests/auth-v1.spec.ts` loads the real hosted Clerk UI against a
+development instance and refuses production publishable keys. It currently
+covers light and dark themes, desktop and mobile layouts, sign-in and sign-up,
+password feedback and reveal, consent, OTP errors and retry, help and password
+recovery, optional passkey availability, resource failure recovery, and test
+user cleanup.
+
+Clerk browser artifacts are exact-version contracts. The package versions and
+the constants in `turbo/apps/platform/src/lib/clerk-versions.ts` must stay
+aligned; runtime loading rejects a mismatched UI version. An upgrade must run
+the existing real-UI E2E and perform a focused visual smoke check on the
+affected themes, viewports, and auth states. Large screenshot snapshot suites
+are not required by default.
+
+## Why the old approach is forbidden
+
+Before Auth V2, hosted Clerk styling combined provider appearance, component
+appearance, and a route-level raw stylesheet of roughly 379 lines. That sheet
+depended on Clerk classes, partial class matches, internal attributes, DOM
+structure, and extensive `!important` declarations.
+
+That model split ownership: Clerk could change the DOM while the application
+remained responsible for every visual break. Fixes accumulated specificity,
+dark-mode, password-toggle, checkbox, OTP, and passkey exceptions. Upgrading
+Clerk effectively meant upgrading an undocumented DOM API with no type safety.
+
+Auth V1 instead gives Clerk semantic constraints through its public API. Auth
+V2 takes the other coherent option and owns both DOM and styling. Do not combine
+those models by asking Clerk to render a page that application CSS then forces
+to behave like Auth V2.

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -36,6 +36,8 @@ surface; the index does not replace their detailed rules.
   contracts, current versus run evidence, account identity, and next actions.
 - [Platform lint boundaries](./platform-lint.md): current transport and lifecycle
   exceptions, polling policy, and retired configuration history.
+- [Clerk customization](./clerk-customize.md): hosted Auth V1 styling ownership,
+  public appearance boundaries, lint enforcement, and upgrade verification.
 - [React commit analysis](./react-commit.md): measuring and attributing React
   work without confusing executions, scheduler events, or DOM mutations with
   commits.

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -82,6 +82,10 @@ Only two exception kinds exist:
 - `global-environment` covers document-level browser or theme state that cannot be represented by a component utility.
 - `third-party-dom-adapter` covers DOM or isolated documents whose element classes are owned outside the business component.
 
+Hosted Clerk authentication does not use a third-party DOM adapter. It stays on
+Clerk's public appearance API under the narrower rules in
+[Clerk customization](./clerk-customize.md).
+
 Every exception identifies the exact file and selector or injected-style fingerprint, its owner, rationale, and removal condition. Third-party adapters also identify their upstream DOM owner. A styling convenience, missing utility, or existing first-party convention is not an exception. Vendored CSS is pinned by exact path and SHA-256 rather than by a directory-wide ignore.
 
 ## Shrink-only legacy state

--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -17,8 +17,9 @@
     "lint:runtime-imports": "node --test scripts/check-runtime-imports.node.mjs",
     "lint:i18n": "tsx --test scripts/check-i18n-fixtures.node.mjs && pnpm i18n:check",
     "lint:localized-ui": "node --test scripts/check-localized-ui.node.mjs && node scripts/check-localized-ui.mjs",
+    "lint:clerk-customize": "node --test scripts/check-clerk-customize.node.mjs && node scripts/check-clerk-customize.mjs",
     "lint:static-assets": "node scripts/check-static-assets.mjs",
-    "lint": "pnpm lint:static-assets && pnpm lint:emoji-data && pnpm lint:localized-ui && pnpm lint:build-config && pnpm lint:runtime-imports && pnpm lint:i18n && oxlint --deny-warnings && oxlint --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings && eslint . --max-warnings 0 --cache --cache-strategy content --cache-location .eslintcache",
+    "lint": "pnpm lint:static-assets && pnpm lint:emoji-data && pnpm lint:localized-ui && pnpm lint:clerk-customize && pnpm lint:build-config && pnpm lint:runtime-imports && pnpm lint:i18n && oxlint --deny-warnings && oxlint --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings && eslint . --max-warnings 0 --cache --cache-strategy content --cache-location .eslintcache",
     "check-types": "tsc -p tsconfig.production.json --noEmit --checkers $(node ../../scripts/tsc-checkers.mjs) && tsc -p tsconfig.tests.json --noEmit --checkers $(node ../../scripts/tsc-checkers.mjs) && tsc -p tsconfig.build-config.json --noEmit --checkers $(node ../../scripts/tsc-checkers.mjs)"
   },
   "dependencies": {

--- a/turbo/apps/platform/scripts/check-clerk-customize.mjs
+++ b/turbo/apps/platform/scripts/check-clerk-customize.mjs
@@ -1,0 +1,250 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const defaultAppRoot = path.resolve(path.dirname(scriptPath), "..");
+const authV1Directory = "src/views/auth-v1";
+const guidePath = "docs/clerk-customize.md";
+
+function getForbiddenTextPatterns() {
+  return [
+    {
+      pattern: /!\s*important\b/iu,
+      reason: "uses !important",
+    },
+    {
+      pattern: /(?:\.cl-[\w-]*|\bcl-internal-[\w-]*)/u,
+      reason: "depends on a Clerk-owned class",
+    },
+    {
+      pattern: /\[\s*class\s*(?:[*^$~|]?=)/iu,
+      reason: "matches Clerk DOM through a class attribute selector",
+    },
+    {
+      pattern: /\bdata-localization-key\b/iu,
+      reason: "depends on Clerk's internal localization attribute",
+    },
+    {
+      pattern: /:has\s*\(/iu,
+      reason: "depends on Clerk's internal DOM structure through :has()",
+    },
+    {
+      pattern: /\b(?:button|input)\s*\[\s*type\s*(?:[*^$~|]?=)/iu,
+      reason: "targets a Clerk control by its rendered element structure",
+    },
+  ];
+}
+
+function propertyName(node) {
+  if (ts.isIdentifier(node) || ts.isStringLiteral(node)) {
+    return node.text;
+  }
+  return null;
+}
+
+function stringValue(node) {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text;
+  }
+  if (ts.isTemplateExpression(node)) {
+    return [
+      node.head.text,
+      ...node.templateSpans.map((span) => {
+        return span.literal.text;
+      }),
+    ].join("{…}");
+  }
+  return null;
+}
+
+function jsxTagName(node, sourceFile) {
+  if (ts.isJsxElement(node)) {
+    return node.openingElement.tagName.getText(sourceFile);
+  }
+  if (ts.isJsxSelfClosingElement(node)) {
+    return node.tagName.getText(sourceFile);
+  }
+  return null;
+}
+
+function moduleSpecifier(node) {
+  if (
+    (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+    node.moduleSpecifier &&
+    ts.isStringLiteral(node.moduleSpecifier)
+  ) {
+    return node.moduleSpecifier.text;
+  }
+  return null;
+}
+
+function getCheckedFiles(appRoot = defaultAppRoot) {
+  const checkedFiles = [];
+
+  function collect(relativeDirectory) {
+    const absoluteDirectory = path.join(appRoot, relativeDirectory);
+    for (const entry of readdirSync(absoluteDirectory, {
+      withFileTypes: true,
+    })) {
+      const relativePath = path.posix.join(relativeDirectory, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name !== "__tests__") {
+          collect(relativePath);
+        }
+        continue;
+      }
+      if (
+        (relativePath.endsWith(".ts") || relativePath.endsWith(".tsx")) &&
+        !relativePath.endsWith(".test.ts") &&
+        !relativePath.endsWith(".test.tsx")
+      ) {
+        checkedFiles.push(relativePath);
+      }
+    }
+  }
+
+  collect(authV1Directory);
+  return checkedFiles.sort();
+}
+
+export function checkSource(relativePath, sourceText) {
+  const sourceFile = ts.createSourceFile(
+    relativePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    relativePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+  const violations = [];
+  const recorded = new Set();
+  const forbiddenTextPatterns = getForbiddenTextPatterns();
+
+  function record(node, reason) {
+    const position = sourceFile.getLineAndCharacterOfPosition(node.getStart());
+    const violation = {
+      column: position.character + 1,
+      line: position.line + 1,
+      reason,
+    };
+    const key = `${violation.line}:${violation.column}:${reason}`;
+    if (!recorded.has(key)) {
+      recorded.add(key);
+      violations.push(violation);
+    }
+  }
+
+  function checkElementsObject(node) {
+    if (
+      !ts.isPropertyAssignment(node) ||
+      propertyName(node.name) !== "elements" ||
+      !ts.isObjectLiteralExpression(node.initializer)
+    ) {
+      return;
+    }
+    for (const element of node.initializer.properties) {
+      if (
+        ts.isPropertyAssignment(element) &&
+        ts.isObjectLiteralExpression(element.initializer)
+      ) {
+        record(
+          element.initializer,
+          "uses a CSS-in-JS object instead of Tailwind classes on a public Clerk element slot",
+        );
+      }
+    }
+  }
+
+  function visit(node) {
+    const value = stringValue(node);
+    if (value !== null) {
+      for (const { pattern, reason } of forbiddenTextPatterns) {
+        if (pattern.test(value)) {
+          record(node, reason);
+        }
+      }
+    }
+
+    const tagName = jsxTagName(node, sourceFile);
+    if (tagName === "style") {
+      record(node, "injects a raw <style> element");
+    }
+
+    if (ts.isJsxAttribute(node)) {
+      const name = propertyName(node.name);
+      if (name === "style") {
+        record(node, "adds inline styles to the Clerk V1 implementation");
+      }
+      if (name === "dangerouslySetInnerHTML") {
+        record(node, "can inject raw styles or Clerk DOM markup");
+      }
+    }
+
+    const specifier = moduleSpecifier(node);
+    if (specifier !== null) {
+      if (/\.css(?:\?.*)?$/iu.test(specifier)) {
+        record(node, "imports a route-owned stylesheet");
+      }
+      if (/(?:^|\/)auth-v2(?:\/|$)/u.test(specifier)) {
+        record(node, "imports the independent Auth V2 implementation");
+      }
+    }
+
+    if (
+      relativePath === `${authV1Directory}/provider-appearance.ts` &&
+      (ts.isPropertyAssignment(node) ||
+        ts.isShorthandPropertyAssignment(node) ||
+        ts.isMethodDeclaration(node)) &&
+      propertyName(node.name) === "elements"
+    ) {
+      record(
+        node,
+        "adds element overrides at provider scope instead of the V1 auth component scope",
+      );
+    }
+
+    checkElementsObject(node);
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return violations;
+}
+
+export function formatFailure(violations) {
+  return `Clerk V1 customization lint failed.
+
+Read ${guidePath} before changing Clerk styles. Use only the public Clerk
+appearance contract described there; do not restore raw CSS or target
+Clerk-owned DOM.
+
+Violations:
+${violations
+  .map((violation) => {
+    return `  - ${violation.relativePath}:${violation.line}:${violation.column} ${violation.reason}`;
+  })
+  .join("\n")}
+`;
+}
+
+function main() {
+  const appRoot = defaultAppRoot;
+  const violations = getCheckedFiles(appRoot).flatMap((relativePath) => {
+    const sourceText = readFileSync(path.join(appRoot, relativePath), "utf8");
+    return checkSource(relativePath, sourceText).map((violation) => {
+      return { relativePath, ...violation };
+    });
+  });
+
+  if (violations.length > 0) {
+    process.stderr.write(formatFailure(violations));
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  main();
+}

--- a/turbo/apps/platform/scripts/check-clerk-customize.node.mjs
+++ b/turbo/apps/platform/scripts/check-clerk-customize.node.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { checkSource, formatFailure } from "./check-clerk-customize.mjs";
+
+const componentAppearancePath = "src/views/auth-v1/component-appearance.ts";
+
+function violationReasons(
+  sourceText,
+  relativePath = "src/views/auth-v1/example.tsx",
+) {
+  return checkSource(relativePath, sourceText).map(({ reason }) => {
+    return reason;
+  });
+}
+
+await test("accepts public Clerk appearance slots and their own states", () => {
+  const reasons = violationReasons(`
+    // E2E may observe .cl-*; production customization never targets it.
+    export const appearance = {
+      theme: "simple",
+      elements: {
+        rootBox: "mx-auto flex w-full",
+        cardBox: cn(cardClassName, "w-full shadow-none"),
+        otpCodeFieldInput:
+          "border-[0.7px] data-[focus-within=true]:border-primary aria-invalid:border-destructive",
+      },
+    };
+  `);
+
+  assert.deepEqual(reasons, []);
+});
+
+await test("rejects the legacy Clerk DOM adapter patterns", () => {
+  const reasons = violationReasons(`
+    const clerkCss = \`
+      .cl-card,
+      [class*="cl-card"],
+      [data-localization-key="formButtonPrimary"],
+      button[type="submit"],
+      .field:has(input) {
+        border: 1px solid red !important;
+      }
+    \`;
+    export function Layout() {
+      return <style>{clerkCss}</style>;
+    }
+  `);
+
+  assert.deepEqual(
+    new Set(reasons),
+    new Set([
+      "depends on a Clerk-owned class",
+      "matches Clerk DOM through a class attribute selector",
+      "depends on Clerk's internal localization attribute",
+      "targets a Clerk control by its rendered element structure",
+      "depends on Clerk's internal DOM structure through :has()",
+      "uses !important",
+      "injects a raw <style> element",
+    ]),
+  );
+});
+
+await test("rejects stylesheet, inline-style, and Auth V2 dependencies", () => {
+  const reasons = violationReasons(`
+    import "./clerk.css";
+    import { AuthV2Shell } from "../auth-v2/auth-v2-shell.tsx";
+    export function Layout() {
+      return <div style={{ color: "red" }} dangerouslySetInnerHTML={{ __html: "" }} />;
+    }
+  `);
+
+  assert.deepEqual(
+    new Set(reasons),
+    new Set([
+      "imports a route-owned stylesheet",
+      "imports the independent Auth V2 implementation",
+      "adds inline styles to the Clerk V1 implementation",
+      "can inject raw styles or Clerk DOM markup",
+    ]),
+  );
+});
+
+await test("keeps element customization out of provider scope and CSS-in-JS", () => {
+  assert.deepEqual(
+    new Set(
+      violationReasons(
+        `
+          export const appearance = {
+            elements: {
+              formFieldInput: { borderColor: "red" },
+            },
+          };
+        `,
+        "src/views/auth-v1/provider-appearance.ts",
+      ),
+    ),
+    new Set([
+      "adds element overrides at provider scope instead of the V1 auth component scope",
+      "uses a CSS-in-JS object instead of Tailwind classes on a public Clerk element slot",
+    ]),
+  );
+});
+
+await test("failure output directs contributors to the Clerk guide", () => {
+  const output = formatFailure([
+    {
+      column: 5,
+      line: 10,
+      reason: "uses !important",
+      relativePath: componentAppearancePath,
+    },
+  ]);
+
+  assert.match(output, /Read docs\/clerk-customize\.md/u);
+  assert.match(output, /component-appearance\.ts:10:5 uses !important/u);
+});

--- a/turbo/apps/platform/src/views/auth-v1/component-appearance.ts
+++ b/turbo/apps/platform/src/views/auth-v1/component-appearance.ts
@@ -3,9 +3,11 @@ import type { SignIn } from "@clerk/react";
 import type { ComponentProps } from "react";
 import { platformOkouWordmarkLightImg } from "../../lib/static-assets.ts";
 import type { AuthBrandContext } from "../../signals/auth.ts";
-import { AUTH_V2_PRIMARY_ACTION_CLASS } from "../auth-v2/auth-v2-action-styles.ts";
 
 type ClerkAppearance = NonNullable<ComponentProps<typeof SignIn>["appearance"]>;
+
+const AUTH_V1_PRIMARY_ACTION_CLASS =
+  "border-transparent bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-pressed";
 
 // Clerk's OTP slots are visual divs; its accessible textbox owns focus. Match
 // the shared Input boundary while adapting focus and error states through the
@@ -36,8 +38,8 @@ export function getAuthV1ComponentAppearance(
       logoImage: "h-auto w-[76px]",
       // Clerk shares colorPrimary between links and filled controls. Keep the
       // accessible link color at provider level, then give only the CTA the
-      // same filled treatment as Auth V2.
-      formButtonPrimary: cn(AUTH_V2_PRIMARY_ACTION_CLASS, "border-transparent"),
+      // application's semantic filled-action colors.
+      formButtonPrimary: AUTH_V1_PRIMARY_ACTION_CLASS,
       otpCodeFieldInput: AUTH_V1_OTP_INPUT_CLASS,
     },
   };


### PR DESCRIPTION
## Summary

- add a focused `lint:clerk-customize` check to reject raw style injection, CSS-in-JS, internal Clerk selectors, provider-wide element overrides, and Auth V2 dependencies in hosted Auth V1
- make every lint failure direct contributors to `docs/clerk-customize.md`
- document the agreed V1/V2 ownership boundary, allowed public-slot exceptions, real hosted Clerk verification, version-upgrade checks, and the retired pre-V2 injection model
- link the Clerk guide from the engineering documentation index and the application style guide

## Policy

- Clerk continues to own V1 control DOM, internal spacing, states, and accessibility behavior.
- The application owns `AuthShell`, semantic variable mapping, brand/card framing, and only narrowly justified public `appearance.elements` slots.
- Public slots are not frozen to today's key count; a verified legibility or interaction defect can add one without restoring the old DOM adapter.
- Auth V2 remains an independent application-owned implementation. This PR changes no V1 or V2 runtime styling.

## Verification

- `cd turbo/apps/platform && pnpm lint`
- `cd turbo && pnpm lint:style`
- `cd turbo && pnpm knip`
- focused Prettier check for all changed files
