### PR TITLE
perf(python): bound response content-type inspection

### DIFF
--- a/crates/runner/mitm-addon/src/http_response_classification.py
+++ b/crates/runner/mitm-addon/src/http_response_classification.py
@@ -7,7 +7,10 @@ _HTTP_STATUS_NO_CONTENT = 204
 _HTTP_STATUS_RESET_CONTENT = 205
 _HTTP_STATUS_REDIRECT_MIN = 300
 _HTTP_STATUS_NOT_MODIFIED = 304
-_HTTP_OWS_CHARS = " \t"
+_HTTP_OWS_BYTES = b" \t"
+_CONTENT_TYPE_NAME = b"content-type"
+_MAX_CONTENT_TYPE_FIELDS = 8 * 1024
+_MAX_CONTENT_TYPE_PREFIX_BYTES = 8 * 1024
 
 
 def can_have_body(flow: http.HTTPFlow, response: http.Response) -> bool:
@@ -26,7 +29,29 @@ def can_have_body(flow: http.HTTPFlow, response: http.Response) -> bool:
 
 
 def has_event_stream_media_type(response: http.Response) -> bool:
-    """Return whether the normalized response media type is exactly SSE."""
-    content_type = response.headers.get("content-type", "")
-    media_type = content_type.partition(";")[0].strip(_HTTP_OWS_CHARS).lower()
-    return media_type == "text/event-stream"
+    """Recognize exactly SSE within bounded raw field and media-type prefixes.
+
+    Missing, repeated, or over-budget fields do not establish SSE. Parameters
+    after an in-budget semicolon are irrelevant and are never copied or decoded.
+    """
+    fields = response.headers.fields
+    if len(fields) > _MAX_CONTENT_TYPE_FIELDS:
+        return False
+
+    content_type: bytes | None = None
+    for name, value in fields:
+        if len(name) != len(_CONTENT_TYPE_NAME) or name.lower() != _CONTENT_TYPE_NAME:
+            continue
+        if content_type is not None:
+            return False
+        content_type = value
+    if content_type is None:
+        return False
+
+    media_type_end = content_type.find(b";", 0, _MAX_CONTENT_TYPE_PREFIX_BYTES)
+    if media_type_end < 0:
+        if len(content_type) > _MAX_CONTENT_TYPE_PREFIX_BYTES:
+            return False
+        media_type_end = len(content_type)
+    media_type = content_type[:media_type_end].strip(_HTTP_OWS_BYTES).lower()
+    return media_type == b"text/event-stream"

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -1017,10 +1017,10 @@ def test_bodyless_response_skips_usage_and_failure_observers(
 
 
 @pytest.mark.parametrize(
-    ("content_type", "body", "usage_finish_key"),
+    ("content_types", "body", "usage_finish_key"),
     [
         pytest.param(
-            "Text/Event-Stream; Charset=UTF-8",
+            (b"Text/Event-Stream; Charset=UTF-8",),
             b"event: error\n"
             b'data: {"type":"error","code":"server_error",'
             b'"message":"provider failed","param":null}\n\n',
@@ -1028,16 +1028,36 @@ def test_bodyless_response_skips_usage_and_failure_observers(
             id="parameterized-sse",
         ),
         pytest.param(
-            'application/json; profile="text/event-stream"',
+            (b'application/json; profile="text/event-stream"',),
             b'{"status":"failed","error":{"code":"server_error"}}',
             "model_json_usage_finish",
             id="sse-profile-lookalike",
         ),
         pytest.param(
-            "text/event-stream+json",
+            (b"text/event-stream+json",),
             b'{"status":"failed","error":{"code":"server_error"}}',
             "model_json_usage_finish",
             id="sse-suffix-lookalike",
+        ),
+        pytest.param(
+            (b"text/event-stream; pad=" + b"\xff" * (1024 * 1024),),
+            b"event: error\n"
+            b'data: {"type":"error","code":"server_error",'
+            b'"message":"provider failed","param":null}\n\n',
+            "model_sse_usage_finish",
+            id="oversized-parameterized-sse",
+        ),
+        pytest.param(
+            (b"text/event-stream; charset=utf-8", b"\xff" * (1024 * 1024)),
+            b'{"status":"failed","error":{"code":"server_error"}}',
+            "model_json_usage_finish",
+            id="repeated-content-type",
+        ),
+        pytest.param(
+            (b"text/event-stream" + b" " * (8 * 1024),),
+            b'{"status":"failed","error":{"code":"server_error"}}',
+            "model_json_usage_finish",
+            id="exhausted-media-type-prefix",
         ),
     ],
 )
@@ -1045,7 +1065,7 @@ def test_media_type_classification_is_shared_by_usage_and_failure_observers(
     tmp_path,
     real_flow,
     mitm_ctx,
-    content_type: str,
+    content_types: tuple[bytes, ...],
     body: bytes,
     usage_finish_key: str,
     model_provider_failure_api,
@@ -1055,13 +1075,22 @@ def test_media_type_classification_is_shared_by_usage_and_failure_observers(
         tmp_path / "proxy.jsonl",
         request_path="/v1/responses",
         response_body=body,
-        response_headers=header_map({"content-type": content_type}),
+        response_headers=http.Headers((b"Content-Type", value) for value in content_types),
     )
     flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
+    assert flow.response is not None
+    original_fields = flow.response.headers.fields
+    original_native = http._native
+
+    def reject_oversized_conversion(value: bytes) -> str:
+        assert len(value) <= 8 * 1024, "shared classifier decoded an oversized header"
+        return original_native(value)
 
     model_provider_failure.admit_flow(flow)
-    mitm_addon.responseheaders(flow)
+    with patch.object(http, "_native", reject_oversized_conversion):
+        mitm_addon.responseheaders(flow)
 
+    assert flow.response.headers.fields == original_fields
     assert usage_finish_key in flow.metadata
     other_usage_finish_key = (
         "model_json_usage_finish"

--- a/crates/runner/mitm-addon/tests/test_response_content_type_budget.py
+++ b/crates/runner/mitm-addon/tests/test_response_content_type_budget.py
@@ -1,0 +1,211 @@
+"""Bounded raw Content-Type classification through the response-header hook."""
+
+from typing import SupportsIndex, overload
+from unittest.mock import patch
+
+import pytest
+from mitmproxy import http
+from mitmproxy.net.http import http1
+
+import flow_metadata_keys as metadata_keys
+import http_response_classification
+import mitm_addon
+import response_streaming
+from tests.flow_helpers import response_stream
+
+_FIELD_LIMIT = 8 * 1024
+_PREFIX_LIMIT = 8 * 1024
+_SSE_MEDIA_TYPE = b"text/event-stream"
+_JSON_USAGE = b'{"model":"gpt-5.5","usage":{"input_tokens":12,"output_tokens":7}}'
+_SSE_USAGE = b'event: response.completed\ndata: {"response":' + _JSON_USAGE + b"}\n\n"
+
+
+def _make_flow(real_flow, fields: tuple[tuple[bytes, bytes], ...]) -> http.HTTPFlow:
+    flow = real_flow(host="api.openai.com", path="/v1/responses", method="POST")
+    flow.response.headers = http.Headers(fields)
+    flow.metadata.update(
+        {
+            metadata_keys.FIREWALL_NAME: "model-provider:openai-api-key",
+            metadata_keys.FIREWALL_BILLABLE: True,
+            metadata_keys.CLI_AGENT_TYPE: "codex",
+            metadata_keys.MODEL_USAGE_PROVIDER: "gpt-5.5",
+        }
+    )
+    return flow
+
+
+def _assert_stream_classification(flow: http.HTTPFlow, *, is_sse: bool) -> None:
+    assert flow.response is not None
+    request_fields = flow.request.headers.fields
+    response_fields = flow.response.headers.fields
+    original_native = http._native
+
+    def reject_oversized_conversion(value: bytes) -> str:
+        assert len(value) <= _PREFIX_LIMIT, "classifier decoded an oversized header value"
+        return original_native(value)
+
+    with patch.object(http, "_native", reject_oversized_conversion):
+        mitm_addon.responseheaders(flow)
+        assert (
+            response_streaming.uses_model_json_fallback(flow, websocket_header_work_limit=8 * 1024)
+            is not is_sse
+        )
+
+    assert ("model_sse_usage_finish" in flow.metadata) is is_sse
+    assert ("model_json_usage_finish" in flow.metadata) is not is_sse
+    body = _SSE_USAGE if is_sse else _JSON_USAGE
+    stream = response_stream(flow)
+    assert stream(body) == body
+    assert stream(b"") == b""
+    response_streaming.finalize_model_sse_usage(flow)
+    response_streaming.finalize_model_json_usage(flow, "")
+    assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {
+        "model": "gpt-5.5",
+        "tokens.input": 12,
+        "tokens.output": 7,
+    }
+    assert flow.request.headers.fields == request_fields
+    assert flow.response.headers.fields == response_fields
+
+
+@pytest.mark.parametrize("padding_byte", [b"x", b"\xff"], ids=["ascii", "non-utf8"])
+def test_http1_large_parameter_preserves_sse_without_full_conversion(real_flow, padding_byte):
+    value = b'Text/Event-Stream; pad="' + padding_byte * (1024 * 1024) + b'"'
+    flow = _make_flow(real_flow, ())
+    flow.response = http1.read_response_head([b"HTTP/1.1 200 OK", b"Content-Type: " + value])
+
+    _assert_stream_classification(flow, is_sse=True)
+
+    assert flow.response.headers.fields == ((b"Content-Type", value),)
+
+
+@pytest.mark.parametrize(
+    ("values", "is_sse"),
+    [
+        pytest.param((), False, id="missing"),
+        pytest.param((b"",), False, id="empty"),
+        pytest.param((b" \tText/Event-Stream\t ; Charset=UTF-8",), True, id="case-and-ows"),
+        pytest.param((b"\vtext/event-stream",), False, id="non-http-whitespace"),
+        pytest.param((b"text/event-stream", b"application/json"), False, id="repeated"),
+        pytest.param(
+            (b"text/event-stream; charset=utf-8", b"application/json"),
+            False,
+            id="repeated-parameterized-first",
+        ),
+        pytest.param((b"", b"text/event-stream"), False, id="empty-first-duplicate"),
+        pytest.param(
+            (_SSE_MEDIA_TYPE + b" " * (_PREFIX_LIMIT - len(_SSE_MEDIA_TYPE)),),
+            True,
+            id="actual-end-at-limit",
+        ),
+        pytest.param(
+            (_SSE_MEDIA_TYPE + b" " * (_PREFIX_LIMIT - len(_SSE_MEDIA_TYPE) - 1) + b";pad=x",),
+            True,
+            id="separator-last-inspectable-byte",
+        ),
+        pytest.param(
+            (_SSE_MEDIA_TYPE + b" " * (_PREFIX_LIMIT - len(_SSE_MEDIA_TYPE)) + b";pad=x",),
+            False,
+            id="separator-beyond-limit",
+        ),
+        pytest.param(
+            (_SSE_MEDIA_TYPE + b" " * (_PREFIX_LIMIT - len(_SSE_MEDIA_TYPE)) + b"x",),
+            False,
+            id="truncated-prefix-is-not-field-end",
+        ),
+        pytest.param(
+            (_SSE_MEDIA_TYPE + b" " * (_PREFIX_LIMIT - len(_SSE_MEDIA_TYPE) + 1),),
+            False,
+            id="actual-end-beyond-limit",
+        ),
+        pytest.param((b" " * _PREFIX_LIMIT + _SSE_MEDIA_TYPE,), False, id="late-media-type"),
+    ],
+)
+def test_response_hook_uses_complete_bounded_singleton(real_flow, values, *, is_sse: bool):
+    flow = _make_flow(real_flow, tuple((b"cOnTeNt-TyPe", value) for value in values))
+
+    _assert_stream_classification(flow, is_sse=is_sse)
+
+
+@pytest.mark.parametrize(
+    ("field_count", "is_sse"),
+    [(_FIELD_LIMIT, True), (_FIELD_LIMIT + 1, False)],
+)
+def test_response_hook_bounds_field_count(real_flow, field_count: int, *, is_sse: bool):
+    fields = ((b"X-Padding", b""),) * (field_count - 1) + ((b"Content-Type", b"text/event-stream"),)
+    flow = _make_flow(real_flow, fields)
+
+    _assert_stream_classification(flow, is_sse=is_sse)
+
+
+def test_response_hook_checks_duplicates_after_early_sse_match(real_flow):
+    fields = (
+        ((b"Content-Type", b"text/event-stream; charset=utf-8"),)
+        + ((b"X-Padding", b""),) * (_FIELD_LIMIT - 2)
+        + ((b"CONTENT-TYPE", b"application/json"),)
+    )
+
+    _assert_stream_classification(_make_flow(real_flow, fields), is_sse=False)
+
+
+class _NoNormalizeName(bytes):
+    def lower(self) -> bytes:
+        raise AssertionError("classifier normalized a name before checking its budget")
+
+
+class _GuardedParameterValue(bytes):
+    def __bytes__(self) -> bytes:
+        raise AssertionError("classifier copied the complete parameterized value")
+
+    def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
+        raise AssertionError("classifier decoded the complete parameterized value")
+
+    def partition(self, sep: bytes) -> tuple[bytes, bytes, bytes]:
+        raise AssertionError("classifier copied the parameter suffix")
+
+    def split(self, sep: bytes | None = None, maxsplit: int = -1) -> list[bytes]:
+        raise AssertionError("classifier split the complete parameterized value")
+
+    def strip(self, chars: bytes | None = None) -> bytes:
+        raise AssertionError("classifier stripped the complete parameterized value")
+
+    def lower(self) -> bytes:
+        raise AssertionError("classifier normalized the complete parameterized value")
+
+    def find(self, sub, start=0, end=None) -> int:
+        assert end is not None
+        assert 0 <= start <= end <= _PREFIX_LIMIT
+        return super().find(sub, start, end)
+
+    @overload
+    def __getitem__(self, key: SupportsIndex) -> int: ...
+
+    @overload
+    def __getitem__(self, key: slice) -> bytes: ...
+
+    def __getitem__(self, key: SupportsIndex | slice) -> int | bytes:
+        if isinstance(key, slice):
+            assert key.stop is not None
+            assert 0 <= key.stop <= len(_SSE_MEDIA_TYPE)
+        else:
+            assert 0 <= key.__index__() <= len(_SSE_MEDIA_TYPE)
+        return super().__getitem__(key)
+
+
+def test_classifier_never_copies_parameter_suffix_or_normalizes_oversized_names():
+    response = http.Response.make(200)
+    response.headers.fields = (
+        (_NoNormalizeName(b"X" * (1024 * 1024)), b"ignored"),
+        (b"Content-Type", _GuardedParameterValue(_SSE_MEDIA_TYPE + b";" + b"x" * (1024 * 1024))),
+    )
+
+    assert http_response_classification.has_event_stream_media_type(response)
+
+
+def test_classifier_rejects_excess_fields_before_name_normalization():
+    response = http.Response.make(200)
+    response.headers.fields = ((_NoNormalizeName(b"Content-Type"), b"text/event-stream"),) * (
+        _FIELD_LIMIT + 1
+    )
+
+    assert not http_response_classification.has_event_stream_media_type(response)

--- a/docs/mitm-addon-contracts.md
+++ b/docs/mitm-addon-contracts.md
@@ -189,6 +189,38 @@ conversion boundary. `test_model_provider_websocket_lifecycle.py` verifies raw
 response confirmation and tracked-flow retention/release. These regressions use
 structural assertions, with no timing or allocation thresholds.
 
+## Response Content-Type inspection boundary
+
+The shared response classifier inspects at most 8,192 raw header fields and
+8,192 leading Content-Type value bytes per call. It checks field count before
+enumeration and name length before ASCII case normalization. Missing or repeated
+Content-Type fields do not establish SSE, including a parameterized first value
+followed by a duplicate.
+
+For a singleton, the media type must end at a semicolon inside the inspected
+prefix or at the actual field end within the byte limit. Exhausting the budget
+does not establish a field ending. Only this bounded media type is copied,
+stripped of SP/HTAB, and compared case-insensitively with exactly
+`text/event-stream`. An arbitrarily large parameter suffix after an early
+semicolon is neither decoded nor copied by the classifier. Lookalikes such as
+`text/event-stream+json` remain non-SSE.
+
+Missing, ambiguous, or over-budget input follows the existing non-SSE inspector
+selection and terminal JSON eligibility shared by usage and failure observers.
+This does not prove the body is JSON: a true SSE body with an unclassifiable
+header may have no parsed usage or failure event. Request and response wire
+headers and streamed bytes are preserved. These local limits do not bound
+mitmproxy's raw HTTP-head buffering or other header consumers; old runners keep
+the previous behavior until updated.
+
+`test_response_content_type_budget.py` covers parsed HTTP/1 ASCII and non-UTF-8
+parameter suffixes through the real response-header hook, guards the dependency
+conversion boundary, and verifies parsed usage and unchanged traffic. Structural
+raw-value guards and exact-boundary cases protect against unbounded suffix
+copies, name normalization, and truncated-prefix matches. The shared failure
+reporting suite also verifies the same classification for usage and failure
+observers without timing or allocation thresholds.
+
 ## Path normalization work boundary
 
 Path safety validation accepts at most 65,536 input characters and five percent


### PR DESCRIPTION
An upstream `Content-Type: text/event-stream; ...` with a large parameter suffix previously caused the synchronous response-header hook to decode and copy the entire value. Classify the raw singleton field within limits of 8,192 fields and 8,192 prefix bytes, and normalize only the complete media type before the first in-budget semicolon.

Ordinary SSE detection, optional SP/HTAB, case-insensitive matching, and large irrelevant parameter suffixes remain supported. Missing/repeated fields and incomplete over-budget prefixes consistently return non-SSE through the existing shared usage/failure classifier. This intentionally removes the semicolon-dependent behavior of duplicate Content-Type fields. Headers and streamed bytes remain unchanged; unclassifiable true SSE responses may lack parsed usage/failure events. The bound is local to this classifier and does not cover mitmproxy's raw head buffering or other header consumers. No wire protocol or persisted-state changes are involved.

Closes #33313.

## Validation

- New raw-header regression suite: 12 failed / 8 passed against the original classifier; all 20 passed after the fix. Covers real HTTP/1 ASCII and non-UTF-8 parameter suffixes, dependency conversion guards, parsed usage, duplicate fields, and exact/over-budget boundaries without timing thresholds.
- **308 related tests passed** in the locked CPython 3.14.0 / mitmproxy 12.2.3 environment, including shared failure reporting, parser setup, SSE accounting, stream lifecycle, response encoding, WebSocket lifecycle, and error cleanup:

  ```bash
  uv run --no-sync python -m pytest tests/test_response_content_type_budget.py tests/test_model_provider_response_parser_setup.py tests/test_model_provider_failure_reporting.py tests/test_response_headers_handler.py tests/test_response_handler_cleanup.py tests/test_response_stream_buffering.py tests/test_response_stream_state_release.py tests/test_response_encoding_inspection_risk.py tests/test_model_provider_sse_usage_openai_responses.py tests/test_model_provider_sse_usage_anthropic.py tests/test_model_provider_websocket_lifecycle.py tests/test_error_handler.py -q --tb=short
  ```

- `uv lock --check`, `uv run --no-sync ruff format --check .`, `uv run --no-sync ruff check .`, and `uv run --no-sync basedpyright -p .` passed.
- `npx --yes --package=prettier@3.8.1 prettier --check docs/mitm-addon-contracts.md`, staged diff whitespace checks, and file-size checks passed.
- Full repository checks are left to the PR pipeline; no local Vitest or development server was run.
