### PR TITLE
ci: configure target aws audit services

### DIFF
--- a/.github/aws-audit-32264/bootstrap-permissions.json
+++ b/.github/aws-audit-32264/bootstrap-permissions.json
@@ -1,0 +1,22 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "InspectExistingGithubMigrationRole",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetRole",
+        "iam:GetRolePolicy",
+        "iam:ListRolePolicies",
+        "iam:ListAttachedRolePolicies"
+      ],
+      "Resource": "arn:aws:iam::251964670836:role/vm0-kms-migration-github-32264"
+    },
+    {
+      "Sid": "AttachAuditingPolicyToExistingMigrationRole",
+      "Effect": "Allow",
+      "Action": "iam:PutRolePolicy",
+      "Resource": "arn:aws:iam::251964670836:role/vm0-kms-migration-github-32264"
+    }
+  ]
+}

--- a/.github/aws-audit-32264/cloudtrail-bucket.json
+++ b/.github/aws-audit-32264/cloudtrail-bucket.json
@@ -1,0 +1,87 @@
+{
+  "encryption": {
+    "Rules": [
+      {
+        "ApplyServerSideEncryptionByDefault": {
+          "SSEAlgorithm": "AES256"
+        }
+      }
+    ]
+  },
+  "publicAccess": {
+    "BlockPublicAcls": true,
+    "IgnorePublicAcls": true,
+    "BlockPublicPolicy": true,
+    "RestrictPublicBuckets": true
+  },
+  "ownership": {
+    "Rules": [
+      {
+        "ObjectOwnership": "BucketOwnerEnforced"
+      }
+    ]
+  },
+  "versioning": "Enabled",
+  "policy": {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "DenyInsecureTransport",
+        "Effect": "Deny",
+        "Principal": "*",
+        "Action": "s3:*",
+        "Resource": [
+          "arn:aws:s3:::vm0-cloudtrail-logs-251964670836-us-west-2",
+          "arn:aws:s3:::vm0-cloudtrail-logs-251964670836-us-west-2/*"
+        ],
+        "Condition": {
+          "Bool": {
+            "aws:SecureTransport": "false",
+            "aws:PrincipalIsAWSService": "false"
+          }
+        }
+      },
+      {
+        "Sid": "AuditServiceBucketCheck",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "cloudtrail.amazonaws.com"
+        },
+        "Action": ["s3:GetBucketAcl"],
+        "Resource": "arn:aws:s3:::vm0-cloudtrail-logs-251964670836-us-west-2",
+        "Condition": {
+          "StringEquals": {
+            "AWS:SourceArn": "arn:aws:cloudtrail:us-west-2:251964670836:trail/vm0-drata-cloudtrail"
+          }
+        }
+      },
+      {
+        "Sid": "AuditServiceDelivery",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "cloudtrail.amazonaws.com"
+        },
+        "Action": "s3:PutObject",
+        "Resource": "arn:aws:s3:::vm0-cloudtrail-logs-251964670836-us-west-2/AWSLogs/251964670836/*",
+        "Condition": {
+          "StringEquals": {
+            "AWS:SourceArn": "arn:aws:cloudtrail:us-west-2:251964670836:trail/vm0-drata-cloudtrail",
+            "s3:x-amz-acl": "bucket-owner-full-control"
+          }
+        }
+      }
+    ]
+  },
+  "lifecycle": [
+    {
+      "ID": "AbortIncompleteUploads",
+      "Status": "Enabled",
+      "Filter": {
+        "Prefix": ""
+      },
+      "AbortIncompleteMultipartUpload": {
+        "DaysAfterInitiation": 7
+      }
+    }
+  ]
+}

--- a/.github/aws-audit-32264/config-bucket.json
+++ b/.github/aws-audit-32264/config-bucket.json
@@ -1,0 +1,93 @@
+{
+  "encryption": {
+    "Rules": [
+      {
+        "ApplyServerSideEncryptionByDefault": {
+          "SSEAlgorithm": "AES256"
+        }
+      }
+    ]
+  },
+  "publicAccess": {
+    "BlockPublicAcls": true,
+    "IgnorePublicAcls": true,
+    "BlockPublicPolicy": true,
+    "RestrictPublicBuckets": true
+  },
+  "ownership": {
+    "Rules": [
+      {
+        "ObjectOwnership": "BucketOwnerEnforced"
+      }
+    ]
+  },
+  "versioning": "Enabled",
+  "policy": {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "DenyInsecureTransport",
+        "Effect": "Deny",
+        "Principal": "*",
+        "Action": "s3:*",
+        "Resource": [
+          "arn:aws:s3:::vm0-dcf478-aws-config-251964670836-us-west-2",
+          "arn:aws:s3:::vm0-dcf478-aws-config-251964670836-us-west-2/*"
+        ],
+        "Condition": {
+          "Bool": {
+            "aws:SecureTransport": "false",
+            "aws:PrincipalIsAWSService": "false"
+          }
+        }
+      },
+      {
+        "Sid": "AuditServiceBucketCheck",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "config.amazonaws.com"
+        },
+        "Action": ["s3:GetBucketAcl", "s3:ListBucket"],
+        "Resource": "arn:aws:s3:::vm0-dcf478-aws-config-251964670836-us-west-2",
+        "Condition": {
+          "StringEquals": {
+            "AWS:SourceAccount": "251964670836"
+          },
+          "ArnLike": {
+            "AWS:SourceArn": "arn:aws:config:us-west-2:251964670836:*"
+          }
+        }
+      },
+      {
+        "Sid": "AuditServiceDelivery",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "config.amazonaws.com"
+        },
+        "Action": "s3:PutObject",
+        "Resource": "arn:aws:s3:::vm0-dcf478-aws-config-251964670836-us-west-2/AWSLogs/251964670836/Config/*",
+        "Condition": {
+          "StringEquals": {
+            "AWS:SourceAccount": "251964670836",
+            "s3:x-amz-acl": "bucket-owner-full-control"
+          },
+          "ArnLike": {
+            "AWS:SourceArn": "arn:aws:config:us-west-2:251964670836:*"
+          }
+        }
+      }
+    ]
+  },
+  "lifecycle": [
+    {
+      "ID": "AbortIncompleteUploads",
+      "Status": "Enabled",
+      "Filter": {
+        "Prefix": ""
+      },
+      "AbortIncompleteMultipartUpload": {
+        "DaysAfterInitiation": 7
+      }
+    }
+  ]
+}

