### PR TITLE
fix(auth): stabilize clerk runtime binding

### DIFF
--- a/turbo/apps/platform/src/signals/auth-v1-clerk.ts
+++ b/turbo/apps/platform/src/signals/auth-v1-clerk.ts
@@ -11,7 +11,7 @@ type ClerkRouter = NonNullable<ClerkProviderProps["routerPush"]>;
 type ClerkRouterMetadata = Parameters<ClerkRouter>[1];
 
 /** A route-owned integration with the external Clerk runtime. */
-export function createAuthV1ClerkSignals() {
+export function createAuthV1ClerkSignals(clerk: Pick<Clerk, "on" | "off">) {
   const navigateClerkUrl$ = command(
     (
       { set },
@@ -75,32 +75,25 @@ export function createAuthV1ClerkSignals() {
   );
   // The provider handle arrives at its committed marker. Own the subscription
   // through onRef so replacement and unmount release the exact SDK listener.
-  const attach$ = command(
-    ({ set }, element: HTMLSpanElement, clerk: Pick<Clerk, "on" | "off">) => {
-      const ref$ = onRef(
-        command(
-          ({ get, set }, _element: HTMLSpanElement, signal: AbortSignal) => {
-            const routeSignal = AbortSignal.any([signal, get(pageSignal$)]);
-            if (routeSignal.aborted) {
-              return;
-            }
-            const unregisterRouter = registerClerkRouter({
-              push(url, metadata) {
-                set(clerkRouterPush$, url, metadata);
-              },
-              replace(url, metadata) {
-                set(clerkRouterReplace$, url, metadata);
-              },
-            });
-            routeSignal.addEventListener("abort", unregisterRouter, {
-              once: true,
-            });
-            set(observe$, clerk, routeSignal);
-          },
-        ),
-      );
-      return set(ref$, element);
-    },
+  const attach$ = onRef(
+    command(({ get, set }, _element: HTMLSpanElement, signal: AbortSignal) => {
+      const routeSignal = AbortSignal.any([signal, get(pageSignal$)]);
+      if (routeSignal.aborted) {
+        return;
+      }
+      const unregisterRouter = registerClerkRouter({
+        push(url, metadata) {
+          set(clerkRouterPush$, url, metadata);
+        },
+        replace(url, metadata) {
+          set(clerkRouterReplace$, url, metadata);
+        },
+      });
+      routeSignal.addEventListener("abort", unregisterRouter, {
+        once: true,
+      });
+      set(observe$, clerk, routeSignal);
+    }),
   );
   return { ready$, attach$, clerkRouterPush$, clerkRouterReplace$ };
 }

--- a/turbo/apps/platform/src/signals/auth-v1-page-setup.ts
+++ b/turbo/apps/platform/src/signals/auth-v1-page-setup.ts
@@ -49,7 +49,7 @@ function setupAuthV1Page(mode: AuthV1PageMode) {
       set(updatePage$, createElement(AuthV1LoadError));
       return;
     }
-    const signals = createAuthV1ClerkSignals();
+    const signals = createAuthV1ClerkSignals(clerk);
     set(
       updatePage$,
       createElement(AuthV1Page, { clerk, mode, ui: uiLoad.value, signals }),

--- a/turbo/apps/platform/src/views/auth-v1/__tests__/auth-v1-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v1/__tests__/auth-v1-page.test.tsx
@@ -3,6 +3,7 @@ import { expect, test } from "vitest";
 
 import { PRESENTATION_ONBOARDING_URL } from "../../../__tests__/presentation-onboarding-fixture.ts";
 import {
+  click,
   queryAllByRoleFast,
   setupPage,
   startPage,
@@ -328,6 +329,22 @@ test("Hosted auth reaches the brand home and the theme toggle", async () => {
   expect(logoImage).not.toHaveAttribute("crossorigin");
   expect(logoImage.closest("a")).toBe(okouBrandLink());
   expect(screen.getByLabelText("Toggle theme")).toBeVisible();
+});
+
+test("Theme changes preserve the Clerk runtime binding", async () => {
+  context.mocks.browser.matchMedia(false);
+  const clerk = context.mocks.clerk();
+  await setupSignedOutPage("/v1/sign-up");
+
+  const clerkRouter = registeredClerkRouter();
+  const themeToggle = screen.getByLabelText("Toggle theme");
+  click(themeToggle);
+
+  await waitFor(() => {
+    expect(document.documentElement).toHaveAttribute("data-theme", "dark");
+  });
+  expect(registeredClerkRouter()).toBe(clerkRouter);
+  expect(clerk.statusListenerCount()).toBe(1);
 });
 
 test("Leaving the hosted page releases the Clerk status subscription", async () => {

--- a/turbo/apps/platform/src/views/auth-v1/clerk-provider.tsx
+++ b/turbo/apps/platform/src/views/auth-v1/clerk-provider.tsx
@@ -1,4 +1,4 @@
-import { ClerkProvider as BaseClerkProvider, useClerk } from "@clerk/react";
+import { ClerkProvider as BaseClerkProvider } from "@clerk/react";
 import type { BrowserClerk } from "@clerk/shared/types";
 import type { ui } from "@clerk/ui";
 import { useGet, useSet } from "ccstate-react";
@@ -29,23 +29,12 @@ function ClerkRuntimeBoundary({
   children,
   signals,
 }: Pick<ClerkProviderProps, "children" | "signals">) {
-  const clerk = useClerk();
   const ready = useGet(signals.ready$);
   const attach = useSet(signals.attach$);
 
   return (
     <>
-      <span
-        hidden
-        ref={(element) => {
-          // The public hook supplies this provider's runtime. Bind it only
-          // after commit and forward the onRef cleanup to React.
-          if (element) {
-            return attach(element, clerk);
-          }
-          return undefined;
-        }}
-      />
+      <span hidden ref={attach} />
       {ready ? children : null}
     </>
   );


### PR DESCRIPTION
## Summary

- bind the app-owned Clerk runtime when creating the route-owned V1 signal group
- expose the `onRef` command directly as a stable React callback ref
- cover theme-driven provider rerenders without replacing the active Clerk router binding

## Verification

- `pnpm --filter @okouai/app exec vitest run src/views/auth-v1/__tests__/auth-v1-page.test.tsx`
- `pnpm --filter @okouai/app check-types`
- `pnpm exec prettier --check` on the four changed files
- normal and type-aware `oxlint` on the four changed files
- `eslint` on the four changed files
