### PR TITLE
feat: enable mailchimp oauth with doppler credentials

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -345,6 +345,7 @@ runs:
           CANVA
           CLOUDFLARE
           HUBSPOT
+          MAILCHIMP
           CLOSE
           META_ADS
           TIKTOK_ADS

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -491,6 +491,8 @@ assert_env_value "$success_env_file" SLACK_OAUTH_CLIENT_ID "doppler-SLACK_OAUTH_
 assert_env_value "$success_env_file" SLACK_OAUTH_CLIENT_SECRET "doppler-SLACK_OAUTH_CLIENT_SECRET"
 assert_env_value "$success_env_file" ZOOM_OAUTH_CLIENT_ID "doppler-ZOOM_OAUTH_CLIENT_ID"
 assert_env_value "$success_env_file" ZOOM_OAUTH_CLIENT_SECRET "doppler-ZOOM_OAUTH_CLIENT_SECRET"
+assert_env_value "$success_env_file" MAILCHIMP_OAUTH_CLIENT_ID "doppler-MAILCHIMP_OAUTH_CLIENT_ID"
+assert_env_value "$success_env_file" MAILCHIMP_OAUTH_CLIENT_SECRET "doppler-MAILCHIMP_OAUTH_CLIENT_SECRET"
 assert_env_value "$success_env_file" BOX_OAUTH_CLIENT_ID "doppler-BOX_OAUTH_CLIENT_ID"
 assert_env_value "$success_env_file" BOX_OAUTH_CLIENT_SECRET "doppler-BOX_OAUTH_CLIENT_SECRET"
 assert_env_value "$success_env_file" QUICKBOOKS_OAUTH_CLIENT_ID "doppler-QUICKBOOKS_OAUTH_CLIENT_ID"
@@ -639,6 +641,8 @@ assert_no_fixture_secret_values "$production_api_output"
 assert_machine_secret_values_absent_from_output "$production_api_output" "github-atom-machine-secret"
 assert_env_value "$production_api_env_file" OKOU_HOST_SCHEME "https"
 assert_debug_absent "$production_api_env_file"
+assert_env_value "$production_api_env_file" MAILCHIMP_OAUTH_CLIENT_ID "doppler-MAILCHIMP_OAUTH_CLIENT_ID"
+assert_env_value "$production_api_env_file" MAILCHIMP_OAUTH_CLIENT_SECRET "doppler-MAILCHIMP_OAUTH_CLIENT_SECRET"
 assert_env_value "$production_api_env_file" R2_PRIVATE_ARTIFACTS_BUCKET_NAME "user-artifact-private-prod"
 assert_env_value "$production_api_env_file" R2_PRIVATE_ARTIFACTS_ACCESS_KEY_ID "private-prod-key"
 assert_env_value "$production_api_env_file" R2_PRIVATE_ARTIFACTS_SECRET_ACCESS_KEY "private-prod-secret"
@@ -697,6 +701,18 @@ if [[ "$status" -eq 0 ]]; then
   fail "expected missing Stripe Doppler OAuth client secret to fail"
 fi
 assert_contains "$missing_stripe_secret_output" "::error::STRIPE_OAUTH_CLIENT_SECRET is missing from Doppler OAuth config"
