### PR TITLE
fix(platform): restore hosted auth last-used badge

### DIFF
--- a/docs/clerk-customize.md
+++ b/docs/clerk-customize.md
@@ -46,12 +46,16 @@ return {
     colorBackground: "hsl(var(--card))",
     colorForeground: "hsl(var(--foreground))",
     colorPrimary: "hsl(var(--brand-text))",
-    colorBorder: "hsl(var(--border))",
+    colorNeutral: "hsl(var(--foreground))",
     colorRing: "hsl(var(--ring))",
     colorDanger: "hsl(var(--destructive))",
   },
 };
 ```
+
+Clerk derives its border scale from `colorNeutral`. Do not map the application's
+`--border` token through Clerk's `colorBorder`: hosted controls also use a local
+`--border` variable, so the deferred value can resolve against the wrong owner.
 
 Provider appearance must not contain `elements`. Authentication-specific
 element overrides belong on `SignIn` and `SignUp`, so unrelated Clerk surfaces

--- a/turbo/apps/platform/src/views/auth-v1/provider-appearance.ts
+++ b/turbo/apps/platform/src/views/auth-v1/provider-appearance.ts
@@ -22,6 +22,8 @@ function clerkVariables(theme: "light" | "dark"): Record<string, string> {
     // Use the readable brand pair and retain its native control hierarchy.
     colorPrimary: "hsl(var(--brand-text))",
     colorBackground: "hsl(var(--card))",
+    // Clerk derives its border scale from this value. Passing our --border
+    // token through colorBorder collides with Clerk's local --border variable.
     colorNeutral: "hsl(var(--foreground))",
     colorForeground: "hsl(var(--foreground))",
     colorMutedForeground: "hsl(var(--muted-foreground))",
@@ -32,7 +34,6 @@ function clerkVariables(theme: "light" | "dark"): Record<string, string> {
     colorMuted: "hsl(var(--muted))",
     colorInput: "hsl(var(--input))",
     colorInputForeground: "hsl(var(--foreground))",
-    colorBorder: "hsl(var(--border))",
     colorRing: "hsl(var(--ring))",
     colorDanger: "hsl(var(--destructive))",
     fontFamily: "var(--font-family-sans)",


### PR DESCRIPTION
## Summary

- let Clerk derive hosted-auth borders from `colorNeutral` instead of forwarding the app's `--border` token
- document the variable ownership boundary that prevents Clerk's local `--border` value from invalidating the badge styles

## Why

Clerk's hosted Google button defines its own local `--border` variable. Passing `hsl(var(--border))` through `colorBorder` is resolved again inside that scope, leaving the `Last used` badge without its native background and border.

## Verification

- `pnpm exec prettier --check ../docs/clerk-customize.md apps/platform/src/views/auth-v1/provider-appearance.ts`
- `pnpm --filter @okouai/app lint:clerk-customize`
- `pnpm --filter @okouai/app check-types`
- `pnpm exec vitest run apps/platform/src/views/auth-v1/__tests__/auth-v1-page.test.tsx` (16 tests)
- focused Oxlint and ESLint for `provider-appearance.ts`

PR Preview browser verification will exercise the real Clerk-hosted `oauth_google` last-used state.
