### PR TITLE
fix(ci): retry interrupted runner binary uploads safely

### DIFF
--- a/.github/scripts/prepare-runner-image.sh
+++ b/.github/scripts/prepare-runner-image.sh
@@ -76,6 +76,7 @@ EXPECTED_BINARY_INPUT_DIGEST="$EXPECTED_BINARY_INPUT_DIGEST" \
   "${SCRIPT_DIR}/runner-binary-cache.sh" fresh-validate >/dev/null
 
 runner_sha=$(jq -r '.runnerSha256' "$FRESH_METADATA_PATH")
+runner_size=$(jq -r '.runnerSizeBytes' "$FRESH_METADATA_PATH")
 guest_sha_json=$(jq -c '.guestSha256' "$FRESH_METADATA_PATH")
 
 prepare_host() {
@@ -177,10 +178,49 @@ REMOTE_SCRIPT
     return 1
   fi
 
-  local tmp_runner="${BIN_DIR}/runner.${head_sha}.${host_index}.tmp"
-  if ! ssh "$remote" sudo install -m 755 /dev/stdin "${tmp_runner}" < "$RUNNER_PATH"; then
-    return 1
-  fi
+  local tmp_runner upload_attempt upload_status upload_started upload_elapsed
+  local tmp_template="${BIN_DIR}/runner.${head_sha}.${host_index}.tmp.XXXXXX"
+  for upload_attempt in 1 2; do
+    # A failed SSH client can leave a remote writer alive. Never let a retry
+    # share its candidate with that writer; existing job-directory cleanup owns
+    # abandoned candidates, which are never eligible for publication.
+    if tmp_runner=$(ssh "$remote" bash -s -- "$tmp_template" <<'REMOTE_SCRIPT'
+set -euo pipefail
+sudo mktemp "$1"
+REMOTE_SCRIPT
+    ); then
+      :
+    else
+      upload_status=$?
+      echo "runner upload candidate allocation failed: host=${host} attempt=${upload_attempt}/2 status=${upload_status}" >&2
+      return "$upload_status"
+    fi
+
+    upload_started=$SECONDS
+    echo "runner upload started: host=${host} attempt=${upload_attempt}/2 expected_bytes=${runner_size} candidate=${tmp_runner}"
+    # Bound only the binary stream (not GC/build or global SSH behavior). Two
+    # stalled uploads still fit within the unchanged 20-minute image job budget.
+    # Reopen stdin on every attempt so the successful candidate gets all bytes.
+    if OKOU_CLOUDFLARE_SSH_OPERATION_TIMEOUT_SECONDS=120 \
+      ssh "$remote" sudo install -m 755 /dev/stdin "${tmp_runner}" < "$RUNNER_PATH"; then
+      echo "runner upload completed: host=${host} attempt=${upload_attempt}/2 elapsed_seconds=$((SECONDS - upload_started))"
+      break
+    else
+      upload_status=$?
+    fi
+
+    upload_elapsed=$((SECONDS - upload_started))
+    echo "runner upload failed: host=${host} attempt=${upload_attempt}/2 status=${upload_status} elapsed_seconds=${upload_elapsed} expected_bytes=${runner_size} candidate=${tmp_runner}" >&2
+    case "$upload_status" in
+      124|141|255) ;; # Operation timeout, broken pipe, or SSH transport failure.
+      *) return "$upload_status" ;;
+    esac
+    if [ "$upload_attempt" -eq 2 ]; then
+      return "$upload_status"
+    fi
+    echo "retrying runner upload on ${host} in 5s with a fresh candidate" >&2
+    sleep 5
+  done
 
   if ! ssh "$remote" bash -s -- "${tmp_runner}" "${BIN_DIR}/runner" "${runner_sha}" <<'REMOTE_SCRIPT'
 set -euo pipefail

--- a/.github/scripts/tests/prepare-runner-image-test.sh
+++ b/.github/scripts/tests/prepare-runner-image-test.sh
@@ -138,7 +138,11 @@ grep -q "missing required env: RUNNER_PATH" "${TMPDIR}/missing-runner.err" || fa
 . "${SCRIPT_DIR}/runner-binary-build/contract.env"
 runner_guest_binaries_load
 runner="${TMPDIR}/runner"
-printf 'prepared runner fixture\n' > "$runner"
+cat > "$runner" <<'BASH'
+#!/usr/bin/env bash
+[ "${1:-}" = --version ] || exit 2
+echo runner-fixture
+BASH
 runner_sha=$(sha256sum "$runner" | awk '{print $1}')
 runner_size=$(stat -c '%s' "$runner")
 input_digest=$(printf 'a%.0s' {1..64})
