### PR TITLE
fix(api): classify on-demand activity-summary deadlines as optional degradation

### DIFF
--- a/docs/chat-thread-activity-summary.md
+++ b/docs/chat-thread-activity-summary.md
@@ -65,7 +65,8 @@ credential-shaped argument keys are additionally redacted.
   timeout and 3 second statement timeout. Provider I/O runs outside the
   transaction. Optional capture failures cannot reject accepted execution
   events or suppress normal message publication.
-- Claims last 12 seconds. The database clock enforces at least 15 seconds
+- Claims last 15 seconds, so a lease always outlives one whole attempt at the
+  10-second provider deadline. The database clock enforces at least 15 seconds
   between attempts across API instances and tabs. A crashed owner's claim
   expires. Completion requires the exact claim ID and claimed revision, an
   unexpired lease/snapshot, and continued run eligibility.
@@ -78,6 +79,11 @@ credential-shaped argument keys are additionally redacted.
   the last phrase or `null`; it never retries inside the request.
 - Failed attempts use a shared 60-second cooldown. HTTP `Retry-After` can extend
   it up to five minutes. Expired or replaced claim owners cannot write results.
+  An attempt whose request lifetime ended first — today the API instance
+  stopping — charges no cooldown: its lease expires like any owner that stopped
+  reporting, and the attempt interval written at claim time still bounds the
+  next provider call. A phrase that finished first is still stored for the next
+  viewer.
 - Relevant capture or visible messages retain evidence for at most 24 hours
   from activity; first observing an old message does not restart its retention. Expired evidence is never returned. An expiry index supports
   one cleanup batch of at most 500 rows with `FOR UPDATE SKIP LOCKED`, attached
@@ -85,23 +91,49 @@ credential-shaped argument keys are additionally redacted.
 
 ## Production diagnostics
 
-The existing activity records use `info` for normal outcomes and `warn` for
-failed operations so they survive the default Axiom transport's `info` threshold.
-The shared logger and unrelated debug filtering are unchanged. Axiom events
-retain `source: api`, the stable message, and the following nested `fields`:
+The existing activity records use `info` for outcomes nobody can act on and
+`warn` for operations that need an operator, so they survive the default Axiom
+transport's `info` threshold. The shared logger and unrelated debug filtering
+are unchanged. Axiom events retain `source: api`, the stable message, and the
+following nested `fields`:
 
-| Message                        | Context                | Level                                                                  | Safe fields besides context                                                                                |
-| ------------------------------ | ---------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `Activity summary cache`       | `api:activity-summary` | info                                                                   | `runId`, `outcome` (existing response status)                                                              |
-| `Activity summary attempt`     | `api:activity-summary` | info                                                                   | `runId`                                                                                                    |
-| `Activity summary completion`  | `api:activity-summary` | info on success; warn otherwise                                        | `runId`, `outcome`, `durationMs`, `cooldownMs`; numeric `providerStatus` only for `OpenRouterRequestError` |
-| `Activity summary unavailable` | `api:activity-summary` | warn                                                                   | `runId`, `outcome: storage_failed`                                                                         |
-| `Activity snapshot capture`    | `api:run-activity`     | info for written/unchanged and for an expected failure; warn otherwise | `runId`, `outcome`, `eventCount`; `stage` and `errorCode` on failure                                       |
-| `Activity snapshot cleanup`    | `api:run-activity`     | info on success; warn on failure                                       | `outcome`, `removed`, `retentionMs`; `errorCode` on failure                                                |
+| Message                        | Context                | Level                                                                                     | Safe fields besides context                                                                                |
+| ------------------------------ | ---------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `Activity summary cache`       | `api:activity-summary` | info                                                                                      | `runId`, `outcome` (existing response status)                                                              |
+| `Activity summary attempt`     | `api:activity-summary` | info                                                                                      | `runId`                                                                                                    |
+| `Activity summary completion`  | `api:activity-summary` | info for success/timeout/cancelled; warn for provider_failure and invalid_or_unconfigured | `runId`, `outcome`, `durationMs`, `cooldownMs`; numeric `providerStatus` only for `OpenRouterRequestError` |
+| `Activity summary unavailable` | `api:activity-summary` | warn                                                                                      | `runId`, `outcome: storage_failed`                                                                         |
+| `Activity snapshot capture`    | `api:run-activity`     | info for written/unchanged and for an expected failure; warn otherwise                    | `runId`, `outcome`, `eventCount`; `stage` and `errorCode` on failure                                       |
+| `Activity snapshot cleanup`    | `api:run-activity`     | info on success; warn on failure                                                          | `outcome`, `removed`, `retentionMs`; `errorCode` on failure                                                |
 
