### PR TITLE
refactor(ui): migrate the running indicator to tailwind utilities

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -122,9 +122,9 @@ The `okou-badge`, `okou-pill`, and `okou-border-r` selectors and their consumers
 
 ### Animated layers
 
-`RunningIndicator` exports `runningIndicatorClassName`,
-`runningIndicatorCenterClassName`, and `runningIndicatorRippleClassName`. Both
-animated layers set their resting offset through an arbitrary
+`RunningIndicator` owns its Tailwind utilities directly in JSX. Reuse the
+component through its props; its internal class strings are not an exported
+styling API. Both animated layers set their resting offset through an arbitrary
 `[transform:translate(-50%,-50%)_scale(...)]` rather than Tailwind's
 `translate-*` and `scale-*` utilities.
 

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -120,6 +120,31 @@ Line height belongs to the badge because a font-size utility with an arbitrary v
 
 The `okou-badge`, `okou-pill`, and `okou-border-r` selectors and their consumers have been removed. `okou-pill` was scoped to `.okou-app` and set the muted foreground; its only consumer now spells that foreground itself. `okou-border-r` was a single settings-dialog divider and became `border-r border-r-gray-300` on that nav, keeping its lighter Gray 300 stroke while its width joins the shared hairline token.
 
+### Animated layers
+
+`RunningIndicator` exports `runningIndicatorClassName`,
+`runningIndicatorCenterClassName`, and `runningIndicatorRippleClassName`. Both
+animated layers set their resting offset through an arbitrary
+`[transform:translate(-50%,-50%)_scale(...)]` rather than Tailwind's
+`translate-*` and `scale-*` utilities.
+
+That is not a style preference. Those utilities set the individual `translate`
+and `scale` CSS properties, while the keyframes animate `transform`. The
+individual properties compose with an animated `transform` instead of being
+replaced by it, so the layer would carry the centring offset twice for the whole
+cycle. Measured, the naive form moves roughly 20,000 pixels of the indicator at
+every sampled phase.
+
+Register a keyframe animation as an `--animate-*` theme entry so consumers reach
+it through `animate-*` rather than an `animation` shorthand. A per-instance
+runtime value, such as the indicator's phase-anchoring
+`--running-indicator-delay`, stays a narrowly named custom property that the
+component sets, read through an arbitrary `[animation-delay:var(...)]`.
+
+The `running-indicator`, `running-indicator-center`, and
+`running-indicator-ripple` recipes have been removed; their keyframes remain,
+since keyframes are not class selectors.
+
 ## Exception boundary
 
 Only two exception kinds exist:

--- a/e2e/playwright/style-migration/running-indicator-cases.json
+++ b/e2e/playwright/style-migration/running-indicator-cases.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "batch": "running-indicator-motion",
+  "cases": [
+    {
+      "id": "running-indicator-light",
+      "path": "/agents",
+      "theme": "light",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "running-indicator-dark",
+      "path": "/agents",
+      "theme": "dark",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "running-indicator-light-retina",
+      "path": "/agents",
+      "theme": "light",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 2
+    },
+    {
+      "id": "running-indicator-dark-retina",
+      "path": "/agents",
+      "theme": "dark",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 2
+    }
+  ]
+}

