### PR TITLE
docs(python): correct permanent delivery failure logging guidance

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer/logging.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/logging.py
@@ -6,10 +6,14 @@ retained or dropped batches can be billing-impacting underbilling signals:
 - ``started`` marks enqueue/admission start.
 - ``enqueued`` marks enqueue/admission completion and may include retained
   counters for batches kept for retry.
-- ``failed`` marks an enqueue exception or permanent asynchronous delivery
-  failure and logs at error level.
+- ``failed`` marks an enqueue/admission exception and logs at error level.
 - ``retained`` marks asynchronous delivery outcomes kept for retry.
 - ``dropped`` marks retained batches whose retry budget was exhausted.
+
+For permanent billing webhook delivery failures (for example, HTTP 400),
+operators should inspect error-level ``usage_event`` webhook records in the
+run's proxy log. These outcomes do not emit ``phase=failed`` flush summaries
+and are not retained for retry or reported as retry-budget drops.
 
 Dropped retained billing batches always emit ``usage_underbilling`` with
 ``reason=retry_budget_exhausted`` and ``underbilling_class=confirmed``.


### PR DESCRIPTION
The usage-buffer phase guide incorrectly directed operators to `phase=failed` for permanent webhook delivery failures. Define that phase as an enqueue/admission exception and point HTTP 400 investigations to error-level `usage_event` webhook records in the run's proxy log, explaining how they differ from retained and retry-budget-drop summaries.

Only the module docstring changes; runtime delivery and logging behavior are unchanged.

Closes #33256

### Validation

- `uv lock --check` and `uv sync --locked` with the repository-pinned uv and Python versions.
- `uv run --no-sync ruff format --check src/usage/buffer/logging.py`
- `uv run --no-sync ruff check src/usage/buffer/logging.py`
- `uv run --no-sync python -m pytest tests/test_usage_buffer_logging.py::test_flush_logs_failure_without_token tests/test_usage_buffer_flush_failures.py::test_permanent_http_delivery_failure_completes_flush` — 2 passed.
- Parsed module comparison confirmed identical executable statements after excluding the module docstring; `git diff --check` passed.

Python commands were run from `crates/runner/mitm-addon/`. Broader suites are left to CI.
