### PR TITLE
refactor(platform): route voice draft observer through shared loop

### DIFF
--- a/turbo/apps/platform/src/signals/voice-io/voice-draft-transcription.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-draft-transcription.ts
@@ -4,7 +4,11 @@ import {
   readVoiceDraftRecording,
   type VoiceDraftSegment,
 } from "../external/voice-draft-store.ts";
-import { createChildAbortController, createDeferredPromise } from "../utils.ts";
+import {
+  createChildAbortController,
+  createDeferredPromise,
+  setLoop,
+} from "../utils.ts";
 import { nextVoiceDraftSegment } from "./voice-draft-audio.ts";
 import { VOICE_DRAFT_PCM_SAMPLE_RATE } from "./voice-draft-pcm.ts";
 import { createVoiceDraftSegmentResult } from "./voice-draft-transcription-segment.ts";
@@ -321,24 +325,30 @@ export function createVoiceDraftTranscriptionSignals(
   // This observer starts newly appended computeds and owns their background
   // lifetime. Request ordering is entirely expressed by predecessor dependencies.
   const watch$ = command(async ({ get, set }, signal: AbortSignal) => {
-    while (!signal.aborted) {
-      const wake = createDeferredPromise<void>(signal);
-      set(wake$, wake);
-      const notified = Promise.allSettled([wake.promise]);
-      if (get(segments$).length > 0) {
-        const [outcome] = await Promise.allSettled([get(result$)]);
-        signal.throwIfAborted();
-        if (outcome?.status === "fulfilled") {
-          if (outcome.value) {
-            set(refreshAudioInputQuota$);
-          } else {
-            await set(openAudioInputQuotaRecovery$, signal);
+    await setLoop(
+      async (loopSignal) => {
+        const wake = createDeferredPromise<void>(loopSignal);
+        set(wake$, wake);
+        const notified = Promise.allSettled([wake.promise]);
+        if (get(segments$).length > 0) {
+          const [outcome] = await Promise.allSettled([get(result$)]);
+          loopSignal.throwIfAborted();
+          if (outcome?.status === "fulfilled") {
+            if (outcome.value) {
+              set(refreshAudioInputQuota$);
+            } else {
+              await set(openAudioInputQuotaRecovery$, loopSignal);
+            }
           }
         }
-      }
-      await notified;
-      signal.throwIfAborted();
-    }
+        await notified;
+        loopSignal.throwIfAborted();
+        return false;
+      },
+      0,
+      signal,
+      { retryTransientErrors: false },
+    );
   });
   return { initialize$, append$, transcribe$, watch$, cancel$ };
 }

--- a/turbo/apps/platform/src/signals/voice-io/voice-draft-transcription.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-draft-transcription.ts
@@ -325,10 +325,10 @@ export function createVoiceDraftTranscriptionSignals(
   // This observer starts newly appended computeds and owns their background
   // lifetime. Request ordering is entirely expressed by predecessor dependencies.
   const watch$ = command(async ({ get, set }, signal: AbortSignal) => {
+    let wake = createDeferredPromise<void>(signal);
+    set(wake$, wake);
     await setLoop(
       async (loopSignal) => {
-        const wake = createDeferredPromise<void>(loopSignal);
-        set(wake$, wake);
         const notified = Promise.allSettled([wake.promise]);
         if (get(segments$).length > 0) {
           const [outcome] = await Promise.allSettled([get(result$)]);
@@ -343,6 +343,10 @@ export function createVoiceDraftTranscriptionSignals(
         }
         await notified;
         loopSignal.throwIfAborted();
+        // `setLoop` yields after this callback, so arm the next notification
+        // first to retain appends that arrive between iterations.
+        wake = createDeferredPromise<void>(loopSignal);
+        set(wake$, wake);
         return false;
       },
       0,


### PR DESCRIPTION
## Summary

- replace the voice draft transcription observer's manual abort loop with the shared `setLoop` helper
- keep the composer mount lifecycle as the owner and pass its `loopSignal` through deferred wakeups and quota recovery
- preserve immediate deferred notifications and direct error propagation by disabling transient retries

## Audit

- the native platform timer scan is empty
- the remaining generic-loop matches are the `setLoop` implementation and two finite pagination traversals

## Verification

- `pnpm exec prettier --check apps/platform/src/signals/voice-io/voice-draft-transcription.ts`
- `pnpm exec oxlint --deny-warnings src/signals/voice-io/voice-draft-transcription.ts`
- `pnpm exec eslint src/signals/voice-io/voice-draft-transcription.ts --max-warnings 0 --no-cache`
- `pnpm -F @okouai/app check-types`
- `pnpm exec vitest run src/views/okou-page/__tests__/chat-capability-voice-draft-confirmation.test.tsx src/views/okou-page/__tests__/chat-capability-voice-draft-hydration.test.tsx` (6 tests)