### PR TITLE
fix(runner): preserve connector diagnostic base specificity

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -82,11 +82,6 @@ class SharedBaseOwnershipResolution:
 
 
 @dataclass(frozen=True)
-class _SharedBaseDiagnosticResolution:
-    candidate: ConnectorDiagnosticCandidate | None
-
-
-@dataclass(frozen=True)
 class _DiagnosticConnectorMatcher:
     base_authorities: frozenset[str]
     compiled_firewalls: matching.CompiledFirewallSet | None
@@ -162,6 +157,8 @@ def find_candidate(
     Model-provider routes are retained only as exclusions and are checked
     before connector ownership.
 
+    Select the most-specific matching base tier before resolving ownership.
+    Broader bases cannot introduce owners or ambiguity into that tier.
     Selection is intentionally asymmetric. A base owned by one eligible
     connector matches broadly without enforcing its catalog permission method
     or rules because ownership is unambiguous. A base shared by eligible
@@ -189,21 +186,20 @@ def find_candidate(
     if _matches_model_provider_exclusion(url, method, catalog):
         return None
 
-    shared_base_resolution = _find_shared_base_candidate(
-        url,
-        method,
-        catalog,
-        active_firewall_names=active_firewall_names,
-    )
-    if shared_base_resolution is not None:
-        return shared_base_resolution.candidate
-
     match = matching.match_compiled_firewall_request(
         url,
         method,
         catalog.compiled_connector_firewalls,
         catalog.compiled_network_policies,
     )
+    if isinstance(match, matching.FirewallAmbiguous):
+        return _find_shared_base_candidate(
+            url,
+            method,
+            catalog,
+            candidate_connector_slugs=match.candidates,
+            active_firewall_names=active_firewall_names,
+        )
     if not isinstance(match, matching.FirewallAllow):
         return None
     if match.name in active_firewall_names:
@@ -217,20 +213,23 @@ def _find_shared_base_candidate(
     method: str,
     catalog: _DiagnosticCatalog,
     *,
+    candidate_connector_slugs: tuple[str, ...],
     active_firewall_names: set[str],
-) -> _SharedBaseDiagnosticResolution | None:
-    matches = _ownership_matches(url, method, catalog)
+) -> ConnectorDiagnosticCandidate | None:
+    matches = _ownership_matches(
+        url, method, catalog, candidate_connector_slugs=candidate_connector_slugs
+    )
     if len(matches) < _SHARED_BASE_MIN_CANDIDATES:
         return None
 
     route_matches = [match for match in matches if match.route_specific]
     if len(route_matches) != 1:
-        return _SharedBaseDiagnosticResolution(candidate=None)
+        return None
 
     selected = route_matches[0].candidate
     if selected.connector_slug in active_firewall_names:
-        return _SharedBaseDiagnosticResolution(candidate=None)
-    return _SharedBaseDiagnosticResolution(candidate=selected)
+        return None
+    return selected
 
 
 def resolve_shared_base_ownership(
@@ -244,6 +243,7 @@ def resolve_shared_base_ownership(
 ) -> SharedBaseOwnershipResolution | None:
     """Resolve shared-base ownership for an active unknown-endpoint allow.
 
+    Only owners in the most-specific matching base tier participate.
     Route-specific ownership takes precedence over connector intent.
 
     ``reason`` values:
@@ -281,7 +281,18 @@ def resolve_shared_base_ownership(
     if _matches_model_provider_exclusion(url, method, catalog):
         return None
 
-    matches = _ownership_matches(url, method, catalog)
+    base_match = matching.match_compiled_firewall_request(
+        url,
+        method,
+        catalog.compiled_connector_firewalls,
+        catalog.compiled_network_policies,
+    )
+    if not isinstance(base_match, matching.FirewallAmbiguous):
+        return None
+
+    matches = _ownership_matches(
+        url, method, catalog, candidate_connector_slugs=base_match.candidates
+    )
     if len(matches) < _SHARED_BASE_MIN_CANDIDATES:
         return None
     if not any(match.candidate.connector_slug == matched_firewall_name for match in matches):
@@ -335,6 +346,8 @@ def _ownership_matches(
     url: str,
     method: str,
     catalog: _DiagnosticCatalog,
+    *,
+    candidate_connector_slugs: tuple[str, ...],
 ) -> list[_OwnershipMatch]:
     matches: list[_OwnershipMatch] = []
     authority = matching.match_url_authority_key(url)
@@ -348,6 +361,8 @@ def _ownership_matches(
             matcher.compiled_network_policies,
         )
         if not isinstance(match, matching.FirewallAllow):
+            continue
+        if match.name not in candidate_connector_slugs:
             continue
         candidate = _candidate_from_match(match)
         if candidate is None:

--- a/crates/runner/mitm-addon/tests/test_connector_diagnostic_base_specificity.py
+++ b/crates/runner/mitm-addon/tests/test_connector_diagnostic_base_specificity.py
@@ -1,0 +1,260 @@
+"""Base-specific connector diagnostics through the production addon hooks."""
+
+import json
+
+import pytest
+from mitmproxy import http
+from mitmproxy.test import tutils
+
+import mitm_addon
+from tests.connector_diagnostic_helpers import (
+    _shared_base_catalog_firewall,
+    write_connector_diagnostic_catalog_cache,
+)
+from tests.flow_helpers import header_map, response_stream
+from tests.request_handler_helpers import (
+    _sandbox_without_firewalls,
+    _single_firewall_sandbox,
+    _write_registry,
+)
+
+
+def _overlapping_catalog(*, broad_connectors=2, specific_rule="GET /items/{id}"):
+    specific = _shared_base_catalog_firewall(
+        "specific",
+        "SPECIFIC_TOKEN",
+        permissions=[{"name": "read", "rules": [specific_rule]}],
+    )
+    specific["apis"][0]["base"] = "https://shared.example.com/special"
+    firewalls = {"specific": specific}
+    if broad_connectors >= 1:
+        firewalls["broad-a"] = _shared_base_catalog_firewall(
+            "broad-a",
+            "BROAD_A_TOKEN",
+            permissions=[{"name": "read", "rules": ["GET /special/items/{id}"]}],
+        )
+    if broad_connectors >= 2:
+        firewalls["broad-b"] = _shared_base_catalog_firewall(
+            "broad-b",
+            "BROAD_B_TOKEN",
+            permissions=[{"name": "read", "rules": ["GET /elsewhere/{id}"]}],
+        )
+    return firewalls
+
+
+def _complete_response(flow: http.HTTPFlow, *, upstream_status: int, streamed: bool) -> bytes:
+    flow.response = tutils.tresp(
+        status_code=upstream_status,
+        headers=header_map({"content-type": "text/plain"}),
+        content=b"upstream",
+    )
+    if streamed:
+        mitm_addon.responseheaders(flow)
+        stream = response_stream(flow)
+        chunks: list[bytes] = []
+        for chunk in (b"upstream", b""):
+            result = stream(chunk)
+            if isinstance(result, bytes):
+                chunks.append(result)
+            else:
+                chunks.extend(result)
+        content = b"".join(chunks)
+        mitm_addon.response(flow)
+    else:
+        mitm_addon.response(flow)
+        content = flow.response.content
+        assert content is not None
+    assert flow.response.status_code == upstream_status
+    return content
+
+
+@pytest.mark.parametrize(
+    ("broad_connectors", "specific_rule"),
+    [
+        (0, "GET /items/{id}"),
+        (1, "GET /items/{id}"),
+        (2, "GET /items/{id}"),
+        (2, "POST /other/{id}"),
+    ],
+)
+@pytest.mark.parametrize("upstream_status", [401, 403])
+@pytest.mark.parametrize("streamed", [False, True])
+async def test_unique_specific_base_keeps_ownership_when_broader_siblings_are_added(
+    tmp_path, real_flow, mitm_ctx, broad_connectors, specific_rule, upstream_status, streamed
+):
+    write_connector_diagnostic_catalog_cache(
+        tmp_path,
+        firewalls=_overlapping_catalog(
+            broad_connectors=broad_connectors,
+            specific_rule=specific_rule,
+        ),
+    )
+    reg_path = _write_registry(tmp_path, sandbox_info=_sandbox_without_firewalls(tmp_path))
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        path="/special/items/123",
+        method="GET",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path)):
+        await mitm_addon.request(flow)
+        assert flow.response is None
+        content = _complete_response(flow, upstream_status=upstream_status, streamed=streamed)
+
+    body = json.loads(content)
+    assert body["connector"] == "specific"
+    assert body["envNames"] == ["SPECIFIC_TOKEN"]
+    assert body["base"] == "https://shared.example.com/special"
+    assert body["upstreamStatus"] == upstream_status
+
+
+@pytest.mark.parametrize(
+    ("specific_rule", "sibling_rule", "expected_connector"),
+    [
+        ("GET /items/{id}", "GET /other/{id}", "specific"),
+        ("GET /items/{id}", "GET /items/123", None),
+        ("GET /other/{id}", "GET /elsewhere/{id}", None),
+    ],
+)
+@pytest.mark.parametrize("upstream_status", [401, 403])
+@pytest.mark.parametrize("streamed", [False, True])
+async def test_shared_specific_base_resolves_only_its_own_route_owners(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    specific_rule,
+    sibling_rule,
+    expected_connector,
+    upstream_status,
+    streamed,
+):
+    firewalls = _overlapping_catalog(specific_rule=specific_rule)
+    sibling = _shared_base_catalog_firewall(
+        "specific-sibling",
+        "SIBLING_TOKEN",
+        permissions=[{"name": "read", "rules": [sibling_rule]}],
+    )
+    sibling["apis"][0]["base"] = "https://shared.example.com/special"
+    firewalls["specific-sibling"] = sibling
+    # A winning connector may also own a broader API with a matching rule.
+    firewalls["specific"]["apis"].append(firewalls["broad-a"]["apis"][0])
+    write_connector_diagnostic_catalog_cache(tmp_path, firewalls=firewalls)
+    reg_path = _write_registry(tmp_path, sandbox_info=_sandbox_without_firewalls(tmp_path))
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        path="/special/items/123",
+        method="GET",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path)):
+        await mitm_addon.request(flow)
+        assert flow.response is None
+        content = _complete_response(flow, upstream_status=upstream_status, streamed=streamed)
+
+    assert flow.response is not None
+    if expected_connector is None:
+        assert content == b"upstream"
+        assert flow.response.headers["content-type"] == "text/plain"
+    else:
+        body = json.loads(content)
+        assert body["connector"] == expected_connector
+        assert body["envNames"] == ["SPECIFIC_TOKEN"]
+        assert body["base"] == "https://shared.example.com/special"
+        assert body["upstreamStatus"] == upstream_status
+
+
+@pytest.mark.parametrize("suppression", ["active-owner", "model-provider"])
+@pytest.mark.parametrize("upstream_status", [401, 403])
+@pytest.mark.parametrize("streamed", [False, True])
+async def test_suppressed_specific_owner_does_not_fall_back_to_broader_connector(
+    tmp_path, real_flow, mitm_ctx, suppression, upstream_status, streamed
+):
+    firewalls = _overlapping_catalog()
+    sandbox_info = _sandbox_without_firewalls(tmp_path)
+    if suppression == "active-owner":
+        # Keep the catalog owner active while this URL takes ordinary Allow.
+        sandbox_info = _single_firewall_sandbox(
+            tmp_path,
+            firewall_name="specific",
+            api_entry={
+                "base": "https://shared.example.com/runtime",
+                "auth": {},
+                "permissions": [{"name": "read", "rules": ["GET /{path+}"]}],
+            },
+            network_policy={"allow": ["read"], "deny": [], "ask": [], "unknownPolicy": "deny"},
+        )
+    else:
+        provider = _shared_base_catalog_firewall(
+            "model-provider:test",
+            "PROVIDER_TOKEN",
+            permissions=[{"name": "read", "rules": ["GET /items/{id}"]}],
+        )
+        provider["apis"][0]["base"] = "https://shared.example.com/special"
+        firewalls["model-provider:test"] = provider
+    write_connector_diagnostic_catalog_cache(tmp_path, firewalls=firewalls)
+    reg_path = _write_registry(tmp_path, sandbox_info=sandbox_info)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        path="/special/items/123",
+        method="GET",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path)):
+        await mitm_addon.request(flow)
+        assert flow.response is None
+        content = _complete_response(flow, upstream_status=upstream_status, streamed=streamed)
+
+    assert content == b"upstream"
+    assert flow.response is not None
+    assert flow.response.headers["content-type"] == "text/plain"
+
+
+@pytest.mark.parametrize("requestheaders_first", [False, True])
+@pytest.mark.parametrize("shared_specific_base", [False, True])
+async def test_broader_shared_owners_cannot_interrupt_active_request_authentication(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, requestheaders_first, shared_specific_base
+):
+    firewalls = _overlapping_catalog()
+    if shared_specific_base:
+        sibling = _shared_base_catalog_firewall("specific-sibling", "SIBLING_TOKEN")
+        sibling["apis"][0]["base"] = "https://shared.example.com/special"
+        firewalls["specific-sibling"] = sibling
+    write_connector_diagnostic_catalog_cache(tmp_path, firewalls=firewalls)
+    reg_path = _write_registry(
+        tmp_path,
+        sandbox_info=_single_firewall_sandbox(
+            tmp_path,
+            firewall_name="broad-b",
+            api_entry=firewalls["broad-b"]["apis"][0],
+            network_policy={"allow": ["read"], "deny": [], "ask": [], "unknownPolicy": "allow"},
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        path="/special/items/123",
+        method="GET",
+    )
+    flow.request.headers["X-VM0-Connector-Intent"] = "broad-a"
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.okou.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer active"}),
+    ):
+        if requestheaders_first:
+            pending = mitm_addon.requestheaders(flow)
+            if pending is not None:
+                await pending
+            assert flow.response is None
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.request.headers["Authorization"] == "Bearer active"
+    assert "X-VM0-Connector-Intent" not in flow.request.headers

--- a/crates/runner/mitm-addon/tests/test_connector_diagnostic_base_specificity.py
+++ b/crates/runner/mitm-addon/tests/test_connector_diagnostic_base_specificity.py
@@ -17,6 +17,7 @@ from tests.request_handler_helpers import (
     _single_firewall_sandbox,
     _write_registry,
 )
+from tests.requestheaders_helpers import await_requestheaders_result
 
 
 def _overlapping_catalog(*, broad_connectors=2, specific_rule="GET /items/{id}"):
@@ -233,6 +234,7 @@ async def test_broader_shared_owners_cannot_interrupt_active_request_authenticat
             firewall_name="broad-b",
             api_entry=firewalls["broad-b"]["apis"][0],
             network_policy={"allow": ["read"], "deny": [], "ask": [], "unknownPolicy": "allow"},
+            sandbox_fields={"captureNetworkBodies": True},
         ),
     )
     flow = real_flow(
@@ -243,6 +245,8 @@ async def test_broader_shared_owners_cannot_interrupt_active_request_authenticat
         method="GET",
     )
     flow.request.headers["X-VM0-Connector-Intent"] = "broad-a"
+    if requestheaders_first:
+        flow.request.headers["Content-Length"] = str(mitm_addon.STREAM_BUFFER_LIMIT + 1)
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.okou.ai"),
@@ -250,9 +254,10 @@ async def test_broader_shared_owners_cannot_interrupt_active_request_authenticat
     ):
         if requestheaders_first:
             pending = mitm_addon.requestheaders(flow)
-            if pending is not None:
-                await pending
+            await await_requestheaders_result(pending)
             assert flow.response is None
+            assert callable(flow.request.stream)
+            assert flow.request.headers["Authorization"] == "Bearer active"
         await mitm_addon.request(flow)
 
     assert flow.response is None


### PR DESCRIPTION
Shared broad API bases can currently override a connector that owns a more-specific base, causing 401/403 responses to recommend the wrong connector and token. Select the winning base tier with the existing global matcher before resolving diagnostic ownership, and restrict shared route owners and intent hints to that tier.

The change covers response diagnostics and the pre-authentication shared-owner check. It preserves broad matching for a unique owner, conservative equal-base ambiguity, active-owner suppression, model-provider exclusions, and upstream status codes. Scope is limited to addon diagnostic selection and hook-level regressions; catalog schemas and credential-injection contracts are unchanged.

Closes #33314

## Validation

Pinned Python 3.14.0 with `uv lock --check` and `uv sync --locked`:

- `uv run --no-sync python -m pytest -q tests/test_connector_diagnostic_base_specificity.py tests/test_request_headers_firewall_auth.py tests/test_request_handler_connector_diagnostics.py --tb=short` — 73 passed, including all 40 new cases and the asynchronous request-header authentication path. The initial 16-case regression produced 8 wrong-connector failures and 8 passing controls before the fix.
- `uv run --no-sync python -m pytest -q tests/test_builtin_connector_diagnostics.py tests/test_connector_diagnostic_catalog_lifecycle.py tests/test_request_handler_connector_diagnostics.py tests/test_response_handler_connector_diagnostics.py tests/test_firewall_request_base_matching.py tests/test_firewall_request_matching.py tests/test_matching_base_url_static.py tests/test_compiled_firewall_base_path_matching.py tests/test_compiled_firewall_indexed_matching.py --tb=short` — 352 passed.
- `uv run --no-sync ruff format --check .`, `uv run --no-sync ruff check .`, and `uv run --no-sync basedpyright -p .` — passed; changed-test checks were refreshed after the final test expansion.
- `git diff --cached --check` and the repository file-size check — passed.

The fix takes effect when updated runners are deployed; existing runners keep their previous diagnostic selection until updated.
