### PR TITLE
feat(artifacts): share presigned thumbnails across composer and chat

### DIFF
--- a/turbo/apps/platform/src/lib/platform-host.ts
+++ b/turbo/apps/platform/src/lib/platform-host.ts
@@ -157,6 +157,14 @@ export function resolvePublicArtifactsBaseUrl():
   return resolvePlatformRuntimeConfig().publicArtifactsBaseUrl;
 }
 
+export function resolveArtifactImageTransformOrigin():
+  | "https://a.okou.io"
+  | "https://cdn.vm7.io" {
+  return resolvePlatformEnvironment() === "production"
+    ? "https://a.okou.io"
+    : "https://cdn.vm7.io";
+}
+
 export function resolveOfficeDocumentViewerBaseUrl(): string {
   return OFFICE_DOCUMENT_VIEWER_BASE_URL;
 }

--- a/turbo/apps/platform/src/signals/attachment-resource-url.ts
+++ b/turbo/apps/platform/src/signals/attachment-resource-url.ts
@@ -1,4 +1,6 @@
 import { computed, type Computed } from "ccstate";
+import { r2ImageTransformUrl } from "@okouai/core/r2-image-transform";
+import { resolvePublicArtifactsBaseUrl } from "../lib/platform-host.ts";
 import { publicAttachmentUrl } from "../views/okou-page/attachment-url.ts";
 import {
   artifactReferencesContract,
@@ -144,12 +146,27 @@ export function createAttachmentPreviewSignals(inputUrl: string) {
     const presigned = await get(presignedToken$);
     return presigned === null ? url : presigned.publicUrl;
   });
+  const thumbnailUrl$ = computed(async (get) => {
+    const presigned = await get(presignedToken$);
+    const source =
+      presigned === null ? url : (presigned.publicUrl ?? presigned.token);
+    return r2ImageTransformUrl(
+      source,
+      { width: 800, height: 720 },
+      resolvePublicArtifactsBaseUrl(),
+    );
+  });
   return {
     presignedToken$,
     resourceUrl$,
     shareUrl$,
+    thumbnailUrl$,
   };
 }
