### PR TITLE
fix(platform): remove sidebar shells from standalone pages

### DIFF
--- a/turbo/apps/platform/src/signals/browser-authorization/browser-authorization-page-setup.ts
+++ b/turbo/apps/platform/src/signals/browser-authorization/browser-authorization-page-setup.ts
@@ -9,7 +9,7 @@ import { updatePage$ } from "../react-router.ts";
 
 export const setupBrowserAuthorizationPage$ = command(
   async ({ set }, signal: AbortSignal) => {
-    set(updatePage$, createElement(BrowserAuthorizationPage), "minimal");
+    set(updatePage$, createElement(BrowserAuthorizationPage), "standalone");
     set(
       updateDocumentTitle$,
       i18n.t(($) => {

--- a/turbo/apps/platform/src/signals/browser-session/browser-session-page-setup.ts
+++ b/turbo/apps/platform/src/signals/browser-session/browser-session-page-setup.ts
@@ -21,7 +21,7 @@ export const setupBrowserSessionPage$ = command(
       setBrowserSessionPageSignals$,
       descriptor ? createBrowserSessionPageSignals(descriptor.threadId) : null,
     );
-    set(updatePage$, createElement(BrowserSessionPage), "minimal");
+    set(updatePage$, createElement(BrowserSessionPage), "standalone");
     set(
       updateDocumentTitle$,
       i18n.t(($) => {

--- a/turbo/apps/platform/src/signals/computer-use-authorization/computer-use-authorization-page-setup.ts
+++ b/turbo/apps/platform/src/signals/computer-use-authorization/computer-use-authorization-page-setup.ts
@@ -8,7 +8,7 @@ import { updatePage$ } from "../react-router.ts";
 
 export const setupComputerUseAuthorizationPage$ = command(
   async ({ set }, signal: AbortSignal) => {
-    set(updatePage$, createElement(ComputerUseAuthorizationPage), "minimal");
+    set(updatePage$, createElement(ComputerUseAuthorizationPage), "standalone");
     set(
       updateDocumentTitle$,
       i18n.t(($) => {

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-page-setup.ts
@@ -13,7 +13,7 @@ export const setupDirectedAuthorizePage$ = command(
     const connectorSlug =
       typeof params?.connectorSlug === "string" ? params.connectorSlug : "";
 
-    set(updatePage$, createElement(DirectedAuthorizePage), "minimal");
+    set(updatePage$, createElement(DirectedAuthorizePage), "standalone");
     set(
       updateDocumentTitle$,
       i18n.t(

--- a/turbo/apps/platform/src/signals/connectors-page/directed-connect-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-connect-page-setup.ts
@@ -13,7 +13,7 @@ export const setupDirectedConnectPage$ = command(
     const connectorSlug =
       typeof params?.connectorSlug === "string" ? params.connectorSlug : "";
 
-    set(updatePage$, createElement(DirectedConnectPage), "minimal");
+    set(updatePage$, createElement(DirectedConnectPage), "standalone");
     set(
       updateDocumentTitle$,
       i18n.t(

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-page-setup.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-page-setup.ts
@@ -12,7 +12,7 @@ export const setupPermissionAllowPage$ = command(
     await get(initialFeatureSwitchHydration$);
     signal.throwIfAborted();
 
-    set(updatePage$, createElement(PermissionAllowPage), "minimal");
+    set(updatePage$, createElement(PermissionAllowPage), "standalone");
     set(
       updateDocumentTitle$,
       i18n.t(($) => {

--- a/turbo/apps/platform/src/signals/react-router.ts
+++ b/turbo/apps/platform/src/signals/react-router.ts
@@ -1,7 +1,7 @@
 import { command, computed, state } from "ccstate";
 import type { ReactNode } from "react";
 
-type PageLayout = "sidebar" | "minimal" | "none";
+type PageLayout = "sidebar" | "standalone" | "none";
 
 const internalLayout$ = state<PageLayout>("none");
 const internalPage$ = state<ReactNode | undefined>(undefined);

--- a/turbo/apps/platform/src/signals/redeem-campaign/redeem-campaign-page-setup.ts
+++ b/turbo/apps/platform/src/signals/redeem-campaign/redeem-campaign-page-setup.ts
@@ -26,7 +26,7 @@ import {
  */
 export const setupRedeemCampaignPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    set(updatePage$, createElement(RedeemCampaignPage), "minimal");
+    set(updatePage$, createElement(RedeemCampaignPage), "standalone");
     set(
       updateDocumentTitle$,
       i18n.t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/directed-shared.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-shared.tsx
@@ -2,22 +2,18 @@ import type { ReactNode } from "react";
 import { useGet, useSet } from "ccstate-react";
 import { Loader2 } from "lucide-react";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { handleAccountAction$ } from "../../signals/okou-page/nav.ts";
 import { ProductBrandMark } from "../components/product-brand-mark.tsx";
 import { Link } from "../router/link.tsx";
 import { CreditPurchaseConfirmDialog } from "./components/org-manage/credit-purchase-confirm-dialog.tsx";
 import { SubscriptionPurchaseConfirmDialog } from "./components/org-manage/subscription-purchase-confirm-dialog.tsx";
 import { SettingsDialogMount } from "./components/settings/settings-dialog.tsx";
-import { AccountDropdown } from "./sidebar-account";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   colorTheme$,
   shellDocumentAttributesRef$,
 } from "../../signals/theme.ts";
-import { WorkspaceInset } from "./workspace-inset.tsx";
 
-export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
-  const onAccountAction = useSet(handleAccountAction$);
+export function StandaloneLayout({ children }: { children: ReactNode }) {
   const colorTheme = useGet(colorTheme$);
   const features = useGet(featureSwitch$);
   const gradientColorThemesEnabled =
@@ -27,20 +23,14 @@ export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
   return (
     <div
       ref={shellDocumentAttributesRef}
-      className="okou-app okou-viewport-shell flex w-full bg-background md:bg-sidebar"
+      className="okou-app okou-viewport-shell flex w-full flex-col bg-background"
       data-gradient-color-themes={gradientColorThemesEnabled || undefined}
       data-color-theme={gradientColorThemesEnabled ? colorTheme : undefined}
     >
       <SettingsDialogMount />
       <CreditPurchaseConfirmDialog />
       <SubscriptionPurchaseConfirmDialog />
-      <aside className="okou-nav hidden md:flex h-full w-[255px] shrink-0 flex-col bg-sidebar">
-        <div className="flex-1" />
-        <div className="p-2">
-          <AccountDropdown onAccountAction={onAccountAction} />
-        </div>
-      </aside>
-      <WorkspaceInset>{children}</WorkspaceInset>
+      {children}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/redeem-campaign-page/redeem-campaign-page.tsx
+++ b/turbo/apps/platform/src/views/redeem-campaign-page/redeem-campaign-page.tsx
@@ -217,7 +217,7 @@ export function RedeemCampaignPage() {
   const info = resolveCard(response, stripeSuccess, orgName, t);
 
   return (
-    <div className="flex min-h-0 flex-1 items-center justify-center px-6 md:-translate-x-[128px]">
+    <div className="flex min-h-0 flex-1 items-center justify-center px-6">
       <div className="flex w-[500px] max-w-full flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-[50px] py-12">
         <ProductBrandMark />
         <div className="flex flex-col items-center gap-4">

--- a/turbo/apps/platform/src/views/router.tsx
+++ b/turbo/apps/platform/src/views/router.tsx
@@ -9,7 +9,7 @@ import {
 } from "../signals/app-skeleton.ts";
 import { AppSkeleton } from "./okou-page/app-skeleton.tsx";
 import { SidebarLayout } from "./okou-page/sidebar-layout.tsx";
-import { MinimalSidebarLayout } from "./okou-page/directed-shared.tsx";
+import { StandaloneLayout } from "./okou-page/directed-shared.tsx";
 
 function PageSlot() {
   const page = useGet(page$);
@@ -21,8 +21,8 @@ function LayoutHost({ children }: { children: ReactNode }) {
   if (layout === "sidebar") {
     return <SidebarLayout>{children}</SidebarLayout>;
   }
-  if (layout === "minimal") {
-    return <MinimalSidebarLayout>{children}</MinimalSidebarLayout>;
+  if (layout === "standalone") {
+    return <StandaloneLayout>{children}</StandaloneLayout>;
   }
   return <>{children}</>;
 }

--- a/turbo/style-legacy-baseline.json
+++ b/turbo/style-legacy-baseline.json
@@ -4048,7 +4048,6 @@
     },
     "apps/platform/src/views/okou-page/directed-shared.tsx": {
       "okou-app": 1,
-      "okou-nav": 1,
       "okou-viewport-shell": 1
     },
     "apps/platform/src/views/okou-page/ideation-page.tsx": {


### PR DESCRIPTION
## Summary

Standalone connector and authorization pages currently render over a 255px sidebar and an inset workspace, leaving empty navigation backgrounds and a rounded workspace frame behind their centered content. Replace that shared layout with a full-width `StandaloneLayout` and a uniform page background.

This covers connector connection, reconnection and authorization, Browser authorization and sessions, Computer Use authorization, permission confirmations, and campaign redemption. Remove the redemption page's 128px sidebar compensation so its card remains centered. Theme handling and shared dialogs are preserved; normal application pages keep their sidebar layout.

Closes #33173

## Verification

- Platform production, test, and build-config TypeScript checks passed.
- ESLint, Oxlint (including type-aware checks), and Tailwind class checks passed for the changed files.
- Style policy and Platform-scoped Knip passed; the legacy style baseline only removes the unused sidebar class reference.
- Formatting and `git diff --check` passed.
- Full Vitest is deferred to the PR pipeline. No local development server or browser QA was run, following the user's repository instructions.
