### PR TITLE
fix(app): show the whole category in the composer connector directory

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/connectors.ts
@@ -119,18 +119,12 @@ export interface ComposerConnectorSignals {
   readonly accounts: ComposerConnectorAccountSignals;
 }
 
-const relatedConnectorCatalogKeyword$ = computed(() => {
-  return "";
-});
-
-const composerRelatedCatalog$ = relatedConnectorCatalog(
-  relatedConnectorCatalogKeyword$,
-);
-
-/** A category-scoped read asks for no keyword, so it browses that category. */
+/** Browse reads ask for no keyword; the category, when set, scopes them. */
 const emptyCatalogKeyword$ = computed(() => {
   return "";
 });
+
+const composerRelatedCatalog$ = relatedConnectorCatalog(emptyCatalogKeyword$);
 
 const composerRelatedCatalogItems$ = computed(async (get) => {
   return (await get(composerRelatedCatalog$)).connectors;

--- a/turbo/apps/platform/src/signals/okou-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/connectors.ts
@@ -127,6 +127,11 @@ const composerRelatedCatalog$ = relatedConnectorCatalog(
   relatedConnectorCatalogKeyword$,
 );
 
+/** A category-scoped read asks for no keyword, so it browses that category. */
+const emptyCatalogKeyword$ = computed(() => {
+  return "";
+});
+
 const composerRelatedCatalogItems$ = computed(async (get) => {
   return (await get(composerRelatedCatalog$)).connectors;
 });
@@ -404,12 +409,28 @@ export function createComposerConnectorSignals(
   const addDialogKeyword$ = computed((get) => {
     return get(ui.connectorUiState$).addDialogSearch;
   });
+  const addDialogCategory$ = computed((get) => {
+    return get(ui.connectorUiState$).directoryCategory;
+  });
   const searchedCatalog$ = relatedConnectorCatalog(addDialogKeyword$);
+  /**
+   * A chosen category is fetched by name, so the directory holds all of it.
+   * The browse response carries a slice per category, which is what the
+   * shelves want and what a category page must not settle for: the count the
+   * chip offers on the way in is the number this has to deliver.
+   */
+  const categoryCatalog$ = relatedConnectorCatalog(
+    emptyCatalogKeyword$,
+    addDialogCategory$,
+  );
   const addDialogCatalogItems$ = computed(async (get) => {
-    if (!get(addDialogKeyword$).trim()) {
-      return await get(composerRelatedCatalogItems$);
+    if (get(addDialogKeyword$).trim()) {
+      return (await get(searchedCatalog$)).connectors;
     }
-    return (await get(searchedCatalog$)).connectors;
+    if (get(addDialogCategory$)) {
+      return (await get(categoryCatalog$)).connectors;
+    }
+    return await get(composerRelatedCatalogItems$);
   });
   const connectorPermissionMetadata$ = computed(async (get) => {
     const connectorSlug = get(ui.connectorUiState$).permissionConnectorSlug;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connectors-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connectors-test-helpers.ts
@@ -230,6 +230,27 @@ function connectorResponse(
   };
 }
 
+/** What the API returns per category when no category is asked for by name. */
+const DISCOVERY_PER_CATEGORY = 12;
+
+/**
+ * Discovery keeps every connected connector and slices the rest per category,
+ * so a fixture of connected connectors is returned whole.
+ */
+function browseSlice<
+  T extends { readonly category: string; readonly connection: unknown },
+>(connectors: readonly T[]): T[] {
+  const shownPerCategory = new Map<string, number>();
+  return connectors.filter((connector) => {
+    if (connector.connection) {
+      return true;
+    }
+    const shown = shownPerCategory.get(connector.category) ?? 0;
+    shownPerCategory.set(connector.category, shown + 1);
+    return shown < DISCOVERY_PER_CATEGORY;
+  });
+}
+
 export function installComposerConnectorFixture(
   options: ConnectorFixtureOptions = {},
 ): ComposerConnectorFixture {
@@ -315,6 +336,15 @@ export function installComposerConnectorFixture(
             return options.featuredConnectorSlugs?.includes(connector.slug);
           })
         : catalog;
+      // Production answers a named category with the whole category, and a
+      // keyword-free browse with every connected connector plus a slice of
+      // each category. The fixture does the same, or a category view is
+      // tested against a response the API never returns.
+      const browsed = query.category
+        ? featured.filter((connector) => {
+            return connector.category === query.category;
+          })
+        : browseSlice(featured);
       const connectors = keyword
         ? catalog.filter((connector) => {
             return [connector.slug, connector.label, ...connector.tags].some(
@@ -323,7 +353,7 @@ export function installComposerConnectorFixture(
               },
             );
           })
-        : featured;
+        : browsed;
       return respond(200, {
         connectors,
         totalConnectorCount: catalog.length,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connector-directory.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connector-directory.test.tsx
@@ -227,6 +227,8 @@ function rankedCatalog() {
   // Four ranked connectors earn "mail" a shelf; "voice" has one, so it stays a
   // counted chip rather than opening on the alphabet.
   return [
+    // Sixteen, so the category holds more than the twelve a keyword-free
+    // browse response returns for it.
     ...[
       "Gmail",
       "Outlook Mail",
@@ -238,6 +240,12 @@ function rankedCatalog() {
       "Zendesk",
       "Intercom",
       "Mailchimp",
+      "Resend",
+      "Twilio",
+      "Front",
+      "Missive",
+      "Crisp",
+      "Help Scout",
     ].map((label, index) => {
       return builtinConnector({
         slug: `mail-${index}` as ConnectorSlug,
@@ -386,4 +394,50 @@ test("Count the whole category on a chip, not the slice discovery returned", asy
       name: "Communication and Collaboration",
     }),
   ).toBeVisible();
+});
+
+test("Show the whole category the chip counted, not the browse slice", async () => {
+  const user = userEvent.setup({ delay: null });
+  installComposerConnectorFixture({
+    catalog: rankedCatalog(),
+    categoryConnectorCounts: { mail: 16, voice: 50 },
+  });
+
+  await setupPage({
+    context,
+    path: `/agents/${SCOUT_AGENT_ID}/chat`,
+    featureSwitches: { [FeatureSwitchKey.ConnectorDirectory]: true },
+  });
+
+  const dialog = await openDirectory(user);
+  const chip = await waitFor(() => {
+    const match = Array.from(
+      dialog.querySelectorAll<HTMLElement>("[data-connector-category-chip]"),
+    ).find((element) => {
+      return element.textContent === "Mail16";
+    });
+    if (!match) {
+      throw new Error("Expected the Mail category chip to count sixteen");
+    }
+    return match;
+  });
+
+  // The chip says sixteen, so entering it has to show sixteen -- a browse
+  // response carries at most twelve of any one category.
+  await user.click(chip);
+  await waitFor(() => {
+    expect(within(dialog).getByText("Help Scout")).toBeVisible();
+  });
+  expect(within(dialog).getAllByTestId("connector-card-label")).toHaveLength(
+    16,
+  );
+
+  // The chip row still offers every category, so the reader can pick another.
+  expect(
+    Array.from(
+      dialog.querySelectorAll<HTMLElement>("[data-connector-category-chip]"),
+    ).map((element) => {
+      return element.textContent;
+    }),
+  ).toContain("Voice50");
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connector-page-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connector-page-test-helpers.ts
@@ -213,6 +213,24 @@ export function publicStatusItem(args: {
 /** What the API returns per category when no category is asked for by name. */
 const DISCOVERY_PER_CATEGORY = 12;
 
+/**
+ * Discovery keeps every connected connector and slices the rest per category,
+ * so a fixture of connected connectors is returned whole.
+ */
+function browseSlice<
+  T extends { readonly category: string; readonly connection: unknown },
+>(connectors: readonly T[]): T[] {
+  const shownPerCategory = new Map<string, number>();
+  return connectors.filter((connector) => {
+    if (connector.connection) {
+      return true;
+    }
+    const shown = shownPerCategory.get(connector.category) ?? 0;
+    shownPerCategory.set(connector.category, shown + 1);
+    return shown < DISCOVERY_PER_CATEGORY;
+  });
+}
+
 export function mockPublicConnectorStatus(
   context: TestContext,
   connectors: readonly PublicConnectorCatalogStatusItem[],
@@ -228,19 +246,15 @@ export function mockPublicConnectorStatus(
   context.mocks.api(
     connectorCatalogContract.discovery,
     ({ query, respond }) => {
-      // Production slices discovery per category and answers a named category
-      // with the whole category. The fixture does the same, or the category view
-      // is tested against a response the API never returns.
-      const perCategory = new Map<string, number>();
+      // Production answers a named category with the whole category, and a
+      // keyword-free browse with every connected connector plus a slice of
+      // each category. The fixture does the same, or the category view is
+      // tested against a response the API never returns.
       const scoped = query.category
         ? connectors.filter((connector) => {
             return connector.category === query.category;
           })
-        : connectors.filter((connector) => {
-            const shown = perCategory.get(connector.category) ?? 0;
-            perCategory.set(connector.category, shown + 1);
-            return shown < DISCOVERY_PER_CATEGORY;
-          });
+        : browseSlice(connectors);
       return respond(200, {
         connectors: [...scoped],
         totalConnectorCount: connectors.length,

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -10815,6 +10815,7 @@ function ComposerConnectorsSlot({
             categoryCounts={connectorData?.categoryConnectorCounts}
             categoryMetadata={connectorData?.categoryMetadata}
             loading={connectorData === undefined}
+            chipCatalog={connectorData?.relatedCatalogItems ?? []}
             connected={agentConnectors}
             unconnected={unconnectedConnectors}
             connectedCustom={agentCustomConnectors}

--- a/turbo/apps/platform/src/views/okou-page/connector-directory-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connector-directory-dialog.tsx
@@ -659,9 +659,12 @@ function DirectoryBrowseView({
   const remoteAccessLabel = t(($) => {
     return $.connectors.catalog.remoteAccess;
   });
+  // The chip row comes from the browse response, not from what is currently
+  // shown: a chip row that empties itself when you pick a chip cannot be used
+  // to pick another one.
   const sections = sshAvailable
     ? [
-        ...model.categorySections,
+        ...model.chipSections,
         {
           category: REMOTE_ACCESS_CATEGORY,
           label: remoteAccessLabel,
@@ -670,7 +673,7 @@ function DirectoryBrowseView({
           connectors: [],
         },
       ]
-    : model.categorySections;
+    : model.chipSections;
   return (
     <>
       <DirectoryToolbar
@@ -879,6 +882,8 @@ interface ConnectorDirectoryDialogProps {
    */
   readonly categoryMetadata: PublicConnectorCatalogCategoryMetadata | undefined;
   readonly loading: boolean;
+  /** Every connector the browse response carried, for the chip row. */
+  readonly chipCatalog: readonly PlatformConnectorCatalogStatusItem[];
   readonly connected: readonly PlatformConnectorCatalogStatusItem[];
   readonly unconnected: readonly PlatformConnectorCatalogStatusItem[];
   readonly connectedCustom: readonly CustomConnectorResponse[];
@@ -919,6 +924,7 @@ export function ConnectorDirectoryDialog({
   categoryCounts,
   categoryMetadata,
   loading,
+  chipCatalog,
   connected,
   unconnected,
   connectedCustom,
@@ -943,6 +949,7 @@ export function ConnectorDirectoryDialog({
   const model = buildConnectorDirectoryModel({
     connected,
     unconnected,
+    chipCatalog,
     connectedCustom,
     unconnectedCustom,
     search,

--- a/turbo/apps/platform/src/views/okou-page/connector-directory-model.ts
+++ b/turbo/apps/platform/src/views/okou-page/connector-directory-model.ts
@@ -30,6 +30,12 @@ export interface ConnectorDirectoryModel {
   readonly discover: readonly PlatformConnectorCatalogStatusItem[];
   readonly custom: readonly CustomConnectorResponse[];
   readonly categorySections: readonly ConnectorCategorySection<PlatformConnectorCatalogStatusItem>[];
+  /**
+   * The categories the chip row offers. They come from the browse response
+   * rather than from what is currently shown, because a chip row that empties
+   * itself when you pick a chip cannot be used to pick another one.
+   */
+  readonly chipSections: readonly ConnectorCategorySection<PlatformConnectorCatalogStatusItem>[];
   /** Shelves for the default browse view: no search, no chosen category. */
   readonly shelfLayout: ConnectorShelfLayout<PlatformConnectorCatalogStatusItem>;
   readonly discoverSlugs: readonly ConnectorSlug[];
@@ -80,6 +86,7 @@ function slugsOf(
 export function buildConnectorDirectoryModel({
   connected,
   unconnected,
+  chipCatalog,
   connectedCustom,
   unconnectedCustom,
   search,
@@ -91,6 +98,8 @@ export function buildConnectorDirectoryModel({
 }: {
   readonly connected: readonly PlatformConnectorCatalogStatusItem[];
   readonly unconnected: readonly PlatformConnectorCatalogStatusItem[];
+  /** Every connector the browse response carried, for the chip row. */
+  readonly chipCatalog: readonly PlatformConnectorCatalogStatusItem[];
   readonly connectedCustom: readonly CustomConnectorResponse[];
   readonly unconnectedCustom: readonly CustomConnectorResponse[];
   readonly search: string;
@@ -118,13 +127,20 @@ export function buildConnectorDirectoryModel({
       return matchesCustomConnectorSearch(search, connector);
     },
   );
-  const categorySections = groupConnectorsByCategory(
-    unconnected,
-    localizeConnectorCategoryMetadata(categoryMetadata),
-    otherCategoryLabel,
-  ).flatMap((group) => {
-    return group.sections;
-  });
+  const localizedMetadata = localizeConnectorCategoryMetadata(categoryMetadata);
+  const sectionsOf = (
+    items: readonly PlatformConnectorCatalogStatusItem[],
+  ): ConnectorCategorySection<PlatformConnectorCatalogStatusItem>[] => {
+    return groupConnectorsByCategory(
+      items,
+      localizedMetadata,
+      otherCategoryLabel,
+    ).flatMap((group) => {
+      return group.sections;
+    });
+  };
+  const categorySections = sectionsOf(unconnected);
+  const chipSections = sectionsOf(chipCatalog);
   const shelfLayout = buildConnectorShelves({
     sections: categorySections,
     categoryCounts,
@@ -144,6 +160,7 @@ export function buildConnectorDirectoryModel({
     discover,
     custom,
     categorySections,
+    chipSections,
     shelfLayout,
     discoverSlugs:
       search.trim() || category !== null || shelfLayout.shelves.length === 0


### PR DESCRIPTION
Re-lands #33189, which was closed unmerged at 08:14 UTC while it sat at position 14 in the merge queue. No review or CI objection was raised on it — CI was green and codecov clean — so this is the same change, cherry-picked onto current `main` and re-verified there.

## The defect

The connectors page stopped promising 329 and delivering 12 in #33112. **The composer's directory still does it.**

Its chips carry the category totals from `categoryConnectorCounts`, but its connectors come from the keyword-free browse response, which holds at most twelve of any one category. So picking a chip that says **329** opens a list of **12**.

## What changed

- **The dialog asks discovery for the category by name**, exactly as the page does, and gets all of it.
- Scoping the fetch moved a second problem into view: the chip row was built from the connectors currently shown, so entering a category left **one chip and no way to pick another**. It now comes from the browse response — what the page already does with its own chip row.

## The fixtures were describing a response the API never returns

Both connector fixtures returned every connector, unsliced, which is why neither surface's category view could be tested. They now behave like discovery:

- a named category → the whole category
- a keyword-free browse → **every connected connector** plus a slice of each category

That second clause matters: `discoveryEffectiveConnectors` puts connected connectors ahead of the slice, so an agent with twenty-five connected connectors gets all twenty-five. Getting it wrong briefly broke three unrelated composer-popover cases; getting it right is what lets the new case fail without the fix.

## Verification on this base

- `@okouai/app` `check-types`, `lint`, `pnpm knip` — clean
- 112 tests across `connector-directory`, `connectors-catalog`, `connectors-ssh`, `connectors-accounts`, `connectors-custom`, `chat-composer-connectors`, `chat-composer-connector-accounts`, `chat-composer-connector-loading`
- New case "Show the whole category the chip counted, not the browse slice": the chip reads `Mail16`, entering it renders sixteen cards, and the row still offers `Voice50` so another category stays reachable

## Feature switch

Unchanged: `connectorDirectory`.