### PR TITLE
test(runner): drain heartbeat scans before asserting workspace promotion

### DIFF
--- a/crates/runner/src/cmd/start/tests/failure_recovery/workspace_promotion.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/workspace_promotion.rs
@@ -118,6 +118,11 @@ async fn startup_finalization_classifies_cache_failures_and_preserves_healthy_ca
         assert_eq!(overrides.stop_call_count(), 1);
         assert_eq!(overrides.destroy_call_count(), 1);
         assert_eq!(env.idle_pool.lock().await.len(), 0);
+
+        // Budget release does not drain heartbeat cache scans. Stop the runner
+        // before inspecting the cache so its nonblocking scan cannot skip a
+        // healthy entry whose lock is held by a concurrent heartbeat refresh.
+        shutdown(&env, run_handle).await;
         let states = cache.held_workspace_states().await;
         assert_eq!(states.len(), usize::from(failure.is_none()));
 
@@ -141,6 +146,5 @@ async fn startup_finalization_classifies_cache_failures_and_preserves_healthy_ca
                 })
             );
         }
-        shutdown(&env, run_handle).await;
     }
 }


### PR DESCRIPTION
## Summary

Fix the intermittent cache-count assertion in `startup_finalization_classifies_cache_failures_and_preserves_healthy_cancelled_cache` by awaiting the existing runner shutdown before inspecting retained workspace cache state and captured logs.

## Cause and change

The test waits for completion and resource-budget release, but those events do not drain the runner's background heartbeat cache refresh. Both the heartbeat refresh and `held_workspace_states()` acquire cache-entry locks. The latter is deliberately nonblocking and skips busy entries, so a one-shot assertion can observe zero retained caches while the healthy cache is temporarily locked by the heartbeat reader.

Keep the completion, released-budget, stop/destroy-count, and empty-idle-pool assertions **before** shutdown so teardown cannot satisfy them on behalf of startup finalization. Then await the existing graceful shutdown, which drains heartbeat and maintenance tasks, before inspecting the retained cache and log classification. This also makes the negative cache assertions run against quiescent state.

## Scope

- Test-only change to one file; no production cache, cancellation, cleanup, heartbeat, or logging behavior changes.
- Preserve all five healthy/failure/cancellation scenarios and their existing assertions.
- No new sleeps, polling, retries, timeouts, ignored tests, or dependencies.

## Validation

- `cargo test --manifest-path crates/Cargo.toml --profile local --locked -p runner --bin runner --all-features -j 2 -- --test-threads=4 --quiet`: **3,668 passed, 30 existing ignored**.
- Repeated the fixed exact test 100 times using the compiled test binary: **100 passed / 500 scenario executions**.
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`: passed.
- `cargo clippy --manifest-path crates/Cargo.toml --profile local --locked --workspace --all-targets --all-features -j 2 -- -D warnings`: passed.
- `cargo doc --manifest-path crates/Cargo.toml --profile local --locked --workspace --all-features --no-deps -j 2`: passed.
- `git diff --check`: passed.

Before the fix, the unmodified test passed 100 exact repetitions and the failure-recovery group passed 20 repetitions locally; the supplied CI failure was not reproduced in those baseline runs. The fix removes the verified synchronization gap rather than claiming a measured local failure rate. Local validation uses Linux aarch64 without LLVM coverage instrumentation; CI remains responsible for its x86_64 coverage configuration.
