### PR TITLE
fix(guest-agent): keep oom evidence waits off tokio workers

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -613,7 +613,7 @@ async fn execute(
         } else {
             guest_contracts::oom_evidence::CaptureReason::CliError
         };
-        if let Some(evidence) = workload_containment.oom_evidence(reason) {
+        if let Some(evidence) = workload_containment.oom_evidence(reason).await {
             telemetry
                 .incident_reporter()
                 .with_sandbox_id(runtime.config.sandbox_id.clone())

--- a/crates/guest-agent/src/metrics.rs
+++ b/crates/guest-agent/src/metrics.rs
@@ -313,7 +313,7 @@ fn elapsed_ms_since(scheduled_at: Instant) -> u64 {
 }
 
 /// Collect one snapshot of system metrics.
-fn collect_metrics(
+async fn collect_metrics(
     cpu_tracker: &mut CpuTracker,
     sources: &MetricsSources,
     scheduled_lag_ms: u64,
@@ -329,17 +329,19 @@ fn collect_metrics(
         .cgroup_cpu_stat
         .as_ref()
         .and_then(|paths| read_cgroup_cpu_stat(paths.workload()));
-    MetricsEntry {
-        memory: sources
-            .evidence
-            .as_ref()
-            .and_then(|(containment, reporter)| {
-                let mut evidence = containment
-                    .oom_evidence(guest_contracts::oom_evidence::CaptureReason::Sample)?;
+    let memory = match sources.evidence.as_ref() {
+        Some((containment, reporter)) => containment
+            .oom_evidence(guest_contracts::oom_evidence::CaptureReason::Sample)
+            .await
+            .map(|mut evidence| {
                 reporter.record(evidence.clone());
                 evidence.incidents.clear();
-                Some(evidence)
+                evidence
             }),
+        None => None,
+    };
+    MetricsEntry {
+        memory,
         ts: guest_telemetry::log::timestamp(),
         cpu: cpu.busy,
         cpu_steal_percent: cpu.steal,
@@ -372,8 +374,13 @@ pub async fn metrics_loop_for_path(
             _ = shutdown.cancelled() => break,
             scheduled_at = interval.tick() => {
                 let scheduled_lag_ms = elapsed_ms_since(scheduled_at);
-                let entry = collect_metrics(&mut cpu_tracker, &sources, scheduled_lag_ms);
-                metrics_sink.append(&entry);
+                tokio::select! {
+                    biased;
+                    _ = shutdown.cancelled() => break,
+                    entry = collect_metrics(&mut cpu_tracker, &sources, scheduled_lag_ms) => {
+                        metrics_sink.append(&entry);
+                    }
+                }
             }
         }
     }
@@ -615,11 +622,11 @@ mod tests {
         assert!(used <= total, "used should be <= total");
     }
 
-    #[test]
-    fn collect_metrics_returns_complete_entry() {
+    #[tokio::test]
+    async fn collect_metrics_returns_complete_entry() {
         let mut tracker = CpuTracker::new();
         let sources = MetricsSources::new(PathBuf::from("/proc/stat"), None);
-        let entry = collect_metrics(&mut tracker, &sources, 0);
+        let entry = collect_metrics(&mut tracker, &sources, 0).await;
         assert!(!entry.ts.is_empty());
         assert!((0.0..=100.0).contains(&entry.cpu));
         assert!((0.0..=100.0).contains(&entry.cpu_steal_percent));
@@ -627,11 +634,11 @@ mod tests {
         assert!(entry.disk_total > 0);
     }
 
-    #[test]
-    fn collect_metrics_serializes_to_valid_jsonl() {
+    #[tokio::test]
+    async fn collect_metrics_serializes_to_valid_jsonl() {
         let mut tracker = CpuTracker::new();
         let sources = MetricsSources::new(PathBuf::from("/proc/stat"), None);
-        let entry = collect_metrics(&mut tracker, &sources, 0);
+        let entry = collect_metrics(&mut tracker, &sources, 0).await;
         let json = serde_json::to_string(&entry).unwrap();
         // Verify it round-trips through the same path metrics_loop uses.
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();

--- a/crates/guest-agent/src/workload_containment.rs
+++ b/crates/guest-agent/src/workload_containment.rs
@@ -17,7 +17,10 @@ use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::os::unix::process::CommandExt;
 use std::path::{Component, Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::Mutex;
 
 use guest_contracts::diagnostics::WorkloadResourceLimitDiagnostic;
 use guest_contracts::process_containment::{
@@ -40,7 +43,14 @@ pub struct WorkloadContainment {
     placement: Arc<OwnedFd>,
     workload_path: Arc<PathBuf>,
     tool_placement_endpoint: Arc<str>,
-    evidence_stream: Arc<Mutex<Option<UnixStream>>>,
+    evidence_stream: Arc<Mutex<Option<EvidenceStream>>>,
+}
+
+/// Bootstrap completes before Tokio exists; register the socket on first capture.
+#[derive(Debug)]
+enum EvidenceStream {
+    Bootstrap(UnixStream),
+    Registered(tokio::net::UnixStream),
 }
 
 /// Read-only paths used to sample control and workload CPU accounting.
@@ -76,32 +86,51 @@ pub struct WorkloadResourceDiagnostics {
 
 impl WorkloadContainment {
     /// Read root-owned evidence over the existing authenticated bootstrap.
-    /// IO failures permanently close this exchange; cleanup retains its own
-    /// root-owned capture path and execution outcomes are unaffected.
-    pub fn oom_evidence(
+    /// I/O failures and cancellation permanently close this exchange; cleanup
+    /// retains its own root-owned capture path and execution outcomes are unaffected.
+    /// Concurrent captures skip rather than queue behind an outstanding exchange.
+    pub async fn oom_evidence(
         &self,
         reason: guest_contracts::oom_evidence::CaptureReason,
     ) -> Option<guest_contracts::oom_evidence::OomEvidence> {
-        use guest_contracts::oom_evidence::{CaptureReason, EVIDENCE_IO_TIMEOUT, read_evidence};
-        use std::io::Write;
+        use guest_contracts::oom_evidence::{
+            CaptureReason, EVIDENCE_IO_TIMEOUT, MAX_EVIDENCE_BYTES, decode_evidence,
+        };
+
         let mut owner = self.evidence_stream.try_lock().ok()?;
-        let mut stream = owner.take()?;
+        // Restore only a complete exchange. Dropping this future closes the socket
+        // so a partial response can never be mistaken for the next capture.
+        let mut stream = match owner.take()? {
+            EvidenceStream::Bootstrap(stream) => {
+                stream.set_nonblocking(true).ok()?;
+                tokio::net::UnixStream::from_std(stream).ok()?
+            }
+            EvidenceStream::Registered(stream) => stream,
+        };
         let request = match reason {
             CaptureReason::CliError => 2,
             _ => 1,
         };
-        let result = (|| {
-            stream.set_write_timeout(Some(EVIDENCE_IO_TIMEOUT))?;
-            stream.write_all(&[request])?;
-            read_evidence(&stream)
-        })();
-        match result {
-            Ok(evidence) => {
-                *owner = Some(stream);
-                Some(evidence)
+        tokio::time::timeout(EVIDENCE_IO_TIMEOUT, stream.write_all(&[request]))
+            .await
+            .ok()?
+            .ok()?;
+        let evidence = tokio::time::timeout(EVIDENCE_IO_TIMEOUT, async {
+            let mut header = [0; 4];
+            stream.read_exact(&mut header).await?;
+            let length = u32::from_be_bytes(header) as usize;
+            if length > MAX_EVIDENCE_BYTES {
+                return Err(io::Error::other("evidence response exceeds byte limit"));
             }
-            Err(_) => None,
-        }
+            let mut bytes = vec![0; length];
+            stream.read_exact(&mut bytes).await?;
+            decode_evidence(&bytes)
+        })
+        .await
+        .ok()?
+        .ok()?;
+        *owner = Some(EvidenceStream::Registered(stream));
+        Some(evidence)
     }
     /// Receive and adopt the production bootstrap descriptor.
     ///
@@ -225,7 +254,7 @@ impl WorkloadContainment {
         let placement = process_control_ipc::receive_workload_placement(&stream)?;
         let mut containment = Self::adopt(placement, tool_endpoint)?;
         process_control_ipc::write_workload_placement_confirmation(&stream)?;
-        containment.evidence_stream = Arc::new(Mutex::new(Some(stream)));
+        containment.evidence_stream = Arc::new(Mutex::new(Some(EvidenceStream::Bootstrap(stream))));
         Ok(containment)
     }
 
@@ -440,6 +469,9 @@ fn write_self_to_cgroup(fd: RawFd) -> io::Result<()> {
         return Err(io::Error::from_raw_os_error(libc::EIO));
     }
 }
+
+#[cfg(test)]
+mod evidence_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/guest-agent/src/workload_containment/evidence_tests.rs
+++ b/crates/guest-agent/src/workload_containment/evidence_tests.rs
@@ -1,0 +1,341 @@
+use super::*;
+use guest_contracts::oom_evidence::{
+    CaptureReason, EVIDENCE_IO_TIMEOUT, MAX_EVIDENCE_BYTES, MAX_INCIDENTS, MAX_KERNEL_EVENTS,
+    OomEvidence,
+};
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+use tokio::net::UnixStream as AsyncUnixStream;
+
+fn containment_pair() -> (WorkloadContainment, UnixStream) {
+    let (client, peer) = UnixStream::pair().unwrap();
+    // Only bootstrap/cgroup setup is synthetic; captures use the production API
+    // and real socket framing, ownership, deadlines, and cancellation.
+    let containment = WorkloadContainment {
+        placement: Arc::new(tempfile::tempfile().unwrap().into()),
+        workload_path: Arc::new(PathBuf::from("/unused")),
+        tool_placement_endpoint: Arc::from("test-tool-endpoint"),
+        evidence_stream: Arc::new(Mutex::new(Some(EvidenceStream::Bootstrap(client)))),
+    };
+    (containment, peer)
+}
+
+fn async_peer(peer: UnixStream) -> AsyncUnixStream {
+    peer.set_nonblocking(true).unwrap();
+    AsyncUnixStream::from_std(peer).unwrap()
+}
+
+fn fixture() -> OomEvidence {
+    serde_json::from_str(include_str!(
+        "../../../guest-contracts/tests/fixtures/oom-evidence-v1.json"
+    ))
+    .unwrap()
+}
+
+fn frame(bytes: &[u8]) -> Vec<u8> {
+    let mut frame = (bytes.len() as u32).to_be_bytes().to_vec();
+    frame.extend_from_slice(bytes);
+    frame
+}
+
+// Keep the paused clock from auto-advancing past socket readiness that the
+// kernel has not delivered to Tokio yet. The bound catches a missing I/O event.
+async fn ready_io<F: Future>(future: F) -> F::Output {
+    tokio::select! {
+        result = future => result,
+        _ = async {
+            for _ in 0..1_000 {
+                tokio::task::yield_now().await;
+            }
+        } => panic!("expected socket I/O did not become ready"),
+    }
+}
+
+async fn expect_request<F: Future>(capture: Pin<&mut F>, peer: &mut AsyncUnixStream, request: u8) {
+    ready_io(async {
+        tokio::select! {
+            _ = capture => panic!("capture finished before the peer could respond"),
+            received = peer.read_u8() => assert_eq!(received.unwrap(), request),
+        }
+    })
+    .await;
+}
+
+async fn expect_disconnect(peer: &mut AsyncUnixStream) {
+    let result = tokio::time::timeout(Duration::from_secs(1), peer.read(&mut [0]))
+        .await
+        .expect("cancelled or failed exchange must close its socket");
+    assert!(
+        matches!(result, Ok(0))
+            || matches!(result, Err(error) if error.kind() == io::ErrorKind::ConnectionReset)
+    );
+}
+
+#[test]
+fn evidence_registers_after_bootstrap_and_keeps_async_progress() {
+    let (containment, peer) = containment_pair();
+    // Production receives the authenticated bootstrap before runtime creation.
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .start_paused(true)
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let mut peer = async_peer(peer);
+        let evidence = fixture();
+        let response = frame(&serde_json::to_vec(&evidence).unwrap());
+        for (reason, request) in [(CaptureReason::Sample, 1), (CaptureReason::CliError, 2)] {
+            let mut capture = Box::pin(containment.oom_evidence(reason));
+            expect_request(capture.as_mut(), &mut peer, request).await;
+
+            // The response stays unavailable until an unrelated async timer runs
+            // on the sole worker. No wall-clock performance threshold is involved.
+            tokio::select! {
+                _ = capture.as_mut() => panic!("evidence completed while the response was held"),
+                _ = tokio::time::sleep(Duration::from_millis(20)) => {}
+            }
+            assert!(
+                containment
+                    .clone()
+                    .oom_evidence(CaptureReason::Sample)
+                    .await
+                    .is_none()
+            );
+            assert_eq!(
+                peer.try_read(&mut [0]).unwrap_err().kind(),
+                io::ErrorKind::WouldBlock
+            );
+
+            ready_io(peer.write_all(&response)).await.unwrap();
+            assert_eq!(ready_io(capture).await, Some(evidence.clone()));
+        }
+    });
+}
+
+#[tokio::test(start_paused = true)]
+async fn evidence_silent_peer_times_out_and_permanently_closes() {
+    let (containment, peer) = containment_pair();
+    let mut peer = async_peer(peer);
+    let mut capture = Box::pin(containment.oom_evidence(CaptureReason::Sample));
+    expect_request(capture.as_mut(), &mut peer, 1).await;
+    let started = tokio::time::Instant::now();
+    assert!(capture.await.is_none());
+    assert_eq!(started.elapsed(), EVIDENCE_IO_TIMEOUT);
+    expect_disconnect(&mut peer).await;
+    assert!(
+        containment
+            .oom_evidence(CaptureReason::CliError)
+            .await
+            .is_none()
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn evidence_request_write_has_a_bounded_deadline() {
+    let (containment, peer) = containment_pair();
+    {
+        let mut owner = containment.evidence_stream.try_lock().unwrap();
+        let Some(EvidenceStream::Bootstrap(stream)) = owner.as_mut() else {
+            panic!("fixture must hold an unregistered bootstrap stream");
+        };
+        stream.set_nonblocking(true).unwrap();
+        // Fill the real socket before capture so even its one-byte request waits.
+        loop {
+            match std::io::Write::write(stream, b"x") {
+                Ok(1) => {}
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => break,
+                result => panic!("unexpected socket fill result: {result:?}"),
+            }
+        }
+        stream.set_nonblocking(false).unwrap();
+    }
+    let started = tokio::time::Instant::now();
+    assert!(
+        containment
+            .oom_evidence(CaptureReason::Sample)
+            .await
+            .is_none()
+    );
+    assert_eq!(started.elapsed(), EVIDENCE_IO_TIMEOUT);
+    assert!(
+        containment
+            .oom_evidence(CaptureReason::CliError)
+            .await
+            .is_none()
+    );
+    let mut peer = async_peer(peer);
+    let mut received = Vec::new();
+    peer.read_to_end(&mut received).await.unwrap();
+    assert!(!received.is_empty());
+    assert!(received.iter().all(|byte| *byte == b'x'));
+}
+
+#[tokio::test(start_paused = true)]
+async fn evidence_header_and_body_share_one_deadline() {
+    let (containment, peer) = containment_pair();
+    let mut peer = async_peer(peer);
+    let mut capture = Box::pin(containment.oom_evidence(CaptureReason::Sample));
+    expect_request(capture.as_mut(), &mut peer, 1).await;
+    let started = tokio::time::Instant::now();
+    tokio::select! {
+        _ = capture.as_mut() => panic!("capture ended before its deadline"),
+        _ = tokio::time::sleep(EVIDENCE_IO_TIMEOUT / 2) => {}
+    }
+    ready_io(peer.write_all(&10u32.to_be_bytes()))
+        .await
+        .unwrap();
+    ready_io(peer.write_all(b"{")).await.unwrap();
+    assert!(capture.await.is_none());
+    assert_eq!(started.elapsed(), EVIDENCE_IO_TIMEOUT);
+    expect_disconnect(&mut peer).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn evidence_cancellation_closes_silent_and_partial_responses() {
+    for partial in [Vec::new(), vec![0], vec![0, 0, 0, 10, b'{']] {
+        let (containment, peer) = containment_pair();
+        let mut peer = async_peer(peer);
+        let mut capture = Box::pin(containment.oom_evidence(CaptureReason::CliError));
+        expect_request(capture.as_mut(), &mut peer, 2).await;
+        ready_io(peer.write_all(&partial)).await.unwrap();
+        tokio::select! {
+            _ = capture.as_mut() => panic!("partial response unexpectedly completed"),
+            _ = tokio::time::sleep(Duration::from_millis(1)) => {}
+        }
+        drop(capture);
+        expect_disconnect(&mut peer).await;
+        assert!(
+            containment
+                .oom_evidence(CaptureReason::Sample)
+                .await
+                .is_none()
+        );
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn evidence_rejects_invalid_frames_and_closes_the_connection() {
+    let mut too_many_incidents = fixture();
+    too_many_incidents.incidents = vec![too_many_incidents.incidents[0].clone(); MAX_INCIDENTS + 1];
+    let mut too_many_events = fixture();
+    too_many_events.incidents[0].kernel_events =
+        vec![too_many_events.incidents[0].kernel_events[0].clone(); MAX_KERNEL_EVENTS + 1];
+    for response in [
+        ((MAX_EVIDENCE_BYTES + 1) as u32).to_be_bytes().to_vec(),
+        frame(b"invalid json"),
+        frame(&serde_json::to_vec(&too_many_incidents).unwrap()),
+        frame(&serde_json::to_vec(&too_many_events).unwrap()),
+    ] {
+        let (containment, peer) = containment_pair();
+        let mut peer = async_peer(peer);
+        let mut capture = Box::pin(containment.oom_evidence(CaptureReason::Sample));
+        expect_request(capture.as_mut(), &mut peer, 1).await;
+        ready_io(peer.write_all(&response)).await.unwrap();
+        assert!(ready_io(capture).await.is_none());
+        expect_disconnect(&mut peer).await;
+        assert!(
+            containment
+                .oom_evidence(CaptureReason::Sample)
+                .await
+                .is_none()
+        );
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn evidence_accepts_a_fragmented_response_within_the_deadline() {
+    let (containment, peer) = containment_pair();
+    let mut peer = async_peer(peer);
+    let evidence = fixture();
+    let mut capture = Box::pin(containment.oom_evidence(CaptureReason::Sample));
+    expect_request(capture.as_mut(), &mut peer, 1).await;
+    let response = frame(&serde_json::to_vec(&evidence).unwrap());
+    let mut chunks = response.chunks(512).peekable();
+    while let Some(chunk) = chunks.next() {
+        ready_io(peer.write_all(chunk)).await.unwrap();
+        if chunks.peek().is_some() {
+            tokio::select! {
+                _ = capture.as_mut() => panic!("fragmented response completed before its last chunk"),
+                _ = tokio::time::sleep(Duration::from_millis(1)) => {}
+            }
+        }
+    }
+    assert_eq!(ready_io(capture).await, Some(evidence));
+}
+
+#[tokio::test(start_paused = true)]
+async fn metrics_records_evidence_and_cancels_an_outstanding_capture() {
+    let (containment, peer) = containment_pair();
+    let mut peer = async_peer(peer);
+    let temp = tempfile::tempdir().unwrap();
+    let paths = crate::paths::GuestPaths::from_runtime_dir(temp.path().join("runtime"));
+    let telemetry = crate::telemetry::Telemetry::spawn_for_paths(
+        "evidence-metrics".into(),
+        &paths,
+        Arc::new(crate::masker::SecretMasker::from_raw("")),
+        crate::http::HttpClient::new().unwrap(),
+    );
+    let sources = crate::metrics::MetricsSources::new(PathBuf::from("/proc/stat"), None)
+        .with_evidence(containment.clone(), telemetry.incident_reporter());
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let mut metrics = Box::pin(crate::metrics::metrics_loop_for_path(
+        shutdown.clone(),
+        paths.metrics_log_file().into(),
+        sources,
+    ));
+    expect_request(metrics.as_mut(), &mut peer, 1).await;
+    let evidence = fixture();
+    ready_io(peer.write_all(&frame(&serde_json::to_vec(&evidence).unwrap())))
+        .await
+        .unwrap();
+    // Observe the completed JSONL append before advancing to the next tick.
+    ready_io(async {
+        tokio::select! {
+            _ = metrics.as_mut() => panic!("metrics stopped before shutdown"),
+            _ = async {
+                while !Path::new(paths.metrics_log_file()).exists() {
+                    tokio::task::yield_now().await;
+                }
+            } => {}
+        }
+    })
+    .await;
+    tokio::time::advance(Duration::from_secs(5)).await;
+    expect_request(metrics.as_mut(), &mut peer, 1).await;
+    let contents = fs::read_to_string(paths.metrics_log_file()).unwrap();
+    let entries: Vec<serde_json::Value> = contents
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(entries.len(), 1);
+    let mut snapshot = evidence.clone();
+    snapshot.incidents.clear();
+    assert_eq!(
+        entries[0]["memory"],
+        serde_json::to_value(snapshot).unwrap()
+    );
+
+    let cancelled_at = tokio::time::Instant::now();
+    shutdown.cancel();
+    metrics.await;
+    assert_eq!(cancelled_at.elapsed(), Duration::ZERO);
+    expect_disconnect(&mut peer).await;
+    assert!(
+        containment
+            .oom_evidence(CaptureReason::CliError)
+            .await
+            .is_none()
+    );
+    telemetry.shutdown().await;
+    let retained =
+        fs::read_to_string(format!("{}.oom-evidence.json", paths.metrics_log_file())).unwrap();
+    assert_eq!(
+        serde_json::from_str::<OomEvidence>(&retained).unwrap(),
+        evidence
+    );
+    assert_eq!(
+        fs::read_to_string(paths.metrics_log_file()).unwrap(),
+        contents
+    );
+}

--- a/crates/guest-agent/src/workload_containment/evidence_tests.rs
+++ b/crates/guest-agent/src/workload_containment/evidence_tests.rs
@@ -63,9 +63,9 @@ async fn expect_request<F: Future>(capture: Pin<&mut F>, peer: &mut AsyncUnixStr
 }
 
 async fn expect_disconnect(peer: &mut AsyncUnixStream) {
-    let result = tokio::time::timeout(Duration::from_secs(1), peer.read(&mut [0]))
-        .await
-        .expect("cancelled or failed exchange must close its socket");
+    // The paused clock can expire a timeout before Tokio observes the close.
+    // Use the same bounded I/O readiness wait as the request and response checks.
+    let result = ready_io(peer.read(&mut [0])).await;
     assert!(
         matches!(result, Ok(0))
             || matches!(result, Err(error) if error.kind() == io::ErrorKind::ConnectionReset)

--- a/crates/guest-contracts/src/oom_evidence.rs
+++ b/crates/guest-contracts/src/oom_evidence.rs
@@ -292,7 +292,15 @@ pub fn read_evidence(stream: &UnixStream) -> io::Result<OomEvidence> {
     }
     let mut bytes = vec![0; length];
     read_exact_until(stream, &mut bytes, deadline)?;
-    let evidence: OomEvidence = serde_json::from_slice(&bytes)?;
+    decode_evidence(&bytes)
+}
+
+/// Decode a response body with the same byte and count limits for every transport.
+pub fn decode_evidence(bytes: &[u8]) -> io::Result<OomEvidence> {
+    if bytes.len() > MAX_EVIDENCE_BYTES {
+        return Err(io::Error::other("evidence response exceeds byte limit"));
+    }
+    let evidence: OomEvidence = serde_json::from_slice(bytes)?;
     if evidence.incidents.len() > MAX_INCIDENTS
         || evidence
             .incidents


### PR DESCRIPTION
## Summary

Slow authenticated OOM evidence responses occupy a Tokio worker during periodic metrics collection and post-CLI capture. Await both exchanges through a lazily registered Tokio UnixStream, with one capture in flight and no queued or detached blocking work.

Take ownership of the stream before awaiting and restore it only after a valid response. Timeout, decoding failure, or cancellation closes it permanently, preventing a partial response from being reused. Metrics shutdown can cancel an outstanding capture before final telemetry flushing. Keep the existing request/read budgets and share byte/count validation with the synchronous protocol reader.

Use the same bounded I/O readiness wait for test disconnect checks as for requests and responses. This prevents the paused Tokio clock from expiring the disconnect assertion before the reactor observes socket closure, addressing the [intermittent coverage failure](https://github.com/vm0-ai/vm0/actions/runs/34562807394/job/103148876218) while preserving the EOF/reset assertion and production deadlines.

Closes #33316.

## Validation

All commands use `--manifest-path crates/Cargo.toml --profile local --locked` unless noted:

- `cargo test -p guest-agent -p guest-contracts --lib --bins`
- `cargo test -p guest-agent --test integration metrics` — 6 passed.
- `cargo test -p guest-control-server --lib oom_evidence` — 17 passed, including authenticated peer cancellation and capture before root cleanup removes sources.
- `cargo test -p guest-agent --lib workload_containment::evidence_tests` — 8 passed. The same compiled suite passed 100 consecutive runs (800 cases), covering async progress, successful/repeated and fragmented responses, contention, invalid frames, write/read deadlines, cancellation/disconnect, and metrics output/incident retention.
- Affected-package `cargo fmt -- --check`, `git diff --check`, and `cargo clippy -p guest-agent -p guest-contracts --all-targets --all-features`.
- `cargo doc -p guest-agent -p guest-contracts --all-features --no-deps`.

## Compatibility and scope

Authentication and descriptor handoff still finish before runtime creation. Request bytes, JSON wire format, evidence limits, root-owned cleanup, and API payloads remain unchanged. Cancellation intentionally discards optional client evidence; root cleanup retains its independent capture path. No privileged VM/cgroup bootstrap or production latency measurement was run locally.
