### PR TITLE
perf(api): reuse trusted clerk organization identity

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
@@ -567,9 +567,13 @@ export function createAuthOrgAgentsBddApi(context: TestContext) {
       context.mocks.clerk.organizations.revokeOrganizationInvitation.mockResolvedValue(
         {},
       );
-      context.mocks.clerk.organizations.updateOrganization.mockResolvedValue(
-        {},
-      );
+      context.mocks.clerk.organizations.updateOrganization.mockResolvedValue({
+        id: actor.orgId,
+        slug,
+        name,
+        createdBy,
+        createdAt,
+      });
       context.mocks.clerk.organizations.updateOrganizationMembership.mockResolvedValue(
         {},
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/org-cache.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-cache.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { testContext } from "../../../__tests__/test-context";
 import { now } from "../../../lib/time";
 import { flushWaitUntilForTest } from "../../context/wait-until";
-import { createDeferredPromise, settleIncludingAbort } from "../../utils";
+import { createDeferredPromise } from "../../utils";
 import {
   createAuthOrgAgentsBddApi,
   type ApiTestUser,
@@ -159,23 +159,20 @@ describe("trusted organization identity cache", () => {
         return organization(actor, "Older provider snapshot");
       },
     );
-    const reading = settleIncludingAbort(api.readOrg(actor));
+    const reading = Promise.allSettled([api.readOrg(actor)]);
     await started.promise;
     context.mocks.clerk.organizations.updateOrganization.mockResolvedValue(
       organization(actor, "Renamed workspace"),
     );
-    const updating = await settleIncludingAbort(
+    const updating = await Promise.allSettled([
       api.requestUpdateOrg(actor, { name: "Renamed workspace" }, [200]),
-    );
+    ]);
     release.resolve();
 
-    await expect(reading).resolves.toMatchObject({
-      ok: true,
-      value: { name: "Renamed workspace" },
-    });
-    if (!updating.ok) {
-      throw updating.error;
-    }
+    await expect(reading).resolves.toMatchObject([
+      { status: "fulfilled", value: { name: "Renamed workspace" } },
+    ]);
+    expect(updating).toMatchObject([{ status: "fulfilled" }]);
     await expect(api.readOrg(actor)).resolves.toMatchObject({
       name: "Renamed workspace",
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/org-cache.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-cache.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+
+import { testContext } from "../../../__tests__/test-context";
+import { now } from "../../../lib/time";
+import { flushWaitUntilForTest } from "../../context/wait-until";
+import { createDeferredPromise, settleIncludingAbort } from "../../utils";
+import {
+  createAuthOrgAgentsBddApi,
+  type ApiTestUser,
+} from "./helpers/api-bdd-auth-org";
+import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+
+const context = testContext();
+const api = createAuthOrgAgentsBddApi(context);
+const webhooks = createWebhookCallbackApi(context);
+
+function organization(actor: ApiTestUser, name: string) {
+  return {
+    id: actor.orgId,
+    name,
+    slug: null,
+    createdBy: actor.userId,
+    createdAt: now(),
+    imageUrl: "",
+    hasImage: false,
+  };
+}
+
+async function createdWebhook(data: unknown): Promise<void> {
+  webhooks.configureClerkWebhookSecret();
+  api.acceptAgentStorageWrites();
+  webhooks.verifyNextClerkWebhook({ type: "organization.created", data });
+  const response = await webhooks.requestClerkWebhook("{}", {}, [200]);
+  expect(response.body).toBe("OK");
+  await flushWaitUntilForTest();
+}
+
+async function bootstrapWithoutIdentity(): Promise<ApiTestUser> {
+  const actor = api.user();
+  api.mockClerkOrg(actor, { name: "Original workspace" });
+  // A partial creation event still bootstraps membership and tier, but cannot
+  // supply a complete organization identity. No direct database setup is used.
+  await createdWebhook({
+    id: actor.orgId,
+    created_by: actor.userId,
+    created_at: now(),
+  });
+  expect(
+    context.mocks.clerk.organizations.getOrganization,
+  ).not.toHaveBeenCalled();
+  return actor;
+}
+
+describe("trusted organization identity cache", () => {
+  it.each(["absent", "present"])(
+    "reuses the provider update response when the cache is %s",
+    async (cacheState) => {
+      const actor = await bootstrapWithoutIdentity();
+      if (cacheState === "present") {
+        await expect(api.readOrg(actor)).resolves.toMatchObject({
+          name: "Original workspace",
+        });
+      }
+
+      context.mocks.clerk.organizations.getOrganization.mockClear();
+      context.mocks.clerk.organizations.updateOrganization.mockResolvedValue(
+        organization(actor, "Provider-normalized workspace"),
+      );
+      const updated = await api.requestUpdateOrg(
+        actor,
+        { name: "Requested workspace" },
+        [200],
+      );
+
+      expect(updated.body).toStrictEqual({
+        id: actor.orgId,
+        name: "Provider-normalized workspace",
+        tier: "limited-free-1",
+      });
+      expect(
+        context.mocks.clerk.organizations.updateOrganization,
+      ).toHaveBeenCalledExactlyOnceWith(actor.orgId, {
+        name: "Requested workspace",
+      });
+      await expect(api.readOrg(actor)).resolves.toStrictEqual({
+        id: actor.orgId,
+        name: "Provider-normalized workspace",
+        createdBy: actor.userId,
+        role: "admin",
+        tier: "limited-free-1",
+      });
+      expect(
+        context.mocks.clerk.organizations.getOrganization,
+      ).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["snake", "camel"])(
+    "prefills identity from a verified %s-case creation event",
+    async (fieldCase) => {
+      const actor = api.user();
+      api.mockClerkOrg(actor, { name: "Unneeded provider read" });
+      await createdWebhook({
+        id: actor.orgId,
+        name: "Created workspace",
+        ...(fieldCase === "snake"
+          ? { created_by: actor.userId, created_at: now() }
+          : { createdBy: actor.userId, createdAt: now() }),
+      });
+
+      await expect(api.readOrg(actor)).resolves.toStrictEqual({
+        id: actor.orgId,
+        name: "Created workspace",
+        createdBy: actor.userId,
+        role: "admin",
+        tier: "limited-free-1",
+      });
+      expect(
+        context.mocks.clerk.organizations.getOrganization,
+      ).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps a profile update when a duplicate creation event arrives later", async () => {
+    const actor = api.user();
+    api.mockClerkOrg(actor);
+    const creation = {
+      id: actor.orgId,
+      name: "Created workspace",
+      created_by: actor.userId,
+      created_at: now(),
+    };
+    await createdWebhook(creation);
+    context.mocks.clerk.organizations.updateOrganization.mockResolvedValue(
+      organization(actor, "Renamed workspace"),
+    );
+    await api.requestUpdateOrg(actor, { name: "Renamed workspace" }, [200]);
+
+    await createdWebhook(creation);
+
+    await expect(api.readOrg(actor)).resolves.toMatchObject({
+      name: "Renamed workspace",
+      role: "admin",
+      tier: "limited-free-1",
+    });
+    expect(
+      context.mocks.clerk.organizations.getOrganization,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns the winning identity when an older cold read finishes after an update", async () => {
+    const actor = await bootstrapWithoutIdentity();
+    const started = createDeferredPromise<void>(context.signal);
+    const release = createDeferredPromise<void>(context.signal);
+    context.mocks.clerk.organizations.getOrganization.mockImplementationOnce(
+      async () => {
+        started.resolve();
+        await release.promise;
+        return organization(actor, "Older provider snapshot");
+      },
+    );
+    const reading = settleIncludingAbort(api.readOrg(actor));
+    await started.promise;
+    context.mocks.clerk.organizations.updateOrganization.mockResolvedValue(
+      organization(actor, "Renamed workspace"),
+    );
+    const updating = await settleIncludingAbort(
+      api.requestUpdateOrg(actor, { name: "Renamed workspace" }, [200]),
+    );
+    release.resolve();
+
+    await expect(reading).resolves.toMatchObject({
+      ok: true,
+      value: { name: "Renamed workspace" },
+    });
+    if (!updating.ok) {
+      throw updating.error;
+    }
+    await expect(api.readOrg(actor)).resolves.toMatchObject({
+      name: "Renamed workspace",
+    });
+    expect(
+      context.mocks.clerk.organizations.getOrganization,
+    ).toHaveBeenCalledOnce();
+  });
+
+  it.each([undefined, null, 42, "", "   "])(
+    "keeps bootstrap and read-through when the creation name is %s",
+    async (name) => {
+      const actor = api.user();
+      api.mockClerkOrg(actor, { name: "Read-through workspace" });
+      await createdWebhook({
+        id: actor.orgId,
+        name,
+        created_by: actor.userId,
+        created_at: now(),
+      });
+
+      await expect(api.readOrg(actor)).resolves.toMatchObject({
+        name: "Read-through workspace",
+        createdBy: actor.userId,
+        role: "admin",
+        tier: "limited-free-1",
+      });
+      expect(
+        context.mocks.clerk.organizations.getOrganization,
+      ).toHaveBeenCalledExactlyOnceWith({ organizationId: actor.orgId });
+    },
+  );
+
+  it("does not prefill identity when the creation event lacks its creator", async () => {
+    const actor = api.user();
+    api.mockClerkOrg(actor, { name: "Read-through workspace" });
+    await createdWebhook({
+      id: actor.orgId,
+      name: "Incomplete event workspace",
+      created_at: now(),
+    });
+
+    await expect(api.readOrg(actor)).resolves.toMatchObject({
+      name: "Read-through workspace",
+      createdBy: actor.userId,
+    });
+    expect(
+      context.mocks.clerk.organizations.getOrganization,
+    ).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an invalid signature without caching the request's identity", async () => {
+    const actor = api.user();
+    api.mockClerkOrg(actor, { name: "Verified provider workspace" });
+    webhooks.configureClerkWebhookSecret();
+    webhooks.rejectNextClerkWebhookVerification();
+    const response = await webhooks.requestClerkWebhook(
+      JSON.stringify({
+        type: "organization.created",
+        data: {
+          id: actor.orgId,
+          name: "Unverified workspace",
+          created_by: actor.userId,
+          created_at: now(),
+        },
+      }),
+      { "svix-signature": "v1,invalid" },
+      [401],
+    );
+
+    expect(response.body).toStrictEqual({ error: "Invalid webhook signature" });
+    await expect(api.readOrg(actor)).resolves.toMatchObject({
+      name: "Verified provider workspace",
+    });
+    expect(
+      context.mocks.clerk.organizations.getOrganization,
+    ).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the cached identity when Clerk rejects a profile update", async () => {
+    const actor = await bootstrapWithoutIdentity();
+    await api.readOrg(actor);
+    context.mocks.clerk.organizations.getOrganization.mockClear();
+    context.mocks.clerk.organizations.updateOrganization.mockRejectedValue(
+      new Error("Provider update failed"),
+    );
+
+    await api.requestUpdateOrg(actor, { name: "Rejected workspace" }, [500]);
+
+    await expect(api.readOrg(actor)).resolves.toMatchObject({
+      name: "Original workspace",
+    });
+    expect(
+      context.mocks.clerk.organizations.getOrganization,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
@@ -1,9 +1,11 @@
 import { webhookClerkContract } from "@okouai/api-contracts/contracts/webhooks";
+import { orgCache } from "@okouai/db/schema/org-cache";
 import { command } from "ccstate";
 
 import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { isLockNotAvailable } from "../../lib/pg-errors";
+import { nowDate } from "../../lib/time";
 import { request$ } from "../context/hono";
 import { type ClerkWebhookEvent, verifyClerkWebhook } from "../external/clerk";
 import { waitUntil } from "../context/wait-until";
@@ -335,6 +337,50 @@ const handleOrganizationDeletedWebhook$ = command(
   },
 );
 
+const handleOrganizationCreatedWebhook$ = command(
+  async ({ set }, data: unknown, signal: AbortSignal): Promise<Response> => {
+    const identity = organizationCreatedIdentity(data);
+    if (!identity) {
+      L.error(
+        "organization.created event missing org/creator user ID or creation time",
+        { data },
+      );
+      return new Response("OK", { status: 200 });
+    }
+
+    enqueueOrgBootstrap({
+      eventType: "organization.created",
+      orgId: identity.orgId,
+      userId: identity.userId,
+      task: set(
+        ensureOrgLimitedFreeBootstrap$,
+        {
+          orgId: identity.orgId,
+          ownerUserId: identity.userId,
+          morningBriefEligibilitySourceCreatedAt: identity.createdAt,
+        },
+        signal,
+      ),
+    });
+
+    const name = stringPropertyOf(data, "name");
+    if (name?.trim()) {
+      await set(writeDb$)
+        .insert(orgCache)
+        .values({
+          orgId: identity.orgId,
+          name,
+          createdBy: identity.userId,
+          cachedAt: nowDate(),
+        })
+        // A duplicate or delayed creation event must not undo a rename.
+        .onConflictDoNothing({ target: orgCache.orgId });
+      signal.throwIfAborted();
+    }
+    return new Response("OK", { status: 200 });
+  },
+);
+
 const postClerkWebhook$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<Response> => {
     const event = await verifiedClerkWebhook(get(request$).raw);
@@ -345,30 +391,7 @@ const postClerkWebhook$ = command(
     L.debug("clerk webhook received", { type: event.type });
 
     if (event.type === "organization.created") {
-      const identity = organizationCreatedIdentity(event.data);
-      if (!identity) {
-        L.error(
-          "organization.created event missing org/creator user ID or creation time",
-          { data: event.data },
-        );
-        return new Response("OK", { status: 200 });
-      }
-
-      enqueueOrgBootstrap({
-        eventType: "organization.created",
-        orgId: identity.orgId,
-        userId: identity.userId,
-        task: set(
-          ensureOrgLimitedFreeBootstrap$,
-          {
-            orgId: identity.orgId,
-            ownerUserId: identity.userId,
-            morningBriefEligibilitySourceCreatedAt: identity.createdAt,
-          },
-          signal,
-        ),
-      });
-      return new Response("OK", { status: 200 });
+      return await set(handleOrganizationCreatedWebhook$, event.data, signal);
     }
 
     if (event.type === "organizationInvitation.accepted") {

--- a/turbo/apps/api/src/signals/services/org-data.service.ts
+++ b/turbo/apps/api/src/signals/services/org-data.service.ts
@@ -269,7 +269,7 @@ export const orgDetail$ = command(
 
       const now = nowDate();
       const writeDb = set(writeDb$);
-      await writeDb
+      const [savedIdentity] = await writeDb
         .insert(orgCache)
         .values({
           orgId: args.orgId,
@@ -277,15 +277,23 @@ export const orgDetail$ = command(
           createdBy: identity.createdBy,
           cachedAt: now,
         })
+        // Preserve a profile update or fill that won during the Clerk read.
+        // A no-op update returns that identity atomically without refreshing
+        // its timestamp or copying fields from this potentially older snapshot.
         .onConflictDoUpdate({
           target: orgCache.orgId,
-          set: {
-            name: identity.name,
-            createdBy: identity.createdBy,
-            cachedAt: now,
-          },
+          set: { name: orgCache.name },
+        })
+        .returning({
+          name: orgCache.name,
+          createdBy: orgCache.createdBy,
         });
       signal.throwIfAborted();
+
+      if (!savedIdentity) {
+        throw new Error("Organization identity cache upsert returned no row");
+      }
+      identity = savedIdentity;
     }
 
     const cachedRole = membership[0]?.role;
@@ -502,13 +510,21 @@ export const updateOrg$ = command(
     }
 
     const client = get(clerk$);
-    await client.organizations.updateOrganization(args.orgId, {
+    const clerkOrg = await client.organizations.updateOrganization(args.orgId, {
       name: args.name,
     });
     signal.throwIfAborted();
 
     const writeDb = set(writeDb$);
-    await writeDb.delete(orgCache).where(eq(orgCache.orgId, args.orgId));
+    const identity = {
+      name: clerkOrg.name,
+      createdBy: clerkOrg.createdBy ?? null,
+      cachedAt: nowDate(),
+    };
+    await writeDb
+      .insert(orgCache)
+      .values({ orgId: args.orgId, ...identity })
+      .onConflictDoUpdate({ target: orgCache.orgId, set: identity });
     signal.throwIfAborted();
 
     const org = await set(


### PR DESCRIPTION
## Summary

Organization profile updates now cache the identity returned by Clerk, avoiding the subsequent organization-read request and the cache invalidation window. Signature-verified organization creation events prefill complete identity without adding a provider read.

Creation events cannot overwrite existing identity. Cold reads preserve and atomically return a concurrently written identity using a no-op conflict update, so a delayed provider response cannot undo a completed rename. Existing bootstrap, role/tier handling and endpoint responses are preserved.

Closes #33282

## Compatibility and limits

Backend-only change with no database migration, frontend change, or authorization/response-contract change. This reduces redundant Clerk reads; an uncached first read can still be rate-limited, and webhook delivery to the historical CI preview is unverified. Separate concurrent profile mutations and draining old API writers retain their existing behavior. Database persistence failures propagate; this PR does not add a provider/database transaction.

## Fallbacks

`updateOrg$` stores Clerk's optional `createdBy` as `null` in the existing nullable cache column, preserving the established identity representation. This is optional provider data under `docs/fallback.md` section 6, with no version-dependent path or rollout removal gate. No fabricated creator or request-supplied identity is used.

## Validation

- `pnpm -F api lint` — passed.
- `TSC_CHECKERS=2 pnpm -F api check-types` — passed, including API type boundaries and tests.
- `pnpm -F api exec vitest run src/signals/routes/__tests__/org-cache.test.ts src/signals/routes/__tests__/org-team.bdd.test.ts src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts --maxWorkers=1 --silent=passed-only` — all 98 tests passed against real PostgreSQL configured for UTC. Includes 14 new cases for warm/cold mutation, normalized provider identity, verified creation, duplicate delivery, deferred cold reads, invalid signatures, incomplete events and mutation failure.
- `pnpm exec knip --workspace apps/api` — passed.
- Formatting and `git diff --check` — passed.

Tests mock Clerk at the existing external boundary; live Clerk behavior and database fault injection were not exercised. Full-suite validation is delegated to the PR pipeline as requested.
