### PR TITLE
fix(chat): honor retained chat thread event cursors

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1030,18 +1030,16 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     await expectExpiredThreadEventCursor(actor, firstEvent.seqId + 1);
   });
 
-  it("reads an exact markerless snapshot watermark atomically", async () => {
+  it("reads retained and exact markerless snapshot cursors atomically", async () => {
     const scenario = await createSnapshotCursorScenario("Markerless cursor");
     const { actor, agent, firstEvent, snapshot, thread } = scenario;
 
-    // The unbounded read proves that the covered cursor row still physically
-    // exists even though the snapshot watermark makes it intentionally stale.
-    expect(
-      (await allThreadEvents(actor)).some((event) => {
-        return event.id === firstEvent.id;
-      }),
-    ).toBeTruthy();
-    await expectExpiredThreadEventCursor(actor, firstEvent.seqId);
+    await expect(
+      threadEventPage(actor, firstEvent.seqId),
+    ).resolves.toStrictEqual({
+      events: [expect.objectContaining({ id: snapshot.latestEventId })],
+      hasMore: false,
+    });
     await deleteSnapshotCursorMarker(scenario);
 
     const held = await holdChatThreadEventInsertTransactionFixture({
@@ -1935,17 +1933,12 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
         return event.id === liveCreateEvent.id;
       }),
     ).toBeTruthy();
-    const coveredBoundaryCursor = await chat.requestThreadEvents(
+    const retainedBoundaryCursor = await chat.requestThreadEvents(
       actor,
       { sinceSeqId: liveCreateEvent.seqId },
-      [410],
+      [200],
     );
-    expect(coveredBoundaryCursor.body).toStrictEqual({
-      error: {
-        message: "Chat thread events cursor has expired",
-        code: "CHAT_THREAD_EVENTS_EXPIRED",
-      },
-    });
+    expect(retainedBoundaryCursor.status).toBe(200);
 
     mockNow(retentionBoundary + 1);
     const retentionCompact = await compactChatThreadSnapshots(actor);
@@ -1964,12 +1957,12 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
 
     mockNow(Date.parse(deletedCreateEvent.createdAt) + 7 * DAY_MS + 1);
     await compactChatThreadSnapshots(actor);
-    const coveredDeletedAgentCursor = await chat.requestThreadEvents(
+    const prunedDeletedAgentCursor = await chat.requestThreadEvents(
       actor,
       { sinceSeqId: deletedCreateEvent.seqId },
       [410],
     );
-    expect(coveredDeletedAgentCursor.body).toStrictEqual({
+    expect(prunedDeletedAgentCursor.body).toStrictEqual({
       error: {
         message: "Chat thread events cursor has expired",
         code: "CHAT_THREAD_EVENTS_EXPIRED",

--- a/turbo/apps/api/src/signals/services/chat-thread-event.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-event.service.ts
@@ -1,5 +1,5 @@
 import type { ReasoningEffort } from "@okouai/api-contracts/contracts/model-reasoning-effort";
-import { and, asc, eq, exists, gt, gte, notExists, sql } from "drizzle-orm";
+import { and, asc, eq, exists, gt, notExists, sql } from "drizzle-orm";
 import { alias, unionAll } from "drizzle-orm/pg-core";
 import type {
   ChatThreadEvent,
@@ -277,6 +277,8 @@ async function getChatThreadEventRowsAfterCursor(
             eq(cursorChatThreadEvent.userId, args.userId),
             eq(cursorChatThreadEvent.orgId, args.orgId),
             eq(cursorChatThreadEvent.seqId, args.sinceSeqId),
+            // Snapshot advancement must not invalidate retained event cursors.
+            // Exclude only the exact watermark so the union branches stay disjoint.
             notExists(
               db
                 .select({ userId: chatThreadSnapshots.userId })
@@ -285,7 +287,7 @@ async function getChatThreadEventRowsAfterCursor(
                   and(
                     eq(chatThreadSnapshots.userId, args.userId),
                     eq(chatThreadSnapshots.orgId, args.orgId),
-                    gte(chatThreadSnapshots.latestEventSeqId, args.sinceSeqId),
+                    eq(chatThreadSnapshots.latestEventSeqId, args.sinceSeqId),
                   ),
                 ),
             ),


### PR DESCRIPTION
## Summary

- keep same-user and same-organization Chat Thread Event cursors valid while their physical event row is retained, even after the snapshot watermark advances
- keep an exact markerless snapshot watermark valid while ensuring the cursor-validation union remains disjoint
- cover retained cursors with a successful tail response while preserving 410 responses after the cursor row is actually pruned

Fixes #33111

## Verification

- `pnpm exec prettier --check apps/api/src/signals/services/chat-thread-event.service.ts apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api check-types:tests`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts --maxWorkers=1 -t "reads retained and exact markerless snapshot cursors atomically|preserves UTC snapshot and event cutoff boundaries outside UTC"` (2 passed)