+
+export type AttachmentPreviewSignals = ReturnType<
+  typeof createAttachmentPreviewSignals
+>;
 
 export function createAttachmentResourceUrl$(url: string) {
   return createAttachmentPreviewSignals(url).resourceUrl$;

--- a/turbo/apps/platform/src/signals/attachment-resource-url.ts
+++ b/turbo/apps/platform/src/signals/attachment-resource-url.ts
@@ -1,6 +1,6 @@
 import { computed, type Computed } from "ccstate";
 import { r2ImageTransformUrl } from "@okouai/core/r2-image-transform";
-import { resolvePublicArtifactsBaseUrl } from "../lib/platform-host.ts";
+import { resolveArtifactImageTransformOrigin } from "../lib/platform-host.ts";
 import { publicAttachmentUrl } from "../views/okou-page/attachment-url.ts";
 import {
   artifactReferencesContract,
@@ -153,7 +153,7 @@ export function createAttachmentPreviewSignals(inputUrl: string) {
     return r2ImageTransformUrl(
       source,
       { width: 800, height: 720 },
-      resolvePublicArtifactsBaseUrl(),
+      resolveArtifactImageTransformOrigin(),
     );
   });
   return {

--- a/turbo/apps/platform/src/signals/attachment-resource-url.ts
+++ b/turbo/apps/platform/src/signals/attachment-resource-url.ts
@@ -136,9 +136,16 @@ function createAttachmentPresignedToken$(
  * API URL for a temporary token after the API has checked ownership. Public
  * addresses need no token and pass through unchanged.
  */
-export function createAttachmentPreviewSignals(inputUrl: string) {
+export function createAttachmentPreviewSignals(
+  inputUrl: string,
+  resolvedToken?: AttachmentPresignedToken,
+) {
   const url = publicAttachmentUrl(inputUrl);
-  const presignedToken$ = createAttachmentPresignedToken$(url);
+  const presignedToken$ = resolvedToken
+    ? computed(() => {
+        return Promise.resolve(resolvedToken);
+      })
+    : createAttachmentPresignedToken$(url);
   const resourceUrl$ = computed(async (get) => {
     return (await get(presignedToken$))?.token ?? url;
   });

--- a/turbo/apps/platform/src/signals/attachment-resource-url.ts
+++ b/turbo/apps/platform/src/signals/attachment-resource-url.ts
@@ -147,11 +147,8 @@ export function createAttachmentPreviewSignals(inputUrl: string) {
     return presigned === null ? url : presigned.publicUrl;
   });
   const thumbnailUrl$ = computed(async (get) => {
-    const presigned = await get(presignedToken$);
-    const source =
-      presigned === null ? url : (presigned.publicUrl ?? presigned.token);
     return r2ImageTransformUrl(
-      source,
+      await get(resourceUrl$),
       { width: 800, height: 720 },
       resolveArtifactImageTransformOrigin(),
     );

--- a/turbo/apps/platform/src/signals/chat-page/artifact-card-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-card-signals.ts
@@ -7,7 +7,11 @@ import {
   createTextPreviewComputed,
   isTextPreviewKind,
 } from "../text-preview.ts";
-import { createAttachmentResourceUrl$ } from "../attachment-resource-url.ts";
+import {
+  createAttachmentResourceUrl$,
+  createAttachmentPreviewSignals,
+  type AttachmentPreviewSignals,
+} from "../attachment-resource-url.ts";
 import {
   createImageLoadSignals,
   type ImageLoadSignals,
@@ -31,11 +35,11 @@ export interface ArtifactDescriptor {
   readonly kind: ArtifactKind;
 }
 
-export interface ArtifactSignals extends ArtifactDescriptor {
+export interface ArtifactSignals
+  extends ArtifactDescriptor, AttachmentPreviewSignals {
   /** Load state of the card's presented image (the image itself, or a poster). */
   readonly previewImageLoad: ImageLoadSignals;
   readonly previewImageUrl$: Computed<Promise<string | undefined>>;
-  readonly resourceUrl$: Computed<Promise<string>>;
   readonly text$?: Computed<Promise<string>>;
 }
 
@@ -48,7 +52,7 @@ function createArtifactSignals(
   descriptor: ArtifactDescriptor,
   previewImageUrlsByUrl$: Computed<Promise<ReadonlyMap<string, string>>>,
 ): ArtifactSignals {
-  const resourceUrl$ = createAttachmentResourceUrl$(descriptor.url);
+  const preview = createAttachmentPreviewSignals(descriptor.url);
   const previewImageLoad = createImageLoadSignals();
   const previewImageUrl$ = computed(async (get) => {
     if (descriptor.kind !== "html" && descriptor.kind !== "video") {
@@ -62,9 +66,14 @@ function createArtifactSignals(
     ...descriptor,
     previewImageLoad,
     previewImageUrl$,
-    resourceUrl$,
+    ...preview,
     ...(isTextPreviewKind(descriptor.kind)
-      ? { text$: createTextPreviewComputed(descriptor.url, resourceUrl$) }
+      ? {
+          text$: createTextPreviewComputed(
+            descriptor.url,
+            preview.resourceUrl$,
+          ),
+        }
       : {}),
   };
 }

--- a/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
@@ -10,7 +10,10 @@ import type {
   UserMessageDocument,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import type { ChatClipboardPayload } from "../okou-page/clipboard.ts";
-import type { ChatEventGroup } from "./chat-event.ts";
+import type {
+  ChatEventGroup,
+  UserMessageRenderDocument,
+} from "./chat-event.ts";
 import type { ChatEvent } from "./chat-event-types.ts";
 import type { ThreadMeta } from "./chat-thread-event-sourcing.ts";
 import type { HeaderAutomationSignals } from "./header-automation-menu.ts";
@@ -50,6 +53,7 @@ export interface EventImageGroupProjection {
   readonly role: ChatEventGroup["role"];
   readonly events: readonly {
     readonly userMessage?: UserMessageDocument;
+    readonly userMessageRenderDocument?: UserMessageRenderDocument;
     readonly tree?: Root;
   }[];
 }

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1095,6 +1095,7 @@ function createRenderedChatGroups(
               userMessage: isInputChatEvent(event)
                 ? event.userMessage
                 : undefined,
+              userMessageRenderDocument: event.userMessageRenderDocument,
               tree: event.tree,
             };
           }),

--- a/turbo/apps/platform/src/signals/chat-page/thread-sidebar-coordinator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-sidebar-coordinator.ts
@@ -175,7 +175,7 @@ const materializeArtifactRef$ = command(
       return withTextPreview(
         {
           url: input.url,
-          ...createAttachmentPreviewSignals(input.url),
+          ...(input.preview ?? createAttachmentPreviewSignals(input.url)),
           kind: classifyChatAttachment({
             contentType: input.contentType,
             filename: input.filename,

--- a/turbo/apps/platform/src/signals/chat-page/thread-sidebar.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-sidebar.ts
@@ -1,4 +1,7 @@
-import { createAttachmentPreviewSignals } from "../attachment-resource-url.ts";
+import {
+  createAttachmentPreviewSignals,
+  type AttachmentPreviewSignals,
+} from "../attachment-resource-url.ts";
 import {
   command,
   computed,
@@ -86,6 +89,7 @@ export type ArtifactMetadataRef = {
   readonly contentType?: string;
   readonly shareAvailable?: boolean;
   readonly text$?: TextPreviewComputed;
+  readonly preview?: AttachmentPreviewSignals;
 };
 
 export type ArtifactRefInput = string | ArtifactFileRef | ArtifactMetadataRef;

--- a/turbo/apps/platform/src/signals/okou-page/attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/okou-page/attachment-chips.ts
@@ -1,4 +1,7 @@
-import { createAttachmentPreviewSignals } from "../attachment-resource-url.ts";
+import {
+  createAttachmentPreviewSignals,
+  type AttachmentPreviewSignals,
+} from "../attachment-resource-url.ts";
 import { command, computed, state } from "ccstate";
 import { openArtifactInOpenSidebar$ } from "../chat-page/thread-sidebar-coordinator.ts";
 import {
@@ -76,6 +79,8 @@ type AttachmentDocumentLightboxInput =
 
 type AttachmentImageLightboxInput = {
   readonly url: string;
+  /** Reuse the initiating thread image's already resolved credential. */
+  readonly preview?: AttachmentPreviewSignals;
   readonly file?: File;
   /**
    * Present only for an image the viewer is allowed to mark up — a composer
@@ -239,6 +244,7 @@ type AttachmentSidebarPreviewInput = {
   readonly shareAvailable?: boolean;
   readonly splitViewAvailable?: boolean;
   readonly text$?: TextPreviewComputed;
+  readonly preview?: AttachmentPreviewSignals;
 };
 
 export function attachmentSidebarRef(
@@ -262,6 +268,7 @@ export function attachmentSidebarRef(
       // The caller's preview content rides along, so the sidebar reuses the
       // already-fetched text instead of fetching its own copy.
       ...(value.text$ ? { text$: value.text$ } : {}),
+      ...(value.preview ? { preview: value.preview } : {}),
       ...share,
     };
   }
@@ -318,7 +325,8 @@ export const openImageLightbox$ = command(
     set(internalLightboxDialogFullscreen$, false);
     set(internalLightboxState$, {
       ...imageLightboxState(resource ? { ...input, url: resource.url } : input),
-      ...createAttachmentPreviewSignals(resource?.url ?? input.url),
+      ...(input.preview ??
+        createAttachmentPreviewSignals(resource?.url ?? input.url)),
     });
   },
 );
@@ -335,6 +343,7 @@ export const navigateImageLightbox$ = command(
       url: string;
       filename?: string;
       threadId?: string;
+      preview?: AttachmentPreviewSignals;
       artifact?: AttachmentArtifactMetadata;
       shareAvailable?: boolean;
       showSizeInSubtitle?: boolean;
@@ -346,7 +355,7 @@ export const navigateImageLightbox$ = command(
     set(internalLightboxState$, {
       kind: "image",
       ...value,
-      ...createAttachmentPreviewSignals(value.url),
+      ...(value.preview ?? createAttachmentPreviewSignals(value.url)),
     });
   },
 );

--- a/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
@@ -37,8 +37,9 @@ import { flattenAnnotatedImage } from "./flatten-annotated-image.ts";
 import { logger } from "../log.ts";
 import {
   createAttachmentPreviewSignals,
-  createAttachmentResourceUrl$,
+  type AttachmentPreviewSignals,
 } from "../attachment-resource-url.ts";
+import { canonicalUserMessageFileUrl } from "../chat-page/user-message-files.ts";
 import { isAnnotationMeaningful } from "./image-annotation.ts";
 
 // ---------------------------------------------------------------------------
@@ -507,7 +508,7 @@ export interface ChatAttachment {
   imageLoad: ImageLoadSignals;
   /** Reactive file info (id + url) — loading while uploading, hasData when done. */
   fileInfo$: Computed<Promise<FileInfo | null>>;
-  resourceUrl$: Computed<Promise<string | null>>;
+  preview$: Computed<Promise<AttachmentPreviewSignals | null>>;
   /** Whether either the original or its annotated derivative is uploading. */
   uploadPending$: Computed<boolean>;
   /** Whether every file required by a send has been uploaded successfully. */
@@ -527,12 +528,14 @@ export interface ChatAttachment {
   cancelAnnotationUpload$: Command<void, []>;
 }
 
-function createComposerAttachmentResourceUrl(
+function createComposerAttachmentPreview(
   fileInfo$: Computed<Promise<FileInfo | null>>,
 ) {
   return computed(async (get) => {
     const file = await get(fileInfo$);
-    return file ? await get(createAttachmentResourceUrl$(file.url)) : null;
+    return file
+      ? createAttachmentPreviewSignals(canonicalUserMessageFileUrl(file.id))
+      : null;
   });
 }
 
@@ -592,7 +595,7 @@ function createChatAttachment(file: File): ChatAttachment {
     size: file.size,
     imageLoad,
     fileInfo$,
-    resourceUrl$: createComposerAttachmentResourceUrl(fileInfo$),
+    preview$: createComposerAttachmentPreview(fileInfo$),
     uploadPending$,
     sendReady$,
     cancel$,
@@ -731,7 +734,7 @@ export function createRestoredAttachment(
     size: persisted.size,
     imageLoad: createImageLoadSignals(),
     fileInfo$,
-    resourceUrl$: createComposerAttachmentResourceUrl(fileInfo$),
+    preview$: createComposerAttachmentPreview(fileInfo$),
     uploadPending$,
     sendReady$: annotation.annotationReady$,
     cancel$,

--- a/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
@@ -688,7 +688,7 @@ export type RestorableAttachment = Omit<PersistedAttachment, "url"> & {
 export function createRestoredAttachment(
   persisted: RestorableAttachment,
 ): ChatAttachment {
-  const fileInfo$ = computed(async (get): Promise<FileInfo | null> => {
+  const restored$ = computed(async (get) => {
     const client = get(apiClient$)(webFilesContract);
     const resolved = await accept(
       client.fileUrl({
@@ -699,10 +699,23 @@ export function createRestoredAttachment(
     return resolved.status === 404
       ? null
       : {
-          id: persisted.id,
-          url: persisted.url ?? resolved.body.url,
-          contentType: persisted.contentType,
+          fileInfo: {
+            id: persisted.id,
+            url: persisted.url ?? resolved.body.url,
+            contentType: persisted.contentType,
+          },
+          preview: createAttachmentPreviewSignals(
+            canonicalUserMessageFileUrl(persisted.id),
+            {
+              token: resolved.body.url,
+              expiresAt: resolved.body.expiresAt,
+              publicUrl: resolved.body.publicUrl,
+            },
+          ),
         };
+  });
+  const fileInfo$ = computed(async (get): Promise<FileInfo | null> => {
+    return (await get(restored$))?.fileInfo ?? null;
   });
   const annotation = createAttachmentAnnotationSignals({
     filename: persisted.filename,
@@ -734,7 +747,9 @@ export function createRestoredAttachment(
     size: persisted.size,
     imageLoad: createImageLoadSignals(),
     fileInfo$,
-    preview$: createComposerAttachmentPreview(fileInfo$),
+    preview$: computed(async (get) => {
+      return (await get(restored$))?.preview ?? null;
+    }),
     uploadPending$,
     sendReady$: annotation.annotationReady$,
     cancel$,

--- a/turbo/apps/platform/src/signals/okou-page/markdown-artifact-preview.ts
+++ b/turbo/apps/platform/src/signals/okou-page/markdown-artifact-preview.ts
@@ -20,7 +20,11 @@ export const openMarkdownArtifact$ = command(
     const { filename, url, kind } = signals;
     switch (kind) {
       case "image": {
-        set(openImageLightbox$, { threadId, url }, target);
+        set(
+          openImageLightbox$,
+          { threadId, url, filename, preview: signals },
+          target,
+        );
         return;
       }
       case "video": {

--- a/turbo/apps/platform/src/views/components/rich-markdown.tsx
+++ b/turbo/apps/platform/src/views/components/rich-markdown.tsx
@@ -21,6 +21,7 @@ import type {
   ArtifactSignals,
 } from "../../signals/chat-page/artifact-card-signals.ts";
 import type { ImageLoadSignals } from "../../signals/image-load.ts";
+import type { AttachmentPreviewSignals } from "../../signals/attachment-resource-url.ts";
 import { isImageUrl, isSafeMediaUrl } from "../../lib/media-url.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { MarkdownCardView } from "../okou-page/chat-body-cards.tsx";
@@ -72,6 +73,8 @@ function MediaImage({
   url,
   alt,
   load,
+  filename,
+  resolvedPreview,
   asLink = false,
   insideLink = false,
 }: {
@@ -79,6 +82,8 @@ function MediaImage({
   url: string;
   alt: string;
   load: ImageLoadSignals;
+  filename?: string;
+  resolvedPreview?: AttachmentPreviewSignals;
   asLink?: boolean;
   insideLink?: boolean;
 }) {
@@ -150,7 +155,12 @@ function MediaImage({
         const threadId = event.currentTarget.closest<HTMLElement>(
           "[data-chat-thread-container-id]",
         )?.dataset.chatThreadContainerId;
-        openImageLightbox(threadId ? { threadId, url } : url);
+        openImageLightbox({
+          threadId,
+          url,
+          filename,
+          preview: resolvedPreview,
+        });
       }}
       className={className}
     >
@@ -224,13 +234,15 @@ function ArtifactImage({
   signals: ArtifactSignals;
   alt: string;
 }) {
-  const src = useLastResolved(signals.resourceUrl$);
+  const src = useLastResolved(signals.thumbnailUrl$);
   return (
     <MediaImage
       src={src}
       url={signals.url}
       alt={alt}
       load={signals.previewImageLoad}
+      filename={signals.filename}
+      resolvedPreview={signals}
     />
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-presigned-previews.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-presigned-previews.test.tsx
@@ -1,0 +1,112 @@
+import { artifactReferencePath } from "@okouai/api-contracts/contracts/artifact-references";
+import { webFilesContract } from "@okouai/api-contracts/contracts/web-files";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { expect, test } from "vitest";
+
+import { click, setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import {
+  ATTACHMENT_THREAD_ID,
+  draftAttachment,
+  draftForAttachment,
+  findNamedButton,
+  mockAttachmentChat,
+} from "./chat-attachment-test-helpers.ts";
+
+const context = testContext();
+const FILE_ID = "f0000000-0000-4000-a000-000000000951";
+const FILENAME = "composer-photo.png";
+const PUBLIC_URL = `https://a.okou.io/0123456789.png`;
+const R2_ORIGIN = `https://${"a".repeat(32)}.r2.cloudflarestorage.com`;
+const ORIGINAL_URL = `${R2_ORIGIN}/uploads/composer%20photo.png?X-Amz-Credential=key%2F20260911%2Fauto%2Fs3%2Faws4_request&X-Amz-Signature=original`;
+const NEXT_URL = `${R2_ORIGIN}/uploads/composer%20photo.png?X-Amz-Signature=next`;
+const THUMBNAIL_URL = `https://a.okou.io/cdn-cgi/image/width=800,height=720,fit=scale-down,format=auto,quality=85,metadata=none/${ORIGINAL_URL}`;
+
+test.each(["upload", "restored public", "restored private"] as const)(
+  "%s composer images show a presigned thumbnail and reopen the same original",
+  async (source) => {
+    const attachment = draftAttachment(FILENAME, {
+      id: FILE_ID,
+      url:
+        source === "restored private"
+          ? artifactReferencePath(FILE_ID, FILENAME)
+          : PUBLIC_URL,
+    });
+    mockAttachmentChat(
+      context,
+      source === "upload" ? {} : { draft: draftForAttachment(attachment, "") },
+    );
+    context.mocks.upload.success({
+      id: FILE_ID,
+      filename: FILENAME,
+      contentType: "image/png",
+      size: 5,
+      url: PUBLIC_URL,
+    });
+    let resolvedUrl = ORIGINAL_URL;
+    context.mocks.api(webFilesContract.fileUrl, ({ respond }) => {
+      return respond(200, {
+        url: resolvedUrl,
+        expiresAt: "2026-09-13T00:00:00.000Z",
+        publicUrl: source === "restored private" ? null : PUBLIC_URL,
+      });
+    });
+
+    await setupPage({
+      context,
+      path: `/chats/${ATTACHMENT_THREAD_ID}`,
+      host: "app.okou.ai",
+    });
+    if (source === "upload") {
+      const input =
+        document.querySelector<HTMLInputElement>('input[type="file"]');
+      if (!input) {
+        throw new Error("Expected the composer file input");
+      }
+      fireEvent.change(input, {
+        target: {
+          files: [new File(["image"], FILENAME, { type: "image/png" })],
+        },
+      });
+    }
+
+    const openPreview = await findNamedButton(
+      `Open image preview for ${FILENAME}`,
+    );
+    await waitFor(() => {
+      expect(openPreview.querySelector("img")).toHaveAttribute(
+        "src",
+        THUMBNAIL_URL,
+      );
+    });
+    const thumbnail = openPreview.querySelector("img");
+    if (!thumbnail) {
+      throw new Error("Expected the composer image thumbnail");
+    }
+    fireEvent.load(thumbnail);
+    resolvedUrl = NEXT_URL;
+
+    click(openPreview);
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+        "src",
+        ORIGINAL_URL,
+      );
+    });
+    expect(
+      screen.getByRole("dialog", { name: `${FILENAME} preview` }),
+    ).toBeVisible();
+    click(await findNamedButton("Close"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("attachment-lightbox")).toBeNull();
+    });
+    click(openPreview);
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+        "src",
+        ORIGINAL_URL,
+      );
+    });
+    expect(thumbnail).toHaveAttribute("src", THUMBNAIL_URL);
+  },
+);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-presigned-previews.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-presigned-previews.test.tsx
@@ -45,8 +45,10 @@ test.each(["upload", "restored public", "restored private"] as const)(
     });
     let resolvedUrl = ORIGINAL_URL;
     context.mocks.api(webFilesContract.fileUrl, ({ respond }) => {
+      const url = resolvedUrl;
+      resolvedUrl = NEXT_URL;
       return respond(200, {
-        url: resolvedUrl,
+        url,
         expiresAt: "2026-09-13T00:00:00.000Z",
         publicUrl: source === "restored private" ? null : PUBLIC_URL,
       });
@@ -84,7 +86,6 @@ test.each(["upload", "restored public", "restored private"] as const)(
       throw new Error("Expected the composer image thumbnail");
     }
     fireEvent.load(thumbnail);
-    resolvedUrl = NEXT_URL;
 
     click(openPreview);
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-artifact-sidebar.test.tsx
@@ -348,8 +348,9 @@ test("Preserve private and public attachments on tab return", async () => {
   const publicFileId = "f0000000-0000-4000-a000-000000000937";
   const publicFilename = "existing-image.png";
   const publicUrl = `https://cdn.vm7.io/artifacts/tests/${publicFilename}`;
-  const publicThumbnailUrl = `https://cdn.vm7.io/cdn-cgi/image/width=800,height=720,fit=scale-down,format=auto,quality=85,metadata=none/artifacts/tests/${publicFilename}`;
-  const firstPublicResourceUrl = `https://storage.example.test/${publicFilename}?signature=first`;
+  const storageOrigin = `https://${"a".repeat(32)}.r2.cloudflarestorage.com`;
+  const firstPublicResourceUrl = `${storageOrigin}/uploads/${publicFilename}?X-Amz-Signature=first`;
+  const publicThumbnailUrl = `https://a.okou.io/cdn-cgi/image/width=800,height=720,fit=scale-down,format=auto,quality=85,metadata=none/${firstPublicResourceUrl}`;
   let publicResourceUrl = firstPublicResourceUrl;
   let resourceUrl = firstUrl;
   const visibility = context.mocks.browser.visibilityState("visible");
@@ -399,7 +400,7 @@ test("Preserve private and public attachments on tab return", async () => {
     visibility.changeTo("hidden");
   });
   resourceUrl = refreshedUrl;
-  publicResourceUrl = `https://storage.example.test/${publicFilename}?signature=refreshed`;
+  publicResourceUrl = `${storageOrigin}/uploads/${publicFilename}?X-Amz-Signature=refreshed`;
   await act(() => {
     visibility.changeTo("visible");
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-artifact-sidebar.test.tsx
@@ -348,6 +348,7 @@ test("Preserve private and public attachments on tab return", async () => {
   const publicFileId = "f0000000-0000-4000-a000-000000000937";
   const publicFilename = "existing-image.png";
   const publicUrl = `https://cdn.vm7.io/artifacts/tests/${publicFilename}`;
+  const publicThumbnailUrl = `https://cdn.vm7.io/cdn-cgi/image/width=800,height=720,fit=scale-down,format=auto,quality=85,metadata=none/artifacts/tests/${publicFilename}`;
   const firstPublicResourceUrl = `https://storage.example.test/${publicFilename}?signature=first`;
   let publicResourceUrl = firstPublicResourceUrl;
   let resourceUrl = firstUrl;
@@ -387,7 +388,7 @@ test("Preserve private and public attachments on tab return", async () => {
     host: "app.okou.ai",
   });
   const publicImage = await screen.findByAltText(publicFilename);
-  expect(publicImage).toHaveAttribute("src", firstPublicResourceUrl);
+  expect(publicImage).toHaveAttribute("src", publicThumbnailUrl);
   click(await screen.findByLabelText(`Preview ${filename}`));
   const dialog = await screen.findByTestId("attachment-lightbox");
   const frame = await within(dialog).findByTitle(`${filename} preview`);
@@ -409,7 +410,7 @@ test("Preserve private and public attachments on tab return", async () => {
   });
   expect(screen.getByAltText(publicFilename)).toHaveAttribute(
     "src",
-    firstPublicResourceUrl,
+    publicThumbnailUrl,
   );
 });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-private-artifact-previews.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-private-artifact-previews.test.tsx
@@ -4,6 +4,7 @@ import {
 } from "@okouai/api-contracts/contracts/artifact-references";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { HttpResponse } from "msw";
+import { webFilesContract } from "@okouai/api-contracts/contracts/web-files";
 import { expect, test } from "vitest";
 import { click, setupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -13,14 +14,19 @@ import {
   artifactFile,
   findNamedButton,
   findNamedMenuItem,
+  findNamedLink,
   mockAttachmentChat,
+  privateAttachmentUrl,
 } from "./chat-attachment-test-helpers.ts";
 
 const context = testContext();
 const FILE_ID = "f0000000-0000-4000-a000-000000000941";
-const FIRST_URL = "https://private-r2.example/photo.png?signature=first";
-const NEXT_URL = "https://private-r2.example/photo.png?signature=next";
-const THIRD_URL = "https://private-r2.example/photo.png?signature=third";
+const R2_ORIGIN = `https://${"a".repeat(32)}.r2.cloudflarestorage.com`;
+const FIRST_URL = `${R2_ORIGIN}/private/photo%20%2B.png?X-Amz-Credential=key%2F20260911%2Fauto%2Fs3%2Faws4_request&X-Amz-Security-Token=token%2B%2F%3D&X-Amz-Signature=first&response-cache-control=private%2C%20no-store`;
+const NEXT_URL = `${R2_ORIGIN}/private/photo.png?X-Amz-Signature=next`;
+const THUMBNAIL_PREFIX =
+  "https://cdn.vm7.io/cdn-cgi/image/width=800,height=720,fit=scale-down,format=auto,quality=85,metadata=none/";
+const THUMBNAIL_URL = `${THUMBNAIL_PREFIX}${FIRST_URL}`;
 
 function mockPrivateImage(content?: string) {
   const canonical = artifactReferencePath(FILE_ID, "photo.png");
@@ -47,7 +53,7 @@ function mockPrivateImage(content?: string) {
   let responseUrl = FIRST_URL;
   context.mocks.api(artifactReferencesContract.resolve, ({ respond }) => {
     const url = responseUrl;
-    responseUrl = url === FIRST_URL ? NEXT_URL : THIRD_URL;
+    responseUrl = NEXT_URL;
     return respond(200, {
       url,
       expiresAt: "2026-09-11T00:00:00.000Z",
@@ -62,7 +68,7 @@ async function openChat() {
   await setupPage({ context, path: `/chats/${ATTACHMENT_THREAD_ID}` });
   const image = await screen.findByAltText("photo.png");
   await waitFor(() => {
-    expect(image).toHaveAttribute("src", FIRST_URL);
+    expect(image).toHaveAttribute("src", THUMBNAIL_URL);
   });
   return image;
 }
@@ -74,7 +80,7 @@ async function closePreview() {
   });
 }
 
-test("each image preview loads independently and preserves the thread image", async () => {
+test("opening and reopening an image uses the same presign as its thread thumbnail", async () => {
   mockPrivateImage();
   const image = await openChat();
   fireEvent.load(image);
@@ -83,7 +89,7 @@ test("each image preview loads independently and preserves the thread image", as
   await waitFor(() => {
     expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
       "src",
-      NEXT_URL,
+      FIRST_URL,
     );
   });
   await closePreview();
@@ -92,14 +98,17 @@ test("each image preview loads independently and preserves the thread image", as
   await waitFor(() => {
     expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
       "src",
-      THIRD_URL,
+      FIRST_URL,
     );
   });
-  expect(screen.getByAltText("photo.png")).toHaveAttribute("src", FIRST_URL);
+  expect(screen.getByAltText("photo.png")).toHaveAttribute(
+    "src",
+    THUMBNAIL_URL,
+  );
   expect(screen.queryByTestId("markdown-image-preview-loading")).toBeNull();
 });
 
-test("repeated thread images reuse their artifact while the preview loads independently", async () => {
+test("repeated thread images and their lightbox share one resolved original", async () => {
   const canonical = artifactReferencePath(FILE_ID, "photo.png");
   mockPrivateImage(`![photo.png](${canonical})\n\n![photo.png](${canonical})`);
   await setupPage({ context, path: `/chats/${ATTACHMENT_THREAD_ID}` });
@@ -107,35 +116,32 @@ test("repeated thread images reuse their artifact while the preview loads indepe
   expect(images).toHaveLength(2);
   await waitFor(() => {
     for (const image of images) {
-      expect(image).toHaveAttribute("src", FIRST_URL);
+      expect(image).toHaveAttribute("src", THUMBNAIL_URL);
     }
   });
   click(images[0]!);
   const dialog = await screen.findByTestId("attachment-lightbox");
   await expect(
     within(dialog).findByTestId("attachment-lightbox-image"),
-  ).resolves.toHaveAttribute("src", NEXT_URL);
+  ).resolves.toHaveAttribute("src", FIRST_URL);
 });
 
 test("downloads obtain a fresh credential without replacing the open image", async () => {
   mockPrivateImage();
   const downloads = context.mocks.browser.blobDownload();
   context.mocks.browser.requestCacheMode();
-  context.mocks.http.get(
-    "https://private-r2.example/photo.png",
-    ({ request }) => {
-      expect(request.cache).toBe("default");
-      return new URL(request.url).searchParams.get("signature") === "third"
-        ? HttpResponse.text("private image bytes")
-        : new HttpResponse(null, { status: 403 });
-    },
-  );
+  context.mocks.http.get(`${R2_ORIGIN}/private/photo.png`, ({ request }) => {
+    expect(request.cache).toBe("default");
+    return new URL(request.url).searchParams.get("X-Amz-Signature") === "next"
+      ? HttpResponse.text("private image bytes")
+      : new HttpResponse(null, { status: 403 });
+  });
   const image = await openChat();
   click(image);
   await waitFor(() => {
     expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
       "src",
-      NEXT_URL,
+      FIRST_URL,
     );
   });
   click(await findNamedButton("Download options"));
@@ -145,7 +151,220 @@ test("downloads obtain a fresh credential without replacing the open image", asy
   });
   expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
     "src",
-    NEXT_URL,
+    FIRST_URL,
   );
-  expect(image).toHaveAttribute("src", FIRST_URL);
+  expect(image).toHaveAttribute("src", THUMBNAIL_URL);
 });
+
+test("uploaded images reuse their thread presign when opened in the lightbox", async () => {
+  const url = privateAttachmentUrl(FILE_ID);
+  mockAttachmentChat(context, {
+    artifacts: [
+      artifactFile("upload.png", {
+        id: FILE_ID,
+        contentType: "image/png",
+        url,
+      }),
+    ],
+    chatEvents: [
+      {
+        id: "uploaded-image-message",
+        role: "user",
+        content: null,
+        runId: ATTACHMENT_RUN_ID,
+        createdAt: "2026-09-09T00:00:00.000Z",
+        userMessage: {
+          version: 1,
+          parts: [
+            {
+              type: "file",
+              fileId: FILE_ID,
+              filenameSnapshot: "upload.png",
+              contentType: "image/png",
+            },
+          ],
+        },
+      },
+    ],
+  });
+  let responseUrl = FIRST_URL;
+  context.mocks.api(webFilesContract.fileUrl, ({ respond }) => {
+    const resolved = responseUrl;
+    responseUrl = NEXT_URL;
+    return respond(200, {
+      url: resolved,
+      expiresAt: "2026-09-13T00:00:00.000Z",
+      publicUrl: null,
+    });
+  });
+  await setupPage({ context, path: `/chats/${ATTACHMENT_THREAD_ID}` });
+  const image = await screen.findByAltText("upload.png");
+  await waitFor(() => {
+    expect(image).toHaveAttribute("src", THUMBNAIL_URL);
+  });
+  expect(image.closest("a")).toHaveAttribute("href", FIRST_URL);
+  click(await findNamedLink("Preview upload.png"));
+  await waitFor(() => {
+    expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+      "src",
+      FIRST_URL,
+    );
+  });
+  expect(image).toHaveAttribute("src", THUMBNAIL_URL);
+});
+
+test("promoting a thread image to split view keeps the same original credential", async () => {
+  mockPrivateImage();
+  const image = await openChat();
+  click(image);
+  const dialog = await screen.findByTestId("attachment-lightbox");
+  await expect(
+    within(dialog).findByTestId("attachment-lightbox-image"),
+  ).resolves.toHaveAttribute("src", FIRST_URL);
+  click(await findNamedButton("Open in split view"));
+  await waitFor(() => {
+    const images = screen.getAllByAltText("photo.png");
+    expect(
+      images.some((candidate) => {
+        return candidate.getAttribute("src") === FIRST_URL;
+      }),
+    ).toBeTruthy();
+  });
+  expect(image).toHaveAttribute("src", THUMBNAIL_URL);
+});
+
+test.each(["assistant", "user"] as const)(
+  "navigating %s images reuses the original already resolved by each thread card",
+  async (role) => {
+    const secondId = "f0000000-0000-4000-a000-000000000942";
+    const files = [
+      { id: FILE_ID, filename: "photo.png", original: FIRST_URL },
+      { id: secondId, filename: "second.png", original: NEXT_URL },
+    ].map((file) => {
+      return {
+        ...file,
+        url:
+          role === "assistant"
+            ? artifactReferencePath(file.id, file.filename)
+            : privateAttachmentUrl(file.id),
+      };
+    });
+    mockAttachmentChat(context, {
+      artifacts: files.map((file) => {
+        return artifactFile(file.filename, {
+          id: file.id,
+          contentType: "image/png",
+          url: file.url,
+        });
+      }),
+      chatEvents: [
+        {
+          id: "two-private-images",
+          role,
+          content:
+            role === "assistant"
+              ? files
+                  .map((file) => {
+                    return `![${file.filename}](${file.url})`;
+                  })
+                  .join("\n\n")
+              : null,
+          runId: ATTACHMENT_RUN_ID,
+          runEventId: "two-private-images-event",
+          sequenceNumber: 1,
+          createdAt: "2026-09-09T00:00:00.000Z",
+          ...(role === "user"
+            ? {
+                userMessage: {
+                  version: 1 as const,
+                  parts: files.map((file) => {
+                    return {
+                      type: "file" as const,
+                      fileId: file.id,
+                      filenameSnapshot: file.filename,
+                      contentType: "image/png",
+                    };
+                  }),
+                },
+              }
+            : {}),
+        },
+      ],
+    });
+    const resolvedIds = new Set<string>();
+    const resolveOriginal = (id: string) => {
+      const file = files.find((candidate) => {
+        return candidate.id === id;
+      });
+      if (!file) {
+        throw new Error("Unexpected image reference");
+      }
+      const url = resolvedIds.has(id)
+        ? `${R2_ORIGIN}/unexpected.png?X-Amz-Signature=reissued`
+        : file.original;
+      resolvedIds.add(id);
+      return {
+        url,
+        filename: file.filename,
+        expiresAt: "2026-09-13T00:00:00.000Z",
+        contentType: "image/png",
+        target: { kind: "file" as const, id },
+      };
+    };
+    context.mocks.api(
+      artifactReferencesContract.resolve,
+      ({ params, respond }) => {
+        const file = files.find((candidate) => {
+          return artifactReferencePath(
+            candidate.id,
+            candidate.filename,
+          ).endsWith(params.reference);
+        });
+        if (!file) {
+          throw new Error("Unexpected image reference");
+        }
+        return respond(200, resolveOriginal(file.id));
+      },
+    );
+    context.mocks.api(webFilesContract.fileUrl, ({ query, respond }) => {
+      return respond(200, {
+        ...resolveOriginal(query.file_id),
+        publicUrl: null,
+      });
+    });
+    await setupPage({ context, path: `/chats/${ATTACHMENT_THREAD_ID}` });
+    const first = await screen.findByAltText("photo.png");
+    const second = await screen.findByAltText("second.png");
+    await waitFor(() => {
+      expect(first).toHaveAttribute("src", THUMBNAIL_URL);
+      expect(second).toHaveAttribute("src", `${THUMBNAIL_PREFIX}${NEXT_URL}`);
+    });
+    if (role === "user") {
+      click(await findNamedLink("Preview photo.png"));
+    } else {
+      click(first);
+    }
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+        "src",
+        FIRST_URL,
+      );
+    });
+    click(await findNamedButton("Next image artifact"));
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+        "src",
+        NEXT_URL,
+      );
+    });
+    click(await findNamedButton("Previous image artifact"));
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+        "src",
+        FIRST_URL,
+      );
+    });
+    expect(first).toHaveAttribute("src", THUMBNAIL_URL);
+    expect(second).toHaveAttribute("src", `${THUMBNAIL_PREFIX}${NEXT_URL}`);
+  },
+);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-private-artifact-previews.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-private-artifact-previews.test.tsx
@@ -180,62 +180,65 @@ test("downloads obtain a fresh credential without replacing the open image", asy
   expect(image).toHaveAttribute("src", THUMBNAIL_URL);
 });
 
-test("uploaded images reuse their thread presign when opened in the lightbox", async () => {
-  const url = privateAttachmentUrl(FILE_ID);
-  mockAttachmentChat(context, {
-    artifacts: [
-      artifactFile("upload.png", {
-        id: FILE_ID,
-        contentType: "image/png",
-        url,
-      }),
-    ],
-    chatEvents: [
-      {
-        id: "uploaded-image-message",
-        role: "user",
-        content: null,
-        runId: ATTACHMENT_RUN_ID,
-        createdAt: "2026-09-09T00:00:00.000Z",
-        userMessage: {
-          version: 1,
-          parts: [
-            {
-              type: "file",
-              fileId: FILE_ID,
-              filenameSnapshot: "upload.png",
-              contentType: "image/png",
-            },
-          ],
+test.each([null, "https://a.okou.io/0123456789.png"])(
+  "uploaded images reuse their thread presign with publicUrl=%s",
+  async (publicUrl) => {
+    const url = privateAttachmentUrl(FILE_ID);
+    mockAttachmentChat(context, {
+      artifacts: [
+        artifactFile("upload.png", {
+          id: FILE_ID,
+          contentType: "image/png",
+          url,
+        }),
+      ],
+      chatEvents: [
+        {
+          id: "uploaded-image-message",
+          role: "user",
+          content: null,
+          runId: ATTACHMENT_RUN_ID,
+          createdAt: "2026-09-09T00:00:00.000Z",
+          userMessage: {
+            version: 1,
+            parts: [
+              {
+                type: "file",
+                fileId: FILE_ID,
+                filenameSnapshot: "upload.png",
+                contentType: "image/png",
+              },
+            ],
+          },
         },
-      },
-    ],
-  });
-  let responseUrl = FIRST_URL;
-  context.mocks.api(webFilesContract.fileUrl, ({ respond }) => {
-    const resolved = responseUrl;
-    responseUrl = NEXT_URL;
-    return respond(200, {
-      url: resolved,
-      expiresAt: "2026-09-13T00:00:00.000Z",
-      publicUrl: null,
+      ],
     });
-  });
-  await setupPage({ context, path: `/chats/${ATTACHMENT_THREAD_ID}` });
-  const image = await screen.findByAltText("upload.png");
-  await waitFor(() => {
+    let responseUrl = FIRST_URL;
+    context.mocks.api(webFilesContract.fileUrl, ({ respond }) => {
+      const resolved = responseUrl;
+      responseUrl = NEXT_URL;
+      return respond(200, {
+        url: resolved,
+        expiresAt: "2026-09-13T00:00:00.000Z",
+        publicUrl,
+      });
+    });
+    await setupPage({ context, path: `/chats/${ATTACHMENT_THREAD_ID}` });
+    const image = await screen.findByAltText("upload.png");
+    await waitFor(() => {
+      expect(image).toHaveAttribute("src", THUMBNAIL_URL);
+    });
+    expect(image.closest("a")).toHaveAttribute("href", FIRST_URL);
+    click(await findNamedLink("Preview upload.png"));
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+        "src",
+        FIRST_URL,
+      );
+    });
     expect(image).toHaveAttribute("src", THUMBNAIL_URL);
-  });
-  expect(image.closest("a")).toHaveAttribute("href", FIRST_URL);
-  click(await findNamedLink("Preview upload.png"));
-  await waitFor(() => {
-    expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
-      "src",
-      FIRST_URL,
-    );
-  });
-  expect(image).toHaveAttribute("src", THUMBNAIL_URL);
-});
+  },
+);
 
 test("promoting a thread image to split view keeps the same original credential", async () => {
   mockPrivateImage();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-private-artifact-previews.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-private-artifact-previews.test.tsx
@@ -80,6 +80,30 @@ async function closePreview() {
   });
 }
 
+test("production thread thumbnails use a.okou.io and open the same original", async () => {
+  mockPrivateImage();
+  await setupPage({
+    context,
+    path: `/chats/${ATTACHMENT_THREAD_ID}`,
+    host: "app.okou.ai",
+  });
+  const image = await screen.findByAltText("photo.png");
+  await waitFor(() => {
+    expect(image).toHaveAttribute(
+      "src",
+      THUMBNAIL_URL.replace("https://cdn.vm7.io/", "https://a.okou.io/"),
+    );
+  });
+  fireEvent.load(image);
+  click(image);
+  await waitFor(() => {
+    expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+      "src",
+      FIRST_URL,
+    );
+  });
+});
+
 test("opening and reopening an image uses the same presign as its thread thumbnail", async () => {
   mockPrivateImage();
   const image = await openChat();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-unsupported-image-previews.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-unsupported-image-previews.test.tsx
@@ -1,0 +1,115 @@
+import {
+  artifactReferencePath,
+  artifactReferencesContract,
+} from "@okouai/api-contracts/contracts/artifact-references";
+import { webFilesContract } from "@okouai/api-contracts/contracts/web-files";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { expect, test } from "vitest";
+import { click, setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import {
+  ATTACHMENT_RUN_ID,
+  ATTACHMENT_THREAD_ID,
+  artifactFile,
+  findNamedLink,
+  mockAttachmentChat,
+  privateAttachmentUrl,
+} from "./chat-attachment-test-helpers.ts";
+
+const context = testContext();
+const FILE_ID = "f0000000-0000-4000-a000-000000000946";
+const FILENAME = "photo.BMP";
+const ORIGINAL_URL =
+  `https://${"a".repeat(32)}.r2.cloudflarestorage.com/private/photo%20%2B.BMP` +
+  "?X-Amz-Signature=original&response-cache-control=private%2C%20no-store";
+
+test.each(["assistant", "user"] as const)(
+  "%s BMP images display the original in the thread and lightbox",
+  async (role) => {
+    const canonical =
+      role === "assistant"
+        ? artifactReferencePath(FILE_ID, FILENAME)
+        : privateAttachmentUrl(FILE_ID);
+    mockAttachmentChat(context, {
+      artifacts: [
+        artifactFile(FILENAME, {
+          id: FILE_ID,
+          contentType: "image/bmp",
+          url: canonical,
+        }),
+      ],
+      chatEvents: [
+        {
+          id: "bmp-preview-message",
+          role,
+          content: role === "assistant" ? `![${FILENAME}](${canonical})` : null,
+          runId: ATTACHMENT_RUN_ID,
+          runEventId: "bmp-preview-event",
+          sequenceNumber: 1,
+          createdAt: "2026-09-11T00:00:00.000Z",
+          ...(role === "user"
+            ? {
+                userMessage: {
+                  version: 1 as const,
+                  parts: [
+                    {
+                      type: "file" as const,
+                      fileId: FILE_ID,
+                      filenameSnapshot: FILENAME,
+                      contentType: "image/bmp",
+                    },
+                  ],
+                },
+              }
+            : {}),
+        },
+      ],
+    });
+    let responseUrl = ORIGINAL_URL;
+    const resolveOriginal = () => {
+      const url = responseUrl;
+      responseUrl = ORIGINAL_URL.replace("=original", "=reissued");
+      return { url, expiresAt: "2026-09-13T00:00:00.000Z" };
+    };
+    context.mocks.api(artifactReferencesContract.resolve, ({ respond }) => {
+      return respond(200, {
+        ...resolveOriginal(),
+        filename: FILENAME,
+        contentType: "image/bmp",
+        target: { kind: "file", id: FILE_ID },
+      });
+    });
+    context.mocks.api(webFilesContract.fileUrl, ({ respond }) => {
+      return respond(200, { ...resolveOriginal(), publicUrl: null });
+    });
+
+    await setupPage({ context, path: `/chats/${ATTACHMENT_THREAD_ID}` });
+    const image = await screen.findByAltText(FILENAME);
+    await waitFor(() => {
+      expect(image).toHaveAttribute("src", ORIGINAL_URL);
+    });
+    fireEvent.load(image);
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId(
+          role === "assistant"
+            ? "markdown-image-preview-loading"
+            : "chat-image-preview-loading",
+        ),
+      ).toBeNull();
+    });
+
+    if (role === "user") {
+      click(await findNamedLink(`Preview ${FILENAME}`));
+    } else {
+      click(image);
+    }
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+        "src",
+        ORIGINAL_URL,
+      );
+    });
+    expect(image).toHaveAttribute("src", ORIGINAL_URL);
+  },
+);

--- a/turbo/apps/platform/src/views/okou-page/artifact-image-navigation.ts
+++ b/turbo/apps/platform/src/views/okou-page/artifact-image-navigation.ts
@@ -4,6 +4,8 @@ import type {
   UserMessageDocument,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import type { Element, Root } from "hast";
+import type { AttachmentPreviewSignals } from "../../signals/attachment-resource-url.ts";
+import type { UserMessageRenderDocument } from "../../signals/chat-page/chat-event.ts";
 
 import { classifyChatAttachment } from "../../signals/chat-page/parse-body-blocks.ts";
 import { artifactPreviewUrlsMatch } from "./attachment-url.ts";
@@ -12,6 +14,7 @@ import { userMessageFileAttachments } from "../../signals/chat-page/user-message
 export type ImageArtifactNavigationItem = {
   readonly url: string;
   readonly filename: string;
+  readonly preview?: AttachmentPreviewSignals;
   /**
    * Present when the image is a run artifact (agent-generated / hosted): carries
    * the artifact file and its run so the lightbox keeps full download/share/sync
@@ -37,6 +40,7 @@ type ImageArtifactNavigation = {
  */
 type EventImageSource = {
   readonly userMessage?: UserMessageDocument;
+  readonly userMessageRenderDocument?: UserMessageRenderDocument;
   readonly tree?: Root;
 };
 
@@ -62,6 +66,7 @@ function isImageDescriptor(descriptor: {
 type EventImage = {
   readonly url: string;
   readonly filename: string;
+  readonly preview?: AttachmentPreviewSignals;
 };
 
 type ArtifactImageMetadata = {
@@ -97,10 +102,14 @@ function filenameFromMarkdownLink(label: string, url: string): string {
 function eventImages(event: EventImageSource): EventImage[] {
   const images: EventImage[] = [];
   const seen = new Set<string>();
-  const add = (url: string, filename: string): void => {
+  const add = (
+    url: string,
+    filename: string,
+    preview?: AttachmentPreviewSignals,
+  ): void => {
     if (!seen.has(url)) {
       seen.add(url);
-      images.push({ url, filename });
+      images.push({ url, filename, preview });
     }
   };
 
@@ -108,7 +117,14 @@ function eventImages(event: EventImageSource): EventImage[] {
     ? userMessageFileAttachments(event.userMessage)
     : []) {
     if (isImageDescriptor(file)) {
-      add(file.url, file.filename);
+      const rendered = event.userMessageRenderDocument?.parts.find((part) => {
+        return part.type === "file" && part.signals.url === file.url;
+      });
+      add(
+        file.url,
+        file.filename,
+        rendered?.type === "file" ? rendered.signals : undefined,
+      );
     }
   }
   if (event.tree) {
@@ -131,7 +147,11 @@ function nodeText(node: Element): string {
 /** Walks a rendered body for its images: card slots, `<img>`, image links. */
 function visitTreeImages(
   root: Root,
-  add: (url: string, filename: string) => void,
+  add: (
+    url: string,
+    filename: string,
+    preview?: AttachmentPreviewSignals,
+  ) => void,
 ): void {
   const visit = (node: Root | Element): void => {
     for (const child of node.children) {
@@ -141,7 +161,7 @@ function visitTreeImages(
       const card = child.data?.card;
       if (card !== undefined) {
         if (card.kind === "artifact" && card.signals.kind === "image") {
-          add(card.signals.url, card.signals.filename);
+          add(card.signals.url, card.signals.filename, card.signals);
         }
         continue;
       }
@@ -229,7 +249,8 @@ export function equalEventImageGroups(
           return (
             nextImage !== undefined &&
             image.url === nextImage.url &&
-            image.filename === nextImage.filename
+            image.filename === nextImage.filename &&
+            image.preview === nextImage.preview
           );
         })
       );
@@ -283,11 +304,12 @@ export function currentEventImageArtifactNavigation(
     if (artifact) {
       return {
         url: image.url,
+        preview: image.preview,
         filename: artifact.file.filename,
         artifact,
       };
     }
-    return { url: image.url, filename: image.filename };
+    return image;
   });
   const currentIndex = images.findIndex((item) => {
     return artifactPreviewUrlsMatch(item.url, currentUrl);

--- a/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
@@ -24,6 +24,8 @@ import type {
   ChatThreadArtifactRun,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import type { ChatAttachment } from "../../signals/okou-page/chat-draft";
+import type { AttachmentPreviewSignals } from "../../signals/attachment-resource-url.ts";
+import { canonicalUserMessageFileUrl } from "../../signals/chat-page/user-message-files.ts";
 import type { ChatPanelSignals } from "../../signals/chat-page/chat-panel-signals.ts";
 import { downloadAttachment$ } from "../../signals/attachment-download.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -1616,25 +1618,25 @@ export function PreviewableAudioAttachmentChip({
 // ---------------------------------------------------------------------------
 
 /**
- * A restored attachment carries the canonical API URL, so the thumbnail needs
- * the same presigned exchange the sent message uses. Kept in its own component
- * so the surrounding button stays one DOM node across the pending-to-uploaded
- * transition. The canonical URL identifies the image load state.
+ * Composer attachments use the same presigned thumbnail as sent messages.
+ * The preview also supplies the original credential to the lightbox. Kept in
+ * its own component so the surrounding button stays one DOM node across the
+ * pending-to-uploaded transition. The canonical URL identifies the load state.
  */
 function ComposerImagePreviewImage({
-  resourceUrl$,
+  preview,
   load,
   loaded,
   url,
 }: {
-  resourceUrl$: ChatAttachment["resourceUrl$"];
+  preview: AttachmentPreviewSignals;
   load: ImageLoadSignals;
   loaded: boolean;
   url: string;
 }) {
   const markLoaded = useSet(load.loaded$);
   const markFailed = useSet(load.failed$);
-  const resolvedUrl = useLastResolved(resourceUrl$) ?? null;
+  const resolvedUrl = useLastResolved(preview.thumbnailUrl$) ?? null;
 
   if (resolvedUrl === null) {
     return null;
@@ -1654,24 +1656,24 @@ function ComposerImagePreviewImage({
 }
 
 function ComposerImagePreviewButton({
-  resourceUrl$,
+  preview,
   filename,
   load,
   markCount,
   openImageLightbox,
   url,
 }: {
-  resourceUrl$: ChatAttachment["resourceUrl$"];
+  preview: AttachmentPreviewSignals | null;
   filename: string;
   load: ImageLoadSignals;
   markCount: number;
-  openImageLightbox: (url: string) => void;
+  openImageLightbox: (url: string, preview: AttachmentPreviewSignals) => void;
   url: string | undefined;
 }) {
   const { t } = useTranslation();
   const currentImageStatus = useGet(load.status$);
 
-  if (!url) {
+  if (!url || !preview) {
     return (
       <button
         type="button"
@@ -1696,7 +1698,7 @@ function ComposerImagePreviewButton({
     <button
       type="button"
       onClick={() => {
-        openImageLightbox(url);
+        openImageLightbox(url, preview);
       }}
       aria-label={t(
         ($) => {
@@ -1722,7 +1724,7 @@ function ComposerImagePreviewButton({
         </span>
       )}
       <ComposerImagePreviewImage
-        resourceUrl$={resourceUrl$}
+        preview={preview}
         load={load}
         loaded={currentImageStatus === "loaded"}
         url={url}
@@ -1795,9 +1797,12 @@ function AttachmentChip({
 }) {
   const { t } = useTranslation();
   const infoLoadable = useLoadable(attachment.fileInfo$);
+  const preview = useLastResolved(attachment.preview$) ?? null;
   const uploading = useGet(attachment.uploadPending$);
   const url =
-    infoLoadable.state === "hasData" ? infoLoadable.data?.url : undefined;
+    infoLoadable.state === "hasData" && infoLoadable.data
+      ? canonicalUserMessageFileUrl(infoLoadable.data.id)
+      : undefined;
   const openImageLightbox = useSet(openImageLightbox$);
   const openAnnotationEditor = useSet(annotationSignals.openAnnotationEditor$);
   const confirmAnnotations = useSet(attachment.confirmAnnotations$);
@@ -1811,15 +1816,17 @@ function AttachmentChip({
     >
       {isImage ? (
         <ComposerImagePreviewButton
-          resourceUrl$={attachment.resourceUrl$}
+          preview={preview}
           filename={attachment.filename}
           load={attachment.imageLoad}
           markCount={annotationMarkCount(annotations)}
-          openImageLightbox={(previewUrl) => {
+          openImageLightbox={(previewUrl, imagePreview) => {
             // A pending upload is not an artifact yet, so checking it must not
             // take over an open artifact sidebar.
             openImageLightbox({
               url: previewUrl,
+              filename: attachment.filename,
+              preview: imagePreview,
               splitViewAvailable: false,
               ...(annotationEnabled && !uploading
                 ? {

--- a/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
@@ -1114,6 +1114,7 @@ function ArtifactPreviewDialogThreadResolver({
           })
         : undefined,
       filename: navigationItem.filename,
+      preview: navigationItem.preview,
       threadId: thread.threadId,
       url: navigationItem.url,
     });

--- a/turbo/apps/platform/src/views/okou-page/chat-body-cards.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-body-cards.tsx
@@ -44,7 +44,6 @@ import {
   UNKNOWN_PERMISSION_GRANT,
   type FirewallPolicyValue,
 } from "@okouai/connectors/firewall-contracts";
-import { r2ImageTransformUrl } from "@okouai/core/r2-image-transform";
 import { Button, Skeleton, cn } from "@okouai/ui";
 import {
   useGet,
@@ -85,6 +84,7 @@ type ChatImagePreviewLinkProps = {
   onPreview: () => void;
   placeholderClassName: string;
   resourceUrl$: ArtifactSignals["resourceUrl$"];
+  thumbnailUrl$: ArtifactSignals["thumbnailUrl$"];
   url: string;
 };
 
@@ -120,6 +120,7 @@ export function ChatImagePreviewLink({
   onPreview,
   placeholderClassName,
   resourceUrl$,
+  thumbnailUrl$,
   url,
 }: ChatImagePreviewLinkProps) {
   const imageStatus = useGet(load.status$);
@@ -127,13 +128,7 @@ export function ChatImagePreviewLink({
   const markFailed = useSet(load.failed$);
   const imageUrl = publicAttachmentUrl(url);
   const resourceUrl = useLastResolved(resourceUrl$) ?? null;
-  const previewImageUrl =
-    resourceUrl === null
-      ? null
-      : r2ImageTransformUrl(resourceUrl, {
-          width: 800,
-          height: 720,
-        });
+  const previewImageUrl = useLastResolved(thumbnailUrl$) ?? null;
 
   const showPlaceholder = imageStatus !== "loaded";
 
@@ -341,7 +336,12 @@ function ArtifactCardView({
   const openImageLightbox = useSet(openAttachmentImageLightbox$);
   const openVideoLightbox = useSet(openAttachmentVideoLightbox$);
   const openLightbox = (url: string): void => {
-    openImageLightbox({ threadId, url });
+    openImageLightbox({
+      threadId,
+      url,
+      filename: signals.filename,
+      preview: signals,
+    });
   };
   const previewImageLoadable = useLastLoadable(signals.previewImageUrl$);
   const previewImagePending = previewImageLoadable.state === "loading";
@@ -370,6 +370,7 @@ function ArtifactCardView({
         load={signals.previewImageLoad}
         placeholderClassName="h-full w-full"
         resourceUrl$={signals.resourceUrl$}
+        thumbnailUrl$={signals.thumbnailUrl$}
         url={signals.url}
       />,
     );

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -5627,7 +5627,7 @@ interface ResolvedMessageAttachment {
   readonly signals: ArtifactSignals;
 }
 
-type OpenMessageImagePreview = (url: string, filename?: string) => void;
+type OpenMessageImagePreview = (attachment: ResolvedMessageAttachment) => void;
 
 function userMessageRenderAttachments(
   document: UserMessageRenderDocument | undefined,
@@ -5712,10 +5712,11 @@ function MessageAttachment({
         imageClassName="block h-full w-full object-contain"
         linkClassName={CHAT_INLINE_IMAGE_PREVIEW_CLASS}
         onPreview={() => {
-          onImageClick(a.url, a.filename);
+          onImageClick(a);
         }}
         placeholderClassName="h-full w-full"
         resourceUrl$={a.signals.resourceUrl$}
+        thumbnailUrl$={a.signals.thumbnailUrl$}
         url={a.url}
       />
     );
@@ -6764,14 +6765,6 @@ function inputPromptRunAnchor(inputEvent: ChatInputEvent | undefined) {
     : undefined;
 }
 
-function messageImageLightboxTarget(
-  threadId: string,
-  url: string,
-  filename: string | undefined,
-) {
-  return { threadId, url, ...(filename ? { filename } : {}) };
-}
-
 function PagedUserMessage({
   event,
   thread,
@@ -6789,10 +6782,13 @@ function PagedUserMessage({
     });
   const pageSignal = useGet(pageSignal$);
   const openImageLightbox = useSet(openAttachmentImageLightbox$);
-  const openLightbox: OpenMessageImagePreview = (url, filename) => {
-    openImageLightbox(
-      messageImageLightboxTarget(thread.threadId, url, filename),
-    );
+  const openLightbox: OpenMessageImagePreview = (attachment) => {
+    openImageLightbox({
+      threadId: thread.threadId,
+      url: attachment.url,
+      filename: attachment.filename,
+      preview: attachment.signals,
+    });
   };
   const copiedId = useGet(thread.copiedEventId$);
   const copied = copiedId === event.id;

--- a/turbo/packages/core/src/__tests__/r2-image-transform.spec.ts
+++ b/turbo/packages/core/src/__tests__/r2-image-transform.spec.ts
@@ -26,6 +26,20 @@ describe("r2ImageTransformUrl", () => {
     );
   });
 
+  it.each([
+    `https://${"a".repeat(32)}.r2.cloudflarestorage.com/private/photo.BMP?X-Amz-Signature=signature#preview`,
+    "https://a.okou.io/0123456789.bmp?download=1#preview",
+    `https://${"a".repeat(32)}.r2.cloudflarestorage.com/private/photo.tiff?X-Amz-Signature=signature`,
+    `https://${"a".repeat(32)}.r2.cloudflarestorage.com/private/image?X-Amz-Signature=signature`,
+  ])(
+    "keeps unsupported or unknown image inputs on their original URL: %s",
+    (url) => {
+      expect(
+        r2ImageTransformUrl(url, { width: 800 }, "https://cdn.vm7.io"),
+      ).toBe(url);
+    },
+  );
+
   it("keeps public shares on their policy-checked URL", () => {
     const url = `https://a.okou.io/${"a".repeat(24)}.png?download=1#preview`;
     expect(r2ImageTransformUrl(url, { width: 400, height: 300 })).toBe(url);

--- a/turbo/packages/core/src/__tests__/r2-image-transform.spec.ts
+++ b/turbo/packages/core/src/__tests__/r2-image-transform.spec.ts
@@ -2,6 +2,30 @@ import { describe, expect, it } from "vitest";
 import { r2ImageTransformUrl } from "../r2-image-transform";
 
 describe("r2ImageTransformUrl", () => {
+  it("wraps a complete R2 presign without changing its path or signature", () => {
+    const url =
+      `https://${"a".repeat(32)}.r2.cloudflarestorage.com/private/photo%20%2B.png` +
+      "?X-Amz-Credential=key%2F20260911%2Fauto%2Fs3%2Faws4_request" +
+      "&X-Amz-Security-Token=token%2B%2F%3D&X-Amz-Expires=172800" +
+      "&response-cache-control=private%2C%20no-store&X-Amz-Signature=signature#preview";
+    expect(
+      r2ImageTransformUrl(
+        url,
+        { width: 800, height: 720 },
+        "https://cdn.vm7.io",
+      ),
+    ).toBe(
+      `https://cdn.vm7.io/cdn-cgi/image/width=800,height=720,fit=scale-down,format=auto,quality=85,metadata=none/${url}`,
+    );
+  });
+
+  it("does not forward unrelated signed URLs to the image service", () => {
+    const url = "https://example.com/photo.png?X-Amz-Signature=signature";
+    expect(r2ImageTransformUrl(url, { width: 800 }, "https://cdn.vm7.io")).toBe(
+      url,
+    );
+  });
+
   it("keeps public shares on their policy-checked URL", () => {
     const url = `https://a.okou.io/${"a".repeat(24)}.png?download=1#preview`;
     expect(r2ImageTransformUrl(url, { width: 400, height: 300 })).toBe(url);

--- a/turbo/packages/core/src/r2-image-transform.ts
+++ b/turbo/packages/core/src/r2-image-transform.ts
@@ -68,10 +68,22 @@ function parseAbsoluteUrl(url: string): URL | null {
 export function r2ImageTransformUrl(
   url: string,
   options: R2ImageTransformOptions,
+  remoteImageOrigin?: string,
 ): string {
   const parsed = parseAbsoluteUrl(url);
   if (parsed === null) {
     return url;
+  }
+
+  if (
+    remoteImageOrigin &&
+    parsed.protocol === "https:" &&
+    parsed.hostname.endsWith(".r2.cloudflarestorage.com") &&
+    parsed.searchParams.has("X-Amz-Signature")
+  ) {
+    // The signature covers the source URL. Preserve its encoded path and query
+    // byte for byte instead of reconstructing it with URLSearchParams.
+    return `${remoteImageOrigin}${R2_IMAGE_TRANSFORM_PREFIX}${r2ImageTransformDirectives(options)}/${url}`;
   }
 
   if (

--- a/turbo/packages/core/src/r2-image-transform.ts
+++ b/turbo/packages/core/src/r2-image-transform.ts
@@ -9,6 +9,8 @@ const R2_IMAGE_TRANSFORM_HOSTS = new Set([
   "static.okou.io",
 ]);
 const R2_IMAGE_TRANSFORM_PREFIX = "/cdn-cgi/image/";
+const R2_IMAGE_TRANSFORM_INPUT_PATH =
+  /\.(?:avif|gif|heic|jpe?g|png|svg|webp)$/iu;
 
 // Output quality for Cloudflare Image Resizing. Tuned to stay crisp on
 // text-heavy presentation thumbnails while still shrinking payloads.
@@ -71,7 +73,9 @@ export function r2ImageTransformUrl(
   remoteImageOrigin?: string,
 ): string {
   const parsed = parseAbsoluteUrl(url);
-  if (parsed === null) {
+  // Unsupported or unknown input formats keep their original URL. A browser
+  // can display formats such as BMP that Cloudflare cannot transform.
+  if (parsed === null || !R2_IMAGE_TRANSFORM_INPUT_PATH.test(parsed.pathname)) {
     return url;
   }
 


### PR DESCRIPTION
Composer and Thread image previews now use thumbnails derived from the authenticated original presign `U`, and opening or reopening the Lightbox reuses that same `U`. Restored drafts reuse the availability check's resolution, so each attachment is resolved once instead of requesting a second signature for its preview.

```text
upload / restored draft / sent file ID / assistant artifact reference
  -> authenticated resolver -> original presign U
  -> preview: /cdn-cgi/image/width=800,height=720,.../<complete U>
  -> Lightbox: U
```

The shared preview computation retains the original, expiry and explicit-sharing URL. A resolver's `publicUrl` no longer overrides file-ID thumbnail sources. Restored drafts preserve their persisted file identity/URL and still remove files the current account cannot resolve; the already-authorized result supplies both the thumbnail and Lightbox. Fresh uploads and other entry points retain lazy resolution.

Production transformations use `a.okou.io`; development/preview uses `cdn.vm7.io`. The complete encoded source path and signature query are preserved. Images scale down to at most 800×720, negotiate format automatically, use quality 85 and omit metadata. BMP/TIFF, unknown extensions and unrelated signed URLs retain original delivery. Direct legacy public images and policy-checked publication aliases retain their existing behavior.

Thread image navigation and split view reuse the initiating original. Downloads keep their existing fresh-credential behavior. Markdown inside a document-preview window retains its existing image loading. This change adds no Worker endpoint, API contract, storage object or database field.

## Design decisions

- No interaction-driven or periodic renewal is introduced. Reusing the retained `U` in a long-lived view is the accepted design for this PR.
- Existing CF cache behavior is retained. The public test fixture demonstrated that a warmed thumbnail can still return 200/HIT after its source U returns 403/ExpiredRequest; this is accepted behavior, not a required cache-policy change for this PR. It does not claim positive private-cache acceptance.
- Keep `privateArtifacts` off, old public files on one-year caching, and existing DNS/Worker routes unchanged. Private video posters, HTML/site screenshots, PDF/presentation conversion and protected publication-alias thumbnails are outside this change.

## Verification

- Strengthened the existing page-level HTTP fixture so every subsequent resolution returns a different U. On the previous implementation, both restored-public and restored-private cases failed by displaying the second U; fresh upload passed.
- After the fix, all 33 focused page tests pass across Composer presigned previews, draft recovery/continuity, annotations and private-artifact previews. Tests verify visible thumbnail/original URLs rather than internal request counters. Unavailable draft files still produce the existing warning without losing text.
- Formatting, scoped Oxlint/type-aware Oxlint/ESLint, repository Knip, style policy, TypeScript checks and commitlint passed. No full local Vitest run or local dev server was used. The new deployed-preview regression also passed: restoring a public image draft adds exactly one resolver request; opening and reopening Lightbox adds zero, with an 800×533 thumbnail and 1800×1200 original sharing the same U. The deployed synthetic merge `5857b58b21e7c751d4df9df35645ed7fa1ae7e8c` contains head `3badc150414a0eba6b8d26b6a408aedfb2be341c`. The preview database reset on deployment, so the equivalent fixture was recreated through normal upload UI.
- Current-head [CI run 34581902198](https://github.com/vm0-ai/vm0/actions/runs/34581902198) has 77 success, 23 skipped and 2 failure: `test-app (2)` failed in `sidebar.test.tsx > Mark all of an agent’s chats read` (missing Support Agent), plus the aggregate gate. That exact test passed in a scoped local rerun; its root cause is not established. CI remains red; no rerun or merge was performed.
- Public live browser acceptance before this narrow fix covered uploads, Composer/Thread Markdown thumbnails, Lightbox open/reopen, navigation, split view, download and BMP original delivery. [Recording](https://a.okou.io/awc3l75f82.mp4); the [earlier report](https://a.okou.io/iw2lydf3qh.md) records the pre-fix duplicate and the expiry/cache observations whose classification is superseded by the design decisions above.
- Test/production CORS and narrow image-source allowlists have been configured and accepted separately. Actual public-presign transformations pass in both environments. Configuration and negative-source results remain in the [canonical issue comment](https://github.com/vm0-ai/vm0/issues/32492#issuecomment-5599918851).
- Valid private-presign and hostless private-reference positive acceptance remains pending an owned private signing fixture; the private feature remains disabled. Required CI and review still apply. This PR remains Draft; no merge or production release is requested by this revision.

Refs #32492. Builds on #32959 and preserves #33031's lazy resolution model.
