### PR TITLE
fix: remove obsolete brand tombstones

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -213,27 +213,15 @@ then the browser language list. It is used only when the workspace locale
 preference is absent.
 _Avoid_: Workspace preference, forced locale
 
-# Clerk Satellite Authentication Context
+# Product Identity Context
 
-This context separates the app that owns authentication from another app that
-shares the same Clerk instance and receives its session.
+This context names the product identity used in application presentation.
 
 ## Language
 
-**Clerk primary app**:
-The app origin where sign-in and sign-up run and where the primary Clerk
-session is established.
-_Avoid_: Main brand, login tab
-
-**Clerk satellite app**:
-A registered app origin that shares the primary app's Clerk instance and
-receives synchronized session state.
-_Avoid_: Secondary login, separate Clerk instance
-
-**Satellite session sync**:
-The Clerk-owned navigation handshake that transfers the active primary-app
-session into the current satellite browser context.
-_Avoid_: Cookie copy, custom auth redirect
+**Okou product identity**:
+The sole current public product, presentation, and application identity.
+_Avoid_: Public brand, VM0 brand, selected brand
 
 # Chat Image Annotation Context
 

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -14,7 +14,7 @@ import {
   desktopProductFromClientHeader,
 } from "@okouai/api-contracts/contracts/client-headers";
 import { serializeError } from "@okouai/core/log-utils";
-// oxlint-disable-next-line no-restricted-imports -- app factory owns the Hono instance, confirmed by ethan@vm0.ai
+// oxlint-disable-next-line no-restricted-imports -- app factory owns the Hono instance
 import { Hono, type Context, type Next } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { matchedRoutes } from "hono/route";

--- a/turbo/apps/api/src/signals/context/wait-until.ts
+++ b/turbo/apps/api/src/signals/context/wait-until.ts
@@ -1,4 +1,4 @@
-// oxlint-disable-next-line no-restricted-imports -- this file is the wrapper around @vercel/functions waitUntil, confirmed by ethan@vm0.ai
+// oxlint-disable-next-line no-restricted-imports -- this file owns the wrapper around @vercel/functions waitUntil
 import { waitUntil as vercelWaitUntil } from "@vercel/functions";
 
 import { env } from "../../lib/env";

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -649,10 +649,6 @@ async function completeThreadGoal(
   );
 }
 
