### PR TITLE
fix(pi): keep model failures actionable when an upstream returns a document

### DIFF
--- a/crates/guest-agent/src/cli/pi_rpc.rs
+++ b/crates/guest-agent/src/cli/pi_rpc.rs
@@ -215,8 +215,13 @@
 //! Each assistant `message_end` updates `PiAssistantTerminal`; it does not
 //! itself close the public run. `stopReason` values `error` and `aborted` set
 //! the cached failure flag. The result text uses `errorMessage` when present,
-//! otherwise the joined non-empty assistant text. If both are empty, it falls
-//! back to `Pi model turn <stopReason>` when a stop reason exists.
+//! otherwise the joined non-empty assistant text. An `errorMessage` is
+//! upstream-controlled, so it passes through
+//! [`crate::upstream_error_text::project_model_error_text`]: a markup document
+//! becomes a bounded content-free description and any other message keeps its
+//! exact text under a size bound. Assistant text is the run's own answer and is
+//! never bounded here. If both are empty, it falls back to
+//! `Pi model turn <stopReason>` when a stop reason exists.
 //!
 //! When `agent_settled` arrives, the cached state is consumed and the public
 //! result contains `type: "result"`, `subtype: "error_during_execution"` and
@@ -243,6 +248,7 @@ use tokio_util::sync::CancellationToken;
 use super::pi_memory_citation::{CitationProjection, project_segments};
 use crate::active_input::{ActiveInputFrame, ActiveInputWriter};
 use crate::error::AgentError;
+use crate::upstream_error_text::project_model_error_text;
 
 const PI_RPC_ABORT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const PI_RPC_RESPONSE_QUEUE_CAPACITY: usize = 2;
