### PR TITLE
fix(api): classify transient provider failures from completion envelopes

### DIFF
--- a/turbo/apps/api/src/signals/external/openrouter-failure.ts
+++ b/turbo/apps/api/src/signals/external/openrouter-failure.ts
@@ -94,6 +94,76 @@ function property(value: unknown, key: string): unknown {
     : undefined;
 }
 
+/**
+ * The HTTP status is absent for a completion envelope, and the provider code is
+ * absent for a bare transport status, so each class is a single enumerated set
+ * matched against whichever of the two is present.
+ */
+function matchesFailure(
+  candidates: readonly (string | number)[],
+  httpStatus: number | undefined,
+  code: unknown,
+): boolean {
+  return candidates.some((candidate) => {
+    return candidate === httpStatus || candidate === code;
+  });
+}
+
+function requestFailureReason(
+  httpStatus: number | undefined,
+  code: unknown,
+  errorType: unknown,
+): OpenRouterFailureReason {
+  if (matchesFailure([401, 403], httpStatus, code)) {
+    return "auth";
+  }
+  if (
+    matchesFailure(
+      [
+        400,
+        402,
+        404,
+        413,
+        422,
+        "invalid_request_error",
+        "invalid_argument",
+        "invalid_parameter",
+        "unsupported_parameter",
+        "unsupported_value",
+        "INVALID_ARGUMENT",
+      ],
+      httpStatus,
+      code,
+    ) ||
+    errorType === "invalid_request_error"
+  ) {
+    return "invalid_request";
+  }
+  if (
+    matchesFailure(
+      [429, "rate_limit_exceeded", "RESOURCE_EXHAUSTED"],
+      httpStatus,
+      code,
+    ) ||
+    errorType === "rate_limit_exceeded"
+  ) {
+    return "rate_limited";
+  }
+  // OpenRouter also delivers an upstream gateway failure inside a 200 body, as
+  // an error envelope with no choices. The wrapper status is then a local
+  // synthetic 502 and only the provider code carries the real outcome, so these
+  // two classes match the code the way the rate-limit class already does. Both
+  // stay last, leaving an enumerated invalid-request or auth code overriding a
+  // transient status exactly as before.
+  if (matchesFailure([408, 504], httpStatus, code)) {
+    return "upstream_timeout";
+  }
+  if (matchesFailure([502, 503, "UNAVAILABLE"], httpStatus, code)) {
+    return "provider_unavailable";
+  }
+  return "unknown";
+}
+
 export function recordOpenRouterRequestFailure(
   error: Error,
   status: number,
@@ -101,66 +171,14 @@ export function recordOpenRouterRequestFailure(
   value: unknown,
 ): void {
   const detail = property(value, "error") ?? value;
-  const code = property(error, "errorCode") ?? property(detail, "code");
-  const errorType = property(property(detail, "metadata"), "error_type");
-  const httpStatus = origin === "http" ? status : undefined;
-  let reason: OpenRouterFailureReason = "unknown";
-  if (
-    [401, 403].some((candidate) => {
-      return candidate === httpStatus || candidate === code;
-    })
-  ) {
-    reason = "auth";
-  } else if (
-    [
-      400,
-      402,
-      404,
-      413,
-      422,
-      "invalid_request_error",
-      "invalid_argument",
-      "invalid_parameter",
-      "unsupported_parameter",
-      "unsupported_value",
-      "INVALID_ARGUMENT",
-    ].some((candidate) => {
-      return candidate === httpStatus || candidate === code;
-    }) ||
-    errorType === "invalid_request_error"
-  ) {
-    reason = "invalid_request";
-  } else if (
-    code === "rate_limit_exceeded" ||
-    code === "RESOURCE_EXHAUSTED" ||
-    code === 429 ||
-    errorType === "rate_limit_exceeded" ||
-    httpStatus === 429
-  ) {
-    reason = "rate_limited";
-  } else if (
-    httpStatus === 408 ||
-    httpStatus === 504 ||
-    code === 408 ||
-    code === 504
-  ) {
-    // OpenRouter also delivers an upstream gateway failure inside a 200 body,
-    // as an error envelope with no choices. The wrapper status is then a local
-    // synthetic 502 and only the provider code carries the real outcome, so
-    // this and the branch below match that code the way the rate-limit branch
-    // already does. Both stay last, leaving an enumerated invalid-request or
-    // auth code overriding a transient status exactly as before.
-    reason = "upstream_timeout";
-  } else if (
-    httpStatus === 502 ||
-    httpStatus === 503 ||
-    code === 502 ||
-    code === 503 ||
-    code === "UNAVAILABLE"
-  ) {
-    reason = "provider_unavailable";
-  }
-  recordOpenRouterFailure(error, reason);
+  recordOpenRouterFailure(
+    error,
+    requestFailureReason(
+      origin === "http" ? status : undefined,
+      property(error, "errorCode") ?? property(detail, "code"),
+      property(property(detail, "metadata"), "error_type"),
+    ),
+  );
 }
 
 /** Call only at fetch/body I/O, never around feature code or output interpretation. */

--- a/turbo/apps/api/src/signals/external/openrouter-failure.ts
+++ b/turbo/apps/api/src/signals/external/openrouter-failure.ts
@@ -39,6 +39,24 @@ export function openRouterFailureReason(
     : "unknown";
 }
 
+/**
+ * The provider was reachable-but-unusable for reasons no caller can act on:
+ * limits, timeouts, transport and upstream unavailability. Optional generations
+ * use this to count an expected omission instead of reporting a defect. It
+ * deliberately excludes budget and output-contract outcomes, which describe our
+ * own request rather than the provider's availability.
+ */
+export function isTransientProviderFailure(
+  reason: OpenRouterFailureReason,
+): boolean {
+  return (
+    reason === "rate_limited" ||
+    reason === "upstream_timeout" ||
+    reason === "network" ||
+    reason === "provider_unavailable"
+  );
+}
+
 export function recordOpenRouterFailure(
   error: unknown,
   reason: OpenRouterFailureReason,
@@ -114,14 +132,32 @@ export function recordOpenRouterRequestFailure(
     reason = "invalid_request";
   } else if (
     code === "rate_limit_exceeded" ||
+    code === "RESOURCE_EXHAUSTED" ||
     code === 429 ||
     errorType === "rate_limit_exceeded" ||
     httpStatus === 429
   ) {
     reason = "rate_limited";
-  } else if (httpStatus === 408 || httpStatus === 504) {
+  } else if (
+    httpStatus === 408 ||
+    httpStatus === 504 ||
+    code === 408 ||
+    code === 504
+  ) {
+    // OpenRouter also delivers an upstream gateway failure inside a 200 body,
+    // as an error envelope with no choices. The wrapper status is then a local
+    // synthetic 502 and only the provider code carries the real outcome, so
+    // this and the branch below match that code the way the rate-limit branch
+    // already does. Both stay last, leaving an enumerated invalid-request or
+    // auth code overriding a transient status exactly as before.
     reason = "upstream_timeout";
-  } else if (httpStatus === 502 || httpStatus === 503) {
+  } else if (
+    httpStatus === 502 ||
+    httpStatus === 503 ||
+    code === 502 ||
+    code === 503 ||
+    code === "UNAVAILABLE"
+  ) {
     reason = "provider_unavailable";
   }
   recordOpenRouterFailure(error, reason);

--- a/turbo/apps/api/src/signals/routes/__tests__/auxiliary-generation.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auxiliary-generation.test.ts
@@ -176,6 +176,74 @@ const cases = Object.freeze([
     outcome: "degraded",
     reason: "rate_limited",
   },
+  // OpenRouter reports an upstream gateway failure inside a 200 body too. The
+  // wrapper status is then a local synthetic 502, so only the provider code
+  // separates a timeout from unavailability.
+  {
+    name: "typed response gateway timeout",
+    response: () => {
+      return HttpResponse.json({ error: { code: 504, message: secret } });
+    },
+    outcome: "degraded",
+    reason: "upstream_timeout",
+  },
+  {
+    name: "typed response bad gateway",
+    response: () => {
+      return HttpResponse.json({ error: { code: 502, message: secret } });
+    },
+    outcome: "degraded",
+    reason: "provider_unavailable",
+  },
+  {
+    name: "wrapped provider unavailability",
+    response: () => {
+      return HttpResponse.json({
+        error: {
+          metadata: {
+            raw: JSON.stringify({
+              error: { status: "UNAVAILABLE", message: secret },
+            }),
+          },
+        },
+      });
+    },
+    outcome: "degraded",
+    reason: "provider_unavailable",
+  },
+  {
+    name: "wrapped provider resource exhaustion",
+    response: () => {
+      return HttpResponse.json({
+        error: {
+          metadata: {
+            raw: JSON.stringify({
+              error: { status: "RESOURCE_EXHAUSTED", message: secret },
+            }),
+          },
+        },
+      });
+    },
+    outcome: "degraded",
+    reason: "rate_limited",
+  },
+  {
+    name: "wrapped invalid parameter overrides a transient provider code",
+    response: () => {
+      return HttpResponse.json({
+        error: {
+          code: 504,
+          metadata: {
+            raw: JSON.stringify({
+              error: { status: "INVALID_ARGUMENT", message: secret },
+            }),
+          },
+        },
+      });
+    },
+    outcome: "error",
+    reason: "invalid_request",
+  },
   {
     name: "wrapped invalid parameter overrides transient HTTP",
     response: () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -21998,6 +21998,23 @@ describe("CHAT-02: initial thinking indicator", () => {
       },
       warned: true,
     },
+    // An exhausted token budget describes our own request rather than the
+    // provider's availability, so it stays outside the suppressed set.
+    {
+      name: "an exhausted token budget",
+      thinkingResponse: () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "length",
+              native_finish_reason: "MAX_TOKENS",
+              message: { content: providerDetail },
+            },
+          ],
+        });
+      },
+      warned: true,
+    },
   ])(
     "omits opening copy and reports a defect only for $name",
     async ({ thinkingResponse, warned }) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -21956,6 +21956,99 @@ describe("CHAT-02: initial thinking indicator", () => {
     },
   );
 
+  const providerDetail = "private-provider-detail";
+
+  it.each([
+    {
+      name: "an upstream gateway timeout delivered inside a 200 envelope",
+      thinkingResponse: () => {
+        return HttpResponse.json({
+          error: { code: 504, message: providerDetail },
+        });
+      },
+      warned: false,
+    },
+    {
+      name: "a provider rate limit",
+      thinkingResponse: () => {
+        return new HttpResponse(providerDetail, { status: 429 });
+      },
+      warned: false,
+    },
+    {
+      name: "an upstream bad gateway",
+      thinkingResponse: () => {
+        return new HttpResponse(providerDetail, { status: 502 });
+      },
+      warned: false,
+    },
+    // Negative control: an unsupported request is our defect, not the
+    // provider's availability, and stays reportable.
+    {
+      name: "a rejected request",
+      thinkingResponse: () => {
+        return new HttpResponse(providerDetail, { status: 400 });
+      },
+      warned: true,
+    },
+    {
+      name: "broken credentials",
+      thinkingResponse: () => {
+        return new HttpResponse(providerDetail, { status: 401 });
+      },
+      warned: true,
+    },
+  ])(
+    "omits opening copy and reports a defect only for $name",
+    async ({ thinkingResponse, warned }) => {
+      const { actor, agentId } = await entitledChatActor();
+      mockOptionalEnv("OPENROUTER_API_KEY", "thinking-classification-key");
+      server.use(
+        http.post(
+          "https://openrouter.ai/api/v1/chat/completions",
+          async ({ request }) => {
+            const payload = openRouterBodySchema.parse(await request.json());
+            const system = payload.messages[0]?.content ?? "";
+            return system.includes("Write user-visible progress copy")
+              ? thinkingResponse()
+              : HttpResponse.json({
+                  choices: [
+                    {
+                      finish_reason: "stop",
+                      message: { content: "Launch Checklist" },
+                    },
+                  ],
+                });
+          },
+        ),
+      );
+
+      const run = await sendChatRun(actor, {
+        agentId,
+        prompt: "Prepare the launch checklist",
+      });
+      await flushWaitUntilForTest();
+
+      // The optional generation is isolated: no marker, and the run proceeds.
+      const events = await chat.listThreadEvents(actor, run.threadId);
+      expect(
+        events.events.filter((event) => {
+          return event.runEventId === "thinking:initial";
+        }),
+      ).toStrictEqual([]);
+      expect((await api.readRun(actor, run.runId)).status).toBe("pending");
+
+      const warnings = context.mocks.axiomLogging.warn.mock.calls.filter(
+        ([message]) => {
+          return message === "Initial thinking generation failed";
+        },
+      );
+      expect(warnings).toHaveLength(warned ? 1 : 0);
+      expect(JSON.stringify(warnings)).not.toContain(providerDetail);
+      await cancelChatRun(actor, run.runId);
+    },
+  );
+
   it("persists a fast assistant thinking marker with paragraphs for active web chat runs", async () => {
     const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();

--- a/turbo/apps/api/src/signals/services/chat-initial-thinking.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-initial-thinking.service.ts
@@ -18,6 +18,10 @@ import {
 import { logger } from "../../lib/log";
 import type { Db } from "../external/db";
 import { FAST_PATH_MODEL, generateText } from "../external/openrouter";
+import {
+  isTransientProviderFailure,
+  openRouterFailureReason,
+} from "../external/openrouter-failure";
 import { publishChatThreadMessageCreatedSafely } from "../external/realtime";
 import { tapError } from "../utils";
 import { assistantEventIdForRunEvent } from "./assistant-event-id";
@@ -269,6 +273,17 @@ export async function generateAndPersistInitialThinkingMessage(args: {
       history,
     }),
     (err) => {
+      // Opening copy is optional, is never retried, and its omission changes no
+      // run outcome, so a provider limit, timeout or upstream gateway failure is
+      // an expected outcome here rather than a defect. Those classes produced
+      // nearly every warning this call site emitted and nothing acted on them.
+      // Narrow suppression only: a rejected request, broken credentials, output
+      // this service cannot interpret and unclassified errors stay visible,
+      // because an unsupported-parameter defect is exactly what this warning
+      // surfaced last.
+      if (isTransientProviderFailure(openRouterFailureReason(err))) {
+        return;
+      }
       log.warn("Initial thinking generation failed", {
         threadId: args.threadId,
         runId: args.runId,


### PR DESCRIPTION
## Problem and change

Closes #33075.

OpenRouter reports an upstream gateway failure inside a `200` body as an error envelope with no choices. `parseOpenRouterGeneration` wraps that in a **local synthetic** `502` with `origin: "completion"`, so `recordOpenRouterRequestFailure` saw `httpStatus === undefined` and its `upstream_timeout` / `provider_unavailable` branches — which matched only `httpStatus` — could never fire. Every transient provider code delivered this way (`504`, `502`, `503`, `408`, `UNAVAILABLE`, `RESOURCE_EXHAUSTED`) classified as `unknown`, which the auxiliary boundary treats as a defect.

The reported event is exactly this shape: `fields.err.status = 502` is the local constant, and `fields.err.errorCode = 504` is the only real upstream signal. Those branches now match the provider `code` the way the rate-limit branch already did, and stay last so an enumerated invalid-request or auth code keeps overriding a transient status.

Initial thinking is the one fast-path caller still outside `generateAuxiliary`, and it reported every provider failure as a warning. Opening copy is optional, is never retried, and its omission changes no run outcome, so a limit, timeout, transport error or upstream gateway failure is an expected outcome there. It now returns without warning for exactly those reasons.

The suppression is deliberately narrow. A rejected request, broken credentials, output the service cannot interpret and unclassified errors all stay reportable. `isTransientProviderFailure` excludes `output_truncated` and `unexpected_tool_calls` for the same reason: they describe our request, not the provider's availability.

## Why not delete the log line

The same call site carried 950–2302 events/day of `fields.err.status = 400` from 2026-09-04 through 2026-09-08. That was a real defect — an unsupported `reasoning.effort` for the exact model — fixed by #32612, and its last hourly bucket is `2026-09-08T09:00Z`, matching that merge. Deleting or blanket-downgrading this warning would have made that class permanently silent.

## Evidence

Read-only Axiom, dataset `vm0-web-logs-prod`, UTC `[2026-09-08T16:00:00Z, 2026-09-09T16:00:00Z)`. `Initial thinking generation failed` was 62 records and the 6th noisiest warn/error message:

| variant | `errorCode` | records |
| --- | --- | --- |
| `OpenRouter request failed: 429` (real HTTP 429) | 429 | 56 |
| `OpenRouter completion failed: 502` (`finish_reason: "error"`) | 429 | 5 |
| `OpenRouter request failed: 502` (no choices, body error) | **504** | **1** |

All 62 fall into the suppressed set, so this call site's warn volume goes to zero while every actionable class stays. For comparison, `Auxiliary generation failed` was 13 records over the same window, and `auxiliary_generation_result` already records `rate_limited` as `degraded` for the four migrated features without warning.

Dataset retention was ~6.6 days at the time of writing (`2026-09-03T11:27:46Z` onward), so no longer-range claim is made. The inner-`504` shape occurred once across that whole visible range.

## Regression evidence

- `auxiliary-generation.test.ts` pins each transient envelope shape end to end: `{error:{code:504}}` → `upstream_timeout`, `{error:{code:502}}` → `provider_unavailable`, and wrapped provider `UNAVAILABLE` / `RESOURCE_EXHAUSTED` inside `metadata.raw` → `provider_unavailable` / `rate_limited`. All are `degraded`, emit no warning and leak no provider text.
- Precedence is pinned in both directions: the existing `INVALID_ARGUMENT`-over-HTTP-503 case is unchanged, and a new case has `INVALID_ARGUMENT` override a transient `code: 504`.
- `chat-events.bdd.test.ts` drives the real chat send path: a gateway timeout, a rate limit and a bad gateway omit opening copy silently, while a `400` and a `401` still warn. Each case asserts no `thinking:initial` event, an unchanged run status, and that no provider text reaches the log.

## Caller and blast-radius review

Based on `origin/main` at `29dfab14531307e67d16322d5fa3972df9c42a99`. `recordOpenRouterRequestFailure` is called only from `openRouterRequestError`, and its `reason` is read only by `generateAuxiliary` and now by initial thinking, so the classification change moves the four migrated features' matching failures from `error` to `degraded` and changes nothing else. `isDegradedReason`, the public error mapping, prompts, budgets, model selection and billing are untouched. Initial thinking keeps its existing isolation: `bestEffort` inside `waitUntil`, and the post-generation `runCanReceiveThinkingMessage` recheck.

## Deliberately out of scope

- Migrating initial thinking onto `generateAuxiliary` for a `duration_ms` / token-count metric. It rewrites roughly eight existing expectations across four test files and deserves its own PR.
- A bounded deadline. `generateInitialThinkingText` still passes no `AbortSignal`, unlike `chat-activity-summary.service.ts`'s `SUMMARY_DEADLINE_MS`. Choosing a value needs this call site's own latency distribution, which the metric above would provide.
- `THINKING_MAX_TOKENS` is still 1024 while `AUXILIARY_TEXT_MAX_TOKENS` moved to 2048 in #32979.
- Provider rate-limit backoff and deduplication remain #32117; this PR changes how those failures are reported, not the limit itself.

## Verification

Local checks were not run: this checkout has no installed dependencies, and per the repository's guidance the PR pipeline owns lint, types and tests. Changed files were syntax-parsed locally. Axiom queries above were read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
