### PR TITLE
chore: correct retired-goal comments in run-origin and chat rendering

### DIFF
--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -84,8 +84,8 @@ import { captureActiveCodexModelProviderAccount } from "./model-provider-account
 
 type AgentRunCreateBody = z.infer<typeof runCreateBodySchema>;
 // Emitted as the agent_run_origin observability dimension. The values name what
-// started the run, so the fallback is "direct" (neither automation nor goal
-// continuation) rather than a restatement that this is an agent run.
+// started the run, so the fallback is "direct" (not started by an automation)
+// rather than a restatement that this is an agent run.
 type AgentRunOrigin = "direct" | "workflow_automation";
 export type AgentRunPreCreateSource =
   | "chat_callback_auto_send"

--- a/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
@@ -479,9 +479,10 @@ function runWorkUnits(events: readonly EnrichedChatEvent[]): RunWorkUnit[] {
       continue;
     }
 
-    // Goal continuations are synthetic user turns. Attach their contiguous
-    // streak to the nearest preceding ungrouped run; an intervening run then
-    // naturally starts a new visual work section after an interruption.
+    // Historical goal continuations are synthetic user turns. Attach their
+    // contiguous streak to the nearest preceding ungrouped run; an intervening
+    // run then naturally starts a new visual work section after an
+    // interruption.
     const previousUnit = units[units.length - 1];
     const anchorUnit = canAnchorGoalRun(previousUnit) ? units.pop() : undefined;
     const groupedEvents = streak.flatMap((item) => {
@@ -581,7 +582,8 @@ interface RunWorkGroupFolding {
 }
 
 // A work group is bounded by visible user inputs, independently of execution:
-// one run can span several groups, and goal continuations can span several runs.
+// one run can span several groups, and historical goal continuations can span
+// several runs.
 interface RunWorkGroup {
   readonly unit: RunWorkUnit;
   readonly events: readonly EnrichedChatEvent[];

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -5598,8 +5598,9 @@ function PagedUserGroup({
   );
 }
 
-// A user event does not always render as a bubble: a workflow run, a goal, and
-// a rejected goal each render as their own card or as nothing at all.
+// A user event does not always render as a bubble: a workflow run, a historical
+// goal, and a rejected historical goal each render as their own card or as
+// nothing at all.
 function rendersUserBubble(event: EnrichedChatEvent): boolean {
   return (
     !isRejectedGoalUserMessage(event) &&


### PR DESCRIPTION
## What

Follow-up cleanup after the Okou Goal retirement (EPIC #32653, completed in S6). No live Goal functionality remains in the codebase; the only leftover was in-code prose. Four comments still described Goal in the present tense as a mechanism a reader could still encounter or use, which misleads both humans and coding agents.

Each comment now states that the Goal path is retained, read-only history with no scheduling or lifecycle authority, following the wording precedent at `turbo/packages/db/src/schema/chat-event.ts:91` and the "Retired Goal History Context" glossary in `CONTEXT.md`.

## Changes

- `turbo/apps/api/src/signals/services/agent-runs-create.service.ts` — the comment contrasted the current `AgentRunOrigin` union against "goal continuation", reading as though a union member were missing. The explanation of why the fallback is named `"direct"` is kept; the Goal clause is dropped because the reason stands on its own.
- `turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx` — "a historical goal, and a rejected historical goal".
- `turbo/apps/platform/src/signals/chat-page/run-work-folding.ts` (x2) — "historical goal continuations".

`run-work-folding.ts:495` is left as-is: it describes how the folding algorithm operates on data.

## Not in scope

The identifiers, types, i18n keys, and rendering branches next to these comments are load-bearing for archived threads and were deliberately preserved by #32653. Nothing was removed, renamed, or narrowed: no `goal` identifier or type, no contract member, no locale string, no migration, no fixture or guard test, and no `crates/guest-agent` switch.

## Verification

- `git diff` is comment-only: no statement, expression, type, or string literal changed.
- `AgentRunOrigin` is unchanged as a type; `rendersUserBubble`, `GoalUserMessage`, and the folding logic are untouched.
- `rg -c goal` over `turbo/apps/platform/src/i18n/locales` is unaffected — no locale file is in the diff.
- Typecheck and lint run in PR CI.

Closes #33382
