### PR TITLE
test(desktop): measure guardian heartbeat silence instead of throughput

### DIFF
--- a/turbo/apps/desktop/cua/guardian-proof/README.md
+++ b/turbo/apps/desktop/cua/guardian-proof/README.md
@@ -83,6 +83,25 @@ is retained unchanged. No production path loads these diagnostic files.
 - No SDK-owned descendant may escape the group. If the supported process API or
   pinned launcher violates this invariant, this candidate cannot ship.
 
+### Main responsiveness evidence
+
+The retirement proof records `beats`, `heartbeatIntervalMs`, and
+`maxHeartbeatGapMs`. Responsiveness requires no heartbeat gap over 500 ms during
+the measured retirement window, including the first and last partial intervals.
+The bound is one tenth of the unchanged five-second cleanup budget: it detects
+coarse main-thread stalls, not frame-rate latency. Callback count is diagnostic
+only because timer throughput varies with scheduling. An actual scheduling pause
+over the bound still fails; the measurement alone cannot attribute its cause.
+
+All existing identity, failure-fence, and independent kqueue exit checks remain.
+Two additional real-process cases exercise the same blocked-helper cleanup:
+`slow-heartbeat` uses a 25 ms cadence and must remain responsive; `main-blocks`
+deliberately blocks main for one second and must violate the responsiveness bound.
+Both still require confirmed reclamation and all four process exits within five
+seconds. Evidence is captured before diagnostic rescue, so rescue cannot improve
+the measured result. These cases add approximately six seconds plus startup to
+the macOS proof and do not change production heartbeats or cleanup timing.
+
 The first-party native module is an additional signed native-code inventory
 entry if this proof succeeds. It performs bounded process syscalls only, never
 CUA, UBRN or UniFFI calls. Product integration, fixed-path validation, typed RPC,

