### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -6632,14 +6632,9 @@ async function claimGptPiSandbox(
   runId: string,
   tier: "fast" | undefined,
 ) {
-  for (const generations of tier === "fast"
-    ? [undefined, [1, 2]]
-    : [undefined]) {
+  if (tier === "fast") {
     const oldClaim = await api.requestClaimRunnerJob(true, runId, [404], {
-      capabilities:
-        generations === undefined
-          ? undefined
-          : { piModelConfigGenerations: generations },
+      capabilities: { piModelConfigGenerations: [1, 2] },
     });
     expectApiError(oldClaim.body);
     await expect(api.readRun(actor, runId)).resolves.toMatchObject({
@@ -19583,19 +19578,12 @@ describe("CHAT-02: run-level model overrides", () => {
       await expectNoBuiltInModelUsage(run.runId);
 
       await api.heartbeatRunner(runnerGroup);
-      const oldCapabilities =
-        tier === "fast" ? [undefined, [1, 2]] : [undefined];
-      for (const generations of oldCapabilities) {
+      if (tier === "fast") {
         const oldClaim = await api.requestClaimRunnerJob(
           true,
           run.runId,
           [404],
-          {
-            capabilities:
-              generations === undefined
-                ? undefined
-                : { piModelConfigGenerations: generations },
-          },
+          { capabilities: { piModelConfigGenerations: [1, 2] } },
         );
         expectApiError(oldClaim.body);
         await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -97,9 +97,16 @@ interface RunsListQuery {
   readonly until?: string;
   readonly limit?: number;
 }
-type RunnerJobClaimRequest = z.infer<
+type RunnerJobClaimRequestBody = z.infer<
   (typeof runnersJobClaimContract.claim)["body"]
 >;
+/** Test claims advertise every current Pi model-config generation unless a scenario narrows them. */
+function defaultClaimCapabilities(): RunnerJobClaimRequestBody["capabilities"] {
+  return { piModelConfigGenerations: [1, 2, 3] };
+}
+type RunnerJobClaimRequest = Omit<RunnerJobClaimRequestBody, "capabilities"> & {
+  readonly capabilities?: RunnerJobClaimRequestBody["capabilities"];
+};
 type RunnerModelProviderFailureRequest = z.infer<
   (typeof runnersModelProviderFailuresContract.report)["body"]
 >;
@@ -496,7 +503,11 @@ export function createRunsApi(
           headers: runnerHeaders(true),
           ...(extraHeaders ? { extraHeaders } : {}),
           params: { id: runId },
-          body: { runnerIdentity: defaultRunnerIdentity, ...body },
+          body: {
+            runnerIdentity: defaultRunnerIdentity,
+            capabilities: defaultClaimCapabilities(),
+            ...body,
+          },
         }),
         [200],
       );
@@ -730,7 +741,7 @@ export function createRunsApi(
       authorization: string | undefined,
       runId: string,
       statuses: readonly (200 | 400 | 401 | 403 | 404 | 500)[],
-      body: z.infer<(typeof runnersJobClaimContract.claim)["body"]> = {},
+      body: RunnerJobClaimRequest = {},
       extraHeaders?: Readonly<Record<string, string>>,
     ) {
       return await accept(
@@ -738,7 +749,7 @@ export function createRunsApi(
           headers: authorization === undefined ? {} : { authorization },
           ...(extraHeaders ? { extraHeaders } : {}),
           params: { id: runId },
-          body,
+          body: { capabilities: defaultClaimCapabilities(), ...body },
         }),
         statuses,
       );
@@ -756,7 +767,7 @@ export function createRunsApi(
           headers: authorization === undefined ? {} : { authorization },
           ...(extraHeaders ? { extraHeaders } : {}),
           params: { id: runId },
-          body: body as RunnerJobClaimRequest,
+          body: body as RunnerJobClaimRequestBody,
         }),
         statuses,
       );
@@ -1311,7 +1322,11 @@ export function createRunsApi(
           headers: runnerHeaders(validAuth),
           ...(extraHeaders ? { extraHeaders } : {}),
           params: { id: runId },
-          body: { runnerIdentity: defaultRunnerIdentity, ...body },
+          body: {
+            runnerIdentity: defaultRunnerIdentity,
+            capabilities: defaultClaimCapabilities(),
+            ...body,
+          },
         }),
         statuses,
       );
@@ -1329,7 +1344,7 @@ export function createRunsApi(
           headers: runnerHeaders(validAuth),
           ...(extraHeaders ? { extraHeaders } : {}),
           params: { id: runId },
-          body: body as RunnerJobClaimRequest,
+          body: body as RunnerJobClaimRequestBody,
         }),
         statuses,
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
@@ -267,21 +267,14 @@ describe("registry resource download", () => {
     });
   });
 
