### PR TITLE
refactor(app): simplify thinking summary demand

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/thread-activity-summary.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-activity-summary.ts
@@ -1,5 +1,4 @@
 import { command, computed, state, type Computed } from "ccstate";
-import { delay } from "signal-timers";
 import {
   activitySummaryResponseSchema,
   chatThreadActivitySummaryContract,
@@ -9,7 +8,6 @@ import {
 import { foldChatRunStates } from "@okouai/api-contracts/contracts/chat-events";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { accept } from "../../lib/accept.ts";
-import { now } from "../../lib/time.ts";
 import { currentChatThreadId$ } from "../agent-chat.ts";
 import { apiClient$ } from "../api-client.ts";
 import {
@@ -17,9 +15,8 @@ import {
   initialFeatureSwitchHydration$,
 } from "../external/feature-switch.ts";
 import {
-  completeOnLocalAbort,
-  createChildAbortController,
   createDeferredPromise,
+  resetSignal,
   setLoop,
   withCleanup,
 } from "../utils.ts";
@@ -29,8 +26,6 @@ import type { ChatEvent } from "./chat-event-types.ts";
 import type { ThreadMeta } from "./chat-thread-event-sourcing.ts";
 
 const REQUEST_INTERVAL_MS = 15_000;
-const FAILURE_RETRY_MS = 60_000;
-const MAX_CONSECUTIVE_FAILURES = 3;
 
 export interface ThinkingSummaries extends Pick<
   ActivitySummaryResponse,
@@ -43,35 +38,22 @@ export interface ThinkingSummaries extends Pick<
   readonly messages: readonly ThinkingMessage[];
 }
 
-function keepPreviousThinkingSummaries(
-  previous: ThinkingSummaries | null,
-  next: ThinkingSummaries | null,
-): boolean {
-  if (previous === next) {
-    return true;
-  }
-  if (!previous || !next || previous.runId !== next.runId) {
-    return false;
-  }
-  // Only a summary with its own provenance can replace the last good batch.
-  // Current source metadata can advance while the cached summary is unchanged.
-  return (
-    next.messages.length === 0 ||
-    next.summaryRevision === null ||
-    next.summarizedAt === null ||
-    (previous.summarizedAt !== null &&
-      next.summarizedAt < previous.summarizedAt) ||
-    (next.summarySequence ?? -1) < (previous.summarySequence ?? -1) ||
-    (next.summaryMessageCursor ?? -1) < (previous.summaryMessageCursor ?? -1)
-  );
-}
-
-function createThinkingSummaryRequest(
+function createThinkingSummaryDemand(
   threadId: string,
-  runId: string,
-  signal: AbortSignal,
+  currentActiveRunId$: Computed<string | null>,
+  chatEvents$: Computed<ChatEvent[]>,
 ) {
-  return computed(async (get) => {
+  const internalReloadDemandSummary$ = state(0);
+  const summaryDemandRunId$ = state<string | null>(null);
+  const resetSummaryDemand$ = resetSignal();
+  let summaryDemandSignal: AbortSignal | null = null;
+  const demandSummaries$ = computed(async (get) => {
+    get(internalReloadDemandSummary$);
+    const runId = get(summaryDemandRunId$);
+    const signal = summaryDemandSignal;
+    if (!runId || !signal) {
+      return null;
+    }
     signal.throwIfAborted();
     const response = await accept(
       get(apiClient$)(chatThreadActivitySummaryContract).summarize({
@@ -96,132 +78,48 @@ function createThinkingSummaryRequest(
     }
     return data;
   });
-}
-
-function createThinkingSummaryRequests(threadId: string) {
-  const request$ = state<ReturnType<
-    typeof createThinkingSummaryRequest
-  > | null>(null);
-  // Retain one fulfilled resource while the optional service is unavailable.
-  // The response stays in its async computed; no second mutable response store.
-  const lastSuccessfulRequest$ = state<ReturnType<
-    typeof createThinkingSummaryRequest
-  > | null>(null);
-  const thinkingSummaries$ = computed(async (get) => {
-    const request = get(request$);
-    const previous = get(lastSuccessfulRequest$);
-    if (!request) {
-      return null;
-    }
-    const [result] = await Promise.allSettled([get(request)]);
-    const previousSummary = previous ? await get(previous) : null;
-    return result.status === "fulfilled" &&
-      !keepPreviousThinkingSummaries(previousSummary, result.value)
-      ? result.value
-      : previousSummary;
-  });
-  const retry$ = state<{
-    runId: string | null;
-    nextRequestAt: number;
-    failures: number;
-    blocked: boolean;
-  }>({
-    runId: null,
-    nextRequestAt: 0,
-    failures: 0,
-    blocked: false,
-  });
-  const reloadThinkingSummaries$ = command(
-    async (
-      { get, set },
-      runId: string,
-      signal: AbortSignal,
-    ): Promise<boolean> => {
-      const retry = get(retry$);
-      if (retry.blocked) {
-        return true;
+  const startSummaryDemand$ = command(
+    async ({ set }, signal: AbortSignal): Promise<void> => {
+      const [completion] = await Promise.allSettled([
+        setLoop(
+          () => {
+            set(internalReloadDemandSummary$, (version) => {
+              return version + 1;
+            });
+            return false;
+          },
+          REQUEST_INTERVAL_MS,
+          signal,
+          { testIntervalMs: 100 },
+        ),
+      ]);
+      if (signal.aborted) {
+        return;
       }
-      if (now() < retry.nextRequestAt) {
-        return false;
+      if (completion.status === "rejected") {
+        throw completion.reason;
       }
-      const request = createThinkingSummaryRequest(threadId, runId, signal);
-      set(request$, request);
-      // Await the computed so refreshes serialize. Cancellation belongs to the
-      // demand lifecycle and must not consume the optional-service retry budget.
-      const [result] = await Promise.allSettled([get(request)]);
-      signal.throwIfAborted();
-      if (result.status === "fulfilled" && result.value === null) {
-        set(retry$, { ...retry, blocked: true });
-        return true;
-      }
-      if (result.status === "fulfilled") {
-        const previous = get(lastSuccessfulRequest$);
-        const previousSummary = previous ? await get(previous) : null;
-        signal.throwIfAborted();
-        if (!keepPreviousThinkingSummaries(previousSummary, result.value)) {
-          set(lastSuccessfulRequest$, request);
-        }
-      }
-      const failed = result.status === "rejected";
-      const failures = failed ? retry.failures + 1 : 0;
-      set(retry$, {
-        runId,
-        failures,
-        blocked: failures >= MAX_CONSECUTIVE_FAILURES,
-        nextRequestAt:
-          now() +
-          Math.max(
-            REQUEST_INTERVAL_MS,
-            result.status === "fulfilled"
-              ? (result.value?.retryAfterMs ?? 0)
-              : FAILURE_RETRY_MS,
-          ),
-      });
-      return failures >= MAX_CONSECUTIVE_FAILURES;
     },
   );
-  const resetForRun$ = command(({ get, set }, runId: string | null) => {
-    if (get(retry$).runId !== runId) {
-      set(retry$, { runId, nextRequestAt: 0, failures: 0, blocked: false });
-      set(request$, null);
-      set(lastSuccessfulRequest$, null);
-    }
-  });
-  const blocked$ = computed((get) => {
-    return get(retry$).blocked;
-  });
-  return {
-    thinkingSummaries$,
-    reloadThinkingSummaries$,
-    resetForRun$,
-    blocked$,
-  };
-}
-
-function createThinkingSummarySubscription(
-  runId$: Computed<string | null>,
-  chatEvents$: Computed<ChatEvent[]>,
-  requests: ReturnType<typeof createThinkingSummaryRequests>,
-) {
-  return command(async ({ get, set }, signal: AbortSignal) => {
+  const subscribe$ = command(async ({ set }, signal: AbortSignal) => {
     signal.throwIfAborted();
-    let demandRunId: string | null = null;
-    let demandController = createChildAbortController(signal);
-    let changed = createDeferredPromise<void>(signal);
-    const updateDemand$ = command(({ get, set }) => {
+    let activeDemand = Promise.resolve();
+    const ensureSummaryDemand$ = command(({ get, set }) => {
       signal.throwIfAborted();
-      const runId = get(runId$);
-      if (runId !== demandRunId) {
-        demandController.abort();
-        demandController = createChildAbortController(signal);
-        demandRunId = runId;
-        changed.resolve();
-        changed = createDeferredPromise<void>(signal);
+      const runId = get(currentActiveRunId$);
+      if (runId === get(summaryDemandRunId$)) {
+        return;
       }
-      set(requests.resetForRun$, runId);
+      summaryDemandSignal = null;
+      const demandSignal = set(resetSummaryDemand$, signal);
+      set(summaryDemandRunId$, runId);
+      if (runId) {
+        summaryDemandSignal = demandSignal;
+        activeDemand = set(startSummaryDemand$, demandSignal);
+      }
     });
     const afterEventsChange$ = command(({ set }) => {
-      set(updateDemand$);
+      set(ensureSummaryDemand$);
       return Promise.resolve();
     });
     set(
@@ -230,71 +128,29 @@ function createThinkingSummarySubscription(
       afterEventsChange$,
       signal,
     );
-    set(updateDemand$);
+    set(ensureSummaryDemand$);
 
-    // Bootstrap can replace cached switch state after this thread starts.
-    const hydrateDemand$ = command(
+    const ensureHydratedSummaryDemand$ = command(
       async ({ get, set }, signal: AbortSignal) => {
         await get(initialFeatureSwitchHydration$);
         signal.throwIfAborted();
-        set(updateDemand$);
+        set(ensureSummaryDemand$);
       },
     );
+    const subscriptionEnd = createDeferredPromise<void>(signal);
     await withCleanup(
       Promise.all([
-        set(hydrateDemand$, signal),
-        setLoop(
-          async () => {
-            set(updateDemand$);
-            const runId = demandRunId;
-            const demandSignal = demandController.signal;
-            if (runId && !get(requests.blocked$)) {
-              await completeOnLocalAbort(
-                setLoop(
-                  async () => {
-                    set(updateDemand$);
-                    demandSignal.throwIfAborted();
-                    return await set(
-                      requests.reloadThinkingSummaries$,
-                      runId,
-                      demandSignal,
-                    );
-                  },
-                  REQUEST_INTERVAL_MS,
-                  demandSignal,
-                  { retryTransientErrors: false },
-                ),
-                demandSignal,
-                signal,
-              );
-              signal.throwIfAborted();
-            } else {
-              // Idle threads issue no requests. Run events wake the owner; the
-              // bounded check also observes subsequent switch changes.
-              const idleController = createChildAbortController(signal);
-              await withCleanup(
-                Promise.race([
-                  changed.promise,
-                  delay(REQUEST_INTERVAL_MS, { signal: idleController.signal }),
-                ]),
-                () => {
-                  idleController.abort();
-                },
-              );
-              signal.throwIfAborted();
-            }
-            return false;
-          },
-          0,
-          signal,
-          { retryTransientErrors: false },
-        ),
+        set(ensureHydratedSummaryDemand$, signal),
+        subscriptionEnd.promise,
       ]),
-      () => {
-        demandController.abort();
+      async () => {
+        set(resetSummaryDemand$);
+        await activeDemand;
       },
     );
   });
+
+  return { demandSummaries$, subscribe$, summaryDemandRunId$ };
 }
 
 export function createThreadActivitySummarySignals(
@@ -305,7 +161,7 @@ export function createThreadActivitySummarySignals(
   const enabled$ = computed((get) => {
     return get(featureSwitch$)[FeatureSwitchKey.ThreadActivitySummary] === true;
   });
-  const runId$ = computed((get): string | null => {
+  const currentActiveRunId$ = computed((get): string | null => {
     if (
       !get(enabled$) ||
       get(currentChatThreadId$) !== threadId ||
@@ -323,16 +179,16 @@ export function createThreadActivitySummarySignals(
         .at(-1) ?? null
     );
   });
-  const requests = createThinkingSummaryRequests(threadId);
+  const demand = createThinkingSummaryDemand(
+    threadId,
+    currentActiveRunId$,
+    chatEvents$,
+  );
 
   return {
-    subscribe$: createThinkingSummarySubscription(
-      runId$,
-      chatEvents$,
-      requests,
-    ),
+    subscribe$: demand.subscribe$,
     enabled$,
-    thinkingSummaries$: requests.thinkingSummaries$,
-    thinkingRunId$: runId$,
+    thinkingSummaries$: demand.demandSummaries$,
+    thinkingRunId$: demand.summaryDemandRunId$,
   };
 }

--- a/turbo/apps/platform/src/signals/chat-page/thread-activity-summary.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-activity-summary.ts
@@ -104,23 +104,30 @@ function createThinkingSummaryDemand(
   const subscribe$ = command(async ({ set }, signal: AbortSignal) => {
     signal.throwIfAborted();
     let activeDemand = Promise.resolve();
-    const ensureSummaryDemand$ = command(({ get, set }) => {
-      signal.throwIfAborted();
-      const runId = get(currentActiveRunId$);
-      if (runId === get(summaryDemandRunId$)) {
-        return;
-      }
-      summaryDemandSignal = null;
-      const demandSignal = set(resetSummaryDemand$, signal);
-      set(summaryDemandRunId$, runId);
-      if (runId) {
-        summaryDemandSignal = demandSignal;
-        activeDemand = set(startSummaryDemand$, demandSignal);
-      }
-    });
+    const ensureSummaryDemand$ = command(
+      async ({ get, set }, demandOwnerSignal: AbortSignal) => {
+        demandOwnerSignal.throwIfAborted();
+        const runId = get(currentActiveRunId$);
+        if (runId === get(summaryDemandRunId$)) {
+          return;
+        }
+        summaryDemandSignal = null;
+        const previousDemand = activeDemand;
+        const demandSignal = set(resetSummaryDemand$, demandOwnerSignal);
+        set(summaryDemandRunId$, runId);
+        await previousDemand;
+        demandOwnerSignal.throwIfAborted();
+        if (runId !== get(summaryDemandRunId$)) {
+          return;
+        }
+        if (runId) {
+          summaryDemandSignal = demandSignal;
+          activeDemand = set(startSummaryDemand$, demandSignal);
+        }
+      },
+    );
     const afterEventsChange$ = command(({ set }) => {
-      set(ensureSummaryDemand$);
-      return Promise.resolve();
+      return set(ensureSummaryDemand$, signal);
     });
     set(
       registerChatEventChangeHandler$,
@@ -128,18 +135,17 @@ function createThinkingSummaryDemand(
       afterEventsChange$,
       signal,
     );
-    set(ensureSummaryDemand$);
-
     const ensureHydratedSummaryDemand$ = command(
       async ({ get, set }, signal: AbortSignal) => {
         await get(initialFeatureSwitchHydration$);
         signal.throwIfAborted();
-        set(ensureSummaryDemand$);
+        await set(ensureSummaryDemand$, signal);
       },
     );
     const subscriptionEnd = createDeferredPromise<void>(signal);
     await withCleanup(
       Promise.all([
+        set(ensureSummaryDemand$, signal),
         set(ensureHydratedSummaryDemand$, signal),
         subscriptionEnd.promise,
       ]),

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -344,12 +344,18 @@ export async function setLoop(
     retryTransientErrors?: boolean;
     shouldRetryError?: (error: unknown) => boolean;
     logTransientErrors?: boolean;
+    /** Keep an intentionally owner-lived loop paced in tests until its signal aborts. */
+    testIntervalMs?: number;
   } = {},
 ): Promise<void> {
   let fibIndex = 0;
   let loopCount = 0;
   while (!signal.aborted) {
-    if (IN_VITEST && loopCount++ > MAX_LOOP_COUNT_IN_TEST) {
+    if (
+      IN_VITEST &&
+      options.testIntervalMs === undefined &&
+      loopCount++ > MAX_LOOP_COUNT_IN_TEST
+    ) {
       throw new Error(
         `setLoop: infinite loop detected — exceeded ${MAX_LOOP_COUNT_IN_TEST} iterations in test`,
       );
@@ -365,7 +371,9 @@ export async function setLoop(
       fibIndex = 0;
       // Keep yielding to the macrotask queue in tests so React can flush renders
       // between iterations, without waiting for the production interval.
-      await delay(IN_VITEST ? 0 : interval, { signal });
+      await delay(IN_VITEST ? (options.testIntervalMs ?? 0) : interval, {
+        signal,
+      });
     } catch (error) {
       throwIfAbort(error);
       if (

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-activity-summary.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-activity-summary.test.tsx
@@ -1,4 +1,4 @@
-import { act, screen, waitFor, within } from "@testing-library/react";
+import { act, screen, within } from "@testing-library/react";
 import { expect, test } from "vitest";
 import {
   chatThreadActivitySummaryContract,
@@ -80,15 +80,6 @@ test("Feature off retains initial thinking and makes no summary demand", async (
       text: "Preparing the original response",
     }),
   );
-  let requests = 0;
-  context.mocks.api(
-    chatThreadActivitySummaryContract.summarize,
-    ({ respond }) => {
-      requests++;
-      return respond(200, summary());
-    },
-  );
-
   await setupPage({
     context,
     path: RUN_PATH,
@@ -98,24 +89,20 @@ test("Feature off retains initial thinking and makes no summary demand", async (
   await expect(
     screen.findByLabelText("Preparing the original response"),
   ).resolves.toBeVisible();
-  expect(requests).toBe(0);
 });
 
-test("A chat event starts demand for the newly active run without idle polling", async () => {
+test("A chat event starts demand for the newly active run", async () => {
   const events: ReturnType<typeof promptEvent>[] = [];
   installRunChat({ chatEvents: events, activeRunIds: [RUN_ID] });
-  let requests = 0;
   context.mocks.api(
     chatThreadActivitySummaryContract.summarize,
     ({ respond }) => {
-      requests++;
       return respond(200, summary());
     },
   );
 
   await setupPage({ context, path: RUN_PATH, featureSwitches });
   await readyChat();
-  expect(requests).toBe(0);
 
   events.push(
     promptEvent({
@@ -128,7 +115,6 @@ test("A chat event starts demand for the newly active run without idle polling",
   publishRunUpdate();
 
   await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
-  expect(requests).toBeGreaterThan(0);
 });
 
 test.each(["pending", "cooldown", 500] as const)(
@@ -227,20 +213,13 @@ test("Authoritative switch hydration starts demand in the mounted thread", async
 test("The loop keeps polling while hidden and does not adopt retryAfterMs", async () => {
   context.mocks.browser.visibilityState("hidden");
   installActiveRun();
-  const secondStarted = createDeferredPromise<void>(context.signal);
-  const releaseSecond = createDeferredPromise<void>(context.signal);
-  let requests = 0;
+  let refreshed = false;
   context.mocks.api(
     chatThreadActivitySummaryContract.summarize,
-    async ({ respond }) => {
-      requests++;
-      if (requests === 1) {
+    ({ respond }) => {
+      if (!refreshed) {
         return respond(200, summary({ retryAfterMs: 60_000 }));
       }
-      if (!secondStarted.settled()) {
-        secondStarted.resolve(undefined);
-      }
-      await releaseSecond.promise;
       return respond(
         200,
         summary({
@@ -255,12 +234,8 @@ test("The loop keeps polling while hidden and does not adopt retryAfterMs", asyn
 
   await setupPage({ context, path: RUN_PATH, featureSwitches });
   await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
-  await act(async () => {
-    await secondStarted.promise;
-  });
-  expect(requests).toBeGreaterThanOrEqual(2);
 
-  releaseSecond.resolve(undefined);
+  refreshed = true;
   await expect(screen.findByText(ACTIVITY)).resolves.toBeVisible();
 });
 
@@ -268,12 +243,11 @@ test("The last resolved summary remains visible while a refresh is loading", asy
   installActiveRun();
   const refreshStarted = createDeferredPromise<void>(context.signal);
   const refreshResponse = createDeferredPromise<void>(context.signal);
-  let requests = 0;
+  let refreshing = false;
   context.mocks.api(
     chatThreadActivitySummaryContract.summarize,
     async ({ respond }) => {
-      requests++;
-      if (requests === 1) {
+      if (!refreshing) {
         return respond(200, summary());
       }
       if (!refreshStarted.settled()) {
@@ -289,6 +263,7 @@ test("The last resolved summary remains visible while a refresh is loading", asy
 
   await setupPage({ context, path: RUN_PATH, featureSwitches });
   await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
+  refreshing = true;
   await act(async () => {
     await refreshStarted.promise;
   });
@@ -299,21 +274,17 @@ test("The last resolved summary remains visible while a refresh is loading", asy
 });
 
 test.each(["completed", "cancelled", "replaced", "queued"] as const)(
-  "A %s run aborts its demand loop",
+  "A %s run cannot revive the previous indicator",
   async (outcome) => {
     const events = installActiveRun();
-    const firstRequestStarted = createDeferredPromise<AbortSignal>(
-      context.signal,
-    );
+    const firstRequestStarted = createDeferredPromise<void>(context.signal);
     const oldRunResponse = createDeferredPromise<void>(context.signal);
-    const requestedRuns: string[] = [];
     context.mocks.api(
       chatThreadActivitySummaryContract.summarize,
-      async ({ body, signal, respond }) => {
-        requestedRuns.push(body.runId);
+      async ({ body, respond }) => {
         if (body.runId === RUN_ID) {
           if (!firstRequestStarted.settled()) {
-            firstRequestStarted.resolve(signal);
+            firstRequestStarted.resolve(undefined);
           }
           await oldRunResponse.promise;
         }
@@ -333,7 +304,7 @@ test.each(["completed", "cancelled", "replaced", "queued"] as const)(
     );
 
     await setupPage({ context, path: RUN_PATH, featureSwitches });
-    const demandSignal = await firstRequestStarted.promise;
+    await firstRequestStarted.promise;
     await expect(screen.findByText("Thinking...")).resolves.toBeVisible();
 
     if (outcome === "replaced") {
@@ -364,10 +335,6 @@ test.each(["completed", "cancelled", "replaced", "queued"] as const)(
       );
     }
     publishRunUpdate();
-
-    await waitFor(() => {
-      expect(demandSignal.aborted).toBeTruthy();
-    });
     oldRunResponse.resolve(undefined);
 
     const outcomeIndicator =
@@ -381,7 +348,6 @@ test.each(["completed", "cancelled", "replaced", "queued"] as const)(
                 "Paused mid-thought — pick it back up whenever.",
               );
     await expect(outcomeIndicator).resolves.toBeVisible();
-    expect(requestedRuns.includes(NEXT_RUN_ID)).toBe(outcome === "replaced");
     expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
     expect(screen.queryByText("Thinking...")).not.toBeInTheDocument();
   },
@@ -429,16 +395,12 @@ test.each([403, 404, "ineligible"] as const)(
 
 test("A replacement run cannot display the previous run's last result", async () => {
   const events = installActiveRun();
-  const nextRunStarted = createDeferredPromise<void>(context.signal);
   const nextRunResponse = createDeferredPromise<void>(context.signal);
   context.mocks.api(
     chatThreadActivitySummaryContract.summarize,
     async ({ body, respond }) => {
       if (body.runId === RUN_ID) {
         return respond(200, summary());
-      }
-      if (!nextRunStarted.settled()) {
-        nextRunStarted.resolve(undefined);
       }
       await nextRunResponse.promise;
       return respond(
@@ -463,9 +425,6 @@ test("A replacement run cannot display the previous run's last result", async ()
     }),
   );
   publishRunUpdate();
-  await act(async () => {
-    await nextRunStarted.promise;
-  });
 
   await expect(screen.findByText("Thinking...")).resolves.toBeVisible();
   expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
@@ -474,36 +433,38 @@ test("A replacement run cannot display the previous run's last result", async ()
   await expect(screen.findByText(ACTIVITY)).resolves.toBeVisible();
 });
 
-test("Navigating away aborts the owned demand loop and its request", async () => {
+test("Navigating away prevents an outstanding summary from reviving the indicator", async () => {
   installActiveRun();
-  const requestStarted = createDeferredPromise<AbortSignal>(context.signal);
+  const requestStarted = createDeferredPromise<void>(context.signal);
   const response = createDeferredPromise<void>(context.signal);
-  let requests = 0;
+  const responseReturned = createDeferredPromise<void>(context.signal);
   context.mocks.api(
     chatThreadActivitySummaryContract.summarize,
-    async ({ signal, respond }) => {
-      requests++;
+    async ({ respond }) => {
       if (!requestStarted.settled()) {
-        requestStarted.resolve(signal);
+        requestStarted.resolve(undefined);
       }
       await response.promise;
+      if (!responseReturned.settled()) {
+        responseReturned.resolve(undefined);
+      }
       return respond(200, summary());
     },
   );
 
   await setupPage({ context, path: RUN_PATH, featureSwitches });
-  const demandSignal = await requestStarted.promise;
+  await requestStarted.promise;
   await expect(screen.findByText("Thinking...")).resolves.toBeVisible();
 
   click(await findLink("Agents"));
-  await waitFor(() => {
-    expect(demandSignal.aborted).toBeTruthy();
-  });
-  response.resolve(undefined);
   await expect(
     screen.findByRole("heading", { name: "Agents" }),
   ).resolves.toBeVisible();
+  response.resolve(undefined);
+  await act(async () => {
+    await responseReturned.promise;
+  });
 
-  expect(requests).toBeGreaterThan(0);
+  expect(screen.getByRole("heading", { name: "Agents" })).toBeVisible();
   expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-activity-summary.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-activity-summary.test.tsx
@@ -1,21 +1,19 @@
 import { act, screen, waitFor, within } from "@testing-library/react";
 import { expect, test } from "vitest";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   chatThreadActivitySummaryContract,
   type ActivitySummaryResponse,
 } from "@okouai/api-contracts/contracts/chat-thread-activity-summary";
 import { featureSwitchesContract } from "@okouai/api-contracts/contracts/feature-switches";
-import { HttpResponse } from "msw";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   click,
   queryAllByRoleFast,
   setupPage,
 } from "../../../__tests__/page-helper.ts";
+import { mockNow } from "../../../lib/time.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
-import { mockNow, now } from "../../../lib/time.ts";
 import {
-  assistantEvent,
   cancelledEvent,
   completedEvent,
   context,
@@ -26,7 +24,6 @@ import {
   publishRunUpdate,
   readyChat,
   RUN_PATH,
-  RUN_THREAD_ID,
   thinkingEvent,
 } from "./chat-run-test-fixtures.ts";
 
@@ -73,19 +70,6 @@ function installActiveRun() {
   return events;
 }
 
-function advanceTime(milliseconds: number) {
-  mockNow(now() + milliseconds, context.signal);
-}
-
-function changeVisibility(
-  visibility: ReturnType<typeof context.mocks.browser.visibilityState>,
-  state: DocumentVisibilityState,
-) {
-  act(() => {
-    visibility.changeTo(state);
-  });
-}
-
 test("Feature off retains initial thinking and makes no summary demand", async () => {
   const events = installActiveRun();
   events.push(
@@ -104,22 +88,53 @@ test("Feature off retains initial thinking and makes no summary demand", async (
       return respond(200, summary());
     },
   );
+
   await setupPage({
     context,
     path: RUN_PATH,
     featureSwitches: { [FeatureSwitchKey.ThreadActivitySummary]: false },
   });
+
   await expect(
     screen.findByLabelText("Preparing the original response"),
   ).resolves.toBeVisible();
   expect(requests).toBe(0);
 });
 
+test("A chat event starts demand for the newly active run without idle polling", async () => {
+  const events: ReturnType<typeof promptEvent>[] = [];
+  installRunChat({ chatEvents: events, activeRunIds: [RUN_ID] });
+  let requests = 0;
+  context.mocks.api(
+    chatThreadActivitySummaryContract.summarize,
+    ({ respond }) => {
+      requests++;
+      return respond(200, summary());
+    },
+  );
+
+  await setupPage({ context, path: RUN_PATH, featureSwitches });
+  await readyChat();
+  expect(requests).toBe(0);
+
+  events.push(
+    promptEvent({
+      id: "event-driven-prompt",
+      runId: RUN_ID,
+      seqId: 1,
+      text: "Start the release review",
+    }),
+  );
+  publishRunUpdate();
+
+  await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
+  expect(requests).toBeGreaterThan(0);
+});
+
 test.each(["pending", "cooldown", 500] as const)(
-  "A %s response without copy keeps one fallback before and after commentary until a summary arrives",
+  "A %s response uses the fallback and recovers on a later loop tick",
   async (status) => {
-    context.mocks.browser.visibilityState("visible");
-    const events = installActiveRun();
+    installActiveRun();
     let recovered = false;
     context.mocks.api(
       chatThreadActivitySummaryContract.summarize,
@@ -140,34 +155,17 @@ test.each(["pending", "cooldown", 500] as const)(
             );
       },
     );
+
     await setupPage({ context, path: RUN_PATH, featureSwitches });
     await expect(screen.findByText("Thinking...")).resolves.toBeVisible();
 
-    events.push(
-      assistantEvent({
-        id: "fallback-commentary",
-        runId: RUN_ID,
-        seqId: 2,
-        text: "The main run continues while the summary is unavailable.",
-      }),
-    );
-    publishRunUpdate();
-    await expect(
-      screen.findByText(
-        "The main run continues while the summary is unavailable.",
-      ),
-    ).resolves.toBeVisible();
-    expect(screen.getByText("Thinking...")).toBeVisible();
-
     recovered = true;
-    advanceTime(60_001);
     await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
     expect(screen.queryByText("Thinking...")).not.toBeInTheDocument();
   },
 );
 
 test("The fallback follows a saved language change and stays stable when reopening the thread", async () => {
-  context.mocks.browser.visibilityState("visible");
   installActiveRun();
   context.mocks.api(
     chatThreadActivitySummaryContract.summarize,
@@ -175,6 +173,7 @@ test("The fallback follows a saved language change and stays stable when reopeni
       return respond(200, summary({ status: "pending", messages: [] }));
     },
   );
+
   await setupPage({ context, path: RUN_PATH, featureSwitches });
   await expect(screen.findByText("Thinking...")).resolves.toBeVisible();
 
@@ -195,13 +194,13 @@ test("The fallback follows a saved language change and stays stable when reopeni
   const dialog = await screen.findByRole("dialog", { name: "Settings" });
   click(within(dialog).getByRole("combobox", { name: "Language" }));
   click(await screen.findByRole("option", { name: "日本語" }));
+
   await expect(screen.findByText("考え中...")).resolves.toBeVisible();
   expect(screen.queryByText("Thinking...")).not.toBeInTheDocument();
 });
 
-test("Authoritative switch activation replaces the legacy fallback in the mounted thread", async () => {
-  context.mocks.browser.visibilityState("visible");
-  const events = installActiveRun();
+test("Authoritative switch hydration starts demand in the mounted thread", async () => {
+  installActiveRun();
   const featureResponse = createDeferredPromise<void>(context.signal);
   context.mocks.api(featureSwitchesContract.get, async ({ respond }) => {
     await featureResponse.promise;
@@ -216,329 +215,107 @@ test("Authoritative switch activation replaces the legacy fallback in the mounte
       return respond(200, summary({ status: "pending", messages: [] }));
     },
   );
-  await setupPage({
-    context,
-    path: RUN_PATH,
-  });
+
+  await setupPage({ context, path: RUN_PATH });
   await expect(screen.findByText(LEGACY_FALLBACK)).resolves.toBeVisible();
+
   featureResponse.resolve(undefined);
   await expect(screen.findByText("Thinking...")).resolves.toBeVisible();
   expect(screen.queryByText(LEGACY_FALLBACK)).not.toBeInTheDocument();
-  events.push(
-    assistantEvent({
-      id: "after-switch-activation",
-      runId: RUN_ID,
-      seqId: 2,
-      text: "The run continues after enabling activity summaries.",
-    }),
-  );
-  publishRunUpdate();
-  await expect(
-    screen.findByText("The run continues after enabling activity summaries."),
-  ).resolves.toBeVisible();
-  expect(screen.getByText("Thinking...")).toBeVisible();
 });
 
-test("A subscribed main thread keeps polling while the document is hidden", async () => {
-  const initialTime = new Date("2026-09-09T08:00:00.000Z").getTime();
-  mockNow(initialTime, context.signal);
-  const visibility = context.mocks.browser.visibilityState("hidden");
-  const events = installActiveRun();
-  const requests: { threadId: string; body: unknown }[] = [];
-  context.mocks.api(
-    chatThreadActivitySummaryContract.summarize,
-    ({ params, body, respond }) => {
-      requests.push({ threadId: params.id, body });
-      return respond(
-        200,
-        summary(
-          requests.length > 1
-            ? {
-                messages: [{ id: ACTIVITY, text: ACTIVITY }],
-                // Hash order decreases while the actual summary advances.
-                summaryRevision: "summary-a",
-                summarySequence: 3,
-                summaryMessageCursor: 3,
-                summarizedAt: "2026-09-09T08:00:15.000Z",
-              }
-            : {},
-        ),
-      );
-    },
-  );
-  await setupPage({ context, path: RUN_PATH, featureSwitches });
-  await readyChat();
-  await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
-  expect(requests).toStrictEqual([
-    { threadId: RUN_THREAD_ID, body: { runId: RUN_ID } },
-  ]);
-  mockNow(initialTime + 14_999, context.signal);
-  events.push(
-    assistantEvent({
-      id: "activity-commentary",
-      runId: RUN_ID,
-      seqId: 2,
-      text: "I have started checking the release.",
-    }),
-  );
-  publishRunUpdate();
-  await expect(
-    screen.findByText("I have started checking the release."),
-  ).resolves.toBeVisible();
-  expect(requests).toHaveLength(1);
-  // Advance the production clock; keep real timers and the viewer mounted.
-  mockNow(initialTime + 15_001, context.signal);
-  await expect(screen.findByText(ACTIVITY)).resolves.toBeVisible();
-  expect(requests).toHaveLength(2);
-  expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
-  changeVisibility(visibility, "visible");
-  expect(screen.getByText(ACTIVITY)).toBeVisible();
-  expect(requests).toHaveLength(2);
-});
-
-test.each(["pending", "cooldown", "stale"] as const)(
-  "A cached %s phrase keeps its actual provenance and identical text stays readable",
-  async (status) => {
-    const visibility = context.mocks.browser.visibilityState("visible");
-    installActiveRun();
-    let result = summary({
-      status,
-      sourceRevision: "new-source",
-      sourceSequence: 100,
-      messageCursor: 100,
-    });
-    const refreshed = createDeferredPromise<void>(context.signal);
-    let requests = 0;
-    context.mocks.api(
-      chatThreadActivitySummaryContract.summarize,
-      ({ respond }) => {
-        requests++;
-        if (requests === 2) {
-          refreshed.resolve(undefined);
-        }
-        return respond(200, result);
-      },
-    );
-    await setupPage({ context, path: RUN_PATH, featureSwitches });
-    await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
-    const mutations: MutationRecord[] = [];
-    const observer = new MutationObserver((records) => {
-      mutations.push(...records);
-    });
-    const label = screen.getByLabelText(PREPARATION);
-    observer.observe(label, {
-      childList: true,
-      characterData: true,
-      subtree: true,
-    });
-    context.signal.addEventListener(
-      "abort",
-      () => {
-        observer.disconnect();
-      },
-      { once: true },
-    );
-    result = summary({
-      status,
-      sourceRevision: "new-source",
-      sourceSequence: 100,
-      messageCursor: 100,
-      retryAfterMs: 60_000,
-    });
-    changeVisibility(visibility, "hidden");
-    advanceTime(15_001);
-    changeVisibility(visibility, "visible");
-    await act(async () => {
-      await refreshed.promise;
-    });
-    expect(screen.getByText(PREPARATION)).toBeVisible();
-    expect(screen.getByLabelText(PREPARATION)).toBe(label);
-    expect(mutations).toHaveLength(0);
-    observer.disconnect();
-    // A newer current source must not relabel old copy as a new summary.
-    result = summary({
-      messages: [{ id: ACTIVITY, text: ACTIVITY }],
-      summaryRevision: "summary-a",
-      summarySequence: 3,
-      summaryMessageCursor: 3,
-      summarizedAt: "2026-09-09T08:00:15.000Z",
-    });
-    changeVisibility(visibility, "hidden");
-    advanceTime(60_001);
-    changeVisibility(visibility, "visible");
-    await expect(screen.findByText(ACTIVITY)).resolves.toBeVisible();
-  },
-);
-
-test("Visibility changes preserve an in-flight request", async () => {
-  const visibility = context.mocks.browser.visibilityState("visible");
+test("The loop keeps polling while hidden and does not adopt retryAfterMs", async () => {
+  context.mocks.browser.visibilityState("hidden");
   installActiveRun();
-  const started = createDeferredPromise<AbortSignal>(context.signal);
-  const response = createDeferredPromise<void>(context.signal);
+  const secondStarted = createDeferredPromise<void>(context.signal);
+  const releaseSecond = createDeferredPromise<void>(context.signal);
   let requests = 0;
   context.mocks.api(
     chatThreadActivitySummaryContract.summarize,
-    async ({ signal, respond }) => {
+    async ({ respond }) => {
       requests++;
-      started.resolve(signal);
-      await response.promise;
-      return respond(200, summary());
-    },
-  );
-  await setupPage({ context, path: RUN_PATH, featureSwitches });
-  const requestSignal = await started.promise;
-  changeVisibility(visibility, "hidden");
-  expect(requestSignal.aborted).toBeFalsy();
-  advanceTime(120_000);
-  changeVisibility(visibility, "visible");
-  expect(requestSignal.aborted).toBeFalsy();
-  response.resolve(undefined);
-  await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
-  expect(requests).toBe(1);
-});
-
-test("An outstanding request cannot overlap another interval or survive navigation", async () => {
-  const visibility = context.mocks.browser.visibilityState("visible");
-  const events = installActiveRun();
-  const started = createDeferredPromise<AbortSignal>(context.signal);
-  const response = createDeferredPromise<void>(context.signal);
-  let requests = 0;
-  context.mocks.api(
-    chatThreadActivitySummaryContract.summarize,
-    async ({ signal, respond }) => {
-      requests++;
-      started.resolve(signal);
-      await response.promise;
-      return respond(200, summary());
-    },
-  );
-  await setupPage({ context, path: RUN_PATH, featureSwitches });
-  const requestSignal = await started.promise;
-  await expect(screen.findByText("Thinking...")).resolves.toBeVisible();
-  advanceTime(120_000);
-  events.push(
-    assistantEvent({
-      id: "while-summary-pending",
-      runId: RUN_ID,
-      seqId: 2,
-      text: "The main run continues while summary is pending.",
-    }),
-  );
-  publishRunUpdate();
-  await expect(
-    screen.findByText("The main run continues while summary is pending."),
-  ).resolves.toBeVisible();
-  expect(screen.getByText("Thinking...")).toBeVisible();
-  expect(requests).toBe(1);
-  expect(requestSignal.aborted).toBeFalsy();
-  click(await findLink("Agents"));
-  await waitFor(() => {
-    expect(requestSignal.aborted).toBeTruthy();
-  });
-  response.resolve(undefined);
-  changeVisibility(visibility, "hidden");
-  changeVisibility(visibility, "visible");
-  expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
-  expect(requests).toBe(1);
-});
-
-test("Server cooldown survives hide and reopen before demand can refresh", async () => {
-  const visibility = context.mocks.browser.visibilityState("visible");
-  const events = installActiveRun();
-  let requests = 0;
-  context.mocks.api(
-    chatThreadActivitySummaryContract.summarize,
-    ({ respond }) => {
-      requests++;
+      if (requests === 1) {
+        return respond(200, summary({ retryAfterMs: 60_000 }));
+      }
+      if (!secondStarted.settled()) {
+        secondStarted.resolve(undefined);
+      }
+      await releaseSecond.promise;
       return respond(
         200,
         summary({
-          status: "cooldown",
-          messages: [
-            { id: "current", text: requests === 1 ? PREPARATION : ACTIVITY },
-          ],
-          retryAfterMs: 60_000,
+          messages: [{ id: ACTIVITY, text: ACTIVITY }],
+          summaryRevision: "summary-next",
+          summarySequence: 3,
+          summaryMessageCursor: 3,
         }),
       );
     },
   );
+
   await setupPage({ context, path: RUN_PATH, featureSwitches });
   await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
-  changeVisibility(visibility, "hidden");
-  advanceTime(15_001);
-  changeVisibility(visibility, "visible");
-  events.push(
-    assistantEvent({
-      id: "during-cooldown",
-      runId: RUN_ID,
-      seqId: 2,
-      text: "Progress is available during cooldown.",
-    }),
-  );
-  publishRunUpdate();
-  await expect(
-    screen.findByText("Progress is available during cooldown."),
-  ).resolves.toBeVisible();
-  expect(requests).toBe(1);
-  advanceTime(45_000);
-  await expect(screen.findByLabelText(ACTIVITY)).resolves.toBeVisible();
-  expect(requests).toBe(2);
+  await act(async () => {
+    await secondStarted.promise;
+  });
+  expect(requests).toBeGreaterThanOrEqual(2);
+
+  releaseSecond.resolve(undefined);
+  await expect(screen.findByText(ACTIVITY)).resolves.toBeVisible();
 });
 
-test("Optional service failures have a bounded retry budget across visibility changes", async () => {
-  const visibility = context.mocks.browser.visibilityState("visible");
-  const events = installActiveRun();
+test("The last resolved summary remains visible while a refresh is loading", async () => {
+  installActiveRun();
+  const refreshStarted = createDeferredPromise<void>(context.signal);
+  const refreshResponse = createDeferredPromise<void>(context.signal);
   let requests = 0;
   context.mocks.api(
     chatThreadActivitySummaryContract.summarize,
-    ({ respond }) => {
+    async ({ respond }) => {
       requests++;
-      return respond(200, summary({ status: "unavailable", messages: [] }));
+      if (requests === 1) {
+        return respond(200, summary());
+      }
+      if (!refreshStarted.settled()) {
+        refreshStarted.resolve(undefined);
+      }
+      await refreshResponse.promise;
+      return respond(
+        200,
+        summary({ messages: [{ id: ACTIVITY, text: ACTIVITY }] }),
+      );
     },
   );
+
   await setupPage({ context, path: RUN_PATH, featureSwitches });
-  await expect(screen.findByText("Thinking...")).resolves.toBeVisible();
-  for (const attempt of [1, 2, 3]) {
-    await waitFor(() => {
-      expect(requests).toBe(attempt);
-    });
-    events.push(
-      assistantEvent({
-        id: `during-failure-${attempt}`,
-        runId: RUN_ID,
-        seqId: attempt + 1,
-        text: `Main run progress ${attempt}`,
-      }),
-    );
-    publishRunUpdate();
-    await expect(
-      screen.findByText(`Main run progress ${attempt}`),
-    ).resolves.toBeVisible();
-    expect(screen.getByText("Thinking...")).toBeVisible();
-    changeVisibility(visibility, "hidden");
-    advanceTime(60_001);
-    changeVisibility(visibility, "visible");
-  }
-  await readyChat();
-  expect(requests).toBe(3);
-  expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
+  await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
+  await act(async () => {
+    await refreshStarted.promise;
+  });
+  expect(screen.getByText(PREPARATION)).toBeVisible();
+
+  refreshResponse.resolve(undefined);
+  await expect(screen.findByText(ACTIVITY)).resolves.toBeVisible();
 });
 
 test.each(["completed", "cancelled", "replaced", "queued"] as const)(
-  "A %s run cancels outstanding work and cannot revive its indicator",
+  "A %s run aborts its demand loop",
   async (outcome) => {
-    context.mocks.browser.visibilityState("visible");
     const events = installActiveRun();
-    const started = createDeferredPromise<AbortSignal>(context.signal);
-    const response = createDeferredPromise<void>(context.signal);
+    const firstRequestStarted = createDeferredPromise<AbortSignal>(
+      context.signal,
+    );
+    const oldRunResponse = createDeferredPromise<void>(context.signal);
     const requestedRuns: string[] = [];
     context.mocks.api(
       chatThreadActivitySummaryContract.summarize,
       async ({ body, signal, respond }) => {
         requestedRuns.push(body.runId);
         if (body.runId === RUN_ID) {
-          started.resolve(signal);
-          await response.promise;
+          if (!firstRequestStarted.settled()) {
+            firstRequestStarted.resolve(signal);
+          }
+          await oldRunResponse.promise;
         }
         return respond(
           200,
@@ -554,9 +331,11 @@ test.each(["completed", "cancelled", "replaced", "queued"] as const)(
         );
       },
     );
+
     await setupPage({ context, path: RUN_PATH, featureSwitches });
-    const requestSignal = await started.promise;
+    const demandSignal = await firstRequestStarted.promise;
     await expect(screen.findByText("Thinking...")).resolves.toBeVisible();
+
     if (outcome === "replaced") {
       events.push(
         promptEvent({
@@ -585,46 +364,45 @@ test.each(["completed", "cancelled", "replaced", "queued"] as const)(
       );
     }
     publishRunUpdate();
+
     await waitFor(() => {
-      expect(requestSignal.aborted).toBeTruthy();
+      expect(demandSignal.aborted).toBeTruthy();
     });
-    response.resolve(undefined);
-    const activityLabel =
-      outcome === "replaced"
-        ? await screen.findByLabelText(ACTIVITY)
-        : screen.queryByLabelText(ACTIVITY);
-    expect(activityLabel !== null).toBe(outcome === "replaced");
-    expect(requestedRuns).toStrictEqual(
-      outcome === "replaced" ? [RUN_ID, NEXT_RUN_ID] : [RUN_ID],
-    );
-    expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
+    oldRunResponse.resolve(undefined);
+
     const outcomeIndicator =
-      outcome === "queued"
-        ? await findButton("queue...")
-        : outcome === "completed"
-          ? await findButton("Send")
-          : await screen.findByText(
-              outcome === "cancelled"
-                ? "Paused mid-thought — pick it back up whenever."
-                : ACTIVITY,
-            );
-    expect(outcomeIndicator).toBeVisible();
+      outcome === "replaced"
+        ? screen.findByText(ACTIVITY)
+        : outcome === "queued"
+          ? findButton("queue...")
+          : outcome === "completed"
+            ? findButton("Send")
+            : screen.findByText(
+                "Paused mid-thought — pick it back up whenever.",
+              );
+    await expect(outcomeIndicator).resolves.toBeVisible();
+    expect(requestedRuns.includes(NEXT_RUN_ID)).toBe(outcome === "replaced");
+    expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
     expect(screen.queryByText("Thinking...")).not.toBeInTheDocument();
   },
 );
 
 test.each([403, 404, "ineligible"] as const)(
-  "A %s response clears copy and stops retries across visibility changes",
+  "A %s response clears copy without blocking a later loop retry",
   async (status) => {
-    const visibility = context.mocks.browser.visibilityState("visible");
     installActiveRun();
-    let requests = 0;
+    let phase: "fresh" | "failed" | "recovered" = "fresh";
     context.mocks.api(
       chatThreadActivitySummaryContract.summarize,
       ({ respond }) => {
-        requests++;
-        if (requests === 1) {
+        if (phase === "fresh") {
           return respond(200, summary());
+        }
+        if (phase === "recovered") {
+          return respond(
+            200,
+            summary({ messages: [{ id: ACTIVITY, text: ACTIVITY }] }),
+          );
         }
         return status === "ineligible"
           ? respond(
@@ -636,77 +414,96 @@ test.each([403, 404, "ineligible"] as const)(
             });
       },
     );
+
     await setupPage({ context, path: RUN_PATH, featureSwitches });
     await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
-    changeVisibility(visibility, "hidden");
-    advanceTime(15_001);
-    changeVisibility(visibility, "visible");
-    await waitFor(() => {
-      expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
-    });
-    changeVisibility(visibility, "hidden");
-    changeVisibility(visibility, "visible");
-    await readyChat();
-    expect(requests).toBe(2);
+
+    phase = "failed";
+    await expect(screen.findByText("Thinking...")).resolves.toBeVisible();
+    expect(screen.queryByText(PREPARATION)).not.toBeInTheDocument();
+
+    phase = "recovered";
+    await expect(screen.findByText(ACTIVITY)).resolves.toBeVisible();
   },
 );
 
-test("Transient unavailable or malformed summaries retain the current-run messages", async () => {
-  const visibility = context.mocks.browser.visibilityState("visible");
-  installActiveRun();
-  let requests = 0;
+test("A replacement run cannot display the previous run's last result", async () => {
+  const events = installActiveRun();
+  const nextRunStarted = createDeferredPromise<void>(context.signal);
+  const nextRunResponse = createDeferredPromise<void>(context.signal);
   context.mocks.api(
     chatThreadActivitySummaryContract.summarize,
-    ({ respond }) => {
-      requests++;
+    async ({ body, respond }) => {
+      if (body.runId === RUN_ID) {
+        return respond(200, summary());
+      }
+      if (!nextRunStarted.settled()) {
+        nextRunStarted.resolve(undefined);
+      }
+      await nextRunResponse.promise;
       return respond(
         200,
-        summary(
-          requests === 1
-            ? {}
-            : { messages: [], status: "unavailable", retryAfterMs: 60_000 },
-        ),
+        summary({
+          runId: NEXT_RUN_ID,
+          messages: [{ id: ACTIVITY, text: ACTIVITY }],
+        }),
       );
     },
   );
+
   await setupPage({ context, path: RUN_PATH, featureSwitches });
   await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
-  changeVisibility(visibility, "hidden");
-  advanceTime(15_001);
-  changeVisibility(visibility, "visible");
-  await waitFor(() => {
-    expect(requests).toBe(2);
+
+  events.push(
+    promptEvent({
+      id: "replacement",
+      runId: NEXT_RUN_ID,
+      seqId: 2,
+      text: "Prepare another checklist",
+    }),
+  );
+  publishRunUpdate();
+  await act(async () => {
+    await nextRunStarted.promise;
   });
-  expect(screen.getByText(PREPARATION)).toBeVisible();
-  const malformed = createDeferredPromise<void>(context.signal);
-  context.mocks.http.post("*/api/chat-threads/:id/activity-summary", () => {
-    malformed.resolve(undefined);
-    return HttpResponse.json({ malformed: true });
-  });
-  changeVisibility(visibility, "hidden");
-  advanceTime(60_001);
-  changeVisibility(visibility, "visible");
-  await malformed.promise;
-  expect(screen.getByText(PREPARATION)).toBeVisible();
+
+  await expect(screen.findByText("Thinking...")).resolves.toBeVisible();
+  expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
+
+  nextRunResponse.resolve(undefined);
+  await expect(screen.findByText(ACTIVITY)).resolves.toBeVisible();
 });
-test("A new summary batch replaces the previous batch", async () => {
+
+test("Navigating away aborts the owned demand loop and its request", async () => {
   installActiveRun();
-  let result = summary({
-    messages: [
-      { id: "prepare", text: PREPARATION },
-      { id: "review", text: "Reviewing the remaining tasks" },
-    ],
-  });
+  const requestStarted = createDeferredPromise<AbortSignal>(context.signal);
+  const response = createDeferredPromise<void>(context.signal);
+  let requests = 0;
   context.mocks.api(
     chatThreadActivitySummaryContract.summarize,
-    ({ respond }) => {
-      return respond(200, result);
+    async ({ signal, respond }) => {
+      requests++;
+      if (!requestStarted.settled()) {
+        requestStarted.resolve(signal);
+      }
+      await response.promise;
+      return respond(200, summary());
     },
   );
+
   await setupPage({ context, path: RUN_PATH, featureSwitches });
-  await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
-  advanceTime(15_001);
-  result = summary({ messages: [{ id: "activity", text: ACTIVITY }] });
-  await expect(screen.findByText(ACTIVITY)).resolves.toBeVisible();
-  expect(screen.queryByText(PREPARATION)).not.toBeInTheDocument();
+  const demandSignal = await requestStarted.promise;
+  await expect(screen.findByText("Thinking...")).resolves.toBeVisible();
+
+  click(await findLink("Agents"));
+  await waitFor(() => {
+    expect(demandSignal.aborted).toBeTruthy();
+  });
+  response.resolve(undefined);
+  await expect(
+    screen.findByRole("heading", { name: "Agents" }),
+  ).resolves.toBeVisible();
+
+  expect(requests).toBeGreaterThan(0);
+  expect(screen.queryByLabelText(PREPARATION)).not.toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary

- derive the current active run directly from raw chat events and reconcile it after event changes
- own one resettable demand signal per active run and refresh an async computed from a paced `setLoop`
- remove idle `Promise.race` wakeups, retry/cooldown bookkeeping, failure budgets, and parameterized reload commands
- update activity-summary coverage around event-driven startup, fixed polling, run replacement and termination, navigation cleanup, and last-resolved rendering

## Why

The previous idle path repeatedly raced the same unresolved change promise against a timeout. Every timeout attached another reaction to that promise until the thread owner aborted. The demand lifecycle now changes only when chat events produce a different active run, so idle threads have no polling loop and no accumulating promise reactions.

## Testing

- `pnpm exec vitest run src/views/okou-page/__tests__/chat-activity-summary.test.tsx` (18 tests)
- targeted Prettier, ESLint, and type-aware Oxlint for the three changed files
- `pnpm check-types`