### PR TITLE
fix(api): keep sandbox telemetry batches alive and name oom upload failures

### DIFF
--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -33,6 +33,40 @@ const FLUSH_THRESHOLD: Duration = Duration::from_secs(30);
 const TELEMETRY_TIMEOUT: Duration = Duration::from_secs(10);
 const RUNNER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Why one bounded OOM evidence upload was not acknowledged.
+///
+/// Only fixed stage names and an HTTP status are reported. Evidence payloads
+/// and response bodies stay out of the log.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OomEvidenceUploadFailure {
+    Timeout,
+    Transport,
+    HttpStatus(u16),
+    BodyOversize,
+    InvalidBody,
+    MissingAck,
+}
+
+impl OomEvidenceUploadFailure {
+    fn reason(self) -> &'static str {
+        match self {
+            Self::Timeout => "timeout",
+            Self::Transport => "transport",
+            Self::HttpStatus(_) => "http_status",
+            Self::BodyOversize => "body_oversize",
+            Self::InvalidBody => "invalid_body",
+            Self::MissingAck => "missing_ack",
+        }
+    }
+
+    fn http_status(self) -> Option<u16> {
+        match self {
+            Self::HttpStatus(status) => Some(status),
+            _ => None,
+        }
+    }
+}
+
 /// Effective resource path once the guest process has spawned.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -412,7 +446,7 @@ impl JobTelemetry {
             "oomEvidence": evidence,
         });
         let send = async {
-            let mut response = self
+            let mut response = match self
                 .http
                 .request_route(
                     routes::webhooks::agent::telemetry::SEND,
@@ -422,26 +456,48 @@ impl JobTelemetry {
                 .json(&payload)
                 .send("oom-evidence")
                 .await
-                .ok()?;
-            if !response.status().is_success() {
-                return None;
+            {
+                Ok(response) => response,
+                Err(_) => return Err(OomEvidenceUploadFailure::Transport),
+            };
+            let status = response.status();
+            if !status.is_success() {
+                return Err(OomEvidenceUploadFailure::HttpStatus(status.as_u16()));
             }
             let mut bytes = Vec::new();
-            while let Some(chunk) = response.chunk().await.ok()? {
-                if bytes.len() + chunk.len() > 1024 {
-                    return None;
+            loop {
+                match response.chunk().await {
+                    Ok(Some(chunk)) => {
+                        if bytes.len() + chunk.len() > 1024 {
+                            return Err(OomEvidenceUploadFailure::BodyOversize);
+                        }
+                        bytes.extend_from_slice(&chunk);
+                    }
+                    Ok(None) => break,
+                    Err(_) => return Err(OomEvidenceUploadFailure::Transport),
                 }
-                bytes.extend_from_slice(&chunk);
             }
-            let body: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
-            (body.get("oomEvidenceVersion")?.as_u64() == Some(1)).then_some(())
+            let Ok(body) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+                return Err(OomEvidenceUploadFailure::InvalidBody);
+            };
+            if body.get("oomEvidenceVersion").and_then(serde_json::Value::as_u64) != Some(1) {
+                return Err(OomEvidenceUploadFailure::MissingAck);
+            }
+            Ok(())
         };
-        if !matches!(
-            tokio::time::timeout(Duration::from_secs(2), send).await,
-            Ok(Some(()))
-        ) {
-            warn!(run_id = %self.run_id, "guest oom evidence upload unacknowledged; host evidence retained");
-        }
+        // Report which delivery stage failed. A bare warning cannot distinguish
+        // a rejected payload from an unconfigured receiver or a slow response.
+        let failure = match tokio::time::timeout(Duration::from_secs(2), send).await {
+            Ok(Ok(())) => return,
+            Ok(Err(failure)) => failure,
+            Err(_) => OomEvidenceUploadFailure::Timeout,
+        };
+        warn!(
+            run_id = %self.run_id,
+            reason = failure.reason(),
+            http_status = failure.http_status(),
+            "guest oom evidence upload unacknowledged; host evidence retained"
+        );
     }
 
     fn record_inner(

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -11,7 +11,7 @@ use tokio::task::JoinHandle;
 use tracing::warn;
 
 use crate::duration::duration_ms;
-use crate::error::RunnerError;
+use crate::error::{ApiFailureKind, RunnerError};
 use crate::http::HttpClient;
 use crate::ids::RunId;
 use crate::resource_budget::ResourceBudget;
@@ -48,6 +48,29 @@ enum OomEvidenceUploadFailure {
 }
 
 impl OomEvidenceUploadFailure {
+    fn from_request_error(error: &RunnerError) -> Self {
+        match error {
+            RunnerError::ApiTransport(error) => Self::from_api_failure_kind(error.failure_kind),
+            _ => Self::Transport,
+        }
+    }
+
+    fn from_api_failure_kind(failure_kind: ApiFailureKind) -> Self {
+        if failure_kind == ApiFailureKind::Timeout {
+            Self::Timeout
+        } else {
+            Self::Transport
+        }
+    }
+
+    fn from_response_body_error(error: &reqwest::Error) -> Self {
+        if error.is_timeout() {
+            Self::Timeout
+        } else {
+            Self::Transport
+        }
+    }
+
     fn reason(self) -> &'static str {
         match self {
             Self::Timeout => "timeout",
@@ -458,7 +481,7 @@ impl JobTelemetry {
                 .await
             {
                 Ok(response) => response,
-                Err(_) => return Err(OomEvidenceUploadFailure::Transport),
+                Err(error) => return Err(OomEvidenceUploadFailure::from_request_error(&error)),
             };
             let status = response.status();
             if !status.is_success() {
@@ -474,13 +497,19 @@ impl JobTelemetry {
                         bytes.extend_from_slice(&chunk);
                     }
                     Ok(None) => break,
-                    Err(_) => return Err(OomEvidenceUploadFailure::Transport),
+                    Err(error) => {
+                        return Err(OomEvidenceUploadFailure::from_response_body_error(&error));
+                    }
                 }
             }
             let Ok(body) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
                 return Err(OomEvidenceUploadFailure::InvalidBody);
             };
-            if body.get("oomEvidenceVersion").and_then(serde_json::Value::as_u64) != Some(1) {
+            if body
+                .get("oomEvidenceVersion")
+                .and_then(serde_json::Value::as_u64)
+                != Some(1)
+            {
                 return Err(OomEvidenceUploadFailure::MissingAck);
             }
             Ok(())
@@ -901,6 +930,25 @@ mod tests {
             encoded_size: 16 * 1024,
             download_source: Some(ResumeSessionHistoryDownloadSource::ConfiguredPublicEndpoint),
         })
+    }
+
+    fn oom_evidence_for_test() -> guest_contracts::oom_evidence::OomEvidence {
+        serde_json::from_str(include_str!(
+            "../../guest-contracts/tests/fixtures/oom-evidence-v1.json"
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn oom_evidence_upload_failure_keeps_timeout_distinct_from_transport() {
+        assert_eq!(
+            OomEvidenceUploadFailure::from_api_failure_kind(crate::error::ApiFailureKind::Timeout,),
+            OomEvidenceUploadFailure::Timeout
+        );
+        assert_eq!(
+            OomEvidenceUploadFailure::from_api_failure_kind(crate::error::ApiFailureKind::Request,),
+            OomEvidenceUploadFailure::Transport
+        );
     }
 
     #[test]
@@ -1448,6 +1496,50 @@ mod tests {
         assert!(request.contains(r#""action_type":"storage_cache_background_fill_filled""#));
         assert!(request.contains(r#""duration_ms":42"#));
         assert!(request.contains(r#""success":true"#));
+    }
+
+    #[tokio::test]
+    async fn oom_evidence_upload_logs_http_status_without_sensitive_data() {
+        const RESPONSE_BODY_SECRET: &str = "oom-evidence-response-secret";
+        const SANDBOX_ID: &str = "oom-evidence-sandbox-secret";
+        let server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(json_response(
+            "400 Bad Request",
+            r#"{"error":"oom-evidence-response-secret"}"#,
+        ))])
+        .await;
+        let evidence = oom_evidence_for_test();
+        let telemetry = JobTelemetry::new(
+            http_client_for_api_url(&server.url()),
+            RunId::nil(),
+            "oom-evidence-token-secret".to_string(),
+            None,
+        );
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+
+        telemetry
+            .upload_oom_evidence(&evidence, SANDBOX_ID)
+            .with_subscriber(subscriber)
+            .await;
+        server.assert_finished().await;
+
+        let event = captured
+            .entries()
+            .into_iter()
+            .find(|event| {
+                event.fields.get("message").is_some_and(|message| {
+                    message == "guest oom evidence upload unacknowledged; host evidence retained"
+                })
+            })
+            .expect("oom evidence upload failure should be logged");
+        assert_eq!(event.level, Level::WARN);
+        assert_eq!(event.fields["reason"], "http_status");
+        assert_eq!(event.fields["http_status"], "Some(400)");
+        let event_debug = format!("{event:#?}");
+        assert!(!event_debug.contains(RESPONSE_BODY_SECRET));
+        assert!(!event_debug.contains(SANDBOX_ID));
+        assert!(!event_debug.contains("oom-evidence-token-secret"));
+        assert!(!event_debug.contains(&evidence.operation_id));
     }
 
     #[tokio::test]

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -1534,7 +1534,7 @@ mod tests {
             .expect("oom evidence upload failure should be logged");
         assert_eq!(event.level, Level::WARN);
         assert_eq!(event.fields["reason"], "http_status");
-        assert_eq!(event.fields["http_status"], "Some(400)");
+        assert_eq!(event.fields["http_status"], "400");
         let event_debug = format!("{event:#?}");
         assert!(!event_debug.contains(RESPONSE_BODY_SECRET));
         assert!(!event_debug.contains(SANDBOX_ID));

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -2496,10 +2496,12 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
     ingested.clear();
     context.mocks.axiom.sdkIngest.mockClear();
     const malformed = structuredClone(body);
-    for (const metric of malformed.metrics) {
-      for (const group of metric.memory.groups) {
-        group.cgroup = group.cgroup.slice(1);
-      }
+    const malformedMemory = malformed.metrics[0]?.memory;
+    if (!malformedMemory) {
+      throw new Error("Expected first periodic memory snapshot");
+    }
+    for (const group of malformedMemory.groups) {
+      group.cgroup = group.cgroup.slice(1);
     }
     const degraded = await api.requestAgentTelemetry(malformed, headers, [200]);
 
@@ -2507,7 +2509,7 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
     // logs, metrics, and sandbox operations batched in the same request.
     expect(degraded.body).toStrictEqual({ success: true, id: runId });
     expect(ingested.get("sandbox-telemetry-metrics")).toStrictEqual(
-      metrics.map((metric) => {
+      metrics.map((metric, index) => {
         return {
           _time: metric.ts,
           runId,
@@ -2517,6 +2519,7 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
           mem_total: metric.mem_total,
           disk_used: metric.disk_used,
           disk_total: metric.disk_total,
+          ...(index === 0 ? {} : { memory: metric.memory }),
         };
       }),
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -2442,10 +2442,17 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
         memory,
       };
     });
+    const networkLogs = [
+      {
+        timestamp: nowDate().toISOString(),
+        host: "telemetry-batch.example.test",
+      },
+    ];
     const body = {
       runId,
       systemLog: "synthetic system event",
       metrics,
+      networkLogs,
       sandboxOperations: [
         {
           ts: nowDate().toISOString(),
@@ -2470,6 +2477,11 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
         log: body.systemLog,
       }),
     ]);
+    expect(ingested.get("sandbox-telemetry-network")).toStrictEqual(
+      networkLogs.map(({ timestamp, ...networkLog }) => {
+        return { _time: timestamp, runId, userId: actor.userId, ...networkLog };
+      }),
+    );
     await flushWaitUntilForTest();
     expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
       "vm0-sandbox-op-log-dev",
@@ -2511,8 +2523,22 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
     expect(ingested.get("sandbox-telemetry-system")).toStrictEqual([
       expect.objectContaining({ runId, log: body.systemLog }),
     ]);
+    expect(ingested.get("sandbox-telemetry-network")).toStrictEqual(
+      networkLogs.map(({ timestamp, ...networkLog }) => {
+        return { _time: timestamp, runId, userId: actor.userId, ...networkLog };
+      }),
+    );
     await flushWaitUntilForTest();
-    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalled();
+    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
+      "vm0-sandbox-op-log-dev",
+      [
+        expect.objectContaining({
+          run_id: runId,
+          op_type: "cli",
+          success: true,
+        }),
+      ],
+    );
   });
 
   it("keeps dedicated OOM evidence strict so an unusable payload is never acknowledged", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -2409,7 +2409,7 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
     },
   );
 
-  it("ingests collector memory in ordinary mixed telemetry and rejects relative paths before any ingestion", async () => {
+  it("ingests collector memory in ordinary mixed telemetry and degrades an unusable snapshot without dropping the batch", async () => {
     const { actor, runId, headers } = await createEventWebhookRun(
       `collector mixed telemetry ${randomUUID()}`,
     );
@@ -2489,9 +2489,65 @@ describe("WHCB-05: sandbox agent webhook boundaries", () => {
         group.cgroup = group.cgroup.slice(1);
       }
     }
-    await api.requestAgentTelemetryUnchecked(malformed, headers, [400]);
-    expect(ingested.size).toBe(0);
-    expect(context.mocks.axiom.sdkIngest).not.toHaveBeenCalled();
+    const degraded = await api.requestAgentTelemetry(malformed, headers, [200]);
+
+    // An unusable periodic snapshot drops itself, never the unrelated system
+    // logs, metrics, and sandbox operations batched in the same request.
+    expect(degraded.body).toStrictEqual({ success: true, id: runId });
+    expect(ingested.get("sandbox-telemetry-metrics")).toStrictEqual(
+      metrics.map((metric) => {
+        return {
+          _time: metric.ts,
+          runId,
+          userId: actor.userId,
+          cpu: metric.cpu,
+          mem_used: metric.mem_used,
+          mem_total: metric.mem_total,
+          disk_used: metric.disk_used,
+          disk_total: metric.disk_total,
+        };
+      }),
+    );
+    expect(ingested.get("sandbox-telemetry-system")).toStrictEqual([
+      expect.objectContaining({ runId, log: body.systemLog }),
+    ]);
+    await flushWaitUntilForTest();
+    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalled();
+  });
+
+  it("keeps dedicated OOM evidence strict so an unusable payload is never acknowledged", async () => {
+    const { runId, headers } = await createEventWebhookRun(
+      `collector strict evidence ${randomUUID()}`,
+    );
+    const ingested: unknown[] = [];
+    mockOptionalEnv("AXIOM_TOKEN_TELEMETRY", `xaat-strict-${randomUUID()}`);
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/:dataset/ingest",
+        async ({ request }) => {
+          const events: unknown = await request.json();
+          ingested.push(events);
+          const count = Array.isArray(events) ? events.length : 0;
+          return HttpResponse.json(successfulAxiomIngestStatus(count));
+        },
+      ),
+    );
+    const relativePaths = collectorEvidence("sample");
+    for (const group of relativePaths.groups) {
+      group.cgroup = group.cgroup.slice(1);
+    }
+
+    await api.requestAgentTelemetryUnchecked(
+      {
+        runId,
+        systemLog: "batched with unusable evidence",
+        oomEvidence: relativePaths,
+      },
+      headers,
+      [400],
+    );
+
+    expect(ingested).toHaveLength(0);
   });
 
   it("projects only present control-path metric fields", async () => {

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -876,7 +876,11 @@ export const webhookHeartbeatContract = c.router({
  * Metric data point schema
  */
 const metricDataSchema = z.object({
-  memory: oomEvidenceSchema.optional(),
+  // A periodic memory snapshot rides along with ordinary metrics. Rejecting it
+  // must never discard the system logs, metrics, network logs, and sandbox
+  // operations batched in the same request; the dedicated `oomEvidence` field
+  // below stays strict because it decides the delivery acknowledgement.
+  memory: oomEvidenceSchema.optional().catch(undefined),
   ts: z.string(),
   cpu: z.number(),
   cpu_steal_percent: z.number().optional(),


### PR DESCRIPTION
Refs #32963

Supersedes #33163, which GitHub cannot reopen after the branch recreation required for the authorized rebase.

## Problem

`metricDataSchema.memory` reused the strict `oomEvidenceSchema` used for dedicated top-level `oomEvidence`. An unusable ordinary memory snapshot could therefore reject an entire telemetry request and discard valid batched system logs, metrics, network logs, and sandbox operations.

The Runner warning for an unacknowledged guest OOM-evidence upload previously lacked a delivery stage, making rejected payloads, unavailable receivers, truncated bodies, and slow responses indistinguishable.

## Change

- Degrade only ordinary `metricDataSchema.memory`: an unusable snapshot drops itself while valid sibling telemetry is ingested.
- Keep dedicated top-level `oomEvidence` strict: invalid evidence is rejected, not ingested, and never acknowledged.
- Add fixed Runner delivery-failure reasons (`timeout`, `transport`, `http_status`, `body_oversize`, `invalid_body`, `missing_ack`) and the actual HTTP status for rejected requests.

## Scope limits

- Preserve warn-level logging for real delivery failures.
- Do not change upload timing, retry behavior, timeout budgets, sampling, or the acknowledgement contract.
- Do not log raw evidence payloads or response bodies.

## Verification

- The mixed-telemetry contract keeps valid system logs, remaining metrics, and sandbox operations when an ordinary memory snapshot is unusable.
- Negative controls retain strict dedicated-`oomEvidence` rejection: invalid evidence yields a failure response, no ingestion, and no acknowledgement.
- Rebased onto current `main`, including #33240; current-head review, targeted validation, and required CI will be recorded here.