### PR TITLE
fix(platform): distinguish and smooth color theme gradients

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -33,6 +33,8 @@ Token names describe meaning rather than a page or component. A reusable interac
 
 Components must not introduce local CSS variables as an alternate token registry. A runtime value that is genuinely computed by the component may use a narrowly named custom property as data, while its visual semantics still come from Tailwind utilities and registered tokens.
 
+Color-theme presets in the App stylesheet share their anchor and companion colors between picker swatches and workspace ambience. Daydream uses cool blue and violet, while Cotton sky uses pastel pink and blue. Each preset's hue and ring values keep semantic surfaces, selected states, and focus indicators aligned with that palette in Light/Dark.
+
 ## Token and variant governance
 
 New tokens must represent a reusable semantic decision, have a documented consumer contract, and define their light and dark theme behavior in the canonical stylesheet. Shared tokens and variants belong to `@okouai/ui`; App-only tokens belong to the App token layer. A new alias for one component's hard-coded values is not a token contract.

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -372,9 +372,8 @@ body {
   }
 }
 
-/* Palette colors are kept as the exact source values. Each named theme pairs
-   one anchor with one companion; the same pair drives the picker swatch and
-   the low-concentration workspace ambience below. */
+/* Each named theme pairs one anchor with one companion; the same pair drives
+   the picker swatch and the low-concentration workspace ambience below. */
 [data-color-theme="golden-hour"] {
   --okou-color-theme-anchor: #f7a102;
   --okou-color-theme-companion: #f4e33c;
@@ -411,10 +410,10 @@ body {
 }
 
 [data-color-theme="daydream"] {
-  --okou-color-theme-anchor: #b5d4e5;
-  --okou-color-theme-companion: #e4abc8;
-  --okou-color-theme-hue: 201.3;
-  --okou-color-theme-ring: 205.1 19.8% 57.5%;
+  --okou-color-theme-anchor: #8aaaf0;
+  --okou-color-theme-companion: #9c78d8;
+  --okou-color-theme-hue: 232;
+  --okou-color-theme-ring: 232 38% 55%;
 }
 
 [data-color-theme="deep-lagoon"] {

--- a/turbo/apps/platform/src/views/okou-page/components/settings/color-theme-settings.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/color-theme-settings.tsx
@@ -132,7 +132,7 @@ export function ColorThemeSettings() {
               <span
                 aria-hidden="true"
                 data-color-theme={value}
-                className="okou-color-theme-swatch h-8 w-8 shrink-0 rounded-full border border-black/5"
+                className="okou-color-theme-swatch h-8 w-8 shrink-0 rounded-full border border-black/5 bg-origin-border"
               />
               <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
                 {label}


### PR DESCRIPTION
Daydream and Cotton sky used the same pink/blue pair in opposite directions, making their previews difficult to distinguish. Daydream now uses cool blue and violet, with matching semantic surface and focus colors in Light/Dark.

Circular swatches also showed seams because their gradients were sized to the padding box and repeated into the border area. Adding `bg-origin-border` makes each gradient cover the entire circle, removing the discontinuous rim.

Validation:

- [Daydream/Cotton sky comparison](https://a.okou.io/j8xex98pbv.png) and [magnified edge correction](https://a.okou.io/hof8hzwasu.png). Both use the production Tailwind stylesheet in isolated Chromium renders, not live app screenshots.
- All eight palettes checked in Light/Dark at desktop/narrow widths and DPR 1/2. Seven other preview gradients retain their colors. The initial edge correction also passed 125% desktop zoom checks.
- Source-derived Daydream surface/input probes retain at least 8.39:1 text contrast and 3.18:1 focus contrast in Light/Dark.
- Passed style policy and Tailwind lint, targeted ESLint, App type checks, App-scoped Knip, Prettier, and `git diff --check`.
- Full application tests are delegated to PR CI. No local dev server or full local Vitest run.
