### PR TITLE
fix(auth): restore hosted input boundaries

### DIFF
--- a/e2e/playwright/tests/auth-v1.spec.ts
+++ b/e2e/playwright/tests/auth-v1.spec.ts
@@ -52,6 +52,15 @@ async function expectPrimary(page: Page, button: Locator): Promise<void> {
   await expect(button).toHaveCSS("text-decoration-line", "none");
 }
 
+async function expectInputBoundary(
+  input: Locator,
+  theme: "light" | "dark",
+): Promise<void> {
+  const expectedBorderColor =
+    theme === "light" ? "rgb(207, 204, 203)" : "rgb(86, 84, 84)";
+  await expect(input).toHaveCSS("border-color", expectedBorderColor);
+}
+
 async function expectSeparated(above: Locator, below: Locator): Promise<void> {
   await expect(above).toBeVisible();
   await expect(below).toBeVisible();
@@ -264,6 +273,7 @@ for (const device of [
         );
         await expectLogo(page);
         await expect(email).toHaveValue("theme-preview@example.com");
+        await expectInputBoundary(email, "dark");
 
         await toggle.click();
         await expect(page.locator("html")).toHaveAttribute(
@@ -273,6 +283,7 @@ for (const device of [
         await expect(logo).toHaveAttribute("src", lightLogoSrc);
         await expectLogo(page);
         await expect(email).toHaveValue("theme-preview@example.com");
+        await expectInputBoundary(email, "light");
       }
     });
 

--- a/turbo/apps/platform/src/views/auth-v1/component-appearance.ts
+++ b/turbo/apps/platform/src/views/auth-v1/component-appearance.ts
@@ -9,6 +9,12 @@ type ClerkAppearance = NonNullable<ComponentProps<typeof SignIn>["appearance"]>;
 const AUTH_V1_PRIMARY_ACTION_CLASS =
   "border-transparent bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-pressed";
 
+// Clerk owns the field geometry and behavior. Keep the public input slot on
+// the application's standard control boundary so fields remain distinguishable
+// from the card surface in every theme.
+const AUTH_V1_TEXT_INPUT_CLASS =
+  "border border-[hsl(var(--gray-400))] bg-input shadow-none focus:border-primary focus:ring-[3px] focus:ring-primary/10 aria-invalid:border-destructive aria-invalid:focus:border-destructive";
+
 // Clerk's OTP slots are visual divs; its accessible textbox owns focus. Match
 // the shared Input boundary while adapting focus and error states through the
 // public attributes that Clerk exposes on each slot.
@@ -40,6 +46,7 @@ export function getAuthV1ComponentAppearance(
       // accessible link color at provider level, then give only the CTA the
       // application's semantic filled-action colors.
       formButtonPrimary: AUTH_V1_PRIMARY_ACTION_CLASS,
+      formFieldInput: AUTH_V1_TEXT_INPUT_CLASS,
       otpCodeFieldInput: AUTH_V1_OTP_INPUT_CLASS,
     },
   };


### PR DESCRIPTION
## Summary

- restore a visible semantic control boundary for Clerk-hosted text and password inputs
- keep Clerk-owned geometry and behavior while using the public `formFieldInput` appearance slot
- cover the light and dark input border colors through the deployed Auth V1 Playwright flow

## Verification

- `pnpm -C turbo/apps/platform lint:clerk-customize`
- `pnpm -C turbo/apps/platform check-types`
- `pnpm -C turbo lint:style`
- `pnpm -C e2e check-types`
- Prettier, scoped Oxlint, type-aware Oxlint, ESLint, and `git diff --check`

## Preview verification

- exact head: `443fa50138c49f7b203d941a351f426b59558241`
- App Preview: `https://pr-33301-app-okou-app-preview.vm0.workers.dev`
- Chromium 152, 1440x900, Clerk development instance, no account or submitted form
- sign-in identifier and sign-up email/password inputs use the gray-400 boundary in light and dark themes
- focus uses the semantic primary border and 3px/10% ring; checkbox styling and layout remain unchanged
- no horizontal overflow or page errors; only the expected Clerk development-key warning
