### PR TITLE
fix(app): keep conversation locator interactions inside the gutter

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/chat-conversation-locator.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-conversation-locator.tsx
@@ -77,7 +77,8 @@ function ConversationLocatorRail({ thread }: { thread: ChatPanelSignals }) {
         className={cn(
           // Hidden on narrow viewports: the rail needs a gutter the phone
           // layout does not have, and those threads are short enough to scroll.
-          "absolute inset-y-0 left-0 z-10 hidden w-14 cursor-pointer transition-opacity duration-300 md:block",
+          // Keep the hit area inside the message content's 24px left gutter.
+          "absolute inset-y-0 left-0 z-10 hidden w-6 cursor-pointer transition-opacity duration-300 md:block",
           !layout.visible && "pointer-events-none opacity-0",
           layout.visible && (engaged ? "opacity-100" : "opacity-[0.68]"),
         )}
@@ -104,7 +105,8 @@ function ConversationLocatorRail({ thread }: { thread: ChatPanelSignals }) {
               className={cn(
                 // Width is written per pointer frame by the locator signals;
                 // React owns everything that only changes with the layout.
-                "absolute left-[14px] h-0.5 -translate-y-1/2 rounded-full transition-colors duration-150",
+                // Magnified ticks must not extend the rail's hit area.
+                "pointer-events-none absolute left-[14px] h-0.5 -translate-y-1/2 rounded-full transition-colors duration-150",
                 tick.current ? "bg-primary/60" : "bg-border",
                 // The turn under the cursor only changes colour — thickness
                 // stays put so the rail keeps one rhythm.


### PR DESCRIPTION
The conversation locator's transparent 56px rail overlaps the first 32px of message content when the chat pane has only its 24px left gutter. Hovering or selecting text there can show the navigation cursor, open a turn preview, or jump to another message.

Limit the hit area to the existing 24px gutter and make the decorative ticks ignore pointer events, including when magnified beyond the rail. Hover previews, tick magnification, click-to-jump, and wheel paging retain their existing behavior within the gutter.

## Verification

- Prettier, focused ESLint, App production type check, App Knip, and repository style policy passed.
- Existing conversation locator page tests: hover/magnification, folded work, click-to-jump, and wheel paging passed. The overview test hit its 5s timeout on the initial run and passed in a focused retry (the timeout was unchanged).
- Browser verification passed on the App/API preview for this head (App build `80889ebc0d2a90446d9bb522fbb07a43a09779d7`, the CI merge commit containing `57ce73f79228d43f47ec6a3cc94c81340f9fac91`). Chromium 152 at 1232×800, sidebar open, with four completed preview mock runs / eight turns and a 7,345px conversation.
- Measured the rail at 24px. A 42px magnified tick passed hit testing through to the paragraph outside the gutter; moving into text closed the preview. Drag selection at the response's left edge selected text without changing scroll position. Clicking the earlier assistant tick jumped from scroll offset 6,797 to 711 and marked the intended turn. `_realAgentInPreview` was verified false; normal Explore onboarding was completed for the test account.

## Acceptance

1. Open a long conversation at desktop width, with the sidebar open or an artifact pane narrowing the chat.
2. Hover and drag-select text at the left edge of an assistant response. The text keeps its normal cursor and selection behavior without opening the locator preview or jumping.
3. Hover the locator gutter, click a tick, and use the wheel over it. Preview, jump, and paging continue to work. Move from a magnified tick into the text and confirm the preview closes.
