### PR TITLE
docs(python): correct jsonl flush warning transport

### DIFF
--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -81,10 +81,13 @@ def _write_jsonl_entry(log_path: str, entry: dict, log_name: str) -> None:
 def flush_log_path(log_path: str, *, timeout: float | None = None) -> bool:
     """Wait until accepted JSONL writes for a path have been processed.
 
-    Failed append attempts count as processed and are reported through mitmproxy
-    warnings without affecting the result. ``False`` only means a configured
-    timeout expired with accepted writes still pending; ``True`` does not
-    confirm that every line was persisted.
+    Failed append attempts count as processed and are reported through addon
+    process events on stderr without affecting the result. ``False`` only means a
+    configured timeout expired with accepted writes still pending; ``True`` does
+    not confirm that every line was persisted.
+
+    See ``addon_process_logging.emit_addon_process_event`` for the structured
+    stderr transport.
     """
     return jsonl_writer.flush_log_path(log_path, timeout=timeout)
 
@@ -92,9 +95,12 @@ def flush_log_path(log_path: str, *, timeout: float | None = None) -> bool:
 def flush_all_logs() -> None:
     """Wait until accepted JSONL writes for all paths have been processed.
 
-    Failed append attempts count as processed and are reported through mitmproxy
-    warnings; completion of this call does not confirm that every line was
-    persisted.
+    Failed append attempts count as processed and are reported through addon
+    process events on stderr; completion of this call does not confirm that every
+    line was persisted.
+
+    See ``addon_process_logging.emit_addon_process_event`` for the structured
+    stderr transport.
     """
     jsonl_writer.flush_all_logs()
 


### PR DESCRIPTION
The public JSONL flush wrappers incorrectly directed callers to mitmproxy warnings when diagnosing failed appends. Update both docstrings to identify addon process events on stderr and reference `addon_process_logging.emit_addon_process_event` for the structured transport.

This is documentation-only: flush results, timeout semantics, persistence guarantees, warning routing, and rate limiting are unchanged.

Closes #33096

## Validation

- `uv lock --check` and `uv sync --locked` using the pinned uv 0.11.32 / Python 3.14.0 environment.
- `uv run --no-sync ruff check src/logging_utils.py`.
- `uv run --no-sync ruff format --check src/logging_utils.py`.
- `git diff --check`.
- Python AST comparison confirmed changes are limited to the two intended docstrings; the emitter reference was verified against its definition and stderr consumer.

No behavior tests were added or run locally for this documentation-only change.
