### PR TITLE
fix(runner): classify transient active-input read recovery

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -115,6 +115,43 @@ The input command rejects disabled forwarding or unavailable job metadata withou
 creating an input entry. A successful command reports file publication, not an
 acknowledgement that the running agent consumed the input.
 
+### API active-input read recovery
+
+The Runner retries failed active-input reserve reads with the existing jittered
+backoff (200–250ms initially, capped at 3.2–4s). The HTTP request deadline remains
+10s. Notifications cannot bypass a pending failure delay; cancellation and run
+completion still interrupt reads and retry waits.
+
+For a send-stage timeout or TCP connection reset, the first failure is INFO.
+If reads continue failing for at least 30s after that first observed failure,
+the next failed response emits one `active-input source reads degraded; retrying`
+WARN. This is an operational threshold, not an input-delivery deadline: the
+initial failed request and subsequent request/backoff durations are separate.
+The threshold does not add a timer, change retries, or stop the run. Other read
+errors retain an immediate WARN, including when they follow an INFO-only
+transient failure. Further consecutive failures retain local retry scheduling
+records without repeating the episode warning.
+
+A successful reserve response resets the episode and emits
+`active-input source read recovered` at INFO, including `reserve_outcome`,
+`recovered_after_failures`, `failure_elapsed_ms` and `was_degraded`. An `empty`,
+`held`, `terminal` or `rejected_*` response is explicitly not delivery. Even
+`reserved` proves only readable reservation state, not Guest acceptance or an
+API delivery receipt. Guest-control uncertainty and receipt-recovery warnings
+are unchanged. Cancellation never fabricates read recovery.
+
+Runner INFO records remain local; Axiom continues ingesting WARN+ only. Before
+closing [#33079](https://github.com/vm0-ai/vm0/issues/33079), record the deployed
+Runner release/commit and a bounded real-traffic window (for example, the first
+24 hours after rollout). Correlate local retry/recovery records by run ID and
+time, separate empty/readable-terminal outcomes from actual pending input, and
+verify durable delivery receipts for sampled inputs that were reserved. Inspect
+degraded and unclassified warning episodes separately, including episodes that
+ended with cancellation or run completion. Report unavailable evidence rather
+than inferring recovery from missing warnings. Old draining Runners can still
+emit the previous immediate warnings, so group evidence by deployed identity.
+This observation does not require or authorize production fault injection.
+
 ### Orphan sandbox termination
 
 `runner kill --sandbox <ID>` first asks the owning runner to terminate the

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -182,7 +182,7 @@ fn init_from_env_values(
 /// runner's production env surface — production code should always call
 /// [`init`], which hard-codes [`DEFAULT_AXIOM_URL`].
 #[cfg(test)]
-fn init_with_base_url(
+pub(crate) fn init_with_base_url(
     base_url: &str,
     token: &str,
     suffix: &str,

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -18,8 +18,11 @@ use crate::active_input::{
     ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES, ActiveInputBatch, ActiveInputSource,
     ApiActiveInputRecovery, local_active_input_delivery_id,
 };
-use crate::error::RunnerError;
 use crate::ids::RunId;
+
+mod read_failures;
+
+use read_failures::ReadFailures;
 
 const ACTIVE_INPUT_READ_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 const ACTIVE_INPUT_CONTROL_TIMEOUT: Duration = Duration::from_secs(1);
@@ -104,7 +107,7 @@ async fn run_forwarder(
 ) {
     let mut next_local_sequence = FIRST_ACTIVE_INPUT_SEQUENCE;
     let mut suppressed_api_delivery_id: Option<String> = None;
-    let mut warned_source_read_failure = false;
+    let mut read_failures = ReadFailures::default();
     let mut warned_payload_too_large = false;
     loop {
         let batch = tokio::select! {
@@ -113,6 +116,9 @@ async fn run_forwarder(
             () = job_cancel.cancelled() => return,
             batch = source.read(next_local_sequence) => batch,
         };
+        if let Ok(batch) = &batch {
+            read_failures.recover(run_id, batch);
+        }
         let retry_after_read_error = match batch {
             Ok(ActiveInputBatch::Local(entries)) => {
                 for entry in entries {
@@ -200,35 +206,10 @@ async fn run_forwarder(
                 },
             },
             Err(error) => {
-                if !warned_source_read_failure {
-                    match &error {
-                        RunnerError::ApiTransport(api_error) => warn!(
-                            run_id = %run_id,
-                            error = %error,
-                            endpoint = api_error.request.endpoint_label,
-                            method = %api_error.request.method,
-                            host = %api_error.request.host,
-                            path = %api_error.request.path,
-                            client_request_id = %api_error.request.client_request_id,
-                            client_session_id = %api_error.request.client_session_id,
-                            client_version = %api_error.request.client_version,
-                            failure_kind = api_error.failure_kind.as_str(),
-                            failure_cause = api_error.failure_cause.as_str(),
-                            error_summary = %api_error.summary,
-                            "active-input source read failed; retrying"
-                        ),
-                        _ => {
-                            warn!(run_id = %run_id, error = %error, "active-input source read failed; retrying")
-                        }
-                    }
-                    warned_source_read_failure = true;
-                }
+                read_failures.record(run_id, &error);
                 true
             }
         };
-        if !retry_after_read_error {
-            warned_source_read_failure = false;
-        }
 
         tokio::select! {
             biased;

--- a/crates/runner/src/executor/active_input/read_failures.rs
+++ b/crates/runner/src/executor/active_input/read_failures.rs
@@ -1,0 +1,122 @@
+//! Read availability is separate from Guest acceptance and delivery receipts.
+
+use std::time::Duration;
+
+use api_contracts::generated::types::runners::runs::active_inputs::reserve::{
+    Response, ResponseRejectedReason,
+};
+use tokio::time::Instant;
+use tracing::{Level, info};
+
+use crate::active_input::ActiveInputBatch;
+use crate::error::{ApiTransportCause, RunnerError};
+use crate::ids::RunId;
+
+// An operational threshold on the same scale as the normal safety recheck,
+// not an input-delivery deadline. Evaluated when a failed request completes.
+const READ_DEGRADED_AFTER: Duration = Duration::from_secs(30);
+
+#[derive(Default)]
+pub(super) struct ReadFailures {
+    episode: Option<ReadFailureEpisode>,
+}
+
+struct ReadFailureEpisode {
+    started_at: Instant,
+    consecutive_failures: u64,
+    warned: bool,
+}
+
+impl ReadFailures {
+    pub(super) fn record(&mut self, run_id: RunId, error: &RunnerError) {
+        let episode = self.episode.get_or_insert_with(|| ReadFailureEpisode {
+            started_at: Instant::now(),
+            consecutive_failures: 0,
+            warned: false,
+        });
+        episode.consecutive_failures = episode.consecutive_failures.saturating_add(1);
+        let elapsed = episode.started_at.elapsed();
+        let transient = matches!(
+            error,
+            RunnerError::ApiTransport(error)
+                if matches!(error.failure_cause,
+                    ApiTransportCause::Timeout | ApiTransportCause::ConnectionReset)
+        );
+        let warn = !episode.warned && (!transient || elapsed >= READ_DEGRADED_AFTER);
+        if episode.consecutive_failures > 1 && !warn {
+            return;
+        }
+        episode.warned |= warn;
+
+        macro_rules! emit {
+            ($level:expr, $message:literal) => {
+                match error {
+                    RunnerError::ApiTransport(api_error) => tracing::event!(
+                        target: "runner::executor::active_input",
+                        $level,
+                        run_id = %run_id,
+                        error = %error,
+                        endpoint = api_error.request.endpoint_label,
+                        method = %api_error.request.method,
+                        host = %api_error.request.host,
+                        path = %api_error.request.path,
+                        client_request_id = %api_error.request.client_request_id,
+                        client_session_id = %api_error.request.client_session_id,
+                        client_version = %api_error.request.client_version,
+                        failure_kind = api_error.failure_kind.as_str(),
+                        failure_cause = api_error.failure_cause.as_str(),
+                        error_summary = %api_error.summary,
+                        consecutive_failures = episode.consecutive_failures,
+                        failure_elapsed_ms = elapsed.as_millis() as u64,
+                        $message
+                    ),
+                    _ => tracing::event!(
+                        target: "runner::executor::active_input",
+                        $level,
+                        run_id = %run_id,
+                        error = %error,
+                        consecutive_failures = episode.consecutive_failures,
+                        failure_elapsed_ms = elapsed.as_millis() as u64,
+                        $message
+                    ),
+                }
+            };
+        }
+
+        if warn && transient {
+            emit!(Level::WARN, "active-input source reads degraded; retrying");
+        } else if warn {
+            emit!(Level::WARN, "active-input source read failed; retrying");
+        } else {
+            emit!(Level::INFO, "active-input source read failed; retrying");
+        }
+    }
+
+    pub(super) fn recover(&mut self, run_id: RunId, batch: &ActiveInputBatch) {
+        let Some(episode) = self.episode.take() else {
+            return;
+        };
+        let ActiveInputBatch::Api(response) = batch else {
+            return;
+        };
+        let reserve_outcome = match response {
+            Response::Reserved { .. } => "reserved",
+            Response::Empty => "empty",
+            Response::Terminal => "terminal",
+            Response::Held { .. } => "held",
+            Response::Rejected { reason } => match reason {
+                ResponseRejectedReason::PayloadTooLarge => "rejected_payload_too_large",
+                ResponseRejectedReason::RunNotRunning => "rejected_run_not_running",
+            },
+        };
+        info!(
+            target: "runner::executor::active_input",
+            run_id = %run_id,
+            reserve_outcome,
+            recovered_after_failures = episode.consecutive_failures,
+            failure_elapsed_ms = episode.started_at.elapsed().as_millis() as u64,
+            was_degraded = episode.warned,
+            "active-input source read recovered"
+        );
+    }
+}

--- a/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
@@ -25,6 +25,7 @@ use crate::test_fixtures::raw_http::{RawHttpAction, RawHttpTestServer, json_resp
 use crate::types::SandboxReuseResult;
 
 mod read_backoff;
+mod read_recovery;
 
 const DELIVERY_ID: &str = "b1e2ad6d-930a-4d51-aa40-7952d54f978b";
 const EVENT_ID: &str = "e6bc287d-8c08-464e-831a-cad771610157";

--- a/crates/runner/src/executor/tests/agent_run_tests/active_input/read_backoff.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/active_input/read_backoff.rs
@@ -17,7 +17,7 @@ use crate::types::SandboxReuseResult;
 
 // Real HTTP I/O must make progress without advancing the paused retry clock.
 // A wall-clock watchdog also bounds assertions when Tokio time is frozen.
-async fn observe<T>(description: &str, mut observed: impl FnMut() -> Option<T>) -> T {
+pub(super) async fn observe<T>(description: &str, mut observed: impl FnMut() -> Option<T>) -> T {
     let deadline = Instant::now() + RUN_IN_SANDBOX_TEST_TIMEOUT;
     loop {
         if let Some(value) = observed() {
@@ -31,7 +31,7 @@ async fn observe<T>(description: &str, mut observed: impl FnMut() -> Option<T>) 
     }
 }
 
-async fn retry_delay(captured: &CapturedEvents, count: usize) -> Duration {
+pub(super) async fn retry_delay(captured: &CapturedEvents, count: usize) -> Duration {
     observe("API read retry scheduling", || {
         let events = captured.entries();
         let retries = events

--- a/crates/runner/src/executor/tests/agent_run_tests/active_input/read_recovery.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/active_input/read_recovery.rs
@@ -1,0 +1,410 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use httpmock::{HttpMockRequest, HttpMockResponse, MockServer};
+use serde_json::Value;
+use tokio::sync::oneshot;
+use tracing::Level;
+use tracing_subscriber::prelude::*;
+
+use super::read_backoff::{observe, retry_delay};
+use super::{DELIVERY_ID, EVENT_ID, api_active_input_source};
+use crate::active_input::ActiveInputNotifications;
+use crate::axiom_layer::{init_with_base_url, with_ingest_filter};
+use crate::error::RunnerResult;
+use crate::executor::agent_run::{AgentExecutionResult, RunControls, RunStart, run_in_sandbox};
+use crate::executor::tests::support::{
+    CapturedEvent, CapturedEvents, create_overridden_sandbox, minimal_context,
+    test_executor_config, test_telemetry,
+};
+use crate::ids::RunId;
+use crate::test_fixtures::raw_http::{RawHttpAction, RawHttpTestServer, json_response};
+use crate::types::SandboxReuseResult;
+
+const FAILURE: &str = "active-input source read failed; retrying";
+const DEGRADED: &str = "active-input source reads degraded; retrying";
+const RECOVERED: &str = "active-input source read recovered";
+
+struct RunningInput {
+    _dir: tempfile::TempDir,
+    run_id: RunId,
+    notifications: ActiveInputNotifications,
+    cancel: tokio_util::sync::CancellationToken,
+    wait_gate: Arc<tokio::sync::Notify>,
+    overrides: Arc<sandbox_mock::MockSandboxOverrides>,
+    task: tokio::task::JoinHandle<RunnerResult<AgentExecutionResult>>,
+}
+
+impl RunningInput {
+    async fn start(server: &RawHttpTestServer) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let wait_gate = Arc::new(tokio::sync::Notify::new());
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+            Arc::clone(&wait_gate),
+        ));
+        let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+        let ctx = minimal_context();
+        let run_id = ctx.run_id;
+        let notifications = ActiveInputNotifications::new();
+        let source = api_active_input_source(server.url(), run_id, &notifications, "read-recovery");
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let run_cancel = cancel.clone();
+        let task = tokio::spawn(async move {
+            let mut telemetry = test_telemetry(&config, &ctx);
+            run_in_sandbox(
+                &*sandbox,
+                &ctx,
+                &config,
+                RunStart {
+                    restore_guest_state: false,
+                    reuse_result: SandboxReuseResult::PoolMiss,
+                    workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+                    prev_storage: None,
+                },
+                &mut telemetry,
+                RunControls::new(run_cancel, Some(source)),
+            )
+            .await
+        });
+        Self {
+            _dir: dir,
+            run_id,
+            notifications,
+            cancel,
+            wait_gate,
+            overrides,
+            task,
+        }
+    }
+
+    async fn expect_delivery(&self) {
+        observe("recovered Guest handoff", || {
+            (self.overrides.process_control_calls().len() == 1).then_some(())
+        })
+        .await;
+        let calls = self.overrides.process_control_calls();
+        assert_eq!(calls[0].message_id, DELIVERY_ID);
+        let payload: Value = serde_json::from_slice(&calls[0].payload).unwrap();
+        assert_eq!(payload["deliveryId"], DELIVERY_ID);
+        assert_eq!(payload["text"], "recovered input");
+    }
+
+    async fn finish(self, cancelled: bool) {
+        if !cancelled {
+            self.wait_gate.notify_one();
+        }
+        observe("run completion", || self.task.is_finished().then_some(())).await;
+        let result = self.task.await.unwrap().unwrap();
+        assert_eq!(result.failure.is_some(), cancelled);
+    }
+}
+
+// Keep real socket I/O progressing while the retry/request clock is controlled.
+// The existing wall-clock observer bounds every wait, including a frozen clock.
+struct PausedClock {
+    release: std::sync::mpsc::Sender<()>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl PausedClock {
+    fn start() -> Self {
+        let (release, receiver) = std::sync::mpsc::channel();
+        let task = tokio::task::spawn_blocking(move || {
+            let _ = receiver.recv_timeout(Duration::from_secs(30));
+        });
+        tokio::time::pause();
+        Self { release, task }
+    }
+
+    async fn finish(self) {
+        tokio::time::resume();
+        drop(self.release);
+        self.task.await.unwrap();
+    }
+}
+
+fn reserved() -> RawHttpAction {
+    RawHttpAction::Respond(json_response(
+        "200 OK",
+        &format!(
+            r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"recovered input"}}"#,
+        ),
+    ))
+}
+
+fn events(captured: &CapturedEvents, message: &str) -> Vec<CapturedEvent> {
+    captured
+        .entries()
+        .into_iter()
+        .filter(|event| event.fields.get("message").map(String::as_str) == Some(message))
+        .collect()
+}
+
+async fn next_retry(captured: &CapturedEvents, count: usize) {
+    let delay = retry_delay(captured, count).await;
+    tokio::time::advance(delay + Duration::from_millis(2)).await;
+}
+
+#[tokio::test]
+async fn run_in_sandbox_recovers_tcp_reset_without_ingesting_a_warning() {
+    let axiom = MockServer::start_async().await;
+    let ingest = axiom
+        .mock_async(|when, then| {
+            when.method(httpmock::Method::POST)
+                .path("/v1/datasets/vm0-web-logs-test/ingest");
+            then.status(200);
+        })
+        .await;
+    let (layer, guard) = init_with_base_url(&axiom.base_url(), "test", "test").unwrap();
+    let captured = CapturedEvents::default();
+    let _subscriber = tracing::subscriber::set_default(
+        tracing_subscriber::registry()
+            .with(captured.clone())
+            .with(with_ingest_filter(layer)),
+    );
+    let server = RawHttpTestServer::spawn(vec![RawHttpAction::ResetConnection, reserved()]).await;
+    let run = RunningInput::start(&server).await;
+    run.expect_delivery().await;
+    run.finish(false).await;
+    server.assert_finished().await;
+    guard.shutdown().await;
+
+    let failures = events(&captured, FAILURE);
+    assert_eq!(failures.len(), 1);
+    assert_eq!(failures[0].level, Level::INFO);
+    assert_eq!(failures[0].fields["failure_cause"], "connection_reset");
+    let recoveries = events(&captured, RECOVERED);
+    assert_eq!(recoveries.len(), 1);
+    assert_eq!(recoveries[0].level, Level::INFO);
+    assert_eq!(recoveries[0].fields["reserve_outcome"], "reserved");
+    assert_eq!(recoveries[0].fields["recovered_after_failures"], "1");
+    assert_eq!(recoveries[0].fields["was_degraded"], "false");
+    ingest.assert_calls_async(0).await;
+}
+
+#[tokio::test]
+async fn run_in_sandbox_recovers_a_real_reserve_request_timeout() {
+    let captured = CapturedEvents::default();
+    let _subscriber =
+        tracing::subscriber::set_default(tracing_subscriber::registry().with(captured.clone()));
+    let (release, response_gate) = oneshot::channel();
+    let mut server = RawHttpTestServer::spawn(vec![
+        RawHttpAction::WaitThenRespond {
+            release: response_gate,
+            // No response bytes: release the timed-out socket before accepting retry.
+            response: Vec::new(),
+        },
+        reserved(),
+    ])
+    .await;
+    let run = RunningInput::start(&server).await;
+    server.next_request("request to time out").await;
+    let clock = PausedClock::start();
+    tokio::time::advance(Duration::from_secs(10) + Duration::from_millis(1)).await;
+    let delay = retry_delay(&captured, 1).await;
+    release.send(()).unwrap();
+    tokio::time::advance(delay + Duration::from_millis(2)).await;
+    run.expect_delivery().await;
+    run.finish(false).await;
+    clock.finish().await;
+    server.assert_finished().await;
+
+    let failures = events(&captured, FAILURE);
+    assert_eq!(failures.len(), 1);
+    assert_eq!(failures[0].level, Level::INFO);
+    assert_eq!(failures[0].fields["failure_cause"], "timeout");
+    assert!(events(&captured, DEGRADED).is_empty());
+    assert_eq!(
+        events(&captured, RECOVERED)[0].fields["reserve_outcome"],
+        "reserved"
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_warns_on_sustained_reads_and_resets_after_empty() {
+    let captured = CapturedEvents::default();
+    let _subscriber =
+        tracing::subscriber::set_default(tracing_subscriber::registry().with(captured.clone()));
+    let server = RawHttpTestServer::spawn(vec![
+        RawHttpAction::ResetConnection,
+        RawHttpAction::ResetConnection,
+        RawHttpAction::ResetConnection,
+        RawHttpAction::ResetConnection,
+        RawHttpAction::Respond(json_response("200 OK", r#"{"outcome":"empty"}"#)),
+        RawHttpAction::ResetConnection,
+        reserved(),
+    ])
+    .await;
+    let clock = PausedClock::start();
+    let run = RunningInput::start(&server).await;
+    retry_delay(&captured, 1).await;
+    tokio::time::advance(Duration::from_secs(29)).await;
+    retry_delay(&captured, 2).await;
+    assert!(events(&captured, DEGRADED).is_empty());
+    tokio::time::advance(Duration::from_secs(1)).await;
+    retry_delay(&captured, 3).await;
+    let warnings = events(&captured, DEGRADED);
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0].level, Level::WARN);
+    assert_eq!(warnings[0].fields["failure_elapsed_ms"], "30000");
+    assert_eq!(warnings[0].fields["consecutive_failures"], "3");
+    next_retry(&captured, 3).await;
+    next_retry(&captured, 4).await;
+    observe("empty reserve recovery", || {
+        (events(&captured, RECOVERED).len() == 1).then_some(())
+    })
+    .await;
+    assert!(run.overrides.process_control_calls().is_empty());
+    let recovery = &events(&captured, RECOVERED)[0];
+    assert_eq!(recovery.fields["reserve_outcome"], "empty");
+    assert_eq!(recovery.fields["recovered_after_failures"], "4");
+    assert_eq!(recovery.fields["was_degraded"], "true");
+    run.notifications.notify(run.run_id);
+    next_retry(&captured, 5).await;
+    run.expect_delivery().await;
+    run.finish(false).await;
+    clock.finish().await;
+    server.assert_finished().await;
+    assert_eq!(events(&captured, DEGRADED).len(), 1);
+    let recoveries = events(&captured, RECOVERED);
+    assert_eq!(recoveries.len(), 2);
+    assert_eq!(recoveries[1].fields["recovered_after_failures"], "1");
+    assert_eq!(recoveries[1].fields["was_degraded"], "false");
+}
+
+#[tokio::test]
+async fn run_in_sandbox_ingests_genuine_read_failures_after_a_transient() {
+    let axiom = MockServer::start_async().await;
+    let ingested = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let sink = Arc::clone(&ingested);
+    let ingest = axiom
+        .mock_async(move |when, then| {
+            when.method(httpmock::Method::POST)
+                .path("/v1/datasets/vm0-web-logs-test/ingest");
+            then.respond_with(move |request: &HttpMockRequest| {
+                let batch: Vec<Value> = serde_json::from_slice(request.body_ref()).unwrap();
+                sink.lock().unwrap().extend(batch);
+                HttpMockResponse::builder().status(200).build()
+            });
+        })
+        .await;
+    let (layer, guard) = init_with_base_url(&axiom.base_url(), "test", "test").unwrap();
+    let captured = CapturedEvents::default();
+    let _subscriber = tracing::subscriber::set_default(
+        tracing_subscriber::registry()
+            .with(captured.clone())
+            .with(with_ingest_filter(layer)),
+    );
+    for failure in [
+        RawHttpAction::Respond(json_response(
+            "401 Unauthorized",
+            r#"{"error":"unauthorized"}"#,
+        )),
+        RawHttpAction::Respond(json_response(
+            "503 Service Unavailable",
+            r#"{"error":"unavailable"}"#,
+        )),
+        RawHttpAction::Respond(json_response("200 OK", r#"{"outcome":"invalid"}"#)),
+        RawHttpAction::Disconnect,
+    ] {
+        let server =
+            RawHttpTestServer::spawn(vec![RawHttpAction::ResetConnection, failure, reserved()])
+                .await;
+        let run = RunningInput::start(&server).await;
+        run.expect_delivery().await;
+        run.finish(false).await;
+        server.assert_finished().await;
+    }
+    guard.shutdown().await;
+    assert!(ingest.calls_async().await > 0);
+    let failures = events(&captured, FAILURE);
+    assert_eq!(
+        failures
+            .iter()
+            .filter(|event| event.level == Level::INFO)
+            .count(),
+        4
+    );
+    assert_eq!(
+        failures
+            .iter()
+            .filter(|event| event.level == Level::WARN)
+            .count(),
+        4
+    );
+    let ingested = ingested.lock().unwrap();
+    assert_eq!(ingested.len(), 4);
+    for event in ingested.iter() {
+        assert_eq!(event["message"], FAILURE);
+        assert_eq!(event["level"], "warn");
+        assert_eq!(event["consecutive_failures"], 2);
+    }
+}
+
+#[tokio::test]
+async fn run_in_sandbox_does_not_claim_read_recovery_on_cancellation() {
+    let captured = CapturedEvents::default();
+    let _subscriber =
+        tracing::subscriber::set_default(tracing_subscriber::registry().with(captured.clone()));
+    let server =
+        RawHttpTestServer::spawn(vec![RawHttpAction::ResetConnection, RawHttpAction::Stall]).await;
+    let clock = PausedClock::start();
+    let run = RunningInput::start(&server).await;
+    retry_delay(&captured, 1).await;
+    assert!(run.overrides.process_control_calls().is_empty());
+    run.cancel.cancel();
+    run.finish(true).await;
+    clock.finish().await;
+    server.cancel_and_reap().await;
+    assert!(events(&captured, RECOVERED).is_empty());
+    assert!(events(&captured, DEGRADED).is_empty());
+}
+
+#[tokio::test]
+async fn run_in_sandbox_reports_readable_non_delivery_outcomes_truthfully() {
+    for (response, expected) in [
+        (r#"{"outcome":"terminal"}"#.to_string(), "terminal"),
+        (
+            format!(
+                r#"{{"outcome":"held","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"]}}"#
+            ),
+            "held",
+        ),
+        (
+            r#"{"outcome":"rejected","reason":"run_not_running"}"#.to_string(),
+            "rejected_run_not_running",
+        ),
+        (
+            r#"{"outcome":"rejected","reason":"payload_too_large"}"#.to_string(),
+            "rejected_payload_too_large",
+        ),
+    ] {
+        let captured = CapturedEvents::default();
+        let _subscriber =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(captured.clone()));
+        let server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::ResetConnection,
+            RawHttpAction::Respond(json_response("200 OK", &response)),
+        ])
+        .await;
+        let run = RunningInput::start(&server).await;
+        observe("readable reserve outcome", || {
+            (!events(&captured, RECOVERED).is_empty()).then_some(())
+        })
+        .await;
+        assert!(run.overrides.process_control_calls().is_empty());
+        run.finish(false).await;
+        server.assert_finished().await;
+        assert_eq!(
+            events(&captured, RECOVERED)[0].fields["reserve_outcome"],
+            expected
+        );
+        if expected == "rejected_payload_too_large" {
+            assert_eq!(
+                events(&captured, "active-input reserve rejected pending input")[0].level,
+                Level::WARN
+            );
+        }
+    }
+}

--- a/crates/runner/src/test_fixtures/raw_http.rs
+++ b/crates/runner/src/test_fixtures/raw_http.rs
@@ -15,6 +15,7 @@ const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
 pub(crate) enum RawHttpAction {
     Respond(Vec<u8>),
     Disconnect,
+    ResetConnection,
     WaitForDisconnect,
     WaitThenRespond {
         release: oneshot::Receiver<()>,
@@ -324,6 +325,7 @@ async fn serve(
                 write_response(index, &mut socket, &response).await?;
             }
             RawHttpAction::Disconnect => {}
+            RawHttpAction::ResetConnection => socket.set_zero_linger()?,
             RawHttpAction::WaitForDisconnect => {
                 let mut byte = [0];
                 let read = tokio::time::timeout(RAW_HTTP_FIXTURE_TIMEOUT, socket.read(&mut byte))


### PR DESCRIPTION
## Summary

Relates to #33079. Keep the issue open for its bounded production recovery/receipt observation gate; this PR does not establish that the historical 11 runs recovered.

- Classify only typed send-stage timeout and TCP reset failures as INFO during short active-input reserve-read episodes.
- Emit one sustained-degradation WARN when a subsequent failure is observed at least 30 seconds after the first failed response. Preserve immediate warnings for other read errors, including errors following an INFO-only transient.
- Record successful reserve reads at INFO with failure count, elapsed time and exact reserve outcome. Empty, held, terminal and rejected outcomes never imply delivery; even reserved is not a Guest acceptance or API receipt.
- Preserve the existing active-input tracing target, safe transport diagnostics, jittered backoff, request deadlines, cancellation, durable delivery identity and Guest-control/receipt uncertainty reporting.
- Exercise real loopback TCP resets/timeouts and the real Axiom filter/dispatcher with a local HTTP capture endpoint. Document the alerting policy and production verification procedure.

## Scope and compatibility

Runner-only process-local observation state. No new dependency, configuration, API/Guest contract, persisted format, database migration, request, background task, mutex or retry delay. No startup-path or coordinated deployment change. Axiom continues to ingest WARN+ only; the additional initializer visibility is test-only.

## Validation

- Focused recovery suite: 6 passed, including real timeout/reset recovery, sustained failure and empty reset, cancellation, non-delivery outcomes, and genuine-failure/Axiom negative controls.
- Full Runner suite: 3,629 passed plus 1 guest-inventory integration test. The 27 pre-existing ignored child-harness entries are unchanged; no new skips.
- Rust formatting, Clippy, Rustdoc, Markdown formatting and whitespace checks.

Commands run from the repository root unless noted:

```sh
cargo fmt --manifest-path crates/Cargo.toml -p runner --check
cargo clippy --manifest-path crates/Cargo.toml --profile local -p runner --all-targets --all-features -j 2 -- -D warnings
RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml --profile local -p runner --all-features --no-deps -j 2
cargo test --manifest-path crates/Cargo.toml --profile local -p runner --all-targets --all-features -j 2 -- --quiet --test-threads=4
git diff --check
# From turbo/
pnpm exec prettier --check ../crates/README.md
```

## Risks and unverified areas

- Short eligible failures become local-only. The 30-second threshold is an operational policy, not a measured input SLA; warning evaluation waits for the next failed response, so existing request/backoff time and scheduler delay remain additional factors.
- Read recovery does not prove pending input was accepted. Existing durable delivery and receipt safety behavior is unchanged.
- Old draining Runners still use the previous warning policy. Production observations must identify release/commit and correlate real input/receipt evidence, not infer success from fewer warnings.
- Production Axiom credentials are unavailable in this workspace; no production rollout, fault injection or recovery census was performed. #33079 retains that acceptance gate.
- The required post-pull local DB migration encountered an OAuth completion table left by earlier branch migrations. No DB reset was performed. This unrelated local DB state does not participate in the Runner checks above; no Turbo/Python test suite is applicable to this change.
