### PR TITLE
refactor(platform): remove chat preference submission state

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/settings/cloud-browser-preference.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/cloud-browser-preference.ts
@@ -1,18 +1,7 @@
-import { command, computed, state } from "ccstate";
+import { command } from "ccstate";
 
 import { cloudBrowserEnabledByDefault$ } from "../../cloud-browser-preference.ts";
-import { pageSignal$ } from "../../page-signal.ts";
 import { updateUserPreference$ } from "./user-preferences.ts";
-
-const internalCloudBrowserSubmission$ = state<{
-  readonly enabled: boolean;
-  readonly signal: AbortSignal;
-} | null>(null);
-
-export const submittedCloudBrowserEnabledByDefault$ = computed((get) => {
-  const submission = get(internalCloudBrowserSubmission$);
-  return submission?.signal === get(pageSignal$) ? submission.enabled : null;
-});
 
 export const updateCloudBrowserEnabledByDefault$ = command(
   async (
@@ -21,7 +10,6 @@ export const updateCloudBrowserEnabledByDefault$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     signal.throwIfAborted();
-    set(internalCloudBrowserSubmission$, { enabled, signal });
     await set(
       updateUserPreference$,
       { cloudBrowserEnabledByDefault: enabled },

--- a/turbo/apps/platform/src/signals/okou-page/settings/default-model-preference.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/default-model-preference.ts
@@ -1,4 +1,4 @@
-import { command, computed, state } from "ccstate";
+import { command } from "ccstate";
 
 import type { ModelProviderSelection } from "../../../views/okou-page/components/model-provider-picker.tsx";
 import {
@@ -6,23 +6,6 @@ import {
   updateUserModelPreference$,
   userModelPreference$,
 } from "../../external/user-model-preference.ts";
-import { pageSignal$ } from "../../page-signal.ts";
-
-interface DefaultModelSubmission {
-  readonly selection: ModelProviderSelection | null;
-  readonly signal: AbortSignal;
-}
-
-const internalDefaultModelSubmission$ = state<DefaultModelSubmission | null>(
-  null,
-);
-
-export const defaultModelSubmission$ = computed((get) => {
-  const submission = get(internalDefaultModelSubmission$);
-  return submission?.signal === get(pageSignal$)
-    ? { selection: submission.selection }
-    : null;
-});
 
 export const updateDefaultModelPreference$ = command(
   async (
@@ -31,7 +14,6 @@ export const updateDefaultModelPreference$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     signal.throwIfAborted();
-    set(internalDefaultModelSubmission$, { selection, signal });
     await set(
       updateUserModelPreference$,
       {

--- a/turbo/apps/platform/src/signals/okou-page/settings/send-mode-preference.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/send-mode-preference.ts
@@ -1,19 +1,8 @@
-import { command, computed, state } from "ccstate";
+import { command } from "ccstate";
 import type { SendMode } from "@okouai/api-contracts/contracts/user-preferences";
 
 import { sendMode$ } from "../../send-mode.ts";
-import { pageSignal$ } from "../../page-signal.ts";
 import { updateUserPreference$ } from "./user-preferences.ts";
-
-const internalSendModeSubmission$ = state<{
-  readonly value: SendMode;
-  readonly signal: AbortSignal;
-} | null>(null);
-
-export const submittedSendMode$ = computed((get) => {
-  const submission = get(internalSendModeSubmission$);
-  return submission?.signal === get(pageSignal$) ? submission.value : null;
-});
 
 /**
  * Update send mode preference. After saving, await the refetched value so the
@@ -22,7 +11,6 @@ export const submittedSendMode$ = computed((get) => {
 export const updateSendMode$ = command(
   async ({ get, set }, value: SendMode, signal: AbortSignal) => {
     signal.throwIfAborted();
-    set(internalSendModeSubmission$, { value, signal });
     await set(updateUserPreference$, { sendMode: value }, signal);
     signal.throwIfAborted();
     await get(sendMode$);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/preferences-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/preferences-page.test.tsx
@@ -467,11 +467,8 @@ test("Chat setting controls disable while their saves settle", async () => {
     ...defaultPreferences(),
     cloudBrowserEnabledByDefault: false,
   };
-  const cloudUpdateStarted = context.mocks.deferred<void>();
   const releaseCloudUpdate = context.mocks.deferred<void>();
-  const sendModeUpdateStarted = context.mocks.deferred<void>();
   const releaseSendModeUpdate = context.mocks.deferred<void>();
-  const updateStarts = [cloudUpdateStarted, sendModeUpdateStarted] as const;
   const updateReleases = [releaseCloudUpdate, releaseSendModeUpdate] as const;
   let updateIndex = 0;
   context.mocks.api(userPreferencesContract.get, ({ respond }) => {
@@ -480,13 +477,11 @@ test("Chat setting controls disable while their saves settle", async () => {
   context.mocks.api(
     userPreferencesContract.update,
     async ({ body, respond, withSignal }) => {
-      const started = updateStarts[updateIndex];
       const release = updateReleases[updateIndex];
-      if (!started || !release) {
+      if (!release) {
         throw new Error("Unexpected preference update");
       }
       updateIndex += 1;
-      started.resolve();
       await withSignal(release.promise);
       preferences = { ...preferences, ...body };
       return respond(200, preferences);
@@ -500,12 +495,10 @@ test("Chat setting controls disable while their saves settle", async () => {
     selectedImageModel: null,
     updatedAt: "2026-09-06T00:00:00.000Z",
   });
-  const modelUpdateStarted = context.mocks.deferred<void>();
   const releaseModelUpdate = context.mocks.deferred<void>();
   context.mocks.api(
     userModelPreferenceContract.update,
     async ({ body, respond, withSignal }) => {
-      modelUpdateStarted.resolve();
       await withSignal(releaseModelUpdate.promise);
       const preference = {
         selectedModel: body.selectedModel,
@@ -532,10 +525,12 @@ test("Chat setting controls disable while their saves settle", async () => {
   const dialog = await screen.findByRole("dialog", { name: "Settings" });
   click(await within(dialog).findByRole("combobox", { name: "GPT 6 Astra" }));
   click(await screen.findByRole("option", { name: "GPT 6 Astra Fast" }));
-  await modelUpdateStarted.promise;
-  expect(
-    within(dialog).queryByRole("combobox", { name: "GPT 6 Astra" }),
-  ).toBeNull();
+  await waitFor(() => {
+    expect(within(dialog).getByLabelText("GPT 6 Astra")).toBeVisible();
+    expect(
+      within(dialog).queryByRole("combobox", { name: "GPT 6 Astra" }),
+    ).toBeNull();
+  });
   releaseModelUpdate.resolve();
   await waitFor(() => {
     expect(
@@ -544,7 +539,6 @@ test("Chat setting controls disable while their saves settle", async () => {
   });
 
   click(within(dialog).getByRole("switch", { name: "Cloud browser" }));
-  await cloudUpdateStarted.promise;
   await waitFor(() => {
     const cloudBrowser = within(dialog).getByRole("switch", {
       name: "Cloud browser",
@@ -561,7 +555,6 @@ test("Chat setting controls disable while their saves settle", async () => {
   });
 
   click(getFastRole("button", "⌘ Enter", dialog));
-  await sendModeUpdateStarted.promise;
   await waitFor(() => {
     expect(getFastRole("button", "Enter", dialog)).toBeDisabled();
     expect(getFastRole("button", "⌘ Enter", dialog)).toBeDisabled();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/preferences-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/preferences-page.test.tsx
@@ -462,6 +462,118 @@ test("Chat settings keep the agreed row order and save chat defaults", async () 
   });
 });
 
+test("Chat setting controls disable while their saves settle", async () => {
+  let preferences = {
+    ...defaultPreferences(),
+    cloudBrowserEnabledByDefault: false,
+  };
+  const cloudUpdateStarted = context.mocks.deferred<void>();
+  const releaseCloudUpdate = context.mocks.deferred<void>();
+  const sendModeUpdateStarted = context.mocks.deferred<void>();
+  const releaseSendModeUpdate = context.mocks.deferred<void>();
+  const updateStarts = [cloudUpdateStarted, sendModeUpdateStarted] as const;
+  const updateReleases = [releaseCloudUpdate, releaseSendModeUpdate] as const;
+  let updateIndex = 0;
+  context.mocks.api(userPreferencesContract.get, ({ respond }) => {
+    return respond(200, preferences);
+  });
+  context.mocks.api(
+    userPreferencesContract.update,
+    async ({ body, respond, withSignal }) => {
+      const started = updateStarts[updateIndex];
+      const release = updateReleases[updateIndex];
+      if (!started || !release) {
+        throw new Error("Unexpected preference update");
+      }
+      updateIndex += 1;
+      started.resolve();
+      await withSignal(release.promise);
+      preferences = { ...preferences, ...body };
+      return respond(200, preferences);
+    },
+  );
+
+  context.mocks.data.userModelPreference({
+    selectedModel: "gpt-6-astra",
+    serviceTier: null,
+    selectedVideoModel: null,
+    selectedImageModel: null,
+    updatedAt: "2026-09-06T00:00:00.000Z",
+  });
+  const modelUpdateStarted = context.mocks.deferred<void>();
+  const releaseModelUpdate = context.mocks.deferred<void>();
+  context.mocks.api(
+    userModelPreferenceContract.update,
+    async ({ body, respond, withSignal }) => {
+      modelUpdateStarted.resolve();
+      await withSignal(releaseModelUpdate.promise);
+      const preference = {
+        selectedModel: body.selectedModel,
+        serviceTier: body.serviceTier,
+        selectedVideoModel: null,
+        selectedImageModel: null,
+        updatedAt: "2026-09-06T00:00:01.000Z",
+      };
+      context.mocks.data.userModelPreference(preference);
+      return respond(200, preference);
+    },
+  );
+
+  await setupPage({
+    context,
+    path: "/?settings=chat",
+    host: "app.okou.ai",
+    featureSwitches: {
+      [FeatureSwitchKey.ChatPreference]: true,
+      [FeatureSwitchKey.CodexFastMode]: true,
+    },
+  });
+
+  const dialog = await screen.findByRole("dialog", { name: "Settings" });
+  click(await within(dialog).findByRole("combobox", { name: "GPT 6 Astra" }));
+  click(await screen.findByRole("option", { name: "GPT 6 Astra Fast" }));
+  await modelUpdateStarted.promise;
+  expect(
+    within(dialog).queryByRole("combobox", { name: "GPT 6 Astra" }),
+  ).toBeNull();
+  releaseModelUpdate.resolve();
+  await waitFor(() => {
+    expect(
+      within(dialog).getByRole("combobox", { name: "GPT 6 Astra Fast" }),
+    ).toBeEnabled();
+  });
+
+  click(within(dialog).getByRole("switch", { name: "Cloud browser" }));
+  await cloudUpdateStarted.promise;
+  await waitFor(() => {
+    const cloudBrowser = within(dialog).getByRole("switch", {
+      name: "Cloud browser",
+    });
+    expect(cloudBrowser).toHaveAttribute("aria-disabled", "true");
+  });
+  releaseCloudUpdate.resolve();
+  await waitFor(() => {
+    const cloudBrowser = within(dialog).getByRole("switch", {
+      name: "Cloud browser",
+    });
+    expect(cloudBrowser).toBeChecked();
+    expect(cloudBrowser).not.toHaveAttribute("aria-disabled", "true");
+  });
+
+  click(getFastRole("button", "⌘ Enter", dialog));
+  await sendModeUpdateStarted.promise;
+  await waitFor(() => {
+    expect(getFastRole("button", "Enter", dialog)).toBeDisabled();
+    expect(getFastRole("button", "⌘ Enter", dialog)).toBeDisabled();
+  });
+  releaseSendModeUpdate.resolve();
+  await waitFor(() => {
+    expectSelected(getFastRole("button", "⌘ Enter", dialog));
+    expect(getFastRole("button", "Enter", dialog)).toBeEnabled();
+    expect(getFastRole("button", "⌘ Enter", dialog)).toBeEnabled();
+  });
+});
+
 test("A user can save message-send and time-zone preferences", async () => {
   const updates = mockPreferences();
 

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/chat-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/chat-section.tsx
@@ -1,7 +1,7 @@
 import { useGet, useLastResolved, useLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
-import { Cpu, Globe, Keyboard, Loader2 } from "lucide-react";
+import { Cpu, Globe, Keyboard } from "lucide-react";
 import { ToggleButton } from "@okouai/ui";
 import { Switch } from "@okouai/ui/components/ui/switch";
 import type { SendMode } from "@okouai/api-contracts/contracts/user-preferences";
@@ -14,18 +14,9 @@ import { sendMode$ } from "../../../../../signals/send-mode.ts";
 import { cloudBrowserEnabledByDefault$ } from "../../../../../signals/cloud-browser-preference.ts";
 import { detach, Reason } from "../../../../../signals/utils.ts";
 import { resolveModelFirstStoredUserSelection } from "../../../../../signals/okou-page/model-default-selection.ts";
-import {
-  defaultModelSubmission$,
-  updateDefaultModelPreference$,
-} from "../../../../../signals/okou-page/settings/default-model-preference.ts";
-import {
-  submittedCloudBrowserEnabledByDefault$,
-  updateCloudBrowserEnabledByDefault$,
-} from "../../../../../signals/okou-page/settings/cloud-browser-preference.ts";
-import {
-  submittedSendMode$,
-  updateSendMode$,
-} from "../../../../../signals/okou-page/settings/send-mode-preference.ts";
+import { updateDefaultModelPreference$ } from "../../../../../signals/okou-page/settings/default-model-preference.ts";
+import { updateCloudBrowserEnabledByDefault$ } from "../../../../../signals/okou-page/settings/cloud-browser-preference.ts";
+import { updateSendMode$ } from "../../../../../signals/okou-page/settings/send-mode-preference.ts";
 import { ModelProviderPicker } from "../../model-provider-picker.tsx";
 import { PreferenceCardRow } from "../preference-card-row.tsx";
 
@@ -39,16 +30,13 @@ function DefaultModelPreference() {
   const [updateLoadable, updatePreference] = useLoadableSet(
     updateDefaultModelPreference$,
   );
-  const submitted = useGet(defaultModelSubmission$);
-  const submission = updateLoadable.state === "loading" ? submitted : null;
   const pageSignal = useGet(pageSignal$);
   const current = resolveModelFirstStoredUserSelection({
     userPreference,
     policies,
     codexFastModeEnabled,
   });
-  const effective = submission === null ? current : submission.selection;
-  const mutating = submission !== null;
+  const mutating = updateLoadable.state === "loading";
 
   const handleChange = (selection: Parameters<typeof updatePreference>[0]) => {
     detach(updatePreference(selection, pageSignal), Reason.DomCallback);
@@ -65,7 +53,7 @@ function DefaultModelPreference() {
       })}
     >
       <ModelProviderPicker
-        value={effective}
+        value={current}
         onChange={handleChange}
         triggerClassName="h-9 w-full sm:w-[260px]"
         disabled={
@@ -86,11 +74,8 @@ function CloudBrowserDefaultPreference() {
   const [updateLoadable, updatePreference] = useLoadableSet(
     updateCloudBrowserEnabledByDefault$,
   );
-  const submitted = useGet(submittedCloudBrowserEnabledByDefault$);
-  const submission = updateLoadable.state === "loading" ? submitted : null;
   const pageSignal = useGet(pageSignal$);
-  const mutating = submission !== null;
-  const effective = submission ?? current;
+  const mutating = updateLoadable.state === "loading";
 
   const handleToggle = (checked: boolean) => {
     detach(updatePreference(checked, pageSignal), Reason.DomCallback);
@@ -110,7 +95,7 @@ function CloudBrowserDefaultPreference() {
         aria-label={t(($) => {
           return $.settings.preferences.chat.cloudBrowser.title;
         })}
-        checked={effective}
+        checked={current}
         onCheckedChange={handleToggle}
         disabled={preferenceLoadable.state !== "hasData" || mutating}
       />
@@ -124,15 +109,12 @@ export function SendModePreference() {
   const current: SendMode =
     prefsLoadable.state === "hasData" ? prefsLoadable.data : "enter";
   const [saveLoadable, saveSendMode] = useLoadableSet(updateSendMode$);
-  const submitted = useGet(submittedSendMode$);
-  const saving = saveLoadable.state === "loading" ? submitted : null;
+  const saving = saveLoadable.state === "loading";
   const pageSignal = useGet(pageSignal$);
 
   const handleChange = (value: SendMode) => {
     detach(saveSendMode(value, pageSignal), Reason.DomCallback);
   };
-
-  const effective: SendMode = saving ?? current;
 
   return (
     <PreferenceCardRow
@@ -141,7 +123,7 @@ export function SendModePreference() {
         return $.settings.preferences.send.title;
       })}
       description={
-        effective === "enter"
+        current === "enter"
           ? t(($) => {
               return $.settings.preferences.send.enterDescription;
             })
@@ -152,8 +134,7 @@ export function SendModePreference() {
     >
       <div className="flex flex-wrap gap-2 shrink-0">
         {SEND_OPTIONS.map((value) => {
-          const isActive =
-            saving === value ? true : saving === null && current === value;
+          const isActive = current === value;
           const label =
             value === "enter"
               ? t(($) => {
@@ -167,14 +148,11 @@ export function SendModePreference() {
               key={value}
               type="button"
               selected={isActive}
-              disabled={saving !== null}
+              disabled={saving}
               onClick={() => {
                 handleChange(value);
               }}
             >
-              {saving === value && (
-                <Loader2 size={14} className="animate-spin" />
-              )}
               {label}
             </ToggleButton>
           );


### PR DESCRIPTION
## Summary

- remove the module-scoped submission signals for default model, Cloud browser, and Send mode
- derive each pending state directly from the `useLoadableSet` invocation owned by its leaf settings component
- keep persisted preference signals as the displayed source of truth while a save and its readback complete
- cover all three controls with a focused page test that verifies pending interaction locks and completed values

## Validation

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/preferences-page.test.tsx --maxWorkers=1 --silent=passed-only` (12/12 passed)
- `pnpm -F @okouai/app check-types`
- targeted Prettier, Oxlint, type-aware Oxlint, and ESLint for all changed files
- `pnpm exec knip --workspace @okouai/app --no-progress`

No full local Vitest run or local development server was started; the PR pipeline provides broader validation.
