### PR TITLE
fix(platform): stabilize voice composer layout

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
@@ -544,7 +544,6 @@ export function createComposerSignals(
     agentId$,
     {
       autoFocus: true,
-      singleLineOnMobile: options.singleLineOnMobile,
     },
     feedback,
   );

--- a/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
@@ -166,12 +166,6 @@ const EDITOR_CONTENT_CLASS =
   "caret-foreground outline-none focus:outline-none [&_p]:m-0 " +
   "selection:bg-primary/20";
 
-function editorContentClass(singleLineOnMobile: boolean): string {
-  return singleLineOnMobile
-    ? `${EDITOR_CONTENT_CLASS} min-h-[68px] md:min-h-[96px]`
-    : `${EDITOR_CONTENT_CLASS} min-h-[96px]`;
-}
-
 const WORKFLOW_HIGHLIGHT_CLASS = "text-brand-text";
 function composerPlaceholder(): string {
   return i18n.t(($) => {
@@ -1754,10 +1748,7 @@ function workflowComposerDocumentForDraft(
   );
 }
 
-function configureMountedWorkflowEditor(
-  editor: Editor,
-  singleLineOnMobile: boolean,
-): void {
+function configureMountedWorkflowEditor(editor: Editor): void {
   editor.setOptions({
     editorProps: {
       clipboardTextSerializer: workflowComposerClipboardText,
@@ -1767,7 +1758,7 @@ function configureMountedWorkflowEditor(
         }),
         placeholder: composerPlaceholder(),
         tabindex: "0",
-        class: editorContentClass(singleLineOnMobile),
+        class: EDITOR_CONTENT_CLASS,
       },
     },
   });
@@ -1931,12 +1922,10 @@ interface MountEditorOptions {
   syncWorkflowNames$: WorkflowNamesSyncCommand;
   syncAgentMentionAvatars$: AgentMentionAvatarsSyncCommand;
   autoFocus: boolean;
-  singleLineOnMobile: boolean;
 }
 
 interface WorkflowComposerOptions {
   readonly autoFocus?: boolean;
-  readonly singleLineOnMobile?: boolean;
 }
 
 function focusMountedEditorAtEnd(editor: Editor): void {
@@ -2003,7 +1992,6 @@ function createMountEditorCommand({
   syncWorkflowNames$,
   syncAgentMentionAvatars$,
   autoFocus,
-  singleLineOnMobile,
 }: MountEditorOptions) {
   return onRef(
     command(async ({ get, set }, element: HTMLElement, signal: AbortSignal) => {
@@ -2045,7 +2033,7 @@ function createMountEditorCommand({
       runtime.removeTemplate = () => {
         set(legacyTemplateAttachment.remove$);
       };
-      configureMountedWorkflowEditor(editor, singleLineOnMobile);
+      configureMountedWorkflowEditor(editor);
       setWorkflowComposerDocument(
         editor,
         workflowComposerDocumentForDraft(editor, {
@@ -2678,7 +2666,6 @@ export function createWorkflowComposerSignals<
     syncWorkflowNames$,
     syncAgentMentionAvatars$,
     autoFocus: options.autoFocus ?? false,
-    singleLineOnMobile: options.singleLineOnMobile ?? false,
   });
   const suggestionInsertionCommands = createSuggestionInsertionCommands(
     editor,

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -9323,12 +9323,48 @@ function useComposerFileUpload(
   };
 }
 
+interface ComposerLayoutHeightClassNames {
+  readonly input: string;
+  readonly shell: string;
+}
+
+// The idle footer is 52px tall and an active voice footer is 72px tall. Keep
+// the shell stable and let its flexible input region absorb that 20px change.
+// A template chip reserves the same additional 38px in both footer modes.
+function composerLayoutHeightClassNames(
+  singleLineOnMobile: boolean,
+  hasTemplateAttachment: boolean,
+): ComposerLayoutHeightClassNames {
+  if (hasTemplateAttachment) {
+    return singleLineOnMobile
+      ? {
+          input: "min-h-[86px] md:min-h-[114px]",
+          shell: "min-h-[158px] md:min-h-[186px]",
+        }
+      : {
+          input: "min-h-[114px]",
+          shell: "min-h-[186px]",
+        };
+  }
+  return singleLineOnMobile
+    ? {
+        input: "min-h-12 md:min-h-[76px]",
+        shell: "min-h-[120px] md:min-h-[148px]",
+      }
+    : {
+        input: "min-h-[76px]",
+        shell: "min-h-[148px]",
+      };
+}
+
 function ComposerInputSlot({
   signals,
   actions,
+  minimumHeightClassName,
 }: {
   signals: ComposerSignals;
   actions: ComposerActions;
+  minimumHeightClassName: string;
 }) {
   const sending = useLastResolved(signals.submission.sending$) ?? false;
   const notifyDraftChanged = useComposerDraftChange(signals);
@@ -9441,17 +9477,24 @@ function ComposerInputSlot({
   };
 
   return (
-    <div className="relative">
-      <TiptapWorkflowComposer
-        signals={signals}
-        onDraftChange={notifyDraftChanged}
-        sending={sending}
-        onKeyDown={handleKeyDown}
-        onPaste={handlePaste}
-      />
+    <div
+      className={cn(
+        "grid flex-1 grid-cols-1 grid-rows-1",
+        minimumHeightClassName,
+      )}
+    >
+      <div className="col-start-1 row-start-1 min-h-0">
+        <TiptapWorkflowComposer
+          signals={signals}
+          onDraftChange={notifyDraftChanged}
+          sending={sending}
+          onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
+        />
+      </div>
       {showVoiceTranscriptionSkeleton ? (
         <div
-          className="pointer-events-none absolute inset-x-0 top-0 flex h-24 flex-col justify-center gap-2 bg-card px-6"
+          className="pointer-events-none col-start-1 row-start-1 flex min-h-0 flex-col justify-center gap-2 bg-card px-6"
           aria-hidden="true"
         >
           <span className="h-2 w-[62%] animate-pulse rounded-full bg-muted/50 motion-reduce:animate-none" />
@@ -10848,7 +10891,7 @@ function ComposerFooter({
   return withChatScrollLayout(
     <div
       className={cn(
-        "flex items-center justify-between gap-1 sm:gap-2",
+        "flex shrink-0 items-center justify-between gap-1 sm:gap-2",
         activeVoiceDraftStatus === "recording"
           ? "px-2 pb-3 pt-3"
           : activeVoiceDraftStatus
@@ -10906,10 +10949,15 @@ function ComposerFooter({
 function ComposerCard({ signals }: { signals: ComposerSignals }) {
   const actions = useComposerActions(signals);
   const connectorActions = useComposerConnectorActions(signals.connector);
+  const hasTemplateAttachment = useGet(signals.template.hasTemplateAttachment$);
   const dragOver = useGet(signals.draft.dragOver$);
   const setDragOver = useSet(signals.draft.setDragOver$);
   const uploadFile = useComposerFileUpload(signals);
   const notifyDraftChanged = useComposerDraftChange(signals);
+  const layoutHeightClassNames = composerLayoutHeightClassNames(
+    signals.editor.singleLineOnMobile,
+    hasTemplateAttachment,
+  );
 
   return (
     <Card
@@ -10943,11 +10991,18 @@ function ComposerCard({ signals }: { signals: ComposerSignals }) {
         }
       }}
     >
-      <CardContent className="p-0">
-        <div ref={actions.bind} className="flex flex-col">
+      <CardContent className="overflow-hidden rounded-[inherit] p-0">
+        <div
+          ref={actions.bind}
+          className={cn("flex flex-col", layoutHeightClassNames.shell)}
+        >
           <ComposerImportedTemplateUrlRefreshLifecycle signals={signals} />
           <ComposerAttachments signals={signals} />
-          <ComposerInputSlot signals={signals} actions={actions} />
+          <ComposerInputSlot
+            signals={signals}
+            actions={actions}
+            minimumHeightClassName={layoutHeightClassNames.input}
+          />
           {/* Recording retains the established 8px/12px outer tray spacing,
               with 12px/8px inner padding for the taller voice controls. Other
               voice states retain their 12px tray inset. */}

--- a/turbo/apps/platform/src/views/okou-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/tiptap-workflow-composer.tsx
@@ -483,15 +483,11 @@ export function TiptapWorkflowComposer({
   onPaste,
 }: TiptapWorkflowComposerProps) {
   const composer = signals;
-  const singleLineOnMobile = composer.editor.singleLineOnMobile;
   const suggestionMenu = useComposerSuggestionMenu({
     composer,
     onKeyDown,
   });
   const insertPromptMarkdown = useSet(composer.editor.insertPromptMarkdown$);
-  const hasTemplateAttachment = useGet(
-    composer.template.hasTemplateAttachment$,
-  );
   const setContainerRef = useSet(composer.editor.setContainerRef$);
 
   function handlePaste(
@@ -532,20 +528,12 @@ export function TiptapWorkflowComposer({
         }
       }}
     >
-      <div className="relative">
+      <div className="relative min-h-full">
         <WorkflowComposerPlaceholder composer={composer} sending={sending} />
         <div
-          // The template chip is 32px tall with 6px bottom spacing. Reserve
-          // those 38px above the input instead of letting the chip consume it.
-          className={
-            hasTemplateAttachment
-              ? singleLineOnMobile
-                ? "min-h-[106px] md:min-h-[134px] [&_.ProseMirror]:min-h-[106px] md:[&_.ProseMirror]:min-h-[134px]"
-                : "min-h-[134px] [&_.ProseMirror]:min-h-[134px]"
-              : singleLineOnMobile
-                ? "min-h-[68px] md:min-h-[96px]"
-                : "min-h-[96px]"
-          }
+          // The composer card owns responsive height allocation so its footer
+          // can change modes without changing the surrounding card height.
+          className="min-h-full [&_.ProseMirror]:min-h-full"
           ref={setContainerRef}
           onInput={(event) => {
             // The mount command targets the container for semantic document


### PR DESCRIPTION
## Summary

- keep the composer card height stable across idle, recording, transcribing, and completed voice-input states
- use flex height allocation and an in-flow grid layer for the transcription skeleton, while keeping TipTap mounted
- clip composer content to the inherited card radius and preserve responsive/template height behavior

## Verification

- `git diff --check`
- Prettier 3.8.1 check for all changed files
- PR pipeline passed on `64e48d80638d286f10deebced5a359a45585fd11`
- PR App/API Preview, real voice capture/upload/transcription with a fixed PCM microphone fixture
  - desktop `1280x900`: idle, recording, transcribing, and completed card height = `150px`
  - mobile thread `402x874`: idle, recording, transcribing, and completed card height = `122px`
  - mobile transcribing skeleton has `12px` equal top/bottom space; card top radii = `24px`; horizontal overflow = `0px`
  - transcription completed with editable text: `This is a responsive voice composer verification.`

## Visual evidence

- [Mobile four-state comparison](https://a.okou.io/gax9vjy0ee.png)
- [Desktop four-state comparison](https://a.okou.io/n9j5ahcttg.png)
- [Mobile transcribing viewport](https://a.okou.io/erur96kq6u.png)

Test setup: per-PR App/API origins, fresh Clerk test account, onboarding bypassed because it is out of scope, `voiceInputV2` enabled, and `realAgentInPreview` left disabled.
