### PR TITLE
perf(runner): reclaim exact idle sandboxes after ci workloads

### DIFF
--- a/.github/scripts/prune-runner-idle.sh
+++ b/.github/scripts/prune-runner-idle.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The deployment receipt is the authority. Never replace its generation by
+# reading the current runner_id/heartbeat_generation during cleanup.
+: "${RUNNER_RECEIPT:?deployment receipt is required}"
+: "${METAL_HOSTS:?metal inventory is required}"
+: "${METAL_USER:?SSH user is required}"
+: "${JOB_REF:?runner image namespace is required}"
+: "${RUNNER_SERVICE_REF:?service namespace is required}"
+
+if [[ ! "$METAL_USER" =~ ^[A-Za-z_][A-Za-z0-9_-]*$ ]] ||
+  [[ ! "$JOB_REF" =~ ^(pr-[1-9][0-9]*|staging-[0-9a-f]{7,40})$ ]]; then
+  echo "Invalid Runner cleanup namespace or SSH user" >&2
+  exit 2
+fi
+expected_service_ref=$JOB_REF
+if [[ "$JOB_REF" == staging-* ]]; then
+  expected_service_ref=staging
+fi
+if [ "$RUNNER_SERVICE_REF" != "$expected_service_ref" ]; then
+  echo "Runner service namespace does not match image namespace" >&2
+  exit 2
+fi
+
+jq -e '
+  type == "object" and
+  (.host | type == "string" and test("^[A-Za-z0-9][A-Za-z0-9.-]*$")) and
+  (.service | type == "string") and (.binDir | type == "string") and
+  (.runnerId | type == "string" and test("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")) and
+  (.heartbeatGeneration | type == "number" and . > 0 and . <= 9007199254740991 and . == floor)
+' <<<"$RUNNER_RECEIPT" >/dev/null
+host=$(jq -r .host <<<"$RUNNER_RECEIPT")
+service=$(jq -r .service <<<"$RUNNER_RECEIPT")
+bin_dir=$(jq -r .binDir <<<"$RUNNER_RECEIPT")
+runner_id=$(jq -r .runnerId <<<"$RUNNER_RECEIPT")
+generation=$(jq -r .heartbeatGeneration <<<"$RUNNER_RECEIPT")
+
+matched=false
+index=0
+for inventory_host in $(echo "$METAL_HOSTS" | tr ',' ' '); do
+  index=$((index + 1))
+  if [ "$inventory_host" = "$host" ] && [ "$service" = "${RUNNER_SERVICE_REF}-${index}" ]; then
+    matched=true
+  fi
+done
+if ! $matched || [ "$bin_dir" != "/var/lib/vm0-runner/bin/${JOB_REF}" ]; then
+  echo "Deployment receipt does not match this namespace and metal inventory" >&2
+  exit 2
+fi
+
+# Every interpolated target is validated above. A missing/old binary, vanished
+# generation, or peer mismatch fails; there is no signal or host-wide fallback.
+# shellcheck disable=SC2029
+timeout 150s ssh -o BatchMode=yes -o ConnectTimeout=15 \
+  -o ServerAliveInterval=15 -o ServerAliveCountMax=3 "${METAL_USER}@${host}" \
+  "sudo ${bin_dir}/runner service prune-idle --name ${service} --expected-runner-id ${runner_id} --expected-heartbeat-generation ${generation} --timeout-secs 120"

--- a/.github/scripts/reconcile-and-start-runner-groups.sh
+++ b/.github/scripts/reconcile-and-start-runner-groups.sh
@@ -49,6 +49,7 @@ export SELECTED_HOST
 echo "Selected runner service host: ${SELECTED_HOST}"
 
 work_dir=$(mktemp -d "${RUNNER_TEMP:-/tmp}/runner-reconcile-start.XXXXXX")
+export RUNNER_RECEIPT_FILE="${work_dir}/receipt.json"
 trap 'rm -rf "$work_dir"' EXIT
 check_output="${work_dir}/check.out"
 
@@ -171,6 +172,23 @@ reconcile_service_on_host() {
   echo "Runner ready on ${HOST}: max_concurrent=${MC}"
   # shellcheck disable=SC2029
   ssh "$REMOTE" "sudo ${BIN_DIR}/runner doctor --name ${RUNNER_SERVICE_SUFFIX}"
+
+  # Capture the deployed generation while the caller still owns its lifecycle
+  # lock. Cleanup must not discover a replacement generation later.
+  local IDENTITY
+  IDENTITY=$(ssh "$REMOTE" bash -s -- "$RUNNER_DIR" <<'REMOTE_SCRIPT'
+set -euo pipefail
+runner_id=$(sudo cat "$1/runner_id")
+generation=$(sudo cat "$1/heartbeat_generation")
+[[ "$runner_id" =~ ^[0-9a-f-]{36}$ && "$generation" =~ ^[1-9][0-9]*$ ]]
+printf '{"runnerId":"%s","heartbeatGeneration":%s}\n' "$runner_id" "$generation"
+REMOTE_SCRIPT
+  )
+  jq -ce --arg host "$HOST" --arg service "$RUNNER_SERVICE_SUFFIX" --arg binDir "$BIN_DIR" '
+    select((.runnerId | type == "string" and test("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")) and
+      (.heartbeatGeneration | type == "number" and . > 0 and . <= 9007199254740991 and . == floor)) |
+    . + {host: $host, service: $service, binDir: $binDir}
+  ' <<<"$IDENTITY" >"$RUNNER_RECEIPT_FILE"
   echo "=== Runner started on ${HOST} ==="
 }
 
@@ -311,4 +329,8 @@ if [ "$FAILED" -ne 0 ]; then
   exit 1
 fi
 
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  receipt=$(jq -ce . "$RUNNER_RECEIPT_FILE")
+  printf 'runner-receipt=%s\n' "$receipt" >>"$GITHUB_OUTPUT"
+fi
 RUNNER_START_SUCCEEDED=1

--- a/.github/scripts/tests/prune-runner-idle-test.sh
+++ b/.github/scripts/tests/prune-runner-idle-test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+script="${repo_root}/.github/scripts/prune-runner-idle.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+mkdir -p "${test_dir}/bin"
+cat >"${test_dir}/bin/ssh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >"$SSH_LOG"
+exit "${SSH_RESULT:-0}"
+SH
+chmod +x "${test_dir}/bin/ssh"
+export PATH="${test_dir}/bin:$PATH" SSH_LOG="${test_dir}/ssh.log"
+export METAL_HOSTS=arm-1,x86-1,x86-2 METAL_USER=ci JOB_REF=pr-123 RUNNER_SERVICE_REF=pr-123
+receipt='{"host":"x86-1","service":"pr-123-2","binDir":"/var/lib/vm0-runner/bin/pr-123","runnerId":"550e8400-e29b-41d4-a716-446655440000","heartbeatGeneration":7}'
+export RUNNER_RECEIPT=$receipt
+bash "$script"
+grep -Fxq 'ci@x86-1' "$SSH_LOG"
+grep -Fxq 'sudo /var/lib/vm0-runner/bin/pr-123/runner service prune-idle --name pr-123-2 --expected-runner-id 550e8400-e29b-41d4-a716-446655440000 --expected-heartbeat-generation 7 --timeout-secs 120' "$SSH_LOG"
+
+# A failed request (including a stale generation or unsupported old binary)
+# remains a failure, and never retries against a newly discovered generation.
+status=0
+SSH_RESULT=1 bash "$script" >"${test_dir}/failure.log" 2>&1 || status=$?
+[ "$status" -eq 1 ]
+for invalid in \
+  '.host = "other-host"' \
+  '.service = "pr-999-2"' \
+  '.service = "pr-123-1"' \
+  '.binDir = "/var/lib/vm0-runner/bin/pr-999"' \
+  '.runnerId = "invalid"' \
+  '.heartbeatGeneration = 0' \
+  '.heartbeatGeneration = 1.5'; do
+  rm -f "$SSH_LOG"
+  invalid_receipt=$(jq -c "$invalid" <<<"$receipt")
+  if RUNNER_RECEIPT="$invalid_receipt" bash "$script" >"${test_dir}/invalid.log" 2>&1; then
+    echo "FAIL: accepted invalid deployment receipt: $invalid" >&2
+    exit 1
+  fi
+  [ ! -f "$SSH_LOG" ]
+done
+
+export JOB_REF=staging-abcdef123 RUNNER_SERVICE_REF=staging
+RUNNER_RECEIPT=$(jq -c '.service = "staging-2" | .binDir = "/var/lib/vm0-runner/bin/staging-abcdef123"' <<<"$receipt")
+bash "$script"
+grep -Fq -- '--name staging-2 --expected-runner-id' "$SSH_LOG"
+echo 'PASS: generation-fenced idle cleanup targets and failure propagation'

