### PR TITLE
fix: recognize invalid claude oauth tokens

### DIFF
--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -306,7 +306,7 @@ fn classify_cli_failure_reason(
         return Some(FailureReason::TermsAcceptanceRequired);
     }
     if matches!(framework, AgentFramework::ClaudeCode)
-        && is_claude_oauth_token_revoked_error(&normalized)
+        && is_claude_oauth_reconnect_required_error(&normalized)
     {
         return Some(FailureReason::ReconnectRequired);
     }
@@ -416,11 +416,20 @@ fn is_claude_invalid_credentials_error(normalized: &str) -> bool {
         && normalized.contains("api error: 401 invalid authentication credentials")
 }
 
-fn is_claude_oauth_token_revoked_error(normalized: &str) -> bool {
+fn is_claude_oauth_reconnect_required_error(normalized: &str) -> bool {
+    const INVALID_TOKEN: &str = "oauth access token is invalid";
+
     normalized.contains("failed to authenticate")
         && has_claude_api_status(normalized, "401")
         && normalized.contains("oauth access token")
-        && normalized.contains("revoked")
+        && (normalized.contains("revoked")
+            || normalized.match_indices(INVALID_TOKEN).any(|(index, _)| {
+                !normalized[..index]
+                    .chars()
+                    .next_back()
+                    .is_some_and(is_error_type_char)
+                    && strip_word_prefix(&normalized[index..], INVALID_TOKEN).is_some()
+            }))
 }
 
 fn is_claude_terms_acceptance_required_error(normalized: &str) -> bool {

--- a/crates/guest-agent/tests/claude_result_failure_logging.rs
+++ b/crates/guest-agent/tests/claude_result_failure_logging.rs
@@ -15,64 +15,79 @@ async fn claude_error_result_is_written_to_system_log() -> Result<(), Box<dyn st
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
     let system_log_path = tmp.path().join("system.log");
-    let failure_message =
-        "Failed to authenticate. API Error: 401 OAuth access token has been revoked.";
-
     unsafe {
-        common::setup_env(
-            &mock,
-            tmp.path(),
-            &format!("printf '{failure_message}'; exit 2"),
-            3,
-            1,
-        )?;
+        common::setup_env(&mock, tmp.path(), "", 3, 1)?;
     }
 
-    let runtime = common::guest_runtime_from_process_env()?;
+    let mut runtime = common::guest_runtime_from_process_env()?;
 
     let _system_log = SystemLogOverrideGuard::set(&system_log_path);
     let masker = SecretMasker::from_raw("");
-    let cli_result = tokio::time::timeout(
-        Duration::from_secs(5),
-        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
-    )
-    .await
-    .expect("execute_cli should return promptly")?;
+    for (failure_message, expected_reason) in [
+        (
+            "Failed to authenticate. API Error: 401 OAuth access token is invalid.",
+            Some(FailureReason::ReconnectRequired),
+        ),
+        (
+            "Failed to authenticate. API Error: 401 OAuth access token has been revoked.",
+            Some(FailureReason::ReconnectRequired),
+        ),
+        (
+            "Failed to authenticate. API Error: 4010 OAuth access token is invalid.",
+            None,
+        ),
+        (
+            "Failed to authenticate. API Error: 401 OAuth access token is invalidated.",
+            None,
+        ),
+        (
+            "Failed to authenticate. API Error: 401 OAuth access token validation is invalid.",
+            None,
+        ),
+    ] {
+        runtime.config.prompt = format!("printf '{failure_message}'; exit 2");
+        let cli_result = tokio::time::timeout(
+            Duration::from_secs(5),
+            common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
+        )
+        .await
+        .expect("execute_cli should return promptly")?;
 
-    assert_eq!(cli_result.exit_code, 2);
-    assert!(cli_result.stderr_lines.is_empty());
-    assert_eq!(
-        cli_result
-            .failure_diagnostic
-            .as_ref()
-            .map(|diagnostic| diagnostic.message.as_str()),
-        Some(failure_message)
-    );
-    assert_eq!(
-        cli_result
-            .failure_diagnostic
-            .as_ref()
-            .map(|diagnostic| diagnostic.source),
-        Some(FailureDetailSource::ClaudeResult)
-    );
-    let terminal_failure = guest_agent::failure_diagnostics::cli_nonzero_failure_for_config(
-        &runtime.config,
-        None,
-        &cli_result,
-    );
-    assert_eq!(terminal_failure.message, failure_message);
-    assert_eq!(
-        terminal_failure.diagnostic.failure_reason,
-        Some(FailureReason::ReconnectRequired)
-    );
+        assert_eq!(cli_result.exit_code, 2);
+        assert!(cli_result.stderr_lines.is_empty());
+        assert_eq!(
+            cli_result
+                .failure_diagnostic
+                .as_ref()
+                .map(|diagnostic| diagnostic.message.as_str()),
+            Some(failure_message)
+        );
+        assert_eq!(
+            cli_result
+                .failure_diagnostic
+                .as_ref()
+                .map(|diagnostic| diagnostic.source),
+            Some(FailureDetailSource::ClaudeResult)
+        );
+        let terminal_failure = guest_agent::failure_diagnostics::cli_nonzero_failure_for_config(
+            &runtime.config,
+            None,
+            &cli_result,
+        );
+        assert_eq!(terminal_failure.message, failure_message);
+        assert_eq!(
+            terminal_failure.diagnostic.failure_reason, expected_reason,
+            "unexpected classification for {failure_message}"
+        );
 
-    let system_log = std::fs::read_to_string(&system_log_path)?;
-    assert!(
-        system_log.contains(&format!(
-            "Claude JSONL failure result seq=4 subtype=error: {failure_message}"
-        )),
-        "system log should include Claude JSONL failure reason: {system_log}"
-    );
+        let system_log = std::fs::read_to_string(&system_log_path)?;
+        assert!(
+            system_log.contains(&format!(
+                "Claude JSONL failure result seq=4 subtype=error: {failure_message}"
+            )),
+            "system log should include Claude JSONL failure reason: {system_log}"
+        );
+    }
 
     Ok(())
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -4470,6 +4470,8 @@ describe("CHAT-02: failed chat callbacks", () => {
       "Failed to authenticate. API Error: 401 Invalid authentication credentials";
     const revokedOAuthError =
       "Failed to authenticate. API Error: 401 OAuth access token has been revoked.";
+    const invalidOAuthError =
+      "Failed to authenticate. API Error: 401 OAuth access token is invalid.";
 
     async function failAndReadError(params: {
       readonly prompt: string;
@@ -4529,6 +4531,48 @@ describe("CHAT-02: failed chat callbacks", () => {
       }
       expect(marker.content).toBe(marker.error);
       expect(marker.error).not.toContain("Report this issue");
+      await expect(
+        api.readRun(fixture.actor, run.runId),
+      ).resolves.toMatchObject({
+        status: "failed",
+        error: params.errorMessage ?? upstreamAuthError,
+      });
+      if (params.failureReason === "reconnect_required") {
+        expect(marker.failureReason).toBe("reconnect_required");
+        expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ runId: run.runId }),
+        );
+        expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+        expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+        await misc.upsertPersonalModelProvider(
+          fixture.actor,
+          {
+            type: "claude-code-oauth-token",
+            secret: "sk-ant-oat-reconnected-bdd",
+          },
+          [200],
+        );
+        const retry = await startChatRun(fixture.actor, {
+          agentId: fixture.agentId,
+          threadId: run.threadId,
+          prompt: "retry after replacing the Claude OAuth token",
+          selectedModel: "claude-opus-4-8",
+        });
+        const retryHeaders = await claimChatRun(
+          fixture.runnerGroup,
+          retry.runId,
+        );
+        await completeChatRunOk(retry.runId, retryHeaders);
+        await expect(
+          api.readRun(fixture.actor, retry.runId),
+        ).resolves.toMatchObject({ status: "completed" });
+      } else if (params.failureReason === undefined) {
+        expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+          "Run failed",
+          expect.objectContaining({ runId: run.runId }),
+        );
+      }
       return marker.error;
     }
 
@@ -4569,6 +4613,48 @@ describe("CHAT-02: failed chat callbacks", () => {
         selectedModel: "claude-sonnet-5",
       }),
     ).resolves.toBe("Oops, something went wrong. Please try again later.");
+    await expect(
+      failAndReadError({
+        prompt: "invalid subscription credential failed",
+        errorMessage: invalidOAuthError,
+        selectedModel: "claude-opus-4-8",
+        configureProvider: configureClaudeCodeSubscriptionProvider,
+      }),
+    ).resolves.toBe(
+      "Claude Code subscription authentication failed. Reconnect Claude Code in Model Providers, then retry.\n\nReconnect Claude Code: https://app.okou.ai/?settings=model",
+    );
+    await expect(
+      failAndReadError({
+        prompt: "structured invalid subscription credential failed",
+        errorMessage: invalidOAuthError,
+        failureReason: "reconnect_required",
+        selectedModel: "claude-opus-4-8",
+        configureProvider: configureClaudeCodeSubscriptionProvider,
+      }),
+    ).resolves.toBe(
+      "Claude Code subscription authentication failed. Reconnect Claude Code in Model Providers, then retry.\n\nReconnect Claude Code: https://app.okou.ai/?settings=model",
+    );
+    await expect(
+      failAndReadError({
+        prompt: "invalid OAuth text with an Anthropic API key",
+        errorMessage: invalidOAuthError,
+        selectedModel: "claude-sonnet-5",
+      }),
+    ).resolves.toBe("Oops, something went wrong. Please try again later.");
+    for (const errorMessage of [
+      "Failed to authenticate. API Error: 4010 OAuth access token is invalid.",
+      "Failed to authenticate. API Error: 401 OAuth access token is invalidated.",
+      "Failed to authenticate. API Error: 401 OAuth access token validation is invalid.",
+    ]) {
+      await expect(
+        failAndReadError({
+          prompt: "unclassified OAuth failure",
+          errorMessage,
+          selectedModel: "claude-opus-4-8",
+          configureProvider: configureClaudeCodeSubscriptionProvider,
+        }),
+      ).resolves.toBe("Oops, something went wrong. Please try again later.");
+    }
     await expect(
       failAndReadError({
         prompt: "legacy callback without public brand failed for admin",

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -591,13 +591,18 @@ export function isClaudeCodeAuthenticationCredentialsError(
   );
 }
 
-function isClaudeCodeOAuthTokenRevokedError(errorMessage: string): boolean {
+function isClaudeCodeOAuthReconnectRequiredError(
+  errorMessage: string,
+): boolean {
   const normalized = errorMessage.toLowerCase();
   return (
     normalized.includes("failed to authenticate") &&
     /api error:[\s:.-]*401(?![a-z0-9_-])/u.test(normalized) &&
     normalized.includes("oauth access token") &&
-    normalized.includes("revoked")
+    (normalized.includes("revoked") ||
+      /(?:^|[^a-z0-9_-])oauth access token is invalid(?![a-z0-9_-])/u.test(
+        normalized,
+      ))
   );
 }
 
@@ -848,7 +853,7 @@ export function formatRunErrorForExternalSurface(params: {
     (isClaudeCodeAuthenticationCredentialsError(errorMessage) ||
       (params.claudeCodeCredentialRecovery.modelProviderType ===
         "claude-code-oauth-token" &&
-        isClaudeCodeOAuthTokenRevokedError(errorMessage)))
+        isClaudeCodeOAuthReconnectRequiredError(errorMessage)))
   ) {
     const recoveryMessage = formatClaudeCodeCredentialRecoveryMessage(
       params.claudeCodeCredentialRecovery,


### PR DESCRIPTION
## Summary

- Recognize Claude Code's `Failed to authenticate. API Error: 401 OAuth access token is invalid.` as the existing `reconnect_required` outcome.
- Preserve the existing revoked-token signature and strict authentication/status/word boundaries. Reuse the established Claude OAuth recovery message and Model Providers action, including errors without a structured reason.
- Keep failed-run status and raw diagnostic details. Existing Runner informational logging and API non-built-in failure suppression now apply to newly classified results; unknown errors and non-OAuth provider contexts retain their current behavior.

## Scope and compatibility

No credential state writes, refresh changes, launch preflight, automatic retries, new UI, failure enum, protocol fields, database migration or log-policy changes. Normal successful runs add no network/database work.

New Guest completions use a reason already supported by API/App readers. Old Guest completions and historical errors remain accepted by the existing raw-message formatter. Their generic API warning policy is unchanged until they have a structured reason. Guest-local system diagnostics retain their existing raw failure logging. No fallback mechanism is introduced or removed.

This does not establish why the external token became invalid or prevent repeated launches. Persisted invalidation would need exact credential-revision ownership to avoid marking a replacement token stale when an older run finishes late.

## Validation

- Red-before-fix: real Claude CLI result integration failed with `None` instead of `Some(ReconnectRequired)` for the observed invalid-token text.
- Full `cargo test --profile local --locked -p guest-agent --all-features -- --quiet` passed. The extended CLI-result test covers invalid/revoked results and nearby nonmatching status/text while preserving diagnostics and deadlines.
- `cargo test --profile local --locked -p runner --all-features job_terminal_log::tests -- --quiet` — 25 selected tests passed.
- Full API chat-callbacks route file — 55/55 passed, including raw failed-run preservation, current and legacy reconnect copy, no current failure WARN/ERROR/Sentry, retained generic warnings, API-key isolation, and token replacement followed by a successful same-thread run through controlled Runner completion. Passed again after local environment preparation.
- API run-lifecycle `completion failure logs` selection — 29/29 passed; full api-contracts suite — 42 files, 821/821 passed.
- API/contracts lint and type checks, scoped Knip, changed-file Prettier and `git diff --check` passed. Knip initially found a missing local @clerk/ui install; repository `scripts/prepare.sh` repaired it without dependency/lockfile changes.
- `cargo fmt --all -- --check`, Guest all-target/all-feature Clippy with `-D warnings`, and Guest documentation with `RUSTDOCFLAGS=-Dwarnings` passed.

Relates to #33068. The issue remains open for a bounded post-deployment observation with deployed API/Runner identities and exercised real traffic. This PR does not deploy, replay production runs, mutate production credentials or claim live-provider recovery validation.
