### PR TITLE
fix(ci): respect rate limits while waiting for runner images

### DIFF
--- a/.github/scripts/tests/wait-runner-image-groups-test.sh
+++ b/.github/scripts/tests/wait-runner-image-groups-test.sh
@@ -39,6 +39,7 @@ if [ "$1" = "api" ]; then
   request="$2"
   artifact_name="${request#*name=}"
   artifact_name="${artifact_name%%&*}"
+  printf 'HTTP/2.0 200 OK\r\n\r\n'
   cat <<JSON
 {
   "artifacts": [

--- a/.github/scripts/tests/wait-runner-image-test.sh
+++ b/.github/scripts/tests/wait-runner-image-test.sh
@@ -49,10 +49,84 @@ cat > "${TMPDIR}/bin/gh" <<'BASH'
 #!/usr/bin/env bash
 set -euo pipefail
 
-printf '%s\n' "$*" >> "${GH_ARGS_LOG}"
+now=$(date +%s)
+printf '%s %s\n' "$now" "$*" >> "${GH_ARGS_LOG}"
+
+respond_error() {
+  printf 'HTTP/2.0 %s Error\r\n' "$1"
+  printf '%b\r\n' "$2"
+  printf '{"message":"%s"}\n' "$3"
+  printf 'gh: %s (HTTP %s)\n' "$3" "$1" >&2
+  exit 1
+}
 
 if [ "$1" = "api" ]; then
-  if [ "${FAKE_MODE:-artifact}" = "failed-run" ]; then
+  [[ "$*" == *' --include' ]] || exit 1
+  case "${FAKE_MODE:-artifact}" in
+    primary)
+      if [ "$now" -lt 1007 ]; then
+        respond_error 403 'X-RateLimit-Remaining: 0\r\nX-RateLimit-Reset: 1006\r\n' 'API rate limit exceeded for installation'
+      fi
+      ;;
+    retry-after)
+      if [ "$now" -lt 1012 ]; then
+        respond_error 429 'rEtRy-AfTeR: 7\r\nX-RateLimit-Remaining: 0\r\nX-RateLimit-Reset: 1011\r\n' 'rate limited'
+      fi
+      ;;
+    headerless)
+      count=$(wc -l <"$GH_ARGS_LOG")
+      if [ "$count" -le 4 ]; then respond_error 403 '' 'API rate limit exceeded for installation'; fi
+      ;;
+    invalid-headers)
+      if [ "$now" -lt 1060 ]; then
+        respond_error 429 'Retry-After: invalid\r\nX-RateLimit-Remaining: 0\r\nX-RateLimit-Reset: invalid\r\n' 'rate limited'
+      fi
+      ;;
+    beyond-deadline)
+      respond_error 403 'X-RateLimit-Remaining: 0\r\nX-RateLimit-Reset: 4000\r\n' 'API rate limit exceeded for installation'
+      ;;
+    forbidden)
+      respond_error 403 'X-RateLimit-Remaining: 42\r\n' 'Resource not accessible by integration'
+      ;;
+    unauthorized)
+      respond_error 401 '' 'Bad credentials'
+      ;;
+    unavailable)
+      respond_error 503 '' 'Service unavailable'
+      ;;
+    transient)
+      if [ "$now" -lt 1060 ]; then respond_error 502 '' 'Bad gateway'; fi
+      ;;
+  esac
+
+  if [[ "$2" == *'/actions/workflows/'* ]]; then
+    if [[ "${FAKE_MODE:-artifact}" == workflow-rate* ]] && [ "$now" -lt 1007 ]; then
+      respond_error 403 'Retry-After: 7\r\n' 'secondary rate limit'
+    fi
+    printf 'HTTP/2.0 200 OK\r\n\r\n'
+    if [ "${FAKE_MODE:-artifact}" = "no-producer" ]; then
+      printf '{"workflow_runs":[]}\n'
+    else
+      status=in_progress
+      conclusion=null
+      if [ "${FAKE_MODE:-artifact}" = "failed-run" ] ||
+        [ "${FAKE_MODE:-artifact}" = "workflow-rate-failure" ] || {
+        [ "${FAKE_MODE:-artifact}" = "later-failure" ] && [ "$now" -ge 1060 ]
+      }; then
+        status=completed
+        conclusion='"failure"'
+      fi
+      printf '{"workflow_runs":[{"id":42,"status":"%s","conclusion":%s,"created_at":"2026-05-11T00:00:00Z","html_url":"https://example.test/run/42","head_sha":"head-sha"}]}\n' "$status" "$conclusion"
+    fi
+    exit 0
+  fi
+
+  [[ "$2" == *'/actions/artifacts?name='* ]] || exit 1
+  printf 'HTTP/2.0 200 OK\r\n\r\n'
+  if [ "${FAKE_MODE:-artifact}" = "failed-run" ] ||
+    [ "${FAKE_MODE:-artifact}" = "later-failure" ] ||
+    [ "${FAKE_MODE:-artifact}" = "no-producer" ] ||
+    [ "$now" -lt "${AVAILABLE_AT:-0}" ]; then
     printf '{"artifacts":[]}\n'
     exit 0
   fi
