### PR TITLE
refactor(app): migrate monochrome icon filter to dark utility

### DIFF
--- a/docs/style-migration.md
+++ b/docs/style-migration.md
@@ -340,3 +340,16 @@ injections. The implementation pipeline retains a separate `/sign-in`
 navigation timeout during CLI TEST credential provisioning, before test
 execution. The batch remains `implemented` while final-head CI is assessed;
 these screenshots establish bounded Chromium acceptance.
+
+The [evidence-only head replay](https://a.okou.io/okin45nt2v.zip) pins source
+`6d4d25d653e49be29d900cd6e73b208d5c1fbc1b` and App/API build
+`a7aae2beca69ca7c0075bf79af4b9cccaf4f006b`, including main
+`724dc63d33064e66f8a41e0bef6ad54e345ef94a`. All 20 states again pass with
+zero changed pixels and equal observations; that source's complete Turbo CI
+passes. Actual Models and Connector pages loaded with the independent TEST
+account. The archive records actual feature switches separately: the fixture
+sets `modelPickerMenu=true` to exercise portaled icons; the live TEST response
+has it false. Both keep `modelPickerFlyout=false` and `_realAgentInPreview=false`.
+No live switch was changed. Earlier manual portal navigation attempts are
+explicitly unaccepted diagnostics, distinct from the four passing frozen portal
+states. The archive was anonymously downloaded and hash-verified.

--- a/docs/style-migration.md
+++ b/docs/style-migration.md
@@ -311,3 +311,19 @@ DOM or CSS. A fresh before/A/A pair passed all 20 states with zero changed
 pixels. The interruption of the earlier A/A returned SIGTERM with an unconfirmed
 cause; per-capture append-only records now preserve measurements before final
 manifest creation. This calibration does not claim unattended reproducibility.
+
+The [frozen BEFORE and unchanged A/A archive](https://a.okou.io/aeguxfgxpx.zip)
+was uploaded and anonymously hash-verified before business edits. It pins source
+`52557ce17da42acce602164a838381039d4407f6` and App/API build
+`ad820032f6237598b8abed4c46e31979d7007ae2`, after integrating main
+`29dfab14531307e67d16322d5fa3972df9c42a99`. All 20 states pass with zero
+changed pixels and identical icon observations. Both original business files,
+the CSS entry point and legacy baseline were byte-identical to that main.
+
+Both consumers now use the existing `dark:invert` utility. The dark variant also
+supports a theme attribute on the element itself, but neither image accepts
+that attribute or caller filter classes; the current consumers and portaled
+options use the same dark ancestor as the removed selector. Provider
+classification, connector inversion flags, scale, fallback DOM and error events
+remain unchanged. Only this token, one CSS declaration and two production uses
+are pruned. No token or shared component changes are needed.

--- a/docs/style-migration.md
+++ b/docs/style-migration.md
@@ -219,3 +219,31 @@ The corresponding source passed 27 focused page tests, App/UI/E2E types,
 formatting, and the [PR CI pipeline](https://github.com/vm0-ai/vm0/actions/runs/34328666624).
 This is bounded Chromium acceptance; the earlier native and motion exclusions
 remain in force.
+
+## Monochrome icon filter batch
+
+The independent `monochrome-icon-filter` batch covers only `ProviderIcon`,
+`ConnectorIcon`, and their final `okou-icon-mono` declaration. Run
+`pnpm exec tsx playwright/style-migration/run-icon-mono.ts` from `e2e` using
+`--app-url`, `--api-url`, `--expected-build`, `--api-build`, `--source-sha`,
+`--storage-state`, `--executable-path`, `--out`, and optional `--baseline`.
+`icon-mono-cases.json` and `icon-mono-fixtures.json` are frozen alongside the
+runner before business-style changes. API bootstrap scripts and browser requests
+receive the same deterministic responses. Credentials remain outside evidence.
+
+Twenty states cover the real Models settings dialog, its portaled model
+options, personal provider marks, and the Connector page in Light/Dark desktop
+and narrow touch/DPR 2 Chromium. Monochrome, colorful, missing-metadata and failed
+image fixtures are distinct. Missing catalog display metadata is intentional
+fault injection for the existing defensive fallback. Synthetic HTTPS icon
+requests are fulfilled locally; no provider authorization or Agent run occurs.
+Automatic signup attribution is fulfilled without writing to the API.
+
+Healthy images use the unchanged shared `capture.ts`. Its mandatory image decode
+cannot accept an intentionally broken image. Only failed-image states use the
+batch's capture function: it verifies the failed image is complete, hidden and
+undecodable, decodes all other images, waits for fonts and finite animations,
+pauses infinite animations at zero, and requires three identical full-page
+frames. It changes no DOM or styles. Both paths use the unchanged `images.ts`
+rounding limits and retain every raw changed pixel without masks. This is bounded
+Chromium evidence; it does not certify native, WebKit or normal-motion behavior.

--- a/docs/style-migration.md
+++ b/docs/style-migration.md
@@ -327,3 +327,16 @@ options use the same dark ancestor as the removed selector. Provider
 classification, connector inversion flags, scale, fallback DOM and error events
 remain unchanged. Only this token, one CSS declaration and two production uses
 are pruned. No token or shared component changes are needed.
+
+The [AFTER archive](https://a.okou.io/gywva3k9z6.zip) and
+[comparison image](https://a.okou.io/vfjoaz2ylx.png) record all 20 states
+passing with zero changed pixels and identical icon observations on App/API
+build `29156a9e945af833fdef2bffe024be4c617d4496`, source
+`318f791155657f6efb477a25f8023fd394f87fb1`. Both downloads were anonymously
+hash-verified. The complete style check, affected App types/ESLint/Knip,
+E2E types, formatting and four selected existing page tests passed. The legacy
+inventory is now 93 tokens, 533 declarations, 307 production uses and two
+injections. The implementation pipeline retains a separate `/sign-in`
+navigation timeout during CLI TEST credential provisioning, before test
+execution. The batch remains `implemented` while final-head CI is assessed;
+these screenshots establish bounded Chromium acceptance.

--- a/docs/style-migration.md
+++ b/docs/style-migration.md
@@ -247,3 +247,13 @@ pauses infinite animations at zero, and requires three identical full-page
 frames. It changes no DOM or styles. Both paths use the unchanged `images.ts`
 rounding limits and retain every raw changed pixel without masks. This is bounded
 Chromium evidence; it does not certify native, WebKit or normal-motion behavior.
+
+Icon-mono calibration found narrow Dark DPR 2 raster differences confined to the
+unrelated dotted price underlines (96/96/16 pixels, maximum channel delta 4).
+Those captures remain rejected under the original limits. Before each capture,
+the independent runner now requests a complete repaint by changing the viewport
+width by one pixel and restoring the exact case dimensions, without changing
+DOM or CSS. A fresh before/A/A pair passed all 20 states with zero changed
+pixels. The interruption of the earlier A/A returned SIGTERM with an unconfirmed
+cause; per-capture append-only records now preserve measurements before final
+manifest creation. This calibration does not claim unattended reproducibility.

--- a/e2e/playwright/style-migration/icon-mono-cases.json
+++ b/e2e/playwright/style-migration/icon-mono-cases.json
@@ -1,0 +1,110 @@
+{
+  "version": 1,
+  "batch": "monochrome-icon-filter",
+  "cases": [
+    {
+      "id": "icon-mono-providers-light",
+      "path": "/?settings=model",
+      "surface": "providers",
+      "theme": "light",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1,
+      "hasTouch": false,
+      "isMobile": false
+    },
+    {
+      "id": "icon-mono-connectors-light",
+      "path": "/connectors",
+      "surface": "connectors",
+      "theme": "light",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1,
+      "hasTouch": false,
+      "isMobile": false
+    },
+    {
+      "id": "icon-mono-providers-dark",
+      "path": "/?settings=model",
+      "surface": "providers",
+      "theme": "dark",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1,
+      "hasTouch": false,
+      "isMobile": false
+    },
+    {
+      "id": "icon-mono-connectors-dark",
+      "path": "/connectors",
+      "surface": "connectors",
+      "theme": "dark",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1,
+      "hasTouch": false,
+      "isMobile": false
+    },
+    {
+      "id": "icon-mono-providers-narrow",
+      "path": "/?settings=model",
+      "surface": "providers",
+      "theme": "light",
+      "viewport": {
+        "width": 390,
+        "height": 844
+      },
+      "deviceScaleFactor": 2,
+      "hasTouch": true,
+      "isMobile": true
+    },
+    {
+      "id": "icon-mono-connectors-narrow",
+      "path": "/connectors",
+      "surface": "connectors",
+      "theme": "light",
+      "viewport": {
+        "width": 390,
+        "height": 844
+      },
+      "deviceScaleFactor": 2,
+      "hasTouch": true,
+      "isMobile": true
+    },
+    {
+      "id": "icon-mono-providers-narrow-dark",
+      "path": "/?settings=model",
+      "surface": "providers",
+      "theme": "dark",
+      "viewport": {
+        "width": 390,
+        "height": 844
+      },
+      "deviceScaleFactor": 2,
+      "hasTouch": true,
+      "isMobile": true
+    },
+    {
+      "id": "icon-mono-connectors-narrow-dark",
+      "path": "/connectors",
+      "surface": "connectors",
+      "theme": "dark",
+      "viewport": {
+        "width": 390,
+        "height": 844
+      },
+      "deviceScaleFactor": 2,
+      "hasTouch": true,
+      "isMobile": true
+    }
+  ]
+}

--- a/e2e/playwright/style-migration/icon-mono-cases.json
+++ b/e2e/playwright/style-migration/icon-mono-cases.json
@@ -4,7 +4,7 @@
   "cases": [
     {
       "id": "icon-mono-providers-light",
-      "path": "/?settings=model",
+      "path": "/connectors?settings=model",
       "surface": "providers",
       "theme": "light",
       "viewport": {
@@ -30,7 +30,7 @@
     },
     {
       "id": "icon-mono-providers-dark",
-      "path": "/?settings=model",
+      "path": "/connectors?settings=model",
       "surface": "providers",
       "theme": "dark",
       "viewport": {
@@ -56,7 +56,7 @@
     },
     {
       "id": "icon-mono-providers-narrow",
-      "path": "/?settings=model",
+      "path": "/connectors?settings=model",
       "surface": "providers",
       "theme": "light",
       "viewport": {
@@ -82,7 +82,7 @@
     },
     {
       "id": "icon-mono-providers-narrow-dark",
-      "path": "/?settings=model",
+      "path": "/connectors?settings=model",
       "surface": "providers",
       "theme": "dark",
       "viewport": {

--- a/e2e/playwright/style-migration/icon-mono-fixtures.json
+++ b/e2e/playwright/style-migration/icon-mono-fixtures.json
@@ -1,0 +1,682 @@
+{
+  "/api/user-preferences": {
+    "timezone": "UTC",
+    "locale": "en-US",
+    "translationLanguage": "en",
+    "supportedLocales": ["en-US"],
+    "pinnedAgentIds": [],
+    "sendMode": "enter",
+    "cloudBrowserEnabledByDefault": false,
+    "theme": "light",
+    "colorTheme": "blue-horizon",
+    "captureNetworkBodiesRemaining": 0,
+    "voiceInputModel": null
+  },
+  "/api/feature-switches": {
+    "switches": {},
+    "effectiveSwitches": {
+      "threadActivitySummary": false,
+      "_dummy": true,
+      "ahrefsConnector": false,
+      "billConnector": false,
+      "bentomlConnector": false,
+      "canvaConnector": false,
+      "calComConnector": false,
+      "copperConnector": false,
+      "datadogConnector": false,
+      "deelConnector": false,
+      "docusignConnector": false,
+      "dropboxConnector": true,
+      "figmaConnector": false,
+      "expensifyConnector": false,
+      "mercuryConnector": false,
+      "neonConnector": false,
+      "netSuiteConnector": false,
+      "garminConnectConnector": false,
+      "redditConnector": false,
+      "supabaseConnector": false,
+      "webflowConnector": false,
+      "closeConnector": false,
+      "posthogConnector": false,
+      "payPalConnector": false,
+      "rampConnector": false,
+      "mailchimpConnector": false,
+      "resendConnector": false,
+      "spotifyConnector": false,
+      "stripeMarketplaceOAuthConnector": false,
+      "_debug": false,
+      "banking": false,
+      "slackRead": false,
+      "_lab": false,
+      "stripeInvoicePaidWorkflowAutomations": false,
+      "officialWorkflows": false,
+      "morningBrief": false,
+      "_testOauthConnector": false,
+      "freshdeskConnector": false,
+      "stabilityAiConnector": false,
+      "zoomConnector": false,
+      "workdayConnector": false,
+      "_fastModel": false,
+      "modelPickerMenu": true,
+      "modelPickerFlyout": false,
+      "chatPreference": false,
+      "_realAgentInPreview": false,
+      "zapierConnector": false,
+      "computerUseDesktopPlugins": false,
+      "chatErrorRecovery": false,
+      "privateArtifacts": false,
+      "agentMessageMath": false,
+      "markdownTime": false,
+      "progressiveArtifactPreview": false,
+      "chatThinkingSpinner": false,
+      "onboarding-chat": false,
+      "responsiveFollowupCards": false,
+      "stableChatThreadNavigation": false,
+      "_sidebarSubscriptionUsage": false,
+      "_multipleSubscriptions": false,
+      "_feishuIntegration": false,
+      "customConnectorMcp": false,
+      "sshAccess": false,
+      "chatReasoningEffort": false,
+      "piLoop": false,
+      "introVideo": false,
+      "chatTranslation": false,
+      "chatTouchSelection": false,
+      "voiceInputV2": false,
+      "composerCreateCommands": false,
+      "composerTaskChips": false,
+      "composerWorkflowFuzzySearch": false,
+      "composerImageAnnotation": false,
+      "gradientColorThemes": false,
+      "avatarNeckSweater": true,
+      "avatarFraming": false,
+      "connectorDirectory": false,
+      "chatThreadHeaderActions": false
+    }
+  },
+  "/api/onboarding/status": {
+    "needsOnboarding": false,
+    "onboardingComplete": true,
+    "isAdmin": true,
+    "hasOrg": true,
+    "hasDefaultAgent": true,
+    "defaultAgentId": "11111111-1111-4111-a111-111111111111",
+    "defaultAgentMetadata": {
+      "displayName": "Icon Mono QA",
+      "sound": "professional",
+      "avatarUrl": null
+    }
+  },
+  "/api/agents": [
+    {
+      "agentId": "11111111-1111-4111-a111-111111111111",
+      "ownerId": "icon-mono-test-owner",
+      "displayName": "Icon Mono QA",
+      "description": "",
+      "sound": "professional",
+      "avatarUrl": null,
+      "modelProviderId": null,
+      "selectedModel": null,
+      "preferPersonalProvider": false,
+      "visibility": "public"
+    }
+  ],
+  "/api/agents/11111111-1111-4111-a111-111111111111": {
+    "agentId": "11111111-1111-4111-a111-111111111111",
+    "ownerId": "icon-mono-test-owner",
+    "displayName": "Icon Mono QA",
+    "description": "",
+    "sound": "professional",
+    "avatarUrl": null,
+    "modelProviderId": null,
+    "selectedModel": null,
+    "preferPersonalProvider": false,
+    "visibility": "public"
+  },
+  "/api/model-providers": {
+    "modelProviders": []
+  },
+  "/api/me/model-providers": {
+    "modelProviders": []
+  },
+  "/api/model-provider-connections": {
+    "connections": []
+  },
+  "/api/connector-catalog/status": {
+    "connectors": [
+      {
+        "slug": "icon-mono",
+        "label": "Icon Mono",
+        "popularityRank": 1,
+        "description": "Icon Mono deterministic test fixture",
+        "category": "data-automation-infrastructure",
+        "generation": [],
+        "tags": [],
+        "authMethods": [],
+        "permissionSummary": {
+          "hasPermissions": false,
+          "permissionCount": 0,
+          "hasCategories": false,
+          "hasDefaultPolicyOverrides": false
+        },
+        "connection": null,
+        "connected": false,
+        "connectionStatus": "not-connected",
+        "scopeMismatch": false,
+        "authMethodSupportsRefresh": false,
+        "tokenExpiresAt": null,
+        "singleAuthCodeAuthMethodId": null,
+        "connectNotice": null,
+        "icon": {
+          "url": "https://icons.example.test/icon-mono.svg",
+          "invertInDarkMode": true
+        }
+      },
+      {
+        "slug": "icon-color",
+        "label": "Icon Color",
+        "popularityRank": 2,
+        "description": "Icon Color deterministic test fixture",
+        "category": "data-automation-infrastructure",
+        "generation": [],
+        "tags": [],
+        "authMethods": [],
+        "permissionSummary": {
+          "hasPermissions": false,
+          "permissionCount": 0,
+          "hasCategories": false,
+          "hasDefaultPolicyOverrides": false
+        },
+        "connection": null,
+        "connected": false,
+        "connectionStatus": "not-connected",
+        "scopeMismatch": false,
+        "authMethodSupportsRefresh": false,
+        "tokenExpiresAt": null,
+        "singleAuthCodeAuthMethodId": null,
+        "connectNotice": null,
+        "icon": {
+          "url": "https://icons.example.test/icon-color.svg",
+          "invertInDarkMode": false
+        }
+      },
+      {
+        "slug": "icon-missing",
+        "label": "Icon Missing",
+        "popularityRank": 3,
+        "description": "Icon Missing deterministic test fixture",
+        "category": "data-automation-infrastructure",
+        "generation": [],
+        "tags": [],
+        "authMethods": [],
+        "permissionSummary": {
+          "hasPermissions": false,
+          "permissionCount": 0,
+          "hasCategories": false,
+          "hasDefaultPolicyOverrides": false
+        },
+        "connection": null,
+        "connected": false,
+        "connectionStatus": "not-connected",
+        "scopeMismatch": false,
+        "authMethodSupportsRefresh": false,
+        "tokenExpiresAt": null,
+        "singleAuthCodeAuthMethodId": null,
+        "connectNotice": null
+      },
+      {
+        "slug": "icon-broken",
+        "label": "Icon Broken",
+        "popularityRank": 4,
+        "description": "Image failure fixture",
+        "category": "data-automation-infrastructure",
+        "generation": [],
+        "tags": [],
+        "authMethods": [],
+        "permissionSummary": {
+          "hasPermissions": false,
+          "permissionCount": 0,
+          "hasCategories": false,
+          "hasDefaultPolicyOverrides": false
+        },
+        "connection": null,
+        "connected": false,
+        "connectionStatus": "not-connected",
+        "scopeMismatch": false,
+        "authMethodSupportsRefresh": false,
+        "tokenExpiresAt": null,
+        "singleAuthCodeAuthMethodId": null,
+        "connectNotice": null,
+        "icon": {
+          "url": "https://icons.example.test/icon-broken.svg",
+          "invertInDarkMode": true
+        }
+      }
+    ]
+  },
+  "/api/connector-catalog/discovery": {
+    "connectors": [
+      {
+        "slug": "icon-mono",
+        "label": "Icon Mono",
+        "popularityRank": 1,
+        "description": "Icon Mono deterministic test fixture",
+        "category": "data-automation-infrastructure",
+        "generation": [],
+        "tags": [],
+        "authMethods": [],
+        "permissionSummary": {
+          "hasPermissions": false,
+          "permissionCount": 0,
+          "hasCategories": false,
+          "hasDefaultPolicyOverrides": false
+        },
+        "connection": null,
+        "connected": false,
+        "connectionStatus": "not-connected",
+        "scopeMismatch": false,
+        "authMethodSupportsRefresh": false,
+        "tokenExpiresAt": null,
+        "singleAuthCodeAuthMethodId": null,
+        "connectNotice": null,
+        "icon": {
+          "url": "https://icons.example.test/icon-mono.svg",
+          "invertInDarkMode": true
+        }
+      },
+      {
+        "slug": "icon-color",
+        "label": "Icon Color",
+        "popularityRank": 2,
+        "description": "Icon Color deterministic test fixture",
+        "category": "data-automation-infrastructure",
+        "generation": [],
+        "tags": [],
+        "authMethods": [],
+        "permissionSummary": {
+          "hasPermissions": false,
+          "permissionCount": 0,
+          "hasCategories": false,
+          "hasDefaultPolicyOverrides": false
+        },
+        "connection": null,
+        "connected": false,
+        "connectionStatus": "not-connected",
+        "scopeMismatch": false,
+        "authMethodSupportsRefresh": false,
+        "tokenExpiresAt": null,
+        "singleAuthCodeAuthMethodId": null,
+        "connectNotice": null,
+        "icon": {
+          "url": "https://icons.example.test/icon-color.svg",
+          "invertInDarkMode": false
+        }
+      },
+      {
+        "slug": "icon-missing",
+        "label": "Icon Missing",
+        "popularityRank": 3,
+        "description": "Icon Missing deterministic test fixture",
+        "category": "data-automation-infrastructure",
+        "generation": [],
+        "tags": [],
+        "authMethods": [],
+        "permissionSummary": {
+          "hasPermissions": false,
+          "permissionCount": 0,
+          "hasCategories": false,
+          "hasDefaultPolicyOverrides": false
+        },
+        "connection": null,
+        "connected": false,
+        "connectionStatus": "not-connected",
+        "scopeMismatch": false,
+        "authMethodSupportsRefresh": false,
+        "tokenExpiresAt": null,
+        "singleAuthCodeAuthMethodId": null,
+        "connectNotice": null
+      },
+      {
+        "slug": "icon-broken",
+        "label": "Icon Broken",
+        "popularityRank": 4,
+        "description": "Image failure fixture",
+        "category": "data-automation-infrastructure",
+        "generation": [],
+        "tags": [],
+        "authMethods": [],
+        "permissionSummary": {
+          "hasPermissions": false,
+          "permissionCount": 0,
+          "hasCategories": false,
+          "hasDefaultPolicyOverrides": false
+        },
+        "connection": null,
+        "connected": false,
+        "connectionStatus": "not-connected",
+        "scopeMismatch": false,
+        "authMethodSupportsRefresh": false,
+        "tokenExpiresAt": null,
+        "singleAuthCodeAuthMethodId": null,
+        "connectNotice": null,
+        "icon": {
+          "url": "https://icons.example.test/icon-broken.svg",
+          "invertInDarkMode": true
+        }
+      }
+    ],
+    "totalConnectorCount": 4
+  },
+  "/api/connectors": {
+    "connectors": []
+  },
+  "/api/custom-connectors": {
+    "connectors": []
+  },
+  "/api/billing/status": {
+    "tier": "limited-free-1",
+    "status": "active",
+    "canBuyConcurrency": false,
+    "concurrencyPurchaseReviewAvailable": true,
+    "canBuyCredits": false,
+    "showUsagePack": false,
+    "memberInvitationAllowed": true,
+    "autoRechargeAllowed": false,
+    "supportByok": false,
+    "restrictedVm0Models": true,
+    "videoGenerationAllowed": false,
+    "workflowWebhookAutomationAllowed": false,
+    "credits": 1000,
+    "onboardingPaymentPending": false,
+    "subscriptionStatus": null,
+    "currentPeriodEnd": null,
+    "cancelAtPeriodEnd": false,
+    "scheduledChange": null,
+    "canRestorePlan": false,
+    "hasSubscription": false,
+    "autoRecharge": {
+      "enabled": false,
+      "threshold": null,
+      "amount": null
+    },
+    "creditExpiry": {
+      "expiringNextCycle": 0,
+      "nextExpiryDate": null
+    },
+    "creditBreakdown": [
+      {
+        "category": "free",
+        "label": "Free plan",
+        "credits": 1000
+      }
+    ],
+    "creditGrants": [],
+    "concurrencyLimit": 1,
+    "concurrencySubscriptions": [],
+    "usageAllowance": null
+  },
+  "/api/model-policies": {
+    "policies": [
+      {
+        "id": "22222222-2222-4222-a222-000000000001",
+        "model": "gpt-6-astra",
+        "modelLabel": "GPT 6 Astra",
+        "isDefault": false,
+        "defaultProviderType": "built-in",
+        "credentialScope": "org",
+        "modelProviderId": null,
+        "modelProviderSurfaceId": null,
+        "routeStatus": "valid",
+        "routeStatusReason": null,
+        "createdAt": "2026-09-01T00:00:00Z",
+        "updatedAt": "2026-09-01T00:00:00Z"
+      },
+      {
+        "id": "22222222-2222-4222-a222-000000000002",
+        "model": "gpt-5.6-luna",
+        "modelLabel": "GPT 5.6 Luna",
+        "isDefault": false,
+        "defaultProviderType": "built-in",
+        "credentialScope": "org",
+        "modelProviderId": null,
+        "modelProviderSurfaceId": null,
+        "routeStatus": "valid",
+        "routeStatusReason": null,
+        "createdAt": "2026-09-01T00:00:00Z",
+        "updatedAt": "2026-09-01T00:00:00Z"
+      },
+      {
+        "id": "22222222-2222-4222-a222-000000000003",
+        "model": "deepseek-v4-pro",
+        "modelLabel": "DeepSeek V4 Pro",
+        "isDefault": true,
+        "defaultProviderType": "built-in",
+        "credentialScope": "org",
+        "modelProviderId": null,
+        "modelProviderSurfaceId": null,
+        "routeStatus": "valid",
+        "routeStatusReason": null,
+        "createdAt": "2026-09-01T00:00:00Z",
+        "updatedAt": "2026-09-01T00:00:00Z"
+      }
+    ],
+    "workspaceDefaultModel": "deepseek-v4-pro",
+    "workspaceDefaultPolicyId": "22222222-2222-4222-a222-000000000003"
+  },
+  "/api/user-model-preference": {
+    "selectedModel": null,
+    "serviceTier": null,
+    "selectedVideoModel": null,
+    "selectedImageModel": null,
+    "updatedAt": null
+  },
+  "/api/voice-io/quota": {
+    "allowed": true,
+    "count": 0,
+    "limit": 10
+  },
+  "/api/workflows": [],
+  "/api/connector-accounts": {
+    "summaries": []
+  },
+  "/api/attribution/google-ads-milestones": {
+    "milestones": [],
+    "googleAdsAccountId": null
+  },
+  "/api/org": {
+    "id": "org_icon_mono_fixture",
+    "name": "Icon Mono QA",
+    "tier": "limited-free-1",
+    "role": "admin",
+    "createdBy": "user_icon_mono_fixture"
+  },
+  "/api/integrations/slack": {
+    "isConnected": false,
+    "isInstalled": false,
+    "isAdmin": true,
+    "installUrl": null,
+    "connectUrl": null
+  },
+  "/api/agents/11111111-1111-4111-a111-111111111111/user-connectors": {
+    "enabledConnectorSlugs": []
+  },
+  "/api/agents/11111111-1111-4111-a111-111111111111/custom-connectors": {
+    "grants": []
+  },
+  "/api/agents/11111111-1111-4111-a111-111111111111/draft": {
+    "draftUserMessage": null,
+    "draftAttachments": null
+  },
+  "/api/presentation-templates": [],
+  "_iconAssets": {
+    "https://icons.example.test/icon-mono.svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path fill=\"#111\" d=\"M4 4h16v16H4z\"/><path fill=\"#fff\" d=\"M9 9h6v6H9z\"/></svg>",
+    "https://icons.example.test/icon-color.svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><circle cx=\"12\" cy=\"12\" r=\"10\" fill=\"#e83e72\"/><path fill=\"#25c9da\" d=\"M12 2v20A10 10 0 0 0 12 2\"/></svg>",
+    "https://icons.example.test/icon-broken.svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path fill=\"#111\" d=\"M4 4h16v16H4z\"/><path fill=\"#fff\" d=\"M9 9h6v6H9z\"/></svg>"
+  },
+  "_statusCodes": {
+    "/api/connector-catalog/cal-com": 404
+  },
+  "/api/connector-catalog/x": {
+    "connector": {
+      "slug": "x",
+      "label": "X",
+      "description": "Connect your X (Twitter) account to read and publish posts, manage media and engagement, and search",
+      "icon": {
+        "url": "https://static.vm0.io/platform/views/zero-page/components/settings/icons/x-c6644387ea39.svg",
+        "invertInDarkMode": true
+      },
+      "category": "marketing-content-growth",
+      "popularityRank": 49,
+      "generation": [],
+      "tags": [],
+      "authMethods": [
+        {
+          "id": "oauth",
+          "label": "OAuth (Recommended)",
+          "description": "Sign in with X to grant the configured read and write access.",
+          "grantKind": "auth-code",
+          "manualFields": [],
+          "startOptions": []
+        }
+      ],
+      "permissionSummary": {
+        "hasPermissions": true,
+        "permissionCount": 21,
+        "hasCategories": false,
+        "hasDefaultPolicyOverrides": false
+      },
+      "connection": null,
+      "connected": false,
+      "connectionStatus": "not-connected",
+      "scopeMismatch": false,
+      "authMethodSupportsRefresh": false,
+      "tokenExpiresAt": null,
+      "singleAuthCodeAuthMethodId": "oauth",
+      "connectNotice": null
+    }
+  },
+  "/api/connector-catalog/slack": {
+    "connector": {
+      "slug": "slack",
+      "label": "Slack",
+      "description": "Connect your Slack account to send messages and manage conversations",
+      "icon": {
+        "url": "https://static.vm0.io/platform/views/zero-page/components/settings/icons/slack-198390069136.svg",
+        "invertInDarkMode": false,
+        "scale": 2.2
+      },
+      "category": "communication-collaboration",
+      "popularityRank": 11,
+      "generation": [],
+      "tags": ["chat", "messaging", "im"],
+      "authMethods": [
+        {
+          "id": "oauth",
+          "label": "OAuth (Recommended)",
+          "description": "Sign in with Slack to grant access.",
+          "grantKind": "auth-code",
+          "manualFields": [],
+          "startOptions": []
+        }
+      ],
+      "permissionSummary": {
+        "hasPermissions": true,
+        "permissionCount": 84,
+        "hasCategories": true,
+        "hasDefaultPolicyOverrides": true
+      },
+      "connection": null,
+      "connected": false,
+      "connectionStatus": "not-connected",
+      "scopeMismatch": false,
+      "authMethodSupportsRefresh": false,
+      "tokenExpiresAt": null,
+      "singleAuthCodeAuthMethodId": "oauth",
+      "connectNotice": null
+    }
+  },
+  "/api/connector-catalog/notion": {
+    "connector": {
+      "slug": "notion",
+      "label": "Notion",
+      "description": "Connect your Notion workspace to access pages and databases",
+      "icon": {
+        "url": "https://static.vm0.io/platform/views/zero-page/components/settings/icons/notion-beeb509915a9.svg",
+        "invertInDarkMode": true
+      },
+      "category": "docs-files-knowledge",
+      "popularityRank": 7,
+      "generation": [],
+      "tags": ["docs", "wiki", "workspace"],
+      "authMethods": [
+        {
+          "id": "oauth",
+          "label": "OAuth (Recommended)",
+          "description": "Sign in with Notion to grant access.",
+          "grantKind": "auth-code",
+          "manualFields": [],
+          "startOptions": []
+        }
+      ],
+      "permissionSummary": {
+        "hasPermissions": true,
+        "permissionCount": 6,
+        "hasCategories": false,
+        "hasDefaultPolicyOverrides": false
+      },
+      "connection": null,
+      "connected": false,
+      "connectionStatus": "not-connected",
+      "scopeMismatch": false,
+      "authMethodSupportsRefresh": false,
+      "tokenExpiresAt": null,
+      "singleAuthCodeAuthMethodId": "oauth",
+      "connectNotice": null
+    }
+  },
+  "/api/connector-catalog/google-calendar": {
+    "connector": {
+      "slug": "google-calendar",
+      "label": "Google Calendar",
+      "description": "Connect your Google account to access and manage calendar events",
+      "icon": {
+        "url": "https://static.vm0.io/platform/views/zero-page/components/settings/icons/google-calendar-58ef860565d1.svg",
+        "invertInDarkMode": false
+      },
+      "category": "meetings-scheduling",
+      "popularityRank": 2,
+      "generation": [],
+      "tags": ["calendar", "scheduling", "gcal"],
+      "authMethods": [
+        {
+          "id": "oauth",
+          "label": "OAuth (Recommended)",
+          "description": "Sign in with Google to grant Google Calendar access.",
+          "grantKind": "auth-code",
+          "manualFields": [],
+          "startOptions": []
+        }
+      ],
+      "permissionSummary": {
+        "hasPermissions": true,
+        "permissionCount": 17,
+        "hasCategories": true,
+        "hasDefaultPolicyOverrides": true
+      },
+      "connection": null,
+      "connected": false,
+      "connectionStatus": "not-connected",
+      "scopeMismatch": false,
+      "authMethodSupportsRefresh": false,
+      "tokenExpiresAt": null,
+      "singleAuthCodeAuthMethodId": "oauth",
+      "connectNotice": null
+    }
+  },
+  "/api/connector-catalog/cal-com": {
+    "error": {
+      "message": "Connector catalog item not found",
+      "code": "NOT_FOUND"
+    }
+  }
+}

--- a/e2e/playwright/style-migration/run-icon-mono.ts
+++ b/e2e/playwright/style-migration/run-icon-mono.ts
@@ -1,0 +1,566 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import {
+  chromium,
+  expect as playwrightExpect,
+  type Page,
+} from "@playwright/test";
+import { seedPreviewBypassCookie } from "../lib/preview-bypass";
+import { fixtureBootstrap } from "./bootstrap";
+import { browserArgs, stableScreenshot } from "./capture";
+import { compareImages, roundingTolerance, sha256 } from "./images";
+
+const expect = playwrightExpect.configure({ timeout: 30_000 });
+interface VisualCase {
+  id: string;
+  path: string;
+  surface: "providers" | "connectors";
+  theme: "light" | "dark";
+  viewport: { width: number; height: number };
+  deviceScaleFactor: number;
+  hasTouch: boolean;
+  isMobile: boolean;
+}
+interface Capture {
+  id: string;
+  image: string;
+  sha256: string;
+  observation: unknown;
+  status: "BASELINE" | "PASS" | "FAIL";
+  changedPixels?: number;
+  contentChangedPixels?: number;
+  roundingPixels?: number;
+}
+interface Manifest {
+  version: 1;
+  protocol: "channel-rounding-v1";
+  sourceSha: string;
+  appBuildSha: string;
+  apiBuildSha: string;
+  appOrigin: string;
+  apiOrigin: string;
+  browser: string;
+  runnerSha256: string;
+  caseSha256: string;
+  fixtureSha256: string;
+  roundingTolerance: typeof roundingTolerance;
+  cases: VisualCase[];
+  captures: Capture[];
+  failures: string[];
+  apiPaths: string[];
+}
+const { values } = parseArgs({
+  options: {
+    "app-url": { type: "string" },
+    "api-url": { type: "string" },
+    "expected-build": { type: "string" },
+    "api-build": { type: "string" },
+    "source-sha": { type: "string" },
+    "storage-state": { type: "string" },
+    "executable-path": { type: "string" },
+    out: { type: "string" },
+    baseline: { type: "string" },
+  },
+});
+function required(key: keyof typeof values) {
+  const value = values[key];
+  assert(value, `--${key} is required`);
+  return value;
+}
+function origin(value: string) {
+  const url = new URL(value);
+  assert.equal(url.protocol, "https:");
+  assert(!url.username && !url.password && !url.search && !url.hash);
+  assert.equal(url.pathname, "/");
+  return url.origin;
+}
+async function observe(page: Page) {
+  return page.evaluate(() =>
+    Array.from(document.querySelectorAll('img, [role="img"]'))
+      .filter((element) => {
+        const box = element.getBoundingClientRect();
+        return box.width > 0 && box.height > 0;
+      })
+      .map((element) => {
+        const style = getComputedStyle(element),
+          box = element.getBoundingClientRect();
+        return {
+          tag: element.tagName,
+          role: element.getAttribute("role"),
+          alt: element.getAttribute("alt"),
+          label: element.getAttribute("aria-label"),
+          hidden: element.hasAttribute("hidden"),
+          source: element
+            .getAttribute("src")
+            ?.startsWith("https://img.clerk.com/")
+            ? "isolated-test-avatar"
+            : element.getAttribute("src"),
+          box: { x: box.x, y: box.y, width: box.width, height: box.height },
+          darkAncestor: Boolean(
+            element.parentElement?.closest('[data-theme="dark"]'),
+          ),
+          themeOnSelf: element.getAttribute("data-theme"),
+          portal: Boolean(
+            element.closest(
+              '[data-base-ui-portal], [data-slot="popover-content"], [data-slot="select-content"]',
+            ),
+          ),
+          styles: Object.fromEntries(
+            [
+              "filter",
+              "width",
+              "height",
+              "max-width",
+              "max-height",
+              "display",
+              "object-fit",
+              "transform",
+              "opacity",
+              "color",
+              "overflow",
+              "flex-shrink",
+            ].map((property) => [property, style.getPropertyValue(property)]),
+          ),
+        };
+      }),
+  );
+}
+// The shared helper deliberately rejects failed image decoding. This fault-only
+// capture keeps the actual broken image and fallback DOM, waits for every other
+// image/font/animation, and requires the same three identical unmasked frames.
+async function captureBrokenIcon(page: Page): Promise<Buffer> {
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+    await Promise.all(
+      Array.from(document.images).map(async (image) => {
+        if (image.currentSrc.endsWith("/icon-broken.svg")) {
+          if (!image.complete || image.naturalWidth !== 0 || !image.hidden)
+            throw new Error("Expected hidden failed image");
+        } else if (image.currentSrc) await image.decode();
+      }),
+    );
+    await Promise.all(
+      document
+        .getAnimations()
+        .filter(
+          (animation) =>
+            animation.effect?.getComputedTiming().iterations !== Infinity,
+        )
+        .map((animation) => animation.finished),
+    );
+    for (const animation of document.getAnimations()) {
+      if (animation.effect?.getComputedTiming().iterations === Infinity) {
+        animation.pause();
+        animation.currentTime = 0;
+      }
+    }
+  });
+  let previous: Buffer | undefined,
+    consecutive = 0;
+  for (let attempt = 0; attempt < 12; attempt++) {
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+        ),
+    );
+    const bytes = await page.screenshot({ fullPage: true, caret: "initial" });
+    consecutive = previous?.equals(bytes) ? consecutive + 1 : 1;
+    if (consecutive === 3) return bytes;
+    previous = bytes;
+  }
+  throw new Error(
+    "Failed-icon page did not produce three identical painted frames",
+  );
+}
+async function run() {
+  const appOrigin = origin(required("app-url")),
+    apiOrigin = origin(required("api-url"));
+  assert.notEqual(appOrigin, apiOrigin);
+  const sourceSha = required("source-sha"),
+    appBuildSha = required("expected-build"),
+    apiBuildSha = required("api-build");
+  for (const sha of [sourceSha, appBuildSha, apiBuildSha])
+    assert(/^[a-f0-9]{40}$/.test(sha));
+  const out = path.resolve(required("out"));
+  const caseBytes = await readFile(
+    path.join(__dirname, "icon-mono-cases.json"),
+  );
+  const fixtureBytes = await readFile(
+    path.join(__dirname, "icon-mono-fixtures.json"),
+  );
+  const fixture: Record<string, unknown> = JSON.parse(fixtureBytes.toString());
+  const caseFile: { version: number; cases: VisualCase[] } = JSON.parse(
+    caseBytes.toString(),
+  );
+  assert.equal(caseFile.version, 1);
+  const runnerSha256 = sha256(
+    Buffer.concat(
+      await Promise.all(
+        [
+          __filename,
+          path.join(__dirname, "capture.ts"),
+          path.join(__dirname, "images.ts"),
+          path.join(__dirname, "bootstrap.ts"),
+          path.join(__dirname, "../lib/preview-bypass.ts"),
+          path.join(__dirname, "../../pnpm-lock.yaml"),
+        ].map((file) => readFile(file)),
+      ),
+    ),
+  );
+  const baseline: Manifest | undefined = values.baseline
+    ? JSON.parse(
+        await readFile(path.join(values.baseline, "manifest.json"), "utf8"),
+      )
+    : undefined;
+  if (baseline) {
+    assert.equal(baseline.protocol, "channel-rounding-v1");
+    assert.equal(baseline.runnerSha256, runnerSha256, "Frozen runner changed");
+    assert.equal(
+      baseline.caseSha256,
+      sha256(caseBytes),
+      "Frozen cases changed",
+    );
+    assert.equal(
+      baseline.fixtureSha256,
+      sha256(fixtureBytes),
+      "Frozen fixture changed",
+    );
+    assert.deepEqual(baseline.roundingTolerance, roundingTolerance);
+    assert.deepEqual(baseline.failures, [], "Cannot accept a failed baseline");
+  }
+  await mkdir(out);
+  const browser = await chromium.launch({
+    executablePath: values["executable-path"],
+    args: browserArgs,
+  });
+  const manifest: Manifest = {
+    version: 1,
+    protocol: "channel-rounding-v1",
+    sourceSha,
+    appBuildSha,
+    apiBuildSha,
+    appOrigin,
+    apiOrigin,
+    browser: browser.version(),
+    runnerSha256,
+    caseSha256: sha256(caseBytes),
+    fixtureSha256: sha256(fixtureBytes),
+    roundingTolerance,
+    cases: caseFile.cases,
+    captures: [],
+    failures: [],
+    apiPaths: [],
+  };
+  try {
+    if (baseline)
+      assert.equal(baseline.browser, manifest.browser, "Browser changed");
+    for (const item of caseFile.cases) {
+      const context = await browser.newContext({
+        storageState: required("storage-state"),
+        viewport: item.viewport,
+        deviceScaleFactor: item.deviceScaleFactor,
+        hasTouch: item.hasTouch,
+        isMobile: item.isMobile,
+        colorScheme: item.theme,
+        locale: "en-US",
+        timezoneId: "UTC",
+        reducedMotion: "reduce",
+      });
+      const page = await context.newPage();
+      page.setDefaultTimeout(30_000);
+      try {
+        await context.clearCookies({ name: "__Secure-okou-theme" });
+        await context.addCookies([
+          {
+            name: "__Secure-okou-theme",
+            value: `v1.${item.theme}`,
+            url: appOrigin,
+            secure: true,
+            sameSite: "Lax",
+          },
+        ]);
+        await seedPreviewBypassCookie(context, appOrigin);
+        await seedPreviewBypassCookie(context, apiOrigin);
+        let brokenIcon = false;
+        const assets = fixture._iconAssets as Record<string, string>;
+        await page.route("https://icons.example.test/**", async (route) => {
+          const url = route.request().url();
+          const body = assets[url];
+          assert(body, "Unknown synthetic icon request");
+          if (brokenIcon && url.endsWith("/icon-broken.svg")) {
+            await route.fulfill({
+              status: 404,
+              contentType: "text/plain",
+              body: "Intentional icon fixture failure",
+            });
+          } else await route.fulfill({ contentType: "image/svg+xml", body });
+        });
+        const responses = {
+          ...fixture,
+          "/api/user-preferences": {
+            ...(fixture["/api/user-preferences"] as object),
+            theme: item.theme,
+          },
+        };
+        await fixtureBootstrap(page, appOrigin, () => responses);
+        await page.route(
+          (url) => url.origin === apiOrigin,
+          async (route) => {
+            const request = route.request(),
+              url = new URL(request.url());
+            if (!manifest.apiPaths.includes(url.pathname))
+              manifest.apiPaths.push(url.pathname);
+            const response: unknown = Reflect.get(responses, url.pathname);
+            if (url.pathname === "/api/attribution/google-ads-account") {
+              await route.fulfill({ json: { googleAdsAccountId: null } });
+              return;
+            }
+            if (url.pathname === "/api/attribution/signup") {
+              await route.fulfill({
+                json: { recorded: true, googleAdsAccountId: null },
+              });
+              return;
+            }
+            if (
+              request.method() === "POST" &&
+              url.pathname === "/api/user-preferences"
+            ) {
+              const update: Record<string, unknown> = request.postDataJSON();
+              for (const [key, value] of Object.entries(update))
+                assert.deepEqual(
+                  value,
+                  Reflect.get(responses["/api/user-preferences"], key),
+                );
+            } else if (
+              request.method() !== "GET" &&
+              request.method() !== "OPTIONS"
+            ) {
+              manifest.failures.push(
+                `${item.id}: prohibited ${request.method()} ${url.pathname}`,
+              );
+              await route.abort();
+              return;
+            }
+            if (response !== undefined) {
+              await route.fulfill({
+                json: response,
+                status:
+                  (fixture._statusCodes as Record<string, number>)[
+                    url.pathname
+                  ] ?? 200,
+              });
+              return;
+            }
+            const secret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+            await route.continue({
+              headers: {
+                ...request.headers(),
+                ...(secret ? { "x-vercel-protection-bypass": secret } : {}),
+              },
+            });
+          },
+        );
+        await page.goto(new URL(item.path, appOrigin).href, {
+          waitUntil: "domcontentloaded",
+        });
+        await expect(
+          page.locator('meta[name="okou-app-git-commit-sha"]'),
+        ).toHaveAttribute("content", appBuildSha);
+        await expect(page.locator("html")).toHaveAttribute(
+          "data-theme",
+          item.theme,
+        );
+        async function capture(state: string, expectedBrokenIcon = false) {
+          await expect(
+            page.locator('meta[name="okou-app-git-commit-sha"]'),
+          ).toHaveAttribute("content", appBuildSha);
+          const id = `${item.id}-${state}`,
+            image = `${id}.png`;
+          const monoImages = page.locator(
+            'img[src*="openai-"], img[src*="okou-logo-mark-dark-"], img[src="https://icons.example.test/icon-mono.svg"]',
+          );
+          for (const icon of await monoImages.all()) {
+            await expect(icon).toHaveCSS(
+              "filter",
+              item.theme === "dark" ? "invert(1)" : "none",
+            );
+            assert.equal(
+              await icon.getAttribute("data-theme"),
+              null,
+              "Theme must remain on an ancestor",
+            );
+          }
+          for (const icon of await page
+            .locator(
+              'img[src*="claude-code-"], img[src*="deepseek-"], img[src="https://icons.example.test/icon-color.svg"]',
+            )
+            .all()) {
+            await expect(icon).toHaveCSS("filter", "none");
+          }
+          if (state === "portaled-options") {
+            assert(
+              await page
+                .getByRole("listbox")
+                .evaluate((element) =>
+                  Boolean(element.closest("[data-base-ui-portal]")),
+                ),
+              "Options must use a real portal",
+            );
+          }
+          await page.mouse.move(0, 0);
+          await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
+          const bytes = expectedBrokenIcon
+              ? await captureBrokenIcon(page)
+              : await stableScreenshot(page),
+            observation = await observe(page);
+          await writeFile(path.join(out, image), bytes, { flag: "wx" });
+          const record: Capture = {
+            id,
+            image,
+            sha256: sha256(bytes),
+            observation,
+            status: "BASELINE",
+          };
+          if (baseline && values.baseline) {
+            const reference = baseline.captures.find(
+              (entry) => entry.id === id,
+            );
+            assert(reference, `Missing ${id}`);
+            assert.equal(reference.image, image);
+            const before = await readFile(path.join(values.baseline, image));
+            assert.equal(sha256(before), reference.sha256);
+            const result = compareImages(before, bytes);
+            record.changedPixels = result.changedPixels;
+            record.contentChangedPixels = result.contentChangedPixels;
+            record.roundingPixels = result.roundingPixels;
+            const observationsEqual =
+              JSON.stringify(reference.observation) ===
+              JSON.stringify(observation);
+            record.status =
+              result.contentChangedPixels === 0 && observationsEqual
+                ? "PASS"
+                : "FAIL";
+            await writeFile(path.join(out, `${id}-before.png`), before, {
+              flag: "wx",
+            });
+            await writeFile(path.join(out, `${id}-diff.png`), result.diff, {
+              flag: "wx",
+            });
+            if (record.status === "FAIL")
+              manifest.failures.push(
+                `${id}: ${result.contentChangedPixels} content pixels; observationsEqual=${observationsEqual}`,
+              );
+          }
+          manifest.captures.push(record);
+          console.log(`${id}: ${record.status} ${record.changedPixels ?? ""}`);
+        }
+        if (item.surface === "providers") {
+          await expect(
+            page.getByRole("dialog", { name: "Settings", exact: true }),
+          ).toBeVisible();
+          const dialog = page.getByRole("dialog", {
+            name: "Settings",
+            exact: true,
+          });
+          const personal = dialog.getByRole("heading", {
+            name: "Personal",
+            exact: true,
+          });
+          await expect(
+            dialog.locator('img[src*="claude-code-"]'),
+          ).toBeAttached();
+          await expect(
+            dialog.locator('img[src*="openai-"]').last(),
+          ).toBeAttached();
+          const picker = dialog
+            .getByRole("combobox")
+            .filter({ hasText: "DeepSeek V4 Pro" });
+          await expect(picker).toBeVisible();
+          await capture("models");
+          await picker.click();
+          const list = page.getByRole("listbox");
+          await expect(list).toBeVisible();
+          await expect(list.locator("img")).toHaveCount(3);
+          await capture("portaled-options");
+          await page.keyboard.press("Escape");
+          await expect(list).not.toBeVisible();
+          await personal.scrollIntoViewIfNeeded();
+          await dialog
+            .locator('img[src*="claude-code-"]')
+            .scrollIntoViewIfNeeded();
+          await expect(
+            dialog.locator('img[src*="claude-code-"]'),
+          ).toBeInViewport({ ratio: 1 });
+          await expect(
+            dialog.locator('img[src*="openai-"]').last(),
+          ).toBeInViewport({ ratio: 1 });
+          await capture("personal");
+        } else {
+          await expect(
+            page.getByText("Icon Mono", { exact: true }),
+          ).toBeVisible();
+          await expect(
+            page.getByText("Icon Color", { exact: true }),
+          ).toBeVisible();
+          await expect(
+            page.getByRole("img", {
+              name: "Connector icon unavailable",
+              exact: true,
+            }),
+          ).toBeVisible();
+          await capture("page");
+          brokenIcon = true;
+          await page.reload({ waitUntil: "domcontentloaded" });
+          await expect(
+            page.locator(
+              'img[src="https://icons.example.test/icon-broken.svg"]',
+            ),
+          ).toHaveAttribute("hidden", "");
+          await expect(
+            page.getByRole("img", {
+              name: "Connector icon unavailable",
+              exact: true,
+            }),
+          ).toHaveCount(2);
+          await capture("failed-image", true);
+        }
+      } catch (error) {
+        const failure = `${item.id}: ${error instanceof Error ? error.message : String(error)}`;
+        manifest.failures.push(failure);
+        console.error(failure);
+        await page.screenshot({
+          path: path.join(out, `${item.id}-failure.png`),
+          fullPage: true,
+        });
+        await writeFile(
+          path.join(out, `${item.id}-failure.txt`),
+          await page.locator("body").innerText(),
+          { flag: "wx" },
+        );
+      } finally {
+        await context.close();
+      }
+    }
+    if (baseline)
+      assert.equal(manifest.captures.length, baseline.captures.length);
+  } finally {
+    await writeFile(
+      path.join(out, "manifest.json"),
+      JSON.stringify(manifest, null, 2) + "\n",
+      { flag: "wx" },
+    );
+    await browser.close();
+  }
+  assert.equal(
+    manifest.failures.length,
+    0,
+    "Visual acceptance failed; all evidence retained",
+  );
+}
+void run().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/e2e/playwright/style-migration/run-icon-mono.ts
+++ b/e2e/playwright/style-migration/run-icon-mono.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parseArgs } from "node:util";
 import {
@@ -254,6 +254,11 @@ async function run() {
     failures: [],
     apiPaths: [],
   };
+  await writeFile(
+    path.join(out, "run-start.json"),
+    JSON.stringify(manifest, null, 2) + "\n",
+    { flag: "wx" },
+  );
   try {
     if (baseline)
       assert.equal(baseline.browser, manifest.browser, "Browser changed");
@@ -411,6 +416,21 @@ async function run() {
             );
           }
           await page.mouse.move(0, 0);
+          // Invalidate cached narrow-DPR text-decoration raster after dialogs settle.
+          // Restore the exact case viewport before measuring; no DOM or CSS changes.
+          await page.setViewportSize({
+            ...item.viewport,
+            width: item.viewport.width + 1,
+          });
+          await page.evaluate(
+            () =>
+              new Promise<void>((resolve) =>
+                requestAnimationFrame(() =>
+                  requestAnimationFrame(() => resolve()),
+                ),
+              ),
+          );
+          await page.setViewportSize(item.viewport);
           await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
           const bytes = expectedBrokenIcon
               ? await captureBrokenIcon(page)
@@ -455,6 +475,10 @@ async function run() {
               );
           }
           manifest.captures.push(record);
+          await appendFile(
+            path.join(out, "captures.jsonl"),
+            JSON.stringify(record) + "\n",
+          );
           console.log(`${id}: ${record.status} ${record.changedPixels ?? ""}`);
         }
         if (item.surface === "providers") {

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -509,12 +509,6 @@ body {
   color: hsl(var(--muted-foreground));
 }
 
-/* Monochrome SVG icons (e.g. connector marks as <img>): invert in dark mode.
-   Scoped to [data-theme="dark"] only—not .okou-app—so portaled popovers/dropdowns still match. */
-:where([data-theme="dark"]) .okou-icon-mono {
-  filter: invert(1);
-}
-
 /* Reusable 0.7px border utilities — replaces inline style={{ border: "0.7px solid ..." }} */
 /* Force the color-emoji font ahead of the inherited CJK/text stack so emoji
    glyphs render in color. Without this, dual-presentation codepoints fall back

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-icons.tsx
@@ -56,7 +56,7 @@ export function ConnectorIcon({
             decoding="async"
             className={cn(
               "block h-full w-full max-h-full max-w-full object-contain",
-              icon.invertInDarkMode && "okou-icon-mono",
+              icon.invertInDarkMode && "dark:invert",
             )}
             style={
               icon.scale === undefined

--- a/turbo/apps/platform/src/views/okou-page/components/settings/provider-icons.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/provider-icons.tsx
@@ -50,7 +50,7 @@ export function ProviderIcon({
       alt=""
       className={cn(
         "shrink-0",
-        providerIconNeedsDarkInvert(type) && "okou-icon-mono",
+        providerIconNeedsDarkInvert(type) && "dark:invert",
       )}
     />
   );

--- a/turbo/style-legacy-baseline.json
+++ b/turbo/style-legacy-baseline.json
@@ -38,7 +38,6 @@
     "okou-desktop-titlebar-drag-region",
     "okou-emoji",
     "okou-fixed-viewport-shell",
-    "okou-icon-mono",
     "okou-managed-bottom-safe-area",
     "okou-markdown-card",
     "okou-mobile-fixed-safe-area",
@@ -691,13 +690,6 @@
         "selector": ".okou-app .okou-pill",
         "property": "color",
         "value": "hsl(var(--muted-foreground))",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ":where([data-theme=\"dark\"]) .okou-icon-mono",
-        "property": "filter",
-        "value": "invert(1)",
         "important": false
       },
       {
@@ -4019,9 +4011,6 @@
       "okou-badge": 4,
       "okou-border": 1
     },
-    "apps/platform/src/views/okou-page/components/settings/connector-icons.tsx": {
-      "okou-icon-mono": 1
-    },
     "apps/platform/src/views/okou-page/components/settings/indexeddb-diagnostics-block.tsx": {
       "okou-badge": 3,
       "okou-border": 1
@@ -4037,9 +4026,6 @@
     },
     "apps/platform/src/views/okou-page/components/settings/preference-card-row.tsx": {
       "okou-border": 1
-    },
-    "apps/platform/src/views/okou-page/components/settings/provider-icons.tsx": {
-      "okou-icon-mono": 1
     },
     "apps/platform/src/views/okou-page/components/settings/sections/account-section.tsx": {
       "okou-border": 1

--- a/turbo/style-migration-manifest.json
+++ b/turbo/style-migration-manifest.json
@@ -241,7 +241,8 @@
         "icon-mono-connectors-narrow-dark"
       ],
       "status": "planned",
-      "evidence": []
+      "evidence": [],
+      "pullRequest": "https://github.com/vm0-ai/vm0/pull/33062"
     }
   ],
   "caseFiles": [

--- a/turbo/style-migration-manifest.json
+++ b/turbo/style-migration-manifest.json
@@ -300,6 +300,18 @@
           "url": "https://a.okou.io/aeguxfgxpx.zip",
           "sha256": "af8a4226a522d7ad41510bbb4ccb8b05b4dd44b7cafcd9c3794789367d02def8",
           "commit": "ad820032f6237598b8abed4c46e31979d7007ae2"
+        },
+        {
+          "kind": "after-with-before-raw-diffs-and-focused-checks",
+          "url": "https://a.okou.io/gywva3k9z6.zip",
+          "sha256": "4a50697ce0fc0243ea64be3b0314f0255b76acdc606d07efd45f0631d4e1181d",
+          "commit": "29156a9e945af833fdef2bffe024be4c617d4496"
+        },
+        {
+          "kind": "before-after-raw-diff-comparison-image",
+          "url": "https://a.okou.io/vfjoaz2ylx.png",
+          "sha256": "6b77a43d84c569f85ef9e9cd2a7cbb9277bfd9bb780d9b5018d015125b7a15ad",
+          "commit": "29156a9e945af833fdef2bffe024be4c617d4496"
         }
       ],
       "pullRequest": "https://github.com/vm0-ai/vm0/pull/33062"

--- a/turbo/style-migration-manifest.json
+++ b/turbo/style-migration-manifest.json
@@ -221,10 +221,32 @@
         }
       ],
       "pullRequest": "https://github.com/vm0-ai/vm0/pull/32873"
+    },
+    {
+      "id": "monochrome-icon-filter",
+      "family": "local-controls",
+      "tokens": ["okou-icon-mono"],
+      "consumers": [
+        "apps/platform/src/views/okou-page/components/settings/provider-icons.tsx",
+        "apps/platform/src/views/okou-page/components/settings/connector-icons.tsx"
+      ],
+      "cases": [
+        "icon-mono-providers-light",
+        "icon-mono-connectors-light",
+        "icon-mono-providers-dark",
+        "icon-mono-connectors-dark",
+        "icon-mono-providers-narrow",
+        "icon-mono-connectors-narrow",
+        "icon-mono-providers-narrow-dark",
+        "icon-mono-connectors-narrow-dark"
+      ],
+      "status": "planned",
+      "evidence": []
     }
   ],
   "caseFiles": [
     "../e2e/playwright/style-migration/cases.json",
-    "../e2e/playwright/style-migration/tone-cases.json"
+    "../e2e/playwright/style-migration/tone-cases.json",
+    "../e2e/playwright/style-migration/icon-mono-cases.json"
   ]
 }

--- a/turbo/style-migration-manifest.json
+++ b/turbo/style-migration-manifest.json
@@ -293,8 +293,15 @@
         "icon-mono-providers-narrow-dark",
         "icon-mono-connectors-narrow-dark"
       ],
-      "status": "planned",
-      "evidence": [],
+      "status": "implemented",
+      "evidence": [
+        {
+          "kind": "before-and-unchanged-aa-with-rejected-calibration",
+          "url": "https://a.okou.io/aeguxfgxpx.zip",
+          "sha256": "af8a4226a522d7ad41510bbb4ccb8b05b4dd44b7cafcd9c3794789367d02def8",
+          "commit": "ad820032f6237598b8abed4c46e31979d7007ae2"
+        }
+      ],
       "pullRequest": "https://github.com/vm0-ai/vm0/pull/33062"
     }
   ],

--- a/turbo/style-migration-manifest.json
+++ b/turbo/style-migration-manifest.json
@@ -293,7 +293,7 @@
         "icon-mono-providers-narrow-dark",
         "icon-mono-connectors-narrow-dark"
       ],
-      "status": "implemented",
+      "status": "verified",
       "evidence": [
         {
           "kind": "before-and-unchanged-aa-with-rejected-calibration",
@@ -312,6 +312,12 @@
           "url": "https://a.okou.io/vfjoaz2ylx.png",
           "sha256": "6b77a43d84c569f85ef9e9cd2a7cbb9277bfd9bb780d9b5018d015125b7a15ad",
           "commit": "29156a9e945af833fdef2bffe024be4c617d4496"
+        },
+        {
+          "kind": "evidence-only-head-after-replay-with-ci-and-live-preview",
+          "url": "https://a.okou.io/okin45nt2v.zip",
+          "sha256": "96b259d89bfbbdae4eb4c9effd1f7539087988f0f5745d7497333b99078c9e68",
+          "commit": "a7aae2beca69ca7c0075bf79af4b9cccaf4f006b"
         }
       ],
       "pullRequest": "https://github.com/vm0-ai/vm0/pull/33062"


### PR DESCRIPTION
Refs #32402

Replace the final `okou-icon-mono` references in `ProviderIcon` and `ConnectorIcon` with `dark:invert`, delete their legacy CSS rule, and prune only this batch's ratchet entries. Native images, dimensions, events, scaling, colored marks and missing/failed-image fallbacks are preserved. Both consumers keep theme on an ancestor, including portaled model options; neither accepts another filter class or a theme attribute on the image.

Legacy inventory: 94 → 93 tokens, 534 → 533 declarations, 309 → 307 production uses; two injections remain. No shared helper, component or token changes.

Validation:

- 20/20 unchanged A/A and 20/20 final-head AFTER states pass with zero changed pixels and identical icon observations. Eight frozen cases cover Models, personal providers and Connectors in Light/Dark desktop and narrow touch/DPR 2, including a real portaled picker and missing/failed-image fixtures.
- Complete style lint, affected App types/ESLint/Knip, E2E types, formatting and four selected existing page tests pass (52 unselected).
- All current-head PR checks are successful or skipped by existing CI conditions; the complete Turbo pipeline passes.

Evidence (anonymously downloaded and SHA256-verified):

- [BEFORE and unchanged A/A](https://a.okou.io/aeguxfgxpx.zip), uploaded before business-style edits; retains every rejected calibration attempt.
- [Canonical batch AFTER and CI](https://a.okou.io/okin45nt2v.zip), recorded in the migration manifest.
- [Final-head replay, raw PNGs/diffs and CI](https://a.okou.io/n6mvo55a37.zip), SHA256 `1b3795a2d8e40ec72515c1c53a235e9ccbc1215aa6053708a83cc8dc54bf4d5c`.
- [BEFORE / AFTER / raw DIFF comparison](https://a.okou.io/vfjoaz2ylx.png), byte-identical for the final-head replay.

Final source: `8584666e0f5785afa84596a4146361654f20ef97`. App/API build: `6221cc191fbfb6379a3b9b4c38cda7e09044990b`, including main `b440c7b27c62b2b79afe88a9762cc51c790bfb95`. The checkout began at `11f142b4b65a2b80f5ccf6b3c5c3ec41deb6fd67` and integrated `29dfab14531307e67d16322d5fa3972df9c42a99` before the accepted baseline. Subsequent commits only record acceptance metadata; source-equivalence proof is archived.

Preview: https://pr-33062-app-okou-app-preview.vm0.workers.dev/connectors?settings=model; API: https://pr-33062-api.vm6.ai. The complete private acceptance link is supplied in the task chat. After Preview TEST login/onboarding, compare Models and Connectors in Light/Dark and open the default-model picker. The independent runner reproduces fault and narrow-DPR cases with deterministic initial-HTML bootstrap and API fixtures; full fixture and actual feature switches are archived. No live switches, connector authorizations or Agent runs were changed or started.

Chromium 152.0.7977.82, runner, fixtures, cases and original rounding limits remain frozen; no masks or widened thresholds. This is bounded Chromium acceptance. No local dev server or full local Vitest suite was used.
