### PR TITLE
perf(platform): unmount template gallery during previews

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-presentation-gallery.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-presentation-gallery.test.tsx
@@ -2,10 +2,7 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, test, vi } from "vitest";
 
-import {
-  queryAllByRoleFast,
-  setupPage,
-} from "../../../__tests__/page-helper.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
 import { PRESENTATION_TEMPLATE_PICKER_ITEMS } from "@okouai/core/presentation-template-items";
 import { VIDEO_TEMPLATE_ITEMS } from "@okouai/core/video-template-items";
 import { WEBSITE_TEMPLATE_ITEMS } from "@okouai/core/website-template-items";
@@ -32,22 +29,6 @@ function builtInTemplate(index = 0) {
 
 function detailGroup(title: string): HTMLElement {
   return screen.getByRole("group", { name: `${title} slide preview` });
-}
-
-function activeButtonNamed(
-  name: string,
-  container: ParentNode = document.body,
-): HTMLElement {
-  const button = queryAllByRoleFast("button", container).find((candidate) => {
-    return (
-      candidate.getAttribute("aria-label") === name &&
-      candidate.closest('[inert], [aria-hidden="true"]') === null
-    );
-  });
-  if (!button) {
-    throw new Error(`Active button named "${name}" not found`);
-  }
-  return button;
 }
 
 function installImmediateAnimationFrames(): void {
@@ -104,9 +85,8 @@ test("Choose a presentation template theme", async () => {
   expect(themedFrame).toBeVisible();
 
   await user.click(
-    activeButtonNamed(
+    within(screen.getByRole("dialog")).getByLabelText(
       `Select template ${template.title}`,
-      screen.getByRole("dialog"),
     ),
   );
   await expectInlineTemplate(template.title);

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -5944,6 +5944,7 @@ export function ComposerPresentationRecommendations({
 
 function PptTemplateGrid({
   items,
+  importedItems,
   runtime,
   value,
   onSelect,
@@ -5954,6 +5955,7 @@ function PptTemplateGrid({
   signals,
 }: {
   items: readonly PresentationTemplateItem[];
+  importedItems: readonly ImportedPresentationTemplatePickerItem[];
   runtime: TemplatePreviewRuntime;
   value: GenerationTemplateRequest | undefined;
   onSelect: (item: PresentationTemplateItem, colorSystemId?: string) => void;
@@ -5965,12 +5967,10 @@ function PptTemplateGrid({
 }) {
   // Import tile, then accessible uploaded decks (owned decks are sorted first),
   // then the built-in templates.
-  const importedTemplateItems =
-    useImportedPresentationTemplatePickerItems(signals);
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       <PptImportCard signals={signals} onImported={onImported} />
-      {importedTemplateItems.map(({ imageBuffers, template }) => {
+      {importedItems.map(({ imageBuffers, template }) => {
         return (
           <ImportedPptCard
             key={template.id}
@@ -6404,94 +6404,90 @@ function TemplatePickerDialog({
         }
         initialFocus={false}
       >
-        <div
-          inert={isPreviewing}
-          aria-hidden={isPreviewing}
-          className={cn(
-            "min-h-0 flex-1 flex-col",
-            isPreviewing ? "hidden" : "flex",
-          )}
-        >
-          <DialogHeader className="shrink-0 border-b border-border px-5 py-4 sm:hidden">
-            <DialogTitle>
-              {t(($) => {
-                return $.artifacts.templates.template;
-              })}
-            </DialogTitle>
-          </DialogHeader>
-          <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
-            <TemplatePickerCategoryNav
-              selectedCategory={selectedCategory}
-              introVideoEnabled={introVideoEnabled}
-              onChange={handleCategoryChange}
-            />
-            <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
-              {selectedCategory === "intro-video" ? (
-                <IntroVideoPicker
-                  signals={signals.template.introVideo}
-                  onCancel={closeTemplatePicker}
-                  onSelect={(template) => {
-                    onChange(template);
-                    closeTemplatePicker();
-                  }}
-                />
-              ) : (
-                <>
-                  <div
-                    className={cn(
-                      "relative h-[68px] shrink-0 items-center px-6 pr-14",
-                      showTemplatePickerSearch || showAvatarPickerToolbar
-                        ? "flex"
-                        : "hidden sm:flex",
-                    )}
-                  >
-                    {showTemplatePickerSearch ? (
-                      <TemplatePickerWorkflowSearch
-                        search={search}
-                        onSearchChange={handleSearchChange}
-                      />
-                    ) : null}
-                    {showAvatarPickerToolbar ? (
-                      <AvatarTemplatePickerToolbar signals={signals} />
-                    ) : null}
-                  </div>
-                  <TemplatePickerCategoryContent
-                    signals={signals}
-                    selectedCategory={selectedCategory}
-                    pptItems={presentationItems}
-                    websiteItems={WEBSITE_TEMPLATE_ITEMS}
-                    illustrationItems={ILLUSTRATION_TEMPLATE_ITEMS}
-                    videoItems={VIDEO_TEMPLATE_ITEMS}
-                    videoGenerationAllowed={videoGenerationAllowed}
-                    workflowCatalog={workflowCatalog}
-                    value={value}
-                    illustrationVariantIndex={illustrationVariantIndex}
-                    onPresentationScroll={setPresentationGridScrollTop}
-                    onRestorePresentationScroll={
-                      restorePresentationGridScrollNode
-                    }
-                    onSelectPresentation={handleSelectPresentation}
-                    onSelectImportedPresentation={
-                      handleSelectImportedPresentation
-                    }
-                    onPreviewPresentation={handlePreview}
-                    onPreviewImportedPresentation={handlePreviewImported}
-                    onImportedPresentation={closeTemplatePicker}
-                    onSelectWebsite={handleSelectWebsite}
-                    onPreviewWebsite={handlePreviewWebsite}
-                    onSelectIllustration={handleSelectIllustration}
-                    onIllustrationVariantChange={setIllustrationVariantIndex}
-                    onSelectVideo={handleSelectVideo}
-                    onSelectAvatar={handleSelectAvatar}
-                    onWorkflowCategoryChange={setWorkflowCategoryFilter}
-                    onSelectWorkflow={handleSelectWorkflow}
-                    runtime={runtime}
+        {!isPreviewing ? (
+          <div className="min-h-0 flex flex-1 flex-col">
+            <DialogHeader className="shrink-0 border-b border-border px-5 py-4 sm:hidden">
+              <DialogTitle>
+                {t(($) => {
+                  return $.artifacts.templates.template;
+                })}
+              </DialogTitle>
+            </DialogHeader>
+            <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
+              <TemplatePickerCategoryNav
+                selectedCategory={selectedCategory}
+                introVideoEnabled={introVideoEnabled}
+                onChange={handleCategoryChange}
+              />
+              <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
+                {selectedCategory === "intro-video" ? (
+                  <IntroVideoPicker
+                    signals={signals.template.introVideo}
+                    onCancel={closeTemplatePicker}
+                    onSelect={(template) => {
+                      onChange(template);
+                      closeTemplatePicker();
+                    }}
                   />
-                </>
-              )}
+                ) : (
+                  <>
+                    <div
+                      className={cn(
+                        "relative h-[68px] shrink-0 items-center px-6 pr-14",
+                        showTemplatePickerSearch || showAvatarPickerToolbar
+                          ? "flex"
+                          : "hidden sm:flex",
+                      )}
+                    >
+                      {showTemplatePickerSearch ? (
+                        <TemplatePickerWorkflowSearch
+                          search={search}
+                          onSearchChange={handleSearchChange}
+                        />
+                      ) : null}
+                      {showAvatarPickerToolbar ? (
+                        <AvatarTemplatePickerToolbar signals={signals} />
+                      ) : null}
+                    </div>
+                    <TemplatePickerCategoryContent
+                      signals={signals}
+                      selectedCategory={selectedCategory}
+                      pptItems={presentationItems}
+                      importedPptItems={importedTemplateItems}
+                      websiteItems={WEBSITE_TEMPLATE_ITEMS}
+                      illustrationItems={ILLUSTRATION_TEMPLATE_ITEMS}
+                      videoItems={VIDEO_TEMPLATE_ITEMS}
+                      videoGenerationAllowed={videoGenerationAllowed}
+                      workflowCatalog={workflowCatalog}
+                      value={value}
+                      illustrationVariantIndex={illustrationVariantIndex}
+                      onPresentationScroll={setPresentationGridScrollTop}
+                      onRestorePresentationScroll={
+                        restorePresentationGridScrollNode
+                      }
+                      onSelectPresentation={handleSelectPresentation}
+                      onSelectImportedPresentation={
+                        handleSelectImportedPresentation
+                      }
+                      onPreviewPresentation={handlePreview}
+                      onPreviewImportedPresentation={handlePreviewImported}
+                      onImportedPresentation={closeTemplatePicker}
+                      onSelectWebsite={handleSelectWebsite}
+                      onPreviewWebsite={handlePreviewWebsite}
+                      onSelectIllustration={handleSelectIllustration}
+                      onIllustrationVariantChange={setIllustrationVariantIndex}
+                      onSelectVideo={handleSelectVideo}
+                      onSelectAvatar={handleSelectAvatar}
+                      onWorkflowCategoryChange={setWorkflowCategoryFilter}
+                      onSelectWorkflow={handleSelectWorkflow}
+                      runtime={runtime}
+                    />
+                  </>
+                )}
+              </div>
             </div>
           </div>
-        </div>
+        ) : null}
         {previewItem ? (
           <TemplatePreviewPage
             item={previewItem}
@@ -6521,6 +6517,7 @@ function TemplatePickerCategoryContent({
   signals,
   selectedCategory,
   pptItems,
+  importedPptItems,
   websiteItems,
   illustrationItems,
   videoItems,
@@ -6548,6 +6545,7 @@ function TemplatePickerCategoryContent({
   signals: ComposerSignals;
   selectedCategory: string;
   pptItems: readonly PresentationTemplateItem[];
+  importedPptItems: readonly ImportedPresentationTemplatePickerItem[];
   websiteItems: readonly WebsiteTemplateItem[];
   illustrationItems: readonly IllustrationTemplateItem[];
   videoItems: readonly VideoTemplateItem[];
@@ -6597,6 +6595,7 @@ function TemplatePickerCategoryContent({
       >
         <PptTemplateGrid
           items={pptItems}
+          importedItems={importedPptItems}
           value={value}
           onSelect={onSelectPresentation}
           onSelectImported={onSelectImportedPresentation}


### PR DESCRIPTION
## Summary

- unmount the template gallery while a detail preview is open instead of retaining the full hidden and inert DOM tree
- keep the uploaded-template data subscription at the dialog boundary and pass its resolved items into the on-demand grid, preserving realtime refreshes without retaining card DOM
- remove the test helper that filtered duplicate hidden template actions now that the detail action is unique

## Motivation

The presentation gallery eagerly renders 23 built-in cards. The retained grid added 299 dialog DOM nodes, including 46 images and 46 buttons. Profiling the failing CI path showed that the hidden grid still participated in six React commits after the preview opened, consuming 158–199 ms of development-mode React duration.

This intentionally allows card image elements to remount when returning from a detail preview. Catalog, selection, and scroll state remain owned outside the visual grid.

Context: https://github.com/vm0-ai/vm0/actions/runs/34508729901

## Verification

- `Choose a presentation template theme` passed 5/5 times with CI-style V8 coverage and one worker; observed test durations were 2.86–3.67 seconds (3.20-second median)
- both presentation gallery files passed together with CI-style V8 coverage: 10/10 tests
- `pnpm --filter @okouai/app lint`
- `pnpm --filter @okouai/app check-types`
- `pnpm lint:style`
- targeted Prettier check
