### PR TITLE
fix(api): retain safe causes for failed activity snapshot writes

### DIFF
--- a/docs/chat-thread-activity-summary.md
+++ b/docs/chat-thread-activity-summary.md
@@ -57,6 +57,10 @@ credential-shaped argument keys are additionally redacted.
   excerpts. Keep sequence and block identity, discard oldest evidence first,
   and canonicalize object keys before hashing so JSONB ordering cannot create
   false revisions. Relevant late events can merge into the retained window.
+- Bound every projected string by code points and drop the two code points
+  PostgreSQL refuses inside a `jsonb` value: `U+0000` and unpaired surrogates.
+  Both are reachable from real tool output, and either one would otherwise
+  reject the whole snapshot write instead of the offending excerpt.
 - Merge and claim under a short row-locking transaction with a 250 ms lock
   timeout and 3 second statement timeout. Provider I/O runs outside the
   transaction. Optional capture failures cannot reject accepted execution
@@ -86,18 +90,30 @@ failed operations so they survive the default Axiom transport's `info` threshold
 The shared logger and unrelated debug filtering are unchanged. Axiom events
 retain `source: api`, the stable message, and the following nested `fields`:
 
-| Message                        | Context                | Level                                             | Safe fields besides context                                                                                |
-| ------------------------------ | ---------------------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `Activity summary cache`       | `api:activity-summary` | info                                              | `runId`, `outcome` (existing response status)                                                              |
-| `Activity summary attempt`     | `api:activity-summary` | info                                              | `runId`                                                                                                    |
-| `Activity summary completion`  | `api:activity-summary` | info on success; warn otherwise                   | `runId`, `outcome`, `durationMs`, `cooldownMs`; numeric `providerStatus` only for `OpenRouterRequestError` |
-| `Activity summary unavailable` | `api:activity-summary` | warn                                              | `runId`, `outcome: storage_failed`                                                                         |
-| `Activity snapshot capture`    | `api:run-activity`     | info for written/unchanged; warn for write_failed | `runId`, `outcome`, `eventCount`                                                                           |
-| `Activity snapshot cleanup`    | `api:run-activity`     | info on success; warn on failure                  | `outcome`, `removed`, `retentionMs`                                                                        |
+| Message                        | Context                | Level                                                                  | Safe fields besides context                                                                                |
+| ------------------------------ | ---------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `Activity summary cache`       | `api:activity-summary` | info                                                                   | `runId`, `outcome` (existing response status)                                                              |
+| `Activity summary attempt`     | `api:activity-summary` | info                                                                   | `runId`                                                                                                    |
+| `Activity summary completion`  | `api:activity-summary` | info on success; warn otherwise                                        | `runId`, `outcome`, `durationMs`, `cooldownMs`; numeric `providerStatus` only for `OpenRouterRequestError` |
+| `Activity summary unavailable` | `api:activity-summary` | warn                                                                   | `runId`, `outcome: storage_failed`                                                                         |
+| `Activity snapshot capture`    | `api:run-activity`     | info for written/unchanged and for an expected failure; warn otherwise | `runId`, `outcome`, `eventCount`; `stage` and `errorCode` on failure                                       |
+| `Activity snapshot cleanup`    | `api:run-activity`     | info on success; warn on failure                                       | `outcome`, `removed`, `retentionMs`; `errorCode` on failure                                                |
 
 Completion outcomes remain `success`, `timeout`, `provider_failure`, and
 `invalid_or_unconfigured`. A provider HTTP 429 is distinguishable by
 `fields.providerStatus: 429`; no error object or provider body is attached.
+
+A failed capture is classified into a finite set instead of one opaque
+`write_failed`. `contended` (`55P03`) and `run_missing` (`23503`) are expected
+consequences of concurrent delivery for one run, so they record at `info`;
+sustained unavailability is read by aggregating `fields.outcome`, not from a
+per-batch error level. `interrupted` (`57014`), `snapshot_missing` (the row
+vanished between the upsert and the locking read) and the residual
+`write_failed` keep `warn` because they need an owner. `fields.stage` is one of
+`admission`, `lock`, `persist` or `commit`, and `fields.errorCode` is the
+SQLSTATE class code alone — five characters, validated before it is published,
+and omitted when the driver reports no SQLSTATE. Driver messages, statement
+text, constraint details and bound parameters are never attached.
 
 Granularity is unchanged: one cache record for a request resolved without a
 claim, one attempt/completion pair per generation attempt, one unavailable
