### PR TITLE
fix(app): align chat bullet lists with response icon rows

### DIFF
--- a/turbo/apps/platform/src/views/components/markdown-frame.tsx
+++ b/turbo/apps/platform/src/views/components/markdown-frame.tsx
@@ -17,6 +17,7 @@ export function MarkdownFrame({
 
   return (
     <div
+      data-slot="markdown"
       data-color-mode={theme}
       className={cn(
         "wmde-markdown wmde-markdown-color",

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -96,6 +96,9 @@ export function ChatAssistantMessageBody({
       data-chat-selection-source
       className={cn(
         "okou-chat-bubble-assistant p-0 text-[0.9375rem] leading-[1.7] min-w-0 [overflow-wrap:anywhere]",
+        // Match the 24px inset of icon-row labels while keeping native markers
+        // and Markdown's indentation for nested lists.
+        "[&_[data-slot=markdown]>ul]:pl-6!",
         className,
       )}
       {...props}


### PR DESCRIPTION
Assistant replies currently indent top-level Markdown bullets by 20px, while response icon rows reserve 24px before their labels. This leaves the bullet text and markers visibly to the left of the corresponding icon-row alignment.

Use the existing `pl-6` utility for top-level unordered lists inside assistant message Markdown, scoped through a `data-slot="markdown"` hook. Native list markers, hanging indentation, nested-list spacing, ordered lists, and Markdown outside assistant replies retain their existing behavior.

## Validation

- Prettier, targeted ESLint, Tailwind style lint, and the repository style policy passed.
- App production/test/build-config type checks and App-scoped Knip passed.
- Chromium rendered the production Markdown parser output with compiled production CSS at 320px, 390px, and 1440px in light/dark themes. Verified 24px text alignment, multiline hanging indentation, nested and mixed lists, ordered lists, checkbox state, list accessibility, and no horizontal overflow.
- Visual evidence is a static CSS fixture, not a deployed application capture. No local dev server or full Vitest run was started; the PR pipeline owns the remaining integration checks.

![Before and after: static fixture using the current Markdown parser and production styles](https://a.okou.io/ke227w8pz9.png)
