### PR TITLE
fix(platform): move mobile chat pin into menu

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-header-actions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-thread-header-actions.test.tsx
@@ -98,6 +98,12 @@ function menuItemNamed(name: string) {
   return item;
 }
 
+function menuItemNames() {
+  return queryAllByRoleFast("menuitem").map((item) => {
+    return item.textContent?.trim();
+  });
+}
+
 test.each([true, false])(
   "Keep the existing header when the switch is off (desktop: %s)",
   async (desktop) => {
@@ -169,18 +175,20 @@ test("Keep rapid pin changes responsive across resize and save without a success
   });
   await waitFor(() => {
     expect(buttonNamed("More actions")).toBeInTheDocument();
-    expect(buttonNamed("Unpin chat")).toBeEnabled();
+    expect(screen.queryByLabelText("Unpin chat")).not.toBeInTheDocument();
   });
 
-  click(buttonNamed("Unpin chat"));
+  click(buttonNamed("More actions"));
   await waitFor(() => {
-    expect(buttonNamed("Pin chat")).toHaveAttribute("aria-pressed", "false");
+    expect(menuItemNamed("Unpin chat")).toBeEnabled();
   });
-  expect(buttonNamed("Pin chat")).toBeEnabled();
-  expect(screen.getByTestId("chat-thread-menu-trigger")).toHaveAttribute(
-    "data-pinned",
-    "false",
-  );
+  click(menuItemNamed("Unpin chat"));
+  await waitFor(() => {
+    expect(screen.getByTestId("chat-thread-menu-trigger")).toHaveAttribute(
+      "data-pinned",
+      "false",
+    );
+  });
 
   pinResponse.resolve();
   await waitFor(() => {
@@ -188,7 +196,6 @@ test("Keep rapid pin changes responsive across resize and save without a success
       "Pin changes saved",
     );
   });
-  expect(buttonNamed("Pin chat")).toHaveAttribute("aria-pressed", "false");
   expect(screen.getByTestId("chat-thread-menu-trigger")).toHaveAttribute(
     "data-pinned",
     "false",
@@ -198,11 +205,11 @@ test("Keep rapid pin changes responsive across resize and save without a success
   expect(screen.queryByText("Undo")).not.toBeInTheDocument();
 });
 
-test("Keep Pin, Share, and More in order and rename from the mobile menu", async () => {
+test("Keep Share and More in the header and match the sidebar menu order", async () => {
   context.mocks.browser.matchMedia(false);
   await setupHeaderPage();
-  const pin = buttonNamed("Pin chat");
-  const group = pin.parentElement;
+  const more = buttonNamed("More actions");
+  const group = more.parentElement;
   if (!group) {
     throw new Error("Header action group is missing");
   }
@@ -210,13 +217,18 @@ test("Keep Pin, Share, and More in order and rename from the mobile menu", async
     queryAllByRoleFast("button", group).map((button) => {
       return button.getAttribute("aria-label");
     }),
-  ).toStrictEqual(["Pin chat", "Share messages", "More actions"]);
+  ).toStrictEqual(["Share messages", "More actions"]);
   expect(buttonNamed("Open menu")).toBeInTheDocument();
+  expect(screen.queryByLabelText("Pin chat")).not.toBeInTheDocument();
   expect(screen.queryByLabelText("Open artifacts")).not.toBeInTheDocument();
 
-  click(buttonNamed("More actions"));
+  click(more);
   await screen.findByRole("menu");
-  expect(menuItemNamed("Artifacts")).toBeInTheDocument();
+  expect(menuItemNames()).toStrictEqual([
+    "Pin chat",
+    "Rename chat",
+    "Artifacts",
+  ]);
   click(menuItemNamed("Rename chat"));
   const dialog = await screen.findByRole("dialog", { name: "Rename chat" });
   expect(within(dialog).getByPlaceholderText("Chat title")).toHaveValue(
@@ -266,7 +278,12 @@ test("Open linked automations from the mobile menu", async () => {
   expect(screen.queryByLabelText("Open mobile automations")).toBeNull();
   click(buttonNamed("More actions"));
   await waitFor(() => {
-    expect(menuItemNamed("Automations")).toBeInTheDocument();
+    expect(menuItemNames()).toStrictEqual([
+      "Pin chat",
+      "Rename chat",
+      "Automations",
+      "Artifacts",
+    ]);
   });
   click(menuItemNamed("Automations"));
   const panel = await screen.findByRole("complementary", {
@@ -287,7 +304,7 @@ test("Retain message selection and restore mobile actions after sharing", async 
   await screen.findAllByText("1 selected");
   click(buttonNamed("Cancel"));
   await waitFor(() => {
-    expect(buttonNamed("Pin chat")).toBeInTheDocument();
+    expect(buttonNamed("Share messages")).toBeInTheDocument();
     expect(buttonNamed("More actions")).toBeInTheDocument();
   });
   click(buttonNamed("Change icon"));
@@ -320,20 +337,34 @@ test("Continue saving the next pin change after an earlier request fails", async
     return respond(500, { error: { message: "Unpin request failed" } });
   });
   await setupHeaderPage();
-  click(buttonNamed("Pin chat"));
+  click(buttonNamed("More actions"));
+  await screen.findByRole("menu");
+  click(menuItemNamed("Pin chat"));
   await waitFor(() => {
-    expect(buttonNamed("Unpin chat")).toBeEnabled();
+    expect(screen.getByTestId("chat-thread-menu-trigger")).toHaveAttribute(
+      "data-pinned",
+      "true",
+    );
   });
-  click(buttonNamed("Unpin chat"));
+  click(buttonNamed("More actions"));
   await waitFor(() => {
-    expect(buttonNamed("Pin chat")).toHaveAttribute("aria-pressed", "false");
+    expect(menuItemNamed("Unpin chat")).toBeEnabled();
+  });
+  click(menuItemNamed("Unpin chat"));
+  await waitFor(() => {
+    expect(screen.getByTestId("chat-thread-menu-trigger")).toHaveAttribute(
+      "data-pinned",
+      "false",
+    );
   });
 
   pinResponse.resolve();
   await screen.findByText("Unpin request failed");
   expect(screen.getByText("Pin request failed")).toBeInTheDocument();
-  expect(buttonNamed("Pin chat")).toBeEnabled();
-  expect(buttonNamed("Pin chat")).toHaveAttribute("aria-pressed", "false");
+  click(buttonNamed("More actions"));
+  await waitFor(() => {
+    expect(menuItemNamed("Pin chat")).toBeEnabled();
+  });
   expect(screen.queryByText("Chat pinned")).not.toBeInTheDocument();
   expect(screen.queryByText("Chat unpinned")).not.toBeInTheDocument();
 });

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-header-actions.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-header-actions.tsx
@@ -1,6 +1,6 @@
 import { useGet, useLastResolved, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
-import { Clock, Ellipsis, Package, Pencil, Pin } from "lucide-react";
+import { Clock, Ellipsis, Package, Pencil, Pin, PinOff } from "lucide-react";
 import {
   Button,
   cn,
@@ -20,10 +20,8 @@ import { useOpenThreadArtifacts } from "./thread-sidebar.tsx";
 
 export function ChatThreadPinButton({
   thread,
-  mobile = false,
 }: {
   readonly thread: ChatPanelSignals;
-  readonly mobile?: boolean;
 }) {
   const { t } = useTranslation();
   const pageSignal = useGet(pageSignal$);
@@ -39,7 +37,6 @@ export function ChatThreadPinButton({
       iconSize="md"
       className={cn(
         "shrink-0 duration-150",
-        mobile && "size-11",
         pinned ? "text-gray-700" : "text-gray-600",
       )}
       aria-label={
@@ -73,6 +70,8 @@ export function MobileChatThreadMoreMenu({
 }) {
   const { t } = useTranslation();
   const pageSignal = useGet(pageSignal$);
+  const pinned = useGet(thread.pin.pinned$);
+  const setPinned = useSet(thread.pin.setPinned$);
   const openRename = useSet(openRenameChatThreadDialogForThreadId$);
   const automations = useLastResolved(thread.headerAutomations.automations$);
   const reloadAutomations = useSet(thread.headerAutomations.reload$);
@@ -98,6 +97,21 @@ export function MobileChatThreadMoreMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-48">
+        <DropdownMenuItem
+          className="min-h-11"
+          onSelect={() => {
+            detach(setPinned(!pinned, pageSignal), Reason.DomCallback);
+          }}
+        >
+          {pinned ? <PinOff size={16} /> : <Pin size={16} />}
+          {pinned
+            ? t(($) => {
+                return $.chat.sidebar.unpin;
+              })
+            : t(($) => {
+                return $.chat.sidebar.pin;
+              })}
+        </DropdownMenuItem>
         <DropdownMenuModalItem
           className="min-h-11"
           onModalSelect={() => {

--- a/turbo/apps/platform/src/views/okou-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-layout.tsx
@@ -55,10 +55,7 @@ import {
 } from "../../signals/theme.ts";
 import { SIDEBAR_DESKTOP_MEDIA_QUERY } from "./sidebar-breakpoint.ts";
 import { WorkspaceInset } from "./workspace-inset.tsx";
-import {
-  ChatThreadPinButton,
-  MobileChatThreadMoreMenu,
-} from "./chat-thread-header-actions.tsx";
+import { MobileChatThreadMoreMenu } from "./chat-thread-header-actions.tsx";
 
 function AgentAvatarInTopBar() {
   const agent = useLastResolved(currentChatAgent$);
@@ -262,7 +259,6 @@ function MobileChatThreadActions({ thread }: { thread: ChatPanelSignals }) {
   }
   return (
     <div className="flex shrink-0 items-center gap-0.5">
-      <ChatThreadPinButton thread={thread} mobile />
       <MobileShareButtonInner thread={thread} largeTarget />
       <MobileChatThreadMoreMenu thread={thread} />
     </div>


### PR DESCRIPTION
## Summary

- Move the mobile chat Pin/Unpin action from the top bar into the More menu
- Keep the shared menu actions in sidebar order: Pin/Unpin before Rename
- Preserve the desktop Pin button and the existing Automations and Artifacts actions
- Update page integration coverage for menu order, responsive state, and failure recovery

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-thread-header-actions.test.tsx --maxWorkers=1` (9 passed)
- `pnpm -F @okouai/app check-types`
- Scoped ESLint and Oxlint, including type-aware checks
- `pnpm lint:style`
- `pnpm knip`
- Prettier check for the three changed files
- PR preview (`390x844`, iPhone Safari user agent): verified the mobile header contains Share then More, the menu order is Pin/Unpin then Rename then Artifacts, both Pin and Unpin return `204`, and there is no horizontal overflow

The protected preview's SharedWorker cannot inherit the browser-scoped API bypass, so the page was refreshed between the Pin and Unpin state assertions after confirming the persisted metadata. No full local Vitest run or local dev server was used.
