### PR TITLE
chore(runner): upgrade firecracker to v1.16.2

### DIFF
--- a/crates/runner/src/deps.rs
+++ b/crates/runner/src/deps.rs
@@ -1,17 +1,17 @@
 //! Third-party dependency metadata: versions, checksums, and download URLs.
 
-pub const FIRECRACKER_VERSION: &str = "v1.15.1";
+pub const FIRECRACKER_VERSION: &str = "v1.16.2";
 pub const KERNEL_VERSION: &str = "6.1.155";
 /// Canonical mitmproxy release for runner artifacts and the embedded add-on.
 pub const MITMPROXY_VERSION: &str = "12.2.3";
 
 // Exact identities for installed artifacts, keyed by arch.
-pub const FIRECRACKER_SIZE_X86_64: u64 = 3_417_392;
-pub const FIRECRACKER_SIZE_AARCH64: u64 = 3_119_984;
+pub const FIRECRACKER_SIZE_X86_64: u64 = 3_539_456;
+pub const FIRECRACKER_SIZE_AARCH64: u64 = 3_255_464;
 pub const FIRECRACKER_SHA256_X86_64: &str =
-    "7e8b57e88c459396d4680d83dcdd8c7f72305447cb55b11f4ac98ad70a3f7825";
+    "8227875ceda44177a4d501052dae4a2f9d7837362f5399f02cf0748e68418377";
 pub const FIRECRACKER_SHA256_AARCH64: &str =
-    "e9ce7466c3b0d879d7a9158f4bf710dd5e131bbc5e580e5269fec66d5b5a0f0a";
+    "f7168507c37b2b047ea2b30433cbe4faa3986c36d1209c046fd1814118ce3d48";
 pub const KERNEL_SIZE_X86_64: u64 = 44_279_576;
 pub const KERNEL_SIZE_AARCH64: u64 = 17_111_552;
 pub const KERNEL_SHA256_X86_64: &str =
@@ -26,12 +26,12 @@ pub const MITMDUMP_SHA256_AARCH64: &str =
     "47612c592db3b0b80164aee2dd1be1f3841d5430891f7ebeabf2284a7cc490b9";
 
 // Exact identities for compressed source archives, keyed by arch.
-pub const FIRECRACKER_ARCHIVE_SIZE_X86_64: u64 = 7_622_285;
-pub const FIRECRACKER_ARCHIVE_SIZE_AARCH64: u64 = 7_422_699;
+pub const FIRECRACKER_ARCHIVE_SIZE_X86_64: u64 = 7_499_848;
+pub const FIRECRACKER_ARCHIVE_SIZE_AARCH64: u64 = 7_321_444;
 pub const FIRECRACKER_ARCHIVE_SHA256_X86_64: &str =
-    "d4a32ab2322d887ca1bc4a4e7afa9cc35393e6362dfc2b3becb389d362e4275a";
+    "32e3cdcd4081f91fe2b024a266f57dcb3b4e5fec5033e0cb22467ad7f7820bda";
 pub const FIRECRACKER_ARCHIVE_SHA256_AARCH64: &str =
-    "00654ac1e702a22744121ea9f10a4f792ebd7c3a744cba587dfac9fcb79b41a5";
+    "751365040ca3dde7616c5a1d97cc1304674fae469ce02993104eab22f5961950";
 pub const MITMPROXY_ARCHIVE_SIZE_X86_64: u64 = 119_209_168;
 pub const MITMPROXY_ARCHIVE_SIZE_AARCH64: u64 = 112_694_307;
 pub const MITMPROXY_ARCHIVE_SHA256_X86_64: &str =
@@ -42,25 +42,6 @@ pub const MITMPROXY_ARCHIVE_SHA256_AARCH64: &str =
 /// System CA certificate bundle path. The standalone mitmproxy binary bundles its
 /// own (incomplete) certifi CA store; we override it with the host's system store.
 pub const SYSTEM_CA_BUNDLE: &str = "/etc/ssl/certs/ca-certificates.crt";
