### PR TITLE
chore(runner): upgrade guest kernel to 6.18.44

### DIFF
--- a/crates/runner/src/deps.rs
+++ b/crates/runner/src/deps.rs
@@ -1,7 +1,7 @@
 //! Third-party dependency metadata: versions, checksums, and download URLs.
 
 pub const FIRECRACKER_VERSION: &str = "v1.16.2";
-pub const KERNEL_VERSION: &str = "6.1.155";
+pub const KERNEL_VERSION: &str = "6.18.44";
 /// Canonical mitmproxy release for runner artifacts and the embedded add-on.
 pub const MITMPROXY_VERSION: &str = "12.2.3";
 
@@ -12,12 +12,12 @@ pub const FIRECRACKER_SHA256_X86_64: &str =
     "8227875ceda44177a4d501052dae4a2f9d7837362f5399f02cf0748e68418377";
 pub const FIRECRACKER_SHA256_AARCH64: &str =
     "f7168507c37b2b047ea2b30433cbe4faa3986c36d1209c046fd1814118ce3d48";
-pub const KERNEL_SIZE_X86_64: u64 = 44_279_576;
-pub const KERNEL_SIZE_AARCH64: u64 = 17_111_552;
+pub const KERNEL_SIZE_X86_64: u64 = 27_846_248;
+pub const KERNEL_SIZE_AARCH64: u64 = 19_397_120;
 pub const KERNEL_SHA256_X86_64: &str =
-    "e20e46d0c36c55c0d1014eb20576171b3f3d922260d9f792017aeff53af3d4f2";
+    "d8ced68bd61e27b6813e2c993cc53a4029c59e13210672180591c84109684fe4";
 pub const KERNEL_SHA256_AARCH64: &str =
-    "e3544b10603acbf3db492cb52e000d22ba202cb4b63b9add027565683e11c591";
+    "3b0233769ed8c89f1f47fdbcc4ff9300a2b1b5c618e25ade966a484481b151dc";
 pub const MITMDUMP_SIZE_X86_64: u64 = 39_172_624;
 pub const MITMDUMP_SIZE_AARCH64: u64 = 36_908_488;
 pub const MITMDUMP_SHA256_X86_64: &str =
@@ -55,10 +55,11 @@ pub fn firecracker_url(arch: &str) -> String {
 }
 
 pub fn kernel_url(arch: &str) -> String {
-    // Pin the kernel artifact source independently of the VMM version. The
-    // v1.16 artifact namespace does not contain the existing 6.1.155 kernel.
+    // Pin a dated upstream Amazon Linux microVM kernel build independently of
+    // the VMM version. Guest 6.18 is supported with Firecracker >= v1.16.1:
+    // https://github.com/firecracker-microvm/firecracker/blob/main/docs/kernel-policy.md#guest-kernel
     format!(
-        "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.15/{arch}/vmlinux-{KERNEL_VERSION}"
+        "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/20260909-a8e1c3830545-0/{arch}/vmlinux-{KERNEL_VERSION}"
     )
 }
 

--- a/docs/runner-guest-process-lifecycle.md
+++ b/docs/runner-guest-process-lifecycle.md
@@ -138,7 +138,7 @@ Tokio adapter.
 
 Direct placement requires cgroup v2 and Linux 5.7; the launcher's
 `close_range(CLOSE_RANGE_CLOEXEC)` additionally requires Linux 5.11. The
-committed guest kernel is 6.1.155. Fixed process-group-only helpers and explicit
+committed guest kernel is 6.18.44. Fixed process-group-only helpers and explicit
 local TestNoop backends still use standard process creation. Guest Agent's
 internal CLI launcher and the managed tool's migrate-self/exec boundary are
 unchanged. There is no persistent cgroup pool, resident launcher or cgroup


### PR DESCRIPTION
## Summary

- Upgrade the Guest kernel from `6.1.155` to `6.18.44` for both x86_64 and aarch64, following the Firecracker `v1.16.2` upgrade in #33300.
- Pin the upstream Amazon Linux microVM kernel build at `firecracker-ci/20260909-a8e1c3830545-0`, independently of the Firecracker version, and update the exact byte lengths and SHA-256 identities used by Runner setup.
- Update the Guest process lifecycle documentation to reflect the selected kernel.

Firecracker's [current Guest kernel support policy](https://github.com/firecracker-microvm/firecracker/blob/main/docs/kernel-policy.md#guest-kernel) lists Guest Linux 6.18 as supported starting with Firecracker `v1.16.1`; the repository already uses `v1.16.2`.

## Scope and compatibility

- No Host kernel, Firecracker version, boot arguments, API, Guest protocol, UI, or user workflow changes.
- The existing snapshot identity includes the Guest kernel version, so image preparation generates a separate snapshot rather than restoring a 6.1 snapshot with the new kernel. Versioned kernel filenames keep the previous kernel available to draining old Runners.
- Downloaded both architecture binaries from the exact committed URLs and verified their lengths, SHA-256 values, and `Linux version 6.18.44+` banners against the committed metadata.
- Inspected the matching upstream kernel configurations: virtio MMIO/block/network/vsock, balloon/free-page reporting, ext4/overlay, devtmpfs, cgroup CPU/memory/PID controllers, and namespaces remain built in. ARM retains 4 KiB pages.

## Risks and remaining validation

- This crosses kernel series and can affect Guest scheduling, memory behavior, and device initialization. In particular, the x86_64 artifact uses ACPI device discovery and disables the legacy MP table / virtio command-line discovery options; Firecracker supports ACPI, but real boot validation is still required.
- The local container has no `/dev/kvm`. Local Rust and shell checks do not establish that a real Guest boots or resumes successfully on this kernel.
- Existing CI must pass image preparation for both architectures and its real Firecracker boot/restore/reuse RPC, balloon, process lifecycle, and host CPU fairness scenarios before merge. No tests or CI gates are changed or weakened.

## Validation

Passed for this exact implementation:

```sh
cd crates
cargo fmt --all -- --check
cargo clippy --profile local -p runner -p sandbox-firecracker -p guest-init --all-targets --all-features
cargo doc --profile local -p runner -p sandbox-firecracker -p guest-init --all-features --no-deps
cargo test --profile local -p runner -p sandbox-firecracker -p guest-init
```

4,584 tests passed. Existing process-isolated child fixtures and metal-only tests retain their existing ignored annotations; no new skips were added. Metal-only coverage remains pending CI.

```sh
cd turbo
pnpm exec prettier --check ../docs/runner-guest-process-lifecycle.md
```

```sh
bash .github/scripts/tests/runner-image-context-test.sh
bash .github/scripts/tests/runner-behavior-guest-rpc-test.sh
bash .github/scripts/tests/prepare-runner-image-test.sh
git diff --check
```

The shell tests validate CI orchestration and artifact selection with fixtures, not real VM execution.
