### PR TITLE
refactor(app): give the product one border-width token

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -33,6 +33,10 @@ Token names describe meaning rather than a page or component. A reusable interac
 
 Components must not introduce local CSS variables as an alternate token registry. A runtime value that is genuinely computed by the component may use a narrowly named custom property as data, while its visual semantics still come from Tailwind utilities and registered tokens.
 
+One hairline serves the whole product. `--default-border-width` in the shared `@theme` is 0.5px, and Tailwind's bare `border`, `border-t`, `border-x`, `divide-y`, and their siblings all read it, so a component asks for "a border" and the system decides how thick it is. Components must not hand-write a width: an arbitrary width such as `border-[0.7px]`, or a literal width inside a `style` prop, is a second registry for a decision this token already owns. `border-0` and the deliberate emphasis widths such as `border-2` stay available, because they express a different decision rather than a competing value for the same one.
+
+The sub-pixel value is a declaration of intent as much as a measurement. Blink and Gecko round a non-zero border up to one device pixel, so it renders exactly like 1px there and layout is unchanged in every engine; WebKit can draw the true hairline on a high-density display. Do not treat a width below 1px as a way to make a border visibly lighter in Chromium — reach for the border color for that.
+
 Color-theme presets in the App stylesheet share their anchor and companion colors between picker swatches and workspace ambience. Daydream uses cool blue and violet, while Cotton sky uses pastel pink and blue. Each preset's hue and ring values keep semantic surfaces, selected states, and focus indicators aligned with that palette in Light/Dark.
 
 ## Token and variant governance
@@ -80,7 +84,7 @@ remain available without hovering.
 | Decision        | Shared token / utility                                    | Theme contract                                                                                       |
 | --------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | Fill            | `bg-card`                                                 | Existing semantic card fill in each theme                                                            |
-| Border          | `--color-surface-border`, `--border-width-surface`        | Gray 400 at 0.7 CSS pixels; the browser rounds for its device scale                                  |
+| Border          | `--color-surface-border`, `--border-width-surface`        | Gray 400 at the shared `--default-border-width` hairline; the browser rounds for its device scale    |
 | Radius          | `rounded-surface`, `rounded-surface-compact`              | 1.25rem and a fixed 12px respectively in every theme                                                 |
 | Elevation       | `shadow-surface` via `--surface-shadow`                   | Neutral lift in Light/Dark; the gradient theme uses the canonical state-layer hue with reduced alpha |
 | Pointer overlay | `bg-state-hover-overlay`                                  | The shared interaction-state overlay painted above the opaque card fill                              |

