### PR TITLE
fix(app): rank compact workflow fuzzy matches first

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/workflow-composer-domain.ts
+++ b/turbo/apps/platform/src/signals/okou-page/workflow-composer-domain.ts
@@ -9,6 +9,8 @@ export function findWorkflowQueryMatches(
   const matches: {
     workflow: ComposerSlashWorkflowMatch;
     rank: number;
+    skippedCharacters: number;
+    start: number;
   }[] = [];
 
   for (const workflow of workflows) {
@@ -22,23 +24,35 @@ export function findWorkflowQueryMatches(
         },
         rank:
           fuzzy && normalizedName === normalizedQuery ? 0 : start === 0 ? 1 : 2,
+        skippedCharacters: 0,
+        start,
       });
       continue;
     }
     if (fuzzy && normalizedQuery.length >= 3) {
-      const matchRanges = findWorkflowSubsequence(
-        normalizedName,
-        normalizedQuery,
-      );
-      if (matchRanges) {
-        matches.push({ workflow: { ...workflow, matchRanges }, rank: 3 });
+      const match = findWorkflowSubsequence(normalizedName, normalizedQuery);
+      if (match) {
+        matches.push({
+          workflow: { ...workflow, matchRanges: match.ranges },
+          rank: 3,
+          skippedCharacters: match.skippedCharacters,
+          start: match.start,
+        });
       }
     }
   }
 
   return matches
     .sort((left, right) => {
-      return left.rank - right.rank;
+      if (left.rank !== 3 || right.rank !== 3) {
+        return left.rank - right.rank;
+      }
+      // Prefer compact abbreviations, then earlier matches and shorter names.
+      return (
+        left.skippedCharacters - right.skippedCharacters ||
+        left.start - right.start ||
+        left.workflow.name.length - right.workflow.name.length
+      );
     })
     .map((match) => {
       return match.workflow;
@@ -48,15 +62,26 @@ export function findWorkflowQueryMatches(
 function findWorkflowSubsequence(
   name: string,
   query: string,
-): readonly WorkflowMatchRange[] | null {
+): {
+  readonly ranges: readonly WorkflowMatchRange[];
+  readonly skippedCharacters: number;
+  readonly start: number;
+} | null {
   const ranges: WorkflowMatchRange[] = [];
   let offset = 0;
+  let skippedCharacters = 0;
+  let matchStart = 0;
 
   // Keep numeric identifiers contiguous while allowing letters to skip ahead.
   for (const [part] of query.matchAll(/\d+|\D/g)) {
     const start = name.indexOf(part, offset);
     if (start === -1) {
       return null;
+    }
+    if (ranges.length === 0) {
+      matchStart = start;
+    } else {
+      skippedCharacters += start - offset;
     }
     offset = start + part.length;
     const previous = ranges.at(-1);
@@ -67,7 +92,7 @@ function findWorkflowSubsequence(
     }
   }
 
-  return ranges;
+  return { ranges, skippedCharacters, start: matchStart };
 }
 
 export interface SlashWorkflowRange {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-workflows.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-workflows.test.tsx
@@ -573,6 +573,57 @@ test("Rank exact workflow names before prefixes, substrings, and abbreviations",
   });
 });
 
+test("Rank compact workflow abbreviations before scattered matches", async () => {
+  mockAgent();
+  mockThread();
+  installWorkflows(() => {
+    return [
+      workflow("pr-32809-app-production-watch"),
+      workflow("team-pr-auto"),
+      workflow("pr-auto-bravo"),
+      workflow("pr-auto-alpha"),
+      workflow("pr-auto"),
+    ];
+  });
+
+  await setupPage({
+    context,
+    path: `/chats/${THREAD_ID}`,
+    featureSwitches: { [FeatureSwitchKey.ComposerWorkflowFuzzySearch]: true },
+  });
+
+  const user = userEvent.setup();
+  const editor = await findComposerEditor();
+  await user.click(editor);
+  await user.keyboard("/prauto");
+
+  await waitFor(() => {
+    expect(slashWorkflowNames()).toStrictEqual([
+      "/pr-auto",
+      "/pr-auto-bravo",
+      "/pr-auto-alpha",
+      "/team-pr-auto",
+      "/pr-32809-app-production-watch",
+    ]);
+  });
+  const highlighted = Array.from(
+    slashButton("/pr-auto").querySelectorAll(
+      '[data-slot="workflow-query-match"]',
+    ),
+    (element) => {
+      return element.textContent;
+    },
+  );
+  expect(highlighted).toStrictEqual(["pr", "auto"]);
+
+  await user.keyboard("{Enter}");
+
+  await waitFor(() => {
+    expect(editor).toHaveTextContent(/^\/pr-auto\s*$/);
+    expect(screen.queryByTestId("slash-workflow-menu")).toBeNull();
+  });
+});
+
 test("Keep numeric workflow identifiers contiguous in abbreviated queries", async () => {
   mockAgent();
   mockThread();


### PR DESCRIPTION
## Summary

Typing `/prauto` could rank `pr-32809-app-production-watch` above `pr-auto` because all subsequence matches kept their original list order. Rank these fuzzy matches by fewer skipped characters, then an earlier match position and a shorter name. Equally relevant results retain their existing order.

Exact, prefix, and substring priorities, numeric identifier matching, and the existing `composerWorkflowFuzzySearch` switch remain unchanged. Matching ranges continue to drive the name highlights.

## Verification

- Reproduced the reported ordering failure with the new page regression test before applying the fix.
- All 17 tests in `chat-composer-workflows.test.tsx` pass, including result order, highlights, and Enter inserting `/pr-auto`.
- App TypeScript checks, focused ESLint/Oxlint checks, App Knip, formatting, and `git diff --check` pass.
- Full test suites are delegated to the PR pipeline; no local development server was started.
- The [App preview](https://pr-33186-app-okou-app-preview.vm0.workers.dev/) loads the sign-in page in Chromium. Its deployed merge SHA is `df7c6dae7bb01c88586f18daba725436ca062e06`, which includes PR head `6dda977845a5e831a4697692cc60fd2fc8ce11ad`.
- The [preview API deployment](https://github.com/vm0-ai/vm0/actions/runs/34442842053/job/102761404237) is blocked by Neon's concurrent-active-endpoint limit during database setup. Full browser acceptance requires that environment to recover.

## Acceptance

1. In a preview account with `composerWorkflowFuzzySearch` enabled, make `pr-auto` and `pr-32809-app-production-watch` available to the selected agent.
2. Type `/prauto` in the chat composer. `pr-auto` should appear first, with `pr` and `auto` highlighted.
3. Press Enter. The composer should contain `/pr-auto` and close the suggestion menu.
