### PR TITLE
refactor(python): share payload-free thread-pool startup

### DIFF
--- a/crates/runner/mitm-addon/src/aws_sigv4_hash_executor.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4_hash_executor.py
@@ -12,6 +12,7 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 
 from aws_sigv4_body_admission import MAX_ADMITTED_AWS_SIGV4_REQUESTS
+from thread_pool import start_thread_pool
 
 _lock = threading.Lock()
 _executor: ThreadPoolExecutor | None = None
@@ -25,27 +26,11 @@ def get_executor() -> ThreadPoolExecutor:
         if _shut_down:
             raise RuntimeError("AWS SigV4 hashing is shut down")
         if _executor is None:
-            _executor = _start_executor()
+            _executor = start_thread_pool(
+                max_workers=MAX_ADMITTED_AWS_SIGV4_REQUESTS,
+                thread_name_prefix="aws-sigv4-hash",
+            )
         return _executor
-
-
-def _start_executor() -> ThreadPoolExecutor:
-    executor = ThreadPoolExecutor(
-        max_workers=MAX_ADMITTED_AWS_SIGV4_REQUESTS,
-        thread_name_prefix="aws-sigv4-hash",
-    )
-    release_workers = threading.Event()
-    try:
-        # Keep startup jobs busy so every submit starts a worker. No body enters
-        # this queue until all worker starts have succeeded.
-        for _ in range(MAX_ADMITTED_AWS_SIGV4_REQUESTS):
-            executor.submit(release_workers.wait)
-    except BaseException:
-        release_workers.set()
-        executor.shutdown(wait=True, cancel_futures=True)
-        raise
-    release_workers.set()
-    return executor
 
 
 def shutdown() -> None:

--- a/crates/runner/mitm-addon/src/model_provider_failure.py
+++ b/crates/runner/mitm-addon/src/model_provider_failure.py
@@ -58,6 +58,7 @@ import openai_responses_events
 import platform_api
 import runtime_url_parsing
 from logging_utils import log_proxy_entry
