### PR TITLE
test(platform): split slow selection and navigation scenarios

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
@@ -162,8 +162,7 @@ function limitedFreeBillingStatus(): BillingStatusResponse {
   };
 }
 
-test("Choose Standard or Fast Codex execution", async () => {
-  const user = userEvent.setup({ delay: null });
+async function openCodexExecutionChat(): Promise<void> {
   installNewChat(["gpt-5.6-sol", "gpt-5.6-luna"], "gpt-5.6-sol");
 
   await setupPage({
@@ -176,6 +175,11 @@ test("Choose Standard or Fast Codex execution", async () => {
   });
 
   await readyComposer();
+}
+
+test("Show and dismiss Fast Codex speed and credit guidance on hover", async () => {
+  const user = userEvent.setup({ delay: null });
+  await openCodexExecutionChat();
   await user.click(await modelPicker("GPT 5.6 Sol"));
   const fastOption = await screen.findByRole("option", {
     name: "GPT 5.6 Sol Fast",
@@ -190,8 +194,12 @@ test("Choose Standard or Fast Codex execution", async () => {
       screen.queryByText("Fast · 1.5× model speed · 2.5× credit usage"),
     ).not.toBeInTheDocument();
   });
+});
 
-  await user.click(fastOption);
+test("Choose Fast then Standard Codex execution before changing models", async () => {
+  const user = userEvent.setup({ delay: null });
+  await openCodexExecutionChat();
+  await chooseModel(user, "GPT 5.6 Sol", "GPT 5.6 Sol Fast");
   await expect(modelPicker("GPT 5.6 Sol Fast")).resolves.toBeVisible();
 
   await user.click(await modelPicker("GPT 5.6 Sol Fast"));

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-media.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-media.test.tsx
@@ -89,7 +89,7 @@ function voice(options: {
   };
 }
 
-test("Find and choose an avatar template", async () => {
+async function openAvatarCatalog() {
   mockTemplateChat();
   const media = mockPlayableMedia();
   const firstPage = [
@@ -123,7 +123,13 @@ test("Find and choose an avatar template", async () => {
       within(dialog).getByLabelText("Select template Social Sam"),
     ).toBeVisible();
   });
+  return { user, dialog, media };
+}
 
+async function filterProfessionalAvatars(
+  user: ReturnType<typeof userEvent.setup>,
+  dialog: HTMLElement,
+): Promise<HTMLElement> {
   const filterControl = buttonNamed("Filters", dialog);
   await user.click(filterControl);
   const filters = await waitFor(() => {
@@ -144,7 +150,12 @@ test("Find and choose an avatar template", async () => {
       within(dialog).queryByLabelText("Select template Social Sam"),
     ).not.toBeInTheDocument();
   });
+  return filters;
+}
 
+test("Filter and preview avatar templates before restoring the full catalog", async () => {
+  const { user, dialog, media } = await openAvatarCatalog();
+  const filters = await filterProfessionalAvatars(user, dialog);
   await user.hover(
     within(dialog).getByLabelText("Select template Motion Maya"),
   );
@@ -152,6 +163,18 @@ test("Find and choose an avatar template", async () => {
   expect(within(dialog).getByAltText("Still Sara")).toBeVisible();
 
   await user.click(buttonNamed("Clear", filters));
+  await expect(
+    within(dialog).findByLabelText("Select template Social Sam"),
+  ).resolves.toBeVisible();
+});
+
+test("Choose a paginated avatar and voice after clearing its style filter", async () => {
+  const { user, dialog } = await openAvatarCatalog();
+  const filters = await filterProfessionalAvatars(user, dialog);
+  await user.click(buttonNamed("Clear", filters));
+  await expect(
+    within(dialog).findByLabelText("Select template Social Sam"),
+  ).resolves.toBeVisible();
   const catalog = dialog.querySelector<HTMLElement>(
     "[data-avatar-template-grid-scroll]",
   );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-keyboard.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-keyboard.test.tsx
@@ -114,7 +114,7 @@ function expectPaneTitle(
   expect(threadContainer(thread.id)).toHaveTextContent(title);
 }
 
-test("Move between neighboring chats from the focused pane", async () => {
+async function openNeighboringChatPanes(mainThread: "current" | "newest") {
   const oldest = continuityThread(16, 1, "Oldest neighboring chat");
   const current = continuityThread(16, 2, "Current keyboard chat");
   const side = continuityThread(16, 3, "Side keyboard chat");
@@ -124,17 +124,23 @@ test("Move between neighboring chats from the focused pane", async () => {
     threads: [oldest, current, side, newest],
   });
 
+  const main = mainThread === "current" ? current : newest;
   await setupPage({
     context,
-    path: `/chats/${current.id}?sidebar=${side.id}`,
+    path: `/chats/${main.id}?sidebar=${side.id}`,
     ...workspace.pageOptions,
   });
 
   await waitFor(() => {
-    expect(composerIn(current.id)).toBeVisible();
+    expect(composerIn(main.id)).toBeVisible();
     expect(composerIn(side.id)).toBeVisible();
     expect(threadContainer(side.id)).toBeVisible();
   });
+  return { current, side, newest };
+}
+
+test("Move to a newer chat from the main pane without changing the side pane", async () => {
+  const { current, side, newest } = await openNeighboringChatPanes("current");
   const mainComposer = composerIn(current.id);
   mainComposer.focus();
   await userEvent.keyboard("{Control>}{Shift>}{ArrowUp}{/Shift}{/Control}");
@@ -151,7 +157,14 @@ test("Move between neighboring chats from the focused pane", async () => {
     "page",
   );
   expectPaneTitle(side, "Side keyboard chat");
+});
 
+test("Move to an older chat from the side pane without changing the main pane", async () => {
+  const { current, side, newest } = await openNeighboringChatPanes("newest");
+  expect(continuitySidebarLink(newest.id)).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
   const sideContainer = threadContainer(side.id);
   sideContainer.focus();
   await userEvent.keyboard("{Control>}{Shift>}{ArrowDown}{/Shift}{/Control}");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
@@ -461,7 +461,7 @@ test("Keep incompatible hairstyle previews stable after selecting another style"
   }
 });
 
-test("Create and save a composer avatar from the profile page", async () => {
+async function openNewComposerAvatar(): Promise<HTMLElement> {
   prepareAgentProfile(null);
   await setupPage({
     context,
@@ -477,6 +477,11 @@ test("Create and save a composer avatar from the profile page", async () => {
     name: "Give your agent a face",
   });
   expect(within(dialog).getByText("Face")).toBeVisible();
+  return dialog;
+}
+
+test("Replace randomized avatar face choices with visible selection feedback", async () => {
+  const dialog = await openNewComposerAvatar();
   click(within(dialog).getByLabelText("Randomize avatar"));
   await waitForAvatarFeedback(dialog);
   click(within(dialog).getByLabelText("Round"));
@@ -491,6 +496,16 @@ test("Create and save a composer avatar from the profile page", async () => {
     "aria-pressed",
     "false",
   );
+  expect(within(dialog).getByLabelText("Oval")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+});
+
+test("Create, save, and reopen a composed avatar from the profile page", async () => {
+  const dialog = await openNewComposerAvatar();
+  click(within(dialog).getByLabelText("Oval"));
+  await waitForAvatarFeedback(dialog);
   expect(within(dialog).getByLabelText("Oval")).toHaveAttribute(
     "aria-pressed",
     "true",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/thread-list-number-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/thread-list-number-shortcuts.test.tsx
@@ -36,7 +36,7 @@ function hintKeys(container: ParentNode): string[] {
     });
 }
 
-test.each([
+const NUMBER_SHORTCUT_PLATFORMS = [
   {
     platform: "Mac Chrome",
     userAgent:
@@ -76,57 +76,63 @@ test.each([
     releaseModifiers: "{/Control}",
     label: "Ctrl+",
   },
-])(
-  "Reveal the first nine thread shortcuts after holding the modifier for 500 ms on $platform",
-  async ({
-    userAgent,
-    maxTouchPoints,
-    modifier,
-    additionalModifier,
-    releaseModifiers,
-    label,
-  }) => {
-    context.mocks.browser.userAgent(userAgent);
-    context.mocks.browser.maxTouchPoints(maxTouchPoints);
-    context.mocks.browser.matchMedia((query) => {
-      return (
-        query === "(display-mode: standalone)" || query === "(min-width: 48rem)"
-      );
+] as const;
+
+async function openNumberShortcutPage(
+  { userAgent, maxTouchPoints }: (typeof NUMBER_SHORTCUT_PLATFORMS)[number],
+  initialChat: "new" | "ninth",
+) {
+  context.mocks.browser.userAgent(userAgent);
+  context.mocks.browser.maxTouchPoints(maxTouchPoints);
+  context.mocks.browser.matchMedia((query) => {
+    return (
+      query === "(display-mode: standalone)" || query === "(min-width: 48rem)"
+    );
+  });
+  const threads = Array.from({ length: 11 }, (_, index) => {
+    return chatListThread(index + 1, `Thread ${index + 1}`, {
+      pinnedAt: index < 2 ? `2026-08-01T00:5${2 - index}:00.000Z` : null,
     });
-    const threads = Array.from({ length: 11 }, (_, index) => {
-      return chatListThread(index + 1, `Thread ${index + 1}`, {
-        pinnedAt: index < 2 ? `2026-08-01T00:5${2 - index}:00.000Z` : null,
-      });
-    });
-    const remoteChatList = context.mocks.deferred<void>();
-    const workspace = installContinuityWorkspace(context, {
-      caseId: 40,
-      threads,
-      chatListRemoteGate: remoteChatList.promise,
-    });
-    await setupPage({
-      context,
-      path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
-      ...workspace.pageOptions,
-      featureSwitches,
-    });
-    await waitFor(() => {
-      expect(sidebarThreadTitles()).toStrictEqual([
-        "Thread 1",
-        "Thread 2",
-        "Thread 11",
-        "Thread 10",
-        "Thread 9",
-        "Thread 8",
-        "Thread 7",
-        "Thread 6",
-        "Thread 5",
-        "Thread 4",
-        "Thread 3",
-      ]);
-    });
-    expect(remoteChatList.settled()).toBeFalsy();
-    const list = screen.getByTestId("chat-list-column");
+  });
+  const remoteChatList = context.mocks.deferred<void>();
+  const workspace = installContinuityWorkspace(context, {
+    caseId: 40,
+    threads,
+    chatListRemoteGate: remoteChatList.promise,
+  });
+  await setupPage({
+    context,
+    path:
+      initialChat === "ninth"
+        ? `/chats/${threads[4]!.id}`
+        : `/agents/${CHAT_LIST_AGENT_ID}/chat`,
+    ...workspace.pageOptions,
+    featureSwitches,
+  });
+  await waitFor(() => {
+    expect(sidebarThreadTitles()).toStrictEqual([
+      "Thread 1",
+      "Thread 2",
+      "Thread 11",
+      "Thread 10",
+      "Thread 9",
+      "Thread 8",
+      "Thread 7",
+      "Thread 6",
+      "Thread 5",
+      "Thread 4",
+      "Thread 3",
+    ]);
+  });
+  expect(remoteChatList.settled()).toBeFalsy();
+  return { threads, list: screen.getByTestId("chat-list-column") };
+}
+
+test.each(NUMBER_SHORTCUT_PLATFORMS)(
+  "Reveal the first nine hints after a 500 ms hold and open the ninth chat on $platform",
+  async (platform) => {
+    const { modifier, additionalModifier, releaseModifiers, label } = platform;
+    const { threads, list } = await openNumberShortcutPage(platform, "new");
     const user = userEvent.setup();
     await user.hover(sidebarThreadLinks()[0]!);
     expect(hintKeys(list)).toStrictEqual([]);
@@ -151,14 +157,24 @@ test.each([
       expect(pathname()).toBe(`/chats/${threads[4]!.id}`);
     });
     expect(hintKeys(list)).toStrictEqual([]);
+  },
+);
 
-    // A known shortcut can be used immediately, without waiting for its hint.
+test.each(NUMBER_SHORTCUT_PLATFORMS)(
+  "Open the first chat immediately from the ninth chat without waiting for hints on $platform",
+  async (platform) => {
+    const { modifier, additionalModifier, releaseModifiers } = platform;
+    const { threads, list } = await openNumberShortcutPage(platform, "ninth");
+    const user = userEvent.setup();
+    expect(pathname()).toBe(`/chats/${threads[4]!.id}`);
+    expect(hintKeys(list)).toStrictEqual([]);
     await user.keyboard(
       `{${modifier}>}${additionalModifier}1${releaseModifiers}`,
     );
     await waitFor(() => {
       expect(pathname()).toBe(`/chats/${threads[0]!.id}`);
     });
+    expect(hintKeys(list)).toStrictEqual([]);
   },
 );
 


### PR DESCRIPTION
Five platform scenario groups still have recent 4-second CI observations or a current local baseline above 4 seconds after checking the affected tests' git history. Split their independent behaviors into 16 cases (previously 8, including four keyboard-platform variants), preserving the real page setup, assertions, platform coverage, and required action sequences.

| Original scenario group | Independent cases after splitting | Local baseline → split durations |
| --- | --- | --- |
| Codex Standard/Fast selection | Hover guidance; Fast → Standard → another model | 4.157s → 3.121s / 1.891s |
| Avatar template selection | Filter/preview/clear; filter/clear/paginate/choose avatar and voice | 4.253s → 2.952s / 2.177s |
| Profile avatar creation | Randomize/replace face feedback; compose/save/reopen | 4.475s → 1.817s / 3.609s |
| Neighboring chat navigation | Main-pane navigation; side-pane navigation | 3.441s → 2.433s / 1.313s on file recheck; first batch had a 5.103s timeout for main-pane navigation |
| Number shortcuts on four platforms | Delayed hints/ninth chat; immediate first-chat shortcut | 2.073–3.878s → 1.017–3.159s across eight cases |

Existing attachment, voice, continuity-history, search-shortcut, and presentation-related repairs were inspected before selecting this batch; their historical timings are not treated as new repairs. No production code, test timeout, retry, skip, fake timer, or full-suite configuration changes are included. Shared setup remains per-test; the avatar filter-clear-pagination and save-reopen sequences stay intact.

Validation:

- Actual baseline on `fece229e75c2b1c57639d9ccc978135040469ba4`: 26 targeted files, 271 cases, 268 passed. Three failures in two unchanged status/welcome files passed in a separate 11-case recheck; these are retained in the audit and are not claimed fixed by this PR.
- All five affected files: 75 cases, 74 passed and the main-pane timeout recorded above. Rechecking the complete keyboard file passed all 10 cases. The first failure is retained; exact-PR CI timing is required to assess the remaining margin under CI load.
- Changed-file Prettier, Oxlint, type-aware Oxlint, and ESLint passed. Platform production/test/build-config type checks and workspace Knip passed.
- Full local Vitest was not run; the PR pipeline supplies full validation.

Closes #33385
Relates to #33319
