### PR TITLE
fix(e2e): require stripe contact email before payment

### DIFF
--- a/e2e/playwright/lib/stripe-checkout.ts
+++ b/e2e/playwright/lib/stripe-checkout.ts
@@ -543,10 +543,6 @@ async function disableLinkSaveInfo(page: Page): Promise<void> {
 export async function fillStripeCheckout(page: Page): Promise<void> {
   await expect(page).toHaveURL(/checkout\.stripe\.com/, { timeout: 30_000 });
 
-  await fillFirst(
-    page.getByLabel(/email/i).or(page.locator('input[name="email"]')),
-    `billing-e2e-${Date.now()}@vm0-e2e.ai`,
-  );
   // Stripe can commit the hosted Checkout navigation while its form is still
   // a skeleton. Use the final purchase control as the single layout-neutral
   // readiness boundary before inspecting Card controls or field frames.
@@ -573,6 +569,16 @@ export async function fillStripeCheckout(page: Page): Promise<void> {
       .or(page.locator('input[name="billingPostalCode"]')),
     "94107",
   );
+
+  // Fill email after the other form actions and verify it before payment.
+  const email = page
+    .getByLabel(/email/i)
+    .or(page.locator('input[name="email"]'))
+    .filter({ visible: true })
+    .first();
+  const emailAddress = `billing-e2e-${Date.now()}@vm0-e2e.ai`;
+  await email.fill(emailAddress, { timeout: 5_000 });
+  await expect(email).toHaveValue(emailAddress);
 
   await checkoutSubmitLocator(page).click({ timeout: 30_000 });
 }


### PR DESCRIPTION
## Summary

Runner credential preparation could submit Stripe Checkout with an empty required Email field, then spend 180 seconds waiting for a paid-onboarding redirect. The retained failure in #33191 shows Email marked `REQUIRED` while the card and address fields are populated.

Fill the visible contact email after the other form actions, immediately before Subscribe, and assert its exact value. Email-fill failures now propagate directly instead of being converted to an ignored `false`. The existing five-second fill timeout is preserved.

Closes #33191.

## Scope and coverage

This changes only the shared E2E helper used by paid-onboarding and runner credential preparation. Card layout/frame handling, actual hosted Stripe payment, and the callers' completion assertions remain intact. It introduces no purchase retry, sleep, timeout increase, fallback, or billing API change.

Existing real-service PR jobs retain the integration coverage. The synthetic Stripe fixture suite removed in #30464 is not restored. The original artifact does not record whether email entry timed out or the input was subsequently reset/replaced; controlled diagnostics validate those failure modes without claiming to reconstruct the original Stripe timing.

## Validation

- `cd e2e && pnpm check-types` — passed.
- `pnpm test` with `PLAYWRIGHT_BROWSERS_PATH` pointing to a local launcher for installed Chromium 152.0.7977.82 — all 43 existing fixture integration tests passed.
- Temporary Chromium diagnostic exercising the exported helper: unmodified baseline failed 4 of 5 cases; the changed helper passed all 5 (normal submission, email replaced during card entry, hidden duplicate email, cleared email, read-only email). Invalid-email cases assert rejection before submission.
- Normal, replacement, and hidden-duplicate cases repeated five times each — 15/15 passed.
- Prettier 3.8.1 check, affected-file size check, `git diff --check`, and commitlint — passed.

The pinned Chromium 148 download was blocked by the sandbox connector policy, so local browser validation used installed Chromium 152. The PR pipeline owns validation with its pinned browser and real Stripe/Clerk services. No local dev server or full local Vitest suite was started.
