### PR TITLE
refactor(platform): stabilize realtime handlers

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/feishu.ts
+++ b/turbo/apps/platform/src/signals/okou-page/feishu.ts
@@ -354,6 +354,34 @@ export const reloadFeishuInstallations$ = command(({ set }) => {
   });
 });
 
+const onFeishuChanged$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const previous = get(internalInstallations$);
+  set(reloadFeishuInstallations$);
+  const next = await get(feishuInstallations$);
+  signal.throwIfAborted();
+  set(internalInstallations$, next);
+  if (
+    previous?.some((installation) => {
+      return (
+        !installation.isConnected &&
+        next.some((candidate) => {
+          return (
+            (candidate.id ?? candidate.appId) ===
+              (installation.id ?? installation.appId) && candidate.isConnected
+          );
+        })
+      );
+    })
+  ) {
+    toast.success(
+      i18n.t(($) => {
+        return $.connectors.providerSettings.toasts.feishuConnected;
+      }),
+    );
+  }
+  return false;
+});
+
 export const showFeishuSettingsResult$ = command(() => {
   const params = new URLSearchParams(window.location.search);
   const error = params.get("error");
@@ -376,36 +404,6 @@ export const startFeishuSettingsRealtime$ = command(
     const current = await get(feishuInstallations$);
     signal.throwIfAborted();
     set(internalInstallations$, current);
-
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const onFeishuChanged$ = command(async ({ get, set }, sig: AbortSignal) => {
-      const previous = get(internalInstallations$);
-      set(reloadFeishuInstallations$);
-      const next = await get(feishuInstallations$);
-      sig.throwIfAborted();
-      set(internalInstallations$, next);
-      if (
-        previous?.some((installation) => {
-          return (
-            !installation.isConnected &&
-            next.some((candidate) => {
-              return (
-                (candidate.id ?? candidate.appId) ===
-                  (installation.id ?? installation.appId) &&
-                candidate.isConnected
-              );
-            })
-          );
-        })
-      ) {
-        toast.success(
-          i18n.t(($) => {
-            return $.connectors.providerSettings.toasts.feishuConnected;
-          }),
-        );
-      }
-      return false;
-    });
 
     await set(
       setAblyLoop$,

--- a/turbo/apps/platform/src/signals/okou-page/slack.ts
+++ b/turbo/apps/platform/src/signals/okou-page/slack.ts
@@ -119,6 +119,20 @@ export const uninstallSlackOrg$ = command(
   },
 );
 
+const onSlackChanged$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const previous = get(internalSlackStatus$);
+  set(reloadSlackOrg$);
+  const next = await get(slackOrgData$);
+  signal.throwIfAborted();
+  set(internalSlackStatus$, next);
+
+  if (hasSlackStatusChanged(previous, next)) {
+    toastSlackStatusChange(previous, next);
+  }
+
+  return false;
+});
+
 /**
  * Subscribe to Slack connection changes for the /works route lifetime.
  */
@@ -127,21 +141,6 @@ export const watchSlackConnection$ = command(
     const current = await get(slackOrgData$);
     signal.throwIfAborted();
     set(internalSlackStatus$, current);
-
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const onSlackChanged$ = command(async ({ get, set }, sig: AbortSignal) => {
-      const previous = get(internalSlackStatus$);
-      set(reloadSlackOrg$);
-      const next = await get(slackOrgData$);
-      sig.throwIfAborted();
-      set(internalSlackStatus$, next);
-
-      if (hasSlackStatusChanged(previous, next)) {
-        toastSlackStatusChange(previous, next);
-      }
-
-      return false;
-    });
 
     await set(
       setAblyLoop$,

--- a/turbo/apps/platform/src/signals/okou-page/teams.ts
+++ b/turbo/apps/platform/src/signals/okou-page/teams.ts
@@ -109,26 +109,25 @@ export const uninstallTeamsOrg$ = command(
   },
 );
 
+const onTeamsChanged$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const previous = get(internalTeamsStatus$);
+  set(reloadTeamsOrg$);
+  const next = await get(teamsOrgData$);
+  signal.throwIfAborted();
+  set(internalTeamsStatus$, next);
+
+  if (hasTeamsStatusChanged(previous, next)) {
+    toastTeamsStatusChange(previous, next);
+  }
+
+  return false;
+});
+
 export const watchTeamsConnection$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const current = await get(teamsOrgData$);
     signal.throwIfAborted();
     set(internalTeamsStatus$, current);
-
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const onTeamsChanged$ = command(async ({ get, set }, sig: AbortSignal) => {
-      const previous = get(internalTeamsStatus$);
-      set(reloadTeamsOrg$);
-      const next = await get(teamsOrgData$);
-      sig.throwIfAborted();
-      set(internalTeamsStatus$, next);
-
-      if (hasTeamsStatusChanged(previous, next)) {
-        toastTeamsStatusChange(previous, next);
-      }
-
-      return false;
-    });
 
     await set(
       setAblyLoop$,

--- a/turbo/apps/platform/src/signals/okou-page/telegram.ts
+++ b/turbo/apps/platform/src/signals/okou-page/telegram.ts
@@ -353,14 +353,13 @@ export const reloadTelegramBots$ = command(({ set }) => {
   });
 });
 
+const onTelegramChanged$ = command(({ set }) => {
+  set(reloadTelegramBots$);
+  return false;
+});
+
 export const startTelegramSettingsRealtime$ = command(
   async ({ set }, signal: AbortSignal) => {
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const onTelegramChanged$ = command(({ set }) => {
-      set(reloadTelegramBots$);
-      return false;
-    });
-
     await set(
       setAblyLoop$,
       {

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -105,15 +105,15 @@ export function findPermissionInMetadata(
 
 const internalUserPermissionGrantsReload$ = state(0);
 
+const onPermissionUpdated$ = command(({ set }) => {
+  set(internalUserPermissionGrantsReload$, (version) => {
+    return version + 1;
+  });
+  return false;
+});
+
 export const subscribePermissionUpdate$ = command(
   async ({ set }, signal: AbortSignal) => {
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const onPermissionUpdated$ = command(({ set }) => {
-      set(internalUserPermissionGrantsReload$, (version) => {
-        return version + 1;
-      });
-      return false;
-    });
     await set(
       setAblyLoop$,
       {


### PR DESCRIPTION
## Summary

- define the Feishu, Slack, Teams, Telegram, and permission realtime handlers at package scope
- remove five `ccstate/no-command-in-command` suppressions without changing handler behavior
- reduce the direct nested-command suppression baseline from 16 to 11

## Verification

- `npx --yes prettier@3.8.1 --check apps/platform/src/signals/okou-page/feishu.ts apps/platform/src/signals/okou-page/slack.ts apps/platform/src/signals/okou-page/teams.ts apps/platform/src/signals/okou-page/telegram.ts apps/platform/src/signals/permission-allow/permission-allow-signals.ts`
- `git diff --check`
- local ESLint and typecheck were not run because workspace dependencies are not installed; PR CI will run the repository checks
