### PR TITLE
fix(platform): open a model type's panel only after the pointer settles

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/model-picker-menu.ts
+++ b/turbo/apps/platform/src/signals/okou-page/model-picker-menu.ts
@@ -1,5 +1,6 @@
 import { command, computed, state } from "ccstate";
-import { onRef } from "../utils.ts";
+import { delay } from "signal-timers";
+import { onRef, resetSignal } from "../utils.ts";
 
 type ModelPickerCategory = "chat" | "image" | "video";
 
@@ -14,6 +15,13 @@ type ModelPickerFlyoutSide = "left" | "right";
 const FLYOUT_PANEL_WIDTH = 258;
 const FLYOUT_VIEWPORT_MARGIN = 8;
 
+/**
+ * How long a pointer has to rest on a type row before its panel opens. A
+ * pointer crossing the rail on its way somewhere else passes each row in far
+ * less than this, so only a row the user stops on swaps the panel.
+ */
+const FLYOUT_HOVER_INTENT_MS = 200;
+
 /** One navigation state per composer, including split chats. */
 export function createModelPickerMenuSignals() {
   const internalPage$ = state<ModelPickerMenuPage>({ kind: "overview" });
@@ -22,6 +30,8 @@ export function createModelPickerMenuSignals() {
   });
   const reset$ = command(({ set }) => {
     set(internalPage$, { kind: "overview" });
+    // Closing the picker drops a swap the pointer scheduled on its way out.
+    set(resetHoverIntent$);
     set(internalFlyoutCategory$, "chat");
   });
   const showModels$ = command(({ set }, category: ModelPickerCategory) => {
@@ -44,11 +54,38 @@ export function createModelPickerMenuSignals() {
   const flyoutCategory$ = computed((get) => {
     return get(internalFlyoutCategory$);
   });
+  // Hovering schedules the swap rather than performing it. The owner stays in
+  // the domain instead of inside debounceCommand because leaving a row has to
+  // cancel a pending swap without scheduling a replacement to supersede it.
+  const resetHoverIntent$ = resetSignal();
+
   const setFlyoutCategory$ = command(
     ({ set }, category: ModelPickerCategory) => {
+      // A click or keyboard move is already deliberate: it takes effect now and
+      // drops whatever the pointer was in the middle of scheduling.
+      set(resetHoverIntent$);
       set(internalFlyoutCategory$, category);
     },
   );
+
+  /** Swap the panel only once the pointer has settled on the row. */
+  const hoverFlyoutCategory$ = command(
+    async (
+      { set },
+      category: ModelPickerCategory,
+      parentSignal: AbortSignal,
+    ) => {
+      const signal = set(resetHoverIntent$, parentSignal);
+      await delay(FLYOUT_HOVER_INTENT_MS, { signal });
+      signal.throwIfAborted();
+      set(internalFlyoutCategory$, category);
+    },
+  );
+
+  /** The pointer left before it settled, so the row it grazed never opens. */
+  const cancelFlyoutCategoryHover$ = command(({ set }) => {
+    set(resetHoverIntent$);
+  });
 
   const internalFlyoutSide$ = state<ModelPickerFlyoutSide>("left");
   const flyoutSide$ = computed((get) => {
@@ -112,6 +149,8 @@ export function createModelPickerMenuSignals() {
     focusPanelRef$,
     flyoutCategory$,
     setFlyoutCategory$,
+    hoverFlyoutCategory$,
+    cancelFlyoutCategoryHover$,
     flyoutSide$,
     flyoutRootRef$,
     focusFlyoutPanelRef$,

--- a/turbo/apps/platform/src/signals/okou-page/model-picker-menu.ts
+++ b/turbo/apps/platform/src/signals/okou-page/model-picker-menu.ts
@@ -125,6 +125,10 @@ export function createModelPickerMenuSignals() {
       signal.addEventListener("abort", () => {
         window.cancelAnimationFrame(frame);
         window.removeEventListener("resize", measure);
+        // The rail cancels a scheduled swap on mouseleave, but an unmounted row
+        // never sends one: closing the picker while the pointer rests on a row
+        // would otherwise swap the category of a menu that is already gone.
+        set(resetHoverIntent$);
       });
     }),
   );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-media-models.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-media-models.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   chatThreadImageModelContract,
@@ -975,4 +975,48 @@ test("Switch model type in the flyout without leaving the panel", async () => {
     throw new Error("Nano Banana 2 option not found");
   }
   expect(banana).toHaveAttribute("aria-selected", "true");
+});
+
+test("Hovering a model type opens its panel only once the pointer settles", async () => {
+  installModelEnvironment();
+  setDesktopViewport();
+  mockThread({
+    selectedModel: DEFAULT_RUN_MODEL,
+    selectedImageModel: null,
+  });
+
+  await setupPage({
+    context,
+    path: `/chats/${THREAD_ID}`,
+    featureSwitches: { [FeatureSwitchKey.ModelPickerFlyout]: true },
+  });
+
+  const flyoutTrigger = await waitFor(() => {
+    const trigger = composerFor()
+      .querySelector('[data-slot="select-value"]')
+      ?.closest("button");
+    if (!(trigger instanceof HTMLElement)) {
+      throw new Error("Composer model picker not found");
+    }
+    return trigger;
+  });
+  click(flyoutTrigger);
+
+  const types = await screen.findByRole("tablist", { name: "Models" });
+  await screen.findByRole("listbox", { name: "Chat models" });
+  const imageType = queryAllByRoleFast("tab", types).find((tab) => {
+    return tab.textContent?.includes("Image");
+  });
+  if (!imageType) {
+    throw new Error("Image type row not found");
+  }
+
+  // A pointer that only crosses the row leaves the panel where it was: the
+  // swap is scheduled, not applied, so this frame still shows chat models.
+  fireEvent.mouseEnter(imageType);
+  expect(screen.getByRole("listbox", { name: "Chat models" })).toBeVisible();
+
+  // Resting on the row is what opens it.
+  await screen.findByRole("listbox", { name: "Image models" });
+  expect(imageType).toHaveAttribute("aria-selected", "true");
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-media-models.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-media-models.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   chatThreadImageModelContract,
@@ -1013,7 +1013,9 @@ test("Hovering a model type opens its panel only once the pointer settles", asyn
 
   // A pointer that only crosses the row leaves the panel where it was: the
   // swap is scheduled, not applied, so this frame still shows chat models.
-  fireEvent.mouseEnter(imageType);
+  // `delay: null` keeps the pointer sequence instant, which keeps the
+  // assertion below well inside the dwell window.
+  await userEvent.setup({ delay: null }).hover(imageType);
   expect(screen.getByRole("listbox", { name: "Chat models" })).toBeVisible();
 
   // Resting on the row is what opens it.

--- a/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
@@ -15,6 +15,8 @@ import {
 } from "@okouai/api-contracts/contracts/model-providers";
 import { useTranslation } from "react-i18next";
 import type { ModelPickerMenuSignals } from "../../../signals/okou-page/model-picker-menu.ts";
+import { pageSignal$ } from "../../../signals/page-signal.ts";
+import { detach, Reason } from "../../../signals/utils.ts";
 import { PriceTierBadge } from "./model-picker-price-tier.tsx";
 import {
   getMediaModelPriceTierLabel,
@@ -22,6 +24,7 @@ import {
 } from "./settings/provider-ui-config.ts";
 import { ProviderIcon } from "./settings/provider-icons.tsx";
 import type {
+  MediaModelCategoryId,
   MediaModelPanelState,
   ModelProviderSelection,
 } from "./model-provider-picker.tsx";
@@ -462,6 +465,8 @@ function ModelPickerFlyoutTypeRow({
   index,
   total,
   onActivate,
+  onHover,
+  onHoverEnd,
 }: {
   icon: ReactNode;
   label: string;
@@ -470,6 +475,8 @@ function ModelPickerFlyoutTypeRow({
   index: number;
   total: number;
   onActivate: () => void;
+  onHover: () => void;
+  onHoverEnd: () => void;
 }) {
   return (
     <Button
@@ -486,7 +493,10 @@ function ModelPickerFlyoutTypeRow({
         "h-11 w-full shrink-0 justify-start gap-2 px-2 text-left font-normal",
         active && "bg-state-hover",
       )}
-      onMouseEnter={onActivate}
+      // Hover waits for the pointer to settle; a click or a keyboard move is
+      // deliberate and swaps the panel straight away.
+      onMouseEnter={onHover}
+      onMouseLeave={onHoverEnd}
       onFocus={onActivate}
       onClick={onActivate}
     >
@@ -623,6 +633,66 @@ function ModelPickerFlyoutOptions({
   });
 }
 
+interface ModelPickerFlyoutType {
+  readonly id: "chat" | MediaModelCategoryId;
+  readonly label: string;
+  readonly current: string;
+  readonly icon: ReactNode;
+}
+
+/**
+ * The type rail owns hover intent for the whole flyout: a row opens its panel
+ * on a settled pointer, and a pointer that leaves before then opens nothing.
+ * Reaching the panel means crossing the rows between it and the pointer, and
+ * without the dwell each of those rows would swap the panel on the way past.
+ */
+function ModelPickerFlyoutTypeRail({
+  signals,
+  types,
+  activeType,
+}: {
+  signals: ModelPickerMenuSignals;
+  types: readonly ModelPickerFlyoutType[];
+  activeType: ModelPickerFlyoutType["id"];
+}) {
+  const { t } = useTranslation();
+  const setCategory = useSet(signals.setFlyoutCategory$);
+  const hoverCategory = useSet(signals.hoverFlyoutCategory$);
+  const cancelCategoryHover = useSet(signals.cancelFlyoutCategoryHover$);
+  const pageSignal = useGet(pageSignal$);
+  return (
+    <div
+      role="tablist"
+      aria-orientation="vertical"
+      aria-label={t(($) => {
+        return $.settings.models.picker.models;
+      })}
+      className="flex flex-col gap-0.5"
+    >
+      {types.map((type, index) => {
+        return (
+          <ModelPickerFlyoutTypeRow
+            key={type.id}
+            icon={type.icon}
+            label={type.label}
+            current={type.current}
+            active={type.id === activeType}
+            index={index}
+            total={types.length}
+            onActivate={() => {
+              setCategory(type.id);
+            }}
+            onHover={() => {
+              detach(hoverCategory(type.id, pageSignal), Reason.DomCallback);
+            }}
+            onHoverEnd={cancelCategoryHover}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
 export function ModelPickerFlyoutContent({
   signals,
   value,
@@ -635,7 +705,6 @@ export function ModelPickerFlyoutContent({
   const { t } = useTranslation();
   const category = useGet(signals.flyoutCategory$);
   const side = useGet(signals.flyoutSide$);
-  const setCategory = useSet(signals.setFlyoutCategory$);
   const rootRef = useSet(signals.flyoutRootRef$);
   const panelRef = useSet(signals.focusFlyoutPanelRef$);
   const selectedOption = options.find((option) => {
@@ -687,31 +756,11 @@ export function ModelPickerFlyoutContent({
       }}
     >
       {types.length > 1 && (
-        <div
-          role="tablist"
-          aria-orientation="vertical"
-          aria-label={t(($) => {
-            return $.settings.models.picker.models;
-          })}
-          className="flex flex-col gap-0.5"
-        >
-          {types.map((type, index) => {
-            return (
-              <ModelPickerFlyoutTypeRow
-                key={type.id}
-                icon={type.icon}
-                label={type.label}
-                current={type.current}
-                active={type.id === activeType}
-                index={index}
-                total={types.length}
-                onActivate={() => {
-                  setCategory(type.id);
-                }}
-              />
-            );
-          })}
-        </div>
+        <ModelPickerFlyoutTypeRail
+          signals={signals}
+          types={types}
+          activeType={activeType}
+        />
       )}
       <div
         ref={panelRef}


### PR DESCRIPTION
## Problem

Users reported the model picker flyout switching to a model category they never
meant to open. The type rail sits between the pointer and the model panel, so
reaching the panel means crossing the rows in between — and every row swapped
the panel on its first `mouseenter`.

## Change

Hovering a type row now *schedules* the swap `200ms` out instead of performing
it, and leaving the row cancels the pending swap. Only a row the pointer rests
on opens its panel.

- Click and keyboard focus stay immediate, and both drop whatever the pointer
  had scheduled, so a deliberate choice always wins.
- Closing the picker cancels a swap the pointer scheduled on its way out.
- The dwell is owned by a domain `resetSignal()` rather than `debounceCommand`,
  because leaving a row has to cancel without scheduling a replacement to
  supersede it — the case the scheduling reference calls out.
- The rail moves into `ModelPickerFlyoutTypeRail`, which owns hover intent for
  the flyout. There is no shared hover-flyout component to host the pattern
  today: `DropdownMenuSub` never sets `openOnHover`, so base-ui's own `delay`
  is inert everywhere it is used.

Rides inside the existing `modelPickerFlyout` switch; no switch change.

## Verification

- `chat-composer-media-models.test.tsx` — 23 passed, including a new case:
  the panel still shows chat models on the frame a type row is entered, and
  opens image models once the pointer settles.
- `chat-composer-model-selection.test.tsx` — 13 passed.
- `check-types`, `oxlint` (both configs), `eslint`, `prettier --check`, and
  `style-policy.mjs` on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)