### PR TITLE
docs(rust): correct guest completion reporting order

### DIFF
--- a/crates/guest-agent/src/complete.rs
+++ b/crates/guest-agent/src/complete.rs
@@ -1,10 +1,21 @@
 //! Guest-side `/webhooks/agent/complete` caller.
 //!
-//! The runner also posts `/complete` after it observes the VM exit, but by
-//! then the run has incurred `final_telemetry`, VM teardown, stop/destroy,
-//! and host observation delays. The guest calls it with a prepared checkpoint
-//! after successful execution or recovery. The runner's subsequent call is
-//! absorbed by the route's idempotency check.
+//! The guest calls `/complete` with a prepared checkpoint after successful
+//! execution or recovery, persisting the checkpoint and terminal state together
+//! before its final telemetry and shutdown work.
+//!
+//! After the executor returns, the API-backed runner posts a checkpoint-less
+//! fallback concurrently with sandbox park-or-destroy finalization
+//! (`ConcurrentWithFinalization`). A subsequent call for an already-terminal run
+//! is idempotent. The VM may remain alive for reuse, and a parked sandbox retains
+//! capacity. Completion alone does not prove that sandbox ownership or active
+//! status has settled, or that capacity has been released.
+//!
+//! `LocalProvider` instead reports after finalization (`AfterFinalization`) so an
+//! immediate local submission can safely depend on reuse. See the [runner timing
+//! contract] on `JobProvider::completion_report_timing` for the provider distinction.
+//!
+//! [runner timing contract]: https://github.com/vm0-ai/vm0/blob/main/crates/runner/src/provider/mod.rs
 //!
 //! Checkpoint-bearing completion uses the checkpoint retry budget and returns
 //! failures to the caller. Checkpoint-less cancellation fallback remains

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -867,9 +867,9 @@ async fn complete_execution(
         match cp_result {
             Ok(checkpoint) => {
                 // Persist the prepared checkpoint and terminal state together
-                // before returning to the top-level final telemetry pass. The
-                // runner still posts a checkpoint-less /complete after VM
-                // exit; its call is idempotency-short-circuited.
+                // before returning to the top-level final telemetry pass. See
+                // the `complete` module docs for the runner's idempotent fallback
+                // and provider-specific finalization ordering.
                 log_info!(LOG_TAG, "▷ Cleanup");
                 let result = complete::report_checkpoint_for_run(
                     runtime,


### PR DESCRIPTION
## Summary

Correct the guest completion docs that placed the runner fallback after VM exit and teardown. Explain guest checkpoint/terminal persistence before final telemetry, API reporting concurrent with park-or-destroy finalization after executor return, and local reporting after finalization. Clarify that completion does not establish settled ownership/status or released capacity, and link the provider-owned timing contract from the module overview.

Update the matching success-path comment to reference that overview. Only comments change; runtime behavior, retries, cancellation, and trust boundaries are preserved.

Closes #33095

## Validation

- Passed: `cargo fmt --manifest-path crates/guest-agent/Cargo.toml -- --check`.
- Passed: `CARGO_BUILD_JOBS=2 cargo doc --manifest-path crates/Cargo.toml --profile local --locked -p guest-agent --no-deps`.
- Passed: `git diff --check`, comments-only source comparison, generated module documentation inspection, and verification of the rendered runner-contract link.
- Checked the wording against both provider timing selections, `spawn_job` settlement ordering, and the existing parking/destruction gate tests. No runtime tests were added or run for this documentation change.

The additional `--document-private-items` check encounters four pre-existing link errors in `artifact/mod.rs`, `constants.rs`, and `masker.rs`. The same errors reproduce on clean base `b440c7b27c62b2b79afe88a9762cc51c790bfb95`; tracked separately in #33120.
