### PR TITLE
fix(pi): preserve provider http status in opaque model failures

### DIFF
--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -24,6 +24,8 @@ use serde_json::Value;
 const LOG_TAG: &str = "sandbox:guest-agent";
 const MAX_LOGGED_CLI_STDERR_LINES: usize = 20;
 const MAX_LOGGED_CLI_STDERR_LINE_BYTES: usize = 4096;
+/// Lowercased marker the Pi model boundary writes before an observed status.
+const PI_PROVIDER_HTTP_MARKER: &str = "provider http ";
 const CODEX_SAFETY_POLICY_REFUSAL_MESSAGE: &str = concat!(
     "This content was flagged for possible cybersecurity risk. ",
     "If this seems wrong, try rephrasing your request. ",
@@ -379,7 +381,54 @@ fn classify_cli_failure_reason(
     {
         return Some(FailureReason::UsageLimit);
     }
+    // Quota and subscription wording above stays authoritative for the statuses
+    // it also covers, so the observed provider status is read last.
+    if matches!(framework, AgentFramework::Pi)
+        && let Some(reason) = pi_provider_http_failure_reason(source, &normalized)
+    {
+        return Some(reason);
+    }
     None
+}
+
+/// Classify the provider status the Pi runtime records for an opaque body.
+///
+/// The Pi model boundary restates a non-JSON provider error as
+/// `provider HTTP <status>: <phrase>`, so an Envoy or edge reply that used to
+/// arrive as bare prose now carries its stage. Only the server-unavailability
+/// family is classified here; every other status keeps whatever message-shaped
+/// classification already applies, or stays unknown.
+fn pi_provider_http_failure_reason(
+    source: FailureDetailSource,
+    normalized: &str,
+) -> Option<FailureReason> {
+    if source != FailureDetailSource::PiResult {
+        return None;
+    }
+    normalized
+        .match_indices(PI_PROVIDER_HTTP_MARKER)
+        .find_map(|(index, _)| {
+            if normalized[..index]
+                .chars()
+                .next_back()
+                .is_some_and(is_error_type_char)
+            {
+                return None;
+            }
+            let detail = &normalized[index + PI_PROVIDER_HTTP_MARKER.len()..];
+            let status_len = detail
+                .find(|c: char| !c.is_ascii_digit())
+                .unwrap_or(detail.len());
+            let (status, remaining) = detail.split_at(status_len);
+            if remaining.chars().next().is_some_and(is_error_type_char) {
+                return None;
+            }
+            match status {
+                "500" | "502" | "503" | "504" => Some(FailureReason::ProviderServerError),
+                "529" => Some(FailureReason::ProviderOverloaded),
+                _ => None,
+            }
+        })
 }
 
 fn is_codex_safety_policy_refusal(source: FailureDetailSource, failure_message: &str) -> bool {

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -929,6 +929,120 @@ fn cli_failure_reason_rejects_untrusted_mid_response_failure_contexts() {
 }
 
 #[test]
+fn cli_failure_reason_classifies_pi_provider_http_unavailability() {
+    for (message, expected_reason) in [
+        (
+            "provider HTTP 503: no healthy upstream",
+            FailureReason::ProviderServerError,
+        ),
+        (
+            "provider HTTP 502: Service Unavailable",
+            FailureReason::ProviderServerError,
+        ),
+        ("provider HTTP 500", FailureReason::ProviderServerError),
+        (
+            "provider HTTP 504: upstream request timeout",
+            FailureReason::ProviderServerError,
+        ),
+        (
+            "provider HTTP 529: overloaded",
+            FailureReason::ProviderOverloaded,
+        ),
+        // The public Responses route prefixes the SDK status before the marker.
+        (
+            "503 provider HTTP 503: no healthy upstream",
+            FailureReason::ProviderServerError,
+        ),
+    ] {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::Pi,
+            FailureDetailSource::PiResult,
+            message,
+        );
+
+        assert_eq!(reason, Some(expected_reason), "message: {message}");
+    }
+}
+
+#[test]
+fn cli_failure_reason_rejects_untrusted_pi_provider_http_contexts() {
+    const MESSAGE: &str = "provider HTTP 503: no healthy upstream";
+
+    for (framework, source) in [
+        (AgentFramework::Pi, FailureDetailSource::Stderr),
+        (AgentFramework::ClaudeCode, FailureDetailSource::PiResult),
+        (AgentFramework::Codex, FailureDetailSource::PiResult),
+    ] {
+        let reason = super::classify_cli_failure_reason(framework, source, MESSAGE);
+
+        assert_eq!(reason, None, "framework: {framework:?} source: {source:?}");
+    }
+
+    for message in [
+        // A status this boundary deliberately leaves to message-shaped rules.
+        "provider HTTP 401: unauthorized",
+        "provider HTTP 402: payment required",
+        "provider HTTP 429: slow down",
+        // Malformed or embedded markers must not be read as a status.
+        "provider HTTP 5031: no healthy upstream",
+        "provider HTTP 503_beta: no healthy upstream",
+        "provider HTTP : no healthy upstream",
+        "the tool printed provider HTTP",
+        "xprovider HTTP 503: no healthy upstream",
+        "no healthy upstream",
+    ] {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::Pi,
+            FailureDetailSource::PiResult,
+            message,
+        );
+
+        assert_eq!(reason, None, "message: {message}");
+    }
+}
+
+#[test]
+fn cli_failure_reason_keeps_quota_wording_authoritative_over_pi_provider_http() {
+    let reason = super::classify_cli_failure_reason(
+        AgentFramework::Pi,
+        FailureDetailSource::PiResult,
+        "provider HTTP 503: You have hit your ChatGPT usage limit.",
+    );
+
+    assert_eq!(reason, Some(FailureReason::UsageLimit));
+}
+
+#[test]
+fn pi_provider_http_failure_reaches_the_structured_diagnostic() {
+    let msg = cli_failure_message(
+        1,
+        &["background stderr noise".to_string()],
+        Some(&cli_diagnostic(
+            "provider HTTP 503: no healthy upstream",
+            FailureDetailSource::PiResult,
+        )),
+    );
+    let diagnostic = FailureDiagnostic::new(
+        FailureClass::CliNonzero,
+        AgentFramework::Pi,
+        PromptMetadata::from_prompt("plain prompt"),
+    )
+    .with_cli_exit_code(1)
+    .with_failure_detail_source(msg.source);
+    let diagnostic = with_cli_failure_reason(diagnostic, &msg);
+
+    assert_eq!(msg.source, FailureDetailSource::PiResult);
+    assert_eq!(
+        diagnostic.failure_reason,
+        Some(FailureReason::ProviderServerError)
+    );
+    assert_eq!(
+        diagnostic.failure_detail_source,
+        Some(FailureDetailSource::PiResult)
+    );
+}
+
+#[test]
 fn cli_failure_reason_classifies_claude_output_token_limit() {
     for message in [
         "API Error: Claude's response exceeded the 32000 output token maximum. To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.",

--- a/turbo/packages/pi-agent-runtime/src/model.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/model.test.ts
@@ -3,10 +3,47 @@ import { once } from "node:events";
 import { createServer, type IncomingHttpHeaders } from "node:http";
 import { describe, expect, it, vi } from "vitest";
 
+import { isRetryableAssistantError } from "@earendil-works/pi-ai/utils/retry";
 import { piModelConfigSchema } from "@okouai/api-contracts/contracts/runners";
 import { materializePiAgentModelConfig } from "./credential";
 
 import { piAgentStreamForConfig, resolvePiAgentModel } from "./model";
+
+const CODEX_ROUTE = {
+  provider: "openai-codex",
+  baseUrl: "https://chatgpt.com/backend-api",
+  model: "gpt-5.6-terra",
+  apiKey: "opaque-not-a-jwt",
+  accountId: "account-id-from-binding",
+  dialect: "openai-codex-responses",
+  transport: "sse",
+} as const;
+
+async function codexFailureResult(response: () => Response) {
+  const model = resolvePiAgentModel(CODEX_ROUTE);
+  if (!model || model.api !== "openai-codex-responses") {
+    throw new Error("Expected a native Codex Responses model");
+  }
+  const providerFetch = vi.fn(() => {
+    return Promise.resolve(response());
+  });
+  const stream = piAgentStreamForConfig(CODEX_ROUTE)(
+    model,
+    {
+      messages: [{ role: "user", content: "hello", timestamp: 1 }],
+      tools: [],
+    },
+    {
+      apiKey: CODEX_ROUTE.apiKey,
+      fetch: providerFetch,
+      signal: AbortSignal.timeout(5_000),
+    },
+  );
+  for await (const _event of stream) {
+    // Drain the failing provider answer before inspecting its canonical result.
+  }
+  return { providerFetch, result: await stream.result() };
+}
 
 const OPENAI_TERRA = {
   provider: "openai",
@@ -440,5 +477,41 @@ describe("Pi agent model adapter", () => {
         },
       ],
     });
+  });
+
+  it("keeps a gateway status in an opaque Codex Responses failure", async () => {
+    const { providerFetch, result } = await codexFailureResult(() => {
+      return new Response("no healthy upstream", {
+        status: 503,
+        headers: { "content-type": "text/plain" },
+      });
+    });
+
+    expect(providerFetch).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorMessage: "provider HTTP 503: no healthy upstream",
+    });
+    // The recorded status is what lets the session retry budget recover a
+    // transient gateway answer instead of ending the run on its first hit.
+    expect(isRetryableAssistantError(result)).toBe(true);
+  });
+
+  it("leaves a provider-authored usage limit terminal and unchanged", async () => {
+    const { providerFetch, result } = await codexFailureResult(() => {
+      return new Response(
+        JSON.stringify({
+          error: { code: "usage_limit_reached", plan_type: "Plus" },
+        }),
+        { status: 429, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    expect(providerFetch).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorMessage: "You have hit your ChatGPT usage limit (plus plan).",
+    });
+    expect(isRetryableAssistantError(result)).toBe(false);
   });
 });

