### PR TITLE
fix(runner): create workspace metadata with private permissions

### DIFF
--- a/crates/runner/src/host_file.rs
+++ b/crates/runner/src/host_file.rs
@@ -153,6 +153,36 @@ pub(crate) fn validate_private_file_destination(path: &Path, context: &str) -> i
     secure_regular_private_file(&file, path, context)
 }
 
+/// Create a new file with `0600` permissions before writing its contents.
+///
+/// Existing paths, including symlinks, are refused. Permissions are normalized
+/// on the opened descriptor regardless of umask, and writes are flushed before
+/// returning. The caller owns parent-directory trust, failed-file cleanup, and
+/// publication. This operation does not fsync the file.
+#[cfg(unix)]
+pub(crate) async fn write_private_new(
+    path: &Path,
+    content: &[u8],
+    context: &str,
+) -> io::Result<()> {
+    use tokio::io::AsyncWriteExt;
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create_new(true).mode(PRIVATE_FILE_MODE);
+    let mut file = options
+        .open(path)
+        .await
+        .map_err(|e| wrap_io(e, format!("open {context} {}", path.display())))?;
+    chmod_private_file_fd(&file, path, context)?;
+    file.write_all(content)
+        .await
+        .map_err(|e| wrap_io(e, format!("write {context} {}", path.display())))?;
+    file.flush()
+        .await
+        .map_err(|e| wrap_io(e, format!("flush {context} {}", path.display())))?;
+    Ok(())
+}
+
 /// Publish a private file through same-directory atomic replacement on Unix.
 ///
 /// The caller remains responsible for parent-directory trust. This operation
