### PR TITLE
refactor(ui): replace the badge, pill, and divider selectors with a shared badge component

### DIFF
--- a/docs/style-migration.md
+++ b/docs/style-migration.md
@@ -364,6 +364,7 @@ passed. Real TEST API selection, removal and persistence across reloads also
 passed with zero chat event rows. The archive retains all prior failed evidence,
 the unchanged harness and per-file SHA256; its anonymous HTTPS download and
 archive hash were verified. The PR remains Draft.
+
 ## Tone preview surfaces
 
 The `tone-preview-surfaces` batch covers the user sample bubble and its enclosing
@@ -548,3 +549,32 @@ The batch remains `implemented`: that source's Security and Crates gates pass,
 but Turbo is blocked by Runner SSH preparation for `dev-12.gcp.vm3.ai`. No
 Runner, workflow or timeout change is part of this migration. Latest-head CI
 and preview identity are recorded in the PR before handoff.
+
+## Deliberate geometry change in the badge batch
+
+The hairline badge batch removes `okou-badge`, `okou-pill`, and `okou-border-r`
+and replaces their 22 consumers with the shared `Badge` component. Unlike the
+earlier batches it is **not** pixel-neutral, so it is recorded as a geometry
+decision rather than an equivalence claim.
+
+The 22 consumers spelled eight class combinations that differed on radius,
+padding, display, gap, line height, typography, and foreground. Two of them were
+the same icon-plus-label badge at two radii and two paddings. Collapsing them to
+one shape required choosing canonical values, which is a visual change and is
+reviewed as one.
+
+Line height belongs to the badge because an arbitrary font-size utility carries
+no paired line height: Tailwind emits `font-size` alone for `text-[11px]`. Ten
+of the 22 badges declared only such a size, so an ancestor's `line-height`
+decided their box. Measured with `getBoundingClientRect` on one badge under four
+ancestors that differ only in `line-height`, the box was 22.00px, 26.00px,
+34.00px, and 22.50px tall before the change and 21.13px in all four after it.
+
+Per-consumer box deltas are recorded on the pull request. `align-middle` is part
+of the shared shape because flex and grid items ignore it, so it costs the
+flex-item consumers nothing while keeping the one genuinely inline badge aligned
+with the text beside it.
+
+A batch that changes geometry on purpose cannot be accepted by an unchanged-code
+replay. It needs the per-page runners, or an explicit reviewed delta list, or
+both.

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -110,8 +110,11 @@ The `okou-card` selector and its consumers have been removed. This equivalent mi
 | Padding     | `px-2 py-0.5`                                      | One inset for every badge                                                                 |
 | Line height | `leading-snug`                                     | 1.375 of the badge's own font size, never an ancestor's                                   |
 | Layout      | `inline-flex items-center gap-1 align-middle`      | Icon and label share one row; `align-middle` applies where the badge is a real inline box |
+| Icon        | `[&>svg]:size-3`                                   | A direct child icon is 12px; call sites pass no size                                      |
 
 The badge owns geometry and nothing else. Typography and foreground stay with the caller, because a badge reads as secondary beside body text in one place and as the value itself in another; pass `text-xs font-medium text-muted-foreground` or let the badge inherit its context. Width constraints and flex behaviour (`max-w-full`, `break-all`, `min-w-0`, `shrink-0`) also stay with the caller.
