### PR TITLE
fix(runner): block managed credential method overrides

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -90,6 +90,7 @@ class _FirewallAuthPlanFailure(Enum):
     """Canonical pre-resolution policy failure for both hook phases."""
 
     UNSAFE_METHOD = "unsafe_method"
+    METHOD_OVERRIDE = "method_override"
     INSECURE_TRANSPORT = "insecure_transport"
     AUTH_UNAVAILABLE = "auth_unavailable"
 
@@ -528,6 +529,10 @@ def _build_firewall_auth_plan(
     failure = None
     if injects_credentials and _request_method_forbids_managed_credentials(flow.request.method):
         failure = _FirewallAuthPlanFailure.UNSAFE_METHOD
+    elif injects_credentials and "x-http-method-override" in flow.request.headers:
+        # The firewall authorizes the wire method. Providers such as Mailchimp
+        # can reinterpret this header as DELETE even when only POST is allowed.
+        failure = _FirewallAuthPlanFailure.METHOD_OVERRIDE
     elif injects_credentials and flow.request.scheme.lower() != "https":
         failure = _FirewallAuthPlanFailure.INSECURE_TRANSPORT
     elif needs_resolution and not sandbox_info.get("encryptedSecrets"):
@@ -1245,6 +1250,24 @@ def _preflight_firewall_auth(
             action="BLOCK",
             error_code="unsafe_auth_method",
             message=f"Firewall credentials cannot be injected into {request_method} requests",
+            permission=context.allow.name,
+        )
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
+
+    if plan.failure is _FirewallAuthPlanFailure.METHOD_OVERRIDE:
+        log_proxy_entry(
+            context.proxy_log_path,
+            "warn",
+            "Refusing to inject firewall credentials into an HTTP method override request",
+            type="firewall",
+            firewall_base=context.firewall_base,
+        )
+        _set_matched_firewall_failure_response(
+            flow,
+            status=403,
+            action="BLOCK",
+            error_code="unsafe_auth_method_override",
+            message="Use the actual HTTP method instead of X-HTTP-Method-Override",
             permission=context.allow.name,
         )
         return FirewallAuthHandlingResult.LOCAL_RESPONSE

--- a/crates/runner/mitm-addon/tests/test_firewall_method_override.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_method_override.py
@@ -1,0 +1,171 @@
+"""Method overrides must not escape the permission for the wire method."""
+
+import inspect
+import json
+
+import pytest
+
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+from body_limits import STREAM_BUFFER_LIMIT
+from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
+from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
+from tests.request_handler_helpers import _single_firewall_sandbox, _write_registry
+from tests.requestheaders_helpers import _assert_no_request_stream, await_requestheaders_result
+
+
+@pytest.mark.parametrize("capture_bodies", [False, True])
+@pytest.mark.parametrize(
+    "override_headers",
+    [
+        [("X-HTTP-Method-Override", "DELETE")],
+        [("x-http-method-override", "PATCH")],
+        [("X-hTtP-mEtHoD-oVeRrIdE", "GET")],
+        [("X-HTTP-Method-Override", "")],
+        [("X-HTTP-Method-Override", "POST"), ("x-http-method-override", "DELETE")],
+    ],
+    ids=["delete", "lowercase", "mixed-case", "empty", "duplicate"],
+)
+@pytest.mark.parametrize(
+    "auth_config",
+    [
+        {"headers": {"Authorization": "Bearer ${{ secrets.MAILCHIMP_TOKEN }}"}},
+        {"query": {"api_key": "${{ secrets.API_TOKEN }}"}},
+        {
+            "awsSigv4": {
+                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+            }
+        },
+        {"base": "${{ secrets.WEBHOOK_URL }}"},
+    ],
+    ids=["headers", "query", "aws-sigv4", "auth-base"],
+)
+async def test_override_cannot_delete_an_audience_with_only_member_write_permission(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    capture_bodies,
+    override_headers,
+    auth_config,
+):
+    reg_path = _write_registry(
+        tmp_path,
+        sandbox_info=_single_firewall_sandbox(
+            tmp_path,
+            firewall_name="mailchimp",
+            api_entry={
+                "base": "https://us6.api.mailchimp.com/3.0",
+                "auth": auth_config,
+                "permissions": [
+                    {"name": "members.write", "rules": ["POST /lists/{list_id}"]},
+                    {"name": "audiences.delete", "rules": ["DELETE /lists/{list_id}"]},
+                ],
+            },
+            network_policy={
+                "allow": ["members.write"],
+                "deny": ["audiences.delete"],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+            sandbox_fields={"captureNetworkBodies": capture_bodies},
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="us6.api.mailchimp.com",
+        method="POST",
+        path="/3.0/lists/audience-id",
+        request_headers=headers(
+            ("Host", "us6.api.mailchimp.com"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+            *override_headers,
+        ),
+    )
+    original_headers = tuple(flow.request.headers.fields)
+    original_url = flow.request.url
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.okou.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
+        fake_forwarder_upstream() as upstream,
+    ):
+        result = mitm_addon.requestheaders(flow)
+        if capture_bodies and ("headers" in auth_config or "query" in auth_config):
+            await await_requestheaders_result(result)
+        elif inspect.isawaitable(result):
+            await result
+        auth_fetch.assert_not_called()
+        _assert_no_request_stream(flow)
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_called()
+    assert upstream.resolve_calls == []
+    assert upstream.connect_calls == []
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "unsafe_auth_method_override"
+    assert tuple(flow.request.headers.fields) == original_headers
+    assert flow.request.url == original_url
+    assert json.loads(flow.response.content) == {
+        "error": "unsafe_auth_method_override",
+        "message": "Use the actual HTTP method instead of X-HTTP-Method-Override",
+        "permission": "mailchimp",
+        "base": "https://us6.api.mailchimp.com/3.0",
+    }
+    [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+    assert entry["level"] == "warn"
+    assert entry["type"] == "firewall"
+    assert "DELETE" not in json.dumps(entry)
+
+
+@pytest.mark.parametrize("managed_auth", [False, True])
+async def test_ordinary_method_and_unmanaged_override_preserve_existing_behavior(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, managed_auth
+):
+    reg_path = _write_registry(
+        tmp_path,
+        sandbox_info=_single_firewall_sandbox(
+            tmp_path,
+            api_entry={
+                "base": "https://api.example.com",
+                "auth": (
+                    {"headers": {"Authorization": "Bearer ${{ secrets.API_TOKEN }}"}}
+                    if managed_auth
+                    else {}
+                ),
+                "permissions": [{"name": "write", "rules": ["POST /items"]}],
+            },
+            network_policy={"allow": ["write"], "deny": [], "ask": [], "unknownPolicy": "deny"},
+        ),
+    )
+    request_headers = headers(("Host", "api.example.com"))
+    if not managed_auth:
+        request_headers["X-HTTP-Method-Override"] = "DELETE"
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.example.com",
+        method="POST",
+        path="/items",
+        request_headers=request_headers,
+    )
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.okou.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    if managed_auth:
+        auth_fetch.assert_awaited_once()
+        assert flow.request.headers["Authorization"] == "Bearer resolved"
+    else:
+        auth_fetch.assert_not_called()
+        assert "Authorization" not in flow.request.headers
+        assert flow.request.headers["X-HTTP-Method-Override"] == "DELETE"

--- a/crates/runner/mitm-addon/tests/test_firewall_method_override.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_method_override.py
@@ -1,6 +1,5 @@
 """Method overrides must not escape the permission for the wire method."""
 
-import inspect
 import json
 
 import pytest
@@ -96,8 +95,8 @@ async def test_override_cannot_delete_an_audience_with_only_member_write_permiss
         result = mitm_addon.requestheaders(flow)
         if capture_bodies and ("headers" in auth_config or "query" in auth_config):
             await await_requestheaders_result(result)
-        elif inspect.isawaitable(result):
-            await result
+        else:
+            assert result is None
         auth_fetch.assert_not_called()
         _assert_no_request_stream(flow)
         await mitm_addon.request(flow)

--- a/docs/mitm-addon-contracts.md
+++ b/docs/mitm-addon-contracts.md
@@ -44,6 +44,23 @@ record already embedded in a malformed line or serialize independently
 interleaved short-write sequences. The existing Runner uploader continues to
 skip malformed physical lines and upload independently parseable records.
 
+## Managed credential method boundary
+
+Firewall permissions authorize the request's actual HTTP method. Requests with
+`X-HTTP-Method-Override` are rejected before managed credentials are resolved or
+injected: providers such as Mailchimp can otherwise reinterpret an allowed POST
+as a denied DELETE. Header names are case-insensitive; empty and repeated values
+are rejected too. Callers must use the actual method and its corresponding
+permission. Requests without managed credential injection retain their existing
+behavior.
+
+The shared auth plan applies this check to both the request-header streaming
+probe and the buffered request hook, including header, query, AWS SigV4, and
+auth-base credentials. `test_firewall_method_override.py` covers the Mailchimp
+audience deletion bypass through these hooks. Old runners keep their previous
+behavior until deployed; permission catalogs that rely on this boundary must
+wait for the runner rollout.
+
 ## WebSocket Framing Contract
 
 [`websocket_framing.py`](../crates/runner/mitm-addon/src/websocket_framing.py)


### PR DESCRIPTION
Mailchimp can reinterpret an allowed `POST /3.0/lists/{list_id}` as a denied audience deletion when the caller sends `X-HTTP-Method-Override: DELETE`. The firewall currently authorizes the wire method and then injects credentials, so the named write/delete permissions do not prevent that override.

Reject requests carrying this header before resolving or injecting managed credentials. The shared auth plan protects the request-header streaming probe and buffered request hook for header, query, AWS SigV4, and auth-base authentication. The response directs the caller to use the actual HTTP method and its corresponding permission. Diagnostics omit the header value, and requests without managed credential injection retain their existing behavior.

## Validation

- Locked uv/Python environment and dependency lock verified.
- **182 focused tests passed** across method-override regressions, firewall authentication handling, both request hooks, and header injection. Regressions cover case-insensitive, duplicate, and empty override headers, capture enabled/disabled, all four managed auth modes, ordinary POST success, and unmanaged passthrough.
- Ruff formatting/lint, BasedPyright (zero errors/warnings), documentation Prettier, and `git diff --check` passed.
- All PR checks passed at current head `76bc9d8060209d13fb96fdf05c86ac2430248156`, including the complete addon suite, both runner architectures, and deployed end-to-end tests.
- No local dev server or full local Vitest run.

## Rollout dependency

Deploy this runner fix before publishing the Mailchimp permission policy in https://github.com/vm0-ai/vm0-connectors/pull/4179. The OAuth rollout in https://github.com/vm0-ai/vm0/pull/33193 follows both the runner rollout and catalog sync. Old runners retain the bypass until updated; no API or catalog schema change can enforce this guard on an old runner. Runner promotion acknowledges soft-drain without waiting for active runs to finish, so verify that old runner processes have fully drained before publishing the dependent permission catalog. Rollback below this fix requires reverting or withholding that dependent rollout.

This PR can proceed independently through normal review and CI. It is a functional prerequisite, not a branch-conflict ordering preference. It does not enable Mailchimp OAuth or publish the connector catalog.

Provider documentation: https://mailchimp.com/developer/marketing/docs/methods-parameters/

Refs #30508
