### PR TITLE
fix: avoid stacking follow-up arrow hover backgrounds

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -4016,7 +4016,7 @@ function RecommendedFollowupList({
             type="button"
             title={followup.prompt}
             className={cn(
-              "group relative flex text-left transition-colors",
+              "group flex text-left transition-colors",
               // A quick reply sizes to its own text, so a short suggestion
               // stays small and more than one fits on screen. The rail equalises
               // their heights, which is why the contents align to the top: a
@@ -4068,7 +4068,7 @@ function RecommendedFollowupList({
               aria-hidden
               size={16}
               className={cn(
-                "pointer-events-none absolute right-2 top-1/2 box-content -translate-y-1/2 bg-state-hover pl-3 text-muted-foreground/60 opacity-0 transition-[color,opacity] group-hover:text-foreground group-hover:opacity-100",
+                "pointer-events-none ml-3 shrink-0 text-muted-foreground/60 opacity-0 transition-[color,opacity] group-hover:text-foreground group-hover:opacity-100",
                 showFollowupCards && "hidden",
               )}
             />


### PR DESCRIPTION
Hovering a recommended follow-up paints the translucent hover background on both the row and its arrow, creating a darker rectangle behind the icon. Remove the arrow background and keep the icon in the flex layout with a fixed gap so long suggestions wrap without overlapping it.

The existing row hover feedback, click-to-edit behavior, and touch quick-reply layout are preserved.

## Verification

- The fresh [Turbo CI run](https://github.com/vm0-ai/vm0/actions/runs/34458834116) passed formatting, ESLint, style policy, Knip, type checks, all eight App test shards, API/CLI tests, and required E2E tasks.
- App and API preview deployments passed. The required Turbo, Security, and Crates gates are successful for HEAD `644f6cb1f45f9947fd4ef1c19deef90687b4727f`.
- No local Vitest run or development server was started, as requested. Browser visual verification was not repeated during recovery; no additional code changes were made.