@@ -214,7 +218,16 @@ if [ "$#" -eq 2 ] && [ "$1" = "uname" ] && [ "$2" = "-m" ]; then
 fi
 
 if [ "${1:-}" = "bash" ] && [ "${2:-}" = "-s" ]; then
-  if [[ "${4:-}" = *.tmp ]]; then
+  if [[ "${4:-}" = *.XXXXXX ]]; then
+    # Map the remote filesystem into the fixture, retaining the real allocator.
+    bash -s -- "${SSH_UPLOAD_DIR}/${4##*/}"
+    exit 0
+  fi
+  if [[ "${4:-}" = *.tmp.* ]]; then
+    if [ -n "${SSH_UPLOAD_STATUSES:-}" ]; then
+      # Execute the production checksum/executable validation and publication.
+      "$@"
+    fi
     exit 0
   fi
 
@@ -227,6 +240,32 @@ if [ "${1:-}" = "bash" ] && [ "${2:-}" = "-s" ]; then
 fi
 
 if [ "${1:-}" = "sudo" ] && [ "${2:-}" = "install" ]; then
+  if [ -n "${SSH_UPLOAD_STATUSES:-}" ]; then
+    upload_attempt=$(( $(< "$SSH_UPLOAD_COUNT_FILE") + 1 ))
+    printf '%s\n' "$upload_attempt" > "$SSH_UPLOAD_COUNT_FILE"
+    IFS=',' read -r -a upload_statuses <<< "$SSH_UPLOAD_STATUSES"
+    if [ "$upload_attempt" -gt "${#upload_statuses[@]}" ]; then
+      echo "unexpected upload attempt ${upload_attempt}" >&2
+      exit 1
+    fi
+    candidate=${*: -1}
+    status=${upload_statuses[$((upload_attempt - 1))]}
+    if [ "$status" -ne 0 ]; then
+      head -c 4 > "$candidate"
+      printf '%s\n' "$candidate" > "${SSH_UPLOAD_DIR}/failed-candidate"
+      echo "fixture transfer interrupted" >&2
+      exit "$status"
+    fi
+
+    install -m 755 /dev/stdin "$candidate"
+    if [ "${SSH_UPLOAD_CORRUPT:-}" = 1 ]; then
+      printf 'corrupt bytes\n' > "$candidate"
+    fi
+    if [ -f "${SSH_UPLOAD_DIR}/failed-candidate" ]; then
+      # A previous remote writer resumes after the new transfer completes.
+      printf 'late stale bytes\n' > "$(< "${SSH_UPLOAD_DIR}/failed-candidate")"
+    fi
+  fi
   exit 0
 fi
 
@@ -254,10 +293,23 @@ set -euo pipefail
 command=$1
 shift
 case "$command" in
+  sha256sum|mktemp)
+    exec "$command" "$@"
+    ;;
+  mv)
+    [ "$1" = -f ] && [ "$3" = /var/lib/vm0-runner/bin/pr-123/runner ] || exit 1
+    mv -f "$2" "${SSH_UPLOAD_DIR}/runner"
+    ;;
+  "${SSH_UPLOAD_DIR}/"*)
+    exec "$command" "$@"
+    ;;
   systemctl)
     exec systemctl "$@"
     ;;
   rm|mkdir|find)
