### PR TITLE
fix(api): classify openai image provider failures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -90,6 +90,10 @@ const FAL_INVALID_ASPECT_RATIO_MESSAGE =
   "Input should be 'auto', '21:9', '16:9', '3:2', '4:3', '5:4', '1:1', '4:5', '3:4', '2:3', '9:16', '4:1', '1:4', '8:1' or '1:8'";
 const FAL_FAILURE_LOG_MESSAGE =
   "Fal built-in generation webhook reported failed generation";
+const OPENAI_FAILURE_LOG_MESSAGE = "OpenAI image generation request failed";
+const OPENAI_PRIVATE_PROVIDER_REQUEST_ID =
+  "req_private0openai0request0identifier";
+const OPENAI_PRIVATE_PROVIDER_MESSAGE = `Invalid image file or mode for image 1, please check your image file. If you believe this is an error, contact us at help.openai.com and include the request ID ${OPENAI_PRIVATE_PROVIDER_REQUEST_ID}.`;
 const FAL_QWEN_IMAGE_URL = "https://queue.fal.run/fal-ai/qwen-image";
 const FAL_MEDIA_URL = "https://fal.media/files/test/qwen.jpg";
 const FAL_FLUX_REDUX_URL = "https://queue.fal.run/fal-ai/flux-pro/v1.1/redux";
@@ -347,6 +351,14 @@ function readAcceptedGenerationId(
     },
   });
   return body.generationId;
