### PR TITLE
fix(api): avoid unrelated archives for current chat writes

### DIFF
--- a/docs/goal-retirement-archival.md
+++ b/docs/goal-retirement-archival.md
@@ -243,6 +243,28 @@ provenance. A stable snapshot-head check closes the READ COMMITTED race with
 snapshot publication and hot retention without changing the usage advisory lock.
 A retained non-Goal prompt alone does not erase a group in archived output.
 
+Repair #33152 gives the initial queue claim the fresh server-generated run UUID
+as its canonical event ID. `prepareLaunchRunIdentity` allocates that UUID;
+`claimQueueFirstRunAssociation` appends the run-attributed replacement before the
+same transaction inserts the run in failed, queued and pending/CTE launches.
+Client event IDs identify the preceding runless input. Active-input delivery
+creates separate replacement IDs; it does not reuse the run UUID. Thus an exact
+hot `input.prompt` with matching event/run/thread identity and a revoke edge
+establishes the run's initial physical position. Only when that position exceeds
+a stable snapshot `lastSeqId` can provenance and first usage omit that archive.
+`terminalSeqId`, wall clocks, trigger labels and arbitrary hot events do not
+establish this bound. The pointer is rechecked across exclusion as well as reads.
+
+This is an event identity convention, not a new payload/schema or Goal store.
+Old writers/readers remain compatible with the same event and revoke grammar.
+Older runs, copied identities, missing claims and already-covered claims keep
+the canonical history path and its explicit errors. A necessary history read
+is shared only within one usage operation under its existing per-run lock;
+there is no cross-operation cache or historical event rewrite.
+An omitted archive read is not reused as resolved empty history: first usage
+retains the hot-before-history ordering if publication and retention move a
+previously hot context after the prior-usage lookup.
+
 Usage corrections inherit the exact prior context pointer, including null,
 revocation identity, strictly later event timestamp and original settled time.
 The first late usage uses available hot/snapshot provenance; absent provenance