@@ -106,7 +122,8 @@ batch (including unchanged duplicates), and one cleanup record per maintenance
 operation (including zero removals). Disabled, irrelevant, and ineligible
 captures remain silent. `eventCount` counts the submitted batch, not new retained
 entries. Failed cleanup reports `removed: 0` with `outcome: failed`; that is not a
-successful empty cleanup.
+successful empty cleanup. A skipped capture still drops that batch's evidence:
+the runner already holds its `200`, and no redelivery or retry is attempted.
 
 These records never contain prompts, phrases, messages, arguments, evidence,
 credentials, database-driver errors, or provider response bodies. The tests call

--- a/docs/chat-thread-activity-summary.md
+++ b/docs/chat-thread-activity-summary.md
@@ -110,7 +110,9 @@ sustained unavailability is read by aggregating `fields.outcome`, not from a
 per-batch error level. `interrupted` (`57014`), `snapshot_missing` (the row
 vanished between the upsert and the locking read) and the residual
 `write_failed` keep `warn` because they need an owner. `fields.stage` is one of
-`admission`, `lock`, `persist` or `commit`, and `fields.errorCode` is the
+`begin`, `admission`, `lock`, `persist` or `commit`, where `begin` covers
+connection acquisition and the transaction's own timeout statements. Its
+companion `fields.errorCode` is the
 SQLSTATE class code alone — five characters, validated before it is published,
 and omitted when the driver reports no SQLSTATE. Driver messages, statement
 text, constraint details and bound parameters are never attached.

--- a/turbo/apps/api/src/lib/__tests__/pg-errors.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/pg-errors.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isForeignKeyViolation,
+  isLockNotAvailable,
+  isQueryCanceled,
+  isUniqueViolation,
+  safeSqlStateCode,
+} from "../pg-errors";
+
+// Public APIs cannot construct arbitrary database-driver failures. Route tests
+// own the end-to-end proof that the installed driver really surfaces a SQLSTATE
+// this way; this file pins the exact classification and redaction boundary.
+function driverError(code: unknown): Error {
+  return new Error("insert into run_activity_snapshots ... failed", {
+    cause: { code },
+  });
+}
+
+describe("SQLSTATE classification", () => {
+  it.each([
+    ["55P03", isLockNotAvailable],
+    ["23503", isForeignKeyViolation],
+    ["23505", isUniqueViolation],
+    ["57014", isQueryCanceled],
+  ])("matches %s only for its own predicate", (code, predicate) => {
+    expect(predicate(driverError(code))).toBeTruthy();
+    expect(
+      [
+        isLockNotAvailable,
+        isForeignKeyViolation,
+        isUniqueViolation,
+        isQueryCanceled,
+      ].filter((other) => {
+        return other(driverError(code));
+      }),
+    ).toStrictEqual([predicate]);
+  });
+});
+
+describe("safeSqlStateCode", () => {
+  it.each(["55P03", "23503", "23505", "57014", "40P01", "22P05"])(
+    "publishes the %s class code",
+    (code) => {
+      expect(safeSqlStateCode(driverError(code))).toBe(code);
+    },
+  );
+
+  it("publishes the class code alone, never the driver message", () => {
+    const code = safeSqlStateCode(driverError("23503"));
+
+    expect(code).toBe("23503");
+    expect(code).not.toContain("run_activity_snapshots");
+  });
+
+  it.each([
+    ["no cause", new Error("plain failure")],
+    ["a non-object cause", new Error("wrapped", { cause: "23503" })],
+    ["a numeric code", driverError(23_503)],
+    ["an absent code", new Error("wrapped", { cause: {} })],
+    // A transport failure carries no SQLSTATE. Publishing it as one would
+    // invent a database fault class that PostgreSQL never returned.
+    ["a transport code", driverError("ECONNRESET")],
+    ["a lowercase code", driverError("55p03")],
+    ["an over-long code", driverError("55P030")],
+  ])("drops %s", (_label, error) => {
+    expect(safeSqlStateCode(error)).toBeUndefined();
+  });
+});

