### PR TITLE
chore(release): add a rollback floor for the computer_use_hosts.client_product drop

### DIFF
--- a/.github/scripts/resolve-production-rollback-target.sh
+++ b/.github/scripts/resolve-production-rollback-target.sh
@@ -10,6 +10,7 @@ readonly OKOU_GOAL_SCHEMA_READER_COMMIT=2c231766e383b651867893852cfb47dcc78af0bd
 readonly OKOU_GOAL_SCHEMA_REPAIR_COMMIT=077a9a644986e13bed4750796f91e55c4a876aad
 readonly OKOU_GOAL_SCHEMA_RELEASE=4a4881bf84cb1d79723fd38c83e00f2215bb1e31
 readonly OKOU_GOAL_RETIREMENT_RELEASE=1f68f182a2457ec3aea52d8063be2bd2d2263abd
+readonly COMPUTER_USE_HOST_CLIENT_PRODUCT_DROP_COMMIT=669d0befc9a181e44e3f1f9e39093efddabcc0f8
 
 fail() {
   echo "::error::$*" >&2
@@ -68,6 +69,14 @@ fi
 if ! git merge-base --is-ancestor "$OKOU_GOAL_SCHEMA_READER_COMMIT" "$TARGET_COMMIT" ||
   ! git merge-base --is-ancestor "$OKOU_GOAL_SCHEMA_REPAIR_COMMIT" "$TARGET_COMMIT"; then
   fail "Target commit lacks the combined S4 Goal schema compatibility boundary. The first verified compatible release is ${OKOU_GOAL_SCHEMA_RELEASE} (API 1.580.0)."
+fi
+
+# Rollback promotes artifacts without restoring schema, so an API target that
+# still declares client_product names a dropped column in every insert,
+# bare select and bare returning.
+if ! git merge-base --is-ancestor \
+  "$COMPUTER_USE_HOST_CLIENT_PRODUCT_DROP_COMMIT" "$TARGET_COMMIT"; then
+  fail "Target commit predates the computer_use_hosts.client_product drop: ${COMPUTER_USE_HOST_CLIENT_PRODUCT_DROP_COMMIT}."
 fi
 
 deployments=$(curl -fsS --get "https://api.vercel.com/v6/deployments" \

--- a/.github/scripts/tests/resolve-production-rollback-target-test.sh
+++ b/.github/scripts/tests/resolve-production-rollback-target-test.sh
@@ -42,6 +42,8 @@ case "${1:-}" in
     elif [ "${3:-}" = "077a9a644986e13bed4750796f91e55c4a876aad" ]; then
       [ "${4:-}" != "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ] &&
         [ "${MOCK_GOAL_SCHEMA_REPAIR_VALID:-1}" = "1" ]
+    elif [ "${3:-}" = "669d0befc9a181e44e3f1f9e39093efddabcc0f8" ]; then
+      [ "${MOCK_CLIENT_PRODUCT_FLOOR_VALID:-1}" = "1" ]
     else
       [ "${MOCK_ANCESTRY_VALID:-1}" = "1" ]
     fi
@@ -219,6 +221,18 @@ for floors in "0 0" "1 0" "0 1"; do
     fail "schema rejection must precede API and Runner artifact resolution"
   fi
 done
+
+# Targets that still declare client_product fail before any artifacts.
+: >"${tmp_dir}/boundaries.log"
+assert_failure "Target commit predates the computer_use_hosts.client_product drop" \
+  run_resolver "${tmp_dir}/client-product-floor.output" MOCK_CLIENT_PRODUCT_FLOOR_VALID=0
+grep -Fq "669d0befc9a181e44e3f1f9e39093efddabcc0f8" "${tmp_dir}/failure.err" ||
+  fail "client_product rejection must identify the drop commit"
+[ ! -s "${tmp_dir}/client-product-floor.output" ] || fail "pre-drop API target must not publish outputs"
+[ ! -s "${tmp_dir}/failure.out" ] || fail "pre-drop API target must not print resolved targets"
+if grep -qE '^(curl|ssh|git (show|rev-list)) ' "${tmp_dir}/boundaries.log"; then
+  fail "client_product rejection must precede API and Runner artifact resolution"
+fi
 
 release_target_script="${tmp_dir}/resolve-release-target.sh"
 ruby -e '

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -557,6 +557,30 @@ Numbered 014 remains a completed historical operation, not a current execution
 path. Both rollback floors remain unchanged; this cleanup authorizes no release,
 rollback, production operation or official resource/workflow disposition.
 
+### Computer Use host client_product rollback floor
+
+The production rollback resolver requires the release/API target to contain
+`669d0befc9a181e44e3f1f9e39093efddabcc0f8`, which removed the
+`computer_use_hosts.client_product` ORM declaration and dropped the physical
+column in migration `1107`. Drizzle builds column lists from the declaration
+rather than from usage, so the declaration removal and the physical contraction
+had to ship in one release. That release is therefore a rollback barrier.
+
+Canonical rollback promotes App, Runner, and API artifacts and does not restore
+an older database schema. Once `1107` has run, an earlier API build still names
+the dropped column in every insert, bare select, and bare returning, failing
+with `42703` and taking out host registration, heartbeat, host stop, and
+host-command claiming until a forward fix. This permanent floor rejects
+pre-drop targets before API or Runner artifact resolution and output
+publication, even while the rollback dashboard still lists those releases.
+
+The first compatible release is the one carrying migration `1107`; record its
+tag here once that release ships. Apply this floor only to the release/API
+target: the independent Runner ancestry, reader, host architecture, and
+release-asset checks are unchanged. The rollback workflow loads the resolver
+from current `main`, so merging the floor constrains future canonical
+executions without a release or test rollback.
+
 ### Usage pack visibility compatibility retirement
 
 `showUsagePack` has an explicit API writer and billing response starting with

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -574,6 +574,12 @@ host-command claiming until a forward fix. This permanent floor rejects
 pre-drop targets before API or Runner artifact resolution and output
 publication, even while the rollback dashboard still lists those releases.
 
+The floor is effective from `main` as soon as it merges, and no tagged release
+satisfied it at that point. Canonical production rollback is therefore
+unavailable by design until the release carrying `1107` is promoted: the
+resolver rejects every target as predating the drop, and recovery in that
+interval is roll-forward. Promoting that release closes the interval.
+
 The first compatible release is the one carrying migration `1107`; record its
 tag here once that release ships. Apply this floor only to the release/API
 target: the independent Runner ancestry, reader, host architecture, and


### PR DESCRIPTION
## Summary

Adds the missing production rollback ancestry floor for the
`computer_use_hosts.client_product` drop.

`669d0befc9a181e44e3f1f9e39093efddabcc0f8` (#32967) removed the ORM declaration
and dropped the physical column in migration `1107` in the same release, because
Drizzle builds column lists from the table declaration rather than from usage.
That makes the release carrying `1107` a **rollback barrier**: canonical
rollback promotes App, Runner, and API artifacts but does not restore an older
database schema. Once `1107` runs, any earlier API build still names the dropped
column in every `INSERT`, bare `SELECT`, and bare `RETURNING`, failing with
`42703` and taking out host registration, heartbeat, host stop, and host-command
claiming until a forward fix.

The resolver already carries floors for exactly this risk class, but none for
`client_product`, so the rollback dashboard still lists pre-drop releases and the
resolver would accept them.

This could not be part of #32967: the floor value is that PR's own squash commit
on `main`, which did not exist before it merged.

## Changes

- `.github/scripts/resolve-production-rollback-target.sh`: add
  `COMPUTER_USE_HOST_CLIENT_PRODUCT_DROP_COMMIT` alongside the existing floor
  constants and enforce it with the same `git merge-base --is-ancestor` shape,
  placed after the Goal schema boundary and before the Vercel deployment query,
  so it fails before API or Runner artifact resolution and before output
  publication.
- `.github/scripts/tests/resolve-production-rollback-target-test.sh`: cover the
  new floor the same way the other five are covered — rejection message, no
  published outputs, no printed targets, and no artifact boundary reached.
- `docs/deployment-compatibility.md`: new section beside the Okou Goal
  retirement rollback floor recording the floor, its commit, and why it exists.

The first compatible release is the one carrying migration `1107`. That release
has not shipped, so no tag is recorded; the doc says to fill it in afterwards
rather than inventing one.

## Scope discipline

- Release/API target floor only. The independent Runner ancestry, reader,
  host-architecture, and release-asset checks are untouched.
- The diff is **insertions only** — all five pre-existing floor constants and
  their enforcement blocks are byte-identical.
- Nothing under `turbo/` changes; `1107` and the `computer_use_hosts` schema are
  untouched.
- Permanent floor: not conditional, feature-switched, or time-limited.

## Verification

- `bash -n` on both scripts.
- `bash .github/scripts/tests/resolve-production-rollback-target-test.sh` passes.
- Negative control: temporarily removing the new enforcement block makes the new
  test case fail (`expected command to fail: Target commit predates the
  computer_use_hosts.client_product drop`), confirming it is a real guard rather
  than a vacuous assertion. Restored and re-run green.
- `prettier --check docs/deployment-compatibility.md` clean.

No release, rollback, or test rollback was performed. The rollback workflow loads
the resolver from current `main`, so this takes effect on merge.

## Release ordering

Must merge **before** the production release carrying migration `1107`.

Closes #33407

🤖 Generated with [Claude Code](https://claude.com/claude-code)
