### PR TITLE
feat(ssh): enable access by default for staff

### DIFF
--- a/docs/runner-rpc-transport.md
+++ b/docs/runner-rpc-transport.md
@@ -4,7 +4,9 @@ The transport delivered by #32012 is infrastructure under #31932. Its first
 consumer is the [Runner SSH dispatcher](runner-ssh-execution.md), installed by
 #32387 for official API-backed Runs. The generic transport itself has no API
 calls or business validators. Local/mock sandbox providers expose no capability.
-SSH remains disabled until the Agent/UI and activation slices are complete.
+The [SSH CLI and owner/Agent UI](ssh-access.md) are delivered. SSH availability
+uses the existing staff-default `sshAccess` switch and current API authority;
+the transport itself does not grant SSH access.
 
 ## Guest boundary
 
@@ -166,15 +168,15 @@ ship together. The old SSH-specific helper was unmerged/unexposed when renamed,
 so there is no compatibility alias. API and control-channel contracts are
 unchanged.
 
-Before activation in #32015, verify complete eligible Runner/rootfs convergence
-and compatible API, UI and selected commit-addressed CLI artifacts. Add no
-negotiation header, fallback routing, plugin registry, batching or pooling.
-See [deployment compatibility](deployment-compatibility.md).
+The staff-default SSH rollout changes no transport or CLI contract. Runner/rootfs,
+API, UI and selected commit-addressed CLI artifacts retain their independent
+deployment boundaries. Add no negotiation header, fallback routing, plugin
+registry, batching or pooling. See [deployment compatibility](deployment-compatibility.md).
 
 Local tests use real sockets, files, the real control handshake and operation
 tracker, plus unrelated external test methods. They require no web server.
-Actual fresh/restored KVM boot and packaged-helper execution remain separate
-metal-host CI/E2E checks before activation.
+Actual fresh/restored KVM boot and packaged-helper execution have separate
+metal-host CI coverage.
 
 The `guest-rpc-firecracker-test` CI job runs the native `guest_rpc` integration
 test against the matching runner-build rootfs and snapshot. It covers a generic
@@ -187,6 +189,8 @@ and one execution even when more request frames arrive.
 For #32804, Runner and bundled helper remain one artifact; guest binary bytes
 participate in rootfs identity and the snapshot identity includes that rootfs.
 There is no cross-version helper negotiation, fallback or replay. CLI stdin/stdout
-and API contracts are unchanged. Keep #32014's owner-authorized packaged CLI/SSH,
-TOFU, live inventory, revoke/invalidation and non-chat acceptance outstanding until
-actually exercised; generic native success alone does not enable #32015.
+and API contracts are unchanged. PR #32722 records owner-authorized two-host SSH,
+TOFU, live inventory, delivered revoke/invalidation and non-chat acceptance
+through the snapshot restore/reuse path. These results are distinct from generic
+native transport coverage and retain their recorded artifact identities. No
+separate cold-boot business SSH path is required.

--- a/docs/runner-ssh-authority.md
+++ b/docs/runner-ssh-authority.md
@@ -1,9 +1,9 @@
 # Runner SSH authority API
 
