### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -113,8 +113,8 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.27.1"
-CLAUDE_CODE_VERSION="2.1.266"
-CODEX_CLI_VERSION="0.153.4"
+CLAUDE_CODE_VERSION="2.1.267"
+CODEX_CLI_VERSION="0.154.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.3.1"
 AGENT_BROWSER_VERSION="0.33.0-vm0.1"


### PR DESCRIPTION
## Summary

- Update Claude Code from `2.1.266` to `2.1.267`.
- Update Codex CLI from `0.153.4` to `0.154.0`.
- Keep the remaining rootfs package and tool pins unchanged after checking their current upstream release channels.

## Validation

- Confirmed the Claude Code 2.1.267 manifest and both Linux binaries (`linux-x64` and `linux-arm64`) are available with published checksums.
- Confirmed the Codex CLI 0.154.0 Linux x64 and arm64 npm variants are published with integrity hashes.
- Confirmed `codex-cli 0.154.0` executes on Linux x64.
- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 cargo check --manifest-path crates/Cargo.toml --profile local -p runner --tests`