+from thread_pool import start_thread_pool
 from usage.json_selective import JsonSelectiveExtractor
 from usage.model_http import (
     FAILURE_SCALAR_FIELDS,
@@ -881,25 +882,6 @@ def _mark_websocket_ambiguous(
     _log_suppressed(flow, reason)
 
 
-def _start_report_executor() -> ThreadPoolExecutor:
-    executor = ThreadPoolExecutor(
-        max_workers=_REPORT_WORKERS,
-        thread_name_prefix="model-provider-failure",
-    )
-    release_workers = threading.Event()
-    try:
-        # submit() queues before starting a worker and can then raise without returning
-        # its future. Start every worker with report-free tasks before enqueueing HTTP.
-        for _ in range(_REPORT_WORKERS):
-            executor.submit(release_workers.wait)
-    except BaseException:
-        release_workers.set()
-        executor.shutdown(wait=True, cancel_futures=True)
-        raise
-    release_workers.set()
-    return executor
-
-
 def _enqueue_report(flow: http.HTTPFlow, run_id: str, failure: Failure) -> None:
     global _report_executor
     with _report_lock:
@@ -935,7 +917,10 @@ def _enqueue_report(flow: http.HTTPFlow, run_id: str, failure: Failure) -> None:
             try:
                 if _report_executor is None:
                     omission_reason = "worker_start_failed"
-                    _report_executor = _start_report_executor()
+                    _report_executor = start_thread_pool(
+                        max_workers=_REPORT_WORKERS,
+                        thread_name_prefix="model-provider-failure",
+                    )
                 omission_reason = "reporter_shut_down"
                 future = _report_executor.submit(
                     _post_report,

--- a/crates/runner/mitm-addon/src/thread_pool.py
+++ b/crates/runner/mitm-addon/src/thread_pool.py
@@ -1,0 +1,26 @@
+"""Start every pool worker before admitting payload-bearing tasks."""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+
+def start_thread_pool(*, max_workers: int, thread_name_prefix: str) -> ThreadPoolExecutor:
+    """Return a fully started pool, joining failed candidates before re-raising."""
+    executor = ThreadPoolExecutor(
+        max_workers=max_workers,
+        thread_name_prefix=thread_name_prefix,
+    )
+    release_workers = threading.Event()
+    try:
+        # Blocking bootstrap tasks prevent idle-worker reuse, so every worker
+        # starts before any caller payload can enter the queue.
+        for _ in range(max_workers):
+            executor.submit(release_workers.wait)
+    except BaseException:
+        release_workers.set()
+        # submit() may queue a task before Thread.start() raises. The failed
+        # candidate owns only bootstrap work, which is safe to cancel and join.
+        executor.shutdown(wait=True, cancel_futures=True)
+        raise
+    release_workers.set()
+    return executor

--- a/crates/runner/mitm-addon/src/usage/executor.py
+++ b/crates/runner/mitm-addon/src/usage/executor.py
@@ -4,6 +4,8 @@ import threading
 from collections.abc import Callable
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
 
+from thread_pool import start_thread_pool
+
 
 class WebhookExecutor(Executor):
     """Lazily publish a fully started pool; failed pools own only bootstrap work."""
@@ -17,32 +19,15 @@ class WebhookExecutor(Executor):
         self._pool: ThreadPoolExecutor | None = None
         self._shutdown = False
 
-    def _start_pool(self) -> ThreadPoolExecutor:
-        pool = ThreadPoolExecutor(
-            max_workers=self._max_workers,
-            thread_name_prefix=self._thread_name_prefix,
-        )
-        ready = threading.Event()
-        try:
-            # Blocking every bootstrap task prevents idle-worker reuse, so all
-            # workers start before submit() can queue a webhook payload.
-            for _ in range(self._max_workers):
-                pool.submit(ready.wait)
-        except BaseException:
-            ready.set()
-            # submit() may have queued a task before Thread.start() failed.
-            # This unpublished pool has no deliveries to cancel or wait for.
-            pool.shutdown(wait=True, cancel_futures=True)
-            raise
-        ready.set()
-        return pool
-
     def submit[T, **P](self, fn: Callable[P, T], /, *args: P.args, **kwargs: P.kwargs) -> Future[T]:
         with self._lock:
             if self._shutdown:
                 raise RuntimeError("cannot schedule new futures after shutdown")
             if self._pool is None:
-                self._pool = self._start_pool()
+                self._pool = start_thread_pool(
+                    max_workers=self._max_workers,
+                    thread_name_prefix=self._thread_name_prefix,
+                )
             return self._pool.submit(fn, *args, **kwargs)
 
     def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:

--- a/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_hash_executor.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_hash_executor.py
@@ -16,6 +16,7 @@ import aws_sigv4_body_admission as admission
 import aws_sigv4_hash_executor
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import thread_pool
 from aws_sigv4 import AwsSigV4BodyHash, hash_request_body
 from tests.aws_sigv4_helpers import RESOLVED_AWS_ACCESS_KEY_ID
 from tests.test_request_handler_aws_sigv4_body import (
@@ -102,9 +103,7 @@ async def test_worker_start_failures_release_bodies_and_recover(
                 auth, "get_firewall_headers", AsyncMock(return_value=_resolved_token_meta())
             ),
             patch.object(auth, "hash_request_body", observe_hash),
-            patch.object(
-                aws_sigv4_hash_executor, "ThreadPoolExecutor", side_effect=create_executor
-            ),
+            patch.object(thread_pool, "ThreadPoolExecutor", side_effect=create_executor),
         ):
             with patch.object(threading.Thread, "start", fail_start):
                 # Five distinct maximum-size bodies exceed the aggregate 128 MiB bound.

--- a/crates/runner/mitm-addon/tests/test_thread_pool.py
+++ b/crates/runner/mitm-addon/tests/test_thread_pool.py
@@ -1,0 +1,108 @@
+"""Infrastructure startup failures cannot be constructed through HTTP input.
+
+Exercise the factory with real workers. Failed submit() calls expose no future,
+so observe the real pool to verify that inaccessible bootstrap work is cleaned
+up. Isolate scenarios in processes so a rollback deadlock cannot hang pytest.
+"""
+
+import multiprocessing
+import threading
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
+import pytest
+
+import thread_pool
+
+
+class _StartupInterrupted(BaseException):
+    pass
+
+
+def _assert_full_capacity(pool: ThreadPoolExecutor, workers: int) -> None:
+    rendezvous = threading.Barrier(workers)
+
+    def run() -> str:
+        rendezvous.wait(timeout=5)
+        return threading.current_thread().name
+
+    # After startup, payload submissions must not depend on creating threads,
+    # even when all requested workers need to run concurrently.
+    with patch.object(threading.Thread, "start", side_effect=RuntimeError("unexpected new worker")):
+        futures = [pool.submit(run) for _ in range(workers)]
+        names = {future.result(timeout=5) for future in futures}
+    assert len(names) == workers
+
+
+def _start_and_use_pool(workers: int) -> None:
+    with thread_pool.start_thread_pool(
+        max_workers=workers, thread_name_prefix="thread-pool-success"
+    ) as pool:
+        _assert_full_capacity(pool, workers)
+
+
+def _fail_start_and_recover(error_type: type[BaseException], failed_worker: int) -> None:
+    pools: list[ThreadPoolExecutor] = []
+    failure = error_type("worker creation failed")
+    start = threading.Thread.start
+
+    class ObservedPool(ThreadPoolExecutor):
+        def __init__(self, **kwargs) -> None:
+            super().__init__(**kwargs)
+            pools.append(self)
+
+    def fail_start(thread: threading.Thread) -> None:
+        if thread.name == f"thread-pool-failure_{failed_worker}":
+            raise failure
+        start(thread)
+
+    with (
+        patch.object(thread_pool, "ThreadPoolExecutor", ObservedPool),
+        patch.object(threading.Thread, "start", fail_start),
+        pytest.raises(error_type, match="worker creation failed") as raised,
+    ):
+        thread_pool.start_thread_pool(max_workers=4, thread_name_prefix="thread-pool-failure")
+
+    assert raised.value is failure
+    [failed_pool] = pools
+    assert len(failed_pool._threads) == failed_worker
+    assert all(not worker.is_alive() for worker in failed_pool._threads)
+    with pytest.raises(RuntimeError, match="shutdown"):
+        failed_pool.submit(lambda: None)
+    # A shutdown sentinel is allowed; queued bootstrap work is not. Keep the
+    # failed pool alive so garbage collection cannot conceal missing cleanup.
+    assert failed_pool._work_queue.get_nowait() is None
+    assert failed_pool._work_queue.empty()
+
+    with thread_pool.start_thread_pool(
+        max_workers=4, thread_name_prefix="thread-pool-recovered"
+    ) as recovered:
+        _assert_full_capacity(recovered, 4)
+
+
+def _run_in_process(target: Callable[..., None], *args: object) -> None:
+    process = multiprocessing.get_context("spawn").Process(target=target, args=args)
+    process.start()
+    try:
+        process.join(timeout=15)
+        assert not process.is_alive(), "thread-pool startup or cleanup deadlocked"
+        assert process.exitcode == 0
+    finally:
+        if process.is_alive():
+            process.kill()
+            process.join(timeout=5)
+        process.close()
+
+
+@pytest.mark.parametrize("workers", [1, 4])
+def test_returned_pool_has_all_workers_available(workers: int) -> None:
+    _run_in_process(_start_and_use_pool, workers)
+
+
+@pytest.mark.parametrize("error_type", [RuntimeError, OSError, _StartupInterrupted])
+@pytest.mark.parametrize("failed_worker", [0, 2], ids=["first-worker", "partial-start"])
+def test_start_failure_cleans_up_and_allows_recovery(
+    error_type: type[BaseException], failed_worker: int
+) -> None:
+    _run_in_process(_fail_start_and_recover, error_type, failed_worker)

--- a/crates/runner/mitm-addon/tests/test_webhook_executor_lifetime.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_executor_lifetime.py
@@ -15,8 +15,8 @@ from unittest.mock import patch
 
 import pytest
 
+import thread_pool
 import usage
-import usage.executor
 from tests.pending_helpers import assert_current_pending
 
 
@@ -34,7 +34,7 @@ def observed_pools() -> Iterator[list[ThreadPoolExecutor]]:
             pools.append(self)
 
     # Observe the real standard-library executor, without changing submission.
-    with patch.object(usage.executor, "ThreadPoolExecutor", ObservedPool):
+    with patch.object(thread_pool, "ThreadPoolExecutor", ObservedPool):
         yield pools
 
 


### PR DESCRIPTION
Reporting, usage webhooks, and SigV4 hashing each maintained the same payload-free thread-pool startup and rollback algorithm. Extract it into `thread_pool.start_thread_pool` so all three owners use one gated bootstrap and failed-candidate cleanup path, preserving their separate pools, worker limits, lazy publication locks, admission, exception handling, and shutdown policies.

Add shared tests for full worker availability, first/partial startup failures (including `BaseException`), joined workers, cleared bootstrap queues, and recovery. Retain consumer regression assertions for payload lifetime, report omissions, webhook fallback/re-entry, and SigV4 admission/cancellation. Scope is limited to these three startup paths; the catalog executor is unchanged.

Closes #33262

## Validation

Using the locked addon environment (uv 0.11.32, Python 3.14.0), from `crates/runner/mitm-addon`:

- 180 passed: `uv run --no-sync python -m pytest -q tests/test_thread_pool.py tests/test_model_provider_failure_reporting.py tests/test_request_handler_aws_sigv4_hash_executor.py tests/test_webhook_executor_lifetime.py tests/test_webhook_partial_submission.py tests/test_webhook_delivery_admission.py tests/test_webhook_http_delivery.py tests/test_fresh_usage_executor.py tests/test_done_hook.py`
- Passed `uv run --no-sync ruff format --check` and `uv run --no-sync ruff check` on all seven changed Python files.
- Passed `uv run --no-sync basedpyright -p .` (0 errors, warnings, or notes).
- Passed `uv run --no-sync python scripts/check-flow-metadata-keys.py`, `git diff --check`, and the changed-file size check.

The broader repository checks run in the PR pipeline.
