### PR TITLE
fix(api): record expected chat event snapshot timeouts without warn noise

### DIFF
--- a/docs/chat-event-snapshot-timeout-logging.md
+++ b/docs/chat-event-snapshot-timeout-logging.md
@@ -1,0 +1,61 @@
+# Chat Event Snapshot candidate timeout diagnostics
+
+The global Chat Event Snapshot sweep archives one thread per candidate under a
+30-second per-head deadline, eight workers, and a two-minute start budget. That
+deadline is designed backpressure so a slow head cannot block unrelated
+convergence; it is not a failure signal.
+
+A candidate that reaches its deadline is logged at **info** with
+`type=chat_event_snapshot_candidate_timed_out` and `expected=true`, plus the
+coarse `stage` it had reached (`resolve_prefix`, `read_events`, `compress`,
+`put_object`, or `publish`), `durationMs`, and `timeoutMs`. The outcome is
+still unsuccessful: the candidate contributes to `skippedTimedOutHeads` on the
+terminal `chat_event_snapshot_completed` event and publishes no pointer.
+
+This is a log-level classification, not a deadline extension, an error filter,
+or a retry change. `chat_event_snapshot_candidate_failed` stays at **error**
+with its inner error, and now also carries `stage`. Deferred, unreadable,
+undecodable, and incomplete heads keep their existing classification, and
+request cancellation still propagates instead of being recorded as a timeout.
+
+## Why downgrading is safe
+
+- **Convergence.** The scan cursor advances past a timed-out candidate, so the
+  head is retried on the next `lastMessageAt`-fenced cycle rather than the next
+  invocation. Recovery is bounded by one full cursor cycle, not by a constant.
+- **Retention.** Chat Event retention deletes a Raw Event only when a
+  current-schema Snapshot with `last_seq_id >= event.seq_id` and a conforming
+  object key exists. An un-archived head therefore blocks its own reclamation;
+  a repeated timeout delays retention and can never lose events.
+- **Publication.** The exact-pointer CAS remains the only publication owner. A
+  deadline that fires around publication can leave a collectable orphan object
+  or record a timeout for a head that actually published, but it cannot move
+  the pointer incorrectly.
+- **No absorbed failures.** `awaitWithSignal` settles the deadline race with
+  the deadline's own reason, so the timeout branch cannot swallow an unrelated
+  archive error. Genuine failures reject before the deadline and keep the error
+  path.
+
+## Alerting
+
+Alert on sustained lag, never on a single timeout. The terminal event carries
+`skippedTimedOutHeads`, `skippedFailedHeads`, `selectedCandidates`,
+`deferredCandidates`, `scanWrapped`, and `oldestCandidateAgeMs` — the age of
+the least recently updated selected candidate. A stuck head keeps reappearing
+each cycle and drags `oldestCandidateAgeMs` upward, while an isolated deadline
+does not. Warn/error-only queries do not contain the downgraded info events.
+
+## Rollout verification
+
+Keep [#33088](https://github.com/vm0-ai/vm0/issues/33088) open after this
+change. Record the deployed API revision and observe a bounded window, then
+check that the warn/error feed carries no
+`chat_event_snapshot_candidate_timed_out` records, that any info record carries
+a non-empty `stage` and `durationMs`, that `chat_event_snapshot_completed`
+keeps its cadence with `skippedFailedHeads` at zero, and that
+`oldestCandidateAgeMs` stays flat.
+
+The observed base rate is roughly one timeout per 40,000 candidates, so a quiet
+window without an exercised timeout is not recovery evidence. Correlate at
+least one real downgraded event, or exercise the fixtures snapshot route, and
+record the limitation otherwise.

--- a/docs/chat-event-snapshot-timeout-logging.md
+++ b/docs/chat-event-snapshot-timeout-logging.md
@@ -41,9 +41,13 @@ request cancellation still propagates instead of being recorded as a timeout.
 Alert on sustained lag, never on a single timeout. The terminal event carries
 `skippedTimedOutHeads`, `skippedFailedHeads`, `selectedCandidates`,
 `deferredCandidates`, `scanWrapped`, and `oldestCandidateAgeMs` — the age of
-the least recently updated selected candidate. A stuck head keeps reappearing
-each cycle and drags `oldestCandidateAgeMs` upward, while an isolated deadline
-does not. Warn/error-only queries do not contain the downgraded info events.
+the least recently updated candidate **in that invocation's batch**. Global
+discovery selects candidates in thread-ID order, so a single invocation sees
+one slice of the eligible set and the per-invocation value varies with batch
+composition. Aggregate it as a maximum over a window: a stuck head keeps
+reappearing every cycle with a `lastMessageAt` that never moves, so its age
+grows monotonically, while an isolated deadline leaves no trend.
+Warn/error-only queries do not contain the downgraded info events.
 
 ## Rollout verification
 
@@ -52,8 +56,8 @@ change. Record the deployed API revision and observe a bounded window, then
 check that the warn/error feed carries no
 `chat_event_snapshot_candidate_timed_out` records, that any info record carries
 a non-empty `stage` and `durationMs`, that `chat_event_snapshot_completed`
-keeps its cadence with `skippedFailedHeads` at zero, and that
-`oldestCandidateAgeMs` stays flat.
+keeps its cadence with `skippedFailedHeads` at zero, and that the windowed
+maximum of `oldestCandidateAgeMs` shows no sustained upward trend.
 
 The observed base rate is roughly one timeout per 40,000 candidates, so a quiet
 window without an exercised timeout is not recovery evidence. Correlate at

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -52,3 +52,6 @@ surface; the index does not replace their detailed rules.
 - [Testing catalog](./testing/anti-patterns.md): detailed testing anti-patterns.
 - [Addon runtime contracts](./mitm-addon-contracts.md): logging ownership,
   WebSocket framing and handshake limits, and path normalization boundaries.
+- [Chat Event Snapshot timeout diagnostics](./chat-event-snapshot-timeout-logging.md):
+  expected per-head deadlines, stage diagnostics, convergence and retention
+  safety, and archive-lag alerting.

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -341,6 +341,20 @@ export default [
     },
   },
   {
+    files: ["src/signals/services/cron-snapshot-chat-events.service.ts"],
+    rules: {
+      // An expected per-head deadline is bounded backpressure, not a warning,
+      // but a genuinely stuck head still needs its stage and duration. Axiom's
+      // default transport drops debug events, so retain this record at info.
+      "api/no-logger-info": [
+        "error",
+        {
+          allowedMessages: ["Timed out Chat Event Snapshot candidate"],
+        },
+      ],
+    },
+  },
+  {
     files: ["src/**/*.ts"],
     ignores: [
       "src/**/__tests__/**",

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
@@ -14,7 +14,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
-import { mockNow } from "../../../lib/time";
+import { mockNow, now } from "../../../lib/time";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise } from "../../utils";
 import { cronSnapshotChatEventsRoutes } from "../cron-snapshot-chat-events";
@@ -798,7 +798,7 @@ describe("cron snapshot chat events", () => {
     // forward by a known offset must be reflected in the reported lag. This
     // fails if the counter stops measuring the selected candidates.
     const lagMs = 60_000;
-    mockNow(new Date(Date.now() + lagMs));
+    mockNow(new Date(now() + lagMs));
     const pending = await runSnapshotCron([threadId]);
     expect(pending).toMatchObject({
       success: true,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
@@ -48,6 +48,9 @@ const DUPLICATE_EVENT_ID_WARNING =
   "Normalized duplicate chat event IDs in snapshot";
 const SNAPSHOT_COMPLETED_MESSAGE = "Completed chat event snapshot";
 const SNAPSHOT_COMPLETED_TYPE = "chat_event_snapshot_completed";
+const SNAPSHOT_TIMED_OUT_TYPE = "chat_event_snapshot_candidate_timed_out";
+const SNAPSHOT_FAILED_TYPE = "chat_event_snapshot_candidate_failed";
+const SNAPSHOT_THREAD_TIMEOUT_MS = 30_000;
 const OBJECT_KEY_PATTERN =
   /^chat-events\/([0-9a-f-]{36})\/(\d+)-r1-([0-9a-f]{64})\.ndjson\.gz$/;
 
@@ -93,6 +96,16 @@ function snapshotCompletionEvents(): readonly Record<string, unknown>[] {
     return events.filter((event): event is Record<string, unknown> => {
       return isRecord(event) && event.type === SNAPSHOT_COMPLETED_TYPE;
     });
+  });
+}
+
+function candidateLogFields(
+  level: "info" | "warn" | "error",
+  type: string,
+): readonly Record<string, unknown>[] {
+  return context.mocks.axiomLogging[level].mock.calls.flatMap((call) => {
+    const fields = call[1];
+    return isRecord(fields) && fields.type === type ? [fields] : [];
   });
 }
 
@@ -615,6 +628,11 @@ describe("cron snapshot chat events", () => {
     });
     expect(putsForThread(failedThreadId)).toHaveLength(0);
     expect(putsForThread(repairableThreadId)).toHaveLength(1);
+    // A genuine archive failure keeps the error feed and now names its stage.
+    const failedLogs = candidateLogFields("error", SNAPSHOT_FAILED_TYPE);
+    expect(failedLogs).toHaveLength(1);
+    expect(failedLogs[0]).toMatchObject({ stage: "put_object" });
+    expect(candidateLogFields("info", SNAPSHOT_TIMED_OUT_TYPE)).toHaveLength(0);
     expect(snapshotCompletionEvents()).toHaveLength(1);
     expect(snapshotCompletionEvents()[0]).toMatchObject({
       snapshots: 1,
@@ -723,6 +741,26 @@ describe("cron snapshot chat events", () => {
       snapshots: 1,
       skippedFailedHeads: 0,
       skippedTimedOutHeads: 1,
+    });
+
+    // An expected bounded deadline is diagnostic info, not a warning: it must
+    // stay out of the warn/error feed while keeping the stuck stage locatable.
+    const timedOutLogs = candidateLogFields("info", SNAPSHOT_TIMED_OUT_TYPE);
+    expect(timedOutLogs).toHaveLength(1);
+    expect(timedOutLogs[0]).toMatchObject({
+      expected: true,
+      stage: "resolve_prefix",
+      timeoutMs: SNAPSHOT_THREAD_TIMEOUT_MS,
+      durationMs: expect.any(Number),
+    });
+    expect(candidateLogFields("warn", SNAPSHOT_TIMED_OUT_TYPE)).toHaveLength(0);
+    expect(candidateLogFields("error", SNAPSHOT_TIMED_OUT_TYPE)).toHaveLength(
+      0,
+    );
+    expect(candidateLogFields("error", SNAPSHOT_FAILED_TYPE)).toHaveLength(0);
+    expect(snapshotCompletionEvents()[0]).toMatchObject({
+      skippedTimedOutHeads: 1,
+      oldestCandidateAgeMs: expect.any(Number),
     });
 
     context.mocks.abortSignal.timeout.mockReset();

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
@@ -783,6 +783,40 @@ describe("cron snapshot chat events", () => {
     ).toBe(2);
   }, 90_000);
 
+  it("reports the selected batch's archive lag and no lag once it converges", async () => {
+    const owner = bdd.user({ orgId: `org_${randomUUID()}` });
+    const agent = await bdd.createAgent(owner, {
+      displayName: "Archive lag snapshot agent",
+    });
+    const threadId = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: `archive-lag-snapshot-${randomUUID()}`,
+    });
+    await projectChatEventSearch(threadId);
+
+    // The candidate's last message is already in the past, so a clock moved
+    // forward by a known offset must be reflected in the reported lag. This
+    // fails if the counter stops measuring the selected candidates.
+    const lagMs = 60_000;
+    mockNow(new Date(Date.now() + lagMs));
+    const pending = await runSnapshotCron([threadId]);
+    expect(pending).toMatchObject({
+      success: true,
+      selectedCandidates: 1,
+      snapshots: 1,
+    });
+    expect(pending.oldestCandidateAgeMs).toBeGreaterThanOrEqual(lagMs);
+
+    // Nothing is eligible once the thread converges, so the batch has no lag.
+    const converged = await runSnapshotCron([threadId]);
+    expect(converged).toMatchObject({
+      success: true,
+      selectedCandidates: 0,
+      snapshots: 0,
+      oldestCandidateAgeMs: 0,
+    });
+  }, 60_000);
+
   it("propagates request cancellation without moving the exact pointer", async () => {
     const owner = bdd.user({ orgId: `org_${randomUUID()}` });
     const agent = await bdd.createAgent(owner, {

--- a/turbo/apps/api/src/signals/routes/cron-snapshot-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/cron-snapshot-chat-events.ts
@@ -22,6 +22,7 @@ interface ChatEventSnapshotCompletionCounters {
   readonly skippedIncompleteHeads: number;
   readonly skippedFailedHeads: number;
   readonly skippedTimedOutHeads: number;
+  readonly oldestCandidateAgeMs: number;
   readonly scanCursorAdvanced: boolean;
   readonly scanWrapped: boolean;
   readonly duplicateEventIdConflictThreads: number;
@@ -53,6 +54,7 @@ export function recordChatEventSnapshotCompleted(
       skippedIncompleteHeads: counters.skippedIncompleteHeads,
       skippedFailedHeads: counters.skippedFailedHeads,
       skippedTimedOutHeads: counters.skippedTimedOutHeads,
+      oldestCandidateAgeMs: counters.oldestCandidateAgeMs,
       scanCursorAdvanced: counters.scanCursorAdvanced,
       scanWrapped: counters.scanWrapped,
       duplicateEventIdConflictThreads: counters.duplicateEventIdConflictThreads,

--- a/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
@@ -69,6 +69,7 @@ interface ChatEventSnapshotStats {
   readonly skippedIncompleteHeads: number;
   readonly skippedFailedHeads: number;
   readonly skippedTimedOutHeads: number;
+  readonly oldestCandidateAgeMs: number;
   readonly scanCursorAdvanced: boolean;
   readonly scanWrapped: boolean;
   readonly duplicateEventIdConflictThreads: number;
@@ -95,6 +96,8 @@ type ChatEventSnapshotScope =
 interface SnapshotCandidate {
   readonly chatThreadId: string;
   readonly indexedSeqId: number;
+  /** Selection timestamp; reported as the batch's archive lag. */
+  readonly lastMessageAt: Date;
   readonly headId: string | null;
   readonly headLastSeqId: number | null;
   readonly headLastEventId: string | null;
@@ -894,16 +897,34 @@ function archivedThreadFromPublication(
   };
 }
 
+/**
+ * Coarse archive phase a candidate had reached when its bounded deadline
+ * fired. It locates a genuinely stuck head without exposing archive content,
+ * object keys or event bodies.
+ */
+type SnapshotArchiveStage =
+  | "resolve_prefix"
+  | "read_events"
+  | "compress"
+  | "put_object"
+  | "publish";
+
+interface SnapshotArchiveStageRecorder {
+  stage: SnapshotArchiveStage;
+}
+
 const archiveThread$ = command(async function archiveThread(
   { get },
   args: {
     readonly db: Db;
     readonly bucket: string;
     readonly candidate: SnapshotCandidate;
+    readonly recorder: SnapshotArchiveStageRecorder;
   },
   signal: AbortSignal,
 ): Promise<ArchivedThread> {
-  const { db, bucket, candidate } = args;
+  const { db, bucket, candidate, recorder } = args;
+  recorder.stage = "resolve_prefix";
   const resolved = await get(
     resolveArchivePrefix({ bucket, candidate }, signal),
   );
@@ -913,6 +934,7 @@ const archiveThread$ = command(async function archiveThread(
   }
   const { source, prefix, terminalSeqId, terminalEventId } = resolved;
   const targetSeqId = Math.max(candidate.indexedSeqId, source?.lastSeqId ?? 0);
+  recorder.stage = "read_events";
   const archive = await readCanonicalEvents(
     db,
     { ...candidate, indexedSeqId: targetSeqId },
@@ -944,6 +966,7 @@ const archiveThread$ = command(async function archiveThread(
     },
     archive,
   );
+  recorder.stage = "compress";
   const compressed = await gzipAsync(prepared.body);
   signal.throwIfAborted();
   const objectKey = chatEventSnapshotObjectKey(
@@ -951,6 +974,7 @@ const archiveThread$ = command(async function archiveThread(
     targetSeqId,
     sha256Hex(compressed),
   );
+  recorder.stage = "put_object";
   const [existingObjectReference] = await db
     .select({ id: chatEventSnapshots.id })
     .from(chatEventSnapshots)
@@ -976,6 +1000,7 @@ const archiveThread$ = command(async function archiveThread(
   }
   signal.throwIfAborted();
 
+  recorder.stage = "publish";
   const published = await settle(
     publishSnapshotVersion(db, candidate, source, {
       lastSeqId: targetSeqId,
@@ -1018,6 +1043,7 @@ export const refreshChatEventSnapshotThread$ = command(
         db,
         bucket: env("R2_USER_STORAGES_BUCKET_NAME"),
         candidate,
+        recorder: { stage: "resolve_prefix" },
       },
       signal,
     );
@@ -1281,6 +1307,7 @@ async function loadSnapshotCandidates(
     .select({
       chatThreadId: chatThreads.id,
       indexedSeqId: chatEventSearchMessageWatermarks.indexedSeqId,
+      lastMessageAt: chatThreads.lastMessageAt,
       headId: currentSnapshot.id,
       headLastSeqId: currentSnapshot.lastSeqId,
       headLastEventId: currentSnapshot.lastEventId,
@@ -1341,6 +1368,7 @@ async function loadSnapshotCandidates(
     return {
       chatThreadId: row.chatThreadId,
       indexedSeqId: row.indexedSeqId,
+      lastMessageAt: row.lastMessageAt,
       headId: row.headId,
       headLastSeqId: row.headLastSeqId,
       headLastEventId: row.headLastEventId,
@@ -1419,29 +1447,46 @@ async function processSnapshotCandidate(
   candidate: SnapshotCandidate,
   archive: (
     candidate: SnapshotCandidate,
+    recorder: SnapshotArchiveStageRecorder,
     signal: AbortSignal,
   ) => Promise<ArchivedThread>,
   signal: AbortSignal,
 ): Promise<SnapshotCandidateOutcome> {
   const timeoutSignal = AbortSignal.timeout(SNAPSHOT_THREAD_TIMEOUT_MS);
   const candidateSignal = AbortSignal.any([signal, timeoutSignal]);
+  const recorder: SnapshotArchiveStageRecorder = { stage: "resolve_prefix" };
+  const startedAt = now();
   const archived = await settleIncludingAbort(
-    awaitWithSignal(archive(candidate, candidateSignal), candidateSignal),
+    awaitWithSignal(
+      archive(candidate, recorder, candidateSignal),
+      candidateSignal,
+    ),
   );
   signal.throwIfAborted();
   if (archived.ok) {
     return { kind: "completed", archived: archived.value };
   }
   if (timeoutSignal.aborted) {
-    log.warn("Timed out Chat Event Snapshot candidate", {
+    // The per-head deadline is designed backpressure, not a failure: the
+    // candidate stays eligible for the next cycle and retention keeps its Raw
+    // Events until a Snapshot covers them. `awaitWithSignal` settles this race
+    // with the deadline's own reason, so no unrelated failure is absorbed
+    // here. `skippedTimedOutHeads` on the terminal event remains the alerting
+    // signal; see docs/chat-event-snapshot-timeout-logging.md.
+    log.info("Timed out Chat Event Snapshot candidate", {
       type: "chat_event_snapshot_candidate_timed_out",
+      expected: true,
       chatThreadId: candidate.chatThreadId,
+      stage: recorder.stage,
+      durationMs: now() - startedAt,
+      timeoutMs: SNAPSHOT_THREAD_TIMEOUT_MS,
     });
     return { kind: "timed_out" };
   }
   log.error("Failed Chat Event Snapshot candidate", {
     type: "chat_event_snapshot_candidate_failed",
     chatThreadId: candidate.chatThreadId,
+    stage: recorder.stage,
     error: archived.error,
   });
   return { kind: "failed" };
@@ -1451,6 +1496,7 @@ async function processSnapshotCandidates(
   candidates: readonly SnapshotCandidate[],
   archive: (
     candidate: SnapshotCandidate,
+    recorder: SnapshotArchiveStageRecorder,
     signal: AbortSignal,
   ) => Promise<ArchivedThread>,
   signal: AbortSignal,
@@ -1554,6 +1600,26 @@ function summarizeSnapshotCandidateOutcomes(
   return stats;
 }
 
+/**
+ * Age of the least recently updated selected candidate. Sustained growth is
+ * the actionable archive-lag signal; one bounded per-head timeout is not.
+ */
+function oldestCandidateAgeMs(
+  candidates: readonly SnapshotCandidate[],
+): number {
+  let oldest: number | null = null;
+  for (const candidate of candidates) {
+    const lastMessageAt = candidate.lastMessageAt.getTime();
+    if (oldest === null || lastMessageAt < oldest) {
+      oldest = lastMessageAt;
+    }
+  }
+  if (oldest === null) {
+    return 0;
+  }
+  return Math.max(0, Math.round(nowDate().getTime() - oldest));
+}
+
 async function finalizeGlobalSnapshotScanState(
   db: Db,
   candidatePage: SnapshotCandidatePage,
@@ -1613,12 +1679,13 @@ export const snapshotChatEvents$ = command(
       ));
     signal.throwIfAborted();
 
+    const candidateAgeMs = oldestCandidateAgeMs(candidates);
     const processed = await processSnapshotCandidates(
       candidates,
-      async (candidate, candidateSignal) => {
+      async (candidate, recorder, candidateSignal) => {
         return await set(
           archiveThread$,
-          { db, bucket, candidate },
+          { db, bucket, candidate, recorder },
           candidateSignal,
         );
       },
@@ -1654,6 +1721,7 @@ export const snapshotChatEvents$ = command(
       selectedCandidates: candidates.length,
       processedCandidates: processed.attemptedCandidates,
       deferredCandidates: processed.deferredCandidates,
+      oldestCandidateAgeMs: candidateAgeMs,
       scanCursorAdvanced,
       scanWrapped: globalCandidatePage?.wrapped ?? false,
       r2ObjectsScanned: r2Gc.scanned,

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -113,6 +113,7 @@ const cronSnapshotChatEventsResponseSchema = z.object({
   skippedIncompleteHeads: z.number().int().nonnegative(),
   skippedFailedHeads: z.number().int().nonnegative(),
   skippedTimedOutHeads: z.number().int().nonnegative(),
+  oldestCandidateAgeMs: z.number().int().nonnegative(),
   scanCursorAdvanced: z.boolean(),
   scanWrapped: z.boolean(),
   duplicateEventIdConflictThreads: z.number().int().nonnegative(),


### PR DESCRIPTION
## Summary

- move the bounded per-head Chat Event Snapshot deadline record from `warn` to `info` with `expected=true`, keeping `skippedTimedOutHeads` as the unsuccessful outcome
- add the coarse archive `stage` (`resolve_prefix`, `read_events`, `compress`, `put_object`, `publish`), `durationMs` and `timeoutMs` so a genuinely stuck head stays locatable, and name the stage on the existing failure record too
- add `oldestCandidateAgeMs` to the terminal `chat_event_snapshot_completed` event — the age of the least recently updated candidate in that batch — so sustained archive lag, aggregated as a windowed maximum, is the alerting signal instead of a single deadline
- document the classification, its safety argument and its rollout check in `docs/chat-event-snapshot-timeout-logging.md`

## Why this is a log-level change, not an error filter

The 30-second per-head deadline added by #30929 is designed backpressure so a slow head cannot block unrelated convergence. Production evidence over `[2026-09-03T12:00Z, 2026-09-10T12:00Z)` in `vm0-web-logs-prod`: 950 invocations, 39,612 candidates processed, 39,611 snapshots published, **1** timed-out head, **0** failed heads, 0 deferred, 898 cursor wraps. The single timed-out candidate published its pointer on the next cycle wrap 29 minutes later, with `last_seq_id` equal to its indexed watermark and no duplicate object.

Nothing else changes:

- **Convergence** — the scan cursor advances past a timed-out candidate, so the head is retried on the next `lastMessageAt`-fenced cycle. Recovery is bounded by one full cursor cycle.
- **Retention** — retention deletes a Raw Event only when a current-schema Snapshot covers its `seq_id`, so an un-archived head blocks its own reclamation and a repeated timeout can never lose events.
- **Publication** — exact-pointer CAS remains the only publication owner.
- **No absorbed failures** — `awaitWithSignal` settles the deadline race with the deadline's own reason, so the timeout branch cannot swallow an unrelated archive error. Genuine failures reject before the deadline and keep `log.error` with their inner error.

`api/no-logger-info` gets one file-scoped allowlist entry, following the existing per-file pattern, because Axiom's default transport drops debug events and this record must survive for a stuck head.

## Safety

- no change to snapshot bytes, canonical ordering, projection variants, fail-closed checks, immutable R2 publication, exact-pointer CAS, GC ownership, the 30-second deadline, the start budget, worker concurrency, or the retry/eligibility rules
- `chat_event_snapshot_candidate_failed` stays at error; deferred, unreadable, undecodable and incomplete heads keep their classification; request cancellation still propagates instead of being recorded as a timeout
- the new fields carry no archive content, object keys or event bodies
- `oldestCandidateAgeMs` is additive on the cron and fixtures response schemas, both read only by their own callers

## Verification

Local checks were limited to formatting; behavior verification is delegated to exact-head CI per the repository's PR pipeline policy.

- `prettier --write` on every changed file (no reformatting needed)
- extended `cron-snapshot-chat-events.test.ts`:
  - the existing timeout case now asserts exactly one info record with `expected`, `stage`, `durationMs` and `timeoutMs`, zero warn/error records for that type, `skippedTimedOutHeads: 1`, `oldestCandidateAgeMs` present, and unchanged single-publication resume
  - the failed-candidate case now asserts the error record names `stage: "put_object"` and that no expected-timeout record is emitted — the negative control that a genuine failure is not reclassified
  - a new case asserts `oldestCandidateAgeMs` against a clock moved forward by a known offset, and asserts exactly `0` once the thread converges and nothing is eligible, so the counter cannot silently stop measuring
- existing cancellation, concurrency/start-budget, and CAS cases are unchanged and must stay green

## Rollout

Issue #33088 must stay open after merge; this PR only lands the code change. After deployment, record the API revision and observe a bounded window: the warn/error feed must carry no `chat_event_snapshot_candidate_timed_out` records, any info record must carry a non-empty `stage` and `durationMs`, `chat_event_snapshot_completed` must keep its cadence with `skippedFailedHeads` at zero, and the windowed maximum of `oldestCandidateAgeMs` must show no sustained upward trend. The observed base rate is about one timeout per 40,000 candidates, so a quiet window without an exercised timeout is not recovery evidence.

Refs #33088

🤖 Generated with [Claude Code](https://claude.com/claude-code)
