### PR TITLE
fix(nbd-cow): derive buffered bytes from retained blocks

### DIFF
--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -162,8 +162,6 @@ pub struct CowLayer {
     dirty: BitVec,
     /// Pending writes: block index -> block data.
     write_buffer: BTreeMap<u64, Vec<u8>>,
-    /// Current buffer usage in bytes.
-    buffer_bytes: usize,
     /// Report that flushing is needed when buffer usage reaches or exceeds this
     /// threshold.
     flush_threshold: usize,
@@ -273,7 +271,6 @@ impl CowLayer {
             cow_fd,
             dirty,
             write_buffer: BTreeMap::new(),
-            buffer_bytes: 0,
             flush_threshold,
             block_size,
             size,
@@ -355,10 +352,7 @@ impl CowLayer {
             self.write_buffer.insert(span.block_idx, block_data);
         }
 
-        // Recalculate buffer bytes
-        self.buffer_bytes = self.write_buffer.len() * self.block_size;
-
-        Ok(self.buffer_bytes >= self.flush_threshold)
+        Ok(self.buffer_bytes() >= self.flush_threshold)
     }
 
     /// Flush the write buffer to the COW file.
@@ -385,8 +379,8 @@ impl CowLayer {
     /// Drain `write_buffer` through `write_fn` in contiguous batches. The
     /// writer returns the number of bytes accepted from the concatenated
     /// buffers. On failure, restores the first incomplete block and all
-    /// unprocessed blocks to `write_buffer`, recomputes `buffer_bytes`, and
-    /// returns the error. Dirty bits are set only for complete blocks.
+    /// unprocessed blocks to `write_buffer` and returns the error. Dirty bits
+    /// are set only for complete blocks.
     ///
     /// The writer boundary is a closure so tests can cover short writes and
     /// partial-success-then-fail at arbitrary byte offsets, which real-I/O
@@ -447,13 +441,11 @@ impl CowLayer {
                         }
                     }
                     self.write_buffer.extend(blocks);
-                    self.buffer_bytes = self.write_buffer.len() * block_size;
                     return Err(error.into());
                 }
             }
         }
 
-        self.buffer_bytes = 0;
         Ok(())
     }
 
