### PR TITLE
fix(platform): show purpose descriptions for related artifacts

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
@@ -50,7 +50,11 @@ export interface RunWorkSection {
 type RunWorkArtifactCard = Extract<
   MarkdownCardRef,
   { readonly kind: "artifact" }
-> & { readonly label?: string; readonly tree: Root };
+> & {
+  readonly label?: string;
+  readonly description?: string;
+  readonly tree: Root;
+};
 
 export interface RunWorkFolding {
   readonly visibleGroups: ChatEventGroup[];
@@ -127,6 +131,99 @@ function artifactNodeLabel(node: Element): string | undefined {
   return normalized || undefined;
 }
 
+function artifactContext(node: Element): {
+  readonly text: string;
+  readonly artifactCount: number;
+} {
+  if (node.data?.card) {
+    return {
+      text: "",
+      artifactCount: node.data.card.kind === "artifact" ? 1 : 0,
+    };
+  }
+  let artifactCount = 0;
+  const text = node.children
+    .map((child) => {
+      if (child.type === "text") {
+        return child.value;
+      }
+      if (child.type !== "element") {
+        return "";
+      }
+      const context = artifactContext(child);
+      artifactCount += context.artifactCount;
+      return ["p", "li", "td", "th", "br"].includes(child.tagName)
+        ? ` ${context.text} `
+        : context.text;
+    })
+    .join("");
+  return { text, artifactCount };
+}
+
+function artifactDescription(
+  node: Element,
+  ancestors: readonly (Root | Element)[],
+): string | undefined {
+  const normalize = (text: string): string | undefined => {
+    const description = text
+      .replace(/\s+/gu, " ")
+      .replace(/^[\s:：,，;；|–—-]+|[\s:：,，;；|–—-]+$/gu, "");
+    return /[\p{L}\p{N}]/u.test(description) &&
+      description !== artifactNodeLabel(node)
+      ? description
+      : undefined;
+  };
+  if (typeof node.properties.title === "string") {
+    const title = normalize(node.properties.title);
+    if (title) {
+      return title;
+    }
+  }
+  // Stay within the artifact's paragraph, list item, or table row. Shared
+  // prose cannot describe one particular file when it contains several.
+  let paragraphIndex = -1;
+  for (let index = ancestors.length - 1; index >= 0; index--) {
+    const ancestor = ancestors[index]!;
+    if (
+      ancestor.type !== "element" ||
+      !["p", "li", "td", "th", "tr"].includes(ancestor.tagName)
+    ) {
+      continue;
+    }
+    if (ancestor.tagName === "p" && paragraphIndex === -1) {
+      paragraphIndex = index;
+    }
+    const context = artifactContext(ancestor);
+    if (context.artifactCount !== 1) {
+      return undefined;
+    }
+    const description = normalize(context.text);
+    if (description) {
+      return description;
+    }
+  }
+  // A standalone link commonly follows its introduction on a separate line.
+  // Only use an immediately adjacent paragraph/heading in the same container.
+  const paragraph = ancestors[paragraphIndex];
+  const parent = ancestors[paragraphIndex - 1];
+  if (!paragraph || paragraph.type !== "element" || !parent) {
+    return undefined;
+  }
+  const siblings = parent.children.filter((child): child is Element => {
+    return child.type === "element";
+  });
+  const previous = siblings[siblings.indexOf(paragraph) - 1];
+  if (
+    !previous ||
+    previous.type !== "element" ||
+    !/^(?:p|h[1-6])$/u.test(previous.tagName)
+  ) {
+    return undefined;
+  }
+  const context = artifactContext(previous);
+  return context.artifactCount === 0 ? normalize(context.text) : undefined;
+}
+
 function artifactCardsInTree(
   tree: Root | undefined,
 ): readonly RunWorkArtifactCard[] {
@@ -134,23 +231,28 @@ function artifactCardsInTree(
     return [];
   }
   const cards: RunWorkArtifactCard[] = [];
-  const visit = (node: Root | Element): void => {
+  const visit = (
+    node: Root | Element,
+    ancestors: readonly (Root | Element)[],
+  ): void => {
     if (node.type === "element" && node.data?.card?.kind === "artifact") {
       const label = artifactNodeLabel(node);
+      const description = artifactDescription(node, ancestors);
       cards.push({
         ...node.data.card,
         ...(label === undefined ? {} : { label }),
+        ...(description === undefined ? {} : { description }),
         tree: { type: "root", children: [node] },
       });
       return;
     }
     for (const child of node.children) {
       if (child.type === "element") {
-        visit(child);
+        visit(child, [...ancestors, node]);
       }
     }
   };
-  visit(tree);
+  visit(tree, []);
   return cards;
 }
 
@@ -162,21 +264,28 @@ function remainingArtifactCards(
       return card.signals.url;
     }),
   );
-  const seenUrls = new Set<string>();
-  const remaining: RunWorkArtifactCard[] = [];
+  const remaining = new Map<string, RunWorkArtifactCard>();
   for (const message of outputMessages) {
     for (const card of artifactCardsInTree(message.tree)) {
       const { url } = card.signals;
-      if (seenUrls.has(url)) {
+      if (finalUrls.has(url)) {
         continue;
       }
-      seenUrls.add(url);
-      if (!finalUrls.has(url)) {
-        remaining.push(card);
-      }
+      const previous = remaining.get(url);
+      const previousLabel = previous?.label;
+      remaining.set(url, {
+        ...card,
+        label:
+          previousLabel &&
+          previousLabel !== url &&
+          previousLabel !== card.signals.filename
+            ? previousLabel
+            : card.label,
+        description: previous?.description ?? card.description,
+      });
     }
   }
-  return remaining;
+  return [...remaining.values()];
 }
 
 export function runWorkSectionForGroup(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
@@ -220,6 +220,173 @@ test("A carried image keeps its label and opens a lightbox over the dialog", asy
   await closeRelatedArtifactPreview(dialog);
 });
 
+test.each([
+  [
+    "inline explanation",
+    "[Editable package](ARTIFACT_URL) — Update the slides for your next presentation.",
+    "Update the slides for your next presentation.",
+  ],
+  [
+    "standalone link introduction",
+    "Use this package to edit the slides offline.\n\nARTIFACT_URL",
+    "Use this package to edit the slides offline.",
+  ],
+  [
+    "list item explanation",
+    "- [Editable package](ARTIFACT_URL)\n\n  Update the slides for your next presentation.",
+    "Update the slides for your next presentation.",
+  ],
+  [
+    "table row explanation",
+    "| File | Purpose |\n| --- | --- |\n| [Editable package](ARTIFACT_URL) | Update the slides for your next presentation. |",
+    "Update the slides for your next presentation.",
+  ],
+  [
+    "explicit link title",
+    '[Editable package](ARTIFACT_URL "Use this package to edit the slides offline.")',
+    "Use this package to edit the slides offline.",
+  ],
+])("Show the artifact's %s before opening it", async (_, markdown, purpose) => {
+  const url = artifactUrl("artifact-purpose", "3qkwcyzuet.zip");
+  await setupArtifactRun([
+    assistantEvent({
+      id: "artifact-purpose-history",
+      runId: RUN_ID,
+      seqId: 2,
+      text: markdown.replace("ARTIFACT_URL", url),
+    }),
+    assistantEvent({
+      id: "artifact-purpose-main",
+      runId: RUN_ID,
+      seqId: 3,
+      text: "The presentation is ready",
+    }),
+  ]);
+
+  const dialog = await openRelatedArtifacts();
+  const artifact = relatedArtifactRow(dialog, url);
+  expect(within(artifact).getByText(purpose)).toBeVisible();
+  expect(artifact).toHaveAccessibleDescription(purpose);
+  click(artifact);
+  const preview = await screen.findByRole("dialog", {
+    name: "3qkwcyzuet.zip preview",
+  });
+  expect(
+    within(preview).getByText("No inline preview available for this file."),
+  ).toBeVisible();
+  await closeRelatedArtifactPreview(dialog);
+});
+
+test("Keep each file's purpose with its own list item", async () => {
+  const editableUrl = artifactUrl("editable-package", "3qkwcyzuet.zip");
+  const evidenceUrl = artifactUrl("source-package", "z6rgfsqp0b.zip");
+  await setupArtifactRun([
+    assistantEvent({
+      id: "separate-purposes-history",
+      runId: RUN_ID,
+      seqId: 2,
+      text: [
+        `- [Editable slides](${editableUrl}) — Customize the presentation.`,
+        `- [Source data](${evidenceUrl}) — Verify the figures in the report.`,
+      ].join("\n"),
+    }),
+    assistantEvent({
+      id: "separate-purposes-main",
+      runId: RUN_ID,
+      seqId: 3,
+      text: "The deliverables are ready",
+    }),
+  ]);
+
+  const dialog = await openRelatedArtifacts();
+  const editable = relatedArtifactRow(dialog, editableUrl);
+  const evidence = relatedArtifactRow(dialog, evidenceUrl);
+  expect(editable).toHaveAccessibleDescription("Customize the presentation.");
+  expect(editable).not.toHaveTextContent("Verify the figures");
+  expect(evidence).toHaveAccessibleDescription(
+    "Verify the figures in the report.",
+  );
+  expect(evidence).not.toHaveTextContent("Customize the presentation");
+});
+
+test("Enrich a repeated bare link without duplicating or reordering files", async () => {
+  const url = artifactUrl("enriched-package", "3qkwcyzuet.zip");
+  const otherUrl = artifactUrl("other-package", "z6rgfsqp0b.zip");
+  await setupArtifactRun([
+    assistantEvent({
+      id: "enriched-purpose-bare",
+      runId: RUN_ID,
+      seqId: 2,
+      text: `${url}\n\n${otherUrl}`,
+    }),
+    assistantEvent({
+      id: "enriched-purpose-explanation",
+      runId: RUN_ID,
+      seqId: 3,
+      text: `[Editable slides](${url}) — Customize the presentation.`,
+    }),
+    assistantEvent({
+      id: "enriched-purpose-repeated",
+      runId: RUN_ID,
+      seqId: 4,
+      text: url,
+    }),
+    assistantEvent({
+      id: "enriched-purpose-main",
+      runId: RUN_ID,
+      seqId: 5,
+      text: "The editable slides are ready",
+    }),
+  ]);
+
+  const dialog = await openRelatedArtifacts();
+  const artifact = relatedArtifactRow(dialog, url);
+  expect(artifact).toHaveAccessibleName("Preview Editable slides");
+  expect(artifact).toHaveAccessibleDescription("Customize the presentation.");
+  expectDocumentOrder(artifact, relatedArtifactRow(dialog, otherUrl));
+});
+
+test("Do not assign shared or unrelated prose to a particular artifact", async () => {
+  const firstUrl = artifactUrl("ambiguous-first", "first.zip");
+  const secondUrl = artifactUrl("ambiguous-second", "second.zip");
+  const bareUrl = artifactUrl("no-description", "third.zip");
+  await setupArtifactRun([
+    assistantEvent({
+      id: "ambiguous-purpose-history",
+      runId: RUN_ID,
+      seqId: 2,
+      text: `Use [one](${firstUrl}) or [the other](${secondUrl}) for the presentation.`,
+    }),
+    assistantEvent({
+      id: "unrelated-purpose-history",
+      runId: RUN_ID,
+      seqId: 3,
+      text: "Reviewed the presentation.",
+    }),
+    assistantEvent({
+      id: "missing-purpose-history",
+      runId: RUN_ID,
+      seqId: 4,
+      text: bareUrl,
+    }),
+    assistantEvent({
+      id: "ambiguous-purpose-main",
+      runId: RUN_ID,
+      seqId: 5,
+      text: "The presentation review is complete",
+    }),
+  ]);
+
+  const dialog = await openRelatedArtifacts();
+  for (const url of [firstUrl, secondUrl, bareUrl]) {
+    expect(relatedArtifactRow(dialog, url)).not.toHaveAttribute(
+      "aria-description",
+    );
+  }
+  expect(relatedArtifactRow(dialog, bareUrl)).toHaveTextContent("third.zip");
+  expect(within(dialog).queryByText("Reviewed the presentation.")).toBeNull();
+});
+
 async function openRelatedArtifactOverSidebar(filename: string, body?: string) {
   const url = artifactUrl("sidebar-preview", filename);
   if (body !== undefined) {
@@ -537,8 +704,8 @@ test("Keep artifacts with the same filename distinct when their URLs differ", as
   const second = relatedArtifactRow(dialog, secondUrl);
   expectDocumentOrder(first, second);
   expect(within(dialog).getAllByText("Report")).toHaveLength(2);
-  expect(screen.queryByText("First report version")).toBeNull();
-  expect(screen.queryByText("Second report version")).toBeNull();
+  expect(first).toHaveAccessibleDescription("First report version");
+  expect(second).toHaveAccessibleDescription("Second report version");
 });
 
 test("Render inline media and action cards after expanding short history", async () => {

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -7477,6 +7477,7 @@ function RelatedArtifactRow({ card }: { readonly card: RelatedArtifactCard }) {
         },
         { filename: name },
       )}
+      aria-description={card.description}
       title={card.signals.url}
       data-chat-run-related-artifact-url={card.signals.url}
       onClick={() => {
@@ -7488,6 +7489,14 @@ function RelatedArtifactRow({ card }: { readonly card: RelatedArtifactCard }) {
         <span className="block truncate text-sm font-medium text-foreground">
           {name}
         </span>
+        {card.description ? (
+          <span
+            className="mt-1 line-clamp-2 whitespace-normal break-words text-xs text-muted-foreground"
+            title={card.description}
+          >
+            {card.description}
+          </span>
+        ) : null}
         <span className="mt-0.5 block truncate text-xs text-muted-foreground">
           {kind}
           {host ? ` · ${host}` : ""}


### PR DESCRIPTION
## Summary

Related artifacts loses the explanatory text around links when earlier chat output is collapsed, leaving files such as `3qkwcyzuet.zip` indistinguishable. Keep each artifact's purpose visible below its name, using the link title or its own paragraph, list item, table row, or immediately preceding introduction. Descriptions wrap to two lines, with the complete text available on hover and to assistive technology.

Repeated URLs fill missing names and descriptions while preserving their original order and the existing exclusion of artifacts already in the final reply. Shared prose containing multiple artifacts is not assigned to an individual file. Preview actions continue to use the existing artifact URLs and lightbox.

## Verification

- Related-artifact page integration tests: 27 passed, including purpose extraction, per-file attribution, repeated bare links, missing context, and preview interactions.
- Platform production, test, and build-configuration type checks passed.
- ESLint and Oxlint checks passed for the changed files.
- Platform Knip, formatting, repository style policy, and affected-source style lint passed.

## Acceptance

1. Open a completed chat whose earlier assistant messages include file links with explanations, then open Related artifacts.
2. Confirm each file shows its corresponding explanation below the name. Repeat a bare link with a descriptive label later in the same run and confirm it appears only once with the additional details.
3. Confirm files without individual explanations remain usable, long descriptions fit within the dialog, and selecting a row opens the existing preview.

## Fallbacks

- `run-work-folding.ts:artifactDescription` derives display text from optional Markdown content: an explicit link title, then local prose, then an adjacent introduction for a standalone link. If none is available, the row keeps its existing name/type/host presentation. `remainingArtifactCards` retains the first available description when later occurrences omit it. These are presentational defaults for legitimately optional source text, with no persisted-data or cross-version contract changes and no rollout removal gate.
