### PR TITLE
feat(chat): move create scene picker inside composer

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1885,12 +1885,15 @@
       "create": {
         "addStyle": "Stil hinzufügen",
         "addTemplate": "Vorlage hinzufügen",
+        "chooseScene": "Wähle, was du erstellen möchtest",
         "chooseType": "Typ auswählen",
         "description": "Präsentationen, Videos und Bilder",
         "exit": "Erstellungsmodus verlassen",
         "image": "Bild erstellen",
+        "imageDescription": "Verwandle eine Idee in ein Bild",
         "imagePlaceholder": "Beschreibe das gewünschte Bild…",
         "presentation": "Präsentation erstellen",
+        "presentationDescription": "Folien für deine Geschichte",
         "presentationPlaceholder": "Worum geht es in deiner Präsentation?",
         "question": "Was möchtest du möglich machen?",
         "settingsAdjusted": "Einige Videoeinstellungen wurden an dieses Modell angepasst",
@@ -1899,6 +1902,7 @@
         "slideCountRange": "{{range}} Folien",
         "title": "Erstellen",
         "video": "Video erstellen",
+        "videoDescription": "Bringe deine Ideen in Bewegung",
         "videoPlaceholder": "Beschreibe das gewünschte Video…"
       },
       "createWorkflow": "Workflow erstellen",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1885,12 +1885,15 @@
       "create": {
         "addStyle": "Add style",
         "addTemplate": "Add template",
+        "chooseScene": "Choose what to create",
         "chooseType": "Choose a type",
         "description": "Presentations, videos, and images",
         "exit": "Exit create mode",
         "image": "Create image",
+        "imageDescription": "Turn an idea into a visual",
         "imagePlaceholder": "Describe the image you want to create…",
         "presentation": "Create presentation",
+        "presentationDescription": "Slides for your story",
         "presentationPlaceholder": "What is your presentation about?",
         "question": "What would you like to make happen?",
         "settingsAdjusted": "Some video settings were adjusted for this model",
@@ -1899,6 +1902,7 @@
         "slideCountRange": "{{range}} slides",
         "title": "Create",
         "video": "Create video",
+        "videoDescription": "Bring your ideas to motion",
         "videoPlaceholder": "Describe the video you want to create…"
       },
       "createWorkflow": "Create workflow",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1914,12 +1914,15 @@
       "create": {
         "addStyle": "Añadir estilo",
         "addTemplate": "Añadir plantilla",
+        "chooseScene": "Elige qué crear",
         "chooseType": "Elige un tipo",
         "description": "Presentaciones, vídeos e imágenes",
         "exit": "Salir del modo de creación",
         "image": "Crear imagen",
+        "imageDescription": "Convierte una idea en una imagen",
         "imagePlaceholder": "Describe la imagen que quieres crear…",
         "presentation": "Crear presentación",
+        "presentationDescription": "Diapositivas para tu historia",
         "presentationPlaceholder": "¿De qué trata tu presentación?",
         "question": "¿Qué te gustaría hacer realidad?",
         "settingsAdjusted": "Se han ajustado algunas opciones de vídeo para este modelo",
@@ -1928,6 +1931,7 @@
         "slideCountRange": "{{range}} diapositivas",
         "title": "Crear",
         "video": "Crear vídeo",
+        "videoDescription": "Da movimiento a tus ideas",
         "videoPlaceholder": "Describe el vídeo que quieres crear…"
       },
       "createWorkflow": "Crear flujo de trabajo",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1914,12 +1914,15 @@
       "create": {
         "addStyle": "Ajouter un style",
         "addTemplate": "Ajouter un modèle",
+        "chooseScene": "Choisissez quoi créer",
         "chooseType": "Choisissez un type",
         "description": "Présentations, vidéos et images",
         "exit": "Quitter le mode création",
         "image": "Créer une image",
+        "imageDescription": "Transformez une idée en image",
         "imagePlaceholder": "Décrivez l’image à créer…",
         "presentation": "Créer une présentation",
+        "presentationDescription": "Des diapositives pour votre histoire",
         "presentationPlaceholder": "Quel est le sujet de votre présentation ?",
         "question": "Que souhaitez-vous réaliser ?",
         "settingsAdjusted": "Certains paramètres vidéo ont été adaptés à ce modèle",
@@ -1928,6 +1931,7 @@
         "slideCountRange": "{{range}} diapositives",
         "title": "Créer",
         "video": "Créer une vidéo",
+        "videoDescription": "Donnez vie à vos idées",
         "videoPlaceholder": "Décrivez la vidéo à créer…"
       },
       "createWorkflow": "Créer un workflow",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1885,12 +1885,15 @@
       "create": {
         "addStyle": "शैली जोड़ें",
         "addTemplate": "टेम्पलेट जोड़ें",
+        "chooseScene": "चुनें कि क्या बनाना है",
         "chooseType": "एक प्रकार चुनें",
         "description": "प्रेज़ेंटेशन, वीडियो और इमेज",
         "exit": "बनाने के मोड से बाहर निकलें",
         "image": "छवि बनाएँ",
+        "imageDescription": "किसी विचार को चित्र में बदलें",
         "imagePlaceholder": "आप जो छवि बनाना चाहते हैं उसका वर्णन करें…",
         "presentation": "प्रस्तुति बनाएँ",
+        "presentationDescription": "आपकी कहानी के लिए स्लाइड",
         "presentationPlaceholder": "आपकी प्रस्तुति का विषय क्या है?",
         "question": "आप क्या साकार करना चाहेंगे?",
         "settingsAdjusted": "इस मॉडल के लिए कुछ वीडियो सेटिंग समायोजित की गई हैं",
@@ -1899,6 +1902,7 @@
         "slideCountRange": "{{range}} स्लाइड",
         "title": "बनाएँ",
         "video": "वीडियो बनाएँ",
+        "videoDescription": "अपने विचारों को गति दें",
         "videoPlaceholder": "आप जो वीडियो बनाना चाहते हैं उसका वर्णन करें…"
       },
       "createWorkflow": "वर्कफ़्लो बनाएँ",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1882,12 +1882,15 @@
       "create": {
         "addStyle": "Tambahkan gaya",
         "addTemplate": "Tambahkan templat",
+        "chooseScene": "Pilih yang ingin dibuat",
         "chooseType": "Pilih jenis",
         "description": "Presentasi, video, dan gambar",
         "exit": "Keluar dari mode pembuatan",
         "image": "Buat gambar",
+        "imageDescription": "Ubah ide menjadi visual",
         "imagePlaceholder": "Jelaskan gambar yang ingin Anda buat…",
         "presentation": "Buat presentasi",
+        "presentationDescription": "Slide untuk cerita Anda",
         "presentationPlaceholder": "Apa topik presentasi Anda?",
         "question": "Apa yang ingin Anda wujudkan?",
         "settingsAdjusted": "Beberapa pengaturan video disesuaikan untuk model ini",
@@ -1896,6 +1899,7 @@
         "slideCountRange": "{{range}} slide",
         "title": "Buat",
         "video": "Buat video",
+        "videoDescription": "Hidupkan ide Anda dengan gerakan",
         "videoPlaceholder": "Jelaskan video yang ingin Anda buat…"
       },
       "createWorkflow": "Buat alur kerja",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1914,12 +1914,15 @@
       "create": {
         "addStyle": "Aggiungi stile",
         "addTemplate": "Aggiungi modello",
+        "chooseScene": "Scegli cosa creare",
         "chooseType": "Scegli un tipo",
         "description": "Presentazioni, video e immagini",
         "exit": "Esci dalla modalità creazione",
         "image": "Crea immagine",
+        "imageDescription": "Trasforma un'idea in un'immagine",
         "imagePlaceholder": "Descrivi l’immagine che vuoi creare…",
         "presentation": "Crea presentazione",
+        "presentationDescription": "Diapositive per la tua storia",
         "presentationPlaceholder": "Di cosa tratta la tua presentazione?",
         "question": "Cosa vorresti realizzare?",
         "settingsAdjusted": "Alcune impostazioni video sono state adattate a questo modello",
@@ -1928,6 +1931,7 @@
         "slideCountRange": "{{range}} diapositive",
         "title": "Crea",
         "video": "Crea video",
+        "videoDescription": "Metti in movimento le tue idee",
         "videoPlaceholder": "Descrivi il video che vuoi creare…"
       },
       "createWorkflow": "Crea flusso di lavoro",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1882,12 +1882,15 @@
       "create": {
         "addStyle": "スタイルを追加",
         "addTemplate": "テンプレートを追加",
+        "chooseScene": "作成するものを選択",
         "chooseType": "種類を選択",
         "description": "プレゼンテーション、動画、画像",
         "exit": "作成モードを終了",
         "image": "画像を作成",
+        "imageDescription": "アイデアを画像に",
         "imagePlaceholder": "作成したい画像を説明してください…",
         "presentation": "プレゼンテーションを作成",
+        "presentationDescription": "ストーリーを伝えるスライド",
         "presentationPlaceholder": "プレゼンテーションのテーマは何ですか？",
         "question": "何を実現したいですか？",
         "settingsAdjusted": "このモデルに合わせて一部の動画設定を調整しました",
@@ -1896,6 +1899,7 @@
         "slideCountRange": "{{range}}枚",
         "title": "作成",
         "video": "動画を作成",
+        "videoDescription": "アイデアを動画に",
         "videoPlaceholder": "作成したい動画を説明してください…"
       },
       "createWorkflow": "ワークフローの作成",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1882,12 +1882,15 @@
       "create": {
         "addStyle": "스타일 추가",
         "addTemplate": "템플릿 추가",
+        "chooseScene": "만들 항목 선택",
         "chooseType": "유형 선택",
         "description": "프레젠테이션, 동영상, 이미지",
         "exit": "만들기 모드 종료",
         "image": "이미지 만들기",
+        "imageDescription": "아이디어를 이미지로 표현",
         "imagePlaceholder": "만들고 싶은 이미지를 설명하세요…",
         "presentation": "프레젠테이션 만들기",
+        "presentationDescription": "이야기를 담은 슬라이드",
         "presentationPlaceholder": "프레젠테이션의 주제는 무엇인가요?",
         "question": "무엇을 실현하고 싶으신가요?",
         "settingsAdjusted": "이 모델에 맞게 일부 동영상 설정을 조정했습니다",
@@ -1896,6 +1899,7 @@
         "slideCountRange": "{{range}}장",
         "title": "만들기",
         "video": "동영상 만들기",
+        "videoDescription": "아이디어를 영상으로 표현",
         "videoPlaceholder": "만들고 싶은 동영상을 설명하세요…"
       },
       "createWorkflow": "워크플로 생성",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1914,12 +1914,15 @@
       "create": {
         "addStyle": "Adicionar estilo",
         "addTemplate": "Adicionar modelo",
+        "chooseScene": "Escolha o que criar",
         "chooseType": "Escolha um tipo",
         "description": "Apresentações, vídeos e imagens",
         "exit": "Sair do modo de criação",
         "image": "Criar imagem",
+        "imageDescription": "Transforme uma ideia em uma imagem",
         "imagePlaceholder": "Descreva a imagem que você quer criar…",
         "presentation": "Criar apresentação",
+        "presentationDescription": "Slides para sua história",
         "presentationPlaceholder": "Qual é o tema da sua apresentação?",
         "question": "O que você gostaria de realizar?",
         "settingsAdjusted": "Algumas configurações de vídeo foram ajustadas para este modelo",
@@ -1928,6 +1931,7 @@
         "slideCountRange": "{{range}} slides",
         "title": "Criar",
         "video": "Criar vídeo",
+        "videoDescription": "Dê movimento às suas ideias",
         "videoPlaceholder": "Descreva o vídeo que você quer criar…"
       },
       "createWorkflow": "Criar fluxo de trabalho",

