### PR TITLE
fix(api): classify initial thinking rate limits as degraded

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/auxiliary-generation.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auxiliary-generation.test.ts
@@ -461,7 +461,7 @@ describe("auxiliary generation outcomes", () => {
       await expect(title.read()).resolves.toStrictEqual(
         outcome === "success" ? ["A usable summary"] : [],
       );
-      expect(auxiliaryResults(context)).toStrictEqual([
+      expect(auxiliaryResults(context, "chat_title")).toStrictEqual([
         expect.objectContaining({
           feature: "chat_title",
           outcome,
@@ -523,7 +523,7 @@ describe("auxiliary generation outcomes", () => {
       });
       await title.create();
       await flushWaitUntilForTest();
-      expect(auxiliaryResults(context)).toStrictEqual([
+      expect(auxiliaryResults(context, "chat_title")).toStrictEqual([
         expect.objectContaining({ feature: "chat_title", ...expected }),
       ]);
       expect(auxiliaryWarnings(context)).toStrictEqual([]);
@@ -566,7 +566,7 @@ describe("auxiliary generation outcomes", () => {
     await flushWaitUntilForTest();
     await expect(title.read()).resolves.toStrictEqual([]);
     // The title scheduler checks configuration before starting auxiliary work.
-    expect(auxiliaryResults(context)).toStrictEqual([]);
+    expect(auxiliaryResults(context, "chat_title")).toStrictEqual([]);
     expect(context.mocks.axiomLogging.warn.mock.calls).toStrictEqual([]);
   });
 
@@ -608,7 +608,7 @@ describe("auxiliary generation outcomes", () => {
     await expect(title.read()).resolves.toStrictEqual(["A usable summary"]);
     expect(auxiliaryWarnings(context)).toStrictEqual([]);
     if (mode === "missing") {
-      expect(auxiliaryResults(context)).toStrictEqual([]);
+      expect(auxiliaryResults(context, "chat_title")).toStrictEqual([]);
     }
   });
 
@@ -746,7 +746,7 @@ describe("auxiliary generation outcomes", () => {
     if (response.status !== 201) {
       throw new Error("Expected an accepted chat event");
     }
-    expect(auxiliaryResults(context)).toStrictEqual([]);
+    expect(auxiliaryResults(context, "chat_title")).toStrictEqual([]);
     expect(context.mocks.axiom.flush.mock.calls.length).toBeGreaterThan(
       beforeSendFlushes,
     );
@@ -769,7 +769,7 @@ describe("auxiliary generation outcomes", () => {
     releaseFlush.resolve(undefined);
     await drain;
     expect(drained).toBeTruthy();
-    expect(auxiliaryResults(context)).toStrictEqual([
+    expect(auxiliaryResults(context, "chat_title")).toStrictEqual([
       expect.objectContaining({ feature: "chat_title", outcome: "success" }),
     ]);
     const events = await chat.requestThreadEvents(actor, {}, [200]);
@@ -800,7 +800,7 @@ describe("auxiliary generation outcomes", () => {
     );
     await title.create();
     await flushWaitUntilForTest();
-    expect(auxiliaryResults(context)).toStrictEqual([
+    expect(auxiliaryResults(context, "chat_title")).toStrictEqual([
       expect.objectContaining({ outcome: "success", duration_ms: 0 }),
     ]);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1494,8 +1494,6 @@ describe("CHAT-02: completed chat callback", () => {
     await chatCallbacks.registerPushSubscription(actor);
     chatCallbacks.enableVapid();
     const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
-    // Separate the eager title from the callback's three generations.
-    const beforeComplete = auxiliaryResults(context).length;
     chatCallbacks.mockChatOutputEvents([
       assistantEvent(0, "The main answer survives"),
     ]);
@@ -1520,31 +1518,32 @@ describe("CHAT-02: completed chat callback", () => {
     ).toContainEqual(
       expect.objectContaining({ body: "Your task is complete" }),
     );
-    const results = auxiliaryResults(context);
-    expect(results.slice(0, beforeComplete)).toStrictEqual([
-      expect.objectContaining({
-        feature: "chat_title",
-        outcome: "degraded",
-        reason: "rate_limited",
-      }),
-    ]);
+    // The eager title runs at send time; the callback owns the other three.
+    const rateLimited = auxiliaryResults(context).filter((event) => {
+      return event.feature !== "chat_initial_thinking";
+    });
     expect(
-      results
-        .slice(beforeComplete)
+      rateLimited
         .map(({ feature }) => {
           return feature;
         })
         .sort(),
     ).toStrictEqual([
+      "chat_title",
       "notification_summary",
       "recommended_followups",
       "run_summary",
     ]);
     expect(
-      results.every((event) => {
+      rateLimited.every((event) => {
         return event.outcome === "degraded" && event.reason === "rate_limited";
       }),
     ).toBeTruthy();
+    // Only the four are rejected, so the optional progress copy still proves
+    // the boundary reports a real success next to the degraded generations.
+    expect(auxiliaryResults(context, "chat_initial_thinking")).toStrictEqual([
+      expect.objectContaining({ outcome: "success", reason: "none" }),
+    ]);
     expect(context.mocks.axiomLogging.warn.mock.calls).toStrictEqual([]);
     expect(context.mocks.axiomLogging.error.mock.calls).toStrictEqual([]);
   });
@@ -1700,6 +1699,11 @@ describe("CHAT-02: completed chat callback", () => {
           return a.feature.localeCompare(b.feature);
         }),
     ).toStrictEqual([
+      {
+        feature: "chat_initial_thinking",
+        outcome: "success",
+        reason: "none",
+      },
       { feature: "chat_title", outcome: "success", reason: "none" },
       { feature: "notification_summary", outcome: "success", reason: "none" },
       { feature: "recommended_followups", outcome: "success", reason: "none" },

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -21910,6 +21910,8 @@ describe("CHAT-02: initial thinking indicator", () => {
           error: { code: 504, message: providerDetail },
         });
       },
+      outcome: "degraded",
+      reason: "upstream_timeout",
       warned: false,
     },
     {
@@ -21917,6 +21919,8 @@ describe("CHAT-02: initial thinking indicator", () => {
       thinkingResponse: () => {
         return new HttpResponse(providerDetail, { status: 429 });
       },
+      outcome: "degraded",
+      reason: "rate_limited",
       warned: false,
     },
     {
@@ -21924,6 +21928,8 @@ describe("CHAT-02: initial thinking indicator", () => {
       thinkingResponse: () => {
         return new HttpResponse(providerDetail, { status: 502 });
       },
+      outcome: "degraded",
+      reason: "provider_unavailable",
       warned: false,
     },
     // Negative control: an unsupported request is our defect, not the
@@ -21933,6 +21939,8 @@ describe("CHAT-02: initial thinking indicator", () => {
       thinkingResponse: () => {
         return new HttpResponse(providerDetail, { status: 400 });
       },
+      outcome: "error",
+      reason: "invalid_request",
       warned: true,
     },
     {
@@ -21940,10 +21948,12 @@ describe("CHAT-02: initial thinking indicator", () => {
       thinkingResponse: () => {
         return new HttpResponse(providerDetail, { status: 401 });
       },
+      outcome: "error",
+      reason: "auth",
       warned: true,
     },
-    // An exhausted token budget describes our own request rather than the
-    // provider's availability, so it stays outside the suppressed set.
+    // The shared boundary counts a token ceiling as expected degradation, but
+    // the optional marker remains absent because shortened copy is unusable.
     {
       name: "an exhausted token budget",
       thinkingResponse: () => {
@@ -21957,11 +21967,13 @@ describe("CHAT-02: initial thinking indicator", () => {
           ],
         });
       },
-      warned: true,
+      outcome: "degraded",
+      reason: "output_truncated",
+      warned: false,
     },
   ])(
     "omits opening copy and reports a defect only for $name",
-    async ({ thinkingResponse, warned }) => {
+    async ({ thinkingResponse, outcome, reason, warned }) => {
       const { actor, agentId } = await entitledChatActor();
       mockOptionalEnv("OPENROUTER_API_KEY", "thinking-classification-key");
       server.use(
@@ -21999,13 +22011,19 @@ describe("CHAT-02: initial thinking indicator", () => {
       ).toStrictEqual([]);
       expect((await api.readRun(actor, run.runId)).status).toBe("pending");
 
-      const warnings = context.mocks.axiomLogging.warn.mock.calls.filter(
-        ([message]) => {
-          return message === "Initial thinking generation failed";
-        },
-      );
+      const warnings = auxiliaryWarnings(context);
       expect(warnings).toHaveLength(warned ? 1 : 0);
       expect(JSON.stringify(warnings)).not.toContain(providerDetail);
+      expect(auxiliaryResults(context, "chat_initial_thinking")).toStrictEqual([
+        expect.objectContaining({
+          outcome,
+          reason,
+          run_id: run.runId,
+        }),
+      ]);
+      expect(
+        JSON.stringify(auxiliaryResults(context, "chat_initial_thinking")),
+      ).not.toContain(providerDetail);
       await cancelChatRun(actor, run.runId);
     },
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -222,6 +222,10 @@ import {
   readCustomConnectorCredentialStorageParent,
   setCustomConnectorCredentialStorageState,
 } from "./helpers/connector-credential-storage-state";
+import {
+  auxiliaryResults,
+  auxiliaryWarnings,
+} from "./helpers/auxiliary-generation";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import {
   commitMemoryVersion,
@@ -21786,6 +21790,9 @@ describe("CHAT-02: incomplete-round context", () => {
 });
 
 describe("CHAT-02: initial thinking indicator", () => {
+  // Provider text is untrusted and must never reach a log or a metric.
+  const privateProviderDetail = "private_prompt_history_authorization_canary";
+
   it.each([
     { enabled: false, existingThread: false },
     { enabled: true, existingThread: false },
@@ -22295,6 +22302,136 @@ describe("CHAT-02: initial thinking indicator", () => {
 
   it.each([
     {
+      name: "an HTTP rate limit",
+      response: () => {
+        return HttpResponse.json(
+          { error: { code: 429 } },
+          { status: 429, headers: { "retry-after": "12" } },
+        );
+      },
+      outcome: "degraded",
+      reason: "rate_limited",
+      retryAfterMs: 12_000,
+    },
+    {
+      // OpenRouter reports an exhausted upstream window as a synthetic gateway
+      // failure. It is the same admission problem, not a separate outage.
+      name: "a rate limit wrapped in a synthetic 502",
+      response: () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "error",
+              error: { code: 429, message: privateProviderDetail },
+            },
+          ],
+        });
+      },
+      outcome: "degraded",
+      reason: "rate_limited",
+      retryAfterMs: undefined,
+    },
+    {
+      name: "an unreachable provider",
+      response: () => {
+        return new HttpResponse(privateProviderDetail, { status: 503 });
+      },
+      outcome: "degraded",
+      reason: "provider_unavailable",
+      retryAfterMs: undefined,
+    },
+    {
+      name: "rejected credentials",
+      response: () => {
+        return new HttpResponse(privateProviderDetail, { status: 401 });
+      },
+      outcome: "error",
+      reason: "auth",
+      retryAfterMs: undefined,
+    },
+    {
+      // Non-empty for the provider, yet nothing survives sanitization.
+      name: "output that sanitizes to nothing",
+      response: () => {
+        return HttpResponse.json({
+          choices: [{ finish_reason: "stop", message: { content: '"""' } }],
+        });
+      },
+      outcome: "error",
+      reason: "unusable_output",
+      retryAfterMs: undefined,
+    },
+  ])(
+    "classifies $name for optional progress copy",
+    async ({ response, outcome, reason, retryAfterMs }) => {
+      const { actor, agentId } = await entitledChatActor();
+      mockOptionalEnv("OPENROUTER_API_KEY", "thinking-key");
+      server.use(
+        http.post(
+          "https://openrouter.ai/api/v1/chat/completions",
+          async ({ request }) => {
+            const body = openRouterBodySchema.parse(await request.json());
+            return body.messages[0]?.content.includes(
+              "Write user-visible progress copy",
+            )
+              ? response()
+              : HttpResponse.json({
+                  choices: [
+                    { finish_reason: "stop", message: { content: "Update" } },
+                  ],
+                });
+          },
+        ),
+      );
+      const run = await sendChatRun(actor, {
+        agentId,
+        prompt: "Prepare an update",
+      });
+      await flushWaitUntilForTest();
+
+      expect(auxiliaryResults(context, "chat_initial_thinking")).toStrictEqual([
+        expect.objectContaining({
+          outcome,
+          reason,
+          run_id: run.runId,
+          // Recorded only when the provider actually asked for a delay.
+          ...(retryAfterMs === undefined
+            ? {}
+            : { retry_after_ms: retryAfterMs }),
+        }),
+      ]);
+      expect(
+        auxiliaryResults(context, "chat_initial_thinking")[0],
+      ).toStrictEqual(
+        retryAfterMs === undefined
+          ? expect.not.objectContaining({ retry_after_ms: expect.anything() })
+          : expect.anything(),
+      );
+      // Only a defect the caller can act on still reaches the log.
+      expect(auxiliaryWarnings(context)).toHaveLength(
+        outcome === "error" ? 1 : 0,
+      );
+      expect(JSON.stringify(auxiliaryWarnings(context))).not.toContain(
+        privateProviderDetail,
+      );
+      expect(JSON.stringify(auxiliaryResults(context))).not.toContain(
+        privateProviderDetail,
+      );
+
+      // The optional copy is absent either way; the run itself is untouched.
+      const page = await chat.listThreadEvents(actor, run.threadId);
+      expect(
+        page.events.some((event) => {
+          return event.runEventId === "thinking:initial";
+        }),
+      ).toBeFalsy();
+      expect((await api.readRun(actor, run.runId)).status).toBe("pending");
+      await cancelChatRun(actor, run.runId);
+    },
+  );
+
+  it.each([
+    {
       name: "empty",
       responseBody: {
         choices: [{ finish_reason: "stop", message: { content: "  " } }],
@@ -22361,18 +22498,28 @@ describe("CHAT-02: initial thinking indicator", () => {
           return event.runEventId === "thinking:initial";
         }),
       ).toBeFalsy();
-      const errors = context.mocks.axiomLogging.warn.mock.calls.filter(
-        ([message]) => {
-          return message === "Initial thinking generation failed";
-        },
-      );
-      expect(errors).toHaveLength(1);
-      const logged = z
-        .object({ err: z.instanceof(Error) })
-        .parse(errors[0]?.[1]);
-      expect(logged.err.message).not.toContain(
+      // Output the feature cannot interpret stays a reported defect; only the
+      // provider-side conditions the caller cannot act on became silent.
+      expect(auxiliaryWarnings(context)).toStrictEqual([
+        [
+          "Auxiliary generation failed",
+          expect.objectContaining({
+            feature: "chat_initial_thinking",
+            reason: "invalid_output",
+            runId: run.runId,
+          }),
+        ],
+      ]);
+      expect(JSON.stringify(auxiliaryWarnings(context))).not.toContain(
         "private_prompt_history_authorization_canary",
       );
+      expect(auxiliaryResults(context, "chat_initial_thinking")).toStrictEqual([
+        expect.objectContaining({
+          outcome: "error",
+          reason: "invalid_output",
+          run_id: run.runId,
+        }),
+      ]);
       await cancelChatRun(actor, run.runId);
     },
   );
@@ -22462,26 +22609,26 @@ describe("CHAT-02: initial thinking indicator", () => {
         prompt: "Prepare an update",
       });
       await flushWaitUntilForTest();
-      const errors = context.mocks.axiomLogging.warn.mock.calls.filter(
-        ([message]) => {
-          return message === "Initial thinking generation failed";
-        },
-      );
-      expect(errors).toHaveLength(1);
-      const logged = z
-        .object({ err: z.instanceof(Error) })
-        .parse(errors[0]?.[1]);
-      expect(logged.err).toMatchObject({
-        name: "OpenRouterRequestError",
-        message: "OpenRouter request failed: 400",
-        status: 400,
-        errorType: undefined,
-        ...expected,
-      });
-      expect(JSON.stringify(logged.err)).not.toContain(
+      // A rejected request is the caller's own defect, so it keeps warning with
+      // the enumerated diagnostics and without the provider's message or stack.
+      expect(auxiliaryWarnings(context)).toStrictEqual([
+        [
+          "Auxiliary generation failed",
+          expect.objectContaining({
+            feature: "chat_initial_thinking",
+            reason: "invalid_request",
+            errorKind: "openrouter_request",
+            status: 400,
+            errorType: undefined,
+            runId: run.runId,
+            ...expected,
+          }),
+        ],
+      ]);
+      expect(JSON.stringify(auxiliaryWarnings(context))).not.toContain(
         "private_prompt_history_authorization_canary",
       );
-      expect(logged.err).not.toHaveProperty("cause");
+      expect(auxiliaryWarnings(context)[0]?.[1]).not.toHaveProperty("err");
       const page = await chat.listThreadEvents(actor, run.threadId);
       expect(
         page.events.some((event) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/auxiliary-generation.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/auxiliary-generation.ts
@@ -9,10 +9,10 @@ const resultSchema = z
     feature: z.enum([
       "chat_title",
       "shared_thread_title",
+      "chat_initial_thinking",
       "run_summary",
       "recommended_followups",
       "notification_summary",
-      "goal_objective_brief",
     ]),
     outcome: z.enum(["success", "degraded", "cancelled", "error", "skipped"]),
     reason: z.enum([
@@ -45,10 +45,30 @@ const resultSchema = z
       .nonnegative()
       .max(Number.MAX_SAFE_INTEGER)
       .optional(),
+    // Present only when the provider sent Retry-After on this failure.
+    retry_after_ms: z
+      .number()
+      .int()
+      .nonnegative()
+      .max(Number.MAX_SAFE_INTEGER)
+      .optional(),
+    // Present only when the caller supplied a run to correlate against.
+    run_id: z.string().optional(),
   })
   .strict();
 
-export function auxiliaryResults(context: TestContext) {
+type AuxiliaryFeature = z.infer<typeof resultSchema>["feature"];
+
+export function auxiliaryResults(
+  context: TestContext,
+  feature?: AuxiliaryFeature,
+) {
+  return allAuxiliaryResults(context).filter((result) => {
+    return feature === undefined || result.feature === feature;
+  });
+}
+
+function allAuxiliaryResults(context: TestContext) {
   return [
     ...context.mocks.axiom.ingest.mock.calls,
     ...context.mocks.axiom.sdkIngest.mock.calls,

--- a/turbo/apps/api/src/signals/routes/__tests__/shared-threads.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/shared-threads.test.ts
@@ -186,7 +186,7 @@ async function expectNoShare(fixture: ShareFixture) {
 }
 
 function expectOutcome(outcome: string, reason: string) {
-  expect(auxiliaryResults(context)).toStrictEqual([
+  expect(auxiliaryResults(context, "shared_thread_title")).toStrictEqual([
     expect.objectContaining({
       feature: "shared_thread_title",
       outcome,
@@ -452,7 +452,7 @@ describe("optional shared-thread titles", () => {
     await flushWaitUntilForTest();
     await expectNoShare(fixture);
     expect(requests).toStrictEqual([]);
-    expect(auxiliaryResults(context)).toStrictEqual([]);
+    expect(auxiliaryResults(context, "shared_thread_title")).toStrictEqual([]);
     expect(auxiliaryWarnings(context)).toStrictEqual([]);
     expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
   });
@@ -558,7 +558,7 @@ describe("optional shared-thread titles", () => {
     );
     expect(unknown.body.error.code).toBe("NO_SHAREABLE_MESSAGES");
     await expectNoShare(fixture);
-    expect(auxiliaryResults(context)).toStrictEqual([]);
+    expect(auxiliaryResults(context, "shared_thread_title")).toStrictEqual([]);
     expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
   });
 
@@ -568,7 +568,7 @@ describe("optional shared-thread titles", () => {
     const response = await accept(client().create(requestBody(fixture)), [413]);
     expect(response.body.error.code).toBe("SHARED_THREAD_TOO_LARGE");
     await expectNoShare(fixture);
-    expect(auxiliaryResults(context)).toStrictEqual([]);
+    expect(auxiliaryResults(context, "shared_thread_title")).toStrictEqual([]);
     expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
   });
 
@@ -594,7 +594,7 @@ describe("optional shared-thread titles", () => {
       "Unknown response status 500 for POST /api/chat-threads/:threadId/shared-threads",
     );
     await flushWaitUntilForTest();
-    expect(auxiliaryResults(context)).toStrictEqual([
+    expect(auxiliaryResults(context, "shared_thread_title")).toStrictEqual([
       expect.objectContaining({
         feature: "shared_thread_title",
         outcome: "degraded",

--- a/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
@@ -17,6 +17,7 @@ import { onRejection, safeSync, settle } from "../utils";
 type AuxiliaryFeature =
   | "chat_title"
   | "shared_thread_title"
+  | "chat_initial_thinking"
   | "run_summary"
   | "recommended_followups"
   | "notification_summary";
@@ -49,7 +50,23 @@ interface AuxiliaryResult {
   readonly outcome: Outcome;
   readonly reason: Reason;
   readonly tokens: OpenRouterTokenCounts;
+  /** Present only when the provider asked for a delay; bounded upstream. */
+  readonly retryAfterMs?: number;
+  readonly runId?: string;
   readonly startedAt: number;
+}
+
+/**
+ * A `rate_limited` outcome only justifies waiting when the provider says how
+ * long to wait. Nothing consumes this delay yet: record it first so the choice
+ * between honoring `Retry-After` and backing off blindly rests on production
+ * evidence rather than on the header's assumed presence.
+ */
+function retryAfterMilliseconds(error: unknown): number | undefined {
+  return error instanceof OpenRouterRequestError &&
+    error.retryAfterMs !== undefined
+    ? Math.trunc(error.retryAfterMs)
+    : undefined;
 }
 
 /** Reasons the caller can do nothing about: counted, never warned. */
@@ -86,6 +103,12 @@ async function deliverResult(result: AuxiliaryResult): Promise<void> {
         ...(result.tokens.reasoningTokens === undefined
           ? {}
           : { reasoning_tokens: result.tokens.reasoningTokens }),
+        ...(result.retryAfterMs === undefined
+          ? {}
+          : { retry_after_ms: result.retryAfterMs }),
+        // One rate-limit window rejects several independent generations at
+        // once, so an event count alone overstates how many runs it reached.
+        ...(result.runId === undefined ? {} : { run_id: result.runId }),
       },
     ]);
   });
@@ -131,6 +154,7 @@ function diagnose(
           errorCode: error.errorCode,
           errorParam: error.errorParam,
           errorType: error.errorType,
+          retryAfterMs: error.retryAfterMs,
         }
       : {}),
   });
@@ -150,6 +174,7 @@ export async function generateAuxiliary<T>(
   signal?: AbortSignal,
 ): Promise<T | undefined> {
   const startedAt = now();
+  const runId = args.diagnosticContext?.runId;
   let detail: AuxiliaryGenerationDetail | undefined;
   const result = await settle(
     onRejection(
@@ -161,6 +186,7 @@ export async function generateAuxiliary<T>(
             outcome: "skipped",
             reason: "not_applicable",
             tokens: {},
+            ...(runId === undefined ? {} : { runId }),
             startedAt,
           });
           return undefined;
@@ -192,6 +218,7 @@ export async function generateAuxiliary<T>(
               ? "none"
               : "unusable_output",
           tokens: detail?.tokens ?? {},
+          ...(runId === undefined ? {} : { runId }),
           startedAt,
         });
         return value;
@@ -211,11 +238,14 @@ export async function generateAuxiliary<T>(
         if (outcome === "error") {
           diagnose(args.feature, reason, error, args.diagnosticContext);
         }
+        const retryAfterMs = retryAfterMilliseconds(error);
         recordResult({
           feature: args.feature,
           outcome,
           reason,
           tokens: openRouterFailureTokenCounts(error),
+          ...(retryAfterMs === undefined ? {} : { retryAfterMs }),
+          ...(runId === undefined ? {} : { runId }),
           startedAt,
         });
       },

--- a/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
@@ -7,6 +7,7 @@ import {
   OpenRouterRequestError,
 } from "../external/openrouter";
 import {
+  isTransientProviderFailure,
   openRouterFailureReason,
   openRouterFailureTokenCounts,
   type OpenRouterFailureReason,
@@ -71,14 +72,21 @@ function retryAfterMilliseconds(error: unknown): number | undefined {
 
 /** Reasons the caller can do nothing about: counted, never warned. */
 function isDegradedReason(reason: Reason): boolean {
-  return (
-    reason === "rate_limited" ||
-    reason === "upstream_timeout" ||
-    reason === "network" ||
-    reason === "provider_unavailable" ||
-    reason === "output_truncated" ||
-    reason === "unexpected_tool_calls"
-  );
+  switch (reason) {
+    case "output_truncated":
+    case "unexpected_tool_calls": {
+      return true;
+    }
+    case "caller_cancelled":
+    case "not_applicable":
+    case "none":
+    case "unusable_output": {
+      return false;
+    }
+    default: {
+      return isTransientProviderFailure(reason);
+    }
+  }
 }
 
 const log = logger("api:auxiliary-generation");

--- a/turbo/apps/api/src/signals/services/chat-initial-thinking.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-initial-thinking.service.ts
@@ -16,16 +16,18 @@ import {
   type SQL,
 } from "drizzle-orm";
 
-import { logger } from "../../lib/log";
 import type { Db } from "../external/db";
-import { FAST_PATH_MODEL, generateText } from "../external/openrouter";
 import {
-  isTransientProviderFailure,
-  openRouterFailureReason,
-} from "../external/openrouter-failure";
+  FAST_PATH_MODEL,
+  generateTextWithUsage,
+  openRouterTokenCounts,
+} from "../external/openrouter";
 import { publishChatThreadMessageCreatedSafely } from "../external/realtime";
-import { tapError } from "../utils";
 import { assistantEventIdForRunEvent } from "./assistant-event-id";
+import {
+  generateAuxiliary,
+  type RecordAuxiliaryGenerationDetail,
+} from "./auxiliary-generation.service";
 import { visibleChatEventCondition } from "./chat-event-shared.service";
 import { insertChatEvent } from "./chat-event.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
@@ -40,8 +42,6 @@ import {
   canonicalChatEventError,
   canonicalChatEventUserMessage,
 } from "./canonical-chat-event-read.service";
-
-const log = logger("api:chat-initial-thinking");
 
 const INITIAL_THINKING_RUN_EVENT_ID = "thinking:initial";
 const THINKING_CONTEXT_MESSAGE_CAP = 8;
@@ -197,6 +197,7 @@ async function runCanReceiveThinkingMessage(args: {
 async function generateInitialThinkingText(args: {
   readonly currentPrompt: string;
   readonly history: readonly ThinkingContextMessage[];
+  readonly record: RecordAuxiliaryGenerationDetail;
 }): Promise<string | null> {
   const history = args.history
     .map((message) => {
@@ -204,7 +205,7 @@ async function generateInitialThinkingText(args: {
     })
     .join("\n\n");
 
-  const text = await generateText(
+  const generation = await generateTextWithUsage(
     FAST_PATH_MODEL,
     [
       {
@@ -233,8 +234,15 @@ async function generateInitialThinkingText(args: {
     THINKING_MAX_TOKENS,
     { reasoning: { effort: "low" } },
   );
+  if (generation === null) {
+    return null;
+  }
+  args.record({
+    truncated: generation.truncated === true,
+    tokens: openRouterTokenCounts(generation.usage),
+  });
 
-  return sanitizeThinkingText(text);
+  return sanitizeThinkingText(generation.text);
 }
 
 export async function generateAndPersistInitialThinkingMessage(args: {
@@ -265,34 +273,24 @@ export async function generateAndPersistInitialThinkingMessage(args: {
   ) {
     return false;
   }
-  const thinking = await tapError(
-    generateInitialThinkingText({
-      currentPrompt: args.currentPrompt,
-      history,
-    }),
-    (err) => {
-      // Opening copy is optional, is never retried, and its omission changes no
-      // run outcome, so a provider limit, timeout or upstream gateway failure is
-      // an expected outcome here rather than a defect. Those classes produced
-      // nearly every warning this call site emitted and nothing acted on them.
-      // Narrow suppression only: a rejected request, broken credentials, output
-      // this service cannot interpret and unclassified errors stay visible,
-      // because an unsupported-parameter defect is exactly what this warning
-      // surfaced last.
-      if (isTransientProviderFailure(openRouterFailureReason(err))) {
-        return;
-      }
-      log.warn("Initial thinking generation failed", {
-        threadId: args.threadId,
-        runId: args.runId,
-        err,
+  // Progress copy is the most disposable of the auxiliary generations: the run
+  // still answers without it. Share the boundary so an exhausted provider
+  // window is counted as expected degradation instead of warned about here.
+  const thinking = await generateAuxiliary({
+    feature: "chat_initial_thinking",
+    generate: (record) => {
+      return generateInitialThinkingText({
+        currentPrompt: args.currentPrompt,
+        history,
+        record,
       });
     },
-  );
-  if (thinking === undefined) {
-    return false;
-  }
-  if (thinking === null) {
+    usable: (value) => {
+      return value !== null;
+    },
+    diagnosticContext: { runId: args.runId, threadId: args.threadId },
+  });
+  if (thinking === undefined || thinking === null) {
     return false;
   }
   if (!(await runCanReceiveThinkingMessage(args))) {


### PR DESCRIPTION
Closes #32117.

Supersedes #33143, which GitHub cannot reopen after the workspace-wide CI pause (`viewerCanReopen=false`). This is the same scoped implementation, rebased onto current `main`; it preserves #33115 transient classification, the approved `output_truncated` degraded outcome, `run_id` and `retry_after_ms` telemetry, and the retired Goal deletion. No retry, backoff, cooldown, token-budget, production, or unrelated behavior is added.