### PR TITLE
fix(guest-agent): handle closed telemetry incident channels

### DIFF
--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -337,6 +337,11 @@ enum Cmd {
 /// Holds both the command channel and the spawned task's [`JoinHandle`],
 /// so callers see one lifecycle object rather than juggling two.
 /// Construct with [`Self::spawn_for_paths`]; release with [`Self::shutdown`].
+///
+/// Dropping this handle, including by cancelling a consuming shutdown, closes
+/// the command channel. The worker finishes queued and in-flight uploads under
+/// the existing HTTP timeouts before exiting. Cancelling a borrowed
+/// [`Self::flush`] future alone leaves the worker running.
 pub struct Telemetry {
     tx: mpsc::Sender<Cmd>,
     handle: JoinHandle<()>,
@@ -489,8 +494,8 @@ async fn run(
                 }
                 Some(Cmd::Shutdown) | None => { incidents.flush(&http, &run_id).await; break; },
             },
-            result = incidents.rx.changed() => {
-                if result.is_ok() { incidents.flush(&http, &run_id).await; }
+            Ok(()) = incidents.rx.changed() => {
+                incidents.flush(&http, &run_id).await;
             }
             _ = interval.tick() => {
                 let _ = upload_with_incidents(&http, &masker, &run_id, &telemetry_paths, UploadMode::Live, &mut incidents).await;
@@ -519,8 +524,10 @@ async fn upload_with_incidents(
     loop {
         tokio::select! {
             biased;
-            result = incidents.rx.changed() => {
-                if result.is_ok() { incidents.flush(http, run_id).await; }
+            // Disable this branch on closure. Looping on its ready error can
+            // starve the upload and its HTTP timeout of cooperative budget.
+            Ok(()) = incidents.rx.changed() => {
+                incidents.flush(http, run_id).await;
             }
             result = &mut upload => return result,
         }

--- a/crates/guest-agent/tests/integration_cases/telemetry.rs
+++ b/crates/guest-agent/tests/integration_cases/telemetry.rs
@@ -266,6 +266,98 @@ async fn final_flush_and_shutdown_uploads_log_emitted_immediately_before_it() {
     remove_telemetry_files(paths);
 }
 
+async fn assert_cancelled_telemetry_owner_finishes_upload(
+    final_shutdown: bool,
+    keep_reporter: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use tokio::io::AsyncWriteExt;
+
+    let files = ExplicitTelemetryFiles::new("cancelled-owner")?;
+    guest_agent::paths::write_private(files.paths.system_log_file(), "pending\n")?;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let http = guest_agent::http::HttpClient::with_api_config(
+        format!("http://{}", listener.local_addr()?),
+        "test-token",
+        "",
+        "test-session",
+        Duration::ZERO,
+    )?;
+    let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
+        "cancelled-owner".into(),
+        &files.paths,
+        Arc::new(SecretMasker::from_raw("")),
+        http,
+    );
+    let reporter = keep_reporter.then(|| telemetry.incident_reporter());
+    let owner = tokio::spawn(async move {
+        if final_shutdown {
+            telemetry.final_flush_and_shutdown().await
+        } else {
+            let result = telemetry
+                .flush(guest_agent::telemetry::UploadMode::Live)
+                .await;
+            telemetry.shutdown().await;
+            result
+        }
+    });
+
+    let (mut stream, _) = tokio::time::timeout(Duration::from_secs(5), listener.accept()).await??;
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        super::http_client::read_raw_request(&mut stream),
+    )
+    .await??;
+    // The complete request proves the upload is in flight. Join the aborted
+    // owner before making its successful response available.
+    owner.abort();
+    assert!(matches!(owner.await, Err(error) if error.is_cancelled()));
+    stream
+        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}")
+        .await?;
+    drop(stream);
+
+    // This test owns its current-thread runtime and starts no mock-server
+    // tasks. Quiescence observes both uploader and HTTP task cleanup without
+    // exposing a private worker handle or waiting an arbitrary amount of time.
+    let metrics = tokio::runtime::Handle::current().metrics();
+    let terminated = tokio::time::timeout(Duration::from_secs(5), async {
+        while metrics.num_alive_tasks() != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+    assert!(
+        terminated.is_ok(),
+        "cancelled owner left {} tasks: final_shutdown={final_shutdown}, keep_reporter={keep_reporter}",
+        metrics.num_alive_tasks()
+    );
+    assert_eq!(
+        std::fs::read_to_string(files.paths.telemetry_system_log_pos_file())?,
+        "8",
+        "the accepted upload must persist its cursor, keep_reporter={keep_reporter}"
+    );
+    drop(reporter);
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn cancelled_telemetry_final_shutdown_finishes_upload_and_exits() {
+    for keep_reporter in [true, false] {
+        assert_cancelled_telemetry_owner_finishes_upload(true, keep_reporter)
+            .await
+            .unwrap();
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn cancelled_telemetry_live_flush_owner_finishes_upload_and_exits() {
+    for keep_reporter in [true, false] {
+        assert_cancelled_telemetry_owner_finishes_upload(false, keep_reporter)
+            .await
+            .unwrap();
+    }
+}
+
 #[tokio::test]
 async fn telemetry_preserves_runtime_session_id_and_masks_secrets() {
     let api = SharedApiMock::new().await;


### PR DESCRIPTION
Cancelling a telemetry owner during an HTTP upload could leave its worker spinning on the closed incident channel, preventing both response processing and request timeout progress.

Match only successful incident changes in both selects so channel closure disables that branch. Pending uploads can then persist their accepted cursors and the worker exits through its existing graceful shutdown path. Document owner-drop behavior and cover final-shutdown and live-flush cancellation through real HTTP request barriers, both with and without a retained reporter.

Closes #33263

## Validation

- Both new regressions failed on unchanged production code with one uploader task remaining when `keep_reporter=false`; retained-reporter controls completed successfully.
- `cargo test --manifest-path crates/Cargo.toml --locked --profile local -j 2 -p guest-agent --test integration integration_cases::telemetry::` — 18 passed, including both cancellation regressions, OOM priority/retries, cursor recovery, and final-tail coverage.
- `cargo test --manifest-path crates/Cargo.toml --locked --profile local -j 2 -p guest-agent --lib` — 676 passed.
- `cargo fmt --manifest-path crates/guest-agent/Cargo.toml --check` and `git diff --check` — passed.
- `cargo clippy --manifest-path crates/Cargo.toml --locked --profile local -j 2 -p guest-agent --all-targets --all-features -- -D warnings` — passed.
- `cargo doc --manifest-path crates/Cargo.toml --locked --profile local -j 2 -p guest-agent --all-features --no-deps` — passed.
