### PR TITLE
fix(rust): bound guest tool placement connections under socket backpressure

### DIFF
--- a/crates/guest-tool-exec/src/lib.rs
+++ b/crates/guest-tool-exec/src/lib.rs
@@ -192,7 +192,7 @@ fn is_canonical_runtime_path(path: &Path) -> bool {
 }
 
 fn place_current_process(endpoint: &str) -> io::Result<()> {
-    let stream = process_control_ipc::connect_abstract(endpoint)?;
+    let stream = process_control_ipc::connect_abstract_with_timeout(endpoint, PLACEMENT_TIMEOUT)?;
     stream.set_read_timeout(Some(PLACEMENT_TIMEOUT))?;
     stream.set_write_timeout(Some(PLACEMENT_TIMEOUT))?;
     let placement = process_control_ipc::receive_tool_placement(&stream)?;
@@ -283,6 +283,8 @@ fn shell_invocation(mut arguments: Vec<OsString>) -> io::Result<(OsString, Vec<O
 mod tests {
     use super::*;
     use std::os::unix::ffi::OsStringExt;
+
+    mod placement;
 
     #[test]
     fn recognizes_only_canonical_runtime_leaf() {

--- a/crates/guest-tool-exec/src/tests/placement.rs
+++ b/crates/guest-tool-exec/src/tests/placement.rs
@@ -1,0 +1,183 @@
+use super::*;
+use std::mem::{MaybeUninit, size_of};
+use std::os::fd::{AsFd, FromRawFd};
+use std::os::unix::net::UnixListener;
+use std::process::Child;
+use std::thread;
+use std::time::Instant;
+
+const QUEUE_TEST_CHILD_ENV: &str = "VM0_TEST_PLACEMENT_CONNECT_CHILD";
+
+struct TestChild(Child);
+
+impl Drop for TestChild {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn fill_accept_queue(listener: &UnixListener) -> Vec<OwnedFd> {
+    // Read the bound address so fixture clients independently exercise the
+    // kernel's nonblocking queue-full result, without using the timed API.
+    let mut address = MaybeUninit::<libc::sockaddr_un>::uninit();
+    let mut address_len = size_of::<libc::sockaddr_un>() as libc::socklen_t;
+    // SAFETY: address and address_len point to writable, correctly sized storage.
+    let result = unsafe {
+        libc::getsockname(
+            listener.as_raw_fd(),
+            address.as_mut_ptr().cast(),
+            &mut address_len,
+        )
+    };
+    assert_eq!(result, 0);
+    let mut queued = Vec::new();
+    for _ in 0..1024 {
+        // SAFETY: the arguments create a nonblocking, close-on-exec Unix socket.
+        let raw_fd = unsafe {
+            libc::socket(
+                libc::AF_UNIX,
+                libc::SOCK_STREAM | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC,
+                0,
+            )
+        };
+        assert!(raw_fd >= 0);
+        // SAFETY: raw_fd is newly created and ownership is transferred once.
+        let socket = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+        // SAFETY: getsockname initialized address_len bytes of the address and
+        // socket owns a valid AF_UNIX descriptor for the entire call.
+        let result =
+            unsafe { libc::connect(socket.as_raw_fd(), address.as_ptr().cast(), address_len) };
+        if result == 0 {
+            queued.push(socket);
+        } else {
+            assert_eq!(io::Error::last_os_error().kind(), io::ErrorKind::WouldBlock);
+            assert!(!queued.is_empty());
+            return queued;
+        }
+    }
+    panic!("fixture could not fill the listener's accept queue");
+}
+
+fn resource_counts() -> (usize, usize) {
+    (
+        std::fs::read_dir("/proc/self/fd").unwrap().count(),
+        std::fs::read_dir("/proc/self/task").unwrap().count(),
+    )
+}
+
+fn assert_queue_deadlines() {
+    let endpoint = format!("vm0-test-tool-connect-full-{}", std::process::id());
+    let listener = process_control_ipc::bind_abstract_listener(&endpoint).unwrap();
+    let queued = fill_accept_queue(&listener);
+    // Only this test runs in the child, so parallel tests cannot perturb counts.
+    let baseline = resource_counts();
+
+    for timeout in [
+        Duration::ZERO,
+        Duration::from_millis(100),
+        Duration::from_millis(100),
+    ] {
+        let started = Instant::now();
+        let error = process_control_ipc::connect_abstract_with_timeout(&endpoint, timeout)
+            .expect_err("a full accept queue must not report a connected stream");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(started.elapsed() >= timeout);
+        assert!(started.elapsed() < timeout + Duration::from_secs(1));
+        assert_eq!(resource_counts(), baseline);
+    }
+
+    let started = Instant::now();
+    let error = place_current_process(&endpoint)
+        .expect_err("placement must time out without requiring the listener to close");
+    assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    assert!(started.elapsed() >= PLACEMENT_TIMEOUT);
+    assert!(started.elapsed() < PLACEMENT_TIMEOUT + Duration::from_secs(1));
+    assert_eq!(resource_counts(), baseline);
+
+    // Keep the listener and all queued clients alive through the assertions.
+    // Freeing one slot must permit a later attempt to connect normally.
+    let accepted =
+        process_control_ipc::accept_with_timeout(&listener, Duration::from_secs(1)).unwrap();
+    let recovered =
+        process_control_ipc::connect_abstract_with_timeout(&endpoint, Duration::from_secs(1))
+            .unwrap();
+    drop(recovered);
+    drop(accepted);
+    assert_eq!(resource_counts(), baseline);
+    drop(queued);
+    drop(listener);
+}
+
+#[test]
+fn placement_connect_deadline_bounds_full_accept_queue() {
+    if env::var_os(QUEUE_TEST_CHILD_ENV).is_some() {
+        assert_queue_deadlines();
+        return;
+    }
+
+    let mut child = TestChild(
+        Command::new(env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "tests::placement::placement_connect_deadline_bounds_full_accept_queue",
+                "--nocapture",
+            ])
+            .env(QUEUE_TEST_CHILD_ENV, "1")
+            .spawn()
+            .unwrap(),
+    );
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        if let Some(status) = child.0.try_wait().unwrap() {
+            assert!(status.success(), "queue-deadline child failed: {status}");
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "queue-deadline child exceeded watchdog"
+        );
+        // Poll only the owned child's exit; the Drop guard kills and reaps it
+        // even when a regressed blocking connect exceeds the watchdog.
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn placement_writes_descriptor_and_requires_broker_acknowledgement() {
+    for acknowledge in [true, false] {
+        let endpoint = format!("vm0-test-tool-ack-{}-{acknowledge}", std::process::id());
+        let listener = process_control_ipc::bind_abstract_listener(&endpoint).unwrap();
+        let mut placement = tempfile::tempfile().unwrap();
+        let broker_placement = placement.try_clone().unwrap();
+        let broker = thread::spawn(move || {
+            let stream =
+                process_control_ipc::accept_with_timeout(&listener, Duration::from_secs(1))
+                    .unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(1)))
+                .unwrap();
+            stream
+                .set_write_timeout(Some(Duration::from_secs(1)))
+                .unwrap();
+            process_control_ipc::send_tool_placement(&stream, broker_placement.as_fd()).unwrap();
+            process_control_ipc::read_tool_placement_confirmation(&stream).unwrap();
+            if acknowledge {
+                process_control_ipc::write_tool_placement_ack(&stream).unwrap();
+            }
+        });
+
+        let result = place_current_process(&endpoint);
+        broker.join().unwrap();
+        if acknowledge {
+            result.unwrap();
+        } else {
+            assert_eq!(result.unwrap_err().kind(), io::ErrorKind::UnexpectedEof);
+        }
+        use std::io::{Seek, SeekFrom};
+        placement.seek(SeekFrom::Start(0)).unwrap();
+        let mut contents = String::new();
+        placement.read_to_string(&mut contents).unwrap();
+        assert_eq!(contents, "0");
+    }
+}

--- a/crates/process-control-ipc/src/lib.rs
+++ b/crates/process-control-ipc/src/lib.rs
@@ -76,8 +76,8 @@ pub use codec::{
     read_hello, read_request, read_response, write_hello, write_request, write_response,
 };
 pub use transport::{
-    accept_with_timeout, bind_abstract_listener, connect_abstract, endpoint_name,
-    read_tool_placement_ack, read_tool_placement_confirmation,
+    accept_with_timeout, bind_abstract_listener, connect_abstract, connect_abstract_with_timeout,
+    endpoint_name, read_tool_placement_ack, read_tool_placement_confirmation,
     read_workload_placement_confirmation, receive_tool_placement, receive_workload_placement,
     send_tool_placement, send_workload_placement, write_tool_placement_ack,
     write_tool_placement_confirmation, write_workload_placement_confirmation,

--- a/crates/process-control-ipc/src/transport.rs
+++ b/crates/process-control-ipc/src/transport.rs
@@ -104,22 +104,69 @@ pub fn bind_abstract_listener(name: &str) -> io::Result<UnixListener> {
 /// not fit in `sockaddr_un.sun_path`. Socket creation and connect failures are
 /// returned as operating-system `io::Error` values.
 pub fn connect_abstract(name: &str) -> io::Result<UnixStream> {
-    let fd = create_unix_socket()?;
+    connect_abstract_before(name, None)
+}
+
+/// Connect to a Linux abstract Unix endpoint within `timeout`.
+///
+/// The budget starts before socket setup and bounds waiting for space in the
+/// listener's accept queue. The returned stream is blocking and close-on-exec,
+/// with no read or write timeout; callers configure their own handshake limits.
+///
+/// # Errors
+///
+/// Returns `InvalidInput` for an invalid name or an overflowing deadline, and
+/// `TimedOut` for an exhausted (including zero) timeout. Other socket errors,
+/// including interruption, are returned without retrying the connection.
+pub fn connect_abstract_with_timeout(name: &str, timeout: Duration) -> io::Result<UnixStream> {
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "connect timeout overflowed"))?;
+    connect_abstract_before(name, Some(deadline))
+}
+
+fn connect_abstract_before(name: &str, deadline: Option<Instant>) -> io::Result<UnixStream> {
     let addr = abstract_sockaddr(name)?;
     let len = sockaddr_len(name);
-    // SAFETY: fd is a valid AF_UNIX socket, addr/len describe a sockaddr_un.
+    let stream = UnixStream::from(create_unix_socket()?);
+    if let Some(deadline) = deadline {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .filter(|remaining| !remaining.is_zero())
+            .ok_or_else(connect_timed_out)?;
+        // Linux applies SO_SNDTIMEO to blocking connect, including AF_UNIX
+        // accept-queue backpressure. A zero socket timeout would disable it.
+        stream.set_write_timeout(Some(remaining))?;
+    }
+    // SAFETY: stream is a valid AF_UNIX socket, addr/len describe a sockaddr_un.
     let ret = unsafe {
         libc::connect(
-            fd.as_raw_fd(),
+            stream.as_raw_fd(),
             &addr as *const _ as *const libc::sockaddr,
             len,
         )
     };
     if ret != 0 {
-        return Err(io::Error::last_os_error());
+        let error = io::Error::last_os_error();
+        if deadline.is_some()
+            && (error.kind() == io::ErrorKind::WouldBlock
+                || error.raw_os_error() == Some(libc::EINPROGRESS))
+        {
+            return Err(connect_timed_out());
+        }
+        return Err(error);
     }
-    // SAFETY: fd is a valid connected stream and ownership is transferred.
-    Ok(unsafe { UnixStream::from_raw_fd(fd.into_raw_fd()) })
+    if deadline.is_some() {
+        stream.set_write_timeout(None)?;
+    }
+    Ok(stream)
+}
+
+fn connect_timed_out() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::TimedOut,
+        "control endpoint connect timed out",
+    )
 }
 
 /// Send one workload-placement descriptor over a connected control stream.
@@ -622,6 +669,9 @@ mod tests {
 
             let err = connect_abstract(name).unwrap_err();
             assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+
+            let err = connect_abstract_with_timeout(name, Duration::from_secs(1)).unwrap_err();
+            assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
         }
 
         let too_long = "x".repeat(sockaddr_un_path_len());
@@ -629,6 +679,9 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
 
         let err = connect_abstract(&too_long).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+
+        let err = connect_abstract_with_timeout(&too_long, Duration::from_secs(1)).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 
@@ -642,6 +695,44 @@ mod tests {
         let server = accept_with_timeout(&listener, Duration::from_secs(1)).unwrap();
         let _client = client.join().unwrap();
         drop(server);
+    }
+
+    #[test]
+    fn timed_connect_returns_blocking_close_on_exec_stream_without_io_timeouts() {
+        let (name, listener) = bind_test_listener("timed-connect");
+        let mut client = connect_abstract_with_timeout(&name, Duration::from_secs(1)).unwrap();
+        let mut server = accept_with_timeout(&listener, Duration::from_secs(1)).unwrap();
+
+        assert_eq!(client.read_timeout().unwrap(), None);
+        assert_eq!(client.write_timeout().unwrap(), None);
+        // SAFETY: both getters only inspect the live client descriptor.
+        let descriptor_flags = unsafe { libc::fcntl(client.as_raw_fd(), libc::F_GETFD) };
+        let status_flags = unsafe { libc::fcntl(client.as_raw_fd(), libc::F_GETFL) };
+        assert!(descriptor_flags >= 0);
+        assert_ne!(descriptor_flags & libc::FD_CLOEXEC, 0);
+        assert!(status_flags >= 0);
+        assert_eq!(status_flags & libc::O_NONBLOCK, 0);
+
+        server
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        client.write_all(b"hello").unwrap();
+        let mut received = [0; 5];
+        server.read_exact(&mut received).unwrap();
+        assert_eq!(&received, b"hello");
+    }
+
+    #[test]
+    fn timed_connect_rejects_invalid_budgets_and_preserves_connection_errors() {
+        let name = format!("vm0-test-missing-connect-{}", std::process::id());
+        for (timeout, expected) in [
+            (Duration::ZERO, io::ErrorKind::TimedOut),
+            (Duration::MAX, io::ErrorKind::InvalidInput),
+            (Duration::from_secs(1), io::ErrorKind::ConnectionRefused),
+        ] {
+            let error = connect_abstract_with_timeout(&name, timeout).unwrap_err();
+            assert_eq!(error.kind(), expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
When the tool-placement broker's accept queue is full, `guest-tool-exec` can block in `connect` before reaching its existing I/O timeouts. Add an opt-in timed abstract-socket connection API and use the launcher's five-second placement timeout before connecting. A timeout closes the owned socket and follows the existing placement-failure path before shell execution.

The connection budget starts before socket setup, rejects zero/overflow appropriately, and uses Linux `SO_SNDTIMEO` to bound queue admission. Successful streams remain blocking and close-on-exec, with the temporary send timeout cleared. Existing untimed callers, broker authentication, wire protocol, and subsequent per-I/O limits retain their contracts.

Closes #33178.

## Validation

- `cargo test --manifest-path crates/Cargo.toml --profile local -p process-control-ipc -p guest-tool-exec` — 46 tests passed.
- `cargo test --manifest-path crates/Cargo.toml --profile local -p guest-control-server --lib process_containment::tests::` — 23 tests passed, including successful placement and broker cancellation.
- A real full-queue regression keeps the listener open, checks repeated timeout descriptor/task counts, exercises the actual launcher placement call, and reconnects after capacity is freed. Its owned child is killed and reaped on watchdog failure. Temporarily restoring the old launcher call made this test fail at its 15-second watchdog; restoring the fix passed.
- `cargo fmt --manifest-path crates/process-control-ipc/Cargo.toml -- --check` and the equivalent `guest-tool-exec` check passed.
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p process-control-ipc -p guest-tool-exec --all-targets --all-features` passed.
- `cargo doc --manifest-path crates/Cargo.toml --profile local -p process-control-ipc -p guest-tool-exec --all-features --no-deps` passed.

Local placement tests use real Linux sockets and file-backed descriptors. Full managed-guest/cgroup E2E was not run locally. Timeout assertions allow kernel timer rounding and scheduling tolerance; this is a connection bound, not a total handshake deadline.
