### PR TITLE
refactor(ui): move the sidebar nav copy tint to the variable layer

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -102,7 +102,7 @@ The variant uses `border-(length:--border-width-surface)` so class merging recog
 
 The pointer overlay reuses the shared `bg-state-hover-overlay` token rather than declaring a surface-specific one, so one interaction-state decision keeps one owner. Like the choice variant, it applies through `[&:hover]` to preserve the existing touch-browser hover contract as well as pointer hover, and it does not replace the card fill with a translucent background. Radius, border, shadow, and transition decisions belong to this variant; use layout utilities for padding, size, alignment, and overflow.
 
-Integration and connector tests scope controls through the documented `data-slot="integration-card"` and `data-slot="connector-card"` component boundaries. These slots carry no styles; tests must not locate surfaces through utility or legacy class names.
+Integration and connector tests scope controls through the documented `data-slot="integration-card"`, `data-slot="connector-card"`, `data-slot="badge"`, and `data-slot="sidebar-thread-title"` component boundaries. These slots carry no styles; tests must not locate surfaces through utility or legacy class names.
 
 The `okou-card` selector and its consumers have been removed. This equivalent migration also removes background, border, shadow, and focus-ring overrides that the old unlayered selector had suppressed; activating those overrides would be a separate visual change. Existing `--okou-card-*` variables still consumed by other legacy components remain frozen until those components migrate; they are not a supported API for new surfaces.
 
@@ -247,6 +247,50 @@ so a control moved onto a differently coloured surface keeps the treatment it
 has today.
 
 The `okou-btn-morandi` selector has been removed.
+
+### Sidebar copy under the gradient color themes
+
+The `okou-nav-copy`, `okou-nav-copy-muted`, and `okou-nav-copy-muted-hover`
+selectors have been removed. They were scoped to
+`.okou-app[data-gradient-color-themes]` and collapsed every nav consumer onto one
+foreground and one muted foreground, overriding whatever each consumer spelled
+for itself. The collapse now happens at the variable layer instead:
+
+```css
+:root[data-gradient-color-themes][data-color-theme] {
+  --nav-copy: hsl(var(--okou-color-theme-hue) 24% 18%);
+  --nav-copy-muted: hsl(var(--okou-color-theme-hue) 18% 38%);
+}
+```
+
+```css
+--color-nav-copy: var(--nav-copy, var(--color-sidebar-foreground));
+--color-nav-copy-muted: var(--nav-copy-muted, var(--color-muted-foreground));
+```
+
+When the gradient themes are on, the raw values exist and every consumer resolves
+to them. Everywhere else they are unset and each consumer falls back to the
+foreground it already had, so both sides keep their current appearance without a
+conditional selector. Consumers whose foreground matches a registered fallback
+use `text-nav-copy` or `text-nav-copy-muted`; the rest carry their own fallback
+in the utility, including `var(--nav-copy, inherit)` where the consumer inherits
+its colour from an ancestor `Link` or `button` and must keep inheriting that
+ancestor's hover.
+
+Measured against `main` with the App's own Tailwind compiler in Chromium over
+CDP — 18 theme states, 19 class variants, hover forced on every row and on its
+colour-bearing ancestor: zero changed computed colours on the default palette and
+zero on all eight gradient palettes. A negative control that perturbs one
+fallback reports changes on both, so the zeros are not degenerate.
+
+One difference remains on a coarse pointer: `group-hover` carries Tailwind's
+`@media (hover: hover)` guard, which the retired selector lacked, so the gradient
+themes no longer paint the hover foreground onto a sticky tap state. Removing
+that guard would need either a first-party selector or a global `hover` variant
+override, and the guard is the better behaviour.
+
+Sidebar thread titles carry `data-slot="sidebar-thread-title"` so tests select
+them through a documented slot instead of the styling class.
 
 ## Exception boundary
 

