### PR TITLE
refactor(auth): remove obsolete clerk domain plumbing

### DIFF
--- a/turbo/apps/platform/src/__tests__/authentication-startup.test.tsx
+++ b/turbo/apps/platform/src/__tests__/authentication-startup.test.tsx
@@ -267,7 +267,7 @@ test("Okou production uses production authentication", async () => {
 
   await waitForReadySignIn();
   expect(clerk.resourceRequests).toStrictEqual([
-    { domain: undefined, publishableKey: "test_production_key" },
+    { publishableKey: "test_production_key" },
   ]);
   expect(clerk.loads).toContainEqual(PRIMARY_LOAD_OPTIONS);
   expect(clerk.uiRequests).toStrictEqual([]);
@@ -288,7 +288,7 @@ test("V1 comparison authentication loads the hosted Clerk UI", async () => {
   );
   expect(screen.queryByTestId("app-auth-v2")).not.toBeInTheDocument();
   expect(clerk.resourceRequests).toStrictEqual([
-    { domain: undefined, publishableKey: "test_production_key" },
+    { publishableKey: "test_production_key" },
   ]);
   expect(clerk.loads).toContainEqual(PRIMARY_LOAD_OPTIONS);
   expect(clerk.uiRequests).toStrictEqual([
@@ -306,7 +306,7 @@ test("Authorized preview hosts use preview authentication", async () => {
   });
   await waitForReadySignIn();
   expect(clerk.resourceRequests).toStrictEqual([
-    { domain: undefined, publishableKey: "test_preview_key" },
+    { publishableKey: "test_preview_key" },
   ]);
 });
 
@@ -322,7 +322,7 @@ test.each(["okou.ai.evil.example", "app.okou.ai.evil.example"])(
     });
     await waitForReadySignIn();
     expect(clerk.resourceRequests).toStrictEqual([
-      { domain: undefined, publishableKey: "test_preview_key" },
+      { publishableKey: "test_preview_key" },
     ]);
   },
 );

