### PR TITLE
perf(e2e): reduce clerk load in setup and cleanup

### DIFF
--- a/.github/scripts/tests/clerk-test-resource-workflow-test.sh
+++ b/.github/scripts/tests/clerk-test-resource-workflow-test.sh
@@ -257,17 +257,22 @@ unless playwright_finalizer_condition.include?("always()") &&
   raise "Playwright finalizer must run after terminal matrix outcomes"
 end
 playwright_finalizer_steps = playwright_finalizer.fetch("steps")
-playwright_cleanup = playwright_finalizer_steps.find do |step|
-  step["name"] == "Cleanup Playwright E2E accounts"
+playwright_steps = turbo_jobs.fetch("cli-e2e-02-playwright").fetch("steps")
+playwright_cleanup = playwright_steps.find do |step|
+  step["name"] == "Cleanup recorded Playwright E2E accounts"
 end
-unless playwright_cleanup && playwright_cleanup.fetch("if") == "always()" &&
-    playwright_cleanup.fetch("run").include?(
-      "cleanup-generation playwright,paid-onboarding",
-    )
-  raise "Playwright final cleanup must reconcile only its current-generation roles"
+unless playwright_cleanup &&
+    playwright_cleanup.fetch("if") == "always() && steps.playwright-tests.outcome != 'skipped'" &&
+    playwright_cleanup.fetch("run").include?("cleanup-recorded playwright,paid-onboarding")
+  raise "Playwright cleanup must use the lane's recorded current-generation resources"
 end
-unless playwright_finalizer_steps.last == playwright_cleanup
-  raise "Playwright generation cleanup must be the final finalizer step"
+playwright_tests = playwright_steps.find { |step| step["id"] == "playwright-tests" }
+unless playwright_tests.dig("env", "E2E_CLERK_RESOURCE_DIR") ==
+    playwright_cleanup.dig("env", "E2E_CLERK_RESOURCE_DIR")
+  raise "Playwright tests and cleanup must share their resource records"
+end
+if playwright_finalizer_steps.any? { |step| step.fetch("run", "").include?("cleanup-generation") }
+  raise "Playwright report finalization must not scan the whole Clerk instance"
 end
 
 runner_cleanup = turbo_jobs.fetch("cli-e2e-03-runner-cleanup")
@@ -297,13 +302,13 @@ runner_run_cleanup = runner_cleanup_steps.find do |step|
   step["name"] == "Cleanup runner E2E workflow run"
 end
 unless runner_generation_cleanup&.fetch("run", "")&.end_with?(
-    "runner-account.ts cleanup-generation",
+    "runner-account.ts cleanup-recorded-generation",
   ) && runner_generation_cleanup["if"] ==
     "steps.cleanup-scope.outputs.scope == 'generation'"
   raise "failed preparation must reconcile only its current generation"
 end
 unless runner_run_cleanup&.fetch("run", "")&.end_with?(
-    "runner-account.ts cleanup-run",
+    "runner-account.ts cleanup-recorded-run",
   ) && runner_run_cleanup["if"] ==
     "steps.cleanup-scope.outputs.scope == 'run'"
   raise "successful runner work must reconcile its exact workflow run"

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -80,8 +80,8 @@ if grep -Fq 'claude-sonnet-4-6' "$REAL_CLAUDE_TEST"; then
 fi
 grep -Fq 'OKOU_MITM_RUNNER_TOKEN' "$BUILT_IN_FALLBACK_TEST" ||
   fail "built-in fallback E2E must require trusted failure authentication"
-grep -Fq 'startVideoOnboardingCheckout' "$RUNNER_TOKEN" ||
-  fail "real runner accounts must upgrade through public paid onboarding"
+grep -Fq 'createRunnerCheckout' "$RUNNER_TOKEN" ||
+  fail "paid runner accounts must use the public checkout API"
 grep -Fq 'fillStripeCheckout' "$RUNNER_TOKEN" ||
   fail "real runner accounts must complete the public Stripe checkout"
 if [[ "$(grep -Fc 'upgradeToPro: true' "$RUNNER_TOKEN")" -ne 3 ]]; then
@@ -711,13 +711,13 @@ unless generation_cleanup_step &&
     generation_cleanup_step["if"] ==
       "steps.cleanup-scope.outputs.scope == 'generation'" &&
     generation_cleanup_step.fetch("run").end_with?(
-      "runner-account.ts cleanup-generation",
+      "runner-account.ts cleanup-recorded-generation",
     )
   raise "incomplete preparation must reconcile only the current generation"
 end
 unless run_cleanup_step &&
     run_cleanup_step["if"] == "steps.cleanup-scope.outputs.scope == 'run'" &&
