### PR TITLE
ci: report unreadable kms exit registries

### DIFF
--- a/.github/scripts/kms-production-exit-check.py
+++ b/.github/scripts/kms-production-exit-check.py
@@ -4,6 +4,7 @@
 import base64
 import binascii
 import datetime as dt
+import errno
 import json
 import os
 from pathlib import Path
@@ -17,6 +18,19 @@ SOURCE = "arn:aws:kms:us-west-2:072707626411:key/a1b3922b-fab1-4ed3-aa9e-40f86f9
 TARGET = "arn:aws:kms:us-west-2:251964670836:key/e68917e2-5541-4597-b6ef-7e9eb5670947"
 PROJECT = "hidden-lab-39609750"
 REGISTRY_LIMIT = 16 * 1024 * 1024
+PRODUCTION_VERSION = re.compile(r"v\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?")
+REGISTRY_FAILURE_CODES = {
+    "invalid_runner_directory",
+    "non_regular_registry",
+    "registry_size_limit",
+    "invalid_registry",
+    "duplicate_json_key",
+    "missing_registry",
+    "registry_access_denied",
+    "symlink_registry",
+    "registry_io_error",
+    "invalid_registry_json",
+}
 COUNTERS = (
     "productionDirectories",
     "registriesRead",
@@ -120,16 +134,19 @@ def key_category(value):
 
 def registry_inventory(root):
     counts = dict.fromkeys(COUNTERS, 0)
+    failures = []
     require(not root.is_symlink() and root.is_dir(), "runner_root_unavailable")
     directories = list(root.iterdir())
     require(len(directories) <= 1000, "runner_directory_limit")
     # Production promotion names directories v{runner_version}. PR and staging
     # directories have separate names and are intentionally outside this scope.
     for directory in directories:
-        if not re.fullmatch(r"v\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?", directory.name):
+        if not PRODUCTION_VERSION.fullmatch(directory.name):
             continue
         counts["productionDirectories"] += 1
         path = directory / "proxy-registry.json"
+        size = None
+        reason = None
         try:
             require(
                 not directory.is_symlink() and directory.is_dir(),
@@ -138,10 +155,9 @@ def registry_inventory(root):
             fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
             with os.fdopen(fd, "rb") as stream:
                 before = os.fstat(stream.fileno())
-                require(
-                    stat.S_ISREG(before.st_mode) and before.st_size <= REGISTRY_LIMIT,
-                    "invalid_registry_file",
-                )
+                size = before.st_size
+                require(stat.S_ISREG(before.st_mode), "non_regular_registry")
+                require(size <= REGISTRY_LIMIT, "registry_size_limit")
                 data = stream.read(REGISTRY_LIMIT + 1)
                 require(len(data) <= REGISTRY_LIMIT, "registry_size_limit")
                 after = os.fstat(stream.fileno())
@@ -168,9 +184,27 @@ def registry_inventory(root):
                     counts["invalid"] += 1
                 else:
                     counts[key_category(entry["encryptedSecrets"])] += 1
-        except (CheckError, OSError, ValueError, UnicodeError):
+        except CheckError as error:
+            reason = str(error)
+        except FileNotFoundError:
+            reason = "missing_registry"
+        except PermissionError:
+            reason = "registry_access_denied"
+        except OSError as error:
+            reason = (
+                "symlink_registry"
+                if error.errno == errno.ELOOP
+                else "registry_io_error"
+            )
+        except (ValueError, UnicodeError):
+            reason = "invalid_registry_json"
+        if reason is not None:
+            require(reason in REGISTRY_FAILURE_CODES, "invalid_registry_failure_code")
             counts["unreadable"] += 1
-    return counts
+            failures.append(
+                {"runnerVersion": directory.name, "reason": reason, "sizeBytes": size}
+            )
+    return {"counts": counts, "failures": failures}
 
 
 def runner_fleet():
@@ -205,10 +239,16 @@ def runner_fleet():
                 timeout=130,
             )
             require(
-                child.returncode == 0 and len(child.stdout) < 10000,
+                child.returncode == 0 and len(child.stdout) < 512 * 1024,
                 "remote_inventory_failed",
             )
-            counts = decode_json(child.stdout)
+            inventory = decode_json(child.stdout)
+            require(
+                isinstance(inventory, dict)
+                and set(inventory) == {"counts", "failures"},
+                "invalid_remote_report",
+            )
+            counts = inventory["counts"]
             require(
                 isinstance(counts, dict) and set(counts) == set(COUNTERS),
                 "invalid_remote_report",
@@ -217,7 +257,33 @@ def runner_fleet():
                 all(type(v) is int and 0 <= v <= 1_000_000 for v in counts.values()),
                 "invalid_remote_report",
             )
+            failures = inventory["failures"]
+            require(
+                isinstance(failures, list)
+                and len(failures) == counts["unreadable"]
+                and len(failures) <= 1000,
+                "invalid_remote_report",
+            )
+            for failure in failures:
+                require(
+                    isinstance(failure, dict)
+                    and set(failure) == {"runnerVersion", "reason", "sizeBytes"},
+                    "invalid_remote_report",
+                )
+                require(
+                    isinstance(failure["runnerVersion"], str)
+                    and bool(PRODUCTION_VERSION.fullmatch(failure["runnerVersion"]))
+                    and isinstance(failure["reason"], str)
+                    and failure["reason"] in REGISTRY_FAILURE_CODES
+                    and (
+                        failure["sizeBytes"] is None
+                        or type(failure["sizeBytes"]) is int
+                        and 0 <= failure["sizeBytes"] < 2**63
+                    ),
+                    "invalid_remote_report",
+                )
             result["counts"] = counts
+            result["registryFailures"] = failures
         except (CheckError, OSError, ValueError, subprocess.TimeoutExpired):
             result["error"] = "remote_inventory_failed"
         results.append(result)

--- a/.github/scripts/tests/kms-production-exit-check-test.py
+++ b/.github/scripts/tests/kms-production-exit-check-test.py
@@ -141,7 +141,7 @@ print(json.dumps(data)+"\\n200", end="")
         (staging / "proxy-registry.json").write_text(SECRET)
         result = self.run_script("runner-local", str(runners))
         self.assertEqual(result.returncode, 0, result.stderr)
-        counts = json.loads(result.stdout)
+        counts = json.loads(result.stdout)["counts"]
         self.assertEqual(
             {
                 k: counts[k]
@@ -175,7 +175,38 @@ print(json.dumps(data)+"\\n200", end="")
         (runners / "v1.2.4" / "proxy-registry.json").symlink_to(outside)
         result = self.run_script("runner-local", str(runners))
         self.assertEqual(result.returncode, 0)
-        self.assertEqual(json.loads(result.stdout)["unreadable"], 2)
+        inventory = json.loads(result.stdout)
+        self.assertEqual(inventory["counts"]["unreadable"], 2)
+        self.assertEqual(
+            {f["runnerVersion"]: f["reason"] for f in inventory["failures"]},
+            {"v1.2.3": "missing_registry", "v1.2.4": "symlink_registry"},
+        )
+
+    def test_oversized_registry_reports_metadata_without_reading_its_contents(self):
+        release = self.root / "runners" / "v1.2.3"
+        release.mkdir(parents=True)
+        path = release / "proxy-registry.json"
+        size = 16 * 1024 * 1024 + 1
+        with path.open("wb") as stream:
+            stream.write(SECRET.encode())
+            stream.truncate(size)
+        before = path.stat()
+        result = self.run_script("runner-local", str(release.parent))
+        self.assertEqual(result.returncode, 0)
+        inventory = json.loads(result.stdout)
+        self.assertEqual(inventory["counts"]["unreadable"], 1)
+        self.assertEqual(
+            inventory["failures"],
+            [
+                {
+                    "runnerVersion": "v1.2.3",
+                    "reason": "registry_size_limit",
+                    "sizeBytes": size,
+                }
+            ],
+        )
+        self.assertEqual(path.stat().st_size, before.st_size)
+        self.assertEqual(path.stat().st_mtime_ns, before.st_mtime_ns)
 
     def test_duplicate_registry_keys_cannot_silently_hide_source_values(self):
         release = self.root / "runners" / "v1.2.3"
@@ -184,7 +215,9 @@ print(json.dumps(data)+"\\n200", end="")
             '{"sandboxes": {"x": {}}, "sandboxes": {}}'
         )
         result = self.run_script("runner-local", str(release.parent))
-        self.assertEqual(json.loads(result.stdout)["unreadable"], 1)
+        inventory = json.loads(result.stdout)
+        self.assertEqual(inventory["counts"]["unreadable"], 1)
+        self.assertEqual(inventory["failures"][0]["reason"], "duplicate_json_key")
 
     def test_paginated_metadata_keeps_all_snapshots_for_review(self):
         self.fake_neon()
@@ -237,6 +270,7 @@ print(json.dumps(data)+"\\n200", end="")
     def test_partial_fleet_failure_preserves_observed_source_dependency(self):
         release = self.root / "runners" / "v1.2.3"
         release.mkdir(parents=True)
+        (release.parent / "v1.2.4").mkdir()
         (release / "proxy-registry.json").write_text(
             json.dumps({"sandboxes": {"x": {"encryptedSecrets": envelope(SOURCE)}}})
         )
@@ -257,8 +291,37 @@ print(open(os.environ["HOST_REPORT_FIXTURE"]).read())
         self.assertEqual(self.run_script("runners").returncode, 1)
         report = json.loads((self.root / "kms-exit-runners.json").read_text())
         self.assertEqual(report["inventory"]["totals"]["source"], 1)
+        self.assertEqual(
+            report["inventory"]["hosts"][0]["registryFailures"],
+            [
+                {
+                    "runnerVersion": "v1.2.4",
+                    "reason": "missing_registry",
+                    "sizeBytes": None,
+                }
+            ],
+        )
         self.assertFalse(report["inventory"]["collectionComplete"])
         self.assertFalse(report["retirementCleared"])
+
+    def test_remote_failure_text_is_not_exported_as_a_diagnostic_reason(self):
+        release = self.root / "runners" / "v1.2.3"
+        release.mkdir(parents=True)
+        local = self.run_script("runner-local", str(release.parent))
+        inventory = json.loads(local.stdout)
+        inventory["failures"][0]["reason"] = SECRET
+        fixture = self.root / "host-report.json"
+        fixture.write_text(json.dumps(inventory))
+        self.env["HOST_REPORT_FIXTURE"] = str(fixture)
+        self.tool(
+            "ssh",
+            "import os,sys\nsys.stdin.read()\n"
+            "print(open(os.environ['HOST_REPORT_FIXTURE']).read())\n",
+        )
+        self.assertEqual(self.run_script("runners").returncode, 1)
+        report = json.loads((self.root / "kms-exit-runners.json").read_text())
+        self.assertFalse(report["inventory"]["collectionComplete"])
+        self.assertTrue(all("error" in h for h in report["inventory"]["hosts"]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The production exit check for #32264 found an unreadable proxy registry on each of three runner hosts ([run 34559009764](https://github.com/vm0-ai/vm0/actions/runs/34559009764)), but the report only exposed a count. Include the runner version, an allow-listed error code, and the available file size so the next read-only check can distinguish missing files, symlinks, size limits, permissions, and malformed registries.

The remote subprocess receives the exact checked-out script over stdin, so its response and caller move together to `{counts, failures}`. Artifacts retain the existing totals and add per-host `registryFailures`. The SSH response boundary validates every diagnostic field; unreadable registries continue to mark collection incomplete. The change preserves the existing 16 MiB file-read limit and production-only scope.

Validation: 11 CLI/file-boundary tests pass, including missing and symlinked files, oversized-file metadata, duplicate JSON keys, retained source-key counts during partial failure, and rejection of arbitrary remote error text. Ruff lint/format and whitespace/file-size checks pass.
