### PR TITLE
fix(runner): bound failure reporter process shutdown

### DIFF
--- a/crates/runner/mitm-addon/src/model_provider_failure.py
+++ b/crates/runner/mitm-addon/src/model_provider_failure.py
@@ -45,7 +45,7 @@ import threading
 import urllib.error
 import urllib.parse
 from collections.abc import Callable
-from concurrent.futures import Future, ThreadPoolExecutor, wait
+from concurrent.futures import Future, wait
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
@@ -58,7 +58,7 @@ import openai_responses_events
 import platform_api
 import runtime_url_parsing
 from logging_utils import log_proxy_entry
-from thread_pool import start_thread_pool
+from model_provider_failure_executor import FailureReportExecutor
 from usage.json_selective import JsonSelectiveExtractor
 from usage.model_http import (
     FAILURE_SCALAR_FIELDS,
@@ -180,7 +180,7 @@ _report_condition = threading.Condition(_report_lock)
 _report_api_url = ""
 _report_bearer_credential = ""
 _report_slots = threading.BoundedSemaphore(_MAX_PENDING_REPORTS)
-_report_executor: ThreadPoolExecutor | None = None
+_report_executor: FailureReportExecutor | None = None
 _reporter_shut_down = False
 _report_futures: set[Future[int]] = set()
 
@@ -606,7 +606,9 @@ def shutdown() -> None:
 
     Reports still queued in the executor are cancelled. Reports already running get at most
     ``_REPORT_TIMEOUT_SECONDS`` to finish; cancellation or timeout may leave a failure report
-    undelivered, so proxy shutdown does not wait indefinitely for it.
+    undelivered. Plain daemon workers are not joined at interpreter exit, so a
+    stalled DNS or network call cannot extend that exit beyond this drain window.
+    Running calls are not interrupted and may finish if the process remains alive.
     """
     global _reporter_shut_down
     configure_reporting(api_url="", bearer_credential="")
@@ -615,7 +617,7 @@ def shutdown() -> None:
         executor = _report_executor
         _reporter_shut_down = True
     if executor is not None:
-        executor.shutdown(wait=False, cancel_futures=True)
+        executor.shutdown(wait=False)
     running = tuple(future for future in pending if not future.cancelled())
     if running:
         wait(running, timeout=_REPORT_TIMEOUT_SECONDS)
@@ -917,16 +919,10 @@ def _enqueue_report(flow: http.HTTPFlow, run_id: str, failure: Failure) -> None:
             try:
                 if _report_executor is None:
                     omission_reason = "worker_start_failed"
-                    _report_executor = start_thread_pool(
-                        max_workers=_REPORT_WORKERS,
-                        thread_name_prefix="model-provider-failure",
-                    )
+                    _report_executor = FailureReportExecutor(max_workers=_REPORT_WORKERS)
                 omission_reason = "reporter_shut_down"
                 future = _report_executor.submit(
-                    _post_report,
-                    report_url,
-                    bearer_credential,
-                    content,
+                    lambda: _post_report(report_url, bearer_credential, content),
                 )
             except RuntimeError:
                 pass

--- a/crates/runner/mitm-addon/src/model_provider_failure_executor.py
+++ b/crates/runner/mitm-addon/src/model_provider_failure_executor.py
@@ -1,0 +1,82 @@
+"""Daemon workers owned only by best-effort model-provider failure reporting."""
+
+import threading
+from collections import deque
+from collections.abc import Callable
+from concurrent.futures import Future
+
+
+class FailureReportExecutor:
+    """Prestart workers without registering an interpreter-exit join.
+
+    The reporter bounds admission before submitting work. Shutdown cancels queued
+    reports; running deliveries retain their futures until completion, but cannot
+    keep the process alive. Billing and other join-required work must not use this
+    owner.
+    """
+
+    def __init__(self, *, max_workers: int) -> None:
+        if max_workers <= 0:
+            raise ValueError("max_workers must be greater than 0")
+        self._condition = threading.Condition()
+        self._pending: deque[tuple[Future[int], Callable[[], int]]] = deque()
+        self._closed = False
+        self._workers: list[threading.Thread] = []
+        try:
+            for index in range(max_workers):
+                worker = threading.Thread(
+                    target=self._work,
+                    name=f"model-provider-failure_{index}",
+                    daemon=True,
+                )
+                worker.start()
+                self._workers.append(worker)
+        except BaseException:
+            # No payload can be submitted until construction succeeds. Wake and
+            # join every started candidate before reporting startup failure.
+            self.shutdown(wait=True)
+            raise
+
+    def submit(self, report: Callable[[], int]) -> Future[int]:
+        with self._condition:
+            if self._closed:
+                raise RuntimeError("cannot schedule reports after shutdown")
+            future: Future[int] = Future()
+            self._pending.append((future, report))
+            self._condition.notify()
+            return future
+
+    def shutdown(self, *, wait: bool) -> None:
+        with self._condition:
+            self._closed = True
+            pending = tuple(self._pending)
+            self._pending.clear()
+            self._condition.notify_all()
+        # Cancellation invokes reporter callbacks, which own their own locks.
+        for future, _report in pending:
+            future.cancel()
+        if wait:
+            for worker in self._workers:
+                worker.join()
+
+    def _work(self) -> None:
+        while True:
+            with self._condition:
+                self._condition.wait_for(lambda: self._closed or bool(self._pending))
+                if self._closed:
+                    return
+                future, report = self._pending.popleft()
+                # Mark running under the same lock as shutdown so a queued report
+                # cannot begin after closure. Completion callbacks run outside it.
+                running = future.set_running_or_notify_cancel()
+            try:
+                if running:
+                    try:
+                        result = report()
+                    except BaseException as error:
+                        future.set_exception(error)
+                    else:
+                        future.set_result(result)
+            finally:
+                # Idle workers must not retain the previous payload/credential.
+                del future, report

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -6,7 +6,7 @@ import json
 import threading
 import urllib.request
 import zlib
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future
 from pathlib import Path
 from typing import Literal
 from unittest.mock import patch
@@ -26,6 +26,7 @@ import usage.anthropic_messages as anthropic_messages
 import usage.model_json as model_json
 import usage.openai_responses as openai_responses
 from body_limits import STREAM_BUFFER_LIMIT
+from model_provider_failure_executor import FailureReportExecutor
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries_after_flush
 from tests.model_provider_flow_helpers import make_openai_responses_websocket_flow
@@ -211,17 +212,16 @@ def _assert_single_report_omission(
 
 def _restart_reporter_after_callbacks(model_provider_failure_api) -> None:
     """Reset reporting only after every executor callback has returned."""
-    original_shutdown = ThreadPoolExecutor.shutdown
+    original_shutdown = FailureReportExecutor.shutdown
 
     def shutdown_and_wait(
-        executor: ThreadPoolExecutor,
-        wait: bool = True,
+        executor: FailureReportExecutor,
         *,
-        cancel_futures: bool = False,
+        wait: bool,
     ) -> None:
-        original_shutdown(executor, wait=True, cancel_futures=cancel_futures)
+        original_shutdown(executor, wait=True)
 
-    with patch.object(ThreadPoolExecutor, "shutdown", shutdown_and_wait):
+    with patch.object(FailureReportExecutor, "shutdown", shutdown_and_wait):
         model_provider_failure.shutdown()
     model_provider_failure.reset_for_tests()
     model_provider_failure.configure_reporting(
@@ -666,7 +666,7 @@ def test_executor_submission_failure_reclaims_capacity(
     model_provider_failure.drain_reports_for_tests()
     proxy_log_path = tmp_path / "submit-failed.jsonl"
     with patch.object(
-        ThreadPoolExecutor,
+        FailureReportExecutor,
         "submit",
         side_effect=RuntimeError("executor shut down"),
     ):
@@ -769,20 +769,19 @@ def test_shutdown_cancels_queued_reports(
 
     assert model_provider_failure_api.wait_for_request_count(_REPORT_WORKERS)
 
-    original_shutdown = ThreadPoolExecutor.shutdown
+    original_shutdown = FailureReportExecutor.shutdown
 
     def observe_shutdown(
-        executor: ThreadPoolExecutor,
-        wait: bool = True,
+        executor: FailureReportExecutor,
         *,
-        cancel_futures: bool = False,
+        wait: bool,
     ) -> None:
-        original_shutdown(executor, wait=wait, cancel_futures=cancel_futures)
+        original_shutdown(executor, wait=wait)
         executor_shutdown_started.set()
 
     shutdown_thread = ThreadUnderTest(target=model_provider_failure.shutdown)
     try:
-        with patch.object(ThreadPoolExecutor, "shutdown", observe_shutdown):
+        with patch.object(FailureReportExecutor, "shutdown", observe_shutdown):
             shutdown_thread.start()
             wait_for_event(
                 executor_shutdown_started,
@@ -825,15 +824,14 @@ def test_shutdown_timeout_returns_with_running_reports_blocked(
 
     assert model_provider_failure_api.wait_for_request_count(_REPORT_WORKERS)
 
-    original_shutdown = ThreadPoolExecutor.shutdown
+    original_shutdown = FailureReportExecutor.shutdown
 
     def pause_after_executor_shutdown(
-        executor: ThreadPoolExecutor,
-        wait: bool = True,
+        executor: FailureReportExecutor,
         *,
-        cancel_futures: bool = False,
+        wait: bool,
     ) -> None:
-        original_shutdown(executor, wait=wait, cancel_futures=cancel_futures)
+        original_shutdown(executor, wait=wait)
         executor_shutdown_started.set()
         if not continue_shutdown.wait(timeout=1):
             raise AssertionError("failure reporter shutdown test did not release executor shutdown")
@@ -842,7 +840,7 @@ def test_shutdown_timeout_returns_with_running_reports_blocked(
     try:
         with (
             patch.object(model_provider_failure, "_REPORT_TIMEOUT_SECONDS", 0.01),
-            patch.object(ThreadPoolExecutor, "shutdown", pause_after_executor_shutdown),
+            patch.object(FailureReportExecutor, "shutdown", pause_after_executor_shutdown),
         ):
             shutdown_thread.start()
             wait_for_event(

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_shutdown.py
@@ -1,0 +1,75 @@
+"""Process-exit coverage for best-effort model-provider reporting."""
+
+import multiprocessing
+import socket
+import threading
+from multiprocessing.connection import Connection
+from unittest.mock import patch
+
+from mitmproxy import http
+from mitmproxy.test import tflow
+
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+import model_provider_failure
+
+
+def _shutdown_with_stalled_dns(status: Connection) -> None:
+    dns_started = threading.Event()
+    release_dns = threading.Event()
+
+    def stalled_dns(*args, **kwargs):
+        dns_started.set()
+        release_dns.wait()
+        raise socket.gaierror("synthetic resolver failure")
+
+    with patch.object(socket, "getaddrinfo", stalled_dns):
+        model_provider_failure.configure_reporting(
+            api_url="https://report.invalid",
+            bearer_credential="synthetic-nonsecret",
+        )
+        flow = tflow.tflow(resp=True)
+        flow.request = http.Request.make("POST", "https://api.openai.com/v1/chat/completions")
+        flow.response = http.Response.make(503, b"")
+        flow.metadata.update(
+            {
+                metadata_keys.SANDBOX_RUN_ID: "run-shutdown-regression",
+                metadata_keys.SANDBOX_PROXY_LOG_PATH: "",
+                metadata_keys.ORIGINAL_URL: flow.request.url,
+                metadata_keys.FIREWALL_NAME: "model-provider:openai-api-key",
+                metadata_keys.FIREWALL_BILLABLE: True,
+                metadata_keys.FIREWALL_ACTION: "ALLOW",
+            }
+        )
+        model_provider_failure.admit_flow(flow)
+        mitm_addon.responseheaders(flow)
+        assert dns_started.wait(timeout=5), "report did not reach DNS"
+        status.send("dns-blocked")
+        # Exercise the production done hook and unchanged ten-second drain.
+        mitm_addon.done()
+        assert not release_dns.is_set()
+        status.send("shutdown-complete")
+        status.close()
+    # Never release DNS: normal interpreter exit is the behavior under test.
+
+
+def test_process_exits_after_shutdown_with_dns_still_blocked():
+    context = multiprocessing.get_context("spawn")
+    status, child_status = context.Pipe(duplex=False)
+    process = context.Process(target=_shutdown_with_stalled_dns, args=(child_status,))
+    process.start()
+    child_status.close()
+    try:
+        assert status.poll(10), "child did not start reporting"
+        assert status.recv() == "dns-blocked"
+        assert status.poll(15), "addon shutdown did not finish its drain window"
+        assert status.recv() == "shutdown-complete"
+        process.join(timeout=5)
+        assert process.exitcode == 0, "reporter kept the child alive after addon shutdown"
+    finally:
+        # A forced kill only cleans up a failed regression; it cannot satisfy the assertion.
+        if process.is_alive():
+            process.kill()
+        process.join(timeout=5)
+        process.close()
+        status.close()

--- a/docs/mitm-addon-contracts.md
+++ b/docs/mitm-addon-contracts.md
@@ -44,6 +44,28 @@ record already embedded in a malformed line or serialize independently
 interleaved short-write sequences. The existing Runner uploader continues to
 skip malformed physical lines and upload independently parseable records.
 
+## Model-provider failure reporting shutdown
+
+Failure reports are best-effort diagnostics with four reporter-owned daemon
+workers and at most 16 admitted reports. Shutdown closes admission, cancels
+queued reports, and gives running deliveries one shared 10-second drain window.
+Unlike standard thread-pool workers, these workers are not registered for an
+interpreter-exit join. A stalled DNS lookup or network operation can therefore
+leave a report undelivered without keeping the process alive after the drain.
+
+Running calls are not forcibly interrupted: if the process remains alive, they
+retain their worker and admission slot until completion. Normal completion and
+queued cancellation keep the same callback-owned cleanup. All workers start
+before any report payload is admitted, and failed startup joins the empty
+candidate workers. Usage webhook and SigV4 workers retain their independent
+joined-shutdown contracts.
+
+`test_model_provider_failure_shutdown.py` exercises the real addon response and
+shutdown hooks in a fresh interpreter. It requires successful process exit
+while DNS remains blocked, with the production drain budget unchanged. Old
+runners retain their previous shutdown behavior until updated; no reporting
+API or persisted format changes.
+
 ## Managed credential method boundary
 
 Firewall permissions authorize the request's actual HTTP method. Requests with


### PR DESCRIPTION
## Summary

A failure report blocked in DNS could outlive the reporter's 10-second shutdown drain, then keep mitmdump alive because Python joined its standard thread-pool worker at interpreter exit. Give best-effort failure reporting four dedicated daemon workers outside that exit registry, preserving the 16-report admission limit, queued cancellation, callback cleanup, and startup rollback. Running network calls may finish while the process remains alive but no longer prevent exit.

The platform HTTP transport, reporting API, usage-webhook/SigV4 join contracts, and Runner stop timeout are unchanged. Document the shutdown ownership and add a fresh-interpreter regression through the real addon response and `done()` hooks, with DNS permanently blocked and the production drain budget unchanged.

Closes #33310

## Validation

Locked environment: uv 0.11.32, CPython 3.14.0, mitmproxy 12.2.3.

- Regression reproduced on the original implementation: `done()` completed, but the child remained alive; the same test passes with this fix and requires exit code 0 without releasing DNS or accepting a forced kill as success.
- `uv run --no-sync python -m pytest tests/test_model_provider_failure_shutdown.py tests/test_model_provider_failure_reporting.py tests/test_thread_pool.py tests/test_request_handler_aws_sigv4_hash_executor.py tests/test_platform_api.py -q` — 141 passed.
- `uv run --no-sync python -m pytest tests/test_webhook_executor_lifetime.py tests/test_webhook_partial_submission.py tests/test_runner_usage_flush_signal.py -q` — 26 passed.
- `uv lock --check`, `uv sync --locked`, `uv run --no-sync ruff check .`, `uv run --no-sync ruff format --check .`, and `uv run --no-sync basedpyright -p .` — passed.
- `npx --yes --package=prettier@3.8.1 prettier --check docs/mitm-addon-contracts.md` and `git diff --check` — passed.

The production standalone mitmdump package and deployment have not been exercised locally; remaining suites run in PR CI.
