### PR TITLE
fix(platform): clear shortcut hints on window blur

### DIFF
--- a/turbo/apps/platform/src/signals/keyboard-shortcut-hints.ts
+++ b/turbo/apps/platform/src/signals/keyboard-shortcut-hints.ts
@@ -7,6 +7,7 @@ const internalKeyboardShortcutHintPhase$ = state<
   "idle" | "pending" | "visible"
 >("idle");
 const resetKeyboardShortcutHintHold$ = resetSignal();
+const resetShortcutHintSignal$ = resetSignal();
 
 export const keyboardShortcutHintsVisible$ = computed((get) => {
   return (
@@ -30,52 +31,102 @@ const showKeyboardShortcutHints$ = command(
   },
 );
 
-const updateKeyboardShortcutHintModifiers$ = command(
-  ({ get, set }, event: KeyboardEvent, signal: AbortSignal) => {
-    const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
-    const modifierHeld = isMac
-      ? event.metaKey
-      : event.ctrlKey && !event.metaKey;
-    if (
-      !get(stableChatThreadNavigationEnabled$) ||
-      !modifierHeld ||
-      event.shiftKey ||
-      event.altKey ||
-      event.isComposing ||
-      event.keyCode === 229 ||
-      (event.type === "keydown" &&
-        event.key !== "Meta" &&
-        event.key !== "Control")
-    ) {
-      set(hideKeyboardShortcutHints$);
-      return;
-    }
-    if (event.repeat || get(internalKeyboardShortcutHintPhase$) !== "idle") {
-      return;
-    }
+function shortcutHintModifierHeld(event: KeyboardEvent): boolean {
+  const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+  return isMac ? event.metaKey : event.ctrlKey && !event.metaKey;
+}
 
+function shortcutHintEventEligible(event: KeyboardEvent): boolean {
+  return (
+    shortcutHintModifierHeld(event) &&
+    !event.shiftKey &&
+    !event.altKey &&
+    !event.isComposing &&
+    event.keyCode !== 229 &&
+    (event.type !== "keydown" ||
+      event.key === "Meta" ||
+      event.key === "Control")
+  );
+}
+
+const startKeyboardShortcutHintHold$ = command(
+  ({ get, set }, signal: AbortSignal) => {
+    if (get(internalKeyboardShortcutHintPhase$) !== "idle") {
+      return;
+    }
     const holdSignal = set(resetKeyboardShortcutHintHold$, signal);
     set(internalKeyboardShortcutHintPhase$, "pending");
     return set(showKeyboardShortcutHints$, holdSignal);
   },
 );
 
-export const setupKeyboardShortcutHints$ = command(
-  ({ set }, signal: AbortSignal) => {
-    const updateModifiers = onDomEventFn((event: KeyboardEvent) => {
-      return set(updateKeyboardShortcutHintModifiers$, event, signal);
-    });
-    const clearModifiers = onDomEventFn(() => {
+const updateKeyboardShortcutHintModifiers$ = command(
+  ({ get, set }, event: KeyboardEvent, hintSignal: AbortSignal) => {
+    if (
+      !get(stableChatThreadNavigationEnabled$) ||
+      !shortcutHintModifierHeld(event)
+    ) {
+      set(resetShortcutHintSignal$);
+      return;
+    }
+    if (!shortcutHintEventEligible(event)) {
       set(hideKeyboardShortcutHints$);
+      return;
+    }
+    if (event.repeat) {
+      return;
+    }
+    return set(startKeyboardShortcutHintHold$, hintSignal);
+  },
+);
+
+const startKeyboardShortcutHint$ = command(
+  ({ get, set }, event: KeyboardEvent, signal: AbortSignal) => {
+    if (
+      !get(stableChatThreadNavigationEnabled$) ||
+      get(internalKeyboardShortcutHintPhase$) !== "idle" ||
+      !shortcutHintEventEligible(event) ||
+      event.repeat
+    ) {
+      return;
+    }
+
+    signal.throwIfAborted();
+    const hintSignal = set(resetShortcutHintSignal$, signal);
+    hintSignal.addEventListener(
+      "abort",
+      () => {
+        set(hideKeyboardShortcutHints$);
+      },
+      { once: true },
+    );
+    const updateModifiers = onDomEventFn((nextEvent: KeyboardEvent) => {
+      return set(updateKeyboardShortcutHintModifiers$, nextEvent, hintSignal);
+    });
+    const resetHint = onDomEventFn(() => {
+      set(resetShortcutHintSignal$);
     });
     document.addEventListener("keydown", updateModifiers, {
       capture: true,
-      signal,
+      signal: hintSignal,
     });
     document.addEventListener("keyup", updateModifiers, {
       capture: true,
+      signal: hintSignal,
+    });
+    window.addEventListener("blur", resetHint, { signal: hintSignal });
+    return set(startKeyboardShortcutHintHold$, hintSignal);
+  },
+);
+
+export const setupKeyboardShortcutHints$ = command(
+  ({ set }, signal: AbortSignal) => {
+    const startHint = onDomEventFn((event: KeyboardEvent) => {
+      return set(startKeyboardShortcutHint$, event, signal);
+    });
+    document.addEventListener("keydown", startHint, {
+      capture: true,
       signal,
     });
-    signal.addEventListener("abort", clearModifiers, { once: true });
   },
 );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
@@ -44,6 +44,10 @@ const SEARCH_LABEL = "Search workspace...";
 
 async function openSearch(modifiers = { ctrlKey: true, metaKey: false }) {
   fireEvent.keyDown(document.body, {
+    key: modifiers.metaKey ? "Meta" : "Control",
+    ...modifiers,
+  });
+  fireEvent.keyDown(document.body, {
     key: "f",
     code: "KeyF",
     shiftKey: true,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/thread-list-number-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/thread-list-number-shortcuts.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, test } from "vitest";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
@@ -162,7 +162,10 @@ test.each([
   },
 );
 
-test("Cancel a short hold and clear hints on release", async () => {
+test("Cancel a short hold and clear hints on release or window blur", async () => {
+  context.mocks.browser.userAgent(
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36",
+  );
   context.mocks.browser.matchMedia((query) => {
     return (
       query === "(display-mode: standalone)" || query === "(min-width: 48rem)"
@@ -183,16 +186,24 @@ test("Cancel a short hold and clear hints on release", async () => {
     expect(sidebarThreadTitles()).toStrictEqual(["Hold lifecycle"]);
   });
   const list = screen.getByTestId("chat-list-column");
-  const user = userEvent.setup();
-  await user.keyboard("{Control>}{/Control}");
+  fireEvent.keyDown(document, { key: "Meta", code: "MetaLeft", metaKey: true });
+  fireEvent.keyUp(document, { key: "Meta", code: "MetaLeft" });
   expect(hintKeys(list)).toStrictEqual([]);
   const pressedAt = now();
-  await user.keyboard("{Control>}");
+  fireEvent.keyDown(document, { key: "Meta", code: "MetaLeft", metaKey: true });
   await waitFor(() => {
-    expect(hintKeys(list)).toStrictEqual(["Ctrl+1"]);
+    expect(hintKeys(list)).toStrictEqual(["⌘1"]);
   });
   expect(now() - pressedAt).toBeGreaterThanOrEqual(500);
-  await user.keyboard("{/Control}");
+  fireEvent.blur(window);
+  await waitFor(() => {
+    expect(hintKeys(list)).toStrictEqual([]);
+  });
+  fireEvent.keyDown(document, { key: "Meta", code: "MetaLeft", metaKey: true });
+  await waitFor(() => {
+    expect(hintKeys(list)).toStrictEqual(["⌘1"]);
+  });
+  fireEvent.keyUp(document, { key: "Meta", code: "MetaLeft" });
   await waitFor(() => {
     expect(hintKeys(list)).toStrictEqual([]);
   });


### PR DESCRIPTION
## Summary

- create a resettable signal for each primary-modifier shortcut-hint session
- bind the active keyboard and window blur listeners to that session so cleanup removes them and resets hint state
- cover the macOS window-switch case where Command keyup occurs outside the Okou window

## Verification

- `corepack pnpm exec prettier --check <changed files>`
- `corepack pnpm exec oxlint --deny-warnings <changed files>`
- `corepack pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings <changed files>`
- `corepack pnpm exec eslint <changed files> --max-warnings 0`
- `corepack pnpm check-types`
- `corepack pnpm exec vitest run src/views/okou-page/__tests__/keyboard-shortcut-hints.test.tsx src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx src/views/okou-page/__tests__/thread-list-number-shortcuts.test.tsx` (22 tests)
