### PR TITLE
fix(platform): match the flyout panel's surface and close it on selection

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
@@ -740,4 +740,10 @@ test("Choose a model from the flyout without leaving the type list", async () =>
   expect(next).toHaveFocus();
   click(next);
   await expect(findButton("GPT 5.6 Luna")).resolves.toBeVisible();
+  // Picking a model finishes the task, so the panel leaves with it.
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("listbox", { name: "Chat models" }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -9689,6 +9689,9 @@ function ComposerRunModelPickerControl({
             : undefined
         }
         flyoutLayout={modelFlyoutEnabled}
+        onSelected={() => {
+          setModelPickerOpen(false);
+        }}
         compactTrigger
         mobileIconTrigger
         open={modelPickerOpen}

--- a/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
@@ -472,16 +472,18 @@ function ModelPickerFlyoutTypeRow({
   onActivate: () => void;
 }) {
   return (
-    <button
+    <Button
       type="button"
+      variant="ghost"
       role="tab"
       aria-selected={active}
       aria-posinset={index + 1}
       aria-setsize={total}
       tabIndex={active ? 0 : -1}
       className={cn(
-        "flex h-11 w-full items-center gap-2 rounded-lg px-2 text-left transition-colors",
-        "hover:bg-state-hover focus-visible:ring-inset",
+        // shrink-0 keeps the row at its own height: a flex column with a
+        // max-height compresses its children before it will scroll.
+        "h-11 w-full shrink-0 justify-start gap-2 px-2 text-left font-normal",
         active && "bg-state-hover",
       )}
       onMouseEnter={onActivate}
@@ -504,7 +506,7 @@ function ModelPickerFlyoutTypeRow({
         aria-hidden="true"
         className="shrink-0 text-muted-foreground"
       />
-    </button>
+    </Button>
   );
 }
 
@@ -524,8 +526,9 @@ function ModelPickerFlyoutOption({
   onSelect: () => void;
 }) {
   return (
-    <button
+    <Button
       type="button"
+      variant="ghost"
       role="option"
       aria-selected={selected}
       aria-posinset={index + 1}
@@ -535,10 +538,12 @@ function ModelPickerFlyoutOption({
       aria-disabled={disabled || undefined}
       tabIndex={-1}
       className={cn(
-        "relative flex h-9 w-full items-center gap-2 rounded-lg py-0 pl-2 pr-8 text-left",
-        "text-[13px] font-normal text-foreground transition-colors",
-        "focus-visible:ring-inset",
-        disabled ? "opacity-55" : "hover:bg-state-hover",
+        // shrink-0: without it a long list compresses every row instead of
+        // scrolling, so the same row is 36px in a short list and 26px in a
+        // long one.
+        "relative h-9 w-full shrink-0 justify-start gap-2 pl-2 pr-8 text-left",
+        "text-[13px] font-normal text-foreground",
+        disabled && "opacity-55 hover:bg-transparent active:bg-transparent",
       )}
       onClick={() => {
         if (!disabled) {
@@ -550,7 +555,7 @@ function ModelPickerFlyoutOption({
       {selected && (
         <Check size={15} aria-hidden="true" className="absolute right-2" />
       )}
-    </button>
+    </Button>
   );
 }
 

--- a/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
@@ -163,6 +163,8 @@ interface ModelPickerMenuContentProps {
   options: readonly ModelPickerMenuOption[];
   mediaModelPanel: MediaModelPanelState | undefined;
   onChange: (selection: ModelProviderSelection) => void;
+  /** Only the flyout uses it: the menu's pages stay open after a selection. */
+  onSelected?: (() => void) | undefined;
 }
 
 function ModelPickerOverview({
@@ -438,12 +440,13 @@ function MediaModelList({
 }
 
 /**
- * Both flyout panels wear the shared popover surface rather than a hand-rolled
- * card: same 0.7px gray-400 hairline, same radius, and no drop shadow, which
- * the design system does not use for popovers.
+ * The type rail is the popover surface itself. The flyout panel floats outside
+ * that box, so it restates the same surface -- hairline, radius and the
+ * popover's own drop shadow, which PopoverContent applies as an inline style
+ * and `shadow-lg` reproduces exactly.
  */
 const FLYOUT_PANEL_CLASS =
-  "rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-1 text-foreground outline-none";
+  "rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-1 text-foreground shadow-lg outline-none";
 
 /**
  * Flyout layout: model types on the left, that type's models in a panel beside
@@ -556,11 +559,13 @@ function ModelPickerFlyoutOptions({
   options,
   value,
   onChange,
+  onSelected,
 }: {
   activeMedia: MediaModelPanelState["categories"][number] | undefined;
   options: readonly ModelPickerMenuOption[];
   value: ModelProviderSelection | null;
   onChange: (selection: ModelProviderSelection) => void;
+  onSelected: (() => void) | undefined;
 }) {
   if (activeMedia) {
     return activeMedia.options.map((option, index) => {
@@ -581,7 +586,10 @@ function ModelPickerFlyoutOptions({
           disabled={false}
           index={index}
           total={activeMedia.options.length}
-          onSelect={option.onSelect}
+          onSelect={() => {
+            option.onSelect();
+            onSelected?.();
+          }}
         />
       );
     });
@@ -601,6 +609,9 @@ function ModelPickerFlyoutOptions({
               ? value
               : { selectedModel: option.model },
           );
+          // Picking a model is the whole task: leave rather than making the
+          // user dismiss a panel that has nothing left to offer.
+          onSelected?.();
         }}
       />
     );
@@ -614,6 +625,7 @@ export function ModelPickerFlyoutContent({
   options,
   mediaModelPanel,
   onChange,
+  onSelected,
 }: ModelPickerMenuContentProps) {
   const { t } = useTranslation();
   const category = useGet(signals.flyoutCategory$);
@@ -664,7 +676,7 @@ export function ModelPickerFlyoutContent({
   return (
     <div
       ref={rootRef}
-      className="relative w-[188px]"
+      className="relative"
       onKeyDown={(event) => {
         moveFlyoutFocus(event, types.length);
       }}
@@ -676,7 +688,7 @@ export function ModelPickerFlyoutContent({
           aria-label={t(($) => {
             return $.settings.models.picker.models;
           })}
-          className={cn("flex flex-col gap-0.5", FLYOUT_PANEL_CLASS)}
+          className="flex flex-col gap-0.5"
         >
           {types.map((type, index) => {
             return (
@@ -701,16 +713,16 @@ export function ModelPickerFlyoutContent({
         role="listbox"
         aria-label={panelLabel}
         className={cn(
-          "flex max-h-[284px] w-[252px] flex-col gap-0.5 overflow-y-auto overscroll-contain",
-          FLYOUT_PANEL_CLASS,
+          "flex max-h-[284px] flex-col gap-0.5 overflow-y-auto overscroll-contain",
           types.length > 1
             ? cn(
-                "absolute bottom-0",
+                "absolute bottom-0 w-[252px]",
+                FLYOUT_PANEL_CLASS,
                 side === "right"
                   ? "left-[calc(100%+6px)]"
                   : "right-[calc(100%+6px)]",
               )
-            : "w-[252px]",
+            : "w-full",
         )}
       >
         <ModelPickerFlyoutOptions
@@ -718,6 +730,7 @@ export function ModelPickerFlyoutContent({
           options={options}
           value={value}
           onChange={onChange}
+          onSelected={onSelected}
         />
         {options.length === 0 && !activeMedia && (
           <p className="px-2 py-2 text-sm text-muted-foreground">

--- a/turbo/apps/platform/src/views/okou-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-provider-picker.tsx
@@ -163,6 +163,8 @@ interface ModelProviderPickerProps {
   menuSignals?: ModelPickerMenuSignals;
   /** Replaces the menu's pages with the detached type/model flyout. */
   flyoutLayout?: boolean;
+  /** Lets the flyout dismiss itself once a model has been committed. */
+  onSelected?: () => void;
   /** Model omitted from this caller's list of available choices. */
   excludedModel?: SupportedRunModel;
 }
@@ -1350,6 +1352,7 @@ function SubscribedExplicitModelFirstModelPickerContent({
   showInheritOption,
   menuSignals,
   flyoutLayout,
+  onSelected,
   onMenuChange,
 }: {
   value: ModelProviderSelection | null;
@@ -1361,6 +1364,7 @@ function SubscribedExplicitModelFirstModelPickerContent({
   showInheritOption: boolean;
   menuSignals: ModelPickerMenuSignals | undefined;
   flyoutLayout: boolean;
+  onSelected: (() => void) | undefined;
   onMenuChange: (selection: ModelProviderSelection) => void;
 }) {
   const { t } = useTranslation();
@@ -1419,6 +1423,7 @@ function SubscribedExplicitModelFirstModelPickerContent({
         placeholder={placeholder}
         mediaModelPanel={mediaModelPanel}
         onChange={onMenuChange}
+        onSelected={onSelected}
         options={state.policies.map((policy) => {
           return {
             model: policy.model,
@@ -1512,6 +1517,7 @@ function EnabledExplicitModelFirstModelPicker(
       showInheritOption={props.showInheritOption ?? false}
       menuSignals={props.menuSignals}
       flyoutLayout={props.flyoutLayout ?? false}
+      onSelected={props.onSelected}
       onMenuChange={handleSelectionChange}
     />
   );
@@ -1556,9 +1562,9 @@ function EnabledExplicitModelFirstModelPicker(
           aria-label={props.placeholder}
           className={cn(
             props.flyoutLayout
-              ? // Each flyout panel carries its own card, so the popover itself
-                // must not paint one -- otherwise they read as a single box.
-                "w-auto border-0 bg-transparent p-0 shadow-none"
+              ? // The popover is the type rail's own card, so it keeps the
+                // component's hairline and shadow and only resizes.
+                "w-[188px] max-w-[calc(100vw-16px)] p-1"
               : "w-[304px] max-w-[calc(100vw-16px)] max-h-[var(--available-height)] overflow-y-auto overscroll-contain p-1",
           )}
         >
@@ -1599,6 +1605,7 @@ export function ModelProviderPicker({
   mediaModelPanel,
   menuSignals,
   flyoutLayout = false,
+  onSelected,
   excludedModel,
 }: ModelProviderPickerProps) {
   const { t } = useTranslation();
@@ -1638,6 +1645,7 @@ export function ModelProviderPicker({
       excludedModel={excludedModel}
       menuSignals={menuSignals}
       flyoutLayout={flyoutLayout}
+      {...(onSelected ? { onSelected } : {})}
       {...(mediaModelPanel ? { mediaModelPanel } : {})}
     />
   );


### PR DESCRIPTION
## What

Three fixes to the model picker flyout, all found on the Lab build.

**Mismatched shadow.** `PopoverContent` applies its drop shadow as an inline
`style`, not a class, so the `shadow-none` the flyout passed could never remove
it: the type rail carried the popover's shadow while the floating panel, which
painted its own card, had none. The popover is now the rail's card — it keeps
the component's hairline, radius and shadow and only overrides the width — and
the floating panel restates that same surface, with `shadow-lg` reproducing the
popover's inline shadow exactly.

**Selection left the panel open.** Picking a model committed the selection but
left the flyout up with nothing else to offer. The composer owns the open state,
so it passes a close callback the flyout invokes once a selection is committed;
this covers chat models and media models alike.

**Rows compressed instead of scrolling.** A flex column with a max-height
shrinks its children before it scrolls, and the rows carried no `shrink-0`.
Seven chat models fit inside the 284px panel, so those rows kept their 36px; ten
image models did not, so every row was squeezed to roughly 26px and the list
never scrolled — the same row rendered at a different height depending on how
many models the category had. Both row types now take `shrink-0`, so a long list
scrolls at its max height, and both are built from the shared ghost `Button`
instead of a raw element with hand-written hover, focus and disabled classes.

## Verification

- `chat-composer-model-selection.test.tsx` + `chat-composer-media-models.test.tsx`
  — 35 passed, with the flyout case asserting the panel is gone after a model is
  picked.
- `pnpm check-types` in `turbo/apps/platform` — clean.
- `eslint --max-warnings 0` on the changed files, `prettier --check`, and
  `node scripts/style-policy.mjs` — clean.

The shadow and the row compression are computed layout that jsdom does not
produce, so both are verified against the Lab build rather than by assertions.

## Fallbacks

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)