### PR TITLE
ci: add production kms exit dependency inventory

### DIFF
--- a/.github/kms-migration-32264/README.md
+++ b/.github/kms-migration-32264/README.md
@@ -133,3 +133,44 @@ cleanup; the sanitized checkpoint records fixture IDs and the random name for
 an operator to inspect and remove through another approved Action. Do not start
 historical migration until that cleanup is verified. Neither synthetic plaintext
 nor credentials, session JWTs, cookies, or ciphertext enter the uploaded reports.
+
+## Read-only exit dependency inventory
+
+After the final database verification, run **KMS Production Exit Dependencies**
+on `main` and approve its existing `production` environment gate. Supply the UTC
+completion time of the accepted full database verification. This timestamp is
+an operator-provided comparison point; this workflow does not validate or replace
+the database certificate.
+
+The two independent jobs reuse existing production credentials:
+
+- Runner inventory uses the existing Cloudflare SSH transport and production
+  host list. A Python program is sent over SSH stdin and only reads
+  `/var/lib/vm0-runner/runners/v{version}/proxy-registry.json`, including retained
+  production release directories. It does not install a program, restart a
+  service, unregister a sandbox, or decrypt a secret. Only aggregate outer-key
+  counts leave each host. PR and staging directories are excluded.
+- Recovery inventory makes GET requests to the production Neon project's
+  metadata, branch list, snapshot list and production backup schedule. It does
+  not request a database connection URI or connect to PostgreSQL. It reports
+  configured history-window overlap and counts every retained snapshot as
+  requiring key review: snapshot creation time does not prove which historical
+  LSN was captured. Other branches are counted without inspecting their data.
+
+The workflow needs no new AWS credentials, IAM roles or KMS grants. It retains
+sanitized reports for 30 days. Failed SSH, unreadable or changing files, unknown
+keys, malformed envelopes, metadata failures, or incomplete pagination prevent
+a successful collection. A missing production registry is unresolved coverage,
+not a zero count. A workflow failure during SSH setup can occur before a report
+exists; do not treat that missing artifact as a successful inventory.
+
+Successful collection is **not retirement clearance**. The reports explicitly
+leave nested runner payloads, state outside these registries, actual earliest
+restorable timestamps, backup ciphertext and external backups unverified. A
+configured recovery window overlapping the migration is a potential recovery
+dependency, not proof that a particular historical point is still restorable.
+Review these results alongside the full database certificate, old-key CloudTrail
+activity, source/target CloudTrail and Config delivery, historical audit-log
+retention, and the agreed rollback requirements before retiring anything. This
+workflow never disables keys/users, changes retention, deletes state, restores
+backups, or changes a deployment.