--- a/turbo/apps/platform/src/signals/okou-page/composer-create.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-create.ts
@@ -72,6 +72,28 @@ export function composerCreateModeName(mode: ComposerCreateMode): string {
   }
 }
 
+export function composerCreateModeDescription(
+  mode: ComposerCreateMode,
+): string {
+  switch (mode) {
+    case "presentation": {
+      return i18n.t(($) => {
+        return $.chat.composer.create.presentationDescription;
+      });
+    }
+    case "video": {
+      return i18n.t(($) => {
+        return $.chat.composer.create.videoDescription;
+      });
+    }
+    case "image": {
+      return i18n.t(($) => {
+        return $.chat.composer.create.imageDescription;
+      });
+    }
+  }
+}
+
 export function composerCreatePlaceholder(mode: ComposerCreateMode): string {
   switch (mode) {
     case "image": {
@@ -97,12 +119,14 @@ export function createComposerCreateSignals(
   ui: ComposerUiSignalGroups,
   media: { readonly image: boolean; readonly video: boolean },
 ) {
+  const pickerId = `composer-create-picker-${crypto.randomUUID()}`;
   const modes = COMPOSER_CREATE_MODES.filter((mode) => {
     return (
       (mode !== "image" || media.image) && (mode !== "video" || media.video)
     );
   });
   const internalMode$ = state<ComposerCreateCommand | null>(null);
+  const internalPickerOpen$ = state(false);
   const internalPresentationSlideCount$ = state<PresentationSlideCount>("8-12");
   const presentationSlideCount$ = computed((get) => {
     return get(internalPresentationSlideCount$);
@@ -126,11 +150,15 @@ export function createComposerCreateSignals(
   const choosing$ = computed((get) => {
     return get(enabled$) && get(internalMode$) === "choose";
   });
+  const pickerOpen$ = computed((get) => {
+    return get(enabled$) && (get(choosing$) || get(internalPickerOpen$));
+  });
   const setMode$ = command(
     ({ get, set }, mode: ComposerCreateCommand | null) => {
       if (!get(enabled$)) {
         return;
       }
+      set(internalPickerOpen$, false);
       set(internalMode$, mode);
       set(composer.closeSuggestionMenu$);
       set(ui.model.setModelPickerOpen$, false);
@@ -150,6 +178,23 @@ export function createComposerCreateSignals(
       }
     },
   );
+  const setPickerOpen$ = command(({ get, set }, open: boolean) => {
+    if (!get(enabled$)) {
+      return;
+    }
+    if (!open && get(choosing$)) {
+      set(setMode$, null);
+      return;
+    }
+    set(internalPickerOpen$, open);
+    if (open) {
+      set(composer.closeSuggestionMenu$);
+      set(ui.model.setModelPickerOpen$, false);
+      set(ui.videoOptions.setVideoOptionsOpen$, false);
+    } else {
+      set(composer.focus$);
+    }
+  });
   const selectCommand$ = command(
     ({ get, set }, mode: ComposerCreateCommand) => {
       if (!get(enabled$)) {
@@ -171,6 +216,9 @@ export function createComposerCreateSignals(
     modes,
     mode$,
     choosing$,
+    pickerId,
+    pickerOpen$,
+    setPickerOpen$,
     setMode$,
     selectCommand$,
     presentationSlideCount$,

--- a/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
@@ -783,7 +783,7 @@ function createComposerPrimaryActionSignal(args: {
   readonly eventSignals: ReturnType<typeof createComposerChatEventSignals>;
   readonly workflowComposer: WorkflowComposerSignals;
   readonly voiceState$: ComposerVoiceInputSignals["state$"];
-  readonly choosingCreateType$: ComposerCreateSignals["choosing$"];
+  readonly createPickerOpen$: ComposerCreateSignals["pickerOpen$"];
 }): Computed<Promise<ComposerPrimaryAction>> {
   const { options, eventSignals, workflowComposer } = args;
   const draft = options.draft.signals;
@@ -799,8 +799,7 @@ function createComposerPrimaryActionSignal(args: {
     const attachments = get(draft.attachments$);
     const hasContent =
       get(workflowComposer.hasInput$) || attachments.length > 0;
-    const canSend =
-      !get(args.choosingCreateType$) && uploadsReady && hasContent;
+    const canSend = !get(args.createPickerOpen$) && uploadsReady && hasContent;
     const sending = await get(eventSignals.sending$);
     if (sending && !canSend) {
       return "stop";
@@ -943,7 +942,7 @@ function createComposerSubmissionSignals(
     eventSignals,
     workflowComposer,
     voiceState$,
-    choosingCreateType$: create.choosing$,
+    createPickerOpen$: create.pickerOpen$,
   });
   const submitCurrentInput$ = createSubmitCurrentInput(
     options,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, test } from "vitest";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
@@ -108,13 +108,22 @@ test("Choose a video through the consolidated Create entry with the keyboard and
   const menu = await screen.findByTestId("slash-workflow-menu");
   expect(button("Create", menu)).toBeInTheDocument();
   await user.keyboard("{Enter}");
-  const types = await screen.findByRole("group", { name: "Choose a type" });
+  const types = await screen.findByRole("listbox", { name: "Choose a type" });
   expect(
-    queryAllByRoleFast("button", types).map((item) => {
-      return item.textContent?.trim();
-    }),
+    within(types)
+      .getAllByRole("option")
+      .map((item) => {
+        return item.getAttribute("aria-label");
+      }),
   ).toStrictEqual(["Presentation", "Video", "Image"]);
-  expect(button("Presentation", types)).toHaveFocus();
+  expect(
+    within(types).getByRole("option", { name: "Presentation" }),
+  ).toHaveFocus();
+  const card = editor.closest('[data-slot="chat-composer-card"]');
+  expect(card).toContainElement(types);
+  expect(card).toContainElement(
+    screen.getByRole("combobox", { name: "Choose a type" }),
+  );
   expect(button("Send")).toBeDisabled();
   await user.keyboard("{ArrowRight}{Enter}");
   await waitFor(() => {
@@ -548,8 +557,8 @@ test("The slash menu exposes one Create entry that opens the image style flow", 
     }),
   ).toHaveLength(1);
   click(button("Create", menu));
-  const types = await screen.findByRole("group", { name: "Choose a type" });
-  click(button("Image", types));
+  const types = await screen.findByRole("listbox", { name: "Choose a type" });
+  click(within(types).getByRole("option", { name: "Image" }));
   await waitFor(() => {
     expect(screen.getByTestId("composer-create-mode")).toHaveTextContent(
       "Create image",
@@ -586,12 +595,11 @@ test("Canceling and switching Create preserve slash text and template references
   await user.paste("Our launch /create");
   const menu = await screen.findByTestId("slash-workflow-menu");
   click(button("Create", menu));
-  const chooser = await screen.findByRole("group", {
+  const chooser = await screen.findByRole("listbox", {
     name: "Choose a type",
   });
-  await user.click(editor);
-  await user.keyboard("{Enter}");
-  expect(chooser).toBeInTheDocument();
+  expect(chooser).toBeVisible();
+  expect(editor).not.toBeVisible();
   expect(button("Send")).toBeDisabled();
   expect(submissions).toHaveLength(0);
   await user.keyboard("{Escape}");
@@ -604,8 +612,8 @@ test("Canceling and switching Create preserve slash text and template references
   await user.paste(" /create");
   const reopened = await screen.findByTestId("slash-workflow-menu");
   click(button("Create", reopened));
-  const types = await screen.findByRole("group", { name: "Choose a type" });
-  click(button("Presentation", types));
+  const types = await screen.findByRole("listbox", { name: "Choose a type" });
+  click(within(types).getByRole("option", { name: "Presentation" }));
   const chip = await screen.findByTestId("composer-create-mode");
   expect(chip).toHaveTextContent("Create presentation");
   expect(types).not.toBeInTheDocument();
@@ -639,4 +647,60 @@ test("Canceling and switching Create preserve slash text and template references
       titleSnapshot: template.title,
     }),
   );
+});
+
+test("Reopening and dismissing the in-composer picker preserves the selected scene and draft", async () => {
+  setupModels();
+  const editor = await setupComposer();
+  const user = userEvent.setup({ delay: null });
+  await chooseCommand(
+    editor,
+    "Our quarterly update /create presentation",
+    "Create presentation",
+  );
+  const trigger = screen.getByRole("combobox", { name: "Choose a type" });
+  const card = editor.closest('[data-slot="chat-composer-card"]');
+  expect(card).toContainElement(trigger);
+  expect(editor).toBeVisible();
+
+  click(screen.getByRole("combobox", { name: "Slide count" }));
+  click(await screen.findByRole("option", { name: "16–20 slides" }));
+  await waitFor(() => {
+    expect(
+      screen.getByRole("combobox", { name: "Slide count" }),
+    ).toHaveTextContent("16–20 slides");
+  });
+  click(trigger);
+  const picker = await screen.findByRole("listbox", { name: "Choose a type" });
+  expect(card).toContainElement(picker);
+  expect(trigger).toHaveAttribute("aria-expanded", "true");
+  expect(trigger).toHaveAttribute("aria-controls", picker.id);
+  expect(
+    within(picker).getByRole("option", { name: "Presentation" }),
+  ).toHaveAttribute("aria-selected", "true");
+  expect(button("Send")).toBeDisabled();
+  await user.keyboard("{ArrowDown}{Escape}");
+  await waitFor(() => {
+    expect(editor).toHaveFocus();
+  });
+  expect(picker).not.toBeInTheDocument();
+  expect(trigger).toHaveTextContent("Create presentation");
+  expect(trigger).toHaveAttribute("aria-expanded", "false");
+  expect(editor).toHaveTextContent("Our quarterly update");
+  expect(
+    screen.getByRole("combobox", { name: "Slide count" }),
+  ).toHaveTextContent("16–20 slides");
+
+  click(trigger);
+  const reopened = await screen.findByRole("listbox", {
+    name: "Choose a type",
+  });
+  click(within(reopened).getByRole("option", { name: "Image" }));
+  await waitFor(() => {
+    expect(editor).toHaveFocus();
+  });
+  expect(trigger).toHaveTextContent("Create image");
+  expect(editor).toHaveTextContent("Our quarterly update");
+  expect(editor).toBeVisible();
+  expect(reopened).not.toBeInTheDocument();
 });

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -9,6 +9,7 @@ import {
 } from "./composer-actions.ts";
 import {
   ComposerCreateControls,
+  ComposerCreatePicker,
   ComposerCreateImageModelPicker,
   ComposerCreateVideoModelPicker,
 } from "./composer-create.tsx";
@@ -9366,6 +9367,7 @@ function ComposerInputSlot({
   actions: ComposerActions;
   minimumHeightClassName: string;
 }) {
+  const createPickerOpen = useGet(signals.create.pickerOpen$);
   const sending = useLastResolved(signals.submission.sending$) ?? false;
   const notifyDraftChanged = useComposerDraftChange(signals);
   const restoreAttachments = useSet(signals.draft.restoreAttachments$);
@@ -9483,7 +9485,10 @@ function ComposerInputSlot({
         minimumHeightClassName,
       )}
     >
-      <div className="col-start-1 row-start-1 min-h-0">
+      <div
+        className="col-start-1 row-start-1 min-h-0"
+        hidden={createPickerOpen}
+      >
         <TiptapWorkflowComposer
           signals={signals}
           onDraftChange={notifyDraftChanged}
@@ -9492,6 +9497,7 @@ function ComposerInputSlot({
           onPaste={handlePaste}
         />
       </div>
+      <ComposerCreatePicker signals={signals} />
       {showVoiceTranscriptionSkeleton ? (
         <div
           className="pointer-events-none col-start-1 row-start-1 flex min-h-0 flex-col justify-center gap-2 bg-card px-6"
@@ -10997,6 +11003,7 @@ function ComposerCard({ signals }: { signals: ComposerSignals }) {
           className={cn("flex flex-col", layoutHeightClassNames.shell)}
         >
           <ComposerImportedTemplateUrlRefreshLifecycle signals={signals} />
+          <ComposerCreateControls signals={signals} />
           <ComposerAttachments signals={signals} />
           <ComposerInputSlot
             signals={signals}
@@ -11032,7 +11039,6 @@ export function ChatComposer({
         className="relative flex w-full min-w-0 flex-col"
       >
         {showPendingItems ? <PendingItemsStrip signals={signals} /> : null}
-        <ComposerCreateControls signals={signals} />
         <ComposerCard signals={signals} />
         <ComposerTemporaryModelNoticeSlot signals={signals} />
         <ReplaceComposerDraftDialog signals={signals} />

--- a/turbo/apps/platform/src/views/okou-page/composer-create.tsx
+++ b/turbo/apps/platform/src/views/okou-page/composer-create.tsx
@@ -2,7 +2,7 @@ import { withChatScrollLayout } from "../components/chat-scroll-layout.tsx";
 import type { KeyboardEvent, ReactNode } from "react";
 import { useGet, useLastResolved, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
-import { X } from "lucide-react";
+import { Check, ChevronDown, X } from "lucide-react";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import { resolveVideoRunOptions } from "../../signals/okou-page/video-run-options.ts";
 import { Button } from "@okouai/ui";
@@ -27,6 +27,7 @@ import type {
   ComposerVideoModelSignals,
 } from "../../signals/okou-page/composer-signals.ts";
 import {
+  composerCreateModeDescription,
   composerCreateModeLabel,
   composerCreateModeName,
   type ComposerCreateMode,
@@ -50,6 +51,25 @@ const CREATE_MODE_ICON_CLASS = {
 } satisfies Record<ComposerCreateMode, string>;
 
 function handleCreateTypeNavigation(event: KeyboardEvent<HTMLDivElement>) {
+  if (event.altKey || event.ctrlKey || event.metaKey) {
+    return;
+  }
+  const options = Array.from(
+    event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="option"]'),
+  );
+  if (event.key.length === 1 && /\S/.test(event.key)) {
+    const match = options.find((option) => {
+      return option
+        .getAttribute("aria-label")
+        ?.toLocaleLowerCase()
+        .startsWith(event.key.toLocaleLowerCase());
+    });
+    if (match) {
+      event.preventDefault();
+      match.focus();
+    }
+    return;
+  }
   if (
     ![
       "ArrowLeft",
@@ -62,11 +82,8 @@ function handleCreateTypeNavigation(event: KeyboardEvent<HTMLDivElement>) {
   ) {
     return;
   }
-  const buttons = Array.from(
-    event.currentTarget.querySelectorAll<HTMLButtonElement>("button"),
-  );
-  const index = buttons.findIndex((button) => {
-    return button === event.target;
+  const index = options.findIndex((option) => {
+    return option === event.target;
   });
   if (index === -1) {
     return;
@@ -76,12 +93,12 @@ function handleCreateTypeNavigation(event: KeyboardEvent<HTMLDivElement>) {
     event.key === "Home"
       ? 0
       : event.key === "End"
-        ? buttons.length - 1
+        ? options.length - 1
         : (index +
             (["ArrowRight", "ArrowDown"].includes(event.key) ? 1 : -1) +
-            buttons.length) %
-          buttons.length;
-  buttons[next]?.focus();
+            options.length) %
+          options.length;
+  options[next]?.focus();
 }
 
 export function ComposerCreateControls({
@@ -92,104 +109,85 @@ export function ComposerCreateControls({
   const { t } = useTranslation();
   const choosing = useGet(signals.create.choosing$);
   const mode = useGet(signals.create.mode$);
+  const pickerOpen = useGet(signals.create.pickerOpen$);
+  const setPickerOpen = useSet(signals.create.setPickerOpen$);
   const setMode = useSet(signals.create.setMode$);
   if (!choosing && !mode) {
     return withChatScrollLayout(null);
   }
+  const Icon = COMPOSER_CREATE_ICONS[mode ?? "choose"];
   return withChatScrollLayout(
     <div
-      className="@container/create-controls"
+      className="@container/create-controls flex shrink-0 items-center gap-2 px-4 pt-4 pb-1"
+      data-testid="composer-create-mode"
       onKeyDown={(event) => {
-        if (event.key === "Escape" && choosing) {
+        if (event.key === "Escape" && pickerOpen) {
           event.preventDefault();
-          setMode(null);
+          setPickerOpen(false);
         }
       }}
-    >
-      <div className="flex min-h-11 min-w-0 items-center gap-1 px-2 pb-3 @max-[350px]/create-controls:px-3">
-        {choosing ? (
-          <>
-            <div
-              className="flex min-w-0 items-center gap-2 @max-[380px]/create-controls:gap-0.5"
-              role="group"
-              aria-label={t(($) => {
-                return $.chat.composer.create.chooseType;
-              })}
-              onKeyDown={handleCreateTypeNavigation}
-            >
-              {signals.create.modes.map((type, index) => {
-                const Icon = COMPOSER_CREATE_ICONS[type];
-                return (
-                  <Button
-                    key={type}
-                    type="button"
-                    variant="quiet"
-                    size="sm"
-                    className={cn(
-                      "gap-2 px-2 font-normal @max-[350px]/create-controls:gap-1 @max-[350px]/create-controls:px-1 @max-[350px]/create-controls:text-xs @max-[350px]/create-controls:[&_svg]:size-3.5",
-                      CREATE_CONTROL_FOCUS,
-                    )}
-                    autoFocus={index === 0}
-                    onClick={() => {
-                      setMode(type);
-                    }}
-                  >
-                    <Icon
-                      className={CREATE_MODE_ICON_CLASS[type]}
-                      aria-hidden
-                    />
-                    {composerCreateModeName(type)}
-                  </Button>
-                );
-              })}
-            </div>
-            <span
-              className="mx-1 h-3.5 w-px shrink-0 bg-gray-300 @max-[380px]/create-controls:hidden"
-              aria-hidden
-            />
-            <Button
-              type="button"
-              variant="quiet"
-              size="icon-sm"
-              className={cn("shrink-0 text-gray-600", CREATE_CONTROL_FOCUS)}
-              aria-label={t(($) => {
-                return $.chat.composer.create.exit;
-              })}
-              onClick={() => {
-                setMode(null);
-              }}
-            >
-              <X size={16} aria-hidden />
-            </Button>
-          </>
-        ) : mode ? (
-          <ComposerCreateChip signals={signals} mode={mode} />
-        ) : null}
-      </div>
-    </div>,
-  );
-}
-
-function ComposerCreateChip({
-  signals,
-  mode,
-}: {
-  readonly signals: ComposerSignals;
-  readonly mode: ComposerCreateMode;
-}) {
-  const { t } = useTranslation();
-  const setMode = useSet(signals.create.setMode$);
-  const Icon = COMPOSER_CREATE_ICONS[mode];
-  return (
-    <div
-      className="group/create-mode flex h-8 max-w-full items-center rounded-lg bg-gray-50 @max-[350px]/create-controls:-ml-1"
-      data-testid="composer-create-mode"
     >
       <Button
         type="button"
         variant="quiet"
+        size="sm"
+        role="combobox"
+        aria-label={t(($) => {
+          return $.chat.composer.create.chooseType;
+        })}
+        aria-haspopup="listbox"
+        aria-expanded={pickerOpen}
+        aria-controls={pickerOpen ? signals.create.pickerId : undefined}
+        className={cn(
+          "min-w-0 gap-2 bg-gray-50 px-2.5 font-normal text-foreground",
+          CREATE_CONTROL_FOCUS,
+        )}
+        onClick={() => {
+          setPickerOpen(!pickerOpen);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+            event.preventDefault();
+            if (pickerOpen) {
+              const picker = document.getElementById(signals.create.pickerId);
+              const option =
+                picker?.querySelector<HTMLElement>('[aria-selected="true"]') ??
+                picker?.querySelector<HTMLElement>('[role="option"]');
+              option?.focus();
+              return;
+            }
+            setPickerOpen(true);
+          }
+        }}
+      >
+        <Icon
+          className={mode ? CREATE_MODE_ICON_CLASS[mode] : undefined}
+          aria-hidden
+        />
+        <span className="truncate">
+          {mode
+            ? composerCreateModeLabel(mode)
+            : t(($) => {
+                return $.chat.composer.create.title;
+              })}
+        </span>
+        <ChevronDown
+          className={cn("shrink-0 opacity-50", pickerOpen && "rotate-180")}
+          aria-hidden
+        />
+      </Button>
+      {choosing && (
+        <span className="min-w-0 truncate text-sm text-muted-foreground @max-[350px]/create-controls:hidden">
+          {t(($) => {
+            return $.chat.composer.create.chooseScene;
+          })}
+        </span>
+      )}
+      <Button
+        type="button"
+        variant="quiet"
         size="icon-sm"
-        className={cn("group relative shrink-0", CREATE_CONTROL_FOCUS)}
+        className={cn("ml-auto shrink-0", CREATE_CONTROL_FOCUS)}
         aria-label={t(($) => {
           return $.chat.composer.create.exit;
         })}
@@ -197,51 +195,82 @@ function ComposerCreateChip({
           setMode(null);
         }}
       >
-        <Icon
-          className={cn(
-            "transition-opacity group-hover/create-mode:opacity-0 group-focus-visible:opacity-0 [@media(hover:none)]:opacity-0",
-            CREATE_MODE_ICON_CLASS[mode],
-          )}
-          aria-hidden
-        />
-        <X
-          className="absolute opacity-0 transition-opacity group-hover/create-mode:opacity-100 group-focus-visible:opacity-100 [@media(hover:none)]:opacity-100"
-          aria-hidden
-        />
+        <X aria-hidden />
       </Button>
-      <Select value={mode} onValueChange={setMode} modal={false}>
-        <SelectTrigger
-          className="h-8 w-auto min-w-0 gap-2 border-0 bg-transparent py-0 pl-0 pr-2.5 font-normal hover:bg-state-hover focus-visible:bg-state-hover"
-          aria-label={t(($) => {
-            return $.chat.composer.create.chooseType;
-          })}
-        >
-          <SelectValue>{composerCreateModeLabel(mode)}</SelectValue>
-        </SelectTrigger>
-        <SelectContent
-          align="start"
-          alignOffset={-32}
-          finalFocus={() => {
-            return signals.editor.editor.view.dom;
-          }}
-        >
-          {signals.create.modes.map((type) => {
-            const TypeIcon = COMPOSER_CREATE_ICONS[type];
-            return (
-              <SelectItem key={type} value={type}>
-                <span className="flex items-center gap-2">
-                  <TypeIcon
-                    className={cn("size-4", CREATE_MODE_ICON_CLASS[type])}
-                    aria-hidden
-                  />
+    </div>,
+  );
+}
+
+export function ComposerCreatePicker({
+  signals,
+}: {
+  readonly signals: ComposerSignals;
+}) {
+  const { t } = useTranslation();
+  const mode = useGet(signals.create.mode$);
+  const pickerOpen = useGet(signals.create.pickerOpen$);
+  const setMode = useSet(signals.create.setMode$);
+  const setPickerOpen = useSet(signals.create.setPickerOpen$);
+  if (!pickerOpen) {
+    return withChatScrollLayout(null);
+  }
+  return withChatScrollLayout(
+    <div className="col-start-1 row-start-1 min-w-0 px-4 pt-2 pb-4">
+      <div
+        id={signals.create.pickerId}
+        role="listbox"
+        aria-label={t(($) => {
+          return $.chat.composer.create.chooseType;
+        })}
+        className="flex w-72 max-w-full flex-col gap-1 rounded-xl border-[0.7px] border-control-border bg-card p-1"
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            setPickerOpen(false);
+            return;
+          }
+          handleCreateTypeNavigation(event);
+        }}
+      >
+        {signals.create.modes.map((type, index) => {
+          const Icon = COMPOSER_CREATE_ICONS[type];
+          const selected = type === mode;
+          const initialFocus = mode ? selected : index === 0;
+          return (
+            <Button
+              key={type}
+              type="button"
+              variant="quiet"
+              role="option"
+              aria-label={composerCreateModeName(type)}
+              aria-selected={selected}
+              autoFocus={initialFocus}
+              tabIndex={initialFocus ? 0 : -1}
+              className={cn(
+                "relative h-auto w-full justify-start gap-2.5 py-2.5 pl-2 pr-8 text-left font-normal text-foreground",
+                CREATE_CONTROL_FOCUS,
+                "hover:bg-gray-50 focus-visible:bg-gray-50",
+                selected && "bg-gray-50",
+              )}
+              onClick={() => {
+                setMode(type);
+              }}
+            >
+              <Icon className={CREATE_MODE_ICON_CLASS[type]} aria-hidden />
+              <span className="min-w-0">
+                <span className="block text-sm">
                   {composerCreateModeName(type)}
                 </span>
-              </SelectItem>
-            );
-          })}
-        </SelectContent>
-      </Select>
-    </div>
+                <span className="block whitespace-normal text-xs text-muted-foreground">
+                  {composerCreateModeDescription(type)}
+                </span>
+              </span>
+              {selected && <Check className="absolute right-2" aria-hidden />}
+            </Button>
+          );
+        })}
+      </div>
+    </div>,
   );
 }
 

--- a/turbo/apps/platform/src/views/okou-page/composer-create.tsx
+++ b/turbo/apps/platform/src/views/okou-page/composer-create.tsx
@@ -118,7 +118,7 @@ export function ComposerCreateControls({
   const Icon = COMPOSER_CREATE_ICONS[mode ?? "choose"];
   return withChatScrollLayout(
     <div
-      className="@container/create-controls flex shrink-0 items-center gap-2 px-4 pt-4 pb-1"
+      className="@container/create-controls flex shrink-0 items-center gap-1 px-4 pt-4 pb-1"
       data-testid="composer-create-mode"
       onKeyDown={(event) => {
         if (event.key === "Escape" && pickerOpen) {
@@ -176,27 +176,28 @@ export function ComposerCreateControls({
           aria-hidden
         />
       </Button>
-      {choosing && (
-        <span className="min-w-0 truncate text-sm text-muted-foreground @max-[350px]/create-controls:hidden">
-          {t(($) => {
-            return $.chat.composer.create.chooseScene;
-          })}
-        </span>
-      )}
       <Button
         type="button"
         variant="quiet"
         size="icon-sm"
-        className={cn("ml-auto shrink-0", CREATE_CONTROL_FOCUS)}
+        className={cn("shrink-0", CREATE_CONTROL_FOCUS)}
         aria-label={t(($) => {
           return $.chat.composer.create.exit;
         })}
+        showTooltip
         onClick={() => {
           setMode(null);
         }}
       >
         <X aria-hidden />
       </Button>
+      {choosing && (
+        <span className="ml-1 min-w-0 truncate text-sm text-muted-foreground @max-[350px]/create-controls:hidden">
+          {t(($) => {
+            return $.chat.composer.create.chooseScene;
+          })}
+        </span>
+      )}
     </div>,
   );
 }


### PR DESCRIPTION
## Summary

Move the Create scene controls from above the input into the composer card, following the approved design: https://create-composer-bj-0910.okou.app. Typing `/create` opens an inline list for Presentation, Video, and Image. Selecting a scene collapses the list and focuses the existing editor.

Keep the exit button immediately beside the Create trigger with a 4px gap and a 32px click target. Its shared tooltip reads "Exit create mode". Reopening, switching, dismissing, or exiting preserves the draft; dismissing also retains the selected scene and generation settings.

The change reuses the existing Create feature gates and generation behavior, keeps the editor mounted, and disables sending while the scene picker is expanded.

## Verification

- Latest head: `73f6a7ca623183665f77320094ec8c4bf70ee636`; deployed merge build: `a24417697a746db84a8db4f4741733502e506b75`.
- App and API previews deployed successfully. Browser acceptance passed at 1440px and 390px: 4px exit spacing in initial, selected, and expanded states; tooltip; draft preservation; focus restoration; no narrow-screen overflow.
- All eight Platform test shards passed on the latest head. The remaining Turbo workflow jobs are still running; no failures were observed.
- Affected formatting, ESLint, Oxlint, Tailwind lint, style policy, and Platform production/test/build TypeScript checks passed locally.
- Test account: existing Clerk test user with `composerCreateCommands` on and real preview runners off. Entered Lab directly after sign-in; no onboarding API bypass, checkout, or generation was submitted. No local dev server or full local Vitest run was started.

## Acceptance

1. Open Lab, enable `composerCreateCommands`, then return to chat and type `/create`.
2. Confirm Create. Verify the trigger, adjacent exit button, and all scene options are inside the composer.
3. Select a scene and enter a draft. Reopen the picker and switch scenes; the draft should remain and focus should return to the editor.
4. Hover the exit button to see "Exit create mode". Click it and verify normal chat returns without clearing the draft. Check the same placement on a narrow viewport.
