### PR TITLE
fix(platform): preserve welcome synchronization after settings dismissal

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
@@ -160,32 +160,15 @@ const initialLocalChatThreadEventsLoaded$ = computed((get) => {
 });
 
 interface ChatThreadEventSyncBarrier {
-  inFlight: boolean;
-  next: ReturnType<typeof createDeferredPromise<void>>;
+  work: Promise<void> | null;
 }
 
 const chatThreadEventSyncBarrier$ = computed(
   (get): ChatThreadEventSyncBarrier => {
-    return {
-      inFlight: false,
-      next: createDeferredPromise<void>(get(rootSignal$)),
-    };
+    get(rootSignal$);
+    return { work: null };
   },
 );
-
-const markChatThreadEventSyncPending$ = command(({ get }) => {
-  get(chatThreadEventSyncBarrier$).inFlight = true;
-});
-
-const resolveNextChatThreadEventSync$ = command(({ get }) => {
-  const barrier = get(chatThreadEventSyncBarrier$);
-  const completed = barrier.next;
-  barrier.inFlight = false;
-  barrier.next = createDeferredPromise<void>(get(rootSignal$));
-  if (!completed.settled()) {
-    completed.resolve();
-  }
-});
 
 const optimisticChatThreadCreateIds$ = computed((get): ReadonlySet<string> => {
   return new Set(
@@ -255,43 +238,57 @@ const applySharedChatThreadEventResult$ = command(
     if (!synced.settled()) {
       synced.resolve();
     }
-    set(resolveNextChatThreadEventSync$);
   },
 );
 
 const syncSharedEventDrivenChatThreads$ = command(
-  async ({ get, set }, signal: AbortSignal): Promise<void> => {
-    set(markChatThreadEventSyncPending$);
-    const dataKey = await get(sharedChatThreadEventDataKey$);
-    signal.throwIfAborted();
-    const currentSeqId = get(chatThreadEventState$).latestSeqId;
-    const cached = await set(
-      queryChatThreadEventSharedDatabase$,
-      {
-        dataKey,
-        afterSeqId: currentSeqId,
-        consistency: "cache-only",
+  ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const barrier = get(chatThreadEventSyncBarrier$);
+    // Keep explicit refreshes independent: a mutation can commit after an
+    // older sync has already read its result. Readers await the latest work.
+    const work = withCleanup(
+      (async () => {
+        const dataKey = await get(sharedChatThreadEventDataKey$);
+        signal.throwIfAborted();
+        const currentSeqId = get(chatThreadEventState$).latestSeqId;
+        const cached = await set(
+          queryChatThreadEventSharedDatabase$,
+          {
+            dataKey,
+            afterSeqId: currentSeqId,
+            consistency: "cache-only",
+          },
+          signal,
+        );
+        signal.throwIfAborted();
+        const cachedLastSeqId =
+          cached.events.at(-1)?.seqId ?? cached.snapshot?.latestSeqId ?? null;
+        const result =
+          cachedLastSeqId !== null &&
+          (currentSeqId === null || cachedLastSeqId > currentSeqId)
+            ? cached
+            : await set(
+                queryChatThreadEventSharedDatabase$,
+                {
+                  dataKey,
+                  afterSeqId: currentSeqId,
+                  consistency: "catch-up",
+                },
+                signal,
+              );
+        signal.throwIfAborted();
+        set(applySharedChatThreadEventResult$, result, "remote", signal);
+      })(),
+      () => {
+        // Failure remains a rejection, never authoritative not-found. An
+        // older completion must not release a newer caller's ownership.
+        if (barrier.work === work) {
+          barrier.work = null;
+        }
       },
-      signal,
     );
-    signal.throwIfAborted();
-    const cachedLastSeqId =
-      cached.events.at(-1)?.seqId ?? cached.snapshot?.latestSeqId ?? null;
-    const result =
-      cachedLastSeqId !== null &&
-      (currentSeqId === null || cachedLastSeqId > currentSeqId)
-        ? cached
-        : await set(
-            queryChatThreadEventSharedDatabase$,
-            {
-              dataKey,
-              afterSeqId: currentSeqId,
-              consistency: "catch-up",
-            },
-            signal,
-          );
-    signal.throwIfAborted();
-    set(applySharedChatThreadEventResult$, result, "remote", signal);
+    barrier.work = work;
+    return work;
   },
 );
 
@@ -531,11 +528,11 @@ export const resolveThreadMeta$ = command(
     const initialRemoteSync = get(initialRemoteChatThreadEventsSyncedDeferred$);
     const syncBarrier = get(chatThreadEventSyncBarrier$);
     // Refresh missing threads against current server state after initial sync.
-    const canonicalSync = syncBarrier.inFlight
-      ? syncBarrier.next.promise
-      : initialRemoteSync.settled()
+    const canonicalSync =
+      syncBarrier.work ??
+      (initialRemoteSync.settled()
         ? set(syncSharedEventDrivenChatThreads$, get(rootSignal$))
-        : initialRemoteSync.promise;
+        : initialRemoteSync.promise);
     const syncVersion = get(chatThreadEventSyncVersion$);
     const resolution = await set(
       resolveColdThreadMeta$,

--- a/turbo/apps/platform/src/signals/okou-page/settings/welcome-thread.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/welcome-thread.ts
@@ -4,6 +4,7 @@ import { accept } from "../../../lib/accept.ts";
 import { apiClient$ } from "../../api-client.ts";
 import { clerk$ } from "../../auth.ts";
 import { syncEventDrivenChatThreads$ } from "../../chat-page/chat-thread-event-sourcing.ts";
+import { rootSignal$ } from "../../root-signal.ts";
 import { createChildAbortController, withCleanup } from "../../utils.ts";
 import { navigateToChat$ } from "../nav.ts";
 import {
@@ -36,10 +37,14 @@ export const welcomeThreadAction$ = computed(
       if (inFlight) {
         return await inFlight;
       }
-      const controller = createChildAbortController(
-        AbortSignal.any([dialogSignal, pageSignal]),
-      );
-      const signal = controller.signal;
+      // A committed welcome's shared list recovery outlives its UI wait, but
+      // remains owned by this app and the captured user/workspace identity.
+      const controller = createChildAbortController(get(rootSignal$));
+      const signal = AbortSignal.any([
+        dialogSignal,
+        pageSignal,
+        controller.signal,
+      ]);
       const unsubscribe = clerk.addListener(() => {
         // Like watchOrgSwitch$, retain the concrete workspace during a
         // transient Clerk token refresh; a different workspace cancels us.
@@ -51,7 +56,7 @@ export const welcomeThreadAction$ = computed(
           controller.abort();
         }
       });
-      signal.addEventListener("abort", unsubscribe, { once: true });
+      controller.signal.addEventListener("abort", unsubscribe, { once: true });
       // Retain the action identity after every failure, including a lost 201.
       const clientThreadId = get(clientThreadId$) ?? crypto.randomUUID();
       set(clientThreadId$, clientThreadId);
@@ -67,7 +72,7 @@ export const welcomeThreadAction$ = computed(
             signal,
           );
           // Recover the ordinary list even when the creation notification was lost.
-          await set(syncEventDrivenChatThreads$, signal);
+          await set(syncEventDrivenChatThreads$, controller.signal);
           signal.throwIfAborted();
           set(closeSettingsModal$);
           set(navigateToChat$, result.body.id);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/welcome-thread-sync-overlap.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/welcome-thread-sync-overlap.test.tsx
@@ -1,4 +1,4 @@
-import { act, screen, waitFor, within } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import { welcomeChatThreadsContract } from "@okouai/api-contracts/contracts/welcome-chat-threads";
 import {
   chatThreadMetadataContract,
@@ -113,7 +113,7 @@ test("An older list refresh cannot finish a newer welcome reader, including afte
   });
   await setupPage({
     context,
-    path: primaryPath,
+    path: "/chats/b0000000-0000-4000-a000-000000033304?settings=debug",
     sharedWorkerTestTransport: "message-port",
     auth: {
       user: { id: `user_${context.resourceId}`, fullName: "Test User" },
@@ -130,15 +130,17 @@ test("An older list refresh cannot finish a newer welcome reader, including afte
       [FeatureSwitchKey.WelcomeThread]: true,
     },
   });
-  await screen.findByText("Primary conversation", {
-    selector: '[data-testid="chat-thread-header-title"]',
+  // The cold route proves the initial list sync finished and opens Debug
+  // directly, without spending this race test on unrelated menu interactions.
+  await screen.findByRole("heading", { name: "Chat thread not found" });
+  await screen.findByRole("dialog", { name: "Settings" });
+  await waitFor(() => {
+    expect(
+      context.mocks.ably.hasChannelSubscriptionOnChannel(
+        `user-org:user_${context.resourceId}:org_${context.resourceId}`,
+      ),
+    ).toBeTruthy();
   });
-  const rail = await screen.findByTestId("labeled-nav-rail");
-  click(within(rail).getByLabelText("Test User"));
-  click(within(await screen.findByRole("menu")).getByText("Settings"));
-  const dialog = await screen.findByRole("dialog", { name: "Settings" });
-  click(fastButton("Debug", dialog));
-  await screen.findByRole("region", { name: "Welcome thread" });
   refreshing = true;
   context.mocks.ably.trigger("threadListChanged");
   await olderRequested.promise;
@@ -150,6 +152,9 @@ test("An older list refresh cannot finish a newer welcome reader, including afte
   });
 
   navigate(sidebarPath);
+  await screen.findByText("Primary conversation", {
+    selector: '[data-testid="chat-thread-header-title"]',
+  });
   await metadataRequested.promise;
   // Abandon one cold reader while the shared welcome synchronization continues.
   navigate(primaryPath);
@@ -168,10 +173,13 @@ test("An older list refresh cannot finish a newer welcome reader, including afte
   releaseNewer.resolve();
   // An incorrectly completed not-found pane does not retry merely because a
   // later list result includes this thread. Its ordinary history must appear.
-  await screen.findByText("Welcome history in the second pane");
+  await screen.findByText("Newly committed welcome", {
+    selector: '[data-testid="chat-thread-header-title"]',
+  });
   expect(screen.getAllByRole("region", { name: "Chat thread" })).toHaveLength(
     2,
   );
+  await screen.findByText("Welcome history in the second pane");
   expect(window.location.pathname).toBe(primaryPath);
   expect(new URL(window.location.href).searchParams.get("sidebar")).toBe(
     welcome.threadId,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/welcome-thread-sync-overlap.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/welcome-thread-sync-overlap.test.tsx
@@ -1,0 +1,183 @@
+import { act, screen, waitFor, within } from "@testing-library/react";
+import { welcomeChatThreadsContract } from "@okouai/api-contracts/contracts/welcome-chat-threads";
+import {
+  chatThreadMetadataContract,
+  chatThreadsContract,
+} from "@okouai/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { expect, test } from "vitest";
+import { click, setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { createMarkdownChatFixture } from "./markdown-page-test-helpers.ts";
+import {
+  chatListEvent,
+  chatListThread,
+  fastButton,
+} from "./chat-list-test-helpers.ts";
+
+const context = testContext();
+
+function navigate(path: string) {
+  act(() => {
+    window.history.pushState({}, "", path);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  });
+}
+
+test("An older list refresh cannot finish a newer welcome reader, including after reader navigation", async () => {
+  const welcome = createMarkdownChatFixture(context);
+  const row = {
+    ...welcome.outputMessage("Welcome history in the second pane", {
+      seqId: 1,
+    }),
+    runId: null,
+    runEventId: null,
+    runEventSequenceNumber: null,
+  };
+  welcome.install({
+    rows: () => {
+      return [row];
+    },
+  });
+  const primary = chatListThread(1, "Primary conversation", {
+    agentId: "c0000000-0000-4000-a000-000000000071",
+  });
+  const primaryPath = `/chats/${primary.id}`;
+  const sidebarPath = `${primaryPath}?sidebar=${welcome.threadId}`;
+  const renamed = chatListEvent(33_303, 2, "renamed", primary.id, {
+    agentId: primary.agentId,
+    title: "Primary conversation refreshed",
+  });
+  const created = chatListEvent(33_303, 3, "created", welcome.threadId, {
+    agentId: primary.agentId,
+    title: "Newly committed welcome",
+  });
+  const olderRequested = context.mocks.deferred<void>();
+  const releaseOlder = context.mocks.deferred<void>();
+  const newerRequested = context.mocks.deferred<void>();
+  const releaseNewer = context.mocks.deferred<void>();
+  let metadataRequested = context.mocks.deferred<void>();
+  let refreshing = false;
+  let committed = false;
+
+  context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+    return respond(200, {
+      chatThreads: [primary],
+      latestEventId: "d0000000-0000-4000-a000-000000000001",
+      latestSeqId: 1,
+    });
+  });
+  context.mocks.api(chatThreadsContract.events, async ({ query, respond }) => {
+    if (!refreshing) {
+      return respond(200, { events: [], hasMore: false });
+    }
+    // Hold the older response before the worker persists its rename, so the
+    // welcome refresh also starts from the initial authoritative snapshot.
+    if (!committed) {
+      if (!olderRequested.settled()) {
+        olderRequested.resolve();
+      }
+      await releaseOlder.promise;
+      return respond(200, {
+        events: [renamed].filter((event) => {
+          return event.seqId > (query.sinceSeqId ?? 0);
+        }),
+        hasMore: false,
+      });
+    }
+    if (!newerRequested.settled()) {
+      newerRequested.resolve();
+    }
+    await releaseNewer.promise;
+    return respond(200, {
+      events: [renamed, created].filter((event) => {
+        return event.seqId > (query.sinceSeqId ?? 0);
+      }),
+      hasMore: false,
+    });
+  });
+  context.mocks.api(chatThreadMetadataContract.get, ({ params, respond }) => {
+    if (params.id === welcome.threadId && !metadataRequested.settled()) {
+      metadataRequested.resolve();
+    }
+    return respond(404, {
+      error: {
+        code: "CHAT_THREAD_NOT_FOUND",
+        message: "Chat thread not found",
+      },
+    });
+  });
+  context.mocks.api(welcomeChatThreadsContract.create, ({ respond }) => {
+    committed = true;
+    return respond(201, { id: welcome.threadId });
+  });
+  await setupPage({
+    context,
+    path: primaryPath,
+    sharedWorkerTestTransport: "message-port",
+    auth: {
+      user: { id: `user_${context.resourceId}`, fullName: "Test User" },
+      organization: {
+        activeOrg: {
+          id: `org_${context.resourceId}`,
+          name: "Welcome workspace",
+        },
+        memberships: [{ id: `org_${context.resourceId}` }],
+      },
+    },
+    featureSwitches: {
+      [FeatureSwitchKey.OkouDebug]: true,
+      [FeatureSwitchKey.WelcomeThread]: true,
+    },
+  });
+  await screen.findByText("Primary conversation", {
+    selector: '[data-testid="chat-thread-header-title"]',
+  });
+  const rail = await screen.findByTestId("labeled-nav-rail");
+  click(within(rail).getByLabelText("Test User"));
+  click(within(await screen.findByRole("menu")).getByText("Settings"));
+  const dialog = await screen.findByRole("dialog", { name: "Settings" });
+  click(fastButton("Debug", dialog));
+  await screen.findByRole("region", { name: "Welcome thread" });
+  refreshing = true;
+  context.mocks.ably.trigger("threadListChanged");
+  await olderRequested.promise;
+  click(fastButton("Create welcome thread"));
+  await newerRequested.promise;
+  click(screen.getByLabelText("Close"));
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog", { name: "Settings" })).toBeNull();
+  });
+
+  navigate(sidebarPath);
+  await metadataRequested.promise;
+  // Abandon one cold reader while the shared welcome synchronization continues.
+  navigate(primaryPath);
+  await screen.findByRole("textbox", { name: "Message" });
+  metadataRequested = context.mocks.deferred<void>();
+  navigate(sidebarPath);
+  await metadataRequested.promise;
+
+  releaseOlder.resolve();
+  await screen.findByText("Primary conversation refreshed", {
+    selector: '[data-testid="chat-thread-header-title"]',
+  });
+  expect(
+    screen.queryByRole("heading", { name: "Chat thread not found" }),
+  ).toBeNull();
+  releaseNewer.resolve();
+  // An incorrectly completed not-found pane does not retry merely because a
+  // later list result includes this thread. Its ordinary history must appear.
+  await screen.findByText("Welcome history in the second pane");
+  expect(screen.getAllByRole("region", { name: "Chat thread" })).toHaveLength(
+    2,
+  );
+  expect(window.location.pathname).toBe(primaryPath);
+  expect(new URL(window.location.href).searchParams.get("sidebar")).toBe(
+    welcome.threadId,
+  );
+  expect(screen.queryByRole("dialog", { name: "Settings" })).toBeNull();
+  expect(
+    screen.queryByRole("heading", { name: "Chat thread not found" }),
+  ).toBeNull();
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/welcome-thread-sync.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/welcome-thread-sync.test.tsx
@@ -1,0 +1,364 @@
+import { act, screen, waitFor } from "@testing-library/react";
+import { welcomeChatThreadsContract } from "@okouai/api-contracts/contracts/welcome-chat-threads";
+import {
+  chatThreadMetadataContract,
+  chatThreadsContract,
+} from "@okouai/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { HttpResponse } from "msw";
+import { expect, test, vi } from "vitest";
+import {
+  click,
+  queryAllByRoleFast,
+  setupPage,
+} from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import {
+  sharedDatabaseClientMessageSchema,
+  sharedDatabaseWorkerMessageSchema,
+} from "../../../shared-database/protocol.ts";
+import type {
+  SharedDatabaseDataKey,
+  SharedDatabaseQuery,
+} from "../../../shared-database/data-key.ts";
+import { SharedDatabaseMessagePortServer } from "../../../shared-database/message-port-server.ts";
+import { createMarkdownChatFixture } from "./markdown-page-test-helpers.ts";
+import { chatListEvent, fastButton } from "./chat-list-test-helpers.ts";
+
+const context = testContext();
+const INITIAL_PATH = "/chats/b0000000-0000-4000-a000-000000033301";
+const MISSING_PATH = "/chats/b0000000-0000-4000-a000-000000033302";
+const AGENT_PATH = "/agents/c0000000-0000-4000-a000-000000000071/chat";
+
+function navigate(path: string) {
+  act(() => {
+    window.history.pushState({}, "", path);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  });
+}
+
+// Delay only transport delivery. Queries run through the real server and
+// worker; cancellation and late-result handling stay in the production client.
+function installWorker(
+  onThreadListResponse: (
+    query: SharedDatabaseQuery<SharedDatabaseDataKey>,
+    deliver: () => Promise<void>,
+  ) => boolean,
+) {
+  class SharedWorkerMock extends EventTarget {
+    readonly port: MessagePort;
+
+    constructor() {
+      super();
+      const channel = new MessageChannel();
+      this.port = channel.port1;
+      const queries = new Map<
+        string,
+        SharedDatabaseQuery<SharedDatabaseDataKey>
+      >();
+      const sendRequest = channel.port1.postMessage.bind(channel.port1);
+      vi.spyOn(channel.port1, "postMessage").mockImplementation(
+        (value: unknown) => {
+          const request = sharedDatabaseClientMessageSchema.parse(value);
+          if (
+            request.type === "query" &&
+            request.query.dataKey.kind === "chat-thread-event"
+          ) {
+            queries.set(request.requestId, request.query);
+          }
+          sendRequest(value);
+        },
+      );
+      const sendResponse = channel.port2.postMessage.bind(channel.port2);
+      vi.spyOn(channel.port2, "postMessage").mockImplementation(
+        (value: unknown) => {
+          const response = sharedDatabaseWorkerMessageSchema.parse(value);
+          if (response.type === "result" || response.type === "error") {
+            const query = queries.get(response.requestId);
+            queries.delete(response.requestId);
+            if (query) {
+              const held = onThreadListResponse(query, async () => {
+                const received = context.mocks.deferred<void>();
+                const onMessage = (event: MessageEvent<unknown>) => {
+                  const message = sharedDatabaseWorkerMessageSchema.parse(
+                    event.data,
+                  );
+                  if (
+                    (message.type === "result" || message.type === "error") &&
+                    message.requestId === response.requestId
+                  ) {
+                    channel.port1.removeEventListener("message", onMessage);
+                    received.resolve();
+                  }
+                };
+                channel.port1.addEventListener("message", onMessage, {
+                  signal: context.signal,
+                });
+                sendResponse(value);
+                await received.promise;
+              });
+              if (held) {
+                return;
+              }
+            }
+          }
+          sendResponse(value);
+        },
+      );
+      new SharedDatabaseMessagePortServer(
+        context.workerStore,
+        channel.port2,
+        context.signal,
+      );
+    }
+  }
+  vi.stubGlobal("SharedWorker", SharedWorkerMock);
+}
+
+function installWelcomeChat() {
+  const chat = createMarkdownChatFixture(context);
+  const row = {
+    ...chat.outputMessage("Persisted welcome after dismissal", { seqId: 1 }),
+    runId: null,
+    runEventId: null,
+    runEventSequenceNumber: null,
+  };
+  chat.install({
+    rows: () => {
+      return [row];
+    },
+  });
+  const created = chatListEvent(33_303, 2, "created", chat.threadId, {
+    agentId: "c0000000-0000-4000-a000-000000000071",
+    title: "Committed welcome",
+  });
+  let committed = false;
+  context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+    return respond(200, {
+      chatThreads: [],
+      latestEventId: "d0000000-0000-4000-a000-000000000001",
+      latestSeqId: 1,
+    });
+  });
+  context.mocks.api(chatThreadsContract.events, ({ query, respond }) => {
+    return respond(200, {
+      events: committed && (query.sinceSeqId ?? 0) < 2 ? [created] : [],
+      hasMore: false,
+    });
+  });
+  context.mocks.api(chatThreadMetadataContract.get, ({ respond }) => {
+    return respond(404, {
+      error: {
+        code: "CHAT_THREAD_NOT_FOUND",
+        message: "Chat thread not found",
+      },
+    });
+  });
+  context.mocks.api(welcomeChatThreadsContract.create, ({ respond }) => {
+    committed = true;
+    return respond(201, { id: chat.threadId });
+  });
+  return {
+    chat,
+    created,
+    isCommitted: () => {
+      return committed;
+    },
+  };
+}
+
+async function openSyncedDebug() {
+  await setupPage({
+    context,
+    path: `${INITIAL_PATH}?settings=debug`,
+    sharedWorkerTestTransport: "browser",
+    auth: {
+      user: { id: `user_${context.resourceId}`, fullName: "Test User" },
+      organization: {
+        activeOrg: {
+          id: `org_${context.resourceId}`,
+          name: "Welcome workspace",
+        },
+        memberships: [{ id: `org_${context.resourceId}` }],
+      },
+    },
+    featureSwitches: {
+      [FeatureSwitchKey.OkouDebug]: true,
+      [FeatureSwitchKey.WelcomeThread]: true,
+    },
+  });
+  // This authoritative result proves initial list synchronization is complete.
+  await screen.findByRole("heading", { name: "Chat thread not found" });
+  await screen.findByRole("dialog", { name: "Settings" });
+}
+
+async function closeSettings() {
+  click(screen.getByLabelText("Close"));
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog", { name: "Settings" })).toBeNull();
+  });
+}
+
+async function openCommittedWelcome() {
+  navigate(AGENT_PATH);
+  await screen.findByRole("textbox", { name: "Message" });
+  const welcomeLink = await waitFor(() => {
+    const link = queryAllByRoleFast("link").find((candidate) => {
+      return candidate.textContent?.includes("Committed welcome");
+    });
+    if (!link) {
+      throw new Error("Committed welcome is missing from the ordinary list");
+    }
+    return link;
+  });
+  click(welcomeLink);
+  await screen.findByText("Persisted welcome after dismissal");
+}
+
+test.each(["cache-only", "catch-up"] as const)(
+  "Closing Settings after welcome 201 during %s preserves cold not-found and committed history",
+  async (stage) => {
+    const { chat, created, isCommitted } = installWelcomeChat();
+    const held = context.mocks.deferred<void>();
+    const release = context.mocks.deferred<void>();
+    const cacheResponse = context.mocks.deferred<() => Promise<void>>();
+    let cacheHeld = false;
+    installWorker((query, deliver) => {
+      if (
+        isCommitted() &&
+        stage === "cache-only" &&
+        !cacheHeld &&
+        query.consistency === "cache-only"
+      ) {
+        cacheHeld = true;
+        cacheResponse.resolve(deliver);
+        held.resolve();
+        return true;
+      }
+      return false;
+    });
+    context.mocks.api(
+      chatThreadsContract.events,
+      async ({ query, respond }) => {
+        if (isCommitted() && stage === "catch-up") {
+          held.resolve();
+          await release.promise;
+        }
+        return respond(200, {
+          events: isCommitted() && (query.sinceSeqId ?? 0) < 2 ? [created] : [],
+          hasMore: false,
+        });
+      },
+    );
+    await openSyncedDebug();
+    click(fastButton("Create welcome thread"));
+    await held.promise;
+    expect(fastButton("Creating…")).toBeDisabled();
+    await closeSettings();
+    if (stage === "cache-only") {
+      const deliver = await cacheResponse.promise;
+      await deliver();
+    } else {
+      release.resolve();
+    }
+
+    // Same app, a different cold thread, and no unrelated realtime delivery.
+    navigate("/agents");
+    await screen.findByRole("heading", { name: "Agents" });
+    navigate(MISSING_PATH);
+    await screen.findByRole("heading", { name: "Chat thread not found" });
+    expect(window.location.pathname).toBe(MISSING_PATH);
+    expect(screen.queryByRole("dialog", { name: "Settings" })).toBeNull();
+    await openCommittedWelcome();
+    expect(window.location.pathname).toBe(chat.path);
+  },
+);
+
+test("A failed committed welcome sync remains an error and permits ordinary recovery", async () => {
+  const { chat, created, isCommitted } = installWelcomeChat();
+  let unavailable = true;
+  installWorker(() => {
+    return false;
+  });
+  context.mocks.http.get("*/api/chat-threads/events", ({ request }) => {
+    if (isCommitted() && unavailable) {
+      return HttpResponse.json(
+        {
+          error: {
+            code: "SERVICE_UNAVAILABLE",
+            message: "List temporarily unavailable",
+          },
+        },
+        { status: 503 },
+      );
+    }
+    const sinceSeqId = Number(
+      new URL(request.url).searchParams.get("sinceSeqId"),
+    );
+    return HttpResponse.json({
+      events: isCommitted() && sinceSeqId < 2 ? [created] : [],
+      hasMore: false,
+    });
+  });
+  await openSyncedDebug();
+  click(fastButton("Create welcome thread"));
+  await expect(screen.findByRole("alert")).resolves.toHaveTextContent(
+    "Could not create the welcome thread. Try again.",
+  );
+  expect(fastButton("Create welcome thread")).toBeEnabled();
+  expect(window.location.pathname).toBe(INITIAL_PATH);
+  unavailable = false;
+  await closeSettings();
+  navigate("/agents");
+  await screen.findByRole("heading", { name: "Agents" });
+  navigate(MISSING_PATH);
+  await screen.findByRole("heading", { name: "Chat thread not found" });
+  await openCommittedWelcome();
+  expect(window.location.pathname).toBe(chat.path);
+});
+
+test.each(["user", "workspace"] as const)(
+  "A %s change after dismissal still cancels committed welcome synchronization",
+  async (identity) => {
+    const { chat, isCommitted } = installWelcomeChat();
+    const response = context.mocks.deferred<() => Promise<void>>();
+    let held = false;
+    installWorker((query, deliver) => {
+      if (isCommitted() && query.consistency === "catch-up" && !held) {
+        held = true;
+        response.resolve(deliver);
+        return true;
+      }
+      return false;
+    });
+    await openSyncedDebug();
+    click(fastButton("Create welcome thread"));
+    const deliver = await response.promise;
+    await closeSettings();
+    navigate(AGENT_PATH);
+    await screen.findByRole("textbox", { name: "Message" });
+    const clerk = context.mocks.clerk();
+    act(() => {
+      if (identity === "user") {
+        clerk.user(
+          { id: "replacement-user", fullName: "Replacement user" },
+          { token: "replacement-session-token" },
+        );
+      } else {
+        clerk.organization({
+          activeOrg: { id: "replacement-org", name: "Replacement workspace" },
+          memberships: [{ id: "replacement-org" }],
+        });
+      }
+      clerk.stateChanged();
+    });
+    // Release the real late RPC only after the externally visible identity
+    // change. Flushing this external event also settles its React updates.
+    await act(async () => {
+      await deliver();
+    });
+    expect(window.location.pathname).not.toBe(chat.path);
+    expect(screen.queryByText("Committed welcome")).toBeNull();
+    expect(screen.queryByRole("dialog", { name: "Settings" })).toBeNull();
+  },
+);


### PR DESCRIPTION
## Summary

Closing Settings after welcome creation returned 201 could abandon shared thread-list synchronization. Later cold threads whose metadata returned 404 then waited indefinitely instead of showing the ordinary not-found page.

Keep committed welcome synchronization owned by the app and its captured user/workspace identity while POST cancellation and navigation remain scoped to the UI. Replace the success-only global barrier with the actual latest synchronization promise: errors propagate, terminal cleanup releases only that task's ownership, and independent explicit refreshes retain their freshness.

Closes #33303. Parent: #33205.

## Verification

- On original main `fc05f140ec37bedaa679b832b88440b93b9bcae8`, the six new Router/API/MessagePort regressions produced **4 failures, 2 passes**. Both post-201 cancellation windows and failed-sync recovery could not reach not-found; overlapping synchronization prematurely showed not-found.
- With the repair, **35 tests passed across six focused files**: welcome creation, the new cancellation/overlap regressions, metadata, offline-cache behavior, and thread-list event ordering. Coverage includes committed history recovery without realtime/reload/recreation, an abandoned concurrent metadata reader, 503 errors, user/workspace changes, POST-pending cancellation, deduplication, and same-UUID retries.
- Platform type checking, targeted ESLint, standard and type-aware Oxlint, formatting, and Platform unused-code analysis passed. No full local Vitest suite or local development server was run.
- Temporarily tying the identity listener back to UI dismissal made both new identity-isolation cases fail by displaying the old committed welcome; the repaired listener lifetime passes them.

The test runs use real application routing and worker/RPC implementations with external browser, Clerk, and HTTP fixtures. No new browser/production validation or production release is claimed. The unchanged S1/S2 content, media, and CLI evidence remains outside this repair's revalidation scope.
