### PR TITLE
fix(platform): preserve ssh forms across clerk refreshes

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -190,7 +190,7 @@ interface MockedUser {
 }
 
 let internalMockedUser: MockedUser | null = null;
-let internalMockedSession: { token: string } | null = null;
+let internalMockedSession: { token: string; id?: string } | null = null;
 let internalMockedOrganization: {
   id: string;
   name: string;
@@ -426,7 +426,7 @@ export function mockUser(
     createOrganizationsLimit?: number | null;
     clientSessions?: MockedClientSession[];
   } | null,
-  session: { token: string } | null,
+  session: { token: string; id?: string } | null,
 ) {
   if (user) {
     internalMockedUser = {
@@ -1231,7 +1231,7 @@ export const mockedClerk = {
       };
     }
     return {
-      id: "test-session-id",
+      id: internalMockedSession.id ?? "test-session-id",
       get lastActiveOrganizationId() {
         return internalMockedOrganization?.id ?? null;
       },

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -26,6 +26,7 @@ import { sessionStorageSignals } from "./external/session-storage.ts";
 
 const reload$ = state(0);
 const clerkVersion$ = state(0);
+const clerkIdentityVersion$ = state(0);
 
 const ATTRIBUTION_SOURCE_PARAM = "vm0_source";
 const HOMEPAGE_ATTRIBUTION_VALUE = "homepage";
@@ -363,6 +364,8 @@ export const setupClerk$ = command(
     // changes (sign-in / sign-out), not on token refreshes which fire the
     // Clerk listener but don't change the user.
     let prevUserId = clerk.user?.id ?? null;
+    let prevOrgId = clerk.organization?.id;
+    let prevSessionId = clerk.session?.id;
     const unsubscribe = clerk.addListener(() => {
       // Update Sentry user context on auth state change
       if (clerk.user) {
@@ -384,8 +387,24 @@ export const setupClerk$ = command(
         return x + 1;
       });
       const currentUserId = clerk.user?.id ?? null;
-      if (currentUserId !== prevUserId) {
+      const currentOrgId = clerk.organization?.id;
+      const currentSessionId = clerk.session?.id;
+      const userChanged = currentUserId !== prevUserId;
+      // Credential ownership changes only with identity, not token or profile
+      // updates. Keep its async projections stable across ordinary refreshes.
+      if (
+        userChanged ||
+        currentOrgId !== prevOrgId ||
+        currentSessionId !== prevSessionId
+      ) {
         prevUserId = currentUserId;
+        prevOrgId = currentOrgId;
+        prevSessionId = currentSessionId;
+        set(clerkIdentityVersion$, (x) => {
+          return x + 1;
+        });
+      }
+      if (userChanged) {
         set(writeConnectionDiagnostic$, { action: "clear" });
         set(reload$, (x) => {
           return x + 1;
@@ -480,6 +499,19 @@ export const authenticatedIdentity$ = computed(async (get) => {
     orgId: clerk.organization.id,
     email: clerk.user.primaryEmailAddress?.emailAddress,
   };
+});
+
+/** Live credential identity, invalidated only by user, org, or session changes. */
+export const currentClerkIdentity$ = computed(async (get) => {
+  get(clerkIdentityVersion$);
+  const clerk = await get(clerk$);
+  const userId = clerk.user?.id;
+  const orgId = clerk.organization?.id;
+  const sessionId = clerk.session?.id;
+  if (!userId || !orgId || !sessionId) {
+    return null;
+  }
+  return { userId, orgId, sessionId };
 });
 
 /**

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -26,7 +26,6 @@ import { sessionStorageSignals } from "./external/session-storage.ts";
 
 const reload$ = state(0);
 const clerkVersion$ = state(0);
-const clerkIdentityVersion$ = state(0);
 
 const ATTRIBUTION_SOURCE_PARAM = "vm0_source";
 const HOMEPAGE_ATTRIBUTION_VALUE = "homepage";
@@ -364,8 +363,6 @@ export const setupClerk$ = command(
     // changes (sign-in / sign-out), not on token refreshes which fire the
     // Clerk listener but don't change the user.
     let prevUserId = clerk.user?.id ?? null;
-    let prevOrgId = clerk.organization?.id;
-    let prevSessionId = clerk.session?.id;
     const unsubscribe = clerk.addListener(() => {
       // Update Sentry user context on auth state change
       if (clerk.user) {
@@ -387,24 +384,8 @@ export const setupClerk$ = command(
         return x + 1;
       });
       const currentUserId = clerk.user?.id ?? null;
-      const currentOrgId = clerk.organization?.id;
-      const currentSessionId = clerk.session?.id;
-      const userChanged = currentUserId !== prevUserId;
-      // Credential ownership changes only with identity, not token or profile
-      // updates. Keep its async projections stable across ordinary refreshes.
-      if (
-        userChanged ||
-        currentOrgId !== prevOrgId ||
-        currentSessionId !== prevSessionId
-      ) {
+      if (currentUserId !== prevUserId) {
         prevUserId = currentUserId;
-        prevOrgId = currentOrgId;
-        prevSessionId = currentSessionId;
-        set(clerkIdentityVersion$, (x) => {
-          return x + 1;
-        });
-      }
-      if (userChanged) {
         set(writeConnectionDiagnostic$, { action: "clear" });
         set(reload$, (x) => {
           return x + 1;
@@ -499,19 +480,6 @@ export const authenticatedIdentity$ = computed(async (get) => {
     orgId: clerk.organization.id,
     email: clerk.user.primaryEmailAddress?.emailAddress,
   };
-});
-
-/** Live credential identity, invalidated only by user, org, or session changes. */
-export const currentClerkIdentity$ = computed(async (get) => {
-  get(clerkIdentityVersion$);
-  const clerk = await get(clerk$);
-  const userId = clerk.user?.id;
-  const orgId = clerk.organization?.id;
-  const sessionId = clerk.session?.id;
-  if (!userId || !orgId || !sessionId) {
-    return null;
-  }
-  return { userId, orgId, sessionId };
 });
 
 /**

--- a/turbo/apps/platform/src/signals/ssh.ts
+++ b/turbo/apps/platform/src/signals/ssh.ts
@@ -12,7 +12,7 @@ import {
   updateSshConnectionRequestSchema,
   SSH_PRIVATE_KEY_MAX_LENGTH,
 } from "@okouai/api-contracts/contracts/ssh-connections";
-import { clerk$, currentClerkIdentity$, currentOrgInfo$ } from "./auth.ts";
+import { clerk$, currentOrgInfo$, user$ } from "./auth.ts";
 import { readClerkToken } from "./clerk-token.ts";
 import { featureSwitch$ } from "./external/feature-switch.ts";
 import { apiClient$ } from "./api-client.ts";
@@ -103,34 +103,34 @@ export const sshIdentity$ = computed(async (get) => {
   if (!enabled) {
     return null;
   }
-  const identity = await get(currentClerkIdentity$);
-  return identity
-    ? `${identity.orgId}:${identity.userId}:${identity.sessionId}`
-    : null;
+  // User changes invalidate SSH state; global org switching reloads the page.
+  // Background token/profile updates must not reset credential forms.
+  const [user, clerk] = await Promise.all([get(user$), get(clerk$)]);
+  const org = clerk.organization;
+  return org && user ? `${org.id}:${user.id}` : null;
 });
 const reload$ = state(0);
 const sshClients$ = computed(async (get) => {
   const identity = await get(sshIdentity$);
   const clerk = await get(clerk$);
-  const sessionId = clerk.session?.id;
   const createClient = get(apiClient$);
-  const assertIdentity = () => {
+  const assertIdentity = (sessionId: string | undefined) => {
     if (
       !identity ||
       !sessionId ||
       sessionId !== clerk.session?.id ||
-      identity !==
-        `${clerk.organization?.id}:${clerk.user?.id}:${clerk.session?.id}`
+      identity !== `${clerk.organization?.id}:${clerk.user?.id}`
     ) {
       throw new DOMException("SSH owner changed", "AbortError");
     }
   };
   const options = {
     getToken: async (signal: AbortSignal) => {
-      assertIdentity();
+      const sessionId = clerk.session?.id;
+      assertIdentity(sessionId);
       const token = await readClerkToken(clerk, signal);
       signal.throwIfAborted();
-      assertIdentity();
+      assertIdentity(sessionId);
       return token;
     },
   };

--- a/turbo/apps/platform/src/signals/ssh.ts
+++ b/turbo/apps/platform/src/signals/ssh.ts
@@ -13,6 +13,7 @@ import {
   SSH_PRIVATE_KEY_MAX_LENGTH,
 } from "@okouai/api-contracts/contracts/ssh-connections";
 import { clerk$, currentOrgInfo$, user$ } from "./auth.ts";
+import { runtimeAuthenticatedIdentity$ } from "./auth-context.ts";
 import { readClerkToken } from "./clerk-token.ts";
 import { featureSwitch$ } from "./external/feature-switch.ts";
 import { apiClient$ } from "./api-client.ts";
@@ -105,9 +106,11 @@ export const sshIdentity$ = computed(async (get) => {
   }
   // User changes invalidate SSH state; global org switching reloads the page.
   // Background token/profile updates must not reset credential forms.
-  const [user, clerk] = await Promise.all([get(user$), get(clerk$)]);
-  const org = clerk.organization;
-  return org && user ? `${org.id}:${user.id}` : null;
+  const [user, identity] = await Promise.all([
+    get(user$),
+    get(runtimeAuthenticatedIdentity$),
+  ]);
+  return user ? `${identity.orgId}:${user.id}` : null;
 });
 const reload$ = state(0);
 const sshClients$ = computed(async (get) => {

--- a/turbo/apps/platform/src/signals/ssh.ts
+++ b/turbo/apps/platform/src/signals/ssh.ts
@@ -12,7 +12,7 @@ import {
   updateSshConnectionRequestSchema,
   SSH_PRIVATE_KEY_MAX_LENGTH,
 } from "@okouai/api-contracts/contracts/ssh-connections";
-import { clerk$, currentOrgInfo$, currentUserInfo$ } from "./auth.ts";
+import { clerk$, currentClerkIdentity$, currentOrgInfo$ } from "./auth.ts";
 import { readClerkToken } from "./clerk-token.ts";
 import { featureSwitch$ } from "./external/feature-switch.ts";
 import { apiClient$ } from "./api-client.ts";
@@ -103,11 +103,10 @@ export const sshIdentity$ = computed(async (get) => {
   if (!enabled) {
     return null;
   }
-  const [org, user] = await Promise.all([
-    get(currentOrgInfo$),
-    get(currentUserInfo$),
-  ]);
-  return org && user ? `${org.id}:${user.id}` : null;
+  const identity = await get(currentClerkIdentity$);
+  return identity
+    ? `${identity.orgId}:${identity.userId}:${identity.sessionId}`
+    : null;
 });
 const reload$ = state(0);
 const sshClients$ = computed(async (get) => {
@@ -120,7 +119,8 @@ const sshClients$ = computed(async (get) => {
       !identity ||
       !sessionId ||
       sessionId !== clerk.session?.id ||
-      identity !== `${clerk.organization?.id}:${clerk.user?.id}`
+      identity !==
+        `${clerk.organization?.id}:${clerk.user?.id}:${clerk.session?.id}`
     ) {
       throw new DOMException("SSH owner changed", "AbortError");
     }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-ssh.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-ssh.test.tsx
@@ -152,56 +152,74 @@ test("Switching Agents does not retain the previous Agent's enabled SSH icon", a
   expect(within(otherTrigger).queryByRole("img", { name: "SSH" })).toBeNull();
 });
 
-test.each(["workspace", "user"])(
-  "Changing %s clears retained SSH presentation while the new owner loads",
-  async (changedIdentity) => {
-    installComposerConnectorFixture();
-    const clerk = context.mocks.clerk();
-    const nextOwner = context.mocks.deferred<void>();
-    let changing = false;
-    context.mocks.api(sshConnectionsContract.summary, async ({ respond }) => {
-      if (changing) {
-        await nextOwner.promise;
-      }
-      return respond(200, { configuredCount: 1 });
+test("Changing user clears retained SSH presentation while the new owner loads", async () => {
+  installComposerConnectorFixture();
+  const clerk = context.mocks.clerk();
+  const nextOwner = context.mocks.deferred<void>();
+  let changing = false;
+  context.mocks.api(sshConnectionsContract.summary, async ({ respond }) => {
+    if (changing) {
+      await nextOwner.promise;
+    }
+    return respond(200, { configuredCount: 1 });
+  });
+  context.mocks.api(agentSshAccessContract.get, ({ respond }) => {
+    return respond(200, { enabled: !changing });
+  });
+  await setupPage({
+    context,
+    path: `/agents/${SCOUT_AGENT_ID}/chat`,
+    featureSwitches: { [FeatureSwitchKey.SshAccess]: true },
+  });
+  const trigger = await findFastControl("button", "Connectors");
+  await within(trigger).findByRole("img", { name: "SSH" });
+  changing = true;
+  act(() => {
+    clerk.user(
+      { id: "other-ssh-user", fullName: "Other user" },
+      { token: "other-user-token" },
+    );
+    clerk.stateChanged();
+  });
+  await waitFor(() => {
+    expect(screen.queryByRole("img", { name: "SSH" })).toBeNull();
+  });
+  nextOwner.resolve();
+  const nextTrigger = await findFastControl("button", "Connectors");
+  click(nextTrigger);
+  await screen.findByLabelText("Add SSH");
+  expect(within(nextTrigger).queryByRole("img", { name: "SSH" })).toBeNull();
+});
+
+test("Changing workspace reloads the chat page before using the new SSH owner", async () => {
+  installComposerConnectorFixture();
+  context.mocks.api(sshConnectionsContract.summary, ({ respond }) => {
+    return respond(200, { configuredCount: 1 });
+  });
+  context.mocks.api(agentSshAccessContract.get, ({ respond }) => {
+    return respond(200, { enabled: true });
+  });
+  await setupPage({
+    context,
+    path: `/agents/${SCOUT_AGENT_ID}/chat`,
+    featureSwitches: { [FeatureSwitchKey.SshAccess]: true },
+  });
+  const trigger = await findFastControl("button", "Connectors");
+  await within(trigger).findByRole("img", { name: "SSH" });
+
+  const clerk = context.mocks.clerk();
+  act(() => {
+    clerk.organization({
+      activeOrg: { id: "org_ssh_other", name: "Other workspace" },
+      memberships: [{ id: "org_ssh_other" }],
     });
-    context.mocks.api(agentSshAccessContract.get, ({ respond }) => {
-      return respond(200, { enabled: !changing });
-    });
-    await setupPage({
-      context,
-      path: `/agents/${SCOUT_AGENT_ID}/chat`,
-      featureSwitches: { [FeatureSwitchKey.SshAccess]: true },
-    });
-    const trigger = await findFastControl("button", "Connectors");
-    await within(trigger).findByRole("img", { name: "SSH" });
-    changing = true;
-    act(() => {
-      if (changedIdentity === "workspace") {
-        clerk.organization({
-          activeOrg: { id: "org_ssh_other", name: "Other workspace" },
-          memberships: [{ id: "org_ssh_other" }],
-        });
-      } else {
-        clerk.user(
-          { id: "other-ssh-user", fullName: "Other user" },
-          {
-            token: "other-user-token",
-          },
-        );
-      }
-      clerk.stateChanged();
-    });
-    await waitFor(() => {
-      expect(screen.queryByRole("img", { name: "SSH" })).toBeNull();
-    });
-    nextOwner.resolve();
-    const nextTrigger = await findFastControl("button", "Connectors");
-    click(nextTrigger);
-    await screen.findByLabelText("Add SSH");
-    expect(within(nextTrigger).queryByRole("img", { name: "SSH" })).toBeNull();
-  },
-);
+    clerk.stateChanged();
+  });
+
+  await waitFor(() => {
+    expect(window.location.pathname).toBe("/");
+  });
+});
 
 test.each([SCOUT_AGENT_ID, OTHER_AGENT_ID])(
   "Chat SSH uses the composer Agent %s, not another Agent's grant",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/ssh-settings.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/ssh-settings.test.tsx
@@ -46,6 +46,47 @@ const base: SshConnectionResponse = Object.freeze({
   updatedAt: "2026-09-01T00:00:00.000Z",
 });
 
+test("SSH recovers after first opening Connectors during a workspace refresh", async () => {
+  context.mocks.api(sshConnectionsContract.summary, ({ respond }) => {
+    return respond(200, { configuredCount: 1 });
+  });
+  context.mocks.api(sshConnectionsContract.list, ({ respond }) => {
+    return respond(200, { connections: [base] });
+  });
+  await page("/agents");
+  await screen.findByRole("heading", { name: "Agents" });
+
+  const clerk = context.mocks.clerk();
+  act(() => {
+    clerk.organization({ ...auth.organization, activeOrg: null });
+    clerk.stateChanged();
+  });
+  click(
+    getAction(
+      "link",
+      "Connectors",
+      screen.getByRole("navigation", { name: "Sidebar" }),
+    ),
+  );
+  await fill(await screen.findByPlaceholderText("Find connectors"), "ssh");
+  await screen.findByText(/No connectors matching/u);
+
+  act(() => {
+    clerk.organization(auth.organization);
+    clerk.stateChanged();
+  });
+  context.mocks.ably.trigger("ssh:changed", { orgId });
+
+  click(
+    await waitFor(() => {
+      return getAction("link", "Manage SSH hosts");
+    }),
+  );
+  await expect(
+    screen.findByText("deploy@ssh.example.com:22"),
+  ).resolves.toBeVisible();
+});
+
 test.each(["token", "profile", "session"])(
   "A same-owner Clerk %s refresh preserves an SSH form that can still be saved",
   async (refresh) => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/ssh-settings.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/ssh-settings.test.tsx
@@ -46,11 +46,24 @@ const base: SshConnectionResponse = Object.freeze({
   updatedAt: "2026-09-01T00:00:00.000Z",
 });
 
-test.each(["token", "profile"])(
-  "A same-owner Clerk %s refresh preserves an unsaved SSH host",
+test.each(["token", "profile", "session"])(
+  "A same-owner Clerk %s refresh preserves an SSH form that can still be saved",
   async (refresh) => {
+    let hosts = [base];
     context.mocks.api(sshConnectionsContract.list, ({ respond }) => {
-      return respond(200, { connections: [base] });
+      return respond(200, { connections: hosts });
+    });
+    context.mocks.api(sshConnectionsContract.create, ({ body, respond }) => {
+      const connection = {
+        ...base,
+        id: "b0000000-0000-4000-8000-000000000002",
+        displayName: body.displayName,
+        host: body.host,
+        port: body.port,
+        username: body.username,
+      };
+      hosts = [...hosts, connection];
+      return respond(201, connection);
     });
     await page();
     await screen.findByText("deploy@ssh.example.com:22");
@@ -72,12 +85,17 @@ test.each(["token", "profile"])(
 
     const clerk = context.mocks.clerk();
     act(() => {
-      if (refresh === "profile") {
-        clerk.user(
-          { ...auth.user, fullName: "Updated profile" },
-          { token: "refreshed-token" },
-        );
-      }
+      clerk.user(
+        {
+          ...auth.user,
+          fullName:
+            refresh === "profile" ? "Updated profile" : auth.user.fullName,
+        },
+        {
+          id: refresh === "session" ? "replacement-session" : "test-session-id",
+          token: "refreshed-token",
+        },
+      );
       clerk.stateChanged();
     });
 
@@ -94,7 +112,9 @@ test.each(["token", "profile"])(
       "unsaved-passphrase",
     );
     expect(screen.getByText("deploy@ssh.example.com:22")).toBeInTheDocument();
-    click(getAction("button", "Cancel", await screen.findByRole("dialog")));
+    click(getAction("button", "Save", await screen.findByRole("dialog")));
+    await screen.findByText("unsaved-user@unsaved.example.com:2222");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     const displayName =
       refresh === "profile" ? "Updated profile" : auth.user.fullName;
     await waitFor(() => {
@@ -103,41 +123,8 @@ test.each(["token", "profile"])(
   },
 );
 
-test("Replacing a Clerk session clears an unsaved SSH credential form", async () => {
-  context.mocks.api(sshConnectionsContract.list, ({ respond }) => {
-    return respond(200, { connections: [base] });
-  });
-  await page();
-  await screen.findByText("deploy@ssh.example.com:22");
-  click(getAction("button", "Add host"));
-  const dialog = await screen.findByRole("dialog");
-  await fill(within(dialog).getByLabelText("Private key"), "old-session-key");
-  await fill(
-    within(dialog).getByLabelText("Passphrase (optional)"),
-    "old-session-passphrase",
-  );
-
-  const clerk = context.mocks.clerk();
-  act(() => {
-    clerk.user(auth.user, {
-      id: "replacement-session",
-      token: "replacement-token",
-    });
-    clerk.stateChanged();
-  });
-
-  await waitFor(() => {
-    expect(getAction("button", "Add host")).toBeEnabled();
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-  });
-  click(getAction("button", "Add host"));
-  const replacement = within(await screen.findByRole("dialog"));
-  expect(replacement.getByLabelText("Private key")).toHaveValue("");
-  expect(replacement.getByLabelText("Passphrase (optional)")).toHaveValue("");
-});
-
 test.each(["session", "organization"])(
-  "Losing the Clerk %s clears an unsaved SSH credential form",
+  "Transiently missing Clerk %s data preserves an unsaved SSH credential form",
   async (missing) => {
     context.mocks.api(sshConnectionsContract.list, ({ respond }) => {
       return respond(200, { connections: [base] });
@@ -146,11 +133,12 @@ test.each(["session", "organization"])(
     await screen.findByText("deploy@ssh.example.com:22");
     click(getAction("button", "Add host"));
     const dialog = await screen.findByRole("dialog");
-    await fill(within(dialog).getByLabelText("Private key"), "old-session-key");
+    await fill(within(dialog).getByLabelText("Private key"), "unsaved-key");
     await fill(
       within(dialog).getByLabelText("Passphrase (optional)"),
-      "old-session-passphrase",
+      "unsaved-passphrase",
     );
+    await userEvent.click(within(dialog).getByLabelText("Private key"));
 
     const clerk = context.mocks.clerk();
     act(() => {
@@ -162,8 +150,27 @@ test.each(["session", "organization"])(
       clerk.stateChanged();
     });
 
-    await screen.findByText("SSH access is not available for this account.");
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    const pending = within(await screen.findByRole("dialog"));
+    expect(pending.getByLabelText("Private key")).toHaveValue("unsaved-key");
+    expect(pending.getByLabelText("Private key")).toHaveFocus();
+    expect(pending.getByLabelText("Passphrase (optional)")).toHaveValue(
+      "unsaved-passphrase",
+    );
+    expect(screen.getByText("deploy@ssh.example.com:22")).toBeInTheDocument();
+
+    act(() => {
+      clerk.user(auth.user, { token: "refreshed-token" });
+      clerk.organization(auth.organization);
+      clerk.stateChanged();
+    });
+
+    const restored = within(await screen.findByRole("dialog"));
+    expect(restored.getByLabelText("Private key")).toHaveValue("unsaved-key");
+    expect(restored.getByLabelText("Private key")).toHaveFocus();
+    expect(restored.getByLabelText("Passphrase (optional)")).toHaveValue(
+      "unsaved-passphrase",
+    );
+    expect(screen.getByText("deploy@ssh.example.com:22")).toBeInTheDocument();
   },
 );
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/ssh-settings.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/ssh-settings.test.tsx
@@ -46,6 +46,127 @@ const base: SshConnectionResponse = Object.freeze({
   updatedAt: "2026-09-01T00:00:00.000Z",
 });
 
+test.each(["token", "profile"])(
+  "A same-owner Clerk %s refresh preserves an unsaved SSH host",
+  async (refresh) => {
+    context.mocks.api(sshConnectionsContract.list, ({ respond }) => {
+      return respond(200, { connections: [base] });
+    });
+    await page();
+    await screen.findByText("deploy@ssh.example.com:22");
+    click(getAction("button", "Add host"));
+    const dialog = await screen.findByRole("dialog");
+    await fill(within(dialog).getByLabelText("Display name"), "Unsaved host");
+    await fill(
+      within(dialog).getByLabelText("Public hostname or IP address"),
+      "unsaved.example.com",
+    );
+    await fill(within(dialog).getByLabelText("Port"), "2222");
+    await fill(within(dialog).getByLabelText("SSH username"), "unsaved-user");
+    await fill(within(dialog).getByLabelText("Private key"), "unsaved-key");
+    await fill(
+      within(dialog).getByLabelText("Passphrase (optional)"),
+      "unsaved-passphrase",
+    );
+    await userEvent.click(within(dialog).getByLabelText("Private key"));
+
+    const clerk = context.mocks.clerk();
+    act(() => {
+      if (refresh === "profile") {
+        clerk.user(
+          { ...auth.user, fullName: "Updated profile" },
+          { token: "refreshed-token" },
+        );
+      }
+      clerk.stateChanged();
+    });
+
+    const current = within(await screen.findByRole("dialog"));
+    expect(current.getByLabelText("Display name")).toHaveValue("Unsaved host");
+    expect(current.getByLabelText("Public hostname or IP address")).toHaveValue(
+      "unsaved.example.com",
+    );
+    expect(current.getByLabelText("Port")).toHaveValue(2222);
+    expect(current.getByLabelText("SSH username")).toHaveValue("unsaved-user");
+    expect(current.getByLabelText("Private key")).toHaveValue("unsaved-key");
+    expect(current.getByLabelText("Private key")).toHaveFocus();
+    expect(current.getByLabelText("Passphrase (optional)")).toHaveValue(
+      "unsaved-passphrase",
+    );
+    expect(screen.getByText("deploy@ssh.example.com:22")).toBeInTheDocument();
+    click(getAction("button", "Cancel", await screen.findByRole("dialog")));
+    const displayName =
+      refresh === "profile" ? "Updated profile" : auth.user.fullName;
+    await waitFor(() => {
+      expect(getAction("button", displayName)).toBeVisible();
+    });
+  },
+);
+
+test("Replacing a Clerk session clears an unsaved SSH credential form", async () => {
+  context.mocks.api(sshConnectionsContract.list, ({ respond }) => {
+    return respond(200, { connections: [base] });
+  });
+  await page();
+  await screen.findByText("deploy@ssh.example.com:22");
+  click(getAction("button", "Add host"));
+  const dialog = await screen.findByRole("dialog");
+  await fill(within(dialog).getByLabelText("Private key"), "old-session-key");
+  await fill(
+    within(dialog).getByLabelText("Passphrase (optional)"),
+    "old-session-passphrase",
+  );
+
+  const clerk = context.mocks.clerk();
+  act(() => {
+    clerk.user(auth.user, {
+      id: "replacement-session",
+      token: "replacement-token",
+    });
+    clerk.stateChanged();
+  });
+
+  await waitFor(() => {
+    expect(getAction("button", "Add host")).toBeEnabled();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+  click(getAction("button", "Add host"));
+  const replacement = within(await screen.findByRole("dialog"));
+  expect(replacement.getByLabelText("Private key")).toHaveValue("");
+  expect(replacement.getByLabelText("Passphrase (optional)")).toHaveValue("");
+});
+
+test.each(["session", "organization"])(
+  "Losing the Clerk %s clears an unsaved SSH credential form",
+  async (missing) => {
+    context.mocks.api(sshConnectionsContract.list, ({ respond }) => {
+      return respond(200, { connections: [base] });
+    });
+    await page();
+    await screen.findByText("deploy@ssh.example.com:22");
+    click(getAction("button", "Add host"));
+    const dialog = await screen.findByRole("dialog");
+    await fill(within(dialog).getByLabelText("Private key"), "old-session-key");
+    await fill(
+      within(dialog).getByLabelText("Passphrase (optional)"),
+      "old-session-passphrase",
+    );
+
+    const clerk = context.mocks.clerk();
+    act(() => {
+      if (missing === "session") {
+        clerk.user(auth.user, null);
+      } else {
+        clerk.organization({ ...auth.organization, activeOrg: null });
+      }
+      clerk.stateChanged();
+    });
+
+    await screen.findByText("SSH access is not available for this account.");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  },
+);
+
 test("Live notifications refresh hosts across reconnect without clearing an open credential form", async () => {
   let host = base;
   context.mocks.api(sshConnectionsContract.list, ({ respond }) => {


### PR DESCRIPTION
Background Clerk token/profile notifications invalidate the asynchronous SSH owner, briefly remounting the credential dialog and discarding unsaved fields. Derive SSH ownership from the existing user-change signal and bootstrapped workspace identity so background maintenance preserves the dialog, focus, credentials, and loaded hosts. Actual user changes clear the old form; workspace switching follows the application's existing navigation lifecycle.

Create both SSH clients with the standard `apiClient$` factory, as Agents and custom Connectors do. The shared client owns token acquisition and cancellation; the API owns session, organization, and user authorization. SSH no longer adds a Clerk resource listener, organization-readiness wait, or separate session-pinning policy. Reads, saves, and realtime updates can complete while Clerk's organization profile is still loading.

Filter SSH realtime notifications by the existing authenticated runtime workspace so valid host updates are preserved during profile refreshes. Malformed and other-workspace payloads remain ignored, and list updates preserve an open credential form.

Production changes are confined to SSH signals. API contracts, server authorization, credential storage, and shared authentication setup are unchanged.

Closes #33135

## Validation

- 75 focused page cases passed across SSH settings (45), connector SSH entry (14), chat composer SSH (14), and organization refresh (2).
- Coverage includes all six unsaved fields and focus, save after token/profile/session maintenance, first entry and successful save before organization-profile restoration, shared API token recovery and navigation cancellation, real user changes, workspace navigation, realtime updates during organization loading, and existing errors/grants/credential cleanup.
- From `turbo/apps/platform`:
  - `pnpm exec vitest run src/views/okou-page/__tests__/ssh-settings.test.tsx src/views/okou-page/__tests__/connectors-ssh.test.tsx src/views/okou-page/__tests__/chat-composer-ssh.test.tsx src/views/okou-page/__tests__/organization-refresh.test.tsx --maxWorkers=2`.
  - `pnpm check-types`.
  - Affected-file ESLint (`--no-warn-ignored --max-warnings=0`), Oxlint (`--deny-warnings`), and type-aware Oxlint (`--type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings`).
- From `turbo`: affected-file Prettier and `pnpm exec knip --workspace apps/platform`.

Live-browser animation verification remains unperformed; full test suites are left to the PR pipeline.
