### PR TITLE
fix(platform): reset official workflow errors on reopen

### DIFF
--- a/turbo/apps/platform/src/signals/workflows-page/official-workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/official-workflows-signals.ts
@@ -109,6 +109,17 @@ export const installOfficialWorkflow$ = command(
     },
     signal: AbortSignal,
   ): Promise<OfficialWorkflowInstallationResponse> => {
+    signal.throwIfAborted();
+    const form = get(internalOfficialWorkflowConfigurationForm$);
+    if (
+      form?.target.operation === "install" &&
+      form.definitionName === input.definitionName
+    ) {
+      set(internalOfficialWorkflowConfigurationForm$, {
+        ...form,
+        submitted: true,
+      });
+    }
     const client = get(apiClient$)(officialWorkflowsContract);
     const result = await accept(
       client.install({
@@ -134,6 +145,17 @@ export const reconfigureOfficialWorkflow$ = command(
     },
     signal: AbortSignal,
   ): Promise<OfficialWorkflowInstallationResponse> => {
+    signal.throwIfAborted();
+    const form = get(internalOfficialWorkflowConfigurationForm$);
+    if (
+      form?.target.operation === "reconfigure" &&
+      form.target.workflowId === input.workflowId
+    ) {
+      set(internalOfficialWorkflowConfigurationForm$, {
+        ...form,
+        submitted: true,
+      });
+    }
     const client = get(apiClient$)(officialWorkflowInstallationsContract);
     const result = await accept(
       client.reconfigure({
@@ -164,6 +186,8 @@ export const uninstallOfficialWorkflow$ = command(
 );
 
 export interface OfficialWorkflowConfigurationForm {
+  /** Error feedback belongs to submissions made from this opening. */
+  readonly submitted: boolean;
   readonly target:
     | { readonly operation: "install" }
     | {

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1829,6 +1829,84 @@ test("Show the current status of a retired Official Workflow", async () => {
   expect(queryButtonByText("Install")).toBeNull();
 });
 
+async function dismissOfficialWorkflowDialog(
+  dialog: HTMLElement,
+  dismissal: "Cancel" | "Close" | "Escape" | "backdrop",
+) {
+  if (dismissal === "Cancel") {
+    click(buttonByText("Cancel", dialog));
+  } else if (dismissal === "Close") {
+    click(within(dialog).getByLabelText("Close"));
+  } else if (dismissal === "Escape") {
+    await userEvent.setup({ delay: null }).keyboard("{Escape}");
+  } else {
+    const viewport = dialog.closest('[data-slot="dialog-viewport"]');
+    if (!(viewport instanceof HTMLElement)) {
+      throw new Error("Expected the Official Workflow dialog viewport");
+    }
+    await userEvent.setup({ delay: null }).click(viewport);
+  }
+  await waitFor(() => {
+    expect(dialog).not.toBeInTheDocument();
+  });
+}
+
+test.each(["Cancel", "Close", "Escape", "backdrop"] as const)(
+  "Clear the previous Official Workflow install error after %s",
+  async (dismissal) => {
+    const definition = officialCatalogDetail();
+    mockAgentPageApis();
+    context.mocks.data.onboardingStatus({ defaultAgentId: AGENT_ID });
+    context.mocks.data.userPreferences({ timezone: "UTC" });
+    mockWorkflowApis([]);
+    context.mocks.api(officialWorkflowsContract.get, ({ respond }) => {
+      return respond(200, definition);
+    });
+    context.mocks.api(officialWorkflowsContract.install, ({ respond }) => {
+      return respond(500, {
+        error: { code: "INTERNAL_SERVER_ERROR", message: "Install failed" },
+      });
+    });
+    await setupPage({
+      context,
+      path: `/workflows/official/${definition.name}`,
+      featureSwitches: { [FeatureSwitchKey.OfficialWorkflows]: true },
+    });
+    const installButton = await waitFor(() => {
+      return buttonByText("Install");
+    });
+    click(installButton);
+    const dialog = await screen.findByRole("dialog");
+    await fill(
+      within(dialog).getByLabelText("interval-seconds (required)"),
+      "7200",
+    );
+    await userEvent
+      .setup({ delay: null })
+      .click(buttonByText("Install", dialog));
+    await expect(
+      within(dialog).findByText("Official Workflow could not be installed"),
+    ).resolves.toBeVisible();
+    expect(buttonByText("Install", dialog)).toBeEnabled();
+
+    await dismissOfficialWorkflowDialog(dialog, dismissal);
+    click(installButton);
+    const reopened = await screen.findByRole("dialog");
+    expect(
+      within(reopened).getByLabelText("interval-seconds (required)"),
+    ).toHaveValue(3600);
+    expect(
+      within(reopened).queryByText("Official Workflow could not be installed"),
+    ).not.toBeInTheDocument();
+    expect(buttonByText("Install", reopened)).toBeEnabled();
+
+    click(buttonByText("Install", reopened));
+    await expect(
+      within(reopened).findByText("Official Workflow could not be installed"),
+    ).resolves.toBeVisible();
+  },
+);
+
 test("Install an Official Workflow with typed Blueprint settings", async () => {
   const definition = officialCatalogDetail();
   const {
@@ -2437,6 +2515,157 @@ test("Show an Official Workflow that needs reconfiguration", async () => {
     ),
   ).resolves.toBeInTheDocument();
 });
+
+test.each(["Cancel", "Close", "Escape", "backdrop"] as const)(
+  "Clear the previous Official Workflow reconfigure error after %s",
+  async (dismissal) => {
+    const workflow = officialSalesResearch();
+    const definition = officialCatalogDetail();
+    mockAgentPageApis();
+    context.mocks.data.userPreferences({ timezone: "UTC" });
+    mockWorkflowApis([workflow]);
+    context.mocks.api(
+      officialWorkflowInstallationsContract.get,
+      ({ respond }) => {
+        return respond(200, {
+          workflow,
+          definition: {
+            name: definition.name,
+            revision: definition.revision,
+            lifecycle: "active",
+            blueprints: definition.blueprints,
+          },
+        });
+      },
+    );
+    context.mocks.api(
+      officialWorkflowInstallationsContract.reconfigure,
+      ({ respond }) => {
+        return respond(500, {
+          error: {
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Reconfigure failed",
+          },
+        });
+      },
+    );
+    await setupWorkflowDetailPage(workflowDetailPath("info"));
+    const reconfigureButton = await waitFor(() => {
+      return buttonByText("Reconfigure");
+    });
+    click(reconfigureButton);
+    const dialog = await screen.findByRole("dialog");
+    await fill(
+      within(dialog).getByLabelText("interval-seconds (required)"),
+      "7200",
+    );
+    await userEvent
+      .setup({ delay: null })
+      .click(buttonByText("Reconfigure", dialog));
+    await expect(
+      within(dialog).findByText("Official Workflow could not be reconfigured"),
+    ).resolves.toBeVisible();
+    expect(buttonByText("Reconfigure", dialog)).toBeEnabled();
+
+    await dismissOfficialWorkflowDialog(dialog, dismissal);
+    click(reconfigureButton);
+    const reopened = await screen.findByRole("dialog");
+    expect(
+      within(reopened).getByLabelText("interval-seconds (required)"),
+    ).toHaveValue(3600);
+    expect(
+      within(reopened).queryByText(
+        "Official Workflow could not be reconfigured",
+      ),
+    ).not.toBeInTheDocument();
+    expect(buttonByText("Reconfigure", reopened)).toBeEnabled();
+
+    click(buttonByText("Reconfigure", reopened));
+    await expect(
+      within(reopened).findByText(
+        "Official Workflow could not be reconfigured",
+      ),
+    ).resolves.toBeVisible();
+  },
+);
+
+test.each(["Install", "Reconfigure"] as const)(
+  "Keep a pending Official Workflow %s submission disabled after reopening",
+  async (operation) => {
+    const workflow = officialSalesResearch();
+    const definition = officialCatalogDetail();
+    const response = context.mocks.deferred<void>();
+    const installing = operation === "Install";
+    mockAgentPageApis();
+    context.mocks.data.onboardingStatus({ defaultAgentId: AGENT_ID });
+    context.mocks.data.userPreferences({ timezone: "UTC" });
+    mockWorkflowApis(installing ? [] : [workflow]);
+    context.mocks.api(officialWorkflowsContract.get, ({ respond }) => {
+      return respond(200, definition);
+    });
+    context.mocks.api(
+      officialWorkflowsContract.install,
+      async ({ respond }) => {
+        await response.promise;
+        return respond(500, {
+          error: { code: "INTERNAL_SERVER_ERROR", message: "Install failed" },
+        });
+      },
+    );
+    context.mocks.api(
+      officialWorkflowInstallationsContract.get,
+      ({ respond }) => {
+        return respond(200, {
+          workflow,
+          definition: {
+            name: definition.name,
+            revision: definition.revision,
+            lifecycle: "active",
+            blueprints: definition.blueprints,
+          },
+        });
+      },
+    );
+    context.mocks.api(
+      officialWorkflowInstallationsContract.reconfigure,
+      async ({ respond }) => {
+        await response.promise;
+        return respond(500, {
+          error: {
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Reconfigure failed",
+          },
+        });
+      },
+    );
+    await setupPage({
+      context,
+      path: installing
+        ? `/workflows/official/${definition.name}`
+        : workflowDetailPath("info"),
+      featureSwitches: { [FeatureSwitchKey.OfficialWorkflows]: true },
+    });
+    const openButton = await waitFor(() => {
+      return buttonByText(operation);
+    });
+    click(openButton);
+    const dialog = await screen.findByRole("dialog");
+    click(buttonByText(operation, dialog));
+    await waitFor(() => {
+      expect(buttonByText(operation, dialog)).toBeDisabled();
+    });
+    await dismissOfficialWorkflowDialog(dialog, "Close");
+    click(openButton);
+    const reopened = await screen.findByRole("dialog");
+    expect(buttonByText(operation, reopened)).toBeDisabled();
+
+    response.resolve();
+    await waitFor(() => {
+      expect(buttonByText(operation, reopened)).toBeEnabled();
+    });
+    expect(within(reopened).queryByRole("alert")).not.toBeInTheDocument();
+  },
+);
 
 test("Reconfigure typed settings for an Official Workflow", async () => {
   const workflow = officialSalesResearch("retired");

--- a/turbo/apps/platform/src/views/workflows-page/official-workflow-configuration.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/official-workflow-configuration.tsx
@@ -79,6 +79,7 @@ export function createOfficialWorkflowConfigurationForm(args: {
     }),
   );
   return {
+    submitted: false,
     target: args.target,
     definitionName: args.definitionName,
     agentId: args.agentId,

--- a/turbo/apps/platform/src/views/workflows-page/official-workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/official-workflows-page.tsx
@@ -363,7 +363,7 @@ function InstallDialog({
             disabled={installing}
           />
         ) : null}
-        {installLoadable.state === "hasError" ? (
+        {activeForm?.submitted && installLoadable.state === "hasError" ? (
           <Alert variant="destructive">
             <AlertTitle>
               {i18n.t(($) => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -1705,7 +1705,7 @@ function OfficialWorkflowReconfigureDialog({
             disabled={reconfiguring}
           />
         ) : null}
-        {reconfigureLoadable.state === "hasError" ? (
+        {activeForm?.submitted && reconfigureLoadable.state === "hasError" ? (
           <Alert variant="destructive">
             <AlertTitle>
               {i18n.t(($) => {


### PR DESCRIPTION
## Summary

After an Official Workflow install or reconfigure request fails, closing and reopening the dialog currently shows the previous error before another submission. Scope error feedback to submissions made from the current form opening, so Cancel, X, Escape, and backdrop dismissal all reopen with a fresh form and no stale error. A new failed submission still displays its error.

Keep the existing request loading state across dismissal, so reopening while a request is pending cannot enable a duplicate submission.

Fixes #33212. This addresses the remaining F4 finding in the modal audit; F1–F3 have shipped. The separately identified F5 risk of an old request closing a newer dialog remains deferred at the user's request.

## Verification

- The install and reconfigure Cancel/reopen regression cases both failed against the original implementation.
- Focused Official Workflow tests: 22 passed, including 10 new cases for all four close paths, repeat failure feedback, and pending-request reopen behavior.
- Changed-file Prettier, ESLint, Oxlint, type-aware Oxlint, and style policy passed; Platform production/test/build-config type checks and workspace Knip passed.
- GitHub CI passed on the unchanged head, including the final `ci-gate-turbo`; a voice-capture test failure cleared on rerun and the cancelled test shard was rerun successfully.
- Browser QA on deployed commit `9d00ce4406f2517c679b9d38a3d689413a7aefb6` (its merge parents include head `1c811140ea601e989a962f7b6eac650ae8dc1d9a`): all eight install/reconfigure dismissal-and-reopen scenarios passed, including restored values and new error feedback on retry.

Browser fixture: fresh Clerk TEST account, ordinary "I will explore on my own" onboarding, `officialWorkflows` enabled and verified in Lab, 1440×1000 Chromium viewport. The preview's real catalog is empty; existing typed test fixtures and simulated HTTP 500 responses were intercepted only in the local browser. No real workflow installation, reconfiguration, or automation run was performed.

App: https://pr-33393-app-okou-app-preview.vm0.workers.dev

API: https://pr-33393-api.vm6.ai

## Acceptance

Enable `officialWorkflows` in Lab on the PR preview. Use a test account and simulate failed requests in the browser; no real installation or reconfiguration is needed.

1. Workflows → Browse Official → an available workflow → Install. Submit with a failed install response, close the dialog, and reopen it. The previous error is absent and defaults are restored; a new failed submission displays its error.
2. Open an installed Official Workflow → Settings → Reconfigure. Repeat the same failure, close, and reopen sequence. The previous error is absent and saved values are restored.
3. Repeat with Cancel, X, Escape, and backdrop dismissal. If the original request is still pending, the reopened submit button stays disabled until it settles.
