### PR TITLE
fix(ci): preserve runner lifecycle lock exit diagnostics

### DIFF
--- a/.github/scripts/tests/runner-lifecycle-lock-diagnostics-test.sh
+++ b/.github/scripts/tests/runner-lifecycle-lock-diagnostics-test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+lock_script="${repo_root}/.github/scripts/with-runner-lifecycle-lock.sh"
+tmp_dir=$(mktemp -d)
+owner_pid=""
+cleanup() {
+  if [ -n "$owner_pid" ]; then
+    kill "$owner_pid" 2>/dev/null || true
+    wait "$owner_pid" 2>/dev/null || true
+  fi
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+mkdir -p "${tmp_dir}/bin"
+cat >"${tmp_dir}/bin/ssh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$MOCK_MODE" = acquire-error ]; then
+  printf '%09000d\n' 0 >&2
+  printf '::error::CF_ACCESS_CLIENT_SECRET=test-secret Authorization: Bearer test-bearer\n' >&2
+  exit 255
+fi
+
+# Keep the actual remote holder and real flock; replace only the external SSH
+# transport, remote privilege escalation and host-local filesystem location.
+local_command=${2#sudo }
+local_command=${local_command//"/var/lock/vm0-runner-lifecycle-${JOB_REF}.lock"/"${MOCK_ROOT}/holder.lock"}
+case "$MOCK_MODE" in
+  release-error)
+    bash -c "$local_command"
+    exit 255
+    ;;
+  missing-confirmation)
+    bash -c "$local_command" 2>"${MOCK_ROOT}/remote.err"
+    sed '/^VM0_RUNNER_LIFECYCLE_LOCK_RELEASED$/d' "${MOCK_ROOT}/remote.err" >&2
+    ;;
+  early-eof)
+    # End the remote input only after the protected command has started. The
+    # holder genuinely releases its flock and exits zero, but ownership is lost.
+    mkfifo "${MOCK_ROOT}/input" "${MOCK_ROOT}/command-started"
+    exec {input_fd}<>"${MOCK_ROOT}/input"
+    exec {ready_fd}<>"${MOCK_ROOT}/command-started"
+    bash -c "$local_command" <"${MOCK_ROOT}/input" {input_fd}>&- {ready_fd}>&- &
+    remote_pid=$!
+    IFS= read -r -t 10 ready <&"$ready_fd"
+    [ "$ready" = ready ]
+    exec {ready_fd}>&-
+    exec {input_fd}>&-
+    wait "$remote_pid"
+    ;;
+  normal) exec bash -c "$local_command" ;;
+  *) exit 2 ;;
+esac
+SH
+
+cat >"${tmp_dir}/bin/protected-command" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+trap 'printf "cancelled\n" >"${MOCK_ROOT}/command-cancelled"; exit 143' TERM
+printf 'ready\n' >"${MOCK_ROOT}/command-ready"
+printf 'ready\n' >"${MOCK_ROOT}/command-started"
+sleep 30 &
+wait "$!"
+printf 'completed\n' >"${MOCK_ROOT}/command-completed"
+SH
+chmod +x "${tmp_dir}/bin/ssh" "${tmp_dir}/bin/protected-command"
+
+export PATH="${tmp_dir}/bin:$PATH"
+export JOB_REF=pr-42 METAL_HOSTS=metal.example.test METAL_USER=runner
+export RUNNER_LIFECYCLE_LOCK_TIMEOUT_SECONDS=5 RUNNER_LIFECYCLE_LOCK_LEASE_SECONDS=5
+export MOCK_ROOT MOCK_MODE
+
+for scenario in acquire-error release-error missing-confirmation command-error early-eof; do
+  MOCK_ROOT="${tmp_dir}/${scenario}"
+  MOCK_MODE=$scenario
+  mkdir -p "$MOCK_ROOT"
+  command=(true)
+  if [ "$scenario" = command-error ]; then
+    MOCK_MODE=release-error
+    command=(bash -c 'exit 37')
+  elif [ "$scenario" = early-eof ]; then
+    command=(protected-command)
+  elif [ "$scenario" = acquire-error ]; then
+    command=(touch "${MOCK_ROOT}/command-ready")
+  fi
+  status=0
+  timeout 15 "$lock_script" "${command[@]}" >"${MOCK_ROOT}/out" 2>"${MOCK_ROOT}/err" || status=$?
+  expected_status=1
+  [ "$scenario" != command-error ] || expected_status=37
+  [ "$status" -eq "$expected_status" ] || {
+    sed 's/^/  /' "${MOCK_ROOT}/err" >&2
+    fail "${scenario}: expected exit ${expected_status}, got ${status}"
+  }
+  case "$scenario" in
+    acquire-error)
+      grep -q 'namespace=pr-42 host=metal.example.test phase=acquire local_exit=255 remote_release=unconfirmed' \
+        "${MOCK_ROOT}/err" || fail "acquisition did not preserve the SSH status"
+      [ ! -e "${MOCK_ROOT}/command-ready" ] || fail "command ran without a lock"
+      ! grep -Eq 'test-secret|test-bearer|::error::' "${MOCK_ROOT}/err" || fail "unsafe diagnostics"
+      grep -Fq 'CF_ACCESS_CLIENT_SECRET=[redacted]' "${MOCK_ROOT}/err" || fail "missing sanitized evidence"
+      [ "$(wc -c <"${MOCK_ROOT}/err")" -lt 8700 ] || fail "unbounded holder diagnostics"
+      ;;
+    release-error|command-error)
+      grep -q 'phase=release local_exit=255 remote_release=confirmed' "${MOCK_ROOT}/err" ||
+        fail "release confirmation hid the transport failure"
+      ;;
+    missing-confirmation)
+      grep -q 'phase=release local_exit=0 remote_release=unconfirmed' "${MOCK_ROOT}/err" ||
+        fail "missing remote confirmation was not reported"
+      ;;
+    early-eof)
+      grep -q 'phase=running local_exit=0 remote_release=confirmed' "${MOCK_ROOT}/err" ||
+        fail "early successful remote exit was not reported as ownership loss"
+      [ -e "${MOCK_ROOT}/command-cancelled" ] || fail "ownership loss did not cancel the command"
+      [ ! -e "${MOCK_ROOT}/command-completed" ] || fail "command completed after ownership loss"
+      ;;
+  esac
+  flock --exclusive --nonblock "${MOCK_ROOT}/holder.lock" true || fail "${scenario}: lock leaked"
+done
+
+# Cancellation preserves the caller's signal exit while releasing real locks
+# and stopping the protected command's process group.
+MOCK_ROOT="${tmp_dir}/cancellation"
+MOCK_MODE=normal
+mkdir -p "$MOCK_ROOT"
+mkfifo "${MOCK_ROOT}/command-started"
+exec {command_ready_fd}<>"${MOCK_ROOT}/command-started"
+"$lock_script" protected-command {command_ready_fd}>&- >"${MOCK_ROOT}/out" 2>"${MOCK_ROOT}/err" &
+owner_pid=$!
+IFS= read -r -t 10 ready <&"$command_ready_fd" || fail "protected command did not start"
+[ "$ready" = ready ] || fail "invalid protected-command readiness marker"
+exec {command_ready_fd}>&-
+kill -TERM "$owner_pid"
+status=0
+wait "$owner_pid" || status=$?
+owner_pid=""
+[ "$status" -eq 143 ] || fail "cancellation did not preserve exit 143"
+[ -e "${MOCK_ROOT}/command-cancelled" ] || fail "cancellation did not stop the command"
+grep -q 'local_exit=0 remote_release=confirmed' "${MOCK_ROOT}/err" || fail "cancellation did not confirm release"
+flock --exclusive --nonblock "${MOCK_ROOT}/holder.lock" true || fail "cancellation leaked the lock"
+
+echo "runner-lifecycle-lock-diagnostics-test: ok"