-  it("still serves the pre-refactor reverse-template digest a drained run context asks for", () => {
-    const id = "skill:presentation-reverse-template";
+  it("rejects the pre-refactor reverse-template digest now that its run contexts drained", () => {
     expect(
       resolvePrivateRegistryResourceArchive(
-        id,
+        "skill:presentation-reverse-template",
         "4d11467afafb68c7ac221a4ac66e237cf7a05a8f4bb17c29e09ba6ec64b394b5",
         "4b2bb4ee2a041d57a2fe9ba07b796a690c6dbe130c6e232fa98364b6ed6aeb11",
       ),
-    ).toStrictEqual({
-      storageName: `registry-resource@${id}`,
-      versionId:
-        "108b2ba3b9d1994da6f4f6ddf219992a2ca9f2584edf5f448269d523e8d5b988",
-      sha256:
-        "4d11467afafb68c7ac221a4ac66e237cf7a05a8f4bb17c29e09ba6ec64b394b5",
-    });
+    ).toBeUndefined();
   });
 
   it("rejects a reverse-template digest that was never published", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
@@ -267,16 +267,6 @@ describe("registry resource download", () => {
     });
   });
 
-  it("rejects the pre-refactor reverse-template digest now that its run contexts drained", () => {
-    expect(
-      resolvePrivateRegistryResourceArchive(
-        "skill:presentation-reverse-template",
-        "4d11467afafb68c7ac221a4ac66e237cf7a05a8f4bb17c29e09ba6ec64b394b5",
-        "4b2bb4ee2a041d57a2fe9ba07b796a690c6dbe130c6e232fa98364b6ed6aeb11",
-      ),
-    ).toBeUndefined();
-  });
-
   it("rejects a reverse-template digest that was never published", () => {
     expect(
       resolvePrivateRegistryResourceArchive(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -5558,7 +5558,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       true,
       run.runId,
       [400],
-      {},
+      { capabilities: { piModelConfigGenerations: [1, 2, 3] } },
     );
     expectApiError(rejected.body);
     await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
@@ -5596,6 +5596,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           heartbeatGeneration: 1,
         },
         runnerHostname: "x".repeat(256),
+        capabilities: { piModelConfigGenerations: [1, 2, 3] },
       },
     );
     expectApiError(invalidHostname.body);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -5852,6 +5852,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           runnerId: randomUUID(),
           heartbeatGeneration: 1,
         },
+        capabilities: { piModelConfigGenerations: [1, 2, 3] },
         telemetry: {
           pollReason: "future-runner-reason",
           jobDiscoveredToClaimRequestMs: -1,
@@ -10714,17 +10715,12 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
         piModelConfig,
       );
       await api.heartbeatRunner(runnerGroup);
-      for (const capabilities of [
-        undefined,
-        { piModelConfigGenerations: [1, 2, 3] },
-      ]) {
-        await api.requestClaimRunnerJob(true, run.runId, [404], {
-          capabilities,
-        });
-        await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
-          status: "pending",
-        });
-      }
+      await api.requestClaimRunnerJob(true, run.runId, [404], {
+        capabilities: { piModelConfigGenerations: [1, 2, 3] },
+      });
+      await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+        status: "pending",
+      });
       const claim = await api.claimRunnerJob(run.runId, {
         capabilities: { piModelConfigGenerations: [1, 2, 3, 4] },
       });