@@ -450,10 +456,14 @@ impl PiAssistantTerminal {
     fn from_message(message: &Value, preserve_empty_result: bool) -> Self {
         let stop_reason = message.get("stopReason").and_then(Value::as_str);
         let failed = matches!(stop_reason, Some("error" | "aborted"));
+        // A model error is upstream-controlled text. Bounding it here keeps the
+        // public result, the delivered event and the failure diagnostic on the
+        // same actionable value; assistant text stays untouched because it is
+        // the run's own answer.
         let result = message
             .get("errorMessage")
             .and_then(Value::as_str)
-            .map_or_else(|| assistant_text(message), ToString::to_string);
+            .map_or_else(|| assistant_text(message), project_model_error_text);
         let result = if result.is_empty() && !preserve_empty_result {
             stop_reason.map_or_else(String::new, |reason| format!("Pi model turn {reason}"))
         } else {

--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -12,6 +12,7 @@ use crate::failure_patterns;
 use crate::paths;
 use crate::session_history;
 use crate::session_metadata::CapturedSessionMetadata;
+use crate::upstream_error_text::upstream_non_api_response_status;
 use guest_contracts::diagnostics::{
     AgentFramework, CliObservedExitDiagnostic, CliTerminationDiagnostic, CliTerminationReason,
     EventDeliveryDiagnostic, FailureClass, FailureDetailSource, FailureDiagnostic, FailureReason,
@@ -303,6 +304,12 @@ fn classify_cli_failure_reason(
     {
         return Some(FailureReason::UnsupportedModel);
     }
+    if matches!(framework, AgentFramework::Pi)
+        && source == FailureDetailSource::PiResult
+        && let Some(reason) = pi_upstream_non_api_response_reason(failure_message)
+    {
+        return Some(reason);
+    }
 
     let normalized = failure_message.to_ascii_lowercase();
     if is_insufficient_credits_error(&normalized) {
@@ -435,6 +442,20 @@ fn pi_provider_http_failure_reason(
                 _ => None,
             }
         })
+}
+
+/// Classify a Pi model error whose upstream answered with a document.
+///
+/// Only a status the Pi runtime actually observed is trusted. An unknown status
+/// stays unclassified so the failure keeps its error-level report instead of
+/// being presented as an expected upstream condition.
+fn pi_upstream_non_api_response_reason(failure_message: &str) -> Option<FailureReason> {
+    match upstream_non_api_response_status(failure_message)? {
+        429 => Some(FailureReason::ProviderRateLimited),
+        529 => Some(FailureReason::ProviderOverloaded),
+        500..=599 => Some(FailureReason::ProviderServerError),
+        _ => None,
+    }
 }
 
 fn is_codex_safety_policy_refusal(source: FailureDetailSource, failure_message: &str) -> bool {

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -965,6 +965,32 @@ fn cli_failure_reason_classifies_pi_provider_http_unavailability() {
 }
 
 #[test]
+fn cli_failure_reason_classifies_pi_upstream_non_api_response_by_observed_status() {
+    for (status, expected_reason) in [
+        (429, Some(FailureReason::ProviderRateLimited)),
+        (500, Some(FailureReason::ProviderServerError)),
+        (502, Some(FailureReason::ProviderServerError)),
+        (529, Some(FailureReason::ProviderOverloaded)),
+        // A client-side status is not an expected upstream condition, so it
+        // stays unclassified and keeps its error-level report.
+        (403, None),
+        (404, None),
+    ] {
+        let message = format!(
+            "upstream_non_api_response status={status} content_type=html bytes=4711 digest=1a2b3c4d"
+        );
+
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::Pi,
+            FailureDetailSource::PiResult,
+            &message,
+        );
+
+        assert_eq!(reason, expected_reason, "message: {message}");
+    }
+}
+
+#[test]
 fn cli_failure_reason_rejects_untrusted_pi_provider_http_contexts() {
     const MESSAGE: &str = "provider HTTP 503: no healthy upstream";
 
@@ -998,6 +1024,42 @@ fn cli_failure_reason_rejects_untrusted_pi_provider_http_contexts() {
         );
 
         assert_eq!(reason, None, "message: {message}");
+    }
+}
+
+#[test]
+fn cli_failure_reason_rejects_pi_upstream_status_without_runtime_evidence() {
+    for message in [
+        // The guest-side fallback never observed the transport.
+        "upstream_non_api_response status=unknown content_type=unknown bytes=4711 digest=1a2b3c4d",
+        // Model prose must never be read as a transport status.
+        "The upstream returned status=502 to my request",
+        "API Error: Overloaded",
+    ] {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::Pi,
+            FailureDetailSource::PiResult,
+            message,
+        );
+
+        assert_eq!(reason, None, "message: {message}");
+    }
+
+    // Only the Pi result boundary produces this marker.
+    let marker =
+        "upstream_non_api_response status=502 content_type=html bytes=4711 digest=1a2b3c4d";
+    for (framework, source) in [
+        (AgentFramework::Pi, FailureDetailSource::Stderr),
+        (
+            AgentFramework::ClaudeCode,
+            FailureDetailSource::ClaudeResult,
+        ),
+        (AgentFramework::Codex, FailureDetailSource::CodexJsonl),
+    ] {
+        assert_eq!(
+            super::classify_cli_failure_reason(framework, source, marker),
+            None
+        );
     }
 }
 

--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -239,6 +239,7 @@ pub mod session_history_identity;
 pub mod session_metadata;
 pub mod telemetry;
 pub mod timing;
+mod upstream_error_text;
 mod urls;
 pub mod workload_containment;
 

--- a/crates/guest-agent/src/upstream_error_text.rs
+++ b/crates/guest-agent/src/upstream_error_text.rs
@@ -2,11 +2,24 @@
 //!
 //! The Pi runtime already replaces a markup error body at its provider
 //! boundary (`turbo/packages/pi-agent-runtime/src/upstream-error-body.ts`), so
-//! a current CLI reports the observed status and content type. The sandbox
-//! resolves that CLI from a caller-supplied package URL, so an older build can
-//! still hand the guest a whole HTML page as its terminal `errorMessage`. This
-//! module keeps that case bounded and content-free, and reads the status back
-//! out of the marker the Pi runtime produced.
+//! a current CLI reports the observed status and content type. This module
+//! reads that status back out of the marker the Pi runtime produced, and bounds
+//! any model error that still arrives as a whole document.
+//!
+//! # Fallback
+//!
+//! The markup branch in [`project_model_error_text`] is a bounded cross-version
+//! rollout fallback (`docs/fallback.md` §6.1). The sandbox resolves its CLI from
+//! a caller-supplied package URL, so a build predating the provider boundary can
+//! still hand the guest an entire page as its terminal `errorMessage`.
+//!
+//! - Surface: existing runner / sandbox (`docs/fallback.md` §7).
+//! - Removal gate: old sandbox CLI artifacts finish draining and no pinnable
+//!   `CLI_PACKAGE_URL` artifact predates `guardPiUpstreamErrorBody`.
+//!
+//! It reports `status=unknown content_type=unknown` rather than claiming
+//! transport evidence the guest never observed, so an unproven failure stays
+//! unclassified and keeps its error-level report.
 
 use sha2::{Digest, Sha256};
 

--- a/crates/guest-agent/src/upstream_error_text.rs
+++ b/crates/guest-agent/src/upstream_error_text.rs
@@ -83,17 +83,38 @@ pub(crate) fn project_model_error_text(raw: &str) -> String {
 /// Returns `None` when the message carries no marker or no parsable status, so
 /// an unproven failure is never given a semantic reason.
 pub(crate) fn upstream_non_api_response_status(message: &str) -> Option<u16> {
-    const STATUS_FIELD: &str = "status=";
+    const STATUS_PREFIX: &str = " status=";
 
-    let marker_end =
-        message.find(UPSTREAM_NON_API_RESPONSE_MARKER)? + UPSTREAM_NON_API_RESPONSE_MARKER.len();
-    let tail = &message[marker_end..];
-    let status_start = tail.find(STATUS_FIELD)? + STATUS_FIELD.len();
-    let digits: String = tail[status_start..]
-        .chars()
-        .take_while(char::is_ascii_digit)
-        .collect();
-    digits.parse().ok()
+    message
+        .match_indices(UPSTREAM_NON_API_RESPONSE_MARKER)
+        .find_map(|(index, _)| {
+            if message[..index]
+                .chars()
+                .next_back()
+                .is_some_and(is_marker_identifier_char)
+            {
+                return None;
+            }
+            let status = message[index + UPSTREAM_NON_API_RESPONSE_MARKER.len()..]
+                .strip_prefix(STATUS_PREFIX)?;
+            let status_len = status
+                .find(|character: char| !character.is_ascii_digit())
+                .unwrap_or(status.len());
+            let (digits, suffix) = status.split_at(status_len);
+            if digits.is_empty()
+                || suffix
+                    .chars()
+                    .next()
+                    .is_some_and(|character| !character.is_ascii_whitespace())
+            {
+                return None;
+            }
+            digits.parse().ok()
+        })
+}
+
+fn is_marker_identifier_char(character: char) -> bool {
+    character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
 }
 
 fn body_digest(body: &str) -> String {
@@ -197,6 +218,17 @@ mod tests {
             ("status=502 without any marker".to_string(), None),
         ] {
             assert_eq!(upstream_non_api_response_status(&message), expected);
+        }
+    }
+
+    #[test]
+    fn status_requires_the_runtime_marker_and_its_exact_status_field() {
+        for message in [
+            "not_upstream_non_api_response status=502 content_type=html bytes=4711 digest=1a2b3c4d",
+            "upstream_non_api_response detail status=502 content_type=html bytes=4711 digest=1a2b3c4d",
+            "upstream_non_api_response status=502unexpected content_type=html bytes=4711 digest=1a2b3c4d",
+        ] {
+            assert_eq!(upstream_non_api_response_status(message), None);
         }
     }
 

--- a/crates/guest-agent/src/upstream_error_text.rs
+++ b/crates/guest-agent/src/upstream_error_text.rs
@@ -1,0 +1,203 @@
+//! Bounded projection for a model error that carries an upstream document.
+//!
+//! The Pi runtime already replaces a markup error body at its provider
+//! boundary (`turbo/packages/pi-agent-runtime/src/upstream-error-body.ts`), so
+//! a current CLI reports the observed status and content type. The sandbox
+//! resolves that CLI from a caller-supplied package URL, so an older build can
+//! still hand the guest a whole HTML page as its terminal `errorMessage`. This
+//! module keeps that case bounded and content-free, and reads the status back
+//! out of the marker the Pi runtime produced.
+
+use sha2::{Digest, Sha256};
+
+/// Stable token marking a model error whose upstream body was a document.
+///
+/// Keep this in sync with `UPSTREAM_NON_API_RESPONSE_MARKER` in
+/// `turbo/packages/pi-agent-runtime/src/upstream-error-body.ts`.
+pub(crate) const UPSTREAM_NON_API_RESPONSE_MARKER: &str = "upstream_non_api_response";
+
+/// Only the leading characters decide whether a body is a markup document.
+const MARKUP_PROBE_CHARS: usize = 512;
+
+/// Enough to group repeated pages in logs without republishing any of one.
+const DIGEST_CHARS: usize = 8;
+
+/// Upper bound for a model error that survives as the terminal result text.
+const MAX_MODEL_ERROR_BYTES: usize = 4096;
+
+const TRUNCATED_SUFFIX: &str = "...[truncated]";
+
+/// Recognize a markup document from the body itself.
+///
+/// A gateway, captive portal or branded status page can serve markup under any
+/// declared content type, and the guest never sees the response headers, so
+/// only the text can decide.
+pub(crate) fn is_markup_document_body(body: &str) -> bool {
+    let head = body
+        .trim_start()
+        .chars()
+        .take(MARKUP_PROBE_CHARS)
+        .collect::<String>()
+        .to_ascii_lowercase();
+    if !head.starts_with('<') {
+        return false;
+    }
+    head.contains("<!doctype html")
+        || head.contains("<html")
+        || head.contains("<body")
+        || head.contains("<svg")
+}
+
+/// Select the terminal text for a model error message.
+///
+/// A markup document is replaced by a content-free description; the status and
+/// content type are unknown here because only the Pi runtime observed them.
+/// Any other message keeps its exact text under a size bound, so a genuine
+/// provider error stays classifiable and readable.
+pub(crate) fn project_model_error_text(raw: &str) -> String {
+    if is_markup_document_body(raw) {
+        return format!(
+            "{UPSTREAM_NON_API_RESPONSE_MARKER} status=unknown content_type=unknown bytes={} digest={}",
+            raw.len(),
+            body_digest(raw)
+        );
+    }
+    truncate_model_error_text(raw)
+}
+
+/// Read the upstream status the Pi runtime recorded in its marker.
+///
+/// Returns `None` when the message carries no marker or no parsable status, so
+/// an unproven failure is never given a semantic reason.
+pub(crate) fn upstream_non_api_response_status(message: &str) -> Option<u16> {
+    const STATUS_FIELD: &str = "status=";
+
+    let marker_end =
+        message.find(UPSTREAM_NON_API_RESPONSE_MARKER)? + UPSTREAM_NON_API_RESPONSE_MARKER.len();
+    let tail = &message[marker_end..];
+    let status_start = tail.find(STATUS_FIELD)? + STATUS_FIELD.len();
+    let digits: String = tail[status_start..]
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect();
+    digits.parse().ok()
+}
+
+fn body_digest(body: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(body.as_bytes());
+    hex::encode(hasher.finalize())
+        .chars()
+        .take(DIGEST_CHARS)
+        .collect()
+}
+
+fn truncate_model_error_text(message: &str) -> String {
+    if message.len() <= MAX_MODEL_ERROR_BYTES {
+        return message.to_string();
+    }
+
+    let mut end = MAX_MODEL_ERROR_BYTES - TRUNCATED_SUFFIX.len();
+    while !message.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}{TRUNCATED_SUFFIX}", &message[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ERROR_PAGE: &str = concat!(
+        "<html>\n  <head><style global>body{font-family:Arial}",
+        ".logo{color:#8e8ea0}</style></head>\n  <body>\n",
+        "    <svg viewBox=\"0 0 41 41\"><path d=\"M37.5324 16.8707\" /></svg>\n",
+        "  </body>\n</html>"
+    );
+
+    #[test]
+    fn markup_document_is_replaced_by_a_content_free_description() {
+        let projected = project_model_error_text(ERROR_PAGE);
+
+        assert!(projected.starts_with(UPSTREAM_NON_API_RESPONSE_MARKER));
+        assert!(projected.contains("status=unknown"));
+        assert!(projected.contains("content_type=unknown"));
+        assert!(projected.contains(&format!("bytes={}", ERROR_PAGE.len())));
+        assert!(!projected.contains("<html"));
+        assert!(!projected.contains("<svg"));
+        assert!(!projected.contains("8e8ea0"));
+        assert!(projected.len() < 128);
+    }
+
+    #[test]
+    fn identical_pages_share_a_digest_and_different_pages_do_not() {
+        let repeat = project_model_error_text(ERROR_PAGE);
+        let other = project_model_error_text(&format!("{ERROR_PAGE}<!-- other -->"));
+
+        assert_eq!(project_model_error_text(ERROR_PAGE), repeat);
+        assert_ne!(repeat, other);
+    }
+
+    #[test]
+    fn genuine_provider_errors_keep_their_exact_text() {
+        for message in [
+            "API Error: Overloaded",
+            "You've hit your usage limit. Try again in ~13 min.",
+            "OpenAI API error (400): {\"error\":{\"message\":\"<html> inside text\"}}",
+            "",
+        ] {
+            assert_eq!(project_model_error_text(message), message);
+        }
+    }
+
+    #[test]
+    fn oversized_plain_errors_are_truncated_on_a_character_boundary() {
+        let oversized = "é".repeat(MAX_MODEL_ERROR_BYTES);
+
+        let projected = project_model_error_text(&oversized);
+
+        assert!(projected.len() <= MAX_MODEL_ERROR_BYTES);
+        assert!(projected.ends_with(TRUNCATED_SUFFIX));
+    }
+
+    #[test]
+    fn status_is_read_from_the_runtime_marker_on_every_route() {
+        // The Codex route reports the marker as the whole message; the public
+        // Responses route wraps it in the provider's own error envelope.
+        for (message, expected) in [
+            (
+                "upstream_non_api_response status=502 content_type=html bytes=4711 digest=1a2b3c4d"
+                    .to_string(),
+                Some(502),
+            ),
+            (
+                concat!(
+                    "OpenAI API error (525): {\"error\":{\"type\":\"upstream_non_api_response\",",
+                    "\"message\":\"upstream_non_api_response status=525 content_type=html ",
+                    "bytes=812 digest=deadbeef\"}}"
+                )
+                .to_string(),
+                Some(525),
+            ),
+            (project_model_error_text(ERROR_PAGE), None),
+            ("API Error: Overloaded".to_string(), None),
+            ("status=502 without any marker".to_string(), None),
+        ] {
+            assert_eq!(upstream_non_api_response_status(&message), expected);
+        }
+    }
+
+    #[test]
+    fn markup_detection_ignores_markup_quoted_inside_a_payload() {
+        assert!(is_markup_document_body("<!DOCTYPE html><html></html>"));
+        assert!(is_markup_document_body("\n  <html><body>x</body></html>"));
+        assert!(is_markup_document_body(
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" />"
+        ));
+        assert!(!is_markup_document_body(
+            "{\"error\":{\"message\":\"<html> in text\"}}"
+        ));
+        assert!(!is_markup_document_body("<Error><Code>x</Code></Error>"));
+        assert!(!is_markup_document_body("Overloaded"));
+    }
+}