+    if [ "$command" = rm ] && [[ "${2:-}" = "${SSH_UPLOAD_DIR}/"* ]]; then
+      exec rm "$@"
+    fi
     {
       printf 'mutate %s' "$command"
       printf ' %s' "$@"
@@ -336,11 +388,12 @@ chmod +x "${TMPDIR}/bin/ssh" "${TMPDIR}/bin/sudo" "${TMPDIR}/bin/systemctl"
 
 prepare_remote_case() {
   local case_dir=$1
-  mkdir -p "${case_dir}/state" "${case_dir}/load-state"
+  mkdir -p "${case_dir}/state" "${case_dir}/load-state" "${case_dir}/uploads"
   : > "${case_dir}/ssh.log"
   : > "${case_dir}/systemctl.log"
   : > "${case_dir}/extra-list-rows"
   printf '0\n' > "${case_dir}/gc-count"
+  printf '0\n' > "${case_dir}/upload-count"
 }
 
 set_unit_state() {
@@ -362,6 +415,10 @@ run_remote_case() {
     SSH_GC_COUNT_FILE="${case_dir}/gc-count" \
     SSH_GC_STATUSES="${REMOTE_GC_STATUSES:-}" \
     SSH_REACH_GC="${REMOTE_REACH_GC:-}" \
+    SSH_UPLOAD_DIR="${case_dir}/uploads" \
+    SSH_UPLOAD_COUNT_FILE="${case_dir}/upload-count" \
+    SSH_UPLOAD_STATUSES="${REMOTE_UPLOAD_STATUSES:-}" \
+    SSH_UPLOAD_CORRUPT="${REMOTE_UPLOAD_CORRUPT:-}" \
     SYSTEMCTL_LOG="${case_dir}/systemctl.log" \
     SYSTEMCTL_STATE_DIR="${case_dir}/state" \
     SYSTEMCTL_LOAD_STATE_DIR="${case_dir}/load-state" \
@@ -378,6 +435,7 @@ run_remote_case() {
     RUNNER_PATH="$runner" \
     FRESH_METADATA_PATH="$metadata" \
     EXPECTED_BINARY_INPUT_DIGEST="$input_digest" \
+    MANIFEST_PATH="${case_dir}/manifest.json" \
     "$PREPARE" >"${case_dir}/out" 2>"${case_dir}/err"; then
     fail "expected mocked post-preparation SSH boundary to fail"
   fi
@@ -501,5 +559,56 @@ grep -Fq 'runner GC failed on dev-arm-1 with status 255' "${gc_transport_failure
 if grep -Fqx -- "$setup_command" "${gc_transport_failure_case}/ssh.log"; then
   fail "persistent SSH failure must not continue to runner setup"
 fi
+
+upload_success_case="${TMPDIR}/upload-success"
+prepare_remote_case "$upload_success_case"
+REMOTE_REACH_GC=1 REMOTE_GC_STATUSES=0 REMOTE_UPLOAD_STATUSES=0 \
+  run_remote_case "$upload_success_case"
+cmp "$runner" "${upload_success_case}/uploads/runner" || fail "successful upload must publish the complete executable"
+[ "$(< "${upload_success_case}/upload-count")" -eq 1 ] || fail "healthy upload must run once"
+grep -Fqx -- "$setup_command" "${upload_success_case}/ssh.log" || fail "validated upload must continue to setup"
+grep -Fq 'runner upload completed: host=dev-arm-1 attempt=1/2 elapsed_seconds=' "${upload_success_case}/out" || fail "expected successful upload timing"
+
+for status in 255 124 141; do
+  upload_retry_case="${TMPDIR}/upload-retry-${status}"
+  prepare_remote_case "$upload_retry_case"
+  REMOTE_REACH_GC=1 REMOTE_GC_STATUSES=0 REMOTE_UPLOAD_STATUSES="${status},0" \
+    run_remote_case "$upload_retry_case"
+  [ "$(< "${upload_retry_case}/upload-count")" -eq 2 ] || fail "transient upload failure must retry once"
+  cmp "$runner" "${upload_retry_case}/uploads/runner" || fail "retry must restart input and publish only the complete candidate"
+  failed_candidate=$(< "${upload_retry_case}/uploads/failed-candidate")
+  grep -Fxq 'late stale bytes' "$failed_candidate" || fail "expected a late write to the failed candidate"
+  grep -Fqx -- "$setup_command" "${upload_retry_case}/ssh.log" || fail "recovered upload must continue to setup"
+  [ "$(grep -c '^mutate mkdir ' "${upload_retry_case}/systemctl.log")" -eq 1 ] || fail "upload retry must not repeat destructive preparation"
+  [ "$(< "${upload_retry_case}/gc-count")" -eq 1 ] || fail "upload retry must not repeat GC"
+  grep -Fq "runner upload failed: host=dev-arm-1 attempt=1/2 status=${status} elapsed_seconds=" "${upload_retry_case}/out" || fail "expected original upload status and timing"
+  grep -Fq "expected_bytes=${runner_size}" "${upload_retry_case}/out" || fail "expected upload size diagnostic"
+  grep -Fq 'fixture transfer interrupted' "${upload_retry_case}/out" || fail "expected original upload stderr"
+done
+
+for statuses in 255,255 7 130 137 143; do
+  upload_failure_case="${TMPDIR}/upload-failure-${statuses}"
+  prepare_remote_case "$upload_failure_case"
+  REMOTE_REACH_GC=1 REMOTE_UPLOAD_STATUSES="$statuses" \
+    run_remote_case "$upload_failure_case"
+  expected_attempts=1
+  if [ "$statuses" = 255,255 ]; then expected_attempts=2; fi
+  [ "$(< "${upload_failure_case}/upload-count")" -eq "$expected_attempts" ] || fail "upload failures must respect retry and cancellation boundaries"
+  [ ! -e "${upload_failure_case}/uploads/runner" ] || fail "failed upload must not publish an executable"
+  [ ! -e "${upload_failure_case}/manifest.json" ] || fail "failed upload must not publish a manifest"
+  [ "$(< "${upload_failure_case}/gc-count")" -eq 0 ] || fail "failed upload must not reach GC"
+  grep -Fq "attempt=${expected_attempts}/2 status=${statuses##*,}" "${upload_failure_case}/out" || fail "expected terminal upload status"
+done
+
+upload_corrupt_case="${TMPDIR}/upload-corrupt"
+prepare_remote_case "$upload_corrupt_case"
+REMOTE_REACH_GC=1 REMOTE_UPLOAD_STATUSES=0 REMOTE_UPLOAD_CORRUPT=1 \
+  run_remote_case "$upload_corrupt_case"
+grep -Fq 'runner sha mismatch' "${upload_corrupt_case}/out" || fail "successful SSH must not bypass checksum validation"
+[ "$(< "${upload_corrupt_case}/upload-count")" -eq 1 ] || fail "checksum failure must not retry upload"
+[ ! -e "${upload_corrupt_case}/uploads/runner" ] || fail "corrupt upload must not publish an executable"
+[ -z "$(find "${upload_corrupt_case}/uploads" -type f -name 'runner.*')" ] || fail "verification failure must clean up its candidate"
+[ ! -e "${upload_corrupt_case}/manifest.json" ] || fail "corrupt upload must not publish a manifest"
+[ "$(< "${upload_corrupt_case}/gc-count")" -eq 0 ] || fail "corrupt upload must not reach GC"
 
 echo "prepare-runner-image-test: ok"


### PR DESCRIPTION
## Summary

- Recover recognized transient Runner executable upload failures with at most two attempts, five seconds apart, using an independently allocated remote temporary file for each attempt.
- Record the host, attempt, expected bytes, candidate path, elapsed time, and original exit status while retaining SSH stderr. Apply a 120-second operation budget only to the upload through the existing SSH wrapper.
- Keep checksum verification, executable validation, and atomic publication. Ordinary command errors, cancellation/kill statuses, and validation failures remain fatal; do not replay cleanup, GC, setup, or the whole image build.

Closes #33410

## Evidence and scope

In [the failed ARM64 producer](https://github.com/vm0-ai/vm0/actions/runs/34555530623/job/103127471117), CI validated a 48,468,504-byte Runner executable but read-only host inspection found only 4,063,232 bytes in its upload candidate. No final executable or subsequent checksum command existed. The downstream manifest wait failed because this producer failed, not because its wait budget expired.

The original transport exit status and underlying interruption cause are unknown. This PR repairs missing bounded recovery and diagnostics; it does not claim a confirmed Cloudflare outage or kernel regression. No kernel, production API/protocol, UI, manifest schema, global SSH retry, or workflow timeout changes.

## Recovery and risks

- Only upload statuses 255 (SSH failure), 124 (operation timeout), and 141 (broken pipe) get one retry. The existing SSH wrapper still owns pre-operation probes/reconnection and single-shot command execution.
- Fresh candidates prevent a late remote writer from a failed attempt corrupting a successful retry. Abandoned candidates stay unpublished under the existing job-directory cleanup policy; checksum/executable validation failures still clean up their selected candidate.
- An exceptionally slow transfer can hit the shorter upload-only budget. A retry adds one transfer and a five-second delay; healthy uploads add only one candidate-allocation SSH operation. Existing probe/recovery time is separate from the stream budget. Permanent SSH failures can also report 255 and therefore receive at most one extra attempt.

## Validation

Passed locally:

```text
bash -n .github/scripts/prepare-runner-image.sh
bash -n .github/scripts/tests/prepare-runner-image-test.sh
shellcheck -x -P .github/scripts .github/scripts/prepare-runner-image.sh .github/scripts/tests/prepare-runner-image-test.sh
bash .github/scripts/tests/prepare-runner-image-test.sh
bash .github/scripts/tests/runner-image-context-test.sh
bash .github/scripts/tests/runner-image-manifest-test.sh
bash .github/scripts/tests/wait-runner-image-test.sh
bash .github/scripts/tests/cloudflare-ssh-command-test.sh
git diff --check
```

Preparation tests run the production entry point, real temporary-file allocation, byte transfer, checksum/executable validation, and final rename behind mocked SSH/systemd boundaries. They cover healthy upload, interrupted upload recovery for each retryable status, late writes to failed candidates, persistent failure, ordinary errors, cancellation/kill statuses, and successful-but-corrupt transfers. Existing service-cleanup and GC tests remain intact.

Actual Cloudflare outage recovery is not claimed from mocked integration tests. No old CI rerun or metal-host mutation was used to validate this patch; the new PR's CI results remain separate from local validation.
