### PR TITLE
fix(runner): ignore systemd comments before continuation handling

### DIFF
--- a/crates/runner/src/cmd/gc/image_refs/tests.rs
+++ b/crates/runner/src/cmd/gc/image_refs/tests.rs
@@ -71,7 +71,7 @@ if [ "$1" = "--no-pager" ] && [ "$2" = "cat" ] && [ "$3" = "--" ]; then
         "ExecStart=/usr/bin/runner start --config /configs/$suffix.yaml"
       exit 0
       ;;
-    effective|malformed-config)
+    effective|malformed-config|comment-hash|comment-semicolon)
       printf '%s\n' \
         '# /etc/systemd/system/vm0-runner-test.service' \
         '[Service]' \
@@ -82,8 +82,12 @@ if [ "$1" = "--no-pager" ] && [ "$2" = "cat" ] && [ "$3" = "--" ]; then
         'ExecStart=/usr/bin/runner start --config /etc/vendor.yaml' \
         '# /run/systemd/system/vm0-runner-test.service.d/20-runtime.conf' \
         '[Service]' \
-        'ExecStart=' \
-        "ExecStart=/usr/bin/runner start --config $OKOU_RUN_GC_ENABLED_SERVICE_CONFIG"
+        'ExecStart='
+      case "$OKOU_RUN_GC_ENABLED_SERVICE_SCENARIO" in
+        comment-hash) printf '%s\n' '  # runner config example \' ;;
+        comment-semicolon) printf '%s\n' '  ; runner config example \' ;;
+      esac
+      printf '%s\n' "ExecStart=/usr/bin/runner start --config $OKOU_RUN_GC_ENABLED_SERVICE_CONFIG"
       exit 0
       ;;
   esac
@@ -519,6 +523,13 @@ async fn effective_enabled_service_config_ref_keeps_image_snapshot() {
 }
 
 #[tokio::test]