--- a/turbo/apps/api/src/signals/routes/__tests__/goal-schema-contraction.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/goal-schema-contraction.test.ts
@@ -1,7 +1,13 @@
+import { http, HttpResponse } from "msw";
+import { z } from "zod";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { mockOptionalEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
+import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import { testChatEventSearchProjectionContract } from "@okouai/api-contracts/contracts/test-chat-event-search-projection";
 import { testChatEventSearchProjectionRoutes } from "../test-chat-event-search-projection";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { expect, test } from "vitest";
 import { testChatEventSnapshotContract } from "@okouai/api-contracts/contracts/test-chat-event-snapshot";
 import { accept, testContext } from "../../../__tests__/test-context";
@@ -11,6 +17,9 @@ import {
   seedRetainedRunProvenance,
   removeSnapshottedRunEvents,
   retainedUsageRows,
+  appendRetainedRunPrompt,
+  appendRetainedUsageWebContext,
+  withEmptySnapshotReadBarrier,
 } from "../../../test-fixtures/goal-schema-contraction";
 import { seedUsagePricingRows } from "../../../test-fixtures/system-config-seeds";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -31,7 +40,7 @@ const api = createRunsApi(context);
 const chat = createChatFilesBddApi(context);
 const webhooks = createWebhookCallbackApi(context);
 
-async function archive(threadId: string): Promise<void> {
+async function archive(threadId: string, keepEventId?: string): Promise<void> {
   const previous = context.mocks.s3.send.getMockImplementation();
   installFakeChatEventR2(context);
   const snapshot = context.mocks.s3.send.getMockImplementation();
@@ -60,7 +69,7 @@ async function archive(threadId: string): Promise<void> {
     ).snapshot({ body: { chat_thread_ids: [threadId], r2_object_keys: [] } }),
     [200],
   );
-  await removeSnapshottedRunEvents(threadId);
+  await removeSnapshottedRunEvents(threadId, keepEventId);
 }
 
 test("executes normal and CTE launches, callbacks and late historical billing after Goal schema contraction", async () => {
@@ -109,13 +118,30 @@ test("executes normal and CTE launches, callbacks and late historical billing af
         unitSize: 1,
       },
     ]);
-    for (const provenance of ["hot", "snapshot", "absent"] as const) {
+    for (const provenance of [
+      "hot",
+      "snapshot",
+      "absent",
+      "manual-hot",
+      "manual-snapshot",
+      "snapshot-null",
+      "snapshot-legacy",
+    ] as const) {
       const run = await send();
       expect((await api.readRun(actor, run.runId)).status).toBe("pending");
       const claim = await api.claimRunnerJob(run.runId);
       const headers = { authorization: `Bearer ${claim.sandboxToken}` };
-      const groupId = provenance === "absent" ? null : randomUUID();
-      await seedRetainedRunProvenance(run.runId, run.threadId, groupId);
+      const archived = provenance.includes("snapshot");
+      const groupId =
+        provenance === "absent" || provenance === "snapshot-null"
+          ? null
+          : randomUUID();
+      await seedRetainedRunProvenance(
+        run.runId,
+        run.threadId,
+        groupId,
+        provenance.startsWith("manual") ? "web" : "goal",
+      );
       // This is a callback from an already-claimed historical run, not a new
       // Goal claim. Its status and output still settle exactly once.
       await webhooks.requestAgentComplete(
@@ -135,8 +161,14 @@ test("executes normal and CTE launches, callbacks and late historical billing af
         return event.eventType === "run.failed";
       });
       expect(terminal).toHaveLength(1);
-      if (provenance === "snapshot") {
-        await archive(run.threadId);
+      if (archived) {
+        // A covered initial claim may remain hot. A later legacy input is not
+        // an initial claim, and neither can exclude the archived Goal context.
+        await archive(
+          run.threadId,
+          provenance === "manual-snapshot" ? run.runId : undefined,
+        );
+        await appendRetainedRunPrompt(run.runId, run.threadId);
       }
       const record = async (key: string) => {
         await webhooks.requestAgentUsageEvent(
@@ -159,8 +191,18 @@ test("executes normal and CTE launches, callbacks and late historical billing af
         await flushWaitUntilForTest();
       };
       const firstKey = randomUUID();
+      const archiveGets = () => {
+        return context.mocks.s3.send.mock.calls.filter(([command]) => {
+          return (
+            command instanceof GetObjectCommand &&
+            command.input.Key?.startsWith("chat-events/")
+          );
+        }).length;
+      };
+      const readsBeforeFirst = archiveGets();
       await record(firstKey);
-      const [first] = await retainedUsageRows(run.runId);
+      expect(archiveGets() - readsBeforeFirst).toBe(archived ? 1 : 0);
+      let first = (await retainedUsageRows(run.runId)).at(-1);
       expect(first).toMatchObject({
         contextType: groupId ? "goal" : null,
         contextId: groupId,
@@ -173,10 +215,18 @@ test("executes normal and CTE launches, callbacks and late historical billing af
       await expect(retainedUsageRows(run.runId)).resolves.toHaveLength(1);
       // Revisions inherit even a null pointer; subsequent unrelated provenance
       // must not silently regroup an already-authoritative usage event.
-      if (provenance === "absent") {
+      if (provenance === "absent" || provenance === "snapshot-null") {
         await seedRetainedRunProvenance(run.runId, run.threadId, randomUUID());
       }
-      if (provenance === "snapshot") {
+      if (provenance === "snapshot-legacy") {
+        // This historical nullable source pointer is not emitted by current billing.
+        await appendRetainedUsageWebContext(run.runId);
+        first = (await retainedUsageRows(run.runId)).at(-1);
+        if (!first) {
+          throw new Error("Expected retained legacy usage");
+        }
+      }
+      if (archived) {
         await archive(run.threadId);
       }
       const secondKey = randomUUID();
@@ -243,3 +293,556 @@ test("executes normal and CTE launches, callbacks and late historical billing af
     ).toBeTruthy();
   });
 }, 180_000);
+
+test.each(
+  (["failed", "completed", "cancelled"] as const).flatMap((terminal) => {
+    return [false, true].map((historicalGoal) => {
+      return {
+        terminal,
+        historicalGoal,
+      };
+    });
+  }),
+)(
+  "persists $terminal ordinary continuation writes with an unavailable prior archive (historical Goal: $historicalGoal)",
+  async ({ terminal, historicalGoal }) => {
+    const actor = bdd.user();
+    const callbacks = createChatCallbacksApi(context);
+    callbacks.acceptChatObjectStorage();
+    callbacks.disableVapid();
+    api.acceptStorageDownloads();
+    api.acceptTelemetryIngest();
+    await api.grantProEntitlement(actor);
+    await api.ensureOrgModelProvider(actor);
+    const agent = await bdd.createAgent(actor, {
+      displayName: "Continue archived conversation",
+      visibility: "private",
+    });
+    const send = async (threadId?: string) => {
+      const response = await chat.requestSendEvent(
+        actor,
+        {
+          agentId: agent.agentId,
+          threadId,
+          prompt: "continue ordinary conversation",
+          model: "claude-sonnet-5",
+        },
+        [201],
+      );
+      if (response.status !== 201 || !response.body.runId) {
+        throw new Error("Expected a new run");
+      }
+      await flushWaitUntilForTest();
+      return { runId: response.body.runId, threadId: response.body.threadId };
+    };
+    const old = await send();
+    // Retired historical provenance cannot be created through the live API.
+    if (historicalGoal) {
+      await seedRetainedRunProvenance(old.runId, old.threadId, randomUUID());
+    }
+    const oldEvents = (await chat.listThreadEvents(actor, old.threadId)).events;
+    const cursor = oldEvents.at(-1);
+    if (!cursor) {
+      throw new Error("Expected a previous conversation cursor");
+    }
+    await archive(old.threadId);
+    const runnerGroup = api.configureRunnerGroup();
+    await api.heartbeatRunner(runnerGroup);
+    const storage = context.mocks.s3.send.getMockImplementation();
+    if (!storage) {
+      throw new Error("Expected object storage fixture");
+    }
+    let archiveGets = 0;
+    let archiveUnavailable = false;
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (
+        archiveUnavailable &&
+        command instanceof GetObjectCommand &&
+        command.input.Key?.startsWith("chat-events/")
+      ) {
+        archiveGets++;
+        throw new Error("Prior archive is unavailable");
+      }
+      return storage(command);
+    });
+    if (!actor.orgId) {
+      throw new Error("Expected an organization");
+    }
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId: actor.orgId },
+      {
+        [FeatureSwitchKey.ThreadActivitySummary]: false,
+      },
+    );
+    mockOptionalEnv("OPENROUTER_API_KEY", "archive-thinking-test");
+    server.use(
+      http.post(
+        "https://openrouter.ai/api/v1/chat/completions",
+        async ({ request }) => {
+          const body = z
+            .object({ messages: z.array(z.object({ content: z.string() })) })
+            .parse(await request.json());
+          if (
+            body.messages[0]?.content.includes(
+              "Write user-visible progress copy",
+            )
+          ) {
+            // The external provider finishes after the old archive becomes unavailable.
+            archiveUnavailable = true;
+          }
+          return HttpResponse.json({
+            choices: [
+              {
+                finish_reason: "stop",
+                message: { content: "Preparing this ordinary reply" },
+              },
+            ],
+          });
+        },
+      ),
+    );
+    const run = await send(old.threadId);
+    expect(archiveUnavailable).toBeTruthy();
+    mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "pending",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+    const headers = { authorization: `Bearer ${claim.sandboxToken}` };
+    for (const sequenceNumber of [0, 1, 1]) {
+      await webhooks.requestAgentEvents(
+        {
+          runId: run.runId,
+          events: [
+            {
+              type: "assistant",
+              sequenceNumber,
+              message: {
+                id: `archive-continuation-${sequenceNumber}`,
+                content: [
+                  { type: "text", text: `Current answer ${sequenceNumber}` },
+                ],
+              },
+            },
+          ],
+        },
+        headers,
+        [200],
+      );
+    }
+    const provider = `archive-continuation-${randomUUID()}`;
+    await seedUsagePricingRows([
+      {
+        kind: "connector",
+        provider,
+        category: "api_request",
+        unitPrice: 7,
+        unitSize: 1,
+      },
+    ]);
+    const usage = {
+      runId: run.runId,
+      events: [
+        {
+          idempotencyKey: randomUUID(),
+          kind: "connector" as const,
+          provider,
+          category: "api_request",
+          quantity: 1,
+        },
+      ],
+    };
+    await webhooks.requestAgentUsageEvent(usage, headers, [200]);
+    if (terminal === "cancelled") {
+      await api.requestCancelRun(actor, run.runId, [200]);
+    }
+    const completion =
+      terminal === "completed"
+        ? {
+            runId: run.runId,
+            exitCode: 0,
+            lastEventSequence: 1,
+            checkpoint: {
+              cliAgentType: "claude-code" as const,
+              cliAgentSessionId: `archive-${run.runId}`,
+              cliAgentSessionHistoryHash: createHash("sha256")
+                .update(run.runId)
+                .digest("hex"),
+            },
+          }
+        : {
+            runId: run.runId,
+            exitCode: 1,
+            error: "ordinary terminal delivery",
+          };
+    for (let delivery = 0; delivery < 2; delivery++) {
+      await webhooks.requestAgentComplete(completion, headers, [200]);
+      await flushWaitUntilForTest();
+    }
+    await webhooks.requestAgentUsageEvent(usage, headers, [200]);
+    await createBillingMediaApi(context).processOrgUsageEvents(actor);
+    await flushWaitUntilForTest();
+    await webhooks.requestAgentUsageEvent(usage, headers, [200]);
+    await createBillingMediaApi(context).processOrgUsageEvents(actor);
+    await flushWaitUntilForTest();
+    expect((await api.readRun(actor, run.runId)).status).toBe(terminal);
+    expect(archiveGets).toBe(0);
+    const events = (
+      await chat.listThreadEvents(actor, run.threadId, {
+        sinceSeqId: cursor.seqId,
+        sinceEventId: cursor.id,
+      })
+    ).events.filter((event) => {
+      return event.runId === run.runId;
+    });
+    expect(
+      events
+        .filter((event) => {
+          return event.eventType === "output.message";
+        })
+        .map((event) => {
+          return event.content;
+        }),
+    ).toStrictEqual(
+      expect.arrayContaining(["Current answer 0", "Current answer 1"]),
+    );
+    expect(
+      events.filter((event) => {
+        return (
+          event.eventType === "output.message" &&
+          event.content?.startsWith("Current answer")
+        );
+      }),
+    ).toHaveLength(2);
+    expect(
+      events.filter((event) => {
+        return event.eventType === `run.${terminal}`;
+      }),
+    ).toHaveLength(1);
+    const usages = events.filter((event) => {
+      return event.eventType === "usage.recorded";
+    });
+    expect(usages).toHaveLength(1);
+    expect(usages[0]).toMatchObject({
+      usage: { totalCredits: 7 },
+    });
+    expect(usages[0]?.runGroupId).toBeUndefined();
+    expect(
+      events.filter((event) => {
+        return event.runEventId === "thinking:initial";
+      }),
+    ).toMatchObject([
+      {
+        eventType: "output.thinking",
+        thinking: "Preparing this ordinary reply",
+      },
+    ]);
+    const firstAssistant = context.mocks.axiom.sdkIngest.mock.calls.flatMap(
+      (call) => {
+        const records: unknown = call[1];
+        return Array.isArray(records)
+          ? records.filter((record: unknown) => {
+              return (
+                typeof record === "object" &&
+                record !== null &&
+                "run_id" in record &&
+                record.run_id === run.runId &&
+                "op_type" in record &&
+                record.op_type === "api_to_first_assistant_message"
+              );
+            })
+          : [];
+      },
+    );
+    expect(firstAssistant).toHaveLength(1);
+  },
+  60_000,
+);
+
+async function startArchiveTestRun() {
+  const actor = bdd.user();
+  const callbacks = createChatCallbacksApi(context);
+  callbacks.acceptChatObjectStorage();
+  callbacks.disableVapid();
+  api.acceptStorageDownloads();
+  api.acceptTelemetryIngest();
+  const runnerGroup = api.configureRunnerGroup();
+  await api.grantProEntitlement(actor);
+  await api.ensureOrgModelProvider(actor);
+  const agent = await bdd.createAgent(actor, {
+    displayName: "Historical delivery",
+    visibility: "private",
+  });
+  const sent = await chat.requestSendEvent(
+    actor,
+    {
+      agentId: agent.agentId,
+      prompt: "ordinary historical input",
+      model: "claude-sonnet-5",
+    },
+    [201],
+  );
+  if (sent.status !== 201 || !sent.body.runId) {
+    throw new Error("Expected run");
+  }
+  await flushWaitUntilForTest();
+  await api.heartbeatRunner(runnerGroup);
+  const claim = await api.claimRunnerJob(sent.body.runId);
+  return {
+    actor,
+    runId: sent.body.runId,
+    threadId: sent.body.threadId,
+    headers: { authorization: `Bearer ${claim.sandboxToken}` },
+  };
+}
+
+test("surfaces a required archive failure and retries historical manual output without losing its context", async () => {
+  const run = await startArchiveTestRun();
+  const groupId = randomUUID();
+  // A retained manual run with Goal provenance cannot be recreated by live admission.
+  await seedRetainedRunProvenance(run.runId, run.threadId, groupId, "web");
+  const cursor = (
+    await chat.listThreadEvents(run.actor, run.threadId)
+  ).events.at(-1);
+  if (!cursor) {
+    throw new Error("Expected retained history");
+  }
+  await archive(run.threadId, run.runId);
+  await appendRetainedRunPrompt(run.runId, run.threadId);
+  const storage = context.mocks.s3.send.getMockImplementation();
+  if (!storage) {
+    throw new Error("Expected object storage fixture");
+  }
+  context.mocks.s3.send.mockImplementation((command: unknown) => {
+    if (
+      command instanceof GetObjectCommand &&
+      command.input.Key?.startsWith("chat-events/")
+    ) {
+      throw new Error("Required history unavailable");
+    }
+    return storage(command);
+  });
+  const batch = {
+    runId: run.runId,
+    events: [
+      {
+        type: "assistant" as const,
+        sequenceNumber: 0,
+        message: {
+          id: "historical-retry",
+          content: [
+            { type: "text" as const, text: "Retried historical output" },
+          ],
+        },
+      },
+    ],
+  };
+  const failed = await webhooks.requestAgentEvents(batch, run.headers, [503]);
+  expect(failed.body).toMatchObject({
+    error: { code: "EVENT_DELIVERY_UNAVAILABLE" },
+  });
+  const failedRows = await chat.listThreadEventRows(run.actor, run.threadId, {
+    lastEventId: cursor.id,
+    lastSeqId: cursor.seqId,
+  });
+  expect(
+    failedRows.filter((event) => {
+      return event.eventType === "output.message";
+    }),
+  ).toHaveLength(0);
+  context.mocks.s3.send.mockImplementation(storage);
+  await webhooks.requestAgentEvents(batch, run.headers, [200]);
+  await webhooks.requestAgentEvents(batch, run.headers, [200]);
+  const rows = await chat.listThreadEventRows(run.actor, run.threadId, {
+    lastEventId: cursor.id,
+    lastSeqId: cursor.seqId,
+  });
+  expect(
+    rows.filter((event) => {
+      return event.eventType === "output.message";
+    }),
+  ).toMatchObject([
+    {
+      contextType: "goal",
+      contextId: groupId,
+      payload: { content: "Retried historical output" },
+    },
+  ]);
+  await webhooks.requestAgentComplete(
+    { runId: run.runId, exitCode: 1, error: "settle historical run" },
+    run.headers,
+    [200],
+  );
+  await flushWaitUntilForTest();
+}, 60_000);
+
+test("recovers first late usage context when snapshot publication and retention move past an in-flight archive read", async () => {
+  const run = await startArchiveTestRun();
+  await webhooks.requestAgentComplete(
+    { runId: run.runId, exitCode: 1, error: "settled manual run" },
+    run.headers,
+    [200],
+  );
+  await flushWaitUntilForTest();
+  const oldCursor = (
+    await chat.listThreadEvents(run.actor, run.threadId)
+  ).events.at(-1);
+  if (!oldCursor) {
+    throw new Error("Expected completed conversation");
+  }
+  await archive(run.threadId);
+  const groupId = randomUUID();
+  // The historical tail exists before reading; publication moves it from hot
+  // storage to a newer snapshot while the earlier immutable GET is in flight.
+  await seedRetainedRunProvenance(run.runId, run.threadId, groupId, "web");
+  const cursor = (
+    await chat.listThreadEvents(run.actor, run.threadId, {
+      sinceEventId: oldCursor.id,
+      sinceSeqId: oldCursor.seqId,
+    })
+  ).events.at(-1);
+  if (!cursor) {
+    throw new Error("Expected retained provenance tail");
+  }
+  const provider = `archive-race-${randomUUID()}`;
+  await seedUsagePricingRows([
+    {
+      kind: "connector",
+      provider,
+      category: "api_request",
+      unitPrice: 7,
+      unitSize: 1,
+    },
+  ]);
+  const usage = {
+    runId: run.runId,
+    events: [
+      {
+        idempotencyKey: randomUUID(),
+        kind: "connector" as const,
+        provider,
+        category: "api_request",
+        quantity: 1,
+      },
+    ],
+  };
+  await webhooks.requestAgentUsageEvent(usage, run.headers, [200]);
+  const storage = context.mocks.s3.send.getMockImplementation();
+  if (!storage) {
+    throw new Error("Expected object storage fixture");
+  }
+  let moved = false;
+  const readWhilePublishing = async (command: unknown): Promise<unknown> => {
+    if (
+      !moved &&
+      command instanceof GetObjectCommand &&
+      command.input.Key?.startsWith("chat-events/")
+    ) {
+      moved = true;
+      await archive(run.threadId);
+      context.mocks.s3.send.mockImplementation(readWhilePublishing);
+    }
+    return await storage(command);
+  };
+  context.mocks.s3.send.mockImplementation(readWhilePublishing);
+  await createBillingMediaApi(context).processOrgUsageEvents(run.actor);
+  await flushWaitUntilForTest();
+  expect(moved).toBeTruthy();
+  const rows = await chat.listThreadEventRows(run.actor, run.threadId, {
+    lastEventId: cursor.id,
+    lastSeqId: cursor.seqId,
+  });
+  const usageRows = rows.filter((event) => {
+    return event.eventType === "usage.recorded";
+  });
+  expect(usageRows).toMatchObject([
+    {
+      contextType: "goal",
+      contextId: groupId,
+      payload: { usage: { totalCredits: 7 } },
+    },
+  ]);
+  await webhooks.requestAgentUsageEvent(usage, run.headers, [200]);
+  await createBillingMediaApi(context).processOrgUsageEvents(run.actor);
+  await flushWaitUntilForTest();
+  await expect(
+    chat.listThreadEventRows(run.actor, run.threadId, {
+      lastEventId: cursor.id,
+      lastSeqId: cursor.seqId,
+    }),
+  ).resolves.toStrictEqual(rows);
+}, 60_000);
+
+test("preserves first late usage context when a first snapshot replaces hot history after an empty head read", async () => {
+  const run = await startArchiveTestRun();
+  const groupId = randomUUID();
+  await seedRetainedRunProvenance(run.runId, run.threadId, groupId, "web");
+  await webhooks.requestAgentComplete(
+    { runId: run.runId, exitCode: 1, error: "settled historical manual run" },
+    run.headers,
+    [200],
+  );
+  await flushWaitUntilForTest();
+  const cursor = (
+    await chat.listThreadEvents(run.actor, run.threadId)
+  ).events.at(-1);
+  if (!cursor) {
+    throw new Error("Expected retained history before publication");
+  }
+  const provider = `first-snapshot-race-${randomUUID()}`;
+  await seedUsagePricingRows([
+    {
+      kind: "connector",
+      provider,
+      category: "api_request",
+      unitPrice: 7,
+      unitSize: 1,
+    },
+  ]);
+  await webhooks.requestAgentUsageEvent(
+    {
+      runId: run.runId,
+      events: [
+        {
+          idempotencyKey: randomUUID(),
+          kind: "connector",
+          provider,
+          category: "api_request",
+          quantity: 1,
+        },
+      ],
+    },
+    run.headers,
+    [200],
+  );
+  await flushWaitUntilForTest();
+  // No API can suspend a completed SQL response. Hold the real driver's empty
+  // result while the real snapshot route and retention fixture move the rows.
+  await withEmptySnapshotReadBarrier({
+    threadId: run.threadId,
+    whileResponseHeld: async () => {
+      await archive(run.threadId);
+    },
+    work: async () => {
+      await createBillingMediaApi(context).processOrgUsageEvents(run.actor);
+      await flushWaitUntilForTest();
+    },
+  });
+  const rows = await chat.listThreadEventRows(run.actor, run.threadId, {
+    lastEventId: cursor.id,
+    lastSeqId: cursor.seqId,
+  });
+  expect(
+    rows.filter((event) => {
+      return event.eventType === "usage.recorded";
+    }),
+  ).toMatchObject([
+    {
+      contextType: "goal",
+      contextId: groupId,
+      payload: { usage: { totalCredits: 7 } },
+    },
+  ]);
+}, 60_000);

--- a/turbo/apps/api/src/signals/services/chat-event-shared.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-shared.service.ts
@@ -172,7 +172,7 @@ async function assistantEventRunContextForRun(
     .where(and(eq(agentRuns.id, runId), isNotNull(agentRuns.triggerSource)))
     .limit(1);
   return {
-    goalId: await historicalRunGroupId(db, runId, signal),
+    goalId: await historicalRunGroupId(db, runId, undefined, signal),
     shouldAttemptFirstAssistantEventClaim:
       run !== undefined &&
       run.apiStartedAt !== null &&

--- a/turbo/apps/api/src/signals/services/chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-queued-event.service.ts
@@ -645,11 +645,14 @@ export async function claimQueueFirstRunAssociation(
         "api_dispatch_persist_queue_first_replacement",
         "nested",
         async () => {
-          return await replaceLoadedChatEvent(
-            db,
-            snapshot.target,
-            snapshot.replacement,
-          );
+          return await replaceLoadedChatEvent(db, snapshot.target, {
+            ...snapshot.replacement,
+            // This fresh server run UUID identifies its initial input claim.
+            // The claim precedes the run INSERT in the same launch transaction;
+            // active-input delivery never assigns this identity. Provenance
+            // readers use its physical sequence as the run's lower bound.
+            id: args.runId,
+          });
         },
         claimDimensions,
       );

--- a/turbo/apps/api/src/signals/services/chat-usage-event.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-usage-event.service.ts
@@ -197,15 +197,18 @@ export const maybeEmitRunUsageEvent$ = command(
         .limit(1);
       signal.throwIfAborted();
 
-      const archivedUsageEvent = hotUsageEvent
+      // Keep a necessary canonical read within this locked operation, so first
+      // late usage can also resolve its group without downloading history twice.
+      const history = hotUsageEvent
         ? undefined
-        : [...(await runEventHistory(tx, context.chatThreadId, signal))]
-            .reverse()
-            .find((event) => {
-              return (
-                event.runId === runId && event.eventType === "usage.recorded"
-              );
-            });
+        : await runEventHistory(tx, context.chatThreadId, runId, signal);
+      const archivedUsageEvent = history
+        ? [...history].reverse().find((event) => {
+            return (
+              event.runId === runId && event.eventType === "usage.recorded"
+            );
+          })
+        : undefined;
       const existingUsageEvent =
         hotUsageEvent ??
         (archivedUsageEvent
@@ -223,6 +226,9 @@ export const maybeEmitRunUsageEvent$ = command(
         return null;
       }
 
+      const runGroupId = existingUsageEvent
+        ? undefined
+        : await historicalRunGroupId(tx, runId, history, signal);
       const event = {
         chatThreadId: context.chatThreadId,
         eventType: "usage.recorded" as const,
@@ -230,11 +236,7 @@ export const maybeEmitRunUsageEvent$ = command(
         runId,
         // A replacement inherits the exact context pointer, including null.
         // Only a first event needs the retained run provenance lookup.
-        ...(existingUsageEvent
-          ? {}
-          : {
-              runGroupId: await historicalRunGroupId(tx, runId, signal),
-            }),
+        ...(existingUsageEvent ? {} : { runGroupId }),
         usagePayload: payload,
       };
       const inserted = existingUsageEvent

--- a/turbo/apps/api/src/signals/services/run-event-provenance.service.ts
+++ b/turbo/apps/api/src/signals/services/run-event-provenance.service.ts
@@ -1,5 +1,5 @@
 import { createStore } from "ccstate";
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, isNotNull } from "drizzle-orm";
 import { agentRuns } from "@okouai/db/runtime/agent-run";
 import { chatEvents } from "@okouai/db/schema/chat-event";
 import { chatEventSnapshots } from "@okouai/db/schema/chat-event-snapshot";
@@ -9,12 +9,15 @@ import { env } from "../../lib/env";
 import type { Db } from "../external/db";
 import { readCurrentChatEventHistoryAtSnapshot } from "./chat-event-history.service";
 
-/** Resolve archived provenance after a hot-row lookup, without Goal authority. */
+/** Resolve archived provenance after a hot-row lookup, without Goal authority.
+ * Undefined means no archive read was needed, not a resolved empty history.
+ */
 export async function runEventHistory(
   db: Pick<Db, "select">,
   threadId: string,
+  runId: string,
   signal: AbortSignal,
-): Promise<readonly ChatEventRow[]> {
+): Promise<readonly ChatEventRow[] | undefined> {
   const head = async () => {
     const [row] = await db
       .select({
@@ -41,15 +44,36 @@ export async function runEventHistory(
   for (let attempt = 0; attempt < 3; attempt++) {
     const before = await head();
     if (before === undefined) {
-      return [];
+      return undefined;
     }
-    const events = await createStore().get(
-      readCurrentChatEventHistoryAtSnapshot(
-        { db, bucket: env("R2_USER_STORAGES_BUCKET_NAME") },
-        threadId,
-        signal,
-      ),
-    );
+    const [initialClaim] = await db
+      .select({ seqId: chatEvents.seqId })
+      .from(chatEvents)
+      .where(
+        and(
+          eq(chatEvents.id, runId),
+          eq(chatEvents.runId, runId),
+          eq(chatEvents.chatThreadId, threadId),
+          eq(chatEvents.eventType, "input.prompt"),
+          isNotNull(chatEvents.revokesEventId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+    // Only the launch transaction writes this identity (before inserting the
+    // run). A later input/output cannot prove absence from an older archive.
+    // Older runs without this witness still require canonical history. Use the
+    // physical watermark, never the logical cursor or publication timestamp.
+    const events =
+      initialClaim !== undefined && initialClaim.seqId > before.lastSeqId
+        ? undefined
+        : await createStore().get(
+            readCurrentChatEventHistoryAtSnapshot(
+              { db, bucket: env("R2_USER_STORAGES_BUCKET_NAME") },
+              threadId,
+              signal,
+            ),
+          );
     const after = await head();
     if (
       before?.objectKey === after?.objectKey &&
@@ -64,6 +88,7 @@ export async function runEventHistory(
 export async function historicalRunGroupId(
   db: Pick<Db, "select">,
   runId: string,
+  resolvedHistory?: readonly ChatEventRow[],
   signal: AbortSignal = new AbortController().signal,
 ): Promise<string | undefined> {
   const [run] = await db
@@ -98,8 +123,9 @@ export async function historicalRunGroupId(
   }
   // A retained prompt can coexist with archived output from the same run.
   // Its non-Goal context does not disprove a canonical archived Goal group.
-  const history = await runEventHistory(db, run.threadId, signal);
-  const original = history.find((event) => {
+  const history =
+    resolvedHistory ?? (await runEventHistory(db, run.threadId, runId, signal));
+  const original = history?.find((event) => {
     return event.runId === runId && event.contextType === "goal";
   });
   // Absent provenance emits ungrouped generic accounting, never an invented group.

--- a/turbo/apps/api/src/test-fixtures/goal-schema-contraction.ts
+++ b/turbo/apps/api/src/test-fixtures/goal-schema-contraction.ts
@@ -9,15 +9,21 @@ import {
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import { Client } from "pg";
+import { z } from "zod";
 import { closeDbPool, db } from "../lib/db";
 import { env, mockEnv, optionalEnv } from "../lib/env";
 import { flushWaitUntilForTest } from "../signals/context/wait-until";
 import { installApiTestConnectorCatalog } from "./connector-catalog";
 import { agentRuns } from "@okouai/db/runtime/agent-run";
+import { chatThreads } from "@okouai/db/schema/chat-thread";
+import { nowDate } from "../lib/time";
 import { chatEvents } from "@okouai/db/schema/chat-event";
-import { eq, and, lte } from "drizzle-orm";
+import { eq, and, lte, ne, sql } from "drizzle-orm";
 import { chatEventSnapshots } from "@okouai/db/schema/chat-event-snapshot";
-import { insertChatEvent } from "../signals/services/chat-event.service";
+import {
+  insertChatEvent,
+  replaceLoadedChatEvent,
+} from "../signals/services/chat-event.service";
 
 /** Contract only a test-owned database; never alter the shared suite database. */
 export async function withContractedGoalSchema(
@@ -90,11 +96,12 @@ export async function seedRetainedRunProvenance(
   runId: string,
   threadId: string,
   groupId: string | null,
+  triggerSource: "goal" | "web" = "goal",
 ): Promise<void> {
   await db().transaction(async (tx) => {
     await tx
       .update(agentRuns)
-      .set({ triggerSource: "goal" })
+      .set({ triggerSource })
       .where(eq(agentRuns.id, runId));
     if (groupId !== null) {
       await insertChatEvent(tx, {
@@ -110,6 +117,7 @@ export async function seedRetainedRunProvenance(
 
 export async function removeSnapshottedRunEvents(
   threadId: string,
+  keepEventId?: string,
 ): Promise<void> {
   const [head] = await db()
     .select({ lastSeqId: chatEventSnapshots.lastSeqId })
@@ -124,6 +132,7 @@ export async function removeSnapshottedRunEvents(
       and(
         eq(chatEvents.chatThreadId, threadId),
         lte(chatEvents.seqId, head.lastSeqId),
+        keepEventId === undefined ? undefined : ne(chatEvents.id, keepEventId),
       ),
     );
 }
@@ -139,4 +148,133 @@ export async function retainedUsageRows(runId: string) {
       ),
     )
     .orderBy(chatEvents.seqId);
+}
+
+/** An old active-input claim can survive after its run's earlier output was archived. */
+export async function appendRetainedRunPrompt(
+  runId: string,
+  threadId: string,
+): Promise<void> {
+  await db().transaction(async (tx) => {
+    const userMessage = {
+      version: 1 as const,
+      parts: [{ type: "text" as const, text: "Later retained input" }],
+    };
+    const source = await insertChatEvent(tx, {
+      chatThreadId: threadId,
+      eventType: "input.prompt",
+      runId: null,
+      contextType: "web",
+      userMessage,
+    });
+    if (!source) {
+      throw new Error("Expected retained active input");
+    }
+    await replaceLoadedChatEvent(
+      tx,
+      {
+        ...source,
+        chatThreadId: threadId,
+        eventType: "input.prompt",
+        contextType: "web",
+        contextId: null,
+      },
+      {
+        chatThreadId: threadId,
+        eventType: "input.prompt",
+        runId,
+        userMessage,
+      },
+    );
+  });
+}
+
+/** Append an old producer's usage revision; the live writer cannot set a web source. */
+export async function appendRetainedUsageWebContext(
+  runId: string,
+): Promise<void> {
+  const prior = (await retainedUsageRows(runId)).at(-1);
+  if (!prior) {
+    throw new Error("Expected prior usage for a legacy revision");
+  }
+  await db().transaction(async (tx) => {
+    const [thread] = await tx
+      .update(chatThreads)
+      .set({
+        lastChatEventSeqId: sql`${chatThreads.lastChatEventSeqId} + 1`,
+      })
+      .where(eq(chatThreads.id, prior.chatThreadId))
+      .returning({ seqId: chatThreads.lastChatEventSeqId });
+    if (!thread) {
+      throw new Error("Expected retained thread");
+    }
+    await tx.insert(chatEvents).values({
+      ...prior,
+      id: randomUUID(),
+      seqId: thread.seqId,
+      revokesEventId: prior.id,
+      createdAt: new Date(
+        Math.max(nowDate().getTime(), prior.createdAt.getTime() + 1),
+      ),
+      contextType: "web",
+      contextId: null,
+    });
+  });
+}
+
+/** Hold a real database response across snapshot publication, without replacing its rows. */
+export async function withEmptySnapshotReadBarrier(args: {
+  readonly threadId: string;
+  readonly whileResponseHeld: () => Promise<void>;
+  readonly work: () => Promise<void>;
+}): Promise<void> {
+  await closeDbPool();
+  const original = Client.prototype.query;
+  let held = false;
+  Client.prototype.query = new Proxy(original, {
+    apply(target, receiver: unknown, queryArgs: unknown[]): unknown {
+      const result: unknown = Reflect.apply(target, receiver, queryArgs);
+      const query = z
+        .object({ text: z.string(), values: z.array(z.unknown()) })
+        .safeParse(queryArgs[0]);
+      if (
+        held ||
+        !(result instanceof Promise) ||
+        !query.success ||
+        !query.data.text.startsWith("select ") ||
+        !query.data.text.includes('from "chat_event_snapshots"') ||
+        !query.data.values.includes(args.threadId)
+      ) {
+        return result;
+      }
+      return (async () => {
+        const response: unknown = await result;
+        if (
+          !held &&
+          z.object({ rows: z.array(z.unknown()).length(0) }).safeParse(response)
+            .success
+        ) {
+          held = true;
+          await args.whileResponseHeld();
+        }
+        return response;
+      })();
+    },
+  });
+  const run = async () => {
+    await args.work();
+    if (!held) {
+      throw new Error("Expected the empty snapshot response barrier");
+    }
+  };
+  const [result] = await Promise.allSettled([run()]);
+  // Pool instrumentation captures bound query methods on each client.
+  const [closed] = await Promise.allSettled([closeDbPool()]);
+  Client.prototype.query = original;
+  if (result.status === "rejected") {
+    throw result.reason;
+  }
+  if (closed.status === "rejected") {
+    throw closed.reason;
+  }
 }


### PR DESCRIPTION
## Summary

Continuing an ordinary conversation in a previously snapshotted thread could make each assistant batch, initial thinking, terminal callback, and first usage depend on downloading unrelated historical events. An unavailable old archive caused required output delivery to return `503 EVENT_DELIVERY_UNAVAILABLE`.

Give the initial queue claim the fresh server-generated run UUID as its event ID. The claim is persisted before the run in the same failed, queued, or pending/CTE launch transaction; client inputs and later active-input claims keep separate identities. An exact retained initial claim beyond a stable snapshot's physical `lastSeqId` proves that run cannot occur in that archive. Other histories retain canonical snapshot-plus-tail resolution and explicit failures.

Share an actually resolved history within the existing usage operation and advisory lock. Distinguish an omitted read from resolved empty history so snapshot publication and retention cannot erase context between first-usage lookups. Preserve prior usage context, revocation, settled time, strictly later revision time, and accounting.

Closes #33152. Repairs the remaining S4 acceptance blocker in #33061 under #32653; S4 acceptance and production release remain separate controller-owned work.

## Compatibility

The event identity convention uses the existing canonical row and revoke grammar. Historical writers/readers and runtime/physical ORM separation remain compatible. The diff adds no migration, Goal authority, schema drop, archive rewrite, or resource cleanup and leaves upstream initial-thinking provider failure classification intact.

## Fallbacks

Historical compatibility remains a permanent event-history contract: older runs, copied identities, missing initial claims, and claims within physical snapshot coverage use the canonical reader. A required archive error remains explicit. There is no cross-operation cache or time-based eligibility rule.

## Verification

- Red: two real output webhook regressions on the original implementation returned `503 EVENT_DELIVERY_UNAVAILABLE` when a continued thread's unrelated archive GET failed.
- Red: a real PostgreSQL response barrier reproduced loss of historical Goal context when an empty head observation was reused across first snapshot publication and retention.
- Green: 63 tests across `goal-schema-contraction`, `goal-retirement-history`, `usage-record`, and `workflow-queue`, including the real PostgreSQL race and actual SQL with Goal objects absent.
- Green: 90 selected callback/chat-event tests covering completed/failed callbacks, durable output delivery, queue/input ownership, admission, client IDs, and initial thinking.
- The archive-outage matrix covers success, failure, and cancellation, each with and without previous Goal history; multiple output batches, initial thinking, first-assistant acknowledgement, first usage, and duplicate delivery remain correct with zero unrelated archive GETs.
- Historical manual/hot/snapshot/absent context, archived usage revisions, null/legacy context, settlement/revoke/timestamp semantics, and snapshot-head movement retain coverage.
- API lint passed; the final TypeScript-library compatibility edit passed scoped Oxlint/ESLint and reran all 10 contraction scenarios. The final fixture type annotations passed the normal repository hooks.
- Normal hooks passed: Prettier, style policy, Knip, repository type checks (14 tasks), file size, and commitlint. No hook was bypassed.
- No full local Vitest suite or dev server was run. Required PR and merge-group CI will provide the full repository validation.