@@ -166,7 +196,6 @@ pub(crate) async fn write_private_atomic(
     context: &str,
 ) -> io::Result<()> {
     use std::ffi::OsString;
-    use tokio::io::AsyncWriteExt;
 
     let file_name = path.file_name().ok_or_else(|| {
         io::Error::new(
@@ -183,20 +212,7 @@ pub(crate) async fn write_private_atomic(
     let tmp = path.with_file_name(tmp_name);
 
     let result = async {
-        let mut options = tokio::fs::OpenOptions::new();
-        options.write(true).create_new(true).mode(PRIVATE_FILE_MODE);
-        let mut file = options
-            .open(&tmp)
-            .await
-            .map_err(|e| wrap_io(e, format!("open {context} tmp {}", tmp.display())))?;
-        chmod_private_file_fd(&file, &tmp, context)?;
-        file.write_all(content)
-            .await
-            .map_err(|e| wrap_io(e, format!("write {context} tmp {}", tmp.display())))?;
-        file.flush()
-            .await
-            .map_err(|e| wrap_io(e, format!("flush {context} tmp {}", tmp.display())))?;
-        drop(file);
+        write_private_new(&tmp, content, context).await?;
 
         tokio::fs::rename(&tmp, path)
             .await
@@ -760,6 +776,27 @@ mod tests {
 
     fn mode(path: &Path) -> u32 {
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    #[tokio::test]
+    async fn write_private_new_preserves_existing_files_and_symlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("existing.json");
+        std::fs::write(&path, b"existing content").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o660)).unwrap();
+        let link = dir.path().join("link.json");
+        symlink(&path, &link).unwrap();
+
+        for destination in [&path, &link] {
+            let error = write_private_new(destination, b"replacement", "test file")
+                .await
+                .unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+            assert_eq!(std::fs::read(&path).unwrap(), b"existing content");
+            assert_eq!(mode(&path), 0o660);
+        }
+        assert!(std::fs::symlink_metadata(&link).unwrap().is_symlink());
     }
 
     #[tokio::test]

--- a/crates/runner/src/workspace_image_cache/metadata.rs
+++ b/crates/runner/src/workspace_image_cache/metadata.rs
@@ -177,7 +177,10 @@ impl WorkspaceImageCache {
         let bytes = serde_json::to_vec_pretty(&metadata)
             .map_err(|e| RunnerError::Internal(format!("serialize workspace metadata: {e}")))?;
         let _ = remove_workspace_cache_path_if_exists(&tmp).await;
-        if let Err(e) = fs::write(&tmp, bytes).await {
+        if let Err(e) =
+            crate::host_file::write_private_new(&tmp, &bytes, "workspace metadata staging file")
+                .await
+        {
             let _ = remove_workspace_cache_path_if_exists(&tmp).await;
             return Err(e.into());
         }

--- a/crates/runner/src/workspace_image_cache/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/sidecar.rs
@@ -333,7 +333,13 @@ impl WorkspaceImageCache {
         let bytes = serde_json::to_vec_pretty(&sidecar_metadata).map_err(|e| {
             RunnerError::Internal(format!("serialize workspace session history sidecar: {e}"))
         })?;
-        if let Err(e) = fs::write(&tmp_metadata_path, bytes).await {
+        if let Err(e) = crate::host_file::write_private_new(
+            &tmp_metadata_path,
+            &bytes,
+            "workspace session history metadata staging file",
+        )
+        .await
+        {
             let _ = remove_workspace_cache_path_if_exists(&tmp_metadata_path).await;
             let _ = remove_workspace_cache_path_if_exists(&source.tmp_path).await;
             return Err(e.into());

--- a/crates/runner/src/workspace_image_cache/tests/promotion.rs
+++ b/crates/runner/src/workspace_image_cache/tests/promotion.rs
@@ -26,6 +26,7 @@ use crate::test_fixtures::ignored_child::{
 };
 
 const PERMISSIVE_UMASK_CHILD_ENV: &str = "OKOU_RUN_WORKSPACE_CACHE_PERMISSIVE_UMASK_TEST";
+const PUBLICATION_UMASK_ENV: &str = "OKOU_WORKSPACE_CACHE_PUBLICATION_UMASK";
 
 fn mode(path: &Path) -> u32 {
     std::fs::metadata(path).unwrap().permissions().mode() & 0o777
@@ -476,24 +477,42 @@ async fn consumed_cache_hit_promotion_moves_active_image_back_to_cache() {
 
 #[tokio::test]
 async fn promotion_enforces_private_permissions_under_permissive_umask() {
-    run_ignored_child_test(
-        "workspace_image_cache::tests::promotion::promotion_enforces_private_permissions_under_permissive_umask_child",
-        (PERMISSIVE_UMASK_CHILD_ENV, "1"),
-        &[],
-        Duration::from_secs(60),
-    )
-    .await;
+    for mask in ["0022", "0002", "0000"] {
+        run_ignored_child_test(
+            "workspace_image_cache::tests::promotion::promotion_enforces_private_permissions_under_permissive_umask_child",
+            (PERMISSIVE_UMASK_CHILD_ENV, "1"),
+            &[(PUBLICATION_UMASK_ENV, Some(mask))],
+            Duration::from_secs(60),
+        )
+        .await;
+    }
 }
 
-#[tokio::test]
+#[test]
 #[ignore]
-async fn promotion_enforces_private_permissions_under_permissive_umask_child() {
+fn promotion_enforces_private_permissions_under_permissive_umask_child() {
     if !ignored_child_test_env_guard_enabled((PERMISSIVE_UMASK_CHILD_ENV, "1")) {
         return;
     }
 
-    let _umask = UmaskGuard::set(Mode::from_bits_truncate(0o022));
-    let (_dir, paths, cache) = local_cache().await;
+    let mask = u32::from_str_radix(&std::env::var(PUBLICATION_UMASK_ENV).unwrap(), 8).unwrap();
+    let _umask = UmaskGuard::set(Mode::from_bits_truncate(mask));
+    let source_mode = if mask == 0o022 { 0o644 } else { 0o600 };
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(assert_promotion_private_permissions(source_mode));
+}
+
+async fn assert_promotion_private_permissions(source_mode: u32) {
+    let (dir, paths, cache) = local_cache().await;
+    fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+        .await
+        .unwrap();
+    fs::set_permissions(paths.base_dir(), std::fs::Permissions::from_mode(0o700))
+        .await
+        .unwrap();
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let reuse_key = "sess-private-permissions";
@@ -512,11 +531,14 @@ async fn promotion_enforces_private_permissions_under_permissive_umask_child() {
         })
         .await;
     let active_image = paths.active_workspace_image(&sandbox_id);
-    fs::create_dir_all(active_image.parent().unwrap())
-        .await
-        .unwrap();
+    crate::host_file::ensure_dir(
+        active_image.parent().unwrap(),
+        crate::host_file::DirMode::Private,
+        "test workspace directory",
+    )
+    .unwrap();
     fs::write(&active_image, image).await.unwrap();
-    fs::set_permissions(&active_image, std::fs::Permissions::from_mode(0o644))
+    fs::set_permissions(&active_image, std::fs::Permissions::from_mode(source_mode))
         .await
         .unwrap();
     let active_metadata = fs::metadata(&active_image).await.unwrap();
@@ -552,6 +574,22 @@ async fn promotion_enforces_private_permissions_under_permissive_umask_child() {
     assert_eq!(mode(&entry_dir), 0o700);
     assert_eq!(mode(&current), 0o600);
     assert_eq!(mode(&metadata), 0o600);
+
+    let next_lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                reuse_key: Some(reuse_key),
+                working_dir: "/workspace",
+                image_size_bytes: image.len() as u64,
+            },
+            workspace_drive_required: false,
+        })
+        .await;
+    assert_eq!(next_lease.result(), WorkspaceCacheCheckoutResult::Hit);
+    assert_eq!(fs::read(&current).await.unwrap(), image);
 }
 
 #[tokio::test]

--- a/crates/runner/src/workspace_image_cache/tests/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/tests/sidecar.rs
@@ -1,5 +1,6 @@
 use std::os::unix::fs::{PermissionsExt, symlink};
 use std::path::Path;
+use std::time::Duration;
 
 use api_contracts::generated::constants::runners::{
     RESUME_SESSION_HISTORY_MAX_BYTES, paths::CANONICAL_WORKING_DIR,
@@ -21,6 +22,12 @@ use super::support::{TEST_PROFILE_NAME, local_cache, write_current_cache_entry};
 use crate::ids::RunId;
 use crate::paths::RunnerPaths;
 use crate::restored_session_identity::RestoredSessionIdentity;
+use crate::test_fixtures::ignored_child::{
+    ignored_child_test_env_guard_enabled, run_ignored_child_test,
+};
+
+const PERMISSIVE_UMASK_CHILD_ENV: &str = "OKOU_RUN_SIDECAR_PERMISSIVE_UMASK_TEST";
+const PUBLICATION_UMASK_ENV: &str = "OKOU_SIDECAR_PUBLICATION_UMASK";
 
 fn mode(path: &Path) -> u32 {
     std::fs::metadata(path).unwrap().permissions().mode() & 0o777
@@ -115,6 +122,91 @@ async fn session_history_sidecar_publish_and_probe_hit() {
     );
     assert_eq!(mode(&metadata_path), 0o600);
     assert_eq!(mode(&sidecar.path), 0o600);
+}
+
+#[tokio::test]
+async fn session_history_sidecar_publishes_under_permissive_umask() {
+    for mask in ["0002", "0000"] {
+        run_ignored_child_test(
+            "workspace_image_cache::tests::sidecar::session_history_sidecar_publishes_under_permissive_umask_child",
+            (PERMISSIVE_UMASK_CHILD_ENV, "1"),
+            &[(PUBLICATION_UMASK_ENV, Some(mask))],
+            Duration::from_secs(60),
+        )
+        .await;
+    }
+}
+
+#[test]
+#[ignore]
+fn session_history_sidecar_publishes_under_permissive_umask_child() {
+    if !ignored_child_test_env_guard_enabled((PERMISSIVE_UMASK_CHILD_ENV, "1")) {
+        return;
+    }
+
+    let mask = u32::from_str_radix(&std::env::var(PUBLICATION_UMASK_ENV).unwrap(), 8).unwrap();
+    // This exact test runs alone in a child; set umask before Tokio starts any workers.
+    nix::sys::stat::umask(nix::sys::stat::Mode::from_bits_truncate(mask));
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(assert_sidecar_private_publication());
+}
+
+async fn assert_sidecar_private_publication() {
+    let (dir, paths, cache) = local_cache().await;
+    fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+        .await
+        .unwrap();
+    fs::set_permissions(paths.base_dir(), std::fs::Permissions::from_mode(0o700))
+        .await
+        .unwrap();
+    let run_id = RunId::new_v4();
+    let session_id = "sess-sidecar-private";
+    let history = br#"{"type":"message","content":"private"}"#;
+    let cache_key =
+        cache.scoped_cache_key(TEST_PROFILE_NAME, session_id, CANONICAL_WORKING_DIR, 4096);
+    cache
+        .ensure_workspace_cache_entry_dir(&cache_key)
+        .await
+        .unwrap();
+    let tmp_path = cache.workspace_image_cache_tmp_sidecar(&cache_key, run_id);
+    fs::write(&tmp_path, history).await.unwrap();
+    fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
+        .await
+        .unwrap();
+    let identity = test_restored_session_identity(session_id, history);
+    let source = WorkspaceSessionHistorySidecarPromotionSource {
+        tmp_path: tmp_path.clone(),
+        representation: WorkspaceSessionHistorySidecarRepresentation::Raw,
+        encoded_size: history.len() as u64,
+        restored_session_identity: identity.clone(),
+    };
+
+    cache
+        .publish_session_history_sidecar(
+            &cache_key,
+            run_id,
+            WorkspaceSessionHistorySidecarPublication::Replace(&source),
+        )
+        .await
+        .unwrap();
+
+    let sidecar = cache
+        .probe_session_history_sidecar(&cache_key, &identity)
+        .await
+        .unwrap();
+    assert_eq!(fs::read(&sidecar.path).await.unwrap(), history);
+    assert_eq!(mode(&sidecar.path), 0o600);
+    let entry_paths = cache.entry_paths(&cache_key);
+    assert_eq!(mode(entry_paths.session_history_sidecar_metadata()), 0o600);
+    assert!(!tmp_path.exists());
+    assert!(
+        !entry_paths
+            .tmp_session_history_sidecar_metadata(run_id)
+            .exists()
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Workspace and session-history metadata publication fails under `umask 0002` or `0000` because newly written staging files inherit group/other write permissions and are rejected by the cache's own validator. Extract `host_file::write_private_new` so both cache publishers and the existing atomic writer share exclusive file creation, `0600` permissions before content, and completed/flushed writes.

The scope is private staging construction. Cache-specific names, source validation, cleanup, image transfer, persisted formats, and the sidecar's body-before-metadata/two-slot commit retain their existing contracts.

Closes #33259

## Validation

Both publisher regressions were observed failing on their metadata staging paths under `0002` and `0000` before the fix. Child-process coverage now verifies private output permissions, workspace cache reuse, and exact sidecar bytes using valid private inputs; the existing `0022`, unsafe-input rejection, GC, and rollback cases also pass.

```sh
cargo test --locked --manifest-path crates/Cargo.toml --profile local -j 1 -p runner --bin runner workspace_image_cache::tests::
cargo test --locked --manifest-path crates/Cargo.toml --profile local -j 1 -p runner --bin runner host_file::tests::
cargo fmt --manifest-path crates/runner/Cargo.toml -- --check
cargo clippy --locked --manifest-path crates/Cargo.toml --profile local -j 1 -p runner --all-targets -- -D warnings
cargo doc --locked --manifest-path crates/Cargo.toml --profile local -j 1 -p runner --no-deps
```

All checks passed: 146 cache-related tests and 16 host-file tests. Ignored child entry points are exercised by their parent tests. Full repository CI and deployed runner/KVM E2E are not included in these local results.