-// Neutral throughout since #30807 retired the branded forms of every
-// chat-thread row; the earlier per-row notes below record which removal took
-// each of the others. A branded request would 404 before reaching the parameter
-// check these cases exist to exercise.
 const malformedChatThreadIdRequests = [
   { method: "GET", path: "/api/chat-threads/:id", paramName: "id" },
   { method: "PATCH", path: "/api/chat-threads/:id", paramName: "id" },
@@ -667,31 +663,22 @@ const malformedChatThreadIdRequests = [
     path: "/api/chat-threads/:id/mark-unread",
     paramName: "id",
   },
-  // Neutral rather than branded, for the same reason as `rename` below: #28916
-  // retired this row's branded forms.
   {
     method: "POST",
     path: "/api/chat-threads/:id/model-selection",
     paramName: "id",
   },
-  // Neutral rather than branded: #28917 retired this row's branded forms, so a
-  // branded request here would 404 before the parameter check it exists to
-  // exercise.
   {
     method: "POST",
     path: "/api/chat-threads/:id/computer-use-host",
     paramName: "id",
   },
   { method: "POST", path: "/api/chat-threads/:id/pin", paramName: "id" },
-  // Neutral for the same reason as `computer-use-host` above.
   {
     method: "POST",
     path: "/api/chat-threads/:id/unpin",
     paramName: "id",
   },
-  // Neutral rather than branded: #28711 retired this row's branded forms, so a
-  // branded request here would 404 before the parameter check it exists to
-  // exercise.
   {
     method: "POST",
     path: "/api/chat-threads/:id/rename",

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -2904,11 +2904,6 @@ describe("Feishu integration", () => {
 
   it("emits the final path and serves it", async () => {
     const fixture = await setupFeishuRunFixture();
-    // #28278 step 3 switched this producer: the URL the connect service hands
-    // the operator now carries the final path on the unchanged callback origin.
-    // Installation ids are UUIDs, so percent-encoding leaves the id verbatim.
-    // #31068 retired this route's branded compatibility row, so the branded
-    // forms this case used to replay alongside it are no longer registered.
     expect(fixture.callbackUrl).toBe(
       `${FEISHU_CALLBACK_ORIGIN}/api/webhooks/feishu/events/${fixture.installationId}`,
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-status.test.ts
@@ -152,7 +152,6 @@ describe("GET /api/integrations/slack", () => {
     );
     expect(connectUrl.searchParams.get("orgId")).toBe(orgId);
     expect(connectUrl.searchParams.get("userId")).toBe(userId);
-    expect(connectUrl.searchParams.get("publicBrand")).toBeNull();
   });
 
   it("returns Okou install URLs on the API origin when Slack is not installed", async () => {
@@ -178,7 +177,6 @@ describe("GET /api/integrations/slack", () => {
     );
     expect(installUrl.searchParams.get("orgId")).toBe(orgId);
     expect(installUrl.searchParams.get("userId")).toBe(userId);
-    expect(installUrl.searchParams.get("publicBrand")).toBeNull();
   });
 
   it("returns Okou install URLs on the Okou API origin", async () => {
@@ -203,7 +201,6 @@ describe("GET /api/integrations/slack", () => {
     expect(`${installUrl.origin}${installUrl.pathname}`).toBe(
       "https://api.okou.ai/api/slack/oauth/install",
     );
-    expect(installUrl.searchParams.get("publicBrand")).toBeNull();
   });
 
   it("returns Okou connect URLs on the Okou API origin", async () => {
@@ -238,7 +235,6 @@ describe("GET /api/integrations/slack", () => {
     expect(`${connectUrl.origin}${connectUrl.pathname}`).toBe(
       "https://api.okou.ai/api/slack/oauth/connect",
     );
-    expect(connectUrl.searchParams.get("publicBrand")).toBeNull();
   });
 
   it("returns workspace info for connected user", async () => {
@@ -474,7 +470,6 @@ describe("GET /api/integrations/slack", () => {
       "https://api.okou.ai/api/slack/oauth/install",
     );
     expect(reinstallUrl.searchParams.get("reinstall")).toBe("1");
-    expect(reinstallUrl.searchParams.get("publicBrand")).toBeNull();
   });
 
   it("returns Okou reinstall URLs on the Okou API origin", async () => {
@@ -510,7 +505,6 @@ describe("GET /api/integrations/slack", () => {
       "https://api.okou.ai/api/slack/oauth/install",
     );
     expect(reinstallUrl.searchParams.get("reinstall")).toBe("1");
-    expect(reinstallUrl.searchParams.get("publicBrand")).toBeNull();
   });
 
   it("treats null bot_scopes as mismatch (requires reinstall)", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/provider-console-paths.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/provider-console-paths.test.ts
@@ -29,23 +29,6 @@ interface ResponseSnapshot {
   readonly body: string;
 }
 
-// Every block below is now narrowed to the single path that serves it, because
-// every provider console and producer that held a branded form has moved. Each
-// request used to be replayed on both branded forms as well, so the assertion
-// was that all three answered identically rather than merely that the neutral
-// path was routed; a dropped branded compatibility row showed up here as one of
-// the three answering differently.
-//
-// #28600 put the Slack OAuth callback and the three inbound webhooks on neutral
-// paths with rows for both branded forms, and #30668 retired those four rows
-// once the Slack app console was repointed at `/api/webhooks/slack/*` and
-// `routes/slack-oauth.ts` began emitting the neutral `redirect_uri`. The Feishu
-// OAuth callback was narrowed the same way by #28709 and the Teams OAuth
-// callback by #30812, which left nothing in this file holding a branded form.
-// #31088 then emptied the table outright and #31090 removed it, so no path
-// anywhere has one. What each block still pins is that the console flow reaches
-// its handler.
-
 async function snapshot(response: Response): Promise<ResponseSnapshot> {
   return {
     status: response.status,
@@ -54,35 +37,18 @@ async function snapshot(response: Response): Promise<ResponseSnapshot> {
   };
 }
 
-async function snapshotEachPath(
-  paths: readonly string[],
-  send: (path: string) => Promise<Response>,
-): Promise<readonly ResponseSnapshot[]> {
-  const snapshots: ResponseSnapshot[] = [];
-  for (const path of paths) {
-    snapshots.push(await snapshot(await send(path)));
-  }
-  return snapshots;
-}
-
-function repeated(
-  expected: ResponseSnapshot,
-  paths: readonly string[],
-): readonly ResponseSnapshot[] {
-  return paths.map(() => {
-    return expected;
-  });
-}
-
 function jsonBody(body: unknown): string {
   return JSON.stringify(body);
 }
 
-function getRequest(routes: readonly RouteEntry[]) {
-  return async (path: string): Promise<Response> => {
-    const app = createAppWithRoutes({ signal: context.signal, routes });
-    return await app.request(`${REQUEST_ORIGIN}${path}`, { method: "GET" });
-  };
+async function getRequest(
+  routes: readonly RouteEntry[],
+  path: string,
+): Promise<ResponseSnapshot> {
+  const app = createAppWithRoutes({ signal: context.signal, routes });
+  return await snapshot(
+    await app.request(`${REQUEST_ORIGIN}${path}`, { method: "GET" }),
+  );
 }
 
 function signedSlackHeaders(body: string): Record<string, string> {
@@ -95,26 +61,27 @@ function signedSlackHeaders(body: string): Record<string, string> {
   };
 }
 
-function slackIngressRequest(args: {
+async function slackIngressRequest(args: {
   readonly routes: readonly RouteEntry[];
+  readonly path: string;
   readonly body: string;
   readonly contentType: string;
   readonly signed: boolean;
-}) {
-  return async (path: string): Promise<Response> => {
-    const app = createAppWithRoutes({
-      signal: context.signal,
-      routes: args.routes,
-    });
-    return await app.request(`${REQUEST_ORIGIN}${path}`, {
+}): Promise<ResponseSnapshot> {
+  const app = createAppWithRoutes({
+    signal: context.signal,
+    routes: args.routes,
+  });
+  return await snapshot(
+    await app.request(`${REQUEST_ORIGIN}${args.path}`, {
       method: "POST",
       headers: {
         "content-type": args.contentType,
         ...(args.signed ? signedSlackHeaders(args.body) : {}),
       },
       body: args.body,
-    });
-  };
+    }),
+  );
 }
 
 describe("provider console paths", () => {
@@ -129,269 +96,175 @@ describe("provider console paths", () => {
   });
 
   describe("GET /api/integrations/slack/oauth/callback", () => {
-    const paths = ["/api/integrations/slack/oauth/callback"];
+    const path = "/api/integrations/slack/oauth/callback";
 
-    it("rejects a callback without an authorization code identically", async () => {
-      const snapshots = await snapshotEachPath(
-        paths,
-        getRequest(slackOauthRoutes),
-      );
-
-      expect(snapshots).toStrictEqual(
-        repeated(
-          {
-            status: 400,
-            location: null,
-            body: jsonBody({ error: "Missing authorization code" }),
-          },
-          paths,
-        ),
-      );
+    it("rejects a callback without an authorization code", async () => {
+      await expect(getRequest(slackOauthRoutes, path)).resolves.toStrictEqual({
+        status: 400,
+        location: null,
+        body: jsonBody({ error: "Missing authorization code" }),
+      });
     });
 
-    it("builds the same failure redirect for a denied authorization", async () => {
-      const send = getRequest(slackOauthRoutes);
-      const snapshots = await snapshotEachPath(paths, (path) => {
-        return send(`${path}?error=access_denied`);
+    it("builds the failure redirect for a denied authorization", async () => {
+      await expect(
+        getRequest(slackOauthRoutes, `${path}?error=access_denied`),
+      ).resolves.toStrictEqual({
+        status: 307,
+        location: `${APP_ORIGIN}/slack/failed?error=access_denied`,
+        body: "",
       });
-
-      expect(snapshots).toStrictEqual(
-        repeated(
-          {
-            status: 307,
-            location: `${APP_ORIGIN}/slack/failed?error=access_denied`,
-            body: "",
-          },
-          paths,
-        ),
-      );
     });
   });
 
-  // Kept here after #28545 moved the contract onto the final path, and narrowed
-  // to that path by #30812. The branded forms were held by the Microsoft app
-  // registration and by `callbackRedirectUri`, which emitted the `zero` form for
-  // the VM0 brand until #30667 unified it; a `redirect_uri` is computed per
-  // request, so that deploy bounded the branded form to authorizations already
-  // in flight. The block stays because the callback is still reached from a
-  // Microsoft console flow.
   describe("GET /api/integrations/teams/oauth/callback", () => {
-    const paths = ["/api/integrations/teams/oauth/callback"];
+    const path = "/api/integrations/teams/oauth/callback";
 
-    it("rejects a callback without an authorization code identically", async () => {
-      const snapshots = await snapshotEachPath(
-        paths,
-        getRequest(teamsOauthRoutes),
-      );
-
-      expect(snapshots).toStrictEqual(
-        repeated(
-          {
-            status: 400,
-            location: null,
-            body: jsonBody({ error: "Missing authorization code" }),
-          },
-          paths,
-        ),
-      );
+    it("rejects a callback without an authorization code", async () => {
+      await expect(getRequest(teamsOauthRoutes, path)).resolves.toStrictEqual({
+        status: 400,
+        location: null,
+        body: jsonBody({ error: "Missing authorization code" }),
+      });
     });
 
-    it("builds the same failure redirect for a denied authorization", async () => {
-      const send = getRequest(teamsOauthRoutes);
-      const snapshots = await snapshotEachPath(paths, (path) => {
-        return send(`${path}?error=access_denied`);
+    it("builds the failure redirect for a denied authorization", async () => {
+      await expect(
+        getRequest(teamsOauthRoutes, `${path}?error=access_denied`),
+      ).resolves.toStrictEqual({
+        status: 307,
+        location: `${APP_ORIGIN}/settings/teams?error=access_denied`,
+        body: "",
       });
-
-      expect(snapshots).toStrictEqual(
-        repeated(
-          {
-            status: 307,
-            location: `${APP_ORIGIN}/settings/teams?error=access_denied`,
-            body: "",
-          },
-          paths,
-        ),
-      );
     });
   });
 
-  // #28544 moved this contract to the neutral path and gave it a branded
-  // compatibility row; #28709 removed that row, because the only thing holding
-  // the branded form was an already-loaded platform tab forwarding a code, a
-  // window that closed well before the retained request log begins, and #31088
-  // emptied the table itself before #31090 removed it. The case stays because the
-  // callback is still reached from a Feishu console flow, narrowed to the path
-  // that serves it.
   describe("GET /api/integrations/feishu/oauth/callback", () => {
     it("rejects a callback without connect state", async () => {
-      const snapshots = await snapshotEachPath(
-        ["/api/integrations/feishu/oauth/callback"],
-        getRequest(feishuOauthRoutes),
-      );
-
-      expect(snapshots).toStrictEqual([
-        {
-          status: 400,
-          location: null,
-          body: jsonBody({ error: "Invalid or expired connect state" }),
-        },
-      ]);
+      await expect(
+        getRequest(
+          feishuOauthRoutes,
+          "/api/integrations/feishu/oauth/callback",
+        ),
+      ).resolves.toStrictEqual({
+        status: 400,
+        location: null,
+        body: jsonBody({ error: "Invalid or expired connect state" }),
+      });
     });
   });
 
   describe("POST /api/webhooks/slack/events", () => {
-    const paths = ["/api/webhooks/slack/events"];
+    const path = "/api/webhooks/slack/events";
     const body = jsonBody({
       type: "url_verification",
       challenge: "provider-console-challenge",
     });
 
     it("verifies the Slack signature and answers URL verification", async () => {
-      const snapshots = await snapshotEachPath(
-        paths,
+      await expect(
         slackIngressRequest({
           routes: slackEventsRoutes,
+          path,
           body,
           contentType: "application/json",
           signed: true,
         }),
-      );
-
-      expect(snapshots).toStrictEqual(
-        repeated(
-          {
-            status: 200,
-            location: null,
-            body: jsonBody({ challenge: "provider-console-challenge" }),
-          },
-          paths,
-        ),
-      );
+      ).resolves.toStrictEqual({
+        status: 200,
+        location: null,
+        body: jsonBody({ challenge: "provider-console-challenge" }),
+      });
     });
 
-    it("rejects an unsigned request identically", async () => {
-      const snapshots = await snapshotEachPath(
-        paths,
+    it("rejects an unsigned request", async () => {
+      await expect(
         slackIngressRequest({
           routes: slackEventsRoutes,
+          path,
           body,
           contentType: "application/json",
           signed: false,
         }),
-      );
-
-      expect(snapshots).toStrictEqual(
-        repeated(
-          {
-            status: 401,
-            location: null,
-            body: jsonBody({ error: "Missing Slack signature headers" }),
-          },
-          paths,
-        ),
-      );
+      ).resolves.toStrictEqual({
+        status: 401,
+        location: null,
+        body: jsonBody({ error: "Missing Slack signature headers" }),
+      });
     });
   });
 
   describe("POST /api/webhooks/slack/commands", () => {
-    const paths = ["/api/webhooks/slack/commands"];
+    const path = "/api/webhooks/slack/commands";
     const body = "command=%2Fokou&text=help";
 
     it("verifies the Slack signature before parsing the command", async () => {
-      const snapshots = await snapshotEachPath(
-        paths,
+      await expect(
         slackIngressRequest({
           routes: slackCommandsRoutes,
+          path,
           body,
           contentType: FORM_CONTENT_TYPE,
           signed: true,
         }),
-      );
-
-      expect(snapshots).toStrictEqual(
-        repeated(
-          {
-            status: 400,
-            location: null,
-            body: jsonBody({ error: "Missing required Slack command fields" }),
-          },
-          paths,
-        ),
-      );
+      ).resolves.toStrictEqual({
+        status: 400,
+        location: null,
+        body: jsonBody({ error: "Missing required Slack command fields" }),
+      });
     });
 
-    it("rejects an unsigned request identically", async () => {
-      const snapshots = await snapshotEachPath(
-        paths,
+    it("rejects an unsigned request", async () => {
+      await expect(
         slackIngressRequest({
           routes: slackCommandsRoutes,
+          path,
           body,
           contentType: FORM_CONTENT_TYPE,
           signed: false,
         }),
-      );
-
-      expect(snapshots).toStrictEqual(
-        repeated(
-          {
-            status: 401,
-            location: null,
-            body: jsonBody({ error: "Missing Slack signature headers" }),
-          },
-          paths,
-        ),
-      );
+      ).resolves.toStrictEqual({
+        status: 401,
+        location: null,
+        body: jsonBody({ error: "Missing Slack signature headers" }),
+      });
     });
   });
 
   describe("POST /api/webhooks/slack/interactive", () => {
-    const paths = ["/api/webhooks/slack/interactive"];
+    const path = "/api/webhooks/slack/interactive";
     const body = "not_a_payload=1";
 
     it("verifies the Slack signature before parsing the payload", async () => {
-      const snapshots = await snapshotEachPath(
-        paths,
+      await expect(
         slackIngressRequest({
           routes: slackInteractiveRoutes,
+          path,
           body,
           contentType: FORM_CONTENT_TYPE,
           signed: true,
         }),
-      );
-
-      expect(snapshots).toStrictEqual(
-        repeated(
-          {
-            status: 400,
-            location: null,
-            body: jsonBody({ error: "Missing payload" }),
-          },
-          paths,
-        ),
-      );
+      ).resolves.toStrictEqual({
+        status: 400,
+        location: null,
+        body: jsonBody({ error: "Missing payload" }),
+      });
     });
 
-    it("rejects an unsigned request identically", async () => {
-      const snapshots = await snapshotEachPath(
-        paths,
+    it("rejects an unsigned request", async () => {
+      await expect(
         slackIngressRequest({
           routes: slackInteractiveRoutes,
+          path,
           body,
           contentType: FORM_CONTENT_TYPE,
           signed: false,
         }),
-      );
-
-      expect(snapshots).toStrictEqual(
-        repeated(
-          {
-            status: 401,
-            location: null,
-            body: jsonBody({ error: "Missing Slack signature headers" }),
-          },
-          paths,
-        ),
-      );
+      ).resolves.toStrictEqual({
+        status: 401,
+        location: null,
+        body: jsonBody({ error: "Missing Slack signature headers" }),
+      });
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
@@ -58,11 +58,6 @@ const trackTeamsFixture = createFixtureTracker<TeamsConnectFixture>(
     await removeTeamsForTest(context.signal, fixture);
   },
 );
-// The final Microsoft console path from #28278. #28917 retired this route's
-// branded compatibility row — the Azure Bot messaging endpoint was already
-// repointed here before #28545 landed — so the branded forms this file used to
-// replay are no longer registered. #31088 emptied that table and #31090 removed
-// it, so no route has a branded form to replay any more.
 const TEAMS_BOT_PATH = "http://api.test/api/webhooks/teams/bot";
 const BOT_APP_ID = "00000000-0000-0000-0000-000000000001";
 const BOT_APP_PASSWORD = "teams-test-password";

--- a/turbo/apps/host-worker/src/index.test.ts
+++ b/turbo/apps/host-worker/src/index.test.ts
@@ -216,18 +216,6 @@ describe("hosted site worker", () => {
     expect(response.headers.get("Vary")).toBe("Origin");
   });
 
-  it("rejects the retired vm0.ai origins", async () => {
-    const response = await fetchWorker(
-      new Request("https://demo.sites.vm0.io/", {
-        headers: { Origin: "https://app.vm0.ai" },
-      }),
-      env(),
-    );
-
-    expect(response.status).toBe(200);
-    expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
-  });
-
   it.each([
     "https://okou.ai",
     "https://app.okou.ai",

--- a/turbo/apps/platform/src/__tests__/clerk-single-domain.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-single-domain.test.ts
@@ -6,7 +6,7 @@ import { testContext } from "../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
 
-test("Okou production authenticates against itself without a satellite", async () => {
+test("Okou production uses its own authentication URLs", async () => {
   const clerk = context.mocks.clerk();
 
   await setupPage({
@@ -28,7 +28,6 @@ test("Okou production authenticates against itself without a satellite", async (
 const BOOTSTRAP_SCRIPT_SELECTOR = "[data-okou-clerk-bootstrap]";
 
 interface InlineBootstrapLoadOptions {
-  readonly isSatellite?: true;
   readonly signInUrl: string;
 }
 
@@ -116,22 +115,15 @@ const PAGE_HOSTNAMES = [
   "pr-30199-app.omby.ai",
 ];
 
-// Only one domain serves the app, so every page authenticates against itself.
-// The page and the app decide this in two languages; a change to one without
-// the other is a silent split-brain that type checking cannot catch.
-test("The inline Clerk bootstrap never configures a satellite", () => {
+test("The inline Clerk bootstrap uses the current page sign-in URL", () => {
   for (const hostname of PAGE_HOSTNAMES) {
     const { bootstrap } = runInlineBootstrap(hostname);
 
     expect({
       hostname,
-      pageDomain: bootstrap.domain ?? null,
-      pageIsSatellite: bootstrap.loadOptions.isSatellite ?? false,
       pageSignInUrl: bootstrap.loadOptions.signInUrl,
     }).toStrictEqual({
       hostname,
-      pageDomain: null,
-      pageIsSatellite: false,
       pageSignInUrl: `https://${hostname}/sign-in`,
     });
   }

--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -5,8 +5,6 @@ import type { DebugLoggers } from "./types/global-method";
 
 interface OkouClerkBootstrapLoadOptions {
   readonly afterSignOutUrl: string;
-  readonly isSatellite?: true;
-  readonly satelliteAutoSync?: true;
   readonly signInUrl: string;
   readonly signUpUrl: string;
 }

--- a/turbo/apps/platform/src/lib/clerk-runtime.ts
+++ b/turbo/apps/platform/src/lib/clerk-runtime.ts
@@ -14,8 +14,6 @@ interface ClerkRuntimeOptions {
 
 interface ClerkRuntimeLoadOptions {
   readonly afterSignOutUrl: string;
-  readonly isSatellite?: true;
-  readonly satelliteAutoSync?: true;
   readonly signInUrl: string;
   readonly signUpUrl: string;
 }
@@ -97,8 +95,6 @@ function matchesEarlyLoadOptions(
 ): boolean {
   return (
     early.afterSignOutUrl === current.afterSignOutUrl &&
-    early.isSatellite === current.isSatellite &&
-    early.satelliteAutoSync === current.satelliteAutoSync &&
     early.signInUrl === current.signInUrl &&
     early.signUpUrl === current.signUpUrl
   );

--- a/turbo/apps/platform/src/lib/push-notifications.ts
+++ b/turbo/apps/platform/src/lib/push-notifications.ts
@@ -59,7 +59,7 @@ export const ensurePushSubscription$ = command(
       return;
     }
     set(subscribing$, true);
-    // TODO: The try-catch block here needs to be cleaned up. confirmed by ethan@vm0.ai
+    // TODO: The try-catch block here needs to be cleaned up.
     // eslint-disable-next-line no-restricted-syntax
     try {
       const createClient = get(apiClient$);

--- a/turbo/apps/platform/src/mocks/ably.ts
+++ b/turbo/apps/platform/src/mocks/ably.ts
@@ -1,7 +1,6 @@
 // The current file still contains .cache and .zyn only because it is currently used for testing purposes,
 // and there hasn't been time to adjust the paradigms within this file yet.
 // In the long term, this file should also stop using .cache and .zyn.
-// confirmed by ethan@vm0.ai
 // oxlint-disable promise/prefer-await-to-then
 import { createDeferredPromise } from "../signals/utils.ts";
 

--- a/turbo/apps/platform/src/signals/page-signal.ts
+++ b/turbo/apps/platform/src/signals/page-signal.ts
@@ -8,7 +8,6 @@ export const setPageSignal$ = command(({ set }, signal: AbortSignal) => {
 
 export const pageSignal$ = computed((get) => {
   // This part is essential. We mainly need to control the downstream "get" of this method so that it cannot retrieve a Signal.
-  // confirmed by ethan@vm0.ai
   // eslint-disable-next-line ccstate/no-get-signal
   const signal = get(innerPageSignal$);
   if (!signal) {

--- a/turbo/apps/platform/src/signals/root-signal.ts
+++ b/turbo/apps/platform/src/signals/root-signal.ts
@@ -3,7 +3,6 @@ import { command, computed, state } from "ccstate";
 const innerRootSignal$ = state<AbortSignal | undefined>(undefined);
 
 export const rootSignal$ = computed((get) => {
-  // confirmed by ethan@vm0.ai
   // eslint-disable-next-line ccstate/no-get-signal
   const signal = get(innerRootSignal$);
   if (!signal) {

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -292,7 +292,7 @@ export const detachedNavigateTo$ = command(
       replace?: boolean;
     },
   ) => {
-    // eslint-disable-next-line ccstate/no-detach-in-signals -- confirmed by ethan@vm0.ai
+    // eslint-disable-next-line ccstate/no-detach-in-signals -- rootSignal$ owns navigation after its event callback returns
     detach(
       set(
         navigate$,

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -37,7 +37,6 @@ export function detach<T>(
 
   if (isPromise) {
     // This instance is necessary because detach itself is a controlled way to generate a floating promise.
-    // confirmed by ethan@vm0.ai
     // oxlint-disable-next-line promise/prefer-await-to-then
     silencePromise = Promise.resolve(promise).then(
       () => {},
@@ -135,7 +134,6 @@ export function jsonParseOr<T>(value: string, fallback: T): T {
   // We must use this approach to silence the exception here. This is because
   // the function itself is designed to help the caller avoid having to handle
   // the try-catch block manually.
-  // confirmed by ethan@vm0.ai
   // eslint-disable-next-line no-restricted-syntax
   try {
     return JSON.parse(value) as T;
@@ -156,7 +154,6 @@ export async function bestEffort(
   p: Promise<unknown>,
   signal?: AbortSignal,
 ): Promise<void> {
-  // confirmed by ethan@vm0.ai
   // eslint-disable-next-line no-restricted-syntax
   try {
     await p;
@@ -177,7 +174,6 @@ export async function tapError<T>(
   p: Promise<T>,
   onError?: (error: unknown) => unknown,
 ): Promise<T | undefined> {
-  // confirmed by ethan@vm0.ai
   // eslint-disable-next-line no-restricted-syntax
   try {
     return await p;
@@ -200,7 +196,6 @@ export async function onRejection<T>(
   operation: Promise<T> | (() => Promise<T> | T),
   fn: (error: unknown) => unknown,
 ): Promise<T> {
-  // confirmed by ethan@vm0.ai
   // eslint-disable-next-line no-restricted-syntax
   try {
     return await (typeof operation === "function" ? operation() : operation);
@@ -225,7 +220,6 @@ export async function settle<T>(
   p: Promise<T>,
   signal?: AbortSignal,
 ): Promise<Settled<T>> {
-  // confirmed by ethan@vm0.ai
   // eslint-disable-next-line no-restricted-syntax
   try {
     const value = await p;
@@ -362,7 +356,6 @@ export async function setLoop(
     }
 
     // use try-catch here to implement an automatic retry.
-    // confirmed by ethan@vm0.ai
     // eslint-disable-next-line no-restricted-syntax
     try {
       const done = await loopBody(signal);

--- a/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
+++ b/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
@@ -51,7 +51,6 @@ export const setupWorksPage$ = command(async ({ set }, signal: AbortSignal) => {
   set(initWorksRedirect$);
   set(initSlackOrg$);
 
-  // confirmed by ethan@vm0.ai
   // eslint-disable-next-line ccstate/no-detach-in-signals -- route-scoped realtime subscriptions run until the /works route signal aborts
   detach(
     Promise.all([

--- a/turbo/apps/platform/src/views/auth-v1/__tests__/auth-v1-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v1/__tests__/auth-v1-page.test.tsx
@@ -162,7 +162,6 @@ test("A trusted Okou destination brands the hosted sign-in", async () => {
     redirectUrl,
   );
   expect(document.title).toBe("Sign in | Okou");
-  expect(screen.queryByAltText("VM0")).not.toBeInTheDocument();
   expect(okouBrandLink()).toHaveAttribute("href", "/");
 });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -1056,7 +1056,7 @@ test("Open personal Settings and manage account security", async () => {
   expect(userProfileLink).toHaveAttribute("rel", "noreferrer");
 });
 
-test("Open personal Settings and manage account security from the production satellite", async () => {
+test("Open personal Settings and manage account security in production", async () => {
   prepareDefaultAgent();
   context.mocks.data.userPreferences({
     captureNetworkBodiesRemaining: 0,
@@ -1075,13 +1075,13 @@ test("Open personal Settings and manage account security from the production sat
     },
   });
 
-  const satelliteMenu = await openAccountMenu();
-  expect(within(satelliteMenu).getByText("Alex Rivera")).toBeInTheDocument();
+  const accountMenu = await openAccountMenu();
+  expect(within(accountMenu).getByText("Alex Rivera")).toBeInTheDocument();
   expect(
-    within(satelliteMenu).getByText("alex.rivera@example.test"),
+    within(accountMenu).getByText("alex.rivera@example.test"),
   ).toBeInTheDocument();
 
-  click(within(satelliteMenu).getByText("Settings"));
+  click(within(accountMenu).getByText("Settings"));
   const settingsDialog = await screen.findByRole("dialog", {
     name: "Settings",
   });

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -253,13 +253,13 @@ describe("getAllFeatureStates", () => {
 
   it("should enable onboarding chat for Ming only", () => {
     const mingStates = getAllFeatureStates({
-      email: "MING@VM0.AI",
+      email: "MING@OKOU.AI",
       orgId: "org_nonexistent",
     });
     expect(mingStates[FeatureSwitchKey.OnboardingChat]).toBe(true);
 
     const otherStaffStates = getAllFeatureStates({
-      email: "ethan@vm0.ai",
+      email: "ethan@okou.ai",
       orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
     });
     expect(otherStaffStates[FeatureSwitchKey.OnboardingChat]).toBe(false);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -432,7 +432,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Show the built-in onboarding chat with Artifact examples and team collaboration guidance.",
     enabled: false,
-    enabledEmailHashes: ["54757055"], // fnv1a("ming@vm0.ai")
+    enabledEmailHashes: ["5a4bda06"], // ming@okou.ai
   },
   [FeatureSwitchKey.ResponsiveFollowupCards]: {
     maintainer: "ethan@okou.ai",


### PR DESCRIPTION
## Summary

- remove obsolete VM0-specific tombstone assertions and retired branded-route history while retaining active security and positive behavior coverage
- drop unused Clerk satellite bootstrap fields and keep the current Okou authentication URL checks
- simplify provider console tests to their single live paths, update the Onboarding Chat allowlist to `ming@okou.ai`, and remove stale `ethan@vm0.ai` approval annotations

## Verification

- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (30 passed)
- `pnpm vitest run apps/host-worker/src/index.test.ts` (14 passed)
- `pnpm -F @okouai/app exec vitest run src/__tests__/clerk-single-domain.test.ts src/views/auth-v1/__tests__/auth-v1-page.test.tsx` (15 passed)
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar-account-menu.test.tsx` (28 passed)
- Core, Host Worker, API, and Platform type checks passed
- Core, Host Worker, API, and Platform lint passed
- affected-workspace Knip passed
- API route tests were blocked before execution by the unavailable local PostgreSQL service (`ECONNREFUSED :5432`); all 28 cases were skipped and remain covered by PR CI

## Deferred

- `PublicBrand` and database brand migration
- Hosted Site namespace migration and legacy-domain redirects
- `static.vm0.io` URL migration
- public Artifact and Official Workflow Queue compatibility cleanup
