### PR TITLE
fix(api): keep sandbox telemetry batches alive and name oom upload failures

### DIFF
--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -33,6 +33,40 @@ const FLUSH_THRESHOLD: Duration = Duration::from_secs(30);
 const TELEMETRY_TIMEOUT: Duration = Duration::from_secs(10);
 const RUNNER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Why one bounded OOM evidence upload was not acknowledged.
+///
+/// Only fixed stage names and an HTTP status are reported. Evidence payloads
+/// and response bodies stay out of the log.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OomEvidenceUploadFailure {
+    Timeout,
+    Transport,
+    HttpStatus(u16),
+    BodyOversize,
+    InvalidBody,
+    MissingAck,
+}
+
+impl OomEvidenceUploadFailure {
+    fn reason(self) -> &'static str {
+        match self {
+            Self::Timeout => "timeout",
+            Self::Transport => "transport",
+            Self::HttpStatus(_) => "http_status",
+            Self::BodyOversize => "body_oversize",
+            Self::InvalidBody => "invalid_body",
+            Self::MissingAck => "missing_ack",
+        }
+    }
+
+    fn http_status(self) -> Option<u16> {
+        match self {
+            Self::HttpStatus(status) => Some(status),
+            _ => None,
+        }
+    }
+}
+
 /// Effective resource path once the guest process has spawned.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -412,7 +446,7 @@ impl JobTelemetry {
             "oomEvidence": evidence,
         });
         let send = async {
-            let mut response = self
+            let mut response = match self
                 .http
                 .request_route(
                     routes::webhooks::agent::telemetry::SEND,
@@ -422,26 +456,48 @@ impl JobTelemetry {
                 .json(&payload)
                 .send("oom-evidence")
                 .await
-                .ok()?;
-            if !response.status().is_success() {
-                return None;
+            {
+                Ok(response) => response,
+                Err(_) => return Err(OomEvidenceUploadFailure::Transport),
+            };
+            let status = response.status();
+            if !status.is_success() {
+                return Err(OomEvidenceUploadFailure::HttpStatus(status.as_u16()));
             }
             let mut bytes = Vec::new();
-            while let Some(chunk) = response.chunk().await.ok()? {
-                if bytes.len() + chunk.len() > 1024 {
-                    return None;
+            loop {
+                match response.chunk().await {
+                    Ok(Some(chunk)) => {
+                        if bytes.len() + chunk.len() > 1024 {
+                            return Err(OomEvidenceUploadFailure::BodyOversize);
+                        }
+                        bytes.extend_from_slice(&chunk);
+                    }
+                    Ok(None) => break,
+                    Err(_) => return Err(OomEvidenceUploadFailure::Transport),
                 }
-                bytes.extend_from_slice(&chunk);
             }
-            let body: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
-            (body.get("oomEvidenceVersion")?.as_u64() == Some(1)).then_some(())
+            let Ok(body) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+                return Err(OomEvidenceUploadFailure::InvalidBody);
+            };
+            if body.get("oomEvidenceVersion").and_then(serde_json::Value::as_u64) != Some(1) {
+                return Err(OomEvidenceUploadFailure::MissingAck);
+            }
+            Ok(())
         };
-        if !matches!(
-            tokio::time::timeout(Duration::from_secs(2), send).await,
-            Ok(Some(()))
-        ) {
-            warn!(run_id = %self.run_id, "guest oom evidence upload unacknowledged; host evidence retained");
-        }
+        // Report which delivery stage failed. A bare warning cannot distinguish
+        // a rejected payload from an unconfigured receiver or a slow response.
+        let failure = match tokio::time::timeout(Duration::from_secs(2), send).await {
+            Ok(Ok(())) => return,
+            Ok(Err(failure)) => failure,
+            Err(_) => OomEvidenceUploadFailure::Timeout,
+        };
+        warn!(
+            run_id = %self.run_id,
+            reason = failure.reason(),
+            http_status = failure.http_status(),
+            "guest oom evidence upload unacknowledged; host evidence retained"
+        );
     }
 
     fn record_inner(

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -2409,7 +2409,7 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
     },
   );
 
-  it("ingests collector memory in ordinary mixed telemetry and rejects relative paths before any ingestion", async () => {
+  it("ingests collector memory in ordinary mixed telemetry and degrades an unusable snapshot without dropping the batch", async () => {
     const { actor, runId, headers } = await createEventWebhookRun(
       `collector mixed telemetry ${randomUUID()}`,
     );
@@ -2489,9 +2489,65 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
         group.cgroup = group.cgroup.slice(1);
       }
     }
-    await api.requestAgentTelemetryUnchecked(malformed, headers, [400]);
-    expect(ingested.size).toBe(0);
-    expect(context.mocks.axiom.sdkIngest).not.toHaveBeenCalled();
+    const degraded = await api.requestAgentTelemetry(malformed, headers, [200]);
+
+    // An unusable periodic snapshot drops itself, never the unrelated system
+    // logs, metrics, and sandbox operations batched in the same request.
+    expect(degraded.body).toStrictEqual({ success: true, id: runId });
+    expect(ingested.get("sandbox-telemetry-metrics")).toStrictEqual(
+      metrics.map((metric) => {
+        return {
+          _time: metric.ts,
+          runId,
+          userId: actor.userId,
+          cpu: metric.cpu,
+          mem_used: metric.mem_used,
+          mem_total: metric.mem_total,
+          disk_used: metric.disk_used,
+          disk_total: metric.disk_total,
+        };
+      }),
+    );
+    expect(ingested.get("sandbox-telemetry-system")).toStrictEqual([
+      expect.objectContaining({ runId, log: body.systemLog }),
+    ]);
+    await flushWaitUntilForTest();
+    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalled();
+  });
+
+  it("keeps dedicated OOM evidence strict so an unusable payload is never acknowledged", async () => {
+    const { runId, headers } = await createEventWebhookRun(
+      `collector strict evidence ${randomUUID()}`,
+    );
+    const ingested: unknown[] = [];
+    mockOptionalEnv("AXIOM_TOKEN_TELEMETRY", `xaat-strict-${randomUUID()}`);
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/:dataset/ingest",
+        async ({ request }) => {
+          const events: unknown = await request.json();
+          ingested.push(events);
+          const count = Array.isArray(events) ? events.length : 0;
+          return HttpResponse.json(successfulAxiomIngestStatus(count));
+        },
+      ),
+    );
+    const relativePaths = collectorEvidence("sample");
+    for (const group of relativePaths.groups) {
+      group.cgroup = group.cgroup.slice(1);
+    }
+
+    await api.requestAgentTelemetryUnchecked(
+      {
+        runId,
+        systemLog: "batched with unusable evidence",
+        oomEvidence: relativePaths,
+      },
+      headers,
+      [400],
+    );
+
+    expect(ingested).toHaveLength(0);
   });
 
   it("projects only present control-path metric fields", async () => {

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -876,7 +876,11 @@ export const webhookHeartbeatContract = c.router({
  * Metric data point schema
  */
 const metricDataSchema = z.object({
-  memory: oomEvidenceSchema.optional(),
+  // A periodic memory snapshot rides along with ordinary metrics. Rejecting it
+  // must never discard the system logs, metrics, network logs, and sandbox
+  // operations batched in the same request; the dedicated `oomEvidence` field
+  // below stays strict because it decides the delivery acknowledgement.
+  memory: oomEvidenceSchema.optional().catch(undefined),
   ts: z.string(),
   cpu: z.number(),
   cpu_steal_percent: z.number().optional(),


### PR DESCRIPTION
Refs #32963

## Problem

`metricDataSchema.memory` reused the same strict `oomEvidenceSchema` as the dedicated top-level `oomEvidence` field, and the guest embeds a memory snapshot in every ordinary 5s metrics entry. One unusable snapshot therefore rejected the entire telemetry request with HTTP 400, discarding the `systemLog`, `metrics`, `networkLogs`, and `sandboxOperations` batched in the same request.

That is not hypothetical. While the relative-cgroup-path defect (#32921 / #32936) was live, production sandbox telemetry coverage collapsed. Distinct `runId` per hour on 2026-09-09 (UTC), in both `vm0-sandbox-telemetry-metrics-prod` and `vm0-sandbox-telemetry-system-prod`:

| hour | 05 | 06 | 07 | 08 | 09 | 10 | 11 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| runs | 146 | 195 | 50 | **6** | **1** | 117 | 132 |

It was also self-silencing: the guest's own `OOM evidence upload unacknowledged` warning is written to the system log, which was uploaded in the same rejected request. That message has zero occurrences in the dataset.

`#32936` removed the trigger, not the coupling.

Separately, the Runner's `guest oom evidence upload unacknowledged; host evidence retained` warning reported no stage, so a rejected payload, an unconfigured receiver, a truncated body, and a slow response were indistinguishable.

## Change

- `metricDataSchema.memory` degrades instead of rejecting: an unusable snapshot drops itself and the rest of the batch is ingested.
- The dedicated `oomEvidence` field stays strict. It decides the delivery acknowledgement, so an unusable payload must be rejected rather than falsely acknowledged.
- The Runner warning now reports a fixed `reason` (`timeout`, `transport`, `http_status`, `body_oversize`, `invalid_body`, `missing_ack`) and, for a rejected request, the HTTP status.

## Scope limits

- The warning keeps its `warn` level. It reports a real delivery failure, and its current production rate is zero; downgrading it would hide a regression.
- No change to upload timing, retries, timeout budgets, sampling, or the acknowledgement contract.
- Evidence payloads and response bodies stay out of the log.

## Verification

- Updated the mixed-telemetry test: an unusable snapshot now yields 200 with the snapshot dropped, while the system log, remaining metric fields, and sandbox operations are still ingested.
- Added a negative control: a request whose dedicated `oomEvidence` carries relative cgroup paths still returns 400, ingests nothing, and is not acknowledged. The existing strict-`oomEvidence` rejection cases are unchanged.

Not run locally: Vitest and the Rust test suites; both are left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)