### PR TITLE
refactor(ui): migrate badge, pill, and hairline divider to utilities

### DIFF
--- a/docs/style-migration.md
+++ b/docs/style-migration.md
@@ -353,3 +353,23 @@ has it false. Both keep `modelPickerFlyout=false` and `_realAgentInPreview=false
 No live switch was changed. Earlier manual portal navigation attempts are
 explicitly unaccepted diagnostics, distinct from the four passing frozen portal
 states. The archive was anonymously downloaded and hash-verified.
+
+## Stylesheet equivalence for mechanical badge migrations
+
+The hairline badge batch is a declaration-for-declaration replacement across 23
+consumption sites on ten pages, several of which need real organization,
+billing, and queue data to render. Its
+[frozen archive](https://a.okou.io/cq91krcx32.zip) records the cheaper check that
+covers all 23 at once. A script reads the BEFORE class strings from `main` and
+the AFTER class strings from the branch, including the `badgeVariants` base read
+back from its own source, so neither side is hand-written. It compiles the real
+App stylesheet at both commits with the App's own Tailwind compiler, renders both
+class lists on identical markup inside `.okou-app`, and compares full-page pixels
+and computed styles in Light/Dark at device scale factor 1 and 2. All four states
+reported zero changed pixels, identical image hashes, and identical computed
+styles; a recorded negative control on the fill and divider stroke made the same
+harness fail.
+
+This establishes that the shared variant reproduces the deleted declarations. It
+is not deployed-preview acceptance of the pages themselves, and it does not
+replace the per-page runners when a batch changes layout, interaction, or state.

--- a/docs/style-migration.md
+++ b/docs/style-migration.md
@@ -361,7 +361,7 @@ consumption sites on ten pages, several of which need real organization,
 billing, and queue data to render. Its
 [frozen archive](https://a.okou.io/cq91krcx32.zip) records the cheaper check that
 covers all 23 at once. A script reads the BEFORE class strings from `main` and
-the AFTER class strings from the branch, including the `badgeVariants` base read
+the AFTER class strings from the branch, including the `badgeClassName` base read
 back from its own source, so neither side is hand-written. It compiles the real
 App stylesheet at both commits with the App's own Tailwind compiler, renders both
 class lists on identical markup inside `.okou-app`, and compares full-page pixels

--- a/docs/style-migration.md
+++ b/docs/style-migration.md
@@ -359,7 +359,7 @@ states. The archive was anonymously downloaded and hash-verified.
 The hairline badge batch is a declaration-for-declaration replacement across 23
 consumption sites on ten pages, several of which need real organization,
 billing, and queue data to render. Its
-[frozen archive](https://a.okou.io/cq91krcx32.zip) records the cheaper check that
+[frozen archive](https://a.okou.io/6ov8hugeng.zip) records the cheaper check that
 covers all 23 at once. A script reads the BEFORE class strings from `main` and
 the AFTER class strings from the branch, including the `badgeClassName` base read
 back from its own source, so neither side is hand-written. It compiles the real

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -92,6 +92,19 @@ Integration and connector tests scope controls through the documented `data-slot
 
 The `okou-card` selector and its consumers have been removed. This equivalent migration also removes background, border, shadow, and focus-ring overrides that the old unlayered selector had suppressed; activating those overrides would be a separate visual change. Existing `--okou-card-*` variables still consumed by other legacy components remain frozen until those components migrate; they are not a supported API for new surfaces.
 
+### Inline badges
+
+`badgeVariants` from `@okouai/ui` owns the shared inline badge and tag treatment: role labels, status pills, version chips, and diagnostic values. Like `surfaceVariants`, it applies to the existing host element through `className` and adds no wrapper.
+
+| Decision | Shared token / utility                             | Theme contract                                                      |
+| -------- | -------------------------------------------------- | ------------------------------------------------------------------- |
+| Fill     | `bg-gray-0`                                        | The neutral base of the gray scale in each theme                    |
+| Border   | `--color-surface-border`, `--border-width-surface` | Gray 400 at 0.7 CSS pixels; the browser rounds for its device scale |
+
+The variant owns only the stroke and the fill, because its consumers legitimately differ in display, radius, padding, typography, and foreground: some badges are inline text, others are `inline-flex` rows with an icon, and one is a `<code>` element. Declare those with layout and typography utilities on the consumer, and use `text-muted-foreground` where a badge reads as secondary. It reuses the page-surface border tokens rather than declaring badge-specific aliases, so one hairline decision keeps one owner.
+
+The `okou-badge`, `okou-pill`, and `okou-border-r` selectors and their consumers have been removed. `okou-pill` was scoped to `.okou-app` and set the muted foreground; its only consumer now spells that foreground itself. `okou-border-r` was a single settings-dialog divider and became `border-r-(length:--border-width-surface) border-r-gray-300` on that nav, keeping its lighter Gray 300 stroke.
+
 ## Exception boundary
 
 Only two exception kinds exist:

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -94,7 +94,7 @@ The `okou-card` selector and its consumers have been removed. This equivalent mi
 
 ### Inline badges
 
-`badgeVariants` from `@okouai/ui` owns the shared inline badge and tag treatment: role labels, status pills, version chips, and diagnostic values. Like `surfaceVariants`, it applies to the existing host element through `className` and adds no wrapper.
+`badgeClassName` from `@okouai/ui` owns the shared inline badge and tag treatment: role labels, status pills, version chips, and diagnostic values. Compose it with `cn()` on the existing host element; it adds no wrapper. It is a class constant rather than a `cva()` variant because it carries no variant axis, which also lets `cn()` resolve a consumer that overrides the stroke or the fill.
 
 | Decision | Shared token / utility                             | Theme contract                                                      |
 | -------- | -------------------------------------------------- | ------------------------------------------------------------------- |

