### PR TITLE
fix(sandbox-firecracker): bound incomplete control socket requests

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -109,6 +109,23 @@ binary overrides must use flags and environment keys matching the runner revisio
 - [Multi-architecture rollout](../docs/runner-multi-architecture.md): select,
   build, deploy, and validate architecture-specific runner artifacts.
 
+### Local control socket limits
+
+Each sandbox's owner-only control socket admits at most 32 concurrent request
+handlers and 64 MiB of raw request payloads in aggregate. Declared lengths reserve
+that byte budget before payload allocation. Excess connections or requests that
+cannot reserve their full declared size are closed without a response.
+
+A request must deliver its entire length prefix and body within 5 seconds of
+acceptance. Timeout, EOF, and server shutdown release the pending receive resources.
+After parsing, the raw buffer and byte budget are released before executing the
+command or waiting for termination acknowledgment. Execution retains its own
+timeout; the existing 64 MiB per-frame ceiling and exec response limits still apply.
+
+Saturated or unusually slow local clients can therefore receive connection errors.
+These limits apply per socket. The payload budget does not include parsed commands,
+responses, allocator overhead, or kernel socket buffers, and does not bound host-wide RSS.
+
 ### Local active input
 
 `runner local input` requires a claimed local job with active-input forwarding

--- a/crates/sandbox-firecracker/src/control/server.rs
+++ b/crates/sandbox-firecracker/src/control/server.rs
@@ -6,17 +6,19 @@ use std::time::Duration;
 
 use sandbox::EXEC_OUTPUT_LIMIT_7_MIB;
 use serde::Serialize;
+use tokio::io::AsyncReadExt;
 use tokio::net::{UnixListener, UnixStream};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc, oneshot};
 use tokio::task::{JoinHandle, JoinSet};
