### PR TITLE
perf(guest-storage-apply): reuse operation-owned archive workers

### DIFF
--- a/crates/guest-storage-apply/src/download.rs
+++ b/crates/guest-storage-apply/src/download.rs
@@ -10,7 +10,7 @@ use std::collections::VecDeque;
 use std::fs;
 use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc;
+use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -248,13 +248,11 @@ impl DownloadScheduler {
             .min()
     }
 
-    fn start_ready_attempts<'scope, 'env: 'scope>(
+    fn start_ready_attempts(
         &mut self,
-        scope: &'scope thread::Scope<'scope, 'env>,
-        completion_tx: &mpsc::Sender<DownloadCompletion>,
-        attempt_runner: AttemptRunner,
+        work_tx: &mpsc::SyncSender<StartedDownload>,
         telemetry: &mut DownloadRunTelemetry,
-    ) {
+    ) -> bool {
         while self.active_attempts < MAX_CONCURRENT {
             let now = Instant::now();
             let retry = self
@@ -297,21 +295,13 @@ impl DownloadScheduler {
                 }
             };
 
-            let completion_tx = completion_tx.clone();
-            scope.spawn(move || {
-                let mut download = download;
-                let outcome =
-                    std::panic::catch_unwind(AssertUnwindSafe(|| attempt_runner(&mut download)))
-                        .map(AttemptOutcome::Finished)
-                        .unwrap_or_else(|e| AttemptOutcome::Panicked(panic_message(e.as_ref())));
-                let _ = completion_tx.send(DownloadCompletion {
-                    download,
-                    completed_at: Instant::now(),
-                    outcome,
-                });
-            });
+            if work_tx.send(download).is_err() {
+                log_error!(LOG_TAG, "Download scheduler worker channel closed");
+                return false;
+            }
             self.active_attempts += 1;
         }