--- a/.github/aws-audit-32264/config-delivery-policy.json
+++ b/.github/aws-audit-32264/config-delivery-policy.json
@@ -1,0 +1,22 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "InspectConfigDeliveryBucket",
+      "Effect": "Allow",
+      "Action": ["s3:GetBucketAcl", "s3:ListBucket"],
+      "Resource": "arn:aws:s3:::vm0-dcf478-aws-config-251964670836-us-west-2"
+    },
+    {
+      "Sid": "DeliverConfigurationRecords",
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::vm0-dcf478-aws-config-251964670836-us-west-2/AWSLogs/251964670836/Config/*",
+      "Condition": {
+        "StringEquals": {
+          "s3:x-amz-acl": "bucket-owner-full-control"
+        }
+      }
+    }
+  ]
+}

--- a/.github/aws-audit-32264/config-trust.json
+++ b/.github/aws-audit-32264/config-trust.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "config.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "AWS:SourceAccount": "251964670836"
+        }
+      }
+    }
+  ]
+}

--- a/.github/aws-audit-32264/operator-permissions.json
+++ b/.github/aws-audit-32264/operator-permissions.json
@@ -1,0 +1,125 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ManageOnlyConfigRecorderRole",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetRole",
+        "iam:CreateRole",
+        "iam:TagRole",
+        "iam:ListRolePolicies",
+        "iam:GetRolePolicy",
+        "iam:PutRolePolicy",
+        "iam:ListAttachedRolePolicies"
+      ],
+      "Resource": "arn:aws:iam::251964670836:role/vm0-dcf478-config-recorder-role"
+    },
+    {
+      "Sid": "AttachOnlyAwsConfigReadPolicy",
+      "Effect": "Allow",
+      "Action": "iam:AttachRolePolicy",
+      "Resource": "arn:aws:iam::251964670836:role/vm0-dcf478-config-recorder-role",
+      "Condition": {
+        "ArnEquals": {
+          "iam:PolicyARN": "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
+        }
+      }
+    },
+    {
+      "Sid": "PassOnlyConfigServiceRole",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::251964670836:role/vm0-dcf478-config-recorder-role",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "config.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "DiscoverOwnedBuckets",
+      "Effect": "Allow",
+      "Action": "s3:ListAllMyBuckets",
+      "Resource": "*"
+    },
+    {
+      "Sid": "ConfigureOnlyTargetAuditBuckets",
+      "Effect": "Allow",
+      "Action": [
+        "s3:CreateBucket",
+        "s3:GetBucketLocation",
+        "s3:GetBucketAcl",
+        "s3:GetBucketTagging",
+        "s3:PutBucketTagging",
+        "s3:GetBucketPolicy",
+        "s3:PutBucketPolicy",
+        "s3:GetBucketPolicyStatus",
+        "s3:GetBucketPublicAccessBlock",
+        "s3:PutBucketPublicAccessBlock",
+        "s3:GetEncryptionConfiguration",
+        "s3:PutEncryptionConfiguration",
+        "s3:GetBucketVersioning",
+        "s3:PutBucketVersioning",
+        "s3:GetBucketOwnershipControls",
+        "s3:PutBucketOwnershipControls",
+        "s3:GetLifecycleConfiguration",
+        "s3:PutLifecycleConfiguration",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::vm0-cloudtrail-logs-251964670836-us-west-2",
+        "arn:aws:s3:::vm0-dcf478-aws-config-251964670836-us-west-2"
+      ]
+    },
+    {
+      "Sid": "ReadOnlyTargetDeliveredAuditRecords",
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": [
+        "arn:aws:s3:::vm0-cloudtrail-logs-251964670836-us-west-2/AWSLogs/251964670836/CloudTrail/*",
+        "arn:aws:s3:::vm0-dcf478-aws-config-251964670836-us-west-2/AWSLogs/251964670836/Config/*"
+      ]
+    },
+    {
+      "Sid": "ManageOnlyTargetTrail",
+      "Effect": "Allow",
+      "Action": [
+        "cloudtrail:CreateTrail",
+        "cloudtrail:GetTrail",
+        "cloudtrail:GetTrailStatus",
+        "cloudtrail:GetEventSelectors",
+        "cloudtrail:PutEventSelectors",
+        "cloudtrail:StartLogging",
+        "cloudtrail:AddTags"
+      ],
+      "Resource": "arn:aws:cloudtrail:us-west-2:251964670836:trail/vm0-drata-cloudtrail",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "us-west-2"
+        }
+      }
+    },
+    {
+      "Sid": "ConfigureAndVerifyTargetConfig",
+      "Effect": "Allow",
+      "Action": [
+        "config:DescribeConfigurationRecorders",
+        "config:DescribeConfigurationRecorderStatus",
+        "config:DescribeDeliveryChannels",
+        "config:DescribeDeliveryChannelStatus",
+        "config:PutConfigurationRecorder",
+        "config:PutDeliveryChannel",
+        "config:StartConfigurationRecorder",
+        "config:DeliverConfigSnapshot",
+        "config:ListDiscoveredResources"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "us-west-2"
+        }
+      }
+    }
+  ]
+}

--- a/.github/aws-audit-32264/operator-trust.json
+++ b/.github/aws-audit-32264/operator-trust.json
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::251964670836:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:vm0-ai/vm0:environment:production"
+        }
+      }
+    }
+  ]
+}

--- a/.github/scripts/aws-audit-target-setup.py
+++ b/.github/scripts/aws-audit-target-setup.py
@@ -7,10 +7,10 @@ import io
 import json
 import os
 from pathlib import Path
+import subprocess
 import sys
 import time
 import urllib.parse
-import urllib.request
 
 import boto3
 from botocore import UNSIGNED
@@ -87,22 +87,46 @@ def workflow_identity():
     require(
         request_url.scheme == "https"
         and request_url.hostname is not None
-        and request_url.hostname.endswith(".actions.githubusercontent.com"),
+        and request_url.hostname.endswith(".actions.githubusercontent.com")
+        and request_url.port in {None, 443}
+        and request_url.username is None
+        and request_url.password is None
+        and not request_url.fragment,
         "unexpected_oidc_url",
     )
     query = urllib.parse.parse_qsl(request_url.query)
     query = [(key, value) for key, value in query if key != "audience"]
     query.append(("audience", "sts.amazonaws.com"))
-    request = urllib.request.Request(
-        urllib.parse.urlunsplit(
-            request_url._replace(query=urllib.parse.urlencode(query))
-        ),
-        headers={
-            "Authorization": "Bearer " + os.environ["ACTIONS_ID_TOKEN_REQUEST_TOKEN"]
-        },
+    # Curl does not follow redirects here. Only the validated GitHub HTTPS origin
+    # can receive the job's request token; response bodies and errors stay private.
+    response = subprocess.run(
+        [
+            "curl",
+            "--silent",
+            "--show-error",
+            "--proto",
+            "=https",
+            "--max-time",
+            "30",
+            "--max-filesize",
+            "1048576",
+            "--header",
+            "Authorization: Bearer " + os.environ["ACTIONS_ID_TOKEN_REQUEST_TOKEN"],
+            "--write-out",
+            "\n%{http_code}",
+            urllib.parse.urlunsplit(
+                request_url._replace(query=urllib.parse.urlencode(query))
+            ),
+        ],
+        text=True,
+        capture_output=True,
+        timeout=35,
+        check=False,
     )
-    with urllib.request.urlopen(request, timeout=30) as response:
-        token = json.load(response)["value"]
+    require(response.returncode == 0, "oidc_request_failed")
+    body, status = response.stdout.rsplit("\n", 1)
+    require(status == "200" and len(body) <= 1048576, "oidc_response_rejected")
+    token = json.loads(body)["value"]
     session_name = "github-audit-" + os.environ["GITHUB_RUN_ID"]
     response = boto3.client(
         "sts", region_name=REGION, config=Config(signature_version=UNSIGNED)
@@ -521,15 +545,19 @@ def verify_delivery(session, report, deadline):
         if "configDelivery" not in report:
             prefix = f"AWSLogs/{ACCOUNT}/Config/{REGION}/"
             for key in recent_objects(s3, CONFIG_BUCKET, prefix, started):
-                if snapshot_id not in key:
+                if "/ConfigSnapshot/" not in key or not key.endswith(
+                    "_" + snapshot_id + ".json.gz"
+                ):
                     continue
                 snapshot = object_json(s3, CONFIG_BUCKET, key)
                 require(
-                    snapshot["configSnapshotId"] == snapshot_id, "wrong_config_snapshot"
+                    snapshot["fileVersion"] == "1.0"
+                    and snapshot["configSnapshotId"] == snapshot_id,
+                    "wrong_config_snapshot",
                 )
                 items = snapshot["configurationItems"]
                 require(
-                    all(item["accountId"] == ACCOUNT for item in items),
+                    all(item["awsAccountId"] == ACCOUNT for item in items),
                     "wrong_config_item_account",
                 )
                 buckets = {

--- a/.github/scripts/aws-audit-target-setup.py
+++ b/.github/scripts/aws-audit-target-setup.py
@@ -1,0 +1,650 @@
+#!/usr/bin/env python3
+"""Configure only the #32264 target audit resources; retain sanitized evidence."""
+
+import datetime as dt
+import gzip
+import io
+import json
+import os
+from pathlib import Path
+import sys
+import time
+import urllib.parse
+import urllib.request
+
+import boto3
+from botocore import UNSIGNED
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+ACCOUNT = "251964670836"
+REGION = "us-west-2"
+TRAIL = "vm0-drata-cloudtrail"
+TRAIL_ARN = f"arn:aws:cloudtrail:{REGION}:{ACCOUNT}:trail/{TRAIL}"
+TRAIL_BUCKET = f"vm0-cloudtrail-logs-{ACCOUNT}-{REGION}"
+CONFIG_BUCKET = f"vm0-dcf478-aws-config-{ACCOUNT}-{REGION}"
+CONFIG_ROLE = "vm0-dcf478-config-recorder-role"
+CONFIG_ROLE_ARN = f"arn:aws:iam::{ACCOUNT}:role/{CONFIG_ROLE}"
+OPERATOR = f"arn:aws:iam::{ACCOUNT}:role/vm0-kms-migration-github-32264"
+MANAGED_POLICY = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
+TAGS = [{"Key": "ManagedBy", "Value": "vm0-audit-32264"}]
+DIRECTORY = Path(__file__).resolve().parents[1] / "aws-audit-32264"
+SDK_CONFIG = Config(retries={"mode": "standard", "max_attempts": 3}, read_timeout=30)
+MAX_OBJECT_BYTES = 20 * 1024 * 1024
+
+
+def require(condition, message):
+    if not condition:
+        raise RuntimeError(message)
+
+
+def expected(name):
+    return json.loads((DIRECTORY / name).read_text())
+
+
+def optional(operation, missing_code, **parameters):
+    try:
+        return operation(**parameters)
+    except ClientError as error:
+        if error.response["Error"]["Code"] == missing_code:
+            return None
+        raise
+
+
+def create_after_policy_propagation(operation, **parameters):
+    deadline = time.monotonic() + 120
+    while True:
+        try:
+            return operation(**parameters)
+        except ClientError as error:
+            if (
+                error.response["Error"]["Code"]
+                not in {
+                    "InvalidRoleException",
+                    "InsufficientDeliveryPolicyException",
+                    "InsufficientS3BucketPolicyException",
+                }
+                or time.monotonic() >= deadline
+            ):
+                raise
+            print(json.dumps({"waiting": "new_audit_policy_propagation"}), flush=True)
+            time.sleep(10)
+
+
+def workflow_identity():
+    require(os.environ.get("GITHUB_REPOSITORY") == "vm0-ai/vm0", "wrong_repository")
+    require(os.environ.get("GITHUB_REF") == "refs/heads/main", "main_required")
+    require(
+        os.environ.get("GITHUB_EVENT_NAME") == "workflow_dispatch",
+        "manual_run_required",
+    )
+    require(
+        os.environ.get("GITHUB_WORKFLOW_REF")
+        == "vm0-ai/vm0/.github/workflows/aws-audit-target-setup.yml@refs/heads/main",
+        "wrong_workflow",
+    )
+    request_url = urllib.parse.urlsplit(os.environ["ACTIONS_ID_TOKEN_REQUEST_URL"])
+    require(
+        request_url.scheme == "https"
+        and request_url.hostname is not None
+        and request_url.hostname.endswith(".actions.githubusercontent.com"),
+        "unexpected_oidc_url",
+    )
+    query = urllib.parse.parse_qsl(request_url.query)
+    query = [(key, value) for key, value in query if key != "audience"]
+    query.append(("audience", "sts.amazonaws.com"))
+    request = urllib.request.Request(
+        urllib.parse.urlunsplit(
+            request_url._replace(query=urllib.parse.urlencode(query))
+        ),
+        headers={
+            "Authorization": "Bearer " + os.environ["ACTIONS_ID_TOKEN_REQUEST_TOKEN"]
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        token = json.load(response)["value"]
+    session_name = "github-audit-" + os.environ["GITHUB_RUN_ID"]
+    response = boto3.client(
+        "sts", region_name=REGION, config=Config(signature_version=UNSIGNED)
+    ).assume_role_with_web_identity(
+        RoleArn=OPERATOR,
+        RoleSessionName=session_name,
+        WebIdentityToken=token,
+        DurationSeconds=3600,
+    )
+    credentials = response["Credentials"]
+    session = boto3.Session(
+        aws_access_key_id=credentials["AccessKeyId"],
+        aws_secret_access_key=credentials["SecretAccessKey"],
+        aws_session_token=credentials["SessionToken"],
+        region_name=REGION,
+    )
+    identity = session.client("sts", config=SDK_CONFIG).get_caller_identity()
+    require(
+        identity["Account"] == ACCOUNT
+        and identity["Arn"]
+        == f"arn:aws:sts::{ACCOUNT}:assumed-role/vm0-kms-migration-github-32264/{session_name}",
+        "wrong_aws_identity",
+    )
+    return session
+
+
+def bucket_settings(s3, bucket):
+    owner = {"Bucket": bucket, "ExpectedBucketOwner": ACCOUNT}
+    encryption = s3.get_bucket_encryption(**owner)["ServerSideEncryptionConfiguration"]
+    for rule in encryption["Rules"]:
+        # S3 can explicitly return this default even for SSE-S3 buckets.
+        if rule.get("BucketKeyEnabled") is False:
+            del rule["BucketKeyEnabled"]
+    return {
+        "encryption": encryption,
+        "publicAccess": s3.get_public_access_block(**owner)[
+            "PublicAccessBlockConfiguration"
+        ],
+        "ownership": s3.get_bucket_ownership_controls(**owner)["OwnershipControls"],
+        "versioning": s3.get_bucket_versioning(**owner).get("Status"),
+        "policy": json.loads(s3.get_bucket_policy(**owner)["Policy"]),
+        "lifecycle": s3.get_bucket_lifecycle_configuration(**owner)["Rules"],
+    }
+
+
+def configure_bucket(s3, bucket, settings, report):
+    existing = {
+        entry["Name"]
+        for page in s3.get_paginator("list_buckets").paginate()
+        for entry in page["Buckets"]
+    }
+    owner = {"Bucket": bucket, "ExpectedBucketOwner": ACCOUNT}
+    if bucket in existing:
+        require(
+            s3.get_bucket_tagging(**owner)["TagSet"] == TAGS,
+            "existing_bucket_ownership_mismatch",
+        )
+        # Existing settings must match; a rerun cannot silently erase policy changes.
+        require(
+            bucket_settings(s3, bucket) == settings, "existing_bucket_settings_drift"
+        )
+    else:
+        s3.create_bucket(
+            Bucket=bucket,
+            CreateBucketConfiguration={"LocationConstraint": REGION},
+            ObjectOwnership="BucketOwnerEnforced",
+        )
+        report["created"].append(bucket)
+        s3.put_bucket_tagging(**owner, Tagging={"TagSet": TAGS})
+        s3.put_public_access_block(
+            **owner, PublicAccessBlockConfiguration=settings["publicAccess"]
+        )
+        s3.put_bucket_encryption(
+            **owner, ServerSideEncryptionConfiguration=settings["encryption"]
+        )
+        s3.put_bucket_versioning(
+            **owner, VersioningConfiguration={"Status": settings["versioning"]}
+        )
+        s3.put_bucket_policy(**owner, Policy=json.dumps(settings["policy"]))
+        s3.put_bucket_lifecycle_configuration(
+            **owner, LifecycleConfiguration={"Rules": settings["lifecycle"]}
+        )
+        require(
+            bucket_settings(s3, bucket) == settings, "bucket_settings_readback_mismatch"
+        )
+    require(
+        s3.get_bucket_location(**owner)["LocationConstraint"] == REGION,
+        "wrong_bucket_region",
+    )
+    require(
+        s3.get_bucket_policy_status(**owner)["PolicyStatus"]["IsPublic"] is False,
+        "public_bucket",
+    )
+    report["buckets"].append(
+        {
+            "name": bucket,
+            "verified": True,
+            "encryption": "AES256",
+            "versioning": "Enabled",
+            "automaticLogExpiration": False,
+        }
+    )
+
+
+def configure_role(iam, report):
+    trust = expected("config-trust.json")
+    policy = expected("config-delivery-policy.json")
+    existing = optional(iam.get_role, "NoSuchEntity", RoleName=CONFIG_ROLE)
+    if existing is None:
+        iam.create_role(
+            RoleName=CONFIG_ROLE, AssumeRolePolicyDocument=json.dumps(trust), Tags=TAGS
+        )
+        report["created"].append(CONFIG_ROLE_ARN)
+    else:
+        require(existing["Role"]["Arn"] == CONFIG_ROLE_ARN, "wrong_config_role")
+        require(
+            existing["Role"]["AssumeRolePolicyDocument"] == trust,
+            "config_role_trust_drift",
+        )
+        require(existing["Role"].get("Tags") == TAGS, "config_role_ownership_mismatch")
+        require(
+            "PermissionsBoundary" not in existing["Role"],
+            "unexpected_config_role_boundary",
+        )
+    attached = {
+        entry["PolicyArn"]
+        for page in iam.get_paginator("list_attached_role_policies").paginate(
+            RoleName=CONFIG_ROLE
+        )
+        for entry in page["AttachedPolicies"]
+    }
+    require(
+        attached.issubset({MANAGED_POLICY}), "unexpected_config_role_managed_policy"
+    )
+    if not attached:
+        iam.attach_role_policy(RoleName=CONFIG_ROLE, PolicyArn=MANAGED_POLICY)
+    names = {
+        name
+        for page in iam.get_paginator("list_role_policies").paginate(
+            RoleName=CONFIG_ROLE
+        )
+        for name in page["PolicyNames"]
+    }
+    require(
+        names.issubset({"audit-delivery-32264"}), "unexpected_config_role_inline_policy"
+    )
+    if names:
+        require(
+            iam.get_role_policy(
+                RoleName=CONFIG_ROLE, PolicyName="audit-delivery-32264"
+            )["PolicyDocument"]
+            == policy,
+            "config_role_policy_drift",
+        )
+    else:
+        iam.put_role_policy(
+            RoleName=CONFIG_ROLE,
+            PolicyName="audit-delivery-32264",
+            PolicyDocument=json.dumps(policy),
+        )
+    require(
+        iam.get_role(RoleName=CONFIG_ROLE)["Role"]["AssumeRolePolicyDocument"] == trust,
+        "config_role_trust_readback_mismatch",
+    )
+    require(
+        iam.get_role_policy(RoleName=CONFIG_ROLE, PolicyName="audit-delivery-32264")[
+            "PolicyDocument"
+        ]
+        == policy,
+        "config_role_policy_readback_mismatch",
+    )
+
+
+def configure_trail(trail, report):
+    desired = {
+        "Name": TRAIL,
+        "S3BucketName": TRAIL_BUCKET,
+        "IncludeGlobalServiceEvents": True,
+        "IsMultiRegionTrail": True,
+        "LogFileValidationEnabled": True,
+        "IsOrganizationTrail": False,
+    }
+    existing = optional(trail.get_trail, "TrailNotFoundException", Name=TRAIL_ARN)
+    if existing is None:
+        parameters = {
+            k: v for k, v in desired.items() if k != "LogFileValidationEnabled"
+        }
+        create_after_policy_propagation(
+            trail.create_trail,
+            **parameters,
+            EnableLogFileValidation=True,
+            TagsList=TAGS,
+        )
+        report["created"].append(TRAIL_ARN)
+    else:
+        require(
+            all(existing["Trail"].get(k) == v for k, v in desired.items()),
+            "existing_trail_settings_drift",
+        )
+        require(
+            not existing["Trail"].get("KmsKeyId")
+            and not existing["Trail"].get("S3KeyPrefix"),
+            "unexpected_trail_destination",
+        )
+    selectors = [
+        {
+            "ReadWriteType": "All",
+            "IncludeManagementEvents": True,
+            "DataResources": [],
+            "ExcludeManagementEventSources": [],
+        }
+    ]
+    current = trail.get_event_selectors(TrailName=TRAIL_ARN)
+    require(
+        not current.get("AdvancedEventSelectors"), "unexpected_advanced_event_selectors"
+    )
+
+    def normalize_selectors(values):
+        return [
+            {
+                "ReadWriteType": value["ReadWriteType"],
+                "IncludeManagementEvents": value["IncludeManagementEvents"],
+                "DataResources": value.get("DataResources", []),
+                "ExcludeManagementEventSources": value.get(
+                    "ExcludeManagementEventSources", []
+                ),
+            }
+            for value in values
+        ]
+
+    if normalize_selectors(current["EventSelectors"]) != selectors:
+        require(existing is None, "existing_trail_event_selector_drift")
+        trail.put_event_selectors(TrailName=TRAIL_ARN, EventSelectors=selectors)
+    trail.start_logging(Name=TRAIL_ARN)
+    actual = trail.get_trail(Name=TRAIL_ARN)["Trail"]
+    require(
+        all(actual.get(k) == v for k, v in desired.items()), "trail_readback_mismatch"
+    )
+    require(
+        normalize_selectors(
+            trail.get_event_selectors(TrailName=TRAIL_ARN)["EventSelectors"]
+        )
+        == selectors,
+        "trail_event_selector_readback_mismatch",
+    )
+
+
+def configure_config(config, report):
+    recorder = {
+        "name": "default",
+        "roleARN": CONFIG_ROLE_ARN,
+        "recordingGroup": {
+            "allSupported": True,
+            "includeGlobalResourceTypes": True,
+            "recordingStrategy": {"useOnly": "ALL_SUPPORTED_RESOURCE_TYPES"},
+        },
+        "recordingMode": {"recordingFrequency": "CONTINUOUS"},
+    }
+    existing = config.describe_configuration_recorders()["ConfigurationRecorders"]
+    require(len(existing) <= 1, "unexpected_config_recorders")
+    if existing:
+        actual = existing[0]
+        require(
+            actual["name"] == "default" and actual["roleARN"] == CONFIG_ROLE_ARN,
+            "existing_config_recorder_mismatch",
+        )
+        require(
+            actual["recordingGroup"]["allSupported"] is True
+            and actual["recordingGroup"]["includeGlobalResourceTypes"] is True,
+            "existing_config_recording_scope_drift",
+        )
+        require(
+            actual["recordingGroup"].get("recordingStrategy", {}).get("useOnly")
+            == "ALL_SUPPORTED_RESOURCE_TYPES"
+            and not actual["recordingGroup"]
+            .get("exclusionByResourceTypes", {})
+            .get("resourceTypes")
+            and not actual["recordingGroup"].get("resourceTypes"),
+            "existing_config_resource_exclusions",
+        )
+        require(
+            actual["recordingMode"]["recordingFrequency"] == "CONTINUOUS"
+            and not actual["recordingMode"].get("recordingModeOverrides"),
+            "existing_config_recording_mode_drift",
+        )
+    else:
+        create_after_policy_propagation(
+            config.put_configuration_recorder, ConfigurationRecorder=recorder
+        )
+        report["created"].append("config:default-recorder")
+    channel = {
+        "name": "default",
+        "s3BucketName": CONFIG_BUCKET,
+        "configSnapshotDeliveryProperties": {"deliveryFrequency": "TwentyFour_Hours"},
+    }
+    existing_channels = config.describe_delivery_channels()["DeliveryChannels"]
+    if existing_channels:
+        require(existing_channels == [channel], "existing_config_channel_drift")
+    else:
+        create_after_policy_propagation(
+            config.put_delivery_channel, DeliveryChannel=channel
+        )
+        report["created"].append("config:default-delivery-channel")
+    config.start_configuration_recorder(ConfigurationRecorderName="default")
+    actual = config.describe_configuration_recorders()["ConfigurationRecorders"]
+    require(
+        len(actual) == 1
+        and actual[0]["name"] == "default"
+        and actual[0]["roleARN"] == CONFIG_ROLE_ARN
+        and actual[0]["recordingGroup"]["allSupported"] is True
+        and actual[0]["recordingGroup"]["includeGlobalResourceTypes"] is True
+        and actual[0]["recordingGroup"]["recordingStrategy"]["useOnly"]
+        == "ALL_SUPPORTED_RESOURCE_TYPES"
+        and not actual[0]["recordingGroup"]
+        .get("exclusionByResourceTypes", {})
+        .get("resourceTypes")
+        and actual[0]["recordingMode"]["recordingFrequency"] == "CONTINUOUS"
+        and not actual[0]["recordingMode"].get("recordingModeOverrides"),
+        "config_recorder_readback_mismatch",
+    )
+    require(
+        config.describe_delivery_channels()["DeliveryChannels"] == [channel],
+        "config_channel_readback_mismatch",
+    )
+
+
+def object_json(s3, bucket, key):
+    response = s3.get_object(Bucket=bucket, Key=key, ExpectedBucketOwner=ACCOUNT)
+    with response["Body"] as body:
+        compressed = body.read(MAX_OBJECT_BYTES + 1)
+    require(len(compressed) <= MAX_OBJECT_BYTES, "audit_object_too_large")
+    with gzip.GzipFile(fileobj=io.BytesIO(compressed)) as stream:
+        raw = stream.read(MAX_OBJECT_BYTES + 1)
+    require(len(raw) <= MAX_OBJECT_BYTES, "audit_object_expands_too_large")
+    return json.loads(raw)
+
+
+def recent_objects(s3, bucket, prefix, started):
+    pages = s3.get_paginator("list_objects_v2").paginate(
+        Bucket=bucket,
+        Prefix=prefix,
+        ExpectedBucketOwner=ACCOUNT,
+        PaginationConfig={"PageSize": 1000},
+    )
+    for number, page in enumerate(pages):
+        require(number < 20, "audit_object_inventory_limit")
+        for item in page.get("Contents", []):
+            if item["LastModified"] >= started and item["Key"].endswith(".json.gz"):
+                yield item["Key"]
+
+
+def await_result(check, deadline, message):
+    while True:
+        result = check()
+        if result:
+            return result
+        require(time.monotonic() < deadline, message)
+        print(json.dumps({"waiting": message}), flush=True)
+        time.sleep(20)
+
+
+def verify_delivery(session, report, deadline):
+    s3 = session.client("s3", config=SDK_CONFIG)
+    trail = session.client("cloudtrail", config=SDK_CONFIG)
+    config = session.client("config", config=SDK_CONFIG)
+    started = dt.datetime.now(dt.timezone.utc)
+    # Match this exact management request in a delivered S3 object, not event history.
+    canary = trail.get_trail_status(Name=TRAIL_ARN)
+    require(canary["IsLogging"] is True, "trail_not_logging")
+    request_id = canary["ResponseMetadata"]["RequestId"]
+    report["cloudTrailCanaryRequestId"] = request_id
+
+    def config_discovered():
+        status = config.describe_configuration_recorder_status(
+            ConfigurationRecorderNames=["default"]
+        )["ConfigurationRecordersStatus"]
+        require(
+            len(status) == 1 and status[0]["recording"] is True, "config_not_recording"
+        )
+        resources = config.list_discovered_resources(
+            resourceType="AWS::S3::Bucket", resourceIds=[TRAIL_BUCKET, CONFIG_BUCKET]
+        )["resourceIdentifiers"]
+        return {r["resourceId"] for r in resources} == {TRAIL_BUCKET, CONFIG_BUCKET}
+
+    await_result(config_discovered, deadline, "config_initial_inventory_pending")
+    snapshot_id = config.deliver_config_snapshot(deliveryChannelName="default")[
+        "configSnapshotId"
+    ]
+    report["configSnapshotRequested"] = snapshot_id
+    checked = set()
+
+    def delivered():
+        if "cloudTrailDelivery" not in report:
+            # A run crossing UTC midnight can receive objects under either date.
+            for date in {started.date(), dt.datetime.now(dt.timezone.utc).date()}:
+                prefix = f"AWSLogs/{ACCOUNT}/CloudTrail/{REGION}/{date:%Y/%m/%d}/"
+                for key in recent_objects(s3, TRAIL_BUCKET, prefix, started):
+                    if key in checked:
+                        continue
+                    checked.add(key)
+                    data = object_json(s3, TRAIL_BUCKET, key)
+                    for event in data["Records"]:
+                        if (
+                            event.get("requestID") == request_id
+                            and event.get("eventName") == "GetTrailStatus"
+                            and event.get("recipientAccountId") == ACCOUNT
+                            and event.get("awsRegion") == REGION
+                        ):
+                            report["cloudTrailDelivery"] = {
+                                "bucket": TRAIL_BUCKET,
+                                "objectKey": key,
+                                "requestId": request_id,
+                                "eventTime": event["eventTime"],
+                                "verified": True,
+                            }
+        if "configDelivery" not in report:
+            prefix = f"AWSLogs/{ACCOUNT}/Config/{REGION}/"
+            for key in recent_objects(s3, CONFIG_BUCKET, prefix, started):
+                if snapshot_id not in key:
+                    continue
+                snapshot = object_json(s3, CONFIG_BUCKET, key)
+                require(
+                    snapshot["configSnapshotId"] == snapshot_id, "wrong_config_snapshot"
+                )
+                items = snapshot["configurationItems"]
+                require(
+                    all(item["accountId"] == ACCOUNT for item in items),
+                    "wrong_config_item_account",
+                )
+                buckets = {
+                    item["resourceId"]
+                    for item in items
+                    if item["resourceType"] == "AWS::S3::Bucket"
+                    and item["configurationItemStatus"] != "ResourceDeleted"
+                }
+                require(
+                    {TRAIL_BUCKET, CONFIG_BUCKET}.issubset(buckets),
+                    "snapshot_missing_audit_bucket_items",
+                )
+                report["configDelivery"] = {
+                    "bucket": CONFIG_BUCKET,
+                    "objectKey": key,
+                    "snapshotId": snapshot_id,
+                    "configurationItemCount": len(items),
+                    "auditBucketItemsVerified": True,
+                    "verified": True,
+                }
+        return "cloudTrailDelivery" in report and "configDelivery" in report
+
+    await_result(delivered, deadline, "fresh_audit_delivery_pending")
+
+    def services_healthy():
+        status = config.describe_delivery_channel_status(
+            DeliveryChannelNames=["default"]
+        )["DeliveryChannelsStatus"]
+        recorder_status = config.describe_configuration_recorder_status(
+            ConfigurationRecorderNames=["default"]
+        )["ConfigurationRecordersStatus"]
+        return (
+            len(status) == 1
+            and status[0]["configSnapshotDeliveryInfo"].get("lastStatus") == "SUCCESS"
+            and len(recorder_status) == 1
+            and recorder_status[0]["recording"] is True
+            and recorder_status[0].get("lastStatus") == "SUCCESS"
+        )
+
+    await_result(services_healthy, deadline, "config_delivery_status_pending")
+    final_trail_status = trail.get_trail_status(Name=TRAIL_ARN)
+    require(
+        final_trail_status["IsLogging"] is True
+        and not final_trail_status.get("LatestDeliveryError"),
+        "trail_unhealthy_after_verification",
+    )
+
+
+def run(session, report):
+    s3 = session.client("s3", config=SDK_CONFIG)
+    iam = session.client("iam", config=SDK_CONFIG)
+    configure_bucket(s3, TRAIL_BUCKET, expected("cloudtrail-bucket.json"), report)
+    configure_bucket(s3, CONFIG_BUCKET, expected("config-bucket.json"), report)
+    configure_role(iam, report)
+    configure_trail(session.client("cloudtrail", config=SDK_CONFIG), report)
+    configure_config(session.client("config", config=SDK_CONFIG), report)
+    report["configurationApplied"] = True
+    verify_delivery(session, report, time.monotonic() + 25 * 60)
+    report["freshDeliveryVerified"] = True
+    report["result"] = "target_audit_delivery_verified"
+
+
+def main():
+    report = {
+        "startedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "account": ACCOUNT,
+        "region": REGION,
+        "runId": os.environ.get("GITHUB_RUN_ID"),
+        "runAttempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
+        "headSha": os.environ.get("GITHUB_SHA"),
+        "created": [],
+        "buckets": [],
+        "configurationApplied": False,
+        "freshDeliveryVerified": False,
+        "oldAccountChanged": False,
+        "kmsChanged": False,
+        "historicalLogsCopied": False,
+        "retirementCleared": False,
+    }
+    result = 1
+    try:
+        run(workflow_identity(), report)
+        result = 0
+    except ClientError as error:
+        # Provider error messages can contain private identifiers or payloads.
+        code = error.response["Error"]["Code"]
+        known = {
+            "AccessDenied",
+            "AccessDeniedException",
+            "InsufficientPermissionsException",
+            "InsufficientDeliveryPolicyException",
+            "InvalidClientTokenId",
+            "ExpiredToken",
+            "BucketAlreadyExists",
+            "BucketAlreadyOwnedByYou",
+            "InvalidRoleException",
+            "ThrottlingException",
+        }
+        report["failure"] = {
+            "operation": error.operation_name,
+            "code": code if code in known else "aws_request_failed",
+        }
+    except RuntimeError as error:
+        report["failure"] = str(error)
+    except Exception:
+        report["failure"] = "unexpected_setup_or_verification_error"
+    finally:
+        report["finishedAt"] = dt.datetime.now(dt.timezone.utc).isoformat()
+        if result:
+            report["result"] = "incomplete_inspect_report"
+        path = Path(os.environ["RUNNER_TEMP"]) / "aws-audit-target.json"
+        path.write_text(json.dumps(report, indent=2) + "\n")
+        print(json.dumps(report), flush=True)
+    return result
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/aws-audit-target-setup.py
+++ b/.github/scripts/aws-audit-target-setup.py
@@ -564,7 +564,7 @@ def verify_delivery(session, report, deadline):
                     item["resourceId"]
                     for item in items
                     if item["resourceType"] == "AWS::S3::Bucket"
-                    and item["configurationItemStatus"] != "ResourceDeleted"
+                    and item["configurationItemStatus"] in {"OK", "ResourceDiscovered"}
                 }
                 require(
                     {TRAIL_BUCKET, CONFIG_BUCKET}.issubset(buckets),

--- a/.github/scripts/tests/aws-audit-target-setup-test.py
+++ b/.github/scripts/tests/aws-audit-target-setup-test.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 import tempfile
 import time
+from types import SimpleNamespace
 import unittest
 from unittest.mock import patch
 
@@ -60,7 +61,7 @@ class AuditSetupTests(unittest.TestCase):
     def client(self, service, **_kwargs):
         return self.clients[service]
 
-    def main(self, account=audit.ACCOUNT, denied=False):
+    def main(self, account=audit.ACCOUNT, denied=False, oidc_status="200"):
         sts = self.stubs["sts"]
         sts.add_response(
             "assume_role_with_web_identity",
@@ -96,9 +97,12 @@ class AuditSetupTests(unittest.TestCase):
             patch.object(boto3, "client", self.client),
             patch.object(boto3, "Session", return_value=Session()),
             patch.object(
-                audit.urllib.request,
-                "urlopen",
-                return_value=io.BytesIO(json.dumps({"value": SECRET}).encode()),
+                audit.subprocess,
+                "run",
+                return_value=SimpleNamespace(
+                    returncode=0,
+                    stdout=json.dumps({"value": SECRET}) + "\n" + oidc_status,
+                ),
             ),
             contextlib.redirect_stdout(captured),
         ):
@@ -128,6 +132,19 @@ class AuditSetupTests(unittest.TestCase):
         result, report = self.main()
         self.assertEqual(result, 1)
         self.assertEqual(report["failure"], "main_required")
+        self.assertEqual(report["created"], [])
+
+    def test_oidc_redirect_is_rejected_before_aws_access(self):
+        result, report = self.main(oidc_status="302")
+        self.assertEqual(result, 1)
+        self.assertEqual(report["failure"], "oidc_response_rejected")
+        self.assertEqual(report["created"], [])
+
+    def test_oidc_token_is_not_sent_to_another_origin(self):
+        self.env["ACTIONS_ID_TOKEN_REQUEST_URL"] = "https://example.test/token"
+        result, report = self.main()
+        self.assertEqual(result, 1)
+        self.assertEqual(report["failure"], "unexpected_oidc_url")
         self.assertEqual(report["created"], [])
 
     def test_new_trail_matches_multi_region_audit_contract(self):
@@ -221,7 +238,7 @@ class AuditSetupTests(unittest.TestCase):
             {"deliveryChannelName": "default"},
         )
         trail_key = f"AWSLogs/{audit.ACCOUNT}/CloudTrail/{audit.REGION}/{now:%Y/%m/%d}/new.json.gz"
-        config_key = f"AWSLogs/{audit.ACCOUNT}/Config/{audit.REGION}/{now:%Y/%m/%d}/ConfigSnapshot/{SNAPSHOT_ID}.json.gz"
+        config_key = f"AWSLogs/{audit.ACCOUNT}/Config/{audit.REGION}/{now:%Y/%m/%d}/ConfigSnapshot/{audit.ACCOUNT}_Config_{audit.REGION}_ConfigSnapshot_{now:%Y%m%dT%H%M%SZ}_{SNAPSHOT_ID}.json.gz"
         buckets = (
             [audit.TRAIL_BUCKET, audit.CONFIG_BUCKET]
             if include_config_bucket
@@ -240,10 +257,11 @@ class AuditSetupTests(unittest.TestCase):
             ]
         }
         snapshot = {
+            "fileVersion": "1.0",
             "configSnapshotId": SNAPSHOT_ID,
             "configurationItems": [
                 {
-                    "accountId": snapshot_account,
+                    "awsAccountId": snapshot_account,
                     "resourceType": "AWS::S3::Bucket",
                     "resourceId": bucket,
                     "configurationItemStatus": "OK",

--- a/.github/scripts/tests/aws-audit-target-setup-test.py
+++ b/.github/scripts/tests/aws-audit-target-setup-test.py
@@ -200,6 +200,7 @@ class AuditSetupTests(unittest.TestCase):
         event_request=REQUEST_ID,
         snapshot_account=audit.ACCOUNT,
         include_config_bucket=True,
+        item_status="OK",
     ):
         now = dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=5)
         trail = self.stubs["cloudtrail"]
@@ -264,7 +265,7 @@ class AuditSetupTests(unittest.TestCase):
                     "awsAccountId": snapshot_account,
                     "resourceType": "AWS::S3::Bucket",
                     "resourceId": bucket,
-                    "configurationItemStatus": "OK",
+                    "configurationItemStatus": item_status,
                     "configuration": SECRET,
                 }
                 for bucket in buckets
@@ -334,6 +335,13 @@ class AuditSetupTests(unittest.TestCase):
 
     def test_snapshot_must_contain_both_new_audit_buckets(self):
         self.delivery_responses(include_config_bucket=False)
+        with self.assertRaisesRegex(
+            RuntimeError, "snapshot_missing_audit_bucket_items"
+        ):
+            self.verify()
+
+    def test_unrecorded_bucket_items_do_not_pass_delivery_verification(self):
+        self.delivery_responses(item_status="ResourceNotRecorded")
         with self.assertRaisesRegex(
             RuntimeError, "snapshot_missing_audit_bucket_items"
         ):

--- a/.github/scripts/tests/aws-audit-target-setup-test.py
+++ b/.github/scripts/tests/aws-audit-target-setup-test.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Exercise AWS response boundaries, delivered evidence and the entry-point guards."""
+
+import contextlib
+import datetime as dt
+import gzip
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+
+import boto3
+from botocore.response import StreamingBody
+from botocore.stub import Stubber
+
+SCRIPT = Path(__file__).resolve().parents[1] / "aws-audit-target-setup.py"
+SPEC = importlib.util.spec_from_file_location("audit_setup", SCRIPT)
+audit = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(audit)
+SECRET = "synthetic-provider-secret-must-not-be-logged"
+REQUEST_ID = "8a09df32-b555-47c3-b6a7-5895764899c0"
+SNAPSHOT_ID = "07c0eeed-e8d8-48d7-b5f4-922c4798f962"
+
+
+class AuditSetupTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.session = boto3.Session(
+            aws_access_key_id="local-test",
+            aws_secret_access_key="local-test",
+            region_name=audit.REGION,
+        )
+        self.clients = {}
+        self.stubs = {}
+        for service in ["sts", "s3", "iam", "cloudtrail", "config"]:
+            client = self.session.client(service)
+            stub = Stubber(client)
+            stub.activate()
+            self.addCleanup(stub.deactivate)
+            self.clients[service] = client
+            self.stubs[service] = stub
+        self.env = {
+            "RUNNER_TEMP": str(self.root),
+            "GITHUB_REPOSITORY": "vm0-ai/vm0",
+            "GITHUB_REF": "refs/heads/main",
+            "GITHUB_EVENT_NAME": "workflow_dispatch",
+            "GITHUB_WORKFLOW_REF": "vm0-ai/vm0/.github/workflows/aws-audit-target-setup.yml@refs/heads/main",
+            "GITHUB_RUN_ID": "1234",
+            "ACTIONS_ID_TOKEN_REQUEST_URL": "https://oidc.actions.githubusercontent.com/example",
+            "ACTIONS_ID_TOKEN_REQUEST_TOKEN": SECRET,
+        }
+
+    def client(self, service, **_kwargs):
+        return self.clients[service]
+
+    def main(self, account=audit.ACCOUNT, denied=False):
+        sts = self.stubs["sts"]
+        sts.add_response(
+            "assume_role_with_web_identity",
+            {
+                "Credentials": {
+                    "AccessKeyId": "A" * 20,
+                    "SecretAccessKey": SECRET,
+                    "SessionToken": SECRET,
+                    "Expiration": dt.datetime.now(dt.timezone.utc)
+                    + dt.timedelta(hours=1),
+                }
+            },
+        )
+        sts.add_response(
+            "get_caller_identity",
+            {
+                "Account": account,
+                "Arn": f"arn:aws:sts::{account}:assumed-role/vm0-kms-migration-github-32264/github-audit-1234",
+                "UserId": "local-test",
+            },
+        )
+        if denied:
+            self.stubs["s3"].add_client_error(
+                "list_buckets", "AccessDenied", SECRET, 403
+            )
+
+        class Session:
+            client = self.client
+
+        captured = io.StringIO()
+        with (
+            patch.dict(os.environ, self.env),
+            patch.object(boto3, "client", self.client),
+            patch.object(boto3, "Session", return_value=Session()),
+            patch.object(
+                audit.urllib.request,
+                "urlopen",
+                return_value=io.BytesIO(json.dumps({"value": SECRET}).encode()),
+            ),
+            contextlib.redirect_stdout(captured),
+        ):
+            result = audit.main()
+        report_text = (self.root / "aws-audit-target.json").read_text()
+        self.assertNotIn(SECRET, captured.getvalue() + report_text)
+        return result, json.loads(report_text)
+
+    def test_wrong_account_stops_before_resource_changes(self):
+        result, report = self.main(account="072707626411")
+        self.assertEqual(result, 1)
+        self.assertEqual(report["failure"], "wrong_aws_identity")
+        self.assertEqual(report["created"], [])
+        self.assertFalse(report["configurationApplied"])
+
+    def test_access_denial_is_not_mistaken_for_an_empty_inventory(self):
+        result, report = self.main(denied=True)
+        self.assertEqual(result, 1)
+        self.assertEqual(
+            report["failure"], {"operation": "ListBuckets", "code": "AccessDenied"}
+        )
+        self.assertEqual(report["created"], [])
+        self.assertFalse(report["freshDeliveryVerified"])
+
+    def test_pull_request_cannot_reach_production(self):
+        self.env["GITHUB_REF"] = "refs/pull/1/merge"
+        result, report = self.main()
+        self.assertEqual(result, 1)
+        self.assertEqual(report["failure"], "main_required")
+        self.assertEqual(report["created"], [])
+
+    def test_new_trail_matches_multi_region_audit_contract(self):
+        desired = {
+            "Name": audit.TRAIL,
+            "S3BucketName": audit.TRAIL_BUCKET,
+            "IncludeGlobalServiceEvents": True,
+            "IsMultiRegionTrail": True,
+            "LogFileValidationEnabled": True,
+            "IsOrganizationTrail": False,
+        }
+        trail = self.stubs["cloudtrail"]
+        trail.add_client_error("get_trail", "TrailNotFoundException", "absent", 400)
+        trail.add_response(
+            "create_trail",
+            {"TrailARN": audit.TRAIL_ARN},
+            {
+                "Name": audit.TRAIL,
+                "S3BucketName": audit.TRAIL_BUCKET,
+                "IncludeGlobalServiceEvents": True,
+                "IsMultiRegionTrail": True,
+                "EnableLogFileValidation": True,
+                "IsOrganizationTrail": False,
+                "TagsList": audit.TAGS,
+            },
+        )
+        selectors = {
+            "EventSelectors": [
+                {"ReadWriteType": "All", "IncludeManagementEvents": True}
+            ]
+        }
+        trail.add_response("get_event_selectors", selectors)
+        trail.add_response("start_logging", {})
+        trail.add_response("get_trail", {"Trail": desired})
+        trail.add_response("get_event_selectors", selectors)
+        report = {"created": []}
+        audit.configure_trail(self.clients["cloudtrail"], report)
+        self.assertEqual(report["created"], [audit.TRAIL_ARN])
+        trail.assert_no_pending_responses()
+
+    def test_conflicting_existing_trail_is_not_reconfigured(self):
+        self.stubs["cloudtrail"].add_response(
+            "get_trail",
+            {"Trail": {"Name": audit.TRAIL, "S3BucketName": "another-bucket"}},
+        )
+        report = {"created": []}
+        with self.assertRaisesRegex(RuntimeError, "existing_trail_settings_drift"):
+            audit.configure_trail(self.clients["cloudtrail"], report)
+        self.assertEqual(report["created"], [])
+
+    def delivery_responses(
+        self,
+        event_request=REQUEST_ID,
+        snapshot_account=audit.ACCOUNT,
+        include_config_bucket=True,
+    ):
+        now = dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=5)
+        trail = self.stubs["cloudtrail"]
+        trail.add_response(
+            "get_trail_status",
+            {"IsLogging": True, "ResponseMetadata": {"RequestId": REQUEST_ID}},
+            {"Name": audit.TRAIL_ARN},
+        )
+        config = self.stubs["config"]
+        status = {
+            "ConfigurationRecordersStatus": [
+                {"name": "default", "recording": True, "lastStatus": "SUCCESS"}
+            ]
+        }
+        config.add_response(
+            "describe_configuration_recorder_status",
+            status,
+            {"ConfigurationRecorderNames": ["default"]},
+        )
+        config.add_response(
+            "list_discovered_resources",
+            {
+                "resourceIdentifiers": [
+                    {"resourceType": "AWS::S3::Bucket", "resourceId": bucket}
+                    for bucket in [audit.TRAIL_BUCKET, audit.CONFIG_BUCKET]
+                ]
+            },
+            {
+                "resourceType": "AWS::S3::Bucket",
+                "resourceIds": [audit.TRAIL_BUCKET, audit.CONFIG_BUCKET],
+            },
+        )
+        config.add_response(
+            "deliver_config_snapshot",
+            {"configSnapshotId": SNAPSHOT_ID},
+            {"deliveryChannelName": "default"},
+        )
+        trail_key = f"AWSLogs/{audit.ACCOUNT}/CloudTrail/{audit.REGION}/{now:%Y/%m/%d}/new.json.gz"
+        config_key = f"AWSLogs/{audit.ACCOUNT}/Config/{audit.REGION}/{now:%Y/%m/%d}/ConfigSnapshot/{SNAPSHOT_ID}.json.gz"
+        buckets = (
+            [audit.TRAIL_BUCKET, audit.CONFIG_BUCKET]
+            if include_config_bucket
+            else [audit.TRAIL_BUCKET]
+        )
+        records = {
+            "Records": [
+                {
+                    "requestID": event_request,
+                    "eventName": "GetTrailStatus",
+                    "recipientAccountId": audit.ACCOUNT,
+                    "awsRegion": audit.REGION,
+                    "eventTime": now.isoformat(),
+                    "privatePayload": SECRET,
+                }
+            ]
+        }
+        snapshot = {
+            "configSnapshotId": SNAPSHOT_ID,
+            "configurationItems": [
+                {
+                    "accountId": snapshot_account,
+                    "resourceType": "AWS::S3::Bucket",
+                    "resourceId": bucket,
+                    "configurationItemStatus": "OK",
+                    "configuration": SECRET,
+                }
+                for bucket in buckets
+            ],
+        }
+        s3 = self.stubs["s3"]
+        for bucket, key, data in [
+            (audit.TRAIL_BUCKET, trail_key, records),
+            (audit.CONFIG_BUCKET, config_key, snapshot),
+        ]:
+            s3.add_response(
+                "list_objects_v2",
+                {"Contents": [{"Key": key, "LastModified": now}], "IsTruncated": False},
+            )
+            body = gzip.compress(json.dumps(data).encode())
+            s3.add_response(
+                "get_object",
+                {"Body": StreamingBody(io.BytesIO(body), len(body))},
+                {"Bucket": bucket, "Key": key, "ExpectedBucketOwner": audit.ACCOUNT},
+            )
+        config.add_response(
+            "describe_delivery_channel_status",
+            {
+                "DeliveryChannelsStatus": [
+                    {
+                        "name": "default",
+                        "configSnapshotDeliveryInfo": {"lastStatus": "SUCCESS"},
+                    }
+                ]
+            },
+            {"DeliveryChannelNames": ["default"]},
+        )
+        config.add_response(
+            "describe_configuration_recorder_status",
+            status,
+            {"ConfigurationRecorderNames": ["default"]},
+        )
+        trail.add_response(
+            "get_trail_status", {"IsLogging": True}, {"Name": audit.TRAIL_ARN}
+        )
+
+    def verify(self):
+        class Session:
+            client = self.client
+
+        report = {}
+        audit.verify_delivery(Session(), report, time.monotonic() - 1)
+        self.assertNotIn(SECRET, json.dumps(report))
+        return report
+
+    def test_actual_matching_event_and_snapshot_complete_delivery_verification(self):
+        self.delivery_responses()
+        report = self.verify()
+        self.assertTrue(report["cloudTrailDelivery"]["verified"])
+        self.assertTrue(report["configDelivery"]["auditBucketItemsVerified"])
+        self.assertEqual(report["configDelivery"]["configurationItemCount"], 2)
+
+    def test_unrelated_event_cannot_prove_this_runs_delivery(self):
+        self.delivery_responses(event_request="different-request")
+        with self.assertRaisesRegex(RuntimeError, "fresh_audit_delivery_pending"):
+            self.verify()
+
+    def test_snapshot_from_another_account_is_rejected(self):
+        self.delivery_responses(snapshot_account="072707626411")
+        with self.assertRaisesRegex(RuntimeError, "wrong_config_item_account"):
+            self.verify()
+
+    def test_snapshot_must_contain_both_new_audit_buckets(self):
+        self.delivery_responses(include_config_bucket=False)
+        with self.assertRaisesRegex(
+            RuntimeError, "snapshot_missing_audit_bucket_items"
+        ):
+            self.verify()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/aws-audit-target-setup-test.sh
+++ b/.github/scripts/tests/aws-audit-target-setup-test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+sdk_dir="$(mktemp -d)"
+trap 'rm -rf "$sdk_dir"' EXIT
+python3 -m pip install --disable-pip-version-check --no-input --quiet \
+  --target "$sdk_dir" boto3==1.40.0
+PYTHONPATH="$sdk_dir${PYTHONPATH:+:$PYTHONPATH}" \
+  python3 "$repo_root/.github/scripts/tests/aws-audit-target-setup-test.py"

--- a/.github/workflows/aws-audit-target-setup.yml
+++ b/.github/workflows/aws-audit-target-setup.yml
@@ -1,5 +1,8 @@
 name: AWS Audit Target Setup
 
+env:
+  npm_config_audit: "false"
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/aws-audit-target-setup.yml
+++ b/.github/workflows/aws-audit-target-setup.yml
@@ -1,0 +1,39 @@
+name: AWS Audit Target Setup
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aws-audit-target-32264
+  cancel-in-progress: false
+
+jobs:
+  setup:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install the pinned AWS SDK
+        run: python3 -m pip install --disable-pip-version-check --no-input boto3==1.40.0
+      - name: Configure target audit services and verify delivered records
+        env:
+          AWS_EC2_METADATA_DISABLED: "true"
+        run: python3 .github/scripts/aws-audit-target-setup.py
+      - name: Retain the sanitized setup and delivery report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: aws-audit-target-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/aws-audit-target.json
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/aws-audit-migration-32264.md
+++ b/docs/aws-audit-migration-32264.md
@@ -53,6 +53,8 @@ After the PR is merged, dispatch **AWS Audit Target Setup** on `main`. The job
 requires the existing protected `production` environment approval, assumes the
 existing Actions role using a one-hour OIDC session, and verifies its exact
 account and role before configuring resources. SDK credentials stay in memory.
+The OIDC request accepts only the GitHub Actions HTTPS origin and rejects
+redirects before requesting AWS credentials.
 
 Existing resources must match their expected identity and configuration. A
 conflicting bucket, role, channel, or trail stops the job; it does not overwrite
@@ -74,6 +76,10 @@ with resource names, request/snapshot IDs, object keys, counts, and verification
 results. It contains no object bodies, configuration payloads, or credentials.
 A timeout or provider error fails the job and retains the incomplete report.
 Created resources remain available for diagnosis; there is no automatic deletion.
+Snapshot verification uses the S3 export schema (`fileVersion`, `configSnapshotId`,
+and item `awsAccountId`) documented in the
+[AWS Config/Athena example](https://aws.amazon.com/blogs/mt/how-to-query-your-aws-resource-configuration-states-using-aws-config-and-amazon-athena/),
+with the snapshot ID matched against the actual object filename.
 
 Source CloudTrail, Config, KMS, historical buckets, database backfill, application
 deployments, and backup settings are outside this workflow's write scope.

--- a/docs/aws-audit-migration-32264.md
+++ b/docs/aws-audit-migration-32264.md
@@ -1,0 +1,88 @@
+# Target AWS audit setup for issue 32264
+
+The production KMS backfill is complete. This operation establishes equivalent
+CloudTrail and AWS Config recording in account `251964670836`, with home region
+`us-west-2`, before the source audit services can be retired.
+
+## Resources and retention
+
+| Resource                             | Target                                         |
+| ------------------------------------ | ---------------------------------------------- |
+| Multi-region management-event trail  | `vm0-drata-cloudtrail`                         |
+| CloudTrail bucket                    | `vm0-cloudtrail-logs-251964670836-us-west-2`   |
+| Config recorder and delivery channel | `default`                                      |
+| Config service role                  | `vm0-dcf478-config-recorder-role`              |
+| Config bucket                        | `vm0-dcf478-aws-config-251964670836-us-west-2` |
+
+The trail includes read and write management events and global service events,
+with log validation enabled. Config continuously records all supported resource
+types, including global IAM resources, and requests a daily snapshot.
+
+Both buckets use SSE-S3, enforced bucket ownership, all four public-access
+blocks, versioning, HTTPS enforcement, and service delivery policies restricted
+to the target account/trail. Logs and noncurrent object versions do not expire.
+The only lifecycle rule removes incomplete multipart uploads after seven days;
+it does not delete delivered audit records. The operation does not introduce a
+dependency on either production KMS key or enable irreversible Object Lock.
+
+Historical source-account logs remain in their original buckets. Their retention
+or copy decision, backup restore dependencies, and the source-account retirement
+decision remain separate acceptance items.
+
+## Existing Actions identity
+
+Reuse `arn:aws:iam::251964670836:role/vm0-kms-migration-github-32264` and its
+existing GitHub OIDC provider and `production` environment trust. No credentials,
+OIDC providers, role trust, KMS policy, or deployment secrets are replaced.
+
+Attach the exact [audit permissions](../.github/aws-audit-32264/operator-permissions.json)
+as a separate inline policy named `audit-target-setup-32264`. Preserve the existing
+KMS migration inline policy. This additional policy grants only the two target
+audit buckets, target trail, and Config service-role setup, plus the required
+regional Config APIs and bucket inventory. It grants no KMS operations or deletion.
+
+The bootstrap caller needs the scoped [bootstrap permissions](../.github/aws-audit-32264/bootstrap-permissions.json).
+The expected existing trust is recorded in
+[operator-trust.json](../.github/aws-audit-32264/operator-trust.json) for read-only
+comparison, not replacement. The Config service role uses AWS's `AWS_ConfigRole`
+read policy plus a delivery policy limited to its audit bucket.
+
+## Execution and verification
+
+After the PR is merged, dispatch **AWS Audit Target Setup** on `main`. The job
+requires the existing protected `production` environment approval, assumes the
+existing Actions role using a one-hour OIDC session, and verifies its exact
+account and role before configuring resources. SDK credentials stay in memory.
+
+Existing resources must match their expected identity and configuration. A
+conflicting bucket, role, channel, or trail stops the job; it does not overwrite
+unrelated configuration. Partially configured buckets fail closed on rerun and
+need their recorded partial state reviewed before continuing. Newly propagated
+service policies have a bounded retry window; permission denials remain errors.
+
+The job waits up to 25 minutes for actual delivered evidence:
+
+1. A read-only `GetTrailStatus` canary appears in a new S3 CloudTrail object,
+   matched by its exact AWS request ID and target account/region.
+2. Config discovers both new audit buckets and delivers a newly requested
+   snapshot containing their configuration items to the target Config bucket.
+3. The recorder and snapshot delivery report success, and the trail remains
+   logging without a delivery error.
+
+The artifact `aws-audit-target-<run>-<attempt>` contains a sanitized JSON report
+with resource names, request/snapshot IDs, object keys, counts, and verification
+results. It contains no object bodies, configuration payloads, or credentials.
+A timeout or provider error fails the job and retains the incomplete report.
+Created resources remain available for diagnosis; there is no automatic deletion.
+
+Source CloudTrail, Config, KMS, historical buckets, database backfill, application
+deployments, and backup settings are outside this workflow's write scope.
+Successful target delivery does not by itself authorize their retirement.
+
+## Local verification
+
+Run `.github/scripts/tests/aws-audit-target-setup-test.sh` for SDK-boundary tests.
+They check the production-entry guard, wrong-account and access-denied behavior,
+and actual delivered-object evidence including unrelated events, wrong-account
+snapshots, missing bucket items, and sensitive payload exclusion. The repository
+workflow-script test job also discovers and runs this test.


### PR DESCRIPTION
Account `251964670836` has no replacement CloudTrail, Config recorder, or audit buckets for #32264. Add a protected, manually dispatched Actions job that creates the two target audit buckets, an equivalent multi-region management-event trail, and continuous all-supported Config recording.

The job reuses the existing GitHub OIDC migration role with a separately scoped audit policy. It verifies bucket protection and retention settings, matches a fresh CloudTrail request ID in a delivered S3 object, and verifies a newly delivered Config snapshot includes both audit buckets. It fails on conflicting existing configuration and retains a sanitized report on failure. Old-account services, KMS, database backfill, application deployments, and backup settings are outside its write scope.

Logs and noncurrent versions are retained without automatic expiration; the lifecycle rule only aborts incomplete multipart uploads after seven days. Historical source-log retention/copy and account retirement remain separate acceptance items.

Validation: 12 SDK-boundary tests passed, including OIDC origin/redirect and production/account guards, access-denied handling, fresh-event matching, wrong-account/missing-item/unrecorded-item snapshots, and sensitive-payload exclusion; Ruff, formatting, shell syntax, and whitespace checks passed. The separate audit policy was applied to the existing Actions role and read back; the original KMS policy is unchanged. Actual resource creation and delivery acceptance will run through the protected workflow after merge.

Fallbacks: expected AWS not-found responses authorize creation of the fixed target resources. Only known new-service policy propagation errors are retried, for at most 120 seconds; other failures stop the operation. No credential or deployment fallback is introduced.

Refs #32264.