--- a/.github/scripts/tests/reconcile-and-start-runner-groups-test.sh
+++ b/.github/scripts/tests/reconcile-and-start-runner-groups-test.sh
@@ -36,6 +36,10 @@ if [ "$*" = "bash -s -- $BIN_DIR" ]; then
   jq -r --arg target "$target" '.[$target]' <<<"$RUNNER_SHA_MAP"
   exit 0
 fi
+if [ "$*" = "bash -s -- $RUNNER_DIR" ]; then
+  bash -s -- "${MOCK_REMOTE_ROOT}/${host}"
+  exit 0
+fi
 
 printf '%s\t%s\n' "$host" "$*" >>"$MOCK_SERVICE_LOG"
 service_name=$(printf '%s\n' "$*" | sed -n "s/.*--name ['\"]*\\([a-z0-9-]*\\).*/\\1/p")
@@ -53,6 +57,11 @@ case "$*" in
   "sudo rm -f ${RUNNER_DIR}/status.json") ;;
   "sudo ${BIN_DIR}/runner service start "*)
     printf '%s\n' "$*" >"${MOCK_REMOTE_ROOT}/${host}/${service_name}"
+    printf '550e8400-e29b-41d4-a716-446655440000\n' >"${MOCK_REMOTE_ROOT}/${host}/runner_id"
+    printf '7\n' >"${MOCK_REMOTE_ROOT}/${host}/heartbeat_generation"
+    if [ "${MOCK_FAILURE:-none}" = identity ]; then
+      printf 'invalid\n' >"${MOCK_REMOTE_ROOT}/${host}/heartbeat_generation"
+    fi
     ;;
   "sudo ${BIN_DIR}/runner service wait-running "*)
     if [ "${MOCK_FAILURE:-none}" = readiness ]; then
@@ -69,6 +78,11 @@ case "$*" in
 esac
 SH
 chmod +x "${tmp_dir}/bin/ssh"
+cat >"${tmp_dir}/bin/sudo" <<'SH'
+#!/usr/bin/env bash
+exec "$@"
+SH
+chmod +x "${tmp_dir}/bin/sudo"
 
 cat >"${tmp_dir}/run-deployment" <<'SH'
 #!/usr/bin/env bash