--- a/crates/guest-agent/tests/pi_cli_settlement_errors.rs
+++ b/crates/guest-agent/tests/pi_cli_settlement_errors.rs
@@ -4,7 +4,7 @@
 mod common;
 
 use guest_agent::masker::SecretMasker;
-use guest_contracts::diagnostics::{AgentFramework, FailureDetailSource};
+use guest_contracts::diagnostics::{AgentFramework, FailureDetailSource, FailureReason};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::ffi::OsStr;
@@ -12,10 +12,21 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::time::Duration;
 
+/// Expected public terminal text for a settled Pi run.
+///
+/// A replaced upstream document cannot be spelled out here because its byte
+/// count and digest come from the discarded page, so that case asserts the
+/// contract instead: the marker, no observed transport evidence, and no markup.
+enum ExpectedTerminalResult<'a> {
+    Exact(&'a str),
+    UpstreamNonApiResponse,
+}
+
 async fn run_settlement_case(
     run_id: &str,
     assistant_messages: &[Value],
-    expected_result: &str,
+    expected_result: ExpectedTerminalResult<'_>,
+    expected_failure_reason: Option<FailureReason>,
     expected_assistant_text: Option<&str>,
     base_path: &OsStr,
     original_directory: &Path,
@@ -147,7 +158,10 @@ fi
         Some(FailureDetailSource::PiResult)
     );
     assert_eq!(terminal_failure.diagnostic.claude_num_turns, None);
-    assert_eq!(terminal_failure.diagnostic.failure_reason, None);
+    assert_eq!(
+        terminal_failure.diagnostic.failure_reason,
+        expected_failure_reason
+    );
 
     let system_log = std::fs::read_to_string(runtime.paths.system_log_file())?;
     assert!(
@@ -198,7 +212,30 @@ fi
         .ok_or_else(|| std::io::Error::other("terminal result was not delivered"))?;
     assert_eq!(terminal["subtype"], "error_during_execution");
     assert_eq!(terminal["is_error"], true);
-    assert_eq!(terminal["result"], expected_result);
+    let result = terminal["result"]
+        .as_str()
+        .ok_or_else(|| std::io::Error::other("terminal result text was not a string"))?;
+    match expected_result {
+        ExpectedTerminalResult::Exact(expected) => assert_eq!(result, expected),
+        ExpectedTerminalResult::UpstreamNonApiResponse => {
+            assert!(
+                result.starts_with("upstream_non_api_response "),
+                "terminal result should carry the upstream marker: {result}"
+            );
+            assert!(
+                result.contains("status=unknown") && result.contains("content_type=unknown"),
+                "guest-side projection cannot claim transport evidence: {result}"
+            );
+            assert!(
+                !result.contains('<'),
+                "terminal result should not republish the upstream document: {result}"
+            );
+            assert!(
+                result.len() < 128,
+                "terminal result should stay bounded: {result}"
+            );
+        }
+    }
     Ok(())
 }
 
@@ -219,7 +256,8 @@ async fn guest_preserves_pi_error_and_aborted_settlement_results()
             "errorMessage": "API Error: Overloaded",
             "timestamp": 1,
         })],
-        "API Error: Overloaded",
+        ExpectedTerminalResult::Exact("API Error: Overloaded"),
+        None,
         Some("ignored assistant text"),
         &base_path,
         &original_directory,
@@ -237,7 +275,8 @@ async fn guest_preserves_pi_error_and_aborted_settlement_results()
             "errorMessage": "",
             "timestamp": 1,
         })],