+
+for mailchimp_key in MAILCHIMP_OAUTH_CLIENT_ID MAILCHIMP_OAUTH_CLIENT_SECRET; do
+  missing_mailchimp_dir="$(mktemp -d)"
+  TEMP_DIRS+=("$missing_mailchimp_dir")
+  status=0
+  missing_mailchimp_output="$(run_action "$(build_doppler_secrets_json "$mailchimp_key")" "$missing_mailchimp_dir" 2>&1)" || status=$?
+  if [[ "$status" -eq 0 ]]; then
+    fail "expected missing Mailchimp Doppler OAuth config to fail"
+  fi
+  assert_contains "$missing_mailchimp_output" "::error::${mailchimp_key} is missing from Doppler OAuth config"
+  assert_no_fixture_secret_values "$missing_mailchimp_output"
+done
 
 missing_cli_pkg_dir="$(mktemp -d)"
 TEMP_DIRS+=("$missing_cli_pkg_dir")

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-input.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-input.test.tsx
@@ -693,7 +693,9 @@ test.each([
   click(await activeVoiceDraftStopButton());
   await transcriptionFailed.promise;
 
-  await expect(screen.findByText(failure.message)).resolves.toBeVisible();
+  await waitFor(() => {
+    expect(screen.getByText(failure.message)).toBeVisible();
+  });
   await expect(findButton("Retry")).resolves.toBeEnabled();
   expect(queryButton("Voice input")).toBeNull();
   expect(transcriptionAttempts).toBe(1);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
@@ -176,8 +176,20 @@ test("Avoid duplicate catalog sections during metadata changes", async () => {
   expect(queryConnectorCard("Billing Stripe")).toBeInTheDocument();
 });
 
+test("Show Mailchimp OAuth without a feature-switch override", async () => {
+  mockConnectors(context, []);
+  await setupPage({ context, path: "/connectors?keywords=mailchimp" });
+
+  await waitFor(() => {
+    expect(getConnectorAction("button", "Connect Mailchimp")).toBeEnabled();
+  });
+});
+
 test("Update connector visibility when availability changes", async () => {
   mockConnectors(context, []);
+  setMockConnectorFeatureSwitches({
+    [FeatureSwitchKey.MailchimpConnector]: false,
+  });
   const switchesReady = context.mocks.deferred<void>();
   context.mocks.api(featureSwitchesContract.get, async ({ respond }) => {
     await switchesReady.promise;

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -193,7 +193,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.MailchimpConnector]: {
     maintainer: "yuma@okou.ai",
     description: "Enable the Mailchimp email marketing connector",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.ResendConnector]: {
     maintainer: "yuma@okou.ai",


### PR DESCRIPTION
Mailchimp OAuth already has a provider and catalog auth method, but deployment omits its Doppler client credentials and discovery is disabled. Inject `MAILCHIMP_OAUTH_CLIENT_ID` / `MAILCHIMP_OAUTH_CLIENT_SECRET` through the existing fail-closed Doppler deployment path and enable `mailchimpConnector`.

## Validation

- `bash .github/scripts/tests/web-api-env-action-test.sh` passed. Coverage verifies development and production injection, rejects either missing Mailchimp value, and checks that output does not disclose credentials.
- `bash -n .github/scripts/tests/web-api-env-action-test.sh`, the locked Prettier 3.8.1 check, and `git diff --check` passed.
- Both Mailchimp key names exist in Doppler project `vm0`, configs `dev` and `prd`. The public client IDs were used only for an unauthenticated registration preflight; client secrets and access tokens were not retrieved or logged.
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/connectors-catalog.test.tsx`: **14 tests passed**, including default Mailchimp discoverability and a scoped visibility override. Core type checking and focused Core/App ESLint passed.
- All **105 current-head PR checks** passed at `f5a16d345e418c4b64004266eb1516ebe58ee998`, including `ci-gate-turbo`, `ci-gate-crates`, and `ci-gate-security`; GitHub reports `CLEAN`.
- Correct an existing voice-retry test synchronization race found in CI: wait for the error toast to become visible, retaining the original recording, retry, and recovery assertions. The complete voice-input test file passes (29 tests), and both error-retry scenarios pass five consecutive runs. Focused ESLint, formatting, and all App type-check projects passed.
- Development preview API and App deployment passed; the API job successfully fetched Doppler and rendered the deployment environment with both Mailchimp values required.
- Existing OAuth route/provider coverage already exercises Mailchimp's code exchange and metadata lookup. Full Vitest and deployed checks are left to the PR pipeline per repository instructions; no local dev server was started.

## Rollout

Before this OAuth rollout ships, deploy the method-override guard from https://github.com/vm0-ai/vm0/pull/33197 to all runners that serve connector requests, then publish and sync https://github.com/vm0-ai/vm0-connectors/pull/4179. The catalog replaces allow-all rules with explicit read/write/send/delete permissions and blocks arbitrary batch execution; its method-based isolation also depends on the runner rejecting `X-HTTP-Method-Override`. This is a functional security dependency.

The provider registration must accept `https://app.okou.ai/connectors/mailchimp/callback` before rollout. An unauthenticated preflight using the public client IDs from both `dev` and `prd` reaches Mailchimp's "Log in to authorize your Mailchimp account to Okou" page. The same page also accepts an intentionally invalid redirect before login, so that preflight does not establish callback registration. The owner has been asked to confirm the exact callback; real OAuth consent and a non-mutating API smoke test remain pending. PR #30582 pre-staged the callback routing and did not establish that provider-console configuration was complete.

No credential-storage, OAuth scopes, token-refresh, or callback-protocol changes are needed. Mailchimp access tokens do not expire automatically and the provider does not offer granular OAuth scopes; Okou enforces the API permissions.

Refs #30508