@@ -60,16 +134,15 @@ if [ "$1" = "api" ]; then
   exit 0
 fi
 
-if [ "$1" = "run" ] && [ "$2" = "list" ]; then
-  if [ "${FAKE_MODE:-artifact}" = "failed-run" ]; then
-    printf '[{"databaseId":42,"status":"completed","conclusion":"failure","createdAt":"2026-05-11T00:00:00Z","url":"https://example.test/run/42","headSha":"head-sha"}]\n'
-    exit 0
-  fi
-  printf '[{"databaseId":42,"status":"completed","conclusion":"success","createdAt":"2026-05-11T00:00:00Z","url":"https://example.test/run/42","headSha":"head-sha"}]\n'
-  exit 0
-fi
-
 if [ "$1" = "run" ] && [ "$2" = "download" ]; then
+  if [ "${FAKE_MODE:-artifact}" = "download-rate" ] && [ "$now" -lt 1060 ]; then
+    echo 'gh: API rate limit exceeded for installation (HTTP 403)' >&2
+    exit 1
+  fi
+  if [ "${FAKE_MODE:-artifact}" = "download-unavailable" ]; then
+    echo 'artifact is not downloadable yet' >&2
+    exit 1
+  fi
   artifact=""
   output_dir=""
   while [ "$#" -gt 0 ]; do
@@ -98,6 +171,25 @@ exit 1
 BASH
 chmod +x "${TMPDIR}/bin/gh"
 