--- a/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
@@ -743,7 +743,7 @@ function AgentCard({ agent, creator, hasUnread, showCreator }: AgentProps) {
                   <TooltipContent
                     side="bottom"
                     align="start"
-                    className="w-64 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] p-3 text-left font-normal"
+                    className="w-64 rounded-lg border border-[hsl(var(--gray-400))] p-3 text-left font-normal"
                     style={{
                       backgroundColor: "hsl(var(--popover))",
                       color: "hsl(var(--popover-foreground))",

--- a/turbo/apps/platform/src/views/auth-v1/component-appearance.ts
+++ b/turbo/apps/platform/src/views/auth-v1/component-appearance.ts
@@ -13,7 +13,7 @@ const AUTH_V1_PRIMARY_ACTION_CLASS =
 // the shared Input boundary while adapting focus and error states through the
 // public attributes that Clerk exposes on each slot.
 const AUTH_V1_OTP_INPUT_CLASS =
-  "border-[0.7px] border-[hsl(var(--gray-400))] bg-input shadow-none data-[focus-within=true]:border-primary data-[focus-within=true]:ring-[3px] data-[focus-within=true]:ring-primary/10 aria-invalid:border-destructive data-[focus-within=true]:aria-invalid:border-destructive";
+  "border border-[hsl(var(--gray-400))] bg-input shadow-none data-[focus-within=true]:border-primary data-[focus-within=true]:ring-[3px] data-[focus-within=true]:ring-primary/10 aria-invalid:border-destructive data-[focus-within=true]:aria-invalid:border-destructive";
 
 /** Keep branding and the page shell; Clerk owns control styles and states. */
 export function getAuthV1ComponentAppearance(

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-style-assertions.ts
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-style-assertions.ts
@@ -19,6 +19,7 @@ const checkboxTheme = `
   @theme {
     --spacing: 0.25rem;
     --radius-md: 0.375rem;
+    --default-border-width: 0.5px;
     --color-border: rgb(10 20 30);
     --color-input: rgb(40 50 60);
     --color-primary: rgb(70 80 90);

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -1644,7 +1644,7 @@ test("A visitor resets a forgotten password and signs in", async () => {
     borderColor: "rgb(70 80 90)",
     borderRadius: "6px",
     borderStyle: "solid",
-    borderWidth: "1px",
+    borderWidth: "0.5px",
     flexShrink: "0",
     height: "calc(4px * 4)",
     width: "calc(4px * 4)",

--- a/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-up/__tests__/sign-up-card.test.tsx
@@ -188,7 +188,7 @@ test("A new sign-up reflects the current account requirements", async () => {
     borderColor: "rgb(10 20 30)",
     borderRadius: "6px",
     borderStyle: "solid",
-    borderWidth: "1px",
+    borderWidth: "0.5px",
     flexShrink: "0",
     height: "calc(4px * 4)",
     width: "calc(4px * 4)",

--- a/turbo/apps/platform/src/views/okou-page/billing-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/billing-dialog.tsx
@@ -29,7 +29,7 @@ import { formatUsd } from "../../i18n/format.ts";
 const CREDITS_PER_DOLLAR = 1000;
 
 const settingsCardBorder = {
-  border: "0.7px solid hsl(var(--gray-400))",
+  border: "var(--border-width-surface) solid hsl(var(--gray-400))",
 } as const;
 
 export function AutoRechargeSection({

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -5193,7 +5193,7 @@ function ImportedPresentationTemplateRenameControl({
       }}
     >
       <div
-        className="grid min-h-10 min-w-0 flex-1 rounded-lg border-[0.7px] border-transparent px-1 py-[5px] text-xl font-semibold leading-7 text-foreground transition-colors after:col-start-1 after:row-start-1 after:invisible after:whitespace-pre-wrap after:break-words after:content-[attr(data-value)_'_'] hover:border-[hsl(var(--gray-400))] focus-within:border-primary focus-within:ring-[3px] focus-within:ring-primary/10"
+        className="grid min-h-10 min-w-0 flex-1 rounded-lg border border-transparent px-1 py-[5px] text-xl font-semibold leading-7 text-foreground transition-colors after:col-start-1 after:row-start-1 after:invisible after:whitespace-pre-wrap after:break-words after:content-[attr(data-value)_'_'] hover:border-[hsl(var(--gray-400))] focus-within:border-primary focus-within:ring-[3px] focus-within:ring-primary/10"
         data-value={title}
       >
         <textarea

--- a/turbo/apps/platform/src/views/okou-page/chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-feedback-selection.tsx
@@ -431,8 +431,8 @@ export function ChatFeedbackSelection({
             finalFocus={false}
             className={
               translationEnabled && translationResult
-                ? "w-[min(380px,calc(100vw-2rem))] rounded-xl border-[0.7px] border-[hsl(var(--gray-400))] bg-[hsl(var(--card)/0.96)] p-3 text-foreground shadow-lg"
-                : "w-auto rounded-xl border-[0.7px] border-[hsl(var(--gray-400))] bg-[hsl(var(--card)/0.85)] p-1 text-foreground shadow-lg"
+                ? "w-[min(380px,calc(100vw-2rem))] rounded-xl border border-[hsl(var(--gray-400))] bg-[hsl(var(--card)/0.96)] p-3 text-foreground shadow-lg"
+                : "w-auto rounded-xl border border-[hsl(var(--gray-400))] bg-[hsl(var(--card)/0.85)] p-1 text-foreground shadow-lg"
             }
           >
             {translationEnabled && translationResult ? (

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -5222,7 +5222,7 @@ function AssistantErrorFallback({ error }: { error: string }) {
       <div
         className="inline-flex items-center gap-2 bg-muted/50 px-3 py-1.5 text-[0.9375rem] text-muted-foreground"
         style={{
-          border: "0.7px solid hsl(var(--border))",
+          border: "var(--border-width-surface) solid hsl(var(--border))",
           borderRadius: "12px",
         }}
       >

--- a/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
@@ -446,7 +446,7 @@ function MediaModelList({
  * and `shadow-lg` reproduces exactly.
  */
 const FLYOUT_PANEL_CLASS =
-  "rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-1 text-foreground shadow-lg outline-none";
+  "rounded-[12px] border border-[hsl(var(--gray-400))] bg-card p-1 text-foreground shadow-lg outline-none";
 
 /**
  * Flyout layout: model types on the left, that type's models in a panel beside

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/buy-credits-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/buy-credits-section.tsx
@@ -25,7 +25,7 @@ const MAX_CUSTOM_USD = 10_000;
 type Preset = (typeof PRESETS)[number];
 
 const settingsCardBorder = {
-  border: "0.7px solid hsl(var(--gray-400))",
+  border: "var(--border-width-surface) solid hsl(var(--gray-400))",
 } as const;
 
 const tileBaseClass =

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/credit-purchase-confirm-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/credit-purchase-confirm-dialog.tsx
@@ -43,7 +43,7 @@ function CreditPurchaseConfirmDialogContent({
             return $.billing.credits.today;
           })}
         </p>
-        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t-[0.7px] border-border py-3.5">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t border-border py-3.5">
           <p className="text-sm font-medium text-foreground">
             {t(($) => {
               return $.billing.credits.dueNow;
@@ -53,7 +53,7 @@ function CreditPurchaseConfirmDialogContent({
             {formatPurchaseAmount(preview.amountCents, preview.currency)}
           </p>
         </div>
-        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t-[0.7px] border-[hsl(var(--gray-100))] py-2.5">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t border-[hsl(var(--gray-100))] py-2.5">
           <p className="text-sm font-medium text-foreground">
             {t(($) => {
               return $.billing.credits.creditsAdded;

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/model-provider-connections-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/model-provider-connections-section.tsx
@@ -49,7 +49,7 @@ import { detach, Reason } from "../../../../signals/utils.ts";
 import { SettingsSectionHeading } from "../settings/settings-section-heading.tsx";
 
 const ZERO_BORDER = {
-  border: "0.7px solid hsl(var(--gray-400))",
+  border: "var(--border-width-surface) solid hsl(var(--gray-400))",
 } as const;
 
 function AddConnectionMenu() {

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-general-tab.tsx
@@ -44,7 +44,7 @@ import {
 import { readImageDimensions } from "./read-image-dimensions.ts";
 
 const sectionCardStyle = {
-  border: "0.7px solid hsl(var(--gray-400))",
+  border: "var(--border-width-surface) solid hsl(var(--gray-400))",
 } as const;
 
 const MIN_LOGO_DIMENSION = 100;

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-invoices-tab.tsx
@@ -39,7 +39,9 @@ import { detach, Reason } from "../../../../signals/utils.ts";
 import { currentLocale } from "../../../../i18n/index.ts";
 import { formatUsd } from "../../../../i18n/format.ts";
 
-const cardBorder = { border: "0.7px solid hsl(var(--gray-400))" } as const;
+const cardBorder = {
+  border: "var(--border-width-surface) solid hsl(var(--gray-400))",
+} as const;
 
 const ROW_GRID = "grid grid-cols-[1fr_8rem_6rem_3rem] gap-x-6 items-center";
 

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-model-policies-section.tsx
@@ -140,7 +140,7 @@ function getOAuthProviderTypes(model: SupportedRunModel): ModelProviderType[] {
 }
 
 const ZERO_BORDER = {
-  border: "0.7px solid hsl(var(--gray-400))",
+  border: "var(--border-width-surface) solid hsl(var(--gray-400))",
 } as const;
 
 function getOAuthRouteKind(
@@ -315,7 +315,9 @@ function DefaultModelRow({
     <div
       data-testid="default-model-row"
       className="flex flex-col gap-3 overflow-hidden rounded-xl bg-card px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
-      style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+      style={{
+        border: "var(--border-width-surface) solid hsl(var(--gray-400))",
+      }}
     >
       <div className="min-w-0">
         <p className="text-sm font-medium text-foreground">
@@ -356,7 +358,9 @@ function DefaultModelRow({
         >
           <SelectTrigger
             className="h-9 w-full shrink-0 rounded-lg bg-card sm:w-[280px]"
-            style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+            style={{
+              border: "var(--border-width-surface) solid hsl(var(--gray-400))",
+            }}
           >
             <SelectValue
               placeholder={t(($) => {
@@ -729,8 +733,8 @@ function RouteChoiceButton({
       onClick={onClick}
       style={{
         border: active
-          ? "0.7px solid hsl(var(--primary))"
-          : "0.7px solid hsl(var(--gray-400))",
+          ? "var(--border-width-surface) solid hsl(var(--primary))"
+          : "var(--border-width-surface) solid hsl(var(--gray-400))",
       }}
       className={cn(
         "flex flex-col gap-0.5 rounded-xl bg-card px-5 py-4 text-left transition-colors",
@@ -1838,7 +1842,9 @@ export function OrgModelPoliciesSection() {
         />
         <div
           className="overflow-hidden rounded-xl bg-card"
-          style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+          style={{
+            border: "var(--border-width-surface) solid hsl(var(--gray-400))",
+          }}
         >
           <div className="hidden grid-cols-[minmax(0,1fr)_236px_96px_36px] gap-3 border-b border-border/50 px-5 py-3 text-xs font-medium text-muted-foreground lg:grid">
             <span>

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/subscription-purchase-confirm-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/subscription-purchase-confirm-dialog.tsx
@@ -34,7 +34,7 @@ function SubscriptionPurchaseSummary({
           return $.billing.credits.today;
         })}
       </p>
-      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t-[0.7px] border-border py-3.5">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t border-border py-3.5">
         <p className="text-sm font-medium text-foreground">
           {t(($) => {
             return $.billing.concurrency.dueNow;
@@ -44,7 +44,7 @@ function SubscriptionPurchaseSummary({
           {formatPurchaseAmount(preview.immediateAmountCents, preview.currency)}
         </p>
       </div>
-      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t-[0.7px] border-[hsl(var(--gray-100))] py-2.5">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t border-[hsl(var(--gray-100))] py-2.5">
         <p className="text-sm font-medium text-foreground">
           {t(($) => {
             return $.billing.plans.usagePacks.planStep;
@@ -59,7 +59,7 @@ function SubscriptionPurchaseSummary({
           return $.billing.plans.usagePacks.management.everyMonth;
         })}
       </p>
-      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t-[0.7px] border-border py-3.5">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t border-border py-3.5">
         <p className="text-sm font-medium text-foreground">
           {t(($) => {
             return $.billing.concurrency.monthlyTotal;

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -459,7 +459,7 @@ function MemberIdentity({ member }: { readonly member: MemberDisplay }) {
    and a shared width is what keeps every amount on one right edge. */
 const LEDGER_ROW =
   "grid min-h-16 grid-cols-[minmax(0,1fr)_minmax(15rem,17rem)_9.5rem] items-center gap-3 py-2.5";
-const LEDGER_RULE = "border-t-[0.7px] border-[hsl(var(--gray-100))]";
+const LEDGER_RULE = "border-t border-[hsl(var(--gray-100))]";
 
 function LedgerPrice({
   fractionDigits = 0,
@@ -554,7 +554,7 @@ function LedgerTotalRow({
   readonly totalUsd: number;
 }) {
   return (
-    <div className={`${LEDGER_ROW} border-t-[0.7px] border-border py-4`}>
+    <div className={`${LEDGER_ROW} border-t border-border py-4`}>
       <span className="text-sm font-medium text-foreground">
         {i18n.t(($) => {
           return $.billing.plans.usagePacks.monthlyTotal;
@@ -823,7 +823,7 @@ function PlanPrice({
   const lowestPackageUsd = Math.min(...packagePrices);
   const highestPackageUsd = Math.max(...packagePrices);
   return (
-    <div className="-mx-6 mt-4 border-y-[0.7px] border-[hsl(var(--gray-200))] bg-[hsl(var(--gray-0))] px-6 py-4">
+    <div className="-mx-6 mt-4 border-y border-[hsl(var(--gray-200))] bg-[hsl(var(--gray-0))] px-6 py-4">
       <p className="text-2xl font-medium leading-tight tabular-nums text-foreground">
         <span className="text-sm font-normal text-muted-foreground">
           {i18n.t(($) => {
@@ -1056,7 +1056,7 @@ function PlanSelectionCard({
       )}
       className={`flex flex-col p-6 ${
         divided
-          ? "border-t-[0.7px] border-[hsl(var(--gray-200))] sm:border-l-[0.7px] sm:border-t-0"
+          ? "border-t border-[hsl(var(--gray-200))] sm:border-l sm:border-t-0"
           : ""
       }`}
     >
@@ -1229,7 +1229,7 @@ function PricingStepDialog({
         {/* The close button is an item in this row rather than a box pinned to
             the frame, so the title, the step counter and the close glyph share
             one centre line and one right inset. */}
-        <DialogHeader className="h-14 flex-row shrink-0 items-center gap-3 space-y-0 border-b-[0.7px] border-[hsl(var(--gray-200))] py-0 pl-6 pr-4 text-left">
+        <DialogHeader className="h-14 flex-row shrink-0 items-center gap-3 space-y-0 border-b border-[hsl(var(--gray-200))] py-0 pl-6 pr-4 text-left">
           {onBack && <PricingBackButton onBack={onBack} />}
           <DialogTitle className="min-w-0 flex-1 text-base font-medium leading-none">
             {title ?? pricingStepTitle(step)}
@@ -1417,7 +1417,7 @@ function PlanSelectionStep({
           );
         })}
       </div>
-      <p className="shrink-0 border-t-[0.7px] border-[hsl(var(--gray-200))] bg-[hsl(var(--gray-0))] px-6 py-5 text-sm leading-snug text-muted-foreground">
+      <p className="shrink-0 border-t border-[hsl(var(--gray-200))] bg-[hsl(var(--gray-0))] px-6 py-5 text-sm leading-snug text-muted-foreground">
         {i18n.t(($) => {
           return $.billing.plans.usagePacks.packagePerMemberNote;
         })}
@@ -1495,8 +1495,8 @@ function useUsagePackMembers(): readonly MemberDisplay[] | undefined {
    once. Rule weight carries the structure: gray-200 opens a block, gray-100
    separates rows inside it. */
 const REVIEW_ROW = "grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3";
-const REVIEW_HAIRLINE = "border-t-[0.7px] border-[hsl(var(--gray-100))]";
-const REVIEW_RULE = "border-t-[0.7px] border-border";
+const REVIEW_HAIRLINE = "border-t border-[hsl(var(--gray-100))]";
+const REVIEW_RULE = "border-t border-border";
 
 /* A step's notice and action stay together on the frame's foot instead of
    scrolling away with the body they belong to: a long member list must never
@@ -1786,7 +1786,7 @@ function ManagedSubscriptionComparisonTooltip({
           collisionPadding={16}
           side="bottom"
           sideOffset={8}
-          className="w-[27.5rem] max-w-[calc(100vw-2rem)] rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] p-4 text-left font-normal"
+          className="w-[27.5rem] max-w-[calc(100vw-2rem)] rounded-[12px] border border-[hsl(var(--gray-400))] p-4 text-left font-normal"
           style={{
             backgroundColor: "hsl(var(--popover))",
             color: "hsl(var(--popover-foreground))",

--- a/turbo/apps/platform/src/views/okou-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/preferences/personal-providers-tab.tsx
@@ -140,7 +140,9 @@ function OAuthAccountGroupsSection() {
       <TooltipProvider delayDuration={100}>
         <div
           className="overflow-hidden rounded-xl bg-card"
-          style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+          style={{
+            border: "var(--border-width-surface) solid hsl(var(--gray-400))",
+          }}
         >
           {isLoading ? (
             <>
@@ -623,7 +625,9 @@ function LegacyOAuthCredentialsSection() {
       <PersonalModelsHeading />
       <div
         className="overflow-hidden rounded-xl bg-card"
-        style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+        style={{
+          border: "var(--border-width-surface) solid hsl(var(--gray-400))",
+        }}
       >
         {isLoading ? (
           <>

--- a/turbo/apps/platform/src/views/okou-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/preferences/personal-usage-record.tsx
@@ -54,7 +54,7 @@ import {
   formatLocalizedNumber,
 } from "../../../../i18n/format.ts";
 
-const CARD_BORDER = "0.7px solid hsl(var(--gray-400))";
+const CARD_BORDER = "var(--border-width-surface) solid hsl(var(--gray-400))";
 
 const SOURCE_ICONS = {
   chat: MessageCircle,

--- a/turbo/apps/platform/src/views/okou-page/components/settings/color-theme-settings.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/color-theme-settings.tsx
@@ -123,7 +123,7 @@ export function ColorThemeSettings() {
                 updateColorTheme(value);
               }}
               className={cn(
-                "flex min-w-0 items-center gap-2 rounded-lg border border-[0.7px] bg-background/80 p-2 text-left transition-[border-color,background-color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                "flex min-w-0 items-center gap-2 rounded-lg border bg-background/80 p-2 text-left transition-[border-color,background-color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                 selected
                   ? "border-[hsl(var(--ring))] bg-[var(--okou-color-theme-selected)] shadow-[0_0_0_1px_hsl(var(--ring)/0.18)]"
                   : "border-border hover:border-[hsl(var(--gray-500))] hover:bg-accent",

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -369,7 +369,9 @@ function AccountsCard({
       value={defaultConnection?.id ?? null}
       // The row radios post their own change; RadioGroup only owns grouping.
       className="overflow-hidden rounded-xl bg-card"
-      style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+      style={{
+        border: "var(--border-width-surface) solid hsl(var(--gray-400))",
+      }}
     >
       {rows.map((account, index) => {
         return (

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
@@ -195,8 +195,7 @@ function CatalogConnectorCard({
  * the way the other portalled surfaces already do; adopting `surfaceVariants`
  * here would newly pick up the gradient-theme elevation and change pixels.
  */
-export const DIRECTORY_HAIRLINE =
-  "border-[0.7px] border-[hsl(var(--gray-400))]";
+export const DIRECTORY_HAIRLINE = "border border-[hsl(var(--gray-400))]";
 export const DIRECTORY_SURFACE = cn(
   "rounded-[1.25rem] bg-card transition-colors",
   DIRECTORY_HAIRLINE,

--- a/turbo/apps/platform/src/views/okou-page/components/settings/permission-policy-toggle.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/permission-policy-toggle.tsx
@@ -75,7 +75,9 @@ export function PermissionPolicyToggle({
         type="button"
         disabled={disabled}
         aria-pressed={policy === "deny"}
-        style={{ borderLeft: "0.7px solid hsl(var(--gray-400))" }}
+        style={{
+          borderLeft: "var(--border-width-surface) solid hsl(var(--gray-400))",
+        }}
         onClick={onDeny}
         className={permissionPolicyButtonClass({
           active: policy === "deny",

--- a/turbo/apps/platform/src/views/okou-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/permissions-dialog.tsx
@@ -296,7 +296,10 @@ function PolicyPill({
             aria-pressed={policy === option}
             style={
               idx > 0
-                ? { borderLeft: "0.7px solid hsl(var(--gray-400))" }
+                ? {
+                    borderLeft:
+                      "var(--border-width-surface) solid hsl(var(--gray-400))",
+                  }
                 : undefined
             }
             onClick={(e) => {

--- a/turbo/apps/platform/src/views/okou-page/composer-create.tsx
+++ b/turbo/apps/platform/src/views/okou-page/composer-create.tsx
@@ -289,7 +289,7 @@ export function ComposerCreatePicker({
         aria-label={t(($) => {
           return $.chat.composer.create.chooseType;
         })}
-        className="flex w-72 max-w-full flex-col gap-1 rounded-xl border-[0.7px] border-control-border bg-card p-1"
+        className="flex w-72 max-w-full flex-col gap-1 rounded-xl border border-control-border bg-card p-1"
         onKeyDown={(event) => {
           if (event.key === "Escape") {
             event.preventDefault();

--- a/turbo/apps/platform/src/views/okou-page/connector-directory-detail.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connector-directory-detail.tsx
@@ -133,7 +133,7 @@ export function ConnectorDetailPanel({
             return $.chat.connectors.directory.detailAccounts;
           })}
         </h3>
-        <div className="mb-5 rounded-xl border-[0.7px] border-[hsl(var(--gray-400))]">
+        <div className="mb-5 rounded-xl border border-[hsl(var(--gray-400))]">
           <div className="flex items-center gap-3 px-4 py-2.5 text-sm">
             <ConnectorAccountSummaryText
               summary={accountSummary}
@@ -150,7 +150,7 @@ export function ConnectorDetailPanel({
             return $.chat.connectors.directory.detailPermissions;
           })}
         </h3>
-        <div className="mb-5 rounded-xl border-[0.7px] border-[hsl(var(--gray-400))]">
+        <div className="mb-5 rounded-xl border border-[hsl(var(--gray-400))]">
           <div className="flex items-center gap-3 px-4 py-2.5">
             <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
               {t(
@@ -182,7 +182,7 @@ export function ConnectorDetailPanel({
             return $.chat.connectors.directory.detailConnection;
           })}
         </h3>
-        <div className="rounded-xl border-[0.7px] border-[hsl(var(--gray-400))]">
+        <div className="rounded-xl border border-[hsl(var(--gray-400))]">
           {authMethodLabel && (
             <DetailRow
               label={t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
+++ b/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
@@ -138,7 +138,7 @@ function GrowthEntry({ slackInstalled }: { slackInstalled: boolean }) {
       <div
         // 12px, not the Button default 8px: the split control and the menu it
         // opens read as one object when their outer radii agree.
-        className="inline-flex h-8 items-stretch rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] bg-card shadow-[var(--okou-card-shadow)]"
+        className="inline-flex h-8 items-stretch rounded-[12px] border border-[hsl(var(--gray-400))] bg-card shadow-[var(--okou-card-shadow)]"
       >
         <Button
           type="button"
@@ -176,7 +176,7 @@ function GrowthEntry({ slackInstalled }: { slackInstalled: boolean }) {
             aria-label={t(($) => {
               return $.chat.actions.more;
             })}
-            className="h-full w-9 rounded-l-none rounded-r-[11px] border-l-[0.7px] border-[hsl(var(--gray-300))] data-popup-open:bg-state-hover data-popup-open:text-foreground"
+            className="h-full w-9 rounded-l-none rounded-r-[11px] border-l border-[hsl(var(--gray-300))] data-popup-open:bg-state-hover data-popup-open:text-foreground"
             data-testid="growth-entry-menu"
           >
             <ChevronDown />

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -226,7 +226,7 @@ function ExpandedSidebar() {
         return $.appShell.sidebar.ariaLabel;
       })}
       className={cn(
-        "okou-nav okou-mobile-sidebar okou-mobile-fixed-safe-area h-full w-[300px] shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar transition-all duration-300 max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-40 max-md:h-auto max-md:shadow-xl",
+        "okou-nav okou-mobile-sidebar okou-mobile-fixed-safe-area h-full w-[300px] shrink-0 flex-col border-r border-sidebar-border bg-sidebar transition-all duration-300 max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-40 max-md:h-auto max-md:shadow-xl",
         "hidden data-[sidebar-expanded]:max-md:flex md:hidden",
       )}
     >
@@ -457,7 +457,7 @@ function ExpandedFooter() {
    what puts the workspace logo and the account mark the same distance from
    the corner they sit in as from the edge beside them. */
 const RAIL_FRAME =
-  "okou-nav okou-nav-rail hidden md:flex h-full w-[72px] shrink-0 flex-col items-center border-r-[0.7px] border-sidebar-border bg-sidebar-rail px-1.5 py-[18px]";
+  "okou-nav okou-nav-rail hidden md:flex h-full w-[72px] shrink-0 flex-col items-center border-r border-sidebar-border bg-sidebar-rail px-1.5 py-[18px]";
 
 function LabeledRailLink({
   id,

--- a/turbo/apps/platform/src/views/okou-page/workspace-inset.tsx
+++ b/turbo/apps/platform/src/views/okou-page/workspace-inset.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 export function WorkspaceInset({ children }: { readonly children: ReactNode }) {
   return (
     <div
-      className="okou-workspace-bg flex min-h-0 min-w-0 flex-1 flex-col bg-background md:m-2 md:ml-0 md:overflow-hidden md:rounded-xl md:border-[0.7px] md:border-border"
+      className="okou-workspace-bg flex min-h-0 min-w-0 flex-1 flex-col bg-background md:m-2 md:ml-0 md:overflow-hidden md:rounded-xl md:border md:border-border"
       data-testid="workspace-inset"
     >
       {children}

--- a/turbo/apps/platform/src/views/workflows-page/official-workflow-configuration.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/official-workflow-configuration.tsx
@@ -278,7 +278,7 @@ export function OfficialWorkflowConfigurationFields({
         return (
           <section
             key={blueprint.key}
-            className="rounded-2xl border-[0.7px] border-border bg-gray-50 p-4"
+            className="rounded-2xl border border-border bg-gray-50 p-4"
           >
             <div className="mb-3">
               <h3 className="text-sm font-semibold text-foreground">

--- a/turbo/apps/platform/src/views/workflows-page/official-workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/official-workflows-page.tsx
@@ -517,7 +517,7 @@ function OfficialWorkflowDefinitionPage() {
                   return (
                     <div
                       key={blueprint.key}
-                      className="rounded-2xl border-[0.7px] border-border bg-gray-50 p-4"
+                      className="rounded-2xl border border-border bg-gray-50 p-4"
                     >
                       <p className="text-sm font-medium text-foreground">
                         {blueprint.key}

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -1135,7 +1135,7 @@ function DetailHeader({
                     <TooltipContent
                       side="bottom"
                       align="start"
-                      className="rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] p-3"
+                      className="rounded-lg border border-[hsl(var(--gray-400))] p-3"
                       style={{
                         backgroundColor: "hsl(var(--card))",
                         color: "hsl(var(--card-foreground))",
@@ -1839,7 +1839,7 @@ function WorkflowMetadataFields({
         description={copy.agentDescription}
         wideControls
       >
-        <div className="flex h-9 w-full items-center rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-gray-50 px-3 text-sm text-muted-foreground">
+        <div className="flex h-9 w-full items-center rounded-lg border border-[hsl(var(--gray-400))] bg-gray-50 px-3 text-sm text-muted-foreground">
           <span className="truncate" title={ownerAgentLabel}>
             {ownerAgentLabel}
           </span>
@@ -4485,7 +4485,7 @@ function AutomationCreateOptionCard({
     <button
       type="button"
       onClick={onSelect}
-      className="flex min-h-[8rem] flex-col items-start gap-3.5 rounded-2xl border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-5 text-left transition-colors hover:border-[hsl(var(--gray-500))] hover:bg-card-hover"
+      className="flex min-h-[8rem] flex-col items-start gap-3.5 rounded-2xl border border-[hsl(var(--gray-400))] bg-card p-5 text-left transition-colors hover:border-[hsl(var(--gray-500))] hover:bg-card-hover"
     >
       <span
         className={cn(

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -137,7 +137,7 @@ function connectorPillClassName({
   readonly muted?: boolean;
 }) {
   return cn(
-    "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border-[0.7px] border-border/80 bg-white px-2 text-[11px] font-medium leading-none shadow-[0_0_2px_rgba(0,0,0,0.06)]",
+    "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border border-border/80 bg-white px-2 text-[11px] font-medium leading-none shadow-[0_0_2px_rgba(0,0,0,0.06)]",
     muted ? "text-muted-foreground" : "text-foreground/70",
     interactive &&
       "cursor-pointer transition-colors hover:border-border hover:bg-state-hover hover:text-foreground",
@@ -500,7 +500,7 @@ function WorkflowRow({
           <TooltipContent
             side="bottom"
             align="start"
-            className="rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] p-3"
+            className="rounded-lg border border-[hsl(var(--gray-400))] p-3"
             style={{
               backgroundColor: "hsl(var(--card))",
               color: "hsl(var(--card-foreground))",

--- a/turbo/packages/ui/src/components/ui/button.tsx
+++ b/turbo/packages/ui/src/components/ui/button.tsx
@@ -27,7 +27,7 @@ const buttonVariants = cva(
         interrupt:
           "bg-interrupt text-interrupt-foreground hover:bg-interrupt-hover active:bg-interrupt-pressed",
         outline:
-          "border-[0.7px] border-[hsl(var(--gray-400))] bg-background hover:bg-state-hover active:bg-state-pressed text-foreground",
+          "border border-[hsl(var(--gray-400))] bg-background hover:bg-state-hover active:bg-state-pressed text-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary-hover active:bg-secondary-pressed",
         ghost: "text-brand-text hover:bg-state-hover active:bg-state-pressed",

--- a/turbo/packages/ui/src/components/ui/command.tsx
+++ b/turbo/packages/ui/src/components/ui/command.tsx
@@ -105,7 +105,7 @@ const CommandInput = React.forwardRef<HTMLInputElement, CommandInputProps>(
       <div
         data-slot="command-input-wrapper"
         className={cn(
-          "flex h-9 items-center gap-2 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm transition-colors focus-within:border-primary focus-within:ring-[3px] focus-within:ring-primary/10",
+          "flex h-9 items-center gap-2 rounded-lg border border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm transition-colors focus-within:border-primary focus-within:ring-[3px] focus-within:ring-primary/10",
           wrapperClassName,
         )}
       >

--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -196,7 +196,7 @@ const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
                     dialogHeightClasses[height],
                     "rounded-xl",
                     surface === "card" &&
-                      "border-[0.7px] border-[hsl(var(--gray-400))] shadow-lg",
+                      "border border-[hsl(var(--gray-400))] shadow-lg",
                     surface === "canvas" &&
                       "shadow-[0_24px_70px_rgba(0,0,0,0.30)]",
                   ]

--- a/turbo/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/turbo/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -132,7 +132,7 @@ const DropdownMenuContent = React.forwardRef<
             data-slot="dropdown-menu-content"
             className={cn(
               anchoredPopupTransitionClassName,
-              "max-h-[var(--available-height)] min-w-[8rem] overflow-x-hidden overflow-y-auto rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-1 text-foreground shadow-lg outline-none dark:shadow-[0_8px_40px_-8px_rgba(0,0,0,0.6)]",
+              "max-h-[var(--available-height)] min-w-[8rem] overflow-x-hidden overflow-y-auto rounded-[12px] border border-[hsl(var(--gray-400))] bg-card p-1 text-foreground shadow-lg outline-none dark:shadow-[0_8px_40px_-8px_rgba(0,0,0,0.6)]",
               className,
             )}
             {...props}

--- a/turbo/packages/ui/src/components/ui/input.tsx
+++ b/turbo/packages/ui/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
         type={type}
         data-slot="input"
         className={cn(
-          "flex h-9 w-full rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground placeholder:text-sm placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 disabled:cursor-not-allowed disabled:opacity-50 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground",
+          "flex h-9 w-full rounded-lg border border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground placeholder:text-sm placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 disabled:cursor-not-allowed disabled:opacity-50 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground",
           type === "password" &&
             "font-mono tracking-wider placeholder:font-sans placeholder:tracking-normal",
           className,

--- a/turbo/packages/ui/src/components/ui/popover.tsx
+++ b/turbo/packages/ui/src/components/ui/popover.tsx
@@ -142,7 +142,7 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
             data-slot="popover-content"
             className={cn(
               anchoredPopupTransitionClassName,
-              "w-72 rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-4 text-foreground outline-none",
+              "w-72 rounded-[12px] border border-[hsl(var(--gray-400))] bg-card p-4 text-foreground outline-none",
               className,
             )}
             style={

--- a/turbo/packages/ui/src/components/ui/select.tsx
+++ b/turbo/packages/ui/src/components/ui/select.tsx
@@ -151,7 +151,7 @@ const SelectTrigger = React.forwardRef<
       ref={ref}
       data-slot="select-trigger"
       className={cn(
-        "flex h-9 w-full items-center justify-start gap-2 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground outline-none disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-9 w-full items-center justify-start gap-2 rounded-lg border border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground outline-none disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}
@@ -276,7 +276,7 @@ const SelectContent = React.forwardRef<HTMLDivElement, SelectContentProps>(
             data-slot="select-content"
             className={cn(
               anchoredPopupTransitionClassName,
-              "relative max-h-[min(24rem,var(--available-height))] min-w-[max(8rem,var(--anchor-width))] overflow-x-hidden overflow-y-auto rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] bg-card text-foreground outline-none data-[side=none]:data-starting-style:opacity-100 data-[side=none]:data-starting-style:[transform:scale(1)] data-[side=none]:transition-none",
+              "relative max-h-[min(24rem,var(--available-height))] min-w-[max(8rem,var(--anchor-width))] overflow-x-hidden overflow-y-auto rounded-[12px] border border-[hsl(var(--gray-400))] bg-card text-foreground outline-none data-[side=none]:data-starting-style:opacity-100 data-[side=none]:data-starting-style:[transform:scale(1)] data-[side=none]:transition-none",
               className,
             )}
             style={

--- a/turbo/packages/ui/src/components/ui/textarea.tsx
+++ b/turbo/packages/ui/src/components/ui/textarea.tsx
@@ -10,7 +10,7 @@ const Textarea = React.forwardRef<
     <textarea
       data-slot="textarea"
       className={cn(
-        "flex w-full rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground placeholder:text-sm placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex w-full rounded-lg border border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground placeholder:text-sm placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       ref={ref}

--- a/turbo/packages/ui/src/components/ui/toggle-button.tsx
+++ b/turbo/packages/ui/src/components/ui/toggle-button.tsx
@@ -11,7 +11,7 @@ import {
 const toggleButtonVariants = cva(
   [
     buttonBaseClassName,
-    "border-[0.7px] transition-all duration-200 focus:outline-none disabled:opacity-60 disabled:cursor-not-allowed",
+    "border transition-all duration-200 focus:outline-none disabled:opacity-60 disabled:cursor-not-allowed",
   ],
   {
     variants: {

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -140,6 +140,23 @@
   --color-brand-text: hsl(var(--brand-text));
   --color-brand-text-hover: hsl(var(--brand-text-hover));
 
+  /* ===================================
+   * Border width
+   *
+   * One hairline for the whole product. Tailwind's bare `border`, `border-t`,
+   * `divide-y`, and friends all read this key, so components ask for "a border"
+   * and the system decides how thick it is. Components must not hand-write a
+   * width; `border-0` and the deliberate emphasis widths (`border-2`) remain
+   * the only exceptions.
+   *
+   * Sub-pixel is a declaration of intent as much as a measurement: Blink and
+   * Gecko round a non-zero border up to one device pixel, so this renders
+   * identically to 1px there, while WebKit can draw the true hairline on a
+   * high-density display. Layout is unaffected in every engine, because the
+   * used value is the rounded one.
+   * =================================== */
+  --default-border-width: 0.5px;
+
   /* Radius */
   --radius-xl: 14px;
   --radius-lg: var(--radius);
@@ -149,7 +166,7 @@
   /* Page surfaces: theme-neutral geometry, theme-aware fill and elevation. */
   --radius-surface: 1.25rem;
   --radius-surface-compact: 12px;
-  --border-width-surface: 0.7px;
+  --border-width-surface: var(--default-border-width);
   --shadow-surface: var(--surface-shadow);
   --ease-surface: ease;
 


### PR DESCRIPTION
Reopens the work from #33148, which was closed twice without a comment (by @e7h4n, most recently 2026-09-10 08:14Z while it sat at position 1 in the merge queue with every check green) and whose branch was then deleted. @e7h4n closed @bingjiez666's #33190 — also a styling refactor — 67 seconds earlier, so this may be a deliberate batch decision I do not have the context for. **If styling refactors are frozen right now, say so and I'll close this again.** Rebuilt on current `main` rather than restored, so the diff is one clean commit.

## What

Border width is decided in three places at once:

| source | value | count |
|---|---|---|
| Tailwind's built-in default for bare `border` | 1px | everywhere |
| hand-written `border*-[0.7px]` utilities | 0.7px | 49 across 27 files |
| `style={{ border: "0.7px solid …" }}` literals | 0.7px | 18 across 12 files |

There is now one owner. `--default-border-width` in the shared `@theme` is **0.5px**, and Tailwind's bare `border`, `border-t`, `border-x`, `divide-y` and their siblings all read it, so a component asks for "a border" and the system decides how thick it is.

- every `border*-[0.7px]` utility becomes the bare `border*` utility
- every inline `0.7px solid` becomes `var(--border-width-surface) solid`
- `--border-width-surface` derives from `--default-border-width` instead of repeating a literal
- `border-0` and the deliberate emphasis widths (`border-2`, `border-l-2`, `border-[1.5px]`, `border-[24px]`) are untouched — they express a different decision, not a competing value for the same one

## What this looks like in Chromium: nothing

Worth being direct about, because it changes how to read this PR. Sampling the rendered border band at `devicePixelRatio` 1, 2 and 3:

| declared | dpr 1 | dpr 2 | dpr 3 |
|---|---|---|---|
| `1px` | 1 device px | 2 | 3 |
| `0.7px` | 1 | 2 | 3 |
| `0.5px` | 1 | 2 | 3 |
| `0.25px` | 1 | 2 | 3 |

Blink rounds every non-zero border width up to one device pixel. The *used* value stays `1px` and `offsetHeight` is identical, so there is no paint change and no layout change in Chrome or Edge. WebKit can draw the true hairline on a high-density display; Gecko rounds like Blink.

So this lands as **one owner for the decision**, not as a visible change. `docs/styles.md` now says so explicitly, so nobody reaches for a sub-pixel width expecting a lighter border — the border colour is the lever for that.

## Out of scope, deliberately

`.okou-app .okou-composer` and the other first-party CSS borders in `views/css/index.css` keep their literals. Those declarations are frozen atoms in `turbo/style-legacy-baseline.json`, and `docs/styles.md` retires that selector by migrating it to utilities rather than by retuning it — the same boundary that shaped #33022.

The 18 inline borders now reference the shared token but remain `style` props. Converting them to `surfaceVariants` is the real cleanup and is a larger, conditional-logic refactor across `org-manage`.

## Tests

The auth checkbox style assertion compiled its classes against a stub `@theme` that omitted this key, so it pinned Tailwind's built-in 1px rather than the product's hairline — a value the App never rendered for that checkbox, since it already used the bare `border` utility. The stub now carries the key and the assertion states `0.5px`. No new tests: this is a token value plus a mechanical class substitution, and `docs/styles.md` forbids locating surfaces through utility class names in tests.

## Verification

- `node scripts/style-policy.mjs` → **Style policy passed** (the shrink-only ratchet; no first-party selector declaration is touched, and `@theme` in `globals.css` is not a baselined atom)
- `node scripts/style-migration.mjs` → **Style migration manifest passed**
- `prettier --check .` clean from `turbo`, and on `docs/styles.md`
- Compiled the real App entry with the repo's pinned Tailwind `4.3.3`: `.border` and `.border-t` emit `0.5px`, `.border-0` stays `0px`, `.border-2` stays `2px`, and both `--default-border-width` and `--border-width-surface` are emitted to `:root` so the inline `var(--border-width-surface)` resolves
- Rendered A/B against current `main` — input, popover, composer card, outline button, `divide-y` list, `border-2` emphasis and the inline-token border — is **pixel-identical at dpr 1 and dpr 2**
- Swept for collateral: one `border border-[0.7px]` collapsed to a redundant `border border` and was reduced to a single `border`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
