### PR TITLE
feat(app): show the template cover on the composer's inline template chip

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
@@ -1024,8 +1024,9 @@ function createInlineTemplateNodeView(
   openButton.type = "button";
   openButton.className = INLINE_TEMPLATE_NAME_ZONE_CLASS;
   // The template was chosen from a grid of covers, so the chip leads with the
-  // same cover rather than a generic glyph. 18px inside the 28px chip keeps the
-  // same optical inset the 20px cover has inside the 32px sent-message chip.
+  // same cover rather than a generic glyph. 18px inside this 28px chip keeps
+  // the cover at the proportion the block template-attachment chip above uses:
+  // a 20px cover inside its 32px chip.
   const glyph = document.createElement("span");
   glyph.className =
     "flex size-[18px] shrink-0 items-center justify-center overflow-hidden " +

--- a/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
@@ -1023,26 +1023,44 @@ function createInlineTemplateNodeView(
   const openButton = document.createElement("button");
   openButton.type = "button";
   openButton.className = INLINE_TEMPLATE_NAME_ZONE_CLASS;
+  // The template was chosen from a grid of covers, so the chip leads with the
+  // same cover rather than a generic glyph. 18px inside the 28px chip keeps the
+  // same optical inset the 20px cover has inside the 32px sent-message chip.
+  const glyph = document.createElement("span");
+  glyph.className =
+    "flex size-[18px] shrink-0 items-center justify-center overflow-hidden " +
+    "rounded-[3px]";
+  const cover = document.createElement("img");
+  cover.alt = "";
+  cover.className = "h-full w-full object-cover";
   // Mirrors Lucide's SwatchBook, which the composer template picker button and
-  // sent-message template chips also use.
+  // sent-message template chips also use. It stands in for the templates whose
+  // catalog entry carries no cover image.
   const icon = createComposerIcon(13, 1.7, [
     "M11 17a4 4 0 0 1-8 0V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2Z",
     "M16.7 13H19a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2H7",
     "M 7 17h.01",
     "m11 8 2.3-2.3a2.4 2.4 0 0 1 3.404.004L18.6 7.6a2.4 2.4 0 0 1 .026 3.434L9.9 19.8",
   ]);
-  icon.setAttribute("class", "shrink-0");
   const title = document.createElement("span");
   title.className =
     "min-w-0 select-none truncate text-[13px] font-medium text-orange-600 " +
     "dark:text-orange-300";
-  openButton.append(icon, title);
+  openButton.append(glyph, title);
   dom.append(openButton);
 
   let currentNode = node;
   function render(nextNode: ProseMirrorNode): void {
     const attachment = templateAttachmentNodeAttributes(nextNode);
     title.textContent = attachment.title;
+    // The node is rewritten in place when the picker changes the selection, so
+    // the cover has to follow the new attributes rather than only the first.
+    if (attachment.previewImageUrl === undefined) {
+      glyph.replaceChildren(icon);
+    } else {
+      cover.src = attachment.previewImageUrl;
+      glyph.replaceChildren(cover);
+    }
     openButton.setAttribute(
       "aria-label",
       templateAttachmentPreviewLabel(attachment),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
@@ -640,3 +640,69 @@ test("Canceling and switching Create preserve slash text and template references
     }),
   );
 });