--- a/turbo/packages/ui/src/components/ui/__tests__/running-indicator.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/running-indicator.test.tsx
@@ -4,11 +4,7 @@ import { render, screen } from "@testing-library/react";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  RunningIndicator,
-  runningIndicatorCenterClassName,
-  runningIndicatorRippleClassName,
-} from "../running-indicator";
+import { RunningIndicator } from "../running-indicator";
 
 const packageStylesPath = resolve(process.cwd(), "src/styles/globals.css");
 const globalsCss = readFileSync(
@@ -67,19 +63,17 @@ describe("RunningIndicator", () => {
   });
 
   it("keeps the center and ripple layers concentric", () => {
-    const { container } = render(<RunningIndicator />);
+    render(<RunningIndicator />);
 
     const indicator = screen.getByLabelText("Running");
-    expect(container.querySelectorAll("[aria-hidden]")).toHaveLength(2);
     expect(indicator.children).toHaveLength(2);
 
-    for (const layer of [
-      runningIndicatorCenterClassName,
-      runningIndicatorRippleClassName,
-    ]) {
-      expect(layer).toContain("top-1/2");
-      expect(layer).toContain("left-1/2");
-      expect(layer).toContain("[transform:translate(-50%,-50%)");
+    for (const layer of indicator.children) {
+      expect(layer).toHaveAttribute("aria-hidden", "true");
+      expect(layer).toHaveClass("top-1/2", "left-1/2");
+      expect(layer.getAttribute("class")).toContain(
+        "[transform:translate(-50%,-50%)",
+      );
     }
 
     const centerKeyframes = getCssBlock("@keyframes running-indicator-center");
@@ -89,30 +83,32 @@ describe("RunningIndicator", () => {
   });
 
   it("sets the resting offset through transform, not translate or scale", () => {
+    render(<RunningIndicator />);
+
     // The keyframes animate `transform`. Tailwind's `translate-*` and `scale-*`
     // utilities set the individual CSS properties, which compose on top of the
     // animation instead of being replaced by it and double the centring offset
     // for the whole cycle.
-    for (const layer of [
-      runningIndicatorCenterClassName,
-      runningIndicatorRippleClassName,
-    ]) {
-      expect(layer).not.toMatch(/(^|\s)-?translate-[xy]-/);
-      expect(layer).not.toMatch(/(^|\s)scale-/);
+    for (const layer of screen.getByLabelText("Running").children) {
+      expect(layer.getAttribute("class")).not.toMatch(
+        /(^|\s)-?translate-[xy]-/,
+      );
+      expect(layer.getAttribute("class")).not.toMatch(/(^|\s)scale-/);
     }
   });
 
   it("keeps a distinct resting state before animations start", () => {
     render(<RunningIndicator />);
 
-    expect(runningIndicatorCenterClassName).toContain(
+    const [center, ripple] = screen.getByLabelText("Running").children;
+    expect(center).toHaveClass(
       "[transform:translate(-50%,-50%)_scale(0.64)]",
+      "opacity-[0.34]",
     );
-    expect(runningIndicatorCenterClassName).toContain("opacity-[0.34]");
-    expect(runningIndicatorRippleClassName).toContain(
+    expect(ripple).toHaveClass(
       "[transform:translate(-50%,-50%)_scale(0.8)]",
+      "opacity-0",
     );
-    expect(runningIndicatorRippleClassName).toContain("opacity-0");
   });
 
   it("keeps indicators mounted at different times on one pulse phase", () => {

--- a/turbo/packages/ui/src/components/ui/__tests__/running-indicator.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/running-indicator.test.tsx
@@ -4,7 +4,11 @@ import { render, screen } from "@testing-library/react";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { RunningIndicator } from "../running-indicator";
+import {
+  RunningIndicator,
+  runningIndicatorCenterClassName,
+  runningIndicatorRippleClassName,
+} from "../running-indicator";
 
 const packageStylesPath = resolve(process.cwd(), "src/styles/globals.css");
 const globalsCss = readFileSync(
@@ -63,42 +67,52 @@ describe("RunningIndicator", () => {
   });
 
   it("keeps the center and ripple layers concentric", () => {
-    render(<RunningIndicator />);
+    const { container } = render(<RunningIndicator />);
 
     const indicator = screen.getByLabelText("Running");
-    const center = indicator.querySelector(".running-indicator-center");
-    const ripple = indicator.querySelector(".running-indicator-ripple");
+    expect(container.querySelectorAll("[aria-hidden]")).toHaveLength(2);
+    expect(indicator.children).toHaveLength(2);
 
-    expect(center).toBeInTheDocument();
-    expect(ripple).toBeInTheDocument();
+    for (const layer of [
+      runningIndicatorCenterClassName,
+      runningIndicatorRippleClassName,
+    ]) {
+      expect(layer).toContain("top-1/2");
+      expect(layer).toContain("left-1/2");
+      expect(layer).toContain("[transform:translate(-50%,-50%)");
+    }
 
-    const centerRule = getCssBlock(".running-indicator-center");
-    const rippleRule = getCssBlock(".running-indicator-ripple");
     const centerKeyframes = getCssBlock("@keyframes running-indicator-center");
     const rippleKeyframes = getCssBlock("@keyframes running-indicator-ripple");
-
-    expect(centerRule).toContain("top: 50%");
-    expect(centerRule).toContain("left: 50%");
-    expect(rippleRule).toContain("top: 50%");
-    expect(rippleRule).toContain("left: 50%");
-    expect(centerRule).toContain("transform: translate(-50%, -50%)");
-    expect(rippleRule).toContain("transform: translate(-50%, -50%)");
     expect(centerKeyframes).not.toMatch(/transform:(?![^;]*translate\()/);
     expect(rippleKeyframes).not.toMatch(/transform:(?![^;]*translate\()/);
+  });
+
+  it("sets the resting offset through transform, not translate or scale", () => {
+    // The keyframes animate `transform`. Tailwind's `translate-*` and `scale-*`
+    // utilities set the individual CSS properties, which compose on top of the
+    // animation instead of being replaced by it and double the centring offset
+    // for the whole cycle.
+    for (const layer of [
+      runningIndicatorCenterClassName,
+      runningIndicatorRippleClassName,
+    ]) {
+      expect(layer).not.toMatch(/(^|\s)-?translate-[xy]-/);
+      expect(layer).not.toMatch(/(^|\s)scale-/);
+    }
   });
 
   it("keeps a distinct resting state before animations start", () => {
     render(<RunningIndicator />);
 
-    const centerRule = getCssBlock(".running-indicator-center");
-    const rippleRule = getCssBlock(".running-indicator-ripple");
-
-    expect(centerRule).toContain(
-      "transform: translate(-50%, -50%) scale(0.64)",
+    expect(runningIndicatorCenterClassName).toContain(
+      "[transform:translate(-50%,-50%)_scale(0.64)]",
     );
-    expect(centerRule).toContain("opacity: 0.34");
-    expect(rippleRule).toContain("transform: translate(-50%, -50%) scale(0.8)");
-    expect(rippleRule).toContain("opacity: 0");
+    expect(runningIndicatorCenterClassName).toContain("opacity-[0.34]");
+    expect(runningIndicatorRippleClassName).toContain(
+      "[transform:translate(-50%,-50%)_scale(0.8)]",
+    );
+    expect(runningIndicatorRippleClassName).toContain("opacity-0");
   });
 
   it("keeps indicators mounted at different times on one pulse phase", () => {

--- a/turbo/packages/ui/src/components/ui/running-indicator.tsx
+++ b/turbo/packages/ui/src/components/ui/running-indicator.tsx
@@ -17,16 +17,6 @@ const RUNNING_INDICATOR_CYCLE_MS = 2400;
  * not started yet — iOS WebKit after the mobile sidebar becomes visible — still
  * sits where the first frame puts it.
  */
-export const runningIndicatorClassName =
-  "relative inline-flex size-[0.86rem] rounded-full text-sky-600";
-
-const layerClassName =
-  "absolute top-1/2 left-1/2 rounded-[inherit] origin-center [animation-delay:var(--running-indicator-delay,0ms)]";
-
-export const runningIndicatorCenterClassName = `${layerClassName} size-[calc(100%-5px)] bg-current opacity-[0.34] [transform:translate(-50%,-50%)_scale(0.64)] animate-running-indicator-center`;
-
-export const runningIndicatorRippleClassName = `${layerClassName} size-[calc(100%-3px)] border border-current opacity-0 [transform:translate(-50%,-50%)_scale(0.8)] animate-running-indicator-ripple`;
-
 function RunningIndicator({
   className,
   label = "Running",
@@ -50,11 +40,20 @@ function RunningIndicator({
     <span
       ref={ref}
       aria-label={label}
-      className={cn(runningIndicatorClassName, className)}
+      className={cn(
+        "relative inline-flex size-[0.86rem] rounded-full text-sky-600",
+        className,
+      )}
       {...rest}
     >
-      <span className={runningIndicatorCenterClassName} aria-hidden />
-      <span className={runningIndicatorRippleClassName} aria-hidden />
+      <span
+        className="absolute top-1/2 left-1/2 rounded-[inherit] origin-center [animation-delay:var(--running-indicator-delay,0ms)] size-[calc(100%-5px)] bg-current opacity-[0.34] [transform:translate(-50%,-50%)_scale(0.64)] animate-running-indicator-center"
+        aria-hidden
+      />
+      <span
+        className="absolute top-1/2 left-1/2 rounded-[inherit] origin-center [animation-delay:var(--running-indicator-delay,0ms)] size-[calc(100%-3px)] border border-current opacity-0 [transform:translate(-50%,-50%)_scale(0.8)] animate-running-indicator-ripple"
+        aria-hidden
+      />
     </span>
   );
 }

--- a/turbo/packages/ui/src/components/ui/running-indicator.tsx
+++ b/turbo/packages/ui/src/components/ui/running-indicator.tsx
@@ -8,6 +8,25 @@ interface RunningIndicatorProps extends HTMLAttributes<HTMLSpanElement> {
 // Keep this in sync with the animation durations in globals.css.
 const RUNNING_INDICATOR_CYCLE_MS = 2400;
 
+/**
+ * The breathing dot. Both animated layers set `transform` directly rather than
+ * Tailwind's `translate`/`scale` utilities: the keyframes animate `transform`,
+ * and the individual properties would compose on top of that animation instead
+ * of being replaced by it, which would double the centring offset for the whole
+ * cycle. The resting values match each animation's 0% frame so a layer that has
+ * not started yet — iOS WebKit after the mobile sidebar becomes visible — still
+ * sits where the first frame puts it.
+ */
+export const runningIndicatorClassName =
+  "relative inline-flex size-[0.86rem] rounded-full text-sky-600";
+
+const layerClassName =
+  "absolute top-1/2 left-1/2 rounded-[inherit] origin-center [animation-delay:var(--running-indicator-delay,0ms)]";
+
+export const runningIndicatorCenterClassName = `${layerClassName} size-[calc(100%-5px)] bg-current opacity-[0.34] [transform:translate(-50%,-50%)_scale(0.64)] animate-running-indicator-center`;
+
+export const runningIndicatorRippleClassName = `${layerClassName} size-[calc(100%-3px)] border border-current opacity-0 [transform:translate(-50%,-50%)_scale(0.8)] animate-running-indicator-ripple`;
+
 function RunningIndicator({
   className,
   label = "Running",
@@ -31,11 +50,11 @@ function RunningIndicator({
     <span
       ref={ref}
       aria-label={label}
-      className={cn("running-indicator", className)}
+      className={cn(runningIndicatorClassName, className)}
       {...rest}
     >
-      <span className="running-indicator-center" aria-hidden />
-      <span className="running-indicator-ripple" aria-hidden />
+      <span className={runningIndicatorCenterClassName} aria-hidden />
+      <span className={runningIndicatorRippleClassName} aria-hidden />
     </span>
   );
 }

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -191,6 +191,15 @@
    * =================================== */
   --icon-stroke-width: 1.5;
 
+  /* Running indicator — the breathing dot's two animated layers. The keyframes
+     animate `transform`, so consumers must set `transform` rather than the
+     individual `translate`/`scale` properties, which would compose on top of
+     the animation instead of being replaced by it. */
+  --animate-running-indicator-center: running-indicator-center 2400ms
+    cubic-bezier(0.33, 0, 0.66, 1) infinite;
+  --animate-running-indicator-ripple: running-indicator-ripple 2400ms ease-out
+    infinite;
+
   /* ===================================
    * Input System
    * Design tokens for consistent input styles across the application
@@ -688,47 +697,6 @@
 
   .dialog-scrollable::-webkit-scrollbar-thumb:hover {
     background-color: rgba(128, 128, 128, 0.5);
-  }
-
-  /* Running indicator — breathing dot for "in progress" state. */
-  .running-indicator {
-    position: relative;
-    display: inline-flex;
-    width: 0.86rem;
-    height: 0.86rem;
-    border-radius: 9999px;
-    color: var(--color-sky-600, #0284c7);
-  }
-  /* Match the 0% keyframes when iOS WebKit has not started the animations
-     after the mobile sidebar changes from hidden to visible. */
-  .running-indicator-center {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: calc(100% - 5px);
-    height: calc(100% - 5px);
-    border-radius: inherit;
-    background: currentColor;
-    transform: translate(-50%, -50%) scale(0.64);
-    transform-origin: center;
-    opacity: 0.34;
-    animation: running-indicator-center 2400ms cubic-bezier(0.33, 0, 0.66, 1)
-      infinite;
-    animation-delay: var(--running-indicator-delay, 0ms);
-  }
-  .running-indicator-ripple {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: calc(100% - 3px);
-    height: calc(100% - 3px);
-    border-radius: inherit;
-    border: 1px solid currentColor;
-    transform: translate(-50%, -50%) scale(0.8);
-    transform-origin: center;
-    opacity: 0;
-    animation: running-indicator-ripple 2400ms ease-out infinite;
-    animation-delay: var(--running-indicator-delay, 0ms);
   }
 }
 

--- a/turbo/style-legacy-baseline.json
+++ b/turbo/style-legacy-baseline.json
@@ -78,9 +78,6 @@
     "owf-diagram-okou-icon",
     "owf-diagram-vertical-control",
     "owf-diagram-wrap",
-    "running-indicator",
-    "running-indicator-center",
-    "running-indicator-ripple",
     "slide-in-from-bottom-2",
     "table-wrapper",
     "toaster",
@@ -3493,216 +3490,6 @@
         "property": "background-color",
         "value": "rgba(128,128,128,0.5)",
         "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator",
-        "property": "position",
-        "value": "relative",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator",
-        "property": "display",
-        "value": "inline-flex",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator",
-        "property": "width",
-        "value": "0.86rem",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator",
-        "property": "height",
-        "value": "0.86rem",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator",
-        "property": "border-radius",
-        "value": "9999px",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator",
-        "property": "color",
-        "value": "var(--color-sky-600, #0284c7)",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-center",
-        "property": "position",
-        "value": "absolute",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-center",
-        "property": "top",
-        "value": "50%",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-center",
-        "property": "left",
-        "value": "50%",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-center",
-        "property": "width",
-        "value": "calc(100% - 5px)",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-center",
-        "property": "height",
-        "value": "calc(100% - 5px)",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-center",
-        "property": "border-radius",
-        "value": "inherit",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-center",
-        "property": "background",
-        "value": "currentColor",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-center",
-        "property": "transform",
-        "value": "translate(-50%,-50%) scale(0.64)",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-center",
-        "property": "transform-origin",
-        "value": "center",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-center",
-        "property": "opacity",
-        "value": "0.34",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-center",
-        "property": "animation",
-        "value": "running-indicator-center 2400ms cubic-bezier(0.33,0,0.66,1) infinite",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-center",
-        "property": "animation-delay",
-        "value": "var(--running-indicator-delay, 0ms)",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-ripple",
-        "property": "position",
-        "value": "absolute",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-ripple",
-        "property": "top",
-        "value": "50%",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-ripple",
-        "property": "left",
-        "value": "50%",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-ripple",
-        "property": "width",
-        "value": "calc(100% - 3px)",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-ripple",
-        "property": "height",
-        "value": "calc(100% - 3px)",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-ripple",
-        "property": "border-radius",
-        "value": "inherit",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-ripple",
-        "property": "border",
-        "value": "1px solid currentColor",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-ripple",
-        "property": "transform",
-        "value": "translate(-50%,-50%) scale(0.8)",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-ripple",
-        "property": "transform-origin",
-        "value": "center",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-ripple",
-        "property": "opacity",
-        "value": "0",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-ripple",
-        "property": "animation",
-        "value": "running-indicator-ripple 2400ms ease-out infinite",
-        "important": false
-      },
-      {
-        "atRules": ["@layer components"],
-        "selector": ".running-indicator-ripple",
-        "property": "animation-delay",
-        "value": "var(--running-indicator-delay, 0ms)",
-        "important": false
       }
     ]
   },
@@ -3933,7 +3720,6 @@
     "apps/platform/src/views/okou-page/settings-tab.tsx": {
       "okou-chat-bubble-assistant": 1
     },
-    "apps/platform/src/views/okou-page/sidebar-account.tsx": {},
     "apps/platform/src/views/okou-page/sidebar-dialogs.tsx": {
       "okou-app": 2
     },
@@ -4048,11 +3834,6 @@
     },
     "packages/ui/src/components/ui/dropdown-menu.tsx": {
       "okou-border-t": 1
-    },
-    "packages/ui/src/components/ui/running-indicator.tsx": {
-      "running-indicator": 1,
-      "running-indicator-center": 1,
-      "running-indicator-ripple": 1
     },
     "packages/ui/src/components/ui/select.tsx": {
       "okou-border-t": 1

--- a/turbo/style-migration-manifest.json
+++ b/turbo/style-migration-manifest.json
@@ -462,6 +462,24 @@
       ],
       "status": "implemented",
       "evidence": []
+    },
+    {
+      "id": "running-indicator-motion",
+      "family": "motion-and-injection",
+      "tokens": [
+        "running-indicator",
+        "running-indicator-center",
+        "running-indicator-ripple"
+      ],
+      "consumers": ["packages/ui/src/components/ui/running-indicator.tsx"],
+      "cases": [
+        "running-indicator-light",
+        "running-indicator-dark",
+        "running-indicator-light-retina",
+        "running-indicator-dark-retina"
+      ],
+      "status": "implemented",
+      "evidence": []
     }
   ],
   "caseFiles": [
@@ -471,6 +489,7 @@
     "../e2e/playwright/style-migration/icon-mono-cases.json",
     "../e2e/playwright/style-migration/settings-select-cases.json",
     "../e2e/playwright/style-migration/badge-cases.json",
-    "../e2e/playwright/style-migration/chat-emoji-cases.json"
+    "../e2e/playwright/style-migration/chat-emoji-cases.json",
+    "../e2e/playwright/style-migration/running-indicator-cases.json"
   ]
 }


### PR DESCRIPTION
Refs #32402.

Migrate the breathing running indicator from the `running-indicator`, `running-indicator-center`, and `running-indicator-ripple` CSS selectors to Tailwind utilities composed directly in the component's JSX. The public API remains `RunningIndicator` and `RunningIndicatorProps`; no className constants are exported. Remove the three legacy recipes and their baseline entries, and register the existing animations as shared `--animate-*` theme entries.

Both animated layers retain their resting offset through `[transform:translate(-50%,-50%)_scale(...)]`. Tailwind's individual `translate` and `scale` properties would compose with the keyframes' animated `transform` and double the centering offset. The initial layer appearance and the negative animation delay that synchronizes mounted indicators are preserved.

The existing regression tests inspect the rendered layers through the indicator's accessible label instead of importing style constants. The style guide documents component ownership of these utilities.

Validation:

- All four `running-indicator` tests pass; UI type checks, lint, scoped Knip, and changed-file Prettier checks pass.
- Style policy and migration suites, baseline/manifest validation, and the complete Tailwind style lint pass.
- This encapsulation revision was compared with `990b361fb7c8c3478c5120775c8ed40168cfb5dd`: the rendered HTML is identical with default and overridden props. Chromium comparison covers Light/Dark, three pinned animation phases, and both prop cases: 792 computed-style comparisons across 12 cases, with zero differences. Both layers retain their animations and remain concentric.

Full application tests and deployed E2E validation run in the PR pipeline.
