### PR TITLE
docs(guest-storage-apply): clarify download task telemetry

### DIFF
--- a/crates/guest-storage-apply/src/telemetry.rs
+++ b/crates/guest-storage-apply/src/telemetry.rs
@@ -51,12 +51,14 @@
 //! # Task totals and dimensions
 //!
 //! Each task that reaches a final success or failure result emits
-//! `storage_download` or `artifact_download`, respectively. The task total
-//! carries two bounded dimensions:
+//! `storage_download` for a storage archive or `artifact_download` for an
+//! artifact archive. The boolean `success` field records whether the task
+//! succeeded or failed. The task total also carries two bounded dimensions:
 //!
-//! - `outcome` identifies the URL kind and compressed-size classification. A
-//!   remote task uses `remote_*`, a local `file://` task uses `file_*`, and any
-//!   other URL uses `other_unknown`. The size suffixes are `zero`,
+//! - `outcome` identifies the URL kind and compressed-size classification,
+//!   independently of task success or failure. A remote task uses `remote_*`,
+//!   a local `file://` task uses `file_*`, and any other URL uses `other_unknown`.
+//!   The size suffixes are `zero`,
 //!   `lt_64_kib`, `64_kib_to_256_kib`, `256_kib_to_1_mib`, `1_mib_to_4_mib`,
 //!   `4_mib_to_16_mib`, `16_mib_to_64_mib`, and `64_mib_plus`; an unavailable
 //!   size is reported as `remote_unknown` or `file_unknown`.


### PR DESCRIPTION
The task-total documentation currently pairs success/failure with `storage_download`/`artifact_download` through “respectively”. Clarify that archive kind selects the action, the boolean `success` field records the final result, and `outcome` classifies URL kind and compressed size. Runtime action names, emission behavior, and attribution assertions remain unchanged.

Closes #33312

## Validation

- Passed: `cargo fmt --manifest-path crates/guest-storage-apply/Cargo.toml --check`
- Passed: `git diff --check` and `git diff --cached --check`
- Passed: `CARGO_BUILD_JOBS=2 cargo doc --manifest-path crates/Cargo.toml --profile local -p guest-storage-apply --no-deps --document-private-items --locked`
- Inspected the generated task-total documentation and traced its statements through task construction, both final-result branches, telemetry serialization, and existing binary attribution assertions. No runtime tests were added or run for this prose-only change.
