### PR TITLE
feat: group connector filter agents by visibility

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/connector-page-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connector-page-test-helpers.ts
@@ -1,4 +1,7 @@
-import type { AgentResponse } from "@okouai/api-contracts/contracts/agents";
+import type {
+  AgentResponse,
+  AgentVisibility,
+} from "@okouai/api-contracts/contracts/agents";
 import {
   type ConnectorAccountConnection,
   connectorAccountsContract,
@@ -113,6 +116,7 @@ export function listAgent(
   agentId: string,
   displayName: string,
   avatarUrl: string | null = null,
+  visibility: AgentVisibility = "public",
 ): AgentResponse {
   return {
     agentId,
@@ -124,7 +128,7 @@ export function listAgent(
     modelProviderId: null,
     selectedModel: null,
     preferPersonalProvider: false,
-    visibility: "public",
+    visibility,
   };
 }
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
@@ -258,7 +258,9 @@ test("Filter connectors by connection state and agent", async () => {
   await fill(screen.getByPlaceholderText("Find connectors"), "");
   click(getConnectorAction("button", "Filter connectors"));
   await waitFor(() => {
-    expect(getConnectorAction("menuitem", "Research Agent")).toBeInTheDocument();
+    expect(
+      getConnectorAction("menuitem", "Research Agent"),
+    ).toBeInTheDocument();
   });
   // One visibility means no split: the section keeps its own heading.
   expect(filterMenuRows()).toContain("Agents");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
@@ -47,6 +47,19 @@ function oauthMethod() {
   };
 }
 
+/** Every row of the open filter menu, in order; separators read as "". */
+function filterMenuRows(): string[] {
+  const content = getConnectorAction("menuitem", "All").closest(
+    '[data-slot="dropdown-menu-content"]',
+  );
+  if (!(content instanceof HTMLElement)) {
+    throw new Error("Expected the connector filter menu to be open");
+  }
+  return Array.from(content.children, (row) => {
+    return row.textContent?.replace(/\s+/gu, " ").trim() ?? "";
+  });
+}
+
 async function expectCards(expected: {
   readonly github: boolean;
   readonly asana: boolean;
@@ -244,14 +257,61 @@ test("Filter connectors by connection state and agent", async () => {
 
   await fill(screen.getByPlaceholderText("Find connectors"), "");
   click(getConnectorAction("button", "Filter connectors"));
-  click(
-    await waitFor(() => {
-      return getConnectorAction("menuitem", "Research Agent");
-    }),
-  );
+  await waitFor(() => {
+    expect(getConnectorAction("menuitem", "Research Agent")).toBeInTheDocument();
+  });
+  // One visibility means no split: the section keeps its own heading.
+  expect(filterMenuRows()).toContain("Agents");
+  click(getConnectorAction("menuitem", "Research Agent"));
   await expectCards({ github: true, asana: false });
   expect(locationSearch()).toContain("connection=agent");
   expect(locationSearch()).toContain(researchId);
+});
+
+test("Split the connector filter agents by visibility", async () => {
+  const defaultId = "c0000000-0000-4000-a000-000000000001";
+  const researchId = "c0000000-0000-4000-a000-000000000010";
+  const soloId = "c0000000-0000-4000-a000-000000000011";
+  mockConnectors(context, [
+    { connectorSlug: "github", externalUsername: "octocat" },
+  ]);
+  context.mocks.data.agents([
+    listAgent(researchId, "Research Agent", "preset:0"),
+    listAgent(defaultId, "Workspace Agent", "preset:0"),
+    listAgent(soloId, "Solo Agent", "preset:0", "private"),
+  ]);
+  context.mocks.api(userConnectorsContract.get, ({ params, respond }) => {
+    return respond(200, {
+      enabledConnectorSlugs: params.id === soloId ? ["github"] : [],
+    });
+  });
+  await setupPage({ context, path: "/connectors" });
+  await expectCards({ github: true, asana: true });
+
+  click(getConnectorAction("button", "Filter connectors"));
+  await waitFor(() => {
+    expect(getConnectorAction("menuitem", "Solo Agent")).toBeInTheDocument();
+  });
+  // The default agent leads its group, and the personal agents sit apart.
+  expect(filterMenuRows()).toStrictEqual([
+    "All",
+    "",
+    "Status",
+    "Connected",
+    "Not connected",
+    "",
+    "Public",
+    "Workspace Agent",
+    "Research Agent",
+    "",
+    "Private",
+    "Solo Agent",
+  ]);
+
+  click(getConnectorAction("menuitem", "Solo Agent"));
+  await expectCards({ github: true, asana: false });
+  expect(locationSearch()).toContain("connection=agent");
+  expect(locationSearch()).toContain(soloId);
 });
 
 test("Navigate the connector catalog with a keyboard", async () => {

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -29,7 +29,7 @@ import {
   openCustomConnectorCreateDialog$,
 } from "../../signals/okou-page/settings/custom-connectors.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
-import { agents$ } from "../../signals/agent.ts";
+import { sortedAgents$ } from "../../signals/agent.ts";
 import { CustomConnectorsPanel } from "./components/settings/custom-connectors-panel.tsx";
 import {
   connectorCatalogDiscovery$,
@@ -350,6 +350,97 @@ function ConnectorFilterOption({
   );
 }
 
+function ConnectorFilterAgentOptions({
+  agents,
+  value,
+  onChange,
+}: {
+  readonly agents: readonly AgentResponse[];
+  readonly value: ConnectorsConnectionFilter;
+  readonly onChange: (value: ConnectorsConnectionFilter) => void;
+}) {
+  return agents.map((agent) => {
+    return (
+      <ConnectorFilterOption
+        key={agent.agentId}
+        active={value.kind === "agent" && value.agentId === agent.agentId}
+        onSelect={() => {
+          onChange({ kind: "agent", agentId: agent.agentId });
+        }}
+      >
+        <AvatarFromUrl
+          avatarUrl={agent.avatarUrl}
+          alt={connectorAgentName(agent)}
+          size={16}
+          className="h-4 w-4 rounded-full object-cover"
+        />
+        <span className="truncate">{connectorAgentName(agent)}</span>
+      </ConnectorFilterOption>
+    );
+  });
+}
+
+/**
+ * Public agents are shared by the whole workspace and capped at a handful;
+ * private agents are personal and unlimited, so a filter list long enough to
+ * scroll is always a private tail. Splitting it costs nothing when both halves
+ * exist, and the group headings borrow the agents page's own words so the two
+ * surfaces name one classification the same way.
+ */
+function agentVisibilityGroups(agents: readonly AgentResponse[]): {
+  readonly publicAgents: readonly AgentResponse[];
+  readonly privateAgents: readonly AgentResponse[];
+} {
+  return {
+    publicAgents: agents.filter((agent) => {
+      return agent.visibility !== "private";
+    }),
+    privateAgents: agents.filter((agent) => {
+      return agent.visibility === "private";
+    }),
+  };
+}
+
+function ConnectorFilterAgentGroups({
+  publicAgents,
+  privateAgents,
+  value,
+  onChange,
+}: {
+  readonly publicAgents: readonly AgentResponse[];
+  readonly privateAgents: readonly AgentResponse[];
+  readonly value: ConnectorsConnectionFilter;
+  readonly onChange: (value: ConnectorsConnectionFilter) => void;
+}) {
+  const { t } = useTranslation("agents");
+
+  return (
+    <>
+      <ConnectorFilterSectionLabel>
+        {t(($) => {
+          return $.list.tabs.public;
+        })}
+      </ConnectorFilterSectionLabel>
+      <ConnectorFilterAgentOptions
+        agents={publicAgents}
+        value={value}
+        onChange={onChange}
+      />
+      <DropdownMenuSeparator />
+      <ConnectorFilterSectionLabel>
+        {t(($) => {
+          return $.list.tabs.private;
+        })}
+      </ConnectorFilterSectionLabel>
+      <ConnectorFilterAgentOptions
+        agents={privateAgents}
+        value={value}
+        onChange={onChange}
+      />
+    </>
+  );
+}
+
 function ConnectorFilterDropdown({
   value,
   agents,
@@ -360,6 +451,7 @@ function ConnectorFilterDropdown({
   readonly onChange: (value: ConnectorsConnectionFilter) => void;
 }) {
   const { t } = useTranslation();
+  const { publicAgents, privateAgents } = agentVisibilityGroups(agents);
   const activeAgent =
     value.kind === "agent"
       ? agents.find((agent) => {
@@ -448,32 +540,27 @@ function ConnectorFilterDropdown({
         {agents.length > 0 && (
           <>
             <DropdownMenuSeparator />
-            <ConnectorFilterSectionLabel>
-              {t(($) => {
-                return $.connectors.catalog.filters.agents;
-              })}
-            </ConnectorFilterSectionLabel>
-            {agents.map((agent) => {
-              return (
-                <ConnectorFilterOption
-                  key={agent.agentId}
-                  active={
-                    value.kind === "agent" && value.agentId === agent.agentId
-                  }
-                  onSelect={() => {
-                    onChange({ kind: "agent", agentId: agent.agentId });
-                  }}
-                >
-                  <AvatarFromUrl
-                    avatarUrl={agent.avatarUrl}
-                    alt={connectorAgentName(agent)}
-                    size={16}
-                    className="h-4 w-4 rounded-full object-cover"
-                  />
-                  <span className="truncate">{connectorAgentName(agent)}</span>
-                </ConnectorFilterOption>
-              );
-            })}
+            {publicAgents.length > 0 && privateAgents.length > 0 ? (
+              <ConnectorFilterAgentGroups
+                publicAgents={publicAgents}
+                privateAgents={privateAgents}
+                value={value}
+                onChange={onChange}
+              />
+            ) : (
+              <>
+                <ConnectorFilterSectionLabel>
+                  {t(($) => {
+                    return $.connectors.catalog.filters.agents;
+                  })}
+                </ConnectorFilterSectionLabel>
+                <ConnectorFilterAgentOptions
+                  agents={agents}
+                  value={value}
+                  onChange={onChange}
+                />
+              </>
+            )}
           </>
         )}
       </DropdownMenuContent>
@@ -1397,7 +1484,7 @@ export function ConnectorsPage() {
   const setConnectionFilter = useSet(setConnectorsConnectionFilter$);
   const categoryFilter = useGet(connectorsCategoryFilter$);
   const setCategoryFilter = useSet(setConnectorsCategoryFilter$);
-  const agentsLoadable = useLastLoadable(agents$);
+  const agentsLoadable = useLastLoadable(sortedAgents$);
   const agents = agentsLoadable.state === "hasData" ? agentsLoadable.data : [];
 
   const filteredConnectors =


### PR DESCRIPTION
## Why

The connector catalog's filter menu lists every agent flat, in raw API order. Two consequences:

- The default agent is not first — the rest of the app reads the same list through `sortedAgents$`, which pins it to the top; this one call site used `agents$`.
- Public agents are capped at `MAX_PUBLIC_AGENTS = 7`, private agents are unlimited and personal, so any menu long enough to scroll is a private tail with no structure.

A teammate asked for "agent categories, in the connector list too". Agents already carry exactly one classification — `visibility` — and the agents page already names it Public / Private. This reuses that rather than adding a second taxonomy.

## What

- `ConnectorsPage` reads `sortedAgents$` instead of `agents$`, so the default agent leads the filter list.
- When the list contains both public and private agents, the section splits into two groups under the agents page's own `agents:list.tabs.public` / `.private` labels — no new strings, so all ten locales are covered on day one.
- A single-visibility list is unchanged: it keeps the existing `Agents` heading and one flat group.

## Design note for review

In the split case the generic `Agents` heading is dropped, because `Agents` immediately followed by `Public` reads as a duplicated label in a 224px menu. Each row still carries an agent avatar, and the group sits below the `Status` separator. If reviewers prefer keeping `Agents` as a parent label above the two groups, that is a one-line change.

## Tests

- `Split the connector filter agents by visibility` asserts the full menu structure in order — `Status` group, then `Public` with the default agent first, then `Private` — and that selecting a private agent still applies the `connection=agent` filter.
- `Filter connectors by connection state and agent` gains an assertion that a single-visibility list keeps the `Agents` heading.

No feature switch: this refines an existing filter rather than adding a page, section, endpoint, or integration.