--- a/.github/scripts/tests/runner-lifecycle-lock-test.sh
+++ b/.github/scripts/tests/runner-lifecycle-lock-test.sh
@@ -74,7 +74,7 @@ lock_file="${MOCK_LOCK_ROOT}/${host}-${JOB_REF}.lock"
 
 # Run the holder the script actually asks for, minus the privilege escalation
 # and the absolute lock path that only exist on a metal host.
-local_command=${remote_command#exec sudo }
+local_command=${remote_command#sudo }
 local_command=${local_command//"/var/lock/vm0-runner-lifecycle-${JOB_REF}.lock"/$lock_file}
 if [ -n "${MOCK_HOLDER_COMMAND_FILE:-}" ]; then
   printf '%s\n' "$local_command" >"$MOCK_HOLDER_COMMAND_FILE"
@@ -259,6 +259,8 @@ PATH="${fake_bin}:$PATH" \
   fail "a multi-host lock did not release promptly after its protected command"
 }
 for multi_host in metal-one.example.test metal-two.example.test; do
+  grep -q "namespace=pr-78 host=${multi_host} phase=release local_exit=0 remote_release=confirmed" \
+    "${tmp_dir}/multi.err" || fail "missing successful release confirmation for ${multi_host}"
   flock --exclusive --timeout 5 \
     "${multi_lock_root}/${multi_host}-pr-78.lock" true ||
     fail "the lock on ${multi_host} was still held after release"
@@ -267,7 +269,7 @@ done
 # An orphaned holder never sees end-of-input on a half-open transport, so the
 # lease is the only thing that stops it from blocking the host indefinitely.
 [ -s "$holder_command_file" ] || fail "the mock did not record the remote holder command"
-IFS= read -r holder_command <"$holder_command_file"
+holder_command=$(cat "$holder_command_file")
 orphan_fifo="${tmp_dir}/orphan-stdin"
 mkfifo "$orphan_fifo"
 exec {orphan_fd}<>"$orphan_fifo"
@@ -290,7 +292,13 @@ flock --exclusive --timeout 1 "$lease_lock_file" true &&
 
 flock --exclusive --timeout "$((lease_seconds * 3))" "$lease_lock_file" true ||
   fail "the orphaned holder kept the lock past its lease"
-wait "$orphan_pid" || fail "the orphaned holder exited abnormally"
+orphan_status=0
+wait "$orphan_pid" || orphan_status=$?
+[ "$orphan_status" -gt 128 ] || fail "the orphaned holder did not report its read timeout"
+grep -Fxq VM0_RUNNER_LIFECYCLE_LOCK_LEASE_EXPIRED "${tmp_dir}/orphan.out" ||
+  fail "the orphaned holder did not distinguish lease expiration from EOF"
+! grep -Fxq VM0_RUNNER_LIFECYCLE_LOCK_RELEASED "${tmp_dir}/orphan.out" ||
+  fail "the orphaned holder reported a normal release"
 background_pids=()
 exec {orphan_fd}>&-
 

--- a/.github/scripts/with-runner-lifecycle-lock.sh
+++ b/.github/scripts/with-runner-lifecycle-lock.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=.github/scripts/cloudflare-ssh-diagnostics.sh
+source "$(dirname "${BASH_SOURCE[0]}")/cloudflare-ssh-diagnostics.sh"
+
 usage() {
   cat <<'USAGE'
 Usage: with-runner-lifecycle-lock.sh <command> [args...]
@@ -102,6 +105,20 @@ declare -a lock_pids=()
 declare -a heartbeat_pids=()
 command_pid=""
 locks_released=false
+phase=acquire
+
+report_holder_result() {
+  local host=$1 holder_phase=$2 holder_status=$3 error_file=$4
+  local remote_release=unconfirmed
+  if grep -Fxq VM0_RUNNER_LIFECYCLE_LOCK_RELEASED "$error_file"; then
+    remote_release=confirmed
+  fi
+  printf 'Runner lifecycle lock: namespace=%s host=%s phase=%s local_exit=%s remote_release=%s\n' \
+    "$JOB_REF" "$host" "$holder_phase" "$holder_status" "$remote_release" >&2
+  # Sanitize before truncating so a cut cannot expose the suffix of a secret.
+  cloudflare_ssh_sanitize_diagnostics "$error_file" | tail -c 8192 | sed 's/^/  /' >&2
+  [ "$holder_status" -eq 0 ] && [ "$remote_release" = confirmed ]
+}
 
 close_fd() {
   local fd=$1
@@ -133,19 +150,19 @@ release_locks() {
   fi
   locks_released=true
 
-  local index status=0
+  local index holder_status status=0
   # Heartbeat writers hold the release descriptors, so the remote holders only
   # see end-of-input once every writer is gone.
   stop_heartbeats
   for ((index = ${#lock_fds[@]} - 1; index >= 0; index--)); do
+    printf 'Requesting runner lifecycle lock release: namespace=%s host=%s phase=%s\n' \
+      "$JOB_REF" "${lock_hosts[$index]}" "$phase" >&2
     close_fd "${lock_fds[$index]}"
   done
   for index in "${!lock_pids[@]}"; do
-    if ! wait "${lock_pids[$index]}"; then
-      echo "runner lifecycle lock holder exited unexpectedly on ${lock_hosts[$index]}" >&2
-      if [ -s "${state_dir}/${index}.err" ]; then
-        sed 's/^/  /' "${state_dir}/${index}.err" >&2
-      fi
+    holder_status=0
+    wait "${lock_pids[$index]}" || holder_status=$?
+    if ! report_holder_result "${lock_hosts[$index]}" "$phase" "$holder_status" "${state_dir}/${index}.err"; then
       status=1
     fi
   done
@@ -181,7 +198,32 @@ for host in "${hosts[@]}"; do
 
   lock_path="/var/lock/vm0-runner-lifecycle-${JOB_REF}.lock"
   remote="${METAL_USER}@${host}"
-  remote_command="exec sudo flock --exclusive --timeout ${lock_timeout} ${lock_path} bash -c 'printf \"%s\\n\" VM0_RUNNER_LIFECYCLE_LOCK_ACQUIRED; while IFS= read -r -t ${lease_timeout} _; do :; done'"
+  remote_command="sudo flock --exclusive --timeout ${lock_timeout} ${lock_path} bash -c '
+    printf \"%s\\n\" VM0_RUNNER_LIFECYCLE_LOCK_ACQUIRED
+    while :; do
+      read_status=0
+      IFS= read -r -t ${lease_timeout} _ || read_status=\$?
+      case \$read_status in
+        0) ;;
+        1) printf \"%s\\n\" VM0_RUNNER_LIFECYCLE_LOCK_INPUT_EOF >&2; exit 0 ;;
+        *)
+          if [ \"\$read_status\" -gt 128 ]; then
+            printf \"%s\\n\" VM0_RUNNER_LIFECYCLE_LOCK_LEASE_EXPIRED >&2
+          else
+            printf \"VM0_RUNNER_LIFECYCLE_LOCK_READ_ERROR status=%s\\n\" \"\$read_status\" >&2
+          fi
+          exit \"\$read_status\"
+          ;;
+      esac
+    done
+  '
+  holder_status=\$?
+  if [ \"\$holder_status\" -eq 0 ]; then
+    printf \"%s\\n\" VM0_RUNNER_LIFECYCLE_LOCK_RELEASED >&2
+  else
+    printf \"VM0_RUNNER_LIFECYCLE_LOCK_REMOTE_EXIT status=%s\\n\" \"\$holder_status\" >&2
+  fi
+  exit \"\$holder_status\""
   # The validated host, timeout, and lock path select the remote lock. The
   # command itself is static and receives no untrusted shell fragments.
   # shellcheck disable=SC2029
@@ -216,11 +258,10 @@ for host in "${hosts[@]}"; do
     close_fd "$ready_fd"
     close_fd "$release_fd"
     kill "$ssh_pid" 2>/dev/null || true
-    wait "$ssh_pid" 2>/dev/null || true
-    echo "failed to acquire runner lifecycle lock on ${host}" >&2
-    if [ -s "$error_file" ]; then
-      sed 's/^/  /' "$error_file" >&2
-    fi
+    holder_status=0
+    wait "$ssh_pid" 2>/dev/null || holder_status=$?
+    echo "failed to acquire runner lifecycle lock on ${host}: waiter_exit=${completed_status}" >&2
+    report_holder_result "$host" acquire "$holder_status" "$error_file" || true
     exit 1
   fi
 
@@ -229,11 +270,10 @@ for host in "${hosts[@]}"; do
   if [ "$marker" != "VM0_RUNNER_LIFECYCLE_LOCK_ACQUIRED" ] || ! kill -0 "$ssh_pid" 2>/dev/null; then
     close_fd "$release_fd"
     kill "$ssh_pid" 2>/dev/null || true
-    wait "$ssh_pid" 2>/dev/null || true
+    holder_status=0
+    wait "$ssh_pid" 2>/dev/null || holder_status=$?
     echo "runner lifecycle lock on ${host} returned an invalid acquisition marker" >&2
-    if [ -s "$error_file" ]; then
-      sed 's/^/  /' "$error_file" >&2
-    fi
+    report_holder_result "$host" acquire "$holder_status" "$error_file" || true
     exit 1
   fi
 
@@ -260,6 +300,7 @@ for host in "${hosts[@]}"; do
   echo "Acquired runner lifecycle lock for ${JOB_REF} on ${host}"
 done
 
+phase=running
 (
   for inherited_fd in "${lock_fds[@]}"; do
     close_fd "$inherited_fd"
@@ -277,6 +318,7 @@ set -e
 if [ "$completed_pid" = "$command_pid" ]; then
   command_pid=""
   command_status=$completed_status
+  phase=release
 else
   lost_index=""
   lost_host="an unidentified host"
@@ -287,8 +329,8 @@ else
     fi
   done
   echo "runner lifecycle lock on ${lost_host} was lost while the protected command was running" >&2
-  if [ -n "$lost_index" ] && [ -s "${state_dir}/${lost_index}.err" ]; then
-    sed 's/^/  /' "${state_dir}/${lost_index}.err" >&2
+  if [ -n "$lost_index" ]; then
+    report_holder_result "$lost_host" running "$completed_status" "${state_dir}/${lost_index}.err" || true
   fi
   terminate_command
   command_status=1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -304,6 +304,7 @@ jobs:
             .github/scripts/tests/reconcile-and-start-runner-groups-test.sh \
             .github/scripts/tests/report-cgroup-memory-peak-test.sh \
             .github/scripts/tests/runner-lifecycle-lock-test.sh \
+            .github/scripts/tests/runner-lifecycle-lock-diagnostics-test.sh \
             .github/scripts/tests/rust-ci-memory-workflow-test.sh \
             .github/scripts/tests/runner-lifecycle-ownership-workflow-test.sh \
             .github/scripts/tests/run-semgrep-test.sh \


### PR DESCRIPTION
## Summary

Closes #33217.

- Preserve the exact local SSH/wrapper exit status with namespace, host and lifecycle phase instead of discarding it during release.
- Separate local release intent, remote stdin EOF/lease expiry and a release acknowledgement emitted only after `flock` returns. Require both local success and remote confirmation; premature holder exit still cancels the protected command.
- Sanitize and bound holder diagnostics, preserve protected-command failure codes, and add entry-point coverage using real local flock with an external SSH fixture.

The triggering failure was [deploy-runner-start](https://github.com/vm0-ai/vm0/actions/runs/34453466408/job/102795012287). Its retained logs do not prove the original SSH exit cause. This PR fixes the diagnostic gap, not a proven SSH transport fault. It does not touch CDN downloads, host configuration, runner runtime, SSH retries/replay, or timeout values.

## Compatibility and risks

The local script and generated remote command ship together in the CI checkout; namespace lock paths and ownership timing are unchanged. No independently deployed API/Runner protocol changes or migrations are needed. A lost acknowledgement conservatively fails cleanup even if the remote lock was released; nonzero local status is never forgiven by an acknowledgement. Lease expiration is now explicit and nonzero.

## Validation

- `bash -n` and `shellcheck` for the changed shell scripts and sourced diagnostics helper.
- `bash .github/scripts/tests/runner-lifecycle-lock-test.sh`
- `bash .github/scripts/tests/runner-lifecycle-lock-diagnostics-test.sh` (three consecutive passes after final edits)
- `bash .github/scripts/tests/runner-lifecycle-ownership-workflow-test.sh`
- `bash .github/scripts/tests/reconcile-and-start-runner-groups-test.sh`
- `bash .github/scripts/tests/cloudflare-ssh-command-test.sh`
- `bash .github/scripts/check-workflow-shell-compatibility.sh`
- YAML parsing, Prettier check for `security.yml`, file-size check and `git diff --check`.

Coverage includes successful multi-host release, live heartbeats, orphan lease expiration, acquisition failure, release-time transport failure despite confirmation, missing confirmation, early EOF cancelling a running command, combined command/release errors, and cancellation cleanup. No production mutations or real-network fault injection were performed.