+}
+
+function openAiFailureLogs(
+  loggingMock: typeof context.mocks.axiomLogging.info,
+): unknown[][] {
+  return loggingMock.mock.calls.filter(([message]) => {
+    return message === OPENAI_FAILURE_LOG_MESSAGE;
+  });
 }
 
 function readGenerationResult(body: unknown): unknown {
@@ -985,6 +997,335 @@ describe("POST /api/image-io/generate", () => {
         error: { code },
       });
       await expect(orgCredits(fixture)).resolves.toBe(1000);
+    },
+  );
+
+  it.each([
+    {
+      caseName: "invalid input media",
+      model: "gpt-image-2.5-sunburst",
+      editing: true,
+      providerErrorCode: "invalid_image_file",
+      moderationDetails: undefined,
+      failureKind: "input_media_invalid",
+      failureStage: "input",
+      retryPolicy: "after_input_change",
+      publicError: {
+        message: "An input image could not be read by the generation provider.",
+        code: "GENERATION_INPUT_MEDIA_INVALID",
+      },
+    },
+    {
+      caseName: "invalid input media without references",
+      model: "gpt-image-2.5-flare",
+      editing: false,
+      providerErrorCode: "invalid_image_file",
+      moderationDetails: undefined,
+      failureKind: "input_media_invalid",
+      failureStage: "input",
+      retryPolicy: "after_input_change",
+      publicError: {
+        message: "An input image could not be read by the generation provider.",
+        code: "GENERATION_INPUT_MEDIA_INVALID",
+      },
+    },
+    {
+      caseName: "input moderation block",
+      model: "gpt-image-2.5-sunburst",
+      editing: true,
+      providerErrorCode: "moderation_blocked",
+      moderationDetails: {
+        moderation_stage: "input",
+        categories: ["violence"],
+      },
+      failureKind: "input_safety_rejected",
+      failureStage: "input",
+      retryPolicy: "after_input_change",
+      publicError: {
+        message:
+          "The prompt or reference image was blocked by the safety filter.",
+        code: "GENERATION_INPUT_SAFETY_REJECTED",
+      },
+    },
+    {
+      caseName: "output moderation block",
+      model: "gpt-image-2.5-flare",
+      editing: false,
+      providerErrorCode: "moderation_blocked",
+      moderationDetails: { moderation_stage: "output", categories: ["sexual"] },
+      failureKind: "output_safety_blocked",
+      failureStage: "output",
+      retryPolicy: "manual_once",
+      publicError: {
+        message: "The generated image was blocked by the safety filter.",
+        code: "GENERATION_OUTPUT_SAFETY_BLOCKED",
+      },
+    },
+    {
+      caseName: "moderation block without a stage",
+      model: "gpt-image-2.5-flare",
+      editing: false,
+      providerErrorCode: "moderation_blocked",
+      moderationDetails: {},
+      failureKind: "input_safety_rejected",
+      failureStage: "input",
+      retryPolicy: "after_input_change",
+      publicError: {
+        message:
+          "The prompt or reference image was blocked by the safety filter.",
+        code: "GENERATION_INPUT_SAFETY_REJECTED",
+      },
+    },
+  ])(
+    "reports OpenAI $caseName as an expected input failure without charging",
+    async ({
+      model,
+      editing,
+      providerErrorCode,
+      moderationDetails,
+      failureKind,
+      failureStage,
+      retryPolicy,
+      publicError,
+    }) => {
+      const fixture = await seedImageFixture({ credits: 1000 });
+      const pricingFixture = await createScopedImagePricing({
+        configured: GPT_IMAGE_2_5_PRICING,
+      });
+      mocks.clerk.session(fixture.userId, fixture.orgId);
+      server.use(
+        http.post(
+          editing ? OPENAI_IMAGE_EDITS_URL : OPENAI_IMAGE_GENERATIONS_URL,
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: OPENAI_PRIVATE_PROVIDER_MESSAGE,
+                  type: "image_generation_user_error",
+                  param: null,
+                  code: providerErrorCode,
+                  ...(moderationDetails
+                    ? { moderation_details: moderationDetails }
+                    : {}),
+                },
+              },
+              { status: 400 },
+            );
+          },
+        ),
+      );
+
+      const app = createImageIoTestApp(pricingFixture.resolution);
+      const response = await app.request("/api/image-io/generate", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          model,
+          prompt: "a product illustration",
+          ...(editing ? { imageUrls: [MOCKUP_IMAGE_URL] } : {}),
+        }),
+      });
+      expect(response.status).toBe(202);
+      const generationId = readAcceptedGenerationId(
+        await response.json(),
+        "image",
+        fixture.userId,
+      );
+      await flushWaitUntilForTest();
+
+      const status = await app.request(
+        `/api/built-in-generations/${generationId}`,
+        { headers: authHeaders() },
+      );
+      expect(status.status).toBe(200);
+      const statusBody: unknown = await status.json();
+      expect(statusBody).toMatchObject({
+        status: "failed",
+        error: publicError,
+      });
+      await expect(orgCredits(fixture)).resolves.toBe(1000);
+
+      const debugLogs = openAiFailureLogs(context.mocks.axiomLogging.debug);
+      expect(debugLogs).toStrictEqual([
+        [
+          OPENAI_FAILURE_LOG_MESSAGE,
+          expect.objectContaining({
+            context: "ImageGeneration",
+            provider: "openai",
+            model,
+            providerStatus: 400,
+            providerErrorType: "image_generation_user_error",
+            providerErrorCode,
+            failureKind,
+            failureStage,
+            publicErrorCode: publicError.code,
+            retryPolicy,
+            billingDisposition: "not_charged",
+            expected: true,
+          }),
+        ],
+      ]);
+      for (const silentMock of [
+        context.mocks.axiomLogging.error,
+        context.mocks.axiomLogging.warn,
+        context.mocks.axiomLogging.info,
+      ]) {
+        expect(openAiFailureLogs(silentMock)).toHaveLength(0);
+      }
+
+      const publicAndLogSurfaces = JSON.stringify({
+        status: statusBody,
+        debugLogs,
+      });
+      for (const privateValue of [
+        OPENAI_PRIVATE_PROVIDER_MESSAGE,
+        OPENAI_PRIVATE_PROVIDER_REQUEST_ID,
+        "a product illustration",
+        MOCKUP_IMAGE_URL,
+      ]) {
+        expect(publicAndLogSurfaces).not.toContain(privateValue);
+      }
+    },
+  );
+
+  it.each([
+    {
+      caseName: "rate limiting",
+      upstreamStatus: 429,
+      responseBody: {
+        error: {
+          message: OPENAI_PRIVATE_PROVIDER_MESSAGE,
+          type: "rate_limit_error",
+          code: "rate_limit_exceeded",
+        },
+      },
+    },
+    {
+      caseName: "provider faults",
+      upstreamStatus: 500,
+      responseBody: {
+        error: {
+          message: OPENAI_PRIVATE_PROVIDER_MESSAGE,
+          type: "server_error",
+          code: "internal_error",
+        },
+      },
+    },
+    {
+      caseName: "authentication failures",
+      upstreamStatus: 401,
+      responseBody: {
+        error: {
+          message: OPENAI_PRIVATE_PROVIDER_MESSAGE,
+          type: "invalid_request_error",
+          code: "invalid_api_key",
+        },
+      },
+    },
+    {
+      caseName: "non-user request errors",
+      upstreamStatus: 400,
+      responseBody: {
+        error: {
+          message: OPENAI_PRIVATE_PROVIDER_MESSAGE,
+          type: "invalid_request_error",
+          code: "unknown_parameter",
+        },
+      },
+    },
+    {
+      caseName: "unrecognized user error codes",
+      upstreamStatus: 400,
+      responseBody: {
+        error: {
+          message: OPENAI_PRIVATE_PROVIDER_MESSAGE,
+          type: "image_generation_user_error",
+          code: "some_future_code",
+        },
+      },
+    },
+    {
+      caseName: "unparseable error bodies",
+      upstreamStatus: 400,
+      responseBody: "not json at all",
+    },
+  ])(
+    "keeps OpenAI $caseName an unexpected provider failure",
+    async ({ upstreamStatus, responseBody }) => {
+      const fixture = await seedImageFixture({ credits: 1000 });
+      const pricingFixture = await createScopedImagePricing({
+        configured: GPT_IMAGE_2_5_PRICING,
+      });
+      mocks.clerk.session(fixture.userId, fixture.orgId);
+      server.use(
+        http.post(OPENAI_IMAGE_EDITS_URL, () => {
+          return typeof responseBody === "string"
+            ? new HttpResponse(responseBody, { status: upstreamStatus })
+            : HttpResponse.json(responseBody, { status: upstreamStatus });
+        }),
+      );
+
+      const app = createImageIoTestApp(pricingFixture.resolution);
+      const response = await app.request("/api/image-io/generate", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          model: "gpt-image-2.5-sunburst",
+          prompt: "a product illustration",
+          imageUrls: [MOCKUP_IMAGE_URL],
+        }),
+      });
+      expect(response.status).toBe(202);
+      const generationId = readAcceptedGenerationId(
+        await response.json(),
+        "image",
+        fixture.userId,
+      );
+      await flushWaitUntilForTest();
+
+      const status = await app.request(
+        `/api/built-in-generations/${generationId}`,
+        { headers: authHeaders() },
+      );
+      expect(status.status).toBe(200);
+      const statusBody: unknown = await status.json();
+      expect(statusBody).toMatchObject({
+        status: "failed",
+        error: {
+          message: "Image generation failed",
+          code: "OPENAI_IMAGE_REQUEST_FAILED",
+        },
+      });
+      await expect(orgCredits(fixture)).resolves.toBe(1000);
+
+      const errorLogs = openAiFailureLogs(context.mocks.axiomLogging.error);
+      expect(errorLogs).toStrictEqual([
+        [
+          OPENAI_FAILURE_LOG_MESSAGE,
+          expect.objectContaining({
+            context: "ImageGeneration",
+            provider: "openai",
+            providerStatus: upstreamStatus,
+            providerErrorType: "unknown",
+            providerErrorCode: "unknown",
+            failureKind: "unknown",
+            failureStage: "provider",
+            publicErrorCode: "OPENAI_IMAGE_REQUEST_FAILED",
+            retryPolicy: "retry_once",
+            billingDisposition: "not_charged",
+            expected: false,
+          }),
+        ],
+      ]);
+      for (const silentMock of [
+        context.mocks.axiomLogging.debug,
+        context.mocks.axiomLogging.info,
+      ]) {
+        expect(openAiFailureLogs(silentMock)).toHaveLength(0);
+      }
+      expect(JSON.stringify({ status: statusBody, errorLogs })).not.toContain(
+        OPENAI_PRIVATE_PROVIDER_MESSAGE,
+      );
     },
   );
 

