### PR TITLE
fix(voice): recover completion-body provider failures

### DIFF
--- a/turbo/apps/api/src/signals/external/openrouter-voice.ts
+++ b/turbo/apps/api/src/signals/external/openrouter-voice.ts
@@ -12,7 +12,11 @@ import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { OpenRouterRequestError, type OpenRouterTextPart } from "./openrouter";
 import { readBoundedResponseText, safeJsonParse } from "../utils";
-import { requestVoiceProvider } from "./voice-provider-request";
+import {
+  isRetryableVoiceProviderStatus,
+  requestVoiceProvider,
+  VoiceProviderTemporaryResponseError,
+} from "./voice-provider-request";
 
 const L = logger("OpenRouterVoice");
 
@@ -264,21 +268,60 @@ function requestError(
   });
 }
 
-function parseCompletionText(value: unknown): string {
+function completionError(
+  value: unknown,
+  context: { readonly model: string; readonly responseSchema: string },
+): Error {
+  const code = objectProperty(value, "code");
+  const status =
+    typeof code === "number" &&
+    Number.isInteger(code) &&
+    code >= 400 &&
+    code < 600
+      ? code
+      : undefined;
+  const errorType = providerErrorType(value);
+  const rawType = objectProperty(
+    objectProperty(value, "metadata"),
+    "error_type",
+  );
+  // A permanent or unknown typed error must not become retryable merely
+  // because its lossy numeric code resembles a temporary failure.
+  if (
+    status !== undefined &&
+    isRetryableVoiceProviderStatus(status) &&
+    (rawType === undefined ||
+      errorType === "rate_limit_exceeded" ||
+      errorType === "provider_overloaded" ||
+      errorType === "provider_unavailable" ||
+      errorType === "server" ||
+      errorType === "timeout")
+  ) {
+    return new VoiceProviderTemporaryResponseError(status, errorType);
+  }
+  L.warn("OpenRouter voice completion rejected", {
+    ...context,
+    source: "completion",
+    status,
+    errorType,
+  });
+  return new Error("OpenRouter voice completion failed");
+}
+
+function parseCompletionText(
+  value: unknown,
+  context: { readonly model: string; readonly responseSchema: string },
+): string {
   const data = value as OpenRouterVoiceResponse;
   const choice = data.choices?.[0];
+  if (data.error !== undefined) {
+    throw completionError(data.error, context);
+  }
   if (!choice) {
-    if (data.error !== undefined) {
-      throw requestError("OpenRouter voice request failed", 502, data);
-    }
     throw new Error("OpenRouter voice response contained no choices");
   }
   if (choice.finish_reason === "error") {
-    throw requestError(
-      "OpenRouter voice completion failed",
-      502,
-      choice.error ?? data.error,
-    );
+    throw completionError(choice.error, context);
   }
   if (choice.finish_reason !== "stop") {
     const nativeReason =
@@ -372,6 +415,7 @@ async function generateStructuredVoiceResponse<T>(
         L.warn("OpenRouter voice request rejected", {
           model: args.model,
           responseSchema: args.jsonSchema.name,
+          source: "http",
           status: error.status,
           errorType: error.errorType,
         });
@@ -381,7 +425,10 @@ async function generateStructuredVoiceResponse<T>(
         throw new Error("OpenRouter voice response was not valid JSON");
       }
 
-      const content = parseCompletionText(parsedBody);
+      const content = parseCompletionText(parsedBody, {
+        model: args.model,
+        responseSchema: args.jsonSchema.name,
+      });
       const generated = args.schema.safeParse(safeJsonParse(content));
       if (!generated.success) {
         throw new Error(

--- a/turbo/apps/api/src/signals/external/voice-input-transcription.ts
+++ b/turbo/apps/api/src/signals/external/voice-input-transcription.ts
@@ -3,6 +3,7 @@ import { VOICE_IO_POLISH_MAX_TEXT_CHARS } from "@okouai/api-contracts/contracts/
 import { z } from "zod";
 
 import { env, optionalEnv } from "../../lib/env";
+import { logger } from "../../lib/log";
 import { readBoundedResponseText, safeJsonParse } from "../utils";
 import type { OpenRouterVoiceAudio } from "./openrouter-voice";
 import { requestVoiceProvider } from "./voice-provider-request";
@@ -14,12 +15,7 @@ const transcriptionSchema = z.object({
   text: z.string().trim().max(VOICE_IO_POLISH_MAX_TEXT_CHARS),
 });
 
-export class VoiceTranscriptionRequestError extends Error {
-  constructor(readonly status: number) {
-    super("Voice transcription provider rejected the request");
-    this.name = "VoiceTranscriptionRequestError";
-  }
-}
+const L = logger("VoiceTranscription");
 
 export function isVoiceTranscriptionConfigured(
   model: TranscriptionModel,
@@ -71,7 +67,13 @@ export async function transcribeVoiceInputAudio(
     async (response) => {
       if (!response.ok) {
         await response.body?.cancel();
-        throw new VoiceTranscriptionRequestError(response.status);
+        L.warn("Voice transcription provider rejected the request", {
+          provider: elevenLabs ? "fal" : "openrouter",
+          model: model.id,
+          source: "http",
+          status: response.status,
+        });
+        throw new Error("Voice transcription provider rejected the request");
       }
       const body = await readBoundedResponseText(response, MAX_RESPONSE_BYTES);
       signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/external/voice-provider-request.ts
+++ b/turbo/apps/api/src/signals/external/voice-provider-request.ts
@@ -2,7 +2,7 @@ import { delay } from "signal-timers";
 
 import { logger } from "../../lib/log";
 import { now } from "../../lib/time";
-import { onRejection } from "../utils";
+import { onRejection, settle } from "../utils";
 
 const L = logger("VoiceProvider");
 const MAX_ATTEMPTS = 3;
@@ -24,7 +24,17 @@ export class VoiceProviderUnavailableError extends Error {
   }
 }
 
-function isRetryableStatus(status: number): boolean {
+export class VoiceProviderTemporaryResponseError extends Error {
+  constructor(
+    readonly status: number,
+    readonly errorType: string | undefined,
+  ) {
+    super("Voice provider returned a temporary completion error");
+    this.name = "VoiceProviderTemporaryResponseError";
+  }
+}
+
+export function isRetryableVoiceProviderStatus(status: number): boolean {
   return (
     status === 429 ||
     status === 500 ||
@@ -47,20 +57,26 @@ function retryAfterMs(value: string | null): number | undefined {
     : undefined;
 }
 
+interface ProviderFailure {
+  readonly status: number;
+  readonly source: "http" | "completion";
+  readonly errorType?: string;
+}
+
 function exhausted(
   context: VoiceProviderContext,
-  status: number,
+  failure: ProviderFailure,
   attempts: number,
 ): VoiceProviderUnavailableError {
   L.warn("Voice provider recovery exhausted", {
     ...context,
-    status,
+    ...failure,
     attempts,
   });
-  return new VoiceProviderUnavailableError(status);
+  return new VoiceProviderUnavailableError(failure.status);
 }
 
-/** Retry only explicit temporary HTTP failures, at the failed provider step. */
+/** Recover classified temporary failures at the failed provider step. */
 export async function requestVoiceProvider<T>(
   request: (signal: AbortSignal) => Promise<Response>,
   readResponse: (response: Response) => Promise<T>,
@@ -70,48 +86,68 @@ export async function requestVoiceProvider<T>(
   signal.throwIfAborted();
   let response = await request(signal);
   signal.throwIfAborted();
-  const deadline = now() + RECOVERY_BUDGET_MS;
+  let deadline: number | undefined;
   let attempts = 1;
   let responseSignal = signal;
-  let status = response.status;
+  let failure: ProviderFailure = { status: response.status, source: "http" };
   const checkSignal = () => {
     signal.throwIfAborted();
-    if (attempts > 1 && (responseSignal.aborted || now() >= deadline)) {
-      throw exhausted(context, status, attempts);
+    if (
+      deadline !== undefined &&
+      (responseSignal.aborted || now() >= deadline)
+    ) {
+      throw exhausted(context, failure, attempts);
     }
   };
-  while (isRetryableStatus(response.status)) {
-    status = response.status;
+  while (true) {
+    if (isRetryableVoiceProviderStatus(response.status)) {
+      failure = { status: response.status, source: "http" };
+    } else {
+      const result = await onRejection(
+        settle(readResponse(response), signal),
+        checkSignal,
+      );
+      checkSignal();
+      if (result.ok) {
+        if (response.ok && attempts > 1) {
+          L.debug("Voice provider request recovered", { ...context, attempts });
+        }
+        return result.value;
+      }
+      if (!(result.error instanceof VoiceProviderTemporaryResponseError)) {
+        throw result.error;
+      }
+      failure = {
+        status: result.error.status,
+        source: "completion",
+        errorType: result.error.errorType,
+      };
+    }
+    deadline ??= now() + RECOVERY_BUDGET_MS;
     const wait = Math.max(
       INITIAL_BACKOFF_MS * 2 ** (attempts - 1),
       retryAfterMs(response.headers.get("Retry-After")) ?? 0,
     );
-    await onRejection(
-      response.body?.cancel() ?? Promise.resolve(),
-      checkSignal,
-    );
+    if (!response.bodyUsed) {
+      await onRejection(
+        response.body?.cancel() ?? Promise.resolve(),
+        checkSignal,
+      );
+    }
     checkSignal();
     // A provider's long retry delay is not permission to retry earlier.
     if (attempts >= MAX_ATTEMPTS || wait >= deadline - now()) {
-      throw exhausted(context, status, attempts);
+      throw exhausted(context, failure, attempts);
     }
     await delay(wait, { signal });
     signal.throwIfAborted();
     const remaining = deadline - now();
     if (remaining <= 0) {
-      throw exhausted(context, status, attempts);
+      throw exhausted(context, failure, attempts);
     }
     responseSignal = AbortSignal.any([signal, AbortSignal.timeout(remaining)]);
     attempts += 1;
     response = await onRejection(request(responseSignal), checkSignal);
     checkSignal();
   }
-  // Keep body consumption inside the recovery deadline and report success only
-  // after the provider response has passed the caller's validation.
-  const result = await onRejection(readResponse(response), checkSignal);
-  checkSignal();
-  if (response.ok && attempts > 1) {
-    L.debug("Voice provider request recovered", { ...context, attempts });
-  }
-  return result;
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
@@ -1374,9 +1374,53 @@ describe("voice provider capacity recovery", () => {
     context.mocks.signalTimers.delay.mockResolvedValue(undefined);
   });
 
-  it.each([429, 503])(
-    "recovers HTTP %i without error signals and counts the recording once",
-    async (status) => {
+  it.each([
+    {
+      name: "HTTP 429",
+      failure: () => {
+        return new HttpResponse(null, { status: 429 });
+      },
+    },
+    {
+      name: "HTTP 503",
+      failure: () => {
+        return new HttpResponse(null, { status: 503 });
+      },
+    },
+    {
+      name: "HTTP 200 with a top-level capacity error",
+      failure: () => {
+        return HttpResponse.json({
+          error: { code: 429, metadata: { error_type: "rate_limit_exceeded" } },
+        });
+      },
+    },
+    {
+      name: "HTTP 200 with an explicit code and no typed metadata",
+      failure: () => {
+        return HttpResponse.json({ error: { code: 503 } });
+      },
+    },
+    {
+      name: "HTTP 200 with a failed completion and partial output",
+      failure: () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "error",
+              error: {
+                code: 502,
+                metadata: { error_type: "provider_unavailable" },
+              },
+              message: { content: "Partial output must not be used" },
+            },
+          ],
+        });
+      },
+    },
+  ])(
+    "recovers $name without error signals and counts the recording once",
+    async ({ failure }) => {
       const actor = await enabledActor();
       if (!actor.orgId) {
         throw new Error("Expected an organization");
@@ -1390,9 +1434,7 @@ describe("voice provider capacity recovery", () => {
       server.use(
         http.post(OPENROUTER_URL, async ({ request }) => {
           requests.push(await request.text());
-          return requests.length === 1
-            ? new HttpResponse(null, { status })
-            : recoveredVoiceResponse();
+          return requests.length === 1 ? failure() : recoveredVoiceResponse();
         }),
       );
       const headers = { authorization: "Bearer clerk-session" };
@@ -1417,6 +1459,89 @@ describe("voice provider capacity recovery", () => {
       );
     },
   );
+
+  it("shares the attempt budget across HTTP and completion failures", async () => {
+    await enabledActor();
+    let attempts = 0;
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        attempts += 1;
+        if (attempts === 1) {
+          return new HttpResponse(null, { status: 503 });
+        }
+        return attempts <= 3
+          ? HttpResponse.json({
+              error: {
+                code: 429,
+                message: "private provider details",
+                metadata: {
+                  error_type: "rate_limit_exceeded",
+                  raw: "private audio context",
+                },
+              },
+            })
+          : recoveredVoiceResponse();
+      }),
+    );
+    const response = await accept(
+      client().segment({
+        headers: { authorization: "Bearer clerk-session" },
+        body: form([audioFile(1)]),
+      }),
+      [503],
+    );
+    expect(response.body.error.code).toBe("PROVIDER_UNAVAILABLE");
+    expect(attempts).toBe(3);
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledExactlyOnceWith(
+      "Voice provider recovery exhausted",
+      expect.objectContaining({
+        source: "completion",
+        status: 429,
+        errorType: "rate_limit_exceeded",
+        attempts: 3,
+      }),
+    );
+    expect(
+      JSON.stringify(context.mocks.axiomLogging.warn.mock.calls),
+    ).not.toContain("private");
+  });
+
+  it.each([
+    { code: 401, metadata: { error_type: "authentication" } },
+    { code: 502, metadata: { error_type: "authentication" } },
+    { code: 400, metadata: { error_type: "invalid_request" } },
+    { code: 502, metadata: { error_type: "unmapped" } },
+    { code: 502, metadata: { error_type: "unexpected/provider/type" } },
+    { metadata: { error_type: "provider_unavailable" } },
+  ])("keeps non-recoverable body error %j actionable", async (error) => {
+    await enabledActor();
+    let attempts = 0;
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        attempts += 1;
+        return attempts === 1
+          ? HttpResponse.json({ error })
+          : recoveredVoiceResponse();
+      }),
+    );
+    const response = await accept(
+      client().segment({
+        headers: { authorization: "Bearer clerk-session" },
+        body: form([audioFile(1)]),
+      }),
+      [502],
+    );
+    expect(response.body.error.code).toBe("VOICE_TRANSCRIPTION_FAILED");
+    expect(attempts).toBe(1);
+    expect(context.mocks.signalTimers.delay).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledExactlyOnceWith(
+      "OpenRouter voice completion rejected",
+      expect.objectContaining({
+        source: "completion",
+        model: expect.any(String),
+      }),
+    );
+  });
 
   it("ends persistent capacity failures after three attempts with actionable reporting", async () => {
     await enabledActor();
@@ -1587,65 +1712,70 @@ describe("voice provider capacity recovery", () => {
     );
   });
 
-  it("keeps the recovery deadline active while reading a successful response body", async () => {
-    await enabledActor();
-    mockNow(new Date("2026-09-09T08:00:00Z"));
-    const deadline = new AbortController();
-    context.mocks.abortSignal.timeout.mockImplementation((milliseconds) => {
-      return milliseconds === 15_000 ? deadline.signal : undefined;
-    });
-    const reading = createDeferredPromise<void>(context.signal);
-    let attempts = 0;
-    server.use(
-      http.post(OPENROUTER_URL, ({ request }) => {
-        attempts += 1;
-        if (attempts === 1) {
-          return new HttpResponse(null, { status: 429 });
-        }
-        const body = new ReadableStream<Uint8Array>(
-          {
-            start(controller) {
-              request.signal.addEventListener(
-                "abort",
-                () => {
-                  controller.error(
-                    new DOMException("Body aborted", "AbortError"),
-                  );
-                },
-                { once: true },
-              );
+  it.each(["http", "completion"])(
+    "keeps the %s recovery deadline active while reading a response body",
+    async (source) => {
+      await enabledActor();
+      mockNow(new Date("2026-09-09T08:00:00Z"));
+      const deadline = new AbortController();
+      context.mocks.abortSignal.timeout.mockImplementation((milliseconds) => {
+        return milliseconds === 15_000 ? deadline.signal : undefined;
+      });
+      const reading = createDeferredPromise<void>(context.signal);
+      let attempts = 0;
+      server.use(
+        http.post(OPENROUTER_URL, ({ request }) => {
+          attempts += 1;
+          if (attempts === 1) {
+            return source === "http"
+              ? new HttpResponse(null, { status: 429 })
+              : HttpResponse.json({ error: { code: 429 } });
+          }
+          const body = new ReadableStream<Uint8Array>(
+            {
+              start(controller) {
+                request.signal.addEventListener(
+                  "abort",
+                  () => {
+                    controller.error(
+                      new DOMException("Body aborted", "AbortError"),
+                    );
+                  },
+                  { once: true },
+                );
+              },
+              pull() {
+                reading.resolve();
+              },
             },
-            pull() {
-              reading.resolve();
-            },
-          },
-          { highWaterMark: 0 },
-        );
-        return new HttpResponse(body, {
-          headers: { "Content-Type": "application/json" },
-        });
-      }),
-    );
-    const pending = client().segment({
-      headers: { authorization: "Bearer clerk-session" },
-      body: form([audioFile(1)]),
-    });
-    await reading.promise;
-    deadline.abort(
-      new DOMException("Recovery deadline reached", "TimeoutError"),
-    );
-    const response = await accept(pending, [503]);
-    expect(response.body.error.code).toBe("PROVIDER_UNAVAILABLE");
-    expect(attempts).toBe(2);
-    expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalledWith(
-      "Voice provider request recovered",
-      expect.anything(),
-    );
-    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledExactlyOnceWith(
-      "Voice provider recovery exhausted",
-      expect.objectContaining({ status: 429, attempts: 2 }),
-    );
-  });
+            { highWaterMark: 0 },
+          );
+          return new HttpResponse(body, {
+            headers: { "Content-Type": "application/json" },
+          });
+        }),
+      );
+      const pending = client().segment({
+        headers: { authorization: "Bearer clerk-session" },
+        body: form([audioFile(1)]),
+      });
+      await reading.promise;
+      deadline.abort(
+        new DOMException("Recovery deadline reached", "TimeoutError"),
+      );
+      const response = await accept(pending, [503]);
+      expect(response.body.error.code).toBe("PROVIDER_UNAVAILABLE");
+      expect(attempts).toBe(2);
+      expect(context.mocks.axiomLogging.debug).not.toHaveBeenCalledWith(
+        "Voice provider request recovered",
+        expect.anything(),
+      );
+      expect(context.mocks.axiomLogging.warn).toHaveBeenCalledExactlyOnceWith(
+        "Voice provider recovery exhausted",
+        expect.objectContaining({ status: 429, attempts: 2 }),
+      );
+    },
+  );
 
   it("keeps provider authentication errors non-retryable and actionable", async () => {
     await enabledActor();
@@ -1778,55 +1908,60 @@ describe("voice provider capacity recovery", () => {
     },
   );
 
-  it("retries failed polish without repeating successful dedicated ASR", async () => {
-    await enabledActor();
-    const headers = { authorization: "Bearer clerk-session" };
-    await accept(
-      preferencesClient().update({
-        headers,
-        body: { voiceInputModel: "qwen/qwen3-asr-1.7b" },
-      }),
-      [200],
-    );
-    let asrAttempts = 0;
-    let polishAttempts = 0;
-    server.use(
-      http.post("https://openrouter.ai/api/v1/audio/transcriptions", () => {
-        asrAttempts += 1;
-        return asrAttempts === 1
-          ? HttpResponse.json({ text: "Recorded speech." })
-          : new HttpResponse(null, { status: 400 });
-      }),
-      http.post(OPENROUTER_URL, () => {
-        polishAttempts += 1;
-        return polishAttempts === 1
-          ? new HttpResponse(null, { status: 503 })
-          : HttpResponse.json({
-              choices: [
-                {
-                  finish_reason: "stop",
-                  message: {
-                    content: JSON.stringify({
-                      polishedText: "Recorded speech.",
-                      language: "en",
-                    }),
+  it.each(["http", "completion"])(
+    "retries %s polish failures without repeating successful dedicated ASR",
+    async (source) => {
+      await enabledActor();
+      const headers = { authorization: "Bearer clerk-session" };
+      await accept(
+        preferencesClient().update({
+          headers,
+          body: { voiceInputModel: "qwen/qwen3-asr-1.7b" },
+        }),
+        [200],
+      );
+      let asrAttempts = 0;
+      let polishAttempts = 0;
+      server.use(
+        http.post("https://openrouter.ai/api/v1/audio/transcriptions", () => {
+          asrAttempts += 1;
+          return asrAttempts === 1
+            ? HttpResponse.json({ text: "Recorded speech." })
+            : new HttpResponse(null, { status: 400 });
+        }),
+        http.post(OPENROUTER_URL, () => {
+          polishAttempts += 1;
+          return polishAttempts === 1
+            ? source === "http"
+              ? new HttpResponse(null, { status: 503 })
+              : HttpResponse.json({ error: { code: 503 } })
+            : HttpResponse.json({
+                choices: [
+                  {
+                    finish_reason: "stop",
+                    message: {
+                      content: JSON.stringify({
+                        polishedText: "Recorded speech.",
+                        language: "en",
+                      }),
+                    },
                   },
-                },
-              ],
-            });
-      }),
-    );
-    const response = await accept(
-      client().segment({ headers, body: form([audioFile(1)]) }),
-      [200],
-    );
-    expect(response.body).toStrictEqual({
-      transcript: "Recorded speech.",
-      polishedText: "Recorded speech.",
-      language: "en",
-    });
-    expect(asrAttempts).toBe(1);
-    expect(polishAttempts).toBe(2);
-    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
-  });
+                ],
+              });
+        }),
+      );
+      const response = await accept(
+        client().segment({ headers, body: form([audioFile(1)]) }),
+        [200],
+      );
+      expect(response.body).toStrictEqual({
+        transcript: "Recorded speech.",
+        polishedText: "Recorded speech.",
+        language: "en",
+      });
+      expect(asrAttempts).toBe(1);
+      expect(polishAttempts).toBe(2);
+      expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/turbo/apps/api/src/signals/services/voice-io-transcribe.service.ts
+++ b/turbo/apps/api/src/signals/services/voice-io-transcribe.service.ts
@@ -13,10 +13,7 @@ import { command } from "ccstate";
 
 import { notConfigured } from "../../lib/error";
 import { requestSignal$, setResHeader$ } from "../context/hono";
-import {
-  isLlmConfigured,
-  OpenRouterRequestError,
-} from "../external/openrouter";
+import { isLlmConfigured } from "../external/openrouter";
 import {
   OPENROUTER_VOICE_NO_SPEECH,
   polishLongVoiceTranscript,
@@ -28,7 +25,6 @@ import {
 import {
   isVoiceTranscriptionConfigured,
   transcribeVoiceInputAudio,
-  VoiceTranscriptionRequestError,
 } from "../external/voice-input-transcription";
 import { settle } from "../utils";
 import { VoiceProviderUnavailableError } from "../external/voice-provider-request";
@@ -76,17 +72,6 @@ function providerError(error: unknown) {
       503,
       "PROVIDER_UNAVAILABLE",
       "Speech recognition is temporarily busy. Please retry in a moment.",
-    );
-  }
-  if (
-    (error instanceof OpenRouterRequestError ||
-      error instanceof VoiceTranscriptionRequestError) &&
-    (error.status === 429 || error.status >= 500)
-  ) {
-    return transcriptionError(
-      503,
-      "PROVIDER_UNAVAILABLE",
-      "Voice draft transcription is temporarily unavailable",
     );
   }
   return transcriptionError(

--- a/turbo/apps/platform/src/signals/okou-page/composer-voice-input.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-voice-input.ts
@@ -150,9 +150,14 @@ function createVoiceDraftData(draftTarget: string) {
   );
   const capture = createVoiceDraftCaptureSignals();
   const captureError$ = state<unknown>(null);
+  const providerUnavailable$ = state<{
+    readonly recordingId: string;
+    readonly message: string;
+  } | null>(null);
   const state$ = computed(async (get): Promise<ComposerVoiceInputState> => {
     const active = get(capture.capture$);
     const captureError = get(captureError$);
+    const unavailable = get(providerUnavailable$);
     const restored = await settle(get(recording$));
     if (!restored.ok) {
       return {
@@ -167,7 +172,11 @@ function createVoiceDraftData(draftTarget: string) {
       message:
         captureError || restored.value?.sampleCount === 0
           ? voiceDraftStorageFailedMessage()
-          : undefined,
+          : unavailable && unavailable.recordingId === restored.value?.id
+            ? `${unavailable.message} ${i18n.t(($) => {
+                return $.chat.voice.retryReady;
+              })}`
+            : undefined,
     };
   });
   return {
@@ -177,6 +186,7 @@ function createVoiceDraftData(draftTarget: string) {
     restoreRecording$,
     capture,
     captureError$,
+    providerUnavailable$,
     state$,
   };
 }
@@ -190,7 +200,8 @@ function createVoiceDraftTranscription(
   readEditorContext$: Command<VoiceIoEditorContext, []>,
   lastAssistantMessage$: Computed<string | undefined>,
 ) {
-  const { recording$, storageKey$, ownedRecording$ } = data;
+  const { recording$, storageKey$, ownedRecording$, providerUnavailable$ } =
+    data;
   const incremental = createVoiceDraftTranscriptionSignals({
     storageKey$,
     readContext$: command(({ get, set }) => {
@@ -204,6 +215,7 @@ function createVoiceDraftTranscription(
     }),
   });
   const transcribe$ = command(async ({ get, set }, signal: AbortSignal) => {
+    set(providerUnavailable$, null);
     const recording = await get(recording$);
     signal.throwIfAborted();
     if (!recording) {
@@ -211,7 +223,19 @@ function createVoiceDraftTranscription(
     }
     const key = await get(storageKey$);
     signal.throwIfAborted();
-    const text = await set(incremental.transcribe$, signal);
+    const result = await set(incremental.transcribe$, signal);
+    signal.throwIfAborted();
+    if (result === undefined) {
+      return;
+    }
+    if (result.kind === "unavailable") {
+      set(providerUnavailable$, {
+        recordingId: recording.id,
+        message: result.message,
+      });
+      return;
+    }
+    const text = result.text;
     if (text === undefined) {
       return;
     }

--- a/turbo/apps/platform/src/signals/voice-io/voice-draft-transcription-segment.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-draft-transcription-segment.ts
@@ -5,7 +5,7 @@ import {
   type VoiceIoTranscribeSegmentResponse,
 } from "@okouai/api-contracts/contracts/voice-io-transcribe";
 import { accept } from "../../lib/accept.ts";
-import { apiClient$ } from "../api-client.ts";
+import { apiClient$, type ApiClientFactory } from "../api-client.ts";
 import {
   readVoiceDraftRecording,
   readVoiceDraftAudio,
@@ -14,10 +14,13 @@ import {
 } from "../external/voice-draft-store.ts";
 import { voiceDraftSegmentFile } from "./voice-draft-audio.ts";
 
-interface VoiceDraftTranscriptionResult {
-  readonly transcript: string;
-  readonly text?: string;
-}
+type VoiceDraftTranscriptionResult =
+  | {
+      readonly kind: "transcribed";
+      readonly transcript: string;
+      readonly text?: string;
+    }
+  | { readonly kind: "unavailable"; readonly message: string };
 
 type SegmentResult = Computed<
   Promise<VoiceDraftTranscriptionResult | undefined>
@@ -82,6 +85,38 @@ function completedText(
   return response.polishedText;
 }
 
+async function requestSegment(
+  createClient: ApiClientFactory,
+  body: FormData,
+  final: boolean,
+  signal: AbortSignal,
+): Promise<VoiceDraftTranscriptionResult | undefined> {
+  const result = await accept(
+    createClient(voiceIoTranscribeContract).segment({
+      body,
+      fetchOptions: { signal },
+    }),
+    [200, 204, 402, 429, 503],
+    signal,
+  );
+  signal.throwIfAborted();
+  if (result.status === 402 || result.status === 429) {
+    return;
+  }
+  if (result.status === 503) {
+    if (result.body.error.code === "PROVIDER_UNAVAILABLE") {
+      return { kind: "unavailable", message: result.body.error.message };
+    }
+    // Only classified provider unavailability is a recovery outcome.
+    return await accept(Promise.resolve(result), [200], signal);
+  }
+  return {
+    kind: "transcribed",
+    transcript: result.status === 200 ? result.body.transcript : "",
+    text: completedText(final, result.status === 200 ? result.body : undefined),
+  };
+}
+
 /** Each segment owns its request and waits for the preceding checkpoint. */
 export function createVoiceDraftSegmentResult(
   options: SegmentOptions,
@@ -91,85 +126,86 @@ export function createVoiceDraftSegmentResult(
   const final = segment?.final ?? true;
   const segmentEnd = segment?.endSample;
   // eslint-disable-next-line ccstate/no-computed-signal -- migrate this computed away from AbortSignal ownership
-  return computed(async (get) => {
-    const previous = options.previous$
-      ? await get(options.previous$)
-      : { transcript: "" };
-    signal.throwIfAborted();
-    // An exhausted quota stops the rest of the chain until an explicit retry.
-    if (!previous) {
-      return;
-    }
-    const recording = await readVoiceDraftRecording(key);
-    signal.throwIfAborted();
-    if (recording?.id !== recordingId) {
-      throw new Error("Voice recording changed during transcription");
-    }
-    let progress = recording.progress ?? {
-      revision: 0,
-      context: options.context,
-      segments: [],
-    };
-    if (progress.text !== undefined) {
-      return { transcript: previous.transcript, text: progress.text };
-    }
-    const saved = progress.segments.find((item) => {
-      return item.endSample === segmentEnd;
-    });
-    if (saved?.transcript !== undefined) {
-      return {
-        transcript: [previous.transcript, saved.transcript]
-          .filter(Boolean)
-          .join(" "),
+  return computed(
+    async (get): Promise<VoiceDraftTranscriptionResult | undefined> => {
+      const previous = options.previous$
+        ? await get(options.previous$)
+        : { kind: "transcribed" as const, transcript: "" };
+      signal.throwIfAborted();
+      // An exhausted quota stops the rest of the chain until an explicit retry.
+      if (!previous) {
+        return;
+      }
+      if (previous.kind === "unavailable") {
+        return previous;
+      }
+      const recording = await readVoiceDraftRecording(key);
+      signal.throwIfAborted();
+      if (recording?.id !== recordingId) {
+        throw new Error("Voice recording changed during transcription");
+      }
+      let progress = recording.progress ?? {
+        revision: 0,
+        context: options.context,
+        segments: [],
       };
-    }
-    if (!segment && !previous.transcript) {
-      return { transcript: "", text: "" };
-    }
-    if (segment && !saved) {
-      progress = {
+      if (progress.text !== undefined) {
+        return {
+          kind: "transcribed",
+          transcript: previous.transcript,
+          text: progress.text,
+        };
+      }
+      const saved = progress.segments.find((item) => {
+        return item.endSample === segmentEnd;
+      });
+      if (saved?.transcript !== undefined) {
+        return {
+          kind: "transcribed",
+          transcript: [previous.transcript, saved.transcript]
+            .filter(Boolean)
+            .join(" "),
+        };
+      }
+      if (!segment && !previous.transcript) {
+        return { kind: "transcribed", transcript: "", text: "" };
+      }
+      if (segment && !saved) {
+        progress = {
+          ...progress,
+          revision: progress.revision + 1,
+          segments: [...progress.segments, segment],
+        };
+        // Persist the boundary before HTTP so retries use the same audio bytes.
+        await saveVoiceDraftProgress(key, recordingId, progress);
+        signal.throwIfAborted();
+      }
+      const body = await segmentBody(
+        options,
+        progress.context,
+        previous.transcript,
+        signal,
+      );
+      const result = await requestSegment(get(apiClient$), body, final, signal);
+      signal.throwIfAborted();
+      if (!result || result.kind === "unavailable") {
+        return result;
+      }
+      const { transcript, text } = result;
+      await saveVoiceDraftProgress(key, recordingId, {
         ...progress,
         revision: progress.revision + 1,
-        segments: [...progress.segments, segment],
-      };
-      // Persist the boundary before HTTP so retries use the same audio bytes.
-      await saveVoiceDraftProgress(key, recordingId, progress);
+        segments: progress.segments.map((item) => {
+          return item.endSample === segmentEnd ? { ...item, transcript } : item;
+        }),
+        ...(text === undefined ? {} : { text }),
+      });
       signal.throwIfAborted();
-    }
-    const body = await segmentBody(
-      options,
-      progress.context,
-      previous.transcript,
-      signal,
-    );
-    const result = await accept(
-      get(apiClient$)(voiceIoTranscribeContract).segment({
-        body,
-        fetchOptions: { signal },
-      }),
-      [200, 204, 402, 429],
-      signal,
-    );
-    if (result.status === 402 || result.status === 429) {
-      return;
-    }
-    const transcript = result.status === 200 ? result.body.transcript : "";
-    const text = completedText(
-      final,
-      result.status === 200 ? result.body : undefined,
-    );
-    await saveVoiceDraftProgress(key, recordingId, {
-      ...progress,
-      revision: progress.revision + 1,
-      segments: progress.segments.map((item) => {
-        return item.endSample === segmentEnd ? { ...item, transcript } : item;
-      }),
-      ...(text === undefined ? {} : { text }),
-    });
-    signal.throwIfAborted();
-    return {
-      transcript: [previous.transcript, transcript].filter(Boolean).join(" "),
-      ...(text === undefined ? {} : { text }),
-    };
-  });
+      return {
+        kind: "transcribed",
+        transcript: [previous.transcript, transcript].filter(Boolean).join(" "),
+        ...(text === undefined ? {} : { text }),
+      };
+    },
+  );
 }

--- a/turbo/apps/platform/src/signals/voice-io/voice-draft-transcription.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-draft-transcription.ts
@@ -294,7 +294,11 @@ export function createVoiceDraftTranscriptionSignals(
     if (previous) {
       const [outcome] = await previous;
       signal.throwIfAborted();
-      if (outcome?.status === "rejected" || !outcome?.value) {
+      if (
+        outcome?.status === "rejected" ||
+        !outcome?.value ||
+        outcome.value.kind === "unavailable"
+      ) {
         await set(retry$, signal);
         await set(append$, true, signal);
       }
@@ -307,8 +311,10 @@ export function createVoiceDraftTranscriptionSignals(
       }
       return;
     }
-    set(refreshAudioInputQuota$);
-    return result.text;
+    if (result.kind === "transcribed") {
+      set(refreshAudioInputQuota$);
+    }
+    return result;
   });
 
   const cancel$ = command(async ({ get, set }, signal: AbortSignal) => {
@@ -334,9 +340,9 @@ export function createVoiceDraftTranscriptionSignals(
           const [outcome] = await Promise.allSettled([get(result$)]);
           loopSignal.throwIfAborted();
           if (outcome?.status === "fulfilled") {
-            if (outcome.value) {
+            if (outcome.value?.kind === "transcribed") {
               set(refreshAudioInputQuota$);
-            } else {
+            } else if (!outcome.value) {
               await set(openAudioInputQuotaRecovery$, loopSignal);
             }
           }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-draft-hydration.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-draft-hydration.test.tsx
@@ -117,7 +117,9 @@ test.each([
     // Reload recovery is covered separately in chat-capability-voice-input.
     click(await findEnabledButton("Voice input"));
     click(await findEnabledButton("Stop recording"));
-    await screen.findByText("Voice transcription is temporarily unavailable");
+    await screen.findByText("Voice transcription is temporarily unavailable", {
+      exact: false,
+    });
     click(await findEnabledButton("Retry"));
     await retryRequested.promise;
     const retryStatus = screen.getByRole("status");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-incremental.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-incremental.test.tsx
@@ -50,6 +50,7 @@ test("Keep transcription pending until server recovery succeeds without reportin
 
 test("Keep recording after an incremental segment fails and finish in order", async () => {
   const capture = context.mocks.deferred<(samples: Float32Array) => void>();
+  const unavailable = context.mocks.deferred<void>();
   context.mocks.browser.voiceInput({
     rms: 0.1,
     onPcmCapture: capture.resolve,
@@ -60,6 +61,7 @@ test("Keep recording after an incremental segment fails and finish in order", as
   context.mocks.http.post(endpoint, () => {
     requestAttempts += 1;
     if (requestAttempts === 1) {
+      unavailable.resolve();
       return HttpResponse.json(
         {
           error: {
@@ -87,7 +89,7 @@ test("Keep recording after an incremental segment fails and finish in order", as
   click(await findEnabledButton("Voice input"));
   const emit = await capture.promise;
   emit(new Float32Array(60 * 16_000).fill(0.1));
-  await screen.findByText("Segment temporarily unavailable");
+  await unavailable.promise;
   await expect(findEnabledButton("Stop recording")).resolves.toBeVisible();
   emit(new Float32Array(5 * 16_000).fill(0.2));
   click(await findEnabledButton("Stop recording"));
@@ -227,11 +229,12 @@ test("Stop during transcription and finalize the saved prefix without retranscri
   });
 });
 
-test("Preserve audio and actionable reporting after provider recovery is exhausted", async () => {
+test.each([
+  "Speech recognition is temporarily busy. Please retry in a moment.",
+  "Voice draft transcription is temporarily unavailable",
+])("Preserve audio without an application error for %s", async (message) => {
   const sentry = context.mocks.sentry();
   initSentry();
-  const message =
-    "Speech recognition is temporarily busy. Please retry in a moment.";
   context.mocks.browser.voiceInput({ rms: 0.1 });
   installRunChat();
   let available = false;
@@ -264,19 +267,15 @@ test("Preserve audio and actionable reporting after provider recovery is exhaust
   click(await findEnabledButton("Voice input"));
   click(await findEnabledButton("Stop recording"));
   await findEnabledButton("Retry");
-  await expect(screen.findByText(message)).resolves.toBeVisible();
+  await expect(
+    screen.findByText(message, { exact: false }),
+  ).resolves.toBeVisible();
   expect(
-    screen.getByText("Your recording is kept. Retry transcription."),
-  ).toBeVisible();
-  expect(sentry.reports).toContainEqual(
-    expect.objectContaining({
-      type: "exception",
-      error: expect.objectContaining({
-        code: "PROVIDER_UNAVAILABLE",
-        status: 503,
-      }),
+    screen.getByText("Your recording is kept. Retry transcription.", {
+      exact: false,
     }),
-  );
+  ).toBeVisible();
+  expect(sentry.reports).toStrictEqual([]);
   available = true;
   click(await findEnabledButton("Retry"));
   await waitFor(() => {
@@ -285,6 +284,36 @@ test("Preserve audio and actionable reporting after provider recovery is exhaust
     );
   });
   expect(audio[1]).toStrictEqual(audio[0]);
+  expect(sentry.reports).toStrictEqual([]);
+});
+
+test.each([
+  { status: 502, code: "VOICE_TRANSCRIPTION_FAILED" },
+  { status: 503, code: "NOT_CONFIGURED" },
+])("Keep genuine $code failures actionable", async ({ status, code }) => {
+  const sentry = context.mocks.sentry();
+  initSentry();
+  context.mocks.browser.voiceInput({ rms: 0.1 });
+  installRunChat();
+  context.mocks.http.post(endpoint, () => {
+    return HttpResponse.json(
+      { error: { code, message: "Transcription configuration failed" } },
+      { status },
+    );
+  });
+  await setupPage({ context, path: RUN_PATH, featureSwitches: flags });
+  click(await findEnabledButton("Voice input"));
+  click(await findEnabledButton("Stop recording"));
+  await findEnabledButton("Retry");
+  await expect(
+    screen.findByText("Transcription configuration failed"),
+  ).resolves.toBeVisible();
+  expect(sentry.reports).toContainEqual(
+    expect.objectContaining({
+      type: "exception",
+      error: expect.objectContaining({ code, status }),
+    }),
+  );
 });
 
 test("Abort pending transcription when removing a recording after a storage failure, then record again", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-input.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-input.test.tsx
@@ -694,7 +694,7 @@ test.each([
   await transcriptionFailed.promise;
 
   await waitFor(() => {
-    expect(screen.getByText(failure.message)).toBeVisible();
+    expect(screen.getByText(failure.message, { exact: false })).toBeVisible();
   });
   await expect(findButton("Retry")).resolves.toBeEnabled();
   expect(queryButton("Voice input")).toBeNull();


### PR DESCRIPTION
## Summary

- Recover explicit temporary OpenRouter completion-body errors through the existing provider retry loop. HTTP and body failures share three total attempts, Retry-After/backoff and the 15-second recovery budget; failed partial output is never used.
- Reserve `503 PROVIDER_UNAVAILABLE` for classified recovery exhaustion. Log safe failure origin/status/type once on exhaustion; permanent, malformed and unknown errors remain actionable `502 VOICE_TRANSCRIPTION_FAILED` responses.
- Carry expected provider unavailability as a typed browser result. Preserve the recording, completed checkpoints and existing Retry controls without reporting a duplicate Sentry application error. Unrelated failures retain normal reporting.

Relates to #33359. This PR implements the challenged code plan, but does not close the historical API/provider attribution or bounded post-deployment observation gates in that issue.

## Scope and compatibility

No provider/model migration, model fallback, new controls, global error filters, new API fields, database migration or persisted recording/checkpoint changes. Existing HTTP status/code contracts are preserved. The browser recognizes the existing `PROVIDER_UNAVAILABLE` code, independent of either existing message text; no version-specific reader or rollout shim is introduced. The existing voice feature switch is unchanged.

## Fallbacks

- **Surface:** `openrouter-voice.ts:completionError`. When OpenRouter omits its documented optional `error.metadata.error_type`, an explicit native retryable numeric `error.code` is sufficient for bounded recovery. A present permanent, malformed or unknown type does not inherit retryability from a lossy status code. This is external-protocol handling, not a deployment fallback: there is no rollout exposure window or retirement issue. Revisit only if OpenRouter makes typed metadata mandatory; no synthetic status is used. [Provider error contract](https://openrouter.ai/docs/api_reference/errors-and-debugging).

## Validation

From `turbo/`:

- `pnpm -F api exec vitest run src/signals/routes/__tests__/voice-io-transcribe.test.ts src/signals/routes/__tests__/voice-io-polish.test.ts --maxWorkers=1 --silent=passed-only` — 77 tests passed.
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-capability-voice --maxWorkers=1 --silent=passed-only` — 93 tests passed across 11 page-test files.
- `pnpm -F api lint` and `pnpm -F @okouai/app lint` — passed, including type-aware Oxlint and ESLint.
- `TSC_CHECKERS=2 pnpm -F api check-types` and `TSC_CHECKERS=2 pnpm -F @okouai/app check-types` — passed.
- `pnpm knip --workspace apps/api --workspace apps/platform` — passed.
- `node scripts/style-policy.mjs`, Prettier on all changed files and `git diff --check` — passed.
- Commit hooks: full-repository `pnpm knip`, `TSC_CHECKERS=2 pnpm check-types` (14 tasks), formatting, style policy, file-size checks and commitlint — passed.

The initial API type check found an unsynchronized local dependency (`image-dimensions`); `scripts/prepare.sh` completed successfully and the rerun passed. No tracked dependency changes were needed.

## Risks and unverified areas

- Recognized completion-body failures can now incur additional latency/provider cost, bounded by the existing retry policy. Successful dedicated ASR is not repeated when only polishing fails.
- New or unknown provider error shapes deliberately remain actionable instead of being silently retried or hidden.
- Historical production event attribution and real-traffic post-deployment verification remain open in #33359. No production replay, deployment or merge was performed.