+
+function inlineTemplateCover(index = 0): HTMLImageElement | null {
+  const chip = composerInlineTemplates()[index];
+  if (!chip) {
+    throw new Error(`Expected an inline template at ${index}`);
+  }
+  return chip.querySelector("img");
+}
+
+test("An inline template chip shows the chosen cover and follows a replacement", async () => {
+  setupModels();
+  mockChatLifecycle(context);
+  const editor = await setupComposer();
+  const user = userEvent.setup({ delay: null });
+  const [first, , replacement] = PRESENTATION_TEMPLATE_PICKER_ITEMS;
+  if (!first || !replacement) {
+    throw new Error("Expected two presentation templates");
+  }
+  await chooseCommand(
+    editor,
+    "Our launch /create presentation",
+    "Create presentation",
+  );
+  click(button("Add template"));
+  await screen.findByRole("dialog");
+  click(await screen.findByLabelText(`Select template ${first.title}`));
+  await waitFor(() => {
+    expect(inlineTemplateCover()?.getAttribute("src")).toContain(first.slug);
+  });
+
+  // The picker rewrites the node in place, so the cover has to follow the new
+  // selection rather than only the first one.
+  const chip = composerInlineTemplates()[0];
+  if (!chip) {
+    throw new Error("Expected the inline template");
+  }
+  click(button(`Preview template ${first.title}`, chip));
+  await screen.findByRole("dialog");
+  click(await screen.findByLabelText(`Select template ${replacement.title}`));
+  await waitFor(() => {
+    expect(inlineTemplateCover()?.getAttribute("src")).toContain(
+      replacement.slug,
+    );
+  });
+  await user.click(editor);
+  expect(composerInlineTemplates()).toHaveLength(1);
+});
+
+test("A template with no cover keeps the template glyph on its chip", async () => {
+  setupModels();
+  mockChatLifecycle(context);
+  const editor = await setupComposer();
+  const [template] = VIDEO_TEMPLATE_ITEMS;
+  if (!template) {
+    throw new Error("Expected a video template");
+  }
+  await chooseCommand(editor, "Our launch /create video", "Create video");
+  click(button("Add template"));
+  await screen.findByRole("dialog");
+  click(await screen.findByLabelText(`Select video template ${template.title}`));
+  await waitFor(() => {
+    expect(composerInlineTemplates()).toHaveLength(1);
+  });
+  expect(inlineTemplateCover()).toBeNull();
+  expect(composerInlineTemplates()[0]?.querySelector("svg")).toBeInTheDocument();
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
@@ -699,10 +699,14 @@ test("A template with no cover keeps the template glyph on its chip", async () =
   await chooseCommand(editor, "Our launch /create video", "Create video");
   click(button("Add template"));
   await screen.findByRole("dialog");
-  click(await screen.findByLabelText(`Select video template ${template.title}`));
+  click(
+    await screen.findByLabelText(`Select video template ${template.title}`),
+  );
   await waitFor(() => {
     expect(composerInlineTemplates()).toHaveLength(1);
   });
   expect(inlineTemplateCover()).toBeNull();
-  expect(composerInlineTemplates()[0]?.querySelector("svg")).toBeInTheDocument();
+  expect(
+    composerInlineTemplates()[0]?.querySelector("svg"),
+  ).toBeInTheDocument();
 });


### PR DESCRIPTION
## What

The composer's inline template chip now leads with the chosen template's cover
image instead of a generic glyph.

## Why

`createInlineTemplateNodeView` already receives `previewImageUrl` on the node —
`selectedComposerTemplateAttachment` resolves it for presentation, illustration,
avatar and explainer templates — but the view never rendered it. A user picks a
template from a wall of covers in the picker and gets back an orange word, so
there is no way to tell two decks apart in the draft without opening the picker
again. The older block-style chip (`createTemplateAttachmentNodeView`) already
draws that cover, so this brings the inline chip in line with it.

## How

- Render the cover in an 18px rounded slot at the head of the chip. 18px inside
  the 28px inline chip keeps the same optical inset the 20px cover has inside the
  32px block chip.
- Keep the SwatchBook glyph for templates whose catalog entry has no cover
  (video, website, workflow).
- Resolve the slot inside `render()` rather than at construction, because the
  picker rewrites the node in place via `setNodeMarkup` when it replaces a
  selection — the cover has to follow the new attributes.

No feature switch: this is a visual refinement of a chip that already ships.

## Verification

- `vitest run src/views/okou-page/__tests__/chat-composer-create.test.tsx` — 17 passed
- `pnpm run check-types` (platform)
- `eslint` on both changed files

Two tests added to `chat-composer-create.test.tsx`:
- a presentation template's cover appears on the chip and follows a replacement
  selection;
- a video template (no catalog cover) keeps the glyph.