--- a/e2e/playwright/style-migration/nav-copy-cases.json
+++ b/e2e/playwright/style-migration/nav-copy-cases.json
@@ -1,0 +1,48 @@
+{
+  "version": 1,
+  "batch": "sidebar-copy-foreground",
+  "cases": [
+    {
+      "id": "nav-copy-gradient-light",
+      "path": "/agents",
+      "theme": "light",
+      "viewport": { "width": 1440, "height": 1000 },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "nav-copy-gradient-dark",
+      "path": "/agents",
+      "theme": "dark",
+      "viewport": { "width": 1440, "height": 1000 },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "nav-copy-default-light",
+      "path": "/agents",
+      "theme": "light",
+      "viewport": { "width": 1280, "height": 900 },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "nav-copy-default-dark",
+      "path": "/agents",
+      "theme": "dark",
+      "viewport": { "width": 1280, "height": 900 },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "nav-copy-rail-light",
+      "path": "/agents",
+      "theme": "light",
+      "viewport": { "width": 900, "height": 900 },
+      "deviceScaleFactor": 2
+    },
+    {
+      "id": "nav-copy-rail-dark",
+      "path": "/agents",
+      "theme": "dark",
+      "viewport": { "width": 900, "height": 900 },
+      "deviceScaleFactor": 2
+    }
+  ]
+}

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -28,6 +28,12 @@
   /* Sidebar colors - using tokens for dark mode support */
   --color-sidebar-border: hsl(var(--gray-200));
 
+  /* Nav copy. The gradient color themes define the two raw values at :root and
+     collapse every nav consumer onto them. Everywhere else the values are
+     unset, so each consumer falls back to the foreground it already spells. */
+  --color-nav-copy: var(--nav-copy, var(--color-sidebar-foreground));
+  --color-nav-copy-muted: var(--nav-copy-muted, var(--color-muted-foreground));
+
   /* Credit balance breakdown segment colors (usage bar chart) */
   --color-credit-free: #008d76;
   --color-credit-promotional: #ff6030;
