### PR TITLE
chore(telegram): drop transient domain probe warn log

### DIFF
--- a/turbo/apps/api/src/signals/external/telegram-domain.ts
+++ b/turbo/apps/api/src/signals/external/telegram-domain.ts
@@ -1,8 +1,6 @@
-import { logger } from "../../lib/log";
 import { tapError } from "../utils";
 
 const TELEGRAM_OAUTH_BASE_URL = "https://oauth.telegram.org/auth";
-const log = logger("telegram:check-domain");
 
 export async function checkTelegramDomain(
   telegramBotId: string,
@@ -12,14 +10,14 @@ export async function checkTelegramDomain(
     bot_id: telegramBotId,
     origin: appUrl,
   });
+  // A probe that cannot reach Telegram is expected transient noise, not an
+  // actionable failure, so it is not logged. The outbound HEAD is already
+  // traced as a client span, which carries its own error status and duration.
   const response = await tapError(
     fetch(`${TELEGRAM_OAUTH_BASE_URL}?${query}`, {
       method: "HEAD",
       signal: AbortSignal.timeout(3000),
     }),
-    (error) => {
-      log.warn("Domain probe failed", { telegramBotId, error });
-    },
   );
   if (!response) {
     return false;


### PR DESCRIPTION
## Summary

`checkTelegramDomain` sends a `HEAD` request to `oauth.telegram.org/auth` to decide whether a bot's Telegram login domain is configured. When that probe could not reach Telegram, it emitted a production `warn` (`telegram:check-domain` / `Domain probe failed`). This removes that log; probe classification and every user-facing state it drives are unchanged.

Closes #33082

## Why this is expected noise, not an actionable failure

Evidence from the reviewed occurrence (`vm0-web-logs-prod`, 1 record at `2026-09-08T16:31:47.333Z`, `warn`, `TypeError: fetch failed`) and from `vm0-traces-prod`:

- The full trace for that request shows `POST /api/telegram/register` returned **201** — the registration succeeded. The failing probe only populated `domainConfigured` on the register response, which no first-party client reads.
- The same bot and origin had been probed **5.6 seconds earlier** on `POST /api/telegram/setup-status` with **HTTP 200 in 565 ms**. Nothing about the bot's configuration changed; a transport error did.
- The failing client span lasted **1.652 s**, well under the 3 s deadline, so the abort deadline was not the trigger.
- Over 90 days of production traces the probe ran **104 times**: 103 succeeded (all HTTP 200, mean 559 ms, max 1.134 s) and 1 failed. A ~1% transport failure rate on a best-effort external probe has no operator action attached.

Availability of the probe remains observable without the log, because `@vercel/otel` already records the outbound `HEAD` as a client span carrying error status and duration, in a dataset with a much longer retention than the application log dataset:

```
['vm0-traces-prod']
| where name startswith 'fetch HEAD https://oauth.telegram.org'
| summarize count() by tostring(['status.code']), bin(_time, 1d)
```

## Scope

Deliberately minimal. Not included here:

- The probe still collapses "could not reach Telegram" and "domain is not configured" into the same `false`, which can misattribute a transient failure to a BotFather misconfiguration on the setup-status and link-status paths. That is a separate behavior change (typed tri-state result, bounded retry, distinct UI copy) and is not bundled into a log-noise cleanup.
- Nearby real failures keep their observability: `getMe` verification, webhook configuration, and every other Telegram error path are untouched.

## Test plan

- No behavior change: the function's return value is identical for every input, so existing Telegram route and BDD coverage (`integrations-telegram.test.ts`, `integrations-telegram-post.test.ts`, `integrations.bdd.test.ts`) continues to exercise the `configured` and `not_configured` paths unchanged.
- Relying on the PR pipeline for lint, types, Knip, and the affected test suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
