### PR TITLE
docs(rust): correct snapshot socket-id listener limits

### DIFF
--- a/crates/sandbox-firecracker/src/paths.rs
+++ b/crates/sandbox-firecracker/src/paths.rs
@@ -267,12 +267,9 @@ impl SnapshotOutputPaths {
     ///
     /// `sock_id` identifies the socket directory under `/run/vm0/sock/` —
     /// typically the config hash so each snapshot gets a unique path. It must
-    /// be a single, non-empty normal path segment containing only ASCII
-    /// letters, digits, `.`, `-`, or `_`. The special `.` and `..` components,
-    /// as well as nested or composite IDs such as `<rootfs>/<snapshot>`, are
-    /// invalid. The complete generated
-    /// `/run/vm0/sock/<sock_id>/vsock/vsock.sock` path must be at most 107
-    /// bytes.
+    /// satisfy the Firecracker socket-ID requirements documented on
+    /// [`sandbox::SnapshotCreateConfig::id`], including room for the `_1000`
+    /// guest-control listener suffix.
     ///
     /// This helper only constructs paths; it does not validate `sock_id`.
     /// Callers must ensure these requirements are met before using the returned

--- a/crates/sandbox-firecracker/src/snapshot/provider.rs
+++ b/crates/sandbox-firecracker/src/snapshot/provider.rs
@@ -12,15 +12,9 @@ use super::{SnapshotError, create_uncommitted_snapshot};
 /// Firecracker-backed snapshot provider.
 ///
 /// Snapshot creation uses [`SnapshotCreateConfig::id`] as the runtime socket
-/// directory identifier. The ID must be a single, non-empty normal ASCII path
-/// segment containing only letters, digits, `.`, `-`, and `_`. The special `.`
-/// and `..` components, nested, parent-relative, and composite values such as
-/// `<rootfs>/<snapshot>` are invalid. The complete generated
-/// `/run/vm0/sock/<id>/vsock/vsock.sock` path must be at most 107 bytes.
-///
-/// The provider validates this contract before checking prerequisites or
-/// cleaning snapshot output. Invalid IDs fail as `sandbox::SnapshotError::Setup`.
-/// Other [`SnapshotProvider`] implementations may impose different
+/// directory identifier. See that field for the Firecracker ID requirements,
+/// including the `_1000` guest-control listener suffix and the limits of early
+/// validation. Other [`SnapshotProvider`] implementations may impose different
 /// requirements on the same provider-neutral configuration type.
 ///
 /// Stateless — can be created with zero cost and used immediately.

--- a/crates/sandbox/src/snapshot.rs
+++ b/crates/sandbox/src/snapshot.rs
@@ -11,12 +11,27 @@ pub struct SnapshotCreateConfig {
     /// value as its runtime socket directory name and requires a single,
     /// non-empty normal ASCII path segment containing only letters, digits,
     /// `.`, `-`, and `_`. The special `.` and `..` components, nested or
-    /// composite values such as `<rootfs>/<snapshot>`, are invalid, and the generated
-    /// `/run/vm0/sock/<id>/vsock/vsock.sock` path must be at most 107 bytes.
-    /// Invalid Firecracker IDs are reported as `SnapshotError::Setup` before
-    /// snapshot-output cleanup. Other providers may impose different
-    /// requirements; this provider-specific contract is not enforced by the
-    /// provider-neutral configuration type.
+    /// composite values such as `<rootfs>/<snapshot>`, are invalid.
+    ///
+    /// The complete guest-control listener path
+    /// `/run/vm0/sock/<id>/vsock/vsock.sock_1000` must be at most 107 bytes,
+    /// the usable Linux Unix socket pathname limit. The current guest-control
+    /// port is 1000, so its `_1000` suffix reserves five bytes: the unsuffixed
+    /// `vsock.sock` path must be at most 102 bytes. With the default socket root
+    /// `/run/vm0/sock/`, this leaves at most 71 ASCII bytes for the ID.
+    ///
+    /// | ID length (ASCII bytes) | Base path (bytes) | Listener path (bytes) | Fits listener limit? |
+    /// | --- | --- | --- | --- |
+    /// | 71 | 102 | 107 | Yes |
+    /// | 72 | 103 | 108 | No |
+    ///
+    /// Firecracker's early validation rejects invalid ID syntax and unsuffixed
+    /// paths longer than 107 bytes as [`SnapshotError::Setup`] before checking
+    /// prerequisites or cleaning snapshot output. It does not reserve the
+    /// listener suffix: IDs of 72 through 76 ASCII bytes under the default root
+    /// pass that length check but exceed the later listener's pathname limit.
+    /// Other providers may impose different requirements; this provider-specific
+    /// contract is not enforced by the provider-neutral configuration type.
     pub id: String,
     /// Path to the sandbox backend binary (e.g., firecracker).
     pub binary_path: PathBuf,


### PR DESCRIPTION
Snapshot socket-ID documentation allowed IDs whose base socket path fits Linux's 107-byte limit but whose guest-control listener path exceeds it after appending `_1000`. Document the five-byte reservation and 71-byte ASCII ID boundary on `SnapshotCreateConfig::id`, with 71/72-byte examples, and link both Firecracker documentation sites to that contract.

Clarify that the existing early guard checks only the unsuffixed path. This change updates documentation only; snapshot creation and validation behavior are unchanged.

Closes #33258

## Validation

- `rustfmt --check --edition 2024 crates/sandbox/src/snapshot.rs crates/sandbox-firecracker/src/snapshot/provider.rs crates/sandbox-firecracker/src/paths.rs`
- `CARGO_BUILD_JOBS=2 RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml --profile local --locked -p sandbox -p sandbox-firecracker --no-deps`
- Verified the rendered boundary table and both canonical-field links, including Rustdoc's re-export redirects.
- Standalone Linux Rust `SocketAddr::from_pathname` probe: the 71-byte ID produces a valid 107-byte listener path; 72/76-byte IDs produce 108/112-byte listener paths and `InvalidInput`, although all unsuffixed addresses fit.
- `git diff --check`; confirmed all changed lines are documentation comments. No Firecracker/KVM integration run.