-This is the API slice (#32386) of SSH execution (#32013, under #31932).
-It does not enable SSH. The [Runner execution slice](runner-ssh-execution.md)
-(#32387) consumes these routes through generated private Rust DTOs;
-Agent/CLI/UI and activation remain later delivery stages.
+The API slice (#32386) and [Runner execution](runner-ssh-execution.md) (#32387)
+deliver SSH authority under #31932. The Runner consumes these routes through
+generated private Rust DTOs. [Owner and Agent consumers](ssh-access.md), including
+the CLI and management UI, were delivered by #32014 / PR #32722.
 
 ## Authority and secret handoff
 
@@ -28,8 +28,9 @@ automations, goals, delegated Agents, webhooks, SDK/non-chat and test Runs use
 the same authority path. A chat thread or trigger metadata is not required;
 workflow automation and goal associations do not restrict access. The session
 identifies the Agent without using chat-thread state as an authorization gate.
-The default-off feature rollout and official-Runner credential boundary are
-unchanged; this does not activate SSH or expose credentials to local Runners.
+The switch defaults to enabled for staff organizations and disabled elsewhere;
+explicit user overrides remain effective. This rollout default does not replace
+authorization or expose credentials to local/PAT Runners.
 
 `POST /api/runners/runs/:runId/ssh/resolve` takes:
 
@@ -171,6 +172,6 @@ The observation table and endpoints are additive. Old Runners and clients do not
 use them and retain existing behavior. A new Runner treats an old API's missing
 observation endpoint as a dropped diagnostic; a new App shows diagnostic status
 unavailable without disabling configuration management. Migration precedes API
-promotion. This does not establish fleet convergence or authorize enabling SSH. See
-[deployment compatibility](deployment-compatibility.md) and
-[guest RPC transport](runner-rpc-transport.md) for the remaining boundaries.
+promotion. The staff-default switch configuration does not establish which
+artifacts are currently deployed. See [deployment compatibility](deployment-compatibility.md)
+and [guest RPC transport](runner-rpc-transport.md) for the cross-version boundaries.

--- a/docs/runner-ssh-execution.md
+++ b/docs/runner-ssh-execution.md
@@ -1,7 +1,9 @@
 # Runner SSH execution
 
 #32387 implements the Runner-owned execution slice of #32013 (under #31932).
-It does not activate SSH, expose a CLI/UI, or support local/PAT Runners.
+The [CLI and owner/Agent UI](ssh-access.md) were delivered by #32014 / PR #32722.
+SSH defaults to enabled for staff organizations through the existing feature
+switch; local/PAT Runners remain unsupported.
 Current [API authority](runner-ssh-authority.md), including the feature
 gate and current Agent grant, is required on a cache miss and for first-use pinning.
 Successful authority snapshots follow the Run-scoped lifetime below. Run source,
@@ -88,9 +90,10 @@ API mutations publish `ssh-authority-invalidated` on the existing Runner-group
 Ably channel, with `{runId, connectionId}`; a null connection ID evicts all entries
 for that Run. Notices contain no credentials and cannot grant access or establish
 trust. Connection edits/rotation, deletion and explicit host-key reset notify
-active owner Runs after commit. New Agent-access/inventory writers must use the
-Run-wide invalidation hook before activation. First-use pin/match records the
-confirmed identity locally only after the authorized N+1 response.
+active owner Runs after commit. Agent grant changes publish Run-wide invalidation
+for the affected user's Agent Runs, including after revocation removes the grant.
+First-use pin/match records the confirmed identity locally only after the
+authorized N+1 response.
 
 Before subscription readiness or while disconnected/failed, the Runner bypasses
 shared caching and resolves each command. Observed connection loss clears cached
@@ -184,10 +187,26 @@ reservation until it exits. Telemetry contains only owned identifiers, fixed
 outcomes, timing, byte counts, truncation and terminal-delivery state. Production
 fmt/Axiom sinks suppress raw russh/ssh-key/ssh-cipher diagnostics at every level.
 
-## Remaining delivery gates
+## Connection observations
 
-Agent inventory/CLI/UI delivery, packaged-helper verification in fresh/restored
-KVM guests, complete Runner/rootfs convergence and controlled production
-activation remain later parent-owned slices. Local mocked-boundary/real-peer
-tests do not establish those rollout gates. No SSH activation is authorized by
-this implementation.
+PR #33165 adds best-effort [connection observations](runner-ssh-authority.md#diagnostic-connection-observations)
+after terminal delivery is attempted. Reports carry only Run/Runner/connection
+identifiers, configuration generation, observation time and an allow-listed failure code or
+authenticated-success observation, never commands, output or credentials.
+They are separate from command outcomes: successful authentication can clear a
+host warning even if its command later fails. Reporting cannot change or replay
+the command, and missing reports do not prove a host is healthy.
+
+## Rollout and validation
+
+Staff-default availability is configured in `sshAccess`; explicit overrides and
+current owner/Agent/Run authority still apply. It is not general availability or
+evidence that every deployed artifact is current. API, Platform, Runner/rootfs
+and the selected CLI retain their [deployment compatibility](deployment-compatibility.md)
+boundaries.
+
+PR #32722 records two-host, same-Run, non-chat and snapshot restore/reuse SSH
+acceptance. Native generic RPC has separate fresh/restored/reused KVM coverage.
+Actual API-backed Runs use the snapshot provider; a separate cold-boot business
+SSH mode is not required. Historical validation retains its recorded revision
+and artifacts, rather than claiming a fresh deployed test of later changes.

--- a/docs/ssh-access.md
+++ b/docs/ssh-access.md
@@ -1,11 +1,14 @@
 # SSH access for owners and Agents
 
-SSH is a standalone capability behind the default-off `SshAccess` (`sshAccess`)
-feature switch. The switch is the only feature-eligibility gate; enabled
-organizations do not need staff membership. Owner, Agent grant and Run
-authorization checks remain mandatory. The Connectors entry and Agent control
-are hidden while the switch is off; this delivery does not activate it. SSH uses neither connector
-accounts nor connector permissions.
+SSH is a standalone capability behind the `SshAccess` (`sshAccess`) feature
+switch, enabled by default for staff organizations and disabled by default for
+other organizations. Explicit user overrides still take precedence, including
+disabling SSH for a staff user or enabling it for a non-staff user. The switch
+appears in Lab's Beta group and is the only feature-eligibility gate; there is no
+additional staff-membership check. Owner, Agent grant and Run authorization
+checks remain mandatory. The Connectors entry and Agent control are hidden
+while the switch is off. SSH uses neither connector accounts nor connector
+permissions.
 
 ## Owner setup
 

--- a/turbo/apps/api/src/signals/routes/__tests__/feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feature-switches.test.ts
@@ -17,6 +17,24 @@ function client() {
 }
 
 describe("/api/feature-switches", () => {
+  it("enables SSH by default only in the staff organization", async () => {
+    const clerk = createRouteMocks(context).clerk;
+    const headers = { authorization: "Bearer clerk-session" };
+    const userId = `user_${randomUUID()}`;
+
+    clerk.session(userId, "org_3ANttyrbWYJk6JKRSTRLEsbsDLe", "org:member");
+    const staff = await accept(client().get({ headers }), [200]);
+    expect(
+      staff.body.effectiveSwitches[FeatureSwitchKey.SshAccess],
+    ).toBeTruthy();
+
+    clerk.session(userId, `org_${randomUUID()}`, "org:member");
+    const ordinary = await accept(client().get({ headers }), [200]);
+    expect(
+      ordinary.body.effectiveSwitches[FeatureSwitchKey.SshAccess],
+    ).toBeFalsy();
+  });
+
   it("defaults the compact model menu to Bingjie and the staff org while excluding other orgs", async () => {
     const clerk = createRouteMocks(context).clerk;
     const headers = { authorization: "Bearer clerk-session" };

--- a/turbo/apps/api/src/signals/routes/__tests__/ssh-connections.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ssh-connections.test.ts
@@ -77,6 +77,38 @@ function createBody(
 }
 
 describe("SSH connection routes", () => {
+  it.each([
+    { staff: true, override: undefined, enabled: true },
+    { staff: false, override: undefined, enabled: false },
+    { staff: true, override: false, enabled: false },
+    { staff: false, override: true, enabled: true },
+  ])(
+    "applies the SSH rollout to host management: staff=$staff, override=$override",
+    async ({ staff, override, enabled }) => {
+      const owner = actor(
+        "rollout",
+        staff ? "org_3ANttyrbWYJk6JKRSTRLEsbsDLe" : undefined,
+      );
+      authenticate(owner);
+      if (override !== undefined) {
+        await updateFeatureSwitchesForUser(context, owner, {
+          [FeatureSwitchKey.SshAccess]: override,
+        });
+      }
+
+      const result = await accept(
+        client().list({ headers: authHeaders() }),
+        [200, 404],
+      );
+      expect(result.status).toBe(enabled ? 200 : 404);
+      if (result.status === 404) {
+        expect(result.body.error.code).toBe("SSH_UNAVAILABLE");
+      } else {
+        expect(result.body.connections).toStrictEqual([]);
+      }
+    },
+  );
+
   it("notifies only the owner after every successful creation, even without visible Agents", async () => {
     useSecretKmsProbe();
     const owner = actor("browser-notice");

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -50,7 +50,7 @@ describe("isFeatureEnabled", () => {
     expect(getFeatureSwitchMetadata()[FeatureSwitchKey.SshAccess]).toEqual({
       maintainer: "liangyou@okou.ai",
       description: "Enable standalone Runner-mediated SSH configuration",
-      rolloutStage: "alpha",
+      rolloutStage: "beta",
     });
   });
 
@@ -203,7 +203,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.MorningBrief]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.SshAccess]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.SshAccess]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadHeaderActions]).toBe(true);
 
     const otherOrgStates = getAllFeatureStates({

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -492,6 +492,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "liangyou@okou.ai",
     description: "Enable standalone Runner-mediated SSH configuration",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ConnectorDirectory]: {
     maintainer: "tongx@okou.ai",


### PR DESCRIPTION
## Summary

- Enable `sshAccess` by default for staff organizations through the existing `STAFF_ORG_ID_HASHES` rollout configuration. Other organizations remain default-off, and explicit user overrides continue to take precedence in either direction.
- Add API integration coverage for effective feature flags and the four host-management combinations: staff/ordinary defaults, staff explicitly disabled, and ordinary users explicitly enabled. Update existing rollout metadata expectations; SSH moves from Alpha to Beta in Lab automatically.
- Reconcile owner, authority, execution, and RPC documentation with the delivered CLI/UI, grant invalidation, connection observations, and historical snapshot-based acceptance.

Relates to #32015. Delivery parent: #31932.

The requested scope is code-only staff availability plus tests and documentation. This PR does not claim completion of the issue's broader operational acceptance gates, so it does not automatically close either issue.

## Boundaries and risks

- This is a rollout default, not a new hard staff authorization gate. Existing owner/workspace, visible-Agent grant, active-Run, and winning official-Runner checks remain mandatory. Local/PAT Runners remain unsupported.
- No API, database, Runner protocol, credential handling, SSH engine, cache lifetime, or invalidation behavior changes. No new UI layout, connection flow, retry, or compatibility fallback.
- Eligible staff users without an explicit override will gain SSH availability when the changed artifacts deploy. Existing explicit `false` overrides remain disabled; non-staff users with explicit `true` overrides remain enabled.
- Source defaults do not establish deployed fleet convergence. No deployment, production override mutation, general availability, operational soak, or new real-Run acceptance was performed. Historical validation remains tied to its recorded revisions and artifacts.

## Validation

410 tests passed: API 89, Core 245, Platform 76. API tests used a newly migrated, task-owned PostgreSQL database; it was removed afterward without changing the development database. The two changed API suites were rerun after lint-only assertion corrections (15 tests passed, included in the 89 above).

Before the registry change, the new staff-default feature response and host-management assertions failed as expected; both passed after the change. All selected full suites passed without skipped tests.

Commands run from `turbo`:

```sh
pnpm -F api exec vitest run src/signals/routes/__tests__/feature-switches.test.ts src/signals/routes/__tests__/ssh-connections.test.ts src/signals/routes/__tests__/ssh-access.test.ts src/signals/routes/__tests__/runner-ssh.test.ts src/signals/auth/__tests__/tokens.test.ts --maxWorkers=2 --silent=passed-only
pnpm -F @okouai/core exec vitest run --maxWorkers=2 --silent=passed-only
pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/connectors-ssh.test.tsx src/views/okou-page/__tests__/chat-composer-ssh.test.tsx src/views/okou-page/__tests__/ssh-settings.test.tsx --maxWorkers=2 --silent=passed-only
pnpm -F api exec vitest run src/signals/routes/__tests__/feature-switches.test.ts src/signals/routes/__tests__/ssh-connections.test.ts --maxWorkers=2 --silent=passed-only
pnpm -F @okouai/core lint
pnpm -F @okouai/core check-types
pnpm -F api lint
pnpm -F api check-types
pnpm -F @okouai/app check-types
pnpm knip --workspace packages/core --workspace apps/api --workspace apps/platform
pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts apps/api/src/signals/routes/__tests__/feature-switches.test.ts apps/api/src/signals/routes/__tests__/ssh-connections.test.ts ../docs/ssh-access.md ../docs/runner-ssh-authority.md ../docs/runner-ssh-execution.md ../docs/runner-rpc-transport.md
```

Also passed: `git diff --check`, validation of 15 relative documentation links, and the normal commit hooks (formatting, style policy, full-repository `pnpm knip`, `TSC_CHECKERS=2 pnpm check-types`, file-size checks, and commitlint).

No Rust code changed; no new Rust or deployed E2E results are claimed. CI and PR review remain pending at submission.
