### PR TITLE
fix(platform): replace onboarding avatar

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -1623,13 +1623,6 @@ details > summary {
   overflow: hidden;
 }
 
-.owf-diagram-okou-icon img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
-
 .owf-diagram-node-source {
   top: 34px;
   left: 94px;

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -1624,14 +1624,10 @@ details > summary {
 }
 
 .owf-diagram-okou-icon img {
-  position: absolute;
-  top: -9.73px;
-  left: -6.4px;
   display: block;
-  width: 76.8px;
-  height: 76.8px;
-  max-width: none;
-  object-fit: fill;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .owf-diagram-node-source {

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -481,6 +481,15 @@ test("Built-in workflows can start without connector setup", async () => {
   expect(preview.querySelector(".owf-diagram-node-source")).toBeNull();
   expect(preview.querySelector(".owf-diagram-dot-source")).toBeNull();
   expect(preview.querySelector('path[d="M170 81H277"]')).toBeNull();
+  expect(preview.querySelectorAll(".owf-diagram-okou-icon img")).toHaveLength(
+    1,
+  );
+  expect(
+    preview.querySelector<HTMLImageElement>(".owf-diagram-okou-icon img"),
+  ).toHaveAttribute(
+    "src",
+    "https://static.okou.io/platform/views/onboarding/assets/okou-avatar-2df72642115f.webp",
+  );
 });
 
 test("Every onboarding role has a curated workflow set", async () => {

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -481,11 +481,13 @@ test("Built-in workflows can start without connector setup", async () => {
   expect(preview.querySelector(".owf-diagram-node-source")).toBeNull();
   expect(preview.querySelector(".owf-diagram-dot-source")).toBeNull();
   expect(preview.querySelector('path[d="M170 81H277"]')).toBeNull();
-  expect(preview.querySelectorAll(".owf-diagram-okou-icon img")).toHaveLength(
-    1,
-  );
   expect(
-    preview.querySelector<HTMLImageElement>(".owf-diagram-okou-icon img"),
+    preview.querySelectorAll('[data-slot="onboarding-okou-avatar"]'),
+  ).toHaveLength(1);
+  expect(
+    preview.querySelector<HTMLImageElement>(
+      '[data-slot="onboarding-okou-avatar"]',
+    ),
   ).toHaveAttribute(
     "src",
     "https://static.okou.io/platform/views/onboarding/assets/okou-avatar-2df72642115f.webp",

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx
@@ -363,7 +363,13 @@ export function WorkflowPreviewDiagram({
           iconClassName="owf-diagram-avatar"
         >
           <span className="owf-diagram-okou-icon" aria-hidden="true">
-            <img src={OKOU_AVATAR_IMG} alt="" aria-hidden />
+            <img
+              data-slot="onboarding-okou-avatar"
+              className="block size-full object-contain"
+              src={OKOU_AVATAR_IMG}
+              alt=""
+              aria-hidden
+            />
           </span>
         </WorkflowDiagramNode>
         {diagram.destinationConnectorSlug ? (

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx
@@ -7,14 +7,8 @@ import { connectorCatalogStatusBySlug$ } from "../../signals/external/connectors
 import { ConnectorIcon } from "../okou-page/components/settings/connector-icons.tsx";
 import { platformStaticAssetUrl } from "../../lib/static-assets.ts";
 
-const AVATAR_HEAD_IMG = platformStaticAssetUrl(
-  "views/onboarding/assets/zero-avatar-head-840043d16b50.svg",
-);
-const AVATAR_HAIR_IMG = platformStaticAssetUrl(
-  "views/onboarding/assets/zero-avatar-hair-c1d917488df8.svg",
-);
-const AVATAR_FACE_IMG = platformStaticAssetUrl(
-  "views/onboarding/assets/zero-avatar-face-19a2ae88c11d.svg",
+const OKOU_AVATAR_IMG = platformStaticAssetUrl(
+  "views/onboarding/assets/okou-avatar-2df72642115f.webp",
 );
 
 export function WorkflowConnectorIcon({
@@ -369,9 +363,7 @@ export function WorkflowPreviewDiagram({
           iconClassName="owf-diagram-avatar"
         >
           <span className="owf-diagram-okou-icon" aria-hidden="true">
-            <img src={AVATAR_HEAD_IMG} alt="" aria-hidden />
-            <img src={AVATAR_HAIR_IMG} alt="" aria-hidden />
-            <img src={AVATAR_FACE_IMG} alt="" aria-hidden />
+            <img src={OKOU_AVATAR_IMG} alt="" aria-hidden />
           </span>
         </WorkflowDiagramNode>
         {diagram.destinationConnectorSlug ? (

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx
@@ -11,6 +11,18 @@ const OKOU_AVATAR_IMG = platformStaticAssetUrl(
   "views/onboarding/assets/okou-avatar-2df72642115f.webp",
 );
 
+function WorkflowDiagramOkouAvatar() {
+  return (
+    <img
+      data-slot="onboarding-okou-avatar"
+      className="block size-full object-contain"
+      src={OKOU_AVATAR_IMG}
+      alt=""
+      aria-hidden
+    />
+  );
+}
+
 export function WorkflowConnectorIcon({
   connectorSlug,
   size,
@@ -363,13 +375,7 @@ export function WorkflowPreviewDiagram({
           iconClassName="owf-diagram-avatar"
         >
           <span className="owf-diagram-okou-icon" aria-hidden="true">
-            <img
-              data-slot="onboarding-okou-avatar"
-              className="block size-full object-contain"
-              src={OKOU_AVATAR_IMG}
-              alt=""
-              aria-hidden
-            />
+            <WorkflowDiagramOkouAvatar />
           </span>
         </WorkflowDiagramNode>
         {diagram.destinationConnectorSlug ? (

--- a/turbo/style-legacy-baseline.json
+++ b/turbo/style-legacy-baseline.json
@@ -2745,62 +2745,6 @@
       },
       {
         "atRules": [],
-        "selector": ".owf-diagram-okou-icon img",
-        "property": "position",
-        "value": "absolute",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".owf-diagram-okou-icon img",
-        "property": "top",
-        "value": "-9.73px",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".owf-diagram-okou-icon img",
-        "property": "left",
-        "value": "-6.4px",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".owf-diagram-okou-icon img",
-        "property": "display",
-        "value": "block",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".owf-diagram-okou-icon img",
-        "property": "width",
-        "value": "76.8px",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".owf-diagram-okou-icon img",
-        "property": "height",
-        "value": "76.8px",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".owf-diagram-okou-icon img",
-        "property": "max-width",
-        "value": "none",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".owf-diagram-okou-icon img",
-        "property": "object-fit",
-        "value": "fill",
-        "important": false
-      },
-      {
-        "atRules": [],
         "selector": ".owf-diagram-node-source",
         "property": "top",
         "value": "34px",
@@ -3933,7 +3877,6 @@
     "apps/platform/src/views/okou-page/settings-tab.tsx": {
       "okou-chat-bubble-assistant": 1
     },
-    "apps/platform/src/views/okou-page/sidebar-account.tsx": {},
     "apps/platform/src/views/okou-page/sidebar-dialogs.tsx": {
       "okou-app": 2
     },


### PR DESCRIPTION
## Summary
- replace the legacy three-layer Zero avatar in onboarding workflow previews with the current Okou mascot
- keep the existing 64px workflow-node framing while switching to one content-hashed static asset
- add a regression assertion for the single Okou avatar URL

## Static asset dependency
- https://github.com/vm0-ai/static-files/pull/200 adds `static.vm0.io/platform/views/onboarding/assets/okou-avatar-2df72642115f.webp`
- that static PR must merge and finish syncing before this consumer change is deployed

## Verification
- `git diff --check`
- `npx --yes prettier@3.6.2 --check apps/platform/src/views/css/index.css apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx`
- visually checked the optimized asset at its 64px UI render size
- full tests deferred to the PR pipeline per repository guidance

Closes #33341