--- a/e2e/playwright/style-migration/badge-cases.json
+++ b/e2e/playwright/style-migration/badge-cases.json
@@ -1,0 +1,90 @@
+{
+  "version": 1,
+  "batch": "hairline-badge-surfaces",
+  "cases": [
+    {
+      "id": "badge-debug-light",
+      "path": "/agents?settings=debug",
+      "theme": "light",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "badge-debug-dark",
+      "path": "/agents?settings=debug",
+      "theme": "dark",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "badge-debug-narrow",
+      "path": "/agents?settings=debug",
+      "theme": "light",
+      "viewport": {
+        "width": 390,
+        "height": 844
+      },
+      "deviceScaleFactor": 2,
+      "hasTouch": true,
+      "isMobile": true
+    },
+    {
+      "id": "badge-debug-narrow-dark",
+      "path": "/agents?settings=debug",
+      "theme": "dark",
+      "viewport": {
+        "width": 390,
+        "height": 844
+      },
+      "deviceScaleFactor": 2,
+      "hasTouch": true,
+      "isMobile": true
+    },
+    {
+      "id": "badge-people-light",
+      "path": "/agents?settings=people",
+      "theme": "light",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "badge-people-dark",
+      "path": "/agents?settings=people",
+      "theme": "dark",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "badge-billing-light",
+      "path": "/agents?settings=billing",
+      "theme": "light",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "badge-billing-dark",
+      "path": "/agents?settings=billing",
+      "theme": "dark",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    }
+  ]
+}

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -502,13 +502,6 @@ body {
   user-select: text;
 }
 
-/* Pill/tag (e.g. status badge, "Super agent") */
-.okou-app .okou-pill {
-  background-color: hsl(var(--gray-0));
-  border: 0.7px solid hsl(var(--gray-400));
-  color: hsl(var(--muted-foreground));
-}
-
 /* Reusable 0.7px border utilities — replaces inline style={{ border: "0.7px solid ..." }} */
 /* Force the color-emoji font ahead of the inherited CJK/text stack so emoji
    glyphs render in color. Without this, dual-presentation codepoints fall back
@@ -522,9 +515,6 @@ body {
 }
 .okou-border-t {
   border-top: 0.7px solid hsl(var(--gray-400));
-}
-.okou-border-r {
-  border-right: 0.7px solid hsl(var(--gray-300));
 }
 
 /* Avatar / logo thumbnails: a hairline lighter than okou-border, so the edge of
@@ -566,12 +556,6 @@ body {
     stroke-dasharray: none;
     animation: none;
   }
-}
-
-/* Role / status badge: pill with 0.7px border on neutral background */
-.okou-badge {
-  border: 0.7px solid hsl(var(--gray-400));
-  background-color: hsl(var(--gray-0));
 }
 
 /* Left nav */

--- a/turbo/apps/platform/src/views/okou-page/components/log-views/status-badge.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/log-views/status-badge.tsx
@@ -6,7 +6,7 @@ import {
   ClockAlert,
   Ban,
 } from "lucide-react";
-import { badgeVariants } from "@okouai/ui";
+import { badgeClassName, cn } from "@okouai/ui";
 import type { LogStatus } from "../../../../signals/okou-page/log-types.ts";
 import { i18n } from "../../../../i18n/index.ts";
 