+async fn enabled_service_config_after_backslash_ended_comment_keeps_image_snapshot() {
+    for scenario in ["comment-hash", "comment-semicolon"] {
+        run_enabled_service_scenario(scenario).await;
+    }
+}
+
+#[tokio::test]
 async fn enabled_service_discovery_failures_make_inventory_incomplete() {
     for scenario in ["enablement-error", "cat-error", "cat-warning"] {
         run_enabled_service_scenario(scenario).await;
@@ -613,7 +624,7 @@ async fn enabled_service_systemctl_child() {
     let system_dir = PathBuf::from(std::env::var(ENABLED_SERVICE_SYSTEM_DIR_ENV).unwrap());
     match scenario.as_str() {
         "bounded" => assert_bounded_enabled_service_discovery(&system_dir).await,
-        "effective" => {
+        "effective" | "comment-hash" | "comment-semicolon" => {
             let home = test_home(Path::new(&std::env::var(ENABLED_SERVICE_HOME_ENV).unwrap()));
             let rootfs_hash = test_hash('a');
             let snapshot_hash = test_hash('b');

--- a/crates/runner/src/cmd/service/gate.rs
+++ b/crates/runner/src/cmd/service/gate.rs
@@ -254,8 +254,33 @@ pub(super) async fn check_active_jobs_gate(
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
+    use std::os::unix::fs::PermissionsExt;
+    use std::time::Duration;
 
     use super::*;
+    use crate::test_fixtures::ignored_child::{
+        ignored_child_test_env_guard_enabled, run_ignored_child_test,
+    };
+
+    const COMMENT_MARKER_ENV: &str = "OKOU_RUN_SERVICE_GATE_COMMENT_MARKER";
+    const COMMENT_CONFIG_ENV: &str = "OKOU_RUN_SERVICE_GATE_COMMENT_CONFIG";
+    const COMMENT_CHILD_TEST: &str =
+        "cmd::service::gate::tests::commented_unit_active_jobs_gate_child";
+    const COMMENT_SYSTEMCTL: &str = r#"#!/bin/sh
+if [ "$1" = "show" ]; then
+  printf '%s\n' 'LoadState=loaded' 'ActiveState=active'
+  exit 0
+fi
+if [ "$1" = "--no-pager" ] && [ "$2" = "cat" ] && [ "$3" = "--" ]; then
+  printf '%s\n' \
+    '[Service]' \
+    "$OKOU_RUN_SERVICE_GATE_COMMENT_MARKER runner config example \\" \
+    "ExecStart=/usr/bin/runner start --config \"$OKOU_RUN_SERVICE_GATE_COMMENT_CONFIG\""
+  exit 0
+fi
+printf '%s\n' "unexpected fake systemctl invocation: $*" >&2
+exit 2
+"#;
 
     struct FakeGateOps {
         active_results: VecDeque<RunnerResult<bool>>,
@@ -747,6 +772,92 @@ mod tests {
 
         assert_eq!(ops.active_queries, 1);
         assert_eq!(ops.config_queries, 1);
+    }
+
+    #[tokio::test]
+    async fn check_active_jobs_gate_uses_config_after_backslash_ended_comments() {
+        let dir = tempfile::tempdir().unwrap();
+        let systemctl = dir.path().join("systemctl");
+        std::fs::write(&systemctl, COMMENT_SYSTEMCTL).unwrap();
+        std::fs::set_permissions(&systemctl, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let config_path = dir.path().join("selected config.yaml");
+
+        for marker in ["#", ";"] {
+            run_ignored_child_test(
+                COMMENT_CHILD_TEST,
+                (COMMENT_MARKER_ENV, marker),
+                &[
+                    ("PATH", Some(dir.path().to_str().unwrap())),
+                    (COMMENT_CONFIG_ENV, Some(config_path.to_str().unwrap())),
+                ],
+                Duration::from_secs(10),
+            )
+            .await;
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "spawned by the commented unit active-jobs gate test"]
+    async fn commented_unit_active_jobs_gate_child() {
+        let Ok(marker) = std::env::var(COMMENT_MARKER_ENV) else {
+            return;
+        };
+        if !ignored_child_test_env_guard_enabled((COMMENT_MARKER_ENV, &marker)) {
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = fake_home(&dir);
+        let unit = service_unit();
+        let config_path = PathBuf::from(std::env::var(COMMENT_CONFIG_ENV).unwrap());
+        let base_dir = home.runners_dir().join("runner-release");
+        let _live_instance = publish_test_live_runner(&home, &config_path, &base_dir).await;
+        tokio::fs::create_dir_all(&base_dir).await.unwrap();
+
+        let run_id = RunId::new_v4();
+        for command in ["stop", "uninstall"] {
+            for active_runs in [Vec::new(), vec![serde_json::json!({"run_id": run_id})]] {
+                tokio::fs::write(
+                    base_dir.join("status.json"),
+                    serde_json::to_vec(&serde_json::json!({
+                        "mode": "running",
+                        "active_runs": active_runs,
+                        "started_at": "2026-04-13T00:00:00Z",
+                    }))
+                    .unwrap(),
+                )
+                .await
+                .unwrap();
+
+                let result = check_active_jobs_gate(
+                    &unit,
+                    &home,
+                    false,
+                    command,
+                    &mut super::super::RealServiceUninstallOps,
+                )
+                .await;
+                if active_runs.is_empty() {
+                    result.unwrap();
+                } else {
+                    let error = result.unwrap_err();
+                    assert!(
+                        matches!(&error, RunnerError::ActiveJobs(jobs) if jobs.run_ids == [run_id]),
+                        "expected active-job protection for {command}, got {error}"
+                    );
+                }
+            }
+        }
+
+        let bounded_config =
+            super::super::unit_config::read_unit_config_path_bounded(&unit, Duration::from_secs(5))
+                .await
+                .unwrap();
+        assert!(matches!(
+            bounded_config,
+            super::super::systemctl::BoundedSystemctlQuery::Completed(Some(path))
+                if path == config_path
+        ));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/service/unit_config.rs
+++ b/crates/runner/src/cmd/service/unit_config.rs
@@ -67,10 +67,10 @@ fn logical_unit_lines(content: &str) -> Vec<String> {
     for raw_line in content.lines() {
         let line = raw_line.trim_end();
         let trimmed_start = line.trim_start();
-        if !continued.is_empty()
-            && (trimmed_start.is_empty()
-                || trimmed_start.starts_with('#')
-                || trimmed_start.starts_with(';'))
+        // Full-line comments must neither start nor end a continuation.
+        if trimmed_start.is_empty()
+            || trimmed_start.starts_with('#')
+            || trimmed_start.starts_with(';')
         {
             continue;
         }
@@ -380,6 +380,78 @@ ExecStart = "/usr/bin/runner" start --config "/etc/runner.yaml"
     }
 
     #[test]
+    fn parse_unit_config_path_ignores_standalone_comments_ending_in_backslash() {
+        for marker in ['#', ';'] {
+            for indent in ["", " \t"] {
+                let content = format!(
+                    r#"[Service]
+{indent}{marker} runner config example \
+ExecStart=/usr/bin/runner start --config /etc/runner.yaml
+"#
+                );
+
+                assert_eq!(
+                    parse_unit_config_path(&content),
+                    Some(PathBuf::from("/etc/runner.yaml")),
+                    "comment marker {marker:?} with indent {indent:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn parse_unit_config_path_comment_does_not_hide_service_section() {
+        for marker in ['#', ';'] {
+            let content = format!(
+                r#"[Unit]
+Description=runner
+  {marker} service settings \
+[Service]
+ExecStart=/usr/bin/runner start --config /etc/runner.yaml
+"#
+            );
+
+            assert_eq!(
+                parse_unit_config_path(&content),
+                Some(PathBuf::from("/etc/runner.yaml")),
+                "comment marker {marker:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_unit_config_path_comment_does_not_hide_leaving_service_section() {
+        for marker in ['#', ';'] {
+            let content = format!(
+                r#"[Service]
+ExecStart=/usr/bin/runner start --config /etc/runner.yaml
+  {marker} install settings \
+[Install]
+ExecStart=/usr/bin/runner start --config /etc/wrong-runner.yaml
+"#
+            );
+
+            assert_eq!(
+                parse_unit_config_path(&content),
+                Some(PathBuf::from("/etc/runner.yaml")),
+                "comment marker {marker:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_unit_config_path_preserves_comment_markers_inside_arguments() {
+        let content = r#"[Service]
+ExecStart=/usr/bin/runner start --config "/etc/#runner;config.yaml"
+"#;
+
+        assert_eq!(
+            parse_unit_config_path(content),
+            Some(PathBuf::from("/etc/#runner;config.yaml"))
+        );
+    }
+
+    #[test]
     fn parse_unit_config_path_ignores_exec_start_outside_service_section() {
         let content = r#"
 [Service]
@@ -415,8 +487,9 @@ ExecStart="/usr/bin/runner" start \
         let content = r#"
 [Service]
 ExecStart="/usr/bin/runner" start \
-  # comment between continued lines
-  ; another comment
+  # comment between continued lines \
+
+  ; another comment \
   --config "/etc/runner.yaml"
 "#;
 
@@ -450,6 +523,39 @@ ExecStart=
 "#;
 
         assert_eq!(parse_unit_config_path(content), None);
+    }
+
+    #[test]
+    fn parse_unit_config_path_comments_preserve_drop_in_reset_and_replacement() {
+        for marker in ['#', ';'] {
+            for (replacement, expected) in [
+                (
+                    "/usr/bin/runner start --config /etc/new-runner.yaml",
+                    Some("/etc/new-runner.yaml"),
+                ),
+                ("/usr/bin/true", None),
+            ] {
+                let content = format!(
+                    r#"# /etc/systemd/system/vm0-runner-test.service
+[Service]
+ExecStart=/usr/bin/runner start --config /etc/old-runner.yaml
+
+# /run/systemd/system/vm0-runner-test.service.d/override.conf
+[Service]
+  {marker} reset original command \
+ExecStart=
+  {marker} replacement command \
+ExecStart={replacement}
+"#
+                );
+
+                assert_eq!(
+                    parse_unit_config_path(&content),
+                    expected.map(PathBuf::from),
+                    "comment marker {marker:?}, replacement {replacement:?}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A full-line systemd comment ending in `\` could absorb the following `ExecStart`, section header, or reset and hide or retain the wrong runner config. Ignore comment and blank lines before continuation handling so lifecycle checks and enabled-service image discovery retain the selected config.

Add regressions for both comment markers, indentation, section boundaries, continued commands, literal marker characters, and drop-in reset/replacement ordering. Add isolated systemctl-boundary coverage for the active-jobs gate, bounded config reads, and actual temporary-image retention during GC. Service selection and lifecycle/GC policies are unchanged.

Fixes #33177

## Validation

- Passed: `cargo fmt --manifest-path crates/runner/Cargo.toml -- --check` and `git diff --check`.
- Passed: an offline harness importing the production parser directly, with uncalled systemctl stubs. All 31 repository parser tests and two issue reproduction probes pass; the four new regression groups and both probes failed before the fix.
- Passed: `cargo clippy --manifest-path crates/Cargo.toml --profile local --locked -j 1 -p runner --all-targets --all-features`.
- Passed: `cargo doc --manifest-path crates/Cargo.toml --profile local --locked -j 1 -p runner --all-features --no-deps`.
- Native Runner test execution awaits CI: the single-job `local` test-binary build ended with exit 137 under memory pressure; a retry with Runner debug info disabled was stopped at approximately 3.7 GB RSS on this 3.8 GB runtime. The service-gate and image-retention tests have not run locally.
