### PR TITLE
chore(api): refresh clerk auth preview qa marker

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createProductionApp } from "./production-bootstrap";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed for sidebar touch preview QA on 2026-09-08)
+// (no-op API release marker refreshed for Clerk V1/V2 visual QA on 2026-09-10)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Purpose

Create a disposable App/API Preview for browser-only comparison of the current Clerk V1 routes (`/v1/sign-in`, `/v1/sign-up`) with the application-owned V2 routes (`/sign-in`, `/sign-up`).

Runtime behavior is unchanged. This PR only refreshes the existing no-op API preview marker so the deployment pipeline provisions an exact-head Preview. It must not be merged as a product change.

## Verification plan

- Confirm `deploy-app` and `deploy-api` correspond to the exact PR head SHA.
- Compare sign-in and sign-up surfaces and reachable authentication states at one fixed desktop viewport.
- Capture and share paired screenshots with PASS / FAIL notes.

## Local checks

- `git diff --check`