### PR TITLE
test(app): split welcome thread sync race scenarios

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/welcome-thread-sync-overlap.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/welcome-thread-sync-overlap.test.tsx
@@ -24,7 +24,7 @@ function navigate(path: string) {
   });
 }
 
-test("An older list refresh cannot finish a newer welcome reader, including after reader navigation", async () => {
+async function setupWelcomeSync() {
   const welcome = createMarkdownChatFixture(context);
   const row = {
     ...welcome.outputMessage("Welcome history in the second pane", {
@@ -68,7 +68,7 @@ test("An older list refresh cannot finish a newer welcome reader, including afte
     });
   });
   context.mocks.api(chatThreadsContract.events, async ({ query, respond }) => {
-    if (!refreshing) {
+    if (!refreshing && !committed) {
       return respond(200, { events: [], hasMore: false });
     }
     // Hold the older response before the worker persists its rename, so the
@@ -131,48 +131,76 @@ test("An older list refresh cannot finish a newer welcome reader, including afte
     },
   });
   // The cold route proves the initial list sync finished and opens Debug
-  // directly, without spending this race test on unrelated menu interactions.
+  // directly, without spending these race tests on unrelated menu interactions.
   await screen.findByRole("heading", { name: "Chat thread not found" });
   await screen.findByRole("dialog", { name: "Settings" });
-  await waitFor(() => {
-    expect(
-      context.mocks.ably.hasChannelSubscriptionOnChannel(
-        `user-org:user_${context.resourceId}:org_${context.resourceId}`,
-      ),
-    ).toBeTruthy();
-  });
-  refreshing = true;
-  context.mocks.ably.trigger("threadListChanged");
-  await olderRequested.promise;
-  click(fastButton("Create welcome thread"));
-  await newerRequested.promise;
-  click(screen.getByLabelText("Close"));
-  await waitFor(() => {
-    expect(screen.queryByRole("dialog", { name: "Settings" })).toBeNull();
-  });
 
-  navigate(sidebarPath);
-  await screen.findByText("Primary conversation", {
-    selector: '[data-testid="chat-thread-header-title"]',
-  });
-  await metadataRequested.promise;
-  // Abandon one cold reader while the shared welcome synchronization continues.
-  navigate(primaryPath);
-  await screen.findByRole("textbox", { name: "Message" });
-  metadataRequested = context.mocks.deferred<void>();
-  navigate(sidebarPath);
-  await metadataRequested.promise;
+  return {
+    primaryPath,
+    welcomeThreadId: welcome.threadId,
+    releaseOlder,
+    releaseNewer,
+    async startOlderRefresh() {
+      await waitFor(() => {
+        expect(
+          context.mocks.ably.hasChannelSubscriptionOnChannel(
+            `user-org:user_${context.resourceId}:org_${context.resourceId}`,
+          ),
+        ).toBeTruthy();
+      });
+      refreshing = true;
+      context.mocks.ably.trigger("threadListChanged");
+      await olderRequested.promise;
+    },
+    async createWelcome() {
+      click(fastButton("Create welcome thread"));
+      await newerRequested.promise;
+      click(screen.getByLabelText("Close"));
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog", { name: "Settings" })).toBeNull();
+      });
+    },
+    async openReader() {
+      metadataRequested = context.mocks.deferred<void>();
+      navigate(sidebarPath);
+      await screen.findByText("Primary conversation", {
+        selector: '[data-testid="chat-thread-header-title"]',
+      });
+      await metadataRequested.promise;
+    },
+  };
+}
 
-  releaseOlder.resolve();
+test("An older list refresh cannot finish a newer welcome reader", async () => {
+  const welcome = await setupWelcomeSync();
+  await welcome.startOlderRefresh();
+  await welcome.createWelcome();
+  await welcome.openReader();
+
+  welcome.releaseOlder.resolve();
   await screen.findByText("Primary conversation refreshed", {
     selector: '[data-testid="chat-thread-header-title"]',
   });
   expect(
     screen.queryByRole("heading", { name: "Chat thread not found" }),
   ).toBeNull();
-  releaseNewer.resolve();
+  welcome.releaseNewer.resolve();
   // An incorrectly completed not-found pane does not retry merely because a
   // later list result includes this thread. Its ordinary history must appear.
+  await screen.findByText("Welcome history in the second pane");
+});
+
+test("Leaving a welcome reader does not cancel synchronization for the next reader", async () => {
+  const welcome = await setupWelcomeSync();
+  await welcome.createWelcome();
+  await welcome.openReader();
+
+  // Abandon one cold reader while the shared welcome synchronization continues.
+  navigate(welcome.primaryPath);
+  await screen.findByRole("textbox", { name: "Message" });
+  await welcome.openReader();
+
+  welcome.releaseNewer.resolve();
   await screen.findByText("Newly committed welcome", {
     selector: '[data-testid="chat-thread-header-title"]',
   });
@@ -180,9 +208,9 @@ test("An older list refresh cannot finish a newer welcome reader, including afte
     2,
   );
   await screen.findByText("Welcome history in the second pane");
-  expect(window.location.pathname).toBe(primaryPath);
+  expect(window.location.pathname).toBe(welcome.primaryPath);
   expect(new URL(window.location.href).searchParams.get("sidebar")).toBe(
-    welcome.threadId,
+    welcome.welcomeThreadId,
   );
   expect(screen.queryByRole("dialog", { name: "Settings" })).toBeNull();
   expect(


### PR DESCRIPTION
## Summary

The combined welcome-thread synchronization test exceeded its default 5-second deadline in [test-app (4) on #33403](https://github.com/vm0-ai/vm0/actions/runs/34556395164/job/103129923118?pr=33403).

Split it into two independent page tests: one covers an older list refresh completing while the welcome reader is pending, and the other covers leaving and reopening that reader during synchronization. Reuse the existing page fixtures and deferred HTTP boundaries, and preserve the history, sidebar, navigation, and not-found checks across the focused cases.

This changes one test file. Production behavior, CI configuration, and the default timeout are unchanged.

## Verification

- Focused Vitest run: **2 passed**, taking **2.172s** and **1.796s** with one worker and the default timeout.
- Platform test types: `tsc -p tsconfig.tests.json --noEmit --checkers 2` passed.
- Targeted Prettier, ESLint, and Oxlint (including type-aware checks) passed.
- `knip --workspace @okouai/app --no-progress` passed.
- `git diff --check` passed. Full test execution is left to the PR pipeline.

Focused test command, from `turbo/apps/platform`:

```sh
./node_modules/.bin/vitest run src/views/okou-page/__tests__/welcome-thread-sync-overlap.test.tsx --maxWorkers=1 --reporter=verbose
```