+use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use super::CONTROL_SOCKET_OVERHEAD_MS;
 use super::exec_response::{ExecResult, write_raw_exec_response};
 use super::protocol::{
-    ExecRequest, TerminateAction, TerminateRequest, TerminateResponse, TerminateStatus, read_frame,
-    write_frame,
+    ExecRequest, TerminateAction, TerminateRequest, TerminateResponse, TerminateStatus,
+    read_frame_payload_len, write_frame,
 };
 use crate::exec_operation_result::{
     captured_exec_output_bytes, exec_termination_from_vsock_termination, reject_stream_overflow,
@@ -28,6 +30,12 @@ use crate::runtime_dirs::set_private_runtime_socket_mode;
 
 const CONTROL_SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 const CONTROL_HANDLER_SHUTDOWN_GRACE: Duration = Duration::from_millis(250);
+// Bound tasks and sockets independently of the declared request sizes.
+const MAX_CONTROL_CONNECTIONS: usize = 32;
+// Allow an existing maximum-size frame without retaining that much per client.
+const CONTROL_REQUEST_BYTE_BUDGET: usize = 64 * 1024 * 1024;
+// One deadline from accept through the entire prefix and body, excluding exec.
+const CONTROL_REQUEST_RECEIVE_TIMEOUT: Duration = Duration::from_secs(5);
 const RUN_CONTROL_MISMATCH_ERROR: &str = "run control target is no longer assigned to this sandbox";
 
 /// Cloneable handle used by the control server to ask the process monitor to
@@ -293,6 +301,7 @@ fn spawn_bound_server(
         info!(path = %sock_path.path().display(), "control socket listening");
 
         let mut handlers = JoinSet::new();
+        let request_bytes = Arc::new(Semaphore::new(CONTROL_REQUEST_BYTE_BUDGET));
 
         loop {
             tokio::select! {
@@ -315,11 +324,22 @@ fn spawn_bound_server(
                         }
                     };
 
+                    if handlers.len() >= MAX_CONTROL_CONNECTIONS {
+                        warn!(limit = MAX_CONTROL_CONNECTIONS, "control connection limit reached");
+                        drop(stream);
+                        continue;
+                    }
+
+                    let request_deadline = Instant::now() + CONTROL_REQUEST_RECEIVE_TIMEOUT;
+                    let request_bytes = Arc::clone(&request_bytes);
                     let guest_operations = guest_operations.clone();
                     let termination = termination.clone();
                     let handler_shutdown = shutdown.clone();
                     handlers.spawn(async move {
-                        if let Err(e) = handle_connection(stream, guest_operations, termination, handler_shutdown).await {
+                        if let Err(e) = handle_connection(
+                            stream, guest_operations, termination, handler_shutdown,
+                            request_bytes, request_deadline,
+                        ).await {
                             warn!(error = %e, "control connection handler error");
                         }
                     });
@@ -369,25 +389,62 @@ async fn shutdown_handlers(handlers: &mut JoinSet<()>) {
     }
 }
 
+struct RequestFrame {
+    // Field order drops the allocation before making its byte budget available.
+    payload: Vec<u8>,
+    _byte_permit: OwnedSemaphorePermit,
+}
+
+async fn read_request_frame(
+    stream: &mut UnixStream,
+    request_bytes: Arc<Semaphore>,
+) -> io::Result<RequestFrame> {
+    let len = read_frame_payload_len(stream).await?;
+    // The validated frame length fits u32. Never queue a waiter or allocate a
+    // declared body until its entire size has been admitted.
+    let byte_permit = request_bytes
+        .try_acquire_many_owned(len as u32)
+        .map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::WouldBlock,
+                format!("control request byte budget unavailable: {error}"),
+            )
+        })?;
+    let mut payload = vec![0u8; len];
+    stream.read_exact(&mut payload).await?;
+    Ok(RequestFrame {
+        payload,
+        _byte_permit: byte_permit,
+    })
+}
+
 /// Handle a single control socket connection.
 async fn handle_connection(
     mut stream: UnixStream,
     guest_operations: GuestOperationStartGate,
     termination: ProcessTerminationHandle,
     shutdown: CancellationToken,
+    request_bytes: Arc<Semaphore>,
+    request_deadline: Instant,
 ) -> io::Result<()> {
     let frame = tokio::select! {
         biased;
         () = shutdown.cancelled() => return Ok(()),
-        result = read_frame(&mut stream) => result?,
+        () = tokio::time::sleep_until(request_deadline) => {
+            return Err(io::Error::new(io::ErrorKind::TimedOut, "control request receive timed out"));
+        }
+        result = read_request_frame(&mut stream, request_bytes) => result?,
     };
 
-    if let Ok(request) = serde_json::from_slice::<TerminateRequest>(&frame) {
+    if let Ok(request) = serde_json::from_slice::<TerminateRequest>(&frame.payload) {
+        drop(frame);
         let response = terminate(request, &termination).await;
         return write_json_frame(&mut stream, &response).await;
     }
 
-    let response = match serde_json::from_slice::<ExecRequest>(&frame) {
+    let request = serde_json::from_slice::<ExecRequest>(&frame.payload);
+    drop(frame);
+    let response = match request {
         Ok(request) => tokio::select! {
             biased;
             () = shutdown.cancelled() => return Ok(()),

--- a/crates/sandbox-firecracker/src/control/server/tests.rs
+++ b/crates/sandbox-firecracker/src/control/server/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod admission;
+
 use std::future::Future;
 use std::os::unix::fs::PermissionsExt;
 use std::pin::Pin;

--- a/crates/sandbox-firecracker/src/control/server/tests/admission.rs
+++ b/crates/sandbox-firecracker/src/control/server/tests/admission.rs
@@ -1,0 +1,252 @@
+use super::*;
+
+use crate::control::protocol::MAX_FRAME_PAYLOAD_SIZE;
+
+async fn expect_closed(stream: &mut UnixStream, within: Duration) {
+    let result = tokio::time::timeout(within, stream.read_u8())
+        .await
+        .expect("server should close the connection before the deadline");
+    let error = result.expect_err("rejected/incomplete requests must not receive a response");
+    assert!(
+        matches!(
+            error.kind(),
+            io::ErrorKind::UnexpectedEof | io::ErrorKind::ConnectionReset
+        ),
+        "unexpected socket error: {error}"
+    );
+}
+
+async fn expect_terminate_available(sock_path: &Path) {
+    assert_eq!(
+        send_terminate(
+            sock_path,
+            &TerminateRequest {
+                action: TerminateAction::Terminate,
+                expected_run_id: None,
+            },
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap(),
+        TerminateResponse::Status {
+            status: TerminateStatus::AlreadyStopped,
+        }
+    );
+}
+
+/// Writing more than the socket's send buffer proves that the real server has
+/// consumed body bytes, rather than merely queueing the connection or prefix.
+async fn partial_body(sock_path: &Path, declared_len: u32) -> UnixStream {
+    let mut stream = UnixStream::connect(sock_path).await.unwrap();
+    stream.write_u32(declared_len).await.unwrap();
+    let body = vec![b' '; 1024 * 1024];
+    tokio::time::timeout(Duration::from_secs(1), stream.write_all(&body))
+        .await
+        .unwrap()
+        .unwrap();
+    stream
+}
+
+#[tokio::test]
+async fn incomplete_headers_and_bodies_expire() {
+    let fixture = ControlServerFixture::new();
+    let mut handle = fixture.spawn_default(CancellationToken::new());
+    let mut streams = Vec::new();
+    for prefix_and_body in [
+        Vec::new(),
+        vec![0, 0],
+        vec![0, 0, 4, 0],
+        vec![0, 0, 4, 0, b'{'],
+    ] {
+        let mut stream = UnixStream::connect(&fixture.sock_path).await.unwrap();
+        stream.write_all(&prefix_and_body).await.unwrap();
+        streams.push(stream);
+    }
+    futures_util::future::join_all(
+        streams
+            .iter_mut()
+            .map(|stream| expect_closed(stream, Duration::from_secs(6))),
+    )
+    .await;
+    expect_terminate_available(&fixture.sock_path).await;
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn receive_deadline_spans_header_and_body() {
+    let fixture = ControlServerFixture::new();
+    let mut handle = fixture.spawn_default(CancellationToken::new());
+    let stream = UnixStream::connect(&fixture.sock_path).await.unwrap();
+    let (mut reader, mut writer) = stream.into_split();
+    let send = async {
+        writer.write_all(&[0, 0]).await.unwrap();
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        writer.write_all(&[4, 0, b'{']).await.unwrap();
+    };
+    let receive = async {
+        let error = tokio::time::timeout(Duration::from_secs(6), reader.read_u8())
+            .await
+            .expect("body progress must not restart the receive deadline")
+            .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
+    };
+
+    tokio::join!(send, receive);
+    expect_terminate_available(&fixture.sock_path).await;
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn connection_limit_rejects_excess_and_recovers_after_eof() {
+    let fixture = ControlServerFixture::new();
+    let mut handle = fixture.spawn_default(CancellationToken::new());
+    let mut streams = Vec::new();
+    for _ in 0..32 {
+        streams.push(UnixStream::connect(&fixture.sock_path).await.unwrap());
+    }
+    let mut excess = UnixStream::connect(&fixture.sock_path).await.unwrap();
+    expect_closed(&mut excess, Duration::from_secs(1)).await;
+
+    for stream in &streams {
+        assert_eq!(
+            stream.try_read(&mut [0]).unwrap_err().kind(),
+            io::ErrorKind::WouldBlock,
+            "admitted incomplete connections should remain open before timeout"
+        );
+    }
+
+    let mut released = streams.pop().unwrap();
+    released.shutdown().await.unwrap();
+    expect_closed(&mut released, Duration::from_secs(1)).await;
+    expect_terminate_available(&fixture.sock_path).await;
+    handle.shutdown().await;
+    for mut stream in streams {
+        expect_closed(&mut stream, Duration::from_secs(1)).await;
+    }
+}
+
+#[tokio::test]
+async fn aggregate_byte_limit_rejects_before_body_and_recovers_after_eof() {
+    let fixture = ControlServerFixture::new();
+    let mut handle = fixture.spawn_default(CancellationToken::new());
+    let mut first = partial_body(&fixture.sock_path, MAX_FRAME_PAYLOAD_SIZE / 2).await;
+    let mut second = partial_body(&fixture.sock_path, MAX_FRAME_PAYLOAD_SIZE / 2).await;
+    let mut excess = UnixStream::connect(&fixture.sock_path).await.unwrap();
+    excess.write_u32(1).await.unwrap();
+    expect_closed(&mut excess, Duration::from_secs(1)).await;
+
+    first.shutdown().await.unwrap();
+    expect_closed(&mut first, Duration::from_secs(1)).await;
+    expect_terminate_available(&fixture.sock_path).await;
+    handle.shutdown().await;
+    expect_closed(&mut second, Duration::from_secs(1)).await;
+}
+
+#[tokio::test]
+async fn maximum_frame_expires_and_releases_entire_byte_budget() {
+    let fixture = ControlServerFixture::new();
+    let mut handle = fixture.spawn_default(CancellationToken::new());
+    let mut stream = partial_body(&fixture.sock_path, MAX_FRAME_PAYLOAD_SIZE).await;
+    expect_closed(&mut stream, Duration::from_secs(6)).await;
+
+    let mut replacement = partial_body(&fixture.sock_path, MAX_FRAME_PAYLOAD_SIZE).await;
+    handle.shutdown().await;
+    expect_closed(&mut replacement, Duration::from_secs(1)).await;
+}
+
+#[tokio::test]
+async fn complete_frame_releases_budget_before_exec() {
+    let (exec_seen_tx, exec_seen_rx) = oneshot::channel();
+    let fixture = VsockExecFixture::connect(|vsock_base| {
+        mock_guest_holds_first_exec_and_completes_second(vsock_base, exec_seen_tx)
+    })
+    .await;
+    let mut handle = fixture.spawn_server();
+    let mut pending = partial_body(&fixture.sock_path, MAX_FRAME_PAYLOAD_SIZE - 1024).await;
+    let mut first = UnixStream::connect(&fixture.sock_path).await.unwrap();
+    let mut request = exec_request("hold-first");
+    request.timeout_secs = 30;
+    let mut frame = serde_json::to_vec(&request).unwrap();
+    // Fill the remaining budget without coupling this test to a 64 MiB transfer.
+    frame.resize(1024, b' ');
+    tokio::time::timeout(Duration::from_secs(1), write_frame(&mut first, &frame))
+        .await
+        .unwrap()
+        .unwrap();
+    drop(frame);
+    tokio::time::timeout(Duration::from_secs(1), exec_seen_rx)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let second = send_exec(
+        &fixture.sock_path,
+        &exec_request("complete-second"),
+        Duration::from_secs(1),
+    )
+    .await
+    .expect("an executing request must release its receive-byte admission");
+    let (termination, stdout, ..) = expect_exec_success(second);
+    assert_eq!(termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(stdout, b"second");
+    assert_eq!(
+        pending.try_read(&mut [0]).unwrap_err().kind(),
+        io::ErrorKind::WouldBlock,
+        "the incomplete frame must still occupy the rest of the byte budget"
+    );
+    assert_eq!(
+        first.try_read(&mut [0]).unwrap_err().kind(),
+        io::ErrorKind::WouldBlock,
+        "the first exec must still be in flight when the second completes"
+    );
+
+    handle.shutdown().await;
+    expect_closed(&mut first, Duration::from_secs(1)).await;
+    expect_closed(&mut pending, Duration::from_secs(1)).await;
+    fixture.guest_task.abort();
+    let _ = fixture.guest_task.await;
+}
+
+#[tokio::test]
+async fn receive_deadline_does_not_cancel_admitted_exec() {
+    let (exec_seen_tx, exec_seen_rx) = oneshot::channel();
+    let fixture = VsockExecFixture::connect(|vsock_base| {
+        mock_guest_holds_first_exec_and_completes_second(vsock_base, exec_seen_tx)
+    })
+    .await;
+    let mut handle = fixture.spawn_server();
+    let mut first = UnixStream::connect(&fixture.sock_path).await.unwrap();
+    let mut request = exec_request("hold-first");
+    request.timeout_secs = 30;
+    write_frame(&mut first, &serde_json::to_vec(&request).unwrap())
+        .await
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(1), exec_seen_rx)
+        .await
+        .unwrap()
+        .unwrap();
+
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(6)).await;
+    tokio::time::resume();
+    let second = send_exec(
+        &fixture.sock_path,
+        &exec_request("complete-second"),
+        Duration::from_secs(1),
+    )
+    .await
+    .unwrap();
+    let (termination, stdout, ..) = expect_exec_success(second);
+    assert_eq!(termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(stdout, b"second");
+    assert_eq!(
+        first.try_read(&mut [0]).unwrap_err().kind(),
+        io::ErrorKind::WouldBlock,
+        "the receive deadline must not cancel an admitted exec"
+    );
+
+    handle.shutdown().await;
+    expect_closed(&mut first, Duration::from_secs(1)).await;
+    fixture.guest_task.abort();
+    let _ = fixture.guest_task.await;
+}


### PR DESCRIPTION
Incomplete local control-socket requests previously retained their declared payload allocation and handler indefinitely. Limit each control socket to 32 handlers and 64 MiB of raw request payloads, reserving bytes before allocation and closing incomplete requests after one 5-second deadline from accept through the prefix and body.

Raw buffers release their admission after parsing, before exec or termination waits. Preserve the existing request encoding, 64 MiB frame ceiling, exec response capacity, and execution timeouts. Saturated or unusually slow clients now receive connection errors; these per-socket limits do not claim a host-wide RSS bound.

Closes #33261.

Validation:

- Five real-socket admission/expiration regressions fail against the unchanged server. All 88 control tests pass with the fix, including seven new cases for partial frames, overload, recovery, shutdown, byte-budget release, and execution beyond the receive deadline.
- `env PATH="/usr/sbin:/sbin:$PATH" cargo test --manifest-path crates/Cargo.toml --profile local -p sandbox-firecracker --all-targets --quiet`: 888 unit tests and 1 integration test pass. Two existing root/KVM/host-hardware tests remain reserved for CI. The PATH addition exposes the installed `mkfs.ext4`/`e2fsck` required by the unchanged workspace-image test.
- Affected-crate Rust formatting, Clippy (`--all-targets --all-features -- -D warnings`), and docs (`--all-features --no-deps`) pass; Clippy/docs use `--profile local`. README Prettier and `git diff --check` pass.
