### PR TITLE
fix(python): bound webhook tasks after worker startup failure

### DIFF
--- a/crates/runner/mitm-addon/src/usage/executor.py
+++ b/crates/runner/mitm-addon/src/usage/executor.py
@@ -1,0 +1,55 @@
+"""Start webhook workers before allowing payload-bearing work into their queue."""
+
+import threading
+from collections.abc import Callable
+from concurrent.futures import Executor, Future, ThreadPoolExecutor
+
+
+class WebhookExecutor(Executor):
+    """Lazily publish a fully started pool; failed pools own only bootstrap work."""
+
+    def __init__(self, *, max_workers: int, thread_name_prefix: str) -> None:
+        if max_workers <= 0:
+            raise ValueError("max_workers must be greater than 0")
+        self._max_workers = max_workers
+        self._thread_name_prefix = thread_name_prefix
+        self._lock = threading.Lock()
+        self._pool: ThreadPoolExecutor | None = None
+        self._shutdown = False
+
+    def _start_pool(self) -> ThreadPoolExecutor:
+        pool = ThreadPoolExecutor(
+            max_workers=self._max_workers,
+            thread_name_prefix=self._thread_name_prefix,
+        )
+        ready = threading.Event()
+        try:
+            # Blocking every bootstrap task prevents idle-worker reuse, so all
+            # workers start before submit() can queue a webhook payload.
+            for _ in range(self._max_workers):
+                pool.submit(ready.wait)
+        except BaseException:
+            ready.set()
+            # submit() may have queued a task before Thread.start() failed.
+            # This unpublished pool has no deliveries to cancel or wait for.
+            pool.shutdown(wait=True, cancel_futures=True)
+            raise
+        ready.set()
+        return pool
+
+    def submit[T, **P](self, fn: Callable[P, T], /, *args: P.args, **kwargs: P.kwargs) -> Future[T]:
+        with self._lock:
+            if self._shutdown:
+                raise RuntimeError("cannot schedule new futures after shutdown")
+            if self._pool is None:
+                self._pool = self._start_pool()
+            return self._pool.submit(fn, *args, **kwargs)
+
+    def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
+        with self._lock:
+            self._shutdown = True
+            pool = self._pool
+        # A delivery callback may enqueue again and use the shutdown fallback.
+        # Joining while holding the lifecycle lock would deadlock that callback.
+        if pool is not None:
+            pool.shutdown(wait=wait, cancel_futures=cancel_futures)

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -5,6 +5,8 @@ first waits for the pending counters to drain, then ``done()`` flushes
 submitted futures during mitmproxy shutdown. Falls back to synchronous
 delivery if submission fails during shutdown or worker startup so reports
 are not silently lost. A worker and fallback share one delivery claim.
+Workers start before payloads enter the pool, so failed startup cannot retain
+completed fallback deliveries in an undrained executor queue.
 """
 
 import json
@@ -13,7 +15,7 @@ import time
 import urllib.error
 import urllib.parse
 from collections.abc import Callable
-from concurrent.futures import Executor, ThreadPoolExecutor
+from concurrent.futures import Executor
 from functools import partial
 from typing import Literal
 
@@ -22,6 +24,7 @@ from logging_utils import log_proxy_entry
 from platform_api import build_api_opener, make_api_request
 
 from .counters import PendingReportLease, admit_pending_report
+from .executor import WebhookExecutor
 
 WebhookDeliveryOutcome = Literal["success", "retryable_failure", "permanent_failure"]
 _DeliveryOutcomeCallback = Callable[[WebhookDeliveryOutcome], None]
@@ -296,7 +299,7 @@ def _is_retryable_http_error(exc: urllib.error.HTTPError) -> bool:
 USAGE_WEBHOOK_WORKERS = 4
 MAX_PENDING_WEBHOOK_PAYLOADS = USAGE_WEBHOOK_WORKERS * 4
 
-usage_executor = ThreadPoolExecutor(
+usage_executor = WebhookExecutor(
     max_workers=USAGE_WEBHOOK_WORKERS,
     thread_name_prefix="usage",
 )

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -535,9 +535,9 @@ def fresh_usage_executor():
     Tests that call ``shutdown(wait=True)`` to flush pending webhook
     reports need a fresh executor afterwards so later tests still see a
     live pool.  This fixture owns the lifecycle: a new
-    :class:`ThreadPoolExecutor` is installed before the test and the
+    :class:`usage.executor.WebhookExecutor` is installed before the test and the
     original is restored after a shutdown-triggered final flush.
-    ``ThreadPoolExecutor.shutdown`` is idempotent, so we always call it
+    ``WebhookExecutor.shutdown`` is idempotent, so we always call it
     on the way out regardless of whether the test already did.
     """
     with fresh_usage_executor_context() as executor:

