### PR TITLE
test(platform): split search result limit from number shortcuts

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
@@ -162,6 +162,52 @@ function installSearchResources() {
   return { agent, workflow, artifact };
 }
 
+test("Limit empty search to 25 cached chats in sidebar order", async () => {
+  context.mocks.browser.matchMedia((query) => {
+    return (
+      query === "(display-mode: standalone)" || query === "(min-width: 48rem)"
+    );
+  });
+  const threads = Array.from({ length: 26 }, (_, index) => {
+    return chatListThread(index + 1, `Chat ${index + 1}`, {
+      pinnedAt: index < 2 ? `2026-08-01T00:5${2 - index}:00.000Z` : null,
+    });
+  });
+  const remoteChatList = context.mocks.deferred<void>();
+  const workspace = installContinuityWorkspace(context, {
+    caseId: 77,
+    threads,
+    chatListRemoteGate: remoteChatList.promise,
+  });
+  await setupPage({
+    context,
+    path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
+    ...workspace.pageOptions,
+    featureSwitches,
+  });
+  const expectedTitles = [
+    "Chat 1",
+    "Chat 2",
+    ...Array.from({ length: 23 }, (_, index) => {
+      return `Chat ${26 - index}`;
+    }),
+  ];
+  const chatThreads = await screen.findByLabelText("Chat threads");
+  await within(chatThreads).findByText(expectedTitles[0]!);
+  expect(sidebarThreadTitles().slice(0, 3)).toStrictEqual(
+    expectedTitles.slice(0, 3),
+  );
+  click(fastButton("Hide chat list"));
+  await waitFor(() => {
+    expect(screen.queryByTestId("chat-list-column")).toBeNull();
+  });
+  const { dialog } = await openSearch();
+  await waitFor(() => {
+    expect(searchResultTitles(dialog)).toStrictEqual(expectedTitles);
+  });
+  expect(remoteChatList.settled()).toBeFalsy();
+});
+
 test.each([
   {
     caseId: 74,
@@ -190,7 +236,7 @@ test.each([
     firstHint: ["Ctrl+1"],
   },
 ])(
-  "Limit empty search to 25 current chats and open the ninth result on $platform",
+  "Number only the first nine search results and open the ninth on $platform",
   async ({ caseId, userAgent, modifiers, numberModifiers, firstHint }) => {
     context.mocks.browser.userAgent(userAgent);
     context.mocks.browser.matchMedia((query) => {
@@ -198,7 +244,8 @@ test.each([
         query === "(display-mode: standalone)" || query === "(min-width: 48rem)"
       );
     });
-    const threads = Array.from({ length: 30 }, (_, index) => {
+    // Keep one result beyond the nine shortcuts; the 25-result cap is separate.
+    const threads = Array.from({ length: 10 }, (_, index) => {
       return chatListThread(index + 1, `Chat ${index + 1}`, {
         pinnedAt: index < 2 ? `2026-08-01T00:5${2 - index}:00.000Z` : null,
       });
@@ -218,8 +265,8 @@ test.each([
     const expectedTitles = [
       "Chat 1",
       "Chat 2",
-      ...Array.from({ length: 23 }, (_, index) => {
-        return `Chat ${30 - index}`;
+      ...Array.from({ length: 8 }, (_, index) => {
+        return `Chat ${10 - index}`;
       }),
     ];
     const chatThreads = await screen.findByLabelText("Chat threads");
@@ -251,6 +298,9 @@ test.each([
         },
       ),
     ).toStrictEqual(firstHint);
+    expect(
+      queryAllByRoleFast("option", dialog)[9]!.querySelector("kbd"),
+    ).toBeNull();
     fireEvent.keyUp(search, { key: modifiers.metaKey ? "Meta" : "Control" });
     await waitFor(() => {
       expect(numberedHints(dialog)).toStrictEqual([]);
@@ -270,7 +320,7 @@ test.each([
     });
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).toBeNull();
-      expect(pathname()).toBe(`/chats/${threads[23]!.id}`);
+      expect(pathname()).toBe(`/chats/${threads[3]!.id}`);
     });
     expect(screen.queryByTestId("chat-list-column")).toBeNull();
   },


### PR DESCRIPTION
The Mac Chrome search-shortcut case exceeded the 5-second test budget in [test-app (7)](https://github.com/vm0-ai/vm0/actions/runs/34465764509/job/102833929851), finishing at 5114 ms. The same application code passed in [the adjacent main run](https://github.com/vm0-ai/vm0/actions/runs/34466097989/job/102835465950) at 4616 ms; the failing merge-group commit only changes Rust and its documentation. The case combines a 30-chat fixture, the 25-result limit, modifier-hint transitions, and navigation, making its runtime sensitive to CI load.

Split the platform-independent result limit and pinned ordering into one page test with 26 cached chats and a blocked remote response. Keep the Mac Chrome, Mac Safari, and Windows shortcut cases on 10 chats, with an explicit check that the tenth result has no number hint. Preserve modifier release/repress, ninth-result navigation, and hidden-sidebar coverage. The change is confined to this test file and retains the default 5-second timeout.

Validation from `turbo/`:

- `pnpm exec vitest run --project=@okouai/app apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx --maxWorkers=1 --coverage.enabled --coverage.reporter=json`: five consecutive process runs, 11/11 tests each (55/55 total). The slowest changed case took 3.734 seconds locally.
- `pnpm -F @okouai/app exec tsc -p tsconfig.tests.json --noEmit --checkers 2`: passed.
- `pnpm exec knip --workspace @okouai/app --no-progress`: passed.
- Focused Prettier, ESLint, Oxlint and type-aware Oxlint checks: passed.
- `node scripts/style-policy.mjs` and the changed-file size check: passed.