+        true
     }
 
     fn record_completion(&mut self, mut completion: DownloadCompletion) {
@@ -386,10 +376,49 @@ fn download_all_parallel_with_runner(
 
     let success = thread::scope(|scope| {
         let (completion_tx, completion_rx) = mpsc::channel();
+        // Admission counts queued and running attempts together, so this queue
+        // cannot add work beyond the existing four-attempt bound. The sender is
+        // local to this scope's closure: every return closes it before joining.
+        let (work_tx, work_rx) = mpsc::sync_channel::<StartedDownload>(MAX_CONCURRENT);
+        let work_rx = Arc::new(Mutex::new(work_rx));
+        for _ in 0..pending.len().min(MAX_CONCURRENT) {
+            let work_rx = Arc::clone(&work_rx);
+            let completion_tx = completion_tx.clone();
+            scope.spawn(move || {
+                loop {
+                    // Only receiving is serialized; extraction and panic
+                    // handling never hold the receiver lock.
+                    let work = match work_rx.lock() {
+                        Ok(receiver) => receiver.recv(),
+                        Err(_) => {
+                            log_error!(LOG_TAG, "Download worker receiver lock poisoned");
+                            break;
+                        }
+                    };
+                    let Ok(mut download) = work else {
+                        break;
+                    };
+                    let outcome = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                        attempt_runner(&mut download)
+                    }))
+                    .map(AttemptOutcome::Finished)
+                    .unwrap_or_else(|e| AttemptOutcome::Panicked(panic_message(e.as_ref())));
+                    let _ = completion_tx.send(DownloadCompletion {
+                        download,
+                        completed_at: Instant::now(),
+                        outcome,
+                    });
+                }
+            });
+        }
+        drop(work_rx);
+        drop(completion_tx);
         let mut scheduler = DownloadScheduler::new(pending);
 
         while scheduler.has_work() {
-            scheduler.start_ready_attempts(scope, &completion_tx, attempt_runner, &mut telemetry);
+            if !scheduler.start_ready_attempts(&work_tx, &mut telemetry) {
+                return false;
+            }
 
             if !scheduler.can_make_progress() {
                 log_error!(LOG_TAG, "Download scheduler cannot make progress");
@@ -637,43 +666,51 @@ mod tests {
     }
 
     #[test]
-    fn task_panic_returns_false_without_unwinding() {
+    fn task_panic_releases_reservation_and_pending_tasks_finish() {
         guest_telemetry::log::clear_system_log_file();
+        let directory = tempfile::tempdir().unwrap();
 
         fn runner(download: &mut StartedDownload) -> Result<(), DownloadError> {
             if download.task.task.url == "panic" {
                 panic!("expected panic");
             }
-            Ok(())
+            fs::write(
+                download
+                    .task
+                    .effective_mount_path()
+                    .join(&download.task.task.url),
+                &download.task.task.url,
+            )
+            .map_err(|error| DownloadError::fatal(error.to_string()))
         }
 
-        let result = std::panic::catch_unwind(|| {
-            download_all_parallel_with_runner(
-                vec![
-                    PreparedDownloadTask {
-                        task: DownloadTask::storage(
-                            "panic".to_owned(),
-                            "panic".to_owned(),
-                            "/tmp/panic".to_owned(),
-                            false,
-                        ),
-                        effective_mount_path: PathBuf::from("/tmp/panic"),
+        // All tasks conflict, so the panic must release its reservation before
+        // any of the more-than-four remaining tasks can produce their files.
+        let tasks = (0..10)
+            .map(|index| PreparedDownloadTask {
+                task: DownloadTask::storage(
+                    format!("task-{index}"),
+                    if index == 0 {
+                        "panic".to_owned()
+                    } else {
+                        format!("file-{index}")
                     },
-                    PreparedDownloadTask {
-                        task: DownloadTask::storage(
-                            "success".to_owned(),
-                            "success".to_owned(),
-                            "/tmp/success".to_owned(),
-                            false,
-                        ),
-                        effective_mount_path: PathBuf::from("/tmp/success"),
-                    },
-                ],
-                runner,
-            )
-        });
+                    directory.path().to_str().unwrap().to_owned(),
+                    false,
+                ),
+                effective_mount_path: directory.path().to_owned(),
+            })
+            .collect();
+        let result = std::panic::catch_unwind(|| download_all_parallel_with_runner(tasks, runner));
 
         assert!(matches!(result, Ok(false)));
+        for index in 1..10 {
+            let name = format!("file-{index}");
+            assert_eq!(
+                fs::read_to_string(directory.path().join(&name)).unwrap(),
+                name
+            );
+        }
     }
 
     #[test]

--- a/crates/guest-storage-apply/tests/integration/file_scheme.rs
+++ b/crates/guest-storage-apply/tests/integration/file_scheme.rs
@@ -34,6 +34,40 @@ fn file_scheme_extraction_success() {
     assert!(staged.exists());
 }
 
+#[test]
+fn failed_parent_archive_does_not_skip_pending_children() {
+    let dir = tempfile::tempdir().unwrap();
+    let parent = dir.path().join("parent");
+    let staged = dir.path().join("valid.tar.gz");
+    let archive = create_tar_gz(&[("value.txt", b"required child contents")]).unwrap();
+    std::fs::write(&staged, &archive).unwrap();
+    let mut mounts = vec![json!({
+        "mountPath": parent,
+        "archiveUrl": format!("file://{}", dir.path().join("missing.tar.gz").display())
+    })];
+    for index in 0..9 {
+        mounts.push(json!({
+            "mountPath": parent.join(format!("child-{index}")),
+            "archiveUrl": format!("file://{}", staged.display())
+        }));
+    }
+    let manifest = dir.path().join("manifest.json");
+    std::fs::write(
+        &manifest,
+        serde_json::to_vec(&json!({"storageMounts": mounts})).unwrap(),
+    )
+    .unwrap();
+
+    assert!(!run_guest_storage_apply(manifest.to_str().unwrap()));
+    for index in 0..9 {
+        assert_eq!(
+            std::fs::read(parent.join(format!("child-{index}/value.txt"))).unwrap(),
+            b"required child contents"
+        );
+    }
+    assert_eq!(std::fs::read(staged).unwrap(), archive);
+}
+
 // Security regression: file:// archives use the same extraction path as HTTP,
 // but this is the production path for runner-staged storage cache tarballs.
 #[test]

--- a/crates/guest-storage-apply/tests/integration/scheduling.rs
+++ b/crates/guest-storage-apply/tests/integration/scheduling.rs
@@ -693,6 +693,65 @@ fn queued_independent_download_starts_when_slot_frees() {
     }
 }
 
+#[cfg(unix)]
+#[test]
+fn termination_with_active_and_pending_downloads_reaps_the_helper() {
+    for cancel_by_drop in [false, true] {
+        let dir = tempfile::tempdir().unwrap();
+        let (event_tx, event_rx) = mpsc::channel();
+        let release = ReleaseGate::new();
+        let observations = RequestObservations::new();
+        let numbered = create_numbered_storages(
+            &dir,
+            &event_tx,
+            |_| Some(release.waiter()),
+            observations.clone(),
+        )
+        .unwrap();
+        let execution = spawn_guest_storage_apply(
+            stringify!(termination_with_active_and_pending_downloads_reaps_the_helper),
+            &dir,
+            &numbered.storages,
+        )
+        .unwrap();
+        let child_id = execution.id().unwrap();
+        let started = wait_for_events(&event_rx, 4, REQUEST_START_TIMEOUT).unwrap();
+        assert_eq!(started.len(), 4);
+        assert_eq!(observations.active(), 4);
+
+        if cancel_by_drop {
+            drop(execution);
+        } else {
+            let error = execution
+                .wait_for_completion(
+                    stringify!(termination_with_active_and_pending_downloads_reaps_the_helper),
+                    Duration::ZERO,
+                    &release,
+                    &observations,
+                )
+                .unwrap_err();
+            assert!(error.contains("guest-storage-apply timed out"), "{error}");
+            assert!(error.contains("reap=completed with"), "{error}");
+        }
+        release.close();
+        observations
+            .wait_until_idle(RESPONDER_CLEANUP_TIMEOUT)
+            .unwrap();
+
+        process::verify_child_reaped(child_id).unwrap();
+        assert_eq!(observations.active(), 0);
+        assert_eq!(observations.max_active(), 4);
+        assert!(event_rx.try_iter().next().is_none());
+        for index in 0..5 {
+            assert!(
+                !dir.path()
+                    .join(format!("mount_{index}/file_{index}.txt"))
+                    .exists()
+            );
+        }
+    }
+}
+
 #[test]
 fn download_concurrency_cap_limits_initial_starts() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Closes #33380. Parent context: #24203. Related research: #33094.

Reuse up to four scoped workers for one storage-helper invocation instead of
creating a thread for every archive attempt. The existing scheduler still owns
admission, retry deadlines and logical/canonical mount reservations. The bounded
work queue counts toward the unchanged four-active-attempt limit. Extraction
does not hold the receiver lock; panic completion and sibling progress remain
intact. Channel endpoints close before scoped joins; broken channels fail.

Add regressions for pending conflicting work after panic/failure and termination
with four active requests plus pending work.

## Native validation

[Full results, artifacts and retained preflight failure](https://github.com/vm0-ai/vm0/issues/33380#issuecomment-5628708607).
64 counterbalanced first-use/concurrent operations on local-11; all 32 matched
operation comparisons favor reuse. Eight observations per cell, nearest-rank p50:

| Scenario | Baseline | Workers |
| --- | ---: | ---: |
| Fresh VM, 117 archives | 94.4 ms | 79.7 ms |
| Fresh VM, 129 mixed-size archives | 121.8 ms | 104.7 ms |
| Two concurrent VMs, 117 archives per operation | 109.0 ms | 92.5 ms |
| Two concurrent VMs, 129 archives per operation | 138.3 ms | 120.4 ms |

All outputs/metadata and cleanup verified; 189 candidate tests passed natively.
Baseline/candidate timeout controls verified peer disconnect, helper/cgroup
cleanup and same-VM recovery. Owner-abandonment controls verified VM retirement
and synthetic-source closure/join; no claim that killing a VM guarantees TCP FIN.
All 70 owned VMs were cleaned up; shared Runner services were unchanged.

## Risks and limits

- Worker/channel ownership, retry-slot release and conflict ordering are the
  main correctness risks; existing and expanded tests cover these paths.
- Mean contained peak grows ~0.04–0.05 MiB for 117 archives and ~0.23–0.29 MiB
  for the mixed fixture, while mean helper CPU falls ~31–36%.
- Frozen Firecracker 1.15.1 / kernel 6.1.155 / surrounding Guest artifacts:
  these storage-only results do not measure main's newer 6.18.44 kernel,
  full api_to_spawn, or fleet p99. Retain the 232-ms baseline outlier.
- No persistent/cross-run pool, experiment flag, dependency, concurrency
  increase, format/cache/protocol change, relative paths, bundling or Guest pull.
  HTTP/HTTPS downloads remain unchanged. No deployment or merge.

## Checks

- `cargo test --locked --profile local -j4 -p guest-storage-apply --all-targets -- --test-threads=4`: 189 passed.
- `cargo fmt --check`.
- `cargo clippy --locked --profile local -j4 -p guest-storage-apply --all-targets -- -D warnings`.
- `cargo clippy --locked --profile local -j4 --all-targets --all-features`.
- `cargo doc --locked --profile local -j4 --workspace --all-features --no-deps`.
- Optimized ci helper builds: x86_64-unknown-linux-musl and aarch64-unknown-linux-musl.
- Native harness build/Clippy, Python syntax and complete raw-result/resource-join checks.
- All commit hooks passed; CI is reported separately for the submitted head.