@@ -10802,18 +10798,12 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       );
       await api.heartbeatRunner(runnerGroup);
 
-      const incompatibleCapabilities =
-        generation === 3
-          ? [undefined, { piModelConfigGenerations: [1, 2] }]
-          : generation === 2
-            ? [undefined]
-            : [];
-      for (const capabilities of incompatibleCapabilities) {
+      if (generation === 3) {
         const legacyClaim = await api.requestClaimRunnerJob(
           true,
           run.runId,
           [404],
-          { capabilities },
+          { capabilities: { piModelConfigGenerations: [1, 2] } },
         );
         expectApiError(legacyClaim.body);
         expect(legacyClaim.body.error.message).toBe("Job not found in queue");

--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -207,125 +207,6 @@ const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
     "6e845f03b79a1c4683f9b9bfe8f018eb9808642d6cadbef9ab505d6892ab5adb",
 } as const satisfies Record<string, string>;
 
-/**
- * Superseded digests that still have to resolve to their own immutable R2
- * version.
- *
- * Rollout fallback. Surface: existing runner/sandbox, up to 2 hours. A run
- * whose execution context pinned a `CLI_PKG_URL` from before a republication
- * carries a CLI whose bundled registry only knows the previous digest, and it
- * keeps asking for that digest for the queue lifetime plus a claimed run —
- * bounded by the shared `AGENT_EXECUTION_TIMEOUT_SECONDS` contract in
- * `turbo/packages/api-contracts/src/contracts/runners.ts`, enforced by
- * `crates/runner/src/executor/mod.rs`. See the "Commit-addressed CLI artifacts"
- * section of `docs/deployment-compatibility.md`.
- *
- * Each entry is removable 2 hours after every new execution context carries a
- * CLI built past the republication that added it.
- */
-const PREVIOUS_PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS_BY_SHA256 = {
-  // Pre-refactor guide from vm0-ai/Template-artifact@fc829f4, replaced when the
-  // extractor pipeline was removed.
-  "skill:presentation-reverse-template": {
-    "4d11467afafb68c7ac221a4ac66e237cf7a05a8f4bb17c29e09ba6ec64b394b5":
-      "108b2ba3b9d1994da6f4f6ddf219992a2ca9f2584edf5f448269d523e8d5b988",
-  },
-  // Superseded presentation runbook digests from the
-  // vm0-ai/Template-artifact@b4b701a republication.
-  "template:html-ppt-bloom-pitch-runbook": {
-    b9003d1545000987eac1868220b4ea1379ec1cdd79e884bc08d13539c1cc5f88:
-      "ec842f388ab90b98e0dadb3ffeb560bbd4b0a0aaaa93b84725732d98bf225710",
-  },
-  "template:html-ppt-blueprint-academy-runbook": {
-    "3ba06b6767eb7fb59c7e4e1599acb908f1684c18bfed2f8d29231e6f057e065e":
-      "7dca9890d2c2416b84cdb953d3c5be4a614f2913599a5e6dd990229e266b12a5",
-  },
-  "template:html-ppt-botane-organic-runbook": {
-    f422972f28f470b894e46739aa0cdec8604b7bda7b0738a9ebca3541e553f2ec:
-      "861c2b0e4d1e819e73498bbfd139ba0b95ee40dabc1d2b8189d63eae557e62e7",
-  },
-  "template:html-ppt-business-data-runbook": {
-    cf039ee1f7a989af9935658f7920b7862ce029b57763f71c8562abdb6e9061d8:
-      "cbe95f8e00c38c5cfdce0b72e5a09f5e4d464f8d7dac3151387027957c55d80f",
-  },
-  "template:html-ppt-crayon-runbook": {
-    "2f67f694ead043195e8ec3cbf3e0843e09df6d93dc49f57a261f0f7bd503ae2a":
-      "16dc23497a7f6b8e4e0ced506bef7f5f126d0b069315cab319543a646e89a988",
-  },
-  "template:html-ppt-creative-agency-runbook": {
-    "14ee0f1e2e3dcfd36fc571bb747681a063dfb43eb62a70f67d0fd06aa79ef977":
-      "68c2d284c9bb93ace0e10f3f4c508549eaebecc2cc0638510ad38349e2324a55",
-  },
-  "template:html-ppt-data-report-runbook": {
-    "199bc3e337e66069ade2d15c3f71488e7d15b1cb2d25da8baffd943e13aceefa":
-      "64cca3c4fde4a49ee4cd215ed02ed85f4a198a6f5938e844c18b172ba68c9db7",
-  },
-  "template:html-ppt-editorial-magazine-runbook": {
-    "0068cfa0a3d91a9cbaeed98685f99afa6355dda8a4cab1d5e3cf7bb0e3d232f3":
-      "8ab0a2a68c7a5020a3d142e75af739144542a7ff41c5a3d2e590881acc6178b3",
-  },
-  "template:html-ppt-landing-consulting-runbook": {
-    "622fa1cca454f057d4b5eaaa412033276ed6ad014ac7a79bc5b82cd1aaba0725":
-      "e79f61d0053d69bcc413963fcb56b3677bc6a84616afe90be20374dfef55174a",
-  },
-  "template:html-ppt-lumina-runbook": {
-    "470aa7096ac3c676d644cdf74369ddcb8d120231e1981d7e7c27844d48142ab1":
-      "9d589fee85ed6094bb064049ae24692e104ccbeb7bcda89e707991e7039abf4e",
-  },
-  "template:html-ppt-meridian-runbook": {
-    "16ceb52885a5a93dd6ff909cbc95d2a8a27d6d8ac79ce4e6b906e57b17d69fde":
-      "f15524e2361922bf0e6eed507c937c642261863a78aa856483238ce954547ba3",
-  },
-  "template:html-ppt-mosaic-geometric-runbook": {
-    "722f6ea996166bdce3a6ab5f0292d1ead73488f03c6ad1138883e47506971cfe":
-      "03be08ea6767942ee6d9d2fd2eced72ec0dfaecd2bc7d473c01a0093c39d48eb",
-  },
-  "template:html-ppt-neo-brutalism-runbook": {
-    "488508a363064e08774ba3fc10eff15f72d0bc0df4ff19df841a8772869bd7a5":
-      "df9fe0cb53d1afd611b47bece0ebd81fb8fb036d84910cd20b302b80706f8a41",
-  },
-  "template:html-ppt-nocturne-runbook": {
-    "22db828e89979fdbc6e388568f600098f781b03cff28a99419b4101057394227":
-      "1b684cfa4128f95aeee027e41324050005cfb528fcc26f099d7eb54e37661e0b",
-  },
-  "template:html-ppt-pixel-glitch-runbook": {
-    "085c7f8276e7ff9f2c26d19da7bffcd436dcdbd895b741b24134e11c685e9d91":
-      "c2e9d8b90f00a6df09d3a4ad33357fc32baab03196b68d52d66b1a2ec1e3c0a0",
-  },
-  "template:html-ppt-playful-launch-runbook": {
-    b336b934a2f18904f2af959bf1da999f17bb71d5b727b30c94c89766dc8adcfb:
-      "4135191a92b54a3babde10edf9f972cf83f3aeae582165bd6eabec274fde8b9d",
-  },
-  "template:html-ppt-playful-pop-runbook": {
-    "6f07a5183e71c5f1ab51fabb606433bf2bce40675c5612e47c0040aa21ca8358":
-      "72bbfc0132f41cc130f5efcbd5f692233375847c46c67e646ac890cbe9bfce97",
-  },
-  "template:html-ppt-prospectus-runbook": {
-    fe2905801b1f8beff802640b717e421c7882da2b015254bba160a92f036f190f:
-      "74ee81efc7b5f6794ddf077357e1e845c773b3d77ae9e02948911b19f8220919",
-  },
-  "template:html-ppt-schoolhouse-runbook": {
-    e37fd617e744c2e89765ec0b24a30977ad89a876a30176e0bacf8e32209f5394:
-      "81e7f95dd13cec5f08f54ac965c51b62f87d9c7f8d29370c027aeeed3758571c",
-  },
-  "template:html-ppt-sticker-scrapbook-runbook": {
-    "8bfb271c21004703cc7151358080b5c622c7ec18eb4a5492643f35c5825aadcf":
-      "899be9feba1fbc6eba3515b6e06c97e800956b399d025269bd2daaa6fc1a9653",
-  },
-  "template:html-ppt-strata-runbook": {
-    "78aea76e0a6aceb8fbe77a771781cbd276255f2728fc31fb5617d19550432617":
-      "518f9b636a8cbf091d9147da200822fbc297a343a3cea95d9546f43a8000d458",
-  },
-  "template:html-ppt-taped-consulting-runbook": {
-    bbf846cbf4c6591375d9b668f6e0fdf380d387fddb5c2eb173d935b03486b83f:
-      "16c64fa119f5aa68607c831b2fa79330f597e10fa01501b8a063443bd7561639",
-  },
-  "template:html-ppt-vantage-runbook": {
-    a6290319d2b8065ce105949a5f02ba37ed1738cf9c354cd74e4742826b7ee753:
-      "7b0b0f91b885c67147dc800191edd4b80a62f9bfe0dd6dbe7fcfb49b8e4f8027",
-  },
-} as const satisfies Readonly<Record<string, Readonly<Record<string, string>>>>;
-
 export function resolvePrivateRegistryResourceArchive(
   id: string,
   expectedSha256: string,
@@ -352,21 +233,13 @@ export function resolvePrivateRegistryResourceArchive(
     return undefined;
   }
 
-  const versionId =
-    expectedSha256 === defaultSha256
-      ? defaultVersionId
-      : (
-          PREVIOUS_PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS_BY_SHA256 as Readonly<
-            Record<string, Readonly<Record<string, string>>>
-          >
-        )[id]?.[expectedSha256];
-  if (!versionId) {
+  if (expectedSha256 !== defaultSha256) {
     return undefined;
   }
 
   return {
     storageName: `registry-resource@${id}`,
-    versionId,
+    versionId: defaultVersionId,
     sha256: expectedSha256,
   };
 }

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -2480,7 +2480,7 @@ async function resolveStoredExecutionContextForClaim(
     readonly runId: string;
     readonly orgId: string;
     readonly executionContext: unknown;
-    readonly capabilities: RunnerClaimCapabilities | undefined;
+    readonly capabilities: RunnerClaimCapabilities;
     readonly timing: ClaimRouteTimingCollector;
     readonly scheduleFailedSideEffects: (
       args: ClaimFailedSideEffectArgs,
@@ -2556,7 +2556,7 @@ const claimAuthorizedJob$ = command(
       readonly runId: string;
       readonly authType: RunnerAuthContext["type"];
       readonly runnerAttribution: RunnerClaimAttribution | undefined;
-      readonly capabilities: RunnerClaimCapabilities | undefined;
+      readonly capabilities: RunnerClaimCapabilities;
       readonly jobWithRun: ClaimableJob;
       readonly telemetry: ClaimTimingTelemetry | undefined;
       readonly claimRequestStartedAtMs: number;

--- a/turbo/apps/api/src/signals/services/pi-model-config-claim-capability.ts
+++ b/turbo/apps/api/src/signals/services/pi-model-config-claim-capability.ts
@@ -41,16 +41,9 @@ function configuredGeneration(value: unknown): number | null {
 
 function supportsGeneration(
   generation: number,
-  capabilities: RunnerClaimCapabilities | undefined,
+  capabilities: RunnerClaimCapabilities,
 ): boolean {
-  // Missing capabilities bridge the backend to pre-capability Runner
-  // artifacts. Remove this legacy-only default after #31373 records that
-  // those Runners have drained through their two-hour run/finalization window
-  // and no supported external claimant still uses the old request shape.
-  const supported = capabilities?.piModelConfigGenerations ?? [
-    PI_MODEL_CONFIG_LEGACY_GENERATION,
-  ];
-  return supported.includes(generation);
+  return capabilities.piModelConfigGenerations.includes(generation);
 }
 
 function invalidModelConfig(value: unknown): PiModelConfigClaimResolution {
@@ -65,7 +58,7 @@ function invalidModelConfig(value: unknown): PiModelConfigClaimResolution {
 export function resolvePiModelConfigForClaim(args: {
   readonly cliAgentType: string;
   readonly modelConfig: unknown;
-  readonly capabilities: RunnerClaimCapabilities | undefined;
+  readonly capabilities: RunnerClaimCapabilities;
   readonly environment?: Readonly<Record<string, string>> | null;
   readonly firewalls?: ExecutionFirewalls;
 }): PiModelConfigClaimResolution {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -104,21 +104,29 @@ describe("cancellation recovery timing contract", () => {
   });
 });
 
+/** Every claim body must advertise capabilities; the tests below vary the other fields. */
+const claimCapabilities = { piModelConfigGenerations: [1, 2, 3] };
+
 describe("runner claim attribution contract", () => {
   it("accepts an optional bounded runner hostname", () => {
-    const previousRequest = runnersJobClaimContract.claim.body.parse({});
+    const previousRequest = runnersJobClaimContract.claim.body.parse({
+      capabilities: claimCapabilities,
+    });
     expect(previousRequest).not.toHaveProperty("runnerHostname");
 
     expect(
       runnersJobClaimContract.claim.body.parse({
+        capabilities: claimCapabilities,
         runnerHostname: "prod-1.aws.vm3.ai",
       }),
     ).toMatchObject({ runnerHostname: "prod-1.aws.vm3.ai" });
 
     for (const runnerHostname of ["", "x".repeat(256)]) {
       expect(
-        runnersJobClaimContract.claim.body.safeParse({ runnerHostname })
-          .success,
+        runnersJobClaimContract.claim.body.safeParse({
+          capabilities: claimCapabilities,
+          runnerHostname,
+        }).success,
       ).toBe(false);
     }
   });
@@ -1975,15 +1983,21 @@ describe("runner resume session contract", () => {
 
 describe("runner claim request contract", () => {
   it("accepts omitted or complete runner identity", () => {
-    expect(runnersJobClaimContract.claim.body.parse({})).toEqual({});
     expect(
       runnersJobClaimContract.claim.body.parse({
+        capabilities: claimCapabilities,
+      }),
+    ).toEqual({ capabilities: claimCapabilities });
+    expect(
+      runnersJobClaimContract.claim.body.parse({
+        capabilities: claimCapabilities,
         runnerIdentity: {
           runnerId: "11111111-1111-4111-8111-111111111111",
           heartbeatGeneration: Number.MAX_SAFE_INTEGER,
         },
       }),
     ).toStrictEqual({
+      capabilities: claimCapabilities,
       runnerIdentity: {
         runnerId: "11111111-1111-4111-8111-111111111111",
         heartbeatGeneration: Number.MAX_SAFE_INTEGER,
@@ -2028,14 +2042,17 @@ describe("runner claim request contract", () => {
       { runnerId, heartbeatGeneration: 1, unexpected: true },
     ]) {
       expect(
-        runnersJobClaimContract.claim.body.safeParse({ runnerIdentity })
-          .success,
+        runnersJobClaimContract.claim.body.safeParse({
+          capabilities: claimCapabilities,
+          runnerIdentity,
+        }).success,
       ).toBe(false);
     }
   });
 
   it("accepts optional direct candidate timing telemetry", () => {
     const result = runnersJobClaimContract.claim.body.safeParse({
+      capabilities: claimCapabilities,
       telemetry: {
         discoverySource: "ably",
         jobDiscoveredToClaimRequestMs: 123,
@@ -2068,6 +2085,7 @@ describe("runner claim request contract", () => {
     ] as const) {
       expect(
         runnersJobClaimContract.claim.body.parse({
+          capabilities: claimCapabilities,
           telemetry: {
             runnerPreference,
             runnerPreferenceClaimState,
@@ -2088,6 +2106,7 @@ describe("runner claim request contract", () => {
 
     expect(
       runnersJobClaimContract.claim.body.parse({
+        capabilities: claimCapabilities,
         telemetry: {
           runnerPreference,
         },
@@ -2100,6 +2119,7 @@ describe("runner claim request contract", () => {
   it("keeps other claim telemetry when canonical preference is malformed", () => {
     expect(
       runnersJobClaimContract.claim.body.parse({
+        capabilities: claimCapabilities,
         telemetry: {
           discoverySource: "poll",
           runnerPreference: { kind: "futurePreference" },
@@ -2115,6 +2135,7 @@ describe("runner claim request contract", () => {
 
   it("discards malformed diagnostic telemetry", () => {
     const body = runnersJobClaimContract.claim.body.parse({
+      capabilities: claimCapabilities,
       telemetry: {
         pollReason: "future-reason",
         jobDiscoveredToClaimRequestMs: -1,

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -1538,7 +1538,7 @@ export const runnersJobClaimContract = c.router({
     body: z.object({
       runnerIdentity: runnerProcessIdentitySchema.optional(),
       runnerHostname: runnerHostnameSchema.optional(),
-      capabilities: runnerClaimCapabilitiesSchema.optional(),
+      capabilities: runnerClaimCapabilitiesSchema,
       telemetry: runnerClaimTelemetrySchema.optional(),
     }),
     responses: {


### PR DESCRIPTION
Daily deployment-compatibility cleanup for 2026-09-10. Two expired cohorts, one branch, no schema changes. Windows follow `docs/deployment-compatibility.md`; timestamps are UTC.

## 1. Previous-digest map for presentation runbook and skill archives

- **Boundary**: `resolvePrivateRegistryResourceArchive` mapped superseded `expectedSha256` digests to their immutable R2 versions so commit-addressed CLI contexts created before a republication could still pull the archive their bundled registry pinned. The current-digest path is the replacement; a mismatched digest now returns `undefined` → 404, the same result as any unpublished archive. The map's own contract (file header) was "removable 2 hours after every new execution context carries a CLI built past the republication that added it".
- **Rollout**: the newest entries came from the 2026-09-07 04:51 repin (`8819a3a2ae`, #32160; 94 of the 102 map lines), the rest from 2026-08-26 (`fff8577468`). The first production release after the repin was promoted 2026-09-07 10:43–11:00, so every later run context selects a CLI whose registry carries the current digests. Consumer class: CLI/Sandbox (2 h after the replacement Sandbox image) plus the documented queue + execution + finalization lifetime of pre-deploy contexts — elapsed more than two days ago.
- **MaskDB** (`vm0-prod-ro`, `agent_runs` aggregate over filterable `status`/`created_at`): 0 rows with status in {queued, pending, running} created before 2026-09-08T21:00Z, so no pre-repin execution context survives.
- **Axiom** (`vm0-request-log-prod`, 2026-09-02T21:20Z → 2026-09-09T21:20Z): `/api/registry/presentation-templates/download` 51 requests (CLI, 200) — the digest-less current-template route; `/api/registry/resources/download` 7 requests (CLI, 200). Coverage note: the request log has no query-string field, so a request's digest cannot be attributed; the MaskDB drain proof above is the eligibility evidence.
- **Removed**: the map and the fallback branch; the test that asserted the pre-refactor reverse-template digest "a drained run context asks for" now asserts rejection. Current-digest, unpublished-digest, and allowlist tests are unchanged.

## 2. Legacy Pi model-config generation default for capability-less Runner claims (#31373)

- **Boundary**: `POST /api/runners/jobs/:id/claim` accepted a body without `capabilities`, and `resolvePiModelConfigForClaim` then assumed the claimant supported only `PI_MODEL_CONFIG_LEGACY_GENERATION` (1) — the bridge for Runner artifacts built before the capability existed. `capabilities` is now required by the contract and the service reads `piModelConfigGenerations` directly; a body without it fails validation (400) instead of being treated as a legacy claimant. Stored configs without `schemaVersion` still decode as generation 1 (persisted data is unchanged).
- **Rollout**: the capability shipped in `9464fb3e99` (#31493, 2026-09-03) and first reached Runner in `runner-rs-v0.184.13` (2026-09-03). The Runner serializes it unconditionally (`ClaimRequestBody.capabilities: RunnerClaimCapabilities`, `crates/runner/src/provider/api.rs`). Consumer class: Runner (5 min after the replacement rollout is healthy). `docs/deployment-compatibility.md` records the 2026-09-09 07:02:02 Runner promotion and the 09:05–09:09 fleet inspection with only 0.189.x services running.
- **Axiom** (`vm0-request-log-prod`, 2026-09-08T21:20Z → 2026-09-09T21:20Z, `x_client_type == "Runner"` by `x_client_version`): 0.188.17 (44 931), 0.189.4 (19 190), 0.189.1 (15 565), 0.189.5 (15 287), 0.189.0 (13 612), 0.188.19 (12 328), 0.189.6 (12 073), 0.189.3 (10 403), 0.189.2 (7 144), 0.188.16 (5 041), 0.188.18 (3 940). No claimant older than v0.184.13 and no non-Runner client type on runner routes, so no supported claimant uses the old request shape. `x_client_version` is populated for all Runner traffic.
- **Removed / changed**: the default and the `undefined` capability plumbing in the claim route and service; the contract field is required. Test helpers advertise `[1, 2, 3]` unless a scenario narrows them; the four "old Runner without capabilities" scenarios now exercise only an explicitly narrowed `[1, 2]` claimant, which still receives 404 for generation-3 jobs.

## Verification

- `check-types` for `api` and `@okouai/api-contracts`, `oxlint` (no new findings), and `eslint --max-warnings 0` on every changed file pass; reference searches for the removed map, the `?? [legacy]` default, and `RunnerClaimCapabilities | undefined` return nothing. No Rust binding regeneration is needed: the claim body is not part of the generated bindings and the Runner already sends the field.
- The `api` Vitest suite needs Postgres, which the sandbox does not provide; `registry-resources-download.test.ts`, `chat-events.bdd.test.ts`, `run-lifecycle.bdd.test.ts`, and the claim helpers run in the PR pipeline.

## Deferred this run (exact blockers)

- `computer_use_hosts.client_product` drop (#32967): the owning issue was explicitly re-gated on 2026-09-09 ("stays undispatched") after acceptance surfaced an uncovered failure direction.
- Usage-pack legacy columns (#32575): the issue is open with a serving/rollback gate, the transition validators (`test-member-invitation-retirement.ts`, `member-invitation-legacy-api.ts`) protect the expand→contract cycle, and MaskDB exposes neither `member_invite_usage_pack_required` nor `__drizzle_migrations`.
- `chat_threads` legacy provider pins: still read by `chat-thread-model.service.ts`; MaskDB shows 153 389 of 154 063 rows with `model_provider_id` set.
- `pi_memory_phase2_jobs.legacy_lease_token`, browser session compatibility structures, personal model-provider singleton expansion: MaskDB has no projection for those tables, and the singleton seeding query needs a join MaskDB cannot express.
- `#29908` queue markers (writers still emit them), `#31964` citation bridge, `#32653` Goal schema drop, `#31085` Slice 2, and the `sourceId`-less secret path (`PersonalModelProviderAccounts` is still staff-only) remain gated.
- The Feishu legacy signed-state completion path overlaps open PR #33049 (`feishu-integration.test.ts`).
