### PR TITLE
fix(chat): make explicit thread creation safe for duplicate client ids

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import {
   chatThreadConnectorSelectionContract,
   chatThreadMetadataContract,
+  chatThreadRenameContract,
   chatThreadsContract,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
@@ -30,6 +31,7 @@ import { createRouteMocks } from "./helpers/route-test";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { chatThreadRoutes } from "../chat-threads";
 import { chatThreadGetRoutes } from "../chat-threads-get";
+import { chatThreadRenameRoutes } from "../chat-threads-rename";
 import { connectorAccountRoutes } from "../connector-accounts";
 import { userModelPreferenceRoutes } from "../user-model-preference";
 
@@ -171,6 +173,25 @@ function connectorAccountsClient() {
   return setupApp({ context, routes: connectorAccountRoutes })(
     connectorAccountsContract,
   );
+}
+
+function renameClient() {
+  return setupApp({ context, routes: chatThreadRenameRoutes })(
+    chatThreadRenameContract,
+  );
+}
+
+async function readCreatedThreadEvents(threadId: string, token: string) {
+  const response = await accept(
+    threadsClient().events({
+      headers: { authorization: `Bearer ${token}` },
+      query: {},
+    }),
+    [200],
+  );
+  return response.body.events.filter((candidate) => {
+    return candidate.kind === "created" && candidate.chatThreadId === threadId;
+  });
 }
 
 async function readCreatedThreadEvent(threadId: string, token: string) {
@@ -1064,6 +1085,302 @@ describe("POST /api/chat-threads", () => {
         code: "FORBIDDEN",
         message: "Missing required capability: chat-thread:write",
       },
+    });
+  });
+
+  it("replays one thread when a create request is delivered twice", async () => {
+    const fixture = await seedAgent();
+    await updateFeatureSwitchesForUser(context, fixture, {});
+    const connection = await connectorApi.connectManualGrant(
+      fixture.actor,
+      "openai",
+      "api-token",
+      { apiKey: "duplicate-delivery-openai-key" },
+      fixture.agentId,
+    );
+    const token = okouToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      capabilities: ["chat-thread:read", "chat-thread:write"],
+    });
+    const clientThreadId = randomUUID();
+    const eventId = randomUUID();
+
+    const created = await accept(
+      threadsClient().create({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          agentId: fixture.agentId,
+          clientThreadId,
+          eventId,
+          title: "Duplicate delivery",
+          model: OTHER_WORKSPACE_MODEL,
+          connectorSelections: [
+            {
+              connectionId: connection.id,
+              target: { kind: "builtin", connectorSlug: "openai" },
+            },
+          ],
+        },
+      }),
+      [201],
+    );
+    expect(created.body.id).toBe(clientThreadId);
+
+    // The same request, delivered a second time.
+    const replayed = await accept(
+      threadsClient().create({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          agentId: fixture.agentId,
+          clientThreadId,
+          eventId,
+          title: "Duplicate delivery",
+          model: OTHER_WORKSPACE_MODEL,
+          connectorSelections: [
+            {
+              connectionId: connection.id,
+              target: { kind: "builtin", connectorSlug: "openai" },
+            },
+          ],
+        },
+      }),
+      [201],
+    );
+    expect(replayed.body).toStrictEqual(created.body);
+
+    await expect(
+      readCreatedThreadEvents(clientThreadId, token),
+    ).resolves.toHaveLength(1);
+    const selections = await accept(
+      connectorSelectionsClient().get({
+        headers: { authorization: `Bearer ${token}` },
+        params: { id: clientThreadId },
+      }),
+      [200],
+    );
+    expect(selections.body.selections).toStrictEqual([
+      {
+        connectionId: connection.id,
+        target: { kind: "builtin", connectorSlug: "openai" },
+      },
+    ]);
+  });
+
+  it("replays the stored thread instead of the repeated request body", async () => {
+    const fixture = await seedAgent();
+    const token = okouToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      capabilities: ["chat-thread:read", "chat-thread:write"],
+    });
+    const clientThreadId = randomUUID();
+
+    const created = await accept(
+      threadsClient().create({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          agentId: fixture.agentId,
+          clientThreadId,
+          title: "Title from the request",
+          model: OTHER_WORKSPACE_MODEL,
+        },
+      }),
+      [201],
+    );
+    await accept(
+      renameClient().rename({
+        headers: { authorization: `Bearer ${token}` },
+        params: { id: clientThreadId },
+        body: { title: "Title the member chose" },
+      }),
+      [204],
+    );
+
+    const replayed = await accept(
+      threadsClient().create({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          agentId: fixture.agentId,
+          clientThreadId,
+          title: "Title from the request",
+          model: OTHER_WORKSPACE_MODEL,
+        },
+      }),
+      [201],
+    );
+    expect(replayed.body).toStrictEqual({
+      id: clientThreadId,
+      title: "Title the member chose",
+      createdAt: created.body.createdAt,
+      selectedModel: OTHER_WORKSPACE_MODEL,
+      serviceTier: null,
+    });
+
+    const metadataResponse = await accept(
+      metadataClient().get({
+        headers: { authorization: `Bearer ${token}` },
+        params: { id: clientThreadId },
+      }),
+      [200],
+    );
+    expect(metadataResponse.body.title).toBe("Title the member chose");
+  });
+
+  it("creates one thread when two deliveries race on a client thread id", async () => {
+    const fixture = await seedAgent();
+    const token = okouToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      capabilities: ["chat-thread:read", "chat-thread:write"],
+    });
+    const clientThreadId = randomUUID();
+    const eventId = randomUUID();
+
+    const [first, second] = await Promise.all([
+      accept(
+        threadsClient().create({
+          headers: { authorization: `Bearer ${token}` },
+          body: {
+            agentId: fixture.agentId,
+            clientThreadId,
+            eventId,
+            title: "Raced delivery",
+            model: OTHER_WORKSPACE_MODEL,
+          },
+        }),
+        [201],
+      ),
+      accept(
+        threadsClient().create({
+          headers: { authorization: `Bearer ${token}` },
+          body: {
+            agentId: fixture.agentId,
+            clientThreadId,
+            eventId,
+            title: "Raced delivery",
+            model: OTHER_WORKSPACE_MODEL,
+          },
+        }),
+        [201],
+      ),
+    ]);
+    expect(second.body).toStrictEqual(first.body);
+    expect(first.body.id).toBe(clientThreadId);
+
+    await expect(
+      readCreatedThreadEvents(clientThreadId, token),
+    ).resolves.toHaveLength(1);
+  });
+
+  it("answers a client thread id owned by another member like a missing thread", async () => {
+    const owner = await seedAgent();
+    const ownerToken = okouToken({
+      userId: owner.userId,
+      orgId: owner.orgId,
+      capabilities: ["chat-thread:read", "chat-thread:write"],
+    });
+    const clientThreadId = randomUUID();
+    await accept(
+      threadsClient().create({
+        headers: { authorization: `Bearer ${ownerToken}` },
+        body: {
+          agentId: owner.agentId,
+          clientThreadId,
+          title: "Owner thread",
+          model: WORKSPACE_DEFAULT_MODEL,
+        },
+      }),
+      [201],
+    );
+
+    const other = await seedAgent();
+    const otherToken = okouToken({
+      userId: other.userId,
+      orgId: other.orgId,
+      capabilities: ["chat-thread:read", "chat-thread:write"],
+    });
+    const collision = await accept(
+      threadsClient().create({
+        headers: { authorization: `Bearer ${otherToken}` },
+        body: {
+          agentId: other.agentId,
+          clientThreadId,
+          title: "Colliding thread",
+          model: WORKSPACE_DEFAULT_MODEL,
+        },
+      }),
+      [404],
+    );
+    expect(collision.body).toStrictEqual({
+      error: { code: "NOT_FOUND", message: "Chat thread not found" },
+    });
+
+    const metadataResponse = await accept(
+      metadataClient().get({
+        headers: { authorization: `Bearer ${ownerToken}` },
+        params: { id: clientThreadId },
+      }),
+      [200],
+    );
+    expect(metadataResponse.body).toMatchObject({
+      agentId: owner.agentId,
+      title: "Owner thread",
+    });
+  });
+
+  it("answers a client thread id held by another agent like a missing thread", async () => {
+    const fixture = await seedAgent();
+    const token = okouToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      capabilities: ["chat-thread:read", "chat-thread:write"],
+    });
+    const clientThreadId = randomUUID();
+    await accept(
+      threadsClient().create({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          agentId: fixture.agentId,
+          clientThreadId,
+          title: "First agent thread",
+          model: WORKSPACE_DEFAULT_MODEL,
+        },
+      }),
+      [201],
+    );
+
+    bdd.acceptAgentStorageWrites();
+    const otherAgent = await bdd.createAgent(fixture.actor, {
+      displayName: "Second chat thread agent",
+      visibility: "private",
+    });
+    const collision = await accept(
+      threadsClient().create({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          agentId: otherAgent.agentId,
+          clientThreadId,
+          title: "Colliding agent thread",
+          model: WORKSPACE_DEFAULT_MODEL,
+        },
+      }),
+      [404],
+    );
+    expect(collision.body).toStrictEqual({
+      error: { code: "NOT_FOUND", message: "Chat thread not found" },
+    });
+
+    const metadataResponse = await accept(
+      metadataClient().get({
+        headers: { authorization: `Bearer ${token}` },
+        params: { id: clientThreadId },
+      }),
+      [200],
+    );
+    expect(metadataResponse.body).toMatchObject({
+      agentId: fixture.agentId,
+      title: "First agent thread",
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/chat-threads-create.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-create.ts
@@ -18,7 +18,12 @@ import { bodyResultOf } from "../context/request";
 import { type Db, writeDb$ } from "../external/db";
 import { publishThreadListChanged } from "../external/realtime";
 import { badRequestMessage, notFound } from "../../lib/error";
-import { createChatThread$ } from "../services/chat-thread.service";
+import { logger } from "../../lib/log";
+import {
+  createChatThread$,
+  type CreatedChatThread,
+  type ExistingChatThread,
+} from "../services/chat-thread.service";
 import { agentExistsInOrg } from "../services/agent-deletion.service";
 import { loadNewChatThreadMediaModels } from "../services/chat-thread-media-model.service";
 import {
@@ -29,6 +34,8 @@ import { chatThreadModelPinColumns } from "../services/chat-thread-model.service
 import { chatThreadServiceTierFromCodex } from "../services/chat-thread-event.service";
 import type { RouteEntry } from "../route-entry";
 
+const L = logger("ChatThreadCreate");
+
 const createBody$ = bodyResultOf(chatThreadsContract.create);
 
 function modelFirstSelection(selectedModel: string) {
@@ -36,6 +43,50 @@ function modelFirstSelection(selectedModel: string) {
     modelProviderId: MODEL_FIRST_SELECTION_PROVIDER_ID,
     selectedModel,
   };
+}
+
+interface ChatThreadCreateSettings {
+  readonly title: string | null;
+  readonly selectedModel: string;
+  readonly codexServiceTier: CodexServiceTier | null;
+}
+
+function chatThreadCreatedResponse(
+  thread: { readonly id: string; readonly createdAt: Date },
+  settings: ChatThreadCreateSettings,
+) {
+  return {
+    status: 201 as const,
+    body: {
+      id: thread.id,
+      title: settings.title,
+      createdAt: thread.createdAt.toISOString(),
+      selectedModel: settings.selectedModel,
+      serviceTier: chatThreadServiceTierFromCodex(settings.codexServiceTier),
+    },
+  };
+}
+
+/**
+ * The created thread, or the one a duplicate delivery replays. A replay answers
+ * with the stored settings rather than the repeated request, because the member
+ * may have renamed or repinned the thread since the original delivery.
+ */
+function chatThreadCreateResponse(
+  thread: CreatedChatThread | ExistingChatThread,
+  requested: ChatThreadCreateSettings,
+) {
+  if (thread.kind === "created") {
+    return chatThreadCreatedResponse(thread, requested);
+  }
+  // Duplicate deliveries are expected and non-actionable, so they stay out of
+  // the error channel while remaining countable in production.
+  L.info("Replayed chat thread create for an existing client thread id");
+  return chatThreadCreatedResponse(thread, {
+    title: thread.title,
+    selectedModel: thread.selectedModel ?? requested.selectedModel,
+    codexServiceTier: thread.codexServiceTier,
+  });
 }
 
 /**
@@ -179,20 +230,22 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (thread.kind === "invalid_connector_selection") {
     return badRequestMessage(thread.message);
   }
+  // The id already belongs to another member, org, or agent. Answer exactly
+  // like a thread that does not exist so a collision discloses no ownership.
+  if (thread.kind === "client_thread_conflict") {
+    return notFound("Chat thread not found");
+  }
 
+  // The thread list invalidation is idempotent, so a replay also repairs a
+  // realtime notification the original delivery may have lost.
   await publishThreadListChanged({ userId: auth.userId, orgId: auth.orgId });
   signal.throwIfAborted();
 
-  return {
-    status: 201 as const,
-    body: {
-      id: thread.id,
-      title: body.data.title ?? null,
-      createdAt: thread.createdAt.toISOString(),
-      selectedModel,
-      serviceTier: chatThreadServiceTierFromCodex(codexServiceTier),
-    },
-  };
+  return chatThreadCreateResponse(thread, {
+    title: body.data.title ?? null,
+    selectedModel,
+    codexServiceTier,
+  });
 });
 
 export const chatThreadCreateRoutes: readonly RouteEntry[] = [

--- a/turbo/apps/api/src/signals/routes/chat-threads-create.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-create.ts
@@ -18,7 +18,6 @@ import { bodyResultOf } from "../context/request";
 import { type Db, writeDb$ } from "../external/db";
 import { publishThreadListChanged } from "../external/realtime";
 import { badRequestMessage, notFound } from "../../lib/error";
-import { logger } from "../../lib/log";
 import {
   createChatThread$,
   type CreatedChatThread,
@@ -33,8 +32,6 @@ import {
 import { chatThreadModelPinColumns } from "../services/chat-thread-model.service";
 import { chatThreadServiceTierFromCodex } from "../services/chat-thread-event.service";
 import type { RouteEntry } from "../route-entry";
-
-const L = logger("ChatThreadCreate");
 
 const createBody$ = bodyResultOf(chatThreadsContract.create);
 
@@ -71,6 +68,10 @@ function chatThreadCreatedResponse(
  * The created thread, or the one a duplicate delivery replays. A replay answers
  * with the stored settings rather than the repeated request, because the member
  * may have renamed or repinned the thread since the original delivery.
+ *
+ * A replay is an expected, non-actionable outcome, so it emits no log of its
+ * own: the request log already records both deliveries under one
+ * `x_client_request_id`, now as two 201s instead of a 201 and a 500.
  */
 function chatThreadCreateResponse(
   thread: CreatedChatThread | ExistingChatThread,
@@ -79,9 +80,6 @@ function chatThreadCreateResponse(
   if (thread.kind === "created") {
     return chatThreadCreatedResponse(thread, requested);
   }
-  // Duplicate deliveries are expected and non-actionable, so they stay out of
-  // the error channel while remaining countable in production.
-  L.info("Replayed chat thread create for an existing client thread id");
   return chatThreadCreatedResponse(thread, {
     title: thread.title,
     selectedModel: thread.selectedModel ?? requested.selectedModel,

--- a/turbo/apps/api/src/signals/services/chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread.service.ts
@@ -54,6 +54,7 @@ import {
 } from "drizzle-orm";
 
 import { zodEnumDriverValueDecoder } from "../../lib/db-structured-result";
+import type { Tx } from "../../lib/db-types";
 import { now, nowDate } from "../../lib/time";
 import { type Db, db$, type ReadonlyDb, writeDb$ } from "../external/db";
 import { inferMimetype } from "./chat-event-shared.service";
@@ -638,6 +639,59 @@ export function chatThreadArtifacts(args: {
   );
 }
 
+export interface CreatedChatThread {
+  readonly kind: "created";
+  readonly id: string;
+  readonly createdAt: Date;
+}
+
+/** The thread a duplicate delivery of one create request replays. */
+export interface ExistingChatThread {
+  readonly kind: "existing";
+  readonly id: string;
+  readonly createdAt: Date;
+  readonly title: string | null;
+  readonly selectedModel: string | null;
+  readonly codexServiceTier: CodexServiceTier | null;
+}
+
+/**
+ * The thread a repeated create request already owns, read inside the same
+ * transaction that lost the insert conflict. Ownership stays scoped to the
+ * caller and the requested agent, so an id held by another member, org, or
+ * agent resolves to a conflict the route answers without disclosing it.
+ */
+async function resolveExistingClientThread(
+  tx: Tx,
+  args: {
+    readonly clientThreadId: string;
+    readonly userId: string;
+    readonly agentId: string;
+  },
+): Promise<ExistingChatThread | { readonly kind: "client_thread_conflict" }> {
+  const [existingThread] = await tx
+    .select({
+      id: chatThreads.id,
+      createdAt: chatThreads.createdAt,
+      title: chatThreads.title,
+      selectedModel: chatThreads.selectedModel,
+      codexServiceTier: chatThreads.codexServiceTier,
+    })
+    .from(chatThreads)
+    .where(
+      and(
+        eq(chatThreads.id, args.clientThreadId),
+        eq(chatThreads.userId, args.userId),
+        eq(chatThreads.agentId, args.agentId),
+      ),
+    )
+    .limit(1);
+  if (!existingThread) {
+    return { kind: "client_thread_conflict" as const };
+  }
+  return { kind: "existing" as const, ...existingThread };
+}
+
 export const createChatThread$ = command(
   async (
     { set },
@@ -659,10 +713,10 @@ export const createChatThread$ = command(
     },
     signal: AbortSignal,
   ): Promise<
+    | CreatedChatThread
+    | ExistingChatThread
     | {
-        readonly kind: "created";
-        readonly id: string;
-        readonly createdAt: Date;
+        readonly kind: "client_thread_conflict";
       }
     | {
         readonly kind: "invalid_connector_selection";
@@ -706,9 +760,21 @@ export const createChatThread$ = command(
           selectedVideoModel: args.selectedVideoModel,
           selectedImageModel: args.selectedImageModel,
         })
+        // A duplicate delivery of one create request must replay the thread the
+        // caller already owns instead of surfacing the primary key violation.
+        // Only that key is tolerated, so every other database fault propagates.
+        .onConflictDoNothing({ target: chatThreads.id })
         .returning({ id: chatThreads.id, createdAt: chatThreads.createdAt });
       if (!createdThread) {
-        return undefined;
+        // A generated id never collides, so its absent row stays an error.
+        if (args.clientThreadId === undefined) {
+          return undefined;
+        }
+        return await resolveExistingClientThread(tx, {
+          clientThreadId: args.clientThreadId,
+          userId: args.userId,
+          agentId: args.agentId,
+        });
       }
       await insertInitialChatThreadConnectorSelections(tx, {
         chatThreadId: createdThread.id,


### PR DESCRIPTION
## Summary

`POST /api/chat-threads` forwarded `clientThreadId` into `chat_threads.id` with a plain insert, so a duplicate delivery of one create request turned the `chat_threads_pkey` violation into an unhandled HTTP 500 — while the thread itself had already been created by the first delivery.

Production evidence (2026-09-09, `vm0-request-log-prod`): the same `x_client_request_id` executed twice on `POST /api/chat-threads`, 20.2 s apart — `201` in 773 ms, then `500` in 53 ms. The platform mints both `clientThreadId` and that request id per attempt and never retries, so the duplicate id could only come from one client request being delivered twice.

The unified send path in `chat-events.command.ts` already had this contract (from #15619); the explicit create route never did.

## Changes

- `createChatThread$` tolerates a conflict on the `chat_threads` primary key only. Every other database fault still propagates.
- On a lost conflict, the same transaction reads the thread scoped to `(id, userId, agentId)`:
  - owned by the caller and the requested agent → `existing`, replayed as **201** with the **stored** title, model, and service tier (the member may have renamed or repinned the thread between deliveries);
  - anything else → `client_thread_conflict`, answered as **404 `Chat thread not found`**, identical to a thread that does not exist, so a collision discloses no ownership.
- A replay appends no second `created` thread event and inserts no duplicate connector selections.
- The expected duplicate delivery leaves the error channel entirely: no Sentry error, no `unhandled_request_error`, and no new log of its own. `api/no-logger-info` forbids an info log here, and that rule's configuration records that Axiom drops debug events, so a demoted log would never reach production. Both deliveries remain visible in the request log under one `x_client_request_id`, now as two 201s instead of a 201 and a 500.

No contract change: `201` and `404` are already in `chatThreadsContract.create.responses`, and the platform client accepts `201` unchanged, so old and new clients behave identically.

## Tests

Added to `chat-threads-create.test.ts` (API route integration, production endpoints only):

- a create delivered twice returns one identical body, one `created` event, and one connector selection;
- a replay after a rename returns the stored title, not the repeated request body;
- two concurrent deliveries of one client thread id both return 201 for the same thread with a single `created` event;
- a client thread id owned by another member answers 404 and leaves the owner's thread untouched;
- a client thread id held by another agent answers 404.

## Verification

- `prettier --check` and `oxlint --deny-warnings` on the changed files: pass.
- Local `tsc` and `vitest` were not run: this sandbox has ~4 GB RAM and the type-check process is killed before emitting output. Types and the new tests rely on the PR pipeline.

Fixes #33089

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Fallbacks

- `chat-threads-create.ts:chatThreadCreateResponse` — `thread.selectedModel ?? requested.selectedModel` when a replayed thread's stored model is null. `chat_threads.selected_model` is a nullable column and every writer fills it from `ModelFirstPin.selectedModel`, which is typed `string | null` (`model-selection.service.ts:56`), so an unset value is a legitimate persisted state while the 201 contract requires a string. Surface: none — genuinely nullable persisted column (fallback guide section 6.3), not a rollout window, so there is no removal gate. Removable only if `selected_model` becomes `NOT NULL` or the pin type stops admitting null.