-
-/// "v1.15.1" → "v1.15"
-const FIRECRACKER_MINOR: &str = strip_patch(FIRECRACKER_VERSION);
-
-#[allow(clippy::panic, clippy::indexing_slicing)] // compile-time only
-const fn strip_patch(version: &str) -> &str {
-    let bytes = version.as_bytes();
-    let mut i = bytes.len();
-    while i > 0 {
-        i -= 1;
-        if bytes[i] == b'.' {
-            // SAFETY: splitting a UTF-8 str at an ASCII '.' boundary yields valid UTF-8
-            return unsafe {
-                std::str::from_utf8_unchecked(std::slice::from_raw_parts(bytes.as_ptr(), i))
-            };
-        }
-    }
-    panic!("FIRECRACKER_VERSION must be in vMAJOR.MINOR.PATCH format")
-}
 
 /// Tarball entry name for firecracker binary.
 pub fn firecracker_tar_entry(arch: &str) -> String {
@@ -74,8 +55,10 @@ pub fn firecracker_url(arch: &str) -> String {
 }
 
 pub fn kernel_url(arch: &str) -> String {
+    // Pin the kernel artifact source independently of the VMM version. The
+    // v1.16 artifact namespace does not contain the existing 6.1.155 kernel.
     format!(
-        "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/{FIRECRACKER_MINOR}/{arch}/vmlinux-{KERNEL_VERSION}"
+        "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.15/{arch}/vmlinux-{KERNEL_VERSION}"
     )
 }
 
@@ -100,11 +83,6 @@ mod tests {
             .lines()
             .filter_map(|line| line.strip_prefix(prefix)?.strip_suffix(suffix))
             .collect()
-    }
-
-    #[test]
-    fn strip_patch_version() {
-        assert_eq!(FIRECRACKER_MINOR, "v1.15");
     }
 
     #[test]

--- a/crates/sandbox-firecracker/src/snapshot/runtime.rs
+++ b/crates/sandbox-firecracker/src/snapshot/runtime.rs
@@ -123,11 +123,11 @@ async fn run_with_firecracker(
     // 12. Create snapshot — Firecracker writes directly to output_dir.
     //
     // File content durability is guaranteed upstream: as of Firecracker
-    // v1.15.1 (see `FIRECRACKER_VERSION` in `runner/src/deps.rs`), both
+    // v1.16.2 (see `FIRECRACKER_VERSION` in `runner/src/deps.rs`), both
     // snapshot.bin and memory.bin are flushed and fsynced before the API
-    // response returns. References (pinned to the v1.15.1 tag):
-    //   - `snapshot_state_to_file` — https://github.com/firecracker-microvm/firecracker/blob/v1.15.1/src/vmm/src/persist.rs
-    //   - `snapshot_memory_to_file` — https://github.com/firecracker-microvm/firecracker/blob/v1.15.1/src/vmm/src/vstate/vm.rs
+    // response returns. References (pinned to the v1.16.2 tag):
+    //   - `snapshot_state_to_file` — https://github.com/firecracker-microvm/firecracker/blob/v1.16.2/src/vmm/src/persist.rs
+    //   - `snapshot_memory_to_file` — https://github.com/firecracker-microvm/firecracker/blob/v1.16.2/src/vmm/src/vstate/vm.rs
     // Re-verify this guarantee whenever `FIRECRACKER_VERSION` is bumped;
     // if it ever regresses, add a host-side `sync_all` on both files here.
     // Directory-entry durability (persisting the `name → inode` mapping)


### PR DESCRIPTION
## Summary

- Upgrade Firecracker from v1.15.1 to [v1.16.2](https://github.com/firecracker-microvm/firecracker/releases/tag/v1.16.2), updating the installed binary and source archive sizes and SHA-256 checksums for both x86_64 and aarch64.
- Keep guest kernel 6.1.155 unchanged and pin its existing v1.15 artifact source independently of the Firecracker version. Both v1.16 kernel URLs return 404 for this kernel; automatically changing their namespace would break setup. Remove the now-unused version-stripping helper and its obsolete test.
- Re-verify snapshot state and memory flush/fsync guarantees against the v1.16.2 upstream source and update the pinned references.

## Compatibility and scope

- v1.16.2 changes the Firecracker snapshot format. Existing snapshot hashes already include the full Firecracker version, so the normal image build creates a separate snapshot for the new VMM. Firecracker binaries also use version-specific installation directories; old runners retain their existing binaries and snapshots while draining.
- Keep existing image-build and configuration-generation paths. Do not manually pair a v1.16.2 binary with a previous-version snapshot.
- No guest kernel upgrade, snapshot format migration, API/protocol changes, new Firecracker feature configuration, or production operations are included.

## Validation

- Downloaded both official v1.16.2 release archives and checked their published SHA-256 files. Verified archive and extracted binary sizes/checksums against the updated `deps.rs` values.
- Downloaded both unchanged v1.15/6.1.155 kernel artifacts and verified their existing sizes/checksums.
- Confirmed upstream `snapshot_state_to_file` and `snapshot_memory_to_file` still flush and fsync before returning.
- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy --profile local -p runner -p sandbox-firecracker --all-targets --all-features`
- `cd crates && cargo doc --profile local -p runner -p sandbox-firecracker --all-features --no-deps`
- `cd crates && cargo test --profile local -p runner -p sandbox-firecracker` — 4,559 passed; no failures. Existing ignored subprocess fixtures and metal-only tests retain their existing selection rules.
- `bash .github/scripts/tests/runner-image-context-test.sh`
- `bash .github/scripts/tests/runner-behavior-guest-rpc-test.sh`
- `bash .github/scripts/tests/prepare-runner-image-test.sh`
- `git diff --check`

The local container has no `/dev/kvm`. Actual VM boot, snapshot restore/reuse, vsock RPC, balloon behavior, and weighted CPU tests must pass in the existing metal CI jobs before merge. The shell RPC test above verifies orchestration, not a real VM.
