### PR TITLE
fix(platform): exclude folded history from thread shares

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-sharing.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-sharing.test.tsx
@@ -141,7 +141,7 @@ test("Share selected message groups as a public conversation snapshot", async ()
   expect(within(answerGroup).getByRole("checkbox")).toBeChecked();
 });
 
-test("A folded multi-message answer counts as one shared selection", async () => {
+test("A folded multi-message answer shares only its visible message", async () => {
   const createRequests: string[][] = [];
   mockChatLifecycle(context, {
     threadId: THREAD_ID,
@@ -201,7 +201,7 @@ test("A folded multi-message answer counts as one shared selection", async () =>
 
   click(requiredButtonNamed("Share"));
   await screen.findByRole("textbox", { name: "Shared conversation link" });
-  expect(createRequests).toStrictEqual([[...GROUPED_ANSWER_EVENT_IDS]]);
+  expect(createRequests).toStrictEqual([[GROUPED_ANSWER_EVENT_IDS.at(-1)]]);
 });
 
 test("An oversized message group cannot be added to a shared snapshot", async () => {

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -5474,13 +5474,7 @@ function SelectablePagedGroupRow({
   const phase = useGet(thread.sharing.phase$);
   const selectedEventIds = useGet(thread.sharing.selectedEventIds$);
   const toggle = useSet(thread.sharing.toggle$);
-  const visualGroupEvents = [
-    ...(runWorkSection?.hiddenGroups.flatMap((hiddenGroup) => {
-      return hiddenGroup.events;
-    }) ?? []),
-    ...group.events,
-  ];
-  const events = visualGroupEvents.flatMap((event) => {
+  const events = group.events.flatMap((event) => {
     const shareable = shareableEventFromChatEvent(event);
     return shareable ? [shareable] : [];
   });


### PR DESCRIPTION
## Summary

- restrict thread-share selection to events in the visible message group
- exclude folded run-work history from shared conversation snapshots
- update page-level coverage to assert only the visible answer is submitted

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-sharing.test.tsx`
- `pnpm exec prettier --check apps/platform/src/views/okou-page/chat-thread-page.tsx apps/platform/src/views/okou-page/__tests__/chat-sharing.test.tsx`
- `pnpm -F @okouai/app exec oxlint --deny-warnings src/views/okou-page/chat-thread-page.tsx src/views/okou-page/__tests__/chat-sharing.test.tsx`
- `pnpm -F @okouai/app exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings src/views/okou-page/chat-thread-page.tsx src/views/okou-page/__tests__/chat-sharing.test.tsx`
- `pnpm -F @okouai/app exec eslint src/views/okou-page/chat-thread-page.tsx src/views/okou-page/__tests__/chat-sharing.test.tsx --max-warnings 0 --cache --cache-strategy content --cache-location .eslintcache`
- `TSC_CHECKERS=2 pnpm -F @okouai/app check-types`
- `pnpm knip`
- `node scripts/style-policy.mjs`
