### PR TITLE
test(platform): decouple sidebar actions from list readiness

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -798,12 +798,7 @@ function mockLongSidebarHistory(
 
 async function scrollToArchivedContext(): Promise<HTMLElement> {
   await waitFor(() => {
-    expect(
-      within(sidebar()).getByTestId("sidebar-chat-threads-virtual-list"),
-    ).toBeInTheDocument();
-    expect(
-      within(sidebar()).getAllByTestId("sidebar-chat-thread-virtual-row"),
-    ).toHaveLength(14);
+    expect(threadLinkByTitle("Release plan")).toBeInTheDocument();
   });
 
   const scrollArea = within(sidebar()).getByTestId("sidebar-scroll-area");
@@ -1608,12 +1603,17 @@ test("Mark all current-agent chats read from the chat-list menu", async () => {
   });
 });
 
-test("Show mark all read in the mobile chat-list menu", async () => {
+test("Show mark all read in the mobile chat-list menu before conversations load", async () => {
   mockMobileLayout();
   prepareDefaultAgent();
-  const cachedChatThreadEvents = mockSidebarThreadStory([
-    createThread(INCIDENT_THREAD_ID, "Unread conversation"),
-  ]);
+  const remote = context.mocks.deferred<void>();
+  mockSidebarThreadStory(
+    [createThread(INCIDENT_THREAD_ID, "Unread conversation")],
+    [],
+    [],
+    context,
+    remote.promise,
+  );
   mockUnreadAgents(() => {
     return [AGENT_ID];
   });
@@ -1621,21 +1621,23 @@ test("Show mark all read in the mobile chat-list menu", async () => {
   await setupSidebarPage({
     context,
     path: `/agents/${AGENT_ID}/chat`,
-    cachedChatThreadEvents,
   });
 
-  const list = await waitFor(() => {
-    const current = mobileSidebar();
-    expect(
-      within(current).getByText("Unread conversation"),
-    ).toBeInTheDocument();
-    return current;
+  const list = await screen.findByRole("complementary", {
+    name: "Sidebar",
   });
+  expect(
+    within(list).queryByText("Unread conversation"),
+  ).not.toBeInTheDocument();
   click(within(list).getByLabelText("Open chat list menu"));
 
   await waitFor(() => {
     expect(menuItemByText("Mark all read")).toBeInTheDocument();
   });
+  expect(
+    within(list).queryByText("Unread conversation"),
+  ).not.toBeInTheDocument();
+  remote.resolve();
 });
 
 test("Mark all of an agent’s chats read", async () => {


### PR DESCRIPTION
## Summary

- wait for a visible leading conversation before scrolling the long sidebar instead of asserting the internal virtual-list container and rendered-row count
- keep the refresh story cache-first and preserve its remote synchronization, offscreen deletion, and browser-clamped scroll assertions
- hold conversation-list hydration in the mobile story and verify that `Mark all read` becomes available from the unread-agent state before any conversation row loads

## Rationale

The cache fixture added in #33168 correctly models the refreshed long-sidebar story, but the shared scroll helper still pinned virtualization internals. The mobile menu story also used the unrelated `Unread conversation` title as its readiness gate even though menu visibility is driven by the current agent's unread indicator.

This change keeps both tests at observable page boundaries. It does not change production behavior, timeouts, retries, scheduling, or cleanup.

## Verification

- `npx --yes prettier@3.8.1 --check turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx`
- `git diff --check`
- Targeted Vitest was not run locally because this fresh checkout has no installed project dependencies; the PR `test-app (2)` job is the behavior validation.