--- a/turbo/apps/api/src/lib/__tests__/run-activity.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/run-activity.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import type { AgentEvent } from "../event-consumer/verify";
+import {
+  activityExcerpt,
+  activityRevision,
+  mergeActivity,
+} from "../run-activity";
+
+const NUL = String.fromCharCode(0);
+const LONE_HIGH_SURROGATE = String.fromCharCode(0xd8_3d);
+const LONE_LOW_SURROGATE = String.fromCharCode(0xde_00);
+const ASTRAL = String.fromCodePoint(0x1_f6_00);
+/**
+ * `JSON.stringify` emits a `\uXXXX` escape for `U+0000` and for an unpaired
+ * surrogate, and leaves a paired surrogate as a literal character. Those two
+ * escapes are exactly what PostgreSQL refuses when parsing a jsonb parameter.
+ */
+const REJECTED_BY_JSONB = /\\u0000|\\ud[0-9a-f]{3}/iu;
+
+function toolEvent(
+  name: string,
+  callId: string,
+  input: unknown,
+  sequenceNumber = 1,
+): AgentEvent {
+  return {
+    type: "assistant",
+    sequenceNumber,
+    message: {
+      content: [{ type: "tool_use", name, id: callId, input }],
+    },
+  };
+}
+
+describe("activityExcerpt", () => {
+  it("drops code points that PostgreSQL refuses inside jsonb", () => {
+    const excerpt = activityExcerpt(
+      `a${NUL}b${LONE_HIGH_SURROGATE}c${LONE_LOW_SURROGATE}d`,
+    );
+
+    expect(excerpt).toBe("abcd");
+    expect(JSON.stringify(excerpt)).not.toMatch(REJECTED_BY_JSONB);
+  });
+
+  it("keeps a paired surrogate intact and counts it as one code point", () => {
+    const excerpt = activityExcerpt(`${ASTRAL}tail`);
+
+    expect(excerpt).toBe(`${ASTRAL}tail`);
+  });
+
+  it("bounds long input by code points rather than UTF-16 units", () => {
+    expect(Array.from(activityExcerpt(ASTRAL.repeat(800)))).toHaveLength(700);
+  });
+});
+
+describe("mergeActivity", () => {
+  it("truncates a tool name without splitting a surrogate pair", () => {
+    const name = `${"n".repeat(99)}${ASTRAL}${"x".repeat(20)}`;
+
+    const [entry] = mergeActivity([], [toolEvent(name, "call-1", "input")]);
+
+    expect(entry?.name).toBe(`${"n".repeat(99)}${ASTRAL}`);
+    expect(JSON.stringify(entry)).not.toMatch(REJECTED_BY_JSONB);
+  });
+
+  it("truncates a call identifier without splitting a surrogate pair", () => {
+    const callId = `${"c".repeat(159)}${ASTRAL}${"x".repeat(20)}`;
+
+    const [entry] = mergeActivity([], [toolEvent("tool", callId, "input")]);
+
+    expect(entry?.callId).toBe(`${"c".repeat(159)}${ASTRAL}`);
+    expect(JSON.stringify(entry)).not.toMatch(REJECTED_BY_JSONB);
+  });
+
+  it("removes jsonb-rejected code points from projected tool arguments", () => {
+    const entries = mergeActivity(
+      [],
+      [
+        toolEvent("tool", "call-1", {
+          command: `cat${NUL}binary${LONE_HIGH_SURROGATE}`,
+        }),
+      ],
+    );
+
+    expect(JSON.stringify(entries)).not.toMatch(REJECTED_BY_JSONB);
+    expect(entries[0]?.excerpt).toContain("catbinary");
+  });
+
+  it("is idempotent for a repeated batch so a failed write can be replayed", () => {
+    const events = [
+      toolEvent("tool", "call-1", "first", 1),
+      toolEvent("tool", "call-2", "second", 2),
+    ];
+
+    const once = mergeActivity([], events);
+    const twice = mergeActivity(once, events);
+
+    expect(twice).toStrictEqual(once);
+    expect(activityRevision(twice)).toBe(activityRevision(once));
+  });
+});