--- a/turbo/apps/platform/src/__tests__/clerk-bootstrap.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-bootstrap.test.ts
@@ -17,7 +17,7 @@ test("Okou production uses its own authentication URLs", async () => {
   });
 
   expect(clerk.resourceRequests).toStrictEqual([
-    { domain: undefined, publishableKey: "test_production_key" },
+    { publishableKey: "test_production_key" },
   ]);
   expect(clerk.loads).toContainEqual({
     afterSignOutUrl: "https://app.okou.ai/sign-in",
@@ -66,7 +66,6 @@ type InlineClerkRouter = (
 ) => unknown;
 
 interface InlineBootstrapConfiguration {
-  readonly domain?: string;
   readonly loadOptions: InlineBootstrapLoadOptions;
 }
 

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -717,7 +717,6 @@ function clearMockedAuth() {
   mockedClerk.redirectToSignIn.mockImplementation(defaultRedirectToSignInImpl);
   mockedClerk.redirectToSignUp.mockReset();
   mockedClerk.redirectToSignUp.mockImplementation(defaultRedirectToSignUpImpl);
-  mockedClerk.initialize.mockReset();
 }
 
 export function clearMockedAuthOnAbort(signal: AbortSignal): void {
@@ -1185,11 +1184,6 @@ async function defaultSetActiveImpl(
   }
 }
 
-const initialize =
-  vi.fn<
-    (publishableKey: string, options?: { readonly domain?: string }) => void
-  >();
-
 type MockedCreateOrganization = (
   params: CreateOrganizationParams,
 ) => Promise<{ readonly id: string }>;
@@ -1200,7 +1194,6 @@ export const mockedClerk = {
   userCreateBackupCode,
   userVerifyTOTP,
   userCreatePhoneNumber,
-  initialize,
   get loaded() {
     return internalMockedClerkLoaded;
   },

--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -12,7 +12,6 @@ interface OkouClerkBootstrapLoadOptions {
 
 interface OkouClerkBootstrap {
   clerk?: PlatformClerk;
-  readonly domain?: string;
   readonly loadOptions: OkouClerkBootstrapLoadOptions;
   loaded?: Promise<void>;
   uiLoaded?: Promise<typeof ui>;

--- a/turbo/apps/platform/src/lib/clerk-runtime.ts
+++ b/turbo/apps/platform/src/lib/clerk-runtime.ts
@@ -12,7 +12,6 @@ import { CLERK_JS_VERSION, CLERK_UI_VERSION } from "./clerk-versions.ts";
 
 interface ClerkRuntimeOptions {
   readonly publishableKey: string;
-  readonly domain?: string;
   readonly loadOptions: ClerkRuntimeLoadOptions;
 }
 
@@ -154,7 +153,6 @@ function adoptEarlyClerkRuntime(
   }
   if (
     bootstrap.publishableKey !== options.publishableKey ||
-    bootstrap.domain !== options.domain ||
     !matchesEarlyLoadOptions(bootstrap.loadOptions, options.loadOptions)
   ) {
     throw new Error("Early Clerk bootstrap configuration mismatch");
@@ -185,7 +183,6 @@ export async function startClerkBrowserRuntime(
 ): Promise<ClerkBrowserRuntime> {
   await loadClerkJSScript({
     __internal_clerkJSVersion: CLERK_JS_VERSION,
-    domain: options.domain,
     publishableKey: options.publishableKey,
   });
   const clerk: unknown = Reflect.get(globalThis, "Clerk");

--- a/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
+++ b/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
@@ -232,7 +232,6 @@ interface PostHogMock {
 }
 
 interface ClerkResourceRequest {
-  readonly domain: string | undefined;
   readonly publishableKey: string;
 }
 

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -370,7 +370,6 @@ export const setupAuthPageWrapper = (
       L.info("redirect unauthenticated user to app sign-in", {
         currentUrl: location.href,
         signInUrl: signInUrl.toString(),
-        domain: signInUrl.searchParams.get("domain"),
         redirectUrl: signInUrl.searchParams.get("redirect_url"),
       });
       window.location.href = signInUrl.toString();

--- a/turbo/apps/platform/src/signals/sign-in-token-setup.ts
+++ b/turbo/apps/platform/src/signals/sign-in-token-setup.ts
@@ -14,8 +14,8 @@ const L = logger("SignInToken");
  * Setup command for /sign-in-token route.
  *
  * Accepts a Clerk sign-in token via `?token=...` query parameter,
- * authenticates the user on the primary platform domain, and redirects to the
- * validated completion URL.
+ * authenticates the user through Clerk, and redirects to the validated
+ * completion URL.
  *
  * This route has no auth guard — the user is not yet authenticated.
  */

--- a/turbo/apps/platform/src/test/mocks/clerk-resource.ts
+++ b/turbo/apps/platform/src/test/mocks/clerk-resource.ts
@@ -4,12 +4,10 @@ import { mockedClerk } from "../../__tests__/mock-auth.ts";
 import { createDeferredPromise } from "../../signals/utils.ts";
 
 interface ClerkResourceOptions {
-  readonly domain?: string;
   readonly publishableKey: string;
 }
 
 interface ClerkResourceRequest {
-  readonly domain: string | undefined;
   readonly publishableKey: string;
 }
 
@@ -81,17 +79,11 @@ export async function loadClerkJSScript(
     throw new Error("Clerk resource behavior was not configured");
   }
   behavior.requests.push({
-    domain: options.domain,
     publishableKey: options.publishableKey,
   });
   await behavior.gate;
   if (behavior.failure) {
     throw behavior.failure;
-  }
-  if (options.domain) {
-    mockedClerk.initialize(options.publishableKey, { domain: options.domain });
-  } else {
-    mockedClerk.initialize(options.publishableKey);
   }
   Reflect.set(globalThis, "Clerk", mockedClerk);
   return null;

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-invitations.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-invitations.test.tsx
@@ -186,11 +186,11 @@ test("Invitation exchange preserves the return URL in Clerk's auth fragment", as
     context,
     host: "app.okou.ai",
     auth: null,
-    path: `/sign-in?__clerk_status=sign_in&__clerk_ticket=${ticket}#/?redirect_url=${encodeURIComponent("https://app.okou.ai/agents?__clerk_synced=false")}`,
+    path: `/sign-in?__clerk_status=sign_in&__clerk_ticket=${ticket}#/?redirect_url=${encodeURIComponent("https://app.okou.ai/agents?source=invitation")}`,
   });
   await screen.findByRole("heading", { name: "Sign-in complete" });
   expect(location.origin).toBe("https://app.okou.ai");
   expect(location.pathname).toBe("/agents");
-  expect(location.search).toBe("?__clerk_synced=false");
+  expect(location.search).toBe("?source=invitation");
   expect(location.href).not.toContain(ticket);
 });

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-navigation-hosts.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-navigation-hosts.test.tsx
@@ -213,7 +213,6 @@ test("Preview authentication stays in the preview environment", async () => {
   const signInUrl = new URL(location.href);
   expect(signInUrl.origin).toBe("https://pr-18532-app.omby.ai:8443");
   expect(signInUrl.pathname).toBe("/sign-in");
-  expect(signInUrl.searchParams.has("domain")).toBeFalsy();
   expect(clerk.loads).toContainEqual({
     afterSignOutUrl: "https://pr-18532-app.omby.ai:8443/sign-in",
     signInUrl: "https://pr-18532-app.omby.ai:8443/sign-in",
@@ -234,7 +233,6 @@ test("An unregistered Okou sibling authenticates against itself", async () => {
     expect(location.origin).toBe("https://console.okou.ai");
     expect(location.pathname).toBe("/sign-in");
   });
-  expect(new URL(location.href).searchParams.has("domain")).toBeFalsy();
   expect(clerk.loads).toContainEqual({
     afterSignOutUrl: "https://console.okou.ai/sign-in",
     signInUrl: "https://console.okou.ai/sign-in",


### PR DESCRIPTION
## Summary

- remove the dormant Clerk `domain` option from Platform runtime bootstrap types, configuration matching, and script loading
- delete the satellite-only Clerk mock initialization branch and stale negative assertions, and rename the remaining test around its actual bootstrap behavior
- replace the legacy `__clerk_synced` fixture with a neutral return-query example while preserving return URL coverage

Current-origin authentication URLs, production/preview publishable-key selection, redirect allowlists, and App Worker `authorizedParties` are unchanged.

## Verification

- `pnpm -F @okouai/app exec vitest run src/__tests__/clerk-bootstrap.test.ts src/__tests__/authentication-startup.test.tsx src/views/auth-v2/__tests__/auth-v2-invitations.test.tsx src/views/auth-v2/__tests__/auth-v2-navigation-hosts.test.tsx` (29 tests)
- `pnpm -F @okouai/app check-types`
- focused Oxlint, type-aware Oxlint, and ESLint checks on all changed TypeScript files
- source scan confirms no active `satellite`, `isSatellite`, `satelliteAutoSync`, `__clerk_synced`, Clerk domain, or Clerk proxy configuration remains outside historical changelogs and unrelated test-email domain constants