--- a/turbo/apps/desktop/cua/guardian-proof/main.mjs
+++ b/turbo/apps/desktop/cua/guardian-proof/main.mjs
@@ -29,10 +29,16 @@ void app.whenReady().then(async () => {
   );
   fs.renameSync(`${socketPath}.main.tmp`, `${socketPath}.main`);
   let beats = 0;
+  let lastHeartbeatAt = performance.now();
+  let maxHeartbeatGapMs = 0;
+  const heartbeatIntervalMs = mode === "slow-heartbeat" ? 25 : 10;
   const heartbeat = setInterval(() => {
+    const now = performance.now();
+    maxHeartbeatGapMs = Math.max(maxHeartbeatGapMs, now - lastHeartbeatAt);
+    lastHeartbeatAt = now;
     ++beats;
     owner.pulse();
-  }, 10);
+  }, heartbeatIntervalMs);
   const pause = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
   if (mode !== "spawn-stop") {
     const until = performance.now() + 6_000;
@@ -45,10 +51,16 @@ void app.whenReady().then(async () => {
   // Ownership and the single total deadline precede any native cleanup.
   const deadline = started + 5_000;
   const beginningBeats = beats;
+  lastHeartbeatAt = started;
+  maxHeartbeatGapMs = 0;
   const samples = [];
   let signalResult = null;
   let crashSample = null;
   let fenceRetained = false;
+  if (mode === "main-blocks") {
+    // Deliberately block the real main thread to verify stall detection.
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1_000);
+  }
   if (mode === "main-dies") process.kill(process.pid, "SIGKILL");
   if (mode === "main-dies-during-force") {
     owner.force(guardian);
@@ -92,7 +104,10 @@ void app.whenReady().then(async () => {
     }
     await pause(10);
   }
-  const elapsedMs = performance.now() - started;
+  const finished = performance.now();
+  const elapsedMs = finished - started;
+  // Include the final partial interval, even if no heartbeat ran at all.
+  maxHeartbeatGapMs = Math.max(maxHeartbeatGapMs, finished - lastHeartbeatAt);
   if (!confirmed) {
     try {
       owner.launch([]);
@@ -109,6 +124,8 @@ void app.whenReady().then(async () => {
         cleanup: confirmed ? "confirmed" : "cleanup_unproven",
         elapsedMs,
         beats: beats - beginningBeats,
+        heartbeatIntervalMs,
+        maxHeartbeatGapMs,
         signalResult,
         signals,
         crashSample,

--- a/turbo/apps/desktop/cua/guardian-proof/run-macos.py
+++ b/turbo/apps/desktop/cua/guardian-proof/run-macos.py
@@ -91,8 +91,12 @@ def run_case(electron, build, sdk, output, native, mode, iteration):
             result = json.loads(Path(f"{socket}.result").read_text())
             negative = mode in {"failed-kill", "identity-mismatch", "lost-observation"}
             assert result["confirmed"] is not negative, result
-            if mode in {"blocked-before-ready", "guardian-dies", "guardian-stops"} or negative:
-                assert result["beats"] >= 200, result
+            if mode in {"blocked-before-ready", "guardian-dies", "guardian-stops",
+                        "slow-heartbeat", "main-blocks"} or negative:
+                # Bound silence, not timer throughput. The injected main stall
+                # must fail the same responsiveness contract as a real stall.
+                responsive = result["maxHeartbeatGapMs"] <= 500
+                assert responsive is (mode != "main-blocks"), result
             if negative:
                 assert result["fenceRetained"], result
                 assert 4990 <= result["elapsedMs"] < 5200, result
@@ -133,7 +137,7 @@ def main():
     cases += [(mode, 0) for mode in [
         "guardian-dies", "guardian-stops", "helper-dies", "main-dies",
         "main-dies-during-force", "failed-kill",
-        "identity-mismatch", "lost-observation",
+        "identity-mismatch", "lost-observation", "slow-heartbeat", "main-blocks",
     ]]
     cases += [("spawn-stop", i) for i in range(10)]
     cases += [("healthy", i) for i in range(3)]


### PR DESCRIPTION
## Summary

Closes #33216.

The macOS guardian proof failed on 191 main-loop callbacks despite confirmed cleanup in 3033 ms and independent kernel exits for all processes within 3057 ms. Requiring 200 callbacks measures timer throughput rather than the longest stall.

- Record the maximum monotonic heartbeat gap over the existing retirement window, including its beginning and end. Keep callback count and configured interval as diagnostics, captured before rescue.
- Replace the count gate with an explicit 500 ms responsiveness bound. This detects coarse stalls independently of timer cadence; it does not claim frame-rate responsiveness or identify the cause of host scheduling pauses.
- Retain all 27 existing native cases and add slow-heartbeat (25 ms cadence) and main-blocks (one-second synchronous block) cases. Both must still prove real cleanup and independent exits within five seconds; the blocked case must violate the same responsiveness contract.

## Scope and risks

Proof scripts and their README only. No production heartbeat, native supervision, startup behavior, dependency, protocol, package, workflow timeout, or five-second retirement budget changes. No fallback is introduced. The separate packaged-host probe is unchanged.

The two added native cases cost approximately six seconds plus process startup. A real host pause exceeding 500 ms still fails; the new evidence exposes that pause instead of inferring it from callback count. The historical failure did not retain heartbeat gaps, so this PR does not claim a replay or a proven CPU-contention cause.

## Validation

Passed locally:

- `node --check turbo/apps/desktop/cua/guardian-proof/main.mjs` and Python AST compilation of `run-macos.py`.
- `cd turbo && pnpm exec prettier --check apps/desktop/cua/guardian-proof/main.mjs apps/desktop/cua/guardian-proof/README.md`.
- `pnpm -F @okouai/desktop lint` and `pnpm -F @okouai/desktop check-types`.
- `pnpm -F @okouai/desktop exec vitest run --maxWorkers=4 --silent=passed-only`: 59 files, 870 tests passed.
- `pnpm exec knip --workspace apps/desktop`.
- File-size check and `git diff --check`.
- Temporary JavaScript diagnostic executing the complete modified proof entry with real timers/filesystem and stand-ins for the external Electron/native boundaries: a responsive 113-callback run had a 31 ms maximum gap; initial and trailing one-second stalls were both detected (the trailing-stall case still had 271 callbacks). This checks JS accounting only, not native process semantics.

The existing macOS CI job owns verification of the complete 29-case real Electron/native proof and the downstream discovery/adapter proofs. Linux validation cannot establish Darwin kqueue, signing, or process-group behavior.