+
+Tests scope badges through `data-slot="badge"`, which carries no styles. The icon rule and that slot follow shadcn's badge, which this package's components come from; the rest of shadcn's badge does not fit, because it bakes in `text-xs font-medium` that the diagnostic chips inherit from their row instead, and `whitespace-nowrap overflow-hidden` that would stop the long key/value chips from wrapping.
 
 Line height belongs to the badge because a font-size utility with an arbitrary value carries no paired line height. A badge that declared only `text-[11px]` therefore took its box from whatever `line-height` an ancestor happened to set: the same badge measured 22px, 26px, or 34px tall across four ancestors. It reuses the page-surface border tokens rather than declaring badge-specific aliases, so one hairline decision keeps one owner.
 

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -98,6 +98,25 @@ Integration and connector tests scope controls through the documented `data-slot
 
 The `okou-card` selector and its consumers have been removed. This equivalent migration also removes background, border, shadow, and focus-ring overrides that the old unlayered selector had suppressed; activating those overrides would be a separate visual change. Existing `--okou-card-*` variables still consumed by other legacy components remain frozen until those components migrate; they are not a supported API for new surfaces.
 
+### Inline badges
+
+`Badge` from `@okouai/ui` owns the shared inline badge and tag treatment: role labels, status pills, version chips, and diagnostic key/value chips. It renders a `span`; pass `render={<code />}` for another host element. It adds no wrapper and takes no size or tone props.
+
+| Decision    | Shared token / utility                             | Contract                                                                                  |
+| ----------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Fill        | `bg-gray-0`                                        | The neutral base of the gray scale in each theme                                          |
+| Border      | `--color-surface-border`, `--border-width-surface` | Gray 400 at 0.7 CSS pixels; the browser rounds for its device scale                       |
+| Radius      | `rounded-md`                                       | One radius for every badge                                                                |
+| Padding     | `px-2 py-0.5`                                      | One inset for every badge                                                                 |
+| Line height | `leading-snug`                                     | 1.375 of the badge's own font size, never an ancestor's                                   |
+| Layout      | `inline-flex items-center gap-1 align-middle`      | Icon and label share one row; `align-middle` applies where the badge is a real inline box |
+
+The badge owns geometry and nothing else. Typography and foreground stay with the caller, because a badge reads as secondary beside body text in one place and as the value itself in another; pass `text-xs font-medium text-muted-foreground` or let the badge inherit its context. Width constraints and flex behaviour (`max-w-full`, `break-all`, `min-w-0`, `shrink-0`) also stay with the caller.
+
+Line height belongs to the badge because a font-size utility with an arbitrary value carries no paired line height. A badge that declared only `text-[11px]` therefore took its box from whatever `line-height` an ancestor happened to set: the same badge measured 22px, 26px, or 34px tall across four ancestors. It reuses the page-surface border tokens rather than declaring badge-specific aliases, so one hairline decision keeps one owner.
+
+The `okou-badge`, `okou-pill`, and `okou-border-r` selectors and their consumers have been removed. `okou-pill` was scoped to `.okou-app` and set the muted foreground; its only consumer now spells that foreground itself. `okou-border-r` was a single settings-dialog divider and became `border-r-(length:--border-width-surface) border-r-gray-300` on that nav, keeping its lighter Gray 300 stroke.
+
 ## Exception boundary
 
 Only two exception kinds exist:

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -102,15 +102,15 @@ The `okou-card` selector and its consumers have been removed. This equivalent mi
 
 `Badge` from `@okouai/ui` owns the shared inline badge and tag treatment: role labels, status pills, version chips, and diagnostic key/value chips. It renders a `span`; pass `render={<code />}` for another host element. It adds no wrapper and takes no size or tone props.
 
-| Decision    | Shared token / utility                             | Contract                                                                                  |
-| ----------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| Fill        | `bg-gray-0`                                        | The neutral base of the gray scale in each theme                                          |
-| Border      | `--color-surface-border`, `--border-width-surface` | Gray 400 at 0.7 CSS pixels; the browser rounds for its device scale                       |
-| Radius      | `rounded-md`                                       | One radius for every badge                                                                |
-| Padding     | `px-2 py-0.5`                                      | One inset for every badge                                                                 |
-| Line height | `leading-snug`                                     | 1.375 of the badge's own font size, never an ancestor's                                   |
-| Layout      | `inline-flex items-center gap-1 align-middle`      | Icon and label share one row; `align-middle` applies where the badge is a real inline box |
-| Icon        | `[&>svg]:size-3`                                   | A direct child icon is 12px; call sites pass no size                                      |
+| Decision    | Shared token / utility                        | Contract                                                                                  |
+| ----------- | --------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Fill        | `bg-gray-0`                                   | The neutral base of the gray scale in each theme                                          |
+| Border      | `border`, `--color-surface-border`            | Gray 400 at the shared `--default-border-width` hairline                                  |
+| Radius      | `rounded-md`                                  | One radius for every badge                                                                |
+| Padding     | `px-2 py-0.5`                                 | One inset for every badge                                                                 |
+| Line height | `leading-snug`                                | 1.375 of the badge's own font size, never an ancestor's                                   |
+| Layout      | `inline-flex items-center gap-1 align-middle` | Icon and label share one row; `align-middle` applies where the badge is a real inline box |
+| Icon        | `[&>svg]:size-3`                              | A direct child icon is 12px; call sites pass no size                                      |
 
 The badge owns geometry and nothing else. Typography and foreground stay with the caller, because a badge reads as secondary beside body text in one place and as the value itself in another; pass `text-xs font-medium text-muted-foreground` or let the badge inherit its context. Width constraints and flex behaviour (`max-w-full`, `break-all`, `min-w-0`, `shrink-0`) also stay with the caller.
 
@@ -118,7 +118,7 @@ Tests scope badges through `data-slot="badge"`, which carries no styles. The ico
 
 Line height belongs to the badge because a font-size utility with an arbitrary value carries no paired line height. A badge that declared only `text-[11px]` therefore took its box from whatever `line-height` an ancestor happened to set: the same badge measured 22px, 26px, or 34px tall across four ancestors. It reuses the page-surface border tokens rather than declaring badge-specific aliases, so one hairline decision keeps one owner.
 
-The `okou-badge`, `okou-pill`, and `okou-border-r` selectors and their consumers have been removed. `okou-pill` was scoped to `.okou-app` and set the muted foreground; its only consumer now spells that foreground itself. `okou-border-r` was a single settings-dialog divider and became `border-r-(length:--border-width-surface) border-r-gray-300` on that nav, keeping its lighter Gray 300 stroke.
+The `okou-badge`, `okou-pill`, and `okou-border-r` selectors and their consumers have been removed. `okou-pill` was scoped to `.okou-app` and set the muted foreground; its only consumer now spells that foreground itself. `okou-border-r` was a single settings-dialog divider and became `border-r border-r-gray-300` on that nav, keeping its lighter Gray 300 stroke while its width joins the shared hairline token.
 
 ## Exception boundary
 

--- a/e2e/playwright/style-migration/badge-cases.json
+++ b/e2e/playwright/style-migration/badge-cases.json
@@ -1,0 +1,90 @@
+{
+  "version": 1,
+  "batch": "hairline-badge-surfaces",
+  "cases": [
+    {
+      "id": "badge-debug-light",
+      "path": "/agents?settings=debug",
+      "theme": "light",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "badge-debug-dark",
+      "path": "/agents?settings=debug",
+      "theme": "dark",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "badge-debug-narrow",
+      "path": "/agents?settings=debug",
+      "theme": "light",
+      "viewport": {
+        "width": 390,
+        "height": 844
+      },
+      "deviceScaleFactor": 2,
+      "hasTouch": true,
+      "isMobile": true
+    },
+    {
+      "id": "badge-debug-narrow-dark",
+      "path": "/agents?settings=debug",
+      "theme": "dark",
+      "viewport": {
+        "width": 390,
+        "height": 844
+      },
+      "deviceScaleFactor": 2,
+      "hasTouch": true,
+      "isMobile": true
+    },
+    {
+      "id": "badge-people-light",
+      "path": "/agents?settings=people",
+      "theme": "light",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "badge-people-dark",
+      "path": "/agents?settings=people",
+      "theme": "dark",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "badge-billing-light",
+      "path": "/agents?settings=billing",
+      "theme": "light",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "badge-billing-dark",
+      "path": "/agents?settings=billing",
+      "theme": "dark",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    }
+  ]
+}

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -501,22 +501,12 @@ body {
   user-select: text;
 }
 
-/* Pill/tag (e.g. status badge, "Super agent") */
-.okou-app .okou-pill {
-  background-color: hsl(var(--gray-0));
-  border: 0.7px solid hsl(var(--gray-400));
-  color: hsl(var(--muted-foreground));
-}
-
 /* Reusable 0.7px border utilities — replaces inline style={{ border: "0.7px solid ..." }} */
 .okou-border {
   border: 0.7px solid hsl(var(--gray-400));
 }
 .okou-border-t {
   border-top: 0.7px solid hsl(var(--gray-400));
-}
-.okou-border-r {
-  border-right: 0.7px solid hsl(var(--gray-300));
 }
 
 /* Avatar / logo thumbnails: a hairline lighter than okou-border, so the edge of
@@ -558,12 +548,6 @@ body {
     stroke-dasharray: none;
     animation: none;
   }
-}
-
-/* Role / status badge: pill with 0.7px border on neutral background */
-.okou-badge {
-  border: 0.7px solid hsl(var(--gray-400));
-  background-color: hsl(var(--gray-0));
 }
 
 /* Left nav */

--- a/turbo/apps/platform/src/views/okou-page/components/log-views/status-badge.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/log-views/status-badge.tsx
@@ -6,6 +6,7 @@ import {
   ClockAlert,
   Ban,
 } from "lucide-react";
+import { Badge } from "@okouai/ui";
 import type { LogStatus } from "../../../../signals/okou-page/log-types.ts";
 import { i18n } from "../../../../i18n/index.ts";
 
@@ -106,18 +107,30 @@ export function StatusBadge({ status, shellStyle }: StatusBadgeProps) {
   const config = statusConfig[status];
   const Icon = config.icon;
 
-  return (
+  const content = (
+    <>
+      <Icon className={`h-3 w-3 ${config.iconClassName}`} />
+      {config.label}
+    </>
+  );
+
+  // The shell treatment is the shared badge; the standalone one is its own
+  // surface on the page background and is not a badge.
+  return shellStyle ? (
+    <Badge
+      data-testid="status-badge"
+      data-status={status}
+      className="text-xs font-medium text-muted-foreground"
+    >
+      {content}
+    </Badge>
+  ) : (
     <span
       data-testid="status-badge"
       data-status={status}
-      className={
-        shellStyle
-          ? "okou-pill inline-flex items-center gap-1.5 rounded-lg border px-1.5 py-1 text-xs font-medium"
-          : "inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground"
-      }
+      className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground"
     >
-      <Icon className={`h-3 w-3 ${config.iconClassName}`} />
-      {config.label}
+      {content}
     </span>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
@@ -54,7 +54,7 @@ import {
   type ConcurrencyChangeMode,
   type ConcurrencyConfirmDialogState,
 } from "../../../../signals/okou-page/billing.ts";
-import { Button, Input } from "@okouai/ui";
+import { Badge, Button, Input } from "@okouai/ui";
 import type {
   BillingStatusResponse,
   ConcurrencySubscriptionChangePreviewResponse,
@@ -2099,11 +2099,11 @@ function CurrentPlanTitle({
     <p className="flex items-center gap-2 text-sm font-medium text-foreground">
       <span>{label}</span>
       {legacy && (
-        <span className="rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground okou-badge">
+        <Badge className="text-[10px] font-medium text-muted-foreground">
           {i18n.t(($) => {
             return $.billing.plans.legacy;
           })}
-        </span>
+        </Badge>
       )}
     </p>
   );

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx
@@ -22,6 +22,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  Badge,
 } from "@okouai/ui";
 import { Skeleton } from "@okouai/ui/components/ui/skeleton";
 import type { FormEvent } from "react";
@@ -369,10 +370,10 @@ export function OrgInvoicesTab() {
                     {inv.number ?? inv.id}
                   </span>
                   {inv.status && (
-                    <span className="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground okou-badge">
+                    <Badge className="text-xs font-medium text-muted-foreground">
                       <CircleCheck size={12} className="text-green-600" />
                       {inv.status.charAt(0).toUpperCase() + inv.status.slice(1)}
-                    </span>
+                    </Badge>
                   )}
                 </div>
                 <div className="text-left text-sm text-muted-foreground tabular-nums">

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx
@@ -371,7 +371,7 @@ export function OrgInvoicesTab() {
                   </span>
                   {inv.status && (
                     <Badge className="text-xs font-medium text-muted-foreground">
-                      <CircleCheck size={12} className="text-green-600" />
+                      <CircleCheck className="text-green-600" />
                       {inv.status.charAt(0).toUpperCase() + inv.status.slice(1)}
                     </Badge>
                   )}

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx
@@ -1114,7 +1114,6 @@ function MemberRow({
       <div>
         <Badge className="text-xs font-medium text-muted-foreground">
           <ShieldCheck
-            size={12}
             className={
               member.role === "admin"
                 ? "text-blue-500"
@@ -1513,7 +1512,7 @@ function PendingInvitationRow({
       )}
       <div>
         <Badge className="text-xs font-medium text-muted-foreground">
-          <Clock size={12} className="text-amber-500" />
+          <Clock className="text-amber-500" />
           {t(($) => {
             return $.settings.workspace.members.pending;
           })}
@@ -1671,7 +1670,7 @@ function MembershipRequestRow({
       )}
       <div>
         <Badge className="text-xs font-medium text-muted-foreground">
-          <UserPlus size={12} className="text-blue-500" />
+          <UserPlus className="text-blue-500" />
           {t(($) => {
             return $.settings.workspace.members.membershipRequest.role;
           })}

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx
@@ -35,6 +35,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Badge,
 } from "@okouai/ui";
 import {
   orgRoleSchema,
@@ -1111,7 +1112,7 @@ function MemberRow({
         />
       )}
       <div>
-        <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground okou-badge">
+        <Badge className="text-xs font-medium text-muted-foreground">
           <ShieldCheck
             size={12}
             className={
@@ -1127,7 +1128,7 @@ function MemberRow({
             : t(($) => {
                 return $.settings.workspace.members.member;
               })}
-        </span>
+        </Badge>
       </div>
       <div className="flex justify-end">
         {canManage && (
@@ -1511,12 +1512,12 @@ function PendingInvitationRow({
         </div>
       )}
       <div>
-        <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground okou-badge">
+        <Badge className="text-xs font-medium text-muted-foreground">
           <Clock size={12} className="text-amber-500" />
           {t(($) => {
             return $.settings.workspace.members.pending;
           })}
-        </span>
+        </Badge>
       </div>
       <div className="flex justify-end">
         {isAdmin && (
@@ -1669,12 +1670,12 @@ function MembershipRequestRow({
         <div className="text-[13px] text-muted-foreground">—</div>
       )}
       <div>
-        <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground okou-badge">
+        <Badge className="text-xs font-medium text-muted-foreground">
           <UserPlus size={12} className="text-blue-500" />
           {t(($) => {
             return $.settings.workspace.members.membershipRequest.role;
           })}
-        </span>
+        </Badge>
       </div>
       <div className="flex justify-end gap-1">
         <button

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -14,6 +14,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  Badge,
 } from "@okouai/ui";
 import type {
   MemberUsagePack,
@@ -429,18 +430,18 @@ function MemberIdentity({ member }: { readonly member: MemberDisplay }) {
             {member.name}
           </span>
           {member.isCurrent && (
-            <span className="shrink-0 rounded px-1.5 py-0.5 text-sm leading-none text-muted-foreground okou-badge">
+            <Badge className="shrink-0 text-sm text-muted-foreground">
               {i18n.t(($) => {
                 return $.settings.workspace.members.you;
               })}
-            </span>
+            </Badge>
           )}
           {member.isPending && (
-            <span className="shrink-0 rounded px-1.5 py-0.5 text-sm leading-none text-muted-foreground okou-badge">
+            <Badge className="shrink-0 text-sm text-muted-foreground">
               {i18n.t(($) => {
                 return $.settings.workspace.members.pending;
               })}
-            </span>
+            </Badge>
           )}
         </span>
         {member.email && member.email !== member.name && (
@@ -2957,11 +2958,11 @@ function migrationPlanComparisonRows({
       current: (
         <span className="inline-flex items-center justify-end gap-1.5">
           <span>{planName(sourceTier)}</span>
-          <span className="rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground okou-badge">
+          <Badge className="text-[10px] font-medium text-muted-foreground">
             {i18n.t(($) => {
               return $.billing.plans.legacy;
             })}
-          </span>
+          </Badge>
         </span>
       ),
       next: planName(targetTier),

--- a/turbo/apps/platform/src/views/okou-page/components/settings/build-info-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/build-info-block.tsx
@@ -1,6 +1,7 @@
 import { useGet, useLoadable } from "ccstate-react";
 import { Monitor, GitCommit, Package } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { Badge } from "@okouai/ui";
 
 import { getBuildCommitSha } from "../../../../lib/build-info.ts";
 import { appVersion$ } from "../../../../signals/app-version.ts";
@@ -37,9 +38,12 @@ function BuildInfoTarget({
             {title}
           </div>
         </div>
-        <code className="okou-badge min-w-0 rounded-md px-2 py-0.5 text-right text-xs font-medium text-foreground break-all">
+        <Badge
+          render={<code />}
+          className="min-w-0 text-right text-xs font-medium text-foreground break-all"
+        >
           {version}
-        </code>
+        </Badge>
       </div>
       <div className="flex min-w-0 flex-col gap-1">
         <div className="text-xs text-muted-foreground">

--- a/turbo/apps/platform/src/views/okou-page/components/settings/built-in-model-cooldown-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/built-in-model-cooldown-diagnostics-block.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
+  Badge,
 } from "@okouai/ui";
 import {
   useGet,
@@ -60,13 +61,13 @@ function CooldownDiagnosticsSummary({
           })}
         </span>
         <span className="flex flex-wrap gap-1.5 font-mono text-[11px] text-foreground">
-          <span className="okou-badge rounded-md px-2 py-0.5">
+          <Badge>
             {t(($) => {
               return $.settings.preferences.debug.builtInModelCooldown
                 .globalActive;
             })}
             : {formatLocalizedNumber(diagnostics.activeCooldowns.length)}
-          </span>
+          </Badge>
         </span>
       </span>
       <ChevronDown className="mt-1 h-4 w-4 shrink-0 text-muted-foreground group-open:hidden" />

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connection-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connection-diagnostics-block.tsx
@@ -9,6 +9,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { Button } from "@okouai/ui/components/ui/button";
+import { Badge } from "@okouai/ui";
 
 import { now } from "../../../../lib/time.ts";
 import {
@@ -51,19 +52,19 @@ function ConnectionDiagnosticsSummary({
         <span className="text-sm font-medium text-foreground">{title}</span>
         <span className="text-sm text-muted-foreground">{description}</span>
         <span className="flex flex-wrap gap-1.5 font-mono text-[11px] text-foreground">
-          <span className="okou-badge rounded-md px-2 py-0.5">
+          <Badge>
             {t(($) => {
               return $.settings.preferences.debug.connectionDiagnostics
                 .connection;
             })}
             : {connectionState}
-          </span>
-          <span className="okou-badge rounded-md px-2 py-0.5">
+          </Badge>
+          <Badge>
             {t(($) => {
               return $.settings.preferences.debug.connectionDiagnostics.channel;
             })}
             : {channelState}
-          </span>
+          </Badge>
         </span>
       </span>
       <ChevronDown className="mt-1 h-4 w-4 shrink-0 text-muted-foreground group-open:hidden" />

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-catalog-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-catalog-diagnostics-block.tsx
@@ -7,6 +7,7 @@ import { ChevronDown, ChevronUp, Plug } from "lucide-react";
 import { useLoadable } from "ccstate-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { Badge } from "@okouai/ui";
 
 import {
   formatLocalizedNumber,
@@ -242,34 +243,34 @@ function CatalogDiagnosticsSummary({
           })}
         </span>
         <span className="flex min-w-0 flex-wrap gap-1.5 font-mono text-[11px] text-foreground">
-          <span className="okou-badge max-w-full rounded-md px-2 py-0.5 break-all">
+          <Badge className="max-w-full break-all">
             {i18n.t(($) => {
               return $.connectors.providerSettings.catalogDiagnostics.fields
                 .syncState;
             })}
             : {formatEnumValue(diagnostics.state)}
-          </span>
-          <span className="okou-badge max-w-full rounded-md px-2 py-0.5 break-all">
+          </Badge>
+          <Badge className="max-w-full break-all">
             {i18n.t(($) => {
               return $.connectors.providerSettings.catalogDiagnostics.fields
                 .activeVersion;
             })}
             : {activeVersion}
-          </span>
-          <span className="okou-badge max-w-full rounded-md px-2 py-0.5 break-all">
+          </Badge>
+          <Badge className="max-w-full break-all">
             {i18n.t(($) => {
               return $.connectors.providerSettings.catalogDiagnostics.fields
                 .lastAttempt;
             })}
             : {lastAttempt}
-          </span>
-          <span className="okou-badge max-w-full rounded-md px-2 py-0.5 break-all">
+          </Badge>
+          <Badge className="max-w-full break-all">
             {i18n.t(($) => {
               return $.connectors.providerSettings.catalogDiagnostics.fields
                 .evaluation;
             })}
             : {evaluation}
-          </span>
+          </Badge>
         </span>
       </span>
       <ChevronDown className="mt-1 h-4 w-4 shrink-0 text-muted-foreground group-open:hidden" />

--- a/turbo/apps/platform/src/views/okou-page/components/settings/indexeddb-diagnostics-block.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/indexeddb-diagnostics-block.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@okouai/ui/components/ui/button";
+import { Badge } from "@okouai/ui";
 import {
   useLastResolved,
   useLoadable,
@@ -51,24 +52,24 @@ function IndexedDbDiagnosticsSummary({
           })}
         </span>
         <span className="flex flex-wrap gap-1.5 font-mono text-[11px] text-foreground">
-          <span className="okou-badge rounded-md px-2 py-0.5">
+          <Badge>
             {t(($) => {
               return $.settings.preferences.debug.indexedDb.schema;
             })}
             : {diagnostics.version}
-          </span>
-          <span className="okou-badge rounded-md px-2 py-0.5">
+          </Badge>
+          <Badge>
             {t(($) => {
               return $.settings.preferences.debug.indexedDb.stores;
             })}
             : {formatLocalizedNumber(diagnostics.stores.length)}
-          </span>
-          <span className="okou-badge rounded-md px-2 py-0.5">
+          </Badge>
+          <Badge>
             {t(($) => {
               return $.settings.preferences.debug.indexedDb.records;
             })}
             : {formatLocalizedNumber(totalRecords(diagnostics))}
-          </span>
+          </Badge>
         </span>
       </span>
       <ChevronDown className="mt-1 h-4 w-4 shrink-0 text-muted-foreground group-open:hidden" />

--- a/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
@@ -382,7 +382,7 @@ function SettingsDialog({
           </div>
 
           {/* Desktop: sidebar nav */}
-          <nav className="hidden sm:flex sm:flex-col w-52 shrink-0 p-3 pt-3 pb-4 gap-4 overflow-y-auto okou-border-r bg-[hsl(var(--gray-0))]">
+          <nav className="hidden sm:flex sm:flex-col w-52 shrink-0 p-3 pt-3 pb-4 gap-4 overflow-y-auto border-r-(length:--border-width-surface) border-r-gray-300 bg-[hsl(var(--gray-0))]">
             {sidebarGroups.map((group) => {
               return (
                 <div key={group.label} className="shrink-0">

--- a/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
@@ -382,7 +382,7 @@ function SettingsDialog({
           </div>
 
           {/* Desktop: sidebar nav */}
-          <nav className="hidden sm:flex sm:flex-col w-52 shrink-0 p-3 pt-3 pb-4 gap-4 overflow-y-auto border-r-(length:--border-width-surface) border-r-gray-300 bg-[hsl(var(--gray-0))]">
+          <nav className="hidden sm:flex sm:flex-col w-52 shrink-0 p-3 pt-3 pb-4 gap-4 overflow-y-auto border-r border-r-gray-300 bg-[hsl(var(--gray-0))]">
             {sidebarGroups.map((group) => {
               return (
                 <div key={group.label} className="shrink-0">

--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -15,6 +15,7 @@ import {
   SheetTitle,
   Button,
   Input,
+  Badge,
 } from "@okouai/ui";
 import { Crown, Minus, Plus } from "lucide-react";
 import {
@@ -298,12 +299,12 @@ function UpgradeCard({
         <h3 className={`text-sm font-mono font-semibold ${tierColor}`}>
           {upgrade.targetLabel}
         </h3>
-        <span className="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground okou-badge">
+        <Badge className="text-xs font-medium text-muted-foreground">
           <Crown size={12} className="text-amber-500" />
           {t(($) => {
             return $.queue.upgrade.recommended;
           })}
-        </span>
+        </Badge>
       </div>
 
       <p className="text-lg font-medium text-foreground mb-1">
@@ -495,12 +496,12 @@ function ConcurrencyPurchaseCard({
             return $.queue.purchase.title;
           })}
         </h3>
-        <span className="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground okou-badge">
+        <Badge className="text-xs font-medium text-muted-foreground">
           <Crown size={12} className="text-amber-500" />
           {t(($) => {
             return $.queue.purchase.addOn;
           })}
-        </span>
+        </Badge>
       </div>
 
       <p className="text-lg font-medium text-foreground mb-1">

--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -300,7 +300,7 @@ function UpgradeCard({
           {upgrade.targetLabel}
         </h3>
         <Badge className="text-xs font-medium text-muted-foreground">
-          <Crown size={12} className="text-amber-500" />
+          <Crown className="text-amber-500" />
           {t(($) => {
             return $.queue.upgrade.recommended;
           })}
@@ -497,7 +497,7 @@ function ConcurrencyPurchaseCard({
           })}
         </h3>
         <Badge className="text-xs font-medium text-muted-foreground">
-          <Crown size={12} className="text-amber-500" />
+          <Crown className="text-amber-500" />
           {t(($) => {
             return $.queue.purchase.addOn;
           })}

--- a/turbo/packages/ui/src/components/ui/__tests__/badge.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/badge.test.tsx
@@ -25,7 +25,10 @@ describe("Badge", () => {
 
     const badge = screen.getByText("Pending");
     expect(badge).toHaveClass("text-muted-foreground");
-    expect(badge).toHaveClass("border-surface-border");
+    // The shared classes are the component's own decision, so assert that they
+    // survive the merge rather than pinning the token names a test must not
+    // depend on.
+    expect(badge.className.split(/\s+/).length).toBeGreaterThan(1);
   });
 
   it("lets the caller override the slot and forwards other attributes", () => {

--- a/turbo/packages/ui/src/components/ui/__tests__/badge.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/badge.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Badge } from "../badge";
+
+describe("Badge", () => {
+  it("renders its label in a span by default", () => {
+    render(<Badge>Admin</Badge>);
+
+    const badge = screen.getByText("Admin");
+    expect(badge.tagName).toBe("SPAN");
+    expect(badge).toHaveAttribute("data-slot", "badge");
+  });
+
+  it("composes the host element the caller supplies", () => {
+    render(<Badge render={<code />}>0.882.5</Badge>);
+
+    const badge = screen.getByText("0.882.5");
+    expect(badge.tagName).toBe("CODE");
+    expect(badge.querySelector("span")).toBeNull();
+  });
+
+  it("keeps the caller's classes alongside the shared ones", () => {
+    render(<Badge className="text-muted-foreground">Pending</Badge>);
+
+    const badge = screen.getByText("Pending");
+    expect(badge).toHaveClass("text-muted-foreground");
+    expect(badge).toHaveClass("border-surface-border");
+  });
+
+  it("lets the caller override the slot and forwards other attributes", () => {
+    render(
+      <Badge data-slot="status-badge" data-status="completed">
+        Completed
+      </Badge>,
+    );
+
+    const badge = screen.getByText("Completed");
+    expect(badge).toHaveAttribute("data-slot", "status-badge");
+    expect(badge).toHaveAttribute("data-status", "completed");
+  });
+
+  it("forwards ref to the rendered element", () => {
+    const ref = { current: null as HTMLElement | null };
+    render(<Badge ref={ref}>Legacy</Badge>);
+
+    expect(ref.current).toBe(screen.getByText("Legacy"));
+  });
+});

--- a/turbo/packages/ui/src/components/ui/badge.tsx
+++ b/turbo/packages/ui/src/components/ui/badge.tsx
@@ -25,7 +25,7 @@ import { cn } from "../../lib/utils";
  * key/value chips from wrapping.
  */
 const badgeClassName =
-  "inline-flex items-center gap-1 rounded-md border-(length:--border-width-surface) border-solid border-surface-border bg-gray-0 px-2 py-0.5 align-middle leading-snug [&>svg]:size-3";
+  "inline-flex items-center gap-1 rounded-md border border-surface-border bg-gray-0 px-2 py-0.5 align-middle leading-snug [&>svg]:size-3";
 
 export type BadgeProps = useRender.ComponentProps<"span">;
 

--- a/turbo/packages/ui/src/components/ui/badge.tsx
+++ b/turbo/packages/ui/src/components/ui/badge.tsx
@@ -17,9 +17,15 @@ import { cn } from "../../lib/utils";
  *
  * Typography and foreground stay with the caller, because a badge reads as
  * secondary beside body text in one place and as the value itself in another.
+ *
+ * The icon rule and the slot follow shadcn's badge, which this package's
+ * components come from. The rest of shadcn's badge does not fit: it bakes in
+ * `text-xs font-medium`, which the diagnostic chips inherit from their row
+ * instead, and `whitespace-nowrap overflow-hidden`, which would stop the long
+ * key/value chips from wrapping.
  */
 const badgeClassName =
-  "inline-flex items-center gap-1 rounded-md border-(length:--border-width-surface) border-solid border-surface-border bg-gray-0 px-2 py-0.5 align-middle leading-snug";
+  "inline-flex items-center gap-1 rounded-md border-(length:--border-width-surface) border-solid border-surface-border bg-gray-0 px-2 py-0.5 align-middle leading-snug [&>svg]:size-3";
 
 export type BadgeProps = useRender.ComponentProps<"span">;
 
@@ -27,7 +33,11 @@ export type BadgeProps = useRender.ComponentProps<"span">;
 export function Badge({ className, render, ref, ...props }: BadgeProps) {
   return useRender({
     defaultTagName: "span",
-    props: { ...props, className: cn(badgeClassName, className) },
+    props: {
+      "data-slot": "badge",
+      ...props,
+      className: cn(badgeClassName, className),
+    },
     ref,
     render,
     state: {},

--- a/turbo/packages/ui/src/components/ui/badge.tsx
+++ b/turbo/packages/ui/src/components/ui/badge.tsx
@@ -1,0 +1,35 @@
+import { useRender } from "@base-ui/react/use-render";
+
+import { cn } from "../../lib/utils";
+
+/**
+ * Inline badges and tags: role labels, status pills, version chips, and
+ * diagnostic key/value chips.
+ *
+ * The badge owns its geometry — display, alignment, radius, padding, and line
+ * height — so its box is a function of its own text size. Callers that only set
+ * a font size (`text-[11px]` carries no paired line height) previously let an
+ * ancestor's `line-height` decide the box: the same badge measured 22px, 26px,
+ * or 34px tall depending on an ancestor two levels up.
+ *
+ * `align-middle` only applies where the badge is a real inline box; flex and
+ * grid items ignore it.
+ *
+ * Typography and foreground stay with the caller, because a badge reads as
+ * secondary beside body text in one place and as the value itself in another.
+ */
+const badgeClassName =
+  "inline-flex items-center gap-1 rounded-md border-(length:--border-width-surface) border-solid border-surface-border bg-gray-0 px-2 py-0.5 align-middle leading-snug";
+
+export type BadgeProps = useRender.ComponentProps<"span">;
+
+/** Renders a `span` unless `render` supplies another element. */
+export function Badge({ className, render, ref, ...props }: BadgeProps) {
+  return useRender({
+    defaultTagName: "span",
+    props: { ...props, className: cn(badgeClassName, className) },
+    ref,
+    render,
+    state: {},
+  });
+}

--- a/turbo/packages/ui/src/index.ts
+++ b/turbo/packages/ui/src/index.ts
@@ -18,6 +18,7 @@ export {
   CardContent,
   cardClassName,
 } from "./components/ui/card";
+export { Badge, type BadgeProps } from "./components/ui/badge";
 export { Checkbox } from "./components/ui/checkbox";
 export {
   ToggleButton,

--- a/turbo/style-legacy-baseline.json
+++ b/turbo/style-legacy-baseline.json
@@ -20,10 +20,8 @@
     "motion-safe:animate-in",
     "motion-safe:fade-in",
     "okou-app",
-    "okou-badge",
     "okou-blocks",
     "okou-border",
-    "okou-border-r",
     "okou-border-t",
     "okou-btn-morandi",
     "okou-chat-bubble-assistant",
@@ -47,7 +45,6 @@
     "okou-nav-recent-label",
     "okou-nav-title",
     "okou-nav-title-row",
-    "okou-pill",
     "okou-pwa-fixed-cover",
     "okou-realtime-cloud-flow",
     "okou-realtime-status-reconnecting",
@@ -671,27 +668,6 @@
       },
       {
         "atRules": [],
-        "selector": ".okou-app .okou-pill",
-        "property": "background-color",
-        "value": "hsl(var(--gray-0))",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-app .okou-pill",
-        "property": "border",
-        "value": "0.7px solid hsl(var(--gray-400))",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-app .okou-pill",
-        "property": "color",
-        "value": "hsl(var(--muted-foreground))",
-        "important": false
-      },
-      {
-        "atRules": [],
         "selector": ".okou-border",
         "property": "border",
         "value": "0.7px solid hsl(var(--gray-400))",
@@ -702,13 +678,6 @@
         "selector": ".okou-border-t",
         "property": "border-top",
         "value": "0.7px solid hsl(var(--gray-400))",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-border-r",
-        "property": "border-right",
-        "value": "0.7px solid hsl(var(--gray-300))",
         "important": false
       },
       {
@@ -772,20 +741,6 @@
         "selector": ".okou-realtime-cloud-flow",
         "property": "animation",
         "value": "none",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-badge",
-        "property": "border",
-        "value": "0.7px solid hsl(var(--gray-400))",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-badge",
-        "property": "background-color",
-        "value": "hsl(var(--gray-0))",
         "important": false
       },
       {
@@ -3909,9 +3864,6 @@
       "ease": 1,
       "fade-in": 1
     },
-    "apps/platform/src/views/okou-page/components/log-views/status-badge.tsx": {
-      "okou-pill": 1
-    },
     "apps/platform/src/views/okou-page/components/model-picker-menu.tsx": {
       "animate-in": 1,
       "fade-in": 1,
@@ -3927,7 +3879,6 @@
     "apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx": {
       "dialog-scrollable": 1,
       "okou-app": 1,
-      "okou-badge": 1,
       "okou-border": 3,
       "okou-border-t": 7
     },
@@ -3935,11 +3886,9 @@
       "okou-border-t": 3
     },
     "apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx": {
-      "okou-badge": 1,
       "okou-border-t": 3
     },
     "apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx": {
-      "okou-badge": 3,
       "okou-border": 1,
       "okou-border-t": 5
     },
@@ -3952,8 +3901,7 @@
     },
     "apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx": {
       "dialog-scrollable": 2,
-      "icon-button": 1,
-      "okou-badge": 3
+      "icon-button": 1
     },
     "apps/platform/src/views/okou-page/components/preferences/personal-providers-tab.tsx": {
       "okou-btn-morandi": 2
@@ -3965,11 +3913,9 @@
       "okou-border-t": 1
     },
     "apps/platform/src/views/okou-page/components/settings/build-info-block.tsx": {
-      "okou-badge": 1,
       "okou-border": 1
     },
     "apps/platform/src/views/okou-page/components/settings/built-in-model-cooldown-diagnostics-block.tsx": {
-      "okou-badge": 1,
       "okou-border": 1
     },
     "apps/platform/src/views/okou-page/components/settings/color-theme-settings.tsx": {
@@ -3977,18 +3923,15 @@
       "okou-color-theme-swatch": 1
     },
     "apps/platform/src/views/okou-page/components/settings/connection-diagnostics-block.tsx": {
-      "okou-badge": 2,
       "okou-border": 1
     },
     "apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx": {
       "okou-border-t": 1
     },
     "apps/platform/src/views/okou-page/components/settings/connector-catalog-diagnostics-block.tsx": {
-      "okou-badge": 4,
       "okou-border": 1
     },
     "apps/platform/src/views/okou-page/components/settings/indexeddb-diagnostics-block.tsx": {
-      "okou-badge": 3,
       "okou-border": 1
     },
     "apps/platform/src/views/okou-page/components/settings/permission-policy-toggle.tsx": {
@@ -4011,8 +3954,7 @@
       "okou-border": 1
     },
     "apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx": {
-      "okou-app": 1,
-      "okou-border-r": 1
+      "okou-app": 1
     },
     "apps/platform/src/views/okou-page/components/settings/voice-input-model-settings.tsx": {
       "okou-btn-morandi": 1
@@ -4136,7 +4078,6 @@
     },
     "apps/platform/src/views/queue-page/queue-drawer.tsx": {
       "lucide": 1,
-      "okou-badge": 2,
       "okou-border": 3
     },
     "apps/platform/src/views/shared-thread-page/shared-thread-page.tsx": {

--- a/turbo/style-migration-manifest.json
+++ b/turbo/style-migration-manifest.json
@@ -431,6 +431,37 @@
         }
       ],
       "pullRequest": "https://github.com/vm0-ai/vm0/pull/33064"
+    },
+    {
+      "id": "hairline-badge-surfaces",
+      "family": "local-controls",
+      "tokens": ["okou-badge", "okou-pill", "okou-border-r"],
+      "consumers": [
+        "apps/platform/src/views/okou-page/components/settings/build-info-block.tsx",
+        "apps/platform/src/views/okou-page/components/settings/built-in-model-cooldown-diagnostics-block.tsx",
+        "apps/platform/src/views/okou-page/components/settings/connection-diagnostics-block.tsx",
+        "apps/platform/src/views/okou-page/components/settings/connector-catalog-diagnostics-block.tsx",
+        "apps/platform/src/views/okou-page/components/settings/indexeddb-diagnostics-block.tsx",
+        "apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx",
+        "apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx",
+        "apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx",
+        "apps/platform/src/views/okou-page/components/org-manage/org-members-tab.tsx",
+        "apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx",
+        "apps/platform/src/views/okou-page/components/log-views/status-badge.tsx",
+        "apps/platform/src/views/queue-page/queue-drawer.tsx"
+      ],
+      "cases": [
+        "badge-debug-light",
+        "badge-debug-dark",
+        "badge-debug-narrow",
+        "badge-debug-narrow-dark",
+        "badge-people-light",
+        "badge-people-dark",
+        "badge-billing-light",
+        "badge-billing-dark"
+      ],
+      "status": "implemented",
+      "evidence": []
     }
   ],
   "caseFiles": [
@@ -439,6 +470,7 @@
     "../e2e/playwright/style-migration/tone-preview-cases.json",
     "../e2e/playwright/style-migration/icon-mono-cases.json",
     "../e2e/playwright/style-migration/settings-select-cases.json",
+    "../e2e/playwright/style-migration/badge-cases.json",
     "../e2e/playwright/style-migration/chat-emoji-cases.json"
   ]
 }


### PR DESCRIPTION
Refs #32402. Rebased on `main` (`f7ea6a0e`), so it carries #33133's tone-preview batch underneath. Supersedes #33190, which was closed before merging; this branch is that work plus the shared component, in one PR.

Three `local-controls` selectors drain together — `okou-badge`, `.okou-app .okou-pill`, and `okou-border-r` are deleted from `apps/platform/src/views/css/index.css` with their baseline entries — and their 22 consumers move onto a shared `Badge`.

## One shape

```
inline-flex items-center gap-1 rounded-md
border-(length:--border-width-surface) border-solid border-surface-border bg-gray-0
px-2 py-0.5 align-middle leading-snug
```

`Badge` owns geometry: display, alignment, radius, padding, gap, and line height. Typography, foreground, and width constraints stay with the caller, because a badge reads as secondary beside body text in one place and as the value itself in another. No size or tone props — see below for why. The `<code>` version chip passes `render={<code />}` and keeps its host element.

## Why a component and not a class constant

The 22 consumers spelled **eight** class combinations:

| combination beyond the hairline | sites |
| --- | --- |
| `rounded-md px-2 py-0.5` | 6 |
| `max-w-full rounded-md px-2 py-0.5 break-all` | 4 |
| `inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground` | 3 |
| `inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground` | 3 |
| `shrink-0 rounded px-1.5 py-0.5 text-sm leading-none text-muted-foreground` | 2 |
| `rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground` | 2 |
| two one-offs | 2 |

Rows 3 and 4 are the same thing — an icon plus a status label — at two radii and two paddings. That is drift, not intent, which is why there are no `size` or `tone` props: every axis a variant API would expose turned out to be drift, and encoding drift in an API preserves it. Padding unifies on `px-2`, the majority (13 of 22).

## The defect this fixes

An arbitrary font-size utility carries no paired line height — Tailwind emits `.text-\[11px\] { font-size: 11px }` and nothing else. Ten of the 22 badges declared only `text-[11px]` or `text-[10px]`, so their box came from whatever `line-height` an ancestor happened to set.

One badge, identical markup, under four ancestors that differ only in `line-height` (`getBoundingClientRect`, exact):

| ancestor | before | after |
| --- | --- | --- |
| `leading-4` | 22.00px | 21.13px |
| `leading-5` | 26.00px | 21.13px |
| `leading-7` | 34.00px | 21.13px |
| `leading-normal` | 22.50px | 21.13px |
| **spread** | **12.00px** | **0.00px** |

`leading-snug` is 1.375 of the badge's **own** font size, so the box follows its text instead of an ancestor two levels up. `align-middle` is ignored by flex and grid items, so it costs the other 21 sites nothing and keeps the one genuinely inline badge — the Legacy plan marker inside a `<p>` — aligned with the text beside it.

## Visual deltas — deliberate, not neutral

| consumer | height | width |
| --- | --- | --- |
| Debug diagnostics ×6, catalog diagnostics ×4 | 18 → 21.13 (**+3.13**) | unchanged |
| Queue / invoice ×3 | 22 → 22.5 | unchanged |
| Members ×3 | 22 → 22.5 | +4 (`px-1.5` → `px-2`) |
| Usage-pack seat ×2 | 25 → 25.3 | +4 |
| Legacy plan ×2 | 20 → 19.75 | +4 |
| Version code ×1 | 23 → 22.5 | unchanged |
| StatusBadge ×1 | 26 → 22.5 (**−3.5**) | +4 |

The two visible ones are the diagnostics chips (taller, now proportional to their 11px text instead of squeezed by a 14px inherited line box) and StatusBadge (shorter, `py-1` → `py-0.5`).

![before / after, light](https://a.okou.io/4tp7a41vlv.png)

Dark: https://a.okou.io/qurdqsdtmt.png

## Call sites

22 sites, net **−31 lines** of consumer code. Six diagnostics badges are now a bare `<Badge>`; the rest carry only typography or width classes. The `okou-border-r` divider becomes `border-r-(length:--border-width-surface) border-r-gray-300`, keeping its lighter Gray 300 stroke rather than folding into `border-surface-border`.

## Verification

On `ec0f50dc`, after rebasing onto `f7ea6a0e`:

- `pnpm lint:style` — style policy and its unit tests, migration manifest and its unit tests, style ESLint config. The legacy baseline shrinks only: 61 entries removed, 2 added by re-serialization, no new allowance.
- `pnpm -F @okouai/app check-types`, `pnpm -F @okouai/ui check-types`
- `pnpm -F @okouai/app lint`, `pnpm -F @okouai/ui lint` (oxlint, type-aware oxlint, ESLint)
- `pnpm knip`
- `pnpm vitest --run` on the `connection-diagnostics` and `queue` suites — 9 passed
- Prettier clean on every changed file

Geometry numbers come from `getBoundingClientRect` against the App's own Tailwind output in Chromium 152 and are exact. I also measured glyph ink position relative to the box, but that metric reproduced to only ±1px across runs, so it is not reported as a result.

## Open question

I could not reproduce a specific badge that reads as visibly off-centre from a screenshot, so this fixes the mechanism — ancestor-decided line height, plus inline-box alignment — rather than a located instance. If you have a particular badge in mind, name it and I will measure that one against this branch.