-Completion outcomes remain `success`, `timeout`, `provider_failure`, and
-`invalid_or_unconfigured`. A provider HTTP 429 is distinguishable by
+Completion outcomes are `success`, `timeout`, `cancelled`, `provider_failure`,
+and `invalid_or_unconfigured`. A provider HTTP 429 is distinguishable by
 `fields.providerStatus: 429`; no error object or provider body is attached.
+
+`timeout` and `cancelled` are accepted degradations of an optional output, not
+failed operations, so they record at `info`. Missing the deadline leaves the
+response truthful (`cooldown` with the caller's last usable phrase) and bounds
+recovery at the shared cooldown; `cancelled` means the request's own lifetime
+ended before the provider answered. Neither has an operator action, so a
+per-event `warn` only trains operators to ignore the record. Persistent
+provider failure and contract or configuration defects keep their `warn`,
+including a repeated 429.
+
+Deadline pressure is a rate, not an event. Detect it from the same records
+instead of a per-event level:
+
+```
+['vm0-web-logs-prod']
+| where ['fields.context'] == 'api:activity-summary' and message == 'Activity summary completion'
+| summarize total=count(),
+            timeouts=countif(['fields.outcome'] == 'timeout'),
+            provider=countif(['fields.outcome'] == 'provider_failure'),
+            invalid=countif(['fields.outcome'] == 'invalid_or_unconfigured')
+        by bin(_time, 30m)
+| extend timeoutRate = todouble(timeouts) / total
+```
+
+Alerting on that rate is an operator decision and is not configured here.
 
 A failed capture is classified into a finite set instead of one opaque
 `write_failed`. `contended` (`55P03`) and `run_missing` (`23503`) are expected
@@ -112,10 +144,10 @@ vanished between the upsert and the locking read) and the residual
 `write_failed` keep `warn` because they need an owner. `fields.stage` is one of
 `begin`, `admission`, `lock`, `persist` or `commit`, where `begin` covers
 connection acquisition and the transaction's own timeout statements. Its
-companion `fields.errorCode` is the
-SQLSTATE class code alone — five characters, validated before it is published,
-and omitted when the driver reports no SQLSTATE. Driver messages, statement
-text, constraint details and bound parameters are never attached.
+companion `fields.errorCode` is the SQLSTATE class code alone — five characters,
+validated before it is published, and omitted when the driver reports no
+SQLSTATE. Driver messages, statement text, constraint details and bound
+parameters are never attached.
 
 Granularity is unchanged: one cache record for a request resolved without a
 claim, one attempt/completion pair per generation attempt, one unavailable

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
@@ -1007,6 +1007,123 @@ describe("thread activity summary", () => {
     expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
   });
 