-    run_cleanup_step.fetch("run").end_with?("runner-account.ts cleanup-run")
+    run_cleanup_step.fetch("run").end_with?("runner-account.ts cleanup-recorded-run")
   raise "successful runner work must reconcile the exact workflow run"
 end
 %w[

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2011,6 +2011,7 @@ jobs:
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       - name: Run Playwright E2E tests
+        id: playwright-tests
         continue-on-error: ${{ vars.CI_CHECK_BROWSER_E2E != '1' }}
         shell: bash
         run: |
@@ -2031,6 +2032,7 @@ jobs:
             "${playwright_command[@]}"
           fi
         env:
+          E2E_CLERK_RESOURCE_DIR: /tmp/e2e-clerk-playwright
           PLAYWRIGHT_PROJECT: ${{ matrix.project }}
           OKOU_API_BACKEND_URL: ${{ needs.deploy-api.outputs.preview-url }}
           OKOU_APP_URL: ${{ needs.deploy-app.outputs.preview-url }}
@@ -2038,6 +2040,15 @@ jobs:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+      - name: Cleanup recorded Playwright E2E accounts
+        if: always() && steps.playwright-tests.outcome != 'skipped'
+        run: >-
+          cd e2e && pnpm exec tsx playwright/clerk-test-resources.ts
+          cleanup-recorded playwright,paid-onboarding
+        env:
+          E2E_CLERK_RESOURCE_DIR: /tmp/e2e-clerk-playwright
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
       - name: Print Stripe webhook forwarding log
         if: always() && github.event_name == 'push' && needs.prepare.outputs.job-ref != 'staging'
         run: |
@@ -2095,14 +2106,6 @@ jobs:
           path: e2e/playwright-report/
           retention-days: 7
           if-no-files-found: ignore
-      - name: Cleanup Playwright E2E accounts
-        if: always()
-        run: >-
-          cd e2e && pnpm exec tsx playwright/clerk-test-resources.ts
-          cleanup-generation playwright,paid-onboarding
-        env:
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
 
   # Build one self-contained package archive per checked-out commit and upload
   # it to the same canonical R2 bucket used by deploy-app. The ready marker is
@@ -2538,6 +2541,8 @@ jobs:
   cli-e2e-03-runner-prepare:
     runs-on: ubuntu-latest
     timeout-minutes: 12
+    env:
+      E2E_CLERK_RESOURCE_DIR: /tmp/e2e-clerk-runner
     concurrency:
       group: cli-e2e-03-runner-prepare-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
@@ -2588,6 +2593,14 @@ jobs:
         env:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+      - name: Upload runner Clerk resource records
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-runner-clerk-resources-${{ github.run_attempt }}
+          path: /tmp/e2e-clerk-runner/*.json
+          if-no-files-found: ignore
+          retention-days: 1
       - name: Install Playwright browsers
         run: cd e2e && pnpm exec playwright install --only-shell chromium
       - name: Generate runner E2E API tokens
@@ -2966,6 +2979,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true
+    env:
+      E2E_CLERK_RESOURCE_DIR: /tmp/e2e-clerk-runner
     needs:
       - prepare
       - cli-e2e-03-runner-prepare
@@ -3009,15 +3024,22 @@ jobs:
       - name: Install E2E dependencies
         if: steps.cleanup-scope.outputs.scope != 'retain'
         run: cd e2e && pnpm install --frozen-lockfile
+      - name: Download runner Clerk resource records
+        if: steps.cleanup-scope.outputs.scope != 'retain'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: e2e-runner-clerk-resources-*
+          path: /tmp/e2e-clerk-runner
+          merge-multiple: true
       - name: Cleanup current runner E2E generation
         if: steps.cleanup-scope.outputs.scope == 'generation'
-        run: cd e2e && pnpm exec tsx playwright/runner-account.ts cleanup-generation
+        run: cd e2e && pnpm exec tsx playwright/runner-account.ts cleanup-recorded-generation
         env:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
       - name: Cleanup runner E2E workflow run
         if: steps.cleanup-scope.outputs.scope == 'run'
-        run: cd e2e && pnpm exec tsx playwright/runner-account.ts cleanup-run
+        run: cd e2e && pnpm exec tsx playwright/runner-account.ts cleanup-recorded-run
         env:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}

--- a/docs/testing/cli-e2e-testing.md
+++ b/docs/testing/cli-e2e-testing.md
@@ -104,6 +104,23 @@ Runner BATS must not mutate shared account-level preferences from parallel
 shards. Coverage that needs mutable account-level state requires a dedicated
 identity or a serialized lane.
 
+The default runner and feature-test accounts use limited-free onboarding. The
+dedicated Codex, Claude, and mock-Claude accounts still require Pro for their
+paid-model and BYOK policies. Runner preparation completes onboarding through
+the public API, creates a public usage-pack checkout, completes hosted Stripe
+payment, and verifies the resulting public entitlement before publishing tokens.
+Only the dedicated paid-onboarding spec exercises the video onboarding UI.
+
+Clerk resource creation records exact IDs in `E2E_CLERK_RESOURCE_DIR`. Normal
+cleanup verifies those IDs' ownership against Clerk and deletes organizations
+before users. Runner records travel with their workflow attempt so successful
+reruns can clean earlier attempts without listing the whole Clerk instance.
+Failed runner shards retain their accounts for reruns. An uncertain organization
+creation keeps its owner user for the existing strict-marker stale sweep.
+Playwright's setup project owns the feature account; unrelated lanes create no
+unused global account. Failed checkouts report HTTP status, request ID, and
+Retry-After, and product Playwright lanes retain traces on the first failure.
+
 Use a different organization-scoped connector slug in each file that can run in
 parallel. Assert sandbox-visible output and Okou-owned telemetry; do not treat an
 external provider's exact response status or body as the test oracle.

--- a/e2e/playwright/clerk-test-resources.ts
+++ b/e2e/playwright/clerk-test-resources.ts
@@ -1,6 +1,7 @@
 import {
   cleanupClerkTestJobRef,
   cleanupCurrentClerkTestGeneration,
+  cleanupRecordedClerkTestResources,
   cleanupStaleClerkTestResources,
   currentClerkTestJobRef,
   parseClerkTestRole,
@@ -18,6 +19,15 @@ async function main(): Promise<void> {
   let result: ClerkCleanupResult;
 
   switch (command) {
+    case "cleanup-recorded": {
+      const roles = parseRoles(requiredArgument(3, "role list"));
+      assertNoExtraArguments(4);
+      if (dryRun) {
+        throw new Error("Recorded cleanup does not support DRY_RUN");
+      }
+      await cleanupRecordedClerkTestResources(roles);
+      return;
+    }
     case "cleanup-generation": {
       const roles = parseRoles(requiredArgument(3, "role list"));
       assertNoExtraArguments(4);
@@ -55,7 +65,7 @@ async function main(): Promise<void> {
     }
     default:
       throw new Error(
-        "Usage: clerk-test-resources.ts cleanup-generation <roles> | cleanup-job-ref | cleanup-stale <roles> --ci-older-than-hours <hours> --staging-browser-older-than-hours <hours>",
+        "Usage: clerk-test-resources.ts cleanup-recorded <roles> | cleanup-generation <roles> | cleanup-job-ref | cleanup-stale <roles> --ci-older-than-hours <hours> --staging-browser-older-than-hours <hours>",
       );
   }
 

--- a/e2e/playwright/clerk.d.ts
+++ b/e2e/playwright/clerk.d.ts
@@ -4,6 +4,7 @@ declare global {
   interface Window {
     Clerk?: {
       loaded: boolean;
+      user?: { readonly id: string } | null;
       organization?: { readonly id: string } | null;
       setActive(options: { readonly organization: string }): Promise<void>;
       session?: {

--- a/e2e/playwright/global-setup.ts
+++ b/e2e/playwright/global-setup.ts
@@ -1,27 +1,10 @@
-import {
-  createOrganization,
-  createUser,
-  deleteClerkTestOwnerResources,
-  generateTestEmail,
-} from "./lib/clerk-api";
+import { mkdir, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 export default async function globalSetup(): Promise<void> {
-  const email = generateTestEmail("playwright");
-  console.log("[globalSetup] creating generation-scoped Clerk resources");
-  process.env.E2E_CLERK_USER_EMAIL = email;
-
-  let organizationId: string | undefined;
-  try {
-    const userId = await createUser(email);
-    organizationId = await createOrganization(
-      "E2E Test Org",
-      userId,
-      "playwright",
-    );
-    process.env.E2E_CLERK_ORG_ID = organizationId;
-    console.log("[globalSetup] Clerk resources ready");
-  } catch (cause) {
-    await deleteClerkTestOwnerResources(email, organizationId, "playwright");
-    throw cause;
-  }
+  process.env.E2E_CLERK_RESOURCE_DIR ??= await mkdtemp(
+    join(tmpdir(), "playwright-clerk-resources-"),
+  );
+  await mkdir(process.env.E2E_CLERK_RESOURCE_DIR, { recursive: true });
 }

--- a/e2e/playwright/global-teardown.ts
+++ b/e2e/playwright/global-teardown.ts
@@ -1,13 +1,5 @@
-import { deleteClerkTestOwnerResources } from "./lib/clerk-api";
+import { cleanupRecordedClerkTestResources } from "./lib/clerk-api";
 
 export default async function globalTeardown(): Promise<void> {
-  const email = process.env.E2E_CLERK_USER_EMAIL;
-  if (email) {
-    console.log("Cleaning up generation-scoped Clerk resources");
-    await deleteClerkTestOwnerResources(
-      email,
-      process.env.E2E_CLERK_ORG_ID,
-      "playwright",
-    );
-  }
+  await cleanupRecordedClerkTestResources(["playwright", "paid-onboarding"]);
 }

--- a/e2e/playwright/lib/api-response.ts
+++ b/e2e/playwright/lib/api-response.ts
@@ -1,0 +1,12 @@
+export function apiFailureMessage(
+  operation: string,
+  status: number,
+  requestId: string | null,
+  retryAfter: string | null,
+): string {
+  return [
+    operation + " failed with HTTP " + status,
+    "request_id=" + (requestId ?? "unavailable"),
+    "retry_after=" + (retryAfter ?? "unavailable"),
+  ].join("; ");
+}

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -1,5 +1,12 @@
 import { randomBytes } from "node:crypto";
 
+import {
+  forgetClerkResource,
+  readClerkResourceRecords,
+  recordClerkResource,
+  type ClerkResourceRecord,
+} from "./clerk-resource-records";
+
 const DEFAULT_CLERK_API_BASE = "https://api.clerk.com/v1";
 const CLERK_PAGE_LIMIT = 500;
 const CLERK_RETRY_DELAYS_MS = [500, 1_500, 3_500] as const;
@@ -290,6 +297,10 @@ export async function createUser(
       `create Clerk user returned an unexpected response: ${formatClerkResponseSummary(response)}`,
     );
   }
+  const owner = parseClerkTestEmail(email);
+  if (owner) {
+    await recordClerkResource({ kind: "user", id: data.id, owner });
+  }
   return data.id;
 }
 
@@ -299,6 +310,13 @@ export async function createOrganization(
   role: ClerkTestRole,
 ): Promise<string> {
   const owner = currentClerkTestOwner(role);
+  // Keep the user if cancellation loses an organization's creation response.
+  // The existing strict-marker sweep can reconcile that ambiguous outcome.
+  await recordClerkResource({
+    kind: "pending-organization",
+    id: createdByUserId,
+    owner,
+  });
   const response = await requestClerkCreate(
     "create Clerk organization",
     "/organizations",
@@ -318,6 +336,9 @@ export async function createOrganization(
       `create Clerk organization returned an unexpected response: ${formatClerkResponseSummary(response)}`,
     );
   }
+
+  await recordClerkResource({ kind: "organization", id: data.id, owner });
+  await forgetClerkResource("pending-organization", createdByUserId);
 
   try {
     await updateOrganizationMembershipRole(
@@ -397,6 +418,118 @@ export async function cleanupClerkTestJobRef(
     throw new Error(`Invalid Clerk test JOB_REF: ${jobRef}`);
   }
   return await cleanupClerkTestResources({ kind: "job-ref", jobRef }, options);
+}
+
+export async function cleanupRecordedClerkTestResources(
+  roles: readonly ClerkTestRole[],
+  scope: "generation" | "run" = "generation",
+): Promise<void> {
+  assertCleanupRoles(roles);
+  const records = (await readClerkResourceRecords()).map(parseResourceRecord);
+  const jobRef = currentClerkTestJobRef();
+  const generation = currentClerkTestGeneration();
+  const selected = records.filter((record) => {
+    const matchesGeneration =
+      scope === "generation"
+        ? record.owner.generation === generation
+        : clerkTestRunId(record.owner.generation) ===
+          clerkTestRunId(generation);
+    if (
+      record.owner.jobRef !== jobRef ||
+      clerkTestRunId(record.owner.generation) !== clerkTestRunId(generation)
+    ) {
+      throw new Error("Recorded Clerk resource belongs to another CI scope");
+    }
+    return matchesGeneration && roles.includes(record.owner.role);
+  });
+  const pendingUsers = new Set(
+    selected
+      .filter((record) => record.kind === "pending-organization")
+      .map((record) => record.id),
+  );
+  const organizations: string[] = [];
+  const users: string[] = [];
+  // Resolve ownership against Clerk before deleting anything from the record.
+  for (const record of selected) {
+    if (record.kind === "pending-organization") {
+      continue;
+    }
+    const collection = record.kind === "user" ? "users" : "organizations";
+    const response = await requestClerkWithRetry(
+      "verify recorded Clerk resource",
+      "/" + collection + "/" + record.id,
+      { method: "GET", headers: getClerkHeaders() },
+    );
+    if (response.status === 404) {
+      await response.body?.cancel();
+      await forgetClerkResource(record.kind, record.id);
+      continue;
+    }
+    const resource = await readClerkJson(
+      response,
+      "verify recorded Clerk resource",
+    );
+    const email =
+      isClerkUserSummary(resource) && resource.email_addresses.length === 1
+        ? resource.email_addresses[0]?.email_address
+        : undefined;
+    const owner =
+      record.kind === "user" &&
+      isClerkUserSummary(resource) &&
+      resource.id === record.id &&
+      email
+        ? parseClerkTestEmail(email)
+        : record.kind === "organization" &&
+            isClerkOrganizationSummary(resource) &&
+            resource.id === record.id
+          ? parseClerkTestOrganizationMetadata(resource.private_metadata)
+          : null;
+    if (
+      !owner ||
+      clerkTestOwnerKey(owner) !== clerkTestOwnerKey(record.owner)
+    ) {
+      throw new Error("Recorded Clerk resource ownership does not match Clerk");
+    }
+    if (record.kind === "organization") {
+      organizations.push(record.id);
+    } else if (!pendingUsers.has(record.id)) {
+      users.push(record.id);
+    }
+  }
+  const totalDeletes = organizations.length + users.length;
+  for (const [index, id] of organizations.entries()) {
+    await deleteOrganizationById(id);
+    await paceClerkBulkRequest(index + 1, totalDeletes);
+  }
+  for (const [index, id] of users.entries()) {
+    await deleteUserById(id);
+    await paceClerkBulkRequest(organizations.length + index + 1, totalDeletes);
+  }
+  console.log("Cleaned recorded Clerk test resources", {
+    organizations: organizations.length,
+    users: users.length,
+    deferredUsers: pendingUsers.size,
+  });
+}
+
+function parseResourceRecord(value: unknown): ClerkResourceRecord {
+  if (!isRecord(value)) {
+    throw new Error("Invalid Clerk resource record");
+  }
+  const owner = parseClerkTestOrganizationMetadata({ vm0CiTest: value.owner });
+  const { kind, id } = value;
+  if (
+    !owner ||
+    typeof id !== "string" ||
+    !/^(?:user|org)_[a-zA-Z0-9_]+$/.test(id) ||
+    (kind !== "user" &&
+      kind !== "organization" &&
+      kind !== "pending-organization") ||
+    (kind === "organization" ? !id.startsWith("org_") : !id.startsWith("user_"))
+  ) {
+    throw new Error("Invalid Clerk resource record");
+  }
+  return { kind, id, owner };
 }
 
 export async function cleanupStaleClerkTestResources(
@@ -733,6 +866,7 @@ export async function deleteOrganizationById(
       `delete Clerk test organization failed with ${formatClerkResponseSummary(response)}`,
     );
   }
+  await forgetClerkResource("organization", organizationId);
   return response.status !== 404;
 }
 
@@ -775,6 +909,7 @@ async function deleteUserById(userId: string): Promise<boolean> {
       `delete Clerk test user failed with ${formatClerkResponseSummary(response)}`,
     );
   }
+  await forgetClerkResource("user", userId);
   return response.status !== 404;
 }
 

--- a/e2e/playwright/lib/clerk-resource-records.test.ts
+++ b/e2e/playwright/lib/clerk-resource-records.test.ts
@@ -1,0 +1,265 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { createServer, type ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  cleanupRecordedClerkTestResources,
+  createOrganization,
+  createUser,
+  generateTestEmail,
+} from "./clerk-api";
+
+interface Fixture {
+  readonly directory: string;
+  readonly resources: Map<string, Record<string, unknown>>;
+  readonly requests: string[];
+  failOrganizationCreate: boolean;
+  failOrganizationDelete: boolean;
+}
+
+test("recorded cleanup deletes only created resources, organizations first, without global lists", async () => {
+  await withFixture(async (fixture) => {
+    fixture.resources.set("user_foreign", { id: "user_foreign" });
+    fixture.resources.set("org_foreign", { id: "org_foreign" });
+    const userId = await createUser(generateTestEmail("playwright"));
+    const orgId = await createOrganization("Fixture", userId, "playwright");
+    await cleanupRecordedClerkTestResources(["playwright"]);
+    assert.equal(fixture.resources.has(userId), false);
+    assert.equal(fixture.resources.has(orgId), false);
+    assert.equal(fixture.resources.has("user_foreign"), true);
+    assert.equal(fixture.resources.has("org_foreign"), true);
+    assert.deepEqual(
+      fixture.requests.filter((request) => request.startsWith("DELETE")),
+      ["DELETE /v1/organizations/" + orgId, "DELETE /v1/users/" + userId],
+    );
+    const requestCount = fixture.requests.length;
+    await cleanupRecordedClerkTestResources(["playwright"]);
+    assert.equal(fixture.requests.length, requestCount);
+  });
+});
+
+test("recorded cleanup verifies Clerk ownership before any deletion", async () => {
+  await withFixture(async (fixture) => {
+    const userId = await createUser(generateTestEmail("playwright"));
+    const orgId = await createOrganization("Fixture", userId, "playwright");
+    fixture.resources.set(orgId, { id: orgId, private_metadata: {} });
+    await assert.rejects(
+      cleanupRecordedClerkTestResources(["playwright"]),
+      /ownership does not match/,
+    );
+    assert.equal(
+      fixture.requests.some((request) => request.startsWith("DELETE")),
+      false,
+    );
+    assert.equal(fixture.resources.has(userId), true);
+  });
+});
+
+test("an ambiguous organization creation retains its user for the strict-marker sweep", async () => {
+  await withFixture(async (fixture) => {
+    const userId = await createUser(generateTestEmail("playwright"));
+    fixture.failOrganizationCreate = true;
+    await assert.rejects(
+      createOrganization("Fixture", userId, "playwright"),
+      /HTTP 503/,
+    );
+    await cleanupRecordedClerkTestResources(["playwright"]);
+    assert.equal(fixture.resources.has(userId), true);
+    assert.equal(
+      fixture.requests.some((request) => request.startsWith("DELETE")),
+      false,
+    );
+  });
+});
+
+test("failed organization deletion retains its user and can be retried from the record", async () => {
+  await withFixture(async (fixture) => {
+    const userId = await createUser(generateTestEmail("playwright"));
+    await createOrganization("Fixture", userId, "playwright");
+    fixture.failOrganizationDelete = true;
+    await assert.rejects(
+      cleanupRecordedClerkTestResources(["playwright"]),
+      /HTTP 403/,
+    );
+    assert.equal(fixture.resources.has(userId), true);
+    fixture.failOrganizationDelete = false;
+    await cleanupRecordedClerkTestResources(["playwright"]);
+    assert.equal(fixture.resources.has(userId), false);
+  });
+});
+
+test("recorded run cleanup includes prior attempts but preserves other roles", async () => {
+  await withFixture(async (fixture) => {
+    process.env.GITHUB_RUN_ATTEMPT = "1";
+    const oldUser = await createUser(generateTestEmail("runner"));
+    await createOrganization("Prior attempt", oldUser, "runner");
+    process.env.GITHUB_RUN_ATTEMPT = "2";
+    const userId = await createUser(generateTestEmail("runner"));
+    await createOrganization("Current attempt", userId, "runner");
+    const otherUser = await createUser(generateTestEmail("paid-onboarding"));
+    await createOrganization("Other role", otherUser, "paid-onboarding");
+    await cleanupRecordedClerkTestResources(["runner"]);
+    assert.equal(fixture.resources.has(userId), false);
+    assert.equal(fixture.resources.has(oldUser), true);
+    await cleanupRecordedClerkTestResources(["runner"], "run");
+    assert.equal(fixture.resources.has(oldUser), false);
+    assert.equal(fixture.resources.has(otherUser), true);
+  });
+});
+
+test("invalid and foreign-run records fail before contacting Clerk", async () => {
+  await withFixture(async (fixture) => {
+    await createUser(generateTestEmail("playwright"));
+    const [name] = await readdir(fixture.directory);
+    assert.ok(name);
+    const path = join(fixture.directory, name);
+    const original: unknown = JSON.parse(await readFile(path, "utf8"));
+    const requests = fixture.requests.length;
+    await writeFile(path, JSON.stringify({ kind: "user", id: "../../other" }));
+    await assert.rejects(
+      cleanupRecordedClerkTestResources(["playwright"]),
+      /Invalid Clerk resource record/,
+    );
+    await writeFile(path, JSON.stringify(original));
+    process.env.GITHUB_RUN_ID = "8001";
+    await assert.rejects(
+      cleanupRecordedClerkTestResources(["playwright"]),
+      /another CI scope/,
+    );
+    assert.equal(fixture.requests.length, requests);
+  });
+});
+
+test("already deleted recorded resources are reconciled without another delete", async () => {
+  await withFixture(async (fixture) => {
+    const userId = await createUser(generateTestEmail("playwright"));
+    await createOrganization("Fixture", userId, "playwright");
+    fixture.resources.clear();
+    await cleanupRecordedClerkTestResources(["playwright"]);
+    assert.deepEqual(await readdir(fixture.directory), []);
+    assert.equal(
+      fixture.requests.some((request) => request.startsWith("DELETE")),
+      false,
+    );
+  });
+});
+
+async function withFixture(
+  run: (fixture: Fixture) => Promise<void>,
+): Promise<void> {
+  const directory = await mkdtemp(join(tmpdir(), "clerk-record-test-"));
+  const fixture: Fixture = {
+    directory,
+    resources: new Map(),
+    requests: [],
+    failOrganizationCreate: false,
+    failOrganizationDelete: false,
+  };
+  let userCount = 0;
+  let orgCount = 0;
+  const server = createServer(async (request, response) => {
+    const url = new URL(request.url ?? "/", "http://fixture.invalid");
+    fixture.requests.push(request.method + " " + url.pathname);
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) {
+      chunks.push(Buffer.from(chunk));
+    }
+    if (request.method === "POST") {
+      const body = JSON.parse(Buffer.concat(chunks).toString()) as Record<
+        string,
+        unknown
+      >;
+      if (url.pathname === "/v1/users") {
+        assert.ok(Array.isArray(body.email_address));
+        const id = "user_" + ++userCount;
+        fixture.resources.set(id, {
+          id,
+          email_addresses: [{ email_address: body.email_address[0] }],
+        });
+        send(response, { id });
+        return;
+      }
+      if (url.pathname === "/v1/organizations") {
+        const id = "org_" + ++orgCount;
+        fixture.resources.set(id, {
+          id,
+          private_metadata: body.private_metadata,
+        });
+        send(response, { id }, fixture.failOrganizationCreate ? 503 : 200);
+        return;
+      }
+    }
+    if (
+      request.method === "PATCH" &&
+      /\/memberships\/user_/.test(url.pathname)
+    ) {
+      send(response, { role: "org:admin" });
+      return;
+    }
+    const match =
+      /^\/v1\/(users|organizations)\/((?:user|org)_[a-zA-Z0-9_]+)$/.exec(
+        url.pathname,
+      );
+    const id = match?.[2];
+    if (id && request.method === "GET") {
+      const resource = fixture.resources.get(id);
+      send(response, resource ?? {}, resource ? 200 : 404);
+      return;
+    }
+    if (id && request.method === "DELETE") {
+      if (match?.[1] === "organizations" && fixture.failOrganizationDelete) {
+        send(response, {}, 403);
+      } else {
+        fixture.resources.delete(id);
+        send(response, {});
+      }
+      return;
+    }
+    send(
+      response,
+      { error: "Unexpected request; global collection is forbidden" },
+      500,
+    );
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+  const environment = {
+    CLERK_API_TEST_BASE_URL: "http://127.0.0.1:" + address.port + "/v1",
+    CLERK_SECRET_KEY: "fixture-secret",
+    E2E_CLERK_RESOURCE_DIR: directory,
+    JOB_REF: "pr-123",
+    GITHUB_RUN_ID: "8000",
+    GITHUB_RUN_ATTEMPT: "2",
+  };
+  const previous = Object.fromEntries(
+    Object.keys(environment).map((key) => [key, process.env[key]]),
+  );
+  Object.assign(process.env, environment);
+  try {
+    await run(fixture);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+function send(response: ServerResponse, body: unknown, status = 200): void {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}

--- a/e2e/playwright/lib/clerk-resource-records.ts
+++ b/e2e/playwright/lib/clerk-resource-records.ts
@@ -1,0 +1,76 @@
+import { randomUUID } from "node:crypto";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { join } from "node:path";
+
+import type { ClerkTestOwner } from "./clerk-api";
+
+export interface ClerkResourceRecord {
+  readonly kind: "user" | "organization" | "pending-organization";
+  readonly id: string;
+  readonly owner: ClerkTestOwner;
+}
+
+export async function recordClerkResource(
+  resource: ClerkResourceRecord,
+): Promise<void> {
+  const directory = process.env.E2E_CLERK_RESOURCE_DIR;
+  if (!directory) {
+    return;
+  }
+  await mkdir(directory, { recursive: true });
+  const destination = resourcePath(directory, resource.kind, resource.id);
+  const temporary = destination + ".tmp-" + randomUUID();
+  await writeFile(temporary, JSON.stringify(resource) + "\n", { mode: 0o600 });
+  await rename(temporary, destination);
+}
+
+export async function forgetClerkResource(
+  kind: ClerkResourceRecord["kind"],
+  id: string,
+): Promise<void> {
+  const directory = process.env.E2E_CLERK_RESOURCE_DIR;
+  if (directory) {
+    await rm(resourcePath(directory, kind, id), { force: true });
+  }
+}
+
+export async function readClerkResourceRecords(): Promise<readonly unknown[]> {
+  const directory = process.env.E2E_CLERK_RESOURCE_DIR;
+  if (!directory) {
+    throw new Error("E2E_CLERK_RESOURCE_DIR is required for recorded cleanup");
+  }
+  let names: string[];
+  try {
+    names = await readdir(directory);
+  } catch (cause) {
+    if (cause instanceof Error && "code" in cause && cause.code === "ENOENT") {
+      return [];
+    }
+    throw cause;
+  }
+  const records: unknown[] = [];
+  for (const name of names.sort()) {
+    if (name.endsWith(".json")) {
+      records.push(JSON.parse(await readFile(join(directory, name), "utf8")));
+    }
+  }
+  return records;
+}
+
+function resourcePath(
+  directory: string,
+  kind: ClerkResourceRecord["kind"],
+  id: string,
+): string {
+  if (!/^(?:user|org)_[a-zA-Z0-9_]+$/.test(id)) {
+    throw new Error("Invalid Clerk resource ID");
+  }
+  return join(directory, kind + "-" + id + ".json");
+}

--- a/e2e/playwright/lib/onboarding.test.ts
+++ b/e2e/playwright/lib/onboarding.test.ts
@@ -48,12 +48,16 @@ test(
           );
           return;
         }
+        if (url.pathname === "/api/billing/usage-pack-checkout") {
+          response.writeHead(200).end("{}");
+          return;
+        }
         if (url.pathname === "/onboarding/video-run") {
           sendHtml(
             response,
             [
               "<h1>Customize your video</h1>",
-              "<button onclick=\"location.href='https://checkout.stripe.com/test-session'\">Upgrade Pro to run</button>",
+              "<button onclick=\"fetch('/api/billing/usage-pack-checkout', {method: 'POST'}).then(() => location.href='https://checkout.stripe.com/test-session')\">Upgrade Pro to run</button>",
             ].join(""),
           );
           return;
@@ -67,7 +71,10 @@ test(
             route.fulfill({ contentType: "text/html", body: "Checkout" }),
           );
 
-          await startVideoOnboardingCheckout(page, { appUrl: fixture.origin });
+          await startVideoOnboardingCheckout(page, {
+            appUrl: fixture.origin,
+            apiUrl: fixture.origin,
+          });
 
           assert.equal(videoTemplateRequests, 2);
           assert.equal(
@@ -110,7 +117,10 @@ test(
         const page = await browser.newPage();
         try {
           await assert.rejects(
-            startVideoOnboardingCheckout(page, { appUrl: fixture.origin }),
+            startVideoOnboardingCheckout(page, {
+              appUrl: fixture.origin,
+              apiUrl: fixture.origin,
+            }),
             /bootstrapSkeleton=removed/u,
           );
           assert.equal(videoTemplateRequests, 1);
@@ -122,6 +132,46 @@ test(
       }
     } finally {
       await browser.close();
+    }
+  },
+);
+
+test(
+  "video onboarding surfaces a failed checkout response without waiting for a Stripe redirect",
+  { timeout: 30_000 },
+  async () => {
+    let checkoutRequests = 0;
+    const fixture = await listen((request, response) => {
+      const url = new URL(request.url ?? "/", "http://fixture.invalid");
+      if (url.pathname === "/api/billing/usage-pack-checkout") {
+        checkoutRequests += 1;
+        response.writeHead(503, { "retry-after": "10" }).end("unavailable");
+        return;
+      }
+      const pages: Record<string, string> = {
+        "/onboarding": "<h1>What do you want to make first</h1>",
+        "/onboarding/video-template":
+          "<h1>Pick a video template to start from</h1><button aria-pressed=\"false\" onclick=\"this.setAttribute('aria-pressed', 'true')\">Video template</button><button onclick=\"location.href='/onboarding/video-run'\">Continue</button>",
+        "/onboarding/video-run":
+          "<h1>Customize your video</h1><button onclick=\"fetch('/api/billing/usage-pack-checkout', {method: 'POST', headers: {'x-client-request-id': 'checkout-fixture'}})\">Upgrade Pro to run</button>",
+      };
+      sendHtml(response, pages[url.pathname] ?? "Not found");
+    });
+    const browser = await chromium.launch();
+    try {
+      const page = await browser.newPage();
+      await assert.rejects(
+        startVideoOnboardingCheckout(page, {
+          appUrl: fixture.origin,
+          apiUrl: fixture.origin,
+        }),
+        /HTTP 503; request_id=checkout-fixture; retry_after=10/,
+      );
+      assert.equal(checkoutRequests, 1);
+      assert.equal(new URL(page.url()).pathname, "/onboarding/video-run");
+    } finally {
+      await browser.close();
+      await close(fixture.server);
     }
   },
 );

--- a/e2e/playwright/lib/onboarding.ts
+++ b/e2e/playwright/lib/onboarding.ts
@@ -1,5 +1,7 @@
 import { errors, expect, type Page } from "@playwright/test";
 
+import { apiFailureMessage } from "./api-response";
+
 import {
   captureClerkReadiness,
   describeClerkReadiness,
@@ -87,7 +89,7 @@ export async function completeExploreOnboarding(
 
 export async function startVideoOnboardingCheckout(
   page: Page,
-  options: OnboardingFlowOptions,
+  options: OnboardingFlowOptions & { readonly apiUrl: string },
 ): Promise<void> {
   await openOnboarding(page, options);
   // The primary video choice now completes onboarding and opens the in-product
@@ -115,7 +117,31 @@ export async function startVideoOnboardingCheckout(
   ).toBeVisible({ timeout: 30_000 });
   expect(new URL(page.url()).pathname).toBe("/onboarding/video-run");
 
-  await clickOnboardingButton(page, /^Upgrade Pro to run$/i);
+  const apiOrigin = new URL(options.apiUrl).origin;
+  const [response] = await Promise.all([
+    page.context().waitForEvent("response", {
+      predicate: (response) => {
+        const url = new URL(response.url());
+        return (
+          url.origin === apiOrigin &&
+          url.pathname === "/api/billing/usage-pack-checkout" &&
+          response.request().method() === "POST"
+        );
+      },
+      timeout: 60_000,
+    }),
+    clickOnboardingButton(page, /^Upgrade Pro to run$/i),
+  ]);
+  if (!response.ok()) {
+    throw new Error(
+      apiFailureMessage(
+        "Create onboarding checkout",
+        response.status(),
+        response.request().headers()["x-client-request-id"] ?? null,
+        response.headers()["retry-after"] ?? null,
+      ),
+    );
+  }
   await expect(page).toHaveURL(/checkout\.stripe\.com/, { timeout: 60_000 });
 }
 

--- a/e2e/playwright/lib/runner-account.test.ts
+++ b/e2e/playwright/lib/runner-account.test.ts
@@ -146,6 +146,29 @@ test("prepares and cleans one generation of runner accounts", async () => {
   }
 });
 
+test("runner resource records survive preparation and a later cleanup attempt", async () => {
+  const fixture = await startClerkFixture();
+  const directory = await mkdtemp(join(tmpdir(), "runner-records-test-"));
+  try {
+    const environment = runnerEnvironment(fixture.apiUrl, {
+      GITHUB_OUTPUT: join(directory, "github-output"),
+      E2E_CLERK_RESOURCE_DIR: join(directory, "resources"),
+    });
+    await runRunnerAccount("prepare", environment);
+    assert.equal(fixture.state.organizations.length, 4);
+    await runRunnerAccount("cleanup-recorded-run", {
+      ...environment,
+      GITHUB_RUN_ATTEMPT: "4",
+    });
+    assert.deepEqual(fixture.state.organizations, []);
+    assert.deepEqual(fixture.state.users, []);
+    assert.equal(fixture.state.deletionEvents.length, 8);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+    await closeServer(fixture.server);
+  }
+});
+
 test("run cleanup removes every runner generation for the exact workflow run", async () => {
   const fixture = await startClerkFixture();
   const tempDirectory = await mkdtemp(
@@ -332,6 +355,33 @@ async function handleClerkRequest(
 ): Promise<void> {
   const path = request.url ?? "";
   const url = new URL(path, "http://clerk.test");
+  if (request.method === "GET" && url.pathname.startsWith("/v1/users/")) {
+    const id = url.pathname.slice("/v1/users/".length);
+    const user = state.users.find((candidate) => candidate.id === id);
+    sendJson(
+      response,
+      user ? { id, email_addresses: [{ email_address: user.email }] } : {},
+      user ? 200 : 404,
+    );
+    return;
+  }
+  if (
+    request.method === "GET" &&
+    url.pathname.startsWith("/v1/organizations/")
+  ) {
+    const id = url.pathname.slice("/v1/organizations/".length);
+    const organization = state.organizations.find(
+      (candidate) => candidate.id === id,
+    );
+    sendJson(
+      response,
+      organization
+        ? { id, private_metadata: organization.request.private_metadata }
+        : {},
+      organization ? 200 : 404,
+    );
+    return;
+  }
   if (request.method === "GET" && url.pathname === "/v1/users") {
     sendJson(
       response,
@@ -506,7 +556,11 @@ function runnerEnvironment(
 }
 
 async function runRunnerAccount(
-  command: "prepare" | "cleanup-generation" | "cleanup-run",
+  command:
+    | "prepare"
+    | "cleanup-generation"
+    | "cleanup-run"
+    | "cleanup-recorded-run",
   environment: Readonly<NodeJS.ProcessEnv>,
 ): Promise<void> {
   await execFileAsync(

--- a/e2e/playwright/lib/runner-onboarding.test.ts
+++ b/e2e/playwright/lib/runner-onboarding.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { test } from "node:test";
+
+import {
+  completeRunnerOnboarding,
+  createRunnerCheckout,
+  readRunnerPaidEntitlement,
+} from "./runner-onboarding";
+
+test("runner setup completes free onboarding and creates checkout through public authenticated APIs", async () => {
+  const paths: string[] = [];
+  await withApi(
+    async (request, response) => {
+      paths.push(request.method + " " + request.url);
+      assert.equal(request.headers.authorization, "Bearer session-token");
+      assert.equal(
+        request.headers["x-vercel-protection-bypass"],
+        "preview-bypass",
+      );
+      assert.match(
+        String(request.headers["x-client-request-id"]),
+        /^[0-9a-f-]{36}$/,
+      );
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.from(chunk));
+      }
+      const body: unknown = JSON.parse(Buffer.concat(chunks).toString());
+      if (request.url === "/api/onboarding/complete") {
+        assert.deepEqual(body, {});
+        send(response, { onboardingComplete: true, needsOnboarding: false });
+      } else {
+        assert.deepEqual(body, {
+          tier: "pro",
+          memberUsagePacks: [{ memberId: "user_runner", usagePackUsd: 20 }],
+          successUrl:
+            "https://app.example.test/?billing=pro&billing_session_id={CHECKOUT_SESSION_ID}",
+          cancelUrl: "https://app.example.test/",
+        });
+        send(response, { url: "https://checkout.stripe.com/c/pay/session" });
+      }
+    },
+    async (apiUrl) => {
+      const options = {
+        apiUrl,
+        clerkSessionToken: "session-token",
+        vercelAutomationBypassSecret: "preview-bypass",
+      };
+      await completeRunnerOnboarding(options);
+      const checkout = await createRunnerCheckout({
+        ...options,
+        appUrl: "https://app.example.test",
+        memberId: "user_runner",
+      });
+      assert.equal(checkout, "https://checkout.stripe.com/c/pay/session");
+      assert.deepEqual(paths, [
+        "POST /api/onboarding/complete",
+        "POST /api/billing/usage-pack-checkout",
+      ]);
+    },
+  );
+});
+
+test("checkout failure reports its request ID and Retry-After without replaying the purchase", async () => {
+  let requests = 0;
+  let requestId: string | undefined;
+  await withApi(
+    (request, response) => {
+      requests += 1;
+      requestId = String(request.headers["x-client-request-id"]);
+      response.setHeader("retry-after", "10");
+      send(response, { error: { message: "Unavailable" } }, 503);
+    },
+    async (apiUrl) => {
+      await assert.rejects(
+        createRunnerCheckout({
+          apiUrl,
+          appUrl: "https://app.example.test",
+          memberId: "user_runner",
+          clerkSessionToken: "session-token",
+        }),
+        (error: unknown) => {
+          assert.ok(error instanceof Error);
+          assert.match(error.message, /HTTP 503/);
+          assert.ok(requestId && error.message.includes(requestId));
+          assert.match(error.message, /retry_after=10/);
+          return true;
+        },
+      );
+      assert.equal(requests, 1);
+    },
+  );
+});
+
+test("runner entitlement requires settled Pro, BYOK and unrestricted models", async () => {
+  let state = {
+    tier: "limited-free-1",
+    onboardingPaymentPending: false,
+    supportByok: false,
+    restrictedVm0Models: true,
+  };
+  await withApi(
+    (request, response) => {
+      assert.equal(request.method, "GET");
+      assert.equal(request.url, "/api/billing/status");
+      send(response, state);
+    },
+    async (apiUrl) => {
+      const options = { apiUrl, clerkSessionToken: "session-token" };
+      assert.equal(await readRunnerPaidEntitlement(options), false);
+      state = {
+        tier: "pro",
+        onboardingPaymentPending: true,
+        supportByok: true,
+        restrictedVm0Models: false,
+      };
+      assert.equal(await readRunnerPaidEntitlement(options), false);
+      state.onboardingPaymentPending = false;
+      assert.equal(await readRunnerPaidEntitlement(options), true);
+    },
+  );
+});
+
+test("runner setup rejects unsuccessful completion and non-Stripe checkout destinations", async () => {
+  await withApi(
+    (request, response) => {
+      send(
+        response,
+        request.url === "/api/onboarding/complete"
+          ? { onboardingComplete: false, needsOnboarding: true }
+          : { url: "https://unexpected.example.test/" },
+      );
+    },
+    async (apiUrl) => {
+      const options = { apiUrl, clerkSessionToken: "session-token" };
+      await assert.rejects(
+        completeRunnerOnboarding(options),
+        /did not return completed onboarding/,
+      );
+      await assert.rejects(
+        createRunnerCheckout({
+          ...options,
+          appUrl: "https://app.example.test",
+          memberId: "user_runner",
+        }),
+        /hosted Stripe Checkout/,
+      );
+    },
+  );
+});
+
+async function withApi(
+  handler: (
+    request: IncomingMessage,
+    response: ServerResponse,
+  ) => void | Promise<void>,
+  run: (apiUrl: string) => Promise<void>,
+): Promise<void> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+  try {
+    await run("http://127.0.0.1:" + address.port);
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+}
+
+function send(response: ServerResponse, body: unknown, status = 200): void {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}

--- a/e2e/playwright/lib/runner-onboarding.ts
+++ b/e2e/playwright/lib/runner-onboarding.ts
@@ -1,0 +1,107 @@
+import { randomUUID } from "node:crypto";
+
+import { apiFailureMessage } from "./api-response";
+import { authHeadersForToken } from "./onboarding";
+
+interface RunnerOnboardingOptions {
+  readonly apiUrl: string;
+  readonly clerkSessionToken: string;
+  readonly vercelAutomationBypassSecret?: string;
+}
+
+export async function completeRunnerOnboarding(
+  options: RunnerOnboardingOptions,
+): Promise<void> {
+  const result = await requestRunnerApi(
+    options,
+    "/api/onboarding/complete",
+    {},
+  );
+  if (
+    !isObject(result) ||
+    result.onboardingComplete !== true ||
+    result.needsOnboarding !== false
+  ) {
+    throw new Error("Runner onboarding did not return completed onboarding");
+  }
+}
+
+export async function createRunnerCheckout(
+  options: RunnerOnboardingOptions & {
+    readonly appUrl: string;
+    readonly memberId: string;
+  },
+): Promise<string> {
+  const result = await requestRunnerApi(
+    options,
+    "/api/billing/usage-pack-checkout",
+    {
+      tier: "pro",
+      memberUsagePacks: [{ memberId: options.memberId, usagePackUsd: 20 }],
+      successUrl: new URL(
+        "/?billing=pro&billing_session_id={CHECKOUT_SESSION_ID}",
+        options.appUrl,
+      ).toString(),
+      cancelUrl: new URL("/", options.appUrl).toString(),
+    },
+  );
+  if (!isObject(result) || typeof result.url !== "string") {
+    throw new Error("Runner checkout did not return a checkout URL");
+  }
+  const url = new URL(result.url);
+  if (url.origin !== "https://checkout.stripe.com") {
+    throw new Error("Runner checkout did not return hosted Stripe Checkout");
+  }
+  return url.toString();
+}
+
+export async function readRunnerPaidEntitlement(
+  options: RunnerOnboardingOptions,
+): Promise<boolean> {
+  const result = await requestRunnerApi(options, "/api/billing/status");
+  if (!isObject(result) || typeof result.tier !== "string") {
+    throw new Error("Runner billing status returned an invalid response");
+  }
+  return (
+    result.tier === "pro" &&
+    result.onboardingPaymentPending === false &&
+    result.supportByok === true &&
+    result.restrictedVm0Models === false
+  );
+}
+
+async function requestRunnerApi(
+  options: RunnerOnboardingOptions,
+  path: string,
+  body?: unknown,
+): Promise<unknown> {
+  const requestId = randomUUID();
+  const response = await fetch(new URL(path, options.apiUrl), {
+    method: body === undefined ? "GET" : "POST",
+    headers: {
+      ...authHeadersForToken(
+        options.clerkSessionToken,
+        options.vercelAutomationBypassSecret,
+      ),
+      "Content-Type": "application/json",
+      "x-client-request-id": requestId,
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  if (!response.ok) {
+    await response.body?.cancel();
+    throw new Error(
+      apiFailureMessage(
+        path,
+        response.status,
+        requestId,
+        response.headers.get("retry-after"),
+      ),
+    );
+  }
+  return await response.json();
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -59,7 +59,7 @@ export default defineConfig({
   use: {
     baseURL: appUrl,
     ignoreHTTPSErrors: true,
-    trace: "on-first-retry",
+    trace: "retain-on-failure",
     ...devices["Desktop Chrome"],
   },
   projects: [

--- a/e2e/playwright/runner-account.ts
+++ b/e2e/playwright/runner-account.ts
@@ -3,6 +3,7 @@ import { appendFile } from "node:fs/promises";
 import {
   cleanupCurrentClerkTestGeneration,
   cleanupCurrentClerkTestRun,
+  cleanupRecordedClerkTestResources,
   createOrganization,
   createUser,
   runnerTestAccounts,
@@ -32,9 +33,17 @@ async function main(): Promise<void> {
     case "cleanup-run":
       await cleanupRunnerAccountRun();
       break;
+    case "cleanup-recorded-generation":
+    case "cleanup-recorded-run":
+      requiredEnvironmentVariable("JOB_REF");
+      await cleanupRecordedClerkTestResources(
+        RUNNER_TEST_ROLES,
+        command === "cleanup-recorded-run" ? "run" : "generation",
+      );
+      break;
     default:
       throw new Error(
-        "Usage: runner-account.ts <prepare|cleanup-generation|cleanup-run>",
+        "Usage: runner-account.ts <prepare|cleanup-generation|cleanup-run|cleanup-recorded-generation|cleanup-recorded-run>",
       );
   }
 }

--- a/e2e/playwright/runner-token.ts
+++ b/e2e/playwright/runner-token.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import { chromium, type Browser, type Page } from "@playwright/test";
+import { chromium, expect, type Browser, type Page } from "@playwright/test";
 
 import { resolveApiBackendUrl } from "./api-backend-url";
 import { refreshClerkSessionToken, signInWithClerkEmailCode } from "./lib/auth";
@@ -9,11 +9,12 @@ import { issueCliToken } from "./lib/cli-token";
 import { runnerTestAccounts } from "./lib/clerk-api";
 import { formatErrorReport } from "./lib/error-report";
 import { captureClerkReadiness } from "./lib/clerk-readiness";
+import { ensureRunnerOrganizationReady } from "./lib/onboarding";
 import {
-  ensureRunnerOrganizationReady,
-  startVideoOnboardingCheckout,
-  waitForPaidOnboardingCompletion,
-} from "./lib/onboarding";
+  completeRunnerOnboarding,
+  createRunnerCheckout,
+  readRunnerPaidEntitlement,
+} from "./lib/runner-onboarding";
 import { seedPreviewBypassCookie } from "./lib/preview-bypass";
 import {
   collectStripeCheckoutState,
@@ -163,11 +164,17 @@ async function provisionRunnerCredential(
       clerkSessionToken,
       vercelAutomationBypassSecret,
     });
+    await completeRunnerOnboarding({
+      apiUrl,
+      clerkSessionToken,
+      vercelAutomationBypassSecret,
+    });
     if (target.upgradeToPro) {
-      await completePaidOnboarding(page, target, appUrl, outputDirectory);
-      clerkSessionToken = await refreshClerkSessionToken(page, {
-        activeOrganizationId: target.organizationId,
-      });
+      clerkSessionToken = await preparePaidRunner(
+        page,
+        options,
+        clerkSessionToken,
+      );
     }
     const token = await issueCliToken({
       apiUrl,
@@ -189,16 +196,63 @@ async function provisionRunnerCredential(
   }
 }
 
-async function completePaidOnboarding(
+async function preparePaidRunner(
   page: Page,
-  target: RunnerCredentialTarget,
-  appUrl: string,
-  outputDirectory: string,
-): Promise<void> {
+  options: ProvisionRunnerCredentialOptions,
+  clerkSessionToken: string,
+): Promise<string> {
+  const {
+    apiUrl,
+    appUrl,
+    target,
+    outputDirectory,
+    vercelAutomationBypassSecret,
+  } = options;
   try {
-    await startVideoOnboardingCheckout(page, { appUrl });
+    const memberId = await page.evaluate(() => window.Clerk?.user?.id);
+    if (!memberId) {
+      throw new Error("Runner checkout requires the signed-in Clerk user");
+    }
+    const checkoutUrl = await createRunnerCheckout({
+      apiUrl,
+      appUrl,
+      memberId,
+      clerkSessionToken,
+      vercelAutomationBypassSecret,
+    });
+    await page.goto(checkoutUrl, { waitUntil: "domcontentloaded" });
     await fillStripeCheckout(page);
-    await waitForPaidOnboardingCompletion(page, { appUrl });
+    await page.waitForURL((url) => url.origin === new URL(appUrl).origin, {
+      timeout: 180_000,
+      waitUntil: "domcontentloaded",
+    });
+    let verifiedToken = await refreshClerkSessionToken(page, {
+      activeOrganizationId: target.organizationId,
+    });
+    // Observe the public entitlement after Stripe/webhook settlement before
+    // exposing credentials to shards that require paid models and BYOK.
+    await expect
+      .poll(
+        async () => {
+          const token = await page.evaluate(
+            async () => await window.Clerk?.session?.getToken(),
+          );
+          if (!token) {
+            throw new Error(
+              "Clerk session unavailable while verifying runner entitlement",
+            );
+          }
+          verifiedToken = token;
+          return await readRunnerPaidEntitlement({
+            apiUrl,
+            clerkSessionToken: token,
+            vercelAutomationBypassSecret,
+          });
+        },
+        { timeout: 60_000, message: "Runner Pro entitlement must be active" },
+      )
+      .toBe(true);
+    return verifiedToken;
   } catch (error: unknown) {
     try {
       await capturePaidOnboardingFailure(page, target, outputDirectory);

--- a/e2e/playwright/tests/paid-onboarding.spec.ts
+++ b/e2e/playwright/tests/paid-onboarding.spec.ts
@@ -36,7 +36,7 @@ test("paid onboarding completes through the video template deep link", async ({
       activeOrganizationId: organizationId,
     });
 
-    await startVideoOnboardingCheckout(page, { appUrl });
+    await startVideoOnboardingCheckout(page, { appUrl, apiUrl });
     await fillStripeCheckout(page);
     const completionUrl = await waitForPaidOnboardingCompletion(page, {
       appUrl,

--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -1,14 +1,20 @@
 import { resolveApiBackendUrl } from "../api-backend-url";
 import { expect, test } from "../fixtures";
 import { signInWithClerkEmailCode } from "../lib/auth";
+import {
+  createOrganization,
+  createUser,
+  generateTestEmail,
+} from "../lib/clerk-api";
 import { completeExploreOnboarding } from "../lib/onboarding";
 import { deriveAppUrl, STORAGE_STATE } from "../playwright.config";
 
 test("complete app onboarding to chat page", async ({ browser, page }) => {
   test.setTimeout(240_000);
 
-  const email = process.env.E2E_CLERK_USER_EMAIL!;
-  const orgId = process.env.E2E_CLERK_ORG_ID!;
+  const email = generateTestEmail("playwright");
+  const userId = await createUser(email);
+  const orgId = await createOrganization("E2E Test Org", userId, "playwright");
   const apiUrl = resolveApiBackendUrl();
   const appUrl = deriveAppUrl(apiUrl);
 


### PR DESCRIPTION
CI created unused Clerk accounts in the auth and paid-onboarding lanes and listed the entire test instance during normal cleanup. One sampled Playwright finalizer scanned 15,696 organizations and deleted none. Runner credential preparation also repeated the full video onboarding journey for three paid identities.

This change scopes feature account creation to its setup project and records exact resource IDs for cleanup. Cleanup verifies ownership against Clerk, preserves run/attempt/role isolation and deletion pacing, deletes organizations before users, and retains users whose organization creation has an ambiguous outcome for the existing strict-marker sweep. Runner records are retained as per-attempt artifacts so later successful reruns can clean their own earlier attempts without global list calls.

All runner identities complete ordinary onboarding through the public API. The three identities exercising paid models and BYOK still obtain Pro through the public usage-pack checkout API and hosted Stripe payment; public entitlement checks must pass before their tokens reach the shards. The dedicated paid-onboarding E2E retains the full video UI journey. Failed checkout responses now report their HTTP status, client request ID, and Retry-After immediately, and the product Playwright lanes retain traces on the first failure.

## Validation

- E2E TypeScript check passed.
- E2E fixture integration suite: 56 passed.
- 13 resource-lifecycle, checkout-error, and runner-setup cases repeated five times: 65/65 passed.
- Playwright/runner workflow, Clerk lifecycle workflow, runner token environment, and workflow shell compatibility checks passed.
- Actionlint, ShellCheck for changed scripts, Prettier, file-size checks, and git diff whitespace check passed.

Local browser checks used installed Chromium 152 because the pinned Chromium 148 download was blocked by the runtime connector policy. The PR pipeline owns validation with the pinned browser and real preview Clerk, Stripe, and runner services. No full local Vitest suite or application dev server was run.
