### PR TITLE
docs(runner): clarify preassigned pi session ids

### DIFF
--- a/crates/runner/src/executor/diagnostics/guest_files.rs
+++ b/crates/runner/src/executor/diagnostics/guest_files.rs
@@ -72,9 +72,9 @@ pub(in crate::executor) async fn read_guest_failure_diagnostic_file(
 /// Read the CLI-generated session ID from the guest filesystem.
 ///
 /// The guest-agent writes the session ID to the guest runtime directory
-/// after the CLI emits its `system/init` event. On first runs (no
-/// `resume_session`), the runner uses this as the late-discovered identity
-/// for session tracking and finalization.
+/// when the CLI reports it. When the execution context supplies no session ID,
+/// the runner uses this as the late-discovered identity for session tracking
+/// and finalization. Preassigned Pi session IDs skip this discovery path.
 pub(in crate::executor) async fn read_guest_cli_agent_session_id(
     sandbox: &dyn Sandbox,
     run_id: RunId,

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -1711,7 +1711,7 @@ pub(super) async fn execute_prepared_sandbox_run_with_process_cancel_timeouts(
             SandboxReuseDisposition::Ineligible(SandboxReuseRejection::PostJobCleanupFailure);
     }
 
-    // Read the CLI-generated session ID after a first-run execution.
+    // Read the CLI-generated session ID after execution only when no ID was supplied.
     let discovered_cli_agent_session_id = if context.cli_agent_session_id().is_none() {
         let id = read_guest_cli_agent_session_id(sandbox.as_ref(), context.run_id)
             .await

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1543,9 +1543,13 @@ impl ExecutionContext {
 
     /// Extract the framework-native session id.
     ///
-    /// Returns `Some` for continued sessions. For first runs this returns
-    /// `None`; the executor reads the CLI-generated session id from the
-    /// guest filesystem post-execution (see `read_guest_cli_agent_session_id`).
+    /// Prefers `pi_session_id`, otherwise returns the resume-session id.
+    /// Pi session ids are preassigned, including on first runs without a
+    /// `resume_session`, so `Some` does not imply a continued session.
+    ///
+    /// Returns `None` only when neither source supplies an id. In that case,
+    /// the executor reads the CLI-generated session id from the guest filesystem
+    /// post-execution (see `read_guest_cli_agent_session_id`).
     pub fn cli_agent_session_id(&self) -> Option<&str> {
         self.pi_session_id.as_deref().or_else(|| {
             self.resume_session
@@ -1892,6 +1896,11 @@ mod tests {
 
         assert_eq!(
             context.pi_session_id.as_deref(),
+            Some("22222222-2222-4222-8222-222222222222")
+        );
+        assert!(context.resume_session.is_none());
+        assert_eq!(
+            context.cli_agent_session_id(),
             Some("22222222-2222-4222-8222-222222222222")
         );
         assert_eq!(
@@ -2307,7 +2316,7 @@ mod tests {
     }
 
     #[test]
-    fn cli_agent_session_id_returns_none_without_resume() {
+    fn cli_agent_session_id_returns_none_without_supplied_id() {
         let json = json!({
             "runId": "550e8400-e29b-41d4-a716-446655440000",
             "prompt": "hello",


### PR DESCRIPTION
Pi receives a preassigned session ID even on its first run, but the runner documentation described every first run as having no ID until guest discovery. Document the actual precedence and discovery condition in the helper and its caller/read function.

Extend the existing first-turn Pi fixture to assert that the helper returns its supplied ID without resume data, and rename the no-ID test to describe its premise. Production behavior is unchanged.

Closes #33311.

Validation passed:

- `cargo fmt --manifest-path crates/runner/Cargo.toml -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --locked --profile local -p runner --bin runner --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml --locked --profile local -p runner --all-features --no-deps`
- `git diff --check`

Local validation limitation: `cargo test --manifest-path crates/Cargo.toml --locked --profile local -p runner --bin runner types::tests::` and Clippy with `--all-targets --all-features` could not complete. With `CARGO_BUILD_JOBS=1`, their runner test-target compiler reached about 3.7 GB RSS in the 4 GB sandbox and was explicitly stopped (SIGTERM) to restore available memory. No test result was produced. Runner test execution and test-target lint validation remain for CI.