+  it("records a missed deadline as an accepted degradation, not a failure", async () => {
+    const f = await fixture();
+    const entered = createDeferredPromise<void>(context.signal);
+    const stalled = createDeferredPromise<string>(context.signal);
+    const inputs = provider(async (_input, index) => {
+      if (index === 1) {
+        return "Preparing the launch checklist";
+      }
+      entered.resolve(undefined);
+      return await stalled.promise;
+    });
+    const first = await summarize(f.actor, f.run);
+    const diagnostics = captureDiagnostics();
+    await deliver(f, [tool(0)]);
+    await advanceRunActivityClockFixture(f.run.runId, 16_000);
+    const deadline = new AbortController();
+    context.mocks.abortSignal.timeout.mockImplementation((milliseconds) => {
+      return milliseconds === 10_000 ? deadline.signal : undefined;
+    });
+    const pending = summarize(f.actor, f.run);
+    await entered.promise;
+    deadline.abort(
+      new DOMException("Summary deadline reached", "TimeoutError"),
+    );
+    stalled.resolve("This phrase arrives after its own deadline");
+    const missed = await pending;
+    // The caller keeps its last real phrase and a bounded, self-recovering wait.
+    expect(missed.messages).toStrictEqual(first.messages);
+    expect(missed.status).toBe("cooldown");
+    expect(missed.summaryRevision).toBe(first.summaryRevision);
+    expect(missed.retryAfterMs).toBeGreaterThan(50_000);
+    expect(missed.retryAfterMs).toBeLessThanOrEqual(60_000);
+    expect(inputs).toHaveLength(2);
+    const logs = await diagnostics();
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        level: "info",
+        message: "Activity summary completion",
+        fields: {
+          context: "api:activity-summary",
+          runId: f.run.runId,
+          outcome: "timeout",
+          durationMs: expect.any(Number),
+          cooldownMs: 60_000,
+        },
+      }),
+    );
+    // An expected deadline must not reach an operator through any record.
+    expect(
+      logs.filter((event) => {
+        return event.level === "warn" || event.level === "error";
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("charges no cooldown when the instance stops before the provider answers", async () => {
+    const f = await fixture();
+    const entered = createDeferredPromise<void>(context.signal);
+    const release = createDeferredPromise<string>(context.signal);
+    const inputs = provider(async (_input, index) => {
+      if (index === 1) {
+        entered.resolve(undefined);
+        return await release.promise;
+      }
+      return "Checking the current launch materials";
+    });
+    const diagnostics = captureDiagnostics();
+    const shutdown = new AbortController();
+    createRouteMocks(context).clerk.session(
+      f.actor.userId,
+      f.actor.orgId,
+      f.actor.orgRole,
+    );
+    const abandoned = settleIncludingAbort(
+      setupApp({
+        context,
+        routes: chatThreadActivitySummaryRoutes,
+        signal: shutdown.signal,
+      })(chatThreadActivitySummaryContract).summarize({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { id: f.run.threadId },
+        body: { runId: f.run.runId },
+      }),
+    );
+    await entered.promise;
+    shutdown.abort(new DOMException("API instance stopping", "AbortError"));
+    release.resolve("This phrase never reaches an absent caller");
+    await abandoned;
+    const logs = await diagnostics();
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        level: "info",
+        message: "Activity summary completion",
+        fields: {
+          context: "api:activity-summary",
+          runId: f.run.runId,
+          outcome: "cancelled",
+          durationMs: expect.any(Number),
+          cooldownMs: 0,
+        },
+      }),
+    );
+    expect(
+      logs.filter((event) => {
+        return event.level === "warn" || event.level === "error";
+      }),
+    ).toStrictEqual([]);
+    // Only the attempt interval was ever charged, so the next viewer generates
+    // again instead of waiting out a failure cooldown it never caused.
+    await advanceRunActivityClockFixture(f.run.runId, 16_000);
+    const recovered = await summarize(f.actor, f.run);
+    expect(recovered.messages[0]?.text).toBe(
+      "Checking the current launch materials",
+    );
+    expect(inputs).toHaveLength(2);
+  });
+
   it("keeps normal publication working when a contended snapshot write is skipped and excludes expired evidence", async () => {
     const f = await fixture();
     const inputs = provider();

--- a/turbo/apps/api/src/signals/services/chat-activity-summary.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-activity-summary.service.ts
@@ -56,7 +56,10 @@ import {
 
 const log = logger("api:activity-summary");
 const ATTEMPT_INTERVAL_MS = 15_000;
-const CLAIM_MS = 12_000;
+// The lease must outlive one whole generation attempt. A completion that lands
+// after its own claim expired cannot write the shared cooldown, which silently
+// shortens the next attempt back to the plain attempt interval.
+const CLAIM_MS = 15_000;
 const FAILURE_COOLDOWN_MS = 60_000;
 const MAX_COOLDOWN_MS = 300_000;
 const SUMMARY_DEADLINE_MS = 10_000;
@@ -315,6 +318,53 @@ async function claimSummary(db: Db, identity: ActivityRunIdentity) {
   });
 }
 
+/**
+ * Completion outcomes an operator cannot act on. The response stays truthful,
+ * the caller keeps its last usable phrase, and the shared cooldown or the
+ * attempt interval bounds recovery. Persistent provider failures and
+ * contract/configuration defects stay at warn.
+ */
+function expectedOutcome(outcome: string): boolean {
+  return (
+    outcome === "success" || outcome === "timeout" || outcome === "cancelled"
+  );
+}
+
+/**
+ * The content-free record of one generation attempt. The caller reads `outcome`
+ * to pick a level and `cooldownMs` to write the next attempt, so the diagnostic
+ * and the stored backoff can never disagree. No prompt, phrase, provider body
+ * or driver message is ever attached.
+ */
+function completionRecord(
+  started: number,
+  phrase: string | null,
+  abandoned: boolean,
+  deadlineReached: boolean,
+  failure: unknown,
+) {
+  const request =
+    failure instanceof OpenRouterRequestError ? failure : undefined;
+  const cooldown = Math.min(
+    MAX_COOLDOWN_MS,
+    Math.max(FAILURE_COOLDOWN_MS, request?.retryAfterMs ?? 0),
+  );
+  return {
+    outcome: phrase
+      ? "success"
+      : abandoned
+        ? "cancelled"
+        : deadlineReached
+          ? "timeout"
+          : request
+            ? "provider_failure"
+            : "invalid_or_unconfigured",
+    durationMs: Math.round(performance.now() - started),
+    cooldownMs: phrase || abandoned ? 0 : cooldown,
+    ...(request ? { providerStatus: request.status } : {}),
+  };
+}
+
 async function generateSummary(
   db: Db,
   identity: ActivityRunIdentity,
@@ -357,33 +407,32 @@ async function generateSummary(
   const phrases = result.ok ? activityPhrases(result.value) : null;
   // The text column stores the bounded batch as one plain-text line per message.
   const phrase = phrases?.join("\n") ?? null;
-  const retryAfterMs =
-    !result.ok && result.error instanceof OpenRouterRequestError
-      ? result.error.retryAfterMs
-      : undefined;
-  const cooldown = Math.min(
-    MAX_COOLDOWN_MS,
-    Math.max(FAILURE_COOLDOWN_MS, retryAfterMs ?? 0),
-  );
+  // The request signal ends this request's whole lifetime — today the API
+  // instance stopping. That is not a failed generation, so it is classified
+  // ahead of the deadline it may have raced.
+  const abandoned = !phrase && signal.aborted;
   const completion = {
     runId: identity.runId,
-    outcome: phrase
-      ? "success"
-      : deadline.aborted
-        ? "timeout"
-        : !result.ok && result.error instanceof OpenRouterRequestError
-          ? "provider_failure"
-          : "invalid_or_unconfigured",
-    durationMs: Math.round(performance.now() - started),
-    cooldownMs: phrase ? 0 : cooldown,
-    ...(!result.ok && result.error instanceof OpenRouterRequestError
-      ? { providerStatus: result.error.status }
-      : {}),
+    ...completionRecord(
+      started,
+      phrase,
+      abandoned,
+      deadline.aborted,
+      result.ok ? null : result.error,
+    ),
   };
-  if (phrase) {
+  if (expectedOutcome(completion.outcome)) {
     log.info("Activity summary completion", completion);
   } else {
     log.warn("Activity summary completion", completion);
+  }
+  // An abandoned attempt must not spend the shared cooldown on the next
+  // viewer's behalf. Its lease expires like any owner that stopped reporting,
+  // and the attempt interval written at claim time still bounds the next
+  // provider call. A phrase that finished first is still stored: this request
+  // is over, but the work is done and the next viewer should read it.
+  if (abandoned) {
+    signal.throwIfAborted();
   }
   const enabled = await activityEnabled(db, identity.orgId, identity.userId);
   if (!enabled) {
@@ -405,7 +454,7 @@ async function generateSummary(
               summarizedAt: activityClock,
             }
           : {
-              nextAttemptAt: sql`${activityClock} + ${cooldown} * interval '1 millisecond'`,
+              nextAttemptAt: sql`${activityClock} + ${completion.cooldownMs} * interval '1 millisecond'`,
             }),
       })
       .where(


### PR DESCRIPTION
Closes #33081

## Problem

`Activity summary completion` splits its log level on success versus anything
else, so every outcome that is not a phrase reaches operators as `warn`:

https://github.com/vm0-ai/vm0/blob/29dfab14531307e67d16322d5fa3972df9c42a99/turbo/apps/api/src/signals/services/chat-activity-summary.service.ts#L383-L387

A missed deadline on an optional summary is not a failed operation. Production
evidence over `[2026-09-09T14:00:00Z, 2026-09-10T02:00:00Z)` in
`vm0-web-logs-prod`, `fields.context == "api:activity-summary"`:

| record | count |
| --- | --- |
| `Activity summary attempt` | 956 |
| completion `success` (info) | 939 |
| completion `timeout` (warn) | 15 |
| completion `provider_failure` (warn, both `providerStatus: 429`) | 2 |

939 + 15 + 2 reconciles exactly against 956 attempts. Successful generations
finish at p50 1599 ms, p95 2953 ms, p99 6025 ms, max 9591 ms, so the 10-second
deadline is roughly 3.4x p95 and is cutting a genuine provider latency tail
rather than being set too tight. The 15 deadlines belong to 15 distinct runs —
no run missed twice — and for every one of them the next attempt on that run
was at least 60.3 s later, so the shared cooldown was honoured each time. The
caller keeps its last usable phrase and recovers on its own, and no Sentry
event is produced from this path.

## Change

- Record `timeout` at `info` alongside `success`. `provider_failure` and
  `invalid_or_unconfigured` keep `warn` because they do need an operator. The
  `outcome`, `durationMs` and `cooldownMs` fields are unchanged, so deadline
  pressure stays queryable as a rate; the doc now carries that query.

Two further defects in the same classification path are fixed here because
downgrading `timeout` would otherwise leave them as the dominant false positive:

- **Cancellation was reported as a failure.** The handler's signal covers the
  whole request lifetime — today the API instance stopping. When it aborted
  mid-generation the attempt fell through to `invalid_or_unconfigured`, logged
  `warn`, and wrote the 60-second failure cooldown on the next viewer's behalf.
  It is now `cancelled`, writes no cooldown, and lets its lease expire like any
  owner that stopped reporting. A phrase that finished first is still stored.
- **The claim lease had no margin.** `CLAIM_MS` was 12 s against a 10 s
  deadline, with an eligibility query, a feature-switch read and transaction
  overhead in between. A completion landing after its own lease expired fails
  the `claimExpiresAt` predicate, so the cooldown is never written and the next
  attempt silently falls back to the plain 15-second interval. Leases now last
  15 s — still within the documented attempt bound — and `next_attempt_at` is
  written from the same `completion.cooldownMs` that was logged, so the
  diagnostic and the stored backoff cannot disagree.

Not changed on purpose: the 10-second deadline (raising it only lengthens the
user-visible wait and would exceed the client's own 15-second poll interval),
and the 1024-token budget (939 successes with zero truncation outcomes).

## Tests

Two endpoint-level tests in `chat-activity-summary.test.ts`, both driving the
real production logger and Axiom transport through the existing
`captureDiagnostics` harness:

- **Missed deadline is an accepted degradation.** Compresses the deadline with
  the existing `context.mocks.abortSignal.timeout` facility, then asserts the
  response is `cooldown` with the caller's previous phrase and a 50–60 s
  `retryAfterMs`, the record is `info` with `outcome: "timeout"` and
  `cooldownMs: 60_000`, and that no `warn` or `error` record is emitted at all.
- **Abandoned attempt charges no cooldown.** Aborts the app signal mid-provider
  call, asserts `info` with `outcome: "cancelled"` and `cooldownMs: 0` and no
  `warn`, then advances the run clock 16 s and shows the next viewer generates
  again — which the previous 60-second cooldown would have blocked.

The existing `provider_failure` (429 + `Retry-After`), `storage_failed`,
`write_failed` and malformed-output cases keep their `warn` assertions
unchanged as the negative control.

## Verification

Run locally: `pnpm run lint` and `pnpm run check-types` for `turbo/apps/api`
both pass, and Prettier is clean on all three files. The API integration suite
needs a real PostgreSQL, which this environment has no Docker or server for, so
the two new tests have **not** been executed locally and are left to CI.

Production acceptance stays with the release owner: on a deployment carrying
this change, slice by `vercel.deploymentId` and require ≥ 12 h and ≥ 500
attempts, then check that no `warn`/`error` record carries `outcome: timeout`,
that the five completion outcomes still sum to the attempt count, that the
timeout rate stays near the 1.6% baseline, and that a real 429 still surfaces
as `warn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)