### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -2003,7 +2003,7 @@ pub mod webhooks {
                 #[serde(rename_all = "camelCase")]
                 pub struct RequestMaintenanceAttestation {
                     /// Maintenance checkpoint attestation version.
-                    pub schema_version: u64,
+                    pub schema_version: i64,
                     /// Opaque token fencing the maintenance claim.
                     pub lease_token: String,
                     /// Exact claimed Phase 2 input revision.
@@ -2078,7 +2078,7 @@ pub mod webhooks {
                 #[serde(rename_all = "camelCase")]
                 pub struct RequestMaintenanceAttestation {
                     /// Maintenance checkpoint attestation version.
-                    pub schema_version: u64,
+                    pub schema_version: i64,
                     /// Opaque token fencing the maintenance claim.
                     pub lease_token: String,
                     /// Exact claimed Phase 2 input revision.

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-worker.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-worker.service.test.ts
@@ -488,7 +488,7 @@ describe("Pi memory Phase 2 sandbox dispatcher", () => {
           parentVersionId: scope.baseVersion.versionId,
           files: invalidFiles,
           maintenanceAttestation: {
-            schemaVersion: 1,
+            schemaVersion: 2,
             leaseToken,
             claimedRevision,
             claimedBaseVersionId: scope.baseVersion.versionId,

--- a/turbo/apps/api/src/signals/services/artifact-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-storage.service.ts
@@ -6,7 +6,6 @@ import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 
 import { env } from "../../lib/env";
 import {
-  buildArtifactKey,
   buildArtifactKeyV2,
   buildArtifactPrefix,
   buildArtifactPrefixV2,
@@ -16,7 +15,6 @@ import {
   OKOU_CDN_ARTIFACTS_ORIGIN,
   OKOU_SHORT_ARTIFACTS_ORIGIN,
   publicArtifactsBaseUrlForBrand,
-  sanitizeArtifactFilename,
 } from "../../lib/file-url";
 import { inferMimetype } from "../../lib/mimetype";
 import {
@@ -544,21 +542,15 @@ export const resolveArtifactMultipartUpload$ = command(
     },
     signal: AbortSignal,
   ): Promise<ResolvedArtifactMultipartUpload | null> => {
-    const sanitizedFilename = sanitizeArtifactFilename(args.filename);
-    const v1Key = buildArtifactKey(args.userId, args.id, sanitizedFilename);
-    const v2Key = buildArtifactKeyV2(args.id, args.filename);
-    // Accept multipart uploads started by previous clients while they drain.
-    const keys = [v2Key, v1Key];
-    const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
-    for (const key of keys) {
-      const parts = await get(
-        tryListMultipartS3Parts(bucket, key, args.uploadId),
-      );
-      signal.throwIfAborted();
-      if (parts !== null) {
-        return { key, parts };
-      }
-    }
-    return null;
+    const key = buildArtifactKeyV2(args.id, args.filename);
+    const parts = await get(
+      tryListMultipartS3Parts(
+        env("R2_USER_ARTIFACTS_BUCKET_NAME"),
+        key,
+        args.uploadId,
+      ),
+    );
+    signal.throwIfAborted();
+    return parts === null ? null : { key, parts };
   },
 );

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -2415,28 +2415,6 @@ test("Keep a retired Official Workflow operable but structurally read-only", asy
   expect(screen.queryByText("Delete selected file")).not.toBeInTheDocument();
 });
 
-test("Preserve safe Official Workflow operations when parameter metadata is unavailable", async () => {
-  const workflow = officialSalesResearch("retired");
-  mockWorkflowApis([workflow]);
-  context.mocks.api(
-    officialWorkflowInstallationsContract.get,
-    ({ respond }) => {
-      return respond(200, { workflow });
-    },
-  );
-
-  await setupWorkflowDetailPage(workflowDetailPath("info"));
-
-  await expect(
-    screen.findByText(
-      "Authoritative parameter metadata is temporarily unavailable.",
-    ),
-  ).resolves.toBeInTheDocument();
-  expect(buttonByText("Reconfigure")).toBeDisabled();
-  expect(buttonByText("Copy workflow")).toBeEnabled();
-  expect(buttonByText("Uninstall")).toBeEnabled();
-});
-
 async function expectOfficialReconciliation(
   status: "current" | "reconciling" | "needs_reconfiguration" | "failed",
   label: string,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -179,43 +179,40 @@ function manifestFile(path: string) {
 }
 
 describe("storage webhook manifest limits", () => {
-  it.each([1, 2])(
-    "accepts exact maintenance checkpoint attestation v%s",
-    (schemaVersion) => {
-      const body = {
-        runId: "run-id",
-        storageId,
-        files: [],
-        parentVersionId: "a".repeat(64),
+  it("accepts the exact v2 maintenance checkpoint attestation", () => {
+    const body = {
+      runId: "run-id",
+      storageId,
+      files: [],
+      parentVersionId: "a".repeat(64),
+      maintenanceAttestation: {
+        schemaVersion: 2,
+        leaseToken: "44754115-d375-4c46-aea7-a55bd1b61ec7",
+        claimedRevision: 7,
+        claimedBaseVersionId: "a".repeat(64),
+        selectionDigest: "b".repeat(64),
+        validatedVersionId: "c".repeat(64),
+      },
+    };
+    expect(
+      webhookStoragesPrepareContract.prepare.body.safeParse(body).success,
+    ).toBe(true);
+    expect(
+      webhookStoragesCommitContract.commit.body.safeParse({
+        ...body,
+        versionId: "c".repeat(64),
+      }).success,
+    ).toBe(true);
+    expect(
+      webhookStoragesPrepareContract.prepare.body.safeParse({
+        ...body,
         maintenanceAttestation: {
-          schemaVersion,
-          leaseToken: "44754115-d375-4c46-aea7-a55bd1b61ec7",
-          claimedRevision: 7,
-          claimedBaseVersionId: "a".repeat(64),
-          selectionDigest: "b".repeat(64),
-          validatedVersionId: "c".repeat(64),
+          ...body.maintenanceAttestation,
+          schemaVersion: 3,
         },
-      };
-      expect(
-        webhookStoragesPrepareContract.prepare.body.safeParse(body).success,
-      ).toBe(true);
-      expect(
-        webhookStoragesCommitContract.commit.body.safeParse({
-          ...body,
-          versionId: "c".repeat(64),
-        }).success,
-      ).toBe(true);
-      expect(
-        webhookStoragesPrepareContract.prepare.body.safeParse({
-          ...body,
-          maintenanceAttestation: {
-            ...body.maintenanceAttestation,
-            schemaVersion: 3,
-          },
-        }).success,
-      ).toBe(false);
-    },
-  );
+      }).success,
+    ).toBe(false);
+  });
 
   it("accepts the exact file-count boundary and rejects one more file", () => {
     const exactFiles = Array.from(

--- a/turbo/packages/api-contracts/src/contracts/official-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/official-workflows.ts
@@ -70,10 +70,7 @@ export type OfficialWorkflowInstallationDefinition = z.infer<
 export const officialWorkflowInstallationResponseSchema = z
   .object({
     workflow: workflowDetailResponseSchema,
-    // New App -> old API fallback. Current APIs always return authoritative
-    // accepted Definition metadata; remove the optional parser in #29991
-    // after pre-P4 APIs are no longer serving or retained for rollback.
-    definition: officialWorkflowInstallationDefinitionSchema.optional(),
+    definition: officialWorkflowInstallationDefinitionSchema,
   })
   .strict();
 export type OfficialWorkflowInstallationResponse = z.infer<

--- a/turbo/packages/api-contracts/src/contracts/user-model-preference.ts
+++ b/turbo/packages/api-contracts/src/contracts/user-model-preference.ts
@@ -11,25 +11,8 @@ const c = initContract();
 export const userModelPreferenceResponseSchema = z.object({
   selectedModel: supportedRunModelSchema.nullable(),
   serviceTier: chatThreadServiceTierSchema.nullable(),
-  /**
-   * Rollout fallback. Optional so a newly promoted bundle can still parse a
-   * response from an API that predates the field. App promotion follows API
-   * promotion, so the reachable direction is an API rollback.
-   *
-   * Surface: frontend -> backend. Window: the API rollback window.
-   * Remove — make it required — once the pre-field API is outside that window.
-   * Follow-up: #26765.
-   */
-  selectedVideoModel: videoModelIdSchema.nullable().optional(),
-  /**
-   * Rollout fallback. Optional so a newly promoted bundle can still parse a
-   * response from an API that predates image preferences after an API rollback.
-   *
-   * Surface: web/app client -> backend. Window: about 2 days.
-   * Remove — make it required — once the pre-field API is outside the supported
-   * rollback and client-skew window. Follow-up: #27786.
-   */
-  selectedImageModel: imageModelIdSchema.nullable().optional(),
+  selectedVideoModel: videoModelIdSchema.nullable(),
+  selectedImageModel: imageModelIdSchema.nullable(),
   updatedAt: z.string().nullable(),
 });
 

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -44,10 +44,7 @@ const sha256HexSchema = z
 
 const piMemoryPhase2CheckpointAttestationSchema = z
   .object({
-    // New Guests require receipt-aware prepare/commit. Old APIs reject v2
-    // before upload. Read v1 while pinned Guests drain (up to two hours);
-    // remove v1 under #31067 after that drain and the API rollback window.
-    schemaVersion: z.number().int().min(1).max(2),
+    schemaVersion: z.literal(2),
     leaseToken: z.uuid(),
     claimedRevision: z.number().int().positive(),
     claimedBaseVersionId: sha256HexSchema,


### PR DESCRIPTION
Daily deployment-compatibility cleanup for 2026-09-11. Four expired cohorts, one branch, no schema changes. Windows follow `docs/deployment-compatibility.md`; timestamps are UTC.

**Rollback floor used below**: the production rollback resolver (`.github/scripts/resolve-production-rollback-target.sh`) rejects any release/API target that does not contain `4a4881bf84cb1d79723fd38c83e00f2215bb1e31` (API 1.580.0, `chore: release main` merged 2026-09-10 09:21, independently accepted in production per `docs/deployment-compatibility.md`). Every commit cited as "inside the floor" is an ancestor of that release (`git merge-base --is-ancestor` verified), so no permitted rollback target lacks the replacement producer.

## 1. Pi memory phase-2 checkpoint attestation v1 (#31067)

- **Boundary**: `piMemoryPhase2CheckpointAttestationSchema.schemaVersion` accepted `1..2` so pinned Guests that still sent v1 could commit checkpoints; the API never branched on the version. It now accepts only `2`.
- **Rollout**: v2 producer and the v1/v2 reader shipped together in `2db67fc8be` (#31947, 2026-09-05 23:39), inside the floor. Consumer class: Guest/CLI (2 h after the replacement Sandbox image) plus the API rollback window; #31067 closed 2026-09-08.
- **Axiom** (`vm0-request-log-prod`, 2026-09-09T21:20Z → 2026-09-10T21:20Z, `x_client_type == "GuestAgent"`): 0.88.0 (358 600) and 0.88.1 (205 439) only — no Guest older than the 0.86.22 producer-stop release recorded in the docs. `x_client_version` is populated for all Guest traffic.
- **Changed**: contract literal, one worker-service test fixture (`schemaVersion: 1` → `2`).

## 2. Official Workflow installation `definition` fallback (#29991)

- **Boundary**: `officialWorkflowInstallationResponseSchema.definition` was optional so a new App could parse a pre-P4 API response; the Platform showed "Authoritative parameter metadata is temporarily unavailable" and disabled Reconfigure. The field is now required.
- **Rollout**: the P4 API that always returns accepted Definition metadata shipped in `71ff589c65` (#29996, 2026-08-28), inside the floor; the installation service types have always populated `definition`. Consumer class: App → old API (old API rollout + 4 s, rollback closed by the floor). #29991 closed 2026-09-02.
- **Changed**: contract required; the Platform test that exercised the missing-definition fallback is removed. The page still handles a null installation while loading.

## 3. `selectedVideoModel` / `selectedImageModel` response optionality (#26765, #27786)

- **Boundary**: both fields were optional in `userModelPreferenceResponseSchema` so a newly promoted bundle could parse a pre-field API response after an API rollback. They are now required (`nullable`). The PATCH request keeps its optional partial-update semantics, which its comment documents as permanent.
- **Rollout**: video preference API `ae1a7197d8` (#27165, 2026-08-14) and image preference API `d3b0c0e020` (#27776, 2026-08-17), both inside the floor. Consumer class: App → old API (rollback closed by the floor). Both follow-up issues are closed.
- **Changed**: contract only; `@okouai/app` and `@okouai/cli` typecheck unchanged (consumers already coalesce `null`).

## 4. Multipart upload v1 object-key fallback

- **Boundary**: `resolveArtifactMultipartUpload$` listed multipart parts under the v2 key and then the v1 key (`artifacts/<user>/<id>/<filename>`) to complete uploads started by previous clients. It now resolves the v2 key only; the private-record path (`resolveUploadedMultipart$`) is unchanged.
- **Rollout**: v2 keys became the only prepare-time key when the switch was removed in `c160b0e1a2` (#25128, 2026-08-05); the exact-key resolution refactor `ef9166edd6` (#29050, 2026-08-24) followed. Consumer class: App (24 h) and CLI (2 h) — a multipart upload prepared under a v1 key more than five weeks ago has no supported completer.
- **Axiom** (`vm0-request-log-prod`, 2026-09-03T21:20Z → 2026-09-10T21:20Z): `/api/uploads/multipart/complete` 48 App requests (200), `/api/uploads/multipart/abort` 7; `/api/uploads/complete` 2 100 CLI requests. Coverage note: the log cannot show which key resolved, so eligibility rests on the prepare-time rollout above.
- **Persisted data**: `buildArtifactKey` (v1) stays exported for persisted objects and the test fixtures that seed them; only the multipart-resolution fallback is removed.

## Verification

- `check-types` for `@okouai/api-contracts`, `api`, `@okouai/app`, `@okouai/cli`; `oxlint` (no new findings); `eslint --max-warnings 0` on every changed file; `pnpm knip` clean; reference searches for the removed optionals, the v1 range, and the removed Platform copy return nothing.
- `api` Vitest needs Postgres, which the sandbox lacks; the touched suites run in the PR pipeline. The Platform suite was not run locally.

## Deferred this run (exact blockers)

- `agentResponseSchema.isDefaultAgent` optional (#33251) and Google Ads attribution aliases (#33059): the producing commits (#33266, #33149, both 2026-09-10) are **not** inside the rollback floor.
- `computer_use_hosts.client_product` drop (#32967): owner re-gated on 2026-09-09.
- Usage-pack legacy columns and billing response optionals (#32575): open issue with transition validators; `supportsFreeMembers` also has an App → API query direction the request log cannot classify.
- `chat_threads` legacy provider pins (still read; 153 389 non-null rows), `pi_memory_phase2_jobs.legacy_lease_token`, browser compatibility structures, personal model-provider singleton expansion: MaskDB projection or join limits.
- `#29908` queue markers (writers live), `#31964` citation bridge, `#31085` Slice 2, `sourceId`-less secret path (`PersonalModelProviderAccounts` staff-only), `featureDisabled`/`noSessionId` reuse enum values (historical rows), SOCIALKIT error-code guidance (API still emits those constants).
