### PR TITLE
test(mitm-addon): close http listener on serving-thread startup failure

### DIFF
--- a/crates/runner/mitm-addon/tests/test_http_test_helpers.py
+++ b/crates/runner/mitm-addon/tests/test_http_test_helpers.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import http.client
+import socket
 import threading
 import urllib.parse
 from collections.abc import Mapping
 from dataclasses import dataclass
+from http.server import ThreadingHTTPServer
 from types import TracebackType
 from unittest.mock import patch
+
+import pytest
 
 from tests.auth_endpoint_helpers import FakeAuthEndpoint
 from tests.thread_helpers import ThreadUnderTest, wait_for_event
@@ -156,6 +160,56 @@ def _start_post(
     thread = ThreadUnderTest(target=post, name=f"http-test-helper-{key}")
     thread.start()
     return thread
+
+
+@pytest.mark.parametrize("failure_point", ["__init__", "start"])
+@pytest.mark.parametrize("failure_type", [RuntimeError, OSError])
+def test_threaded_http_server_closes_listener_after_startup_failure(
+    failure_point: str,
+    failure_type: type[Exception],
+) -> None:
+    server = ThreadedHttpTestServer(
+        request_factory=_CapturedRequest,
+        default_status=204,
+        thread_name="startup-failure-http-test-server",
+    )
+    failure = failure_type("injected thread startup failure")
+    listener: socket.socket | None = None
+
+    def fail_startup(*args: object, **kwargs: object) -> None:
+        nonlocal listener
+        assert server._server is not None
+        listener = server._server.socket
+        raise failure
+
+    try:
+        with (
+            patch.object(threading.Thread, failure_point, side_effect=fail_startup),
+            # An incorrect rollback must fail rather than block in shutdown().
+            patch.object(
+                ThreadingHTTPServer,
+                "shutdown",
+                side_effect=AssertionError("cannot shut down an unstarted server"),
+            ),
+            pytest.raises(failure_type, match="injected thread startup failure") as caught,
+            server.run(),
+        ):
+            pytest.fail("failed startup unexpectedly yielded")
+
+        assert caught.value is failure
+        assert listener is not None
+        assert listener.fileno() == -1
+        with pytest.raises(AssertionError):
+            _ = server.api_url
+    finally:
+        if listener is not None:
+            listener.close()
+
+    with server.run():
+        assert _post(f"{server.api_url}/recovered") == (204, b"")
+
+    with pytest.raises(AssertionError):
+        _ = server.api_url
 
 
 def test_threaded_http_server_aligns_responses_with_recorded_order():

--- a/crates/runner/mitm-addon/tests/threaded_http_test_server.py
+++ b/crates/runner/mitm-addon/tests/threaded_http_test_server.py
@@ -95,30 +95,32 @@ class ThreadedHttpTestServer[Request]:
             def log_message(self, message_format: str, *args: object) -> None:
                 return None
 
-        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
-        server = self._server
+        with ThreadingHTTPServer(("127.0.0.1", 0), _Handler) as server:
+            self._server = server
+            try:
 
-        def serve_forever() -> None:
-            server.serve_forever(poll_interval=0.01)
+                def serve_forever() -> None:
+                    server.serve_forever(poll_interval=0.01)
 
-        thread = threading.Thread(
-            target=serve_forever,
-            name=self._thread_name,
-            daemon=True,
-        )
-        thread.start()
-        try:
-            yield
-        finally:
-            with self._condition:
-                release_events = tuple(self._release_events)
-                self._release_events.clear()
-            for release_event in release_events:
-                release_event.set()
-            server.shutdown()
-            thread.join(timeout=2.0)
-            server.server_close()
-            self._server = None
+                thread = threading.Thread(
+                    target=serve_forever,
+                    name=self._thread_name,
+                    daemon=True,
+                )
+                thread.start()
+                # Only a started serving loop can be shut down and joined.
+                try:
+                    yield
+                finally:
+                    with self._condition:
+                        release_events = tuple(self._release_events)
+                        self._release_events.clear()
+                    for release_event in release_events:
+                        release_event.set()
+                    server.shutdown()
+                    thread.join(timeout=2.0)
+            finally:
+                self._server = None
 
     def _record_request_and_reserve_response(self, request: Request) -> _QueuedResponse:
         with self._condition:


### PR DESCRIPTION
When the shared HTTP test server's serving thread cannot be constructed or started, `run()` currently leaves its listener open. Use the HTTP server's context manager to close that socket and always clear the active owner, while keeping shutdown and join after successful startup.

Add four deterministic regressions covering construction/startup failures with `RuntimeError` and `OSError`. They retain the real socket, verify closure and exception identity, and reuse the same helper for a successful HTTP request. The change is limited to test infrastructure; production request handling and response-queue semantics are unchanged.

Closes #33208

## Validation

- The four new cases failed at the open-descriptor assertion before the fix and passed afterward.
- 307 helper, redirect, auth, and usage tests passed with locked Python 3.14.0.
- Addon Ruff formatting, lint, and BasedPyright passed.

Commands run from `crates/runner/mitm-addon` after `uv lock --check` and `uv sync --locked`:

```sh
uv run --no-sync python -m pytest tests/test_http_test_helpers.py -k startup_failure -q
uv run --no-sync python -m pytest tests/test_http_test_helpers.py tests/test_update_x_tlds.py tests/test_firewall_auth_client.py tests/test_auth_cache.py tests/test_firewall_aws_sigv4_auth.py tests/test_webhook_http_delivery.py tests/test_fresh_usage_executor.py tests/test_done_hook.py -q
uv run --no-sync ruff format --check .
uv run --no-sync ruff check .
uv run --no-sync basedpyright -p .
```
