### PR TITLE
fix(platform): align recovery card icons with titles

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -5169,7 +5169,7 @@ function AssistantErrorRecoveryCard({
     <div
       role="status"
       data-testid="assistant-error-recovery"
-      className="okou-chat-card grid min-h-[88px] w-full grid-cols-[auto_minmax(0,1fr)] items-start gap-x-2.5 gap-y-3 px-3.5 py-3 text-foreground @[640px]:grid-cols-[auto_minmax(0,1fr)_auto] @[640px]:items-center"
+      className="okou-chat-card grid min-h-[88px] w-full grid-cols-[auto_minmax(0,1fr)] items-start gap-x-2.5 gap-y-3 px-3.5 py-3 text-foreground @[640px]:grid-cols-[auto_minmax(0,1fr)_auto] @[640px]:content-center"
     >
       {recovery.kind === "usage-limit" ||
       recovery.kind === "execution-timeout" ? (


### PR DESCRIPTION
In wide chat layouts, recovery text was vertically centered inside a stretched grid row while the coffee or clock icon stayed at the row's top, placing the icon above the title. Center the grid content instead so the icon aligns with the title's first line while the action group keeps its own vertical centering.

## Verification

- Prettier and `git diff --check` passed.
- Repository style policy passed.
- Chromium static layout checks used the source classes and compiled production CSS at 360, 639, 640, and 900px container widths, with English and German copy for all four recovery states. All 32 updated cases aligned the icon with the first title line and had no horizontal overflow; narrow layouts retained their original geometry. The reported wide capacity case changed from an 8px offset to 0px.
- The browser check used an isolated layout fixture with static controls, not a live app session. No local development server or Vitest suite was started; full lint, type, and test checks are left to the PR pipeline.
