### PR TITLE
fix(platform): reset workspace deletion confirmation between attempts

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/settings-dialog.ts
@@ -18,6 +18,7 @@ import {
   clearPendingLogo$,
   initProfileName$,
   requestBuyCreditsScroll$,
+  resetDeleteConfirm$,
   setBillingPlansStandalone$,
   setBillingSubPage$,
 } from "./workspace-settings-state.ts";
@@ -188,6 +189,7 @@ const releaseSettingsDialogSession$ = command(({ set }) => {
   set(internalSettingsDialogSignal$, null);
   set(internalSettingsDialogSessionActive$, false);
   set(clearPendingLogo$);
+  set(resetDeleteConfirm$);
   set(resetUsagePackPricing$);
   // The billing sub-page belongs to the session, not to the tab: a closed
   // dialog must not reopen on the plans page the next time it is opened.

--- a/turbo/apps/platform/src/signals/okou-page/settings/workspace-settings-state.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/workspace-settings-state.ts
@@ -175,6 +175,10 @@ export const setDeleteConfirm$ = command(({ set }, value: string) => {
   set(internalDeleteConfirm$, value);
 });
 
+export const resetDeleteConfirm$ = command(({ set }) => {
+  set(internalDeleteConfirm$, "");
+});
+
 // ---------------------------------------------------------------------------
 // Billing sub-page
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-general-tab.test.tsx
@@ -14,6 +14,7 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
 
 const context = testContext();
 
@@ -393,6 +394,45 @@ test("Require fresh workspace confirmation after closing Settings or navigating 
   expect(buttonWithText(afterNavigation, "Delete workspace")).toBeDisabled();
 });
 
+test("Require fresh confirmation after workspace details finish saving", async () => {
+  const saveReady = createDeferredPromise<void>(context.signal);
+  const refreshReady = createDeferredPromise<void>(context.signal);
+  let workspace = { id: "org_1", name: "Old Name", role: "admin" as const };
+  context.mocks.api(orgContract.get, async ({ respond }) => {
+    if (workspace.name === "New Name") {
+      await refreshReady.promise;
+    }
+    return respond(200, workspace);
+  });
+  context.mocks.api(orgContract.update, async ({ respond }) => {
+    await saveReady.promise;
+    workspace = { ...workspace, name: "New Name" };
+    return respond(200, workspace);
+  });
+  await openGeneralTab();
+
+  await fill(screen.getByDisplayValue("Old Name"), "New Name");
+  click(screen.getByText("Save changes"));
+  await screen.findByText("Saving...");
+  const dialog = await openDeleteDialog();
+  await fill(within(dialog).getByPlaceholderText("confirm"), "confirm");
+  expect(buttonWithText(dialog, "Delete workspace")).toBeEnabled();
+
+  saveReady.resolve();
+  await screen.findByText("Workspace updated");
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("dialog", { name: "Delete workspace?" }),
+    ).not.toBeInTheDocument();
+  });
+  refreshReady.resolve();
+  await screen.findByDisplayValue("New Name");
+
+  const reopened = await openDeleteDialog();
+  expect(within(reopened).getByPlaceholderText("confirm")).toHaveValue("");
+  expect(buttonWithText(reopened, "Delete workspace")).toBeDisabled();
+});
+
 test("Navigate to a fresh page when the workspace changes after cancelling deletion", async () => {
   let workspace = { id: "org_a", name: "Workspace A", role: "admin" as const };
   context.mocks.api(orgContract.get, ({ respond }) => {
@@ -432,6 +472,34 @@ test("Navigate to a fresh page when the workspace changes after cancelling delet
     expect(window.location.pathname).toBe("/");
     expect(window.location.search).toBe("");
   });
+});
+
+test("Keep a pending workspace deletion running when its dialog closes", async () => {
+  const deletionReady = createDeferredPromise<void>(context.signal);
+  context.mocks.data.org({ id: "org_1", name: "Acme", role: "admin" });
+  context.mocks.api(orgDeleteContract.delete, async ({ respond }) => {
+    await deletionReady.promise;
+    return respond(200, { message: "Workspace deleted" });
+  });
+  await openGeneralTab();
+
+  const dialog = await openDeleteDialog();
+  await fill(within(dialog).getByPlaceholderText("confirm"), "confirm");
+  click(buttonWithText(dialog, "Delete workspace"));
+  await within(dialog).findByText("Deleting...");
+  click(buttonWithText(dialog, "Cancel"));
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("dialog", { name: "Delete workspace?" }),
+    ).not.toBeInTheDocument();
+  });
+
+  const reopened = await openDeleteDialog();
+  expect(within(reopened).getByPlaceholderText("confirm")).toHaveValue("");
+  expect(buttonWithText(reopened, "Deleting...")).toBeDisabled();
+  deletionReady.resolve();
+  await screen.findByText("Workspace deleted");
+  expect(window.location.pathname).toBe("/sign-in/tasks/choose-organization");
 });
 
 test("Enable workspace deletion only for the exact confirmation and keep the success flow", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-general-tab.test.tsx
@@ -1,5 +1,8 @@
-import { orgContract } from "@okouai/api-contracts/contracts/org-routes";
-import { screen, waitFor } from "@testing-library/react";
+import {
+  orgContract,
+  orgDeleteContract,
+} from "@okouai/api-contracts/contracts/org-routes";
+import { act, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, test } from "vitest";
 
@@ -12,6 +15,32 @@ import {
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
+
+function buttonWithText(container: HTMLElement, text: string): HTMLElement {
+  const button = queryAllByRoleFast("button", container).find((candidate) => {
+    return candidate.textContent?.trim() === text;
+  });
+  if (!button) {
+    throw new Error(`Button not found: ${text}`);
+  }
+  return button;
+}
+
+async function openDeleteDialog(): Promise<HTMLElement> {
+  const settings = screen.getByRole("dialog", { name: "Settings" });
+  click(buttonWithText(settings, "Delete"));
+  return await screen.findByRole("dialog", { name: "Delete workspace?" });
+}
+
+async function reopenSettings(): Promise<void> {
+  const rail = await screen.findByTestId("labeled-nav-rail");
+  click(within(rail).getByLabelText("Test User"));
+  const menu = await screen.findByRole("menu");
+  click(within(menu).getByText("Settings"));
+  const settings = await screen.findByRole("dialog", { name: "Settings" });
+  click(buttonWithText(settings, "General"));
+  await within(settings).findByRole("heading", { name: "General" });
+}
 
 async function openGeneralTab(): Promise<void> {
   await setupPage({ context, path: "/?settings=general" });
@@ -284,4 +313,127 @@ test("Explain the billing effects before deleting a workspace", async () => {
   expect(
     screen.getByRole("heading", { name: "Delete workspace?" }),
   ).toBeInTheDocument();
+});
+
+test.each(["Cancel", "Close", "Escape", "backdrop"] as const)(
+  "Require fresh workspace confirmation after dismissing with %s",
+  async (dismissal) => {
+    const user = userEvent.setup({ delay: null });
+    context.mocks.data.org({ id: "org_1", name: "Acme", role: "admin" });
+    await openGeneralTab();
+
+    const dialog = await openDeleteDialog();
+    await fill(within(dialog).getByPlaceholderText("confirm"), "confirm");
+    expect(buttonWithText(dialog, "Delete workspace")).toBeEnabled();
+
+    if (dismissal === "Cancel") {
+      click(buttonWithText(dialog, "Cancel"));
+    } else if (dismissal === "Close") {
+      click(within(dialog).getByLabelText("Close"));
+    } else if (dismissal === "Escape") {
+      await user.keyboard("{Escape}");
+    } else {
+      const viewport = dialog.closest('[data-slot="dialog-viewport"]');
+      if (!(viewport instanceof HTMLElement)) {
+        throw new Error("Delete dialog viewport not found");
+      }
+      await user.click(viewport);
+    }
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Delete workspace?" }),
+      ).not.toBeInTheDocument();
+    });
+
+    const reopened = await openDeleteDialog();
+    expect(within(reopened).getByPlaceholderText("confirm")).toHaveValue("");
+    expect(buttonWithText(reopened, "Delete workspace")).toBeDisabled();
+  },
+);
+
+test("Require fresh workspace confirmation after closing Settings", async () => {
+  context.mocks.data.org({ id: "org_1", name: "Acme", role: "admin" });
+  await openGeneralTab();
+
+  const dialog = await openDeleteDialog();
+  await fill(within(dialog).getByPlaceholderText("confirm"), "confirm");
+  expect(buttonWithText(dialog, "Delete workspace")).toBeEnabled();
+  click(buttonWithText(dialog, "Cancel"));
+  const settings = await screen.findByRole("dialog", { name: "Settings" });
+  click(within(settings).getByLabelText("Close"));
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  await reopenSettings();
+  const reopened = await openDeleteDialog();
+  expect(within(reopened).getByPlaceholderText("confirm")).toHaveValue("");
+  expect(buttonWithText(reopened, "Delete workspace")).toBeDisabled();
+});
+
+test("Navigate to a fresh page when the workspace changes after cancelling deletion", async () => {
+  let workspace = { id: "org_a", name: "Workspace A", role: "admin" as const };
+  context.mocks.api(orgContract.get, ({ respond }) => {
+    return respond(200, workspace);
+  });
+  const memberships = [
+    { id: "membership_a", organization: { id: "org_a", name: "Workspace A" } },
+    { id: "membership_b", organization: { id: "org_b", name: "Workspace B" } },
+  ];
+  await setupPage({
+    context,
+    path: "/agents?settings=general",
+    auth: {
+      user: { id: "test-user-123", fullName: "Test User" },
+      organization: { activeOrg: workspace, memberships },
+    },
+  });
+  await screen.findByDisplayValue("Workspace A");
+
+  const dialog = await openDeleteDialog();
+  await fill(within(dialog).getByPlaceholderText("confirm"), "confirm");
+  expect(buttonWithText(dialog, "Delete workspace")).toBeEnabled();
+  click(buttonWithText(dialog, "Cancel"));
+  const settings = await screen.findByRole("dialog", { name: "Settings" });
+  click(within(settings).getByLabelText("Close"));
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  const clerk = context.mocks.clerk();
+  workspace = { id: "org_b", name: "Workspace B", role: "admin" };
+  act(() => {
+    clerk.organization({ activeOrg: workspace, memberships });
+    clerk.stateChanged();
+  });
+  await waitFor(() => {
+    expect(window.location.pathname).toBe("/");
+    expect(window.location.search).toBe("");
+  });
+});
+
+test("Enable workspace deletion only for the exact confirmation and keep the success flow", async () => {
+  context.mocks.data.org({ id: "org_1", name: "Acme", role: "admin" });
+  context.mocks.api(orgDeleteContract.delete, ({ respond }) => {
+    return respond(200, { message: "Workspace deleted" });
+  });
+  await openGeneralTab();
+
+  const dialog = await openDeleteDialog();
+  const input = within(dialog).getByPlaceholderText("confirm");
+  const deleteButton = buttonWithText(dialog, "Delete workspace");
+  expect(input).toHaveValue("");
+  expect(deleteButton).toBeDisabled();
+  await fill(input, "confirm");
+  expect(deleteButton).toBeEnabled();
+  await fill(input, "Confirm");
+  expect(deleteButton).toBeDisabled();
+  await fill(input, "confirm ");
+  expect(deleteButton).toBeDisabled();
+  await fill(input, "confirm");
+  expect(deleteButton).toBeEnabled();
+
+  click(deleteButton);
+  await screen.findByText("Workspace deleted");
+  expect(window.location.pathname).toBe("/sign-in/tasks/choose-organization");
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-general-tab.test.tsx
@@ -10,6 +10,7 @@ import {
   click,
   setupPage,
   fill,
+  holdElementAnimations,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -325,6 +326,7 @@ test.each(["Cancel", "Close", "Escape", "backdrop"] as const)(
     const dialog = await openDeleteDialog();
     await fill(within(dialog).getByPlaceholderText("confirm"), "confirm");
     expect(buttonWithText(dialog, "Delete workspace")).toBeEnabled();
+    const finishCloseTransition = holdElementAnimations(dialog);
 
     if (dismissal === "Cancel") {
       click(buttonWithText(dialog, "Cancel"));
@@ -339,6 +341,10 @@ test.each(["Cancel", "Close", "Escape", "backdrop"] as const)(
       }
       await user.click(viewport);
     }
+    expect(dialog).toBeVisible();
+    expect(within(dialog).getByPlaceholderText("confirm")).toHaveValue("");
+    expect(buttonWithText(dialog, "Delete workspace")).toBeDisabled();
+    finishCloseTransition();
     await waitFor(() => {
       expect(
         screen.queryByRole("dialog", { name: "Delete workspace?" }),
@@ -351,7 +357,7 @@ test.each(["Cancel", "Close", "Escape", "backdrop"] as const)(
   },
 );
 
-test("Require fresh workspace confirmation after closing Settings", async () => {
+test("Require fresh workspace confirmation after closing Settings or navigating back", async () => {
   context.mocks.data.org({ id: "org_1", name: "Acme", role: "admin" });
   await openGeneralTab();
 
@@ -369,6 +375,22 @@ test("Require fresh workspace confirmation after closing Settings", async () => 
   const reopened = await openDeleteDialog();
   expect(within(reopened).getByPlaceholderText("confirm")).toHaveValue("");
   expect(buttonWithText(reopened, "Delete workspace")).toBeDisabled();
+
+  await fill(within(reopened).getByPlaceholderText("confirm"), "confirm");
+  expect(buttonWithText(reopened, "Delete workspace")).toBeEnabled();
+  act(() => {
+    window.history.back();
+  });
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  await reopenSettings();
+  const afterNavigation = await openDeleteDialog();
+  expect(within(afterNavigation).getByPlaceholderText("confirm")).toHaveValue(
+    "",
+  );
+  expect(buttonWithText(afterNavigation, "Delete workspace")).toBeDisabled();
 });
 
 test("Navigate to a fresh page when the workspace changes after cancelling deletion", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-general-tab.test.tsx
@@ -382,7 +382,14 @@ test("Require fresh workspace confirmation after closing Settings or navigating 
   act(() => {
     window.history.back();
   });
+  await screen.findByRole("heading", { name: "Preference" });
+  act(() => {
+    window.history.back();
+  });
   await waitFor(() => {
+    expect(
+      new URLSearchParams(window.location.search).has("settings"),
+    ).toBeFalsy();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-general-tab.tsx
@@ -442,10 +442,9 @@ function DangerZoneSection({ isAdmin }: { isAdmin: boolean }) {
                 </p>
               </div>
               <Dialog
-                onOpenChange={(open) => {
-                  if (!open) {
-                    resetDeleteConfirm();
-                  }
+                onOpenChange={() => {
+                  // Opening also resets after an org refresh unmounts the dialog.
+                  resetDeleteConfirm();
                 }}
               >
                 <DialogTrigger asChild>

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-general-tab.tsx
@@ -443,7 +443,7 @@ function DangerZoneSection({ isAdmin }: { isAdmin: boolean }) {
               </div>
               <Dialog
                 onOpenChange={(open) => {
-                  if (open) {
+                  if (!open) {
                     resetDeleteConfirm();
                   }
                 }}

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-general-tab.tsx
@@ -35,6 +35,7 @@ import {
   setLogoLoaded$,
   deleteConfirm$,
   setDeleteConfirm$,
+  resetDeleteConfirm$,
   loadOrgLogo$,
   saveOrgProfile$,
   leaveOrg$,
@@ -318,6 +319,7 @@ function DangerZoneSection({ isAdmin }: { isAdmin: boolean }) {
 
   const deleteConfirm = useGet(deleteConfirm$);
   const setDeleteConfirm = useSet(setDeleteConfirm$);
+  const resetDeleteConfirm = useSet(resetDeleteConfirm$);
 
   const handleLeave = async () => {
     if (leaving || !modalSignal) {
@@ -439,7 +441,13 @@ function DangerZoneSection({ isAdmin }: { isAdmin: boolean }) {
                   })}
                 </p>
               </div>
-              <Dialog>
+              <Dialog
+                onOpenChange={(open) => {
+                  if (open) {
+                    resetDeleteConfirm();
+                  }
+                }}
+              >
                 <DialogTrigger asChild>
                   <Button
                     variant="destructive"


### PR DESCRIPTION
Entering `confirm` and dismissing Delete workspace previously left the confirmation filled on the next opening. Clear this temporary input when the deletion dialog closes and when its Settings session ends, so a later attempt requires fresh confirmation.

Initialize the input on opening as well: a pending workspace profile save can refresh the organization and unmount the deletion dialog without firing its close callback. This initialization covers that path without interrupting the save. Confirmation cleanup preserves saved workspace data and the existing deletion request lifecycle.

Refs #33212 (F2 only).

## Regression coverage

- Cancel, close button, Escape, and backdrop dismissal clear the input and disable Delete workspace during the closing transition; reopening requires fresh confirmation.
- Completed Settings close/reopen and browser Back while the deletion dialog is open both discard the confirmation.
- A pending workspace profile save completes, refreshes General, and removes the deletion dialog; reopening starts empty while the saved workspace name is preserved.
- A pending mocked deletion continues through dialog close/reopen, remains disabled while loading, and completes through the existing success flow.
- Exact confirmation matching, including case and trailing-space rejection, and workspace identity changes navigating to a fresh document.

## Verification

- Focused Platform page tests: `org-general-tab.test.tsx` — 15 passed. After tightening the browser-history synchronization, the affected navigation case passed again (1 passed, 14 skipped).
- Changed-file formatting, ESLint, Oxlint, and type-aware Oxlint passed.
- Platform production/test/build-config type checks, Platform-scoped Knip, style policy, file-size checks, and commitlint passed.
- No full local Vitest run or local development server. All deletion requests in tests are intercepted by MSW; browser acceptance does not submit deletion.

## Acceptance

Use a preview test account with workspace admin access.

1. Open Settings → General → Delete. Expect an empty confirmation and disabled Delete workspace button; only exact `confirm` enables it.
2. Enter `confirm`, then dismiss with Cancel, X, Escape, or a background click. Reopen after each path and expect an empty input and disabled button.
3. Close Settings completely and reopen it. When Settings was opened through the account menu, use browser Back with the deletion dialog open to return to Preference, then Back again to exit Settings, and reopen it. Each new deletion attempt must require fresh confirmation.
4. Switch from test workspace A to B and reopen Settings → General → Delete. Expect an empty input and disabled button. Cancel without deleting either workspace.

## Remote verification

- PASS: App and API deployments belong to head `9cbcca85faa3711c2911e3eb3ccff4ebf3518d77`. Both the rendered App commit metadata and `/api/build-info` report CI merge commit `bbd692f5d2f7ef0503d21feb9815a858c052477d`, whose second parent is this head.
- App: https://pr-33242-app-okou-app-preview.vm0.workers.dev/agents?settings=general
- API: https://pr-33242-api.vm6.ai
- PASS: Runtime-local `agent-browser`/Chromium 152 at 1440 × 1000 verified the exact confirmation rule, all four dismissal paths, completed Settings close/reopen, browser Back through Preference and out of Settings, and switching in both directions between two isolated admin workspaces. Each new deletion dialog had an empty input and disabled button. The test workspaces completed onboarding through the preview API; no feature-switch overrides were required.
- Browser acceptance did not submit deletion or make purchases. Profile-refresh and pending-deletion cases were verified through controlled MSW page tests.
- CI: 80 checks passed and 22 were conditionally skipped, with no failed or active checks. All eight App test shards, both deployments, and [ci-gate-turbo](https://github.com/vm0-ai/vm0/actions/runs/34465222914/job/102833998003) passed on this head.
