### PR TITLE
fix(pi): preserve streamed provider error body integrity

### DIFF
--- a/turbo/packages/pi-agent-runtime/src/provider-error-body.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/provider-error-body.test.ts
@@ -14,6 +14,43 @@ function respondWith(
   };
 }
 
+interface ChunkedResponseOptions {
+  readonly errorAfterChunks?: unknown;
+  readonly headers?: Record<string, string>;
+  readonly onCancel?: (reason: unknown) => void;
+}
+
+function respondWithChunks(
+  status: number,
+  chunks: readonly Uint8Array[],
+  options: ChunkedResponseOptions = {},
+): NonNullable<Parameters<typeof preserveProviderErrorStatus>[0]> {
+  return () => {
+    let nextChunk = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        const chunk = chunks[nextChunk];
+        if (chunk !== undefined) {
+          nextChunk += 1;
+          controller.enqueue(chunk);
+          return;
+        }
+        if (options.errorAfterChunks !== undefined) {
+          controller.error(options.errorAfterChunks);
+          return;
+        }
+        controller.close();
+      },
+      cancel(reason) {
+        options.onCancel?.(reason);
+      },
+    });
+    return Promise.resolve(
+      new Response(stream, { status, headers: options.headers }),
+    );
+  };
+}
+
 async function normalizedBody(
   status: number,
   body: string | null,
@@ -103,12 +140,123 @@ describe("Pi provider error body boundary", () => {
     },
   );
 
-  it("passes an oversized body through without normalization", async () => {
-    const body = "x".repeat(70 * 1024);
+  it("passes a multi-chunk oversized opaque body through without cancellation", async () => {
+    const body = "gateway unavailable ".repeat(5_000);
+    const bytes = new TextEncoder().encode(body);
+    let upstreamCancelled = false;
+    const response = await preserveProviderErrorStatus(
+      respondWithChunks(
+        503,
+        [
+          bytes.slice(0, 40_960),
+          bytes.slice(40_960, 69_632),
+          bytes.slice(69_632),
+        ],
+        {
+          headers: { "content-length": String(bytes.byteLength) },
+          onCancel() {
+            upstreamCancelled = true;
+          },
+        },
+      ),
+    )(REQUEST_URL);
 
-    const { text } = await normalizedBody(503, body);
+    expect(await response.text()).toBe(body);
+    expect(response.headers.get("content-length")).toBe(
+      String(bytes.byteLength),
+    );
+    expect(upstreamCancelled).toBe(false);
+  });
 
-    expect(text).toBe(body);
+  it("preserves a multi-chunk oversized provider envelope without cancellation", async () => {
+    const original = JSON.stringify({
+      padding: "x".repeat(70 * 1024),
+      error: {
+        code: "usage_limit_reached",
+        message: "You have hit your ChatGPT usage limit.",
+      },
+    });
+    const bytes = new TextEncoder().encode(original);
+    let upstreamCancelled = false;
+    const response = await preserveProviderErrorStatus(
+      respondWithChunks(
+        429,
+        [
+          bytes.slice(0, 40_960),
+          bytes.slice(40_960, 69_632),
+          bytes.slice(69_632),
+        ],
+        {
+          headers: {
+            "content-length": String(bytes.byteLength),
+            "content-type": "application/json",
+          },
+          onCancel() {
+            upstreamCancelled = true;
+          },
+        },
+      ),
+    )(REQUEST_URL);
+    const text = await response.text();
+
+    expect(bytes.byteLength).toBe(71_784);
+    expect(text).toBe(original);
+    expect(JSON.parse(text)).toStrictEqual({
+      padding: "x".repeat(70 * 1024),
+      error: {
+        code: "usage_limit_reached",
+        message: "You have hit your ChatGPT usage limit.",
+      },
+    });
+    expect(response.headers.get("content-length")).toBe(
+      String(bytes.byteLength),
+    );
+    expect(upstreamCancelled).toBe(false);
+  });
+
+  it("propagates an upstream error after an oversized prefix", async () => {
+    const error = new Error("provider stream failed");
+    const bytes = new TextEncoder().encode("x".repeat(70 * 1024));
+    const response = await preserveProviderErrorStatus(
+      respondWithChunks(
+        503,
+        [bytes.slice(0, 40_960), bytes.slice(40_960, 69_632)],
+        { errorAfterChunks: error },
+      ),
+    )(REQUEST_URL);
+
+    await expect(response.text()).rejects.toThrow("provider stream failed");
+  });
+
+  it("cancels upstream when a consumer abandons an oversized pass-through", async () => {
+    const bytes = new TextEncoder().encode("x".repeat(70 * 1024));
+    const reason = new Error("consumer stopped");
+    let cancellationReason: unknown;
+    const response = await preserveProviderErrorStatus(
+      respondWithChunks(
+        503,
+        [
+          bytes.slice(0, 40_960),
+          bytes.slice(40_960, 69_632),
+          bytes.slice(69_632),
+        ],
+        {
+          onCancel(value) {
+            cancellationReason = value;
+          },
+        },
+      ),
+    )(REQUEST_URL);
+    const body = response.body;
+    if (body === null) {
+      throw new Error("expected oversized response body");
+    }
+    const reader = body.getReader();
+    expect((await reader.read()).value).toStrictEqual(bytes.slice(0, 40_960));
+
+    await reader.cancel(reason);
+
+    expect(cancellationReason).toBe(reason);
   });
 
   it.each([200, 201])(

--- a/turbo/packages/pi-agent-runtime/src/provider-error-body.ts
+++ b/turbo/packages/pi-agent-runtime/src/provider-error-body.ts
@@ -23,17 +23,78 @@ const PROVIDER_HTTP_STATUS_MARKER = "provider HTTP";
 /** Statuses whose responses must not carry a body. */
 const NULL_BODY_STATUSES: ReadonlySet<number> = new Set([204, 205, 304]);
 
-interface BufferedErrorBody {
-  readonly bytes: Uint8Array;
-  readonly truncated: boolean;
+type InspectedErrorBody =
+  | { readonly kind: "buffered"; readonly bytes: Uint8Array }
+  | {
+      readonly kind: "passthrough";
+      readonly stream: ReadableStream<Uint8Array>;
+    };
+
+/**
+ * Replay the bounded prefix already read for inspection, then transfer the
+ * original reader to the returned stream for the unread remainder.
+ */
+function replayErrorBody(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  chunks: readonly Uint8Array[],
+): ReadableStream<Uint8Array> {
+  let nextChunk = 0;
+  let cancelled = false;
+  let released = false;
+  const releaseReader = () => {
+    if (!released) {
+      released = true;
+      reader.releaseLock();
+    }
+  };
+
+  return new ReadableStream({
+    async pull(controller) {
+      if (cancelled) {
+        return;
+      }
+      const chunk = chunks[nextChunk];
+      if (chunk !== undefined) {
+        nextChunk += 1;
+        controller.enqueue(chunk);
+        return;
+      }
+      try {
+        const result = await reader.read();
+        if (cancelled) {
+          return;
+        }
+        if (result.done) {
+          releaseReader();
+          controller.close();
+          return;
+        }
+        controller.enqueue(result.value);
+      } catch (error) {
+        if (!cancelled) {
+          controller.error(error);
+        }
+        releaseReader();
+      }
+    },
+    async cancel(reason) {
+      cancelled = true;
+      try {
+        await reader.cancel(reason);
+      } finally {
+        releaseReader();
+      }
+    },
+  });
 }
 
 async function bufferErrorBody(
   body: ReadableStream<Uint8Array>,
-): Promise<BufferedErrorBody> {
+): Promise<InspectedErrorBody> {
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
   let size = 0;
+  let readerTransferred = false;
   try {
     for (;;) {
       const result = await reader.read();
@@ -43,16 +104,22 @@ async function bufferErrorBody(
       chunks.push(result.value);
       size += result.value.byteLength;
       if (size > MAX_BUFFERED_ERROR_BODY_BYTES) {
-        // An oversized error body is passed through untouched, so cancelling
-        // the remainder would truncate what the adapter still parses.
-        await reader.cancel();
-        return { bytes: concatChunks(chunks, size), truncated: true };
+        // Stop inspecting here, but replay the prefix and retain the reader so
+        // the adapter can still consume the complete provider response.
+        const stream = replayErrorBody(reader, chunks);
+        readerTransferred = true;
+        return { kind: "passthrough", stream };
       }
     }
   } finally {
-    reader.releaseLock();
+    if (!readerTransferred) {
+      reader.releaseLock();
+    }
   }
-  return { bytes: concatChunks(chunks, size), truncated: false };
+  return {
+    kind: "buffered",
+    bytes: concatChunks(chunks, size),
+  };
 }
 
 function concatChunks(chunks: readonly Uint8Array[], size: number): Uint8Array {
@@ -115,10 +182,17 @@ export function preserveProviderErrorStatus(
     ) {
       return response;
     }
-    const { bytes, truncated } = await bufferErrorBody(response.body);
-    const text = new TextDecoder().decode(bytes);
-    if (truncated || isJsonBody(text)) {
-      return new Response(bytes, {
+    const body = await bufferErrorBody(response.body);
+    if (body.kind === "passthrough") {
+      return new Response(body.stream, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    }
+    const text = new TextDecoder().decode(body.bytes);
+    if (isJsonBody(text)) {
+      return new Response(body.bytes, {
         status: response.status,
         statusText: response.statusText,
         headers: response.headers,


### PR DESCRIPTION
## Problem

The oversized-error-body pass-through added in [#33129](https://github.com/vm0-ai/vm0/pull/33129) read chunks until crossing 64 KiB, then cancelled the original reader and returned only the retained prefix. A multi-chunk provider JSON response could therefore be truncated while retaining its original `Content-Length`, leaving invalid JSON and dropping a tail `usage_limit_reached` diagnostic.

This was independently reproduced against `main@6b3e05a6bfb0844e7349cc112e3abd9fb0551ef2` in [`provider-error-body.ts`](https://github.com/vm0-ai/vm0/blob/28a9d7642e0b5c07fe09ef6cd93b80e92f6dd65a/turbo/packages/pi-agent-runtime/src/provider-error-body.ts#L43-L49): a 71,784-byte `429` JSON body split at 40,960 and 69,632 bytes returned a 69,632-byte invalid prefix and observed upstream cancellation. The equivalent single-chunk control stayed intact.

## Change

- Keep inspection bounded at the existing 64 KiB threshold, but hand the original reader to a replay stream after it is crossed.
- Replay the already-read chunks and stream the unread remainder without changing the provider response headers or bytes.
- Propagate later upstream errors and forward consumer cancellation to the original reader before releasing its lock.

## Verification

- `pnpm --filter @okouai/pi-agent-runtime exec vitest run src/provider-error-body.test.ts src/model.test.ts` — 38 passed.
- `pnpm --filter @okouai/pi-agent-runtime lint` — passed.
- `pnpm --filter @okouai/pi-agent-runtime check-types` — passed.
- `pnpm --filter @okouai/pi-agent-runtime build` — passed; public declaration boundary remains `entries=2; declarations=11; forbidden=0`.

The new regression coverage verifies a multi-chunk tail quota envelope is byte-complete, parseable, and not cancelled early; long opaque pass-through; later upstream stream failure; and consumer cancellation. Existing 503 recovery and 429 quota controls remain covered by `model.test.ts`.

## Scope

Fixes #33071. This is a corrective source/response-integrity change, not evidence of a production incident or a measured SDK retry outcome. No production release or production acceptance is included.