--- a/turbo/apps/api/src/signals/services/image-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/image-generation.service.ts
@@ -2040,6 +2040,110 @@ const openAiImageResponseSchema = z.object({
   }),
 });
 
+const openAiImageErrorSchema = z.object({
+  error: z.object({
+    type: z.string().optional(),
+    code: z.string().optional(),
+    moderation_details: z
+      .object({
+        moderation_stage: z.enum(["input", "output", "unknown"]).optional(),
+      })
+      .optional(),
+  }),
+});
+
+interface OpenAiImageFailure {
+  readonly response: ErrorResponse;
+  readonly providerErrorType: string;
+  readonly providerErrorCode: string;
+  readonly failureKind: string;
+  readonly failureStage: string;
+  readonly retryPolicy: string;
+  readonly expected: boolean;
+}
+
+const OPENAI_IMAGE_USER_ERROR_TYPE = "image_generation_user_error";
+
+function unclassifiedOpenAiImageFailure(): OpenAiImageFailure {
+  return {
+    response: badGateway(
+      "Image generation failed",
+      "OPENAI_IMAGE_REQUEST_FAILED",
+    ),
+    providerErrorType: "unknown",
+    providerErrorCode: "unknown",
+    failureKind: "unknown",
+    failureStage: "provider",
+    retryPolicy: "retry_once",
+    expected: false,
+  };
+}
+
+/**
+ * OpenAI documents `image_generation_user_error` as user-correctable, tells
+ * callers not to retry it unmodified, and names `error.code` the stable
+ * discriminator. Only the allowlisted codes below become an actionable input
+ * failure; every other status, type, or code keeps the provider-fault
+ * classification so an unrecognized failure stays visible at error level.
+ */
+function classifyOpenAiImageFailure(
+  status: number,
+  body: unknown,
+): OpenAiImageFailure {
+  const parsed = openAiImageErrorSchema.safeParse(body);
+  if (!parsed.success || status !== 400) {
+    return unclassifiedOpenAiImageFailure();
+  }
+  const providerError = parsed.data.error;
+  if (providerError.type !== OPENAI_IMAGE_USER_ERROR_TYPE) {
+    return unclassifiedOpenAiImageFailure();
+  }
+  if (providerError.code === "invalid_image_file") {
+    return {
+      response: badRequest(
+        "An input image could not be read by the generation provider.",
+        "GENERATION_INPUT_MEDIA_INVALID",
+      ),
+      providerErrorType: OPENAI_IMAGE_USER_ERROR_TYPE,
+      providerErrorCode: providerError.code,
+      failureKind: "input_media_invalid",
+      failureStage: "input",
+      retryPolicy: "after_input_change",
+      expected: true,
+    };
+  }
+  if (providerError.code === "moderation_blocked") {
+    // Only an explicit output stage means our generated image was blocked;
+    // input and unknown stages stay a caller-correctable input rejection.
+    return providerError.moderation_details?.moderation_stage === "output"
+      ? {
+          response: badRequest(
+            "The generated image was blocked by the safety filter.",
+            "GENERATION_OUTPUT_SAFETY_BLOCKED",
+          ),
+          providerErrorType: OPENAI_IMAGE_USER_ERROR_TYPE,
+          providerErrorCode: providerError.code,
+          failureKind: "output_safety_blocked",
+          failureStage: "output",
+          retryPolicy: "manual_once",
+          expected: true,
+        }
+      : {
+          response: badRequest(
+            "The prompt or reference image was blocked by the safety filter.",
+            "GENERATION_INPUT_SAFETY_REJECTED",
+          ),
+          providerErrorType: OPENAI_IMAGE_USER_ERROR_TYPE,
+          providerErrorCode: providerError.code,
+          failureKind: "input_safety_rejected",
+          failureStage: "input",
+          retryPolicy: "after_input_change",
+          expected: true,
+        };
+  }
+  return unclassifiedOpenAiImageFailure();
+}
+
 export async function generateOpenAiImage(
   options: ImageOptions,
   references: ImageProviderReferences,
@@ -2082,13 +2186,35 @@ export async function generateOpenAiImage(
     },
   );
   if (!response.ok) {
-    const responseBody = await readImageProviderErrorBody(response, signal);
-    L.error("OpenAI image generation request failed", {
+    const responseBody = await response.text();
+    signal.throwIfAborted();
+    const failure = classifyOpenAiImageFailure(
+      response.status,
+      safeJsonParse(responseBody),
+    );
+    // Bounded taxonomy fields only. The provider body echoes request input and
+    // provider request IDs, so it never reaches the log.
+    const fields = {
+      provider: "openai",
       model: options.model,
-      status: response.status,
-      body: responseBody,
-    });
-    return badGateway("Image generation failed", "OPENAI_IMAGE_REQUEST_FAILED");
+      providerStatus: response.status,
+      providerErrorType: failure.providerErrorType,
+      providerErrorCode: failure.providerErrorCode,
+      failureKind: failure.failureKind,
+      failureStage: failure.failureStage,
+      publicErrorCode: failure.response.body.error.code,
+      retryPolicy: failure.retryPolicy,
+      billingDisposition: "not_charged",
+      expected: failure.expected,
+    };
+    if (failure.expected) {
+      // Provider-rejected input is routine and not actionable by us. The job
+      // row keeps the durable record through its public error code.
+      L.debug("OpenAI image generation request failed", fields);
+    } else {
+      L.error("OpenAI image generation request failed", fields);
+    }
+    return failure.response;
   }
 
   const responseText = await response.text();


