### PR TITLE
fix(api): serve desktop update feeds through transient manifest 5xx

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -370,6 +370,75 @@ describe("Axiom log source field", () => {
     });
   });
 
+  it("lifts desktop update manifest outcome fields into the Axiom event root", () => {
+    const log = logger("desktop-update-manifest-test");
+    log.warn("Desktop update manifest upstream unavailable", {
+      type: "desktop_update_manifest_upstream",
+      outcome: "unavailable",
+      provider: "github_release_asset",
+      provider_status: 503,
+      failure_class: "transient_read_exhausted",
+      attempts: 3,
+      line: "ai-okou-desktop",
+      method: "GET",
+      route:
+        "/api/desktop/updates/:product/:channel/:platform/:arch/RELEASES.json",
+    });
+
+    expect(axiomLogging.warn).toHaveBeenCalledWith(
+      "Desktop update manifest upstream unavailable",
+      {
+        type: "desktop_update_manifest_upstream",
+        outcome: "unavailable",
+        provider: "github_release_asset",
+        provider_status: 503,
+        failure_class: "transient_read_exhausted",
+        attempts: 3,
+        line: "ai-okou-desktop",
+        method: "GET",
+        route:
+          "/api/desktop/updates/:product/:channel/:platform/:arch/RELEASES.json",
+        context: "desktop-update-manifest-test",
+        [EVENT]: {
+          source: "api",
+          type: "desktop_update_manifest_upstream",
+          outcome: "unavailable",
+          provider: "github_release_asset",
+          provider_status: 503,
+          failure_class: "transient_read_exhausted",
+          attempts: 3,
+          line: "ai-okou-desktop",
+          method: "GET",
+          route:
+            "/api/desktop/updates/:product/:channel/:platform/:arch/RELEASES.json",
+        },
+      },
+    );
+  });
+
+  it("does not lift a desktop update manifest event with an unknown outcome", () => {
+    const log = logger("desktop-update-manifest-outcome-test");
+    log.warn("manifest event", {
+      type: "desktop_update_manifest_upstream",
+      outcome: "degraded",
+      provider: "github_release_asset",
+      failure_class: "transient_read",
+      attempts: 1,
+      line: "ai-okou-desktop",
+    });
+
+    expect(axiomLogging.warn).toHaveBeenCalledWith("manifest event", {
+      type: "desktop_update_manifest_upstream",
+      outcome: "degraded",
+      provider: "github_release_asset",
+      failure_class: "transient_read",
+      attempts: 1,
+      line: "ai-okou-desktop",
+      context: "desktop-update-manifest-outcome-test",
+      [EVENT]: { source: "api" },
+    });
+  });
+
   it("does not lift unknown type fields into the Axiom event root", () => {
     const log = logger("unknown-type-test");
     log.error("custom event", {

--- a/turbo/apps/api/src/lib/error.ts
+++ b/turbo/apps/api/src/lib/error.ts
@@ -53,6 +53,10 @@ export function eventDeliveryUnavailable(message: string) {
   return httpError(503, "EVENT_DELIVERY_UNAVAILABLE", message);
 }
 
+export function desktopUpdateUnavailable(message: string) {
+  return httpError(503, "DESKTOP_UPDATE_UNAVAILABLE", message);
+}
+
 export function insufficientCredits() {
   return httpError(
     402,

--- a/turbo/apps/api/src/lib/log.ts
+++ b/turbo/apps/api/src/lib/log.ts
@@ -190,6 +190,59 @@ interface ProviderUnavailableRootFields {
   readonly route: string;
 }
 
+type DesktopUpdateManifestOutcome =
+  | "retry_recovered"
+  | "served_stale"
+  | "unavailable";
+
+interface DesktopUpdateManifestRootFields {
+  readonly type: "desktop_update_manifest_upstream";
+  readonly outcome: DesktopUpdateManifestOutcome;
+  readonly provider: "github_release_asset";
+  readonly provider_status?: number;
+  readonly failure_class: "transient_read" | "transient_read_exhausted";
+  readonly attempts: number;
+  readonly stale_age_ms?: number;
+  readonly line: string;
+  readonly method?: string;
+  readonly route?: string;
+}
+
+function isDesktopUpdateManifestOutcome(
+  value: unknown,
+): value is DesktopUpdateManifestOutcome {
+  return (
+    value === "retry_recovered" ||
+    value === "served_stale" ||
+    value === "unavailable"
+  );
+}
+
+function isDesktopUpdateManifestFailureClass(
+  value: unknown,
+): value is DesktopUpdateManifestRootFields["failure_class"] {
+  return value === "transient_read" || value === "transient_read_exhausted";
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isInteger(value) && Number(value) >= 1;
+}
+
+function isOptionalNonNegativeInteger(value: unknown): value is number {
+  return value === undefined || (Number.isInteger(value) && Number(value) >= 0);
+}
+
+function isOptionalUpstreamStatus(value: unknown): value is number {
+  return (
+    value === undefined ||
+    (Number.isInteger(value) && Number(value) >= 400 && Number(value) <= 599)
+  );
+}
+
+function isOptionalString(value: unknown): value is string {
+  return value === undefined || typeof value === "string";
+}
+
 function usageUnderbillingRootFields(
   fields: Record<string, unknown>,
 ): UsageUnderbillingRootFields | null {
@@ -277,17 +330,64 @@ function providerUnavailableRootFields(
   };
 }
 
+function desktopUpdateManifestRootFields(
+  fields: Record<string, unknown>,
+): DesktopUpdateManifestRootFields | null {
+  const type = fields.type;
+  const outcome = fields.outcome;
+  const provider = fields.provider;
+  const providerStatus = fields.provider_status;
+  const failureClass = fields.failure_class;
+  const attempts = fields.attempts;
+  const staleAgeMs = fields.stale_age_ms;
+  const line = fields.line;
+  const method = fields.method;
+  const route = fields.route;
+
+  if (
+    type !== "desktop_update_manifest_upstream" ||
+    !isDesktopUpdateManifestOutcome(outcome) ||
+    provider !== "github_release_asset" ||
+    !isOptionalUpstreamStatus(providerStatus) ||
+    !isDesktopUpdateManifestFailureClass(failureClass) ||
+    !isPositiveInteger(attempts) ||
+    !isOptionalNonNegativeInteger(staleAgeMs) ||
+    typeof line !== "string" ||
+    !isOptionalString(method) ||
+    !isOptionalString(route)
+  ) {
+    return null;
+  }
+
+  return {
+    type,
+    outcome,
+    provider,
+    ...(providerStatus === undefined
+      ? {}
+      : { provider_status: providerStatus }),
+    failure_class: failureClass,
+    attempts,
+    ...(staleAgeMs === undefined ? {} : { stale_age_ms: staleAgeMs }),
+    line,
+    ...(method === undefined ? {} : { method }),
+    ...(route === undefined ? {} : { route }),
+  };
+}
+
 function rootEventFields(
   fields: Record<string, unknown>,
 ):
   | UsageUnderbillingRootFields
   | UnhandledRequestErrorRootFields
   | ProviderUnavailableRootFields
+  | DesktopUpdateManifestRootFields
   | null {
   return (
     usageUnderbillingRootFields(fields) ??
     unhandledRequestErrorRootFields(fields) ??
-    providerUnavailableRootFields(fields)
+    providerUnavailableRootFields(fields) ??
+    desktopUpdateManifestRootFields(fields)
   );
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -1,3 +1,4 @@
+import { EVENT } from "@axiomhq/logging";
 import { desktopUpdatesContract } from "@okouai/api-contracts/contracts/desktop-updates";
 import { testDesktopUpdateManifestStateContract } from "@okouai/api-contracts/contracts/test-desktop-update-manifest-state";
 import { HttpResponse, http } from "msw";
@@ -413,6 +414,17 @@ describe("desktop update routes", () => {
     );
   }
 
+  // The logger attaches the emitting context and lifts the recognized root
+  // fields into the Axiom event root, so asserting the whole record also
+  // proves the event was promoted rather than passed through unrecognized.
+  function loggedManifestEvent(fields: Record<string, unknown>) {
+    return {
+      ...fields,
+      context: "DesktopUpdates",
+      [EVENT]: { source: "api", ...fields },
+    };
+  }
+
   function manifestLogFields(
     calls: readonly (readonly unknown[])[],
   ): readonly Record<string, unknown>[] {
@@ -464,7 +476,7 @@ describe("desktop update routes", () => {
     expect(
       manifestLogFields(context.mocks.axiomLogging.warn.mock.calls),
     ).toStrictEqual([
-      {
+      loggedManifestEvent({
         type: "desktop_update_manifest_upstream",
         outcome: "unavailable",
         provider: "github_release_asset",
@@ -475,7 +487,7 @@ describe("desktop update routes", () => {
         method: "GET",
         route:
           "/api/desktop/updates/:product/:channel/:platform/:arch/RELEASES.json",
-      },
+      }),
     ]);
   });
 
@@ -521,7 +533,7 @@ describe("desktop update routes", () => {
     expect(
       manifestLogFields(context.mocks.axiomLogging.warn.mock.calls),
     ).toStrictEqual([
-      {
+      loggedManifestEvent({
         type: "desktop_update_manifest_upstream",
         outcome: "unavailable",
         provider: "github_release_asset",
@@ -531,7 +543,7 @@ describe("desktop update routes", () => {
         method: "GET",
         route:
           "/api/desktop/updates/:product/:channel/:platform/:arch/RELEASES.json",
-      },
+      }),
     ]);
   });
 
@@ -583,7 +595,7 @@ describe("desktop update routes", () => {
       expect(
         manifestLogFields(context.mocks.axiomLogging.debug.mock.calls),
       ).toStrictEqual([
-        {
+        loggedManifestEvent({
           type: "desktop_update_manifest_upstream",
           outcome: "served_stale",
           provider: "github_release_asset",
@@ -591,7 +603,7 @@ describe("desktop update routes", () => {
           attempts: 3,
           stale_age_ms: 30 * 60_000 - 1,
           line: "ai-okou-desktop",
-        },
+        }),
       ]);
     });
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -366,6 +366,353 @@ describe("desktop update routes", () => {
     expect(response.body.error.code).toBe("NOT_FOUND");
   });
 
+  // The manifest lives on a host we do not control. A request that only
+  // failed to read it must not look like "no release exists": a Squirrel
+  // updater treats 404 as up to date and the migration wall's download button
+  // would dead-end. The cases below pin that separation, and pin that a
+  // genuinely broken manifest still fails loudly.
+  function feedRequest() {
+    return client().productFeed({
+      params: {
+        product: "ai-okou-desktop",
+        channel: "stable",
+        platform: "darwin",
+        arch: "arm64",
+      },
+    });
+  }
+
+  function countingManifestHandler(respond: (attempt: number) => Response): {
+    readonly attempts: () => number;
+  } {
+    let attempts = 0;
+    server.use(
+      http.get(OKOU_DESKTOP_UPDATE_MANIFEST_URL, () => {
+        attempts += 1;
+        return respond(attempts);
+      }),
+    );
+    return {
+      attempts: () => {
+        return attempts;
+      },
+    };
+  }
+
+  function unhandledRequestErrors(
+    testCase: ReturnType<typeof testContext>,
+  ): readonly Record<string, unknown>[] {
+    return testCase.mocks.axiomLogging.error.mock.calls.flatMap(
+      ([, fields]) => {
+        return typeof fields === "object" &&
+          fields !== null &&
+          (fields as Record<string, unknown>).type === "unhandled_request_error"
+          ? [fields as Record<string, unknown>]
+          : [];
+      },
+    );
+  }
+
+  function manifestLogFields(
+    calls: readonly (readonly unknown[])[],
+  ): readonly Record<string, unknown>[] {
+    return calls.flatMap(([, fields]) => {
+      return typeof fields === "object" &&
+        fields !== null &&
+        (fields as Record<string, unknown>).type ===
+          "desktop_update_manifest_upstream"
+        ? [fields as Record<string, unknown>]
+        : [];
+    });
+  }
+
+  it("still serves a release after transient upstream failures", async () => {
+    const upstream = countingManifestHandler((attempt) => {
+      if (attempt < 3) {
+        return new HttpResponse(null, { status: 502 });
+      }
+      return HttpResponse.json(
+        stableManifest("1.2.3", {
+          "1.2.3": darwinArm64Release("1.2.3", okouZipUrl("1.2.3")),
+        }),
+      );
+    });
+
+    const response = await accept(feedRequest(), [200]);
+
+    expect(response.body.currentRelease).toBe("1.2.3");
+    expect(upstream.attempts()).toBe(3);
+    // Absorbed, so it must not reach the error channels that page a human.
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+    expect(unhandledRequestErrors(context)).toStrictEqual([]);
+    expect(
+      manifestLogFields(context.mocks.axiomLogging.warn.mock.calls),
+    ).toStrictEqual([]);
+  });
+
+  it("stops retrying at the attempt bound and reports the upstream status", async () => {
+    const upstream = countingManifestHandler(() => {
+      return new HttpResponse(null, { status: 500 });
+    });
+
+    const response = await accept(feedRequest(), [503]);
+
+    expect(response.body.error.code).toBe("DESKTOP_UPDATE_UNAVAILABLE");
+    expect(upstream.attempts()).toBe(3);
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+    expect(unhandledRequestErrors(context)).toStrictEqual([]);
+    expect(
+      manifestLogFields(context.mocks.axiomLogging.warn.mock.calls),
+    ).toStrictEqual([
+      {
+        type: "desktop_update_manifest_upstream",
+        outcome: "unavailable",
+        provider: "github_release_asset",
+        provider_status: 500,
+        failure_class: "transient_read_exhausted",
+        attempts: 3,
+        line: "ai-okou-desktop",
+        method: "GET",
+        route:
+          "/api/desktop/updates/:product/:channel/:platform/:arch/RELEASES.json",
+      },
+    ]);
+  });
+
+  it("keeps an unavailable feed uncacheable and tells the caller to retry", async () => {
+    countingManifestHandler(() => {
+      return HttpResponse.error();
+    });
+
+    const response = await appRequest(
+      "http://api.test/api/desktop/updates/ai-okou-desktop/stable/darwin/arm64/RELEASES.json",
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("bounds each attempt so a hanging upstream cannot hold the request", async () => {
+    // A real deadline would make this test wait for it. Firing it immediately
+    // proves the same thing that matters: the fetch is bound to a deadline
+    // signal, and tripping it is retried and then reported as unavailable
+    // rather than surfacing as an unhandled error.
+    context.mocks.abortSignal.timeout.mockImplementation(() => {
+      const controller = new AbortController();
+      controller.abort(
+        new DOMException("The operation timed out", "TimeoutError"),
+      );
+      return controller.signal;
+    });
+    countingManifestHandler(() => {
+      return HttpResponse.json(
+        stableManifest("1.2.3", {
+          "1.2.3": darwinArm64Release("1.2.3", okouZipUrl("1.2.3")),
+        }),
+      );
+    });
+
+    const response = await accept(feedRequest(), [503]);
+
+    expect(response.body.error.code).toBe("DESKTOP_UPDATE_UNAVAILABLE");
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+    // No response ever arrived, so there is no upstream status to report.
+    expect(
+      manifestLogFields(context.mocks.axiomLogging.warn.mock.calls),
+    ).toStrictEqual([
+      {
+        type: "desktop_update_manifest_upstream",
+        outcome: "unavailable",
+        provider: "github_release_asset",
+        failure_class: "transient_read_exhausted",
+        attempts: 3,
+        line: "ai-okou-desktop",
+        method: "GET",
+        route:
+          "/api/desktop/updates/:product/:channel/:platform/:arch/RELEASES.json",
+      },
+    ]);
+  });
+
+  it("reports every manifest-backed route as unavailable, including the wall's download", async () => {
+    countingManifestHandler(() => {
+      return HttpResponse.error();
+    });
+
+    const feedResponse = await accept(feedRequest(), [503]);
+    expect(feedResponse.body.error.code).toBe("DESKTOP_UPDATE_UNAVAILABLE");
+
+    // The redirect routes read the same manifest, so they share the status.
+    // This one is the migration wall's `Download Okou` target.
+    const dmgResponse = await appRequest(
+      "http://api.test/api/desktop/updates/stable/darwin/arm64/dmg",
+    );
+    expect(dmgResponse.status).toBe(503);
+
+    const releaseResponse = await appRequest(
+      "http://api.test/api/desktop/updates/stable/darwin/arm64/release",
+    );
+    expect(releaseResponse.status).toBe(503);
+  });
+
+  it("serves the cached release while the manifest host is unreachable", async () => {
+    const initialNow = Date.parse("2026-06-08T00:00:00.000Z");
+
+    await withMockNowForTest(initialNow, async () => {
+      mockDesktopUpdateManifest(
+        stableManifest("1.2.3", {
+          "1.2.3": darwinArm64Release("1.2.3", okouZipUrl("1.2.3")),
+        }),
+      );
+
+      const warmed = await accept(feedRequest(), [200]);
+      expect(warmed.body.currentRelease).toBe("1.2.3");
+
+      countingManifestHandler(() => {
+        return HttpResponse.error();
+      });
+      mockNow(initialNow + 30 * 60_000 - 1);
+
+      const stale = await accept(feedRequest(), [200]);
+
+      expect(stale.body.currentRelease).toBe("1.2.3");
+      expect(
+        manifestLogFields(context.mocks.axiomLogging.warn.mock.calls),
+      ).toStrictEqual([]);
+      expect(
+        manifestLogFields(context.mocks.axiomLogging.debug.mock.calls),
+      ).toStrictEqual([
+        {
+          type: "desktop_update_manifest_upstream",
+          outcome: "served_stale",
+          provider: "github_release_asset",
+          failure_class: "transient_read",
+          attempts: 3,
+          stale_age_ms: 30 * 60_000 - 1,
+          line: "ai-okou-desktop",
+        },
+      ]);
+    });
+  });
+
+  // The window is anchored to the fetch, so a run of stale hits cannot renew
+  // it. Without that, a long outage would serve one manifest forever and a
+  // blocked release would keep being offered.
+  it("expires the cached release instead of renewing it on each stale hit", async () => {
+    const initialNow = Date.parse("2026-06-08T00:00:00.000Z");
+
+    await withMockNowForTest(initialNow, async () => {
+      mockDesktopUpdateManifest(
+        stableManifest("1.2.3", {
+          "1.2.3": darwinArm64Release("1.2.3", okouZipUrl("1.2.3")),
+        }),
+      );
+      await accept(feedRequest(), [200]);
+
+      countingManifestHandler(() => {
+        return HttpResponse.error();
+      });
+
+      for (const minutes of [10, 20, 29]) {
+        mockNow(initialNow + minutes * 60_000);
+        const stale = await accept(feedRequest(), [200]);
+        expect(stale.body.currentRelease).toBe("1.2.3");
+      }
+
+      mockNow(initialNow + 30 * 60_000);
+      const expired = await accept(feedRequest(), [503]);
+
+      expect(expired.body.error.code).toBe("DESKTOP_UPDATE_UNAVAILABLE");
+    });
+  });
+
+  it("keeps the cached release usable across a failed refresh", async () => {
+    const initialNow = Date.parse("2026-06-08T00:00:00.000Z");
+
+    await withMockNowForTest(initialNow, async () => {
+      mockDesktopUpdateManifest(
+        stableManifest("1.2.3", {
+          "1.2.3": darwinArm64Release("1.2.3", okouZipUrl("1.2.3")),
+        }),
+      );
+      await accept(feedRequest(), [200]);
+
+      countingManifestHandler(() => {
+        return HttpResponse.error();
+      });
+      mockNow(initialNow + 5 * 60_000);
+      await accept(feedRequest(), [200]);
+
+      // A failed refresh must not evict or age the entry, and a later success
+      // must replace it outright rather than merge with it.
+      mockDesktopUpdateManifest(
+        stableManifest("1.2.4", {
+          "1.2.4": darwinArm64Release("1.2.4", okouZipUrl("1.2.4")),
+        }),
+      );
+      mockNow(initialNow + 10 * 60_000);
+      const refreshed = await accept(feedRequest(), [200]);
+
+      expect(refreshed.body.currentRelease).toBe("1.2.4");
+    });
+  });
+
+  it("fails loudly when the manifest is missing or unreadable", async () => {
+    const missing = countingManifestHandler(() => {
+      return new HttpResponse(null, { status: 404 });
+    });
+
+    const missingResponse = await appRequest(
+      "http://api.test/api/desktop/updates/stable/darwin/arm64/dmg",
+    );
+
+    expect(missingResponse.status).toBe(500);
+    // A manifest our own release pipeline publishes is not an outage, so it
+    // is neither retried nor downgraded.
+    expect(missing.attempts()).toBe(1);
+    expect(context.mocks.sentry.captureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Desktop update manifest fetch failed with 404",
+      }),
+    );
+
+    countingManifestHandler(() => {
+      return HttpResponse.json({ schemaVersion: 1 });
+    });
+
+    const invalidResponse = await appRequest(
+      "http://api.test/api/desktop/updates/stable/darwin/arm64/dmg",
+    );
+    expect(invalidResponse.status).toBe(500);
+  });
+
+  // A cached manifest must not paper over a broken release: the loud failures
+  // above stay loud even when an older copy is sitting in the cache.
+  it("does not answer a broken manifest from the cache", async () => {
+    const initialNow = Date.parse("2026-06-08T00:00:00.000Z");
+
+    await withMockNowForTest(initialNow, async () => {
+      mockDesktopUpdateManifest(
+        stableManifest("1.2.3", {
+          "1.2.3": darwinArm64Release("1.2.3", okouZipUrl("1.2.3")),
+        }),
+      );
+      await accept(feedRequest(), [200]);
+
+      countingManifestHandler(() => {
+        return new HttpResponse(null, { status: 404 });
+      });
+      mockNow(initialNow + 5 * 60_000);
+
+      const response = await appRequest(
+        "http://api.test/api/desktop/updates/ai-okou-desktop/stable/darwin/arm64/RELEASES.json",
+      );
+
+      expect(response.status).toBe(500);
+    });
+  });
+
   it("returns not found when no dmg release is available", async () => {
     mockDesktopUpdateManifest(
       stableManifest("0.11.2", {

--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -687,6 +687,26 @@ describe("desktop update routes", () => {
     expect(invalidResponse.status).toBe(500);
   });
 
+  // Invalid JSON is not an unreadable host. The bytes arrived and they are not
+  // a manifest, so it must not be retried, absorbed, or answered from cache.
+  it("fails loudly when the manifest body is not json", async () => {
+    const upstream = countingManifestHandler(() => {
+      return new HttpResponse("not-a-manifest", {
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const response = await appRequest(
+      "http://api.test/api/desktop/updates/ai-okou-desktop/stable/darwin/arm64/RELEASES.json",
+    );
+
+    expect(response.status).toBe(500);
+    expect(upstream.attempts()).toBe(1);
+    expect(context.mocks.sentry.captureException).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "SyntaxError" }),
+    );
+  });
+
   // A cached manifest must not paper over a broken release: the loud failures
   // above stay loud even when an older copy is sitting in the cache.
   it("does not answer a broken manifest from the cache", async () => {

--- a/turbo/apps/api/src/signals/routes/desktop-updates.ts
+++ b/turbo/apps/api/src/signals/routes/desktop-updates.ts
@@ -3,19 +3,37 @@ import {
   DESKTOP_UPDATE_LINE_OKOU,
   DESKTOP_UPDATE_LINE_ZERO,
   desktopUpdatesContract,
+  type DesktopUpdateLine,
   type DesktopZeroMigrationPolicy,
 } from "@okouai/api-contracts/contracts/desktop-updates";
 import { command } from "ccstate";
 
-import { notFound } from "../../lib/error";
+import { desktopUpdateUnavailable, notFound } from "../../lib/error";
+import { logger } from "../../lib/log";
 import { setResHeader$ } from "../context/hono";
 import { pathParamsOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
 import {
+  DESKTOP_UPDATE_MANIFEST_LOG_TYPE,
+  DESKTOP_UPDATE_MANIFEST_PROVIDER,
+  desktopUpdateManifestUnavailable,
   loadDesktopDmgDownloadUrl,
   loadDesktopReleasePageUrl,
   loadDesktopUpdateFeed,
+  type DesktopUpdateManifestUnavailable,
 } from "../services/desktop-updates.service";
+import { settle } from "../utils";
+
+const L = logger("DesktopUpdates");
+
+/**
+ * How long a client should wait before re-asking after a `503`.
+ *
+ * Shorter than the desktop updater's own 30-minute poll, so it never delays
+ * the schedule the client already keeps; it only helps anything that retries
+ * on its own.
+ */
+const DESKTOP_UPDATE_RETRY_AFTER_SECONDS = "60";
 
 const releasePageParams$ = pathParamsOf(desktopUpdatesContract.releasePage);
 const dmgDownloadParams$ = pathParamsOf(desktopUpdatesContract.dmgDownload);
@@ -64,51 +82,146 @@ const getDesktopMigrationPolicy$ = command(({ set }) => {
  */
 const UNQUALIFIED_DESKTOP_UPDATE_LINE = DESKTOP_UPDATE_LINE_OKOU;
 
-const getDesktopReleasePage$ = command(async ({ get }, signal: AbortSignal) => {
-  const url = await loadDesktopReleasePageUrl(
-    {
-      line: UNQUALIFIED_DESKTOP_UPDATE_LINE,
-      ...get(releasePageParams$),
-    },
-    signal,
-  );
-  signal.throwIfAborted();
-
-  if (!url) {
-    return notFound("No desktop release is available for this feed.");
+/**
+ * Settle a manifest-backed load, separating "the release host could not be
+ * read" from every other failure.
+ *
+ * Only that one outcome is reported back; a missing or invalid manifest, a
+ * bug in release selection, and a cancelled request all keep propagating to
+ * the unhandled-error path, where they stay loud.
+ */
+async function settleManifestLoad<T>(
+  load: Promise<T>,
+  signal: AbortSignal,
+): Promise<
+  | { readonly ok: true; readonly value: T }
+  | {
+      readonly ok: false;
+      readonly unavailable: DesktopUpdateManifestUnavailable;
+    }
+> {
+  const settled = await settle(load, signal);
+  if (settled.ok) {
+    return { ok: true, value: settled.value };
   }
 
-  return new Response(null, {
-    status: 302,
-    headers: {
-      Location: url,
-      "Cache-Control": "no-store",
-    },
-  });
-});
-
-const getDesktopDmgDownload$ = command(async ({ get }, signal: AbortSignal) => {
-  const url = await loadDesktopDmgDownloadUrl(
-    {
-      line: UNQUALIFIED_DESKTOP_UPDATE_LINE,
-      ...get(dmgDownloadParams$),
-    },
-    signal,
-  );
-  signal.throwIfAborted();
-
-  if (!url) {
-    return notFound("No desktop DMG is available for this feed.");
+  const unavailable = desktopUpdateManifestUnavailable(settled.error);
+  if (!unavailable) {
+    throw settled.error;
   }
+  return { ok: false, unavailable };
+}
 
-  return new Response(null, {
-    status: 302,
-    headers: {
-      Location: url,
-      "Cache-Control": "no-store",
+/**
+ * Answer a poll whose manifest could not be read.
+ *
+ * This is a classified outcome, not an unhandled error: it is logged at `warn`
+ * with the upstream status and attempt count and never reaches Sentry, because
+ * a single one needs no intervention. A sustained rate is the real signal, and
+ * it stays visible both here and as `503` in the request log.
+ */
+const desktopUpdateUnavailable$ = command(
+  (
+    { set },
+    args: {
+      readonly line: DesktopUpdateLine;
+      readonly route: string;
+      readonly unavailable: DesktopUpdateManifestUnavailable;
     },
-  });
-});
+  ) => {
+    L.warn("Desktop update manifest upstream unavailable", {
+      type: DESKTOP_UPDATE_MANIFEST_LOG_TYPE,
+      outcome: "unavailable",
+      provider: DESKTOP_UPDATE_MANIFEST_PROVIDER,
+      ...(args.unavailable.providerStatus === null
+        ? {}
+        : { provider_status: args.unavailable.providerStatus }),
+      failure_class: "transient_read_exhausted",
+      attempts: args.unavailable.attempts,
+      line: args.line,
+      method: "GET",
+      route: args.route,
+    });
+
+    set(setResHeader$, "Cache-Control", "no-store");
+    set(setResHeader$, "Retry-After", DESKTOP_UPDATE_RETRY_AFTER_SECONDS);
+    return desktopUpdateUnavailable(
+      "The desktop release manifest is temporarily unavailable. Try again shortly.",
+    );
+  },
+);
+
+const getDesktopReleasePage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const loaded = await settleManifestLoad(
+      loadDesktopReleasePageUrl(
+        {
+          line: UNQUALIFIED_DESKTOP_UPDATE_LINE,
+          ...get(releasePageParams$),
+        },
+        signal,
+      ),
+      signal,
+    );
+    if (!loaded.ok) {
+      return set(desktopUpdateUnavailable$, {
+        line: UNQUALIFIED_DESKTOP_UPDATE_LINE,
+        route: desktopUpdatesContract.releasePage.path,
+        unavailable: loaded.unavailable,
+      });
+    }
+    const url = loaded.value;
+    signal.throwIfAborted();
+
+    if (!url) {
+      return notFound("No desktop release is available for this feed.");
+    }
+
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: url,
+        "Cache-Control": "no-store",
+      },
+    });
+  },
+);
+
+const getDesktopDmgDownload$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const loaded = await settleManifestLoad(
+      loadDesktopDmgDownloadUrl(
+        {
+          line: UNQUALIFIED_DESKTOP_UPDATE_LINE,
+          ...get(dmgDownloadParams$),
+        },
+        signal,
+      ),
+      signal,
+    );
+    if (!loaded.ok) {
+      return set(desktopUpdateUnavailable$, {
+        line: UNQUALIFIED_DESKTOP_UPDATE_LINE,
+        route: desktopUpdatesContract.dmgDownload.path,
+        unavailable: loaded.unavailable,
+      });
+    }
+    const url = loaded.value;
+    signal.throwIfAborted();
+
+    if (!url) {
+      return notFound("No desktop DMG is available for this feed.");
+    }
+
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: url,
+        "Cache-Control": "no-store",
+      },
+    });
+  },
+);
 
 // All three `:product` handlers below reject the same retired lines. `okou` is
 // the pre-adoption Okou line. `zero` joined it in #31475: its manifest had been
@@ -118,7 +231,7 @@ const getDesktopDmgDownload$ = command(async ({ get }, signal: AbortSignal) => {
 // removed from the contract union — see the note there.
 
 const getProductDesktopReleasePage$ = command(
-  async ({ get }, signal: AbortSignal) => {
+  async ({ get, set }, signal: AbortSignal) => {
     const { product, ...params } = get(productReleasePageParams$);
     if (
       product === DESKTOP_UPDATE_LINE_LEGACY_OKOU ||
@@ -126,10 +239,18 @@ const getProductDesktopReleasePage$ = command(
     ) {
       return notFound("This desktop update line is retired.");
     }
-    const url = await loadDesktopReleasePageUrl(
-      { line: product, ...params },
+    const loaded = await settleManifestLoad(
+      loadDesktopReleasePageUrl({ line: product, ...params }, signal),
       signal,
     );
+    if (!loaded.ok) {
+      return set(desktopUpdateUnavailable$, {
+        line: product,
+        route: desktopUpdatesContract.productReleasePage.path,
+        unavailable: loaded.unavailable,
+      });
+    }
+    const url = loaded.value;
     signal.throwIfAborted();
 
     if (!url) {
@@ -147,7 +268,7 @@ const getProductDesktopReleasePage$ = command(
 );
 
 const getProductDesktopUpdateFeed$ = command(
-  async ({ get }, signal: AbortSignal) => {
+  async ({ get, set }, signal: AbortSignal) => {
     const { product, ...params } = get(productFeedParams$);
     if (
       product === DESKTOP_UPDATE_LINE_LEGACY_OKOU ||
@@ -155,10 +276,18 @@ const getProductDesktopUpdateFeed$ = command(
     ) {
       return notFound("This desktop update line is retired.");
     }
-    const feed = await loadDesktopUpdateFeed(
-      { line: product, ...params },
+    const loaded = await settleManifestLoad(
+      loadDesktopUpdateFeed({ line: product, ...params }, signal),
       signal,
     );
+    if (!loaded.ok) {
+      return set(desktopUpdateUnavailable$, {
+        line: product,
+        route: desktopUpdatesContract.productFeed.path,
+        unavailable: loaded.unavailable,
+      });
+    }
+    const feed = loaded.value;
     signal.throwIfAborted();
 
     if (!feed) {
@@ -173,7 +302,7 @@ const getProductDesktopUpdateFeed$ = command(
 );
 
 const getProductDesktopDmgDownload$ = command(
-  async ({ get }, signal: AbortSignal) => {
+  async ({ get, set }, signal: AbortSignal) => {
     const { product, ...params } = get(productDmgDownloadParams$);
     if (
       product === DESKTOP_UPDATE_LINE_LEGACY_OKOU ||
@@ -181,10 +310,18 @@ const getProductDesktopDmgDownload$ = command(
     ) {
       return notFound("This desktop update line is retired.");
     }
-    const url = await loadDesktopDmgDownloadUrl(
-      { line: product, ...params },
+    const loaded = await settleManifestLoad(
+      loadDesktopDmgDownloadUrl({ line: product, ...params }, signal),
       signal,
     );
+    if (!loaded.ok) {
+      return set(desktopUpdateUnavailable$, {
+        line: product,
+        route: desktopUpdatesContract.productDmgDownload.path,
+        unavailable: loaded.unavailable,
+      });
+    }
+    const url = loaded.value;
     signal.throwIfAborted();
 
     if (!url) {

--- a/turbo/apps/api/src/signals/services/desktop-updates.service.ts
+++ b/turbo/apps/api/src/signals/services/desktop-updates.service.ts
@@ -391,8 +391,12 @@ async function fetchDesktopUpdateManifestOnce(
 
   const body = await settle(response.json(), signal);
   if (!body.ok) {
-    // A body that does not arrive intact is an unreadable host, not a
-    // malformed manifest: the bytes never got here to be judged.
+    // A body that never arrived intact is an unreadable host. Invalid JSON is
+    // the opposite: the bytes did arrive and they are not a manifest, which is
+    // a broken release and must stay as loud as a schema failure.
+    if (body.error instanceof SyntaxError) {
+      throw body.error;
+    }
     return { ok: false, providerStatus: null, cause: body.error };
   }
 

--- a/turbo/apps/api/src/signals/services/desktop-updates.service.ts
+++ b/turbo/apps/api/src/signals/services/desktop-updates.service.ts
@@ -12,10 +12,27 @@ import {
   DESKTOP_PRODUCTS,
   DESKTOP_PRODUCT_OKOU,
 } from "@okouai/api-contracts/contracts/client-headers";
+import { delay } from "signal-timers";
 import { z } from "zod";
 
+import { logger } from "../../lib/log";
 import { testOverride } from "../../lib/singleton";
 import { now } from "../../lib/time";
+import { settle } from "../utils";
+
+const L = logger("DesktopUpdates");
+
+/**
+ * Shared identity for the structured events this path emits.
+ *
+ * An unreadable release host is routine and self-correcting, so it is reported
+ * as a classified outcome rather than an unhandled request error. Keeping the
+ * type and provider in one place lets the three outcomes — `retry_recovered`,
+ * `served_stale`, `unavailable` — be queried as one family.
+ */
+export const DESKTOP_UPDATE_MANIFEST_LOG_TYPE =
+  "desktop_update_manifest_upstream";
+export const DESKTOP_UPDATE_MANIFEST_PROVIDER = "github_release_asset";
 
 const DESKTOP_RELEASE_DOWNLOAD_URL_PREFIX =
   "https://github.com/vm0-ai/vm0/releases/download";
@@ -24,6 +41,82 @@ const DESKTOP_RELEASE_PAGE_URL_PREFIX =
 const MIN_DESKTOP_DMG_VERSION = "0.12.0";
 
 const DESKTOP_UPDATE_MANIFEST_CACHE_TTL_MS = 60_000;
+
+/**
+ * How long a manifest may still answer requests while the upstream host is
+ * unreachable, measured from the moment it was fetched.
+ *
+ * The manifest describes releases that already exist, so serving a slightly
+ * old copy hands an updater a real artifact instead of an error. The window is
+ * bounded because a stale manifest also keeps serving a version that a later
+ * publish may have blocked, and that must not outlive a short outage. It is
+ * anchored to the fetch, never to the last stale hit, so a long outage expires
+ * the copy instead of renewing it: past this age the routes answer `503` and
+ * sustained unavailability stays visible.
+ *
+ * One desktop poll interval. A client that receives a stale manifest re-asks
+ * within that interval, so the worst case is one skipped update check.
+ */
+const DESKTOP_UPDATE_MANIFEST_STALE_MAX_AGE_MS = 30 * 60_000;
+
+/**
+ * Attempts, per-attempt deadline, and spacing for one request's manifest
+ * fetch.
+ *
+ * A desktop updater polls on its own schedule, so the retry budget only has to
+ * absorb a single-instance blip; anything longer is the caller's next poll or
+ * the stale window above, not a longer wait inside this request. The
+ * per-attempt deadline matters as much as the retry: production has recorded
+ * an upstream gateway that held a request for 11s before failing, and three
+ * unbounded attempts would be worse than the single unbounded one it replaces.
+ */
+const DESKTOP_UPDATE_MANIFEST_FETCH_ATTEMPTS = 3;
+const DESKTOP_UPDATE_MANIFEST_ATTEMPT_TIMEOUT_MS = 3000;
+const DESKTOP_UPDATE_MANIFEST_RETRY_DELAY_MS = 200;
+
+/**
+ * The upstream manifest could not be read and no usable copy was cached.
+ *
+ * Distinct from every other manifest failure: it means "try again", not "a
+ * human has to fix the manifest", so the routes answer `503` instead of `500`.
+ * `providerStatus` is the upstream status when there was one, and `null` when
+ * the attempt never got a response (connection failure or the per-attempt
+ * deadline).
+ */
+export interface DesktopUpdateManifestUnavailable {
+  readonly providerStatus: number | null;
+  readonly attempts: number;
+}
+
+class DesktopUpdateManifestUnavailableError
+  extends Error
+  implements DesktopUpdateManifestUnavailable
+{
+  constructor(
+    readonly providerStatus: number | null,
+    readonly attempts: number,
+    options?: { readonly cause?: unknown },
+  ) {
+    super("Desktop update manifest is temporarily unavailable", options);
+    this.name = "DesktopUpdateManifestUnavailableError";
+  }
+}
+
+export function desktopUpdateManifestUnavailable(
+  error: unknown,
+): DesktopUpdateManifestUnavailable | null {
+  return error instanceof DesktopUpdateManifestUnavailableError ? error : null;
+}
+
+/**
+ * Upstream statuses that describe the host, not the manifest.
+ *
+ * A `404` is excluded on purpose: the manifest asset is published by our own
+ * release pipeline, so its absence is a broken release, not an outage.
+ */
+function isTransientManifestStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
 
 /**
  * Every artifact this service can still name belongs to the Okou desktop
@@ -93,8 +186,16 @@ interface DesktopUpdateFeedRequest {
   readonly arch: DesktopUpdateArchitecture;
 }
 
+/**
+ * `freshUntil` and `staleUntil` are both derived from `fetchedAt` when the
+ * entry is written, and an entry is only ever written after a successful
+ * fetch. A failed fetch therefore cannot extend either deadline, and neither
+ * can a stale hit.
+ */
 interface DesktopUpdateManifestCacheEntry {
-  readonly expiresAt: number;
+  readonly fetchedAt: number;
+  readonly freshUntil: number;
+  readonly staleUntil: number;
   readonly manifest: DesktopUpdateManifest;
 }
 
@@ -239,6 +340,73 @@ function buildDesktopUpdateFeed(
   };
 }
 
+/**
+ * One manifest read. A retryable outage is returned so the caller can decide
+ * whether any attempts remain; every other failure throws, because no number
+ * of retries will fix it.
+ */
+type DesktopUpdateManifestFetchResult =
+  | { readonly ok: true; readonly manifest: DesktopUpdateManifest }
+  | {
+      readonly ok: false;
+      readonly providerStatus: number | null;
+      readonly cause: unknown;
+    };
+
+async function fetchDesktopUpdateManifestOnce(
+  line: ResolvableDesktopUpdateLine,
+  signal: AbortSignal,
+): Promise<DesktopUpdateManifestFetchResult> {
+  // The attempt gets its own deadline, but `settle` is given the caller's
+  // signal: a caller cancellation re-throws as a cancellation, while the
+  // deadline surfaces as a `TimeoutError` this function can retry.
+  const attemptSignal = AbortSignal.any([
+    signal,
+    AbortSignal.timeout(DESKTOP_UPDATE_MANIFEST_ATTEMPT_TIMEOUT_MS),
+  ]);
+  const fetched = await settle(
+    fetch(desktopUpdateManifestUrl(line), {
+      headers: { accept: "application/json" },
+      signal: attemptSignal,
+    }),
+    signal,
+  );
+  if (!fetched.ok) {
+    return {
+      ok: false,
+      providerStatus: null,
+      cause: fetched.error,
+    };
+  }
+
+  const response = fetched.value;
+  if (!response.ok) {
+    if (isTransientManifestStatus(response.status)) {
+      return { ok: false, providerStatus: response.status, cause: undefined };
+    }
+    throw new Error(
+      `Desktop update manifest fetch failed with ${response.status}`,
+    );
+  }
+
+  const body = await settle(response.json(), signal);
+  if (!body.ok) {
+    // A body that does not arrive intact is an unreadable host, not a
+    // malformed manifest: the bytes never got here to be judged.
+    return { ok: false, providerStatus: null, cause: body.error };
+  }
+
+  const manifest = desktopUpdateManifestSchema.parse(body.value);
+  // Fail closed: a manifest that does not declare the Okou product is not
+  // served, including one that omits the field entirely.
+  if (manifest.product !== DESKTOP_PRODUCT_OKOU) {
+    throw new Error(
+      `Desktop update manifest product mismatch: expected ${DESKTOP_PRODUCT_OKOU}, received ${manifest.product ?? "none"}`,
+    );
+  }
+  return { ok: true, manifest };
+}
+
 async function fetchDesktopUpdateManifest(
   line: ResolvableDesktopUpdateLine,
   signal: AbortSignal,
@@ -248,25 +416,30 @@ async function fetchDesktopUpdateManifest(
     return override;
   }
 
-  const response = await fetch(desktopUpdateManifestUrl(line), {
-    headers: { accept: "application/json" },
-    signal,
-  });
-  if (!response.ok) {
-    throw new Error(
-      `Desktop update manifest fetch failed with ${response.status}`,
-    );
+  for (let attempt = 1; ; attempt += 1) {
+    const result = await fetchDesktopUpdateManifestOnce(line, signal);
+    if (result.ok) {
+      if (attempt > 1) {
+        L.debug("Desktop update manifest fetch recovered on retry", {
+          type: DESKTOP_UPDATE_MANIFEST_LOG_TYPE,
+          outcome: "retry_recovered",
+          provider: DESKTOP_UPDATE_MANIFEST_PROVIDER,
+          failure_class: "transient_read",
+          attempts: attempt,
+          line,
+        });
+      }
+      return result.manifest;
+    }
+    if (attempt >= DESKTOP_UPDATE_MANIFEST_FETCH_ATTEMPTS) {
+      throw new DesktopUpdateManifestUnavailableError(
+        result.providerStatus,
+        attempt,
+        result.cause === undefined ? undefined : { cause: result.cause },
+      );
+    }
+    await delay(DESKTOP_UPDATE_MANIFEST_RETRY_DELAY_MS, { signal });
   }
-
-  const manifest = desktopUpdateManifestSchema.parse(await response.json());
-  // Fail closed: a manifest that does not declare the Okou product is not
-  // served, including one that omits the field entirely.
-  if (manifest.product !== DESKTOP_PRODUCT_OKOU) {
-    throw new Error(
-      `Desktop update manifest product mismatch: expected ${DESKTOP_PRODUCT_OKOU}, received ${manifest.product ?? "none"}`,
-    );
-  }
-  return manifest;
 }
 
 async function loadDesktopUpdateManifest(
@@ -276,19 +449,48 @@ async function loadDesktopUpdateManifest(
   const cache = desktopUpdateManifestCache.get();
   const cacheEntry = cache[line];
   const nowMs = now();
-  if (cacheEntry && cacheEntry.expiresAt > nowMs) {
+  if (cacheEntry && cacheEntry.freshUntil > nowMs) {
     return cacheEntry.manifest;
   }
 
-  const manifest = await fetchDesktopUpdateManifest(line, signal);
+  const fetched = await settle(
+    fetchDesktopUpdateManifest(line, signal),
+    signal,
+  );
+  if (!fetched.ok) {
+    const unavailable = desktopUpdateManifestUnavailable(fetched.error);
+    // A missing or invalid manifest is not covered here on purpose: only an
+    // unreadable host may be answered from an older copy, so a broken release
+    // still surfaces instead of being papered over by the last good manifest.
+    if (!unavailable || !cacheEntry || cacheEntry.staleUntil <= nowMs) {
+      throw fetched.error;
+    }
+
+    L.debug("Served a stale desktop update manifest", {
+      type: DESKTOP_UPDATE_MANIFEST_LOG_TYPE,
+      outcome: "served_stale",
+      provider: DESKTOP_UPDATE_MANIFEST_PROVIDER,
+      ...(unavailable.providerStatus === null
+        ? {}
+        : { provider_status: unavailable.providerStatus }),
+      failure_class: "transient_read",
+      attempts: unavailable.attempts,
+      stale_age_ms: nowMs - cacheEntry.fetchedAt,
+      line,
+    });
+    return cacheEntry.manifest;
+  }
+
   desktopUpdateManifestCache.set({
     ...cache,
     [line]: {
-      expiresAt: nowMs + DESKTOP_UPDATE_MANIFEST_CACHE_TTL_MS,
-      manifest,
+      fetchedAt: nowMs,
+      freshUntil: nowMs + DESKTOP_UPDATE_MANIFEST_CACHE_TTL_MS,
+      staleUntil: nowMs + DESKTOP_UPDATE_MANIFEST_STALE_MAX_AGE_MS,
+      manifest: fetched.value,
     },
   });
-  return manifest;
+  return fetched.value;
 }
 
 export async function loadDesktopUpdateFeed(

--- a/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
+++ b/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
@@ -66,6 +66,14 @@ const squirrelMacReleasesSchema = z.object({
 
 export type SquirrelMacReleases = z.infer<typeof squirrelMacReleasesSchema>;
 
+/**
+ * Every route that resolves a release reads the same upstream release-asset
+ * manifest, so they all share the same `503`: the manifest host was
+ * unreachable, the API retried within its bound, and no manifest recent enough
+ * to serve was cached. It is deliberately distinct from `404` ("this feed
+ * resolves to no release") and from `500` ("the manifest is missing or
+ * invalid"), which stay loud because they need a human.
+ */
 export const desktopUpdatesContract = c.router({
   migrationPolicy: {
     method: "GET",
@@ -86,6 +94,7 @@ export const desktopUpdatesContract = c.router({
     responses: {
       302: c.noBody(),
       404: apiErrorSchema,
+      503: apiErrorSchema,
     },
     summary: "Redirect to the current desktop release page",
   },
@@ -100,6 +109,7 @@ export const desktopUpdatesContract = c.router({
     responses: {
       302: c.noBody(),
       404: apiErrorSchema,
+      503: apiErrorSchema,
     },
     summary: "Redirect to the current desktop DMG download",
   },
@@ -115,6 +125,7 @@ export const desktopUpdatesContract = c.router({
     responses: {
       302: c.noBody(),
       404: apiErrorSchema,
+      503: apiErrorSchema,
     },
     summary: "Redirect to an identity-specific desktop release page",
   },
@@ -130,6 +141,7 @@ export const desktopUpdatesContract = c.router({
     responses: {
       302: c.noBody(),
       404: apiErrorSchema,
+      503: apiErrorSchema,
     },
     summary: "Redirect to an identity-specific desktop DMG download",
   },
@@ -146,6 +158,7 @@ export const desktopUpdatesContract = c.router({
       200: squirrelMacReleasesSchema,
       400: apiErrorSchema,
       404: apiErrorSchema,
+      503: apiErrorSchema,
     },
     summary: "Get an identity-specific desktop auto-update feed",
   },


### PR DESCRIPTION
## Summary

Closes #33084.

The desktop update routes read a release manifest from `github.com/vm0-ai/vm0/releases/download/...`, a host we do not control. Any non-OK response threw, so one upstream blip became a `500`, an `unhandled_request_error`, and a Sentry event — for a condition that needs no intervention and that the client recovers from on its next 30-minute poll.

This classifies the failure instead of flattening it, and reclassifies the signal to match.

## Evidence this is worth separating

Sentry group `API-11` holds **34 events since 2026-06-17**, and they are two different problems:

| Upstream status | Events | What it is |
| --- | --- | --- |
| `404` | 30 | The manifest asset was missing — 30 of them clustered on 2026-08-12, the Okou identity cutover. A real broken release. |
| `504` / `503` / `500` | 4 | The host was briefly unreadable. Self-correcting. |

So the loud channel has caught a real problem exactly once, and the transient class fires about **once every three weeks**. Over 2026-09-06 → 09-10 the feed route served **662 / 736 / 790** requests per day with **one** `5xx` on 09-07 and **one** on 09-09 — a 0.04% failure rate. Both were real Squirrel clients (`Okou/… CFNetwork/… Darwin/…`), and the affected build was back to `200` within the same 30-minute window.

The two failures also had very different shapes: the 09-09 one failed in **271 ms**, the 09-07 one took **11 072 ms** before the upstream gateway gave up.

## What changed

**Availability failures** — connection failure, per-attempt deadline, `408`, `429`, `5xx`:
1. retried up to 3 times, 200 ms apart;
2. then answered from an already-validated cached manifest, bounded to 30 minutes from the fetch;
3. then reported as `503` with `Cache-Control: no-store` and `Retry-After: 60`.

**Integrity failures** — upstream `404`, schema failure, product mismatch — still throw, still reach Sentry, and are never answered from the cache. That manifest is published by our own release pipeline, so its absence is a broken release, not an outage. A `404` is not retried either.

**Each attempt now carries its own 3s deadline.** This is the part that is easy to miss: given the recorded 11s gateway hang, retrying *without* a deadline would have made the worst case ~33s — worse than the single unbounded attempt it replaces.

**Outcomes are one structured event family**, `desktop_update_manifest_upstream`, lifted into the Axiom event root:

| Outcome | Level | Sentry |
| --- | --- | --- |
| `retry_recovered` | `debug` | no |
| `served_stale` | `debug` | no |
| `unavailable` (the `503`) | `warn` | no |

`debug` for the absorbed cases follows the repo's `api/no-logger-info` rule — routine diagnostics are not `info`. A single blip no longer pages anyone; a sustained rate stays visible both as `warn` and as `503` in `vm0-request-log-prod`.

All five manifest-backed routes share the loader, so they share the `503` and it is declared on each in the contract. That deliberately includes `dmgDownload`, the migration wall's `Download Okou` target.

### Why `503` and not `204`

`204` would tell Squirrel "you are up to date", which we do not know. That silently swallows a real pending update. `503` is truthful, and on the automatic poll path the client only logs it — the "Unable to Check for Updates" dialog appears only on a manual check, which is the correct thing to show.

## Cache freshness and integrity

- The 60s fresh TTL is **unchanged**, so the happy path has no freshness regression.
- `staleUntil` is derived from `fetchedAt` at write time, and an entry is only written after a successful fetch. Neither a failed fetch nor a stale hit can extend it, so a long outage expires the copy into a `503` instead of serving one manifest forever. There is a test for exactly that.
- Worst case a client sees a manifest 30 minutes old and self-corrects on its next poll. This widens `blocked`-list propagation from `60s + poll` to `30min + poll`; `channels.stable.blocked` is currently empty. If we start relying on the blocklist, revisit that constant.

## Fallbacks

- `desktop-updates.service.ts:loadDesktopUpdateManifest` — answers from a manifest already fetched and validated when the upstream host cannot be read. Surface: API -> third-party release host, a state production has reached four times in 84 days. Bounded to 30 minutes measured from the fetch and never renewed by a stale hit. Remove if the manifest moves to a first-party host with an availability guarantee.

## Verification

Ran locally:
- `pnpm -F api check-types` — clean (all six projects).
- `pnpm -F @okouai/api-contracts check-types` — clean.
- `oxlint --deny-warnings` and `eslint --max-warnings 0` on every changed file — clean.
- `knip` — no new unused exports.
- `prettier --check` — clean.

**Not run locally:** Vitest. This sandbox has no Postgres and no Docker, and the API suite's global setup opens a DB connection before any test file loads, so it fails at `ECONNREFUSED 127.0.0.1:5432` regardless of the file selected. The tests below are new and **unproven until CI runs them** — please read CI as the first real execution.

New tests in `signals/routes/__tests__/desktop-updates.test.ts`:
- serves a release after transient upstream failures, exactly 3 attempts, nothing on the error channels;
- stops at the attempt bound and reports `provider_status: 500` in the `warn` event;
- `503` carries `Cache-Control: no-store` and `Retry-After: 60`;
- a tripped per-attempt deadline is retried then reported, with **no** `provider_status` (no response ever arrived);
- feed, `release`, and the wall's `dmg` all report `503` together;
- serves the cached release inside the window and logs `served_stale` with `stale_age_ms`;
- expires the cache at 30 minutes instead of renewing it across repeated stale hits;
- a failed refresh neither evicts nor ages the entry, and a later success replaces it;
- upstream `404` and an unparseable manifest still `500`, hit Sentry, and are **not** retried;
- a broken manifest is not answered from a warm cache.

Plus two in `lib/__tests__/log.test.ts` for the event-root lifting and its rejection of an unknown outcome.

### Not covered

Caller cancellation mid-fetch. The code routes it through `settle(…, signal)` so an `AbortError` propagates as a cancellation rather than becoming a `503`, but I did not find a non-flaky way to drive a mid-flight client abort through this route's harness, so that path is argued from the code, not tested.

### Post-deploy acceptance

On the release containing this, over ~7 days on `/api/desktop/updates/:product/:channel/:platform/:arch/RELEASES.json`:
- `status == 500` → 0 in `vm0-request-log-prod`;
- no new `API-11` event whose message ends in a `5xx` (a new `404`-class event is still expected and still correct);
- `200`/day at or above the 662–790 baseline; `503` ≈ 0.

Honest limit: at ~1 transient event per 3 weeks, a 7-day window will most likely observe **zero**. That window can accept the silencing, not the recovery. Confirming recovery in production needs ~30 days or a deliberate fault injection on a preview deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
