### PR TITLE
test(api): reduce chat search reader setup to avoid timeouts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-search-reader.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-search-reader.test.ts
@@ -90,7 +90,8 @@ describe("GET /api/chat/search durable reader", () => {
     const prompts = [
       `${sparseKeyword} older`,
       `${sparseKeyword} newer`,
-      ...Array.from({ length: 80 }, (_, index) => {
+      // One extra match proves the 25-result cap without redundant API sends.
+      ...Array.from({ length: 26 }, (_, index) => {
         return `${frequentKeyword} ${index}`;
       }),
     ];
@@ -123,7 +124,7 @@ describe("GET /api/chat/search durable reader", () => {
       }),
     ).toStrictEqual(
       Array.from({ length: 25 }, (_, index) => {
-        return `${frequentKeyword} ${79 - index}`;
+        return `${frequentKeyword} ${25 - index}`;
       }),
     );
     expect(frequent).not.toHaveProperty("hasMore");


### PR DESCRIPTION
The [reported `test-api (6)` job](https://github.com/vm0-ai/vm0/actions/runs/34451810978/job/102789096289?pr=33165) times out in `returns up to 25 newest matches without pagination` at the default 5-second limit. The test prepares 82 messages through sequential send API requests before projecting and searching them, making it sensitive to CI execution time. The identical test file passed on adjacent main CI in 3.28 seconds.

Create 26 frequent matches plus the existing two sparse matches, reducing setup to 28 sends. One match beyond the public cap still proves truncation and newest-first ordering. Preserve the sparse and empty results, ignored legacy limits, both search-query branches, and the default timeout.

## Validation

- V8 coverage enabled: all 4 tests in `chat-search-reader.test.ts` passed; the affected test passed 5 consecutive runs at 1.68–1.82 seconds. The unmodified test passed locally in 3.44 seconds. These are single-worker local measurements.
- Changed-file Prettier, Oxlint, type-aware Oxlint, and ESLint passed.
- API gateway, core, and test type checks passed after building their declaration dependencies.
- API workspace Knip passed.
