### PR TITLE
fix(platform): align the flyout panel's bottom with the rail card

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
@@ -770,7 +770,10 @@ export function ModelPickerFlyoutContent({
           "flex max-h-[284px] flex-col gap-0.5 overflow-y-auto overscroll-contain",
           types.length > 1
             ? cn(
-                "absolute bottom-0 w-[252px]",
+                // The two cards share a bottom edge. This box is anchored to
+                // the rail's content edge, which sits the popover's `p-1` and
+                // its hairline above the card's own bottom, so cancel both.
+                "absolute bottom-[-5px] w-[252px]",
                 FLYOUT_PANEL_CLASS,
                 side === "right"
                   ? "left-[calc(100%+6px)]"

--- a/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
@@ -771,9 +771,10 @@ export function ModelPickerFlyoutContent({
           types.length > 1
             ? cn(
                 // The two cards share a bottom edge. This box is anchored to
-                // the rail's content edge, which sits the popover's `p-1` and
-                // its hairline above the card's own bottom, so cancel both.
-                "absolute bottom-[-5px] w-[252px]",
+                // the rail's content edge, which sits the popover's `p-1`
+                // (4px) plus the shared 0.5px hairline above the card's own
+                // bottom, so cancel both.
+                "absolute bottom-[-4.5px] w-[252px]",
                 FLYOUT_PANEL_CLASS,
                 side === "right"
                   ? "left-[calc(100%+6px)]"


### PR DESCRIPTION
## Problem

The model-picker flyout's two cards are meant to share a bottom edge, but the
floating model panel sits about five pixels high.

The panel is `absolute bottom-0` against the flyout root, and that root is a
child of `PopoverContent`. The rail *is* the popover surface, so the root's
content edge sits one `p-1` (4px) plus the card's hairline above the popover's
own outer bottom. `bottom-0` therefore anchors the panel to the wrong line.

Measured from the reported screenshot (2× capture): the rail's hover background
ends at device `y=514`, followed by 8 device px of popover padding, with the
popover border at `y=523` — while the floating panel's border sits at `y=514`.

## Change

Offset the panel by the popover's padding and hairline
(`bottom-[-5px]`) so both cards end on the same line. `bottom-[-Npx]` is the
existing idiom for this in `log-views/event-group-card.tsx`.

Only the two-panel branch changes; the single-type layout renders `w-full`
in flow and is untouched.

## Verification

- `chat-composer-media-models.test.tsx` — 23 passed.
- `check-types`, `oxlint`, `prettier --check`, and `style-policy.mjs` clean.
- Geometry is not assertable in happy-dom (no layout engine), so the change is
  verified by the box-model derivation and the measured screenshot above rather
  than by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)