### PR TITLE
fix: match cloudtrail bucket policy readback

### DIFF
--- a/.github/aws-audit-32264/cloudtrail-bucket.json
+++ b/.github/aws-audit-32264/cloudtrail-bucket.json
@@ -47,7 +47,7 @@
         "Principal": {
           "Service": "cloudtrail.amazonaws.com"
         },
-        "Action": ["s3:GetBucketAcl"],
+        "Action": "s3:GetBucketAcl",
         "Resource": "arn:aws:s3:::vm0-cloudtrail-logs-251964670836-us-west-2",
         "Condition": {
           "StringEquals": {

--- a/.github/scripts/tests/aws-audit-target-setup-test.py
+++ b/.github/scripts/tests/aws-audit-target-setup-test.py
@@ -2,6 +2,7 @@
 """Exercise AWS response boundaries, delivered evidence and the entry-point guards."""
 
 import contextlib
+import copy
 import datetime as dt
 import gzip
 import importlib.util
@@ -146,6 +147,45 @@ class AuditSetupTests(unittest.TestCase):
         self.assertEqual(result, 1)
         self.assertEqual(report["failure"], "unexpected_oidc_url")
         self.assertEqual(report["created"], [])
+
+    def test_existing_trail_bucket_accepts_s3_policy_readback(self):
+        settings = audit.expected("cloudtrail-bucket.json")
+        policy = copy.deepcopy(settings["policy"])
+        # S3 returns this single action as a string, even when written as a list.
+        for statement in policy["Statement"]:
+            if statement["Sid"] == "AuditServiceBucketCheck":
+                statement["Action"] = "s3:GetBucketAcl"
+        owner = {"Bucket": audit.TRAIL_BUCKET, "ExpectedBucketOwner": audit.ACCOUNT}
+        s3 = self.stubs["s3"]
+        s3.add_response("list_buckets", {"Buckets": [{"Name": audit.TRAIL_BUCKET}]})
+        responses = [
+            ("get_bucket_tagging", {"TagSet": audit.TAGS}),
+            (
+                "get_bucket_encryption",
+                {"ServerSideEncryptionConfiguration": settings["encryption"]},
+            ),
+            (
+                "get_public_access_block",
+                {"PublicAccessBlockConfiguration": settings["publicAccess"]},
+            ),
+            (
+                "get_bucket_ownership_controls",
+                {"OwnershipControls": settings["ownership"]},
+            ),
+            ("get_bucket_versioning", {"Status": settings["versioning"]}),
+            ("get_bucket_policy", {"Policy": json.dumps(policy)}),
+            ("get_bucket_lifecycle_configuration", {"Rules": settings["lifecycle"]}),
+            ("get_bucket_location", {"LocationConstraint": audit.REGION}),
+            ("get_bucket_policy_status", {"PolicyStatus": {"IsPublic": False}}),
+        ]
+        for operation, response in responses:
+            s3.add_response(operation, response, owner)
+        report = {"created": [], "buckets": []}
+        audit.configure_bucket(self.clients["s3"], audit.TRAIL_BUCKET, settings, report)
+        self.assertEqual(report["created"], [])
+        self.assertEqual(report["buckets"][0]["name"], audit.TRAIL_BUCKET)
+        self.assertTrue(report["buckets"][0]["verified"])
+        s3.assert_no_pending_responses()
 
     def test_new_trail_matches_multi_region_audit_contract(self):
         desired = {


### PR DESCRIPTION
AWS Audit Target Setup [run 34479149765](https://github.com/vm0-ai/vm0/actions/runs/34479149765) stopped after creating its CloudTrail bucket because S3 returned `AuditServiceBucketCheck.Action` as `"s3:GetBucketAcl"`, while the expected policy used `["s3:GetBucketAcl"]`. Read-only inspection of account `251964670836` on 2026-09-11 confirmed this was the only difference across all six bucket settings groups; tags, region and non-public status also matched.

Use the scalar representation in the CloudTrail bucket template so its existing exact comparison accepts the verified S3 response and can reuse the existing bucket. This preserves the action, principal, resource and conditions. Add an AWS-boundary regression test that checks an existing bucket using S3's actual response format and permits no write calls.

Validation: the new regression failed against the original template and passes with the fix; all 13 audit setup tests, Ruff lint/format and whitespace checks pass. The corrected template also matches the captured live readback exactly. No AWS resources were changed and the production workflow has not been rerun.

Refs #32264.
