### PR TITLE
fix(connectors): place remote access before custom connectors

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-ssh.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-ssh.test.tsx
@@ -1,5 +1,6 @@
 import { agentSshAccessContract } from "@okouai/api-contracts/contracts/ssh-access";
 import { sshConnectionsContract } from "@okouai/api-contracts/contracts/ssh-connections";
+import { customConnectorsContract } from "@okouai/api-contracts/contracts/custom-connectors";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { connectorSlugSchema } from "@okouai/api-contracts/contracts/connector-identity";
 import { screen, waitFor, within } from "@testing-library/react";
@@ -12,6 +13,7 @@ import {
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
+  customConnector,
   getConnectorAction,
   listAgent,
   mockConnectors,
@@ -24,7 +26,7 @@ const context = testContext();
 const agentId = "c0000000-0000-4000-8000-000000000001";
 
 test.each([0, 2])(
-  "SSH with %i hosts remains visible in the directory and respects its category filter",
+  "SSH with %i hosts appears before custom connectors and respects its category filter",
   async (configuredCount) => {
     mockCatalog();
     mockPublicConnectorStatus(
@@ -42,6 +44,9 @@ test.each([0, 2])(
     context.mocks.api(sshConnectionsContract.summary, ({ respond }) => {
       return respond(200, { configuredCount });
     });
+    context.mocks.api(customConnectorsContract.list, ({ respond }) => {
+      return respond(200, { connectors: [customConnector()] });
+    });
     await setupPage({
       context,
       path: "/connectors",
@@ -51,7 +56,14 @@ test.each([0, 2])(
       },
     });
     await screen.findByTestId("connector-shelf-communication-collaboration");
-    await screen.findByRole("heading", { name: "Remote access" });
+    const remoteAccess = await screen.findByRole("heading", {
+      name: "Remote access",
+    });
+    const custom = await screen.findByText("Acme Search");
+    expect(
+      remoteAccess.compareDocumentPosition(custom) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(getConnectorAction("link", "Manage SSH hosts")).toHaveAttribute(
       "href",
       configuredCount === 0 ? "/connectors/ssh?add=1" : "/connectors/ssh",

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -949,6 +949,7 @@ function ConnectorsBuiltinPanel({
   browse,
   renderCard,
   fallback,
+  remoteAccessPanel,
   customPanel,
 }: {
   readonly browse: ConnectorsBrowseModel;
@@ -956,6 +957,7 @@ function ConnectorsBuiltinPanel({
     connector: PlatformConnectorCatalogStatusItem,
   ) => ReactNode;
   readonly fallback: ReactNode;
+  readonly remoteAccessPanel: ReactNode;
   readonly customPanel: ReactNode;
 }) {
   return (
@@ -969,11 +971,9 @@ function ConnectorsBuiltinPanel({
       ) : (
         fallback
       )}
-      {/* Custom connectors used to be a tab. They are one more thing the
-          directory offers, so they sit at the end of it rather than behind a
-          switch of surfaces. They belong to the directory view only: the
-          panel does not read the page's keyword, so under a search or inside
-          a category it would answer a question nobody asked. */}
+      {remoteAccessPanel}
+      {/* Custom connectors end the directory, after Remote access. The panel
+          does not read the page's filters, so only show it while browsing. */}
       {browse.showShelves && customPanel}
     </>
   );
@@ -1542,20 +1542,22 @@ export function ConnectorsPage() {
     connectionFilter,
   });
   const builtinPanel = (
-    <>
-      <ConnectorsBuiltinPanel
-        browse={browse}
-        renderCard={renderCard}
-        fallback={builtinList}
-        customPanel={<CustomConnectorsPanel />}
-      />
-      <SshDirectoryLoadError />
-      <SshShelfCategory
-        enabled={browse.showShelves}
-        groups={grouped}
-        renderCard={renderPresentationCard}
-      />
-    </>
+    <ConnectorsBuiltinPanel
+      browse={browse}
+      renderCard={renderCard}
+      fallback={builtinList}
+      remoteAccessPanel={
+        <>
+          <SshDirectoryLoadError />
+          <SshShelfCategory
+            enabled={browse.showShelves}
+            groups={grouped}
+            renderCard={renderPresentationCard}
+          />
+        </>
+      }
+      customPanel={<CustomConnectorsPanel />}
+    />
   );
   return (
     <div


### PR DESCRIPTION
## Summary

- Render Remote access before custom connectors when browsing the unified Connectors directory.
- Keep SSH load errors and shelf visibility in their existing flow while letting the directory panel own section order.
- Extend the existing page integration test to assert ordering with zero and two configured SSH hosts.

Closes #33104

## Scope

This only changes section order under `connectorDirectory`. Search/category filtering, the flag-disabled tabbed layout, SSH host links, and connector connection/management workflows are preserved. No API, feature-switch default, or card styling changes.

## Validation

The new order assertion failed on the original implementation for both host counts, then passed with the fix. All checks below passed for the submitted source.

From `turbo/`:

```sh
pnpm exec prettier --check apps/platform/src/views/okou-page/connectors-page.tsx apps/platform/src/views/okou-page/__tests__/connectors-ssh.test.tsx
pnpm -F @okouai/app check-types
pnpm exec knip --workspace @okouai/app
pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/connectors-ssh.test.tsx src/views/okou-page/__tests__/connectors-catalog.test.tsx src/views/okou-page/__tests__/connectors-custom.test.tsx --maxWorkers=2 --silent=passed-only
```

Vitest: **3 files, 53 tests passed**.

From `turbo/apps/platform/`:

```sh
pnpm exec oxlint --deny-warnings src/views/okou-page/connectors-page.tsx src/views/okou-page/__tests__/connectors-ssh.test.tsx
pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings src/views/okou-page/connectors-page.tsx src/views/okou-page/__tests__/connectors-ssh.test.tsx
pnpm exec eslint src/views/okou-page/connectors-page.tsx src/views/okou-page/__tests__/connectors-ssh.test.tsx --max-warnings 0
```

`git diff --check` also passed.

The commit hooks also passed repository style policy, full-workspace `pnpm knip`, `TSC_CHECKERS=2 pnpm check-types` (14 tasks), file-size checks, and commit-message validation.