+# Control the external clock and sleep commands so real cooldowns can be tested
+# without waiting minutes or replacing any production script functions.
+cat > "${TMPDIR}/bin/date" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$*" = '+%s' ]
+cat "$CLOCK_FILE"
+BASH
+cat > "${TMPDIR}/bin/sleep" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+now=$(cat "$CLOCK_FILE")
+echo "$((now + $1))" >"$CLOCK_FILE"
+printf '%s\n' "$1" >>"$SLEEP_LOG"
+BASH
+chmod +x "${TMPDIR}/bin/date" "${TMPDIR}/bin/sleep"
+export CLOCK_FILE="${TMPDIR}/clock" SLEEP_LOG="${TMPDIR}/sleep.log"
+echo 1000 >"$CLOCK_FILE"
+
 out=$(PATH="${TMPDIR}/bin:${PATH}" \
   GH_ARGS_LOG="${TMPDIR}/gh-args.log" \
   FAKE_MANIFEST="${TMPDIR}/manifest.json" \
@@ -113,9 +205,9 @@ out=$(PATH="${TMPDIR}/bin:${PATH}" \
   POLL_SECONDS=0 \
   "$WAIT")
 
-grep -q -- 'api repos/vm0-ai/vm0/actions/artifacts?name=runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123&per_page=100 --jq .' "${TMPDIR}/gh-args.log" || fail "expected artifact lookup by exact name"
-if grep -q -- 'run list' "${TMPDIR}/gh-args.log"; then
-  fail "expected artifact-first path to skip run list after artifact is found"
+grep -q -- 'api repos/vm0-ai/vm0/actions/artifacts?name=runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123&per_page=100 --include' "${TMPDIR}/gh-args.log" || fail "expected artifact lookup by exact name"
+if grep -q -- '/actions/workflows/' "${TMPDIR}/gh-args.log"; then
+  fail "expected artifact-first path to skip producer lookup after artifact is found"
 fi
 grep -q -- 'run download 42 -n runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123' "${TMPDIR}/gh-args.log" || fail "expected artifact name to include target and HEAD_SHA"
 grep -qxF 'producer-run-id=42' <<<"$out" || fail "expected producer-run-id output"
@@ -136,7 +228,7 @@ out=$(PATH="${TMPDIR}/bin:${PATH}" \
   OUTPUT_DIR="${TMPDIR}/out-x86" \
   POLL_SECONDS=0 \
   "$WAIT")
-grep -q -- 'api repos/vm0-ai/vm0/actions/artifacts?name=runner-image-manifest-x86_64-unknown-linux-musl-build-sha-pr-123&per_page=100 --jq .' "${TMPDIR}/gh-args.log" || fail "expected x86 artifact lookup by exact name"
+grep -q -- 'api repos/vm0-ai/vm0/actions/artifacts?name=runner-image-manifest-x86_64-unknown-linux-musl-build-sha-pr-123&per_page=100 --include' "${TMPDIR}/gh-args.log" || fail "expected x86 artifact lookup by exact name"
 grep -q -- 'run download 42 -n runner-image-manifest-x86_64-unknown-linux-musl-build-sha-pr-123' "${TMPDIR}/gh-args.log" || fail "expected x86 artifact download by exact name"
 grep -qxF 'producer-run-id=42' <<<"$out" || fail "expected x86 producer-run-id output"
 
@@ -176,7 +268,91 @@ if PATH="${TMPDIR}/bin:${PATH}" \
   "$WAIT" >"${TMPDIR}/failed.out" 2>"${TMPDIR}/failed.err"; then
   fail "expected failed producer run without artifact to fail"
 fi
-grep -q -- '--commit head-sha' "${TMPDIR}/gh-args.log" || fail "expected failed path to query producer run by LOOKUP_SHA"
+grep -q -- '/actions/workflows/runner-image.yml/runs?head_sha=head-sha&per_page=20' "${TMPDIR}/gh-args.log" || fail "expected failed path to query producer run by LOOKUP_SHA"
 grep -q -- 'runner image workflow completed with conclusion=failure' "${TMPDIR}/failed.err" || fail "expected producer failure message"
+
+run_wait() {
+  echo 1000 >"$CLOCK_FILE"
+  : >"$SLEEP_LOG"
+  : >"${TMPDIR}/gh-args.log"
+  env PATH="${TMPDIR}/bin:${PATH}" \
+    GH_ARGS_LOG="${TMPDIR}/gh-args.log" \
+    FAKE_MANIFEST="${TMPDIR}/manifest.json" \
+    EXPECTED_ARTIFACT_NAME=runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123 \
+    REPO=vm0-ai/vm0 HEAD_SHA=build-sha LOOKUP_SHA=head-sha JOB_REF=pr-123 \
+    METAL_HOSTS=dev-1 TARGET=aarch64-unknown-linux-musl PROFILE=vm0/default \
+    OUTPUT_DIR="${TMPDIR}/out" "$@" "$WAIT" >"${TMPDIR}/case.out" 2>"${TMPDIR}/case.err"
+}
+
+expect_success() {
+  if ! run_wait "$@"; then
+    cat "${TMPDIR}/case.err" >&2
+    fail "expected successful manifest: $*"
+  fi
+  grep -qxF 'bin-dir=/var/lib/vm0-runner/bin/pr-123' "${TMPDIR}/case.out" || fail "expected validated manifest outputs"
+}
+
+expect_failure() {
+  if run_wait "$@"; then fail "expected failure: $*"; fi
+  if grep -q '^bin-dir=' "${TMPDIR}/case.out"; then fail "failed wait must not publish manifest outputs"; fi
+}
+
+expect_success FAKE_MODE=primary
+[ "$(cat "$SLEEP_LOG")" = 7 ] || fail "expected primary quota reset plus boundary second"
+grep -q '^1007 run download ' "${TMPDIR}/gh-args.log" || fail "expected download after primary reset"
+
+expect_success FAKE_MODE=retry-after
+[ "$(cat "$SLEEP_LOG")" = 12 ] || fail "expected later of Retry-After and quota reset"
+
+expect_success FAKE_MODE=headerless
+[ "$(paste -sd, "$SLEEP_LOG")" = '60,120,240,300' ] || fail "expected capped exponential cooldown beyond three responses"
+
+expect_success FAKE_MODE=invalid-headers
+[ "$(cat "$SLEEP_LOG")" = 60 ] || fail "expected cooldown for unusable headers"
+
+expect_success FAKE_MODE=workflow-rate AVAILABLE_AT=1007
+grep -q '^1007 api .*workflows/' "${TMPDIR}/gh-args.log" || fail "expected producer request after Retry-After"
+
+expect_success FAKE_MODE=workflow-rate-failure AVAILABLE_AT=1007
+grep -q '^1007 run download ' "${TMPDIR}/gh-args.log" || fail "expected artifact uploaded during status cooldown to take priority"
+
+expect_success FAKE_MODE=download-rate
+[ "$(cat "$SLEEP_LOG")" = 60 ] || fail "expected conservative download cooldown"
+
+expect_success FAKE_MODE=transient
+[ "$(paste -sd, "$SLEEP_LOG")" = '30,30' ] || fail "expected transient metadata recovery"
+
+for mode in forbidden unauthorized beyond-deadline; do
+  expect_failure FAKE_MODE="$mode"
+  [ ! -s "$SLEEP_LOG" ] || fail "expected immediate permanent failure or unsatisfiable deadline"
+  [ "$(wc -l <"${TMPDIR}/gh-args.log")" -eq 1 ] || fail "must not retry permanent failures or before quota reset"
+done
+grep -q 'cannot retry within runner image wait deadline' "${TMPDIR}/case.err" || fail "expected deadline diagnosis"
+
+expect_failure FAKE_MODE=unavailable
+[ "$(wc -l <"${TMPDIR}/gh-args.log")" -eq 3 ] || fail "expected bounded transient error attempts"
+
+expect_failure FAKE_MODE=headerless TIMEOUT_SECONDS=100
+[ "$(cat "$SLEEP_LOG")" = 60 ] || fail "must not shorten cooldown to fit deadline"
+
+expect_failure FAKE_MODE=no-producer TIMEOUT_SECONDS=60
+grep -q 'cannot retry within runner image wait deadline' "${TMPDIR}/case.err" || fail "expected bounded producer discovery"
+
+expect_failure TIMEOUT_SECONDS=0
+[ ! -s "${TMPDIR}/gh-args.log" ] || fail "must not start requests after deadline"
+
+expect_failure FAKE_MODE=download-unavailable TIMEOUT_SECONDS=10
+[ "$(cat "$SLEEP_LOG")" = 5 ] || fail "expected download retry budget bounded by deadline"
+
+expect_success AVAILABLE_AT=1090
+[ "$(grep -c '/actions/workflows/' "${TMPDIR}/gh-args.log")" -eq 2 ] || fail "expected fewer producer status requests"
+grep -q '^1060 api .*workflows/' "${TMPDIR}/gh-args.log" || fail "expected producer refresh after 60 seconds"
+grep -q '^1090 run download ' "${TMPDIR}/gh-args.log" || fail "expected artifact readiness between producer checks"
+
+expect_failure FAKE_MODE=later-failure
+grep -q 'workflow completed with conclusion=failure' "${TMPDIR}/case.err" || fail "expected refreshed producer failure"
+
+expect_failure HEAD_SHA=wrong-sha EXPECTED_ARTIFACT_NAME=runner-image-manifest-aarch64-unknown-linux-musl-wrong-sha-pr-123
+grep -q 'headSha mismatch' "${TMPDIR}/case.err" || fail "expected exact manifest identity validation"
 
 echo "wait-runner-image-test: ok"

--- a/.github/scripts/wait-runner-image.sh
+++ b/.github/scripts/wait-runner-image.sh
@@ -4,14 +4,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${SCRIPT_DIR}/runner-image-target.sh"
 
-require_env() {
-  local name=$1
-  if [ -z "${!name:-}" ]; then
-    echo "missing required env: ${name}" >&2
-    exit 2
-  fi
-}
-
 emit() {
   local key=$1 value=$2
   printf '%s=%s\n' "$key" "$value"
@@ -20,18 +12,18 @@ emit() {
   fi
 }
 
-require_env HEAD_SHA
-require_env JOB_REF
-require_env METAL_HOSTS
-require_env TARGET
-require_env PROFILE
+: "${HEAD_SHA:?missing required env: HEAD_SHA}"
+: "${JOB_REF:?missing required env: JOB_REF}"
+: "${METAL_HOSTS:?missing required env: METAL_HOSTS}"
+: "${TARGET:?missing required env: TARGET}"
+: "${PROFILE:?missing required env: PROFILE}"
 
 runner_image_validate_target "$TARGET"
 
 REPO="${GITHUB_REPOSITORY:-${REPO:-}}"
 WORKFLOW="${WORKFLOW:-runner-image.yml}"
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-1800}"
-POLL_SECONDS="${POLL_SECONDS:-10}"
+POLL_SECONDS="${POLL_SECONDS:-30}"
 OUTPUT_DIR="${OUTPUT_DIR:-/tmp/runner-image-manifest}"
 DEFAULT_ARTIFACT_NAME=$(runner_image_artifact_name "$TARGET" "$HEAD_SHA" "$JOB_REF")
 ARTIFACT_NAME="${ARTIFACT_NAME:-$DEFAULT_ARTIFACT_NAME}"
@@ -49,33 +41,99 @@ fi
 mkdir -p "$OUTPUT_DIR"
 
 GH_ERR=$(mktemp)
+GH_RESPONSE=$(mktemp)
 cleanup() {
-  rm -f "$GH_ERR"
+  rm -f "$GH_ERR" "$GH_RESPONSE"
 }
 trap cleanup EXIT
 
 deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+
+check_deadline() {
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "timed out waiting for runner image workflow ${WORKFLOW} at ${LOOKUP_SHA} with artifact ${ARTIFACT_NAME}" >&2
+    exit 1
+  fi
+}
+
+wait_with_deadline() {
+  local seconds=$1
+  check_deadline
+  if [ "$seconds" -ge "$((deadline - $(date +%s)))" ]; then
+    echo "cannot retry within runner image wait deadline: required delay=${seconds}s artifact=${ARTIFACT_NAME}" >&2
+    exit 1
+  fi
+  sleep "$seconds"
+}
+
+response_header() {
+  awk -v name="$1" '
+    /^\r?$/ { exit }
+    tolower($1) == name ":" { sub(/\r$/, "", $2); print $2; exit }
+  ' "$GH_RESPONSE"
+}
+
+api_get() {
+  local endpoint=$1 failures=0 backoff=60
+  local status retry_after remaining reset delay now
+  while true; do
+    check_deadline
+    if gh api "$endpoint" --include >"$GH_RESPONSE" 2>"$GH_ERR"; then
+      sed '1,/^\r\{0,1\}$/d' "$GH_RESPONSE"
+      return
+    fi
+    cat "$GH_ERR" >&2
+    status=$(awk 'NR == 1 && /^HTTP\// { print $2 }' "$GH_RESPONSE")
+    retry_after=$(response_header retry-after)
+    remaining=$(response_header x-ratelimit-remaining)
+    reset=$(response_header x-ratelimit-reset)
+    if [ "$status" = "429" ] || {
+      [ "$status" = "403" ] && {
+        [ -n "$retry_after" ] || [ "$remaining" = "0" ] ||
+          grep -qi 'rate limit' "$GH_RESPONSE" "$GH_ERR"
+      }
+    }; then
+      # GitHub requires waiting for the declared recovery time. Without usable
+      # headers, wait at least a minute and back off instead of spending the
+      # ordinary transport-error retry budget on a shared quota cooldown.
+      delay=0
+      now=$(date +%s)
+      if [[ "$retry_after" =~ ^[0-9]+$ ]]; then
+        delay=$((10#$retry_after))
+      fi
+      if [ "$remaining" = "0" ] && [[ "$reset" =~ ^[0-9]+$ ]] &&
+        [ "$((10#$reset - now + 1))" -gt "$delay" ]; then
+        delay=$((10#$reset - now + 1))
+      fi
+      if [ "$delay" -le 0 ]; then
+        delay=$backoff
+      fi
+      echo "GitHub API rate limited: status=${status} remaining=${remaining:-unknown} reset=${reset:-unknown}; retrying in ${delay}s" >&2
+      wait_with_deadline "$delay"
+      backoff=$((backoff * 2))
+      if [ "$backoff" -gt 300 ]; then backoff=300; fi
+      continue
+    fi
+    if [[ "$status" == 4* ]]; then
+      echo "GitHub API request failed with HTTP ${status}: ${endpoint}" >&2
+      exit 1
+    fi
+    failures=$((failures + 1))
+    echo "GitHub API request failed (${failures}/3): ${endpoint}" >&2
+    if [ "$failures" -ge 3 ]; then exit 1; fi
+    wait_with_deadline "$POLL_SECONDS"
+  done
+}
+
 selected_run=""
 selected_url=""
 selected_run_id=""
 selected_artifact=""
-artifact_failures=0
-list_failures=0
+next_run_check=0
+producer_failure_url=""
 
 while true; do
-  if ! artifacts_json=$(gh api \
-    "repos/${REPO}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100" \
-    --jq . 2>"$GH_ERR"); then
-    artifact_failures=$((artifact_failures + 1))
-    echo "gh api artifacts failed (${artifact_failures}/3) while waiting for ${ARTIFACT_NAME}" >&2
-    cat "$GH_ERR" >&2
-    if [ "$artifact_failures" -ge 3 ]; then
-      exit 1
-    fi
-    sleep "$POLL_SECONDS"
-    continue
-  fi
-  artifact_failures=0
+  artifacts_json=$(api_get "repos/${REPO}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100")
 
   selected_artifact=$(jq -c \
     --arg name "$ARTIFACT_NAME" \
@@ -91,14 +149,27 @@ while true; do
     rm -rf "${OUTPUT_DIR:?}"/*
     download_ok=false
     download_attempts=0
+    download_backoff=60
     while [ "$download_attempts" -lt 5 ]; do
-      download_attempts=$((download_attempts + 1))
-      if gh run download "$selected_run_id" -n "$ARTIFACT_NAME" -D "$OUTPUT_DIR"; then
+      check_deadline
+      if gh run download "$selected_run_id" -n "$ARTIFACT_NAME" -D "$OUTPUT_DIR" 2>"$GH_ERR"; then
         download_ok=true
         break
       fi
+      cat "$GH_ERR" >&2
+      # gh run download does not expose response headers. Use GitHub's
+      # conservative headerless cooldown rather than five-second retries.
+      if grep -qi 'rate limit\|HTTP 429' "$GH_ERR"; then
+        echo "GitHub artifact download rate limited; retrying in ${download_backoff}s" >&2
+        wait_with_deadline "$download_backoff"
+        download_backoff=$((download_backoff * 2))
+        if [ "$download_backoff" -gt 300 ]; then download_backoff=300; fi
+        continue
+      fi
+      if grep -qE 'HTTP (401|403)' "$GH_ERR"; then exit 1; fi
+      download_attempts=$((download_attempts + 1))
       echo "artifact ${ARTIFACT_NAME} is listed but not downloadable yet from run ${selected_run_id}; retrying"
-      sleep 5
+      wait_with_deadline 5
     done
     if [ "$download_ok" = "true" ]; then
       break
@@ -106,47 +177,41 @@ while true; do
     echo "artifact ${ARTIFACT_NAME} could not be downloaded from run ${selected_run_id}; continuing to wait"
   fi
 
-  if ! runs_json=$(gh run list \
-    --workflow "$WORKFLOW" \
-    --commit "$LOOKUP_SHA" \
-    --limit 20 \
-    --json databaseId,status,conclusion,createdAt,url,headSha 2>"$GH_ERR"); then
-    list_failures=$((list_failures + 1))
-    echo "gh run list failed (${list_failures}/3) while waiting for ${WORKFLOW} at ${LOOKUP_SHA}" >&2
-    cat "$GH_ERR" >&2
-    if [ "$list_failures" -ge 3 ]; then
-      exit 1
-    fi
-    sleep "$POLL_SECONDS"
-    continue
+  if [ -n "$producer_failure_url" ]; then
+    echo "runner image workflow completed with conclusion=${conclusion}: ${producer_failure_url}" >&2
+    exit 1
   fi
-  list_failures=0
 
-  selected_run=$(jq -c 'sort_by(.createdAt) | reverse | .[0] // empty' <<<"$runs_json")
+  # Artifact readiness is checked more often than producer failure. A direct
+  # workflow endpoint also avoids resolving the workflow on every gh run list.
+  if [ "$(date +%s)" -ge "$next_run_check" ]; then
+    runs_json=$(api_get "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?head_sha=${LOOKUP_SHA}&per_page=20")
+    selected_run=$(jq -c '.workflow_runs | sort_by(.created_at) | reverse | .[0] // empty' <<<"$runs_json")
+    next_run_check=$(( $(date +%s) + 60 ))
+  fi
 
   if [ -n "$selected_run" ]; then
     status=$(jq -r '.status' <<<"$selected_run")
     conclusion=$(jq -r '.conclusion // empty' <<<"$selected_run")
-    run_id=$(jq -r '.databaseId' <<<"$selected_run")
-    selected_url=$(jq -r '.url' <<<"$selected_run")
+    run_id=$(jq -r '.id' <<<"$selected_run")
+    selected_url=$(jq -r '.html_url' <<<"$selected_run")
     selected_run_id="$run_id"
     echo "waiting for runner image artifact: name=${ARTIFACT_NAME} lookup_sha=${LOOKUP_SHA} producer_run=${run_id} status=${status} conclusion=${conclusion} url=${selected_url}"
 
     if [ "$status" = "completed" ]; then
       if [ "$conclusion" != "success" ]; then
-        echo "runner image workflow completed with conclusion=${conclusion}: ${selected_url}" >&2
-        exit 1
+        # The requested architecture may have uploaded its artifact during a
+        # status-request cooldown even if another producer job failed. Recheck
+        # artifact readiness once before reporting the producer failure.
+        producer_failure_url="$selected_url"
+        continue
       fi
     fi
   else
     echo "waiting for runner image artifact ${ARTIFACT_NAME}; no ${WORKFLOW} run found at ${LOOKUP_SHA} yet"
   fi
 
-  if [ "$(date +%s)" -ge "$deadline" ]; then
-    echo "timed out waiting for runner image workflow ${WORKFLOW} at ${LOOKUP_SHA} with artifact ${ARTIFACT_NAME}" >&2
-    exit 1
-  fi
-  sleep "$POLL_SECONDS"
+  wait_with_deadline "$POLL_SECONDS"
 done
 
 MANIFEST_PATH="${OUTPUT_DIR}/manifest.json"


### PR DESCRIPTION
## Summary

- Handle GitHub metadata rate limits using response headers, with bounded cooldowns instead of failing after three rate-limited responses. Fail immediately on ordinary authorization/client errors and retain bounded transient retries.
- Apply the existing wait deadline before requests and sleeps, including downloads. Never shorten a declared cooldown to fit the budget.
- Poll artifacts every 30 seconds and producer status at most every 60 seconds through one filtered REST request. Keep exact artifact identity, real manifest validation, newest producer selection and existing output keys.
- Recheck artifact readiness before reporting producer failure: the requested architecture may have published during a status-query cooldown even when another job failed.

Closes #33221

## Scope and risks

Shell-only CI consumer change. No Runner runtime, credentials, workflow topology, deployment protocol, job timeout, or test-selection changes.

Normal artifact detection can be roughly 20 seconds later than before; producer failure detection uses a 60-second interval. Shared quota pressure can still outlast the job budget, in which case the waiter fails explicitly. No claim is made about which historical requests exhausted the quota.

## Fallbacks

- `wait-runner-image.sh:api_get` uses 60/120/240/300-second cooldowns when GitHub rate-limit responses lack usable recovery headers. Surface: optional external response metadata, not cross-version compatibility. Retain while GitHub documents headerless secondary rate limits; remove only if the external contract guarantees usable headers. No rollout removal issue is applicable.
- The `gh run download` retry path uses the same conservative capped backoff for rate-limit errors because that CLI operation does not expose headers. Retain while using this transport; remove if replaced with header-aware download handling. Existing eventual-download retry behavior remains deadline-bounded. No fallback image or credential is introduced.

## Validation

- Bash syntax checks for all three changed scripts.
- `shellcheck -x -P SCRIPTDIR .github/scripts/wait-runner-image.sh .github/scripts/tests/wait-runner-image-test.sh .github/scripts/tests/wait-runner-image-groups-test.sh`
- `bash .github/scripts/tests/wait-runner-image-test.sh`
- `bash .github/scripts/tests/wait-runner-image-groups-test.sh`
- `bash .github/scripts/tests/runner-image-manifest-test.sh`
- `bash .github/scripts/tests/runner-image-context-test.sh`
- `bash .github/scripts/tests/prepare-runner-image-test.sh`
- `PATH="/workspaces/vm1/codex-work/bin:$PATH" bash .github/scripts/tests/runner-image-workflow-test.sh` (existing local yq binary)
- `git diff --check`
- Live smoke: the modified waiter downloaded and validated the exact x86_64 manifest from producer run `34454628469` for merge SHA `6f6719e842b080c05c6e89f162573c2430afb9c4`; the direct filtered workflow endpoint also returned that producer successfully. No SSH deployment or Runner mutation was performed.

The waiter tests invoke the real script and manifest validator, using a controlled external GitHub CLI and clock/sleep boundary to exercise minute-scale cooldowns without real delays. Cases include primary/secondary/headerless limits, more than three limited responses, malformed headers, status/download recovery, artifact availability during a failed-producer cooldown, permanent auth failures, transient 5xx, deadlines, both architectures, and exact SHA rejection.

Local environment preparation and DB migrations also completed. No production quota was deliberately exhausted. Remote CI status is tracked separately from these local checks.
