### PR TITLE
feat(app): list the create types directly in the slash menu behind a switch

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
@@ -640,3 +640,66 @@ test("Canceling and switching Create preserve slash text and template references
     }),
   );
 });
+
+async function setupComposerWithFlatSlash(
+  flatSlash: boolean,
+): Promise<HTMLElement> {
+  await setupPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+    featureSwitches: {
+      [FeatureSwitchKey.ComposerCreateCommands]: true,
+      [FeatureSwitchKey.ComposerCreateFlatSlash]: flatSlash,
+    },
+  });
+  return await findComposerEditor();
+}
+
+test("The slash menu keeps the Create type chooser until the Lab switch is on", async () => {
+  setupModels();
+  mockChatLifecycle(context);
+  const editor = await setupComposerWithFlatSlash(false);
+  await fill(editor, "Our launch /create");
+  const menu = await screen.findByTestId("slash-workflow-menu");
+  expect(
+    queryAllByRoleFast("button", menu)
+      .map((item) => {
+        return item.getAttribute("aria-label");
+      })
+      .filter((label) => {
+        return label?.startsWith("Create");
+      }),
+  ).toStrictEqual(["Create"]);
+  click(button("Create", menu));
+  await screen.findByRole("group", { name: "Choose a type" });
+});
+
+test("The slash menu lists every create type in one step when the switch is on", async () => {
+  setupModels();
+  mockChatLifecycle(context);
+  const editor = await setupComposerWithFlatSlash(true);
+  await fill(editor, "Our launch /create");
+  const menu = await screen.findByTestId("slash-workflow-menu");
+  expect(
+    queryAllByRoleFast("button", menu)
+      .map((item) => {
+        return item.getAttribute("aria-label");
+      })
+      .filter((label) => {
+        return label?.startsWith("Create");
+      }),
+  ).toStrictEqual(["Create presentation", "Create video", "Create image"]);
+
+  click(button("Create video", menu));
+  await waitFor(() => {
+    expect(screen.getByTestId("composer-create-mode")).toHaveTextContent(
+      "Create video",
+    );
+  });
+  // The second row of type buttons is what moved the composer; it must never
+  // appear on this path.
+  expect(screen.queryByRole("group", { name: "Choose a type" })).toBeNull();
+  expect(screen.queryByTestId("slash-workflow-menu")).toBeNull();
+  expect(editor).toHaveTextContent("Our launch");
+  expect(editor).not.toHaveTextContent("/create");
+});

--- a/turbo/apps/platform/src/views/okou-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/tiptap-workflow-composer.tsx
@@ -306,6 +306,8 @@ function useComposerCreateSuggestions(
 ): readonly ComposerCreateCommand[] {
   useTranslation();
   const enabled = useGet(composer.create.enabled$);
+  const flatSlash =
+    useGet(featureSwitch$)[FeatureSwitchKey.ComposerCreateFlatSlash] === true;
   if (!enabled || query === undefined) {
     return [];
   }
@@ -314,7 +316,10 @@ function useComposerCreateSuggestions(
     "create".startsWith(normalized) ||
     composerCreateCommandLabel("choose").toLowerCase().startsWith(normalized)
   ) {
-    return ["choose"];
+    // Under ComposerCreateFlatSlash the menu answers the query in one level.
+    // The `choose` entry exists only to open a second row of type buttons above
+    // the composer, which moves the composer by its own height.
+    return flatSlash ? composer.create.modes : ["choose"];
   }
   return composer.create.modes.filter((mode) => {
     return (

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -81,4 +81,5 @@ export enum FeatureSwitchKey {
   AvatarFraming = "avatarFraming",
   ConnectorDirectory = "connectorDirectory",
   ChatThreadHeaderActions = "chatThreadHeaderActions",
+  ComposerCreateFlatSlash = "composerCreateFlatSlash",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -508,6 +508,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ComposerCreateFlatSlash]: {
+    maintainer: "tongx@okou.ai",
+    description:
+      "List the create types directly in the slash menu instead of a Create entry that opens a second row of type buttons above the composer.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## What

Adds `composerCreateFlatSlash` (Lab -> Beta, staff orgs). With it on, typing `/`
lists **Create presentation**, **Create video** and **Create image** as ordinary
menu entries. With it off, the existing `Create ▸` entry and its type-chooser
row are untouched.

## Why

`Create ▸` is a second presentation of the same three options, and it presents
them somewhere else: `ComposerCreateControls`' `choosing` branch mounts a
`min-h-11` row with `pb-3` directly above `ComposerCard`. Entering and leaving
that row moves the composer by 56px, and while it is open `canSend` is forced
false, so the send control goes disabled with content already in the draft.

Removing the level makes the choice one keystroke instead of two and takes the
composer's position out of the interaction.

This replaces #33151, which removed the chooser outright and was closed. Gating
it means both paths stay live, so the two can be compared in Lab before either
is deleted.

## How

- New key + registry entry, `enabled: false` + `STAFF_ORG_ID_HASHES`, so it
  lands in Lab under Beta and is off for everyone else.
- `useComposerCreateSuggestions` returns `composer.create.modes` for a `create`
  query when the switch is on, and the existing `"choose"` entry when it is off.

That is the whole behavioural change. `choosing$`, the chooser row, its Escape
handler and the `choosingCreateType$` send guard are all still in place and are
still reached with the switch off; deleting them belongs to the switch's
graduation, not to this PR.

## Verification

- `vitest run src/views/okou-page/__tests__/chat-composer-create.test.tsx` — 17 passed
- `vitest run src` in `packages/core` — 244 passed
- `pnpm run check-types` (platform), `eslint` on changed files, `prettier --check`

Two tests added:
- switch off — `/create` still offers exactly one `Create` entry and it opens
  the `Choose a type` group;
- switch on — `/create` lists the three types, picking one sets the mode in a
  single step, no `Choose a type` group is ever rendered, and the slash text is
  consumed.

The existing two-step tests are unchanged and cover the switch-off default.
