### PR TITLE
fix: preflight pending artifact registrations before full verification

### DIFF
--- a/.github/workflows/public-artifact-registration.yml
+++ b/.github/workflows/public-artifact-registration.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: "Inventory, backfill then independently verify, or verify only"
+        description: "Inventory, backfill, verify, or inspect pending multipart uploads"
         type: choice
-        options: [dry-run, migrate, verify]
+        options: [dry-run, migrate, verify, multipart-check]
         default: dry-run
         required: true
       max_objects:
@@ -58,7 +58,32 @@ jobs:
           corepack enable pnpm
           pnpm install --frozen-lockfile --ignore-scripts --filter @okouai/db...
 
+      # Verify the cheap multipart gate before resolving the DB or scanning all
+      # objects. Final verification still checks it again before its last scan.
+      - name: Check pending public multipart registrations
+        if: inputs.mode == 'verify' || inputs.mode == 'multipart-check'
+        working-directory: turbo/packages/db
+        env:
+          REGISTRATION_LIMIT: ${{ inputs.max_objects }}
+          REGISTRATION_CONCURRENCY: ${{ inputs.concurrency }}
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
+          R2_USER_ARTIFACTS_BUCKET_NAME: ${{ vars.R2_USER_ARTIFACTS_BUCKET_NAME }}
+          R2_USER_ARTIFACTS_ACCESS_KEY_ID: ${{ secrets.R2_USER_ARTIFACTS_ACCESS_KEY_ID }}
+          R2_USER_ARTIFACTS_SECRET_ACCESS_KEY: ${{ secrets.R2_USER_ARTIFACTS_SECRET_ACCESS_KEY }}
+          R2_HOSTED_SITES_BUCKET_NAME: ${{ vars.R2_HOSTED_SITES_BUCKET_NAME }}
+          R2_HOSTED_SITES_ACCESS_KEY_ID: ${{ secrets.R2_HOSTED_SITES_ACCESS_KEY_ID }}
+          R2_HOSTED_SITES_SECRET_ACCESS_KEY: ${{ secrets.R2_HOSTED_SITES_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          test "$R2_USER_ARTIFACTS_BUCKET_NAME" = "user-artifact-prod"
+          test "$R2_HOSTED_SITES_BUCKET_NAME" = "vm0-hosted-sites"
+          pnpm exec tsx scripts/migrations/014-public-artifact-registration/multipart.ts \
+            --max-objects "$REGISTRATION_LIMIT" \
+            --concurrency "$REGISTRATION_CONCURRENCY" \
+            --report public-artifact-registration-multipart.json
+
       - name: Resolve protected production database
+        if: inputs.mode != 'multipart-check'
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
           NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
@@ -126,6 +151,7 @@ jobs:
       # creates metadata only; it cannot write completion markers or change
       # privateArtifacts, DNS, Worker routes, cache rules or artifact bytes.
       - name: Register or verify historical public artifacts
+        if: inputs.mode != 'multipart-check'
         working-directory: turbo/packages/db
         env:
           REGISTRATION_MODE: ${{ inputs.mode }}
@@ -171,6 +197,7 @@ jobs:
         with:
           name: public-artifact-registration-${{ github.run_id }}
           path: |
+            turbo/packages/db/public-artifact-registration-multipart.json
             turbo/packages/db/public-artifact-registration.json
             turbo/packages/db/public-artifact-registration-verification.json
           if-no-files-found: ignore

--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/README.md
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/README.md
@@ -55,6 +55,9 @@ Never point this inventory at the private-artifact bucket.
 Run from `turbo/packages/db`:
 
 ```bash
+# Check pending multipart registrations without scanning objects or using the DB.
+pnpm exec tsx scripts/migrations/014-public-artifact-registration/multipart.ts --report multipart.json
+
 # Default: two read-only inventories, DB reconciliation and conflict report.
 pnpm exec tsx scripts/migrations/014-public-artifact-registration/backfill.ts --report inventory.json
 
@@ -70,6 +73,23 @@ pnpm exec tsx scripts/migrations/014-public-artifact-registration/backfill.ts --
 
 `--migrate` always performs exact read-back; `--verify` also permits independent
 read-only verification.
+
+The standalone multipart command uses only the R2 environment variables above;
+it does not need `DATABASE_URL`. It lists pending uploads and reads their frozen
+v1 registry records. It writes an aggregate report before exiting: zero for a
+clear multipart gate, one for unregistered sessions. Both outcomes have
+`verified: false` and `finalized: false`; this preflight cannot establish full
+object coverage. Invalid registrations, incomplete pagination or storage errors
+also fail the command. It accepts no migration, verification or finalization
+flags and never writes storage, completes uploads or aborts parts.
+
+The report includes the scan interval, pending/unregistered counts, oldest and
+newest unregistered initiation times, and a count of sessions whose optional
+initiation time is absent. It contains no object keys, upload IDs or filenames.
+Missing initiation times stay unknown; a present invalid timestamp fails the
+check. Consult the actual bucket lifecycle separately before estimating expiry.
+Age alone does not prove storage has aborted a session, so recheck the live
+multipart gate before scheduling full verification.
 
 Every pass is paginated and limited to 100,000 objects per bucket by default;
 `--max-objects` can explicitly raise that bound. Production already exceeds this
@@ -128,8 +148,18 @@ click-only records and later optional pointer/typing fields are recognized.
    Its artifact preserves `public-artifact-registration.json` for the backfill
    and `public-artifact-registration-verification.json` for the independent pass,
    including the first report if the second pass fails. The `verify` mode remains
-   available for a standalone read-only run. All modes use production R2 credentials
-   and read-only Neon queries and never pass `--finalize`. Accept coverage only
+   available for a standalone read-only run. It first checks multipart registrations
+   before resolving the database or scanning objects. The explicit `multipart-check`
+   mode runs only that same preflight, preserving
+   `public-artifact-registration-multipart.json` even when sessions block it.
+   It never resolves the production database or starts the historical inventory.
+   A clear preflight still requires the full independent pass, including the
+   original multipart check immediately before its final object inventory; the
+   early check does not replace this race boundary. The historical `dry-run` and
+   `migrate` modes keep their existing sequence, so a pending upload cannot stop
+   an authorized backfill of already-completed objects before its writes.
+   All modes use production R2 credentials; full inventories also use read-only
+   Neon queries. No workflow mode passes `--finalize`. Accept coverage only
    with zero missing, conflicting or unclassified records and zero unregistered
    pending multipart uploads.
 3. Review the separate `a.okou.io` delivery cutover (#32959) after coverage is

--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/backfill.ts
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/backfill.ts
@@ -5,13 +5,13 @@ import { pathToFileURL } from "node:url";
 import {
   GetObjectCommand,
   HeadObjectCommand,
-  ListMultipartUploadsCommand,
   ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
 import postgres from "postgres";
 import { forEachConcurrent } from "./concurrent";
+import { pendingMultipartRegistrations } from "./multipart";
 import { resolveLegacyClickTrackContentType } from "./legacy-click-track";
 // Frozen v1 format: numbered data migrations must remain runnable after app
 // contracts evolve. Only confirmed historical Public records are constructed.
@@ -118,74 +118,6 @@ function objectRecord(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value))
     throw new Error("Invalid historical pointer or manifest");
   return value as Record<string, unknown>;
-}
-
-async function pendingMultipartRegistrations(
-  publicClient: S3Client,
-  hostedClient: S3Client,
-  options: Options,
-) {
-  let keyMarker: string | undefined;
-  let uploadIdMarker: string | undefined;
-  let pending = 0;
-  let unregistered = 0;
-  do {
-    const page = await publicClient.send(
-      new ListMultipartUploadsCommand({
-        Bucket: options.publicBucket,
-        Prefix: "artifacts/",
-        MaxUploads: 1000,
-        KeyMarker: keyMarker,
-        UploadIdMarker: uploadIdMarker,
-      }),
-    );
-    await forEachConcurrent(
-      page.Uploads ?? [],
-      options.concurrency ?? 16,
-      async (upload) => {
-        const key = upload.Key;
-        if (!key?.startsWith("artifacts/") || !upload.UploadId)
-          throw new Error("Invalid pending multipart upload identity");
-        if (++pending > options.maxObjects)
-          throw new Error("Pending multipart upload inventory limit reached");
-        const value = await readJson(
-          hostedClient,
-          options.hostedBucket,
-          artifactDeliveryKey("vm0", "file", key.slice("artifacts/".length)),
-        );
-        if (value === undefined) {
-          unregistered++;
-          return;
-        }
-        const record = objectRecord(value);
-        if (
-          record.version !== 1 ||
-          record.kind !== "legacy-file" ||
-          record.audience !== "public" ||
-          record.key !== key ||
-          (record.publicBrand !== "vm0" && record.publicBrand !== "okou") ||
-          typeof record.filename !== "string" ||
-          !record.filename ||
-          typeof record.contentType !== "string" ||
-          !record.contentType
-        )
-          throw new Error("Pending multipart upload registration is invalid");
-      },
-    );
-    if (
-      page.IsTruncated &&
-      (!page.NextKeyMarker ||
-        !page.NextUploadIdMarker ||
-        (page.NextKeyMarker === keyMarker &&
-          page.NextUploadIdMarker === uploadIdMarker))
-    )
-      throw new Error("Pending multipart upload pagination is incomplete");
-    keyMarker = page.IsTruncated ? page.NextKeyMarker : undefined;
-    uploadIdMarker = page.IsTruncated ? page.NextUploadIdMarker : undefined;
-  } while (keyMarker);
-  options.onProgress?.("pending-multipart-uploads", pending);
-  options.onProgress?.("unregistered-multipart-uploads", unregistered);
-  return { pending, unregistered };
 }
 
 function stringField(value: Record<string, unknown>, key: string): string {

--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/multipart.test.ts
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/multipart.test.ts
@@ -1,0 +1,218 @@
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  GetObjectCommand,
+  ListMultipartUploadsCommand,
+  S3Client,
+  type MultipartUpload,
+} from "@aws-sdk/client-s3";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { runMultipartPreflight } from "./multipart";
+
+const directories: string[] = [];
+
+beforeEach(() => {
+  vi.stubEnv("DATABASE_URL", undefined);
+  vi.stubEnv("R2_ACCOUNT_ID", "test-account");
+  vi.stubEnv("R2_USER_ARTIFACTS_BUCKET_NAME", "public");
+  vi.stubEnv("R2_USER_ARTIFACTS_ACCESS_KEY_ID", "test-public-id");
+  vi.stubEnv("R2_USER_ARTIFACTS_SECRET_ACCESS_KEY", "test-public-secret");
+  vi.stubEnv("R2_HOSTED_SITES_BUCKET_NAME", "hosted");
+  vi.stubEnv("R2_HOSTED_SITES_ACCESS_KEY_ID", "test-hosted-id");
+  vi.stubEnv("R2_HOSTED_SITES_SECRET_ACCESS_KEY", "test-hosted-secret");
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  await Promise.all(
+    directories.splice(0).map((directory) => {
+      return rm(directory, { recursive: true, force: true });
+    }),
+  );
+});
+
+async function fixture() {
+  const directory = await mkdtemp(join(tmpdir(), "multipart-preflight-"));
+  directories.push(directory);
+  const reportPath = join(directory, "report.json");
+  const uploads: MultipartUpload[] = [];
+  const records = new Map<string, string>();
+  const sender: {
+    send(
+      command: GetObjectCommand | ListMultipartUploadsCommand,
+    ): Promise<unknown>;
+  } = S3Client.prototype;
+  const send = vi.spyOn(sender, "send").mockImplementation(async (command) => {
+    if (command instanceof ListMultipartUploadsCommand) {
+      if (
+        command.input.Bucket !== "public" ||
+        command.input.Prefix !== "artifacts/"
+      )
+        throw new Error("Unexpected multipart namespace");
+      const offset = command.input.KeyMarker
+        ? uploads.findIndex((upload) => {
+            return (
+              upload.Key === command.input.KeyMarker &&
+              upload.UploadId === command.input.UploadIdMarker
+            );
+          }) + 1
+        : 0;
+      const upload = uploads[offset];
+      const truncated = offset + 1 < uploads.length;
+      return {
+        Uploads: upload ? [upload] : [],
+        IsTruncated: truncated,
+        NextKeyMarker: truncated ? upload?.Key : undefined,
+        NextUploadIdMarker: truncated ? upload?.UploadId : undefined,
+      };
+    }
+    if (command instanceof GetObjectCommand) {
+      if (command.input.Bucket !== "hosted" || !command.input.Key)
+        throw new Error("Unexpected registration namespace");
+      const body = records.get(command.input.Key);
+      if (body === undefined)
+        throw Object.assign(new Error("Missing registration"), {
+          name: "NoSuchKey",
+        });
+      return {
+        Body: {
+          transformToString: async () => {
+            return body;
+          },
+        },
+      };
+    }
+    // The standalone command has no reason to read file bytes or write storage.
+    throw new Error("Unexpected storage operation");
+  });
+  return { reportPath, uploads, records, send };
+}
+
+function registeredUpload(key: string) {
+  return JSON.stringify({
+    version: 1,
+    kind: "legacy-file",
+    audience: "public",
+    publicBrand: "okou",
+    key,
+    filename: "private-user-filename.mp4",
+    contentType: "video/mp4",
+  });
+}
+
+test("blocked preflight writes aggregate initiation evidence without a database", async () => {
+  const f = await fixture();
+  f.uploads.push(
+    {
+      Key: "artifacts/newer.mp4",
+      UploadId: "newer-secret-upload",
+      Initiated: new Date("2026-09-09T12:00:00Z"),
+    },
+    {
+      Key: "artifacts/older.mp4",
+      UploadId: "older-secret-upload",
+      Initiated: new Date("2026-09-08T12:00:00Z"),
+    },
+    { Key: "artifacts/unknown.mp4", UploadId: "unknown-secret-upload" },
+    {
+      Key: "artifacts/registered.mp4",
+      UploadId: "registered-secret-upload",
+      Initiated: new Date("2026-09-10T12:00:00Z"),
+    },
+  );
+  f.records.set(
+    "artifact-delivery/files/registered.mp4.json",
+    registeredUpload("artifacts/registered.mp4"),
+  );
+  expect(
+    await runMultipartPreflight([
+      "--report",
+      f.reportPath,
+      "--concurrency",
+      "2",
+    ]),
+  ).toBe(1);
+  const body = await readFile(f.reportPath, "utf8");
+  expect(JSON.parse(body)).toMatchObject({
+    kind: "multipart-preflight",
+    status: "blocked",
+    startedAt: expect.any(String),
+    completedAt: expect.any(String),
+    pendingMultipartUploads: 4,
+    unregisteredMultipartUploads: 3,
+    oldestUnregisteredInitiatedAt: "2026-09-08T12:00:00.000Z",
+    newestUnregisteredInitiatedAt: "2026-09-09T12:00:00.000Z",
+    unregisteredWithUnknownInitiationTime: 1,
+    verified: false,
+    finalized: false,
+  });
+  for (const upload of f.uploads) {
+    expect(body).not.toContain(upload.Key);
+    expect(body).not.toContain(upload.UploadId);
+  }
+  expect(body).not.toContain("private-user-filename");
+});
+
+test.each([false, true])(
+  "clear preflight permits full verification without claiming coverage (pending=%s)",
+  async (pending) => {
+    const f = await fixture();
+    if (pending) {
+      f.uploads.push(
+        { Key: "artifacts/registered.mp4", UploadId: "upload-1" },
+        { Key: "artifacts/registered.mp4", UploadId: "upload-2" },
+      );
+      f.records.set(
+        "artifact-delivery/files/registered.mp4.json",
+        registeredUpload("artifacts/registered.mp4"),
+      );
+    }
+    expect(await runMultipartPreflight(["--report", f.reportPath])).toBe(0);
+    expect(JSON.parse(await readFile(f.reportPath, "utf8"))).toMatchObject({
+      status: "clear",
+      pendingMultipartUploads: pending ? 2 : 0,
+      unregisteredMultipartUploads: 0,
+      oldestUnregisteredInitiatedAt: null,
+      newestUnregisteredInitiatedAt: null,
+      unregisteredWithUnknownInitiationTime: 0,
+      verified: false,
+      finalized: false,
+    });
+  },
+);
+
+test.each([
+  registeredUpload("artifacts/wrong.mp4"),
+  JSON.stringify({ kind: "publication", audience: "private" }),
+  "malformed user metadata: sensitive filename",
+])("invalid registration cannot clear the gate", async (record) => {
+  const f = await fixture();
+  f.uploads.push({ Key: "artifacts/test.mp4", UploadId: "upload-1" });
+  f.records.set("artifact-delivery/files/test.mp4.json", record);
+  await expect(
+    runMultipartPreflight(["--report", f.reportPath]),
+  ).rejects.toThrow(/registration.*invalid/);
+  await expect(stat(f.reportPath)).rejects.toMatchObject({ code: "ENOENT" });
+});
+
+test("partial multipart listing cannot produce a clear report", async () => {
+  const f = await fixture();
+  f.send.mockResolvedValue({ Uploads: [], IsTruncated: true });
+  await expect(
+    runMultipartPreflight(["--report", f.reportPath]),
+  ).rejects.toThrow("multipart upload pagination is incomplete");
+  await expect(stat(f.reportPath)).rejects.toMatchObject({ code: "ENOENT" });
+});
+
+test.each(["--migrate", "--verify", "--finalize"])(
+  "the standalone read-only parser rejects %s",
+  async (flag) => {
+    const f = await fixture();
+    await expect(
+      runMultipartPreflight([flag, "--report", f.reportPath]),
+    ).rejects.toThrow("Unknown option");
+    await expect(stat(f.reportPath)).rejects.toMatchObject({ code: "ENOENT" });
+  },
+);

--- a/turbo/packages/db/scripts/migrations/014-public-artifact-registration/multipart.ts
+++ b/turbo/packages/db/scripts/migrations/014-public-artifact-registration/multipart.ts
@@ -1,0 +1,218 @@
+import { writeFile } from "node:fs/promises";
+import { parseArgs } from "node:util";
+import { pathToFileURL } from "node:url";
+import {
+  GetObjectCommand,
+  ListMultipartUploadsCommand,
+  S3Client,
+  type GetObjectCommandOutput,
+} from "@aws-sdk/client-s3";
+import { forEachConcurrent } from "./concurrent";
+
+interface Options {
+  readonly publicBucket: string;
+  readonly hostedBucket: string;
+  readonly maxObjects: number;
+  readonly concurrency?: number;
+  readonly onProgress?: (phase: string, completed: number) => void;
+}
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new Error("Pending multipart upload registration is invalid");
+  return value as Record<string, unknown>;
+}
+
+function validateRegistration(value: unknown, key: string) {
+  const record = objectRecord(value);
+  if (
+    record.version !== 1 ||
+    record.kind !== "legacy-file" ||
+    record.audience !== "public" ||
+    record.key !== key ||
+    (record.publicBrand !== "vm0" && record.publicBrand !== "okou") ||
+    typeof record.filename !== "string" ||
+    !record.filename ||
+    typeof record.contentType !== "string" ||
+    !record.contentType
+  )
+    throw new Error("Pending multipart upload registration is invalid");
+}
+
+async function registration(client: S3Client, bucket: string, key: string) {
+  let result: GetObjectCommandOutput;
+  try {
+    result = await client.send(
+      new GetObjectCommand({ Bucket: bucket, Key: key }),
+    );
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      ["NoSuchKey", "NotFound"].includes(error.name)
+    )
+      return undefined;
+    throw error;
+  }
+  if (!result.Body)
+    throw new Error("Pending multipart registration has no body");
+  const body = await result.Body.transformToString();
+  try {
+    const value: unknown = JSON.parse(body);
+    return value;
+  } catch {
+    throw new Error("Pending multipart registration contains invalid JSON");
+  }
+}
+
+/** Frozen v1 public registration check, shared by preflight and final coverage. */
+export async function pendingMultipartRegistrations(
+  publicClient: S3Client,
+  hostedClient: S3Client,
+  options: Options,
+) {
+  const concurrency = options.concurrency ?? 16;
+  if (!Number.isSafeInteger(concurrency) || concurrency < 1 || concurrency > 64)
+    throw new Error("Concurrency must be between 1 and 64");
+  if (!Number.isSafeInteger(options.maxObjects) || options.maxObjects < 1)
+    throw new Error("--max-objects must be a positive integer");
+  const startedAt = new Date().toISOString();
+  let keyMarker: string | undefined;
+  let uploadIdMarker: string | undefined;
+  let pending = 0;
+  let unregistered = 0;
+  let unknownInitiated = 0;
+  let oldestInitiated: string | null = null;
+  let newestInitiated: string | null = null;
+  do {
+    const page = await publicClient.send(
+      new ListMultipartUploadsCommand({
+        Bucket: options.publicBucket,
+        Prefix: "artifacts/",
+        MaxUploads: 1000,
+        KeyMarker: keyMarker,
+        UploadIdMarker: uploadIdMarker,
+      }),
+    );
+    await forEachConcurrent(page.Uploads ?? [], concurrency, async (upload) => {
+      const key = upload.Key;
+      if (!key?.startsWith("artifacts/") || !upload.UploadId)
+        throw new Error("Invalid pending multipart upload identity");
+      if (++pending > options.maxObjects)
+        throw new Error("Pending multipart upload inventory limit reached");
+      const alias = encodeURIComponent(key.slice("artifacts/".length));
+      const value = await registration(
+        hostedClient,
+        options.hostedBucket,
+        `artifact-delivery/files/${alias}.json`,
+      );
+      if (value === undefined) {
+        unregistered++;
+        if (upload.Initiated === undefined) {
+          unknownInitiated++;
+        } else {
+          if (!Number.isFinite(upload.Initiated.getTime()))
+            throw new Error("Invalid pending multipart initiation time");
+          const initiated = upload.Initiated.toISOString();
+          if (oldestInitiated === null || initiated < oldestInitiated)
+            oldestInitiated = initiated;
+          if (newestInitiated === null || initiated > newestInitiated)
+            newestInitiated = initiated;
+        }
+        return;
+      }
+      validateRegistration(value, key);
+    });
+    if (
+      page.IsTruncated &&
+      (!page.NextKeyMarker ||
+        !page.NextUploadIdMarker ||
+        (page.NextKeyMarker === keyMarker &&
+          page.NextUploadIdMarker === uploadIdMarker))
+    )
+      throw new Error("Pending multipart upload pagination is incomplete");
+    keyMarker = page.IsTruncated ? page.NextKeyMarker : undefined;
+    uploadIdMarker = page.IsTruncated ? page.NextUploadIdMarker : undefined;
+  } while (keyMarker);
+  options.onProgress?.("pending-multipart-uploads", pending);
+  options.onProgress?.("unregistered-multipart-uploads", unregistered);
+  return {
+    pending,
+    unregistered,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    oldestUnregisteredInitiatedAt: oldestInitiated,
+    newestUnregisteredInitiatedAt: newestInitiated,
+    unregisteredWithUnknownInitiationTime: unknownInitiated,
+  };
+}
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+/** Read-only CLI: no database, object inventory, registration writes or finalize. */
+export async function runMultipartPreflight(args: string[]) {
+  const { values } = parseArgs({
+    args,
+    options: {
+      "max-objects": { type: "string", default: "100000" },
+      concurrency: { type: "string", default: "16" },
+      report: { type: "string" },
+    },
+  });
+  const endpoint = `https://${required("R2_ACCOUNT_ID")}.r2.cloudflarestorage.com`;
+  const publicClient = new S3Client({
+    endpoint,
+    region: "auto",
+    credentials: {
+      accessKeyId: required("R2_USER_ARTIFACTS_ACCESS_KEY_ID"),
+      secretAccessKey: required("R2_USER_ARTIFACTS_SECRET_ACCESS_KEY"),
+    },
+  });
+  const hostedClient = new S3Client({
+    endpoint,
+    region: "auto",
+    credentials: {
+      accessKeyId: required("R2_HOSTED_SITES_ACCESS_KEY_ID"),
+      secretAccessKey: required("R2_HOSTED_SITES_SECRET_ACCESS_KEY"),
+    },
+  });
+  try {
+    const result = await pendingMultipartRegistrations(
+      publicClient,
+      hostedClient,
+      {
+        publicBucket: required("R2_USER_ARTIFACTS_BUCKET_NAME"),
+        hostedBucket: required("R2_HOSTED_SITES_BUCKET_NAME"),
+        maxObjects: Number(values["max-objects"]),
+        concurrency: Number(values.concurrency),
+      },
+    );
+    const report = {
+      kind: "multipart-preflight",
+      status: result.unregistered > 0 ? "blocked" : "clear",
+      startedAt: result.startedAt,
+      completedAt: result.completedAt,
+      pendingMultipartUploads: result.pending,
+      unregisteredMultipartUploads: result.unregistered,
+      oldestUnregisteredInitiatedAt: result.oldestUnregisteredInitiatedAt,
+      newestUnregisteredInitiatedAt: result.newestUnregisteredInitiatedAt,
+      unregisteredWithUnknownInitiationTime:
+        result.unregisteredWithUnknownInitiationTime,
+      verified: false,
+      finalized: false,
+    };
+    if (values.report)
+      await writeFile(values.report, `${JSON.stringify(report, null, 2)}\n`);
+    console.log(JSON.stringify(report));
+    return result.unregistered > 0 ? 1 : 0;
+  } finally {
+    publicClient.destroy();
+    hostedClient.destroy();
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)
+  process.exitCode = await runMultipartPreflight(process.argv.slice(2));


### PR DESCRIPTION
## Summary

Independent production verification [34422606017](https://github.com/vm0-ai/vm0/actions/runs/34422606017) spent about 105 minutes scanning existing objects before failing on three unregistered multipart sessions. Its failure left no report of their initiation times. Add a read-only multipart preflight that preserves aggregate timing evidence and blocks a standalone `verify` run before database resolution and the expensive object inventory when those sessions remain.

The existing protected workflow also gains `multipart-check` for this inspection alone. It writes `public-artifact-registration-multipart.json` before returning a blocked exit status, with pending/unregistered counts, scan bounds, initiation-time bounds and unknown-time count. It emits no user keys, upload IDs or filenames, and always reports `verified: false` and `finalized: false`.

The preflight and full inventory share the frozen v1 multipart validator. Full verification retains its original multipart check immediately before the final object scan; a clear preflight is not coverage acceptance. Historical backfill, conditional registration writes, database reconciliation and finalization gates retain their sequence. No runtime API/Worker, DNS, cache, feature switch, upload parts or lifecycle changes. Relates to #32492; #32959 remains a separate draft cutover.

## Fallbacks

- `multipart.ts:pendingMultipartRegistrations` records an absent provider `MultipartUpload.Initiated` as unknown instead of inventing a timestamp. The installed AWS SDK explicitly makes this field optional. This is optional external diagnostic data, not a rollout reader; missing times never clear an unregistered-session gate or establish expiry. Keep this representation while the provider contract permits absence. A present invalid date fails the check.

## Verification

- 30 focused tests passed, covering the existing backfill plus the real standalone command parser, persisted diagnostic reports, paginated sessions, registered sessions, unknown times, invalid/private registrations, incomplete listings, and rejection of write/finalize flags.
- DB workspace lint and TypeScript checks passed.
- Workflow actionlint and formatting checks passed.
- Production session inspection will use `multipart-check` on reviewed `main` through the existing protected production environment. It does not require an API release. Final coverage remains blocked until live session state permits a full independent verification.
