### PR TITLE
fix(platform): focus composer from empty input area

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-layout.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-layout.test.tsx
@@ -1,3 +1,4 @@
+import userEvent from "@testing-library/user-event";
 import { expect, test } from "vitest";
 
 import { setupPage } from "../../../__tests__/page-helper.ts";
@@ -10,7 +11,7 @@ import {
 
 const APP_HOST = "app.okou.ai";
 
-test("Keep the iPadOS composer from stealing focus", async () => {
+function installIPadBrowser(): void {
   context.mocks.browser.userAgent(
     "Mozilla/5.0 (iPad; CPU OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Version/18.0 Mobile/15E148 Safari/604.1",
   );
@@ -19,6 +20,10 @@ test("Keep the iPadOS composer from stealing focus", async () => {
   context.mocks.browser.matchMedia((query) => {
     return query === "(pointer: coarse)" || query === "(any-pointer: fine)";
   });
+}
+
+test("Keep the iPadOS composer from stealing focus", async () => {
+  installIPadBrowser();
   installMessageExperienceChat();
 
   await setupPage({
@@ -36,4 +41,27 @@ test("Keep the iPadOS composer from stealing focus", async () => {
   expect(
     editor.closest("[data-slot='chat-composer-card']"),
   ).not.toContainElement(activeElement);
+});
+
+test("Focus the composer from its empty input area", async () => {
+  const user = userEvent.setup();
+  installIPadBrowser();
+  installMessageExperienceChat();
+
+  await setupPage({
+    context,
+    path: `/agents/${MESSAGE_EXPERIENCE_AGENT_ID}/chat`,
+    host: APP_HOST,
+  });
+
+  const editor = await findComposer();
+  const input = editor.closest("[data-slot='chat-composer-input']");
+  if (!(input instanceof HTMLElement)) {
+    throw new Error("The composer input area was not found");
+  }
+  expect(editor).not.toHaveFocus();
+
+  await user.click(input);
+
+  expect(editor).toHaveFocus();
 });

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -9365,6 +9365,7 @@ function ComposerInputSlot({
   const notifyDraftChanged = useComposerDraftChange(signals);
   const restoreAttachments = useSet(signals.draft.restoreAttachments$);
   const pageSignal = useGet(pageSignal$);
+  const focusEditor = useSet(signals.editor.focus$);
   const insertPromptMarkdown = useSet(signals.editor.insertPromptMarkdown$);
   const insertUserMessage = useSet(signals.editor.insertUserMessage$);
   const uploadFile = useComposerFileUpload(signals);
@@ -9473,7 +9474,17 @@ function ComposerInputSlot({
     >
       <div
         className="col-start-1 row-start-1 min-h-0"
+        data-slot="chat-composer-input"
         hidden={createPickerOpen}
+        onClick={(event) => {
+          const target = event.target;
+          if (
+            target instanceof Node &&
+            !signals.editor.editor.view.dom.contains(target)
+          ) {
+            focusEditor();
+          }
+        }}
       >
         <TiptapWorkflowComposer
           signals={signals}


### PR DESCRIPTION
## Summary

- focus the TipTap editor when a user clicks the empty composer input area
- preserve native cursor placement and interactions inside the editor itself
- cover the behavior through the mounted Platform page on iPadOS, where the composer does not auto-focus

## Verification

- `pnpm exec vitest run src/views/okou-page/__tests__/chat-composer-layout.test.tsx` (2 tests passed)
- `pnpm exec oxlint --deny-warnings src/views/okou-page/chat-composer.tsx src/views/okou-page/__tests__/chat-composer-layout.test.tsx`
- `pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings src/views/okou-page/chat-composer.tsx src/views/okou-page/__tests__/chat-composer-layout.test.tsx`
- `pnpm exec eslint src/views/okou-page/chat-composer.tsx src/views/okou-page/__tests__/chat-composer-layout.test.tsx --max-warnings 0`
- `pnpm exec prettier --check src/views/okou-page/chat-composer.tsx src/views/okou-page/__tests__/chat-composer-layout.test.tsx`
