### PR TITLE
fix(desktop): recover computer use after background auth refresh

### DIFF
--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -28,6 +28,7 @@ import {
 import { resolveComputerUseApiBaseUrl } from "./desktop-api-base-url";
 import type { DesktopClientHeaderInjector } from "./desktop-client-headers";
 import type { ComputerUseCommandSession } from "./computer-use-driver";
+import type { DesktopAuthRequestOptions } from "./desktop-auth-session";
 
 const HEARTBEAT_POLL_MS = 2_000;
 const COMMAND_COLD_POLL_MS = 5_000;
@@ -61,6 +62,12 @@ export type ComputerUseHostFetch = (
   init?: RequestInit,
 ) => Promise<Response>;
 
+type ComputerUseSessionFetch = (
+  input: string,
+  init?: RequestInit,
+  options?: DesktopAuthRequestOptions,
+) => Promise<Response>;
+
 type MaybePromise<T> = T | Promise<T>;
 
 interface ComputerUseHostRuntimeOptions {
@@ -69,7 +76,7 @@ interface ComputerUseHostRuntimeOptions {
   readonly installationId: string;
   readonly hostName: string;
   readonly appVersion: string;
-  readonly sessionFetch: ComputerUseHostFetch;
+  readonly sessionFetch: ComputerUseSessionFetch;
   readonly hostFetch: ComputerUseHostFetch;
   readonly addClientHeaders: DesktopClientHeaderInjector;
   readonly getPermissions: (
@@ -250,7 +257,7 @@ export class ComputerUseHostRuntime {
   private readonly installationId: string;
   private readonly hostName: string;
   private readonly appVersion: string;
-  private readonly sessionFetch: ComputerUseHostFetch;
+  private readonly sessionFetch: ComputerUseSessionFetch;
   private readonly hostFetchRequest: ComputerUseHostFetch;
   private readonly addClientHeaders: DesktopClientHeaderInjector;
   private readonly getPermissions: ComputerUseHostRuntimeOptions["getPermissions"];
@@ -270,7 +277,6 @@ export class ComputerUseHostRuntime {
   private commandExecutionRunning = false;
   private draining = false;
   private sessionGeneration = 0;
-  private registrationController: AbortController | null = null;
   private pauseGeneration = 0;
   private commandDrained = createComputerUseDrain();
   private readonly commandRequests = new Set<Promise<unknown>>();
@@ -340,7 +346,6 @@ export class ComputerUseHostRuntime {
 
   async stop(): Promise<void> {
     this.running = false;
-    this.registrationController?.abort();
     for (const controller of this.reportingControllers) controller.abort();
     this.sessionGeneration++;
     this.pauseGeneration++;
@@ -813,22 +818,17 @@ export class ComputerUseHostRuntime {
     this.setState({ status: "connecting", lastError: null });
     const runtimeBody = await this.runtimeBody();
     if (!this.running || generation !== this.sessionGeneration) return null;
-    const registration = new AbortController();
-    this.registrationController = registration;
     const response = await this.sessionFetch(
       `${this.apiBaseUrl}/api/computer-use/hosts/start`,
       {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(runtimeBody),
-        // A background auth refresh can retire this runtime while fetching a
-        // new bearer. Its original registration must not retry after retirement.
-        signal: registration.signal,
       },
-    ).finally(() => {
-      if (this.registrationController === registration)
-        this.registrationController = null;
-    });
+      // Auth refresh retires this runtime; its replacement owns registration.
+      // Keep the original response readable so a late success can be stopped.
+      { retryAfterRefresh: false },
+    );
     if (!this.running || generation !== this.sessionGeneration) {
       if (response.ok) {
         const body = (await response.json()) as ComputerUseHostStartResponse;

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -270,6 +270,7 @@ export class ComputerUseHostRuntime {
   private commandExecutionRunning = false;
   private draining = false;
   private sessionGeneration = 0;
+  private registrationController: AbortController | null = null;
   private pauseGeneration = 0;
   private commandDrained = createComputerUseDrain();
   private readonly commandRequests = new Set<Promise<unknown>>();
@@ -339,6 +340,7 @@ export class ComputerUseHostRuntime {
 
   async stop(): Promise<void> {
     this.running = false;
+    this.registrationController?.abort();
     for (const controller of this.reportingControllers) controller.abort();
     this.sessionGeneration++;
     this.pauseGeneration++;
@@ -811,14 +813,22 @@ export class ComputerUseHostRuntime {
     this.setState({ status: "connecting", lastError: null });
     const runtimeBody = await this.runtimeBody();
     if (!this.running || generation !== this.sessionGeneration) return null;
+    const registration = new AbortController();
+    this.registrationController = registration;
     const response = await this.sessionFetch(
       `${this.apiBaseUrl}/api/computer-use/hosts/start`,
       {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(runtimeBody),
+        // A background auth refresh can retire this runtime while fetching a
+        // new bearer. Its original registration must not retry after retirement.
+        signal: registration.signal,
       },
-    );
+    ).finally(() => {
+      if (this.registrationController === registration)
+        this.registrationController = null;
+    });
     if (!this.running || generation !== this.sessionGeneration) {
       if (response.ok) {
         const body = (await response.json()) as ComputerUseHostStartResponse;

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -71,6 +71,7 @@ type ComputerUseSessionFetch = (
 type MaybePromise<T> = T | Promise<T>;
 
 interface ComputerUseHostRuntimeOptions {
+  readonly refreshRegistrationAuth?: boolean;
   readonly commandClock?: ComputerUseCommandClock;
   readonly platformUrl: URL;
   readonly installationId: string;
@@ -258,6 +259,7 @@ export class ComputerUseHostRuntime {
   private readonly hostName: string;
   private readonly appVersion: string;
   private readonly sessionFetch: ComputerUseSessionFetch;
+  private refreshRegistrationAuth: boolean;
   private readonly hostFetchRequest: ComputerUseHostFetch;
   private readonly addClientHeaders: DesktopClientHeaderInjector;
   private readonly getPermissions: ComputerUseHostRuntimeOptions["getPermissions"];
@@ -304,6 +306,7 @@ export class ComputerUseHostRuntime {
     this.hostName = options.hostName;
     this.appVersion = options.appVersion;
     this.sessionFetch = options.sessionFetch;
+    this.refreshRegistrationAuth = options.refreshRegistrationAuth ?? true;
     this.hostFetchRequest = options.hostFetch;
     this.addClientHeaders = options.addClientHeaders;
     this.getPermissions = options.getPermissions;
@@ -321,10 +324,14 @@ export class ComputerUseHostRuntime {
   private readonly acquireCommand: ComputerUseHostRuntimeOptions["acquireCommand"];
   private readonly commandClock: ComputerUseCommandClock;
 
-  async start(): Promise<void> {
+  async start(
+    options: { readonly userInitiated?: boolean } = {},
+  ): Promise<void> {
     if (this.running) {
       return;
     }
+    // Only a user action can reset a rejected recovery attempt's budget.
+    if (options.userInitiated) this.refreshRegistrationAuth = true;
     this.running = true;
     this.sessionGeneration++;
     const generation = this.sessionGeneration;
@@ -827,7 +834,10 @@ export class ComputerUseHostRuntime {
       },
       // Auth refresh retires this runtime; its replacement owns registration.
       // Keep the original response readable so a late success can be stopped.
-      { retryAfterRefresh: false },
+      {
+        retryAfterRefresh: false,
+        refreshOn401: this.refreshRegistrationAuth,
+      },
     );
     if (!this.running || generation !== this.sessionGeneration) {
       if (response.ok) {
@@ -837,6 +847,14 @@ export class ComputerUseHostRuntime {
       return null;
     }
     if (response.status === 401) {
+      if (!this.refreshRegistrationAuth) {
+        this.setRuntimeErrorState(
+          "start",
+          "Computer Use registration was rejected after authentication refreshed. Sign in and retry.",
+          { hostId: null },
+        );
+        return null;
+      }
       const authenticated = await this.hasAuthenticatedSession();
       if (!this.running || generation !== this.sessionGeneration) return null;
       if (authenticated) {
@@ -883,6 +901,8 @@ export class ComputerUseHostRuntime {
       return null;
     }
     this.hostToken = body.hostToken;
+    // A later reconnect is a new episode once this registration succeeds.
+    this.refreshRegistrationAuth = true;
     this.lastCommandActivityAtMs = null;
     this.lastCommandCompletionAtMs = null;
     this.clearRecoveryTimer();

--- a/turbo/apps/desktop/src/computer-use-runtime-controller.ts
+++ b/turbo/apps/desktop/src/computer-use-runtime-controller.ts
@@ -13,6 +13,8 @@ import {
   type ComputerUseLifecycleTimers,
 } from "./computer-use-lifecycle-deadline";
 import type { DesktopAuthState } from "./desktop-bridge";
+import type { DesktopAuthRefreshEvent } from "./desktop-auth-session";
+import { latestWinsSingleFlight } from "./desktop-async-control";
 import { resolveComputerUseStartupGate } from "./computer-use-startup-gate";
 import {
   OFFLINE_COMPUTER_USE_HOST_STATE,
@@ -119,6 +121,13 @@ export class ComputerUseRuntimeController {
   private readonly preparePlugins: () => Promise<void>;
   private pluginStartupIntent: number | null = null;
   private permissionRefresh: PermissionRefresh | null = null;
+  private backgroundAuthRefresh: {
+    readonly signal: AbortSignal;
+    authority: object | null;
+  } | null = null;
+  private readonly reconcileAuthRecovery = latestWinsSingleFlight(() =>
+    this.recoverAfterAuthRefresh(),
+  );
 
   constructor(private readonly options: ComputerUseRuntimeControllerOptions) {
     this.getPluginCapabilities = options.getPluginCapabilities ?? (() => []);
@@ -152,6 +161,73 @@ export class ComputerUseRuntimeController {
 
   pluginsMayRun(): boolean {
     return this.isRuntimeOnline() || this.pluginStartupIntent === this.intent;
+  }
+
+  /** Auth refresh owns fresh authority; the controller owns the user's online intent. */
+  handleBackgroundAuthRefresh(event: DesktopAuthRefreshEvent): void {
+    if (this.quitStopStarted || event.signal.aborted) return;
+    if (event.phase === "started") {
+      this.backgroundAuthRefresh = { signal: event.signal, authority: null };
+      return;
+    }
+    const refresh = this.backgroundAuthRefresh;
+    if (refresh?.signal !== event.signal) return;
+    if (event.phase === "failed" || event.identity === "changed") {
+      // A changed identity must not inherit online intent through a later CUA grant.
+      this.runningRequested = false;
+      this.backgroundAuthRefresh = null;
+      return;
+    }
+    refresh.authority = this.options.getAuthAuthority?.() ?? null;
+    this.reconcileAuthRecovery();
+  }
+
+  private async recoverAfterAuthRefresh(): Promise<void> {
+    const refresh = this.backgroundAuthRefresh;
+    if (!refresh?.authority) return;
+    const current = () =>
+      this.backgroundAuthRefresh === refresh &&
+      !refresh.signal.aborted &&
+      refresh.authority === this.options.getAuthAuthority?.();
+    // Completion is synchronous. Let auth/change subscribers enqueue their
+    // cleanup before observing its owner; auth never awaits this recovery.
+    await Promise.resolve();
+    let intent = this.intent;
+    try {
+      await withComputerUseDeadline(
+        this.stopping,
+        this.transitionTimeoutMs,
+        this.lifecycleTimers,
+      );
+      await withComputerUseDeadline(
+        this.transitionTail,
+        this.transitionTimeoutMs,
+        this.lifecycleTimers,
+      );
+      if (
+        !current() ||
+        !this.runningRequested ||
+        this.manualStopRequested ||
+        this.quitStopStarted
+      )
+        return;
+      intent = this.intent;
+      await this.start({ signal: refresh.signal });
+      if (current() && intent === this.intent && this.isRuntimeOnline())
+        this.backgroundAuthRefresh = null;
+    } catch {
+      if (
+        !current() ||
+        intent !== this.intent ||
+        this.manualStopRequested ||
+        this.quitStopStarted
+      )
+        return;
+      this.backgroundAuthRefresh = null;
+      this.nativeError =
+        "Authentication recovered, but Computer Use could not restart. Retry after cleanup.";
+      this.onChange();
+    }
   }
 
   /** Read-only refreshes share one episode under this lifecycle's current intent.
@@ -393,7 +469,12 @@ export class ComputerUseRuntimeController {
       !this.nativeError &&
       !this.driver?.getState().error
     ) {
-      if (this.runtime) await this.transitionDriver(this.requestedDriver);
+      if (
+        this.backgroundAuthRefresh &&
+        !this.backgroundAuthRefresh.signal.aborted
+      )
+        this.reconcileAuthRecovery();
+      else if (this.runtime) await this.transitionDriver(this.requestedDriver);
       else await this.start();
     }
     this.onChange();
@@ -854,6 +935,7 @@ export class ComputerUseRuntimeController {
     reason: ComputerUseNativeShutdownReason = "app_quit",
   ): Promise<void> {
     if (this.quitPromise) return this.quitPromise;
+    this.backgroundAuthRefresh = null;
     this.quitStopStarted = true;
     this.supersede();
     const runtime = this.runtime;

--- a/turbo/apps/desktop/src/computer-use-runtime-controller.ts
+++ b/turbo/apps/desktop/src/computer-use-runtime-controller.ts
@@ -46,7 +46,7 @@ interface PermissionRecovery {
 
 /** The `ComputerUseHostRuntime` surface the controller drives. */
 interface ComputerUseRuntimeLike {
-  start(): Promise<void>;
+  start(options?: { readonly userInitiated?: boolean }): Promise<void>;
   stop(): Promise<void>;
   drainAndStop(): Promise<void>;
   pauseAndDrainCommands(): Promise<() => void>;
@@ -64,7 +64,9 @@ interface ComputerUseRuntimeControllerOptions {
    * exists. The production implementation wires all Electron/session
    * dependencies into a `ComputerUseHostRuntime`.
    */
-  readonly createRuntime: () => ComputerUseRuntimeLike;
+  readonly createRuntime: (options: {
+    readonly refreshRegistrationAuth: boolean;
+  }) => ComputerUseRuntimeLike;
   readonly refreshPermissions: () => Promise<ComputerUsePermissionState>;
   readonly getAuthState: () => Promise<DesktopAuthState>;
   readonly getAuthAuthority?: () => object | null;
@@ -88,7 +90,7 @@ interface ComputerUseRuntimeControllerOptions {
  * stop-and-detach paths and the ad-hoc quit flags into one owner.
  */
 export class ComputerUseRuntimeController {
-  private readonly createRuntime: () => ComputerUseRuntimeLike;
+  private readonly createRuntime: ComputerUseRuntimeControllerOptions["createRuntime"];
   private readonly refreshPermissions: () => Promise<ComputerUsePermissionState>;
   private readonly getAuthState: () => Promise<DesktopAuthState>;
   private readonly setHostRuntimeOnline: (online: boolean) => void;
@@ -124,6 +126,7 @@ export class ComputerUseRuntimeController {
   private backgroundAuthRefresh: {
     readonly signal: AbortSignal;
     authority: object | null;
+    refreshed: boolean;
   } | null = null;
   private readonly reconcileAuthRecovery = latestWinsSingleFlight(() =>
     this.recoverAfterAuthRefresh(),
@@ -167,7 +170,11 @@ export class ComputerUseRuntimeController {
   handleBackgroundAuthRefresh(event: DesktopAuthRefreshEvent): void {
     if (this.quitStopStarted || event.signal.aborted) return;
     if (event.phase === "started") {
-      this.backgroundAuthRefresh = { signal: event.signal, authority: null };
+      this.backgroundAuthRefresh = {
+        signal: event.signal,
+        authority: null,
+        refreshed: false,
+      };
       return;
     }
     const refresh = this.backgroundAuthRefresh;
@@ -179,6 +186,7 @@ export class ComputerUseRuntimeController {
       return;
     }
     refresh.authority = this.options.getAuthAuthority?.() ?? null;
+    refresh.refreshed = event.identity === "same";
     this.reconcileAuthRecovery();
   }
 
@@ -208,7 +216,8 @@ export class ComputerUseRuntimeController {
         !current() ||
         !this.runningRequested ||
         this.manualStopRequested ||
-        this.quitStopStarted
+        this.quitStopStarted ||
+        this.runtime?.getState().status === "error"
       )
         return;
       intent = this.intent;
@@ -491,6 +500,8 @@ export class ComputerUseRuntimeController {
       readonly signal?: AbortSignal;
     } = {},
   ): Promise<void> {
+    if (this.backgroundAuthRefresh?.signal.aborted)
+      this.backgroundAuthRefresh = null;
     if (
       this.quitStopStarted ||
       ((this.nativeError !== null || this.driver?.getState().error) &&
@@ -501,6 +512,10 @@ export class ComputerUseRuntimeController {
     options.signal?.throwIfAborted();
     this.runningRequested = true;
     if (options.userInitiated) {
+      // A new explicit Start gets its own auth budget. A pending refresh still
+      // owns the completion that will finish Start after credentials arrive.
+      if (this.backgroundAuthRefresh?.authority)
+        this.backgroundAuthRefresh = null;
       if (this.driver?.getState().error) {
         this.stopping = Promise.all([
           this.stopping,
@@ -520,7 +535,12 @@ export class ComputerUseRuntimeController {
     };
     options.signal?.addEventListener("abort", abort, { once: true });
     const selection = this.selectionRevision;
-    const start = this.startRuntime(intent, selection, this.transitionTail);
+    const start = this.startRuntime(
+      intent,
+      selection,
+      this.transitionTail,
+      options.userInitiated,
+    );
     this.starting = start;
     this.phaseStartedAt = performance.now();
     try {
@@ -545,6 +565,7 @@ export class ComputerUseRuntimeController {
     intent: number,
     selection: number,
     transitions: Promise<void>,
+    userInitiated = false,
   ): Promise<void> {
     await withComputerUseDeadline(
       this.stopping,
@@ -605,8 +626,10 @@ export class ComputerUseRuntimeController {
       !this.nativeBlockReason()
     )
       this.driver?.activate();
-    const runtime = (this.runtime ??= this.createRuntime());
-    await runtime.start();
+    const runtime = (this.runtime ??= this.createRuntime({
+      refreshRegistrationAuth: !this.backgroundAuthRefresh?.refreshed,
+    }));
+    await runtime.start({ userInitiated });
     if (intent !== this.intent || selection !== this.selectionRevision) return;
     this.setHostRuntimeOnline(runtime.getState().status === "online");
   }

--- a/turbo/apps/desktop/src/desktop-auth-lifecycle.test.ts
+++ b/turbo/apps/desktop/src/desktop-auth-lifecycle.test.ts
@@ -121,6 +121,7 @@ async function desktop(selectedDriver: ComputerUseDriverId) {
       windows.push(request);
       return await (replies.shift()?.promise ?? Promise.resolve(null));
     },
+    onBackgroundRefresh: (event) => runtime.handleBackgroundAuthRefresh(event),
     onChange: () => {
       notifications++;
       // Bound only the old-code reproduction. Production has no depth cap.
@@ -132,11 +133,7 @@ async function desktop(selectedDriver: ComputerUseDriverId) {
       const authority = session.getAuthority();
       if (authority !== lastAuthority) {
         lastAuthority = authority;
-        if (
-          selection.requestedDriver().id === "cua" ||
-          driver.selectedDriver.id === "cua"
-        )
-          own(runtime.stopForAuthChange());
+        own(runtime.stopForAuthChange());
       }
       tray.refreshAuth();
       developer.requestRefresh();
@@ -185,6 +182,7 @@ async function desktop(selectedDriver: ComputerUseDriverId) {
     }),
     nativeBlockReason: (selected) => selection.blockReason(selected),
     getAuthState: () => own(session.getAuthState()),
+    getAuthAuthority: () => session.getAuthority(),
     setHostRuntimeOnline: () => {},
   });
   const preferences = new DesktopComputerUseDriverPreferences(() => file);
@@ -404,6 +402,17 @@ describe.each(["okou", "cua"] as const)(
       const release = deferred<void>();
       onTestFinished(() => release.resolve());
       server.use(
+        // Token rotation preserves the server-verified account and workspace.
+        http.get(`${api}/api/auth/me`, () =>
+          HttpResponse.json({
+            userId: "Bearer expired",
+            email: "fixture@example.test",
+            orgId: "org-Bearer expired",
+          }),
+        ),
+        http.get(`${api}/api/org`, () =>
+          HttpResponse.json({ id: "org-Bearer expired", name: "Workspace" }),
+        ),
         http.get(
           `${api}/api/protected`,
           ({ request }) =>

--- a/turbo/apps/desktop/src/desktop-auth-session.test.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.test.ts
@@ -9,7 +9,10 @@ import {
 } from "vitest";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
-import { DesktopAuthSession } from "./desktop-auth-session";
+import {
+  DesktopAuthSession,
+  type DesktopAuthRefreshEvent,
+} from "./desktop-auth-session";
 import { resolveDesktopConfig } from "./config";
 import {
   buildDesktopAuthConsumeUrl,
@@ -37,12 +40,19 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-function createSession(onChange?: (session: DesktopAuthSession) => void) {
+function createSession(
+  onChange?: (session: DesktopAuthSession) => void,
+  onBackgroundRefresh?: (
+    event: DesktopAuthRefreshEvent,
+    session: DesktopAuthSession,
+  ) => void,
+) {
   const config = resolveDesktopConfig();
   const windows: DesktopAuthWindowRequest[] = [];
   const replies: Promise<string | null>[] = [];
   const completed: string[] = [];
   const changes: (string | null)[] = [];
+  const refreshes: DesktopAuthRefreshEvent[] = [];
   const session = new DesktopAuthSession({
     apiBaseUrl: api,
 
@@ -64,12 +74,16 @@ function createSession(onChange?: (session: DesktopAuthSession) => void) {
     onAuthCompleted: () => {
       completed.push("completed");
     },
+    onBackgroundRefresh: (event) => {
+      refreshes.push(event);
+      onBackgroundRefresh?.(event, session);
+    },
   });
-  return { session, windows, replies, completed, changes };
+  return { session, windows, replies, completed, changes, refreshes };
 }
 
 function identityHandlers(
-  options: { orgId?: string; observed?: string[] } = {},
+  options: { userId?: string; orgId?: string; observed?: string[] } = {},
 ) {
   server.use(
     http.get(`${api}/api/auth/me`, ({ request }) => {
@@ -77,7 +91,7 @@ function identityHandlers(
       options.observed?.push(`me:${token}`);
       expect(request.headers.get("cookie")).toBeNull();
       return HttpResponse.json({
-        userId: token,
+        userId: options.userId ?? token,
         email: "app@example.test",
         orgId: "app-org",
       });
@@ -201,7 +215,7 @@ describe("Okou App session authority", () => {
 
   it("does one bounded App refresh after 401 without a cookie-only retry", async () => {
     const { session, replies, windows } = createSession();
-    identityHandlers();
+    identityHandlers({ userId: "same-user" });
     replies.push(Promise.resolve("expired"), Promise.resolve("fresh"));
     await session.getToken();
     const tokens: (string | null)[] = [];
@@ -222,11 +236,182 @@ describe("Okou App session authority", () => {
     expect(windows).toHaveLength(2);
   });
 
+  it("publishes a verified background identity before notifying recovery and subscribers", async () => {
+    identityHandlers({ userId: "same-user" });
+    const observed: string[] = [];
+    const reads: ReturnType<DesktopAuthSession["getAuthState"]>[] = [];
+    const { session, replies, refreshes, completed } = createSession(
+      (current) => {
+        if (current.getAuthority()) {
+          expect(current.getCachedToken()).not.toBeNull();
+          observed.push(`change:${current.getCachedToken()}`);
+        }
+      },
+      (event, current) => {
+        if (event.phase === "completed") {
+          expect(current.getAuthority()).not.toBeNull();
+          observed.push(`completed:${current.getCachedToken()}`);
+          reads.push(current.getAuthState());
+        }
+      },
+    );
+    replies.push(Promise.resolve("old"));
+    await session.getToken();
+    await Promise.all(reads);
+    const previousAuthority = session.getAuthority();
+    const previousSignal = refreshes[0]?.signal;
+    const reply = deferred<string | null>();
+    replies.push(reply.promise);
+    const refresh = session.getToken({ forceRefresh: true });
+    expect(session.getAuthority()).toBeNull();
+    expect(session.getCachedToken()).toBeNull();
+    expect(previousSignal?.aborted).toBe(true);
+    expect(refreshes.map((event) => event.phase)).toEqual([
+      "started",
+      "completed",
+      "started",
+    ]);
+    reply.resolve("fresh");
+    expect(await refresh).toBe("fresh");
+    await Promise.all(reads);
+    expect(refreshes[3]).toMatchObject({
+      phase: "completed",
+      identity: "same",
+      signal: refreshes[2]?.signal,
+    });
+    expect(session.getAuthority()).not.toBe(previousAuthority);
+    expect(observed).toEqual([
+      "completed:old",
+      "change:old",
+      "completed:fresh",
+      "change:fresh",
+    ]);
+    expect(completed).toEqual([]);
+  });
+
+  it.each(["user", "organization"] as const)(
+    "does not replay a request after a hidden refresh changes the %s",
+    async (changed) => {
+      const { session, replies, refreshes } = createSession();
+      const requests: (string | null)[] = [];
+      const identity = (request: Request) => {
+        const fresh = request.headers.get("authorization") === "Bearer fresh";
+        return {
+          userId: fresh && changed === "user" ? "new-user" : "old-user",
+          orgId: fresh && changed === "organization" ? "new-org" : "old-org",
+        };
+      };
+      server.use(
+        http.get(`${api}/api/auth/me`, ({ request }) =>
+          HttpResponse.json({
+            ...identity(request),
+            email: "app@example.test",
+          }),
+        ),
+        http.get(`${api}/api/org`, ({ request }) =>
+          HttpResponse.json({ id: identity(request).orgId, name: "Workspace" }),
+        ),
+        http.post(`${api}/api/protected`, ({ request }) => {
+          requests.push(request.headers.get("authorization"));
+          return new HttpResponse(null, { status: 401 });
+        }),
+      );
+      replies.push(Promise.resolve("old"), Promise.resolve("fresh"));
+      const response = await session.fetchWithSessionAuth(
+        new URL(`${api}/api/protected`),
+        { method: "POST", body: JSON.stringify({ action: "test" }) },
+      );
+      expect(response.status).toBe(401);
+      expect(requests).toEqual(["Bearer old"]);
+      expect(session.getCachedToken()).toBe("fresh");
+      expect(refreshes.at(-1)).toMatchObject({
+        phase: "completed",
+        identity: "changed",
+      });
+    },
+  );
+
+  it("remembers the verified identity after an unsuccessful status read withdraws authority", async () => {
+    identityHandlers({ userId: "old-user" });
+    const { session, replies, refreshes } = createSession();
+    replies.push(Promise.resolve("old"));
+    await session.getToken();
+    server.use(
+      http.get(
+        `${api}/api/auth/me`,
+        () => new HttpResponse(null, { status: 503 }),
+      ),
+    );
+    await expect(session.getAuthState()).rejects.toThrow(
+      "Desktop auth status failed: 503",
+    );
+    expect(session.getAuthority()).toBeNull();
+    identityHandlers({ userId: "new-user" });
+    replies.push(Promise.resolve("fresh"));
+    expect(await session.getToken({ forceRefresh: true })).toBe("fresh");
+    expect(refreshes.at(-1)).toMatchObject({
+      phase: "completed",
+      identity: "changed",
+    });
+  });
+
+  it("shares the current refresh while an older concurrent 401 is cancelled", async () => {
+    identityHandlers({ userId: "same-user" });
+    const { session, replies, windows, refreshes } = createSession();
+    replies.push(Promise.resolve("old"));
+    await session.getToken();
+    const bothEntered = deferred<void>();
+    const firstResponse = deferred<void>();
+    const secondResponse = deferred<void>();
+    const fresh = deferred<string | null>();
+    replies.push(fresh.promise);
+    let oldRequests = 0;
+    server.use(
+      http.get(`${api}/api/protected`, async ({ request }) => {
+        if (request.headers.get("authorization") === "Bearer fresh")
+          return new HttpResponse(null, { status: 200 });
+        oldRequests++;
+        if (oldRequests === 2) bothEntered.resolve();
+        await (oldRequests === 1
+          ? firstResponse.promise
+          : secondResponse.promise);
+        return new HttpResponse(null, { status: 401 });
+      }),
+    );
+    const first = session.fetchWithSessionAuth(new URL(`${api}/api/protected`));
+    const second = session.fetchWithSessionAuth(
+      new URL(`${api}/api/protected`),
+    );
+    const cancelled = expect(second).rejects.toThrow();
+    try {
+      await bothEntered.promise;
+      firstResponse.resolve();
+      await vi.waitFor(() => expect(windows).toHaveLength(2));
+      const joined = session.getToken({ forceRefresh: true });
+      fresh.resolve("fresh");
+      expect(await joined).toBe("fresh");
+      expect((await first).status).toBe(200);
+      secondResponse.resolve();
+      await cancelled;
+      expect(windows).toHaveLength(2);
+      expect(refreshes.map((event) => event.phase)).toEqual([
+        "started",
+        "completed",
+        "started",
+        "completed",
+      ]);
+    } finally {
+      firstResponse.resolve();
+      secondResponse.resolve();
+      fresh.resolve(null);
+    }
+  });
+
   it.each([null, "rejected"])(
     "clears rejected credentials when refresh delivers %s",
     async (refreshed) => {
       const { session, replies, windows } = createSession();
-      identityHandlers();
+      identityHandlers({ userId: "same-user" });
       replies.push(Promise.resolve("expired"), Promise.resolve(refreshed));
       await session.getToken();
       let count = 0;
@@ -247,7 +432,7 @@ describe("Okou App session authority", () => {
   );
 
   it("notifies subscribers of a failed App refresh and waits for explicit sign-in", async () => {
-    const { session, replies, windows, changes } = createSession();
+    const { session, replies, windows, changes, refreshes } = createSession();
     identityHandlers();
     replies.push(Promise.resolve("expired"), Promise.resolve(null));
     await session.getToken();
@@ -261,7 +446,13 @@ describe("Okou App session authority", () => {
       (await session.fetchWithSessionAuth(new URL(`${api}/api/protected`)))
         .status,
     ).toBe(401);
-    expect(changes).toEqual([null, null, "expired", null, null]);
+    expect(changes).toEqual([null, "expired", null, null]);
+    expect(refreshes.map((event) => event.phase)).toEqual([
+      "started",
+      "completed",
+      "started",
+      "failed",
+    ]);
     expect(session.getAuthority()).toBeNull();
     expect(await session.getAuthState()).toEqual(signedOut);
     expect(await session.getToken({ forceRefresh: true })).toBeNull();
@@ -303,7 +494,7 @@ describe("Okou App session authority", () => {
   });
 
   it("coalesces refreshes and recognizes a new delivery even if the token bytes are identical", async () => {
-    const { session, replies, windows, completed } = createSession();
+    const { session, replies, windows, completed, refreshes } = createSession();
     identityHandlers();
     const reply = deferred<string | null>();
     replies.push(reply.promise);
@@ -315,6 +506,14 @@ describe("Okou App session authority", () => {
     expect(await session.getToken({ forceRefresh: true })).toBe("same");
     expect(windows).toHaveLength(2);
     expect(completed).toEqual([]);
+    expect(refreshes[1]).toMatchObject({
+      phase: "completed",
+      identity: "initial",
+    });
+    expect(refreshes[3]).toMatchObject({
+      phase: "completed",
+      identity: "same",
+    });
     replies.push(Promise.resolve(null));
     expect(await session.getToken({ forceRefresh: true })).toBeNull();
     expect(session.getCachedToken()).toBeNull();

--- a/turbo/apps/desktop/src/desktop-auth-session.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.ts
@@ -21,6 +21,11 @@ export type DesktopAuthRefreshEvent =
     }
   | { readonly phase: "failed"; readonly signal: AbortSignal };
 
+export interface DesktopAuthRequestOptions {
+  /** Stateful callers can let their fresh runtime own retry after auth refresh. */
+  readonly retryAfterRefresh?: boolean;
+}
+
 interface DesktopAuthSessionOptions {
   /** Pre-resolved API base URL (`resolveComputerUseApiBaseUrl(platformUrl)`). */
   readonly apiBaseUrl: string;
@@ -159,8 +164,9 @@ export class DesktopAuthSession {
   async fetchWithSessionAuth(
     requestUrl: URL,
     init?: RequestInit,
+    options?: DesktopAuthRequestOptions,
   ): Promise<Response> {
-    return await this.fetchWithAppAuth(requestUrl, init);
+    return await this.fetchWithAppAuth(requestUrl, init, options);
   }
 
   getCachedToken(): string | null {
@@ -419,6 +425,7 @@ export class DesktopAuthSession {
   private async fetchWithAppAuth(
     requestUrl: URL,
     init?: RequestInit,
+    options?: DesktopAuthRequestOptions,
   ): Promise<Response> {
     const token = await this.getToken();
     if (!token || token !== this.token)
@@ -438,6 +445,7 @@ export class DesktopAuthSession {
     const refreshed = await refresh;
     // A successful refresh is not permission to replay another identity's request.
     if (
+      options?.retryAfterRefresh === false ||
       !refreshed ||
       refreshed !== this.token ||
       refreshLifetime !== this.lifetime ||

--- a/turbo/apps/desktop/src/desktop-auth-session.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.ts
@@ -24,6 +24,8 @@ export type DesktopAuthRefreshEvent =
 export interface DesktopAuthRequestOptions {
   /** Stateful callers can let their fresh runtime own retry after auth refresh. */
   readonly retryAfterRefresh?: boolean;
+  /** A recovery attempt must not open another refresh cycle after rejection. */
+  readonly refreshOn401?: boolean;
 }
 
 interface DesktopAuthSessionOptions {
@@ -438,7 +440,8 @@ export class DesktopAuthSession {
       lifetime.signal,
       init,
     );
-    if (response.status !== 401) return response;
+    if (response.status !== 401 || options?.refreshOn401 === false)
+      return response;
     // No cookie-only retry. One App refresh and at most one authenticated retry.
     const refresh = this.getToken({ forceRefresh: true });
     const refreshLifetime = this.lifetime;

--- a/turbo/apps/desktop/src/desktop-auth-session.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.ts
@@ -12,6 +12,15 @@ type RunAuthWindow = (
   request: DesktopAuthWindowRequest,
 ) => Promise<string | null>;
 
+export type DesktopAuthRefreshEvent =
+  | { readonly phase: "started"; readonly signal: AbortSignal }
+  | {
+      readonly phase: "completed";
+      readonly signal: AbortSignal;
+      readonly identity: "initial" | "same" | "changed";
+    }
+  | { readonly phase: "failed"; readonly signal: AbortSignal };
+
 interface DesktopAuthSessionOptions {
   /** Pre-resolved API base URL (`resolveComputerUseApiBaseUrl(platformUrl)`). */
   readonly apiBaseUrl: string;
@@ -31,6 +40,8 @@ interface DesktopAuthSessionOptions {
    * trigger it.
    */
   readonly onAuthCompleted?: (signal: AbortSignal) => Promise<void> | void;
+  /** Synchronous lifecycle notification; dependent recovery must not block auth. */
+  readonly onBackgroundRefresh?: (event: DesktopAuthRefreshEvent) => void;
 }
 
 function signedOutDesktopAuthState(): DesktopAuthState {
@@ -68,6 +79,9 @@ export class DesktopAuthSession {
   private readonly onAuthCompleted: (
     signal: AbortSignal,
   ) => Promise<void> | void;
+  private readonly onBackgroundRefresh: (
+    event: DesktopAuthRefreshEvent,
+  ) => void;
 
   private token: string | null = null;
   private lifetime = new AbortController();
@@ -92,8 +106,8 @@ export class DesktopAuthSession {
   private rememberAuthority(
     state: DesktopAuthState,
     lifetime: AbortController,
-  ): void {
-    if (this.lifetime !== lifetime || lifetime.signal.aborted) return;
+  ): boolean {
+    if (this.lifetime !== lifetime || lifetime.signal.aborted) return false;
     const next =
       state.status === "signed_in" && state.organization
         ? {
@@ -107,9 +121,9 @@ export class DesktopAuthSession {
       this.authority?.orgId === next?.orgId &&
       this.authority?.lifetime === next?.lifetime
     )
-      return;
+      return false;
     this.authority = next;
-    this.onChange();
+    return true;
   }
 
   constructor(options: DesktopAuthSessionOptions) {
@@ -121,6 +135,7 @@ export class DesktopAuthSession {
     this.runAuthWindow = options.runAuthWindow;
     this.onChange = options.onChange ?? (() => {});
     this.onAuthCompleted = options.onAuthCompleted ?? (() => {});
+    this.onBackgroundRefresh = options.onBackgroundRefresh ?? (() => {});
   }
 
   async getToken(options?: {
@@ -228,6 +243,7 @@ export class DesktopAuthSession {
     interactive: boolean,
     visible: boolean,
   ): Promise<string | null> {
+    const previousState = this.appState;
     this.lifetime.abort();
     const lifetime = new AbortController();
     this.lifetime = lifetime;
@@ -235,6 +251,8 @@ export class DesktopAuthSession {
     this.restoreEnabled = true;
     this.token = null;
     this.appState = signedOutDesktopAuthState();
+    if (!interactive)
+      this.onBackgroundRefresh({ phase: "started", signal: lifetime.signal });
     this.setSigningIn(interactive);
     // Even a hidden token restoration replaces session execution authority.
     this.onChange();
@@ -256,9 +274,23 @@ export class DesktopAuthSession {
       signal.throwIfAborted();
       if (state.status !== "signed_in") return null;
       this.appState = state;
-      this.rememberAuthority(state, lifetime);
       this.token = token;
+      this.rememberAuthority(state, lifetime);
+      if (!interactive) {
+        this.onBackgroundRefresh({
+          phase: "completed",
+          signal: lifetime.signal,
+          identity:
+            previousState.status !== "signed_in" || !previousState.organization
+              ? "initial"
+              : previousState.user.userId === state.user.userId &&
+                  previousState.organization.id === state.organization?.id
+                ? "same"
+                : "changed",
+        });
+      }
       this.onChange();
+      lifetime.signal.throwIfAborted();
       if (interactive) {
         this.setSigningIn(false);
         await this.onAuthCompleted(lifetime.signal);
@@ -269,6 +301,7 @@ export class DesktopAuthSession {
       if (this.lifetime === lifetime) {
         this.token = null;
         this.appState = signedOutDesktopAuthState();
+        this.authority = null;
       }
       if (!interactive && signal.aborted) return null;
       throw error;
@@ -278,6 +311,11 @@ export class DesktopAuthSession {
           // Notify renderer/tray subscribers, and keep their reads from
           // reopening a failed hidden restore until explicit sign-in.
           this.restoreEnabled = false;
+          if (!interactive && !lifetime.signal.aborted)
+            this.onBackgroundRefresh({
+              phase: "failed",
+              signal: lifetime.signal,
+            });
           this.onChange();
         }
         this.setSigningIn(false);
@@ -365,14 +403,15 @@ export class DesktopAuthSession {
       lifetime.signal.throwIfAborted();
       if (state.status === "signed_in") {
         this.appState = state;
-        this.rememberAuthority(state, lifetime);
+        if (this.rememberAuthority(state, lifetime)) this.onChange();
         return state;
       }
       await this.getToken({ forceRefresh: true });
       return this.appState;
     } catch (error) {
       if (lifetime.signal.aborted) return signedOutDesktopAuthState();
-      this.rememberAuthority(signedOutDesktopAuthState(), lifetime);
+      if (this.rememberAuthority(signedOutDesktopAuthState(), lifetime))
+        this.onChange();
       throw error;
     }
   }
@@ -385,6 +424,7 @@ export class DesktopAuthSession {
     if (!token || token !== this.token)
       return new Response(null, { status: 401 });
     const lifetime = this.lifetime;
+    const previousState = this.appState;
     const response = await this.appRequest(
       requestUrl,
       token,
@@ -393,8 +433,21 @@ export class DesktopAuthSession {
     );
     if (response.status !== 401) return response;
     // No cookie-only retry. One App refresh and at most one authenticated retry.
-    const refreshed = await this.getToken({ forceRefresh: true });
-    if (!refreshed || refreshed !== this.token) return response;
+    const refresh = this.getToken({ forceRefresh: true });
+    const refreshLifetime = this.lifetime;
+    const refreshed = await refresh;
+    // A successful refresh is not permission to replay another identity's request.
+    if (
+      !refreshed ||
+      refreshed !== this.token ||
+      refreshLifetime !== this.lifetime ||
+      previousState.status !== "signed_in" ||
+      !previousState.organization ||
+      this.appState.status !== "signed_in" ||
+      previousState.user.userId !== this.appState.user.userId ||
+      previousState.organization.id !== this.appState.organization?.id
+    )
+      return response;
     const retried = await this.appRequest(
       requestUrl,
       refreshed,

--- a/turbo/apps/desktop/src/desktop-computer-use-api.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-api.ts
@@ -55,7 +55,9 @@ export function createDesktopComputerUseHostRuntime(
       };
     },
     // Share the App session's bearer, refresh and sign-out lifetime.
-    sessionFetch: (input, init) =>
-      auth.getAuthSession().fetchWithSessionAuth(new URL(input), init),
+    sessionFetch: (input, init, requestOptions) =>
+      auth
+        .getAuthSession()
+        .fetchWithSessionAuth(new URL(input), init, requestOptions),
   });
 }

--- a/turbo/apps/desktop/src/desktop-computer-use-runtime.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-runtime.test.ts
@@ -1,4 +1,5 @@
 import { ComputerUseDriverController } from "./computer-use-driver";
+import { ComputerUseRuntimeController } from "./computer-use-runtime-controller";
 import { createComputerUseNativeBackend } from "./computer-use-native";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { http, HttpResponse } from "msw";
@@ -21,9 +22,12 @@ const startUrl = `${api}/api/computer-use/hosts/start`;
 const permissions = { accessibility: true, screenRecording: true };
 const server = setupServer();
 const runtimes: ComputerUseHostRuntime[] = [];
+const controllers: ComputerUseRuntimeController[] = [];
 
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterEach(async () => {
+  for (const controller of controllers.splice(0))
+    await controller.stopForQuit();
   for (const runtime of runtimes.splice(0)) await runtime.stop();
   server.resetHandlers();
 });
@@ -42,6 +46,9 @@ function createDesktop() {
   const windows: DesktopAuthWindowRequest[] = [];
   const replies: Promise<string | null>[] = [];
   const requests: Request[] = [];
+  const cleanup: Promise<void>[] = [];
+  let controller: ComputerUseRuntimeController | null = null;
+  let lastAuthority: object | null = null;
   const addClientHeaders = createDesktopClientHeaderInjector({
     clientVersion: "1.2.3",
   });
@@ -56,6 +63,15 @@ function createDesktop() {
       windows.push(request);
       return await (replies.shift() ?? Promise.resolve(null));
     },
+    onChange: () => {
+      const authority = authSession.getAuthority();
+      if (lastAuthority !== authority) {
+        lastAuthority = authority;
+        if (controller) cleanup.push(controller.stopForAuthChange());
+      }
+    },
+    onBackgroundRefresh: (event) =>
+      controller?.handleBackgroundAuthRefresh(event),
   });
   server.use(
     http.all(`${api}/*`, ({ request }) => {
@@ -78,6 +94,7 @@ function createDesktop() {
   );
   function createRuntime(
     options: {
+      refreshRegistrationAuth?: boolean;
       platformUrl?: URL;
       getPermissions?: () => Promise<ComputerUsePermissionState>;
     } = {},
@@ -86,6 +103,7 @@ function createDesktop() {
     // the runtime and auth session real so an alternate request policy fails.
     const runtime = createDesktopComputerUseHostRuntime(
       {
+        refreshRegistrationAuth: options.refreshRegistrationAuth,
         platformUrl: options.platformUrl ?? config.platformUrl,
         installationId: "00000000-0000-4000-8000-000000000001",
         hostName: "test-host",
@@ -112,6 +130,20 @@ function createDesktop() {
     replies,
     requests,
     createRuntime,
+    createController: () => {
+      controller = new ComputerUseRuntimeController({
+        createRuntime,
+        refreshPermissions: async () => permissions,
+        getAuthState: () => authSession.getAuthState(),
+        getAuthAuthority: () => authSession.getAuthority(),
+        setHostRuntimeOnline: () => {},
+      });
+      controllers.push(controller);
+      return controller;
+    },
+    settleCleanup: async () => {
+      while (cleanup.length) await Promise.all(cleanup.splice(0));
+    },
   };
 }
 
@@ -165,6 +197,7 @@ describe("production Okou Computer Use session wiring", () => {
     "bounds a 401 refresh delivering %s without a cookie request or probe bypass",
     async (refreshed) => {
       const desktop = createDesktop();
+      const controller = desktop.createController();
       desktop.replies.push(
         Promise.resolve("expired"),
         Promise.resolve(refreshed),
@@ -172,6 +205,16 @@ describe("production Okou Computer Use session wiring", () => {
       await desktop.authSession.getToken();
       const starts: Request[] = [];
       server.use(
+        http.get(`${api}/api/auth/me`, ({ request }) => {
+          desktop.requests.push(request);
+          return request.headers.get("authorization") === "Bearer rejected"
+            ? new HttpResponse(null, { status: 401 })
+            : HttpResponse.json({
+                userId: "app-user",
+                email: "app@example.test",
+                orgId: "app-org",
+              });
+        }),
         http.post(startUrl, ({ request }) => {
           starts.push(request);
           return request.headers.get("authorization") === "Bearer fresh"
@@ -179,16 +222,19 @@ describe("production Okou Computer Use session wiring", () => {
             : new HttpResponse(null, { status: 401 });
         }),
       );
-      const runtime = desktop.createRuntime();
-      await runtime.start();
-      expect(runtime.getState().status).toBe(
-        refreshed === "fresh" ? "online" : "unauthenticated",
-      );
+      await controller.start();
+      await expect
+        .poll(() => controller.getHostState().status)
+        .toBe(refreshed === "fresh" ? "online" : "offline");
+      expect(await desktop.authSession.getAuthState()).toMatchObject({
+        status: refreshed === "fresh" ? "signed_in" : "signed_out",
+      });
+      await desktop.settleCleanup();
       expect(
         starts.map((request) => request.headers.get("authorization")),
       ).toEqual(
-        refreshed
-          ? ["Bearer expired", `Bearer ${refreshed}`]
+        refreshed === "fresh"
+          ? ["Bearer expired", "Bearer fresh"]
           : ["Bearer expired"],
       );
       for (const request of [...desktop.requests, ...starts])
@@ -204,6 +250,67 @@ describe("production Okou Computer Use session wiring", () => {
       ]);
     },
   );
+
+  it("bounds automatic recovery when host registration rejects a newly validated bearer", async () => {
+    const desktop = createDesktop();
+    const controller = desktop.createController();
+    const unexpectedRefresh = deferred<string | null>();
+    // A third window is held only to bound the old-code reproduction. Both
+    // supplied bearers pass the real identity validation HTTP contract.
+    desktop.replies.push(
+      Promise.resolve("expired"),
+      Promise.resolve("fresh"),
+      unexpectedRefresh.promise,
+    );
+    await desktop.authSession.getToken();
+    const starts: Request[] = [];
+    server.use(
+      http.post(startUrl, ({ request }) => {
+        starts.push(request);
+        return request.headers.get("authorization") === "Bearer retry"
+          ? hostStarted()
+          : new HttpResponse(null, { status: 401 });
+      }),
+    );
+    try {
+      await controller.start();
+      await expect
+        .poll(() => ({
+          status: controller.getHostState().status,
+          authWindows: desktop.windows.length,
+        }))
+        .toEqual({ status: "error", authWindows: 2 });
+      expect(
+        starts.map((request) => request.headers.get("authorization")),
+      ).toEqual(["Bearer expired", "Bearer fresh"]);
+      expect(controller.getHostState().hostId).toBeNull();
+
+      // Only an explicit Start may spend a new refresh budget after failure.
+      unexpectedRefresh.resolve("retry");
+      await controller.start({ userInitiated: true });
+      await expect.poll(() => controller.getHostState().status).toBe("online");
+      expect(desktop.windows).toHaveLength(3);
+      expect(
+        starts.map((request) => request.headers.get("authorization")),
+      ).toEqual([
+        "Bearer expired",
+        "Bearer fresh",
+        "Bearer fresh",
+        "Bearer retry",
+      ]);
+      expect(await desktop.authSession.getAuthState()).toMatchObject({
+        status: "signed_in",
+      });
+      expect(controller.getHostState().hostId).toBe("host-1");
+      for (const request of [...desktop.requests, ...starts])
+        expectAppRequest(request);
+    } finally {
+      desktop.authSession.signOut();
+      unexpectedRefresh.resolve(null);
+      await controller.stopForQuit();
+      await desktop.settleCleanup();
+    }
+  });
 
   it("refuses redirects from host registration without exposing credentials to the target", async () => {
     const desktop = createDesktop();

--- a/turbo/apps/desktop/src/desktop-computer-use-selection.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-selection.test.ts
@@ -86,6 +86,7 @@ lines.on('line', line => {
   let authWindows = 0;
   let rejectIdentityOnce = false;
   let rejectHostStartOnce = false;
+  let rejectHostStarts = false;
   const stoppedHostTokens: (string | null)[] = [];
   let debug = true;
   let hostGranted = true;
@@ -219,9 +220,10 @@ lines.on('line', line => {
     preparePlugins: () => plugin.prepareForHost(),
     transitionTimeoutMs: 1234,
     lifecycleTimers: { setTimeout: schedule, clearTimeout: clear },
-    createRuntime: () =>
+    createRuntime: (options) =>
       createDesktopComputerUseHostRuntime(
         {
+          refreshRegistrationAuth: options.refreshRegistrationAuth,
           platformUrl: new URL("https://app.okou.ai"),
           installationId: readOrCreateComputerUseInstallationId(file),
           hostName: "fixture",
@@ -293,7 +295,7 @@ lines.on('line', line => {
         return HttpResponse.json({ effectiveSwitches: { _debug: enabled } });
       }
       if (url.pathname.endsWith("/hosts/start")) {
-        if (rejectHostStartOnce) {
+        if (rejectHostStartOnce || rejectHostStarts) {
           rejectHostStartOnce = false;
           return new HttpResponse(null, { status: 401 });
         }
@@ -355,6 +357,9 @@ lines.on('line', line => {
     },
     rejectHostStart: () => {
       rejectHostStartOnce = true;
+    },
+    set rejectHostStarts(value: boolean) {
+      rejectHostStarts = value;
     },
     acceptedHosts: () => hostStarts,
     stoppedHostTokens,
@@ -1374,4 +1379,42 @@ it("recovers a hidden refresh triggered by host registration without registering
     nativeStarts: 2,
     nativeActive: true,
   });
+});
+
+it("keeps a terminal CUA registration error after developer access is refreshed", async () => {
+  const app = desktop();
+  await app.authorize();
+  await app.selection.select("cua");
+  const unexpectedRefresh = deferred<string | null>();
+  app.authReply(Promise.resolve("first"));
+  // Bound a broken automatic retry loop without granting another refresh.
+  app.authReply(unexpectedRefresh.promise);
+  app.rejectHostStarts = true;
+  try {
+    await app.controller.start({ userInitiated: true });
+    await vi.waitFor(() =>
+      expect(app.controller.getHostState().status).toBe("error"),
+    );
+    expect(app.authWindows()).toBe(2);
+    expect(
+      app.requests.filter((request) => request.path.endsWith("/hosts/start")),
+    ).toHaveLength(2);
+    expect(app.acceptedHosts()).toBe(0);
+
+    app.developer.requestRefresh();
+    await vi.waitFor(() =>
+      expect(app.developer.getAvailability()).toBe("available"),
+    );
+    await app.settle();
+    await nextTurn();
+    expect(app.controller.getHostState().status).toBe("error");
+    expect(app.authWindows()).toBe(2);
+    expect(
+      app.requests.filter((request) => request.path.endsWith("/hosts/start")),
+    ).toHaveLength(2);
+    expect(app.acceptedHosts()).toBe(0);
+  } finally {
+    app.auth.signOut();
+    unexpectedRefresh.resolve(null);
+  }
 });

--- a/turbo/apps/desktop/src/desktop-computer-use-selection.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-selection.test.ts
@@ -7,6 +7,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { setImmediate as nextTurn } from "node:timers/promises";
 import { afterAll, afterEach, beforeAll, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
@@ -81,6 +82,11 @@ lines.on('line', line => {
   );
   chmodSync(helper, 0o755);
   let identity = "first";
+  const authReplies: Promise<string | null>[] = [];
+  let authWindows = 0;
+  let rejectIdentityOnce = false;
+  let rejectHostStartOnce = false;
+  const stoppedHostTokens: (string | null)[] = [];
   let debug = true;
   let hostGranted = true;
   let failLoad = false;
@@ -128,8 +134,13 @@ lines.on('line', line => {
     tokenUrl: `${api}/token`,
     selectOrgUrl: `${api}/select-org`,
     consumeUrl: () => `${api}/consume`,
-    runAuthWindow: async () => identity,
+    runAuthWindow: async () => {
+      authWindows++;
+      return await (authReplies.shift() ?? Promise.resolve(identity));
+    },
     onChange: () => authChanged(),
+    onBackgroundRefresh: (event) =>
+      controller.handleBackgroundAuthRefresh(event),
   });
   let developerChanged = () => {};
   const developer = new DeveloperToolsController({
@@ -264,6 +275,10 @@ lines.on('line', line => {
       const user =
         request.headers.get("authorization")?.replace("Bearer ", "") ??
         "unknown";
+      if (url.pathname === "/api/auth/me" && rejectIdentityOnce) {
+        rejectIdentityOnce = false;
+        return new HttpResponse(null, { status: 401 });
+      }
       if (url.pathname === "/api/auth/me")
         return HttpResponse.json({
           userId: user,
@@ -277,11 +292,18 @@ lines.on('line', line => {
         await featureRead?.();
         return HttpResponse.json({ effectiveSwitches: { _debug: enabled } });
       }
-      if (url.pathname.endsWith("/hosts/start"))
+      if (url.pathname.endsWith("/hosts/start")) {
+        if (rejectHostStartOnce) {
+          rejectHostStartOnce = false;
+          return new HttpResponse(null, { status: 401 });
+        }
         return HttpResponse.json({
           hostId: `host-${++hostStarts}`,
-          hostToken: "host-token",
+          hostToken: `host-token-${hostStarts}`,
         });
+      }
+      if (url.pathname.endsWith("/host/stop"))
+        stoppedHostTokens.push(request.headers.get("authorization"));
       if (url.pathname.endsWith("/commands/next")) {
         const next = command;
         command = null;
@@ -328,6 +350,19 @@ lines.on('line', line => {
     directory,
     tick,
     completed,
+    expireIdentity: () => {
+      rejectIdentityOnce = true;
+    },
+    rejectHostStart: () => {
+      rejectHostStartOnce = true;
+    },
+    acceptedHosts: () => hostStarts,
+    stoppedHostTokens,
+    authWindows: () => authWindows,
+    authReply: (reply: Promise<string | null>) => authReplies.push(reply),
+    settle: async () => {
+      while (pending.size) await Promise.allSettled([...pending]);
+    },
     holdNativePermissions: () => writeFileSync(permissionGate, "hold"),
     releaseNativeExit: () => {
       rmSync(permissionGate, { force: true });
@@ -1024,3 +1059,319 @@ it.each(["refresh", "sign-out", "quit"] as const)(
     ).toBe(false);
   },
 );
+
+it.each(["okou", "cua"] as const)(
+  "recovers %s after repeated hidden identity refresh and executes a new command",
+  async (selectedDriver) => {
+    const app = desktop(
+      JSON.stringify({
+        computerUseDriver: {
+          experimentalCuaEnabled: selectedDriver === "cua",
+          selectedDriver,
+        },
+      }),
+    );
+    await app.authorize();
+    await app.restore();
+    await app.controller.start({ userInitiated: true });
+    expect(app.controller.getHostState().status).toBe("online");
+    for (let refresh = 0; refresh < 2; refresh++) {
+      const previousAuthority = app.auth.getAuthority();
+      const previousHost = app.controller.getHostState().hostId;
+      app.expireIdentity();
+      expect(await app.auth.getAuthState()).toMatchObject({
+        status: "signed_in",
+      });
+      expect(app.auth.getAuthority()).not.toBe(previousAuthority);
+      await vi.waitFor(() => {
+        expect(app.controller.getHostState().status).toBe("online");
+        expect(app.controller.getHostState().hostId).not.toBe(previousHost);
+      });
+      expect(
+        app.requests.filter((request) => request.path.endsWith("/hosts/start")),
+      ).toHaveLength(refresh + 2);
+      expect(
+        app.requests.filter((request) => request.path.endsWith("/host/stop")),
+      ).toHaveLength(refresh + 1);
+    }
+    expect(app.authWindows()).toBe(3);
+    app.command = { id: "after-refresh", kind: "apps.list", payload: {} };
+    app.tick(5000);
+    expect(await app.completed.promise).toMatchObject({ status: "succeeded" });
+    await vi.waitFor(() =>
+      expect(app.controller.getHostState().localCommandLog).toHaveLength(1),
+    );
+    expect(app.controller.getHostState().localCommandLog[0]).toMatchObject({
+      status: "succeeded",
+      driver: { id: selectedDriver },
+    });
+    if (selectedDriver === "cua")
+      expect(app.boundaries.filter((boundary) => boundary.live)).toHaveLength(
+        1,
+      );
+  },
+);
+
+it("waits for old CUA cleanup and renewed developer access before recovering hidden auth", async () => {
+  const app = desktop();
+  await app.authorize();
+  await app.selection.select("cua");
+  await app.controller.start({ userInitiated: true });
+  const old = app.boundaries[0]!;
+  const exit = deferred<void>();
+  const feature = deferred<void>();
+  const featureEntered = deferred<void>();
+  old.intercept = async (name) => {
+    if (name === "stop") await exit.promise;
+  };
+  app.featureRead = async () => {
+    featureEntered.resolve();
+    await feature.promise;
+  };
+  try {
+    app.expireIdentity();
+    const refreshing = app.auth.getAuthState();
+    await old.stopEntered.promise;
+    expect(app.driver.getCapabilities()).toHaveLength(0);
+    expect(await refreshing).toMatchObject({ status: "signed_in" });
+    await featureEntered.promise;
+    expect(app.controller.getHostState().status).toBe("offline");
+    expect(app.boundaries).toHaveLength(1);
+    expect(
+      app.requests.filter((request) => request.path.endsWith("/hosts/start")),
+    ).toHaveLength(1);
+    exit.resolve();
+    await vi.waitFor(() => expect(old.live).toBe(false));
+    expect(app.boundaries).toHaveLength(1);
+    app.featureRead = null;
+    feature.resolve();
+    await vi.waitFor(() =>
+      expect(app.controller.getHostState().status).toBe("online"),
+    );
+    expect(
+      app.requests.filter((request) => request.path.endsWith("/hosts/start")),
+    ).toHaveLength(2);
+    expect(app.boundaries.filter((boundary) => boundary.live)).toHaveLength(1);
+  } finally {
+    exit.resolve();
+    feature.resolve();
+  }
+});
+
+it.each([
+  ["okou", "stop"],
+  ["okou", "quit"],
+  ["okou", "sign-out"],
+  ["cua", "stop"],
+  ["cua", "quit"],
+  ["cua", "sign-out"],
+] as const)(
+  "does not recover %s when %s supersedes a hidden refresh",
+  async (selectedDriver, action) => {
+    const app = desktop(
+      JSON.stringify({
+        computerUseDriver: {
+          experimentalCuaEnabled: selectedDriver === "cua",
+          selectedDriver,
+        },
+      }),
+    );
+    await app.authorize();
+    await app.restore();
+    await app.controller.start({ userInitiated: true });
+    const reply = deferred<string | null>();
+    app.authReply(reply.promise);
+    app.expireIdentity();
+    const refreshing = app.auth.getAuthState();
+    try {
+      await vi.waitFor(() => expect(app.authWindows()).toBe(2));
+      if (action === "stop") await app.controller.stop();
+      else if (action === "quit") await app.controller.stopForQuit();
+      else app.auth.signOut();
+      reply.resolve("first");
+      expect(await refreshing).toMatchObject({
+        status: action === "sign-out" ? "signed_out" : "signed_in",
+      });
+      await app.settle();
+      await nextTurn();
+      expect(app.controller.getHostState().status).toBe("offline");
+      expect(
+        app.requests.filter((request) => request.path.endsWith("/hosts/start")),
+      ).toHaveLength(1);
+      expect(app.driver.getCapabilities()).toHaveLength(0);
+      expect(app.boundaries.every((boundary) => !boundary.live)).toBe(true);
+    } finally {
+      reply.resolve(null);
+      await refreshing;
+    }
+  },
+);
+
+it.each([
+  ["okou", "failed"],
+  ["okou", "different identity"],
+  ["cua", "failed"],
+  ["cua", "different identity"],
+] as const)(
+  "does not reuse %s online intent after a hidden refresh returns %s",
+  async (selectedDriver, outcome) => {
+    const app = desktop(
+      JSON.stringify({
+        computerUseDriver: {
+          experimentalCuaEnabled: selectedDriver === "cua",
+          selectedDriver,
+        },
+      }),
+    );
+    await app.authorize();
+    await app.restore();
+    await app.controller.start({ userInitiated: true });
+    app.authReply(Promise.resolve(outcome === "failed" ? null : "second"));
+    app.expireIdentity();
+    expect(await app.auth.getAuthState()).toMatchObject({
+      status: outcome === "failed" ? "signed_out" : "signed_in",
+    });
+    await app.settle();
+    await nextTurn();
+    expect(app.controller.getHostState().status).toBe("offline");
+    expect(
+      app.requests.filter((request) => request.path.endsWith("/hosts/start")),
+    ).toHaveLength(1);
+    expect(app.driver.getCapabilities()).toHaveLength(0);
+    expect(app.boundaries.every((boundary) => !boundary.live)).toBe(true);
+  },
+);
+
+it.each(["okou", "cua"] as const)(
+  "finishes initial hidden authentication triggered by %s startup",
+  async (selectedDriver) => {
+    const app = desktop(
+      JSON.stringify({
+        computerUseDriver: {
+          experimentalCuaEnabled: selectedDriver === "cua",
+          selectedDriver,
+        },
+      }),
+    );
+    await app.restore();
+    await app.controller.start();
+    await vi.waitFor(() =>
+      expect(app.controller.getHostState().status).toBe("online"),
+    );
+    expect(app.authWindows()).toBe(1);
+    expect(
+      app.requests.filter((request) => request.path.endsWith("/hosts/start")),
+    ).toHaveLength(1);
+    expect(app.selection.getState().actual).toMatchObject({
+      id: selectedDriver,
+    });
+  },
+);
+
+it.each(["okou", "cua"] as const)(
+  "preserves a newer manual Start for %s while hidden authentication is pending",
+  async (selectedDriver) => {
+    const app = desktop(
+      JSON.stringify({
+        computerUseDriver: {
+          experimentalCuaEnabled: selectedDriver === "cua",
+          selectedDriver,
+        },
+      }),
+    );
+    await app.authorize();
+    await app.restore();
+    await app.controller.start({ userInitiated: true });
+    const reply = deferred<string | null>();
+    app.authReply(reply.promise);
+    app.expireIdentity();
+    const refreshing = app.auth.getAuthState();
+    try {
+      await vi.waitFor(() => expect(app.authWindows()).toBe(2));
+      await app.controller.stop();
+      const starting = app.controller.start({ userInitiated: true });
+      reply.resolve("first");
+      await refreshing;
+      await starting;
+      await vi.waitFor(() =>
+        expect(app.controller.getHostState().status).toBe("online"),
+      );
+      expect(
+        app.requests.filter((request) => request.path.endsWith("/hosts/start")),
+      ).toHaveLength(2);
+      expect(app.selection.getState().actual).toMatchObject({
+        id: selectedDriver,
+      });
+    } finally {
+      reply.resolve(null);
+      await refreshing;
+    }
+  },
+);
+
+it.each(["okou", "cua"] as const)(
+  "keeps %s offline when hidden authentication refresh has no online intent",
+  async (selectedDriver) => {
+    const app = desktop(
+      JSON.stringify({
+        computerUseDriver: {
+          experimentalCuaEnabled: selectedDriver === "cua",
+          selectedDriver,
+        },
+      }),
+    );
+    await app.authorize();
+    await app.restore();
+    app.expireIdentity();
+    expect(await app.auth.getAuthState()).toMatchObject({
+      status: "signed_in",
+    });
+    await app.settle();
+    await nextTurn();
+    expect(app.controller.getHostState().status).toBe("offline");
+    expect(
+      app.requests.filter((request) => request.path.endsWith("/hosts/start")),
+    ).toHaveLength(0);
+    expect(app.nativeStarts()).toBe(0);
+    expect(app.boundaries).toHaveLength(0);
+  },
+);
+
+it("recovers a hidden refresh triggered by host registration without registering a retired owner", async () => {
+  const app = desktop();
+  await app.authorize();
+  await app.restore();
+  app.rejectHostStart();
+  await app.controller.start({ userInitiated: true });
+  await vi.waitFor(() =>
+    expect(app.controller.getHostState().status).toBe("online"),
+  );
+  app.command = {
+    id: "after-registration-refresh",
+    kind: "apps.list",
+    payload: {},
+  };
+  app.tick(5000);
+  expect(await app.completed.promise).toMatchObject({ status: "succeeded" });
+  await vi.waitFor(() =>
+    expect(app.controller.getHostState().localCommandLog).toHaveLength(1),
+  );
+  await app.settle();
+  expect({
+    registrationAttempts: app.requests.filter((request) =>
+      request.path.endsWith("/hosts/start"),
+    ).length,
+    acceptedHosts: app.acceptedHosts(),
+    stoppedHostTokens: app.stoppedHostTokens,
+    onlineHost: app.controller.getHostState().hostId,
+    nativeStarts: app.nativeStarts(),
+    nativeActive: app.driver.getCapabilities().length > 0,
+  }).toEqual({
+    registrationAttempts: 2,
+    acceptedHosts: 1,
+    stoppedHostTokens: [],
+    onlineHost: "host-1",
+    nativeStarts: 2,
+    nativeActive: true,
+  });
+});

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -560,6 +560,8 @@ function getAuthSession(): DesktopAuthSession {
       return await authWindow.run(request);
     },
     onChange: notifyAuthChanged,
+    onBackgroundRefresh: (event) =>
+      computerUseController.handleBackgroundAuthRefresh(event),
     onAuthCompleted: maybeStartComputerUseAfterAuth,
   });
 

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -752,12 +752,15 @@ function supportedPluginCapabilities(): readonly string[] {
   ];
 }
 
-function createComputerUseHostRuntime(): ComputerUseHostRuntime {
+function createComputerUseHostRuntime(options: {
+  readonly refreshRegistrationAuth: boolean;
+}): ComputerUseHostRuntime {
   const installationId = readOrCreateComputerUseInstallationId(
     desktopPreferencesPath(),
   );
   return createDesktopComputerUseHostRuntime(
     {
+      refreshRegistrationAuth: options.refreshRegistrationAuth,
       platformUrl: config.platformUrl,
       installationId,
       hostName: readSystemHostName(config.identity.displayName),


### PR DESCRIPTION
Background authentication refresh currently stops an online Computer Use host and leaves it offline after authentication succeeds. Preserve the user's online intent through a fresh, verified auth lifetime and serialized cleanup, then restore the runtime for the same account/workspace. Initial restoration can finish an explicit startup; Stop, quit, sign-out, failed refresh and changed identity prevent stale recovery.

Auth publishes verified credentials atomically and emits non-blocking refresh outcomes. Both drivers share recovery ownership, including delayed CUA authorization. Authenticated requests cannot retry across account/workspace changes. Host registration leaves the authenticated retry to the replacement runtime, preventing the retired instance from rotating its token. The original response remains readable so any late successful registration can still be stopped. The replacement receives one registration attempt with refreshed auth; another 401 becomes a terminal error, and only explicit Start resets that budget. CUA authorization updates cannot restart the failed attempt.

Fixes #32953.

Validation:
- 195 targeted tests passed together on the corrected revision across auth session/lifecycle, driver selection, runtime controller, driver, host and runtime-wiring suites. Coverage includes repeated refresh and a successful subsequent command for both drivers, slow cleanup/authorization, initial restoration, Stop then Start, concurrent 401s, changed identity, and registration-triggered refresh.
- Reproduced the original offline failure before the fix. Also reproduced registration-triggered refresh creating two accepted hosts, then verified the fix allows only one accepted registration.
- Desktop type checking, lint, formatting, Electron build/bootstrap guard, style policy, commitlint and file-size checks passed.
- Scoped Knip reports the existing unused `@sentry/cli` and `sharp` devDependencies; neither dependency nor Desktop Knip configuration changed. The local hook reports Lefthook unavailable, so applicable checks were run directly.

This changes Desktop only; no API or native protocol changes. Validation uses real Desktop modules with external HTTP/helper/SDK fixtures. The installed signed macOS app was not replaced, so real-machine acceptance over multiple live credential refreshes remains to be performed on the released build.
