### PR TITLE
refactor(platform): stabilize workflow realtime handler

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -3029,6 +3029,13 @@ function createOnSubscribedCommand({
   });
 }
 
+const onWorkflowsChanged$ = command(
+  async ({ set }, signal: AbortSignal): Promise<boolean> => {
+    await set(reloadMountedComposerWorkflows$, signal);
+    return false;
+  },
+);
+
 function createRunTracking({
   threadId,
   setupChatEvents$,
@@ -3075,15 +3082,6 @@ function createRunTracking({
       set(reloadArtifacts$);
       return false;
     });
-
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const onWorkflowsChanged$ = command(
-      async ({ set }, signal: AbortSignal): Promise<boolean> => {
-        L.debug("onWorkflowsChanged$ fired", { threadId });
-        await set(reloadMountedComposerWorkflows$, signal);
-        return false;
-      },
-    );
 
     await Promise.all([
       set(syncHydratedEventTrees$, signal),


### PR DESCRIPTION
## Summary

- define the workflow realtime handler in the package-scope command graph
- preserve the realtime event signal while reloading every mounted composer
- remove the corresponding `ccstate/no-command-in-command` suppression

The three remaining suppressions in `create-chat-thread.ts` depend on thread-owned reload commands. Moving them only to the surrounding factory would hide runtime command creation without making the graph static, so they remain unchanged.

## Verification

- `git diff --check`
- Existing page-level coverage: `Refresh workflow suggestions without disrupting the draft` exercises primary and split-thread workflow notifications and verifies both mounted composers refresh without losing draft content
- Local lint and Vitest were not run because this fresh checkout has no installed dependencies; the PR pipeline is the verification boundary
