### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -692,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
 
 [[package]]
 name = "bitvec"
@@ -3458,9 +3458,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.63.2"
+version = "0.63.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e134e2480f4e86f83e4aa45b4c0a9723f84beaffa694c54bdf056e74efdd7dd"
+checksum = "036204edbd199552a5b3832f63c60dcdf395dc44c7f06b4af1c0e8139cc11bce"
 dependencies = [
  "aes",
  "bitflags",
@@ -4854,9 +4854,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.26.0"
+version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+checksum = "2ef6dac1e96601b4fb3acccccff2139741fcb757cb9a36089bf5be91cfb285ce"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -95,7 +95,7 @@ reqwest = { version = "0.13", default-features = false }
 rmp-serde = { version = "1", default-features = false }
 rmpv = { version = "1", default-features = false }
 rsa = { version = "=0.10.0-rc.18", default-features = false }
-russh = { version = "=0.63.2", default-features = false }
+russh = { version = "=0.63.3", default-features = false }
 rustix = { version = "1", default-features = false }
 sentry = { version = "0.49", default-features = false }
 serde = { version = "1", default-features = false }


### PR DESCRIPTION
## Summary

- Refresh the Rust workspace lockfile with `cargo update`.
- Update `bitflags` from 2.13.1 to 2.13.2.
- Update `uuid` from 1.26.0 to 1.26.1.
- Update the exact workspace `russh` requirement from 0.63.2 to 0.63.3 after reviewing the upstream patch, which enforces the existing inactivity timeout during stalled writes.

## Deferred updates

- `generic-array` 0.14.9 remains blocked because `crypto-common` 0.1.7 requires exactly 0.14.7 through `digest` / `crc-fast` / `aws-smithy-checksums` / `aws-sdk-s3`.
- `zstd` 0.14.0 is a major update outside the workspace's current `^0.13` requirement and is deferred for dedicated compatibility work.

## Manual manifest changes

- Bumped the exact `russh` workspace dependency from `=0.63.2` to `=0.63.3`; no public API, feature, or MSRV changes were found in the upstream patch.

## Validation

- `cargo +stable test --locked --workspace --exclude runner --profile local` (passed)
- `cargo +stable check --locked --profile local -p runner --tests` (passed)
- `cargo +stable test --no-default-features --features ring,rsa --test test_backpressure -- --test-threads=1` against the published `russh` 0.63.3 source (2 passed)
- A filtered runner SSH test binary could not be linked in the local 3.8 GiB, no-swap environment: both the default linker and GNU gold were terminated with exit 137 before any test case ran. The runner test targets compile successfully, and CI will provide the full runner test execution.