--- a/turbo/packages/pi-agent-runtime/src/model.ts
+++ b/turbo/packages/pi-agent-runtime/src/model.ts
@@ -20,6 +20,7 @@ import type {
 import { clampThinkingLevel } from "@earendil-works/pi-ai";
 
 import type { PiAgentModelConfig } from "./types";
+import { preserveProviderErrorStatus } from "./provider-error-body";
 import {
   observePiResponseStatus,
   type PiAgentStreamOptions,
@@ -257,6 +258,10 @@ function piAgentCodexStream(
     // Codex keeps fast in config but sends priority on Responses requests.
     serviceTier: serviceTier === "fast" ? "priority" : undefined,
     accountId,
+    // Transport retries stay off here: the Codex adapter replaces a capped
+    // Retry-After with a bare delay error, which would discard the friendly
+    // usage-limit message the failure classifiers depend on. Recovery for a
+    // transient answer belongs to the session retry budget instead.
     maxRetries: 0,
     transport: "sse",
   });
@@ -315,15 +320,21 @@ export function piAgentStreamForConfig(
     ) {
       return streamPiNative(config, model, context, configuredOptions);
     }
-    const responseOptions = configuredOptions.onObservedResponseStatus
-      ? {
-          ...configuredOptions,
-          fetch: observePiResponseStatus(
-            configuredOptions.fetch ?? globalThis.fetch,
+    // Both OpenAI Responses routes answer an opaque gateway body with the raw
+    // text alone, so the observed status has to be preserved here to stay in
+    // the terminal error at all.
+    const boundaryFetch = preserveProviderErrorStatus(
+      configuredOptions.fetch ?? globalThis.fetch,
+    );
+    const responseOptions = {
+      ...configuredOptions,
+      fetch: configuredOptions.onObservedResponseStatus
+        ? observePiResponseStatus(
+            boundaryFetch,
             configuredOptions.onObservedResponseStatus,
-          ),
-        }
-      : configuredOptions;
+          )
+        : boundaryFetch,
+    };
     if (config.dialect === "openai-responses") {
       if (!isResponsesModel(model)) {
         throw new Error(

--- a/turbo/packages/pi-agent-runtime/src/provider-error-body.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/provider-error-body.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import { preserveProviderErrorStatus } from "./provider-error-body";
+
+const REQUEST_URL = "https://provider.example/responses";
+
+function respondWith(
+  status: number,
+  body: string | null,
+  headers: Record<string, string> = {},
+): NonNullable<Parameters<typeof preserveProviderErrorStatus>[0]> {
+  return () => {
+    return Promise.resolve(new Response(body, { status, headers }));
+  };
+}
+
+async function normalizedBody(
+  status: number,
+  body: string | null,
+  headers?: Record<string, string>,
+): Promise<{ response: Response; text: string }> {
+  const response = await preserveProviderErrorStatus(
+    respondWith(status, body, headers),
+  )(REQUEST_URL);
+  return { response, text: await response.text() };
+}
+
+describe("Pi provider error body boundary", () => {
+  it("restates an Envoy local reply with its observed status", async () => {
+    const { response, text } = await normalizedBody(
+      503,
+      "no healthy upstream",
+      {
+        "content-type": "text/plain",
+      },
+    );
+
+    expect(response.status).toBe(503);
+    expect(JSON.parse(text)).toStrictEqual({
+      error: {
+        message: "provider HTTP 503: no healthy upstream",
+        type: "http_error",
+      },
+    });
+    expect(response.headers.get("content-type")).toBe("application/json");
+  });
+
+  it("reduces an edge HTML error page to one readable phrase", async () => {
+    const page = [
+      "<!doctype html><html><head>",
+      '<meta name="viewport" content="width=device-width, initial-scale=1">',
+      "<style>body { color: red }</style>",
+      "<script>console.log('noise')</script>",
+      "</head><body><h1>Service Unavailable</h1></body></html>",
+    ].join("");
+
+    const { text } = await normalizedBody(502, page, {
+      "content-type": "text/html",
+    });
+
+    const { message } = (JSON.parse(text) as { error: { message: string } })
+      .error;
+    expect(message).toBe("provider HTTP 502: Service Unavailable");
+    expect(message).not.toContain("console.log");
+    expect(message).not.toContain("viewport");
+    expect(message).not.toContain("<");
+  });
+
+  it("keeps the status alone when the body carries no phrase", async () => {
+    const { text } = await normalizedBody(503, "   \n  ");
+
+    expect((JSON.parse(text) as { error: { message: string } }).error).toEqual({
+      message: "provider HTTP 503",
+      type: "http_error",
+    });
+  });
+
+  it("bounds a long opaque body", async () => {
+    const { text } = await normalizedBody(500, "upstream ".repeat(1000));
+
+    const { message } = (JSON.parse(text) as { error: { message: string } })
+      .error;
+    expect(message.startsWith("provider HTTP 500: upstream upstream")).toBe(
+      true,
+    );
+    expect(message.endsWith("...")).toBe(true);
+    expect(message.length).toBeLessThan(250);
+  });
+
+  it.each([
+    ['{"error":{"message":"You have hit your ChatGPT usage limit."}}', 429],
+    ['{"error":"insufficient_credits"}', 402],
+    ['{"error":{"code":"token_refresh_failed"}}', 401],
+  ])(
+    "leaves the provider-authored envelope %s untouched",
+    async (body, status) => {
+      const { response, text } = await normalizedBody(status, body, {
+        "content-type": "application/json",
+      });
+
+      expect(response.status).toBe(status);
+      expect(text).toBe(body);
+    },
+  );
+
+  it("passes an oversized body through without normalization", async () => {
+    const body = "x".repeat(70 * 1024);
+
+    const { text } = await normalizedBody(503, body);
+
+    expect(text).toBe(body);
+  });
+
+  it.each([200, 201])(
+    "never touches a successful response %i",
+    async (status) => {
+      const { response, text } = await normalizedBody(
+        status,
+        "event: done\n\n",
+      );
+
+      expect(response.status).toBe(status);
+      expect(text).toBe("event: done\n\n");
+    },
+  );
+
+  it("preserves a bodyless failure status", async () => {
+    const { response, text } = await normalizedBody(304, null);
+
+    expect(response.status).toBe(304);
+    expect(text).toBe("");
+  });
+});

--- a/turbo/packages/pi-agent-runtime/src/provider-error-body.ts
+++ b/turbo/packages/pi-agent-runtime/src/provider-error-body.ts
@@ -1,0 +1,139 @@
+import type { SimpleStreamOptions } from "@earendil-works/pi-ai";
+
+/**
+ * Restate an opaque provider error body as the adapter's own JSON envelope.
+ *
+ * A model request can be answered by a gateway rather than the provider: an
+ * Envoy local reply (`no healthy upstream`) or an edge HTML error page. The
+ * upstream adapters reduce such a body to its raw text and drop the HTTP
+ * status, so the terminal assistant error carries no stage evidence, no retry
+ * classifier recognizes it, and a single transient answer ends the whole run.
+ *
+ * This boundary only rewrites a body that is not already JSON, so every
+ * provider-authored error envelope keeps reaching its existing classifier
+ * unchanged.
+ */
+
+/** Largest error body buffered before normalization is abandoned. */
+const MAX_BUFFERED_ERROR_BODY_BYTES = 64 * 1024;
+/** Longest upstream phrase retained in the normalized message. */
+const MAX_PRESERVED_SNIPPET_CHARS = 200;
+/** Marker that carries the observed status into the terminal error text. */
+const PROVIDER_HTTP_STATUS_MARKER = "provider HTTP";
+/** Statuses whose responses must not carry a body. */
+const NULL_BODY_STATUSES: ReadonlySet<number> = new Set([204, 205, 304]);
+
+interface BufferedErrorBody {
+  readonly bytes: Uint8Array;
+  readonly truncated: boolean;
+}
+
+async function bufferErrorBody(
+  body: ReadableStream<Uint8Array>,
+): Promise<BufferedErrorBody> {
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    for (;;) {
+      const result = await reader.read();
+      if (result.done) {
+        break;
+      }
+      chunks.push(result.value);
+      size += result.value.byteLength;
+      if (size > MAX_BUFFERED_ERROR_BODY_BYTES) {
+        // An oversized error body is passed through untouched, so cancelling
+        // the remainder would truncate what the adapter still parses.
+        await reader.cancel();
+        return { bytes: concatChunks(chunks, size), truncated: true };
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return { bytes: concatChunks(chunks, size), truncated: false };
+}
+
+function concatChunks(chunks: readonly Uint8Array[], size: number): Uint8Array {
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function isJsonBody(text: string): boolean {
+  try {
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Reduce markup and layout to the one phrase worth keeping for diagnosis. */
+function providerErrorSnippet(text: string): string {
+  const withoutMarkup = text
+    .replaceAll(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/giu, " ")
+    .replaceAll(/<[^>]*>/gu, " ");
+  const collapsed = withoutMarkup.replaceAll(/\s+/gu, " ").trim();
+  return collapsed.length > MAX_PRESERVED_SNIPPET_CHARS
+    ? `${collapsed.slice(0, MAX_PRESERVED_SNIPPET_CHARS)}...`
+    : collapsed;
+}
+
+/** Build the terminal message an opaque provider body would otherwise lose. */
+function providerHttpErrorMessage(status: number, body: string): string {
+  const snippet = providerErrorSnippet(body);
+  return snippet
+    ? `${PROVIDER_HTTP_STATUS_MARKER} ${status}: ${snippet}`
+    : `${PROVIDER_HTTP_STATUS_MARKER} ${status}`;
+}
+
+function jsonEnvelopeHeaders(headers: Headers): Headers {
+  const rewritten = new Headers(headers);
+  // The buffered bytes are already decoded and re-sized by this boundary.
+  rewritten.delete("content-length");
+  rewritten.delete("content-encoding");
+  rewritten.set("content-type", "application/json");
+  return rewritten;
+}
+
+/** Wrap a fetch so opaque provider error bodies keep their observed status. */
+export function preserveProviderErrorStatus(
+  fetchImpl: NonNullable<SimpleStreamOptions["fetch"]>,
+): NonNullable<SimpleStreamOptions["fetch"]> {
+  return async (input, init) => {
+    const response = await fetchImpl(input, init);
+    if (
+      response.ok ||
+      response.body === null ||
+      NULL_BODY_STATUSES.has(response.status)
+    ) {
+      return response;
+    }
+    const { bytes, truncated } = await bufferErrorBody(response.body);
+    const text = new TextDecoder().decode(bytes);
+    if (truncated || isJsonBody(text)) {
+      return new Response(bytes, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    }
+    const envelope = {
+      error: {
+        message: providerHttpErrorMessage(response.status, text),
+        type: "http_error",
+      },
+    };
+    return new Response(JSON.stringify(envelope), {
+      status: response.status,
+      statusText: response.statusText,
+      headers: jsonEnvelopeHeaders(response.headers),
+    });
+  };
+}


### PR DESCRIPTION
## Problem

A gateway can answer a Pi model request with an opaque body instead of a provider error envelope — an Envoy local reply (`no healthy upstream`) or an edge HTML error page. The OpenAI Responses adapters reduce such a body to its raw text and drop the HTTP status, which breaks three things at once:

1. The terminal assistant error carries no provider stage evidence at all.
2. `AgentSession` auto-retry is enabled in the sandbox (3 attempts, 2s backoff) but classifies retryability from that text, and `isRetryableAssistantError("no healthy upstream")` is `false`. A single transient gateway answer therefore ended the whole run on its first hit.
3. `classify_cli_failure_reason` had no `AgentFramework::Pi` branch, so the result stayed unclassified. The runner logged `job execution failed` at `error` and the API logged `Run failed` at `warn`, and the user saw the bare Envoy string.

Production evidence for #33071: one `web` run on `gpt-5.6-sol` via `codex-oauth-token` failed after already producing an assistant message, with `failure_class=cli_nonzero`, `failure_framework=pi`, `failure_detail_source=pi_result`, `error="no healthy upstream"` and no `failure_reason`. In the same 24h window, all 68 `pi` + `cli_nonzero` terminal failures had an empty `failure_reason`.

## Change

- New `provider-error-body.ts` boundary: when a Pi model response is not OK and its body is **not** valid JSON, restate it as the adapter's own envelope, `{"error":{"message":"provider HTTP <status>: <phrase>","type":"http_error"}}`. Markup is stripped, whitespace collapsed, and the phrase bounded to 200 chars. Bodies above 64 KiB pass through untouched.
- `piAgentStreamForConfig` installs that boundary for both OpenAI Responses routes, composed with the existing `onObservedResponseStatus` observer. The native Anthropic/Bedrock branch is untouched so it keeps `nativePublicFetch` and its DNS-rebinding protection.
- `classify_cli_failure_reason` gains a `Pi` + `PiResult` branch that reads the recorded status: `500/502/503/504` → `provider_server_error`, `529` → `provider_overloaded`. It is evaluated **after** the quota/subscription wording so `usage_limit` stays authoritative.

Nothing else changes: runner level policy (`is_info_level_job_failure`) and API failure-log suppression (`shouldSuppressKnownFailureLog`) already key on that reason, so a classified failure logs at `info` in the runner — below the `level <= WARN` Axiom ingest filter — and the API `warn` is suppressed for non-built-in providers while a built-in provider still warns. An exhausted recovery keeps a truthful failed run and now renders the shared transient-error copy instead of raw gateway text.

## Deliberately out of scope

- **Transport retries stay at `maxRetries: 0`.** Enabling them on the Codex adapter looked attractive, but its `validateRetryDelayMs` throws a bare `RetryDelayExceededError` when a `Retry-After` exceeds the cap, discarding the friendly ChatGPT usage-limit message the failure classifiers depend on — and that error text is itself retryable, so a quota-exhausted turn would burn the session budget. Recovery is left to the session retry budget, which the status marker now unblocks. A comment records this so it is not "fixed" later by accident.
- `401/402/429` and other statuses stay with their existing message-shaped rules rather than gaining an unevidenced status mapping.
- BYOK model-provider flows are still outside the mitm addon's `model_provider_failure` observation (`admit_flow` requires a billable firewall, and only built-in providers contribute one). That is a separate decision, not a blocker here.

This boundary also covers the HTML error-page signature tracked in #33067; that issue still needs its own verification and is not closed by this PR.

## Verification

Run locally:

- `vitest run` for `@okouai/pi-agent-runtime` — **416 passed / 25 files**, including 11 new boundary tests and 2 new adapter integration tests.
- `cargo test -p guest-agent --lib failure_diagnostics` — **106 passed**, including 4 new classification tests.
- `cargo clippy -p guest-agent --lib --all-targets` — clean; `cargo fmt -p guest-agent --check` — clean.
- `tsc --noEmit`, package `lint` (oxlint + type-aware oxlint + eslint), `tsc -p tsconfig.build.json`, and `check-public-declarations` — all clean.

New behavioral coverage:

- Positive: a 503 `no healthy upstream` from the Codex Responses route now ends with `errorMessage === "provider HTTP 503: no healthy upstream"` and `isRetryableAssistantError(result) === true`, so the session budget can recover it.
- Negative control: a 429 `usage_limit_reached` envelope keeps `"You have hit your ChatGPT usage limit (plus plan)."` verbatim, stays non-retryable, and issues exactly one request.
- Untouched envelopes: usage-limit, `insufficient_credits` and `token_refresh_failed` JSON bodies are byte-identical after the boundary.
- Rust negatives: wrong framework, wrong detail source, `401/402/429`, malformed statuses (`5031`, `503_beta`, empty), an embedded marker (`xprovider HTTP 503`), and bare `no healthy upstream` all stay unclassified; quota wording still wins over a 503 status.

Not run locally: `knip` (the filtered install lacks sibling workspace deps) and the wider Rust/TS suites — left to the PR pipeline.

## Post-deploy check

`pi-agent-runtime`/`okou` CLI and `runner` ship separately, so accept them separately. After both are live, over ≥72h on `vm0-web-logs-prod`: the share of `pi` + `cli_nonzero` `job execution failed` records with a non-empty `failure_reason` should rise from the current 0%; `no healthy upstream` error/warn records should reach 0 **while the matching runs stop reaching `run.failed`** (cross-check in the DB, so this is recovery rather than a hidden log); and a `built-in` provider failure must still produce the API `warn`.

Refs #33071