--- a/.github/scripts/kms-production-exit-check.py
+++ b/.github/scripts/kms-production-exit-check.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Collect read-only recovery and runner evidence; never grant retirement clearance."""
+
+import base64
+import binascii
+import datetime as dt
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+import urllib.parse
+
+SOURCE = "arn:aws:kms:us-west-2:072707626411:key/a1b3922b-fab1-4ed3-aa9e-40f86f92a7a8"
+TARGET = "arn:aws:kms:us-west-2:251964670836:key/e68917e2-5541-4597-b6ef-7e9eb5670947"
+PROJECT = "hidden-lab-39609750"
+REGISTRY_LIMIT = 16 * 1024 * 1024
+COUNTERS = (
+    "productionDirectories",
+    "registriesRead",
+    "entries",
+    "noSecret",
+    "source",
+    "target",
+    "unknownKey",
+    "invalid",
+    "unreadable",
+    "changedDuringRead",
+)
+
+
+class CheckError(Exception):
+    pass
+
+
+def require(condition, code):
+    if not condition:
+        raise CheckError(code)
+
+
+def timestamp(value):
+    require(isinstance(value, str), "invalid_timestamp")
+    require(
+        bool(re.fullmatch(r"\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d{1,6})?Z", value)),
+        "invalid_timestamp",
+    )
+    try:
+        return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        raise CheckError("invalid_timestamp") from None
+
+
+def now():
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def strict_object(pairs):
+    result = {}
+    for key, value in pairs:
+        require(key not in result, "duplicate_json_key")
+        result[key] = value
+    return result
+
+
+def decode_json(content):
+    return json.loads(content, object_pairs_hook=strict_object)
+
+
+def decode_base64(value, size=None):
+    require(isinstance(value, str), "invalid_base64")
+    decoded = base64.b64decode(value, validate=True)
+    require(base64.b64encode(decoded).decode() == value, "invalid_base64")
+    require(size is None or len(decoded) == size, "invalid_base64_size")
+    return decoded
+
+
+def key_category(value):
+    """Inspect only the documented outer envelope, without decrypting anything."""
+    if value is None:
+        return "noSecret"
+    try:
+        require(
+            isinstance(value, str) and value.startswith("vm0secret:v1:"),
+            "invalid_envelope",
+        )
+        encoded = value[len("vm0secret:v1:") :]
+        require(bool(re.fullmatch(r"[A-Za-z0-9_-]+", encoded)), "invalid_envelope")
+        decoded = base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
+        require(
+            base64.urlsafe_b64encode(decoded).decode().rstrip("=") == encoded,
+            "invalid_envelope",
+        )
+        envelope = decode_json(decoded)
+        require(isinstance(envelope, dict), "invalid_envelope")
+        require(
+            type(envelope.get("v")) is int
+            and envelope["v"] == 1
+            and envelope.get("kind") == "stored-secret",
+            "invalid_envelope",
+        )
+        kms = envelope.get("kms")
+        require(isinstance(kms, dict), "invalid_envelope")
+        decode_base64(kms.get("ciphertext"))
+        if any(k in kms for k in ("encryptedDataKey", "iv", "authTag")):
+            require(
+                bool(decode_base64(kms.get("encryptedDataKey"))), "invalid_envelope"
+            )
+            decode_base64(kms.get("iv"), 12)
+            decode_base64(kms.get("authTag"), 16)
+        key = kms.get("keyId")
+        require(isinstance(key, str) and bool(key), "invalid_envelope")
+        return (
+            "source" if key == SOURCE else "target" if key == TARGET else "unknownKey"
+        )
+    except (CheckError, ValueError, TypeError, UnicodeError, binascii.Error):
+        return "invalid"
+
+
+def registry_inventory(root):
+    counts = dict.fromkeys(COUNTERS, 0)
+    require(not root.is_symlink() and root.is_dir(), "runner_root_unavailable")
+    directories = list(root.iterdir())
+    require(len(directories) <= 1000, "runner_directory_limit")
+    # Production promotion names directories v{runner_version}. PR and staging
+    # directories have separate names and are intentionally outside this scope.
+    for directory in directories:
+        if not re.fullmatch(r"v\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?", directory.name):
+            continue
+        counts["productionDirectories"] += 1
+        path = directory / "proxy-registry.json"
+        try:
+            require(
+                not directory.is_symlink() and directory.is_dir(),
+                "invalid_runner_directory",
+            )
+            fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+            with os.fdopen(fd, "rb") as stream:
+                before = os.fstat(stream.fileno())
+                require(
+                    stat.S_ISREG(before.st_mode) and before.st_size <= REGISTRY_LIMIT,
+                    "invalid_registry_file",
+                )
+                data = stream.read(REGISTRY_LIMIT + 1)
+                require(len(data) <= REGISTRY_LIMIT, "registry_size_limit")
+                after = os.fstat(stream.fileno())
+            current = path.stat(follow_symlinks=False)
+
+            def identity(s):
+                return (s.st_dev, s.st_ino, s.st_size, s.st_mtime_ns)
+
+            if identity(before) != identity(after) or identity(before) != identity(
+                current
+            ):
+                counts["changedDuringRead"] += 1
+                continue
+            registry = decode_json(data)
+            require(
+                isinstance(registry, dict)
+                and isinstance(registry.get("sandboxes"), dict),
+                "invalid_registry",
+            )
+            counts["registriesRead"] += 1
+            for entry in registry["sandboxes"].values():
+                counts["entries"] += 1
+                if not isinstance(entry, dict) or "encryptedSecrets" not in entry:
+                    counts["invalid"] += 1
+                else:
+                    counts[key_category(entry["encryptedSecrets"])] += 1
+        except (CheckError, OSError, ValueError, UnicodeError):
+            counts["unreadable"] += 1
+    return counts
+
+
+def runner_fleet():
+    hosts = os.environ.get("AWS_METAL_RUNNER_HOSTS", "").split(",")
+    hosts = [h.strip() for h in hosts]
+    user = os.environ.get("AWS_METAL_RUNNER_USER", "")
+    require(bool(re.fullmatch(r"[a-z_][a-z0-9_-]{0,31}", user)), "invalid_ssh_user")
+    require(
+        0 < len(hosts) <= 32 and len(hosts) == len(set(hosts)), "invalid_host_inventory"
+    )
+    require(
+        all(re.fullmatch(r"[a-zA-Z0-9][a-zA-Z0-9.-]*\.vm3\.ai", h) for h in hosts),
+        "invalid_host_inventory",
+    )
+    script = Path(__file__).read_text()
+    results = []
+    for index, host in enumerate(hosts, 1):
+        result = {"hostOrdinal": index}
+        try:
+            child = subprocess.run(
+                [
+                    "ssh",
+                    "-T",
+                    "-o",
+                    "BatchMode=yes",
+                    f"{user}@{host}",
+                    "sudo -n python3 - runner-local /var/lib/vm0-runner/runners",
+                ],
+                input=script,
+                capture_output=True,
+                text=True,
+                timeout=130,
+            )
+            require(
+                child.returncode == 0 and len(child.stdout) < 10000,
+                "remote_inventory_failed",
+            )
+            counts = decode_json(child.stdout)
+            require(
+                isinstance(counts, dict) and set(counts) == set(COUNTERS),
+                "invalid_remote_report",
+            )
+            require(
+                all(type(v) is int and 0 <= v <= 1_000_000 for v in counts.values()),
+                "invalid_remote_report",
+            )
+            result["counts"] = counts
+        except (CheckError, OSError, ValueError, subprocess.TimeoutExpired):
+            result["error"] = "remote_inventory_failed"
+        results.append(result)
+    totals = dict.fromkeys(COUNTERS, 0)
+    for result in results:
+        for field, count in result.get("counts", {}).items():
+            totals[field] += count
+    complete = all(
+        "counts" in result and result["counts"]["productionDirectories"] > 0
+        for result in results
+    )
+    complete = complete and not any(
+        totals[k] for k in ("unreadable", "changedDuringRead", "invalid", "unknownKey")
+    )
+    return {
+        "hostsExpected": len(hosts),
+        "hosts": results,
+        "totals": totals,
+        "collectionComplete": complete,
+        "outerHeadersOnly": True,
+        "cryptographicVerification": False,
+        "nestedPayloadInspection": False,
+        "retainedStateOutsideProductionRegistriesInspected": False,
+    }
+
+
+def neon_read(suffix):
+    require(
+        suffix == "" or suffix.startswith(("/branches", "/snapshots")),
+        "invalid_metadata_endpoint",
+    )
+    response = subprocess.run(
+        [
+            "curl",
+            "--silent",
+            "--show-error",
+            "--max-time",
+            "30",
+            "--max-filesize",
+            "8388608",
+            "--proto",
+            "=https",
+            "--header",
+            "Authorization: Bearer " + os.environ["NEON_API_KEY"],
+            "--write-out",
+            "\n%{http_code}",
+            f"https://console.neon.tech/api/v2/projects/{PROJECT}" + suffix,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=35,
+    )
+    require(response.returncode == 0, "neon_metadata_request_failed")
+    body, code = response.stdout.rsplit("\n", 1)
+    require(code == "200", "neon_metadata_request_failed")
+    return decode_json(body)
+
+
+def neon_list(collection):
+    items, seen = [], set()
+    suffix = "/" + collection
+    for _ in range(100):
+        result = neon_read(suffix)
+        require(
+            isinstance(result, dict) and isinstance(result.get(collection), list),
+            "invalid_neon_listing",
+        )
+        items.extend(result[collection])
+        require(len(items) <= 10000, "neon_listing_limit")
+        pagination = result.get("pagination", {})
+        require(isinstance(pagination, dict), "invalid_neon_pagination")
+        cursor = pagination.get("cursor")
+        if not cursor:
+            require(
+                not pagination.get("has_more") and not result.get("has_more"),
+                "incomplete_neon_listing",
+            )
+            return items
+        require(
+            collection == "branches" and isinstance(cursor, str) and cursor not in seen,
+            "unsupported_neon_pagination",
+        )
+        seen.add(cursor)
+        suffix = "/branches?" + urllib.parse.urlencode({"cursor": cursor})
+    raise CheckError("neon_pagination_limit")
+
+
+def recovery_history():
+    require(os.environ.get("NEON_PROJECT_ID") == PROJECT, "production_project_mismatch")
+    cutoff = timestamp(os.environ.get("MIGRATION_VERIFIED_AT"))
+    checked = now()
+    require(cutoff <= checked, "future_migration_timestamp")
+    project = neon_read("")["project"]
+    require(project.get("id") == PROJECT, "production_project_mismatch")
+    retention = project.get("history_retention_seconds")
+    require(type(retention) is int and retention >= 0, "missing_history_retention")
+    branches = neon_list("branches")
+    require(all(isinstance(b, dict) for b in branches), "invalid_neon_branch")
+    production = [b for b in branches if b.get("name") == "production"]
+    require(len(production) == 1, "production_branch_not_unique")
+    branch_id = production[0].get("id")
+    require(
+        isinstance(branch_id, str) and bool(re.fullmatch(r"br-[a-z0-9-]+", branch_id)),
+        "invalid_branch_id",
+    )
+    snapshots = neon_list("snapshots")
+    require(all(isinstance(s, dict) for s in snapshots), "invalid_neon_snapshot")
+    # Snapshot creation time does NOT prove which historical LSN was captured.
+    # All retained snapshots need separate recovery/key review, even when new.
+    schedule = neon_read(f"/branches/{branch_id}/backup_schedule")
+    require(
+        isinstance(schedule, dict) and isinstance(schedule.get("schedule"), list),
+        "invalid_backup_schedule",
+    )
+    return {
+        "collectionComplete": True,
+        "project": PROJECT,
+        "migrationVerifiedAt": cutoff.isoformat(),
+        "cutoffProvidedByOperator": True,
+        "historyRetentionSeconds": retention,
+        "configuredHistoryWindowStart": (
+            checked - dt.timedelta(seconds=retention)
+        ).isoformat(),
+        "configuredHistoryWindowOverlapsMigration": checked
+        - dt.timedelta(seconds=retention)
+        < cutoff,
+        "productionBranchFound": True,
+        "otherBranchesNotInspected": len(branches) - 1,
+        "retainedSnapshotsRequiringKeyReview": len(snapshots),
+        "backupScheduleEntries": len(schedule["schedule"]),
+        "actualEarliestRestorableTimeVerified": False,
+        "backupCiphertextVerified": False,
+        "externalBackupsInspected": False,
+        "databaseConnected": False,
+    }
+
+
+def main():
+    require(len(sys.argv) >= 2, "missing_mode")
+    mode = sys.argv[1]
+    if mode == "runner-local":
+        require(len(sys.argv) == 3, "invalid_runner_arguments")
+        print(json.dumps(registry_inventory(Path(sys.argv[2]))))
+        return
+    require(mode in ("runners", "backups") and len(sys.argv) == 2, "invalid_mode")
+    report = {
+        "version": 1,
+        "scope": mode,
+        "runId": os.environ.get("GITHUB_RUN_ID"),
+        "commit": os.environ.get("GITHUB_SHA"),
+        "startedAt": now().isoformat(),
+        "source": SOURCE,
+        "target": TARGET,
+        "result": "incomplete",
+        "retirementCleared": False,
+        "productionResourcesChanged": False,
+    }
+    try:
+        require(
+            os.environ.get("GITHUB_REPOSITORY") == "vm0-ai/vm0"
+            and os.environ.get("GITHUB_REF") == "refs/heads/main"
+            and os.environ.get("GITHUB_EVENT_NAME") == "workflow_dispatch"
+            and os.environ.get("GITHUB_WORKFLOW_REF")
+            == "vm0-ai/vm0/.github/workflows/kms-production-exit-check.yml@refs/heads/main",
+            "protected_workflow_required",
+        )
+        report["inventory"] = (
+            runner_fleet() if mode == "runners" else recovery_history()
+        )
+        if report["inventory"]["collectionComplete"]:
+            report["result"] = "collected"
+    except CheckError as error:
+        report["failure"] = str(error)
+    except Exception:
+        # Never emit a provider body, subprocess stdout/stderr or exception text.
+        report["failure"] = "metadata_collection_failed"
+    report["finishedAt"] = now().isoformat()
+    path = Path(os.environ["RUNNER_TEMP"]) / f"kms-exit-{mode}.json"
+    path.write_text(json.dumps(report, indent=2) + "\n")
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a") as stream:
+            stream.write(
+                f"KMS exit dependency inventory ({mode}): **{report['result']}**.\n\n"
+            )
+            stream.write(
+                "This read-only inventory does not clear key or account retirement. Review retained state, recovery history, CloudTrail/Config and rollback requirements.\n\n"
+            )
+            stream.write("```json\n" + json.dumps(report, indent=2) + "\n```\n")
+    print(
+        f"KMS exit dependency inventory ({mode}): {report['result']}; retirement is not cleared."
+    )
+    if report["result"] != "collected":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except CheckError:
+        raise SystemExit("kms_exit_check_failed") from None
+    except Exception:
+        raise SystemExit("kms_exit_check_failed") from None

--- a/.github/scripts/tests/kms-production-exit-check-test.py
+++ b/.github/scripts/tests/kms-production-exit-check-test.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Exercise the actual CLI, files and child-process boundaries without live access."""
+
+import base64
+import datetime as dt
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "kms-production-exit-check.py"
+SOURCE = "arn:aws:kms:us-west-2:072707626411:key/a1b3922b-fab1-4ed3-aa9e-40f86f92a7a8"
+TARGET = "arn:aws:kms:us-west-2:251964670836:key/e68917e2-5541-4597-b6ef-7e9eb5670947"
+SECRET = "must-not-leak-secret"
+
+
+def envelope(key, direct=False):
+    kms = {"keyId": key, "ciphertext": base64.b64encode(SECRET.encode()).decode()}
+    if not direct:
+        kms.update(
+            {
+                "encryptedDataKey": "eA==",
+                "iv": "AAAAAAAAAAAAAAAA",
+                "authTag": "AAAAAAAAAAAAAAAAAAAAAA==",
+            }
+        )
+    body = json.dumps({"v": 1, "kind": "stored-secret", "kms": kms}).encode()
+    return "vm0secret:v1:" + base64.urlsafe_b64encode(body).decode().rstrip("=")
+
+
+class ExitCheckTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.env = os.environ.copy()
+        self.env.update(
+            {
+                "RUNNER_TEMP": str(self.root),
+                "GITHUB_STEP_SUMMARY": str(self.root / "summary.md"),
+                "GITHUB_REPOSITORY": "vm0-ai/vm0",
+                "GITHUB_REF": "refs/heads/main",
+                "GITHUB_EVENT_NAME": "workflow_dispatch",
+                "GITHUB_RUN_ID": "1234",
+                "GITHUB_SHA": "a" * 40,
+                "GITHUB_WORKFLOW_REF": "vm0-ai/vm0/.github/workflows/kms-production-exit-check.yml@refs/heads/main",
+                "NEON_PROJECT_ID": "hidden-lab-39609750",
+                "NEON_API_KEY": SECRET,
+                "MIGRATION_VERIFIED_AT": (
+                    dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=1)
+                )
+                .isoformat()
+                .replace("+00:00", "Z"),
+                "AWS_METAL_RUNNER_USER": "ubuntu",
+                "AWS_METAL_RUNNER_HOSTS": "a.vm3.ai,b.vm3.ai",
+            }
+        )
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.env["PATH"] = str(self.bin) + os.pathsep + self.env["PATH"]
+
+    def run_script(self, *args):
+        result = subprocess.run(
+            ["python3", str(SCRIPT), *args],
+            env=self.env,
+            text=True,
+            capture_output=True,
+            timeout=15,
+        )
+        for value in (
+            result.stdout,
+            result.stderr,
+            *(p.read_text() for p in self.root.glob("kms-exit-*.json")),
+            *(p.read_text() for p in self.root.glob("summary.md")),
+        ):
+            self.assertNotIn(SECRET, value)
+        return result
+
+    def tool(self, name, content):
+        path = self.bin / name
+        path.write_text("#!/usr/bin/env python3\n" + content)
+        path.chmod(0o755)
+
+    def fake_neon(self):
+        self.env["REQUEST_LOG"] = str(self.root / "requests.jsonl")
+        self.tool(
+            "curl",
+            """import json,os,sys,urllib.parse
+url=sys.argv[-1]
+assert url.startswith("https://console.neon.tech/api/v2/projects/hidden-lab-39609750")
+assert not any(arg in sys.argv for arg in ["-L", "--location", "--data", "-X", "--request"])
+with open(os.environ["REQUEST_LOG"],"a") as f: f.write(json.dumps(url)+"\\n")
+path=urllib.parse.urlsplit(url).path
+if path.endswith("/branches"):
+    if "cursor=page2" in url:
+        data={"branches":[{"id":"br-other","name":"other"}]}
+    else:
+        data={"branches":[{"id":"br-prod","name":"production"}],"pagination":{"cursor":"page2"}}
+elif path.endswith("/snapshots"):
+    if os.environ.get("FAIL_SNAPSHOTS"):
+        print(json.dumps({"message":"must-not-leak-secret"})+"\\n403", end="")
+        sys.stderr.write("must-not-leak-secret")
+        sys.exit(0)
+    data={"snapshots":[{"id":"old","created_at":"2025-01-01T00:00:00Z"},{"id":"new-historical-lsn","created_at":"2099-01-01T00:00:00Z"}]}
+elif path.endswith("/backup_schedule"):
+    data={"schedule":[{"frequency":"daily","hour":3,"retention_seconds":604800}]}
+else:
+    data={"project":{"id":"hidden-lab-39609750","history_retention_seconds":int(os.environ.get("RETENTION","604800")),"unrelated_secret":"must-not-leak-secret"}}
+print(json.dumps(data)+"\\n200", end="")
+""",
+        )
+
+    def test_registry_inventory_counts_source_and_unknown_without_exposing_or_writing(
+        self,
+    ):
+        runners = self.root / "runners"
+        release = runners / "v1.2.3"
+        release.mkdir(parents=True)
+        values = [
+            envelope(SOURCE),
+            envelope(TARGET),
+            envelope(SOURCE, direct=True),
+            envelope("alias/unknown"),
+            "malformed",
+            None,
+        ]
+        data = {
+            "sandboxes": {
+                str(i): {"encryptedSecrets": value, "sandboxToken": SECRET}
+                for i, value in enumerate(values)
+            }
+        }
+        path = release / "proxy-registry.json"
+        path.write_text(json.dumps(data))
+        before = hashlib.sha256(path.read_bytes()).hexdigest()
+        staging = runners / "staging"
+        staging.mkdir()
+        (staging / "proxy-registry.json").write_text(SECRET)
+        result = self.run_script("runner-local", str(runners))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        counts = json.loads(result.stdout)
+        self.assertEqual(
+            {
+                k: counts[k]
+                for k in [
+                    "source",
+                    "target",
+                    "unknownKey",
+                    "invalid",
+                    "noSecret",
+                    "entries",
+                ]
+            },
+            {
+                "source": 2,
+                "target": 1,
+                "unknownKey": 1,
+                "invalid": 1,
+                "noSecret": 1,
+                "entries": 6,
+            },
+        )
+        self.assertEqual(counts["productionDirectories"], 1)
+        self.assertEqual(hashlib.sha256(path.read_bytes()).hexdigest(), before)
+
+    def test_missing_and_symlink_registries_are_unreadable(self):
+        runners = self.root / "runners"
+        for version in ["v1.2.3", "v1.2.4"]:
+            (runners / version).mkdir(parents=True)
+        outside = self.root / "outside.json"
+        outside.write_text('{"sandboxes": {}}')
+        (runners / "v1.2.4" / "proxy-registry.json").symlink_to(outside)
+        result = self.run_script("runner-local", str(runners))
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(json.loads(result.stdout)["unreadable"], 2)
+
+    def test_duplicate_registry_keys_cannot_silently_hide_source_values(self):
+        release = self.root / "runners" / "v1.2.3"
+        release.mkdir(parents=True)
+        (release / "proxy-registry.json").write_text(
+            '{"sandboxes": {"x": {}}, "sandboxes": {}}'
+        )
+        result = self.run_script("runner-local", str(release.parent))
+        self.assertEqual(json.loads(result.stdout)["unreadable"], 1)
+
+    def test_paginated_metadata_keeps_all_snapshots_for_review(self):
+        self.fake_neon()
+        result = self.run_script("backups")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads((self.root / "kms-exit-backups.json").read_text())
+        self.assertFalse(report["retirementCleared"])
+        inventory = report["inventory"]
+        self.assertTrue(inventory["configuredHistoryWindowOverlapsMigration"])
+        self.assertEqual(inventory["otherBranchesNotInspected"], 1)
+        self.assertEqual(inventory["retainedSnapshotsRequiringKeyReview"], 2)
+        self.assertFalse(inventory["databaseConnected"])
+        self.assertNotIn("connection_uri", (self.root / "requests.jsonl").read_text())
+
+    def test_zero_history_window_does_not_clear_retained_snapshots(self):
+        self.fake_neon()
+        self.env["RETENTION"] = "0"
+        self.assertEqual(self.run_script("backups").returncode, 0)
+        report = json.loads((self.root / "kms-exit-backups.json").read_text())
+        self.assertFalse(
+            report["inventory"]["configuredHistoryWindowOverlapsMigration"]
+        )
+        self.assertEqual(report["inventory"]["retainedSnapshotsRequiringKeyReview"], 2)
+        self.assertFalse(report["retirementCleared"])
+
+    def test_provider_failure_is_incomplete_and_sanitized(self):
+        self.fake_neon()
+        self.env["FAIL_SNAPSHOTS"] = "1"
+        self.assertEqual(self.run_script("backups").returncode, 1)
+        report = json.loads((self.root / "kms-exit-backups.json").read_text())
+        self.assertEqual(report["result"], "incomplete")
+        self.assertEqual(report["failure"], "neon_metadata_request_failed")
+
+    def test_nonproduction_context_never_contacts_neon(self):
+        self.fake_neon()
+        self.env["GITHUB_REF"] = "refs/heads/feature"
+        self.assertEqual(self.run_script("backups").returncode, 1)
+        self.assertFalse((self.root / "requests.jsonl").exists())
+
+    def test_unexpected_remote_fields_are_never_exported(self):
+        self.tool(
+            "ssh",
+            'import sys\nsys.stdin.read()\nprint(\'{"secret":"must-not-leak-secret"}\')\n',
+        )
+        self.assertEqual(self.run_script("runners").returncode, 1)
+        report = json.loads((self.root / "kms-exit-runners.json").read_text())
+        self.assertEqual(report["inventory"]["hostsExpected"], 2)
+        self.assertFalse(report["inventory"]["collectionComplete"])
+
+    def test_partial_fleet_failure_preserves_observed_source_dependency(self):
+        release = self.root / "runners" / "v1.2.3"
+        release.mkdir(parents=True)
+        (release / "proxy-registry.json").write_text(
+            json.dumps({"sandboxes": {"x": {"encryptedSecrets": envelope(SOURCE)}}})
+        )
+        local = self.run_script("runner-local", str(release.parent))
+        fixture = self.root / "host-report.json"
+        fixture.write_text(local.stdout)
+        self.env["HOST_REPORT_FIXTURE"] = str(fixture)
+        self.tool(
+            "ssh",
+            """import os,sys
+sys.stdin.read()
+if "ubuntu@b.vm3.ai" in sys.argv:
+    sys.stderr.write("must-not-leak-secret")
+    sys.exit(1)
+print(open(os.environ["HOST_REPORT_FIXTURE"]).read())
+""",
+        )
+        self.assertEqual(self.run_script("runners").returncode, 1)
+        report = json.loads((self.root / "kms-exit-runners.json").read_text())
+        self.assertEqual(report["inventory"]["totals"]["source"], 1)
+        self.assertFalse(report["inventory"]["collectionComplete"])
+        self.assertFalse(report["retirementCleared"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/kms-production-exit-check-test.sh
+++ b/.github/scripts/tests/kms-production-exit-check-test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+python3 "$repo_root/.github/scripts/tests/kms-production-exit-check-test.py"

--- a/.github/workflows/kms-production-exit-check.yml
+++ b/.github/workflows/kms-production-exit-check.yml
@@ -1,5 +1,8 @@
 name: KMS Production Exit Dependencies
 
+env:
+  npm_config_audit: "false"
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/kms-production-exit-check.yml
+++ b/.github/workflows/kms-production-exit-check.yml
@@ -1,0 +1,74 @@
+name: KMS Production Exit Dependencies
+
+on:
+  workflow_dispatch:
+    inputs:
+      migration_verified_at:
+        description: "UTC completion time of the accepted full DB verification"
+        required: true
+        type: string
+        default: "2026-09-10T07:38:23.484Z"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kms-production-operation-32264
+  cancel-in-progress: false
+
+jobs:
+  recovery-history:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Inspect production recovery metadata without connecting to the database
+        env:
+          MIGRATION_VERIFIED_AT: ${{ inputs.migration_verified_at }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+        run: python3 .github/scripts/kms-production-exit-check.py backups
+      - name: Retain sanitized recovery inventory
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kms-production-exit-backups-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/kms-exit-backups.json
+          if-no-files-found: error
+          retention-days: 30
+
+  runner-registries:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Connect to the existing production runner fleet
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+          operation-timeout-seconds: "120"
+      - name: Inventory encrypted-secret headers on production runner hosts
+        env:
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          AWS_METAL_RUNNER_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+        run: python3 .github/scripts/kms-production-exit-check.py runners
+      - name: Retain sanitized runner inventory
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kms-production-exit-runners-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/kms-exit-runners.json
+          if-no-files-found: error
+          retention-days: 30


### PR DESCRIPTION
The final KMS database verification does not inspect retained runner registries or database recovery history. Add a manually dispatched, production-gated Actions workflow that reads production runner secret-envelope headers and Neon recovery metadata using existing SSH and Neon credentials.

Reports contain aggregate key counts, configured recovery-window overlap, and snapshot counts. Missing hosts/files, malformed or unknown envelopes, changed files, provider failures and incomplete pagination prevent successful collection. Every report explicitly leaves retirement uncleared: outer headers do not authenticate nested payloads, configured retention does not prove an actual restore point, and historical/external backup ciphertext plus CloudTrail/Config remain separate checks.

No database connection, credential creation, IAM/KMS change, deployment change, state cleanup, or backup/retention mutation is performed. PR/staging runner directories are excluded. Related to #32264.

Validation: 9 CLI/process/file-boundary tests pass, including source-key detection, partial fleet failure, pagination, symlink/missing-file handling and secret redaction. Ruff, actionlint, Bash syntax and Prettier checks pass. Live production execution follows merge and the existing production environment approval.