--- a/crates/runner/mitm-addon/tests/test_fresh_usage_executor.py
+++ b/crates/runner/mitm-addon/tests/test_fresh_usage_executor.py
@@ -1,7 +1,7 @@
 """Tests for the fresh usage executor fixture lifecycle."""
 
 from collections.abc import Callable
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Executor, Future
 from typing import Any
 from unittest.mock import Mock, patch
 
@@ -45,7 +45,7 @@ class _RecordingExecutor:
 
 def test_fresh_usage_executor_restores_and_shuts_down_after_flush_failure(tmp_path):
     original = usage.webhook.usage_executor
-    executors: list[ThreadPoolExecutor] = []
+    executors: list[Executor] = []
     enqueue = Mock(side_effect=RuntimeError("flush failed"))
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
 
@@ -77,7 +77,7 @@ def test_fresh_usage_executor_restores_and_shuts_down_after_flush_failure(tmp_pa
 def test_fresh_usage_executor_uses_owned_executor_when_global_changes(tmp_path, mitm_ctx):
     original = usage.webhook.usage_executor
     replacement = _RecordingExecutor()
-    executors: list[ThreadPoolExecutor] = []
+    executors: list[Executor] = []
     server = UsageWebhookServer()
 
     with (

--- a/crates/runner/mitm-addon/tests/test_webhook_executor_lifetime.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_executor_lifetime.py
@@ -199,8 +199,9 @@ def _enqueue_during_shutdown_join(url: str) -> None:
 
     def on_outcome(outcome: usage.webhook.WebhookDeliveryOutcome) -> None:
         outcomes.append(("A", outcome))
-        assert joining.wait(timeout=5)
-        assert usage.webhook.enqueue_webhook_delivery(
+        shutdown_started = joining.wait(timeout=5)
+        assert shutdown_started
+        admitted = usage.webhook.enqueue_webhook_delivery(
             url,
             "tok",
             {"runId": "B", "events": []},
@@ -208,11 +209,13 @@ def _enqueue_during_shutdown_join(url: str) -> None:
             "usage_event",
             lambda value: outcomes.append(("B", value)),
         )
+        assert admitted
 
     with patch.object(threading.Thread, "join", observe_join):
-        assert usage.webhook.enqueue_webhook_delivery(
+        admitted = usage.webhook.enqueue_webhook_delivery(
             url, "tok", {"runId": "A", "events": []}, "", "usage_event", on_outcome
         )
+        assert admitted
         usage.webhook.shutdown_delivery_executor(wait=True)
     assert outcomes == [("A", "success"), ("B", "success")]
     assert usage.webhook.pending_delivery_payload_count_for_tests() == 0

--- a/crates/runner/mitm-addon/tests/test_webhook_executor_lifetime.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_executor_lifetime.py
@@ -1,0 +1,241 @@
+"""Delivery lifetime across infrastructure failures that HTTP input cannot cause.
+
+Use real executors and HTTP delivery; inject only the OS thread-start failure.
+Weak references expose retained caller data that HTTP success cannot detect.
+"""
+
+import gc
+import multiprocessing
+import threading
+import weakref
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext
+from unittest.mock import patch
+
+import pytest
+
+import usage
+import usage.executor
+from tests.pending_helpers import assert_current_pending
+
+
+class _Payload(dict):
+    pass
+
+
+@pytest.fixture
+def observed_pools() -> Iterator[list[ThreadPoolExecutor]]:
+    pools: list[ThreadPoolExecutor] = []
+
+    class ObservedPool(ThreadPoolExecutor):
+        def __init__(self, **kwargs) -> None:
+            super().__init__(**kwargs)
+            pools.append(self)
+
+    # Observe the real standard-library executor, without changing submission.
+    with patch.object(usage.executor, "ThreadPoolExecutor", ObservedPool):
+        yield pools
+
+
+@pytest.mark.parametrize("error_type", [RuntimeError, OSError])
+@pytest.mark.parametrize("failed_worker", [0, 2], ids=["first-worker", "third-worker"])
+def test_repeated_start_failure_releases_completed_delivery_data(
+    tmp_path, usage_webhook_server, fresh_usage_executor, observed_pools, error_type, failed_worker
+):
+    pending_path = tmp_path / "usage-pending"
+    usage.set_pending_path(str(pending_path))
+    payload_refs: list[weakref.ReferenceType[_Payload]] = []
+    snapshot_refs: list[weakref.ReferenceType[_Payload]] = []
+    outcomes: list[tuple[int, usage.webhook.WebhookDeliveryOutcome]] = []
+    start = threading.Thread.start
+
+    def fail_start(thread: threading.Thread) -> None:
+        if thread.name == f"usage-test_{failed_worker}":
+            raise error_type("worker creation failed")
+        start(thread)
+
+    def enqueue(index: int) -> None:
+        snapshot = _Payload(events=[{"quantity": 1}] * 100)
+        payload = _Payload(runId=f"run-{index}", events=snapshot["events"])
+        payload_refs.append(weakref.ref(payload))
+        snapshot_refs.append(weakref.ref(snapshot))
+
+        def on_outcome(outcome: usage.webhook.WebhookDeliveryOutcome) -> None:
+            assert snapshot["events"]
+            outcomes.append((index, outcome))
+            assert usage.webhook.pending_delivery_payload_count_for_tests() == 1
+            assert_current_pending(pending_path, flows=0, buffered=0, reports=1)
+
+        assert usage.webhook.enqueue_webhook_delivery(
+            usage_webhook_server.url(),
+            "tok",
+            payload,
+            "",
+            "usage_event",
+            on_outcome,
+        )
+
+    try:
+        with patch.object(threading.Thread, "start", fail_start):
+            for index in range(64):
+                error_context = (
+                    pytest.raises(OSError, match="worker creation failed")
+                    if error_type is OSError
+                    else nullcontext()
+                )
+                with error_context:
+                    enqueue(index)
+                del error_context
+
+            expected = 0 if error_type is OSError else 64
+            assert usage_webhook_server.request_count == expected
+            assert outcomes == [(index, "success") for index in range(expected)]
+            assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+            assert_current_pending(pending_path, flows=0, buffered=0, reports=0)
+            gc.collect()
+            assert all(ref() is None for ref in payload_refs)
+            assert all(ref() is None for ref in snapshot_refs)
+
+            # Queue observations are required: clearing payloads alone could
+            # leave an unbounded number of empty tasks behind. Deliberately
+            # retain failed pools to verify cleanup without relying on GC.
+            assert observed_pools
+            assert all(pool._work_queue.qsize() <= 1 for pool in observed_pools)
+            assert all(not thread.is_alive() for pool in observed_pools for thread in pool._threads)
+            pool_refs = [weakref.ref(pool) for pool in observed_pools]
+            observed_pools.clear()
+            gc.collect()
+            assert all(ref() is None for ref in pool_refs)
+
+        # Recovery must not replay completed or rolled-back work.
+        enqueue(64)
+        fresh_usage_executor.shutdown(wait=True)
+        assert usage_webhook_server.request_count == expected + 1
+        assert outcomes == [(index, "success") for index in range(expected)] + [(64, "success")]
+        gc.collect()
+        assert all(ref() is None for ref in payload_refs)
+        assert all(ref() is None for ref in snapshot_refs)
+        assert_current_pending(pending_path, flows=0, buffered=0, reports=0)
+    finally:
+        fresh_usage_executor.shutdown(wait=True, cancel_futures=True)
+
+
+def test_healthy_pool_preserves_capacity_and_drains_admitted_work(
+    tmp_path, usage_webhook_server, fresh_usage_executor
+):
+    pending_path = tmp_path / "usage-pending"
+    usage.set_pending_path(str(pending_path))
+    release_requests = threading.Event()
+    outcomes: list[usage.webhook.WebhookDeliveryOutcome] = []
+    capacity = usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS
+    workers = usage.webhook.USAGE_WEBHOOK_WORKERS
+    for _ in range(workers):
+        usage_webhook_server.queue_response(204, release_event=release_requests)
+
+    def enqueue(index: int) -> bool:
+        return usage.webhook.enqueue_webhook_delivery(
+            usage_webhook_server.url(),
+            "tok",
+            {"runId": f"run-{index}", "events": []},
+            "",
+            "usage_event",
+            outcomes.append,
+        )
+
+    try:
+        for index in range(capacity):
+            assert enqueue(index)
+        assert usage_webhook_server.wait_for_request_count(workers)
+        assert not enqueue(capacity)
+        assert usage_webhook_server.request_count == workers
+        assert usage.webhook.pending_delivery_payload_count_for_tests() == capacity
+        assert_current_pending(pending_path, flows=0, buffered=0, reports=capacity)
+
+        fresh_usage_executor.shutdown(wait=False)
+        assert outcomes == []
+        assert_current_pending(pending_path, flows=0, buffered=0, reports=capacity)
+    finally:
+        release_requests.set()
+        fresh_usage_executor.shutdown(wait=True)
+
+    assert {body["runId"] for body in usage_webhook_server.json_bodies()} == {
+        f"run-{index}" for index in range(capacity)
+    }
+    assert usage_webhook_server.request_count == capacity
+    assert outcomes == ["success"] * capacity
+    assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+    assert_current_pending(pending_path, flows=0, buffered=0, reports=0)
+
+
+def test_shutdown_before_first_delivery_uses_synchronous_fallback(
+    usage_webhook_server, fresh_usage_executor
+):
+    outcomes: list[usage.webhook.WebhookDeliveryOutcome] = []
+    caller = threading.current_thread()
+
+    def on_outcome(outcome: usage.webhook.WebhookDeliveryOutcome) -> None:
+        assert threading.current_thread() is caller
+        outcomes.append(outcome)
+
+    fresh_usage_executor.shutdown(wait=True)
+    assert usage.webhook.enqueue_webhook_delivery(
+        usage_webhook_server.url(), "tok", {"events": []}, "", "usage_event", on_outcome
+    )
+    assert usage_webhook_server.request_count == 1
+    assert outcomes == ["success"]
+    assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+
+
+def _enqueue_during_shutdown_join(url: str) -> None:
+    joining = threading.Event()
+    join = threading.Thread.join
+    outcomes: list[tuple[str, usage.webhook.WebhookDeliveryOutcome]] = []
+
+    def observe_join(thread: threading.Thread, timeout: float | None = None) -> None:
+        if thread.name.startswith("usage_"):
+            joining.set()
+        join(thread, timeout)
+
+    def on_outcome(outcome: usage.webhook.WebhookDeliveryOutcome) -> None:
+        outcomes.append(("A", outcome))
+        assert joining.wait(timeout=5)
+        assert usage.webhook.enqueue_webhook_delivery(
+            url,
+            "tok",
+            {"runId": "B", "events": []},
+            "",
+            "usage_event",
+            lambda value: outcomes.append(("B", value)),
+        )
+
+    with patch.object(threading.Thread, "join", observe_join):
+        assert usage.webhook.enqueue_webhook_delivery(
+            url, "tok", {"runId": "A", "events": []}, "", "usage_event", on_outcome
+        )
+        usage.webhook.shutdown_delivery_executor(wait=True)
+    assert outcomes == [("A", "success"), ("B", "success")]
+    assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+
+
+def test_shutdown_join_allows_callback_to_enqueue_again(usage_webhook_server):
+    # Isolate a potential deadlock in a process so timeout can terminate all
+    # executor threads. Thread.join is the real infrastructure boundary that
+    # tells the callback shutdown is waiting; no scheduling sleeps are needed.
+    process = multiprocessing.get_context("spawn").Process(
+        target=_enqueue_during_shutdown_join,
+        args=(usage_webhook_server.url(),),
+        name="webhook-shutdown-reentry",
+    )
+    process.start()
+    try:
+        process.join(timeout=15)
+        assert not process.is_alive(), "webhook callback deadlocked during executor shutdown"
+        assert process.exitcode == 0
+    finally:
+        if process.is_alive():
+            process.kill()
+            process.join(timeout=5)
+        process.close()
+
+    assert [body["runId"] for body in usage_webhook_server.json_bodies()] == ["A", "B"]

--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -7,12 +7,12 @@ import json
 import threading
 import uuid
 from collections.abc import Callable, Iterator, Sequence
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Literal, Protocol
 
 import usage
 from tests.threaded_http_test_server import ThreadedHttpTestServer
+from usage.executor import WebhookExecutor
 
 _DeliveryOutcomeCallback = Callable[[usage.webhook.WebhookDeliveryOutcome], None]
 _EnqueueWebhook = Callable[[str, str, dict, str, str, _DeliveryOutcomeCallback], bool]
@@ -91,10 +91,10 @@ def install_recording_usage_timer(
 
 
 @contextlib.contextmanager
-def fresh_usage_executor_context() -> Iterator[ThreadPoolExecutor]:
+def fresh_usage_executor_context() -> Iterator[WebhookExecutor]:
     """Install a temporary usage executor and restore the original on exit."""
     original = usage.webhook.usage_executor
-    executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="usage-test")
+    executor = WebhookExecutor(max_workers=4, thread_name_prefix="usage-test")
     usage.webhook.usage_executor = executor
     try:
         yield executor


### PR DESCRIPTION
## Summary

Repeated webhook worker-start failures can retain already-delivered payloads and callback-owned flush snapshots in an ever-growing executor queue. Lazily start all four workers with payload-free bootstrap tasks before accepting delivery work. Failed candidates are cancelled and joined before retrying initialization, so cleanup cannot cancel unrelated deliveries.

Preserve the existing single-delivery claim, retry outcomes, callback/counter ordering and synchronous failure/shutdown delivery. The first delivery now starts all four workers; subsequent submissions use the initialized pool. Shutdown releases its lifecycle lock before joining workers so callbacks can safely enqueue again.

Closes #33101.

## Validation

- Added deterministic real-executor and loopback-HTTP coverage for repeated first/third worker failure, rollback, payload and callback lifetime, bounded failed queues, recovery, capacity, shutdown draining and callback re-entry. Updated the real-executor fixture to use the production owner.
- Both initial lifetime regressions failed on the unchanged executor and passed with the fix.
- The same 64-delivery diagnostic changed from 64 retained payloads and 64 retained callback snapshots to zero of each, with 64 successful HTTP requests/callbacks and zero pending capacity.
- 433 focused tests passed across webhook delivery, usage buffers, counters, shutdown, runner flush, provider/timing/accounting and all real-executor fixture consumers. After the test-only review cleanup, all seven lifetime regressions, affected Ruff checks and full BasedPyright were rerun successfully.
- Locked uv 0.11.32 / CPython 3.14.0: `uv lock --check`, `uv sync --locked`, `uv run --no-sync ruff check .`, `uv run --no-sync ruff format --check .`, and `uv run --no-sync basedpyright -p .` passed. Complete repository validation runs in CI.
