### PR TITLE
test(platform): stabilize sidebar initial thread readiness

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -41,6 +41,7 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { mockNow } from "../../../__tests__/time.ts";
+import type { ChatThreadEventQueryResult } from "../../../shared-database/data-key.ts";
 import { emptySearchImg } from "../platform-assets.ts";
 import {
   testContext,
@@ -246,41 +247,47 @@ function createThread(
   };
 }
 
+function sidebarThreadSnapshot(
+  threads: readonly SidebarThread[],
+): NonNullable<ChatThreadEventQueryResult["snapshot"]> {
+  return {
+    chatThreads: threads.map((thread, index) => {
+      return {
+        id: thread.id,
+        agentId: thread.agent.id,
+        title: thread.title,
+        sortAt:
+          thread.sortAt ??
+          new Date(
+            Date.parse("2026-03-10T00:00:00Z") +
+              (threads.length - index) * 1000,
+          ).toISOString(),
+        createdAt: thread.createdAt,
+        updatedAt: thread.updatedAt,
+        pinnedAt: thread.pinnedAt ?? null,
+        renamedAt: thread.renamedAt ?? null,
+        selectedModel: null,
+        serviceTier: null,
+        computerUseHostId: null,
+        selectedVideoModel: null,
+      };
+    }),
+    latestEventId: null,
+    latestSeqId: null,
+  };
+}
+
 function mockChatThreadSnapshot(
   threads: () => readonly SidebarThread[],
   activeThreadIds: () => readonly string[] = () => {
     return [];
   },
   targetContext = context,
+  remoteGate?: Promise<void>,
 ): void {
-  targetContext.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
-    const snapshotThreads = threads();
-    const response = respond(200, {
-      chatThreads: snapshotThreads.map((thread, index) => {
-        return {
-          id: thread.id,
-          agentId: thread.agent.id,
-          title: thread.title,
-          sortAt:
-            thread.sortAt ??
-            new Date(
-              Date.parse("2026-03-10T00:00:00Z") +
-                (snapshotThreads.length - index) * 1000,
-            ).toISOString(),
-          createdAt: thread.createdAt,
-          updatedAt: thread.updatedAt,
-          pinnedAt: thread.pinnedAt ?? null,
-          renamedAt: thread.renamedAt ?? null,
-          selectedModel: null,
-          serviceTier: null,
-          computerUseHostId: null,
-          selectedVideoModel: null,
-        };
-      }),
-      latestEventId: null,
-      latestSeqId: null,
-    });
-    return response;
+  targetContext.mocks.api(chatThreadsContract.snapshot, async ({ respond }) => {
+    await remoteGate;
+    return respond(200, sidebarThreadSnapshot(threads()));
   });
   targetContext.mocks.api(chatThreadsContract.events, ({ respond }) => {
     return respond(200, { events: [], hasMore: false });
@@ -692,7 +699,8 @@ function mockSidebarThreadStory(
   extraThreads: SidebarThread[] = [],
   activeThreadIds: readonly string[] = [],
   targetContext = context,
-): { threads: SidebarThread[] } {
+  remoteGate?: Promise<void>,
+): ChatThreadEventQueryResult {
   let threads = [...firstPageThreads];
 
   mockChatThreadSnapshot(
@@ -703,6 +711,7 @@ function mockSidebarThreadStory(
       return activeThreadIds;
     },
     targetContext,
+    remoteGate,
   );
 
   targetContext.mocks.api(chatThreadByIdContract.get, ({ respond }) => {
@@ -753,10 +762,15 @@ function mockSidebarThreadStory(
     },
   );
 
-  return { threads };
+  return {
+    snapshot: sidebarThreadSnapshot([...threads, ...extraThreads]),
+    events: [],
+  };
 }
 
-function mockLongSidebarHistory(): void {
+function mockLongSidebarHistory(
+  remoteGate?: Promise<void>,
+): ChatThreadEventQueryResult {
   prepareDefaultAgent();
   const overflowThreads = Array.from({ length: 23 }, (_, index) => {
     return createThread(
@@ -764,12 +778,18 @@ function mockLongSidebarHistory(): void {
       `Refresh overflow ${index + 1}`,
     );
   });
-  mockSidebarThreadStory([
-    createThread(EXISTING_THREAD_ID, "Release plan"),
-    createThread(AUTOMATION_THREAD_ID, "Scheduled launch"),
-    ...overflowThreads,
-    createThread(ARCHIVED_THREAD_ID, "Archived context"),
-  ]);
+  return mockSidebarThreadStory(
+    [
+      createThread(EXISTING_THREAD_ID, "Release plan"),
+      createThread(AUTOMATION_THREAD_ID, "Scheduled launch"),
+      ...overflowThreads,
+      createThread(ARCHIVED_THREAD_ID, "Archived context"),
+    ],
+    [],
+    [],
+    context,
+    remoteGate,
+  );
 }
 
 async function scrollToArchivedContext(): Promise<HTMLElement> {
@@ -795,12 +815,13 @@ async function scrollToArchivedContext(): Promise<HTMLElement> {
 }
 
 test("Browse a long sidebar chat history", async () => {
-  mockLongSidebarHistory();
+  const cachedChatThreadEvents = mockLongSidebarHistory();
   mockSidebarViewport(200, 1000);
 
   await setupSidebarPage({
     context,
     path: `/chats/${EXISTING_THREAD_ID}`,
+    cachedChatThreadEvents,
   });
 
   const scrollArea = await scrollToArchivedContext();
@@ -808,15 +829,19 @@ test("Browse a long sidebar chat history", async () => {
 });
 
 test("Refresh a long sidebar after deleting an offscreen chat", async () => {
-  mockLongSidebarHistory();
+  const remote = context.mocks.deferred<void>();
+  const cachedChatThreadEvents = mockLongSidebarHistory(remote.promise);
   mockSidebarViewport(200, 1000);
 
   await setupSidebarPage({
     context,
     path: `/agents/${AGENT_ID}/chat`,
+    cachedChatThreadEvents,
   });
 
+  // The existing-list scene must be usable before remote synchronization.
   const scrollArea = await scrollToArchivedContext();
+  remote.resolve();
   openThreadMenu("Archived context");
   click(menuItemByText("Delete chat"));
   const dialog = await screen.findByRole("dialog", {
@@ -1175,7 +1200,7 @@ test("Keep chat navigation usable while secondary data is unavailable", async ()
   const draftResponse = context.mocks.deferred<void>();
   const draftRequestStarted = context.mocks.deferred<void>();
   const draftResponseReturned = context.mocks.deferred<void>();
-  mockSidebarThreadStory([
+  const cachedChatThreadEvents = mockSidebarThreadStory([
     createThread(EXISTING_THREAD_ID, "Existing conversation"),
   ]);
   context.mocks.api(chatThreadsContract.indicators, async ({ respond }) => {
@@ -1195,7 +1220,11 @@ test("Keep chat navigation usable while secondary data is unavailable", async ()
     return response;
   });
 
-  await setupSidebarPage({ context, path: `/agents/${AGENT_ID}/chat` });
+  await setupSidebarPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+    cachedChatThreadEvents,
+  });
 
   await waitFor(() => {
     expect(
@@ -1578,7 +1607,7 @@ test("Mark all current-agent chats read from the chat-list menu", async () => {
 test("Show mark all read in the mobile chat-list menu", async () => {
   mockMobileLayout();
   prepareDefaultAgent();
-  mockSidebarThreadStory([
+  const cachedChatThreadEvents = mockSidebarThreadStory([
     createThread(INCIDENT_THREAD_ID, "Unread conversation"),
   ]);
   mockUnreadAgents(() => {
@@ -1588,6 +1617,7 @@ test("Show mark all read in the mobile chat-list menu", async () => {
   await setupSidebarPage({
     context,
     path: `/agents/${AGENT_ID}/chat`,
+    cachedChatThreadEvents,
   });
 
   const list = await waitFor(() => {


### PR DESCRIPTION
Closes #33150.

## Summary

- Seed the existing chat-thread scene through `setupPage.cachedChatThreadEvents` for the long-sidebar and mobile mark-all-read stories that failed before their first interaction.
- Build cached and remote snapshots from one typed fixture so titles, ordering, and identifiers cannot drift.
- Hold remote synchronization during the long-sidebar readiness assertion, then release it and preserve the original offscreen deletion and browser-clamped scroll behavior.

## Root cause

The new-chat route intentionally exposes its usable shell before cold IndexedDB startup and remote chat-thread synchronization finish. Under coverage and concurrent file work, the tests could begin their one-second visible-state wait while the thread projection was still empty.

- [Main run 34435509483, test-app (2)](https://github.com/vm0-ai/vm0/actions/runs/34435509483/job/102739699841) failed the long-sidebar initial virtual-list lookup before scrolling or deletion.
- [Merge-group run 34436039006, test-app (2)](https://github.com/vm0-ai/vm0/actions/runs/34436039006/job/102741265204) failed both that lookup and the mobile `Unread conversation` lookup before opening either menu.

This is test fixture/readiness nondeterminism, not a product deletion or mark-all-read regression. The production early-shell contract and existing timeout remain unchanged.

## Verification

This PR reuses the exact previously validated commit `fea1243e831e25da7e8b2bac22a8a22679796920`:

- Controlled no-cache reproduction matched the missing virtual-list failure; the cache-backed target passed in five fresh coverage-enabled processes with two workers.
- `chat-list-cache.test.tsx` and `sidebar-virtualization.test.tsx`: 16/16 passed with coverage and two workers.
- Exact-head `test-app (2)`: 31/31 files and 291/291 tests passed: https://github.com/vm0-ai/vm0/actions/runs/34437178128/job/102744642390
- Affected formatting, lint, type-aware lint, style policy, Platform type checks, and Platform Knip passed.

No timeout increase, sleep, retry, fake timer, test skip, or manual detached-work cleanup is introduced.
