### PR TITLE
fix(runner): report the real termination reason for oom-killed agent runs

### DIFF
--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -661,7 +661,22 @@ fn cli_failure_message(
         };
     }
 
-    if stderr_lines.is_empty() {
+    // Structured agent telemetry shares stderr with real failure output. It
+    // stays in the guest log below, but must never become the user-visible
+    // reason a run failed.
+    let reported_lines: Vec<&String> = stderr_lines
+        .iter()
+        .filter(|line| !is_structured_agent_diagnostic_line(line))
+        .collect();
+
+    if reported_lines.is_empty() {
+        for line in stderr_lines {
+            log_info!(
+                LOG_TAG,
+                "CLI stderr diagnostic: {}",
+                truncate_cli_stderr_line(line)
+            );
+        }
         return CliFailureMessage {
             message: format!("Agent exited with code {code}"),
             source: FailureDetailSource::FallbackExitCode,
@@ -670,11 +685,11 @@ fn cli_failure_message(
     }
 
     log_info!(LOG_TAG, "Captured {} stderr lines", stderr_lines.len());
-    let omitted_lines = stderr_lines
+    let omitted_lines = reported_lines
         .len()
         .saturating_sub(MAX_LOGGED_CLI_STDERR_LINES);
     let mut message_lines = Vec::with_capacity(
-        stderr_lines.len().min(MAX_LOGGED_CLI_STDERR_LINES) + usize::from(omitted_lines > 0),
+        reported_lines.len().min(MAX_LOGGED_CLI_STDERR_LINES) + usize::from(omitted_lines > 0),
     );
     if omitted_lines > 0 {
         log_warn!(
@@ -686,7 +701,7 @@ fn cli_failure_message(
             "...[omitted {omitted_lines} earlier stderr line(s)]"
         ));
     }
-    for line in stderr_lines.iter().skip(omitted_lines) {
+    for line in reported_lines.into_iter().skip(omitted_lines) {
         let line = truncate_cli_stderr_line(line);
         log_warn!(LOG_TAG, "CLI stderr: {line}");
         message_lines.push(line.into_owned());
@@ -696,6 +711,23 @@ fn cli_failure_message(
         source: FailureDetailSource::Stderr,
         failure_reason: stdout_failure_reason,
     }
+}
+
+/// Structured agent telemetry envelopes that agent runtimes emit on stderr.
+///
+/// Only these exact `type` values are recognized. Any other JSON object, and
+/// any line that is not a JSON object, remains user-visible failure output.
+const STRUCTURED_AGENT_DIAGNOSTIC_TYPES: [&str; 2] =
+    ["pi_memory_recall_outcome", "pi_memory_tool_source_use"];
+
+fn is_structured_agent_diagnostic_line(line: &str) -> bool {
+    let Ok(Value::Object(fields)) = serde_json::from_str::<Value>(line.trim()) else {
+        return false;
+    };
+    fields
+        .get("type")
+        .and_then(Value::as_str)
+        .is_some_and(|value| STRUCTURED_AGENT_DIAGNOSTIC_TYPES.contains(&value))
 }
 
 fn is_generic_stdout_failure_diagnostic(source: FailureDetailSource, message: &str) -> bool {

--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -664,19 +664,20 @@ fn cli_failure_message(
     // Structured agent telemetry shares stderr with real failure output. It
     // stays in the guest log below, but must never become the user-visible
     // reason a run failed.
-    let reported_lines: Vec<&String> = stderr_lines
-        .iter()
-        .filter(|line| !is_structured_agent_diagnostic_line(line))
-        .collect();
-
-    if reported_lines.is_empty() {
-        for line in stderr_lines {
+    let mut reported_lines = Vec::with_capacity(stderr_lines.len());
+    for line in stderr_lines {
+        if is_structured_agent_diagnostic_line(line) {
             log_info!(
                 LOG_TAG,
                 "CLI stderr diagnostic: {}",
                 truncate_cli_stderr_line(line)
             );
+        } else {
+            reported_lines.push(line);
         }
+    }
+
+    if reported_lines.is_empty() {
         return CliFailureMessage {
             message: format!("Agent exited with code {code}"),
             source: FailureDetailSource::FallbackExitCode,

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -1750,3 +1750,115 @@ fn pi_memory_phase2_terminal_diagnostics_survive_guest_error_persistence() {
         assert!(!log.contains("PRIVATE_"));
     }
 }
+
+const PI_MEMORY_RECALL_DIAGNOSTIC_LINE: &str = concat!(
+    r#"{"type":"pi_memory_recall_outcome","runId":"run-1","mode":"sandbox","#,
+    r#""status":"miss","parity":"frozen-no-content","reason":"frozen-no-content","#,
+    r#""injectedTokenCount":0}"#
+);
+
+#[test]
+fn cli_failure_message_reports_the_termination_line_without_memory_diagnostics() {
+    let _system_log_state_guard = crate::lock_system_log_test_state();
+    let tmp = tempfile::tempdir().unwrap();
+    let system_log_path = tmp.path().join("system.log");
+    let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
+
+    let stderr_lines = vec![
+        PI_MEMORY_RECALL_DIAGNOSTIC_LINE.to_string(),
+        "Killed".to_string(),
+    ];
+    let msg = cli_failure_message(137, &stderr_lines, None);
+
+    assert_eq!(msg.source, FailureDetailSource::Stderr);
+    assert_eq!(msg.message, "Killed");
+    assert!(!msg.message.contains("pi_memory_recall_outcome"));
+
+    let system_log = std::fs::read_to_string(&system_log_path).unwrap();
+    assert!(
+        system_log.contains("pi_memory_recall_outcome"),
+        "the structured diagnostic must stay in the guest log"
+    );
+}
+
+#[test]
+fn cli_failure_message_keeps_a_real_error_alongside_memory_diagnostics() {
+    let stderr_lines = vec![
+        PI_MEMORY_RECALL_DIAGNOSTIC_LINE.to_string(),
+        "TypeError: cannot read properties of undefined".to_string(),
+    ];
+    let msg = cli_failure_message(1, &stderr_lines, None);
+
+    assert_eq!(msg.source, FailureDetailSource::Stderr);
+    assert_eq!(
+        msg.message,
+        "TypeError: cannot read properties of undefined"
+    );
+}
+
+#[test]
+fn cli_failure_message_falls_back_when_only_memory_diagnostics_remain() {
+    let _system_log_state_guard = crate::lock_system_log_test_state();
+    let tmp = tempfile::tempdir().unwrap();
+    let system_log_path = tmp.path().join("system.log");
+    let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
+
+    let stderr_lines = vec![
+        PI_MEMORY_RECALL_DIAGNOSTIC_LINE.to_string(),
+        r#"{"type":"pi_memory_tool_source_use","runId":"run-1","sessionId":"s-1"}"#.to_string(),
+    ];
+    let msg = cli_failure_message(137, &stderr_lines, None);
+
+    assert_eq!(msg.source, FailureDetailSource::FallbackExitCode);
+    assert_eq!(msg.message, "Agent exited with code 137");
+
+    let system_log = std::fs::read_to_string(&system_log_path).unwrap();
+    assert!(system_log.contains("pi_memory_tool_source_use"));
+}
+
+#[test]
+fn cli_failure_message_preserves_agent_output_that_is_not_a_known_diagnostic() {
+    for line in [
+        r#"{"type":"user_output","message":"build failed"}"#,
+        r#"{"error":"boom"}"#,
+        r#"{"type":42}"#,
+        "{not json}",
+        r#"["pi_memory_recall_outcome"]"#,
+        r#"prefix {"type":"pi_memory_recall_outcome"}"#,
+    ] {
+        let stderr_lines = vec![line.to_string()];
+        let msg = cli_failure_message(1, &stderr_lines, None);
+
+        assert_eq!(
+            msg.source,
+            FailureDetailSource::Stderr,
+            "line must stay user visible: {line}"
+        );
+        assert_eq!(msg.message, line);
+    }
+}
+
+#[test]
+fn cli_failure_message_keeps_an_incomplete_diagnostic_envelope_visible() {
+    // A cut-off envelope is no longer parseable. It must stay visible rather
+    // than silently removing the only failure detail the user would see.
+    let incomplete = r#"{"type":"pi_memory_recall_outcome","runId":"run-1""#;
+    let stderr_lines = vec![incomplete.to_string()];
+    let msg = cli_failure_message(137, &stderr_lines, None);
+
+    assert_eq!(msg.source, FailureDetailSource::Stderr);
+    assert_eq!(msg.message, incomplete);
+}
+
+#[test]
+fn cli_failure_message_drops_a_long_diagnostic_envelope_before_display_truncation() {
+    let long_diagnostic = format!(
+        r#"{{"type":"pi_memory_recall_outcome","runId":"{}"}}"#,
+        "x".repeat(MAX_LOGGED_CLI_STDERR_LINE_BYTES)
+    );
+    let stderr_lines = vec![long_diagnostic, "Killed".to_string()];
+    let msg = cli_failure_message(137, &stderr_lines, None);
+
+    assert_eq!(msg.source, FailureDetailSource::Stderr);
+    assert_eq!(msg.message, "Killed");
+}

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -1097,6 +1097,72 @@ fn sandbox_reuse_disposition_for_process_exit(
     }
 }
 
+/// User-visible reason for an agent process killed by the guest OOM killer.
+const GUEST_MEMORY_OOM_KILLED_ERROR: &str =
+    "The agent process ran out of memory and was terminated by the sandbox out-of-memory killer";
+
+/// Whether retained guest kernel records name a victim in the agent's own
+/// containment domain.
+///
+/// Shell tools run in separately contained `<workload>/tools/tool-*` leaves.
+/// The kernel routinely reclaims those without ending the run, so only the
+/// workload domain itself and its runtime leaf attribute a terminated agent.
+/// Evidence whose identity could not be correlated cannot attribute anything.
+/// Whether this failed run was terminated by a guest out-of-memory kill of the
+/// agent process itself.
+///
+/// The kernel record supplies the attribution. The terminal exit code only
+/// corroborates that the process the guest waited on was killed: depending on
+/// the launcher, that arrives either as an observed signal or as a shell's
+/// `137` exit translation, so a signal field is not required here.
+fn guest_memory_oom_killed_agent(agent_domain_oom_kill: bool, exit: &sandbox::ProcessExit) -> bool {
+    agent_domain_oom_kill
+        && matches!(exit.termination, ExecTermination::Exited { exit_code } if exit_code == EXIT_SIGKILL)
+}
+
+/// Select the user-visible reason a failed agent run stopped.
+fn agent_failure_error(
+    guest_memory_oom_killed: bool,
+    stderr: String,
+    guest_error: Option<String>,
+    failure_exit_code: i32,
+) -> String {
+    if guest_memory_oom_killed {
+        // The captured stderr tail describes whatever the agent last reported,
+        // not why it stopped. Guest logs retain that tail either way.
+        return GUEST_MEMORY_OOM_KILLED_ERROR.to_string();
+    }
+    if !stderr.is_empty() {
+        return stderr;
+    }
+    // Stderr is empty (redirected to log file). Check for a structured error
+    // file written by the guest-agent for final failure handoff.
+    guest_error.unwrap_or_else(|| agent_exit_failure_message(failure_exit_code))
+}
+
+fn guest_kernel_oom_killed_agent_domain(
+    evidence: &guest_contracts::oom_evidence::OomEvidence,
+) -> bool {
+    use guest_contracts::oom_evidence::EvidenceStatus;
+
+    let workload = evidence.groups[0].cgroup.as_str();
+    let runtime = format!("{workload}/runtime");
+    evidence
+        .incidents
+        .iter()
+        .filter(|incident| {
+            !matches!(
+                incident.kernel_status,
+                EvidenceStatus::Recreated | EvidenceStatus::Uncorrelated
+            )
+        })
+        .flat_map(|incident| incident.kernel_events.iter())
+        .any(|event| {
+            event.boottime_us >= evidence.started_boottime_us
+                && (event.task_cgroup == workload || event.task_cgroup == runtime)
+        })
+}
+
 fn take_oom_evidence(
     diagnostic: &mut String,
 ) -> Option<guest_contracts::oom_evidence::OomEvidence> {
@@ -2568,6 +2634,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 .with_active_input_delivery_ids(active_input_delivery_ids));
         }
     };
+    let mut agent_domain_oom_kill = false;
     if let Some(evidence) = take_oom_evidence(&mut exit.diagnostic).or(oom_evidence) {
         if evidence
             .incidents
@@ -2578,6 +2645,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 evidence_kind = ResourceFailureKind::GuestMemoryOomKilled.as_str(),
                 "preserved operation-scoped guest kernel oom evidence");
         }
+        agent_domain_oom_kill = guest_kernel_oom_killed_agent_domain(&evidence);
         let path = config.log_paths.oom_evidence_log(context.run_id);
         if let Ok(bytes) = serde_json::to_vec(&evidence) {
             let retained =
@@ -2702,14 +2770,19 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 .await;
             }
         }
-        let error = if !stderr.is_empty() {
-            stderr
-        } else {
-            // Stderr is empty (redirected to log file). Check for a structured
-            // error file written by the guest-agent for final failure
-            // handoff.
-            guest_error.unwrap_or_else(|| agent_exit_failure_message(failure_exit_code))
-        };
+        let guest_memory_oom_killed = guest_memory_oom_killed_agent(agent_domain_oom_kill, &exit);
+        if guest_memory_oom_killed {
+            resource_diagnostics = Some(ResourceFailureDiagnostics {
+                failure_kind: Some(ResourceFailureKind::GuestMemoryOomKilled),
+                ..resource_diagnostics.unwrap_or_default()
+            });
+        }
+        let error = agent_failure_error(
+            guest_memory_oom_killed,
+            stderr,
+            guest_error,
+            failure_exit_code,
+        );
         let is_runner_job_timeout = matches!(exit.termination, ExecTermination::TimedOut)
             || diagnostic_is_agent_execution_timeout(failure_diagnostic.as_ref());
         Some(if is_runner_job_timeout {
@@ -2821,6 +2894,217 @@ mod tests {
 
     fn nonzero_process_exit() -> sandbox::ProcessExit {
         sandbox::ProcessExit::new(42, 1, Vec::new(), Vec::new())
+    }
+
+    const TEST_WORKLOAD_CGROUP: &str = "/vm0-exec/exec-281-10-3/workload";
+    const TEST_OPERATION_STARTED_US: u64 = 1_000_000;
+
+    fn test_memory_snapshot(
+        role: &str,
+        cgroup: &str,
+    ) -> guest_contracts::oom_evidence::MemorySnapshot {
+        guest_contracts::oom_evidence::MemorySnapshot {
+            role: role.to_string(),
+            cgroup: cgroup.to_string(),
+            inode: None,
+            status: guest_contracts::oom_evidence::EvidenceStatus::Available,
+            current: None,
+            peak: None,
+            limit: None,
+            initial_limit: None,
+            anon: None,
+            file: None,
+            kernel: None,
+            baseline: guest_contracts::oom_evidence::MemoryEvents::default(),
+            events: guest_contracts::oom_evidence::MemoryEvents::default(),
+            delta: guest_contracts::oom_evidence::MemoryEvents::default(),
+            local_baseline: guest_contracts::oom_evidence::MemoryEvents::default(),
+            local_events: guest_contracts::oom_evidence::MemoryEvents::default(),
+            local_delta: guest_contracts::oom_evidence::MemoryEvents::default(),
+        }
+    }
+
+    fn test_memory_groups() -> [guest_contracts::oom_evidence::MemorySnapshot; 3] {
+        [
+            test_memory_snapshot("workload", TEST_WORKLOAD_CGROUP),
+            test_memory_snapshot("runtime", &format!("{TEST_WORKLOAD_CGROUP}/runtime")),
+            test_memory_snapshot("tools", &format!("{TEST_WORKLOAD_CGROUP}/tools")),
+        ]
+    }
+
+    fn test_kernel_event(
+        task_cgroup: &str,
+        boottime_us: u64,
+    ) -> guest_contracts::oom_evidence::KernelOomEvent {
+        guest_contracts::oom_evidence::KernelOomEvent {
+            source: "guest".to_string(),
+            sequence: 7,
+            boottime_us,
+            constraint: "CONSTRAINT_NONE".to_string(),
+            oom_cgroup: None,
+            victim_pid: 4242,
+            victim_comm: "tsc".to_string(),
+            task_cgroup: task_cgroup.to_string(),
+        }
+    }
+
+    fn test_oom_evidence(
+        kernel_status: guest_contracts::oom_evidence::EvidenceStatus,
+        kernel_events: Vec<guest_contracts::oom_evidence::KernelOomEvent>,
+    ) -> guest_contracts::oom_evidence::OomEvidence {
+        guest_contracts::oom_evidence::OomEvidence {
+            operation_id: "1e1e1e1e-1e1e-4e1e-8e1e-1e1e1e1e1e1e".to_string(),
+            guest_boot_id: None,
+            started_boottime_us: TEST_OPERATION_STARTED_US,
+            sampled_at: "2026-09-09T10:34:57.253Z".to_string(),
+            kernel_cursor: None,
+            kernel_status,
+            groups: test_memory_groups(),
+            incidents: vec![guest_contracts::oom_evidence::OomIncident {
+                id: "1e1e1e1e-1e1e-4e1e-8e1e-1e1e1e1e1e1e:1".to_string(),
+                captured_at: "2026-09-09T10:34:57.253Z".to_string(),
+                reason: guest_contracts::oom_evidence::CaptureReason::Cleanup,
+                after_observation: true,
+                before_cleanup: true,
+                kernel_status,
+                kernel_events,
+                groups: test_memory_groups(),
+            }],
+            dropped_incidents: 0,
+        }
+    }
+
+    fn sigkill_process_exit() -> sandbox::ProcessExit {
+        // Production observes the launcher's 137 exit translation, not a
+        // signal field, so the exit shape here matches the recorded incident.
+        sandbox::ProcessExit::new(42, EXIT_SIGKILL, Vec::new(), Vec::new())
+    }
+
+    #[test]
+    fn guest_kernel_evidence_attributes_agent_domain_victims() {
+        for task_cgroup in [
+            TEST_WORKLOAD_CGROUP.to_string(),
+            format!("{TEST_WORKLOAD_CGROUP}/runtime"),
+        ] {
+            let evidence = test_oom_evidence(
+                guest_contracts::oom_evidence::EvidenceStatus::Available,
+                vec![test_kernel_event(&task_cgroup, TEST_OPERATION_STARTED_US)],
+            );
+
+            assert!(
+                guest_kernel_oom_killed_agent_domain(&evidence),
+                "agent domain victim must be attributed: {task_cgroup}"
+            );
+        }
+    }
+
+    #[test]
+    fn guest_kernel_evidence_ignores_separately_contained_tool_victims() {
+        // A reclaimed shell tool is the ordinary case in production and must
+        // keep the run's original terminal outcome.
+        let evidence = test_oom_evidence(
+            guest_contracts::oom_evidence::EvidenceStatus::Available,
+            vec![test_kernel_event(
+                &format!("{TEST_WORKLOAD_CGROUP}/tools/tool-281-10-3-1"),
+                TEST_OPERATION_STARTED_US + 10,
+            )],
+        );
+
+        assert!(!guest_kernel_oom_killed_agent_domain(&evidence));
+        assert!(!guest_memory_oom_killed_agent(
+            guest_kernel_oom_killed_agent_domain(&evidence),
+            &sigkill_process_exit(),
+        ));
+    }
+
+    #[test]
+    fn guest_kernel_evidence_requires_a_correlated_record_from_this_operation() {
+        let no_records = test_oom_evidence(
+            guest_contracts::oom_evidence::EvidenceStatus::Missing,
+            Vec::new(),
+        );
+        let stale_record = test_oom_evidence(
+            guest_contracts::oom_evidence::EvidenceStatus::Available,
+            vec![test_kernel_event(
+                TEST_WORKLOAD_CGROUP,
+                TEST_OPERATION_STARTED_US - 1,
+            )],
+        );
+
+        assert!(!guest_kernel_oom_killed_agent_domain(&no_records));
+        assert!(!guest_kernel_oom_killed_agent_domain(&stale_record));
+
+        for kernel_status in [
+            guest_contracts::oom_evidence::EvidenceStatus::Recreated,
+            guest_contracts::oom_evidence::EvidenceStatus::Uncorrelated,
+        ] {
+            let evidence = test_oom_evidence(
+                kernel_status,
+                vec![test_kernel_event(
+                    TEST_WORKLOAD_CGROUP,
+                    TEST_OPERATION_STARTED_US,
+                )],
+            );
+
+            assert!(
+                !guest_kernel_oom_killed_agent_domain(&evidence),
+                "uncorrelated identity cannot attribute a victim: {kernel_status:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn guest_memory_oom_attribution_requires_a_kill_shaped_exit() {
+        assert!(guest_memory_oom_killed_agent(true, &sigkill_process_exit()));
+        assert!(!guest_memory_oom_killed_agent(
+            true,
+            &nonzero_process_exit()
+        ));
+        assert!(!guest_memory_oom_killed_agent(
+            false,
+            &sigkill_process_exit()
+        ));
+        assert!(!guest_memory_oom_killed_agent(
+            true,
+            &sandbox::ProcessExit {
+                termination: ExecTermination::TimedOut,
+                ..sigkill_process_exit()
+            }
+        ));
+    }
+
+    #[test]
+    fn oom_killed_agent_reports_the_termination_reason_over_captured_stderr() {
+        let error = agent_failure_error(
+            true,
+            "{\"type\":\"pi_memory_recall_outcome\",\"status\":\"miss\"} Killed".to_string(),
+            Some("guest error file".to_string()),
+            EXIT_SIGKILL,
+        );
+
+        assert_eq!(error, GUEST_MEMORY_OOM_KILLED_ERROR);
+        assert!(!error.contains("pi_memory_recall_outcome"));
+    }
+
+    #[test]
+    fn ordinary_failures_keep_their_existing_error_selection() {
+        assert_eq!(
+            agent_failure_error(false, "boom".to_string(), None, 1),
+            "boom"
+        );
+        assert_eq!(
+            agent_failure_error(
+                false,
+                String::new(),
+                Some("guest error file".to_string()),
+                1
+            ),
+            "guest error file"
+        );
+        assert_eq!(
+            agent_failure_error(false, String::new(), None, EXIT_SIGKILL),
+            agent_exit_failure_message(EXIT_SIGKILL)
+        );
     }
 
     #[test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -1368,7 +1368,7 @@ async fn execute_inner_nonzero_records_agent_execute_error() {
 }
 
 #[tokio::test]
-async fn execute_inner_retains_trusted_oom_evidence_without_changing_terminal_semantics() {
+async fn execute_inner_retains_trusted_oom_evidence_and_attributes_agent_domain_sigkill() {
     let evidence =
         include_str!("../../../../../guest-contracts/tests/fixtures/oom-evidence-v1.json");
     let parsed: guest_contracts::oom_evidence::OomEvidence =
@@ -1414,15 +1414,29 @@ async fn execute_inner_retains_trusted_oom_evidence_without_changing_terminal_se
                 "recovered tool OOM must preserve success"
             );
         } else {
-            assert!(
-                !outcome
-                    .failure
-                    .as_ref()
-                    .unwrap()
-                    .error
-                    .as_str()
-                    .contains("OKOU_OOM_EVIDENCE")
-            );
+            let failure = outcome.failure.as_ref().unwrap();
+            assert!(!failure.error.as_str().contains("OKOU_OOM_EVIDENCE"));
+            if matches!(
+                termination,
+                ExecTermination::Exited {
+                    exit_code: EXIT_SIGKILL
+                }
+            ) {
+                assert_eq!(
+                    failure.error,
+                    "The agent process ran out of memory and was terminated by the sandbox out-of-memory killer"
+                );
+                assert_eq!(
+                    failure
+                        .resource_diagnostics
+                        .and_then(|diagnostics| diagnostics.failure_kind),
+                    Some(ResourceFailureKind::GuestMemoryOomKilled)
+                );
+                assert_eq!(
+                    outcome.sandbox_reuse_disposition,
+                    SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ResourceFailure)
+                );
+            }
         }
         if termination == ExecTermination::TimedOut {
             assert!(matches!(
@@ -1431,4 +1445,47 @@ async fn execute_inner_retains_trusted_oom_evidence_without_changing_terminal_se
             ));
         }
     }
+}
+
+#[tokio::test]
+async fn execute_inner_keeps_tool_domain_oom_out_of_agent_terminal_attribution() {
+    let evidence =
+        include_str!("../../../../../guest-contracts/tests/fixtures/oom-evidence-v1.json");
+    let mut parsed: guest_contracts::oom_evidence::OomEvidence =
+        serde_json::from_str(evidence).unwrap();
+    let workload = parsed.groups[0].cgroup.clone();
+    parsed.incidents[0].kernel_events[0].task_cgroup = format!("{workload}/tools/tool-281-10-3-1");
+
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let mut exit = ProcessExit::new(1, EXIT_SIGKILL, Vec::new(), Vec::new());
+    exit.diagnostic = format!(
+        "{}{}",
+        guest_contracts::oom_evidence::EVIDENCE_PREFIX,
+        serde_json::to_string(&parsed).unwrap()
+    );
+    overrides.push_wait_process_exit(exit);
+    let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
+    let ctx = minimal_context();
+
+    let outcome = run_new_sandbox_outcome(&factory, &ctx, &config, &default_params())
+        .await
+        .unwrap();
+
+    let failure = outcome
+        .failure
+        .as_ref()
+        .expect("tool OOM must retain the failed run");
+    assert_eq!(failure.error, "Agent exited with code 137");
+    assert_ne!(
+        failure
+            .resource_diagnostics
+            .and_then(|diagnostics| diagnostics.failure_kind),
+        Some(ResourceFailureKind::GuestMemoryOomKilled)
+    );
+    assert_eq!(
+        outcome.sandbox_reuse_disposition,
+        SandboxReuseDisposition::Eligible(SandboxReuseTerminal::NonzeroExit)
+    );
 }


### PR DESCRIPTION
Refs #32963

## Problem

A Pi run killed by the guest out-of-memory killer reported the agent's last stderr lines as the failure reason. Pi writes structured memory telemetry to stderr, so the user-visible error became a successful memory-recall JSON envelope joined to the shell's `Killed` line:

```
{"type":"pi_memory_recall_outcome",...,"injectedTokenCount":0} Killed
```

The run's actual termination reason was never reported. Two further defects followed from the same stderr:

- Because stderr was non-empty and the detail source was `stderr`, both abnormal-exit resource probes stayed disabled, so a 137 exit collected no resource diagnostics.
- `ResourceFailureKind::GuestMemoryOomKilled` existed and was logged as an `evidence_kind`, but was never attached to a failure. `resource_failure_kind` has never been emitted in production.

## Change

- Drop the known structured telemetry envelopes (`pi_memory_recall_outcome`, `pi_memory_tool_source_use`) from the selected failure message. They stay in the guest log. A real error alongside them stays visible, and a run with no other stderr falls back to the exit-code message — which also restores the existing unattributed-SIGKILL resource probe.
- Attribute the termination from retained guest kernel evidence. When a kernel OOM record names a victim in the operation's own `workload` or `workload/runtime` cgroup and the agent exited 137, classify the failure as `guest_memory_oom_killed` and report that reason.

## Scope limits

- Only an exhaustive `type` allowlist is filtered. Any other JSON object, and any line that is not a JSON object, stays user-visible.
- Shell tools run in separately contained `workload/tools/tool-*` leaves and are reclaimed routinely without ending a run. A tool victim keeps its existing outcome, message, and sandbox reuse disposition. Production kernel records since 2026-09-09 name a tool leaf in 100% of cases, so this is the dominant path and it is unchanged.
- A 137 exit alone attributes nothing. Evidence whose identity could not be correlated (`recreated`, `uncorrelated`) and records older than the operation attribute nothing.
- The exit code, failed run state, and cancellation/timeout precedence are unchanged.
- Only `resource_failure_kind` is added to the terminal log. No victim PID, comm, or cgroup path is emitted.

## Consequence to review

A classified run now carries resource diagnostics, so `sandbox_reuse_disposition_for_process_exit` marks the sandbox `Ineligible(ResourceFailure)`. That is intended: after a guest-global OOM the sandbox's memory state is uncertain. It is a rare path — no exit-137 run has occurred in production since 2026-09-08.

## Verification

Added unit tests:

- agent-domain victim (`workload`, `workload/runtime`) is attributed.
- **negative control:** a `workload/tools/tool-*` victim is not attributed and does not change the outcome.
- a kernel record is required; records before the operation start, and `recreated`/`uncorrelated` evidence, attribute nothing.
- attribution requires a kill-shaped exit; `TimedOut` and ordinary nonzero exits do not qualify.
- the OOM reason replaces the captured stderr; ordinary failures keep their existing error selection (stderr, then guest error file, then exit-code message).
- guest-agent: the termination line survives without the memory envelope; a real error is preserved; only-envelope stderr falls back to `FallbackExitCode`; **negative controls** keep unknown JSON `type` values, non-JSON lines, and incomplete envelopes visible.

Ran locally: `cargo check -p guest-agent --tests` passed. The runner crate check did not finish inside the session's time budget; the runner test suite is left to CI.

Not run locally: full Rust test suites and Vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)