### PR TITLE
fix(api): describe every category while browsing one of them

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-catalog.test.ts
@@ -616,6 +616,17 @@ describe("GET /api/connector-catalog", () => {
       expect(connector.category).toBe(category);
     }
 
+    // The category list describes the catalog, not the response. A client
+    // offers the other categories from it, so collapsing it to the one being
+    // browsed would leave no way to reach any of them.
+    expect(
+      (scoped.body.categoryMetadata?.categories ?? [])
+        .map((entry) => {
+          return entry.id;
+        })
+        .sort(),
+    ).toStrictEqual(Object.keys(counts).sort());
+
     // Still ranked, and still without the connectors Okou runs for itself.
     const ranks = scoped.body.connectors.map((connector) => {
       return connector.popularityRank ?? Number.MAX_SAFE_INTEGER;

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -1241,6 +1241,12 @@ export async function discoverExternalPublicConnectorCatalogStatus(
   const read = connectorCatalogStatusRead({
     catalog,
     effective: discoveryEffectiveConnectors(effective, args),
+    // The category list and the category counts describe the same thing, so
+    // they are computed from the same set: the whole catalog minus the
+    // connectors Okou runs for itself, not the slice that came back for a
+    // named category. Offering a category the counts do not know would be a
+    // chip that opens nothing.
+    categorySource: withoutInternalConnectors(effective),
     connections: args.connections,
     referenceConnectorSlugs: args.referenceConnectorSlugs,
   });
@@ -1257,6 +1263,13 @@ export async function discoverExternalPublicConnectorCatalogStatus(
 function connectorCatalogStatusRead(args: {
   readonly catalog: AcceptedConnectorCatalogSnapshot;
   readonly effective: readonly EffectiveConnector[];
+  /**
+   * The connectors the category list describes, when that is wider than the
+   * ones being returned. Discovery answers a named category with only that
+   * category, and the category list is how a client offers the others, so it
+   * has to keep describing the whole catalog. Defaults to what is returned.
+   */
+  readonly categorySource?: readonly EffectiveConnector[];
   readonly connections: readonly ConnectorCatalogConnection[];
   readonly referenceConnectorSlugs: readonly string[];
 }): ConnectorCatalogStatusRead {
@@ -1279,7 +1292,7 @@ function connectorCatalogStatusRead(args: {
       connectors,
       categoryMetadata: categoryMetadataForConnectors(
         args.catalog,
-        args.effective,
+        args.categorySource ?? args.effective,
       ),
     },
     referenceMetadata: referenceMetadataForCatalog(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
@@ -459,6 +459,26 @@ test("Present a connector with no accounts", async () => {
   oauthStarted.resolve();
 });
 
+function shelfCategoryMetadata() {
+  return {
+    categories: [
+      {
+        id: "communication-collaboration",
+        label: "Communication and Collaboration",
+        menuLabel: "Communication",
+        groupId: null,
+      },
+      {
+        id: "ai-voice-audio",
+        label: "Voice / Audio",
+        menuLabel: "Voice and Audio",
+        groupId: null,
+      },
+    ],
+    groups: [],
+  };
+}
+
 function shelfCatalog() {
   // Sixteen, so the category holds more than the twelve discovery returns for
   // it when no category is asked for by name.
@@ -502,7 +522,7 @@ function shelfCatalog() {
 
 test("Browse the catalog as shelves, then enter a category and come back", async () => {
   mockConnectors(context, []);
-  mockPublicConnectorStatus(context, shelfCatalog(), undefined, {
+  mockPublicConnectorStatus(context, shelfCatalog(), shelfCategoryMetadata(), {
     "communication-collaboration": 327,
     "ai-voice-audio": 50,
   });
@@ -557,28 +577,10 @@ test("Browse the catalog as shelves, then enter a category and come back", async
 
 test("Keep every category in the filter while one of them is open", async () => {
   mockConnectors(context, []);
-  mockPublicConnectorStatus(
-    context,
-    shelfCatalog(),
-    {
-      categories: [
-        {
-          id: "communication-collaboration",
-          label: "Communication and Collaboration",
-          menuLabel: "Communication",
-          groupId: null,
-        },
-        {
-          id: "ai-voice-audio",
-          label: "Voice / Audio",
-          menuLabel: "Voice and Audio",
-          groupId: null,
-        },
-      ],
-      groups: [],
-    },
-    { "communication-collaboration": 327, "ai-voice-audio": 50 },
-  );
+  mockPublicConnectorStatus(context, shelfCatalog(), shelfCategoryMetadata(), {
+    "communication-collaboration": 327,
+    "ai-voice-audio": 50,
+  });
   await setupPage({
     context,
     path: "/connectors?category=communication-collaboration",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
@@ -554,3 +554,53 @@ test("Browse the catalog as shelves, then enter a category and come back", async
     screen.getByTestId("connector-shelf-communication-collaboration"),
   ).toBeInTheDocument();
 });
+
+test("Keep every category in the filter while one of them is open", async () => {
+  mockConnectors(context, []);
+  mockPublicConnectorStatus(
+    context,
+    shelfCatalog(),
+    {
+      categories: [
+        {
+          id: "communication-collaboration",
+          label: "Communication and Collaboration",
+          menuLabel: "Communication",
+          groupId: null,
+        },
+        {
+          id: "ai-voice-audio",
+          label: "Voice / Audio",
+          menuLabel: "Voice and Audio",
+          groupId: null,
+        },
+      ],
+      groups: [],
+    },
+    { "communication-collaboration": 327, "ai-voice-audio": 50 },
+  );
+  await setupPage({
+    context,
+    path: "/connectors?category=communication-collaboration",
+    featureSwitches: { [FeatureSwitchKey.ConnectorDirectory]: true },
+  });
+
+  await waitFor(() => {
+    expect(getConnectorCard("Zendesk")).toBeInTheDocument();
+  });
+
+  // Inside a category the response carries only that category. The filter
+  // describes the catalog, not the response, or it becomes a dead end: the
+  // only way back out would be the breadcrumb.
+  await click(screen.getByLabelText("Filter connectors"));
+  const menu = await screen.findByRole("menu");
+  const options = queryAllByRoleFast("menuitem", menu).map((item) => {
+    return item.textContent;
+  });
+  expect(options).toContain("All");
+  expect(
+    options.some((option) => {
+      return option?.startsWith("Voice");
+    }),
+  ).toBeTruthy();
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-ssh.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-ssh.test.tsx
@@ -167,6 +167,19 @@ test.each([0, 2])(
           connected: false,
         });
       }),
+      // Discovery always names the catalog's categories, and the filter is
+      // built from that list rather than from the connectors that came back.
+      {
+        categories: [
+          {
+            id: "communication-collaboration",
+            label: "Communication and Collaboration",
+            menuLabel: "Communication",
+            groupId: null,
+          },
+        ],
+        groups: [],
+      },
     );
     context.mocks.api(sshConnectionsContract.summary, ({ respond }) => {
       return respond(200, { configuredCount });

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -846,6 +846,36 @@ function discoveryCategoryCounts(
     : undefined;
 }
 
+/**
+ * The categories the filter offers. Category metadata describes the whole
+ * catalog, so it survives a category-scoped response; grouping the returned
+ * connectors is what a response without metadata leaves to work with.
+ */
+function categoryFilterSections(
+  categoryMetadata: PublicConnectorCatalogCategoryMetadata | undefined,
+  connectors: readonly PlatformConnectorCatalogStatusItem[],
+  otherCategoryLabel: string,
+): ConnectorCategorySection<PlatformConnectorCatalogStatusItem>[] {
+  if (!categoryMetadata) {
+    return groupConnectorsByCategory(
+      connectors,
+      categoryMetadata,
+      otherCategoryLabel,
+    ).flatMap((group) => {
+      return group.sections;
+    });
+  }
+  return categoryMetadata.categories.map((category) => {
+    return {
+      category: category.id,
+      label: category.label,
+      menuLabel: category.menuLabel,
+      groupId: category.groupId,
+      connectors: [],
+    };
+  });
+}
+
 interface ConnectorsBrowseModel {
   readonly showShelves: boolean;
   /**
@@ -922,7 +952,14 @@ function buildConnectorsBrowseModel({
     // The page's card grid is three wide, so six is two whole rows.
     previewSize: 6,
   });
-  const chipSections = sectionsOf(allConnectors);
+  // The filter lists the catalog's categories, not the ones the current
+  // response happens to contain: inside a category the response holds only
+  // that category, and a filter that offers nothing else is a dead end.
+  const chipSections = categoryFilterSections(
+    categoryMetadata,
+    allConnectors,
+    otherCategoryLabel,
+  );
   if (sshAvailable) {
     chipSections.push({
       category: REMOTE_ACCESS_CATEGORY,

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -847,25 +847,15 @@ function discoveryCategoryCounts(
 }
 
 /**
- * The categories the filter offers. Category metadata describes the whole
- * catalog, so it survives a category-scoped response; grouping the returned
- * connectors is what a response without metadata leaves to work with.
+ * The categories the filter offers. They come from the catalog's own category
+ * list rather than from the connectors that came back, because inside a
+ * category the response holds only that category and a filter offering
+ * nothing else is a dead end.
  */
 function categoryFilterSections(
   categoryMetadata: PublicConnectorCatalogCategoryMetadata | undefined,
-  connectors: readonly PlatformConnectorCatalogStatusItem[],
-  otherCategoryLabel: string,
 ): ConnectorCategorySection<PlatformConnectorCatalogStatusItem>[] {
-  if (!categoryMetadata) {
-    return groupConnectorsByCategory(
-      connectors,
-      categoryMetadata,
-      otherCategoryLabel,
-    ).flatMap((group) => {
-      return group.sections;
-    });
-  }
-  return categoryMetadata.categories.map((category) => {
+  return (categoryMetadata?.categories ?? []).map((category) => {
     return {
       category: category.id,
       label: category.label,
@@ -901,7 +891,6 @@ interface ConnectorsBrowseModel {
  */
 function buildConnectorsBrowseModel({
   catalogItems,
-  allConnectors,
   categoryMetadata,
   categoryCounts,
   otherCategoryLabel,
@@ -914,7 +903,6 @@ function buildConnectorsBrowseModel({
   remoteAccessLabel,
 }: {
   readonly catalogItems: readonly PlatformConnectorCatalogStatusItem[];
-  readonly allConnectors: readonly PlatformConnectorCatalogStatusItem[];
   readonly categoryMetadata: PublicConnectorCatalogCategoryMetadata | undefined;
   readonly categoryCounts: Readonly<Record<string, number>> | undefined;
   readonly otherCategoryLabel: string;
@@ -955,11 +943,7 @@ function buildConnectorsBrowseModel({
   // The filter lists the catalog's categories, not the ones the current
   // response happens to contain: inside a category the response holds only
   // that category, and a filter that offers nothing else is a dead end.
-  const chipSections = categoryFilterSections(
-    categoryMetadata,
-    allConnectors,
-    otherCategoryLabel,
-  );
+  const chipSections = categoryFilterSections(categoryMetadata);
   if (sshAvailable) {
     chipSections.push({
       category: REMOTE_ACCESS_CATEGORY,
@@ -1568,7 +1552,6 @@ export function ConnectorsPage() {
   );
   const browse = buildConnectorsBrowseModel({
     catalogItems: filteredConnectors,
-    allConnectors,
     categoryMetadata,
     categoryCounts: discoveryCategoryCounts(catalogStatusLoadable),
     otherCategoryLabel,


### PR DESCRIPTION
Opening a category and then reopening the filter offered **only the category already open** — so the filter became a dead end and the breadcrumb was the only way back to the other eleven.

## Two fields disagreed about what a category list is for

Discovery answers a named category with that category alone (#33112), and the response's `categoryMetadata` was derived from **the connectors it returned**, so it collapsed with them. Verified against production:

| `GET /api/connector-catalog/discovery?category=ai-general-models` | |
| --- | --- |
| `connectors` | 71, all `ai-general-models` ✅ |
| `categoryConnectorCounts` | **12 keys** ✅ — always described the whole catalog |
| `categoryMetadata.categories` | **1** ❌ |

`categoryMetadataForConnectors(catalog, args.effective)` received the already-scoped list. The counts never worked that way, which is why the page could still show `71` next to a category it could no longer offer.

## The fix

The category list now comes from the same set as the counts — the whole catalog minus the connectors Okou runs for itself — so it never offers a category the counts do not know. `list` and `status` are unaffected: their effective set already is the whole catalog.

The connectors page builds its filter from that metadata instead of grouping whatever came back, which is what made the page's own list follow the response.

## Verification

- `@okouai/app` and `@okouai/api` `check-types` and `lint`, `pnpm knip` — clean
- 61 tests across `connectors-catalog`, `connectors-ssh`, `connector-directory`, `connectors-accounts`
- New page case "Keep every category in the filter while one of them is open" — loads `/connectors?category=…`, opens the filter, asserts the other category is still listed. **Verified load-bearing**: reverting the page to `sectionsOf(allConnectors)` fails it.
- New API assertion in "answers a named category with the whole category": the scoped response's `categoryMetadata` ids equal the `categoryConnectorCounts` keys. The DB-backed API suite needs Postgres, which this sandbox has no server for; it runs in CI.