### PR TITLE
feat: add calendly oauth support

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -350,6 +350,7 @@ runs:
           TIKTOK_ADS
           AHREFS
           AIRTABLE
+          CALENDLY
           TODOIST
           ASANA
           POSTHOG

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
@@ -181,6 +181,35 @@ const LAUNCH_GATED_DIRECT_OKOU_CASES: readonly LaunchGatedDirectOkouCase[] = [
     },
   },
   {
+    connectorSlug: "calendly",
+    label: "Calendly",
+    clientEnvPrefix: "CALENDLY",
+    authorizationEndpoint: "https://auth.calendly.com/oauth/authorize",
+    tokenUrl: "https://auth.calendly.com/oauth/token",
+    pkce: true,
+    jsonTokenRequest: true,
+    tokenResponse: {
+      token_type: "Bearer",
+      access_token: "calendly-test-token",
+      refresh_token: "calendly-refresh-token",
+      expires_in: 7200,
+      scope: "users:read scheduled_events:read scheduled_events:write",
+    },
+    mockUserInfo: () => {
+      server.use(
+        http.get("https://api.calendly.com/users/me", () => {
+          return HttpResponse.json({
+            resource: {
+              uri: "https://api.calendly.com/users/calendly-test-user",
+              name: "Calendly Test User",
+              email: "calendly@example.test",
+            },
+          });
+        }),
+      );
+    },
+  },
+  {
     connectorSlug: "canva",
     label: "Canva",
     clientEnvPrefix: "CANVA",

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -146,7 +146,7 @@ const DEFAULT_API_VERSION = apiPackage.version;
 const ZERO_DIGEST = `sha256:${"0".repeat(64)}`;
 const PREVIOUS_CONNECTOR_CATALOG_MAX_RAW_BYTES = 32 * 1024 * 1024;
 const EXPECTED_CAPABILITY_DIGEST =
-  "sha256:dc794c1167865d737412da7275be82d46074c9557c6efc60ce1c5cac959150f0";
+  "sha256:04537c7e421814ff44d72d5b9b300c88117a6f151da6fe2e99aa275a49af4f10";
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const SLACK_OAUTH_TOKEN_URL = "https://slack.com/api/oauth.v2.access";

--- a/turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts
+++ b/turbo/apps/api/src/signals/services/connector-auth-method-feature-switches.ts
@@ -16,6 +16,7 @@ const FEATURE_SWITCH_BY_AUTH_METHOD = Object.freeze<
   "bill\0api-token": FeatureSwitchKey.BillConnector,
   "cal-com\0api-token": FeatureSwitchKey.CalComConnector,
   "cal-com\0oauth": FeatureSwitchKey.CalComConnector,
+  "calendly\0oauth": FeatureSwitchKey.CalendlyOAuthConnector,
   "canva\0oauth": FeatureSwitchKey.CanvaConnector,
   "close\0oauth": FeatureSwitchKey.CloseConnector,
   "copper\0oauth": FeatureSwitchKey.CopperConnector,

--- a/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
@@ -729,6 +729,33 @@ const connectors = [
     ],
   }),
   connector({
+    connectorSlug: "calendly",
+    label: "Calendly",
+    authMethods: [
+      standardOauthMethod({
+        connectorSlug: "calendly",
+        prefix: "CALENDLY",
+        tokenEnvironmentNames: ["CALENDLY_TOKEN"],
+        scopes: [
+          "users:read",
+          "scheduled_events:read",
+          "scheduled_events:write",
+        ],
+      }),
+      manualMethod({
+        fields: [
+          manualField({
+            privateName: "CALENDLY_TOKEN",
+            publicId: "accessToken",
+            label: "Personal Access Token",
+            storage: "secret",
+          }),
+        ],
+        envBindings: { CALENDLY_TOKEN: secret("CALENDLY_TOKEN") },
+      }),
+    ],
+  }),
+  connector({
     connectorSlug: "canva",
     label: "Canva",
     authMethods: [

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -57,6 +57,7 @@ import { awsProvider } from "./connectors/aws/provider";
 import { base44Provider } from "./connectors/base44/provider";
 import { boxProvider } from "./connectors/box/provider";
 import { calComProvider } from "./connectors/cal-com/provider";
+import { calendlyProvider } from "./connectors/calendly/provider";
 import { canvaProvider } from "./connectors/canva/provider";
 import { closeProvider } from "./connectors/close/provider";
 import { copperProvider } from "./connectors/copper/provider";
@@ -980,6 +981,11 @@ const CONNECTOR_AUTH_METHOD_PROVIDER_ENTRIES = [
   deviceAuthRefreshProviderEntry("base44", "oauth", base44Provider),
   authCodeRefreshProviderEntry("box", "oauth", boxProvider),
   authCodeRefreshProviderEntry("cal-com", "oauth", calComProvider),
+  authCodeRefreshTokenRevokeProviderEntry(
+    "calendly",
+    "oauth",
+    calendlyProvider,
+  ),
   authCodeRefreshProviderEntry("canva", "oauth", canvaProvider),
   authCodeRefreshProviderEntry("close", "oauth", closeProvider),
   authCodeProviderEntry("copper", "oauth", copperProvider),

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/calendly.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/calendly.test.ts
@@ -1,0 +1,277 @@
+import { createHash } from "node:crypto";
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import type { ConnectorAuthMethodRuntimeConfig } from "../../../connector-config";
+import {
+  buildConnectorAuthCodeAuthorizationUrlWithMethod,
+  exchangeConnectorAuthCodeWithMethod,
+  refreshConnectorAuthProviderAccessTokenWithMethod,
+  revokeConnectorAuthMethodAccessTokenWithMethod,
+} from "../../connector-auth";
+import { server } from "../../__tests__/test-server";
+
+const method = {
+  client: {
+    clientRegistration: "static",
+    clientType: "confidential",
+    clientIdEnv: "CALENDLY_OAUTH_CLIENT_ID",
+    clientSecretEnv: "CALENDLY_OAUTH_CLIENT_SECRET",
+  },
+  storage: {
+    version: 1,
+    secrets: ["CALENDLY_ACCESS_TOKEN", "CALENDLY_REFRESH_TOKEN"],
+    variables: [],
+  },
+  grant: {
+    kind: "auth-code",
+    callbackOrigin: "web",
+    scopes: ["users:read", "scheduled_events:write"],
+    outputs: {
+      accessToken: "$secrets.CALENDLY_ACCESS_TOKEN",
+      refreshToken: "$secrets.CALENDLY_REFRESH_TOKEN",
+    },
+  },
+  access: {
+    kind: "refresh-token",
+    envBindings: { CALENDLY_TOKEN: "$secrets.CALENDLY_ACCESS_TOKEN" },
+    inputs: { refreshToken: "$secrets.CALENDLY_REFRESH_TOKEN" },
+    outputs: {
+      accessToken: "$secrets.CALENDLY_ACCESS_TOKEN",
+      refreshToken: "$secrets.CALENDLY_REFRESH_TOKEN",
+    },
+    refreshableSecrets: ["CALENDLY_ACCESS_TOKEN"],
+  },
+  revoke: {
+    kind: "token-revoke",
+    revokePreviousOnReplace: false,
+    inputs: { refreshToken: "$secrets.CALENDLY_REFRESH_TOKEN" },
+  },
+} as const satisfies ConnectorAuthMethodRuntimeConfig;
+const selection = { connectorSlug: "calendly", authMethodId: "oauth", method };
+const authClient = {
+  clientRegistration: "static",
+  clientType: "confidential",
+  clientId: "test-calendly-client",
+  clientSecret: "test-calendly-secret",
+} as const;
+const redirectUri = "https://app.okou.ai/connectors/calendly/callback";
+const tokenResponse = {
+  token_type: "Bearer",
+  access_token: "test-calendly-access",
+  refresh_token: "test-calendly-refresh-1",
+  expires_in: 7200,
+  created_at: 1789000000,
+  owner: "https://api.calendly.com/users/test-user",
+  organization: "https://api.calendly.com/organizations/test-org",
+};
+
+async function authorize() {
+  const result = await buildConnectorAuthCodeAuthorizationUrlWithMethod({
+    ...selection,
+    authClient,
+    redirectUri,
+    state: "test-state",
+  });
+  if (typeof result === "string" || result.codeVerifier === undefined) {
+    throw new Error("Calendly must preserve a PKCE verifier");
+  }
+  return { url: result.url, codeVerifier: result.codeVerifier };
+}
+function exchange(codeVerifier: string | undefined, authorizationUrl: string) {
+  return exchangeConnectorAuthCodeWithMethod({
+    ...selection,
+    authClient,
+    authorizationUrl,
+    code: "test-authorization-code",
+    redirectUri,
+    state: "test-state",
+    codeVerifier,
+    oauthContext: undefined,
+  });
+}
+function refresh(refreshToken: string) {
+  return refreshConnectorAuthProviderAccessTokenWithMethod(
+    { ...selection, authClient, inputs: { refreshToken } },
+    new AbortController().signal,
+  );
+}
+
+describe("Calendly registered OAuth provider", () => {
+  it.each(["users:read", undefined])(
+    "preserves PKCE and resolves reported scopes (%s)",
+    async (scope) => {
+      const authorization = await authorize();
+      const url = new URL(authorization.url);
+      expect(url.origin + url.pathname).toBe(
+        "https://auth.calendly.com/oauth/authorize",
+      );
+      expect(url.searchParams.get("client_id")).toBe(authClient.clientId);
+      expect(url.searchParams.get("redirect_uri")).toBe(redirectUri);
+      expect(url.searchParams.get("scope")).toBe(
+        "users:read scheduled_events:write",
+      );
+      expect(url.searchParams.get("state")).toBe("test-state");
+      expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+      expect(url.searchParams.get("code_challenge")).toBe(
+        createHash("sha256")
+          .update(authorization.codeVerifier)
+          .digest("base64url"),
+      );
+      server.use(
+        http.post(
+          "https://auth.calendly.com/oauth/token",
+          async ({ request }) => {
+            expect(request.headers.get("authorization")).toBe(
+              `Basic ${btoa(`${authClient.clientId}:${authClient.clientSecret}`)}`,
+            );
+            expect(await request.json()).toStrictEqual({
+              grant_type: "authorization_code",
+              code: "test-authorization-code",
+              redirect_uri: redirectUri,
+              code_verifier: authorization.codeVerifier,
+            });
+            return HttpResponse.json({ ...tokenResponse, scope });
+          },
+        ),
+        http.get("https://api.calendly.com/users/me", ({ request }) => {
+          expect(request.headers.get("authorization")).toBe(
+            "Bearer test-calendly-access",
+          );
+          return HttpResponse.json({
+            resource: {
+              uri: tokenResponse.owner,
+              name: "Calendly User",
+              email: "user@example.com",
+            },
+          });
+        }),
+      );
+      expect(
+        await exchange(authorization.codeVerifier, authorization.url),
+      ).toMatchObject({
+        outputs: {
+          accessToken: tokenResponse.access_token,
+          refreshToken: tokenResponse.refresh_token,
+        },
+        expiresIn: 7200,
+        scopes:
+          scope === undefined
+            ? ["users:read", "scheduled_events:write"]
+            : ["users:read"],
+        userInfo: {
+          id: tokenResponse.owner,
+          username: "Calendly User",
+          email: "user@example.com",
+        },
+      });
+    },
+  );
+
+  it("rejects exchange without the saved PKCE verifier", async () => {
+    const authorization = await authorize();
+    await expect(exchange(undefined, authorization.url)).rejects.toThrow(
+      "original PKCE code verifier",
+    );
+  });
+
+  it("returns each rotated token for the next refresh and rejects a reused token", async () => {
+    const responses: Record<string, string> = {
+      "test-calendly-refresh-1": "test-calendly-refresh-2",
+      "test-calendly-refresh-2": "test-calendly-refresh-3",
+    };
+    server.use(
+      http.post(
+        "https://auth.calendly.com/oauth/token",
+        async ({ request }) => {
+          expect(request.headers.get("authorization")).toBe(
+            `Basic ${btoa(`${authClient.clientId}:${authClient.clientSecret}`)}`,
+          );
+          const body = await request.json();
+          expect(body).toMatchObject({ grant_type: "refresh_token" });
+          if (
+            typeof body !== "object" ||
+            body === null ||
+            !("refresh_token" in body) ||
+            typeof body.refresh_token !== "string"
+          ) {
+            throw new Error("Expected a refresh token request");
+          }
+          const next = responses[body.refresh_token];
+          if (next === undefined) {
+            return HttpResponse.json(
+              { error: "invalid_grant" },
+              { status: 400 },
+            );
+          }
+          delete responses[body.refresh_token];
+          return HttpResponse.json({ ...tokenResponse, refresh_token: next });
+        },
+      ),
+    );
+    const first = await refresh("test-calendly-refresh-1");
+    expect(first.outputs.refreshToken).toBe("test-calendly-refresh-2");
+    expect(first.scopes).toBeUndefined();
+    const second = await refresh(first.outputs.refreshToken!);
+    expect(second.outputs.refreshToken).toBe("test-calendly-refresh-3");
+    await expect(refresh("test-calendly-refresh-1")).rejects.toMatchObject({
+      status: 400,
+      oauthError: "invalid_grant",
+    });
+  });
+
+  it("rejects refresh without a replacement refresh token", async () => {
+    server.use(
+      http.post("https://auth.calendly.com/oauth/token", () => {
+        return HttpResponse.json({
+          ...tokenResponse,
+          refresh_token: undefined,
+        });
+      }),
+    );
+    await expect(refresh("test-calendly-refresh-1")).rejects.toThrow();
+  });
+
+  it("preserves an explicitly empty scope grant when refreshing", async () => {
+    server.use(
+      http.post("https://auth.calendly.com/oauth/token", () => {
+        return HttpResponse.json({ ...tokenResponse, scope: "" });
+      }),
+    );
+    expect((await refresh("test-calendly-refresh-1")).scopes).toStrictEqual([]);
+  });
+
+  it("revokes the saved refresh token when disconnecting", async () => {
+    server.use(
+      http.post(
+        "https://auth.calendly.com/oauth/revoke",
+        async ({ request }) => {
+          expect(await request.json()).toStrictEqual({
+            client_id: authClient.clientId,
+            client_secret: authClient.clientSecret,
+            token: "test-calendly-refresh-1",
+          });
+          return new HttpResponse(null, { status: 200 });
+        },
+      ),
+    );
+    await expect(
+      revokeConnectorAuthMethodAccessTokenWithMethod(
+        {
+          ...selection,
+          readEnv: (name) => {
+            return name === "CALENDLY_OAUTH_CLIENT_ID"
+              ? authClient.clientId
+              : name === "CALENDLY_OAUTH_CLIENT_SECRET"
+                ? authClient.clientSecret
+                : undefined;
+          },
+          loadInputs: () => {
+            return { refreshToken: "test-calendly-refresh-1" };
+          },
+        },
+        new AbortController().signal,
+      ),
+    ).resolves.toStrictEqual({ status: "revoked" });
+  });
+});

--- a/turbo/packages/connectors/src/auth-providers/connectors/calendly/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/calendly/oauth.ts
@@ -1,0 +1,155 @@
+import { z } from "zod";
+
+import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
+import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
+
+const TOKEN_URL = "https://auth.calendly.com/oauth/token";
+const tokenResponseSchema = z.object({
+  token_type: z.literal("Bearer"),
+  access_token: z.string().min(1),
+  // Calendly rotates single-use refresh tokens on every successful exchange.
+  refresh_token: z.string().min(1),
+  expires_in: z.number().positive(),
+  scope: z.string().optional(),
+});
+
+function base64Url(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export async function buildCalendlyAuthorizationUrl(
+  grant: ConnectorAuthCodeGrantConfig,
+  clientId: string,
+  redirectUri: string,
+  state: string,
+): Promise<{ url: string; codeVerifier: string }> {
+  const codeVerifier = base64Url(crypto.getRandomValues(new Uint8Array(32)));
+  const challenge = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(codeVerifier),
+  );
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: grant.scopes.join(" "),
+    state,
+    code_challenge: base64Url(new Uint8Array(challenge)),
+    code_challenge_method: "S256",
+  });
+  return {
+    url: `https://auth.calendly.com/oauth/authorize?${params.toString()}`,
+    codeVerifier,
+  };
+}
+
+export async function exchangeCalendlyCode(
+  grant: ConnectorAuthCodeGrantConfig,
+  clientId: string,
+  clientSecret: string,
+  code: string,
+  redirectUri: string,
+  codeVerifier: string | undefined,
+) {
+  if (!codeVerifier) {
+    throw new Error("Calendly requires the original PKCE code verifier");
+  }
+  const response = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+    },
+    body: JSON.stringify({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri,
+      code_verifier: codeVerifier,
+    }),
+  });
+  if (!response.ok) {
+    await throwOAuthError("Calendly", "exchange", response);
+  }
+  const token = tokenResponseSchema.parse(await response.json());
+  const userResponse = await fetch("https://api.calendly.com/users/me", {
+    headers: { Authorization: `Bearer ${token.access_token}` },
+  });
+  if (!userResponse.ok) {
+    throw new Error(`Calendly user info fetch failed: ${userResponse.status}`);
+  }
+  const { resource } = z
+    .object({
+      resource: z.object({
+        uri: z.url().startsWith("https://api.calendly.com/users/"),
+        name: z.string(),
+        email: z.string(),
+      }),
+    })
+    .parse(await userResponse.json());
+  return {
+    accessToken: token.access_token,
+    refreshToken: token.refresh_token,
+    expiresIn: token.expires_in,
+    scopes: effectiveOAuthScopes(token.scope, grant.scopes, " "),
+    userInfo: {
+      id: resource.uri,
+      username: resource.name,
+      email: resource.email,
+    },
+  };
+}
+
+export async function refreshCalendlyToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+  signal: AbortSignal,
+) {
+  const response = await fetch(TOKEN_URL, {
+    signal,
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+    },
+    body: JSON.stringify({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+  if (!response.ok) {
+    await throwOAuthError("Calendly", "refresh", response);
+  }
+  const token = tokenResponseSchema.parse(await response.json());
+  return {
+    accessToken: token.access_token,
+    refreshToken: token.refresh_token,
+    expiresIn: token.expires_in,
+    scopes: reportedOAuthScopes(token.scope, " "),
+  };
+}
+
+export async function revokeCalendlyToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+  signal: AbortSignal,
+): Promise<void> {
+  const response = await fetch("https://auth.calendly.com/oauth/revoke", {
+    signal,
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      client_id: clientId,
+      client_secret: clientSecret,
+      token: refreshToken,
+    }),
+  });
+  if (!response.ok) {
+    await throwOAuthError("Calendly", "revoke", response);
+  }
+}

