### PR TITLE
refactor: remove final obsolete goal source references

### DIFF
--- a/turbo/apps/api/src/lib/strip-markdown.ts
+++ b/turbo/apps/api/src/lib/strip-markdown.ts
@@ -1,7 +1,7 @@
 /**
  * Remove the Markdown syntax a model tends to emit even when asked for plain
  * text. Shared by every surface that renders generated text unstyled: chat
- * titles, run summaries, and goal objective briefs.
+ * titles and run summaries.
  */
 export function stripMarkdown(text: string): string {
   return text

--- a/turbo/apps/api/src/signals/external/openrouter.ts
+++ b/turbo/apps/api/src/signals/external/openrouter.ts
@@ -23,9 +23,9 @@ const OPENROUTER_ERROR_RESPONSE_MAX_BYTES = 64 * 1024;
 /**
  * The model behind every internal fast-path generation: chat and shared-thread
  * titles, recommended follow-ups, notification summaries, initial thinking
- * copy, run summaries, goal objective briefs, and voice I/O polish. These are
- * short, latency-sensitive calls that are not user-selectable, so they share a
- * single model rather than one constant per service.
+ * copy, run summaries, and voice I/O polish. These are short, latency-sensitive
+ * calls that are not user-selectable, so they share a single model rather than
+ * one constant per service.
  */
 export const FAST_PATH_MODEL = "google/gemini-3.8-flash";
 

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -253,7 +253,7 @@ export async function publishChatThreadDetailChangedSafely(
 /**
  * Notify the chat message background sync that a new row was appended. It
  * refreshes IndexedDB and forwards newly fetched rows into visible threads, so
- * derived UI state (e.g. the composer's folded goal state) updates live.
+ * derived UI state (e.g. rendered chat messages) updates live.
  *
  * `syncThroughSeqId` is an optional watermark for the last row appended by the
  * publishing mutation. Clients that have already cached that sequence can

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -87,7 +87,6 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_pre_create_agent_materialize_bootstrap_context"
   | "api_dispatch_pre_create_agent_resolve_firewall_metadata"
   | "api_dispatch_pre_create_agent_resolve_thread_session"
-  | "api_dispatch_pre_create_agent_resolve_paused_thread_goal"
   | "api_dispatch_pre_create_agent_web_chat_resolve_session_prompt_context"
   | "api_dispatch_pre_create_agent_build_create_run_args"
   | "api_dispatch_pre_create_agent_web_chat_prepare_normal_send"

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -329,7 +329,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.PiLoop]: {
     maintainer: "lancy@okou.ai",
     description:
-      "Run owned chat threads with the official Pi runtime, native session persistence, and shared memory learning across interactive, Automation, and Goal turns.",
+      "Run owned chat threads with the official Pi runtime, native session persistence, and shared memory learning across interactive and automation turns.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },


### PR DESCRIPTION
## Summary

Remove the unused Goal-only dispatch timing union member and correct four stale descriptions/comments. Lab now describes PiLoop's interactive and automation turns. PiLoop's key, maintainer, defaults, allowlist, and evaluation are unchanged; the Markdown, model, realtime, and telemetry implementations retain their behavior.

Closes #33331. Final source-only follow-up to EPIC #32653.

## Scope evidence

- Started from freshly fetched/rebased `origin/main` at `1cd0ae24f034db0360d0f43519131c1f1ea83c58`. All five target blobs were identical to the issue's `d64bf61a160bd3339a645c199d74534dd50afab1` anchors; no residual was already removed.
- Whole-repository exact-token search found the removed timing action only in its declaration. Its typed consumers and supported actions remain intact.
- The complete diff touches exactly the five authorized files. Comment-stripped JavaScript is identical for all four API files; the PiLoop description is the sole emitted change in `feature-switch.ts`.
- The current 16-open-PR inventory found only #33283 and #33227 overlapping these files, both in `feature-switch.ts`; neither is a functional or ordering dependency.
- Historical events/status/provenance/accounting, security rejections, ordinary objective wording, immutable migrations, native Codex disabling, and existing workflows/resources are untouched. No production operation or release is part of this PR. Controller retains independent source acceptance and normal App publication confirmation for the Lab text.

## Verification

- Existing `packages/core/src/__tests__/feature-switch.test.ts`: **29 passed**, one targeted Vitest process.
- `pnpm --filter @okouai/core run check-types`: passed.
- `TSC_CHECKERS=2 pnpm --filter api run check-types`: passed, including dependencies, boundaries, gateways, core, bootstrap, tests, and bootstrap wiring.
- Prettier, Oxlint, type-aware Oxlint, and ESLint on the five changed files: passed.
- Source caller inventory, fixed-anchor blob comparison, emitted JavaScript comparison, and `git diff --check`: passed.
- Normal commit hooks: Prettier, style policy, Knip, all 14 type/build tasks, file-size check, and commitlint passed without bypasses.
- No new comment/union-mirroring tests; no full local Vitest or development server. Required PR and merge-group CI remain the full-check gates.
