### PR TITLE
fix(pi-memory): retain the cause of failed phase 2 maintenance sessions

### DIFF
--- a/fixtures/pi-memory-phase2-terminal.json
+++ b/fixtures/pi-memory-phase2-terminal.json
@@ -1,10 +1,12 @@
 [
   {
     "name": "legacy",
+    "errorClass": "agent_output_invalid",
     "stderr": "Pi memory Phase 2 agent output was invalid."
   },
   {
     "name": "summary_tokens",
+    "errorClass": "agent_output_invalid",
     "diagnostic": {
       "stage": "output_validation",
       "reason": "summary_tokens",
@@ -16,6 +18,7 @@
   },
   {
     "name": "summary_header",
+    "errorClass": "agent_output_invalid",
     "diagnostic": {
       "stage": "output_validation",
       "reason": "summary_header",
@@ -25,6 +28,7 @@
   },
   {
     "name": "apply_eacces",
+    "errorClass": "agent_output_invalid",
     "diagnostic": {
       "stage": "mounted_apply",
       "reason": "filesystem",
@@ -35,6 +39,7 @@
   },
   {
     "name": "apply_enospc",
+    "errorClass": "agent_output_invalid",
     "diagnostic": {
       "stage": "mounted_apply",
       "reason": "filesystem",
@@ -45,6 +50,7 @@
   },
   {
     "name": "apply_unknown",
+    "errorClass": "agent_output_invalid",
     "diagnostic": {
       "stage": "mounted_apply",
       "reason": "unknown",
@@ -52,5 +58,70 @@
       "errno": "unknown"
     },
     "stderr": "Pi memory Phase 2 agent output was invalid. pi_memory_phase2={\"stage\":\"mounted_apply\",\"reason\":\"unknown\",\"fileClass\":\"immutable\",\"errno\":\"unknown\"}"
+  },
+  {
+    "name": "session_final_stop_length",
+    "errorClass": "session_failed",
+    "diagnostic": {
+      "stage": "final_response",
+      "reason": "final_stop_length"
+    },
+    "stderr": "Pi memory Phase 2 maintenance session failed. pi_memory_phase2={\"stage\":\"final_response\",\"reason\":\"final_stop_length\"}"
+  },
+  {
+    "name": "session_final_message_missing",
+    "errorClass": "session_failed",
+    "diagnostic": {
+      "stage": "final_response",
+      "reason": "final_message_missing"
+    },
+    "stderr": "Pi memory Phase 2 maintenance session failed. pi_memory_phase2={\"stage\":\"final_response\",\"reason\":\"final_message_missing\"}"
+  },
+  {
+    "name": "session_create_failed",
+    "errorClass": "session_failed",
+    "diagnostic": {
+      "stage": "session_create",
+      "reason": "session_create_failed",
+      "errno": "unknown"
+    },
+    "stderr": "Pi memory Phase 2 maintenance session failed. pi_memory_phase2={\"stage\":\"session_create\",\"reason\":\"session_create_failed\",\"errno\":\"unknown\"}"
+  },
+  {
+    "name": "workspace_stage_enospc",
+    "errorClass": "session_failed",
+    "diagnostic": {
+      "stage": "workspace_stage",
+      "reason": "workspace_stage_failed",
+      "errno": "ENOSPC"
+    },
+    "stderr": "Pi memory Phase 2 maintenance session failed. pi_memory_phase2={\"stage\":\"workspace_stage\",\"reason\":\"workspace_stage_failed\",\"errno\":\"ENOSPC\"}"
+  },
+  {
+    "name": "unexpected_error",
+    "errorClass": "session_failed",
+    "diagnostic": {
+      "stage": "unknown",
+      "reason": "unexpected_error"
+    },
+    "stderr": "Pi memory Phase 2 maintenance session failed. pi_memory_phase2={\"stage\":\"unknown\",\"reason\":\"unexpected_error\"}"
+  },
+  {
+    "name": "model_turn_failed",
+    "errorClass": "model_failed",
+    "diagnostic": {
+      "stage": "model_turn",
+      "reason": "model_turn_failed"
+    },
+    "stderr": "Pi memory Phase 2 model request failed. pi_memory_phase2={\"stage\":\"model_turn\",\"reason\":\"model_turn_failed\"}"
+  },
+  {
+    "name": "final_stop_aborted",
+    "errorClass": "aborted",
+    "diagnostic": {
+      "stage": "final_response",
+      "reason": "final_stop_aborted"
+    },
+    "stderr": "Pi memory Phase 2 consolidation was cancelled. pi_memory_phase2={\"stage\":\"final_response\",\"reason\":\"final_stop_aborted\"}"
   }
 ]

--- a/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
@@ -709,8 +709,13 @@ describe("sandbox Pi agent loop", () => {
   });
 
   it.each(
+    // Only the output-validation and mounted-apply fixtures are reproducible
+    // by this scenario. Session-lifecycle fixtures are covered by the engine
+    // tests and the shared serializer boundary.
     terminalFixtures.filter((fixture) => {
-      return fixture.diagnostic;
+      return (
+        fixture.diagnostic && fixture.errorClass === "agent_output_invalid"
+      );
     }),
   )(
     "carries $name through the real mounted runtime and CLI terminal serializer",

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-diagnostics.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-diagnostics.test.ts
@@ -5,7 +5,10 @@ import {
   phase2DiagnosticForError,
   sanitizePiMemoryPhase2Diagnostic,
 } from "./phase2-memory-diagnostics";
-import { PiMemoryPhase2EngineError } from "./phase2-memory-types";
+import {
+  PiMemoryPhase2EngineError,
+  type PiMemoryPhase2FailureClass,
+} from "./phase2-memory-types";
 
 const counts = {
   candidateCount: 0,
@@ -14,12 +17,29 @@ const counts = {
   heartbeatCount: 0,
 };
 
+const FIXTURE_ERROR_CLASSES: Readonly<
+  Record<string, PiMemoryPhase2FailureClass>
+> = {
+  aborted: "aborted",
+  agent_output_invalid: "agent_output_invalid",
+  model_failed: "model_failed",
+  session_failed: "session_failed",
+};
+
+function fixtureErrorClass(name: string): PiMemoryPhase2FailureClass {
+  const errorClass = FIXTURE_ERROR_CLASSES[name];
+  if (!errorClass) {
+    throw new Error("Unknown Pi memory Phase 2 fixture error class");
+  }
+  return errorClass;
+}
+
 describe("Pi Phase 2 terminal diagnostic boundary", () => {
   it.each(fixtures)(
     "serializes the cross-language $name fixture",
     (fixture) => {
       const error = new PiMemoryPhase2EngineError(
-        "agent_output_invalid",
+        fixtureErrorClass(fixture.errorClass),
         counts,
         fixture.diagnostic
           ? sanitizePiMemoryPhase2Diagnostic(fixture.diagnostic)

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-diagnostics.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-diagnostics.ts
@@ -1,7 +1,30 @@
 /** Content-free diagnostics carried by the existing terminal error string. */
-const STAGES = ["output_validation", "mounted_apply", "unknown"] as const;
+const STAGES = [
+  "workspace_stage",
+  "session_create",
+  "model_turn",
+  "final_response",
+  "output_validation",
+  "mounted_apply",
+  "commit",
+  "unknown",
+] as const;
 const REASONS = [
   "unknown",
+  "unexpected_error",
+  "workspace_stage_failed",
+  "session_create_failed",
+  "model_turn_failed",
+  "final_message_missing",
+  "final_stop_error",
+  "final_stop_length",
+  "final_stop_tool_use",
+  "final_stop_pending",
+  "final_stop_aborted",
+  "provider_result_missing",
+  "heartbeat_stopped",
+  "caller_disposed",
+  "result_missing",
   "filesystem",
   "unsafe_path",
   "unsafe_tree",
@@ -136,6 +159,36 @@ export class Phase2OutputInvalidError extends Error {
   }
 }
 
+/**
+ * Read only a data property: raw text and arbitrary getters stay outside this
+ * best-effort diagnostic boundary.
+ */
+function phase2Errno(error: unknown): PiMemoryPhase2Diagnostic["errno"] {
+  try {
+    const value: unknown =
+      error !== null && typeof error === "object"
+        ? Object.getOwnPropertyDescriptor(error, "code")?.value
+        : undefined;
+    return allowed(ERRNOS, value);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Attribute a bounded lifecycle stage without inspecting failure content. */
+export function phase2StageDiagnostic(
+  stage: PiMemoryPhase2Diagnostic["stage"],
+  reason: PiMemoryPhase2Diagnostic["reason"],
+  error?: unknown,
+): PiMemoryPhase2Diagnostic {
+  const errno = error === undefined ? undefined : phase2Errno(error);
+  return sanitizePiMemoryPhase2Diagnostic({
+    stage,
+    reason,
+    ...(errno === undefined ? {} : { errno }),
+  });
+}
+
 export function phase2DiagnosticForError(
   error: unknown,
   stage: PiMemoryPhase2Diagnostic["stage"],
@@ -144,18 +197,7 @@ export function phase2DiagnosticForError(
   if (error instanceof Phase2OutputInvalidError) {
     return sanitizePiMemoryPhase2Diagnostic({ ...error.diagnostic, stage });
   }
-  // Read only a data property: raw text and arbitrary getters stay outside
-  // this best-effort diagnostic boundary.
-  let errno: PiMemoryPhase2Diagnostic["errno"];
-  try {
-    const value: unknown =
-      error !== null && typeof error === "object"
-        ? Object.getOwnPropertyDescriptor(error, "code")?.value
-        : undefined;
-    errno = allowed(ERRNOS, value);
-  } catch {
-    errno = undefined;
-  }
+  const errno = phase2Errno(error);
   return sanitizePiMemoryPhase2Diagnostic({
     stage,
     reason: errno && errno !== "unknown" ? "filesystem" : "unknown",

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-types.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-types.ts
@@ -121,7 +121,11 @@ export interface PiMemoryPhase2NoDiffResult extends PiMemoryPhase2ResultBase {
 
 export interface PiMemoryPhase2PreparedResult extends PiMemoryPhase2ResultBase {
   readonly status: "prepared";
-  readonly responseId: string;
+  /**
+   * Provider evidence only. Phase 2 correctness comes from the validated
+   * memory tree, so a provider that omits a response id is not a failure.
+   */
+  readonly responseId: string | null;
   readonly usage: PiMemoryPhase2ProviderUsage;
 }
 

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import type { PiMemoryPhase2Diagnostic } from "./phase2-memory-diagnostics";
 import { renderPiMemoryPhase2Prompt } from "./phase2-memory-prompt";
 import { PI_MEMORY_PHASE2_TOOL_NAMES } from "./phase2-memory-tools";
 import {
@@ -168,7 +169,13 @@ type ProviderStep =
       readonly name: string;
       readonly arguments: Record<string, unknown>;
     }
-  | { readonly type: "text"; readonly text: string }
+  | {
+      readonly type: "text";
+      readonly text: string;
+      /** Reproduce a provider that returns no response id for the turn. */
+      readonly omitResponseId?: true;
+    }
+  | { readonly type: "incomplete"; readonly reason: string }
   | { readonly type: "http-error" }
   | { readonly type: "hang"; readonly onRequest?: () => void };
 
@@ -255,7 +262,15 @@ function toolSse(
   ]);
 }
 
-function textSse(response: ServerResponse, index: number, text: string): void {
+function textSse(
+  response: ServerResponse,
+  index: number,
+  step: ProviderStep,
+): void {
+  if (step.type !== "text") {
+    throw new Error("Expected text provider step");
+  }
+  const text = step.text;
   const responseId = `resp_phase2_final_${index.toString()}`;
   const messageId = `msg_phase2_${index.toString()}`;
   const item = {
@@ -269,7 +284,7 @@ function textSse(response: ServerResponse, index: number, text: string): void {
     {
       type: "response.created",
       response: {
-        id: responseId,
+        ...(step.omitResponseId ? {} : { id: responseId }),
         object: "response",
         status: "in_progress",
         output: [],
@@ -291,9 +306,61 @@ function textSse(response: ServerResponse, index: number, text: string): void {
     {
       type: "response.completed",
       response: {
-        id: responseId,
+        ...(step.omitResponseId ? {} : { id: responseId }),
         object: "response",
         status: "completed",
+        output: [item],
+        usage: usage(),
+      },
+    },
+  ]);
+}
+
+/** A turn the provider truncated, such as an exhausted output budget. */
+function incompleteSse(
+  response: ServerResponse,
+  index: number,
+  reason: string,
+): void {
+  const responseId = `resp_phase2_incomplete_${index.toString()}`;
+  const messageId = `msg_phase2_${index.toString()}`;
+  const item = {
+    type: "message",
+    id: messageId,
+    role: "assistant",
+    status: "incomplete",
+    content: [{ type: "output_text", text: "truncated", annotations: [] }],
+  };
+  writeSse(response, [
+    {
+      type: "response.created",
+      response: {
+        id: responseId,
+        object: "response",
+        status: "in_progress",
+        output: [],
+        usage: null,
+      },
+    },
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...item, status: "in_progress", content: [] },
+    },
+    {
+      type: "response.output_text.delta",
+      output_index: 0,
+      content_index: 0,
+      delta: "truncated",
+    },
+    { type: "response.output_item.done", output_index: 0, item },
+    {
+      type: "response.incomplete",
+      response: {
+        id: responseId,
+        object: "response",
+        status: "incomplete",
+        incomplete_details: { reason },
         output: [item],
         usage: usage(),
       },
@@ -332,7 +399,11 @@ async function startProvider(steps: readonly ProviderStep[]): Promise<{
           return;
         }
         case "text": {
-          textSse(response, index, step.text);
+          textSse(response, index, step);
+          return;
+        }
+        case "incomplete": {
+          incompleteSse(response, index, step.reason);
           return;
         }
         case "http-error": {
@@ -384,6 +455,7 @@ function metadataWithoutContents<
 function expectBoundedFailure(
   promise: Promise<unknown>,
   errorClass: PiMemoryPhase2EngineError["errorClass"],
+  diagnostic?: PiMemoryPhase2Diagnostic,
 ): Promise<void> {
   return promise.then(
     () => {
@@ -394,6 +466,16 @@ function expectBoundedFailure(
       expect(error).toMatchObject({ errorClass });
       expect(error).not.toHaveProperty("files");
       expect(JSON.stringify(error)).not.toContain("SECRET_");
+      if (!diagnostic) {
+        return;
+      }
+      if (!(error instanceof PiMemoryPhase2EngineError)) {
+        throw new Error("Expected a Pi memory Phase 2 engine error");
+      }
+      expect(error.diagnostic).toStrictEqual(diagnostic);
+      expect(error.terminalMessage()).toBe(
+        `${error.message} pi_memory_phase2=${JSON.stringify(diagnostic)}`,
+      );
     },
   );
 }
@@ -866,16 +948,34 @@ describe("Pi memory Phase 2 consolidation engine", () => {
     const cases: ReadonlyArray<{
       readonly steps: readonly ProviderStep[];
       readonly errorClass: PiMemoryPhase2EngineError["errorClass"];
+      readonly diagnostic?: PiMemoryPhase2Diagnostic;
       readonly input?: Partial<PiMemoryPhase2ConsolidationArgs>;
     }> = [
       {
         steps: [{ type: "http-error" }],
         errorClass: "model_failed",
+        diagnostic: {
+          stage: "final_response",
+          reason: "final_stop_error",
+        },
         input: { baseFiles: [] },
       },
       {
-        steps: [{ type: "text", text: "" }],
+        steps: [{ type: "incomplete", reason: "max_output_tokens" }],
         errorClass: "session_failed",
+        diagnostic: {
+          stage: "final_response",
+          reason: "final_stop_length",
+        },
+        input: { baseFiles: [] },
+      },
+      {
+        steps: [{ type: "incomplete", reason: "content_filter" }],
+        errorClass: "model_failed",
+        diagnostic: {
+          stage: "final_response",
+          reason: "final_stop_error",
+        },
         input: { baseFiles: [] },
       },
       {
@@ -913,11 +1013,87 @@ describe("Pi memory Phase 2 consolidation engine", () => {
           new AbortController().signal,
         ),
         testCase.errorClass,
+        testCase.diagnostic,
       );
       await expect(stat(cleanupRoot ?? "missing")).rejects.toMatchObject({
         code: "ENOENT",
       });
     }
+  });
+
+  it("accepts a validated result without completion text or a response id", async () => {
+    const provider = await startProvider([
+      {
+        type: "tool",
+        name: "phase2_write",
+        arguments: {
+          path: "memory/MEMORY.md",
+          content: "# Task Group: silent completion\n",
+        },
+      },
+      {
+        type: "tool",
+        name: "phase2_write",
+        arguments: {
+          path: "memory/memory_summary.md",
+          content: "v1\n## User Profile\n- silent completion\n",
+        },
+      },
+      { type: "text", text: "", omitResponseId: true },
+    ]);
+
+    const result = await runPiMemoryPhase2Consolidation(
+      args(provider.baseUrl),
+      new AbortController().signal,
+    );
+
+    expect(result.status).toBe("prepared");
+    expect(result.responseId).toBeNull();
+    expect(result.usage.output).toBeGreaterThan(0);
+    const files = new Map(
+      result.files.map((file) => {
+        return [
+          file.path,
+          Buffer.from(file.contentBase64, "base64").toString(),
+        ];
+      }),
+    );
+    expect(files.get("MEMORY.md")).toBe("# Task Group: silent completion\n");
+    expect(files.get("memory_summary.md")).toBe(
+      "v1\n## User Profile\n- silent completion\n",
+    );
+  });
+
+  it("attributes an unexpected engine failure to a bounded stage and errno", async () => {
+    const provider = await startProvider([
+      {
+        type: "tool",
+        name: "phase2_write",
+        arguments: {
+          path: "memory/MEMORY.md",
+          content: "# Task Group: unexpected\n",
+        },
+      },
+      { type: "text", text: "done" },
+    ]);
+
+    await expectBoundedFailure(
+      runPiMemoryPhase2ConsolidationForTest(
+        args(provider.baseUrl),
+        {
+          beforeOutputValidation() {
+            return Promise.reject(
+              Object.assign(new Error("PRIVATE_ENGINE_SECRET_33066"), {
+                code: "ENOSPC",
+              }),
+            );
+          },
+        },
+        new AbortController().signal,
+      ),
+      "session_failed",
+      { stage: "unknown", reason: "unexpected_error", errno: "ENOSPC" },
+    );
   });
 
   it("confirms the heartbeat before model use and aborts on periodic lease loss", async () => {

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory.ts
@@ -35,6 +35,8 @@ import {
 import {
   Phase2OutputInvalidError,
   phase2DiagnosticForError,
+  phase2StageDiagnostic,
+  type PiMemoryPhase2Diagnostic,
 } from "./phase2-memory-diagnostics";
 import { renderPiMemoryPhase2Prompt } from "./phase2-memory-prompt";
 import {
@@ -71,9 +73,23 @@ interface Phase2RuntimeState {
 }
 
 interface Phase2ProviderResult {
-  readonly responseId: string;
+  /** Provider evidence only: no Phase 2 outcome depends on its presence. */
+  readonly responseId: string | null;
   readonly usage: PiMemoryPhase2ProviderUsage;
 }
+
+/**
+ * Stop reasons that leave the maintenance turn truncated or undecided. These
+ * still fail; only the recorded reason becomes attributable. Keyed by string so
+ * the table stays valid against the pinned runtime's own stop-reason union.
+ */
+const INCOMPLETE_STOP_REASONS: Readonly<
+  Record<string, PiMemoryPhase2Diagnostic["reason"]>
+> = {
+  length: "final_stop_length",
+  toolUse: "final_stop_tool_use",
+  pending: "final_stop_pending",
+};
 
 type Phase2ModelTerminal = Readonly<{
   source: "model";
@@ -189,8 +205,13 @@ function engineError(
   errorClass: PiMemoryPhase2FailureClass,
   input: SnapshotPhase2Input | null,
   state: Phase2RuntimeState,
+  diagnostic?: PiMemoryPhase2Diagnostic,
 ): PiMemoryPhase2EngineError {
-  return new PiMemoryPhase2EngineError(errorClass, failureCounts(input, state));
+  return new PiMemoryPhase2EngineError(
+    errorClass,
+    failureCounts(input, state),
+    diagnostic,
+  );
 }
 
 function durationMs(startedAt: number): number {
@@ -414,7 +435,14 @@ function terminalFailure(
   switch (terminal.source) {
     case "model": {
       return terminal.status === "failed"
-        ? { error: engineError("model_failed", input, state) }
+        ? {
+            error: engineError(
+              "model_failed",
+              input,
+              state,
+              phase2StageDiagnostic("model_turn", "model_turn_failed"),
+            ),
+          }
         : undefined;
     }
     case "heartbeat": {
@@ -422,20 +450,28 @@ function terminalFailure(
         return { error: terminal.error };
       }
       return {
-        error: engineError(
-          terminal.status === "aborted" ? "aborted" : "session_failed",
-          input,
-          state,
-        ),
+        error:
+          terminal.status === "aborted"
+            ? engineError("aborted", input, state)
+            : engineError(
+                "session_failed",
+                input,
+                state,
+                phase2StageDiagnostic("model_turn", "heartbeat_stopped"),
+              ),
       };
     }
     case "caller": {
       return {
-        error: engineError(
-          terminal.status === "aborted" ? "aborted" : "session_failed",
-          input,
-          state,
-        ),
+        error:
+          terminal.status === "aborted"
+            ? engineError("aborted", input, state)
+            : engineError(
+                "session_failed",
+                input,
+                state,
+                phase2StageDiagnostic("model_turn", "caller_disposed"),
+              ),
       };
     }
   }
@@ -456,20 +492,27 @@ function settlementFailure(
     return { error: engineError("aborted", input, state) };
   }
   if (settlement.model.status === "failed") {
-    return { error: engineError("model_failed", input, state) };
+    return {
+      error: engineError(
+        "model_failed",
+        input,
+        state,
+        phase2StageDiagnostic("model_turn", "model_turn_failed"),
+      ),
+    };
   }
   return undefined;
 }
 
-async function abortMaintenanceSession(
-  session: AgentSession,
-  input: SnapshotPhase2Input,
-  state: Phase2RuntimeState,
-): Promise<void> {
+/**
+ * Best-effort teardown for an already-decided failure. A failing abort must not
+ * replace the decided cause with a generic session failure.
+ */
+async function abortMaintenanceSession(session: AgentSession): Promise<void> {
   try {
     await session.abort();
   } catch {
-    throw engineError("session_failed", input, state);
+    // The decided failure stays authoritative; teardown adds no new cause.
   }
 }
 
@@ -503,11 +546,7 @@ async function runMaintenancePrompt(args: {
   }
 
   if (failure && arbiter) {
-    try {
-      await abortMaintenanceSession(args.session, args.input, args.state);
-    } catch (error) {
-      failure = { error };
-    }
+    await abortMaintenanceSession(args.session);
   }
   args.session.dispose();
   const settlement = arbiter ? await arbiter.settle() : undefined;
@@ -522,7 +561,12 @@ async function runMaintenancePrompt(args: {
   }
   args.input.signal.throwIfAborted();
   if (!provider) {
-    throw engineError("session_failed", args.input, args.state);
+    throw engineError(
+      "session_failed",
+      args.input,
+      args.state,
+      phase2StageDiagnostic("final_response", "provider_result_missing"),
+    );
   }
   return provider;
 }
@@ -540,19 +584,40 @@ function providerResult(
 ): Phase2ProviderResult {
   const messages = finalAssistantMessages(session);
   const final = messages.at(-1);
-  if (final?.stopReason === "error") {
-    throw engineError("model_failed", input, state);
+  if (!final) {
+    throw engineError(
+      "session_failed",
+      input,
+      state,
+      phase2StageDiagnostic("final_response", "final_message_missing"),
+    );
   }
-  const hasCompletionText = final?.content.some((content) => {
-    return content.type === "text" && content.text.trim().length > 0;
-  });
-  if (
-    !final ||
-    final.stopReason !== "stop" ||
-    !hasCompletionText ||
-    !final.responseId
-  ) {
-    throw engineError("session_failed", input, state);
+  if (final.stopReason === "error") {
+    throw engineError(
+      "model_failed",
+      input,
+      state,
+      phase2StageDiagnostic("final_response", "final_stop_error"),
+    );
+  }
+  if (final.stopReason === "aborted") {
+    throw engineError(
+      "aborted",
+      input,
+      state,
+      phase2StageDiagnostic("final_response", "final_stop_aborted"),
+    );
+  }
+  if (final.stopReason !== "stop") {
+    throw engineError(
+      "session_failed",
+      input,
+      state,
+      phase2StageDiagnostic(
+        "final_response",
+        INCOMPLETE_STOP_REASONS[final.stopReason] ?? "unknown",
+      ),
+    );
   }
   const usage = messages.reduce<PiMemoryPhase2ProviderUsage>(
     (total, message) => {
@@ -566,7 +631,7 @@ function providerResult(
     },
     ZERO_USAGE,
   );
-  return { responseId: final.responseId, usage: Object.freeze(usage) };
+  return { responseId: final.responseId ?? null, usage: Object.freeze(usage) };
 }
 
 async function createMaintenanceSession(args: {
@@ -693,7 +758,12 @@ function normalizeFailure(
   if (signal?.aborted) {
     return engineError("aborted", input, state);
   }
-  return engineError("session_failed", input, state);
+  return engineError(
+    "session_failed",
+    input,
+    state,
+    phase2StageDiagnostic("unknown", "unexpected_error", error),
+  );
 }
 
 async function executeConsolidation(
@@ -711,7 +781,21 @@ async function executeConsolidation(
   } catch {
     throw engineError("prompt_invariant", input, state);
   }
-  const workspace = await createPiMemoryPhase2Workspace(root, input);
+  let workspace: Phase2PrivateWorkspace;
+  try {
+    workspace = await createPiMemoryPhase2Workspace(root, input);
+  } catch (error) {
+    signal.throwIfAborted();
+    if (error instanceof Phase2InputInvalidError) {
+      throw error;
+    }
+    throw engineError(
+      "session_failed",
+      input,
+      state,
+      phase2StageDiagnostic("workspace_stage", "workspace_stage_failed", error),
+    );
+  }
   state.fileCount = workspace.agentBaseline.size;
   state.totalBytes = [...workspace.agentBaseline.values()].reduce(
     (sum, content) => {
@@ -754,7 +838,12 @@ async function executeConsolidation(
     if (error instanceof Phase2InputInvalidError) {
       throw error;
     }
-    throw engineError("session_failed", input, state);
+    throw engineError(
+      "session_failed",
+      input,
+      state,
+      phase2StageDiagnostic("session_create", "session_create_failed", error),
+    );
   }
   const provider = await runMaintenancePrompt({
     session,
@@ -884,7 +973,12 @@ export async function runPiMemoryPhase2ConsolidationForTest(
     throw failure;
   }
   if (!result) {
-    const missing = engineError("session_failed", input, state);
+    const missing = engineError(
+      "session_failed",
+      input,
+      state,
+      phase2StageDiagnostic("commit", "result_missing"),
+    );
     emitFailure(input, state, startedAt, missing);
     throw missing;
   }


### PR DESCRIPTION
## Problem

`session_failed` is the Phase 2 engine's catch-all class: eight structurally
different lifecycle branches all emit the same parameterless terminal line
`Pi memory Phase 2 maintenance session failed.` The diagnostic channel added in
#32911 is only wired to `agent_output_invalid`, so a failed maintenance session
carries no stage, no reason and no errno anywhere — production logs, the guest
error file and Sentry all see one opaque sentence.

In the reviewed Beijing day (UTC `[2026-09-08T16:00:00Z, 2026-09-09T16:00:00Z)`)
`vm0-web-logs-prod` recorded 23 such terminal failures across runner 0.188.16 →
0.189.4, alongside 41 `agent_output_invalid`. Each failing run has exactly two
records — the runner `job execution failed` error and the API `Run failed` warn
for the same failure — and the runner record carries no stage, duration or
sandbox CLI version. Sentry production has no matching events at all.

The same window contains zero `model request failed` and zero
`consolidation was cancelled` records, so provider transport failures, the 2h
timeout and lease loss are excluded; and the 41 output-validation failures prove
session construction and the model turn work in the same deployments. What is
left is a per-run condition inside the final-assistant invariant or an
unattributed non-provider branch — and today's logs cannot tell them apart.

A failed maintenance run is not noise: the API retries it hourly and gives up
after `PI_MEMORY_PHASE2_MAX_ATTEMPTS = 3`, so memory consolidation stalls for
that Storage, and the discarded attempt still costs provider tokens.

## What this changes

**1. Every session-lifecycle failure becomes attributable.**
`PiMemoryPhase2Diagnostic` gains bounded `workspace_stage`, `session_create`,
`model_turn`, `final_response` and `commit` stages plus the matching reasons.
All eight `session_failed` sites now pass one, so `terminalMessage()` appends
`pi_memory_phase2={...}` through the channel #32911 already proved end to end.
No new log line, no level change, no new field on the runner event.

**2. The final-assistant invariant is split instead of collapsed.**
A missing final message, a truncated turn (`length` / `toolUse` / `pending`), a
provider error and a real cancellation were one class; they are now
`session_failed`, `model_failed` and `aborted` with distinct reasons. A turn the
model aborted is no longer reported as a session fault.

**3. Two dead gates stop failing correct runs.**
`providerResult` also required non-empty completion text and a provider
`responseId`. Both fed only the maintenance usage journal, which #32805 deleted
together with `onUsage` and `maintenance_usage.rs`; `runPiMemoryPhase2MountedConsolidation`
returns only `{status, validatedVersionId}`. Phase 2 correctness comes from
`validatePiMemoryPhase2Output`, so a provider that omits a response id or a model
that ends without a closing sentence no longer discards a validated memory tree.
`PiMemoryPhase2PreparedResult.responseId` is now `string | null`.

**4. A failing abort no longer overwrites the decided cause.**
`runMaintenancePrompt` called `abortMaintenanceSession` only after a failure was
already captured, and a throwing `session.abort()` replaced that precise cause
(`model_failed`, `agent_output_invalid`, an errno) with a generic
`session_failed`. Teardown is now best-effort and the decided failure stays
authoritative.

Truncated and undecided turns still fail, and every output-validation,
immutability, integrity and byte/token check is untouched.

## Verification

Run locally:

- `pi-agent-runtime` `check-types`, `lint`, `build` (public declaration boundary
  clean) — pass.
- `pi-agent-runtime` full package Vitest — 412 tests pass. One unrelated
  `phase2-memory-filesystem.test.ts` boundary test timed out only at
  `--maxWorkers=4` under local contention and passes in isolation; its timeout
  was not touched.
- `apps/cli` `check-types`, `lint`, and `src/lib/pi-agent-loop.test.ts` — 44
  tests pass, including the real mounted-runtime terminal serialization fixtures.

New coverage:

- Positive: a validated result with an empty final message and no provider
  response id now returns `prepared` with `responseId === null`.
- Negative, distinguishable: `response.incomplete` / `max_output_tokens` →
  `session_failed` + `final_response/final_stop_length`;
  `response.incomplete` / `content_filter` and a provider HTTP failure →
  `model_failed` + `final_response/final_stop_error`; an unexpected engine error
  → `session_failed` + `unknown/unexpected_error` + `errno`.
- Adjacent real failures unchanged: the `.git` write rejection, missing required
  artifacts and the summary-token boundary still fail as `agent_output_invalid`
  with their existing diagnostics.
- Boundary: each assertion also checks the exact `terminalMessage()` string, and
  the shared `fixtures/pi-memory-phase2-terminal.json` gains session, model and
  cancellation samples so the guest-agent stderr tail, guest error persistence
  and runner field projection tests cover them.

Not run locally: the Rust fixture tests, because no Rust toolchain is installed
in this environment. They are data-driven — every new fixture line is far under
`CLI_STDERR_RESULT_MAX_LINE_BYTES` (16 KiB), single-line, free of `PRIVATE_`, and
matches no framework-agnostic `classify_cli_failure_reason` pattern. CI covers
them.

The `pi-agent-loop` end-to-end fixture case is scoped to the
`agent_output_invalid` fixtures, which are the only ones that scenario can
actually reproduce; the session fixtures are covered by the engine tests and the
shared serializer boundary.

## Post-deploy acceptance

Not part of this PR. Once the sandbox CLI carrying this change is released, take
one bounded 24h window on `vm0-web-logs-prod` and check that every
`Pi memory Phase 2 maintenance session failed.` record carries
`pi_memory_phase2=`, then report the reason distribution. `final_text_missing`
and `final_response_id_missing` are gone by construction. Note that the runner
terminal event has no sandbox CLI version field, so deployment identity must
come from the release, not from `runner_version`.

Refs #33066

🤖 Generated with [Claude Code](https://claude.com/claude-code)