--- a/turbo/packages/connectors/src/auth-providers/connectors/calendly/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/calendly/provider.ts
@@ -1,0 +1,65 @@
+import type { AuthCodeConnectorAuthProvider } from "../../types";
+import { oauthRefreshResultToProviderResult } from "../../oauth/types";
+import {
+  buildCalendlyAuthorizationUrl,
+  exchangeCalendlyCode,
+  refreshCalendlyToken,
+  revokeCalendlyToken,
+} from "./oauth";
+
+export const calendlyProvider: AuthCodeConnectorAuthProvider<"calendly"> = {
+  grant: {
+    kind: "auth-code",
+    buildAuthUrl: (args) => {
+      return buildCalendlyAuthorizationUrl(
+        args.authCodeGrant,
+        args.authClient.clientId,
+        args.redirectUri,
+        args.state,
+      );
+    },
+    exchangeCode: async (args) => {
+      const result = await exchangeCalendlyCode(
+        args.authCodeGrant,
+        args.authClient.clientId,
+        args.authClient.clientSecret,
+        args.code,
+        args.redirectUri,
+        args.codeVerifier,
+      );
+      return {
+        outputs: {
+          accessToken: result.accessToken,
+          refreshToken: result.refreshToken,
+        },
+        expiresIn: result.expiresIn,
+        scopes: result.scopes,
+        userInfo: result.userInfo,
+      };
+    },
+  },
+  access: {
+    kind: "refresh-token",
+    refresh: async (args, signal) => {
+      return oauthRefreshResultToProviderResult(
+        await refreshCalendlyToken(
+          args.authClient.clientId,
+          args.authClient.clientSecret,
+          args.inputs.refreshToken,
+          signal,
+        ),
+      );
+    },
+  },
+  revoke: {
+    kind: "token-revoke",
+    revokeToken: async (args, signal) => {
+      await revokeCalendlyToken(
+        args.authClient.clientId,
+        args.authClient.clientSecret,
+        args.inputs.refreshToken,
+        signal,
+      );
+    },
+  },
+};

