### PR TITLE
fix(pi): surface api first-turn recovery outcomes in production

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -341,6 +341,20 @@ export default [
     },
   },
   {
+    files: ["src/signals/services/pi-api-first-turn.service.ts"],
+    rules: {
+      // Recovery, discarded late results and attempt timeouts are the only
+      // evidence that an API-owned first turn kept single execution and
+      // truthful usage after handing off, and they must survive Axiom's info
+      // default. They stay non-error because a successful recovery is not a
+      // failure; ordinary API completion keeps using debug.
+      "api/no-logger-info": [
+        "error",
+        { allowedMessages: ["Pi API first-turn outcome"] },
+      ],
+    },
+  },
+  {
     files: ["src/signals/services/cron-snapshot-chat-events.service.ts"],
     rules: {
       // An expected per-head deadline is bounded backpressure, not a warning,

--- a/turbo/apps/api/src/lib/log.ts
+++ b/turbo/apps/api/src/lib/log.ts
@@ -154,7 +154,12 @@ const getAxiomLogger = singleton((): AxiomLogger | null => {
       reportAxiomLogDeliveryError(dataset, error);
     },
   });
+  // State the threshold the SDK would otherwise apply implicitly: `L.debug`
+  // records are dropped here and never reach the dataset, whatever `OKOU_DEBUG`
+  // selects for console output. A signal that must be observable in production
+  // has to be emitted at info or above.
   return new AxiomLogger({
+    logLevel: "info",
     transports: [
       new AxiomJSTransport({
         axiom,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -9850,6 +9850,7 @@ describe("CHAT-02: model-first provider policies", () => {
           events: (await chat.listThreadEvents(actor, run.threadId)).events,
           telemetry: [
             ...context.mocks.axiomLogging.debug.mock.calls,
+            ...context.mocks.axiomLogging.info.mock.calls,
             ...context.mocks.axiomLogging.warn.mock.calls,
           ],
         }),
@@ -9974,6 +9975,7 @@ describe("CHAT-02: model-first provider policies", () => {
           events: (await chat.listThreadEvents(actor, run.threadId)).events,
           logs: [
             ...context.mocks.axiomLogging.debug.mock.calls,
+            ...context.mocks.axiomLogging.info.mock.calls,
             ...context.mocks.axiomLogging.warn.mock.calls,
           ],
         }),
@@ -12770,7 +12772,7 @@ describe("CHAT-02: model-first provider policies", () => {
     await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
       status: "completed",
     });
-    expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+    expect(context.mocks.axiomLogging.info).toHaveBeenCalledWith(
       "Pi API first-turn outcome",
       expect.objectContaining({
         runId: run.runId,
@@ -12778,7 +12780,7 @@ describe("CHAT-02: model-first provider policies", () => {
         reason: "api_attempt_timed_out",
       }),
     );
-    expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+    expect(context.mocks.axiomLogging.info).toHaveBeenCalledWith(
       "Pi API first-turn outcome",
       expect.objectContaining({
         runId: run.runId,
@@ -14038,6 +14040,7 @@ describe("CHAT-02: model-first provider policies", () => {
       ).toStrictEqual([]);
       const telemetry = JSON.stringify([
         ...context.mocks.axiomLogging.debug.mock.calls,
+        ...context.mocks.axiomLogging.info.mock.calls,
         ...context.mocks.axiomLogging.warn.mock.calls,
       ]);
       expect(telemetry).not.toContain(partialText);
@@ -14563,7 +14566,9 @@ describe("CHAT-02: model-first provider policies", () => {
       );
       expect(warningCallsForRun(run.runId)).toStrictEqual([]);
       expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
-      expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+      // Info is the lowest level the Axiom transport ingests, so this is the
+      // only production evidence that the run recovered instead of dying.
+      expect(context.mocks.axiomLogging.info).toHaveBeenCalledWith(
         "Pi API first-turn outcome",
         expect.objectContaining({
           runId: run.runId,
@@ -14572,6 +14577,10 @@ describe("CHAT-02: model-first provider policies", () => {
           modelFailureCategory: scenario.category,
           modelFailureHttpStatus: scenario.status,
         }),
+      );
+      expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalledWith(
+        "Pi API first-turn outcome",
+        expect.objectContaining({ outcome: "sandbox_retry_started" }),
       );
       for (const log of Object.values(context.mocks.axiomLogging)) {
         expect(JSON.stringify(log.mock.calls)).not.toContain(privateMarker);
@@ -14730,7 +14739,7 @@ describe("CHAT-02: model-first provider policies", () => {
         );
       }),
     ).toStrictEqual([]);
-    expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+    expect(context.mocks.axiomLogging.info).toHaveBeenCalledWith(
       "Pi API first-turn outcome",
       expect.objectContaining({
         runId: run.runId,
@@ -15374,7 +15383,7 @@ describe("CHAT-02: model-first provider policies", () => {
           prompt: originalPrompt,
           piLaunchConfig: { apiFirstTurn: { sandboxEventSequenceStart: 1 } },
         });
-        const outcomes = context.mocks.axiomLogging.debug.mock.calls.filter(
+        const outcomes = context.mocks.axiomLogging.info.mock.calls.filter(
           (call) => {
             return (
               call[0] === "Pi API first-turn outcome" &&
@@ -16052,7 +16061,7 @@ describe("CHAT-02: model-first provider policies", () => {
       );
     });
     await waitForRunStatus(actor, second.runId, "queued");
-    context.mocks.axiomLogging.debug.mockClear();
+    context.mocks.axiomLogging.info.mockClear();
     await completeChatRunOk(anchor.runId, anchorSandboxHeaders);
 
     const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${second.runId}/manifest.json`;
@@ -16106,7 +16115,7 @@ describe("CHAT-02: model-first provider policies", () => {
       },
     });
     expect(transferredH0).not.toContain("serviceTier");
-    expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+    expect(context.mocks.axiomLogging.info).toHaveBeenCalledWith(
       "Pi API first-turn outcome",
       expect.objectContaining({
         runId: second.runId,
@@ -17871,6 +17880,7 @@ describe("CHAT-02: model-first provider policies", () => {
           h2,
           telemetry: [
             ...context.mocks.axiomLogging.debug.mock.calls,
+            ...context.mocks.axiomLogging.info.mock.calls,
             ...context.mocks.axiomLogging.warn.mock.calls,
           ],
         }),
@@ -17983,6 +17993,7 @@ describe("CHAT-02: model-first provider policies", () => {
       );
       const piLogCalls = JSON.stringify([
         ...context.mocks.axiomLogging.debug.mock.calls,
+        ...context.mocks.axiomLogging.info.mock.calls,
         ...context.mocks.axiomLogging.warn.mock.calls,
       ]);
       expect(piLogCalls).not.toContain(initialSecret);
@@ -18164,6 +18175,7 @@ describe("CHAT-02: model-first provider policies", () => {
       );
       const telemetry = JSON.stringify([
         ...context.mocks.axiomLogging.debug.mock.calls,
+        ...context.mocks.axiomLogging.info.mock.calls,
         ...context.mocks.axiomLogging.warn.mock.calls,
       ]);
       expect(telemetry).not.toContain(secret);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -12788,6 +12788,15 @@ describe("CHAT-02: model-first provider policies", () => {
         outcome: "sandbox_retry_started",
       }),
     );
+    // Reaching sandbox_retry_started through the deadline path requires the
+    // attempt-timeout record, so pin its level here too.
+    expect(context.mocks.axiomLogging.info).toHaveBeenCalledWith(
+      "Pi API first-turn outcome",
+      expect.objectContaining({
+        runId: run.runId,
+        outcome: "api_attempt_timed_out",
+      }),
+    );
     expect(warningCallsForRun(run.runId)).toStrictEqual([]);
   }, 90_000);
 

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -1258,7 +1258,7 @@ async function observeDiscardedProviderResult(
 ): Promise<void> {
   const late = await settleIncludingAbort(operation);
   if (late.ok) {
-    L.debug("Pi API first-turn outcome", {
+    L.info("Pi API first-turn outcome", {
       runId: args.activation.runId,
       ...piApiFirstTurnOutcomeTelemetry(args.activation.executionContext),
       outcome: "discarded_late_provider_result",
@@ -1274,7 +1274,7 @@ async function discardCompletedProviderResult(
   args: ApiFirstTurnContext,
   ownership: PiApiFirstTurnOwnership,
 ): Promise<void> {
-  L.debug("Pi API first-turn outcome", {
+  L.info("Pi API first-turn outcome", {
     runId: args.activation.runId,
     ...piApiFirstTurnOutcomeTelemetry(args.activation.executionContext),
     outcome: "discarded_late_provider_result",
@@ -2182,7 +2182,7 @@ function logCanonicalApiFirstTurnCancellation(
     failure instanceof PiApiFirstTurnCanonicalCancellationError &&
     ownership.stage === "provider-may-have-started"
   ) {
-    L.debug("Pi API first-turn outcome", {
+    L.info("Pi API first-turn outcome", {
       runId: args.activation.runId,
       ...piApiFirstTurnOutcomeTelemetry(args.activation.executionContext),
       outcome: "discarded_late_provider_result",
@@ -2207,7 +2207,7 @@ function logApiFirstTurnAttemptTimedOut(
   ownership: PiApiFirstTurnOwnership,
   failure: PiApiFirstTurnError,
 ): void {
-  L.debug("Pi API first-turn outcome", {
+  L.info("Pi API first-turn outcome", {
     runId: activation.runId,
     ...piApiFirstTurnOutcomeTelemetry(activation.executionContext),
     outcome: "api_attempt_timed_out",
@@ -2252,13 +2252,20 @@ function sandboxFirstPublicationOutcome(reason: PiSandboxFirstReason): {
   }
 }
 
+/**
+ * Recovery, late-result and attempt-timeout records are the only production
+ * evidence that a run kept single execution and truthful usage after ownership
+ * moved to Sandbox, so they stay at info. `L.debug` never reaches Axiom, and
+ * warn would report a successful recovery as a failure. Ordinary API
+ * completion stays at debug because it happens on every API-owned first turn.
+ */
 function logSandboxFirstPublication(
   activation: PiApiFirstTurnActivation,
   ownership: PiApiFirstTurnOwnership,
   reason: PiSandboxFirstReason,
   modelFailure: PiApiModelFailureDiagnostic | undefined,
 ): void {
-  L.debug("Pi API first-turn outcome", {
+  L.info("Pi API first-turn outcome", {
     runId: activation.runId,
     ...piApiFirstTurnOutcomeTelemetry(activation.executionContext),
     handoffOwner: "sandbox",


### PR DESCRIPTION
## Replacement

This is the sole same-branch replacement for #33137. GitHub rejected reopening that closed PR after its branch was force-pushed or recreated (`422: state cannot be changed`), so the original stays closed. This PR uses the same branch, rebased head, scope, and issue reference; it does not replace any product behavior beyond the original intended observability change.

## Problem

Issue #32751's API-owned first-turn recovery needs a natural production sample of `model failure -> Sandbox -> completion`. The recovery, late-result, and attempt-timeout records were emitted at debug, while the Axiom transport ingests info and above. That made the required recovery evidence unavailable in production.

## Change

Promote only bounded recovery-class `Pi API first-turn outcome` records from `debug` to `info`:

| Record | Purpose |
| --- | --- |
| Sandbox-first publication | Recovery/ownership-transfer evidence |
| Discarded late provider result | Single-execution and truthful-usage evidence |
| API first-turn attempt timeout | Recovery-path evidence |

The PR adds the exact message to the existing file-scoped `api/no-logger-info` allowlist and states the SDK's existing Axiom `info` threshold explicitly in `log.ts`.

## Deliberately unchanged

- Ordinary API completion remains at debug to avoid unbounded ingest.
- Ordinary canonical cancellation remains at debug.
- Terminal failures remain warn/error.
- Ownership, cancellation, usage accounting, persisted data, API contracts, payload shape, and recovery control flow are unchanged.
- The current `main` allowlist for `cron-snapshot-chat-events.service.ts` is retained.

## Verification

- Rebased onto `ba5b6dda95ee8fe65ff3b8f932abad0686fe63b0`.
- Targeted ESLint for the four changed API sources passed with `--max-warnings 0`.
- `git diff --check origin/main...HEAD` passed.
- Required PR CI must run on this replacement PR; no prior PR's checks are used as a gate for this rebased head.

The natural production recovery-sample criterion remains post-merge acceptance work; merge is not production verification.

Refs #32751