--- a/turbo/apps/api/src/lib/pg-errors.ts
+++ b/turbo/apps/api/src/lib/pg-errors.ts
@@ -1,6 +1,9 @@
 const PG_FOREIGN_KEY_VIOLATION = "23503";
 const PG_LOCK_NOT_AVAILABLE = "55P03";
+const PG_QUERY_CANCELED = "57014";
 const PG_UNIQUE_VIOLATION = "23505";
+/** SQLSTATE is a fixed five-character class code; longer driver text is not. */
+const SQL_STATE_PATTERN = /^[0-9A-Z]{5}$/u;
 
 function pgErrorCode(error: unknown): unknown {
   if (!(error instanceof Error)) {
@@ -23,6 +26,22 @@ export function isLockNotAvailable(error: unknown): boolean {
   return pgErrorCode(error) === PG_LOCK_NOT_AVAILABLE;
 }
 
+export function isQueryCanceled(error: unknown): boolean {
+  return pgErrorCode(error) === PG_QUERY_CANCELED;
+}
+
 export function isUniqueViolation(error: unknown): boolean {
   return pgErrorCode(error) === PG_UNIQUE_VIOLATION;
+}
+
+/**
+ * The SQLSTATE class code alone, for diagnostics that must never carry driver
+ * messages, statements or bound parameters. Anything that is not exactly a
+ * five-character code is dropped rather than published.
+ */
+export function safeSqlStateCode(error: unknown): string | undefined {
+  const code = pgErrorCode(error);
+  return typeof code === "string" && SQL_STATE_PATTERN.test(code)
+    ? code
+    : undefined;
 }

--- a/turbo/apps/api/src/lib/run-activity.ts
+++ b/turbo/apps/api/src/lib/run-activity.ts
@@ -27,7 +27,8 @@ function record(value: unknown): Record<string, unknown> {
 function boundedText(value: string, limit: number): string {
   return Array.from(value)
     .filter((character) => {
-      const code = character.codePointAt(0) ?? 0;
+      // `Array.from` yields one non-empty code point per element.
+      const code = character.codePointAt(0)!;
       return code !== 0 && (code < 0xd8_00 || code > 0xdf_ff);
     })
     .slice(0, limit)

--- a/turbo/apps/api/src/lib/run-activity.ts
+++ b/turbo/apps/api/src/lib/run-activity.ts
@@ -8,6 +8,8 @@ import type { AgentEvent } from "./event-consumer/verify";
 const ACTIVITY_ENTRY_LIMIT = 16;
 const ACTIVITY_BYTE_LIMIT = 16 * 1024;
 const ACTIVITY_EXCERPT_LIMIT = 700;
+const ACTIVITY_NAME_LIMIT = 100;
+const ACTIVITY_CALL_ID_LIMIT = 160;
 export const ACTIVITY_RETENTION_MS = 24 * 60 * 60 * 1000;
 
 function record(value: unknown): Record<string, unknown> {
@@ -15,8 +17,24 @@ function record(value: unknown): Record<string, unknown> {
     ? (value as Record<string, unknown>)
     : {};
 }
+/**
+ * Bound a projected string by code points, dropping the two code points that
+ * PostgreSQL refuses inside a `jsonb` value: `U+0000` and unpaired surrogates.
+ * Both are reachable from real tool output, and either one would reject the
+ * whole snapshot write rather than the offending excerpt. Iterating by code
+ * point also keeps truncation from splitting a surrogate pair into one.
+ */
+function boundedText(value: string, limit: number): string {
+  return Array.from(value)
+    .filter((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code !== 0 && (code < 0xd8_00 || code > 0xdf_ff);
+    })
+    .slice(0, limit)
+    .join("");
+}
 export function activityExcerpt(value: string): string {
-  return Array.from(value).slice(0, ACTIVITY_EXCERPT_LIMIT).join("");
+  return boundedText(value, ACTIVITY_EXCERPT_LIMIT);
 }
 function text(value: unknown): string {
   return typeof value === "string" ? activityExcerpt(value) : "";
@@ -102,8 +120,8 @@ function projectEvent(event: AgentEvent): RunActivityEntry[] {
         sequence: event.sequenceNumber,
         index,
         kind,
-        name: text(name).slice(0, 100),
-        callId: text(callId).slice(0, 160),
+        name: boundedText(text(name), ACTIVITY_NAME_LIMIT),
+        callId: boundedText(text(callId), ACTIVITY_CALL_ID_LIMIT),
         excerpt: content,
       });
       if (entries.length > ACTIVITY_ENTRY_LIMIT) {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
@@ -397,6 +397,57 @@ describe("thread activity summary", () => {
     expect(inputs).toHaveLength(1);
   });
 
+  it("retains activity for tool output PostgreSQL cannot store verbatim", async () => {
+    const f = await fixture();
+    const inputs = provider();
+    const diagnostics = captureDiagnostics();
+    // A runtime can emit a NUL byte or a lone surrogate through a tool
+    // argument, and a long tool name can end mid surrogate pair. PostgreSQL
+    // rejects every one of those while parsing the jsonb value, which would
+    // otherwise drop the whole batch rather than the offending characters.
+    const astral = String.fromCodePoint(0x1_f6_00);
+    await deliver(f, [
+      {
+        type: "assistant",
+        sequenceNumber: 0,
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: `call-0${astral}`,
+              name: `${"n".repeat(99)}${astral}${"tail".repeat(20)}`,
+              input: {
+                command: `read${String.fromCharCode(0)}binary${String.fromCharCode(0xd8_3d)}`,
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    await expect(summarize(f.actor, f.run)).resolves.toMatchObject({
+      status: "fresh",
+      messages: [
+        {
+          id: "Preparing the launch checklist",
+          text: "Preparing the launch checklist",
+        },
+      ],
+    });
+    expect(inputs).toHaveLength(1);
+    await expect(diagnostics()).resolves.toContainEqual(
+      expect.objectContaining({
+        level: "info",
+        message: "Activity snapshot capture",
+        fields: {
+          context: "api:run-activity",
+          runId: f.run.runId,
+          outcome: "written",
+          eventCount: 1,
+        },
+      }),
+    );
+  });
+
   it("rejects queued and superseded run identities before cached or model output", async () => {
     const f = await fixture();
     const inputs = provider();

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
@@ -956,7 +956,7 @@ describe("thread activity summary", () => {
     expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
   });
 
-  it("keeps normal publication working when snapshot writes fail and excludes expired evidence", async () => {
+  it("keeps normal publication working when a contended snapshot write is skipped and excludes expired evidence", async () => {
     const f = await fixture();
     const inputs = provider();
     await summarize(f.actor, f.run);
@@ -985,15 +985,20 @@ describe("thread activity summary", () => {
       status: "unavailable",
       messages: [],
     });
-    await expect(diagnostics()).resolves.toStrictEqual([
+    const records = await diagnostics();
+    // A concurrent writer for the same run is expected delivery behavior, so the
+    // capture stays below warn while the adjacent real failure keeps its level.
+    expect(records).toStrictEqual([
       expect.objectContaining({
-        level: "warn",
+        level: "info",
         message: "Activity snapshot capture",
         fields: {
           context: "api:run-activity",
           runId: f.run.runId,
-          outcome: "write_failed",
+          outcome: "contended",
           eventCount: 1,
+          stage: "lock",
+          errorCode: "55P03",
         },
       }),
       expect.objectContaining({
@@ -1006,6 +1011,13 @@ describe("thread activity summary", () => {
         },
       }),
     ]);
+    // The classification adds a SQLSTATE class code and nothing else: no driver
+    // message, no statement text and no bound evidence.
+    expect(JSON.stringify(records)).not.toContain("lock_timeout");
+    expect(JSON.stringify(records)).not.toContain("run_activity_snapshots");
+    expect(JSON.stringify(records)).not.toContain(
+      "Normal message survives the optional failure",
+    );
     held.release();
     await held.done;
     const page = await chat.listThreadEvents(f.actor, f.run.threadId);

--- a/turbo/apps/api/src/signals/services/run-activity-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/run-activity-snapshot.service.ts
@@ -7,6 +7,12 @@ import { and, asc, eq, getTableColumns, inArray, lte, sql } from "drizzle-orm";
 import { eventConsumerPayload$ } from "../../lib/event-consumer/route";
 import { logger } from "../../lib/log";
 import {
+  isForeignKeyViolation,
+  isLockNotAvailable,
+  isQueryCanceled,
+  safeSqlStateCode,
+} from "../../lib/pg-errors";
+import {
   ACTIVITY_RETENTION_MS,
   activityRevision,
   mergeActivity,
@@ -17,6 +23,43 @@ import { chatThreadOrganizationCondition } from "./chat-thread-organization.serv
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 
 const log = logger("api:run-activity");
+/** The snapshot row disappeared between the upsert and the locking read. */
+const SNAPSHOT_MISSING = "Activity snapshot missing after insert";
+/** Where the transaction stood when it failed. Finite and content-free. */
+type CaptureStage = "admission" | "lock" | "persist" | "commit";
+/**
+ * Failure classes worth separating in production. `contended` and `run_missing`
+ * are expected outcomes of concurrent delivery, not defects; everything else
+ * keeps an actionable level and carries its SQLSTATE class code.
+ */
+type CaptureFailure =
+  | "contended"
+  | "run_missing"
+  | "interrupted"
+  | "snapshot_missing"
+  | "write_failed";
+
+function captureFailure(error: unknown): CaptureFailure {
+  if (isLockNotAvailable(error)) {
+    return "contended";
+  }
+  if (isForeignKeyViolation(error)) {
+    return "run_missing";
+  }
+  if (isQueryCanceled(error)) {
+    return "interrupted";
+  }
+  if (error instanceof Error && error.message === SNAPSHOT_MISSING) {
+    return "snapshot_missing";
+  }
+  return "write_failed";
+}
+
+/** Concurrent delivery for one run is normal; only real faults need a level. */
+function isExpectedFailure(failure: CaptureFailure): boolean {
+  return failure === "contended" || failure === "run_missing";
+}
+
 export const activityClock = sql`(statement_timestamp() AT TIME ZONE 'UTC')`;
 const activityExpiry = sql`${activityClock} + interval '24 hours'`;
 export type ActivityTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
@@ -85,7 +128,7 @@ export async function lockActivitySnapshot(tx: ActivityTx, runId: string) {
     .where(eq(runActivitySnapshots.runId, runId))
     .for("update");
   if (!row) {
-    throw new Error("Activity snapshot missing after insert");
+    throw new Error(SNAPSHOT_MISSING);
   }
   return row;
 }
@@ -94,6 +137,7 @@ export const captureRunActivity$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const payload = get(eventConsumerPayload$);
     const db = set(writeDb$);
+    let stage: CaptureStage = "admission";
     const outcome = await settleIncludingAbort(
       activityTransaction(db, async (tx) => {
         const [run] = await tx
@@ -126,6 +170,7 @@ export const captureRunActivity$ = command(
           return "irrelevant";
         }
         signal.throwIfAborted();
+        stage = "lock";
         const row = await lockActivitySnapshot(tx, payload.runId);
         const expired = row.expiresAt <= row.clock;
         const entries = mergeActivity(
@@ -136,6 +181,7 @@ export const captureRunActivity$ = command(
         if (!expired && revision === row.activityRevision) {
           return "unchanged";
         }
+        stage = "persist";
         await tx
           .update(runActivitySnapshots)
           .set({
@@ -156,6 +202,7 @@ export const captureRunActivity$ = command(
               : {}),
           })
           .where(eq(runActivitySnapshots.runId, payload.runId));
+        stage = "commit";
         return "written";
       }),
     );
@@ -166,13 +213,26 @@ export const captureRunActivity$ = command(
     ) {
       return { status: 200 };
     }
+    if (outcome.ok) {
+      log.info("Activity snapshot capture", {
+        runId: payload.runId,
+        outcome: outcome.value,
+        eventCount: payload.events.length,
+      });
+      return { status: 200 };
+    }
     // Never attach a database error: driver messages can include bound evidence.
+    // The SQLSTATE class code and the stage carry no content and stay.
+    const failure = captureFailure(outcome.error);
+    const errorCode = safeSqlStateCode(outcome.error);
     const capture = {
       runId: payload.runId,
-      outcome: outcome.ok ? outcome.value : "write_failed",
+      outcome: failure,
       eventCount: payload.events.length,
+      stage,
+      ...(errorCode === undefined ? {} : { errorCode }),
     };
-    if (outcome.ok) {
+    if (isExpectedFailure(failure)) {
       log.info("Activity snapshot capture", capture);
     } else {
       log.warn("Activity snapshot capture", capture);
@@ -223,15 +283,20 @@ export const cleanupExpiredRunActivity$ = command(
       }),
     );
     signal.throwIfAborted();
-    const cleanup = {
-      outcome: outcome.ok ? "success" : "failed",
-      removed: outcome.ok ? outcome.value : 0,
-      retentionMs: ACTIVITY_RETENTION_MS,
-    };
     if (outcome.ok) {
-      log.info("Activity snapshot cleanup", cleanup);
-    } else {
-      log.warn("Activity snapshot cleanup", cleanup);
+      log.info("Activity snapshot cleanup", {
+        outcome: "success",
+        removed: outcome.value,
+        retentionMs: ACTIVITY_RETENTION_MS,
+      });
+      return;
     }
+    const errorCode = safeSqlStateCode(outcome.error);
+    log.warn("Activity snapshot cleanup", {
+      outcome: "failed",
+      removed: 0,
+      retentionMs: ACTIVITY_RETENTION_MS,
+      ...(errorCode === undefined ? {} : { errorCode }),
+    });
   },
 );

--- a/turbo/apps/api/src/signals/services/run-activity-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/run-activity-snapshot.service.ts
@@ -25,8 +25,12 @@ import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 const log = logger("api:run-activity");
 /** The snapshot row disappeared between the upsert and the locking read. */
 const SNAPSHOT_MISSING = "Activity snapshot missing after insert";
-/** Where the transaction stood when it failed. Finite and content-free. */
-type CaptureStage = "admission" | "lock" | "persist" | "commit";
+/**
+ * Where the transaction stood when it failed. Finite and content-free. `begin`
+ * covers connection acquisition and the transaction's own timeout statements,
+ * which run before any of this command's work.
+ */
+type CaptureStage = "begin" | "admission" | "lock" | "persist" | "commit";
 /**
  * Failure classes worth separating in production. `contended` and `run_missing`
  * are expected outcomes of concurrent delivery, not defects; everything else
@@ -137,9 +141,10 @@ export const captureRunActivity$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const payload = get(eventConsumerPayload$);
     const db = set(writeDb$);
-    let stage: CaptureStage = "admission";
+    let stage: CaptureStage = "begin";
     const outcome = await settleIncludingAbort(
       activityTransaction(db, async (tx) => {
+        stage = "admission";
         const [run] = await tx
           .select({
             threadId: agentRuns.chatThreadId,


### PR DESCRIPTION
Closes #33091

## Problem

A failed activity snapshot capture recorded only `outcome: write_failed`, so
every failure class collapsed into one opaque signal. Lock contention, a run
deleted mid-flight, a cancelled statement and a genuine persistence fault were
indistinguishable in production, and all of them were reported at `warn`.

Production evidence (`vm0-web-logs-prod`, `fields.context: "api:run-activity"`):

- `2026-09-09T15:07:25.085Z` and `2026-09-10T01:39:48.964Z`, both
  `eventCount: 1`, `pdx1`, deployments `dpl_33ZrJJoo7ptYumLYJfQyRzfh2ryy` and
  `dpl_GAdSRp1VGGB3kFQeM4BgZnu26iM1`.
- The first `api:run-activity` record is `2026-09-09T14:15:24.689Z`, so the
  observed window is roughly 12 hours: **2 failures in 56,188 records**. The
  issue's "1 record in 24 hours" covered only ~1h45m of the feature's logging.
- In `[15:00Z, 16:00Z)` alone, 9,794 captures fell into 6,570 `(runId, 1s)`
  buckets and **2,426 of them (37%) held two or more captures for the same run
  in the same second**. With `lock_timeout = 250ms`, overlapping row locks for
  one run are routine.
- Each failure was followed by a successful capture for the same run 0.243 s and
  0.313 s later.

The failures are not cancellations: `signal.throwIfAborted()` runs before the
log, and the only in-transaction abort source is that same signal, so a logged
failure is always a real rejection from `activityTransaction`.

## What this changes

**Classification.** `captureFailure` maps the rejection to a finite set.
`contended` (`55P03`) and `run_missing` (`23503`) are expected consequences of
concurrent delivery for one run, so they record at `info` — matching the
existing precedents in `agent-webhook-events.service.ts`, which already logs
`Required database run output projection backpressured` at `info` for `55P03`
and ignores a deleted run for `23503`. `interrupted` (`57014`),
`snapshot_missing` and the residual `write_failed` keep `warn` because they need
an owner. Sustained unavailability is read by aggregating `fields.outcome`, not
from a per-batch error level.

**Safe diagnostics.** `safeSqlStateCode` publishes the SQLSTATE class code
alone, validated against `/^[0-9A-Z]{5}$/` so a non-conforming driver value is
dropped rather than emitted. `fields.stage` (`admission` / `lock` / `persist` /
`commit`) reports how far the transaction got. Driver messages, statement text,
constraint details and bound parameters are still never attached.

**A real defect in the projection.** `name` and `callId` were truncated with
`String.prototype.slice`, which can split a surrogate pair and leave an unpaired
surrogate, and excerpts were never filtered for `U+0000`. PostgreSQL rejects
both while parsing a jsonb parameter, which fails the entire snapshot write
rather than the offending excerpt — and both are reachable from real tool
output. Every projected string is now bounded by code points with those two
code points dropped.

This is deliberately the diagnostic step. A bounded retry for `contended` is a
separate decision, to be made once a day of classified production data shows
whether contention actually dominates; `mergeActivity` idempotency (now covered
by a test) is the precondition for it.

## Behavior that is unchanged

The endpoint still returns `200`; an optional consumer cannot reject accepted
execution events or suppress normal message publication. `Activity summary
unavailable` / `storage_failed` and the `unavailable` response keep their
meaning. Log messages are unchanged, so the `api/no-logger-info` allowlist needs
no edit. No schema, migration or feature-switch change.

## Verification

Run locally against a local PostgreSQL 18:

- `vitest --run apps/api/src/lib/__tests__/run-activity.test.ts` — 7 passed
  (code-point truncation, `U+0000` and unpaired-surrogate removal, no
  jsonb-rejected escape survives, `mergeActivity` idempotency).
- `vitest --run apps/api/src/lib/__tests__/pg-errors.test.ts` — 18 passed
  (exact SQLSTATE classification; class code published without driver text;
  numeric, lowercase, over-long, absent and transport codes all dropped).
- `oxlint --deny-warnings` and `eslint --max-warnings 0` on the changed files —
  clean.
- `pnpm run check-types`: `deps`, `boundaries`, `gateways`, `core` and `tests`
  passed; `bootstrap-wiring` had not finished locally when this PR was opened.

Not run locally: `apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts`.
That suite fails identically on unmodified `main` in this environment
(`claimRunnerJob` → 404 "Job not found in queue"), so it needs setup this
sandbox lacks. Its updated expectation — `info` / `contended` / `stage: "lock"`
/ `errorCode: "55P03"` through the real endpoint, plus assertions that no
driver text, statement text or message content reaches the record, and that the
adjacent `Activity summary unavailable` warn is untouched — is verified by CI,
not by me.

## Production acceptance (after release, controller-owned)

Baseline: 2 `write_failed` in 56,188 records over
`2026-09-09T14:15:24Z–2026-09-10T02:14:39Z`. After deployment, over ≥12 hours
and ≥40,000 capture records: every failure carries a classification, no
`write_failed` remains without an `errorCode`, `warn` volume drops but does not
reach zero, and an APL check confirms `fields` holds exactly the documented key
set.
