### PR TITLE
fix(guest-agent): classify upstream content policy rejections

### DIFF
--- a/crates/codex-mock/src/app_server/messages.rs
+++ b/crates/codex-mock/src/app_server/messages.rs
@@ -577,14 +577,13 @@ pub(super) fn turn_failed_notification(
     turn_id: &str,
     failure: TurnFailure,
 ) -> Value {
+    let message = turn_failure_message(failure);
     let error = match turn_failure_error_info(failure) {
         Some(codex_error_info) => json!({
-            "message": "mock codex primary failure",
+            "message": message,
             "codexErrorInfo": codex_error_info
         }),
-        None => json!({
-            "message": "mock codex primary failure"
-        }),
+        None => json!({ "message": message }),
     };
 
     json!({
@@ -605,9 +604,23 @@ pub(super) fn turn_failed_notification(
     })
 }
 
+fn turn_failure_message(failure: TurnFailure) -> &'static str {
+    match failure {
+        TurnFailure::ContentPolicyRejection => {
+            r#"{"error":{"message":"Content Exists Risk","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}"#
+        }
+        TurnFailure::InvalidRequestFormat => {
+            r#"{"error":{"message":"Invalid Format","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}"#
+        }
+        _ => "mock codex primary failure",
+    }
+}
+
 fn turn_failure_error_info(failure: TurnFailure) -> Option<Value> {
     match failure {
-        TurnFailure::Generic => None,
+        TurnFailure::Generic
+        | TurnFailure::ContentPolicyRejection
+        | TurnFailure::InvalidRequestFormat => None,
         TurnFailure::ContextWindowExceeded => Some(json!("contextWindowExceeded")),
         TurnFailure::InternalServerError => Some(json!("internalServerError")),
         TurnFailure::ResponseStreamConnectionFailed => Some(json!({

--- a/crates/codex-mock/src/app_server/scenario.rs
+++ b/crates/codex-mock/src/app_server/scenario.rs
@@ -39,6 +39,8 @@ pub(super) enum Scenario {
     RuntimeTurnFailedResponseTooManyFailedAttempts,
     RuntimeTurnFailedUnauthorized,
     RuntimeTurnFailedUnknown,
+    RuntimeTurnFailedContentPolicyRejection,
+    RuntimeTurnFailedInvalidRequestFormat,
     RuntimeTurnCompleteAfterSteer,
     RuntimeTurnCompleteBeforeSteerResponse,
     RuntimeTurnStartedBeforeSteer,
@@ -153,6 +155,12 @@ impl Scenario {
                 }
                 "runtime-turn-failed-unauthorized" => Ok(Self::RuntimeTurnFailedUnauthorized),
                 "runtime-turn-failed-unknown" => Ok(Self::RuntimeTurnFailedUnknown),
+                "runtime-turn-failed-content-policy-rejection" => {
+                    Ok(Self::RuntimeTurnFailedContentPolicyRejection)
+                }
+                "runtime-turn-failed-invalid-request-format" => {
+                    Ok(Self::RuntimeTurnFailedInvalidRequestFormat)
+                }
                 "runtime-turn-complete-after-steer" => Ok(Self::RuntimeTurnCompleteAfterSteer),
                 "runtime-turn-complete-before-steer-response" => {
                     Ok(Self::RuntimeTurnCompleteBeforeSteerResponse)
@@ -249,6 +257,10 @@ impl Scenario {
             }
             Self::RuntimeTurnFailedUnauthorized => Some(TurnFailure::Unauthorized),
             Self::RuntimeTurnFailedUnknown => Some(TurnFailure::Unknown),
+            Self::RuntimeTurnFailedContentPolicyRejection => {
+                Some(TurnFailure::ContentPolicyRejection)
+            }
+            Self::RuntimeTurnFailedInvalidRequestFormat => Some(TurnFailure::InvalidRequestFormat),
             _ => None,
         }
     }
@@ -279,4 +291,10 @@ pub(super) enum TurnFailure {
     ResponseTooManyFailedAttempts,
     Unauthorized,
     Unknown,
+    /// Upstream content-safety rejection passed through as a raw provider
+    /// envelope, with no structured `codexErrorInfo` to classify from.
+    ContentPolicyRejection,
+    /// Same error type and code as the rejection above, but a genuine
+    /// request-shape complaint that must stay unclassified.
+    InvalidRequestFormat,
 }

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -1910,6 +1910,62 @@ mod tests {
     }
 
     #[test]
+    fn failed_turn_completed_classifies_upstream_content_policy_rejection() {
+        const ENVELOPE: &str = r#"{"error":{"message":"Content Exists Risk","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}"#;
+        let event = mapped_event(
+            "turn/completed",
+            json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "turn-1",
+                    "status": "failed",
+                    "error": {"message": ENVELOPE},
+                    "startedAt": 10,
+                    "completedAt": 20,
+                    "durationMs": 1000
+                }
+            }),
+        );
+
+        assert_eq!(
+            events::masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(events::CodexFailureDiagnostic {
+                event_type: "turn.completed",
+                message: ENVELOPE.to_string(),
+                failure_reason: Some(FailureReason::SafetyPolicyRefusal),
+            })
+        );
+    }
+
+    #[test]
+    fn failed_turn_completed_keeps_request_format_errors_unclassified() {
+        const ENVELOPE: &str = r#"{"error":{"message":"Invalid Format","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}"#;
+        let event = mapped_event(
+            "turn/completed",
+            json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "turn-1",
+                    "status": "failed",
+                    "error": {"message": ENVELOPE},
+                    "startedAt": 10,
+                    "completedAt": 20,
+                    "durationMs": 1000
+                }
+            }),
+        );
+
+        assert_eq!(
+            events::masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(events::CodexFailureDiagnostic {
+                event_type: "turn.completed",
+                message: ENVELOPE.to_string(),
+                failure_reason: None,
+            })
+        );
+    }
+
+    #[test]
     fn failed_turn_completed_classifies_misalignment_policy_violation() {
         let event = mapped_event(
             "turn/completed",

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -9,6 +9,7 @@ use crate::error::AgentError;
 use crate::failure_patterns::{
     has_exact_codex_oauth_connector, is_codex_chatgpt_account_unsupported_model_message,
     is_codex_context_window_exceeded_message, is_codex_model_capacity_message,
+    is_content_policy_rejection_message,
 };
 use crate::http::{HttpAttemptObserver, HttpClient};
 use crate::masker::SecretMasker;
@@ -340,6 +341,12 @@ fn codex_error_failure_reason(error: Option<&Value>) -> Option<FailureReason> {
     }
     if let Some(failure_reason) = codex_error_info_failure_reason(error) {
         return Some(failure_reason);
+    }
+    if codex_error_message(Some(error))
+        .as_deref()
+        .is_some_and(is_content_policy_rejection_message)
+    {
+        return Some(FailureReason::SafetyPolicyRefusal);
     }
     if codex_error_message(Some(error))
         .as_deref()

--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -285,6 +285,12 @@ fn classify_cli_failure_reason(
     }
     if matches!(framework, AgentFramework::Codex)
         && source == FailureDetailSource::CodexJsonl
+        && failure_patterns::is_content_policy_rejection_message(failure_message)
+    {
+        return Some(FailureReason::SafetyPolicyRefusal);
+    }
+    if matches!(framework, AgentFramework::Codex)
+        && source == FailureDetailSource::CodexJsonl
         && failure_patterns::is_codex_rate_limit_retry_exhausted_message(failure_message)
     {
         return Some(FailureReason::ProviderRateLimited);
@@ -403,7 +409,7 @@ fn has_insufficient_credits_response_envelope(normalized: &str) -> bool {
     };
 
     let Some((Some(value), _)) =
-        parse_next_json_object(normalized, status_index + STATUS_MARKER.len())
+        failure_patterns::parse_next_json_object(normalized, status_index + STATUS_MARKER.len())
     else {
         return false;
     };
@@ -567,7 +573,9 @@ fn is_codex_oauth_reconnect_required_run_error(error_message: &str) -> bool {
     }
 
     let mut search_start = 0;
-    while let Some((value, end_index)) = parse_next_json_object(error_message, search_start) {
+    while let Some((value, end_index)) =
+        failure_patterns::parse_next_json_object(error_message, search_start)
+    {
         if value
             .as_ref()
             .is_some_and(is_codex_oauth_reconnect_required_value)
@@ -581,7 +589,9 @@ fn is_codex_oauth_reconnect_required_run_error(error_message: &str) -> bool {
 
 fn is_codex_chatgpt_account_unsupported_model_run_error(error_message: &str) -> bool {
     let mut search_start = 0;
-    while let Some((value, end_index)) = parse_next_json_object(error_message, search_start) {
+    while let Some((value, end_index)) =
+        failure_patterns::parse_next_json_object(error_message, search_start)
+    {
         if value.as_ref().is_some_and(|value| {
             value.get("type").and_then(Value::as_str) == Some("error")
                 && value.get("status").and_then(Value::as_u64) == Some(400)
@@ -597,18 +607,6 @@ fn is_codex_chatgpt_account_unsupported_model_run_error(error_message: &str) -> 
         search_start = end_index;
     }
     false
-}
-
-fn parse_next_json_object(message: &str, search_start: usize) -> Option<(Option<Value>, usize)> {
-    let body_start = message[search_start.min(message.len())..]
-        .find('{')
-        .map(|offset| search_start + offset)?;
-    let mut stream = serde_json::Deserializer::from_str(&message[body_start..]).into_iter();
-
-    match stream.next() {
-        Some(Ok(value)) => Some((Some(value), body_start + stream.byte_offset())),
-        Some(Err(_)) | None => Some((None, body_start + 1)),
-    }
 }
 
 fn is_codex_oauth_reconnect_required_value(value: &Value) -> bool {

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -1378,6 +1378,72 @@ fn cli_failure_reason_does_not_broadly_classify_safety_policy_text() {
 }
 
 #[test]
+fn cli_failure_reason_classifies_codex_content_policy_rejection_envelope() {
+    for message in [
+        r#"{"error":{"message":"Content Exists Risk","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}"#,
+        r#"unexpected status 400 Bad Request: {"error":{"message":"Content Exists Risk","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}, url: https://api.example.com/responses"#,
+        r#"{"error":{"message":"  Content Exists Risk  ","type":"invalid_request_error","code":"invalid_request_error"}}"#,
+    ] {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::Codex,
+            FailureDetailSource::CodexJsonl,
+            message,
+        );
+
+        assert_eq!(
+            reason,
+            Some(FailureReason::SafetyPolicyRefusal),
+            "message: {message}"
+        );
+    }
+}
+
+#[test]
+fn cli_failure_reason_keeps_other_invalid_request_errors_unclassified() {
+    for message in [
+        // Real request-shape defects share the `invalid_request_error` type and
+        // must keep their actionable unclassified failure.
+        r#"{"error":{"message":"Invalid Format","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}"#,
+        r#"{"error":{"message":"Input token length too long","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}"#,
+        // Same phrase, different envelope shape or missing fields.
+        r#"{"error":{"message":"Content Exists Risk","type":"invalid_request_error"}}"#,
+        r#"{"error":{"message":"Content Exists Risk","type":"content_filter","code":"content_filter"}}"#,
+        r#"{"detail":"Content Exists Risk"}"#,
+        "the provider reported Content Exists Risk for this request",
+    ] {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::Codex,
+            FailureDetailSource::CodexJsonl,
+            message,
+        );
+
+        assert_eq!(reason, None, "message: {message}");
+    }
+}
+
+#[test]
+fn cli_failure_reason_scopes_content_policy_rejection_to_codex_jsonl() {
+    const ENVELOPE: &str = r#"{"error":{"message":"Content Exists Risk","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}"#;
+
+    assert_eq!(
+        super::classify_cli_failure_reason(
+            AgentFramework::Codex,
+            FailureDetailSource::Stderr,
+            ENVELOPE,
+        ),
+        None
+    );
+    assert_eq!(
+        super::classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            FailureDetailSource::CodexJsonl,
+            ENVELOPE,
+        ),
+        None
+    );
+}
+
+#[test]
 fn cli_failure_reason_classifies_codex_oauth_reconnect_required() {
     let reason = classify_cli_failure_reason(
         AgentFramework::Codex,

--- a/crates/guest-agent/src/failure_patterns.rs
+++ b/crates/guest-agent/src/failure_patterns.rs
@@ -12,6 +12,8 @@ const CODEX_RATE_LIMIT_RETRY_EXHAUSTED_MESSAGE: &str =
     "exceeded retry limit, last status: 429 too many requests";
 const CODEX_UNSUPPORTED_MODEL_MESSAGE_SUFFIX: &str =
     "' model is not supported when using Codex with a ChatGPT account.";
+const CONTENT_POLICY_REJECTION_ERROR_TYPE: &str = "invalid_request_error";
+const CONTENT_POLICY_REJECTION_MESSAGE: &str = "Content Exists Risk";
 
 pub(crate) fn is_generic_codex_failure_diagnostic(message: &str) -> bool {
     let message = message.trim().to_ascii_lowercase();
@@ -64,6 +66,61 @@ pub(crate) fn is_codex_chatgpt_account_unsupported_model_message(message: &str) 
         return false;
     };
     !model.is_empty() && !model.contains('\'')
+}
+
+/// Whether a failure message carries an exact content-policy rejection envelope.
+///
+/// Codex passes the upstream provider response through as the failure message,
+/// sometimes wrapped in its own prose, so scan every embedded JSON object
+/// instead of comparing the whole message.
+pub(crate) fn is_content_policy_rejection_message(message: &str) -> bool {
+    let mut search_start = 0;
+    while let Some((value, end_index)) = parse_next_json_object(message, search_start) {
+        if value
+            .as_ref()
+            .is_some_and(is_content_policy_rejection_envelope)
+        {
+            return true;
+        }
+        search_start = end_index;
+    }
+    false
+}
+
+/// Exact OpenAI-compatible content-policy rejection envelope.
+///
+/// Providers behind the OpenAI-compatible surface report a content-safety
+/// rejection as an `invalid_request_error` whose message is a fixed phrase
+/// rather than a request-shape complaint. Match the message, type, and code
+/// together so a genuine malformed request, which shares the same error type,
+/// keeps its unclassified actionable failure.
+fn is_content_policy_rejection_envelope(value: &Value) -> bool {
+    value.get("error").is_some_and(|error| {
+        error.get("type").and_then(Value::as_str) == Some(CONTENT_POLICY_REJECTION_ERROR_TYPE)
+            && error.get("code").and_then(Value::as_str)
+                == Some(CONTENT_POLICY_REJECTION_ERROR_TYPE)
+            && error
+                .get("message")
+                .and_then(Value::as_str)
+                .is_some_and(|message| message.trim() == CONTENT_POLICY_REJECTION_MESSAGE)
+    })
+}
+
+/// Parse the next embedded JSON object, returning the value when it decodes and
+/// the offset to resume scanning from.
+pub(crate) fn parse_next_json_object(
+    message: &str,
+    search_start: usize,
+) -> Option<(Option<Value>, usize)> {
+    let body_start = message[search_start.min(message.len())..]
+        .find('{')
+        .map(|offset| search_start + offset)?;
+    let mut stream = serde_json::Deserializer::from_str(&message[body_start..]).into_iter();
+
+    match stream.next() {
+        Some(Ok(value)) => Some((Some(value), body_start + stream.byte_offset())),
+        Some(Err(_)) | None => Some((None, body_start + 1)),
+    }
 }
 
 pub(crate) fn has_exact_codex_oauth_connector(value: &Value) -> bool {
@@ -165,6 +222,40 @@ mod tests {
         ] {
             assert!(
                 !is_codex_rate_limit_retry_exhausted_message(message),
+                "message: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn content_policy_rejection_matcher_accepts_the_exact_envelope() {
+        for message in [
+            r#"{"error":{"message":"Content Exists Risk","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}"#,
+            r#"stream error: {"error":{"message":"Content Exists Risk","type":"invalid_request_error","code":"invalid_request_error"}} (retrying)"#,
+            r#"{"not":"json-object-first"} {"error":{"message":"Content Exists Risk","type":"invalid_request_error","code":"invalid_request_error"}}"#,
+        ] {
+            assert!(
+                is_content_policy_rejection_message(message),
+                "message: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn content_policy_rejection_matcher_rejects_other_invalid_requests() {
+        for message in [
+            r#"{"error":{"message":"Invalid Format","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}"#,
+            r#"{"error":{"message":"Content Exists Risk","type":"invalid_request_error"}}"#,
+            r#"{"error":{"message":"Content Exists Risk","code":"invalid_request_error"}}"#,
+            r#"{"error":{"message":"Content Exists Risk","type":"content_filter","code":"content_filter"}}"#,
+            r#"{"error":{"message":"Content Exists Risk detected in input","type":"invalid_request_error","code":"invalid_request_error"}}"#,
+            r#"{"detail":"Content Exists Risk"}"#,
+            "Content Exists Risk",
+            "{not valid json",
+            "",
+        ] {
+            assert!(
+                !is_content_policy_rejection_message(message),
                 "message: {message}"
             );
         }

--- a/crates/guest-agent/tests/codex_app_server_backend_structured_errors.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_structured_errors.rs
@@ -54,6 +54,14 @@ async fn codex_app_server_classifies_supported_structured_errors()
             scenario: "runtime-turn-failed-unknown",
             expected_reason: None,
         },
+        StructuredErrorCase {
+            scenario: "runtime-turn-failed-content-policy-rejection",
+            expected_reason: Some(FailureReason::SafetyPolicyRefusal),
+        },
+        StructuredErrorCase {
+            scenario: "runtime-turn-failed-invalid-request-format",
+            expected_reason: None,
+        },
     ];
 
     for (index, case) in cases.iter().enumerate() {

--- a/crates/runner/src/cmd/start/job_terminal_log.rs
+++ b/crates/runner/src/cmd/start/job_terminal_log.rs
@@ -685,6 +685,37 @@ mod tests {
     }
 
     #[test]
+    fn codex_content_policy_rejection_logs_job_execution_failed_at_info() {
+        const ENVELOPE: &str = r#"{"error":{"message":"Content Exists Risk","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}"#;
+        let diagnostic = job_failure_diagnostic(Some(FailureReason::SafetyPolicyRefusal));
+        let failure = executor::ExecutionFailure::new(1, ENVELOPE, Some(diagnostic));
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_eq!(event.level, Level::INFO);
+        assert_field_eq(&event, "error", ENVELOPE);
+        assert_field_eq(&event, "failure_reason", "safety_policy_refusal");
+        assert_field_eq(&event, "failure_framework", "codex");
+        assert_field_eq(&event, "failure_class", "cli_nonzero");
+        assert_field_eq(&event, "failure_detail_source", "codex_jsonl");
+    }
+
+    #[test]
+    fn unclassified_codex_provider_envelope_stays_at_error() {
+        let diagnostic = job_failure_diagnostic(None);
+        let failure = executor::ExecutionFailure::new(
+            1,
+            r#"{"error":{"message":"Invalid Format","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}"#,
+            Some(diagnostic),
+        );
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_eq!(event.level, Level::ERROR);
+        assert!(!event.fields.contains_key("failure_reason"));
+    }
+
+    #[test]
     fn oversized_codex_input_logs_cli_execution_failure_at_info() {
         let diagnostic = FailureDiagnostic::new(
             FailureClass::CliExecutionError,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -19511,7 +19511,11 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       },
     );
 
-    describe.each(["input_too_large", "execution_timeout"] as const)(
+    describe.each([
+      "input_too_large",
+      "execution_timeout",
+      "safety_policy_refusal",
+    ] as const)(
       "globally suppresses %s",
       (failureReason) => {
         it.each([

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -19515,28 +19515,25 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       "input_too_large",
       "execution_timeout",
       "safety_policy_refusal",
-    ] as const)(
-      "globally suppresses %s",
-      (failureReason) => {
-        it.each([
-          { name: "BYOK", modelProvider: "anthropic-api-key" },
-          { name: "built-in", modelProvider: "built-in" },
-          {
-            name: "legacy provider",
-            persistedModelProvider: "legacy-unknown-provider",
-          },
-        ] satisfies readonly (FailureCase & { readonly name: string })[])(
-          "suppresses the generic log for $name",
-          async (provider) => {
-            const { runId } = await completeFailure({
-              ...provider,
-              failureReason,
-            });
-            expect(genericFailureLogCalls(runId)).toHaveLength(0);
-          },
-        );
-      },
-    );
+    ] as const)("globally suppresses %s", (failureReason) => {
+      it.each([
+        { name: "BYOK", modelProvider: "anthropic-api-key" },
+        { name: "built-in", modelProvider: "built-in" },
+        {
+          name: "legacy provider",
+          persistedModelProvider: "legacy-unknown-provider",
+        },
+      ] satisfies readonly (FailureCase & { readonly name: string })[])(
+        "suppresses the generic log for $name",
+        async (provider) => {
+          const { runId } = await completeFailure({
+            ...provider,
+            failureReason,
+          });
+          expect(genericFailureLogCalls(runId)).toHaveLength(0);
+        },
+      );
+    });
 
     it.each([
       {

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -211,6 +211,9 @@ function shouldSuppressKnownFailureLog(
   failureReason: KnownRunFailureReason,
 ): boolean {
   switch (failureReason) {
+    // A content-safety rejection is decided by the submitted input, so it needs
+    // no operator action even when the built-in provider owns the credential.
+    case "safety_policy_refusal":
     case "input_too_large":
     case "execution_timeout": {
       return true;
@@ -226,7 +229,6 @@ function shouldSuppressKnownFailureLog(
     case "provider_stream_timeout":
     case "provider_server_error":
     case "response_connection_lost":
-    case "safety_policy_refusal":
     case "reconnect_required":
     case "usage_limit": {
       const providerType = modelProviderTypeSchema.safeParse(run.modelProvider);

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CHAT_RUN_CONTENT_POLICY_REJECTED_MESSAGE,
   CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE,
   CHAT_RUN_TRANSIENT_ERROR_MESSAGE,
   formatRunErrorForExternalSurface,
@@ -54,6 +55,32 @@ describe("formatRunErrorForExternalSurface", () => {
         failureReason: "execution_timeout",
       }),
     ).toBe(CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE);
+  });
+
+  it("replaces a content-policy refusal with non-retry guidance", () => {
+    const formatted = formatRunErrorForExternalSurface({
+      code: "UNKNOWN",
+      message:
+        '{"error":{"message":"Content Exists Risk","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}',
+      failureReason: "safety_policy_refusal",
+      framework: "codex",
+    });
+
+    expect(formatted).toBe(CHAT_RUN_CONTENT_POLICY_REJECTED_MESSAGE);
+    // The rejection is deterministic, so the copy must not invite a retry and
+    // must not echo the raw provider envelope back to the user.
+    expect(formatted).not.toContain("try again later");
+    expect(formatted).not.toContain("Content Exists Risk");
+  });
+
+  it("keeps an unclassified provider envelope on the generic message", () => {
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message:
+          '{"error":{"message":"Invalid Format","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}',
+      }),
+    ).toBe(CHAT_RUN_TRANSIENT_ERROR_MESSAGE);
   });
 
   it("keeps the canonical execution timeout message stable", () => {

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -238,6 +238,14 @@ export const CHAT_RUN_TRANSIENT_ERROR_MESSAGE =
 export const CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE =
   "This run reached its execution time limit.";
 
+/**
+ * A provider content-safety rejection is deterministic for the same input, so
+ * this copy must not invite a retry. It names the actions the user can take
+ * without describing or attributing the rejected content.
+ */
+export const CHAT_RUN_CONTENT_POLICY_REJECTED_MESSAGE =
+  "The model provider rejected this request under its content safety policy. Retrying the same input will fail again. Try rephrasing the request, starting a new conversation, or switching to a different model.";
+
 const AGENT_EXECUTION_TIMEOUT_RUN_ERROR =
   /^Agent execution timed out after [1-9]\d* seconds$/u;
 
@@ -680,6 +688,7 @@ export function isGenericRunErrorForDisplay(errorMessage: string): boolean {
 }
 
 type StructuredRunErrorBehavior =
+  | "content-policy"
   | "credential"
   | "execution-timeout"
   | "generic"
@@ -707,7 +716,7 @@ const STRUCTURED_RUN_ERROR_BEHAVIOR: Record<
   provider_stream_timeout: "generic",
   provider_server_error: "generic",
   response_connection_lost: "generic",
-  safety_policy_refusal: "generic",
+  safety_policy_refusal: "content-policy",
   reconnect_required: "reconnect",
   unsupported_model: "passthrough",
   usage_limit: "passthrough",
@@ -730,6 +739,9 @@ function formatStructuredRunError(params: {
   switch (STRUCTURED_RUN_ERROR_BEHAVIOR[knownReason.data]) {
     case "execution-timeout": {
       return CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE;
+    }
+    case "content-policy": {
+      return CHAT_RUN_CONTENT_POLICY_REJECTED_MESSAGE;
     }
     case "insufficient-credits": {
       return "insufficient_credits";

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -722,6 +722,21 @@ const STRUCTURED_RUN_ERROR_BEHAVIOR: Record<
   usage_limit: "passthrough",
 };
 
+function formatReconnectRunError(
+  recovery: ClaudeCodeCredentialRecovery | undefined,
+): string {
+  if (recovery?.modelProviderType === "codex-oauth-token") {
+    return CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE;
+  }
+  if (recovery?.modelProviderType === "claude-code-oauth-token") {
+    return (
+      formatClaudeCodeCredentialRecoveryMessage(recovery) ??
+      CHAT_RUN_TRANSIENT_ERROR_MESSAGE
+    );
+  }
+  return CHAT_RUN_TRANSIENT_ERROR_MESSAGE;
+}
+
 function formatStructuredRunError(params: {
   readonly failureReason: RunFailureReasonToken;
   readonly errorMessage: string;
@@ -756,23 +771,7 @@ function formatStructuredRunError(params: {
       return recoveryMessage ?? CHAT_RUN_TRANSIENT_ERROR_MESSAGE;
     }
     case "reconnect": {
-      if (
-        params.claudeCodeCredentialRecovery?.modelProviderType ===
-        "codex-oauth-token"
-      ) {
-        return CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE;
-      }
-      if (
-        params.claudeCodeCredentialRecovery?.modelProviderType ===
-        "claude-code-oauth-token"
-      ) {
-        return (
-          formatClaudeCodeCredentialRecoveryMessage(
-            params.claudeCodeCredentialRecovery,
-          ) ?? CHAT_RUN_TRANSIENT_ERROR_MESSAGE
-        );
-      }
-      return CHAT_RUN_TRANSIENT_ERROR_MESSAGE;
+      return formatReconnectRunError(params.claudeCodeCredentialRecovery);
     }
     case "terms": {
       return withOptionalActionUrl(


### PR DESCRIPTION
## Problem

Fixes #33072.

An OpenAI-compatible provider reports a content-safety rejection as an `invalid_request_error` envelope whose message is a fixed phrase rather than a request-shape complaint:

```json
{"error":{"message":"Content Exists Risk","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}
```

Codex passes that envelope through as the turn failure message. It carries no `codexErrorInfo` variant, and the existing Codex safety matcher requires an exact different phrase, so nothing classified it. Every affected run therefore ended as an unclassified `cli_nonzero` failure with `failure_reason` absent.

That single gap produced three separate problems:

1. `is_info_level_job_failure` only downgrades a `cli_nonzero` failure when a reason is present, so the runner logged `job execution failed` at `error`.
2. `shouldSuppressFailureLog` cannot parse an absent reason, so the API logged `Run failed` at `warn`.
3. `formatRunErrorForExternalSurface` fell through to `CHAT_RUN_TRANSIENT_ERROR_MESSAGE` — "Oops, something went wrong. Please try again later." — which invites a retry for a rejection that is deterministic for the same input. `safety_policy_refusal` was already mapped to the same `generic` behavior, so classifying alone would not have changed the copy.

Production evidence for the reviewed window (Axiom `vm0-web-logs-prod`, full-text `search 'Content Exists Risk'`) showed exactly 20 records across 10 distinct runs, all with `failure_reason` null, `failure_class=cli_nonzero`, `failure_framework=codex`, `failure_detail_source=codex_jsonl`, and a retry burst of 7 attempts inside 7 minutes with two pairs of near-identical `prompt_bytes`.

## Change

**Classification** (`crates/guest-agent`)

- Add `is_content_policy_rejection_message` to `failure_patterns`, the module that already owns predicates shared by structured event extraction and final diagnostic classification. It scans embedded JSON objects and requires `message`, `type`, and `code` to match together, so a genuine malformed request — which shares the `invalid_request_error` type — keeps its actionable unclassified failure.
- Move `parse_next_json_object` into `failure_patterns` so both modules use one scanner instead of a copy.
- Wire the predicate into `codex_error_failure_reason` (event extraction) and `classify_cli_failure_reason` (final diagnostic), scoped to the Codex framework and the `codex_jsonl` detail source.

`SafetyPolicyRefusal` is reused rather than adding a token: the semantics match, it is already in the runner's info-level allowlist, and `FailureReason` / `KnownRunFailureReason` are a cross-language wire contract whose extension would need a compatibility window for no behavioral gain.

**User-facing copy** (`turbo/packages/api-contracts`)

- Add `CHAT_RUN_CONTENT_POLICY_REJECTED_MESSAGE` and a `content-policy` structured behavior, and map `safety_policy_refusal` to it. The copy states the outcome, says a retry of the same input will fail again, and names three actions that exist in the product (rephrase, start a new conversation, switch model). It does not describe or attribute the rejected content, and it does not echo the provider envelope back to the user.

**API log suppression** (`turbo/apps/api`)

- Suppress the `Run failed` warning for `safety_policy_refusal` for every provider, alongside `input_too_large` and `execution_timeout`. The provider-scoped rule exists because a built-in credential failure may need operator action; a content-safety rejection is decided by the submitted input, so no operator action exists regardless of who owns the credential.

No log level, alert filter, or catch was broadened. Unclassified provider failures still surface at `error` / `warn` with the generic copy.

## Tests

- `failure_patterns`: envelope accepted bare, wrapped in prose, and after a leading non-matching object; rejected for `Invalid Format`, `Input token length too long`, a missing `type` or `code`, a `content_filter` type, a superstring message, a non-envelope `detail` shape, bare prose, malformed JSON, and empty input.
- `failure_diagnostics`: classified for Codex + `codex_jsonl`; unclassified for other `invalid_request_error` messages; unclassified for the `stderr` source and the Claude Code framework.
- `codex_app_server_events`: a failed `turn/completed` carrying the envelope resolves to `SafetyPolicyRefusal`; the `Invalid Format` envelope stays `None`.
- `job_terminal_log`: the classified failure logs at `INFO` with `failure_reason=safety_policy_refusal`; an unclassified provider envelope stays at `ERROR` with no reason field (negative control).
- `codex_app_server_backend_structured_errors`: two new `codex-mock` scenarios drive the real guest-agent entry point end to end — `runtime-turn-failed-content-policy-rejection` expects the reason, `runtime-turn-failed-invalid-request-format` expects none.
- `errors.test.ts`: the refusal returns the new copy and contains neither "try again later" nor the raw provider phrase; an unclassified envelope still returns the generic message.
- `run-lifecycle.bdd.test.ts`: `safety_policy_refusal` joins the globally suppressed group, covering BYOK, built-in, and legacy providers. The existing "keeps visible" controls (built-in `provider_rate_limited`, absent reason, `session_history_limit`, `unsupported_model`) are unchanged.

## Verification

Ran locally: `cargo fmt --all --check` (clean), `cargo clippy --profile local -p guest-agent -p codex-mock --all-targets` (clean), and `cargo test --profile local -p guest-agent --lib` for the classification modules — 141 passed, including every new case.

The `runner` binary test target and the TypeScript suites were not run locally; this environment has no installed JS dependencies and the runner target had not finished compiling. Both are left to CI.

## Deployment compatibility

Forward and backward compatible in both directions. An old runner sends no `failureReason` and keeps today's behavior. A new runner sends `safety_policy_refusal`, which the current API already accepts through `knownRunFailureReasonSchema`; an API without this change simply applies the older provider-scoped suppression.

## Follow-up, not in this PR

The affected runs were threadless and had already been removed by `threadless-run-cleanup`, so no per-run model or provider attribution was recoverable from the database. Adding a non-sensitive `model_runtime_provider` / `selected_model` field to the terminal failure telemetry would make this class of incident attributable after the fact. That is an observability change beyond this issue and should be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