@@ -113,10 +113,10 @@ export function StatusBadge({ status, shellStyle }: StatusBadgeProps) {
       data-status={status}
       className={
         shellStyle
-          ? badgeVariants({
-              className:
-                "inline-flex items-center gap-1.5 rounded-lg px-1.5 py-1 text-xs font-medium text-muted-foreground",
-            })
+          ? cn(
+              badgeClassName,
+              "inline-flex items-center gap-1.5 rounded-lg px-1.5 py-1 text-xs font-medium text-muted-foreground",
+            )
           : "inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground"
       }
     >

--- a/turbo/apps/platform/src/views/okou-page/components/log-views/status-badge.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/log-views/status-badge.tsx
@@ -6,6 +6,7 @@ import {
   ClockAlert,
   Ban,
 } from "lucide-react";
+import { badgeVariants } from "@okouai/ui";
 import type { LogStatus } from "../../../../signals/okou-page/log-types.ts";
 import { i18n } from "../../../../i18n/index.ts";
 
@@ -112,7 +113,10 @@ export function StatusBadge({ status, shellStyle }: StatusBadgeProps) {
       data-status={status}
       className={
         shellStyle
-          ? "okou-pill inline-flex items-center gap-1.5 rounded-lg border px-1.5 py-1 text-xs font-medium"
+          ? badgeVariants({
+              className:
+                "inline-flex items-center gap-1.5 rounded-lg px-1.5 py-1 text-xs font-medium text-muted-foreground",
+            })
           : "inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground"
       }
     >

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
@@ -54,7 +54,7 @@ import {
   type ConcurrencyChangeMode,
   type ConcurrencyConfirmDialogState,
 } from "../../../../signals/okou-page/billing.ts";
-import { Button, Input } from "@okouai/ui";
+import { Button, Input, badgeVariants } from "@okouai/ui";
 import type {
   BillingStatusResponse,
   ConcurrencySubscriptionChangePreviewResponse,
@@ -2099,7 +2099,12 @@ function CurrentPlanTitle({
     <p className="flex items-center gap-2 text-sm font-medium text-foreground">
       <span>{label}</span>
       {legacy && (
-        <span className="rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground okou-badge">
+        <span
+          className={badgeVariants({
+            className:
+              "rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground",
+          })}
+        >
           {i18n.t(($) => {
             return $.billing.plans.legacy;
           })}

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
@@ -54,7 +54,7 @@ import {
   type ConcurrencyChangeMode,
   type ConcurrencyConfirmDialogState,
 } from "../../../../signals/okou-page/billing.ts";
-import { Button, Input, badgeVariants } from "@okouai/ui";
+import { Button, Input, badgeClassName, cn } from "@okouai/ui";
 import type {
   BillingStatusResponse,
   ConcurrencySubscriptionChangePreviewResponse,
@@ -2100,10 +2100,10 @@ function CurrentPlanTitle({
       <span>{label}</span>
       {legacy && (
         <span
-          className={badgeVariants({
-            className:
-              "rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground",
-          })}
+          className={cn(
+            badgeClassName,
+            "rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground",
+          )}
         >
           {i18n.t(($) => {
             return $.billing.plans.legacy;

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx
@@ -22,7 +22,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-  badgeVariants,
+  badgeClassName,
 } from "@okouai/ui";
 import { Skeleton } from "@okouai/ui/components/ui/skeleton";
 import type { FormEvent } from "react";
@@ -43,10 +43,10 @@ import { formatUsd } from "../../../../i18n/format.ts";
 const cardBorder = { border: "0.7px solid hsl(var(--gray-400))" } as const;
 
 const ROW_GRID = "grid grid-cols-[1fr_8rem_6rem_3rem] gap-x-6 items-center";
-const STATUS_BADGE = badgeVariants({
-  className:
-    "inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground",
-});
+const STATUS_BADGE = cn(
+  badgeClassName,
+  "inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground",
+);
 
 function formatDate(unixTimestamp: number): string {
   return new Date(unixTimestamp * 1000).toLocaleDateString(currentLocale());

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx
@@ -43,6 +43,10 @@ import { formatUsd } from "../../../../i18n/format.ts";
 const cardBorder = { border: "0.7px solid hsl(var(--gray-400))" } as const;
 
 const ROW_GRID = "grid grid-cols-[1fr_8rem_6rem_3rem] gap-x-6 items-center";
+const STATUS_BADGE = badgeVariants({
+  className:
+    "inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground",
+});
 
 function formatDate(unixTimestamp: number): string {
   return new Date(unixTimestamp * 1000).toLocaleDateString(currentLocale());
@@ -368,12 +372,7 @@ export function OrgInvoicesTab() {
                     {inv.number ?? inv.id}
                   </span>
                   {inv.status && (
-                    <span
-                      className={badgeVariants({
-                        className:
-                          "inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground",
-                      })}
-                    >
+                    <span className={STATUS_BADGE}>
                       <CircleCheck size={12} className="text-green-600" />
                       {inv.status.charAt(0).toUpperCase() + inv.status.slice(1)}
                     </span>

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx
@@ -22,6 +22,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  badgeVariants,
 } from "@okouai/ui";
 import { Skeleton } from "@okouai/ui/components/ui/skeleton";
 import type { FormEvent } from "react";
@@ -367,7 +368,12 @@ export function OrgInvoicesTab() {
                     {inv.number ?? inv.id}
                   </span>
                   {inv.status && (
-                    <span className="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground okou-badge">
+                    <span
+                      className={badgeVariants({
+                        className:
+                          "inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground",
+                      })}
+                    >
                       <CircleCheck size={12} className="text-green-600" />
                       {inv.status.charAt(0).toUpperCase() + inv.status.slice(1)}
                     </span>

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx
@@ -35,7 +35,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  badgeVariants,
+  badgeClassName,
 } from "@okouai/ui";
 import {
   orgRoleSchema,
@@ -1113,10 +1113,10 @@ function MemberRow({
       )}
       <div>
         <span
-          className={badgeVariants({
-            className:
-              "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground",
-          })}
+          className={cn(
+            badgeClassName,
+            "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground",
+          )}
         >
           <ShieldCheck
             size={12}
@@ -1518,10 +1518,10 @@ function PendingInvitationRow({
       )}
       <div>
         <span
-          className={badgeVariants({
-            className:
-              "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground",
-          })}
+          className={cn(
+            badgeClassName,
+            "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground",
+          )}
         >
           <Clock size={12} className="text-amber-500" />
           {t(($) => {
@@ -1681,10 +1681,10 @@ function MembershipRequestRow({
       )}
       <div>
         <span
-          className={badgeVariants({
-            className:
-              "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground",
-          })}
+          className={cn(
+            badgeClassName,
+            "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground",
+          )}
         >
           <UserPlus size={12} className="text-blue-500" />
           {t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx
@@ -35,6 +35,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  badgeVariants,
 } from "@okouai/ui";
 import {
   orgRoleSchema,
@@ -1111,7 +1112,12 @@ function MemberRow({
         />
       )}
       <div>
-        <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground okou-badge">
+        <span
+          className={badgeVariants({
+            className:
+              "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground",
+          })}
+        >
           <ShieldCheck
             size={12}
             className={
@@ -1511,7 +1517,12 @@ function PendingInvitationRow({
         </div>
       )}
       <div>
-        <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground okou-badge">
+        <span
+          className={badgeVariants({
+            className:
+              "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground",
+          })}
+        >
           <Clock size={12} className="text-amber-500" />
           {t(($) => {
             return $.settings.workspace.members.pending;
@@ -1669,7 +1680,12 @@ function MembershipRequestRow({
         <div className="text-[13px] text-muted-foreground">—</div>
       )}
       <div>
-        <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground okou-badge">
+        <span
+          className={badgeVariants({
+            className:
+              "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground",
+          })}
+        >
           <UserPlus size={12} className="text-blue-500" />
           {t(($) => {
             return $.settings.workspace.members.membershipRequest.role;

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -14,6 +14,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  badgeVariants,
 } from "@okouai/ui";
 import type {
   MemberUsagePack,
@@ -429,14 +430,24 @@ function MemberIdentity({ member }: { readonly member: MemberDisplay }) {
             {member.name}
           </span>
           {member.isCurrent && (
-            <span className="shrink-0 rounded px-1.5 py-0.5 text-sm leading-none text-muted-foreground okou-badge">
+            <span
+              className={badgeVariants({
+                className:
+                  "shrink-0 rounded px-1.5 py-0.5 text-sm leading-none text-muted-foreground",
+              })}
+            >
               {i18n.t(($) => {
                 return $.settings.workspace.members.you;
               })}
             </span>
           )}
           {member.isPending && (
-            <span className="shrink-0 rounded px-1.5 py-0.5 text-sm leading-none text-muted-foreground okou-badge">
+            <span
+              className={badgeVariants({
+                className:
+                  "shrink-0 rounded px-1.5 py-0.5 text-sm leading-none text-muted-foreground",
+              })}
+            >
               {i18n.t(($) => {
                 return $.settings.workspace.members.pending;
               })}
@@ -2957,7 +2968,12 @@ function migrationPlanComparisonRows({
       current: (
         <span className="inline-flex items-center justify-end gap-1.5">
           <span>{planName(sourceTier)}</span>
-          <span className="rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground okou-badge">
+          <span
+            className={badgeVariants({
+              className:
+                "rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground",
+            })}
+          >
             {i18n.t(($) => {
               return $.billing.plans.legacy;
             })}

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -14,7 +14,8 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-  badgeVariants,
+  badgeClassName,
+  cn,
 } from "@okouai/ui";
 import type {
   MemberUsagePack,
@@ -431,10 +432,10 @@ function MemberIdentity({ member }: { readonly member: MemberDisplay }) {
           </span>
           {member.isCurrent && (
             <span
-              className={badgeVariants({
-                className:
-                  "shrink-0 rounded px-1.5 py-0.5 text-sm leading-none text-muted-foreground",
-              })}
+              className={cn(
+                badgeClassName,
+                "shrink-0 rounded px-1.5 py-0.5 text-sm leading-none text-muted-foreground",
+              )}
             >
               {i18n.t(($) => {
                 return $.settings.workspace.members.you;
@@ -443,10 +444,10 @@ function MemberIdentity({ member }: { readonly member: MemberDisplay }) {
           )}
           {member.isPending && (
             <span
-              className={badgeVariants({
-                className:
-                  "shrink-0 rounded px-1.5 py-0.5 text-sm leading-none text-muted-foreground",
-              })}
+              className={cn(
+                badgeClassName,
+                "shrink-0 rounded px-1.5 py-0.5 text-sm leading-none text-muted-foreground",
+              )}
             >
               {i18n.t(($) => {
                 return $.settings.workspace.members.pending;
@@ -2969,10 +2970,10 @@ function migrationPlanComparisonRows({
         <span className="inline-flex items-center justify-end gap-1.5">
           <span>{planName(sourceTier)}</span>
           <span
-            className={badgeVariants({
-              className:
-                "rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground",
-            })}
+            className={cn(
+              badgeClassName,
+              "rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground",
+            )}
           >
             {i18n.t(($) => {
               return $.billing.plans.legacy;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/build-info-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/build-info-block.tsx
@@ -1,6 +1,7 @@
 import { useGet, useLoadable } from "ccstate-react";
 import { Monitor, GitCommit, Package } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { badgeVariants } from "@okouai/ui";
 
 import { getBuildCommitSha } from "../../../../lib/build-info.ts";
 import { appVersion$ } from "../../../../signals/app-version.ts";
@@ -37,7 +38,12 @@ function BuildInfoTarget({
             {title}
           </div>
         </div>
-        <code className="okou-badge min-w-0 rounded-md px-2 py-0.5 text-right text-xs font-medium text-foreground break-all">
+        <code
+          className={badgeVariants({
+            className:
+              "min-w-0 rounded-md px-2 py-0.5 text-right text-xs font-medium text-foreground break-all",
+          })}
+        >
           {version}
         </code>
       </div>

--- a/turbo/apps/platform/src/views/okou-page/components/settings/build-info-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/build-info-block.tsx
@@ -1,7 +1,7 @@
 import { useGet, useLoadable } from "ccstate-react";
 import { Monitor, GitCommit, Package } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { badgeVariants } from "@okouai/ui";
+import { badgeClassName, cn } from "@okouai/ui";
 
 import { getBuildCommitSha } from "../../../../lib/build-info.ts";
 import { appVersion$ } from "../../../../signals/app-version.ts";
@@ -39,10 +39,10 @@ function BuildInfoTarget({
           </div>
         </div>
         <code
-          className={badgeVariants({
-            className:
-              "min-w-0 rounded-md px-2 py-0.5 text-right text-xs font-medium text-foreground break-all",
-          })}
+          className={cn(
+            badgeClassName,
+            "min-w-0 rounded-md px-2 py-0.5 text-right text-xs font-medium text-foreground break-all",
+          )}
         >
           {version}
         </code>

--- a/turbo/apps/platform/src/views/okou-page/components/settings/built-in-model-cooldown-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/built-in-model-cooldown-diagnostics-block.tsx
@@ -9,7 +9,8 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-  badgeVariants,
+  badgeClassName,
+  cn,
 } from "@okouai/ui";
 import {
   useGet,
@@ -61,9 +62,7 @@ function CooldownDiagnosticsSummary({
           })}
         </span>
         <span className="flex flex-wrap gap-1.5 font-mono text-[11px] text-foreground">
-          <span
-            className={badgeVariants({ className: "rounded-md px-2 py-0.5" })}
-          >
+          <span className={cn(badgeClassName, "rounded-md px-2 py-0.5")}>
             {t(($) => {
               return $.settings.preferences.debug.builtInModelCooldown
                 .globalActive;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/built-in-model-cooldown-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/built-in-model-cooldown-diagnostics-block.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
+  badgeVariants,
 } from "@okouai/ui";
 import {
   useGet,
@@ -60,7 +61,9 @@ function CooldownDiagnosticsSummary({
           })}
         </span>
         <span className="flex flex-wrap gap-1.5 font-mono text-[11px] text-foreground">
-          <span className="okou-badge rounded-md px-2 py-0.5">
+          <span
+            className={badgeVariants({ className: "rounded-md px-2 py-0.5" })}
+          >
             {t(($) => {
               return $.settings.preferences.debug.builtInModelCooldown
                 .globalActive;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connection-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connection-diagnostics-block.tsx
@@ -9,7 +9,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { Button } from "@okouai/ui/components/ui/button";
-import { badgeVariants } from "@okouai/ui";
+import { badgeClassName, cn } from "@okouai/ui";
 
 import { now } from "../../../../lib/time.ts";
 import {
@@ -52,18 +52,14 @@ function ConnectionDiagnosticsSummary({
         <span className="text-sm font-medium text-foreground">{title}</span>
         <span className="text-sm text-muted-foreground">{description}</span>
         <span className="flex flex-wrap gap-1.5 font-mono text-[11px] text-foreground">
-          <span
-            className={badgeVariants({ className: "rounded-md px-2 py-0.5" })}
-          >
+          <span className={cn(badgeClassName, "rounded-md px-2 py-0.5")}>
             {t(($) => {
               return $.settings.preferences.debug.connectionDiagnostics
                 .connection;
             })}
             : {connectionState}
           </span>
-          <span
-            className={badgeVariants({ className: "rounded-md px-2 py-0.5" })}
-          >
+          <span className={cn(badgeClassName, "rounded-md px-2 py-0.5")}>
             {t(($) => {
               return $.settings.preferences.debug.connectionDiagnostics.channel;
             })}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connection-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connection-diagnostics-block.tsx
@@ -9,6 +9,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { Button } from "@okouai/ui/components/ui/button";
+import { badgeVariants } from "@okouai/ui";
 
 import { now } from "../../../../lib/time.ts";
 import {
@@ -51,14 +52,18 @@ function ConnectionDiagnosticsSummary({
         <span className="text-sm font-medium text-foreground">{title}</span>
         <span className="text-sm text-muted-foreground">{description}</span>
         <span className="flex flex-wrap gap-1.5 font-mono text-[11px] text-foreground">
-          <span className="okou-badge rounded-md px-2 py-0.5">
+          <span
+            className={badgeVariants({ className: "rounded-md px-2 py-0.5" })}
+          >
             {t(($) => {
               return $.settings.preferences.debug.connectionDiagnostics
                 .connection;
             })}
             : {connectionState}
           </span>
-          <span className="okou-badge rounded-md px-2 py-0.5">
+          <span
+            className={badgeVariants({ className: "rounded-md px-2 py-0.5" })}
+          >
             {t(($) => {
               return $.settings.preferences.debug.connectionDiagnostics.channel;
             })}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-catalog-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-catalog-diagnostics-block.tsx
@@ -7,7 +7,7 @@ import { ChevronDown, ChevronUp, Plug } from "lucide-react";
 import { useLoadable } from "ccstate-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import { badgeVariants } from "@okouai/ui";
+import { badgeClassName, cn } from "@okouai/ui";
 
 import {
   formatLocalizedNumber,
@@ -244,9 +244,10 @@ function CatalogDiagnosticsSummary({
         </span>
         <span className="flex min-w-0 flex-wrap gap-1.5 font-mono text-[11px] text-foreground">
           <span
-            className={badgeVariants({
-              className: "max-w-full rounded-md px-2 py-0.5 break-all",
-            })}
+            className={cn(
+              badgeClassName,
+              "max-w-full rounded-md px-2 py-0.5 break-all",
+            )}
           >
             {i18n.t(($) => {
               return $.connectors.providerSettings.catalogDiagnostics.fields
@@ -255,9 +256,10 @@ function CatalogDiagnosticsSummary({
             : {formatEnumValue(diagnostics.state)}
           </span>
           <span
-            className={badgeVariants({
-              className: "max-w-full rounded-md px-2 py-0.5 break-all",
-            })}
+            className={cn(
+              badgeClassName,
+              "max-w-full rounded-md px-2 py-0.5 break-all",
+            )}
           >
             {i18n.t(($) => {
               return $.connectors.providerSettings.catalogDiagnostics.fields
@@ -266,9 +268,10 @@ function CatalogDiagnosticsSummary({
             : {activeVersion}
           </span>
           <span
-            className={badgeVariants({
-              className: "max-w-full rounded-md px-2 py-0.5 break-all",
-            })}
+            className={cn(
+              badgeClassName,
+              "max-w-full rounded-md px-2 py-0.5 break-all",
+            )}
           >
             {i18n.t(($) => {
               return $.connectors.providerSettings.catalogDiagnostics.fields
@@ -277,9 +280,10 @@ function CatalogDiagnosticsSummary({
             : {lastAttempt}
           </span>
           <span
-            className={badgeVariants({
-              className: "max-w-full rounded-md px-2 py-0.5 break-all",
-            })}
+            className={cn(
+              badgeClassName,
+              "max-w-full rounded-md px-2 py-0.5 break-all",
+            )}
           >
             {i18n.t(($) => {
               return $.connectors.providerSettings.catalogDiagnostics.fields

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-catalog-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-catalog-diagnostics-block.tsx
@@ -7,6 +7,7 @@ import { ChevronDown, ChevronUp, Plug } from "lucide-react";
 import { useLoadable } from "ccstate-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { badgeVariants } from "@okouai/ui";
 
 import {
   formatLocalizedNumber,
@@ -242,28 +243,44 @@ function CatalogDiagnosticsSummary({
           })}
         </span>
         <span className="flex min-w-0 flex-wrap gap-1.5 font-mono text-[11px] text-foreground">
-          <span className="okou-badge max-w-full rounded-md px-2 py-0.5 break-all">
+          <span
+            className={badgeVariants({
+              className: "max-w-full rounded-md px-2 py-0.5 break-all",
+            })}
+          >
             {i18n.t(($) => {
               return $.connectors.providerSettings.catalogDiagnostics.fields
                 .syncState;
             })}
             : {formatEnumValue(diagnostics.state)}
           </span>
-          <span className="okou-badge max-w-full rounded-md px-2 py-0.5 break-all">
+          <span
+            className={badgeVariants({
+              className: "max-w-full rounded-md px-2 py-0.5 break-all",
+            })}
+          >
             {i18n.t(($) => {
               return $.connectors.providerSettings.catalogDiagnostics.fields
                 .activeVersion;
             })}
             : {activeVersion}
           </span>
-          <span className="okou-badge max-w-full rounded-md px-2 py-0.5 break-all">
+          <span
+            className={badgeVariants({
+              className: "max-w-full rounded-md px-2 py-0.5 break-all",
+            })}
+          >
             {i18n.t(($) => {
               return $.connectors.providerSettings.catalogDiagnostics.fields
                 .lastAttempt;
             })}
             : {lastAttempt}
           </span>
-          <span className="okou-badge max-w-full rounded-md px-2 py-0.5 break-all">
+          <span
+            className={badgeVariants({
+              className: "max-w-full rounded-md px-2 py-0.5 break-all",
+            })}
+          >
             {i18n.t(($) => {
               return $.connectors.providerSettings.catalogDiagnostics.fields
                 .evaluation;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/indexeddb-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/indexeddb-diagnostics-block.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@okouai/ui/components/ui/button";
-import { badgeVariants } from "@okouai/ui";
+import { badgeClassName, cn } from "@okouai/ui";
 import {
   useLastResolved,
   useLoadable,
@@ -52,25 +52,19 @@ function IndexedDbDiagnosticsSummary({
           })}
         </span>
         <span className="flex flex-wrap gap-1.5 font-mono text-[11px] text-foreground">
-          <span
-            className={badgeVariants({ className: "rounded-md px-2 py-0.5" })}
-          >
+          <span className={cn(badgeClassName, "rounded-md px-2 py-0.5")}>
             {t(($) => {
               return $.settings.preferences.debug.indexedDb.schema;
             })}
             : {diagnostics.version}
           </span>
-          <span
-            className={badgeVariants({ className: "rounded-md px-2 py-0.5" })}
-          >
+          <span className={cn(badgeClassName, "rounded-md px-2 py-0.5")}>
             {t(($) => {
               return $.settings.preferences.debug.indexedDb.stores;
             })}
             : {formatLocalizedNumber(diagnostics.stores.length)}
           </span>
-          <span
-            className={badgeVariants({ className: "rounded-md px-2 py-0.5" })}
-          >
+          <span className={cn(badgeClassName, "rounded-md px-2 py-0.5")}>
             {t(($) => {
               return $.settings.preferences.debug.indexedDb.records;
             })}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/indexeddb-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/indexeddb-diagnostics-block.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@okouai/ui/components/ui/button";
+import { badgeVariants } from "@okouai/ui";
 import {
   useLastResolved,
   useLoadable,
@@ -51,19 +52,25 @@ function IndexedDbDiagnosticsSummary({
           })}
         </span>
         <span className="flex flex-wrap gap-1.5 font-mono text-[11px] text-foreground">
-          <span className="okou-badge rounded-md px-2 py-0.5">
+          <span
+            className={badgeVariants({ className: "rounded-md px-2 py-0.5" })}
+          >
             {t(($) => {
               return $.settings.preferences.debug.indexedDb.schema;
             })}
             : {diagnostics.version}
           </span>
-          <span className="okou-badge rounded-md px-2 py-0.5">
+          <span
+            className={badgeVariants({ className: "rounded-md px-2 py-0.5" })}
+          >
             {t(($) => {
               return $.settings.preferences.debug.indexedDb.stores;
             })}
             : {formatLocalizedNumber(diagnostics.stores.length)}
           </span>
-          <span className="okou-badge rounded-md px-2 py-0.5">
+          <span
+            className={badgeVariants({ className: "rounded-md px-2 py-0.5" })}
+          >
             {t(($) => {
               return $.settings.preferences.debug.indexedDb.records;
             })}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
@@ -382,7 +382,7 @@ function SettingsDialog({
           </div>
 
           {/* Desktop: sidebar nav */}
-          <nav className="hidden sm:flex sm:flex-col w-52 shrink-0 p-3 pt-3 pb-4 gap-4 overflow-y-auto okou-border-r bg-[hsl(var(--gray-0))]">
+          <nav className="hidden sm:flex sm:flex-col w-52 shrink-0 p-3 pt-3 pb-4 gap-4 overflow-y-auto border-r-(length:--border-width-surface) border-r-gray-300 bg-[hsl(var(--gray-0))]">
             {sidebarGroups.map((group) => {
               return (
                 <div key={group.label} className="shrink-0">

--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -15,6 +15,7 @@ import {
   SheetTitle,
   Button,
   Input,
+  badgeVariants,
 } from "@okouai/ui";
 import { Crown, Minus, Plus } from "lucide-react";
 import {
@@ -298,7 +299,12 @@ function UpgradeCard({
         <h3 className={`text-sm font-mono font-semibold ${tierColor}`}>
           {upgrade.targetLabel}
         </h3>
-        <span className="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground okou-badge">
+        <span
+          className={badgeVariants({
+            className:
+              "inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground",
+          })}
+        >
           <Crown size={12} className="text-amber-500" />
           {t(($) => {
             return $.queue.upgrade.recommended;
@@ -495,7 +501,12 @@ function ConcurrencyPurchaseCard({
             return $.queue.purchase.title;
           })}
         </h3>
-        <span className="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground okou-badge">
+        <span
+          className={badgeVariants({
+            className:
+              "inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground",
+          })}
+        >
           <Crown size={12} className="text-amber-500" />
           {t(($) => {
             return $.queue.purchase.addOn;

--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -15,7 +15,8 @@ import {
   SheetTitle,
   Button,
   Input,
-  badgeVariants,
+  badgeClassName,
+  cn,
 } from "@okouai/ui";
 import { Crown, Minus, Plus } from "lucide-react";
 import {
@@ -300,10 +301,10 @@ function UpgradeCard({
           {upgrade.targetLabel}
         </h3>
         <span
-          className={badgeVariants({
-            className:
-              "inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground",
-          })}
+          className={cn(
+            badgeClassName,
+            "inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground",
+          )}
         >
           <Crown size={12} className="text-amber-500" />
           {t(($) => {
@@ -502,10 +503,10 @@ function ConcurrencyPurchaseCard({
           })}
         </h3>
         <span
-          className={badgeVariants({
-            className:
-              "inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground",
-          })}
+          className={cn(
+            badgeClassName,
+            "inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground",
+          )}
         >
           <Crown size={12} className="text-amber-500" />
           {t(($) => {

--- a/turbo/packages/ui/src/components/ui/badge.tsx
+++ b/turbo/packages/ui/src/components/ui/badge.tsx
@@ -1,0 +1,12 @@
+import { cva } from "class-variance-authority";
+
+/**
+ * Inline badges and tags: a hairline stroke over the neutral fill, applied to
+ * the host element so its layout, display, radius, and text semantics stay
+ * where the consumer declares them.
+ */
+const badgeVariants = cva(
+  "border-(length:--border-width-surface) border-solid border-surface-border bg-gray-0",
+);
+
+export { badgeVariants };

--- a/turbo/packages/ui/src/components/ui/badge.tsx
+++ b/turbo/packages/ui/src/components/ui/badge.tsx
@@ -1,12 +1,7 @@
-import { cva } from "class-variance-authority";
-
 /**
  * Inline badges and tags: a hairline stroke over the neutral fill, applied to
  * the host element so its layout, display, radius, and text semantics stay
  * where the consumer declares them.
  */
-const badgeVariants = cva(
-  "border-(length:--border-width-surface) border-solid border-surface-border bg-gray-0",
-);
-
-export { badgeVariants };
+export const badgeClassName =
+  "border-(length:--border-width-surface) border-solid border-surface-border bg-gray-0";

--- a/turbo/packages/ui/src/index.ts
+++ b/turbo/packages/ui/src/index.ts
@@ -18,7 +18,7 @@ export {
   CardContent,
   cardClassName,
 } from "./components/ui/card";
-export { badgeVariants } from "./components/ui/badge";
+export { badgeClassName } from "./components/ui/badge";
 export { Checkbox } from "./components/ui/checkbox";
 export {
   ToggleButton,

--- a/turbo/packages/ui/src/index.ts
+++ b/turbo/packages/ui/src/index.ts
@@ -18,6 +18,7 @@ export {
   CardContent,
   cardClassName,
 } from "./components/ui/card";
+export { badgeVariants } from "./components/ui/badge";
 export { Checkbox } from "./components/ui/checkbox";
 export {
   ToggleButton,

--- a/turbo/style-legacy-baseline.json
+++ b/turbo/style-legacy-baseline.json
@@ -20,10 +20,8 @@
     "motion-safe:animate-in",
     "motion-safe:fade-in",
     "okou-app",
-    "okou-badge",
     "okou-blocks",
     "okou-border",
-    "okou-border-r",
     "okou-border-t",
     "okou-btn-morandi",
     "okou-bubble-cool",
@@ -49,7 +47,6 @@
     "okou-nav-recent-label",
     "okou-nav-title",
     "okou-nav-title-row",
-    "okou-pill",
     "okou-pwa-fixed-cover",
     "okou-realtime-cloud-flow",
     "okou-realtime-status-reconnecting",
@@ -673,27 +670,6 @@
       },
       {
         "atRules": [],
-        "selector": ".okou-app .okou-pill",
-        "property": "background-color",
-        "value": "hsl(var(--gray-0))",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-app .okou-pill",
-        "property": "border",
-        "value": "0.7px solid hsl(var(--gray-400))",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-app .okou-pill",
-        "property": "color",
-        "value": "hsl(var(--muted-foreground))",
-        "important": false
-      },
-      {
-        "atRules": [],
         "selector": ".okou-emoji",
         "property": "font-family",
         "value": "var(--font-family-emoji)",
@@ -711,13 +687,6 @@
         "selector": ".okou-border-t",
         "property": "border-top",
         "value": "0.7px solid hsl(var(--gray-400))",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-border-r",
-        "property": "border-right",
-        "value": "0.7px solid hsl(var(--gray-300))",
         "important": false
       },
       {
@@ -781,20 +750,6 @@
         "selector": ".okou-realtime-cloud-flow",
         "property": "animation",
         "value": "none",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-badge",
-        "property": "border",
-        "value": "0.7px solid hsl(var(--gray-400))",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-badge",
-        "property": "background-color",
-        "value": "hsl(var(--gray-0))",
         "important": false
       },
       {
@@ -3933,9 +3888,6 @@
       "ease": 1,
       "fade-in": 1
     },
-    "apps/platform/src/views/okou-page/components/log-views/status-badge.tsx": {
-      "okou-pill": 1
-    },
     "apps/platform/src/views/okou-page/components/model-picker-menu.tsx": {
       "animate-in": 1,
       "fade-in": 1,
@@ -3951,7 +3903,6 @@
     "apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx": {
       "dialog-scrollable": 1,
       "okou-app": 1,
-      "okou-badge": 1,
       "okou-border": 3,
       "okou-border-t": 7
     },
@@ -3959,11 +3910,9 @@
       "okou-border-t": 3
     },
     "apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx": {
-      "okou-badge": 1,
       "okou-border-t": 3
     },
     "apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx": {
-      "okou-badge": 3,
       "okou-border": 1,
       "okou-border-t": 5
     },
@@ -3976,8 +3925,7 @@
     },
     "apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx": {
       "dialog-scrollable": 2,
-      "icon-button": 1,
-      "okou-badge": 3
+      "icon-button": 1
     },
     "apps/platform/src/views/okou-page/components/preferences/personal-providers-tab.tsx": {
       "okou-btn-morandi": 2
@@ -3989,11 +3937,9 @@
       "okou-border-t": 1
     },
     "apps/platform/src/views/okou-page/components/settings/build-info-block.tsx": {
-      "okou-badge": 1,
       "okou-border": 1
     },
     "apps/platform/src/views/okou-page/components/settings/built-in-model-cooldown-diagnostics-block.tsx": {
-      "okou-badge": 1,
       "okou-border": 1
     },
     "apps/platform/src/views/okou-page/components/settings/color-theme-settings.tsx": {
@@ -4001,18 +3947,15 @@
       "okou-color-theme-swatch": 1
     },
     "apps/platform/src/views/okou-page/components/settings/connection-diagnostics-block.tsx": {
-      "okou-badge": 2,
       "okou-border": 1
     },
     "apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx": {
       "okou-border-t": 1
     },
     "apps/platform/src/views/okou-page/components/settings/connector-catalog-diagnostics-block.tsx": {
-      "okou-badge": 4,
       "okou-border": 1
     },
     "apps/platform/src/views/okou-page/components/settings/indexeddb-diagnostics-block.tsx": {
-      "okou-badge": 3,
       "okou-border": 1
     },
     "apps/platform/src/views/okou-page/components/settings/language-settings.tsx": {
@@ -4038,8 +3981,7 @@
       "okou-border": 1
     },
     "apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx": {
-      "okou-app": 1,
-      "okou-border-r": 1
+      "okou-app": 1
     },
     "apps/platform/src/views/okou-page/components/settings/timezone-settings.tsx": {
       "okou-btn-morandi": 1
@@ -4169,7 +4111,6 @@
     },
     "apps/platform/src/views/queue-page/queue-drawer.tsx": {
       "lucide": 1,
-      "okou-badge": 2,
       "okou-border": 3
     },
     "apps/platform/src/views/shared-thread-page/shared-thread-page.tsx": {

--- a/turbo/style-migration-manifest.json
+++ b/turbo/style-migration-manifest.json
@@ -350,8 +350,21 @@
         "badge-billing-light",
         "badge-billing-dark"
       ],
-      "status": "planned",
-      "evidence": []
+      "status": "implemented",
+      "evidence": [
+        {
+          "kind": "local-stylesheet-and-computed-style-equivalence",
+          "url": "https://a.okou.io/cq91krcx32.zip",
+          "sha256": "3cf69d4308d18a5a7bcc1ecaadaaf49335e6c8a35d98e11c28892d3baef84656",
+          "commit": "9cbd46e546b1de820327f5fa7732981beab3df8b"
+        },
+        {
+          "kind": "before-after-comparison-image",
+          "url": "https://a.okou.io/8rio8pap8b.png",
+          "sha256": "e7a3fb5795fa32b8b1978c70b516c8f87fd9da81252356970e105b22906f8d8b",
+          "commit": "9cbd46e546b1de820327f5fa7732981beab3df8b"
+        }
+      ]
     }
   ],
   "caseFiles": [

--- a/turbo/style-migration-manifest.json
+++ b/turbo/style-migration-manifest.json
@@ -354,15 +354,15 @@
       "evidence": [
         {
           "kind": "local-stylesheet-and-computed-style-equivalence",
-          "url": "https://a.okou.io/cq91krcx32.zip",
-          "sha256": "3cf69d4308d18a5a7bcc1ecaadaaf49335e6c8a35d98e11c28892d3baef84656",
-          "commit": "9cbd46e546b1de820327f5fa7732981beab3df8b"
+          "url": "https://a.okou.io/6ov8hugeng.zip",
+          "sha256": "784681d8dc49b30472467d23bd1c6761104726e7eb3f95719f01f1add79b3c28",
+          "commit": "63c0f7efb4c43bd62ca8f6565aaa7dcdd39bf09d"
         },
         {
           "kind": "before-after-comparison-image",
           "url": "https://a.okou.io/8rio8pap8b.png",
           "sha256": "e7a3fb5795fa32b8b1978c70b516c8f87fd9da81252356970e105b22906f8d8b",
-          "commit": "9cbd46e546b1de820327f5fa7732981beab3df8b"
+          "commit": "63c0f7efb4c43bd62ca8f6565aaa7dcdd39bf09d"
         }
       ]
     }

--- a/turbo/style-migration-manifest.json
+++ b/turbo/style-migration-manifest.json
@@ -321,11 +321,43 @@
         }
       ],
       "pullRequest": "https://github.com/vm0-ai/vm0/pull/33062"
+    },
+    {
+      "id": "hairline-badge-surfaces",
+      "family": "local-controls",
+      "tokens": ["okou-badge", "okou-pill", "okou-border-r"],
+      "consumers": [
+        "apps/platform/src/views/okou-page/components/settings/build-info-block.tsx",
+        "apps/platform/src/views/okou-page/components/settings/built-in-model-cooldown-diagnostics-block.tsx",
+        "apps/platform/src/views/okou-page/components/settings/connection-diagnostics-block.tsx",
+        "apps/platform/src/views/okou-page/components/settings/connector-catalog-diagnostics-block.tsx",
+        "apps/platform/src/views/okou-page/components/settings/indexeddb-diagnostics-block.tsx",
+        "apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx",
+        "apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx",
+        "apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx",
+        "apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx",
+        "apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx",
+        "apps/platform/src/views/okou-page/components/log-views/status-badge.tsx",
+        "apps/platform/src/views/queue-page/queue-drawer.tsx"
+      ],
+      "cases": [
+        "badge-debug-light",
+        "badge-debug-dark",
+        "badge-debug-narrow",
+        "badge-debug-narrow-dark",
+        "badge-people-light",
+        "badge-people-dark",
+        "badge-billing-light",
+        "badge-billing-dark"
+      ],
+      "status": "planned",
+      "evidence": []
     }
   ],
   "caseFiles": [
     "../e2e/playwright/style-migration/cases.json",
     "../e2e/playwright/style-migration/tone-cases.json",
-    "../e2e/playwright/style-migration/icon-mono-cases.json"
+    "../e2e/playwright/style-migration/icon-mono-cases.json",
+    "../e2e/playwright/style-migration/badge-cases.json"
   ]
 }


### PR DESCRIPTION
Refs #32402

Three `local-controls` legacy selectors drain in one batch, so `okou-badge`, `okou-pill`, and `okou-border-r` are deleted from `apps/platform/src/views/css/index.css` together with their baseline entries.

## Shared contract

`badgeVariants` in `@okouai/ui` owns the inline badge surface: `border-(length:--border-width-surface) border-solid border-surface-border bg-gray-0`. It reuses the existing page-surface border tokens rather than declaring badge-specific aliases, and it applies to the existing host element through `className`, adding no wrapper. Display, radius, padding, typography, and foreground stay on the consumer, because the 22 real consumers legitimately differ there — inline text, `inline-flex` rows with an icon, and one `<code>` element.

## Consumers

| Legacy class | Sites | Replacement |
| --- | --- | --- |
| `okou-badge` | 21 | `badgeVariants({ className: … })` |
| `okou-pill` | 1 | `badgeVariants({ className: "… text-muted-foreground" })` |
| `okou-border-r` | 1 | `border-r-(length:--border-width-surface) border-r-gray-300` |

`.okou-app .okou-pill` was the only one of the three that also set a foreground; its single consumer (`StatusBadge` in shell style) now spells `text-muted-foreground` itself. That consumer also carried a `border` utility whose 1px width the unlayered selector had overridden with 0.7px; the migrated class list drops it and keeps 0.7px.

`okou-border-r` used Gray 300 rather than the Gray 400 of the other hairlines, so it keeps `border-r-gray-300` instead of `border-surface-border`.

## Verification

Recorded in the PR comments.