--- a/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
@@ -247,6 +247,33 @@ export const CONNECTOR_AUTH_PROVIDER_METHOD_REGISTRATIONS = [
     },
   },
   {
+    connectorSlug: "calendly",
+    authMethodId: "oauth",
+    contract: {
+      client: {
+        kind: "static-confidential-env",
+        clientIdEnv: "CALENDLY_OAUTH_CLIENT_ID",
+        clientSecretEnv: "CALENDLY_OAUTH_CLIENT_SECRET",
+      },
+      grant: {
+        kind: "auth-code",
+        callbackOrigin: "web",
+        outputNames: ["accessToken", "refreshToken"],
+        startOptionNames: [],
+      },
+      access: {
+        kind: "refresh-token",
+        inputNames: ["refreshToken"],
+        outputNames: ["accessToken", "refreshToken"],
+        platformSecrets: [],
+      },
+      revoke: {
+        kind: "token-revoke",
+        inputNames: ["refreshToken"],
+      },
+    },
+  },
+  {
     connectorSlug: "canva",
     authMethodId: "oauth",
     contract: {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -11,6 +11,7 @@ export enum FeatureSwitchKey {
   BentomlConnector = "bentomlConnector",
   CanvaConnector = "canvaConnector",
   CalComConnector = "calComConnector",
+  CalendlyOAuthConnector = "calendlyOAuthConnector",
   CopperConnector = "copperConnector",
   DatadogConnector = "datadogConnector",
   DeelConnector = "deelConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -95,6 +95,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Canva design connector",
     enabled: false,
   },
+  [FeatureSwitchKey.CalendlyOAuthConnector]: {
+    maintainer: "yuma@okou.ai",
+    description: "Enable Calendly OAuth connections",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.CalComConnector]: {
     maintainer: "yuma@okou.ai",
     description: "Enable the Cal.com scheduling connector",


### PR DESCRIPTION
Calendly currently offers only personal access tokens. Add its OAuth provider with S256 PKCE, confidential-client token exchange, account identity from `/users/me`, single-use refresh token rotation, and disconnect revocation. The companion [vm0-connectors PR #4181](https://github.com/vm0-ai/vm0-connectors/pull/4181) adds the OAuth method, all 23 requested provider scopes, and the API permission inventory.

Deployment reads the existing `CALENDLY_OAUTH_CLIENT_ID` and `CALENDLY_OAUTH_CLIENT_SECRET` from Doppler through the shared environment action. Both are present in `vm0/dev` and `vm0/prd`; no credential values are committed or exposed. OAuth discovery uses the staff-enabled `calendlyOAuthConnector` switch. Personal access token connections keep their existing storage contract.

## Compatibility and rollout

Deploy this runtime and its OAuth discovery association before publishing the companion catalog change. The existing executable compatibility filter prevents an earlier API from advertising an unsupported OAuth method. No database migration, Runner protocol change, or App version floor is required.

The production App callback is `https://app.okou.ai/connectors/calendly/callback`. Provider-console registration and a real user authorization/refresh cycle still need verification; local and CI tests use synthetic credentials and intercepted provider HTTP.

## Provider references

- [OAuth application setup and PKCE](https://developer.calendly.com/docs/authentication/creating-an-oauth-app)
- [Official OAuth OpenAPI](https://developer.calendly.com/openapi/calendly-oauth.json): JSON token requests with HTTP Basic authentication for web clients; JSON revocation requests containing the client credentials.
- [Refresh token rotation](https://developer.calendly.com/docs/authentication/refresh-token-rotation-guide): every successful refresh must replace the previous refresh token.

## Fallbacks

Calendly documents `scope` as optional in token responses. On initial exchange, the existing `effectiveOAuthScopes` helper uses the saved authorization request scopes only when the provider omits the field; an explicit narrower or empty grant is preserved. On refresh, an omitted field leaves the saved scopes unchanged through the existing provider-result contract. These are permanent provider-protocol semantics, not a rollout fallback. Missing access tokens, replacement refresh tokens, or expiration values fail validation.

## Validation

- Cross-repository contract verification passed: the new runtime accepts both methods, an earlier runtime filters only OAuth, missing client configuration filters OAuth, and the 23 requested scopes exactly cover the reviewed API scopes.

- Registered-provider tests cover PKCE, exact callback URI, Basic authentication, identity, optional/narrowed scopes, two refresh rotations, reused-token rejection, missing replacement tokens, empty scopes, and disconnect revocation.
- The executable-capability digest fixture was independently verified to change only with the new Calendly registration and its two client configuration names.
- API route coverage adds Calendly to the existing real OAuth start/callback and provider-error cases, with both OAuth and personal-token catalog fixtures.
- Passed the shared deployment environment test with the new Doppler prefix. PR preview logs confirm both Calendly client credentials are injected; the corrected head's [API preview deployment](https://github.com/vm0-ai/vm0/actions/runs/34453414684/job/102794287012) succeeded.
- Passed connector/core lint and types, API types, affected API lint, Knip, and formatting.
- Full Vitest and deployed checks run in PR CI. No local development server was started.
