### PR TITLE
docs(rust): fix guest-agent private rustdoc links

### DIFF
--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -1,7 +1,7 @@
 //! VAS artifact upload — SHA-256 hashing, tar.gz creation, S3 presigned upload.
 //!
 //! Flow (caller first walks the mount via [`walk_files_for_checkpoint`], then
-//! invokes [`create_snapshot`] with the pre-walked file list):
+//! invokes [`create_snapshot_with_attestation`] with the pre-walked file list):
 //! 1. POST `/storages/prepare` with file list to get version/upload metadata
 //! 2. If prepare found an existing version, validate the local archive inputs,
 //!    then POST `/storages/commit` to update HEAD

--- a/crates/guest-agent/src/constants.rs
+++ b/crates/guest-agent/src/constants.rs
@@ -48,7 +48,7 @@ pub const ACTIVE_INPUT_SINK_QUIESCENCE_TIMEOUT_SECS: u64 = 5;
 /// Kill the CLI process if a network tool hasn't returned a result within
 /// this duration. Override with the `OKOU_STUCK_TOOL_TIMEOUT_SECS` bootstrap
 /// environment variable.
-/// See: https://github.com/anthropics/claude-code/issues/11650
+/// See: <https://github.com/anthropics/claude-code/issues/11650>
 pub const STUCK_TOOL_TIMEOUT_SECS: u64 = 300;
 
 /// How often (in seconds) to check for stuck tools in the select loop.
@@ -65,7 +65,7 @@ pub const STDOUT_DRAIN_DEADLINE_SECS: u64 = 5;
 /// still be blocked draining long-running backgrounded Bash tasks it spawned
 /// via its 2-minute auto-background timeout. Those tasks have been observed
 /// holding the sandbox alive for tens of minutes until external cancel.
-/// See: https://github.com/vm0-ai/vm0/issues/10879
+/// See: <https://github.com/vm0-ai/vm0/issues/10879>
 pub const POST_RESULT_SIGTERM_GRACE_SECS: u64 = 10;
 
 /// Absolute cap after observing a `type=result` event before SIGTERM-ing the

--- a/crates/guest-agent/src/masker.rs
+++ b/crates/guest-agent/src/masker.rs
@@ -425,7 +425,7 @@ impl SecretMasker {
 /// Unescaped set per ECMAScript spec (uriUnescaped):
 ///   A-Z a-z 0-9 - _ . ! ~ * ' ( )
 ///
-/// See: https://tc39.es/ecma262/#sec-encodeuricomponent-uricomponent
+/// See: <https://tc39.es/ecma262/#sec-encodeuricomponent-uricomponent>
 fn url_encode(s: &str) -> String {
     let mut encoded = String::with_capacity(s.len() * 3);
     // Rust &str is valid UTF-8, so iterating bytes and percent-encoding


### PR DESCRIPTION
Building `guest-agent` documentation with `--document-private-items` fails on a link to the test-only `create_snapshot` function and three bare URLs. Point the artifact overview to the production `create_snapshot_with_attestation` function and turn the existing URLs into Rustdoc autolinks. Only four documentation lines change; runtime behavior and strict lint settings are preserved.

Closes #33120

## Validation

- Reproduced all four link errors on clean `main` at `e5e52075f4f2285ebaf93bd62b61465d91f05b9e` with Cargo 1.98.1.
- Passed: `cargo fmt --manifest-path crates/guest-agent/Cargo.toml -- --check`.
- Passed: `CARGO_BUILD_JOBS=2 cargo doc --manifest-path crates/Cargo.toml --profile local --locked -p guest-agent --no-deps --document-private-items`.
- Passed: `CARGO_BUILD_JOBS=2 cargo doc --manifest-path crates/Cargo.toml --profile local --locked -p guest-agent --no-deps`.
- Verified the generated snapshot link points to an existing function page and all three external links retain their exact destinations.
- Passed `git diff --check`; confirmed all non-documentation source lines are unchanged. Runtime tests were not added or run for this documentation-only change.
