### PR TITLE
refactor(platform): restore dom-owned chat container refs

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
@@ -181,8 +181,9 @@ export interface ChatPanelSignals {
     (() => void) | undefined,
     [HTMLElement | null]
   >;
-  readonly mainContainerRef$: Computed<
-    Command<(() => void) | undefined, [HTMLElement | null]>
+  readonly setMainContainerRef$: Command<
+    (() => void) | undefined,
+    [HTMLElement | null]
   >;
   // True when the event list is scrolled away from the bottom - drives the
   // feature-gated scroll-to-bottom button. Read-only outside scroll signals.

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-container.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-container.ts
@@ -48,7 +48,7 @@ const attachMainThreadFocusFallback$ = command(
   },
 );
 
-export function createChatThreadContainerSignals(pageSignal: AbortSignal) {
+export function createChatThreadContainerSignals() {
   const internalContainerEl$ = state<HTMLElement | null>(null);
   const containerEl$ = computed((get) => {
     return get(internalContainerEl$);
@@ -62,16 +62,11 @@ export function createChatThreadContainerSignals(pageSignal: AbortSignal) {
     },
   );
   const setContainerRef$ = onRef(attachContainer$);
-  // eslint-disable-next-line ccstate/no-computed-signal -- migrate this computed away from AbortSignal ownership
-  const mainContainerRef$ = computed(() => {
-    return onRef(
-      command(({ set }, el: HTMLElement, mountSignal: AbortSignal) => {
-        const signal = AbortSignal.any([mountSignal, pageSignal]);
-        signal.throwIfAborted();
-        set(attachContainer$, el, signal);
-        set(attachMainThreadFocusFallback$, el, signal);
-      }),
-    );
-  });
-  return { containerEl$, setContainerRef$, mainContainerRef$ };
+  const setMainContainerRef$ = onRef(
+    command(({ set }, el: HTMLElement, signal: AbortSignal) => {
+      set(attachContainer$, el, signal);
+      set(attachMainThreadFocusFallback$, el, signal);
+    }),
+  );
+  return { containerEl$, setContainerRef$, setMainContainerRef$ };
 }

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -3982,7 +3982,7 @@ function createChatPanelSignalsWithDraft(
     chatEvents.chatEvents$,
     threadMeta$,
   );
-  const container = createChatThreadContainerSignals(signal);
+  const container = createChatThreadContainerSignals();
   const threadOwned = createThreadOwnedSignals(threadId);
   const cancellationRecovery = createCancellationRecoverySignals(threadId);
   const composer = createThreadComposerSignalsWithContext(

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -2822,9 +2822,8 @@ function ChatThread({
   thread: ChatPanelSignals;
 }) {
   const { t } = useTranslation();
-  const mainContainerRef = useGet(thread.mainContainerRef$);
   const setContainerRef = useSet(
-    isMain ? mainContainerRef : thread.setContainerRef$,
+    isMain ? thread.setMainContainerRef$ : thread.setContainerRef$,
   );
 
   return (


### PR DESCRIPTION
## Summary

- restore the main chat container ref as a stable DOM-owned `onRef` command
- remove the stale dependency-free computed wrapper, pane signal capture, and combined lifecycle
- consume the main and secondary container refs directly through `useSet`

## Context

The computed ref command originally reacted to the activity-summary attachment command. Activity polling later moved to the thread subscription lifecycle, leaving this wrapper without reactive dependencies while it still captured the pane signal.

The remaining container state and focus fallback listener are both owned by the mounted element. This change returns their cleanup to the `onRef` signal and removes the `ccstate/no-computed-signal` suppression without changing the focus behavior.

## Verification

- `pnpm exec prettier --write` on all four changed files
- targeted ESLint on all four changed files, including `ccstate/no-computed-signal`
- targeted Oxlint and type-aware Oxlint on all four changed files
- `pnpm --filter @okouai/app check-types`
- `pnpm exec knip --workspace @okouai/app`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-emoji.test.tsx -t 'Restore chat focus after closing the mobile emoji picker' --reporter=verbose` (1 passed, 9 skipped)

## Fallbacks

- None. This removes obsolete lifecycle indirection and keeps the existing DOM-owned cleanup path.
