### PR TITLE
fix(host-worker): serve artifacts through a worker custom domain

### DIFF
--- a/turbo/apps/host-worker/wrangler.jsonc
+++ b/turbo/apps/host-worker/wrangler.jsonc
@@ -4,7 +4,7 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-05-13",
   "routes": [
-    { "pattern": "a.okou.io/*", "zone_name": "okou.io" },
+    { "pattern": "a.okou.io", "custom_domain": true },
     {
       "pattern": "*.sites.vm0.io/*",
       "zone_name": "vm0.io",


### PR DESCRIPTION
Configure `a.okou.io` as a Worker Custom Domain instead of a zone Route backed by the R2-managed DNS record. The existing Worker already serves files through R2 bindings, so future deployments should preserve direct Worker ownership of this hostname.

## Deployment blocker

Do not merge or deploy this PR until a migration path that preserves uninterrupted service has been established. The owner requires no production outage. Cloudflare rejects attaching the Custom Domain while the R2-managed CNAME exists: HTTP 409, error 100117, `Hostname 'a.okou.io' already has externally managed DNS records (A, CNAME, etc). Delete them first or try a different hostname.`

Removing the current R2 registration first also removes its managed DNS entry. The documented delete-then-attach sequence therefore introduces a DNS availability window and is not approved under the current no-outage constraint. The [Cloudflare maintainer clarification](https://github.com/cloudflare/workers-sdk/issues/9878#issuecomment-4479240529) states that the DNS override option applies to another Worker's record, not generic external DNS records.

The existing R2 custom domain, CNAME and Worker Route remain unchanged. The attach attempt was rejected without creating a Worker Custom Domain. All required Okou connector permissions are now allowed; this blocker is the Cloudflare domain ownership constraint. Keep the PR in draft while that constraint remains unresolved.

## Validation

- `npx --yes prettier@3.8.1 --check turbo/apps/host-worker/wrangler.jsonc` passed.
- `git diff --check` passed.
- Read-only production inspection confirms that the Worker reads public files through the `PUBLIC_ARTIFACTS_BUCKET` binding.
- After the rejected attach attempt, exact read-back confirmed unchanged DNS, R2 custom-domain and Worker Route definitions, with no Worker Custom Domain created.
- The sample original PNG and resized preview both return HTTP 200 and match their pre-migration SHA-256 hashes; a byte-range request returns HTTP 206 with the expected 32 bytes.