@@ -478,7 +470,7 @@ impl CowLayer {
 
     /// Current write buffer size in bytes.
     pub fn buffer_bytes(&self) -> usize {
-        self.buffer_bytes
+        self.write_buffer.len() * self.block_size
     }
 
     fn check_bounds(&self, offset: u64, length: u64) -> Result<()> {

--- a/crates/nbd-cow/tests/cow_buffer_accounting.rs
+++ b/crates/nbd-cow/tests/cow_buffer_accounting.rs
@@ -1,0 +1,125 @@
+use std::io::ErrorKind;
+
+use nbd_cow::BLOCK_SIZE;
+use nbd_cow::cow::CowLayer;
+use nbd_cow::cow_io::{CowIo, CowIoStatus};
+use nbd_cow::error::NbdCowError;
+use tempfile::NamedTempFile;
+
+type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+fn create_cow() -> TestResult<(NamedTempFile, NamedTempFile, CowLayer)> {
+    let base = NamedTempFile::new()?;
+    let cow_file = NamedTempFile::new()?;
+    let size = (3 * BLOCK_SIZE) as u64;
+    base.as_file().set_len(size)?;
+    let cow = CowLayer::new(
+        base.path(),
+        cow_file.path(),
+        size,
+        BLOCK_SIZE,
+        2 * BLOCK_SIZE,
+    )?;
+    Ok((base, cow_file, cow))
+}
+
+fn expected_data(preexisting_block: bool) -> Vec<u8> {
+    let mut data = vec![if preexisting_block { 0xBB } else { 0 }; BLOCK_SIZE];
+    data.extend_from_slice(&vec![0xAA; BLOCK_SIZE]);
+    data
+}
+
+fn check_sync_write_error_accounting(preexisting_block: bool) -> TestResult<()> {
+    let (base, cow_file, mut cow) = create_cow()?;
+    if preexisting_block {
+        assert!(!cow.write(0, &vec![0xBB; BLOCK_SIZE])?);
+    }
+    // Block 1 can be inserted, but the partial write to block 2 must read past EOF.
+    base.as_file().set_len((2 * BLOCK_SIZE) as u64)?;
+    let result = cow.write(BLOCK_SIZE as u64, &vec![0xAA; BLOCK_SIZE + 1]);
+    assert!(
+        matches!(&result, Err(NbdCowError::Io(error)) if error.kind() == ErrorKind::UnexpectedEof)
+    );
+
+    let retained_blocks = 1 + usize::from(preexisting_block);
+    assert_eq!(cow.buffered_block_count(), retained_blocks);
+    assert_eq!(cow.buffer_bytes(), retained_blocks * BLOCK_SIZE);
+    assert_eq!(cow.dirty_block_count(), 0);
+    let expected = expected_data(preexisting_block);
+    let mut data = vec![0; expected.len()];
+    cow.read(0, &mut data)?;
+    assert_eq!(data, expected);
+
+    // An overwrite adds no block; a successful write still signals at the threshold.
+    assert_eq!(cow.write(BLOCK_SIZE as u64, &[0xAA])?, preexisting_block);
+    assert_eq!(cow.buffer_bytes(), retained_blocks * BLOCK_SIZE);
+    cow.sync()?;
+    assert_eq!(cow.buffered_block_count(), 0);
+    assert_eq!(cow.buffer_bytes(), 0);
+    assert_eq!(cow.dirty_block_count(), retained_blocks);
+    assert_eq!(std::fs::read(cow_file.path())?, expected);
+    cow.read(0, &mut data)?;
+    assert_eq!(data, expected);
+    Ok(())
+}
+
+async fn check_async_write_error_accounting(preexisting_block: bool) -> TestResult<()> {
+    let (base, cow_file, cow) = create_cow()?;
+    let cow = CowIo::new(cow);
+    if preexisting_block {
+        cow.write(0, vec![0xBB; BLOCK_SIZE]).await?;
+    }
+    base.as_file().set_len((2 * BLOCK_SIZE) as u64)?;
+    let result = cow
+        .write(BLOCK_SIZE as u64, vec![0xAA; BLOCK_SIZE + 1])
+        .await;
+    assert!(
+        matches!(&result, Err(NbdCowError::Io(error)) if error.kind() == ErrorKind::UnexpectedEof)
+    );
+
+    // A failed write retains its blocks without triggering a threshold flush.
+    let retained_blocks = 1 + usize::from(preexisting_block);
+    assert_eq!(
+        cow.status().await?,
+        CowIoStatus {
+            dirty_blocks: 0,
+            buffered_blocks: retained_blocks,
+            buffer_bytes: retained_blocks * BLOCK_SIZE,
+        }
+    );
+    let expected = expected_data(preexisting_block);
+    assert_eq!(cow.read(0, vec![0; expected.len()]).await?, expected);
+
+    cow.sync().await?;
+    assert_eq!(
+        cow.status().await?,
+        CowIoStatus {
+            dirty_blocks: retained_blocks,
+            buffered_blocks: 0,
+            buffer_bytes: 0,
+        }
+    );
+    assert_eq!(std::fs::read(cow_file.path())?, expected);
+    assert_eq!(cow.read(0, vec![0; expected.len()]).await?, expected);
+    Ok(())
+}
+
+#[test]
+fn sync_write_error_accounts_for_newly_buffered_block() -> TestResult<()> {
+    check_sync_write_error_accounting(false)
+}
+
+#[test]
+fn sync_write_error_accounts_for_preexisting_and_new_blocks() -> TestResult<()> {
+    check_sync_write_error_accounting(true)
+}
+
+#[tokio::test]
+async fn async_write_error_accounts_for_newly_buffered_block() -> TestResult<()> {
+    check_async_write_error_accounting(false).await
+}
+
+#[tokio::test]
+async fn async_write_error_accounts_for_preexisting_and_new_blocks() -> TestResult<()> {
+    check_async_write_error_accounting(true).await
+}


### PR DESCRIPTION
When a cross-block write fails while reading a later partial block, `CowLayer` and `CowIo::status()` now report the bytes of every retained buffered block. Derive the count from the buffer's length and block size, use it for successful-write threshold signaling, and remove the redundant counter and its write/flush maintenance.

Add four public-API regressions covering synchronous and async failures with and without a preexisting buffered block. They verify retained data, accurate accounting, threshold behavior, and persistence after sync. Partial failed writes, flush recovery, cancellation, public signatures, and on-disk formats retain their existing behavior.

Closes #33206

Validation:

- All four new regressions failed on unchanged production code with the expected `0` vs `4096` and `4096` vs `8192` mismatches, then passed with the fix.
- `cargo test --manifest-path crates/Cargo.toml --profile local --locked -p nbd-cow --all-targets --all-features`: 312 passed; 13 existing root/NBD-device tests ignored.
- `cargo fmt --manifest-path crates/nbd-cow/Cargo.toml -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local --locked -p nbd-cow --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml --profile local --locked -p nbd-cow --all-features --no-deps`
- `git diff --check` and the repository file-size check passed.

CI on `46276b09ff6ecbe882071b67e08feb7dc9c9df90`: native NBD integration passed all 13 tests on both [x86_64](https://github.com/vm0-ai/vm0/actions/runs/34460763393/job/102817947654) and [arm64](https://github.com/vm0-ai/vm0/actions/runs/34460763393/job/102817947778). Other CI jobs are still running.