@@ -119,6 +133,7 @@ run_case() {
     MOCK_REMOTE_ROOT="$case_dir" \
     MOCK_SERVICE_LOG="${case_dir}/service.log" \
     MOCK_FAILURE="$failure" \
+    GITHUB_OUTPUT="${case_dir}/github-output" \
     bash "${tmp_dir}/run-deployment" "$script" >"${case_dir}/output" 2>&1 || status=$?
 
   if [ "$failure" != none ]; then
@@ -137,6 +152,11 @@ run_case() {
       fail "${case_name}: selected service lost its original inventory index"
     grep -Fq -- "--hostname ${selected_host}" "${case_dir}/${selected_host}/config" ||
       fail "${case_name}: config does not use the selected host"
+    receipt=$(sed -n 's/^runner-receipt=//p' "${case_dir}/github-output" | tail -n1)
+    jq -e --arg host "$selected_host" --arg service "${service_ref}-${selected_index}" '
+      .host == $host and .service == $service and
+      .runnerId == "550e8400-e29b-41d4-a716-446655440000" and .heartbeatGeneration == 7
+    ' <<<"$receipt" >/dev/null || fail "${case_name}: invalid deployment receipt"
   fi
 
   [ "$(awk '!/runner service stop / {print $1}' "${case_dir}/service.log" | sort -u)" = "$selected_host" ] ||
@@ -168,6 +188,7 @@ run_case x86 pr-1 x86-1 2 none
 run_case x86 pr-1 x86-1 2 none
 run_case arm pr-2 arm-1 1 none
 run_case failed-start pr-9 x86-2 3 readiness
+run_case invalid-identity pr-9 x86-2 3 identity
 run_case failed-retirement pr-1 x86-1 2 retire
 run_case cancelled-start pr-9 x86-2 3 cancel
 # A new staging image ref can select another host while service names stay fixed.

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -660,6 +660,7 @@ resolve_cleanup_scope = lambda do |prepare_result, runner_result|
   end
 end
 {
+  ["skipped", "skipped"] => "none",
   ["failure", "skipped"] => "generation",
   ["cancelled", "success"] => "generation",
   ["success", "success"] => "run",
@@ -690,15 +691,36 @@ cleanup_node_setup_step = cleanup_steps.find do |step|
 end
 
 conditional_setup_steps = [
-  cleanup_steps.find { |step| step.fetch("uses", "").start_with?("actions/checkout@") },
   cleanup_pnpm_setup_step,
   cleanup_node_setup_step,
   cleanup_steps.find { |step| step["name"] == "Install E2E dependencies" },
 ]
 unless conditional_setup_steps.all? do |step|
-    step && step["if"] == "steps.cleanup-scope.outputs.scope != 'retain'"
+    step && step["if"] == "steps.cleanup-scope.outputs.scope == 'generation' || steps.cleanup-scope.outputs.scope == 'run'"
   end
-  raise "retained accounts must skip checkout and dependency setup"
+  raise "retained or absent accounts must skip dependency setup"
+end
+
+unless Array(account_cleanup["needs"]).include?("cli-e2e-02-playwright") &&
+    Array(account_cleanup["needs"]).include?("deploy-runner-start")
+  raise "idle cleanup must wait for every shared Runner consumer"
+end
+shared_runner_consumers = jobs.select do |id, job|
+  Array(job["needs"]).include?("deploy-runner-start") &&
+    !["cli-e2e-03-runner-cleanup", "ci-gate-turbo"].include?(id)
+end.keys
+unless (shared_runner_consumers - Array(account_cleanup["needs"])).empty?
+  raise "every preview Runner consumer must finish before idle cleanup: #{shared_runner_consumers}"
+end
+unless account_cleanup.fetch("if").include?("needs.deploy-runner-start.result == 'success'")
+  raise "Playwright-only Runner deployments must remain eligible for cleanup"
+end
+checkout = cleanup_steps.find { |step| step.fetch("uses", "").start_with?("actions/checkout@") }
+raise "idle cleanup needs checkout even with retained accounts" if checkout.key?("if")
+prune_step = cleanup_steps.find { |step| step["name"] == "Reclaim exact idle sandboxes from the deployed runner" }
+unless prune_step && prune_step["if"] == "always() && needs.deploy-runner-start.result == 'success'" &&
+    prune_step.dig("env", "RUNNER_RECEIPT") == "${{ needs.deploy-runner-start.outputs.runner-receipt }}"
+  raise "idle cleanup must use the captured deployment receipt independently of account cleanup"
 end
 
 generation_cleanup_step = cleanup_steps.find do |step|

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -717,6 +717,12 @@ unless account_cleanup.fetch("if").include?("needs.deploy-runner-start.result ==
 end
 checkout = cleanup_steps.find { |step| step.fetch("uses", "").start_with?("actions/checkout@") }
 raise "idle cleanup needs checkout even with retained accounts" if checkout.key?("if")
+prune_ssh_step = cleanup_steps.find { |step| step["name"] == "Setup SSH for idle sandbox cleanup" }
+unless prune_ssh_step &&
+    prune_ssh_step["if"] == "always() && needs.deploy-runner-start.result == 'success'" &&
+    prune_ssh_step.dig("with", "ssh-hosts") == "${{ fromJSON(needs.deploy-runner-start.outputs.runner-receipt).host }}"
+  raise "idle cleanup must preconnect only its deployed host, independently of unrelated host availability"
+end
 prune_step = cleanup_steps.find { |step| step["name"] == "Reclaim exact idle sandboxes from the deployed runner" }
 unless prune_step && prune_step["if"] == "always() && needs.deploy-runner-start.result == 'success'" &&
     prune_step.dig("env", "RUNNER_RECEIPT") == "${{ needs.deploy-runner-start.outputs.runner-receipt }}"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -263,6 +263,7 @@ jobs:
             .github/scripts/verify-okou-app-assets.sh \
             .github/scripts/verify-okou-app-runtime.sh \
             .github/scripts/reconcile-and-start-runner-groups.sh \
+            .github/scripts/prune-runner-idle.sh \
             .github/scripts/reconcile-runner-binary-groups.sh \
             .github/actions/report-memory-peak/report.sh \
             .github/scripts/resolve-desktop-version-change.sh \
@@ -302,6 +303,7 @@ jobs:
             .github/scripts/tests/runner-promotion-ansible-test.sh \
             .github/scripts/tests/reconcile-runner-binary-groups-test.sh \
             .github/scripts/tests/reconcile-and-start-runner-groups-test.sh \
+            .github/scripts/tests/prune-runner-idle-test.sh \
             .github/scripts/tests/report-cgroup-memory-peak-test.sh \
             .github/scripts/tests/runner-lifecycle-lock-test.sh \
             .github/scripts/tests/rust-ci-memory-workflow-test.sh \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -3061,7 +3061,7 @@ jobs:
         uses: ./.github/actions/setup-ssh-tunnel
         with:
           ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
-          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          ssh-hosts: ${{ fromJSON(needs.deploy-runner-start.outputs.runner-receipt).host }}
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2473,6 +2473,8 @@ jobs:
   # Waits for both deploy-runner-prepare (binaries + image) and deploy-api (preview URL)
   deploy-runner-start:
     runs-on: ubuntu-latest
+    outputs:
+      runner-receipt: ${{ steps.start.outputs.runner-receipt }}
     permissions:
       actions: read
       contents: read
@@ -2506,6 +2508,7 @@ jobs:
       # manifest check, any validated recovery, and service readiness so a late
       # approval cannot turn the cleanup handoff into a check-then-act race.
       - name: Reconcile and start runner under lifecycle lock
+        id: start
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_DEFAULT_REGION: auto
@@ -2981,15 +2984,23 @@ jobs:
     continue-on-error: true
     env:
       E2E_CLERK_RESOURCE_DIR: /tmp/e2e-clerk-runner
+    # All tests that can submit runs to this preview service must finish first.
+    # Keep this list in sync with deploy-runner-start consumers (all matrix lanes).
+    # Crates behavior lanes own different local-provider Runner instances.
     needs:
       - prepare
+      - deploy-runner-start
+      - cli-e2e-02-playwright
       - cli-e2e-03-runner-prepare
       - cli-e2e-03-runner
     if: |
       always() &&
       needs.prepare.outputs.job-ref != '' &&
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      needs.cli-e2e-03-runner-prepare.result != 'skipped'
+      (
+        needs.cli-e2e-03-runner-prepare.result != 'skipped' ||
+        needs.deploy-runner-start.result == 'success'
+      )
     steps:
       - name: Determine runner E2E cleanup scope
         id: cleanup-scope
@@ -2999,7 +3010,9 @@ jobs:
           RUNNER_RESULT: ${{ needs.cli-e2e-03-runner.result }}
         run: |
           set -euo pipefail
-          if [[ "$PREPARE_RESULT" != "success" ]]; then
+          if [[ "$PREPARE_RESULT" == "skipped" ]]; then
+            scope="none"
+          elif [[ "$PREPARE_RESULT" != "success" ]]; then
             scope="generation"
           elif [[ "$RUNNER_RESULT" == "success" ]]; then
             scope="run"
@@ -3012,20 +3025,19 @@ jobs:
         if: steps.cleanup-scope.outputs.scope == 'retain'
         run: echo "Retaining runner E2E accounts until a successful rerun or fallback cleanup"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: steps.cleanup-scope.outputs.scope != 'retain'
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
-        if: steps.cleanup-scope.outputs.scope != 'retain'
+        if: steps.cleanup-scope.outputs.scope == 'generation' || steps.cleanup-scope.outputs.scope == 'run'
         with:
           version: 10.33.4
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        if: steps.cleanup-scope.outputs.scope != 'retain'
+        if: steps.cleanup-scope.outputs.scope == 'generation' || steps.cleanup-scope.outputs.scope == 'run'
         with:
           node-version: 22
       - name: Install E2E dependencies
-        if: steps.cleanup-scope.outputs.scope != 'retain'
+        if: steps.cleanup-scope.outputs.scope == 'generation' || steps.cleanup-scope.outputs.scope == 'run'
         run: cd e2e && pnpm install --frozen-lockfile
       - name: Download runner Clerk resource records
-        if: steps.cleanup-scope.outputs.scope != 'retain'
+        if: steps.cleanup-scope.outputs.scope == 'generation' || steps.cleanup-scope.outputs.scope == 'run'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: e2e-runner-clerk-resources-*
@@ -3043,6 +3055,26 @@ jobs:
         env:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+
+      - name: Setup SSH for idle sandbox cleanup
+        if: always() && needs.deploy-runner-start.result == 'success'
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+      - name: Reclaim exact idle sandboxes from the deployed runner
+        if: always() && needs.deploy-runner-start.result == 'success'
+        shell: bash
+        env:
+          RUNNER_RECEIPT: ${{ needs.deploy-runner-start.outputs.runner-receipt }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          JOB_REF: ${{ needs.prepare.outputs.runner-image-job-ref }}
+          RUNNER_SERVICE_REF: ${{ needs.prepare.outputs.job-ref }}
+        run: bash .github/scripts/prune-runner-idle.sh
 
   lint-runtime-api-compat:
     runs-on: ubuntu-latest

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -16,6 +16,7 @@ mod drain_override;
 mod drain_override_cleanup;
 mod drain_resume;
 mod gate;
+mod prune_idle;
 mod reload;
 mod signal;
 mod state;
@@ -67,6 +68,8 @@ enum ServiceCommand {
     Drain(drain_resume::DrainArgs),
     /// Resume a draining runner (SIGUSR2, reverses `drain` before teardown begins)
     Resume(drain_resume::ResumeArgs),
+    /// Reclaim only exact idle sandboxes in an explicitly identified process generation
+    PruneIdle(prune_idle::PruneIdleArgs),
     /// Wait until a runner service is active and job-admitting. On success, emit the resolved
     /// max_concurrent as one machine-readable integer line on stdout for scripts; diagnostics go
     /// to stderr.
@@ -152,6 +155,7 @@ pub async fn run_service(args: ServiceArgs) -> RunnerResult<()> {
         ServiceCommand::Uninstall(a) => uninstall(a).await,
         ServiceCommand::Drain(a) => drain_resume::run_drain(a).await,
         ServiceCommand::Resume(a) => drain_resume::run_resume(a).await,
+        ServiceCommand::PruneIdle(a) => prune_idle::run(a).await,
         ServiceCommand::WaitRunning(a) => wait_running(a).await,
         ServiceCommand::UnitState(a) => state::run(a).await,
         ServiceCommand::Status(a) => status(a).await,

--- a/crates/runner/src/cmd/service/prune_idle.rs
+++ b/crates/runner/src/cmd/service/prune_idle.rs
@@ -1,0 +1,184 @@
+use std::time::Duration;
+
+use clap::Args;
+use uuid::Uuid;
+
+use crate::error::{RunnerError, RunnerResult};
+use crate::idle_prune_control;
+use crate::paths::HomePaths;
+use crate::runner_process_identity::RunnerProcessIdentity;
+
+use super::{RunnerServiceUnit, read_unit_config_path, selected_config_live_instance};
+
+#[derive(Args)]
+pub(super) struct PruneIdleArgs {
+    /// Exact service suffix; never selects other Runner services
+    #[arg(long)]
+    name: String,
+    /// Runner UUID captured when the target deployment became ready
+    #[arg(long)]
+    expected_runner_id: Uuid,
+    /// Process generation captured with --expected-runner-id
+    #[arg(long)]
+    expected_heartbeat_generation: u64,
+    /// Whole-command deadline; admitted cleanup continues after client timeout
+    #[arg(long, default_value_t = 120, value_parser = clap::value_parser!(u64).range(1..=3600))]
+    timeout_secs: u64,
+}
+
+pub(super) async fn run(args: PruneIdleArgs) -> RunnerResult<()> {
+    run_with_home(args, &HomePaths::new()?).await
+}
+
+async fn run_with_home(args: PruneIdleArgs, home: &HomePaths) -> RunnerResult<()> {
+    let unit = RunnerServiceUnit::from_suffix(&args.name)?;
+    let identity =
+        RunnerProcessIdentity::new(args.expected_runner_id, args.expected_heartbeat_generation)
+            .map_err(|error| RunnerError::Config(error.to_string()))?;
+    let report = tokio::time::timeout(Duration::from_secs(args.timeout_secs), async {
+        let config = read_unit_config_path(&unit).await?.ok_or_else(|| {
+            RunnerError::Internal("service has no Runner config; nothing was pruned".into())
+        })?;
+        let instance = selected_config_live_instance(&unit, &config, home).await?.ok_or_else(|| {
+            RunnerError::Internal("service has no live Runner process; nothing was pruned".into())
+        })?;
+        idle_prune_control::request(home, &instance.base_dir, identity, instance.pid).await
+            .map_err(|error| RunnerError::Internal(format!(
+                "could not prune the expected Runner generation: {error}; verify the deployment identity and command support"
+            )))?
+            .map_err(RunnerError::Internal)
+    }).await.map_err(|_| RunnerError::Internal(
+        "idle prune command timed out; admitted cleanup may still be running".into()
+    ))??;
+    println!(
+        "{}",
+        serde_json::to_string(&report).map_err(|error| RunnerError::Internal(error.to_string()))?
+    );
+    if report.uncertain > 0 {
+        return Err(RunnerError::Internal(
+            "idle pruning could not confirm all destructions; inspect Runner logs".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_fixtures::ignored_child::{
+        ignored_child_test_env_guard_enabled, run_ignored_child_test,
+    };
+    use clap::Parser;
+    use std::os::unix::fs::PermissionsExt;
+
+    const SCENARIO: &str = "RUNNER_PRUNE_IDLE_SCENARIO";
+    const CHILD: &str = "cmd::service::prune_idle::tests::prune_idle_command_child";
+
+    #[tokio::test]
+    async fn prune_idle_command_resolves_exact_service_and_reports_results() {
+        for scenario in ["completed", "uncertain", "stale"] {
+            let dir = tempfile::tempdir().unwrap();
+            let systemctl = dir.path().join("systemctl");
+            tokio::fs::write(&systemctl, "#!/bin/sh\nprintf '[Service]\\nExecStart=/runner start --config %s\\n' \"$PRUNE_TEST_CONFIG\"\n").await.unwrap();
+            tokio::fs::set_permissions(&systemctl, std::fs::Permissions::from_mode(0o755))
+                .await
+                .unwrap();
+            let config = dir.path().join("config.yaml");
+            let config_text = config.to_str().unwrap();
+            run_ignored_child_test(
+                CHILD,
+                (SCENARIO, scenario),
+                &[
+                    ("PATH", Some(dir.path().to_str().unwrap())),
+                    ("PRUNE_TEST_CONFIG", Some(config_text)),
+                ],
+                Duration::from_secs(10),
+            )
+            .await;
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "spawned by prune_idle_command_resolves_exact_service_and_reports_results"]
+    async fn prune_idle_command_child() {
+        let scenario = std::env::var(SCENARIO).unwrap_or_default();
+        if !ignored_child_test_env_guard_enabled((SCENARIO, &scenario)) || scenario.is_empty() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        let identity = RunnerProcessIdentity::new(Uuid::new_v4(), 7).unwrap();
+        let _live = crate::live_runner_instances::publish(
+            &home,
+            crate::live_runner_instances::LiveRunnerInstanceMetadata {
+                config_path: std::env::var("PRUNE_TEST_CONFIG").unwrap().into(),
+                base_dir: dir.path().to_path_buf(),
+                runner_group: "test".into(),
+                subcommand: "start".into(),
+            },
+        )
+        .await
+        .unwrap();
+        let listener =
+            idle_prune_control::PruneIdleListener::bind(&home, dir.path(), identity).unwrap();
+        let generation = if scenario == "stale" { "6" } else { "7" };
+        let cli = crate::Cli::try_parse_from([
+            "runner",
+            "service",
+            "prune-idle",
+            "--name",
+            "pr-123-1",
+            "--expected-runner-id",
+            &identity.runner_id().to_string(),
+            "--expected-heartbeat-generation",
+            generation,
+        ])
+        .unwrap();
+        let crate::Command::Service(service) = cli.command else {
+            panic!("expected service command")
+        };
+        let super::super::ServiceCommand::PruneIdle(args) = service.command else {
+            panic!("expected prune command")
+        };
+        let uncertain = usize::from(scenario == "uncertain");
+        let server = tokio::spawn(async move {
+            let mut stream = listener.accept().await.unwrap();
+            idle_prune_control::read_request(&mut stream, identity)
+                .await
+                .unwrap();
+            idle_prune_control::write_response(
+                &mut stream,
+                &Ok(idle_prune_control::PruneIdleReport {
+                    selected: 1,
+                    completed: 1 - uncertain,
+                    uncertain,
+                }),
+            )
+            .await
+            .unwrap();
+        });
+        let result = run_with_home(args, &home).await;
+        match scenario.as_str() {
+            "completed" => result.unwrap(),
+            "uncertain" => assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("could not confirm")
+            ),
+            "stale" => {
+                assert!(
+                    result
+                        .unwrap_err()
+                        .to_string()
+                        .contains("expected Runner generation")
+                );
+                server.abort();
+                assert!(server.await.unwrap_err().is_cancelled());
+                return;
+            }
+            _ => panic!("unknown scenario"),
+        }
+        server.await.unwrap();
+    }
+}

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -103,6 +103,7 @@ mod job_terminal_log;
 mod mitm_restart;
 mod orphan_reap;
 mod ownership;
+mod prune_idle;
 mod sandbox_finalization;
 mod signals;
 
@@ -1799,6 +1800,34 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         )));
     }
 
+    let prune_listener = match crate::idle_prune_control::PruneIdleListener::bind(
+        &paths.home,
+        &paths.base_dir,
+        runner.identity,
+    ) {
+        Ok(listener) => listener,
+        Err(error) => {
+            shutdown_startup_resources_after_startup_failure(
+                StartupFailureResources {
+                    provider: provider_state.provider.as_ref(),
+                    runtime: Some(runtime.as_mut()),
+                    mitm: &mut mitm,
+                    kmsg_handle,
+                    dns_handle,
+                    memory_prefetch: &mut memory_prefetch,
+                    status: shared.status.as_ref(),
+                },
+                "prune_control_startup_failure",
+            )
+            .await;
+            if let Some(handler_task) = signal_handler_task.take() {
+                abort_signal_handler_task(handler_task, "prune_control_startup_failure").await;
+            }
+            return Err(error.into());
+        }
+    };
+    let prune_admission = Arc::new(tokio::sync::Semaphore::new(1));
+
     if let Err(e) = provider_state.provider.prepare_startup_readiness().await {
         let startup_readiness_cancelled = provider_state.cancel.is_cancelled();
         let cleanup_reason = if startup_readiness_cancelled {
@@ -2188,6 +2217,29 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             .and_then(JobCandidate::runner_preference)
             .map(crate::provider::ActiveRunnerPreference::deadline);
         tokio::select! {
+            connection = prune_listener.accept() => {
+                match connection {
+                    Ok(stream) => {
+                        if let Ok(permit) = Arc::clone(&prune_admission).try_acquire_owned() {
+                            let context = prune_idle::PruneIdleContext {
+                                identity: runner.identity,
+                                pool: Arc::clone(&shared.idle_pool),
+                                status: Arc::clone(&shared.status),
+                                lifecycle: lifecycle.clone(),
+                                tracker: idle_destroy_tracker.clone(),
+                            };
+                            idle_destroy_tracker.spawn_cleanup(
+                                prune_idle::handle(stream, context, permit), "operator_prune_idle",
+                            );
+                        }
+                        // Busy requests are closed without admitting any work.
+                    }
+                    Err(error) => {
+                        terminal_error = Some(error.into());
+                        break;
+                    }
+                }
+            }
             result = blank_pool.wait_for_preparation(), if blank_pool.is_preparing() => {
                 if let Some(result) = result {
                     blank_pool
@@ -2567,6 +2619,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // Shutdown — drain idle pool, release discovery resources, then drain running jobs
     // -----------------------------------------------------------------------
     let teardown = TeardownTimer::start();
+    drop(prune_listener);
     memory_prefetch.cancel();
     teardown.event("memory_prefetch_cancelled");
 

--- a/crates/runner/src/cmd/start/prune_idle.rs
+++ b/crates/runner/src/cmd/start/prune_idle.rs
@@ -1,0 +1,90 @@
+//! One-shot exact reclamation, independently scheduled from the reactor.
+
+use std::sync::Arc;
+
+use futures_util::stream::{FuturesUnordered, StreamExt};
+use tokio::net::UnixStream;
+use tokio::sync::OwnedSemaphorePermit;
+
+use super::idle_lifecycle::{IdleDestroyTracker, SharedIdlePool};
+use crate::idle_pool::DestroyOutcome;
+use crate::idle_prune_control::{PruneIdleReport, PruneIdleResponse, read_request, write_response};
+use crate::lifecycle::{LifecycleController, RunnerMode};
+use crate::runner_process_identity::RunnerProcessIdentity;
+use crate::status::StatusTracker;
+
+pub(super) struct PruneIdleContext {
+    pub identity: RunnerProcessIdentity,
+    pub pool: SharedIdlePool,
+    pub status: Arc<StatusTracker>,
+    pub lifecycle: LifecycleController,
+    pub tracker: IdleDestroyTracker,
+}
+
+pub(super) async fn handle(
+    mut stream: UnixStream,
+    context: PruneIdleContext,
+    _permit: OwnedSemaphorePermit,
+) {
+    let response = match read_request(&mut stream, context.identity).await {
+        Err(error) => Err(error.to_string()),
+        Ok(()) if context.lifecycle.current_mode() != RunnerMode::Running => {
+            Err("runner is not running; idle pruning was not started".into())
+        }
+        Ok(()) => prune(&context).await,
+    };
+    if let Err(error) = write_response(&mut stream, &response).await {
+        tracing::warn!(%error, "could not acknowledge idle pruning; admitted cleanup has finished");
+    }
+}
+
+async fn prune(context: &PruneIdleContext) -> PruneIdleResponse {
+    let (jobs, snapshot) = {
+        let mut pool = context.pool.lock().await;
+        let jobs = pool.drain_exact();
+        (jobs, pool.status_snapshot())
+    };
+    let mut report = PruneIdleReport {
+        selected: jobs.len(),
+        completed: 0,
+        uncertain: 0,
+    };
+    // Transfer every selected resource to an independent task before any I/O.
+    // Neither a disconnected client nor a failed status write may drop jobs
+    // without destruction or release their budget ahead of physical cleanup.
+    let mut tasks: FuturesUnordered<_> = jobs
+        .into_iter()
+        .map(|job| {
+            tokio::spawn(async move { job.run_retaining_lease("operator_prune_idle").await })
+        })
+        .collect();
+    context.tracker.notify_reuse_state();
+    let status_result = context.status.set_idle_snapshot(snapshot).await;
+    while let Some(result) = tasks.next().await {
+        match result {
+            Ok(result) => {
+                match result.outcome {
+                    DestroyOutcome::Completed => report.completed += 1,
+                    DestroyOutcome::Uncertain => report.uncertain += 1,
+                }
+                if result.workspace_cache_promoted {
+                    context.tracker.notify_reuse_state();
+                }
+                drop(result.budget_lease);
+            }
+            Err(error) => {
+                report.uncertain += 1;
+                tracing::warn!(%error, "idle prune destruction task failed");
+            }
+        }
+    }
+    tracing::info!(
+        selected = report.selected,
+        completed = report.completed,
+        uncertain = report.uncertain,
+        "exact idle pruning finished"
+    );
+    status_result
+        .map_err(|error| format!("idle pruning finished but status publication failed: {error}"))?;
+    Ok(report)
+}

--- a/crates/runner/src/cmd/start/tests/idle_reuse/mod.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/mod.rs
@@ -4,6 +4,7 @@ mod blank_session_history;
 mod device_limits;
 mod drain;
 mod parking;
+mod prune_idle;
 mod same_thread_reuse;
 mod status;
 mod workspace_cache;

--- a/crates/runner/src/cmd/start/tests/idle_reuse/prune_idle.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/prune_idle.rs
@@ -1,0 +1,244 @@
+use super::super::super::*;
+use super::super::support::{
+    context_with_session, mock_run_config, push_job, seed_idle_pool, seed_idle_pool_with_overrides,
+    shutdown, test_profiles, wait_discover_entered, wait_idle_pool_len, wait_idle_pool_reuse_keys,
+};
+use crate::idle_prune_control::request;
+use sandbox_mock::{MockLifecycleGate, MockSandboxOverrides};
+
+#[tokio::test]
+async fn prune_idle_publishes_workspace_cache_before_acknowledging() {
+    use crate::idle_pool::{IdleParkRequest, IdleParkRequestParts, ParkResult};
+    use crate::workspace_promotion::test_support::WorkspacePromotionFixture;
+    use sandbox::{ResourceLimits, SandboxConfig, SandboxFactory};
+    let fixture = WorkspacePromotionFixture::new("thread:pruned-workspace").await;
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let home = config.paths.home.clone();
+    let base = config.paths.base_dir.clone();
+    let identity = config.runner.identity;
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher(&overrides);
+    let factory: Arc<Box<dyn SandboxFactory>> = Arc::new(Box::new(
+        sandbox_mock::MockSandboxFactory::with_overrides(overrides),
+    ));
+    let sandbox = factory
+        .create(SandboxConfig {
+            id: fixture.sandbox_id,
+            resources: ResourceLimits {
+                cpu_count: 2,
+                memory_mb: 4096,
+            },
+            device_rate_limits: None,
+            workspace_drive: None,
+        })
+        .await
+        .unwrap();
+    let lease = ResourceBudget::try_reserve_lease(&config.capacity.budget, 2, 4096).unwrap();
+    let park = IdleParkRequest::new(IdleParkRequestParts {
+        run_id: RunId::new_v4(),
+        sandbox,
+        factory,
+        reuse_key: fixture.reuse_key.clone(),
+        sandbox_id: fixture.sandbox_id,
+        profile_name: "vm0/default".into(),
+        device_rate_limits: None,
+        budget_lease: lease,
+        source_ip: "10.0.0.1".into(),
+        storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
+        restored_session_identity: None,
+        history_generation_run_id: None,
+        guest_timezone_intent: crate::guest_timezone::GuestTimezoneIntent::Unknown,
+        workspace_image_size_bytes: b"workspace image".len() as u64,
+        workspace_promotion: Some(fixture.promotion),
+        handoff: None,
+    });
+    let candidate = match park.park_for_idle().await {
+        Ok(outcome) => outcome.expect_reusable(),
+        Err(_) => panic!("park must succeed"),
+    };
+    assert!(matches!(
+        config.shared.idle_pool.lock().await.park(candidate),
+        ParkResult::Parked
+    ));
+    let runner = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    let report = request(&home, &base, identity, std::process::id())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(report.completed, 1);
+    let cached = fixture.cache.held_workspace_states().await;
+    assert_eq!(cached.len(), 1);
+    assert_eq!(cached[0].reuse_key, fixture.reuse_key);
+    shutdown(&env, runner).await;
+    assert_eq!(fixture.cache.held_workspace_states().await.len(), 1);
+}
+
+#[tokio::test]
+async fn prune_idle_preserves_blanks_reservations_and_later_job_parking() {
+    let (config, env) = mock_run_config(test_profiles(), 16, 32768, 8);
+    let home = config.paths.home.clone();
+    let base = config.paths.base_dir.clone();
+    let identity = config.runner.identity;
+    let pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    seed_idle_pool(&pool, &budget, "pruned", "vm0/default", 2, 4096).await;
+    seed_idle_pool(&pool, &budget, "reserved", "vm0/default", 2, 4096).await;
+    let reservation = pool.lock().await.take_reserved("reserved").unwrap();
+    let runner = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    wait_idle_pool_len(&pool, 2, Duration::from_secs(5)).await;
+    let blank = pool.lock().await.status_snapshot().blank_sandboxes[0].sandbox_id;
+
+    let report = request(&home, &base, identity, std::process::id())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        (report.selected, report.completed, report.uncertain),
+        (1, 1, 0)
+    );
+    assert_eq!(
+        pool.lock().await.status_snapshot().blank_sandboxes[0].sandbox_id,
+        blank
+    );
+    assert_eq!(
+        budget.allocated().2,
+        2,
+        "blank and reserved budgets remain owned"
+    );
+    assert_eq!(env.lifecycle.current_mode(), RunnerMode::Running);
+
+    // A reservation outside the pool remains owned and can still be restored.
+    let restored = pool.lock().await.restore_reserved(reservation);
+    assert!(matches!(
+        restored,
+        crate::idle_pool::RestoreReservedIdleResult::Restored
+    ));
+    let report = request(&home, &base, identity, std::process::id())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(report.completed, 1);
+    let report = request(&home, &base, identity, std::process::id())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(report.selected, 0, "repeating one-shot cleanup is harmless");
+
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(run_id, "after-prune")),
+    );
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(completion.exit_code, 0);
+    wait_idle_pool_reuse_keys(&pool, &["after-prune"], Duration::from_secs(5)).await;
+    shutdown(&env, runner).await;
+    assert_eq!(budget.allocated().2, 0);
+}
+
+#[tokio::test]
+async fn prune_idle_client_disconnect_keeps_cleanup_owned_and_reactor_progressing() {
+    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let home = config.paths.home.clone();
+    let base = config.paths.base_dir.clone();
+    let identity = config.runner.identity;
+    let budget = Arc::clone(&config.capacity.budget);
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    let gate = MockLifecycleGate::new();
+    overrides.set_destroy_lifecycle_gate(gate.clone());
+    seed_idle_pool_with_overrides(
+        &config.shared.idle_pool,
+        &budget,
+        &overrides,
+        "slow-prune",
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    let runner = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    let client =
+        tokio::spawn(async move { request(&home, &base, identity, std::process::id()).await });
+    gate.wait_entered(1, Duration::from_secs(5)).await.unwrap();
+    assert_eq!(
+        budget.allocated().2,
+        1,
+        "budget stays reserved through destruction"
+    );
+    client.abort();
+    assert!(client.await.unwrap_err().is_cancelled());
+
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(run_id, "during-prune")),
+    );
+    assert_eq!(
+        env.handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await
+            .unwrap()
+            .exit_code,
+        0
+    );
+    assert_eq!(budget.allocated().2, 2);
+    env.trigger_stopping().await;
+    env.start_observer
+        .wait_for(
+            Duration::from_secs(5),
+            "tracked destruction drain",
+            |event| matches!(event, StartLoopEvent::DestroyTasksDrainEntered).then_some(()),
+        )
+        .await;
+    assert!(
+        !runner.is_finished(),
+        "shutdown must await admitted pruning"
+    );
+    assert_eq!(budget.allocated().2, 1, "pruning still owns its budget");
+    gate.release_one();
+    shutdown(&env, runner).await;
+    assert_eq!(budget.allocated().2, 0);
+}
+
+#[tokio::test]
+async fn prune_idle_reports_uncertain_destruction_without_stopping_runner() {
+    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let home = config.paths.home.clone();
+    let base = config.paths.base_dir.clone();
+    let identity = config.runner.identity;
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.push_destroy_panic("prune destroy failure");
+    seed_idle_pool_with_overrides(
+        &config.shared.idle_pool,
+        &config.capacity.budget,
+        &overrides,
+        "uncertain-prune",
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    let runner = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    let report = request(&home, &base, identity, std::process::id())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        (report.selected, report.completed, report.uncertain),
+        (1, 0, 1)
+    );
+    assert_eq!(env.lifecycle.current_mode(), RunnerMode::Running);
+    shutdown(&env, runner).await;
+}

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -490,6 +490,20 @@ impl IdlePool {
         self.parking_gate.clone()
     }
 
+    /// Detach only the currently pool-owned exact entries. Reservations and
+    /// blanks are not part of this one-shot operation; later parking stays open.
+    pub(crate) fn drain_exact(&mut self) -> Vec<IdleDestroyJob> {
+        let jobs: Vec<_> = self
+            .exact_entries
+            .drain()
+            .map(|(_, entry)| entry.into_destroy_job())
+            .collect();
+        if !jobs.is_empty() {
+            self.bump_revision();
+        }
+        jobs
+    }
+
     /// Drain all entries from the pool. Parking permission is controlled by
     /// [`ParkingGate`] so soft-drain resume can reopen parking before
     /// [`crate::lifecycle::RunnerMode::Running`] becomes visible.

--- a/crates/runner/src/idle_prune_control.rs
+++ b/crates/runner/src/idle_prune_control.rs
@@ -1,0 +1,249 @@
+//! Generation-fenced, private local IPC for one-shot exact idle reclamation.
+
+use std::io;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{UnixListener, UnixStream};
+
+use crate::host_file::{DirMode, ensure_dir, validate_dir};
+use crate::paths::HomePaths;
+use crate::runner_process_identity::RunnerProcessIdentity;
+
+const FRAME_LIMIT: usize = 4096;
+const IO_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PruneIdleReport {
+    pub selected: usize,
+    pub completed: usize,
+    pub uncertain: usize,
+}
+
+pub(crate) type PruneIdleResponse = Result<PruneIdleReport, String>;
+
+pub(crate) struct PruneIdleListener {
+    listener: UnixListener,
+    path: PathBuf,
+    inode: u64,
+}
+
+impl PruneIdleListener {
+    pub(crate) fn bind(
+        home: &HomePaths,
+        base_dir: &Path,
+        identity: RunnerProcessIdentity,
+    ) -> io::Result<Self> {
+        ensure_dir(
+            &home.runner_control_dir(),
+            DirMode::Private,
+            "runner control",
+        )?;
+        let path = socket_path(home, &base_dir.canonicalize()?, identity);
+        // Never unlink an existing endpoint to make bind succeed: it may still
+        // belong to a live process. Generations use independent endpoints.
+        let listener = UnixListener::bind(&path)?;
+        let inode = std::fs::symlink_metadata(&path)?.ino();
+        let server = Self {
+            listener,
+            path,
+            inode,
+        };
+        std::fs::set_permissions(&server.path, std::fs::Permissions::from_mode(0o600))?;
+        Ok(server)
+    }
+
+    pub(crate) async fn accept(&self) -> io::Result<UnixStream> {
+        self.listener.accept().await.map(|(stream, _)| stream)
+    }
+}
+
+impl Drop for PruneIdleListener {
+    fn drop(&mut self) {
+        if let Ok(metadata) = std::fs::symlink_metadata(&self.path)
+            && metadata.ino() == self.inode
+            && let Err(error) = std::fs::remove_file(&self.path)
+        {
+            tracing::warn!(%error, "failed to remove runner prune endpoint");
+        }
+    }
+}
+
+fn socket_path(home: &HomePaths, base_dir: &Path, identity: RunnerProcessIdentity) -> PathBuf {
+    let mut digest = Sha256::new();
+    digest.update(base_dir.as_os_str().as_encoded_bytes());
+    digest.update([0]);
+    digest.update(identity.runner_id().as_bytes());
+    digest.update(identity.heartbeat_generation().to_le_bytes());
+    // Keep the Unix socket pathname short. Full identity is also checked in
+    // the request, so a digest collision can fail bind but cannot authorize it.
+    let digest = digest.finalize();
+    let (prefix, _) = digest.split_at(16);
+    home.runner_control_dir().join(hex::encode(prefix))
+}
+
+pub(crate) async fn read_request(
+    stream: &mut UnixStream,
+    identity: RunnerProcessIdentity,
+) -> io::Result<()> {
+    verify_peer(stream, None)?;
+    let expected: RunnerProcessIdentity = read_frame(stream).await?;
+    if expected != identity {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "runner generation mismatch",
+        ));
+    }
+    Ok(())
+}
+
+fn verify_peer(stream: &UnixStream, expected_pid: Option<u32>) -> io::Result<()> {
+    let peer = stream.peer_cred()?;
+    if peer.uid() != nix::unistd::geteuid().as_raw()
+        || expected_pid
+            .is_some_and(|pid| peer.pid().and_then(|pid| u32::try_from(pid).ok()) != Some(pid))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "runner control peer mismatch",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) async fn request(
+    home: &HomePaths,
+    base_dir: &Path,
+    identity: RunnerProcessIdentity,
+    expected_pid: u32,
+) -> io::Result<PruneIdleResponse> {
+    validate_dir(
+        &home.runner_control_dir(),
+        DirMode::Private,
+        "runner control",
+    )?;
+    let mut stream = UnixStream::connect(socket_path(home, base_dir, identity)).await?;
+    verify_peer(&stream, Some(expected_pid))?;
+    write_frame(&mut stream, &identity).await?;
+    // Physical reclamation is bounded by the operator's whole-command timeout,
+    // not the short framing timeout used for incoming requests.
+    read_frame_unbounded(&mut stream).await
+}
+
+pub(crate) async fn write_response(
+    stream: &mut UnixStream,
+    response: &PruneIdleResponse,
+) -> io::Result<()> {
+    write_frame(stream, response).await
+}
+
+async fn read_frame<T: DeserializeOwned>(stream: &mut UnixStream) -> io::Result<T> {
+    tokio::time::timeout(IO_TIMEOUT, read_frame_unbounded(stream))
+        .await
+        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "runner control read timed out"))?
+}
+
+async fn read_frame_unbounded<T: DeserializeOwned>(stream: &mut UnixStream) -> io::Result<T> {
+    let length = stream.read_u32().await? as usize;
+    if length > FRAME_LIMIT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "runner control frame too large",
+        ));
+    }
+    let mut data = vec![0; length];
+    stream.read_exact(&mut data).await?;
+    serde_json::from_slice(&data).map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+}
+
+async fn write_frame<T: Serialize>(stream: &mut UnixStream, value: &T) -> io::Result<()> {
+    let data = serde_json::to_vec(value).map_err(io::Error::other)?;
+    if data.len() > FRAME_LIMIT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "runner control frame too large",
+        ));
+    }
+    tokio::time::timeout(IO_TIMEOUT, async {
+        stream.write_u32(data.len() as u32).await?;
+        stream.write_all(&data).await
+    })
+    .await
+    .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "runner control write timed out"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn prune_idle_control_round_trip_is_generation_and_peer_fenced() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        let identity = RunnerProcessIdentity::new(uuid::Uuid::new_v4(), 1).unwrap();
+        let listener = PruneIdleListener::bind(&home, dir.path(), identity).unwrap();
+        let path = listener.path.clone();
+        let replaced = RunnerProcessIdentity::new(identity.runner_id(), 2).unwrap();
+        assert!(
+            request(&home, dir.path(), replaced, std::process::id())
+                .await
+                .is_err()
+        );
+        assert!(
+            request(&home, dir.path(), identity, u32::MAX)
+                .await
+                .is_err()
+        );
+        // Consume the connection rejected by the client peer check.
+        drop(listener.accept().await.unwrap());
+        let server = tokio::spawn(async move {
+            let mut stream = listener.accept().await.unwrap();
+            read_request(&mut stream, identity).await.unwrap();
+            write_response(
+                &mut stream,
+                &Ok(PruneIdleReport {
+                    selected: 3,
+                    completed: 3,
+                    uncertain: 0,
+                }),
+            )
+            .await
+            .unwrap();
+        });
+        let report = request(&home, dir.path(), identity, std::process::id())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(report.completed, 3);
+        server.await.unwrap();
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn prune_idle_control_rejects_wrong_generation_and_oversized_requests() {
+        let identity = RunnerProcessIdentity::new(uuid::Uuid::new_v4(), 1).unwrap();
+        let wrong = RunnerProcessIdentity::new(identity.runner_id(), 2).unwrap();
+        let (mut client, mut server) = UnixStream::pair().unwrap();
+        write_frame(&mut client, &wrong).await.unwrap();
+        assert_eq!(
+            read_request(&mut server, identity)
+                .await
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        client.write_u32((FRAME_LIMIT + 1) as u32).await.unwrap();
+        assert_eq!(
+            read_request(&mut server, identity)
+                .await
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+}

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -22,6 +22,7 @@ mod host_env;
 mod host_file;
 mod http;
 mod idle_pool;
+mod idle_prune_control;
 mod idle_reuse_preparation;
 mod ids;
 mod image_hash;

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -229,6 +229,10 @@ impl HomePaths {
         self.root.join("live-runner-instances")
     }
 
+    pub(crate) fn runner_control_dir(&self) -> PathBuf {
+        self.root.join("control")
+    }
+
     pub fn live_runner_instance_record_path(&self, pid: u32, starttime: u64) -> PathBuf {
         self.live_runner_instances_dir()
             .join(format!("{pid}-{starttime}.json"))

--- a/docs/runner-host-configuration.md
+++ b/docs/runner-host-configuration.md
@@ -73,6 +73,34 @@ memory usage; the profile budget is not a measurement of resident memory.
 
 ## Idle Workspace Reclamation Concurrency
 
+### One-shot CI idle reclamation
+
+`runner service prune-idle --name <service-suffix> --expected-runner-id <uuid>
+--expected-heartbeat-generation <generation> --timeout-secs 120` reclaims only
+the exact idle inventory owned by that Runner when the request is accepted.
+Blank sandboxes, active/reserved sandboxes, admission and later parking remain
+unchanged. This is not service drain, a no-idle mode, or host-wide GC.
+
+CI captures the Runner UUID and heartbeat generation at deployment readiness.
+`cli-e2e-03-runner-cleanup` waits for BATS and shared Playwright consumers, then
+uses that receipt even when failed-test accounts are retained. The command
+resolves the service's exact config/live process and uses a private,
+generation-scoped local socket. Missing services, old binaries without the
+command, generation changes and control failures fail visibly without signals
+or a fallback to another process.
+
+The command reports selected, completed and uncertain counts only after the
+selected reclamation attempts finish; uncertain destruction fails the command.
+Transport/status failures also fail. A client timeout or disconnect does not
+cancel admitted destruction. Normal Runner shutdown waits for these tasks.
+Workspace promotion and workspace/session-history disk caches are preserved;
+the existing reclamation limits below still apply. Later runs may lose exact
+hot reuse but retain blank/cache paths. Blank replenishment may use newly freed
+capacity under its unchanged policy, so reclaimed budget is not an RSS savings
+measurement.
+
+### Reclamation admission
+
 Workspace promotion uses two independent runner-process-local admission gates,
 each sized as `(host_cpus / 2).clamp(1, 4)`. Cache clones share the gates.
 The existing sidecar export gate covers guest export execution only. Idle


### PR DESCRIPTION
## Summary

Closes #33183.

- Add `runner service prune-idle` to reclaim only the current process's pool-owned **exact idle** sandboxes through a private, generation-fenced local socket. Preserve blanks, active/reserved ownership, normal admission and later parking.
- Reuse the existing workspace promotion/destruction path and its concurrency limits. Keep resource leases through destruction, publish cache results before acknowledging, and keep admitted cleanup owned through client disconnect and Runner teardown.
- Capture the selected host/service/binary directory/Runner UUID/heartbeat generation at preview deployment readiness. Cleanup uses the captured generation, never a replacement discovered at cleanup time.
- Run cleanup after **all BATS shards and all shared Playwright lanes** finish, including failed tests and Playwright-only deployments. Keep failed-test account retention unchanged. Add a workflow guard for missing shared-consumer dependencies.

## Scope and trade-offs

This is one-shot snapshot reclamation, not service drain, host-wide GC, a TTL, or a persistent no-idle mode. Blank prewarming and workspace/session-history disk caches remain unchanged. Later runs can lose exact hot reuse and continue through existing blank/cache paths. Reclamation can perform workspace export I/O under the existing gates; no deployed RSS savings or cleanup latency has been measured.

The single selected hostname is passed as a job output, following the existing Crates `runner-build.outputs.host` pattern and the user's explicit direction; the full host inventory is not published. Missing/old capabilities, stale generations, transport/status errors and uncertain destruction fail visibly. The existing non-blocking cleanup job does not mask the test verdict.

## Compatibility and fallbacks

No API, database, guest protocol or persisted cache format changes. Old Runner binaries do not support the new command/endpoint and fail safely. New processes retain normal reuse policy unless explicitly pruned. No new fallback is introduced: there are no blind signals, alternate-generation retries, service stops or host-wide deletion paths.

## Validation

- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner prune_idle -- --test-threads=4`: 7 passed; the ignored helper is exercised in three isolated child scenarios by its parent test.
- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner cmd::start::tests -- --test-threads=4`: 261 passed.
- `cargo fmt --all --manifest-path crates/Cargo.toml -- --check`.
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p runner --all-targets --all-features -- -D warnings`.
- `cargo doc --manifest-path crates/Cargo.toml --profile local -p runner --all-features --no-deps`.
- ShellCheck on the two affected scripts and three affected shell tests.
- Shell suites: `prune-runner-idle`, `reconcile-and-start-runner-groups`, `turbo-playwright-runner-workflow`, `clerk-test-resource-workflow`, `runner-lifecycle-ownership-workflow`, and `runner-lifecycle-lock` under `.github/scripts/tests/`.
- Changed YAML/Markdown Prettier, conventional PR title, and `git diff --check`.

Deployed Firecracker cleanup and both host architectures remain for CI validation; local tests use the existing sandbox boundary mocks and real Unix IPC/filesystem/process selection.