### PR DESCRIPTION
## Problem

Five production requests on `2026-09-09` failed with OpenAI `400` /
`image_generation_user_error` / `invalid_image_file` (#33080). The provider was
telling us a reference image was unusable. Our code reported it as a provider
fault.

[`generateOpenAiImage`](https://github.com/vm0-ai/vm0/blob/854bd18d8bb1f71cc704dca92d2d7b23030d9620/turbo/apps/api/src/signals/services/image-generation.service.ts#L2084-L2092)
collapsed every non-OK response into one branch:

```ts
L.error("OpenAI image generation request failed", { model, status, body: responseBody });
return badGateway("Image generation failed", "OPENAI_IMAGE_REQUEST_FAILED");
```

So a 400 input rejection, a 429, a 401 and a 502 were indistinguishable to the
caller and to Axiom. The user and the agent saw only `Image generation failed`,
which is why the request was retried four more times against an unchanged input
that OpenAI documents as non-retryable.

## Not a request-construction bug

Worth stating explicitly, because the issue leaves it open:

- The JSON `images: [{ image_url }]` shape is the documented contract for
  `POST /v1/images/edits` on `gpt-image-2.5-sunburst` / `-flare`.
- 48 of 53 image jobs since the models shipped completed successfully, and all
  18 `gpt-image-2.5` generations reported non-zero `tokens.input.image`, so
  every one of them exercised the reference/edits path.
- The same run and the same model succeeded four times a few minutes after the
  five failures.

The request path works. The classification of its failures did not.

## Change

Apply the failure taxonomy this repository already established for the Fal
webhook path in #31690.

When the response is HTTP 400 **and** `error.type = "image_generation_user_error"`,
map allowlisted `error.code` values:

| `error.code` | public code | kind / stage | retry |
| --- | --- | --- | --- |
| `invalid_image_file` | `GENERATION_INPUT_MEDIA_INVALID` | `input_media_invalid` / `input` | `after_input_change` |
| `moderation_blocked`, `moderation_stage = "output"` | `GENERATION_OUTPUT_SAFETY_BLOCKED` | `output_safety_blocked` / `output` | `manual_once` |
| `moderation_blocked`, otherwise | `GENERATION_INPUT_SAFETY_REJECTED` | `input_safety_rejected` / `input` | `after_input_change` |

**No new public error code.** All three already exist in `RUN_ERROR_GUIDANCE`
and already map to HTTP 422 in `statusForBuiltInGenerationError`, so the CLI and
Platform render the actionable text with no client change. A caller now gets
"Input image invalid — Replace or re-encode the image in a supported format,
then try again." instead of "Image generation failed".

OpenAI names `error.code` the stable discriminator and documents this class as
user-correctable and non-retryable, which is what the allowlist keys on.

### What deliberately does not change

Everything outside that exact condition keeps its current behavior — 502
`OPENAI_IMAGE_REQUEST_FAILED` at `error` level:

- any non-400 status (429, 401, 5xx);
- a 400 whose `error.type` is not `image_generation_user_error`;
- **an unrecognized `error.code` inside the user-error class**;
- an unparseable or empty body.

That last pair is the point: this is an allowlist, not a blanket downgrade. If
OpenAI renames a code or adds a new one, it surfaces at error level rather than
disappearing.

### Logging

The raw provider body is removed from the log and replaced with bounded
taxonomy fields (`provider`, `model`, `providerStatus`, `providerErrorType`,
`providerErrorCode`, `failureKind`, `failureStage`, `publicErrorCode`,
`retryPolicy`, `billingDisposition`, `expected`).

A provider-rejected input is a routine diagnostic that we cannot act on, so it
logs at `debug`, which is what `api/no-logger-info` prescribes. Unclassified
failures stay at `error`. No lint configuration is touched and no suppression
comment is added.

Note the consequence: the Axiom SDK logger is constructed without `logLevel` and
defaults to `info`, so `debug` records do not reach Axiom. Expected input
rejections therefore produce no production log line at all. That is intended —
the durable record is the `built_in_generation_jobs` row, which carries
`status = failed` and the public error code, is joined to org and run, and is
retained. It is a better substrate for this than a log line, and it is what the
investigation behind #33080 actually queried.

The body was being logged up to 4000 characters with only presigned-URL
redaction. In the five observed records it carried just the message and an
OpenAI request ID, but `invalid_request_error` bodies echo parameter values —
the same exposure class removed for Fal in #31129. No leak is claimed here; this
removes the shape that allows one.

Failure settlement is untouched: no credits charged, no artifact or usage event
recorded, admission still completes as failed.

## Still unknown

Why OpenAI considered that particular JPEG invalid — colour mode, encoding,
pixel dimensions, or something on their fetch side — is not recoverable from
masked telemetry and is not publicly documented. This PR does not claim to
eliminate `invalid_image_file`. It makes the failure correctly classified,
actionable, and observable. A metadata-only content-type pre-check on our own
artifacts is a plausible follow-up, but it would not have prevented this
incident: the file's stored content type was `image/jpeg`.

## Fallbacks

Both entries handle documented-optional fields on the external OpenAI Images
**error** response, the same class #32730 already declared for the success
response. Neither is a rollout fallback, so neither has a section 7 gate or a
follow-up issue; the window is the lifetime of OpenAI's error contract and is
independent of our deployments.

- `image-generation.service.ts:openAiImageErrorSchema` — `error.type` and
  `error.code` are optional. What it protects: an OpenAI error body that omits
  them, which is normal for 429, 5xx, 401, and malformed responses. An absent or
  unrecognized value routes to `unclassifiedOpenAiImageFailure()`, preserving the
  existing 502 `OPENAI_IMAGE_REQUEST_FAILED` at error level. Surface: external
  OpenAI Images error response. Remove when OpenAI guarantees `type` and `code`
  on every image error body and the schema can require them.
- `image-generation.service.ts:classifyOpenAiImageFailure` — an absent
  `moderation_details`, or an absent or `"unknown"` `moderation_stage`, is
  classified as an input-stage rejection rather than an output block. What it
  protects: `moderation_blocked` bodies without the optional detail object.
  Input-stage is the safe default because it produces the caller-actionable
  outcome; only an explicit `"output"` stage attributes the block to our
  generated image. Surface: external OpenAI Images error response. Remove when
  OpenAI guarantees `moderation_details.moderation_stage` on every
  `moderation_blocked` error.

## Verification

- `image-io-generate.test.ts`: **74 passed**, up from 63 on the same
  baseline — 11 new cases.
  - 5 expected-input cases: `invalid_image_file` with and without references,
    input moderation, output moderation, moderation without a stage. Each
    asserts the public error, zero credit movement, exactly one `debug` record
    with the full field set, zero `error`/`warn`/`info` records, and that the
    provider message, provider request ID, prompt and reference URL appear in
    neither the status response nor the log.
  - 6 negative controls: 429, 500, 401, a 400 `invalid_request_error`, a 400
    user-error with an unrecognized code, and a non-JSON body. Each asserts the
    unchanged 502 code, that the record stays at `error`, and that nothing was
    emitted at `debug`/`info`.
- `webhooks-built-in-generations.test.ts`: 6 passed — the neighbouring Fal
  classification path is unaffected.
- `pnpm check-types` (all five API projects), `eslint --max-warnings 0`,
  `oxlint` including `--type-aware`, `prettier --check`, and
  `knip --workspace apps/api`: all clean.

One pre-existing failure in this file, `uses allowance for a legacy runless
generation under shared debt`, reproduces identically on unmodified `main` in
this environment (`{short: 0, weekly: 0}` vs `{short: 50, weekly: 50}`). It is a
local billing-fixture gap, unrelated to this change. Full suites run in CI.

No live provider calls were made; all provider HTTP is mocked at the msw
boundary.

## Post-deploy check

Bounded 72-hour window on `vm0-web-logs-prod`, keyed on the new deployment ID:

1. Axiom: every remaining OpenAI image `error`/`warn` record maps to a real
   non-input failure (429, 5xx, 401, or an unclassified 400);
2. Axiom: records carrying `fields.body` == 0;
3. MaskDB `built_in_generation_jobs`: failed image jobs now carry
   `GENERATION_INPUT_MEDIA_INVALID` / `GENERATION_INPUT_SAFETY_REJECTED` /
   `GENERATION_OUTPUT_SAFETY_BLOCKED` rather than a blanket
   `OPENAI_IMAGE_REQUEST_FAILED`;
4. the overall image failure rate does **not** move — reclassification must not
   change how often generation fails.

Expected input rejections are verified in (3), not in Axiom, because `debug`
does not reach the dataset.

Fixes #33080