@@ -591,15 +597,6 @@ body {
 .okou-app[data-gradient-color-themes] .okou-nav {
   --color-sidebar: hsl(var(--sidebar));
   --color-sidebar-border: hsl(var(--border) / 0.5);
-}
-.okou-app[data-gradient-color-themes] .okou-nav .okou-nav-copy {
-  color: hsl(var(--okou-nav-foreground));
-}
-.okou-app[data-gradient-color-themes] .okou-nav .okou-nav-copy-muted {
-  color: hsl(var(--okou-nav-muted-foreground));
-}
-.okou-app[data-gradient-color-themes] .group:hover .okou-nav-copy-muted-hover {
-  color: hsl(var(--okou-nav-foreground));
 }
 .okou-app[data-gradient-color-themes] .okou-nav.okou-nav-rail {
   background-color: hsl(var(--okou-nav-rail));
@@ -1839,8 +1836,8 @@ details > summary {
      white sheet overpowers it. The rail keeps its depth and stays the anchor. */
   --sidebar: var(--okou-color-theme-hue) 30% 98.4%;
   --okou-nav-rail: var(--okou-color-theme-hue) 36% 93.5%;
-  --okou-nav-foreground: var(--okou-color-theme-hue) 24% 18%;
-  --okou-nav-muted-foreground: var(--okou-color-theme-hue) 18% 38%;
+  --nav-copy: hsl(var(--okou-color-theme-hue) 24% 18%);
+  --nav-copy-muted: hsl(var(--okou-color-theme-hue) 18% 38%);
   --background-50: var(--gray-50);
   --state-layer: var(--okou-color-theme-ring);
   --segment-selected: var(--card);
@@ -1880,8 +1877,8 @@ details > summary {
   --ring: var(--okou-color-theme-hue) 45% 62%;
   --sidebar: var(--okou-color-theme-hue) 14% 12%;
   --okou-nav-rail: var(--okou-color-theme-hue) 18% 8%;
-  --okou-nav-foreground: var(--okou-color-theme-hue) 22% 90%;
-  --okou-nav-muted-foreground: var(--okou-color-theme-hue) 16% 64%;
+  --nav-copy: hsl(var(--okou-color-theme-hue) 22% 90%);
+  --nav-copy-muted: hsl(var(--okou-color-theme-hue) 16% 64%);
   --background-50: var(--gray-50);
   --state-layer: var(--okou-color-theme-hue) 35% 82%;
   --segment-selected: var(--gray-400);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-test-helpers.ts
@@ -364,7 +364,7 @@ export function sidebarThreadTitles(): string[] {
   return sidebarThreadLinks().map((link) => {
     return (
       link
-        .querySelector(".okou-nav-copy")
+        .querySelector('[data-slot="sidebar-thread-title"]')
         ?.textContent?.replace(/\s+/gu, " ")
         .trim() ?? ""
     );

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -352,7 +352,7 @@ function PinnedAgentGridCard({
       </span>
       <span
         data-testid="pinned-agent-label-frame"
-        className={`okou-nav-copy ${pinnedAgentGridLabelFrameClassName} w-full truncate text-center text-[11px] ${
+        className={`text-[color:var(--nav-copy,inherit)] ${pinnedAgentGridLabelFrameClassName} w-full truncate text-center text-[11px] ${
           isPrimarySelected ? "font-medium" : ""
         } ${isDragging ? "opacity-0" : ""}`}
       >
@@ -506,7 +506,7 @@ export function PinnedAgentListSection({
 
     return (
       <div className="shrink-0" data-testid="pinned-agents-horizontal">
-        <span className="okou-nav-copy-muted flex h-8 items-center pl-2 text-[13px] font-medium leading-4 text-muted-foreground">
+        <span className="flex h-8 items-center pl-2 text-[13px] font-medium leading-4 text-nav-copy-muted">
           {t(($) => {
             return $.sidebar.pinnedAgents;
           })}
@@ -532,7 +532,7 @@ export function PinnedAgentListSection({
               </span>
               <span
                 data-testid="pinned-agent-label-frame"
-                className={`okou-nav-copy-muted ${pinnedAgentGridLabelFrameClassName} text-[11px]`}
+                className={`text-[color:var(--nav-copy-muted,inherit)] ${pinnedAgentGridLabelFrameClassName} text-[11px]`}
               >
                 {t(($) => {
                   return $.sidebar.addPin;
@@ -555,7 +555,7 @@ export function PinnedAgentListSection({
           return setCollapsed(!collapsed);
         }}
       >
-        <span className="okou-nav-copy-muted okou-nav-copy-muted-hover flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-muted-foreground group-hover:text-sidebar-foreground transition-colors">
+        <span className="flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-nav-copy-muted group-hover:text-nav-copy transition-colors">
           {t(($) => {
             return $.sidebar.pinned;
           })}
@@ -625,7 +625,7 @@ export function PinnedAgentListSection({
                       alt={agent.displayName ?? agent.agentId}
                       className="h-5 w-5 shrink-0 rounded-md object-cover object-top"
                     />
-                    <span className="okou-nav-copy truncate">
+                    <span className="text-[color:var(--nav-copy,inherit)] truncate">
                       {agent.displayName ?? agent.agentId}
                     </span>
                   </Link>

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -422,7 +422,11 @@ function ChatThreadItemLink({
     >
       <span className="flex min-w-0 items-center gap-2 pr-8">
         <ChatThreadListPaneIcon signals={signals} />
-        <span className="okou-nav-copy okou-nav-title" ref={measureTitle}>
+        <span
+          data-slot="sidebar-thread-title"
+          className="text-[color:var(--nav-copy,inherit)] okou-nav-title"
+          ref={measureTitle}
+        >
           <span>
             {title ??
               t(($) => {
@@ -699,7 +703,7 @@ function ChatThreads({
 
   if (threadCount === 0) {
     return (
-      <p className="okou-nav-copy-muted px-2 py-2 text-xs text-muted-foreground leading-relaxed">
+      <p className="px-2 py-2 text-xs text-nav-copy-muted leading-relaxed">
         {unreadOnly
           ? t(($) => {
               return $.chat.sidebar.noUnread;
@@ -907,7 +911,7 @@ function ChatThreadsTitle({ showMarkAllRead }: { showMarkAllRead: boolean }) {
         return setCollapsed(!collapsed);
       }}
     >
-      <span className="okou-nav-copy-muted okou-nav-copy-muted-hover flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-muted-foreground group-hover:text-sidebar-foreground transition-colors">
+      <span className="flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-nav-copy-muted group-hover:text-nav-copy transition-colors">
         {titleLabel}
         <span className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
           <ChevronRight

--- a/turbo/apps/platform/src/views/okou-page/sidebar-upgrade.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-upgrade.tsx
@@ -73,7 +73,7 @@ export function SidebarUpgradeCard() {
       })}
     >
       <div className="min-w-0 flex-1">
-        <p className="okou-nav-copy text-sm font-medium text-foreground">
+        <p className="text-sm font-medium text-[color:var(--nav-copy,var(--color-foreground))]">
           {t(
             ($) => {
               return $.billing.sidebar.getPlan;
@@ -81,7 +81,7 @@ export function SidebarUpgradeCard() {
             { plan: nextLabel },
           )}
         </p>
-        <p className="okou-nav-copy-muted mt-0.5 text-[11px] text-muted-foreground">
+        <p className="mt-0.5 text-[11px] text-nav-copy-muted">
           {t(($) => {
             return $.billing.sidebar.description;
           })}

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -307,7 +307,7 @@ function ExpandedManageSection() {
           return setManageCollapsed(!manageCollapsed);
         }}
       >
-        <span className="okou-nav-copy-muted okou-nav-copy-muted-hover flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-sidebar-foreground/50 group-hover:text-sidebar-foreground transition-colors">
+        <span className="flex flex-1 items-center gap-1 truncate text-[13px] font-medium leading-4 text-[color:var(--nav-copy-muted,color-mix(in_oklab,var(--color-sidebar-foreground)_50%,transparent))] group-hover:text-nav-copy transition-colors">
           {t(($) => {
             return $.appShell.sidebar.manage;
           })}
@@ -345,7 +345,9 @@ function ExpandedManageSection() {
                   }`}
                 >
                   <Icon size={16} className="shrink-0" />
-                  <span className="okou-nav-copy truncate">{label}</span>
+                  <span className="text-[color:var(--nav-copy,inherit)] truncate">
+                    {label}
+                  </span>
                 </Link>
               );
             },
@@ -431,7 +433,9 @@ function ExpandedFooter() {
                 ) : (
                   <Icon size={16} className="shrink-0" />
                 )}
-                <span className="okou-nav-copy flex-1 truncate">{label}</span>
+                <span className="text-[color:var(--nav-copy,inherit)] flex-1 truncate">
+                  {label}
+                </span>
                 {id === "works" && slackScopeMismatch && (
                   <span
                     data-testid="slack-scope-mismatch-indicator"
@@ -546,8 +550,8 @@ function LabeledRailLink({
       <span
         className={`max-w-full truncate px-0.5 text-[10px] font-medium leading-[14px] ${
           isActive
-            ? "okou-nav-copy text-sidebar-foreground"
-            : "okou-nav-copy-muted text-sidebar-foreground/70"
+            ? "text-nav-copy"
+            : "text-[color:var(--nav-copy-muted,color-mix(in_oklab,var(--color-sidebar-foreground)_70%,transparent))]"
         }`}
       >
         {caption}
@@ -763,7 +767,7 @@ function ChatListColumn() {
           CHAT_LIST_INSET,
         )}
       >
-        <span className="okou-nav-copy flex-1 pl-2 text-[15px] font-semibold text-sidebar-foreground">
+        <span className="flex-1 pl-2 text-[15px] font-semibold text-nav-copy">
           {t(($) => {
             return $.appShell.sidebar.chat;
           })}

--- a/turbo/style-legacy-baseline.json
+++ b/turbo/style-legacy-baseline.json
@@ -33,9 +33,6 @@
     "okou-mobile-fixed-safe-area",
     "okou-mobile-sidebar",
     "okou-nav",
-    "okou-nav-copy",
-    "okou-nav-copy-muted",
-    "okou-nav-copy-muted-hover",
     "okou-nav-recent-label",
     "okou-nav-title",
     "okou-nav-title-row",
@@ -667,27 +664,6 @@
         "selector": ".okou-app[data-gradient-color-themes] .okou-nav",
         "property": "--color-sidebar-border",
         "value": " hsl(var(--border) / 0.5)",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-app[data-gradient-color-themes] .okou-nav .okou-nav-copy",
-        "property": "color",
-        "value": "hsl(var(--okou-nav-foreground))",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-app[data-gradient-color-themes] .okou-nav .okou-nav-copy-muted",
-        "property": "color",
-        "value": "hsl(var(--okou-nav-muted-foreground))",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-app[data-gradient-color-themes] .group:hover .okou-nav-copy-muted-hover",
-        "property": "color",
-        "value": "hsl(var(--okou-nav-foreground))",
         "important": false
       },
       {
@@ -3274,22 +3250,10 @@
       "okou-pwa-fixed-cover": 1,
       "okou-viewport-shell": 1
     },
-    "apps/platform/src/views/okou-page/sidebar-pinned.tsx": {
-      "okou-nav-copy": 2,
-      "okou-nav-copy-muted": 3,
-      "okou-nav-copy-muted-hover": 1
-    },
     "apps/platform/src/views/okou-page/sidebar-threads.tsx": {
-      "okou-nav-copy": 1,
-      "okou-nav-copy-muted": 2,
-      "okou-nav-copy-muted-hover": 1,
       "okou-nav-recent-label": 1,
       "okou-nav-title": 1,
       "okou-nav-title-row": 1
-    },
-    "apps/platform/src/views/okou-page/sidebar-upgrade.tsx": {
-      "okou-nav-copy": 1,
-      "okou-nav-copy-muted": 1
     },
     "apps/platform/src/views/okou-page/sidebar.tsx": {
       "okou-desktop-no-drag": 1,
@@ -3297,9 +3261,6 @@
       "okou-mobile-fixed-safe-area": 1,
       "okou-mobile-sidebar": 1,
       "okou-nav": 3,
-      "okou-nav-copy": 4,
-      "okou-nav-copy-muted": 2,
-      "okou-nav-copy-muted-hover": 1,
       "okou-sidebar-header": 1
     },
     "apps/platform/src/views/okou-page/tiptap-instructions-editor.tsx": {

--- a/turbo/style-migration-manifest.json
+++ b/turbo/style-migration-manifest.json
@@ -615,6 +615,32 @@
       ],
       "status": "implemented",
       "evidence": []
+    },
+    {
+      "id": "sidebar-copy-foreground",
+      "family": "navigation",
+      "tokens": [
+        "okou-nav-copy",
+        "okou-nav-copy-muted",
+        "okou-nav-copy-muted-hover"
+      ],
+      "consumers": [
+        "apps/platform/src/views/okou-page/sidebar.tsx",
+        "apps/platform/src/views/okou-page/sidebar-pinned.tsx",
+        "apps/platform/src/views/okou-page/sidebar-threads.tsx",
+        "apps/platform/src/views/okou-page/sidebar-upgrade.tsx",
+        "apps/platform/src/views/okou-page/__tests__/chat-list-test-helpers.ts"
+      ],
+      "cases": [
+        "nav-copy-gradient-light",
+        "nav-copy-gradient-dark",
+        "nav-copy-default-light",
+        "nav-copy-default-dark",
+        "nav-copy-rail-light",
+        "nav-copy-rail-dark"
+      ],
+      "status": "implemented",
+      "evidence": []
     }
   ],
   "caseFiles": [
@@ -624,6 +650,7 @@
     "../e2e/playwright/style-migration/icon-mono-cases.json",
     "../e2e/playwright/style-migration/settings-select-cases.json",
     "../e2e/playwright/style-migration/badge-cases.json",
+    "../e2e/playwright/style-migration/nav-copy-cases.json",
     "../e2e/playwright/style-migration/chat-emoji-cases.json",
     "../e2e/playwright/style-migration/running-indicator-cases.json",
     "../e2e/playwright/style-migration/swatch-cases.json",


### PR DESCRIPTION
Drains `okou-nav-copy`, `okou-nav-copy-muted`, and `okou-nav-copy-muted-hover` — 20 class dependencies across 15 class sites in four sidebar files — and deletes the three selectors. **Neither theme changes appearance.** Part of #32402.

## What the selectors did

All three were scoped to `.okou-app[data-gradient-color-themes]` and collapsed every nav consumer onto one foreground and one muted foreground, overriding whatever each consumer spelled for itself:

```css
.okou-app[data-gradient-color-themes] .okou-nav .okou-nav-copy { color: hsl(var(--okou-nav-foreground)); }
.okou-app[data-gradient-color-themes] .okou-nav .okou-nav-copy-muted { color: hsl(var(--okou-nav-muted-foreground)); }
.okou-app[data-gradient-color-themes] .group:hover .okou-nav-copy-muted-hover { color: hsl(var(--okou-nav-foreground)); }
```

So each consumer already had two appearances: its own foreground outside the gradient themes, and the collapsed one inside them.

## The replacement

The collapse moves to the variable layer. The `:root` block that already carries the gradient theme's other values supplies the two colours, and the registered tokens fall back to what each consumer already rendered when they are unset:

```css
:root[data-gradient-color-themes][data-color-theme] {
  --nav-copy: hsl(var(--okou-color-theme-hue) 24% 18%);
  --nav-copy-muted: hsl(var(--okou-color-theme-hue) 18% 38%);
}
```

```css
--color-nav-copy: var(--nav-copy, var(--color-sidebar-foreground));
--color-nav-copy-muted: var(--nav-copy-muted, var(--color-muted-foreground));
```

Gradient on → the raw values exist → everything resolves to them. Gradient off → unset → every consumer falls back to its existing foreground. Both sides keep their appearance with no conditional selector.

Consumers whose foreground matches a registered fallback use `text-nav-copy` / `text-nav-copy-muted`. Three carry their own fallback in the utility, and six use `var(--nav-copy, inherit)` because they inherit from an ancestor `Link` or `button` and must keep following that ancestor's hover:

```
text-[color:var(--nav-copy,inherit)]
text-[color:var(--nav-copy,var(--color-foreground))]
text-[color:var(--nav-copy-muted,color-mix(in_oklab,var(--color-sidebar-foreground)_50%,transparent))]
```

The `color-mix(in oklab, …)` forms reproduce exactly what Tailwind already emits for `text-sidebar-foreground/50` and `/70`.

The gradient palette stays one pair of variables, so its owner sets the nav colours when the switch ships without touching any consumer.

## Measured before/after

Both stylesheets built with the App's own Tailwind compiler, rendered in Chromium over CDP. 18 theme states (8 gradient palettes + the default palette, light and dark) × 19 class variants, with hover forced on every row **and on its colour-bearing ancestor**.

| Surface | Result |
| --- | --- |
| Default palette, light and dark | **0 changed computed colours** |
| All eight gradient palettes, light and dark | **0 changed computed colours** |
| Coarse pointer | 48 readings differ — see below |

**Negative control:** perturbing one consumer's fallback reports changes on both the default palette (0 → 4) and the gradient palettes, so the zeros are not degenerate.

### The coarse-pointer difference

All 48 are the three collapsible section headers' hover state under the gradient themes. Tailwind's `group-hover` carries an `@media (hover: hover)` guard that the retired selector lacked, so the gradient themes no longer paint the hover foreground onto a sticky tap state. Removing that guard would need either a first-party selector — the thing this migration deletes — or a global `hover` variant override affecting every `hover:` in the App. The guard is the better behaviour, and the default themes already behaved this way on `main`.

## Tests

`sidebarThreadTitles()` moves off `.okou-nav-copy` to a new `data-slot="sidebar-thread-title"` boundary, matching the guide's slot contract for test selectors.

## Checks

`pnpm lint:style` (0 failures, baseline pruned with no allowance added), `pnpm knip` (0 issues), `check-types` and `lint` for `@okouai/app`, Prettier on every changed file, and 119 tests across the sidebar and chat-list suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
