### PR TITLE
fix(runner): preserve hostname label boundaries in catalog templates

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import stat
 from dataclasses import dataclass
 from pathlib import Path
@@ -23,12 +24,13 @@ from url_syntax import has_raw_whitespace, has_unsafe_url_codepoint
 
 _SHA256_HEX_LENGTH = 64
 _UNTRUSTED_WRITE_BITS = stat.S_IWGRP | stat.S_IWOTH
-# Use the shortest valid witness for each URL component so materialization does
-# not push an otherwise satisfiable DNS label past its 63-byte limit.
+# Keep component witnesses small; hostname fragments also preserve adjacent
+# literal label boundaries when materialized below.
 _BASE_URL_TEMPLATE_WHOLE_BASE_PLACEHOLDER = "https://x.y"
 _BASE_URL_TEMPLATE_HOST_PLACEHOLDER = "x.y"
 _BASE_URL_TEMPLATE_PORT_PLACEHOLDER = "1"
 _BASE_URL_TEMPLATE_PATH_PLACEHOLDER = "x"
+_BASE_URL_TEMPLATE_HOST_LABEL_DELIMITERS = re.compile(r"[.:/?#@\[\]\u3002\uff0e\uff61]")
 _BASE_URL_TEMPLATE_PLACEHOLDERS: dict[
     builtin_base_url_template.BaseUrlTemplateComponentKind, str
 ] = {
@@ -465,13 +467,38 @@ def _base_url_template_syntax_target(firewall_name: str, raw_base: str) -> str |
 
     result: list[str] = []
     last_index = 0
-    for variable in variables:
+    for index, variable in enumerate(variables):
         reference = variable.reference
         result.append(raw_base[last_index : reference.start])
         placeholder = _BASE_URL_TEMPLATE_PLACEHOLDERS[variable.kind]
         if variable.authority_fragment_shape == "ip-literal":
             placeholder = _BASE_URL_TEMPLATE_PORT_PLACEHOLDER
+        elif variable.authority_fragment_shape == "hostname":
+            literal_end = (
+                variables[index + 1].reference.start
+                if index + 1 < len(variables)
+                else len(raw_base)
+            )
+            placeholder = _base_url_template_hostname_placeholder(
+                raw_base[last_index : reference.start], raw_base[reference.end : literal_end]
+            )
         result.append(placeholder)
         last_index = reference.end
     result.append(raw_base[last_index:])
     return "".join(result)
+
+
+def _base_url_template_hostname_placeholder(prefix: str, suffix: str) -> str:
+    prefix_label = _BASE_URL_TEMPLATE_HOST_LABEL_DELIMITERS.split(prefix)[-1]
+    suffix_label = _BASE_URL_TEMPLATE_HOST_LABEL_DELIMITERS.split(suffix, maxsplit=1)[0]
+    # A variable may supply a dot, so a complete literal label need not grow.
+    # Incomplete labels still join the witness; final URL validation checks both.
+    leading_dot = "." if _base_url_template_literal_label_is_valid(prefix_label) else ""
+    trailing_dot = "." if _base_url_template_literal_label_is_valid(suffix_label) else ""
+    return f"{leading_dot}{_BASE_URL_TEMPLATE_HOST_PLACEHOLDER}{trailing_dot}"
+
+
+def _base_url_template_literal_label_is_valid(label: str) -> bool:
+    return (
+        bool(label) and matching.static_firewall_base_config_key(f"https://x.{label}.y") is not None
+    )

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_validation.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_validation.py
@@ -297,6 +297,57 @@ class TestRegistryBuiltinCatalogValidation:
         assert compiled_firewalls is not None
         assert sandbox_info["firewalls"][0]["apis"][0]["base"] == "https://acme.example.com"
 
+    @pytest.mark.parametrize(
+        "literal_label",
+        ["a" * 62, "a" * 63, "é" * 57, "%C3%A9" * 57],
+        ids=["62-characters", "63-characters", "63-byte-idna", "encoded-63-byte-idna"],
+    )
+    def test_hostname_suffix_template_preserves_unrelated_catalog_connector(
+        self, tmp_path, mitm_ctx, literal_label
+    ):
+        base = "https://" + literal_label + "${{ vars.SUFFIX }}"
+        registry_path, cache_path = write_registry_with_cache(
+            tmp_path,
+            {
+                "10.200.0.1": builtin_sandbox(
+                    "run-template", "templated", {"SUFFIX": ".example.com"}
+                ),
+                "10.200.0.2": builtin_sandbox("run-static", "static"),
+            },
+            {
+                "templated": {
+                    "name": "templated",
+                    "apis": [
+                        {
+                            "base": base,
+                            "hostPolicy": {"kind": "providerOwned", "suffixes": ["example.com"]},
+                            "auth": {"headers": {}},
+                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
+                        }
+                    ],
+                },
+                "static": cache_firewall("static", "https://api.static.example.com"),
+            },
+        )
+
+        with mitm_ctx(
+            registry_path=str(registry_path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            template_context = registry.get_sandbox_context("10.200.0.1", str(registry_path))
+            static_context = registry.get_sandbox_context("10.200.0.2", str(registry_path))
+
+        assert template_context is not None
+        template_info, template_firewalls, _ = template_context
+        assert template_firewalls is not None
+        assert template_info["firewalls"][0]["apis"][0]["base"] == (
+            "https://" + literal_label + ".example.com"
+        )
+        assert static_context is not None
+        static_info, static_firewalls, _ = static_context
+        assert static_firewalls is not None
+        assert static_info["firewalls"][0]["apis"][0]["base"] == "https://api.static.example.com"
+
     def test_runner_catalog_cache_resolves_whole_host_template_with_path_parameter(
         self, tmp_path, mitm_ctx
     ):
@@ -352,6 +403,43 @@ class TestRegistryBuiltinCatalogValidation:
             sandbox_info["firewalls"][0]["apis"][0]["base"]
             == "https://acme.uspacy.com/v1/hooks/{hookKey}"
         )
+
+    @pytest.mark.parametrize(
+        ("base", "vars_map", "resolved_base"),
+        [
+            pytest.param(
+                "https://${{ vars.PREFIX }}\u0301.example.com",
+                {"PREFIX": "e"},
+                "https://e\u0301.example.com",
+                id="incomplete-combining-label",
+            ),
+            pytest.param(
+                "https://api\u3002${{ vars.HOST }}.example.com",
+                {"HOST": "tenant"},
+                "https://api\u3002tenant.example.com",
+                id="existing-unicode-label-separator",
+            ),
+        ],
+    )
+    def test_hostname_template_preserves_literal_label_syntax(
+        self, tmp_path, mitm_ctx, base, vars_map, resolved_base
+    ):
+        registry_path, cache_path = write_registry_with_cache(
+            tmp_path,
+            {"10.200.0.1": builtin_sandbox("run-template", "templated", vars_map)},
+            {"templated": {"name": "templated", "apis": [{"base": base, "auth": {}}]}},
+        )
+
+        with mitm_ctx(
+            registry_path=str(registry_path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            context = registry.get_sandbox_context("10.200.0.1", str(registry_path))
+
+        assert context is not None
+        sandbox_info, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        assert sandbox_info["firewalls"][0]["apis"][0]["base"] == resolved_base
 
     @pytest.mark.parametrize(
         "raw_json",

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -488,12 +488,15 @@ fn is_unsafe_url_codepoint(ch: char) -> bool {
     ch < '\u{0020}' || ch == '\u{007f}'
 }
 
-// Use the shortest valid witness for each URL component so materialization does
-// not push an otherwise satisfiable DNS label past its 63-byte limit.
+// Keep component witnesses small; hostname fragments also preserve adjacent
+// literal label boundaries when materialized below.
 const BASE_URL_TEMPLATE_WHOLE_BASE_PLACEHOLDER: &str = "https://x.y";
 const BASE_URL_TEMPLATE_HOST_PLACEHOLDER: &str = "x.y";
 const BASE_URL_TEMPLATE_PORT_PLACEHOLDER: &str = "1";
 const BASE_URL_TEMPLATE_PATH_PLACEHOLDER: &str = "x";
+const BASE_URL_TEMPLATE_HOST_LABEL_DELIMITERS: &[char] = &[
+    '.', ':', '/', '?', '#', '@', '[', ']', '\u{3002}', '\u{ff0e}', '\u{ff61}',
+];
 
 // Precompute fixed URL delimiters once; a catalog base can contain many templates.
 struct BaseUrlTemplateComponentBoundaries {
@@ -618,6 +621,7 @@ fn base_url_template_syntax_target_for_cache(base: &str) -> Result<Option<String
         let template_end = end + "}}".len();
         result.push_str(base_url_template_syntax_placeholder_for_cache(
             base,
+            search_start,
             start,
             template_end,
             &boundaries,
@@ -658,6 +662,7 @@ fn is_ecmascript_whitespace(ch: char) -> bool {
 
 fn base_url_template_syntax_placeholder_for_cache(
     base: &str,
+    literal_start: usize,
     start: usize,
     template_end: usize,
     boundaries: &BaseUrlTemplateComponentBoundaries,
@@ -675,12 +680,43 @@ fn base_url_template_syntax_placeholder_for_cache(
         if base[..start].ends_with(':') && ends_base_or_starts_path {
             return Ok(BASE_URL_TEMPLATE_PORT_PLACEHOLDER);
         }
-        return Ok(BASE_URL_TEMPLATE_HOST_PLACEHOLDER);
+        let prefix = &base[literal_start..start];
+        let remaining = &base[template_end..];
+        let suffix = remaining
+            .split_once("${{")
+            .map_or(remaining, |(literal, _)| literal);
+        return Ok(base_url_template_hostname_placeholder(prefix, suffix));
     }
     if boundaries.prefix_is_inside_path(start) {
         return Ok(BASE_URL_TEMPLATE_PATH_PLACEHOLDER);
     }
     Err("base URL template variable is used in an unsupported position".to_string())
+}
+
+fn base_url_template_hostname_placeholder(prefix: &str, suffix: &str) -> &'static str {
+    let prefix_label = prefix
+        .rsplit_once(BASE_URL_TEMPLATE_HOST_LABEL_DELIMITERS)
+        .map_or(prefix, |(_, label)| label);
+    let suffix_label = suffix
+        .split_once(BASE_URL_TEMPLATE_HOST_LABEL_DELIMITERS)
+        .map_or(suffix, |(label, _)| label);
+    // A variable may supply a dot, so a complete literal label need not grow.
+    // Incomplete labels still join the witness; final URL validation checks both.
+    match (
+        base_url_template_literal_label_is_valid(prefix_label),
+        base_url_template_literal_label_is_valid(suffix_label),
+    ) {
+        (true, true) => ".x.y.",
+        (true, false) => ".x.y",
+        (false, true) => "x.y.",
+        (false, false) => BASE_URL_TEMPLATE_HOST_PLACEHOLDER,
+    }
+}
+
+fn base_url_template_literal_label_is_valid(label: &str) -> bool {
+    !label.is_empty()
+        && validate_parameterized_firewall_base_authority("https", &format!("x.{label}.y"), "")
+            .is_ok()
 }
 
 fn validate_template_identifier(name: &str, label: &str) -> Result<(), String> {

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -3,6 +3,24 @@
   "baseUrlTemplateResolutionCases": [
     {
       "category": "authority-fragment",
+      "name": "host suffix cannot extend a full literal label",
+      "base": "https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa${{ vars.SUFFIX }}/v1/{resource}",
+      "vars": {
+        "SUFFIX": "x.example.com"
+      },
+      "expectedResolvedBase": null
+    },
+    {
+      "category": "authority-fragment",
+      "name": "host suffix cannot introduce authority or path structure",
+      "base": "https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa${{ vars.SUFFIX }}/v1/{resource}",
+      "vars": {
+        "SUFFIX": ".example.com:443/capture"
+      },
+      "expectedResolvedBase": null
+    },
+    {
+      "category": "authority-fragment",
       "name": "trailing authority fragment before path resolves",
       "base": "https://api-${{ vars.HOST }}/v1",
       "vars": { "HOST": "tenant.example.com" },
@@ -160,6 +178,77 @@
       },
       "expectedValid": true,
       "expectedResolvedBase": "https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaax.example/v1/{resource}"
+    },
+    {
+      "category": "valid",
+      "name": "host suffix starts a new label after 62 literal characters",
+      "base": "https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa${{ vars.SUFFIX }}/v1/{resource}",
+      "vars": {
+        "SUFFIX": ".example.com"
+      },
+      "expectedValid": true,
+      "expectedResolvedBase": "https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.example.com/v1/{resource}"
+    },
+    {
+      "category": "valid",
+      "name": "host suffix starts a new label after 63 literal characters",
+      "base": "https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa${{ vars.SUFFIX }}/v1/{resource}",
+      "vars": {
+        "SUFFIX": ".example.com"
+      },
+      "expectedValid": true,
+      "expectedResolvedBase": "https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.example.com/v1/{resource}"
+    },
+    {
+      "category": "valid",
+      "name": "host prefix ends a label before 63 literal characters",
+      "base": "https://${{ vars.PREFIX }}bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/v1/{resource}",
+      "vars": {
+        "PREFIX": "api."
+      },
+      "expectedValid": true,
+      "expectedResolvedBase": "https://api.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/v1/{resource}"
+    },
+    {
+      "category": "valid",
+      "name": "host variable separates two full literal labels",
+      "base": "https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa${{ vars.MIDDLE }}bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/v1/{resource}",
+      "vars": {
+        "MIDDLE": "."
+      },
+      "expectedValid": true,
+      "expectedResolvedBase": "https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/v1/{resource}"
+    },
+    {
+      "category": "valid",
+      "name": "adjacent host variables separate full literal labels",
+      "base": "https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa${{ vars.FIRST }}${{ vars.SECOND }}bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/v1/{resource}",
+      "vars": {
+        "FIRST": ".api",
+        "SECOND": "."
+      },
+      "expectedValid": true,
+      "expectedResolvedBase": "https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.api.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/v1/{resource}"
+    },
+    {
+      "category": "valid",
+      "name": "host variable preserves a canonical alabel",
+      "base": "https://xn--bcher-kva${{ vars.SUFFIX }}/v1/{resource}",
+      "vars": {
+        "SUFFIX": ".example.com"
+      },
+      "expectedValid": true,
+      "expectedResolvedBase": "https://xn--bcher-kva.example.com/v1/{resource}"
+    },
+    {
+      "category": "authority",
+      "name": "host suffix cannot repair an overlong literal label",
+      "base": "https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa${{ vars.SUFFIX }}/v1/{resource}",
+      "vars": {
+        "SUFFIX": ".example.com"
+      },
+      "expectedValid": false,
+      "expectedResolvedBase": null
     },
     {
       "category": "valid",


### PR DESCRIPTION
A valid hostname suffix template such as a 63-character label followed by `${{ vars.SUFFIX }}` with `.example.com` can make the shared firewall catalog unavailable. Preserve independently valid literal hostname labels when constructing catalog-validation witnesses in the Python addon and Rust runner, while retaining strict validation of complete resolved URLs and host policies.

Add shared contract cases for prefix/suffix boundaries, variables between full labels, adjacent references, canonical A-labels, and unsafe or overlong resolved values. Registry regressions verify that unrelated catalog connectors remain available, including Unicode and percent-encoded label boundaries. The catalog format and runtime variable policy are unchanged; this PR does not publish a catalog.

Closes #33210.

## Validation

- Before the fix: 7 expected regression failures, with 62-character controls passing.
- Focused Python catalog, registry, matching, template, and host-policy suites: 760 passed.
- `uv run --no-sync ruff check .` and `ruff format --check .`: passed.
- `uv run --no-sync basedpyright -p .`: 0 errors, 0 warnings.
- `pnpm --filter @okouai/connectors exec vitest run src/__tests__/firewall-base-url-validation-contract.test.ts`: 136 passed.
- Shared JSON fixture formatted with Prettier; runner `cargo fmt --check` passed.
- Local runner test compilation exhausted the 4 GB environment, including a single-job retry without debug information (exit 137). Rust execution was verified in [PR CI](https://github.com/vm0-ai/vm0/actions/runs/34465145162) for `82f502b7d083a40423608b342e4b63950ba5042c`: logs confirm both `firewall_base_url_validation_matches_shared_contract` and `write_catalog_cache_accepts_valid_template_bases` passed.
- `CARGO_BUILD_JOBS=1 CARGO_PROFILE_LOCAL_DEBUG=0 cargo clippy --manifest-path crates/Cargo.toml --locked --profile local -p runner --all-targets --all-features`: passed, including test targets.
- `CARGO_BUILD_JOBS=1 CARGO_PROFILE_LOCAL_DEBUG=0 cargo doc --manifest-path crates/Cargo.toml --locked --profile local -p runner --all-features --no-deps`: passed.
- Required PR checks `ci-gate-crates`, `ci-gate-turbo`, and `ci-gate-security`: passed on the reviewed head. Overall: 99 passed, 7 skipped, none failed or pending.
