### PR TITLE
test(e2e): validate auth fixtures against the clerk runtime

### DIFF
--- a/e2e/playwright/clerk.d.ts
+++ b/e2e/playwright/clerk.d.ts
@@ -4,6 +4,7 @@ declare global {
   interface Window {
     Clerk?: {
       loaded: boolean;
+      readonly publishableKey: string;
       user?: { readonly id: string } | null;
       organization?: { readonly id: string } | null;
       setActive(options: { readonly organization: string }): Promise<void>;

--- a/e2e/playwright/lib/auth.test.ts
+++ b/e2e/playwright/lib/auth.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { chromium } from "@playwright/test";
+
+import { expectClerkTestInstance } from "./auth";
+
+// Exercise the fixture guard in a browser without connecting test credentials
+// to a live Clerk instance. Only the external SDK runtime is supplied here.
+test("auth fixtures require a loaded Clerk test instance", async (context) => {
+  const browser = await chromium.launch();
+  try {
+    await context.test(
+      "accepts a test instance after script cleanup",
+      async () => {
+        const page = await browser.newPage();
+        try {
+          await page.setContent(`
+          <script data-clerk-publishable-key="pk_test_fixture">
+            window.Clerk = { loaded: true, publishableKey: "pk_test_fixture" };
+            document.currentScript.remove();
+          </script>
+        `);
+          await expectClerkTestInstance(page);
+        } finally {
+          await page.close();
+        }
+      },
+    );
+
+    for (const scenario of [
+      {
+        name: "a production instance",
+        runtime: { loaded: true, publishableKey: "pk_live_fixture" },
+      },
+      { name: "a missing instance", runtime: undefined },
+      {
+        name: "an unloaded test instance",
+        runtime: { loaded: false, publishableKey: "pk_test_fixture" },
+      },
+      { name: "a missing key", runtime: { loaded: true } },
+      {
+        name: "an empty key",
+        runtime: { loaded: true, publishableKey: "" },
+      },
+      {
+        name: "an invalid key",
+        runtime: { loaded: true, publishableKey: "invalid" },
+      },
+      {
+        name: "a non-string key",
+        runtime: { loaded: true, publishableKey: 42 },
+      },
+    ]) {
+      await context.test(
+        `rejects ${scenario.name} despite a test script`,
+        async () => {
+          const page = await browser.newPage();
+          try {
+            await page.setContent(`
+            <script data-clerk-publishable-key="pk_test_fixture">
+              window.Clerk = ${JSON.stringify(scenario.runtime)};
+            </script>
+          `);
+            await assert.rejects(
+              () => expectClerkTestInstance(page),
+              /Auth fixtures require a loaded Clerk test instance/u,
+            );
+          } finally {
+            await page.close();
+          }
+        },
+      );
+    }
+  } finally {
+    await browser.close();
+  }
+});

--- a/e2e/playwright/lib/auth.ts
+++ b/e2e/playwright/lib/auth.ts
@@ -11,6 +11,23 @@ import { waitForClerkReadiness } from "./clerk-readiness";
 
 const CLERK_TEST_EMAIL_CODE = "424242";
 
+export async function expectClerkTestInstance(page: Page): Promise<void> {
+  // Clerk can remove its loader script after successfully initializing.
+  // Check the running instance before interacting with auth fixtures.
+  const isTestInstance = await page.evaluate(() => {
+    const clerk = window.Clerk;
+    return (
+      clerk?.loaded === true &&
+      typeof clerk.publishableKey === "string" &&
+      clerk.publishableKey.startsWith("pk_test_")
+    );
+  });
+  expect(
+    isTestInstance,
+    "Auth fixtures require a loaded Clerk test instance",
+  ).toBe(true);
+}
+
 export interface ClerkEmailCodeSignInOptions {
   readonly activeOrganizationId: string;
 }
@@ -49,8 +66,8 @@ export async function signInWithClerkEmailCode(
         (organizationId) => {
           return Boolean(
             window.Clerk?.loaded &&
-              window.Clerk.session &&
-              window.Clerk.organization?.id === organizationId,
+            window.Clerk.session &&
+            window.Clerk.organization?.id === organizationId,
           );
         },
         options.activeOrganizationId,

--- a/e2e/playwright/tests/auth-v1.spec.ts
+++ b/e2e/playwright/tests/auth-v1.spec.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { Locator, Page } from "@playwright/test";
 
 import { expect, test } from "../fixtures";
+import { expectClerkTestInstance } from "../lib/auth";
 import { openAuthV2 } from "../lib/auth-v2-ui";
 import {
   createUser,
@@ -16,10 +17,7 @@ async function openAuth(
 ): Promise<void> {
   await page.goto(path, { waitUntil: "domcontentloaded" });
   await expect(page.getByLabel("Email address", { exact: true })).toBeVisible();
-  // Never submit these fixtures against a production Clerk instance.
-  await expect(
-    page.locator("script[data-clerk-publishable-key]").first(),
-  ).toHaveAttribute("data-clerk-publishable-key", /^pk_test_/);
+  await expectClerkTestInstance(page);
   await page.evaluate(async () => {
     await document.fonts.ready;
   });


### PR DESCRIPTION
Auth V1 E2E could reject a usable test Clerk instance after SDK loader cleanup because its fixture-safety guard required the script element to remain attached ([failed job](https://github.com/vm0-ai/vm0/actions/runs/34556895232/job/103132529590)). Validate the loaded browser runtime's public `publishableKey` at the same pre-interaction boundary, preserving test-key enforcement even when a stale script advertises a different instance.

Add controlled Chromium coverage for script cleanup and rejection of live, absent, unloaded, and invalid runtime state. The change is limited to E2E helpers, types, and tests; production bootstrap/recovery, Actions definitions, and trace retention remain outside scope.

Closes #33412.

## Validation

- `cd e2e && pnpm exec tsx --test playwright/lib/auth.test.ts`: all 8 regression scenarios failed against the extracted original DOM guard, then passed with the runtime guard (9 Node test entries including the parent).
- `cd e2e && pnpm check-types`: passed.
- `cd e2e && pnpm test`: 65 passed.
- Prettier 3.8.1 on the four changed TypeScript files, `git diff --check`, repository file-size checks, and Commitlint 20.5.0: passed.
- Deployed auth validation runs in the existing PR pipeline. The historical request that triggered loader recovery is unconfirmed because the failed auth lane retained no trace.
