### PR TITLE
test(rust): isolate dns readiness transaction-id rejection

### DIFF
--- a/crates/sandbox-firecracker/src/network/readiness.rs
+++ b/crates/sandbox-firecracker/src/network/readiness.rs
@@ -649,9 +649,9 @@ mod tests {
     }
 
     #[test]
-    fn response_validation_rejects_wrong_transaction_and_answer() {
+    fn response_validation_rejects_wrong_transaction() {
         let query = build_dns_query(0x1234, DNS_READINESS_HOSTNAME).unwrap();
-        let response = response_for_query(&query, Ipv4Addr::new(192, 0, 2, 2));
+        let response = response_for_query(&query, DNS_READINESS_IPV4);
 
         assert!(
             validate_dns_response(
@@ -662,6 +662,13 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn response_validation_rejects_wrong_answer() {
+        let query = build_dns_query(0x1234, DNS_READINESS_HOSTNAME).unwrap();
+        let response = response_for_query(&query, Ipv4Addr::new(192, 0, 2, 2));
+
         assert!(validate_readiness_response(&response).is_err());
     }
 


### PR DESCRIPTION
The previous negative test used an incorrect answer IP in both assertions, so removing DNS transaction-ID validation did not make it fail. Split it into independent wrong-ID/valid-IP and matching-ID/wrong-IP tests, retaining the existing successful-response coverage. The patch is confined to the existing readiness parser tests.

Closes #33257.

## Validation

- Native readiness module tests: 16 passed. Temporarily disabling only the ID comparison produced exactly 15 passes and one failure in `response_validation_rejects_wrong_transaction`; the wrong-answer case still passed. Restored the guard and verified the production module matches the base exactly.
- `cargo fmt --manifest-path crates/sandbox-firecracker/Cargo.toml -- --check`
- `PATH="$PATH:/usr/sbin:/sbin" CARGO_BUILD_JOBS=2 cargo test --manifest-path crates/Cargo.toml --profile local --locked -p sandbox-firecracker -- --quiet`: 882 unit tests and 1 integration test passed. Two specialized Firecracker integration tests are ignored by repository configuration because they require root/KVM/NBD/cgroup fixtures.
- `CARGO_BUILD_JOBS=2 cargo clippy --manifest-path crates/Cargo.toml --profile local --locked -p sandbox-firecracker --all-targets --all-features`
- `CARGO_BUILD_JOBS=2 cargo doc --manifest-path crates/Cargo.toml --profile local --locked -p sandbox-firecracker --all-features --no-deps`
- `git diff --check`

The first full-suite attempt could not find the installed `mkfs.ext4` because `/usr/sbin` was absent from PATH. The complete rerun passed after adding the system tool directories to that command's PATH.