-        "Pi model turn aborted",
+        ExpectedTerminalResult::Exact("Pi model turn aborted"),
+        None,
         Some("ignored assistant text"),
         &base_path,
         &original_directory,
@@ -252,7 +291,56 @@ async fn guest_preserves_pi_error_and_aborted_settlement_results()
     run_settlement_case(
         "00000000-0000-4000-8000-000000000126",
         std::slice::from_ref(&assistant_end["message"]),
-        "This operation was aborted",
+        ExpectedTerminalResult::Exact("This operation was aborted"),
+        None,
+        None,
+        &base_path,
+        &original_directory,
+    )
+    .await?;
+    // An older sandbox CLI can still hand Guest a whole upstream page. Guest
+    // must bound it without claiming transport evidence it never observed.
+    run_settlement_case(
+        "00000000-0000-4000-8000-000000000128",
+        &[serde_json::json!({
+            "role": "assistant",
+            "content": [],
+            "model": "deepseek-v4-flash",
+            "responseId": "response-upstream-document",
+            "usage": {},
+            "stopReason": "error",
+            "errorMessage": format!(
+                "<html>\n  <head><style global>body{{color:#8e8ea0}}</style></head>\n  <body>{}</body>\n</html>",
+                "<svg viewBox=\"0 0 41 41\"><path d=\"M37.5324 16.8707\" /></svg>".repeat(200)
+            ),
+            "timestamp": 1,
+        })],
+        ExpectedTerminalResult::UpstreamNonApiResponse,
+        None,
+        None,
+        &base_path,
+        &original_directory,
+    )
+    .await?;
+    // A current CLI already replaced the page at its provider boundary, so the
+    // observed status classifies the failure as an upstream server error.
+    run_settlement_case(
+        "00000000-0000-4000-8000-000000000129",
+        &[serde_json::json!({
+            "role": "assistant",
+            "content": [],
+            "model": "deepseek-v4-flash",
+            "responseId": "response-upstream-marker",
+            "usage": {},
+            "stopReason": "error",
+            "errorMessage":
+                "upstream_non_api_response status=502 content_type=html bytes=4711 digest=1a2b3c4d",
+            "timestamp": 1,
+        })],
+        ExpectedTerminalResult::Exact(
+            "upstream_non_api_response status=502 content_type=html bytes=4711 digest=1a2b3c4d",
+        ),
+        Some(FailureReason::ProviderServerError),
         None,
         &base_path,
         &original_directory,
@@ -267,7 +355,8 @@ async fn guest_preserves_pi_error_and_aborted_settlement_results()
     run_settlement_case(
         "00000000-0000-4000-8000-000000000127",
         &[success["message"].clone(), aborted["message"].clone()],
-        "This operation was aborted",
+        ExpectedTerminalResult::Exact("This operation was aborted"),
+        None,
         None,
         &base_path,
         &original_directory,

--- a/crates/runner/src/cmd/start/job_terminal_log.rs
+++ b/crates/runner/src/cmd/start/job_terminal_log.rs
@@ -798,6 +798,30 @@ mod tests {
     }
 
     #[test]
+    fn pi_result_upstream_server_error_logs_job_execution_failed_at_info() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::Pi,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_detail_source(FailureDetailSource::PiResult)
+        .with_session_history_status(SessionHistoryStatus::NotApplicable)
+        .with_failure_reason(FailureReason::ProviderServerError);
+        let error =
+            "upstream_non_api_response status=502 content_type=html bytes=4711 digest=1a2b3c4d";
+        let failure = executor::ExecutionFailure::new(1, error, Some(diagnostic));
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_eq!(event.level, Level::INFO);
+        assert_field_eq(&event, "error", error);
+        assert_field_eq(&event, "failure_reason", "provider_server_error");
+        assert_field_eq(&event, "failure_framework", "pi");
+        assert_field_eq(&event, "failure_detail_source", "pi_result");
+    }
+
+    #[test]
     fn claude_result_provider_overloaded_logs_job_execution_failed_at_info() {
         let diagnostic = FailureDiagnostic::new(
             FailureClass::CliNonzero,

--- a/turbo/packages/pi-agent-runtime/src/model.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/model.test.ts
@@ -204,6 +204,70 @@ describe("Pi agent model adapter", () => {
     },
   );
 
+  it.each([
+    {
+      name: "public Responses",
+      config: {
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        apiKey: "test-key",
+        model: "gpt-5.6-terra",
+        dialect: "openai-responses",
+      } as const,
+    },
+    {
+      name: "Codex Responses",
+      config: {
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+        apiKey: "opaque-not-a-jwt",
+        accountId: "account-id-from-binding",
+        model: "gpt-5.6-terra",
+        dialect: "openai-codex-responses",
+        transport: "sse",
+      } as const,
+    },
+  ])(
+    "reports transport evidence instead of an upstream $name error page",
+    async ({ config }) => {
+      const page = [
+        "<html>",
+        "  <head><style global>body{font-family:Arial}.logo{color:#8e8ea0}</style></head>",
+        '  <body><svg viewBox="0 0 41 41"><path d="M37.5324 16.8707" /></svg></body>',
+        "</html>",
+      ].join("\n");
+      const providerFetch = vi.fn(() => {
+        return Promise.resolve(
+          new Response(page, {
+            status: 502,
+            statusText: "Bad Gateway",
+            headers: { "content-type": "text/html; charset=utf-8" },
+          }),
+        );
+      });
+      const model = resolvePiAgentModel(config);
+      if (!model) {
+        throw new Error("Expected a resolvable model");
+      }
+
+      const result = await piAgentStreamForConfig(config)(
+        model,
+        { messages: [{ role: "user", content: "hello", timestamp: 1 }] },
+        { apiKey: config.apiKey, fetch: providerFetch },
+      ).result();
+
+      expect(providerFetch).toHaveBeenCalled();
+      expect(result.stopReason).toBe("error");
+      const errorMessage = result.errorMessage ?? "";
+      expect(errorMessage).toContain("upstream_non_api_response");
+      expect(errorMessage).toContain("status=502");
+      expect(errorMessage).toContain("content_type=html");
+      expect(errorMessage).not.toContain("<html");
+      expect(errorMessage).not.toContain("<svg");
+      expect(errorMessage).not.toContain("8e8ea0");
+    },
+  );
+
   it("uses product admission instead of a second runtime model allowlist", () => {
     expect(
       resolvePiAgentModel({

--- a/turbo/packages/pi-agent-runtime/src/model.ts
+++ b/turbo/packages/pi-agent-runtime/src/model.ts
@@ -25,6 +25,7 @@ import {
   observePiResponseStatus,
   type PiAgentStreamOptions,
 } from "./stream-options";
+import { guardPiUpstreamErrorBody } from "./upstream-error-body";
 
 const PI_AGENT_USER_AGENT = "okou-pi-agent/1.0";
 
@@ -320,11 +321,11 @@ export function piAgentStreamForConfig(
     ) {
       return streamPiNative(config, model, context, configuredOptions);
     }
-    // Both OpenAI Responses routes answer an opaque gateway body with the raw
-    // text alone, so the observed status has to be preserved here to stay in
-    // the terminal error at all.
+    // Every public route drops an upstream markup error page before the
+    // adapter can fold it into its terminal message. Other opaque gateway
+    // bodies then retain their observed status in the terminal error.
     const boundaryFetch = preserveProviderErrorStatus(
-      configuredOptions.fetch ?? globalThis.fetch,
+      guardPiUpstreamErrorBody(configuredOptions.fetch ?? globalThis.fetch),
     );
     const responseOptions = {
       ...configuredOptions,

--- a/turbo/packages/pi-agent-runtime/src/native-stream.ts
+++ b/turbo/packages/pi-agent-runtime/src/native-stream.ts
@@ -15,6 +15,7 @@ import {
   observePiResponseStatus,
   type PiAgentStreamOptions,
 } from "./stream-options";
+import { guardPiUpstreamErrorBody } from "./upstream-error-body";
 
 function isMessages(model: Model<Api>): model is Model<"anthropic-messages"> {
   return model.api === "anthropic-messages";
@@ -52,7 +53,7 @@ export function streamPiNative(
     ...options,
     maxRetries: 0,
     fetch: observePiResponseStatus(
-      options.fetch ?? nativePublicFetch,
+      guardPiUpstreamErrorBody(options.fetch ?? nativePublicFetch),
       options.onObservedResponseStatus,
     ),
     // Neither ambient cache policy nor provider authentication is inherited.

--- a/turbo/packages/pi-agent-runtime/src/native.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/native.test.ts
@@ -395,6 +395,47 @@ describe("native Pi execution edges", () => {
     },
   );
 
+  // Bedrock reaches its upstream through the AWS SDK request handler rather
+  // than the adapter fetch, so only the Messages route crosses this boundary.
+  it.each(
+    fixtures.filter(({ config }) => {
+      return config.dialect === "anthropic-messages";
+    }),
+  )(
+    "reports transport evidence instead of an upstream $name error page",
+    async ({ config: input }) => {
+      const config = piModelConfigV4Schema.parse(input);
+      const page =
+        "<html><head><style global>.logo{color:#8e8ea0}</style></head>" +
+        '<body><svg viewBox="0 0 41 41"><path d="M37.5324 16.8707" /></svg></body></html>';
+      server.use(
+        http.post(piNativeInferenceUrl(config), () => {
+          return new HttpResponse(page, {
+            status: 503,
+            headers: { "content-type": "text/html; charset=utf-8" },
+          });
+        }),
+      );
+      const materialized = await materialize(config);
+      const model = resolvePiAgentModel(materialized);
+      if (!model) throw new Error("Missing native model");
+
+      const result = await piAgentStreamForConfig(materialized)(
+        model,
+        { messages: [{ role: "user", content: "hello", timestamp: 1 }] },
+        { apiKey: materialized.apiKey },
+      ).result();
+
+      expect(result.stopReason).toBe("error");
+      const errorMessage = result.errorMessage ?? "";
+      expect(errorMessage).toContain("upstream_non_api_response");
+      expect(errorMessage).toContain("status=503");
+      expect(errorMessage).toContain("content_type=html");
+      expect(errorMessage).not.toContain("<svg");
+      expect(errorMessage).not.toContain("8e8ea0");
+    },
+  );
+
   it.each(fixtures)(
     "cancels $name at the actual request boundary without a retry",
     async ({ config: input }) => {

--- a/turbo/packages/pi-agent-runtime/src/upstream-error-body.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/upstream-error-body.test.ts
@@ -205,6 +205,42 @@ describe("Pi upstream error body guard", () => {
     await expect(response.text()).resolves.toBe("no healthy upstream");
   });
 
+  it("bounds an all-whitespace opaque error probe before returning it", async () => {
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    const prefix = " ".repeat(2_048);
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start(next) {
+          controller = next;
+          next.enqueue(new TextEncoder().encode(prefix));
+        },
+      }),
+      { status: 503, headers: { "content-type": "text/plain" } },
+    );
+    const guarded = guardPiUpstreamErrorBody(() => {
+      return Promise.resolve(upstream);
+    });
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const response = await Promise.race([
+      guarded("https://provider.example/v1/responses"),
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error("opaque error probe did not stay bounded"));
+        }, 1_000);
+      }),
+    ]);
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+    controller.enqueue(new TextEncoder().encode("later provider detail"));
+    controller.close();
+
+    expect(response.status).toBe(503);
+    await expect(response.text()).resolves.toBe(
+      `${prefix}later provider detail`,
+    );
+  });
+
   it("drops transfer framing the consumed body invalidated", async () => {
     const guarded = guardPiUpstreamErrorBody(
       respondWith(ERROR_PAGE, {

--- a/turbo/packages/pi-agent-runtime/src/upstream-error-body.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/upstream-error-body.test.ts
@@ -172,6 +172,39 @@ describe("Pi upstream error body guard", () => {
     );
   });
 
+  it("does not buffer a non-markup error before returning it", async () => {
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start(next) {
+          controller = next;
+          next.enqueue(new TextEncoder().encode("no healthy upstream"));
+        },
+      }),
+      { status: 503, headers: { "content-type": "text/plain" } },
+    );
+    const guarded = guardPiUpstreamErrorBody(() => {
+      return Promise.resolve(upstream);
+    });
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const response = await Promise.race([
+      guarded("https://provider.example/v1/responses"),
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error("non-markup error body was buffered before return"));
+        }, 1_000);
+      }),
+    ]);
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+    controller.close();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("content-type")).toBe("text/plain");
+    await expect(response.text()).resolves.toBe("no healthy upstream");
+  });
+
   it("drops transfer framing the consumed body invalidated", async () => {
     const guarded = guardPiUpstreamErrorBody(
       respondWith(ERROR_PAGE, {

--- a/turbo/packages/pi-agent-runtime/src/upstream-error-body.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/upstream-error-body.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  UPSTREAM_NON_API_RESPONSE_MARKER,
+  describeUpstreamNonApiResponse,
+  guardPiUpstreamErrorBody,
+  isMarkupDocumentBody,
+} from "./upstream-error-body";
+
+const ERROR_PAGE = [
+  "<html>",
+  "  <head><style global>body{font-family:Arial}.logo{color:#8e8ea0}</style></head>",
+  "  <body>",
+  '    <div class="container"><svg viewBox="0 0 41 41"><path d="M37.5324 16.8707" /></svg></div>',
+  "  </body>",
+  "</html>",
+].join("\n");
+
+function respondWith(
+  body: string | null,
+  init: ResponseInit,
+): NonNullable<Parameters<typeof guardPiUpstreamErrorBody>[0]> {
+  return () => {
+    return Promise.resolve(new Response(body, init));
+  };
+}
+
+describe("Pi upstream error body guard", () => {
+  it("replaces a failed markup body with a bounded description", async () => {
+    const guarded = guardPiUpstreamErrorBody(
+      respondWith(ERROR_PAGE, {
+        status: 502,
+        statusText: "Bad Gateway",
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+
+    const response = await guarded("https://provider.example/v1/responses");
+    const text = await response.text();
+
+    expect(response.status).toBe(502);
+    expect(response.statusText).toBe("Bad Gateway");
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(text).not.toContain("<html");
+    expect(text).not.toContain("<svg");
+    expect(text).not.toContain("8e8ea0");
+    expect(JSON.parse(text)).toStrictEqual({
+      error: {
+        type: UPSTREAM_NON_API_RESPONSE_MARKER,
+        message: describeUpstreamNonApiResponse({
+          status: 502,
+          contentType: "text/html; charset=utf-8",
+          body: ERROR_PAGE,
+        }),
+      },
+    });
+  });
+
+  it("records the observed status and content type in the description", () => {
+    const message = describeUpstreamNonApiResponse({
+      status: 525,
+      contentType: "text/html; charset=utf-8",
+      body: ERROR_PAGE,
+    });
+
+    expect(message).toMatch(
+      /^upstream_non_api_response status=525 content_type=html bytes=\d+ digest=[0-9a-f]{8}$/u,
+    );
+    expect(message).toContain(
+      `bytes=${new TextEncoder().encode(ERROR_PAGE).length}`,
+    );
+  });
+
+  it.each([
+    { contentType: "application/json", expected: "content_type=json" },
+    { contentType: "text/plain", expected: "content_type=text" },
+    { contentType: "application/octet-stream", expected: "content_type=other" },
+    { contentType: null, expected: "content_type=unknown" },
+  ])(
+    "annotates $contentType without letting it override the body",
+    ({ contentType, expected }) => {
+      const message = describeUpstreamNonApiResponse({
+        status: 503,
+        contentType,
+        body: ERROR_PAGE,
+      });
+
+      expect(message).toContain(expected);
+      expect(message).toContain(UPSTREAM_NON_API_RESPONSE_MARKER);
+    },
+  );
+
+  it("groups identical pages and separates different ones by digest", () => {
+    const shared = { status: 502, contentType: "text/html" } as const;
+    const first = describeUpstreamNonApiResponse({
+      ...shared,
+      body: ERROR_PAGE,
+    });
+    const repeat = describeUpstreamNonApiResponse({
+      ...shared,
+      body: ERROR_PAGE,
+    });
+    const other = describeUpstreamNonApiResponse({
+      ...shared,
+      body: `${ERROR_PAGE}<!-- other -->`,
+    });
+
+    expect(first).toBe(repeat);
+    expect(first).not.toBe(other);
+  });
+
+  it.each([
+    {
+      name: "structured provider error",
+      contentType: "application/json",
+      body: '{"error":{"code":"rate_limit_exceeded","message":"You have hit your usage limit."}}',
+    },
+    {
+      name: "plain text provider error",
+      contentType: "text/plain",
+      body: "You've hit your usage limit. Try again in ~13 min.",
+    },
+    {
+      name: "empty body",
+      contentType: "text/plain",
+      body: "",
+    },
+  ])("preserves a $name verbatim", async ({ contentType, body }) => {
+    const guarded = guardPiUpstreamErrorBody(
+      respondWith(body, {
+        status: 429,
+        headers: { "content-type": contentType },
+      }),
+    );
+
+    const response = await guarded("https://provider.example/v1/responses");
+
+    expect(await response.text()).toBe(body);
+    expect(response.status).toBe(429);
+    expect(response.headers.get("content-type")).toBe(contentType);
+  });
+
+  it("leaves a successful streamed response untouched", async () => {
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("data: {}\n\n"));
+          controller.close();
+        },
+      }),
+      { status: 200, headers: { "content-type": "text/event-stream" } },
+    );
+    const guarded = guardPiUpstreamErrorBody(() => {
+      return Promise.resolve(upstream);
+    });
+
+    const response = await guarded("https://provider.example/v1/responses");
+
+    expect(response).toBe(upstream);
+    expect(response.bodyUsed).toBe(false);
+    expect(await response.text()).toBe("data: {}\n\n");
+  });
+
+  it("leaves a failed response without a body untouched", async () => {
+    const upstream = new Response(null, { status: 504 });
+    const guarded = guardPiUpstreamErrorBody(() => {
+      return Promise.resolve(upstream);
+    });
+
+    expect(await guarded("https://provider.example/v1/responses")).toBe(
+      upstream,
+    );
+  });
+
+  it("drops transfer framing the consumed body invalidated", async () => {
+    const guarded = guardPiUpstreamErrorBody(
+      respondWith(ERROR_PAGE, {
+        status: 502,
+        headers: {
+          "content-type": "text/html",
+          "content-encoding": "gzip",
+          "x-request-id": "request-42",
+        },
+      }),
+    );
+
+    const response = await guarded("https://provider.example/v1/responses");
+
+    expect(response.headers.get("content-encoding")).toBeNull();
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("x-request-id")).toBe("request-42");
+  });
+
+  it.each([
+    {
+      name: "doctype page",
+      body: "<!DOCTYPE html><html><body>x</body></html>",
+    },
+    {
+      name: "leading whitespace page",
+      body: "\n  <html><body>x</body></html>",
+    },
+    {
+      name: "bare svg document",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" />',
+    },
+  ])("detects a $name as markup", ({ body }) => {
+    expect(isMarkupDocumentBody(body)).toBe(true);
+  });
+
+  it.each([
+    { name: "json object", body: '{"error":{"message":"<html> in text"}}' },
+    { name: "plain sentence", body: "Overloaded" },
+    { name: "empty body", body: "" },
+    {
+      name: "xml without markup document markers",
+      body: "<Error><Code>x</Code></Error>",
+    },
+  ])("does not treat a $name as markup", ({ body }) => {
+    expect(isMarkupDocumentBody(body)).toBe(false);
+  });
+});

--- a/turbo/packages/pi-agent-runtime/src/upstream-error-body.ts
+++ b/turbo/packages/pi-agent-runtime/src/upstream-error-body.ts
@@ -7,13 +7,16 @@ import type { SimpleStreamOptions } from "@earendil-works/pi-ai";
  *
  * Guest-agent recognizes the same token when it projects a Pi terminal result
  * and classifies the failure, so the spelling is a cross-language contract.
- * Keep it in sync with `PI_UPSTREAM_NON_API_RESPONSE_MARKER` in
- * `crates/guest-agent/src/failure_patterns.rs`.
+ * Keep it in sync with `UPSTREAM_NON_API_RESPONSE_MARKER` in
+ * `crates/guest-agent/src/upstream_error_text.rs`.
  */
 export const UPSTREAM_NON_API_RESPONSE_MARKER = "upstream_non_api_response";
 
 /** Only the leading bytes decide whether a failed body is a markup document. */
 const MARKUP_PROBE_CHARS = 512;
+
+/** A UTF-8 code point needs at most four bytes in the bounded probe. */
+const MARKUP_PROBE_BYTES = MARKUP_PROBE_CHARS * 4;
 
 /** Enough to group repeated pages in logs without republishing any of one. */
 const DIGEST_CHARS = 8;
@@ -64,12 +67,26 @@ export function describeUpstreamNonApiResponse(args: {
     .update(args.body, "utf8")
     .digest("hex")
     .slice(0, DIGEST_CHARS);
+  return describeUpstreamNonApiResponseMetadata({
+    status: args.status,
+    contentType: args.contentType,
+    bytes,
+    digest,
+  });
+}
+
+function describeUpstreamNonApiResponseMetadata(args: {
+  readonly status: number;
+  readonly contentType: string | null;
+  readonly bytes: number;
+  readonly digest: string;
+}): string {
   return [
     UPSTREAM_NON_API_RESPONSE_MARKER,
     `status=${args.status}`,
     `content_type=${contentTypeFamily(args.contentType)}`,
-    `bytes=${bytes}`,
-    `digest=${digest}`,
+    `bytes=${args.bytes}`,
+    `digest=${args.digest}`,
   ].join(" ");
 }
 
@@ -100,26 +117,89 @@ export function guardPiUpstreamErrorBody(
     if (response.ok || response.body === null) {
       return response;
     }
-    const body = await response.text();
-    if (!isMarkupDocumentBody(body)) {
-      // Genuine provider errors keep their exact text; only the framing that
-      // the consumed body invalidated is rebuilt.
-      return new Response(body, {
-        headers: replayableHeaders(response.headers),
-        status: response.status,
-        statusText: response.statusText,
-      });
+
+    // A non-markup provider error must keep streaming exactly as supplied. For
+    // markup, retain only a bounded probe while consuming the other branch to
+    // count and hash the discarded document. This avoids buffering an
+    // arbitrarily large gateway page merely to make its safe description.
+    const [inspectionBody, passthroughBody] = response.body.tee();
+    const reader = inspectionBody.getReader();
+    const hasher = createHash("sha256");
+    const decoder = new TextDecoder();
+    let bytes = 0;
+    let probe = "";
+    let markup: boolean | undefined;
+
+    try {
+      while (markup === undefined) {
+        const next = await reader.read();
+        if (next.done) {
+          probe = `${probe}${decoder.decode()}`.trimStart();
+          markup = isMarkupDocumentBody(probe);
+          break;
+        }
+
+        bytes += next.value.byteLength;
+        hasher.update(next.value);
+        for (
+          let offset = 0;
+          offset < next.value.byteLength && markup === undefined;
+          offset += MARKUP_PROBE_BYTES
+        ) {
+          const segment = next.value.subarray(
+            offset,
+            Math.min(offset + MARKUP_PROBE_BYTES, next.value.byteLength),
+          );
+          probe = `${probe}${decoder.decode(segment, { stream: true })}`
+            .trimStart()
+            .slice(0, MARKUP_PROBE_CHARS);
+          if (probe.length > 0 && !probe.startsWith("<")) {
+            markup = false;
+          } else if (
+            isMarkupDocumentBody(probe) ||
+            probe.length === MARKUP_PROBE_CHARS
+          ) {
+            markup = isMarkupDocumentBody(probe);
+          }
+        }
+      }
+
+      if (!markup) {
+        // The untouched tee branch preserves the original body and framing.
+        void reader.cancel().catch(() => {});
+        return new Response(passthroughBody, {
+          headers: response.headers,
+          status: response.status,
+          statusText: response.statusText,
+        });
+      }
+
+      // The passthrough branch is intentionally discarded before the full
+      // markup stream is drained for metadata only.
+      void passthroughBody.cancel().catch(() => {});
+      for (;;) {
+        const next = await reader.read();
+        if (next.done) {
+          break;
+        }
+        bytes += next.value.byteLength;
+        hasher.update(next.value);
+      }
+    } finally {
+      reader.releaseLock();
     }
+
     const headers = replayableHeaders(response.headers);
     headers.set("content-type", "application/json");
     return new Response(
       JSON.stringify({
         error: {
           type: UPSTREAM_NON_API_RESPONSE_MARKER,
-          message: describeUpstreamNonApiResponse({
+          message: describeUpstreamNonApiResponseMetadata({
             status: response.status,
             contentType: response.headers.get("content-type"),
-            body,
+            bytes,
+            digest: hasher.digest("hex").slice(0, DIGEST_CHARS),
           }),
         },
       }),

--- a/turbo/packages/pi-agent-runtime/src/upstream-error-body.ts
+++ b/turbo/packages/pi-agent-runtime/src/upstream-error-body.ts
@@ -1,0 +1,133 @@
+import { createHash } from "node:crypto";
+
+import type { SimpleStreamOptions } from "@earendil-works/pi-ai";
+
+/**
+ * Stable token marking a provider error body this boundary replaced.
+ *
+ * Guest-agent recognizes the same token when it projects a Pi terminal result
+ * and classifies the failure, so the spelling is a cross-language contract.
+ * Keep it in sync with `PI_UPSTREAM_NON_API_RESPONSE_MARKER` in
+ * `crates/guest-agent/src/failure_patterns.rs`.
+ */
+export const UPSTREAM_NON_API_RESPONSE_MARKER = "upstream_non_api_response";
+
+/** Only the leading bytes decide whether a failed body is a markup document. */
+const MARKUP_PROBE_CHARS = 512;
+
+/** Enough to group repeated pages in logs without republishing any of one. */
+const DIGEST_CHARS = 8;
+
+type ContentTypeFamily = "json" | "html" | "text" | "other" | "unknown";
+
+function contentTypeFamily(header: string | null): ContentTypeFamily {
+  const normalized = header?.trim().toLowerCase() ?? "";
+  if (normalized.length === 0) {
+    return "unknown";
+  }
+  if (normalized.includes("json")) {
+    return "json";
+  }
+  if (normalized.includes("html")) {
+    return "html";
+  }
+  return normalized.startsWith("text/") ? "text" : "other";
+}
+
+/**
+ * Recognize a markup document from the body itself.
+ *
+ * A gateway, captive portal or branded status page can serve markup under any
+ * declared content type, so the body decides and the header only annotates.
+ */
+export function isMarkupDocumentBody(body: string): boolean {
+  const head = body.trimStart().slice(0, MARKUP_PROBE_CHARS).toLowerCase();
+  if (!head.startsWith("<")) {
+    return false;
+  }
+  return (
+    head.includes("<!doctype html") ||
+    head.includes("<html") ||
+    head.includes("<body") ||
+    head.includes("<svg")
+  );
+}
+
+/** Describe a discarded upstream document without republishing any of it. */
+export function describeUpstreamNonApiResponse(args: {
+  readonly status: number;
+  readonly contentType: string | null;
+  readonly body: string;
+}): string {
+  const bytes = new TextEncoder().encode(args.body).length;
+  const digest = createHash("sha256")
+    .update(args.body, "utf8")
+    .digest("hex")
+    .slice(0, DIGEST_CHARS);
+  return [
+    UPSTREAM_NON_API_RESPONSE_MARKER,
+    `status=${args.status}`,
+    `content_type=${contentTypeFamily(args.contentType)}`,
+    `bytes=${bytes}`,
+    `digest=${digest}`,
+  ].join(" ");
+}
+
+function replayableHeaders(headers: Headers): Headers {
+  const replayable = new Headers(headers);
+  // The body was decoded and is re-sent as plain bytes; the transfer-encoding
+  // metadata of the original response no longer describes it.
+  replayable.delete("content-length");
+  replayable.delete("content-encoding");
+  return replayable;
+}
+
+/**
+ * Replace a markup error body with a bounded, API-shaped description.
+ *
+ * Provider adapters compose their terminal `errorMessage` from a failed
+ * response body. When an upstream answers with an HTML page instead of an API
+ * error, that whole document becomes the run's failure text, and truncation
+ * downstream keeps only its stylesheet and logo markup. This boundary keeps
+ * the transport status and content type, drops the document, and leaves
+ * successful responses, streamed bodies and genuine API errors untouched.
+ */
+export function guardPiUpstreamErrorBody(
+  fetchImpl: NonNullable<SimpleStreamOptions["fetch"]>,
+): NonNullable<SimpleStreamOptions["fetch"]> {
+  return async (input, init) => {
+    const response = await fetchImpl(input, init);
+    if (response.ok || response.body === null) {
+      return response;
+    }
+    const body = await response.text();
+    if (!isMarkupDocumentBody(body)) {
+      // Genuine provider errors keep their exact text; only the framing that
+      // the consumed body invalidated is rebuilt.
+      return new Response(body, {
+        headers: replayableHeaders(response.headers),
+        status: response.status,
+        statusText: response.statusText,
+      });
+    }
+    const headers = replayableHeaders(response.headers);
+    headers.set("content-type", "application/json");
+    return new Response(
+      JSON.stringify({
+        error: {
+          type: UPSTREAM_NON_API_RESPONSE_MARKER,
+          message: describeUpstreamNonApiResponse({
+            status: response.status,
+            contentType: response.headers.get("content-type"),
+            body,
+          }),
+        },
+      }),
+      {
+        headers,
+        status: response.status,
+        statusText: response.statusText,
+      },
+    );
+  };
+}

--- a/turbo/packages/pi-agent-runtime/src/upstream-error-body.ts
+++ b/turbo/packages/pi-agent-runtime/src/upstream-error-body.ts
@@ -100,6 +100,62 @@ function replayableHeaders(headers: Headers): Headers {
 }
 
 /**
+ * Replay the bounded prefix already inspected at the provider boundary, then
+ * continue from the original reader on demand.
+ *
+ * Reading a `tee()` inspection branch while leaving its sibling unconsumed
+ * queues every later chunk in that sibling. Keeping one reader avoids that
+ * hidden full-document buffer: only the probe prefix is retained before the
+ * caller starts consuming the returned response.
+ */
+function replayInspectedBody(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  inspected: readonly Uint8Array[],
+): ReadableStream<Uint8Array> {
+  let inspectedIndex = 0;
+  let readerReleased = false;
+  const releaseReader = () => {
+    if (!readerReleased) {
+      readerReleased = true;
+      reader.releaseLock();
+    }
+  };
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (inspectedIndex < inspected.length) {
+        controller.enqueue(inspected[inspectedIndex]);
+        inspectedIndex += 1;
+        return;
+      }
+
+      try {
+        const next = await reader.read();
+        if (next.done) {
+          controller.close();
+          releaseReader();
+          return;
+        }
+        controller.enqueue(next.value);
+      } catch (error) {
+        controller.error(error);
+        releaseReader();
+      }
+    },
+    async cancel(reason) {
+      if (readerReleased) {
+        return;
+      }
+      try {
+        await reader.cancel(reason);
+      } finally {
+        releaseReader();
+      }
+    },
+  });
+}
+
+/**
  * Replace a markup error body with a bounded, API-shaped description.
  *
  * Provider adapters compose their terminal `errorMessage` from a failed
@@ -118,15 +174,17 @@ export function guardPiUpstreamErrorBody(
       return response;
     }
 
-    // A non-markup provider error must keep streaming exactly as supplied. For
-    // markup, retain only a bounded probe while consuming the other branch to
-    // count and hash the discarded document. This avoids buffering an
-    // arbitrarily large gateway page merely to make its safe description.
-    const [inspectionBody, passthroughBody] = response.body.tee();
-    const reader = inspectionBody.getReader();
+    // A non-markup provider error must keep streaming exactly as supplied. Use
+    // one reader rather than `tee()`: an unconsumed tee sibling would queue the
+    // complete markup document while this branch hashes it. The returned
+    // non-markup stream replays only this bounded inspected prefix, then reads
+    // the original body on demand.
+    const reader = response.body.getReader();
+    const inspected: Uint8Array[] = [];
     const hasher = createHash("sha256");
     const decoder = new TextDecoder();
     let bytes = 0;
+    let inspectedBytes = 0;
     let probe = "";
     let markup: boolean | undefined;
 
@@ -134,49 +192,50 @@ export function guardPiUpstreamErrorBody(
       while (markup === undefined) {
         const next = await reader.read();
         if (next.done) {
-          probe = `${probe}${decoder.decode()}`.trimStart();
+          probe = `${probe}${decoder.decode()}`
+            .trimStart()
+            .slice(0, MARKUP_PROBE_CHARS);
           markup = isMarkupDocumentBody(probe);
           break;
         }
 
+        inspected.push(next.value);
         bytes += next.value.byteLength;
         hasher.update(next.value);
-        for (
-          let offset = 0;
-          offset < next.value.byteLength && markup === undefined;
-          offset += MARKUP_PROBE_BYTES
+        const remainingProbeBytes = MARKUP_PROBE_BYTES - inspectedBytes;
+        const segment = next.value.subarray(
+          0,
+          Math.max(0, remainingProbeBytes),
+        );
+        inspectedBytes += segment.byteLength;
+        probe = `${probe}${decoder.decode(segment, { stream: true })}`
+          .trimStart()
+          .slice(0, MARKUP_PROBE_CHARS);
+        if (probe.length > 0 && !probe.startsWith("<")) {
+          markup = false;
+        } else if (isMarkupDocumentBody(probe)) {
+          markup = true;
+        } else if (
+          inspectedBytes === MARKUP_PROBE_BYTES ||
+          probe.length === MARKUP_PROBE_CHARS
         ) {
-          const segment = next.value.subarray(
-            offset,
-            Math.min(offset + MARKUP_PROBE_BYTES, next.value.byteLength),
-          );
-          probe = `${probe}${decoder.decode(segment, { stream: true })}`
-            .trimStart()
-            .slice(0, MARKUP_PROBE_CHARS);
-          if (probe.length > 0 && !probe.startsWith("<")) {
-            markup = false;
-          } else if (
-            isMarkupDocumentBody(probe) ||
-            probe.length === MARKUP_PROBE_CHARS
-          ) {
-            markup = isMarkupDocumentBody(probe);
-          }
+          // The bounded probe did not identify a document. Preserve this
+          // opaque error rather than waiting for an arbitrarily long stream.
+          markup = false;
         }
       }
 
       if (!markup) {
-        // The untouched tee branch preserves the original body and framing.
-        void reader.cancel().catch(() => {});
-        return new Response(passthroughBody, {
+        return new Response(replayInspectedBody(reader, inspected), {
           headers: response.headers,
           status: response.status,
           statusText: response.statusText,
         });
       }
 
-      // The passthrough branch is intentionally discarded before the full
-      // markup stream is drained for metadata only.
-      void passthroughBody.cancel().catch(() => {});
+      // Do not retain the raw probe once it is known to be markup. Continue
+      // through the same reader to count and hash the discarded document.
+      inspected.length = 0;
       for (;;) {
         const next = await reader.read();
         if (next.done) {
@@ -186,7 +245,11 @@ export function guardPiUpstreamErrorBody(
         hasher.update(next.value);
       }
     } finally {
-      reader.releaseLock();
+      // The replay stream owns this reader after a non-markup return. Every
+      // other path has finished with it here, including probe/read failures.
+      if (markup !== false) {
+        reader.releaseLock();
+      }
     }
 
     const headers = replayableHeaders(response.headers);


### PR DESCRIPTION
## Problem

A Pi model upstream can return a markup document instead of an API error. Without a boundary, that document can become the terminal failure text and erase actionable transport evidence.

This is the same scoped implementation as closed-unmerged #33156. GitHub rejected reopening that PR because its head branch had been deleted and recreated, so this is the single replacement PR on the restored branch.

## Change

- Replace non-2xx markup response bodies at the Pi provider boundary with a bounded metadata-only envelope carrying observed status, content-type family, byte count, and a short digest.
- Preserve successful responses, genuine JSON errors, plain-text provider errors, and opaque streams without retaining a second unbounded stream.
- Apply a bounded Guest projection for older pinned sandbox CLI artifacts, without fabricating transport evidence.
- Classify only observed Pi marker statuses using existing failure-reason tokens; unknown and client-side statuses remain error-level.
- Rebase onto current `main` and retain #33198's oversized-error replay, cancellation, and error-propagation behavior.

## Fallbacks

- `crates/guest-agent/src/upstream_error_text.rs:project_model_error_text` accepts a raw markup `errorMessage` only for a new Guest paired with an older pinned `CLI_PACKAGE_URL` artifact that predates `guardPiUpstreamErrorBody`. Surface: existing runner / sandbox. It emits `status=unknown content_type=unknown` rather than claiming transport evidence. Removal gate: old sandbox CLI artifacts have drained and no pinnable CLI artifact predates the guard. Follow-up: #33067. This is the bounded cross-version compatibility category in `docs/fallback.md` §6.1 and is declared here per §9.

## Validation

- `pnpm vitest run src/provider-error-body.test.ts src/upstream-error-body.test.ts src/model.test.ts src/native.test.ts` — 137 passed.
- `pnpm run check-types`, `pnpm run lint`, and focused Prettier check — passed.
- `cargo test -p guest-agent --lib upstream_error_text` — 7 passed.
- `cargo test -p guest-agent --lib failure_diagnostics` — 111 passed.
- `cargo test -p guest-agent --test pi_cli_settlement_errors` — 1 passed.
- `cargo fmt --check` and `git diff --check` — passed.

Not run locally: the full Vitest suite, a local dev server, and the runner target. Required PR CI remains the authority for those checks. Merge is not production acceptance.

Refs #33067