### PR TITLE
test(platform): seed sidebar stories with initial chat history

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -41,6 +41,7 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { mockNow } from "../../../__tests__/time.ts";
+import type { ChatThreadEventQueryResult } from "../../../shared-database/data-key.ts";
 import { emptySearchImg } from "../platform-assets.ts";
 import {
   testContext,
@@ -246,41 +247,47 @@ function createThread(
   };
 }
 
+function sidebarThreadSnapshot(
+  threads: readonly SidebarThread[],
+): NonNullable<ChatThreadEventQueryResult["snapshot"]> {
+  return {
+    chatThreads: threads.map((thread, index) => {
+      return {
+        id: thread.id,
+        agentId: thread.agent.id,
+        title: thread.title,
+        sortAt:
+          thread.sortAt ??
+          new Date(
+            Date.parse("2026-03-10T00:00:00Z") +
+              (threads.length - index) * 1000,
+          ).toISOString(),
+        createdAt: thread.createdAt,
+        updatedAt: thread.updatedAt,
+        pinnedAt: thread.pinnedAt ?? null,
+        renamedAt: thread.renamedAt ?? null,
+        selectedModel: null,
+        serviceTier: null,
+        computerUseHostId: null,
+        selectedVideoModel: null,
+      };
+    }),
+    latestEventId: null,
+    latestSeqId: null,
+  };
+}
+
 function mockChatThreadSnapshot(
   threads: () => readonly SidebarThread[],
   activeThreadIds: () => readonly string[] = () => {
     return [];
   },
   targetContext = context,
+  remoteGate?: Promise<void>,
 ): void {
-  targetContext.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
-    const snapshotThreads = threads();
-    const response = respond(200, {
-      chatThreads: snapshotThreads.map((thread, index) => {
-        return {
-          id: thread.id,
-          agentId: thread.agent.id,
-          title: thread.title,
-          sortAt:
-            thread.sortAt ??
-            new Date(
-              Date.parse("2026-03-10T00:00:00Z") +
-                (snapshotThreads.length - index) * 1000,
-            ).toISOString(),
-          createdAt: thread.createdAt,
-          updatedAt: thread.updatedAt,
-          pinnedAt: thread.pinnedAt ?? null,
-          renamedAt: thread.renamedAt ?? null,
-          selectedModel: null,
-          serviceTier: null,
-          computerUseHostId: null,
-          selectedVideoModel: null,
-        };
-      }),
-      latestEventId: null,
-      latestSeqId: null,
-    });
-    return response;
+  targetContext.mocks.api(chatThreadsContract.snapshot, async ({ respond }) => {
+    await remoteGate;
+    return respond(200, sidebarThreadSnapshot(threads()));
   });
   targetContext.mocks.api(chatThreadsContract.events, ({ respond }) => {
     return respond(200, { events: [], hasMore: false });
@@ -692,7 +699,8 @@ function mockSidebarThreadStory(
   extraThreads: SidebarThread[] = [],
   activeThreadIds: readonly string[] = [],
   targetContext = context,
-): { threads: SidebarThread[] } {
+  remoteGate?: Promise<void>,
+): ChatThreadEventQueryResult {
   let threads = [...firstPageThreads];
 
   mockChatThreadSnapshot(
@@ -703,6 +711,7 @@ function mockSidebarThreadStory(
       return activeThreadIds;
     },
     targetContext,
+    remoteGate,
   );
 
   targetContext.mocks.api(chatThreadByIdContract.get, ({ respond }) => {
@@ -753,10 +762,15 @@ function mockSidebarThreadStory(
     },
   );
 
-  return { threads };
+  return {
+    snapshot: sidebarThreadSnapshot([...threads, ...extraThreads]),
+    events: [],
+  };
 }
 
-function mockLongSidebarHistory(): void {
+function mockLongSidebarHistory(
+  remoteGate?: Promise<void>,
+): ChatThreadEventQueryResult {
   prepareDefaultAgent();
   const overflowThreads = Array.from({ length: 23 }, (_, index) => {
     return createThread(
@@ -764,12 +778,18 @@ function mockLongSidebarHistory(): void {
       `Refresh overflow ${index + 1}`,
     );
   });
-  mockSidebarThreadStory([
-    createThread(EXISTING_THREAD_ID, "Release plan"),
-    createThread(AUTOMATION_THREAD_ID, "Scheduled launch"),
-    ...overflowThreads,
-    createThread(ARCHIVED_THREAD_ID, "Archived context"),
-  ]);
+  return mockSidebarThreadStory(
+    [
+      createThread(EXISTING_THREAD_ID, "Release plan"),
+      createThread(AUTOMATION_THREAD_ID, "Scheduled launch"),
+      ...overflowThreads,
+      createThread(ARCHIVED_THREAD_ID, "Archived context"),
+    ],
+    [],
+    [],
+    context,
+    remoteGate,
+  );
 }
 
 async function scrollToArchivedContext(): Promise<HTMLElement> {
@@ -795,12 +815,13 @@ async function scrollToArchivedContext(): Promise<HTMLElement> {
 }
 
 test("Browse a long sidebar chat history", async () => {
-  mockLongSidebarHistory();
+  const cachedChatThreadEvents = mockLongSidebarHistory();
   mockSidebarViewport(200, 1000);
 
   await setupSidebarPage({
     context,
     path: `/chats/${EXISTING_THREAD_ID}`,
+    cachedChatThreadEvents,
   });
 
   const scrollArea = await scrollToArchivedContext();
@@ -808,15 +829,19 @@ test("Browse a long sidebar chat history", async () => {
 });
 
 test("Refresh a long sidebar after deleting an offscreen chat", async () => {
-  mockLongSidebarHistory();
+  const remote = context.mocks.deferred<void>();
+  const cachedChatThreadEvents = mockLongSidebarHistory(remote.promise);
   mockSidebarViewport(200, 1000);
 
   await setupSidebarPage({
     context,
     path: `/agents/${AGENT_ID}/chat`,
+    cachedChatThreadEvents,
   });
 
+  // The existing-list scene must be usable before remote synchronization.
   const scrollArea = await scrollToArchivedContext();
+  remote.resolve();
   openThreadMenu("Archived context");
   click(menuItemByText("Delete chat"));
   const dialog = await screen.findByRole("dialog", {
@@ -1175,7 +1200,7 @@ test("Keep chat navigation usable while secondary data is unavailable", async ()
   const draftResponse = context.mocks.deferred<void>();
   const draftRequestStarted = context.mocks.deferred<void>();
   const draftResponseReturned = context.mocks.deferred<void>();
-  mockSidebarThreadStory([
+  const cachedChatThreadEvents = mockSidebarThreadStory([
     createThread(EXISTING_THREAD_ID, "Existing conversation"),
   ]);
   context.mocks.api(chatThreadsContract.indicators, async ({ respond }) => {
@@ -1195,7 +1220,11 @@ test("Keep chat navigation usable while secondary data is unavailable", async ()
     return response;
   });
 
-  await setupSidebarPage({ context, path: `/agents/${AGENT_ID}/chat` });
+  await setupSidebarPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+    cachedChatThreadEvents,
+  });
 
   await waitFor(() => {
     expect(
@@ -1578,7 +1607,7 @@ test("Mark all current-agent chats read from the chat-list menu", async () => {
 test("Show mark all read in the mobile chat-list menu", async () => {
   mockMobileLayout();
   prepareDefaultAgent();
-  mockSidebarThreadStory([
+  const cachedChatThreadEvents = mockSidebarThreadStory([
     createThread(INCIDENT_THREAD_ID, "Unread conversation"),
   ]);
   mockUnreadAgents(() => {
@@ -1588,6 +1617,7 @@ test("Show mark all read in the mobile chat-list menu", async () => {
   await setupSidebarPage({
     context,
     path: `/agents/${AGENT_ID}/chat`,
+    cachedChatThreadEvents,
   });
 
   const list = await waitFor(() => {


### PR DESCRIPTION
Closes #33150.

The offscreen-delete story could start its initial list assertion after the new-chat shell was ready but before cold IndexedDB startup and remote thread hydration completed. Supply the existing `cachedChatThreadEvents` page fixture explicitly for the long-history and two related existing-list stories, using the same typed snapshot builder as their mutable HTTP fixtures.

Hold the remote snapshot response until the original deletion story has rendered its 14 initial rows and scrolled to the offscreen chat. Then release it and keep the original deletion and browser-clamped scroll assertions. This changes one test file; production startup, shared helpers, timeout limits, and CI configuration are unchanged.

## CI evidence

[Main run 34441673501, test-app (2)](https://github.com/vm0-ai/vm0/actions/runs/34441673501/job/102757881820), at `f570332481b4164fe42dbe18c53dbe2e218e7661`, also failed `Show mark all read in the mobile chat-list menu` at its initial `Unread conversation` lookup (`sidebar.test.tsx:1593`), before opening the menu. This PR supplies that story's initial snapshot through `cachedChatThreadEvents`, using the same typed fixture as the remote response.

Verified against the current PR head, `fea1243e831e25da7e8b2bac22a8a22679796920`:

- [The PR's test-app (2) job](https://github.com/vm0-ai/vm0/actions/runs/34437178128/job/102744642390) passed all 31 files and 291 tests, including all 41 sidebar tests and the reported mobile case.
- [The latest Turbo run for this PR head](https://github.com/vm0-ai/vm0/actions/runs/34438839414) completed successfully, including [test-app (2)](https://github.com/vm0-ai/vm0/actions/runs/34438839414/job/102749482485).

## Validation

- Controlled regression: holding the remote response without cached data reproduced the original missing virtual list; with cached data, the complete deletion story passed in five fresh coverage-enabled processes (`--maxWorkers=2`).
- Adjacent `chat-list-cache.test.tsx` and `sidebar-virtualization.test.tsx`: 16/16 passed with coverage and two workers.
- `pnpm exec vitest run --project=@okouai/app --shard=2/8 --maxWorkers=2 --coverage.enabled --coverage.reporter=json`: Sidebar 41/41 passed; overall 288/291 passed (31 files). Two total-test timeouts in `chat-composer-create`/`chat-composer-mentions` and one missing mention suggestion menu remain in those unchanged files. Their causes were not established in this task, so broader local validation is not fully green.
- Affected-file Prettier, oxlint, type-aware oxlint, ESLint, and repository style policy: passed.
- `TSC_CHECKERS=2 pnpm -F @okouai/app check-types` and `pnpm exec knip --workspace @okouai/app --no-progress`: passed.

The separate two-file coverage cohort completed with 76/78 passing: two unchanged tests failed their initial unread-only Support Agent lookup. A clean checkout of baseline main `04d3c7e5b600b195e272e80b2bcef2b66ffc7c26` independently reproduced the agent mark-all-read failure; the shortcut failure's causal relationship is unconfirmed. Evidence and follow-up are tracked in #33160. All four changed stories passed in that cohort. No full local Vitest run or dev server was used.
