### PR TITLE
test: split compound timeout-risk scenarios from daily audit

### DIFF
--- a/e2e/playwright/tests/auth-v1.spec.ts
+++ b/e2e/playwright/tests/auth-v1.spec.ts
@@ -287,7 +287,7 @@ for (const device of [
       }
     });
 
-    test("hosted password feedback and reveal remain clear after reflow", async ({
+    test("hosted password feedback remains clear after reflow", async ({
       page,
     }) => {
       await openAuth(page, "/v1/sign-up", device.theme);
@@ -316,7 +316,14 @@ for (const device of [
         })
         .toBeGreaterThan(0);
       await expectAuthBackgroundCoversViewport(page);
+    });
 
+    test("hosted password reveal preserves the password and fits a short viewport", async ({
+      page,
+    }) => {
+      await openAuth(page, "/v1/sign-up", device.theme);
+      await page.setViewportSize({ width: 375, height: 568 });
+      const password = page.getByLabel("Password", { exact: true });
       const longPassword = "A-Long-Password-For-Reveal-Layout!2026";
       await password.fill(longPassword);
       const show = page.getByRole("button", {
@@ -325,17 +332,6 @@ for (const device of [
       });
       await expectPasswordControlFits(password, show);
 
-      await legalConsent.focus();
-      await page.keyboard.press("Space");
-      await expect(legalConsent).toBeChecked();
-      await page.keyboard.press("Space");
-      await expect(legalConsent).not.toBeChecked();
-      const legalLinks = page.locator(".cl-formFieldCheckboxLabel a");
-      await expect(legalLinks).toHaveCount(2);
-      for (const link of await legalLinks.all()) {
-        await expect(link).toBeVisible();
-        await expect(link).toHaveAttribute("href", /^https:\/\//);
-      }
       await show.focus();
       await page.keyboard.press("Enter");
       const hide = page.getByRole("button", {
@@ -348,6 +344,25 @@ for (const device of [
       await hide.click();
       await expect(password).toHaveAttribute("type", "password");
       await expectPasswordControlFits(password, show);
+    });
+
+    test("hosted legal consent remains keyboard accessible in a short viewport", async ({
+      page,
+    }) => {
+      await openAuth(page, "/v1/sign-up", device.theme);
+      await page.setViewportSize({ width: 375, height: 568 });
+      const legalConsent = page.getByRole("checkbox");
+      await legalConsent.focus();
+      await page.keyboard.press("Space");
+      await expect(legalConsent).toBeChecked();
+      await page.keyboard.press("Space");
+      await expect(legalConsent).not.toBeChecked();
+      const legalLinks = page.locator(".cl-formFieldCheckboxLabel a");
+      await expect(legalLinks).toHaveCount(2);
+      for (const link of await legalLinks.all()) {
+        await expect(link).toBeVisible();
+        await expect(link).toHaveAttribute("href", /^https:\/\//);
+      }
     });
 
     test("hosted signup keeps native OTP feedback clear of inputs and resend on retry", async ({

--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -80,65 +80,68 @@ test("dialog width caps preserve the sm breakpoint and shrink on narrow screens"
   await expect(dialog).toBeHidden();
 });
 
-test("artifact dialogs keep their panel and fullscreen controls inside safe areas", async ({
-  page,
-}) => {
-  await page.goto(appUrl);
-  await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
-  await expect(page.getByTestId("chat-tagline")).toBeVisible({
-    timeout: 20_000,
-  });
+for (const scenario of [
+  { width: 402, height: 874, top: 62, right: 0, bottom: 34, left: 0 },
+  { width: 874, height: 402, top: 0, right: 62, bottom: 21, left: 62 },
+  { width: 390, height: 640, top: 59, right: 0, bottom: 34, left: 0 },
+  { width: 1920, height: 1200, top: 0, right: 0, bottom: 0, left: 0 },
+]) {
+  test(`artifact dialog controls stay inside safe areas at ${scenario.width}x${scenario.height}`, async ({
+    page,
+  }) => {
+    await page.goto(appUrl);
+    await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+    await expect(page.getByTestId("chat-tagline")).toBeVisible({
+      timeout: 20_000,
+    });
 
-  // The lane's disposable account owns this thread and is cleaned up by global teardown.
-  const [created] = await Promise.all([
-    page.waitForResponse(
-      (response) =>
-        response.request().method() === "POST" &&
-        new URL(response.url()).pathname === "/api/chat-threads",
-    ),
-    page.getByRole("button", { name: "New chat", exact: true }).last().click(),
-  ]);
-  expect(created.status()).toBe(201);
-  const thread: unknown = await created.json();
-  if (
-    typeof thread !== "object" ||
-    thread === null ||
-    !("id" in thread) ||
-    typeof thread.id !== "string"
-  ) {
-    throw new Error("Expected the created dialog-test thread id");
-  }
-  await expect(page).toHaveURL(new URL(`/chats/${thread.id}`, appUrl).href);
-  // Wait for the destination composer before attaching the owned fixture.
-  const threadPage = page.getByRole("region", {
-    name: "Chat thread",
-    exact: true,
-  });
-  await expect(
-    threadPage.getByRole("textbox", { name: "Message", exact: true }),
-  ).toBeEditable();
-  await threadPage
-    .locator('input[type="file"][multiple]')
-    .setInputFiles(await dialogImageFixture(page));
-  const imagePreview = threadPage.getByRole("button", {
-    name: "Open image preview for dialog-safe-area.png",
-    exact: true,
-  });
-  await expect(imagePreview).toBeEnabled({ timeout: 30_000 });
-  await imagePreview.click();
-  const dialog = page.getByTestId("attachment-lightbox");
-  await expect(dialog).toBeVisible();
-  const zoom = dialog.getByTestId("artifact-dialog-image-zoom-level");
-  await expect(zoom).toHaveText("100%");
-  await dialog.getByRole("button", { name: "Zoom in", exact: true }).click();
-  await expect(zoom).toHaveText("115%");
+    // The lane's disposable account owns this thread and is cleaned up by global teardown.
+    const [created] = await Promise.all([
+      page.waitForResponse(
+        (response) =>
+          response.request().method() === "POST" &&
+          new URL(response.url()).pathname === "/api/chat-threads",
+      ),
+      page
+        .getByRole("button", { name: "New chat", exact: true })
+        .last()
+        .click(),
+    ]);
+    expect(created.status()).toBe(201);
+    const thread: unknown = await created.json();
+    if (
+      typeof thread !== "object" ||
+      thread === null ||
+      !("id" in thread) ||
+      typeof thread.id !== "string"
+    ) {
+      throw new Error("Expected the created dialog-test thread id");
+    }
+    await expect(page).toHaveURL(new URL(`/chats/${thread.id}`, appUrl).href);
+    // Wait for the destination composer before attaching the owned fixture.
+    const threadPage = page.getByRole("region", {
+      name: "Chat thread",
+      exact: true,
+    });
+    await expect(
+      threadPage.getByRole("textbox", { name: "Message", exact: true }),
+    ).toBeEditable();
+    await threadPage
+      .locator('input[type="file"][multiple]')
+      .setInputFiles(await dialogImageFixture(page));
+    const imagePreview = threadPage.getByRole("button", {
+      name: "Open image preview for dialog-safe-area.png",
+      exact: true,
+    });
+    await expect(imagePreview).toBeEnabled({ timeout: 30_000 });
+    await imagePreview.click();
+    const dialog = page.getByTestId("attachment-lightbox");
+    await expect(dialog).toBeVisible();
+    const zoom = dialog.getByTestId("artifact-dialog-image-zoom-level");
+    await expect(zoom).toHaveText("100%");
+    await dialog.getByRole("button", { name: "Zoom in", exact: true }).click();
+    await expect(zoom).toHaveText("115%");
 
-  for (const scenario of [
-    { width: 402, height: 874, top: 62, right: 0, bottom: 34, left: 0 },
-    { width: 874, height: 402, top: 0, right: 62, bottom: 21, left: 62 },
-    { width: 390, height: 640, top: 59, right: 0, bottom: 34, left: 0 },
-    { width: 1920, height: 1200, top: 0, right: 0, bottom: 0, left: 0 },
-  ]) {
     await page.setViewportSize({
       width: scenario.width,
       height: scenario.height,
@@ -218,21 +221,25 @@ test("artifact dialogs keep their panel and fullscreen controls inside safe area
       dialog.getByRole("button", { name: "Enter fullscreen", exact: true }),
     ).toBeVisible();
     await expect(zoom).toHaveText("115%");
-  }
 
-  // Native outside-press ownership must distinguish a drag from a deliberate click.
-  const panel = await dialog.boundingBox();
-  if (!panel) throw new Error("Expected the preview before testing dismissal");
-  await page.mouse.move(panel.x + panel.width / 2, panel.y + panel.height / 2);
-  await page.mouse.down();
-  await page.mouse.move(5, 5);
-  await page.mouse.up();
-  await expect(dialog).toBeVisible();
-  await page.mouse.click(5, 5);
-  await expect(dialog).toBeHidden();
-});
+    // Native outside-press ownership must distinguish a drag from a deliberate click.
+    const panel = await dialog.boundingBox();
+    if (!panel)
+      throw new Error("Expected the preview before testing dismissal");
+    await page.mouse.move(
+      panel.x + panel.width / 2,
+      panel.y + panel.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(5, 5);
+    await page.mouse.up();
+    await expect(dialog).toBeVisible();
+    await page.mouse.click(5, 5);
+    await expect(dialog).toBeHidden();
+  });
+}
 
-test("short dialogs keep nested avatar and agent footer actions reachable by scrolling", async ({
+test("a short nested avatar dialog keeps its footer reachable by scrolling", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 390, height: 640 });
@@ -272,7 +279,21 @@ test("short dialogs keep nested avatar and agent footer actions reachable by scr
   await expect(
     agent.getByRole("textbox", { name: "Name", exact: true }),
   ).toHaveValue("Safe area draft");
+});
 
+test("a short agent dialog keeps footer actions reachable after landscape reflow", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 640 });
+  await page.goto(new URL("/agents", appUrl).href);
+  await page.getByRole("button", { name: "New agent", exact: true }).click();
+  const agent = page.getByRole("dialog", {
+    name: "Create a new agent",
+    exact: true,
+  });
+  await agent
+    .getByRole("textbox", { name: "Name", exact: true })
+    .fill("Safe area draft");
   await page.setViewportSize({ width: 874, height: 402 });
   await page.evaluate(() => {
     const style = document.documentElement.style;

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -102,11 +102,12 @@ function customConnectorValuesClient() {
 
 async function cleanupFixture(fixture: Fixture): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId);
+  const accountsApi = accountClient();
   for (const connectorSlug of ["openai", "github"] as const) {
     let hasBuiltinAccounts = true;
     while (hasBuiltinAccounts) {
       const accounts = await accept(
-        accountClient().connections({
+        accountsApi.connections({
           headers: authHeaders(),
           query: { kind: "builtin", connectorSlug, limit: 100 },
         }),
@@ -119,7 +120,7 @@ async function cleanupFixture(fixture: Fixture): Promise<void> {
       }
       for (const account of accounts.body.connections) {
         await accept(
-          accountClient().delete({
+          accountsApi.delete({
             headers: authHeaders(),
             params: { connectionId: account.id },
             body: {
@@ -798,14 +799,15 @@ describe("connector account lifecycle routes", () => {
     ).toHaveLength(1);
   });
 
-  it("paginates and searches more than one hundred accounts", async () => {
+  async function createBulkAccounts(): Promise<string[]> {
     await seedFixture();
 
     const createdAccountIds: string[] = [];
+    const connectorsApi = connectorClient();
     for (let index = 0; index < 101; index += 1) {
       const label = `Bulk ${index.toString().padStart(3, "0")}`;
       const created = await accept(
-        connectorClient().connect({
+        connectorsApi.connect({
           headers: authHeaders(),
           params: { connectorSlug: "openai" },
           body: {
@@ -818,9 +820,12 @@ describe("connector account lifecycle routes", () => {
       );
       createdAccountIds.push(created.body.id);
     }
+    return createdAccountIds;
+  }
 
+  it("paginates and summarizes more than one hundred accounts", async () => {
+    await createBulkAccounts();
     const ids = new Set<string>();
-    const firstPageIds = new Set<string>();
     let cursor: string | undefined;
     do {
       const page = await accept(
@@ -837,14 +842,24 @@ describe("connector account lifecycle routes", () => {
       );
       for (const account of page.body.connections) {
         ids.add(account.id);
-        if (!cursor) {
-          firstPageIds.add(account.id);
-        }
       }
       cursor = page.body.nextCursor ?? undefined;
     } while (cursor);
     expect(ids.size).toBe(101);
+    const summary = await accept(
+      accountClient().summaries({ headers: authHeaders() }),
+      [200],
+    );
+    expect(summary.body.summaries).toContainEqual(
+      expect.objectContaining({
+        target: { kind: "builtin", connectorSlug: "openai" },
+        accountCount: 101,
+      }),
+    );
+  });
 
+  it("searches display names across more than one hundred accounts", async () => {
+    await createBulkAccounts();
     const searched = await accept(
       accountClient().connections({
         headers: authHeaders(),
@@ -859,7 +874,22 @@ describe("connector account lifecycle routes", () => {
     );
     expect(searched.body.connections).toHaveLength(1);
     expect(searched.body.connections[0]!.displayName).toBe("Bulk 042");
+  });
 
+  it("searches fallback names outside the first account page", async () => {
+    const createdAccountIds = await createBulkAccounts();
+    const firstPage = await accept(
+      accountClient().connections({
+        headers: authHeaders(),
+        query: { kind: "builtin", connectorSlug: "openai", limit: 23 },
+      }),
+      [200],
+    );
+    const firstPageIds = new Set(
+      firstPage.body.connections.map((account) => {
+        return account.id;
+      }),
+    );
     const accountOutsideFirstPage = createdAccountIds.find((id) => {
       return !firstPageIds.has(id);
     });
@@ -895,7 +925,10 @@ describe("connector account lifecycle routes", () => {
         displayName: null,
       }),
     );
+  });
 
+  it("returns no matches and rejects blank searches with more than one hundred accounts", async () => {
+    await createBulkAccounts();
     const noMatch = await accept(
       accountClient().connections({
         headers: authHeaders(),
@@ -924,17 +957,6 @@ describe("connector account lifecycle routes", () => {
         },
       }),
       [400],
-    );
-
-    const summary = await accept(
-      accountClient().summaries({ headers: authHeaders() }),
-      [200],
-    );
-    expect(summary.body.summaries).toContainEqual(
-      expect.objectContaining({
-        target: { kind: "builtin", connectorSlug: "openai" },
-        accountCount: 101,
-      }),
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -3896,9 +3896,8 @@ describe.sequential("Official Workflow installations", () => {
     failedCopyAgentDeleted = true;
   });
 
-  it("uninstalls, reinstalls, retires, and copies through lifecycle boundaries", async () => {
+  it("uninstalls and reinstalls Official Workflows, including zero-Blueprint installations", async () => {
     const {
-      actor,
       agentId,
       definitionName,
       headers,
@@ -3931,13 +3930,6 @@ describe.sequential("Official Workflow installations", () => {
       [201],
     );
     expect(reinstalled.body.workflow.id).not.toBe(firstWorkflowId);
-    const reinstalledDailyAutomation =
-      reinstalled.body.workflow.automations.find((automation) => {
-        return automation.official?.blueprintKey === "daily";
-      });
-    if (!reinstalledDailyAutomation) {
-      throw new Error("Expected reinstalled daily automation");
-    }
 
     const zeroInstalled = await accept(
       officialClient().install({
@@ -3955,7 +3947,24 @@ describe.sequential("Official Workflow installations", () => {
       }),
       [204],
     );
+  });
 
+  async function retireInstalledLifecycleScenario() {
+    const {
+      actor,
+      definitionName,
+      headers,
+      installBody,
+      installed: reinstalled,
+      zeroBlueprintName,
+    } = await installOfficialWorkflowLifecycleScenario();
+    const reinstalledDailyAutomation =
+      reinstalled.body.workflow.automations.find((automation) => {
+        return automation.official?.blueprintKey === "daily";
+      });
+    if (!reinstalledDailyAutomation) {
+      throw new Error("Expected installed daily automation");
+    }
     await syncCatalog(
       catalog([
         retiredDefinition(definitionName),
@@ -4038,7 +4047,12 @@ describe.sequential("Official Workflow installations", () => {
         }),
       ]),
     });
+    return { actor, headers, reinstalled, reinstalledDailyAutomation };
+  }
 
+  it("retains and copies a retired Official installation while discovery is disabled", async () => {
+    const { actor, headers, reinstalled } =
+      await retireInstalledLifecycleScenario();
     const { agentId: retiredCopyAgentId } =
       await workflowBdd.createAgent(actor);
     let retiredCopyAgentDeleted = false;
@@ -4076,7 +4090,11 @@ describe.sequential("Official Workflow installations", () => {
     ).toBeTruthy();
     await bdd.deleteAgent(actor, retiredCopyAgentId);
     retiredCopyAgentDeleted = true;
+  });
 
+  it("rejects copying a stale retired installation and allows reconfiguration and uninstall", async () => {
+    const { actor, headers, reinstalled, reinstalledDailyAutomation } =
+      await retireInstalledLifecycleScenario();
     const { agentId: staleCopyAgentId } = await workflowBdd.createAgent(actor);
     let staleCopyAgentDeleted = false;
     onTestFinished(async () => {
@@ -7987,255 +8005,268 @@ describe.sequential("Official Workflow Run admission", () => {
     expect(ordinaryWorkflowId).not.toBe(firstInstallation.body.workflow.id);
   });
 
-  it("routes enabled result email through explicit, scheduled, once, and webhook Official admission", async () => {
-    installCatalogStorageFixture();
-    mockEnv("OKOU_WEB_URL", "https://api.okou.ai");
-    const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
-    const definitionName = `api-test-producers-${suffix}`;
-    await syncCatalog(
-      catalog([
-        activeDefinition(definitionName, [
-          loopBlueprint(true),
-          onceBlueprint(true),
-          webhookBlueprint(true),
-        ]),
-      ]),
-    );
-    const setup = await workflowBdd.setupWorkflowOrg({
-      timezone: "Asia/Shanghai",
-      tier: "team",
-    });
-    const { actor } = setup;
-    if (!actor.orgId) {
-      throw new Error("Expected organization-scoped actor");
-    }
-    await selectBuiltInDefaultModel(actor);
-    const { agentId } = await workflowBdd.createAgent(actor);
-    const headers = authHeaders(actor);
-    configureResultEmailRecipient(actor);
-    await setOfficialWorkflowsEnabled(actor, true);
-    const atTime = new Date(now() + 60_000).toISOString();
-    const installed = await accept(
-      officialClient().install({
-        headers,
-        params: { definitionName },
-        body: {
-          agentId,
-          blueprints: [
-            {
-              blueprintKey: "pulse",
-              bindings: [{ key: "interval-seconds", value: 60 }],
-            },
-            {
-              blueprintKey: "one-shot",
-              bindings: [
-                { key: "at-time", value: atTime },
-                {
-                  key: "callback-url",
-                  value: "https://example.test/official-callback",
-                },
-                { key: "correlation-id", value: randomUUID() },
-              ],
-            },
-            { blueprintKey: "webhook-trigger", bindings: [] },
-          ],
-        },
-      }),
-      [201],
-    );
-    onTestFinished(async () => {
+  it.each(["explicit and scheduled", "once", "webhook"])(
+    "routes enabled result email through %s Official admission",
+    async (producerKind) => {
       installCatalogStorageFixture();
-      await bdd.deleteAgent(actor, agentId);
-      await cleanupCatalog();
-    });
-    const runnerGroup = runs.configureRunnerGroup();
-    runs.acceptStorageDownloads();
-    runs.acceptTelemetryIngest();
-
-    const automations = new Map(
-      installed.body.workflow.automations.flatMap((automation) => {
-        return automation.official
-          ? [[automation.official.blueprintKey, automation] as const]
-          : [];
-      }),
-    );
-    const loopAutomation = automations.get("pulse");
-    const onceAutomation = automations.get("one-shot");
-    const webhookAutomation = automations.get("webhook-trigger");
-    if (!loopAutomation || !onceAutomation || !webhookAutomation) {
-      throw new Error("Expected all Official Workflow producer automations");
-    }
-
-    const explicit = await accept(
-      automationClient().run({
-        headers,
-        extraHeaders: { origin: "https://app.okou.ai" },
-        params: { id: loopAutomation.id },
-      }),
-      [201],
-    );
-    if (!explicit.body.runId) {
-      throw new Error("Expected explicit Official Automation Run");
-    }
-    const producerRuns: {
-      readonly runId: string;
-      readonly automationId: string;
-    }[] = [
-      {
-        runId: explicit.body.runId,
-        automationId: loopAutomation.id,
-      },
-    ];
-    await completeSuccessfulRun(
-      runnerGroup,
-      explicit.body.runId,
-      "Explicit Official result",
-    );
-
-    const scheduled = await withMockNowForTest(now() + 120_000, async () => {
-      return await accept(
-        automationExecutionClient().execute({
-          body: { automation_id: loopAutomation.id },
-        }),
-        [200],
-      );
-    });
-    expect(scheduled.body.executed).toBe(1);
-    const scheduledRun = await readLatestWorkflowAutomationRunFixture(
-      context,
-      loopAutomation.id,
-    );
-    if (!scheduledRun || scheduledRun.runId === explicit.body.runId) {
-      throw new Error("Expected a distinct scheduled Official Automation Run");
-    }
-    producerRuns.push({
-      runId: scheduledRun.runId,
-      automationId: loopAutomation.id,
-    });
-    await completeSuccessfulRun(
-      runnerGroup,
-      scheduledRun.runId,
-      "Scheduled Official result",
-    );
-
-    const once = await withMockNowForTest(now() + 120_000, async () => {
-      return await accept(
-        automationExecutionClient().execute({
-          body: { automation_id: onceAutomation.id },
-        }),
-        [200],
-      );
-    });
-    expect(once.body.executed).toBe(1);
-    const onceRun = await readLatestWorkflowAutomationRunFixture(
-      context,
-      onceAutomation.id,
-    );
-    if (!onceRun) {
-      throw new Error("Expected once Official Automation Run");
-    }
-    producerRuns.push({
-      runId: onceRun.runId,
-      automationId: onceAutomation.id,
-    });
-    await completeSuccessfulRun(
-      runnerGroup,
-      onceRun.runId,
-      "Once Official result",
-    );
-
-    if (
-      webhookAutomation.kind !== "event" ||
-      webhookAutomation.eventType !== "webhook-received"
-    ) {
-      throw new Error("Expected Official webhook automation");
-    }
-    const webhookCredentials = await accept(
-      automationClient().revealWebhookSecret({
-        headers,
-        params: { id: webhookAutomation.id },
-        body: undefined,
-      }),
-      [200],
-    );
-    const webhook = await postOfficialWorkflowWebhook({
-      webhookUrl: webhookCredentials.body.webhookUrl,
-      secret: webhookCredentials.body.webhookSecret,
-      body: JSON.stringify({ event: "official-p2-regression" }),
-    });
-    expect(webhook).toMatchObject({
-      status: 200,
-      body: { success: true, duplicate: false },
-    });
-    await expect
-      .poll(async () => {
-        return (
-          await readLatestWorkflowAutomationRunFixture(
-            context,
-            webhookAutomation.id,
-          )
-        )?.runId;
-      })
-      .toEqual(expect.any(String));
-    const webhookRun = await readLatestWorkflowAutomationRunFixture(
-      context,
-      webhookAutomation.id,
-    );
-    if (!webhookRun) {
-      throw new Error("Expected Official webhook Automation Run");
-    }
-    producerRuns.push({
-      runId: webhookRun.runId,
-      automationId: webhookAutomation.id,
-    });
-    await completeSuccessfulRun(
-      runnerGroup,
-      webhookRun.runId,
-      "Event Official result",
-    );
-
-    const accepted = await readAcceptedDefinitionFixture(definitionName);
-    for (const producer of producerRuns) {
-      const state = await readOfficialWorkflowRunStateFixture(
-        context,
-        producer.runId,
-      );
-      expect(state.model_provider).toBe("built-in");
-      expect(state.provenance?.definitions).toStrictEqual([
-        expect.objectContaining({
-          name: definitionName,
-          revision: accepted.definition.revision,
-        }),
-      ]);
-      expect(state.storage_mounts).toStrictEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            org_id: SYSTEM_ORG_ID,
-            user_id: VOLUME_ORG_USER_ID,
-            storage_id: accepted.definition.artifact.storageId,
-            version: accepted.definition.artifact.storageVersion,
-          }),
+      mockEnv("OKOU_WEB_URL", "https://api.okou.ai");
+      const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
+      const definitionName = `api-test-producers-${suffix}`;
+      await syncCatalog(
+        catalog([
+          activeDefinition(definitionName, [
+            loopBlueprint(true),
+            onceBlueprint(true),
+            webhookBlueprint(true),
+          ]),
         ]),
       );
-      const source = await outbox.findSourceState({
-        sourceRunId: producer.runId,
-        sourceWorkflowAutomationId: producer.automationId,
+      const setup = await workflowBdd.setupWorkflowOrg({
+        timezone: "Asia/Shanghai",
+        tier: "team",
       });
-      expect(source.claim).not.toBeNull();
-      expect(source.items).toStrictEqual([
-        expect.objectContaining({
-          public_brand: "okou",
-          subject: `Display ${definitionName}`,
-          source_run_id: producer.runId,
-          source_workflow_automation_id: producer.automationId,
-          status: "pending",
-          template: expect.objectContaining({
-            template: "official-automation-result",
-          }),
+      const { actor } = setup;
+      if (!actor.orgId) {
+        throw new Error("Expected organization-scoped actor");
+      }
+      await selectBuiltInDefaultModel(actor);
+      const { agentId } = await workflowBdd.createAgent(actor);
+      const headers = authHeaders(actor);
+      configureResultEmailRecipient(actor);
+      await setOfficialWorkflowsEnabled(actor, true);
+      const atTime = new Date(now() + 60_000).toISOString();
+      const installed = await accept(
+        officialClient().install({
+          headers,
+          params: { definitionName },
+          body: {
+            agentId,
+            blueprints: [
+              {
+                blueprintKey: "pulse",
+                bindings: [{ key: "interval-seconds", value: 60 }],
+              },
+              {
+                blueprintKey: "one-shot",
+                bindings: [
+                  { key: "at-time", value: atTime },
+                  {
+                    key: "callback-url",
+                    value: "https://example.test/official-callback",
+                  },
+                  { key: "correlation-id", value: randomUUID() },
+                ],
+              },
+              { blueprintKey: "webhook-trigger", bindings: [] },
+            ],
+          },
         }),
-      ]);
-    }
-  });
+        [201],
+      );
+      onTestFinished(async () => {
+        installCatalogStorageFixture();
+        await bdd.deleteAgent(actor, agentId);
+        await cleanupCatalog();
+      });
+      const runnerGroup = runs.configureRunnerGroup();
+      runs.acceptStorageDownloads();
+      runs.acceptTelemetryIngest();
+
+      const automations = new Map(
+        installed.body.workflow.automations.flatMap((automation) => {
+          return automation.official
+            ? [[automation.official.blueprintKey, automation] as const]
+            : [];
+        }),
+      );
+      const loopAutomation = automations.get("pulse");
+      const onceAutomation = automations.get("one-shot");
+      const webhookAutomation = automations.get("webhook-trigger");
+      if (!loopAutomation || !onceAutomation || !webhookAutomation) {
+        throw new Error("Expected all Official Workflow producer automations");
+      }
+
+      const producerRuns: {
+        readonly runId: string;
+        readonly automationId: string;
+      }[] = [];
+      if (producerKind === "explicit and scheduled") {
+        const explicit = await accept(
+          automationClient().run({
+            headers,
+            extraHeaders: { origin: "https://app.okou.ai" },
+            params: { id: loopAutomation.id },
+          }),
+          [201],
+        );
+        if (!explicit.body.runId) {
+          throw new Error("Expected explicit Official Automation Run");
+        }
+        producerRuns.push({
+          runId: explicit.body.runId,
+          automationId: loopAutomation.id,
+        });
+        await completeSuccessfulRun(
+          runnerGroup,
+          explicit.body.runId,
+          "Explicit Official result",
+        );
+
+        const scheduled = await withMockNowForTest(
+          now() + 120_000,
+          async () => {
+            return await accept(
+              automationExecutionClient().execute({
+                body: { automation_id: loopAutomation.id },
+              }),
+              [200],
+            );
+          },
+        );
+        expect(scheduled.body.executed).toBe(1);
+        const scheduledRun = await readLatestWorkflowAutomationRunFixture(
+          context,
+          loopAutomation.id,
+        );
+        if (!scheduledRun || scheduledRun.runId === explicit.body.runId) {
+          throw new Error(
+            "Expected a distinct scheduled Official Automation Run",
+          );
+        }
+        producerRuns.push({
+          runId: scheduledRun.runId,
+          automationId: loopAutomation.id,
+        });
+        await completeSuccessfulRun(
+          runnerGroup,
+          scheduledRun.runId,
+          "Scheduled Official result",
+        );
+      }
+
+      if (producerKind === "once") {
+        const once = await withMockNowForTest(now() + 120_000, async () => {
+          return await accept(
+            automationExecutionClient().execute({
+              body: { automation_id: onceAutomation.id },
+            }),
+            [200],
+          );
+        });
+        expect(once.body.executed).toBe(1);
+        const onceRun = await readLatestWorkflowAutomationRunFixture(
+          context,
+          onceAutomation.id,
+        );
+        if (!onceRun) {
+          throw new Error("Expected once Official Automation Run");
+        }
+        producerRuns.push({
+          runId: onceRun.runId,
+          automationId: onceAutomation.id,
+        });
+        await completeSuccessfulRun(
+          runnerGroup,
+          onceRun.runId,
+          "Once Official result",
+        );
+      }
+
+      if (producerKind === "webhook") {
+        if (
+          webhookAutomation.kind !== "event" ||
+          webhookAutomation.eventType !== "webhook-received"
+        ) {
+          throw new Error("Expected Official webhook automation");
+        }
+        const webhookCredentials = await accept(
+          automationClient().revealWebhookSecret({
+            headers,
+            params: { id: webhookAutomation.id },
+            body: undefined,
+          }),
+          [200],
+        );
+        const webhook = await postOfficialWorkflowWebhook({
+          webhookUrl: webhookCredentials.body.webhookUrl,
+          secret: webhookCredentials.body.webhookSecret,
+          body: JSON.stringify({ event: "official-p2-regression" }),
+        });
+        expect(webhook).toMatchObject({
+          status: 200,
+          body: { success: true, duplicate: false },
+        });
+        await expect
+          .poll(async () => {
+            return (
+              await readLatestWorkflowAutomationRunFixture(
+                context,
+                webhookAutomation.id,
+              )
+            )?.runId;
+          })
+          .toEqual(expect.any(String));
+        const webhookRun = await readLatestWorkflowAutomationRunFixture(
+          context,
+          webhookAutomation.id,
+        );
+        if (!webhookRun) {
+          throw new Error("Expected Official webhook Automation Run");
+        }
+        producerRuns.push({
+          runId: webhookRun.runId,
+          automationId: webhookAutomation.id,
+        });
+        await completeSuccessfulRun(
+          runnerGroup,
+          webhookRun.runId,
+          "Event Official result",
+        );
+      }
+
+      const accepted = await readAcceptedDefinitionFixture(definitionName);
+      for (const producer of producerRuns) {
+        const state = await readOfficialWorkflowRunStateFixture(
+          context,
+          producer.runId,
+        );
+        expect(state.model_provider).toBe("built-in");
+        expect(state.provenance?.definitions).toStrictEqual([
+          expect.objectContaining({
+            name: definitionName,
+            revision: accepted.definition.revision,
+          }),
+        ]);
+        expect(state.storage_mounts).toStrictEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              org_id: SYSTEM_ORG_ID,
+              user_id: VOLUME_ORG_USER_ID,
+              storage_id: accepted.definition.artifact.storageId,
+              version: accepted.definition.artifact.storageVersion,
+            }),
+          ]),
+        );
+        const source = await outbox.findSourceState({
+          sourceRunId: producer.runId,
+          sourceWorkflowAutomationId: producer.automationId,
+        });
+        expect(source.claim).not.toBeNull();
+        expect(source.items).toStrictEqual([
+          expect.objectContaining({
+            public_brand: "okou",
+            subject: `Display ${definitionName}`,
+            source_run_id: producer.runId,
+            source_workflow_automation_id: producer.automationId,
+            status: "pending",
+            template: expect.objectContaining({
+              template: "official-automation-result",
+            }),
+          }),
+        ]);
+      }
+    },
+  );
 
   it("uses Okou email brand for session and agent-token launches across Official result callback retry", async () => {
     const scenario = await installResultEmailLoopScenario(

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
@@ -890,7 +890,10 @@ describe("POST /api/voice-io/transcribe/segment", () => {
     expect(response.body.error.code).toBe("VOICE_TRANSCRIPTION_FAILED");
   });
 
-  it("counts one free-tier recording only after finalization, including a failed final attempt", async () => {
+  it.each([
+    "unfinished segments",
+    "failed final attempt followed by a successful retry",
+  ])("counts free-tier recordings correctly for %s", async (phase) => {
     mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
     const actor = await enabledActor();
     if (!actor.orgId) {
@@ -949,33 +952,36 @@ describe("POST /api/voice-io/transcribe/segment", () => {
       }),
       [200],
     );
-    await expect(readQuota()).resolves.toMatchObject({
-      allowed: true,
-      count: 0,
-    });
-    await accept(
-      client().segment({
-        headers,
-        body: segmentForm([], "First part. Second part.", true, 120),
-      }),
-      [503],
-    );
-    await expect(readQuota()).resolves.toMatchObject({
-      allowed: true,
-      count: 0,
-    });
-    failFinal = false;
-    await accept(
-      client().segment({
-        headers,
-        body: segmentForm([], "First part. Second part.", true, 120),
-      }),
-      [200],
-    );
-    await expect(readQuota()).resolves.toMatchObject({
-      allowed: true,
-      count: 1,
-    });
+    if (phase === "unfinished segments") {
+      await expect(readQuota()).resolves.toMatchObject({
+        allowed: true,
+        count: 0,
+      });
+    } else {
+      await accept(
+        client().segment({
+          headers,
+          body: segmentForm([], "First part. Second part.", true, 120),
+        }),
+        [503],
+      );
+      await expect(readQuota()).resolves.toMatchObject({
+        allowed: true,
+        count: 0,
+      });
+      failFinal = false;
+      await accept(
+        client().segment({
+          headers,
+          body: segmentForm([], "First part. Second part.", true, 120),
+        }),
+        [200],
+      );
+      await expect(readQuota()).resolves.toMatchObject({
+        allowed: true,
+        count: 1,
+      });
+    }
   });
 
   it("meters unique recording time without charging the boundary overlap twice", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-activity-summary.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-activity-summary.test.tsx
@@ -151,7 +151,7 @@ test.each(["pending", "cooldown", 500] as const)(
   },
 );
 
-test("The fallback follows a saved language change and stays stable when reopening the thread", async () => {
+async function openPendingActivitySummary() {
   installActiveRun();
   context.mocks.api(
     chatThreadActivitySummaryContract.summarize,
@@ -162,14 +162,20 @@ test("The fallback follows a saved language change and stays stable when reopeni
 
   await setupPage({ context, path: RUN_PATH, featureSwitches });
   await expect(screen.findByText("Thinking...")).resolves.toBeVisible();
+}
 
+test("The pending summary fallback stays stable when reopening the thread", async () => {
+  await openPendingActivitySummary();
   click(await findLink("Agents"));
   await expect(
     screen.findByRole("heading", { name: "Agents" }),
   ).resolves.toBeVisible();
   click(await findLink("Run conversation"));
   await expect(screen.findByText("Thinking...")).resolves.toBeVisible();
+});
 
+test("The pending summary fallback follows a saved language change", async () => {
+  await openPendingActivitySummary();
   click(await findButton("Test User"));
   const menu = await screen.findByRole("menu");
   const settings = queryAllByRoleFast("menuitem", menu).find((item) => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-automations.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-automations.test.tsx
@@ -61,7 +61,7 @@ function automationControl(
   return control;
 }
 
-test("Browse workflow automations and their available controls", async () => {
+async function openAutomationBrowser(): Promise<void> {
   const automations = [
     {
       id: ACTIVE_SCHEDULE_ID,
@@ -161,7 +161,10 @@ test("Browse workflow automations and their available controls", async () => {
     name: "Automations",
   });
   expect(automationSidebar).toBeVisible();
+}
 
+test("Browse an active scheduled workflow and its available controls", async () => {
+  await openAutomationBrowser();
   const activeSchedule = automationPanel("Active release schedule");
   expect(within(activeSchedule).getByText("Active")).toBeVisible();
   expect(within(activeSchedule).getByText("Every 2 hours")).toBeVisible();
@@ -170,7 +173,10 @@ test("Browse workflow automations and their available controls", async () => {
   expect(automationControl(activeSchedule, "link", "View")).toBeVisible();
   expect(automationControl(activeSchedule, "button", "Run now")).toBeVisible();
   expect(automationControl(activeSchedule, "button", "Edit")).toBeVisible();
+});
 
+test("Browse a webhook workflow without offering schedule editing", async () => {
+  await openAutomationBrowser();
   const webhook = automationPanel("Release webhook");
   expect(automationControl(webhook, "link", "View")).toBeVisible();
   expect(automationControl(webhook, "button", "Run now")).toBeVisible();
@@ -179,7 +185,10 @@ test("Browse workflow automations and their available controls", async () => {
       return button.textContent?.trim() === "Edit";
     }),
   ).toBeFalsy();
+});
 
+test("Browse a paused scheduled workflow without an inline switch", async () => {
+  await openAutomationBrowser();
   const disabledSchedule = automationPanel("Paused digest schedule");
   expect(within(disabledSchedule).getByText("Disabled")).toBeVisible();
   expect(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-input.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-input.test.tsx
@@ -626,18 +626,25 @@ test("Show a longer history of recent voice levels", async () => {
   });
 });
 
-test.each([
-  {
-    status: 503,
-    code: "PROVIDER_UNAVAILABLE",
-    message: "Voice transcription is temporarily unavailable",
-  },
-  {
-    status: 502,
-    code: "VOICE_TRANSCRIPTION_FAILED",
-    message: "Voice draft transcription failed to produce a usable response",
-  },
-])("Retry the original recording after $code", async (failure) => {
+test.each(
+  [
+    {
+      status: 503,
+      code: "PROVIDER_UNAVAILABLE",
+      message: "Voice transcription is temporarily unavailable",
+    },
+    {
+      status: 502,
+      code: "VOICE_TRANSCRIPTION_FAILED",
+      message: "Voice draft transcription failed to produce a usable response",
+    },
+  ].flatMap((failure) => {
+    return [
+      { ...failure, phase: "failure feedback" },
+      { ...failure, phase: "recovery after repeated failure" },
+    ];
+  }),
+)("Voice retry $phase after $code", async (failure) => {
   const transcriptionFailed = context.mocks.deferred<void>();
   const retryRequest = context.mocks.deferred<void>();
   const retryResponse = context.mocks.deferred<void>();
@@ -712,6 +719,11 @@ test.each([
   retryResponse.resolve();
   await findEnabledButton("Retry");
   expect(normalizedComposerText()).toBe("Keep these notes.");
+  expect(transcriptionAttempts).toBe(2);
+  expect(recordings[1]).toStrictEqual(recordings[0]);
+  if (failure.phase === "failure feedback") {
+    return;
+  }
   click(await findButton("Retry"));
 
   await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-accounts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-accounts.test.tsx
@@ -5,7 +5,7 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, test } from "vitest";
 
-import { fill, setupPage } from "../../../__tests__/page-helper.ts";
+import { click, fill, setupPage } from "../../../__tests__/page-helper.ts";
 import {
   accountSummary,
   builtinConnector,
@@ -53,10 +53,9 @@ async function loadComposer(): Promise<void> {
 }
 
 async function openConnectors(
-  user: ReturnType<typeof userEvent.setup>,
   container: ParentNode = document.body,
 ): Promise<void> {
-  await user.click(await findFastControl("button", "Connectors", container));
+  click(await findFastControl("button", "Connectors", container));
   await expect(
     findFastControl("button", "Add connectors"),
   ).resolves.toBeVisible();
@@ -92,7 +91,7 @@ function githubAccounts(count = 2) {
   });
 }
 
-test("Keep connector access scoped to each chat’s agent", async () => {
+async function openAgentScopedConnectors(pendingAuthorization: boolean) {
   const user = userEvent.setup({ delay: null });
   const otherAuthorization = context.mocks.deferred<void>();
   const fixture = installComposerConnectorFixture({
@@ -101,7 +100,9 @@ test("Keep connector access scoped to each chat’s agent", async () => {
       [SCOUT_AGENT_ID]: [],
       [OTHER_AGENT_ID]: [SLACK_SLUG],
     },
-    authorizationGates: { [OTHER_AGENT_ID]: otherAuthorization.promise },
+    authorizationGates: pendingAuthorization
+      ? { [OTHER_AGENT_ID]: otherAuthorization.promise }
+      : {},
     threads: [
       { id: SCOUT_THREAD_ID, title: "Scout chat", agentId: SCOUT_AGENT_ID },
       { id: OTHER_THREAD_ID, title: "Other chat", agentId: OTHER_AGENT_ID },
@@ -127,19 +128,32 @@ test("Keep connector access scoped to each chat’s agent", async () => {
   await expect(
     findFastControl("button", "Connectors", otherPane),
   ).resolves.toBeVisible();
-  await openConnectors(user, scoutPane);
+  return { user, fixture, scoutPane, otherPane, otherAuthorization };
+}
+
+test("A pending connector authorization does not borrow the other chat agent's access", async () => {
+  const { user, scoutPane, otherPane, otherAuthorization } =
+    await openAgentScopedConnectors(true);
+  await openConnectors(scoutPane);
   await expect(screen.findByLabelText("Add Slack")).resolves.toBeVisible();
   await user.keyboard("{Escape}");
-  await openConnectors(user, otherPane);
+  await openConnectors(otherPane);
   expect(screen.queryByLabelText("Remove Slack")).toBeNull();
   expect(screen.queryByLabelText("Add Slack")).toBeNull();
 
   otherAuthorization.resolve(undefined);
   await expect(screen.findByLabelText("Remove Slack")).resolves.toBeVisible();
+});
+
+test("Removing a connector updates only the selected chat agent's access", async () => {
+  const { user, fixture, scoutPane, otherPane } =
+    await openAgentScopedConnectors(false);
+  await openConnectors(otherPane);
+  await screen.findByLabelText("Remove Slack");
   await user.click(screen.getByLabelText("Remove Slack"));
   await expect(screen.findByLabelText("Add Slack")).resolves.toBeVisible();
   await user.keyboard("{Escape}");
-  await openConnectors(user, scoutPane);
+  await openConnectors(scoutPane);
   expect(screen.getByLabelText("Add Slack")).toBeVisible();
   expect(fixture.builtinAuthorizationUpdates).toStrictEqual([
     {
@@ -166,7 +180,7 @@ test("Carry a connector account choice into a new chat", async () => {
   });
 
   await loadComposer();
-  await openConnectors(user);
+  await openConnectors();
   const chooser = await openAccountChooser(
     user,
     "GitHub · Using default account: Work",
@@ -220,7 +234,7 @@ test("Preserve connector context across chats with the same agent", async () => 
   await setupPage({ context, path: `/chats/${SCOUT_THREAD_ID}` });
 
   await loadComposer();
-  await openConnectors(user);
+  await openConnectors();
   await expect(screen.findByLabelText("Remove GitHub")).resolves.toBeVisible();
   await user.click(await findFastControl("link", "Second Scout chat"));
   await waitFor(() => {
@@ -275,7 +289,7 @@ test("Choose an account for a custom MCP connector", async () => {
   });
 
   await loadComposer();
-  await openConnectors(user);
+  await openConnectors();
   const chooser = await openAccountChooser(
     user,
     "DeepWiki · Using default account: Team",
@@ -320,7 +334,7 @@ test("Keep the selected connector account visible during search", async () => {
   });
 
   await loadComposer();
-  await openConnectors(user);
+  await openConnectors();
   const chooser = await openAccountChooser(
     user,
     "GitHub · Selected account: Personal",
@@ -357,7 +371,7 @@ test("Choose which connector account a chat uses", async () => {
   });
 
   await loadComposer();
-  await openConnectors(user);
+  await openConnectors();
   let chooser = await openAccountChooser(
     user,
     "GitHub · Using default account: Work",
@@ -433,16 +447,16 @@ test("Keep connector access synchronized across split chats for the same agent",
   await expect(
     findFastControl("button", "Connectors", secondPane),
   ).resolves.toBeVisible();
-  await openConnectors(user, firstPane);
+  await openConnectors(firstPane);
   await expect(screen.findByLabelText("Remove Slack")).resolves.toBeVisible();
   await user.keyboard("{Escape}");
-  await openConnectors(user, secondPane);
+  await openConnectors(secondPane);
   await expect(screen.findByLabelText("Remove Slack")).resolves.toBeVisible();
 
   await user.click(screen.getByLabelText("Remove Slack"));
   await expect(screen.findByLabelText("Add Slack")).resolves.toBeVisible();
   await user.keyboard("{Escape}");
-  await openConnectors(user, firstPane);
+  await openConnectors(firstPane);
   expect(screen.getByLabelText("Add Slack")).toBeVisible();
   expect(fixture.builtinAuthorizationUpdates).toStrictEqual([
     {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, test } from "vitest";
+import { agentDraftContract } from "@okouai/api-contracts/contracts/agent-draft";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { PRESENTATION_TEMPLATE_PICKER_ITEMS } from "@okouai/core";
 import {
@@ -368,14 +369,22 @@ test("Image mode sends when the model menu is still open", async () => {
   });
 });
 
-test.each([
+const createTemplateScenarios = [
   {
     mode: "image",
     commandLabel: "Create image",
     pickerLabel: "Add style",
     selectLabel: "Select template",
     previewLabel: "Preview template",
-    templates: ILLUSTRATION_TEMPLATE_ITEMS,
+    templates: ILLUSTRATION_TEMPLATE_ITEMS.map((template) => {
+      return {
+        ...template,
+        request: {
+          type: "illustration" as const,
+          selection: { illustrationStyleId: template.illustrationStyleId },
+        },
+      };
+    }),
   },
   {
     mode: "video",
@@ -383,7 +392,15 @@ test.each([
     pickerLabel: "Add template",
     selectLabel: "Select video template",
     previewLabel: "Preview video template",
-    templates: VIDEO_TEMPLATE_ITEMS,
+    templates: VIDEO_TEMPLATE_ITEMS.map((template) => {
+      return {
+        ...template,
+        request: {
+          type: "video" as const,
+          selection: { stylePresetId: template.id },
+        },
+      };
+    }),
   },
   {
     mode: "presentation",
@@ -391,32 +408,31 @@ test.each([
     pickerLabel: "Add template",
     selectLabel: "Select template",
     previewLabel: "Preview template",
-    templates: PRESENTATION_TEMPLATE_PICKER_ITEMS,
+    templates: PRESENTATION_TEMPLATE_PICKER_ITEMS.map((template) => {
+      return {
+        ...template,
+        request: {
+          type: "presentation" as const,
+          selection: {
+            templateId: template.templateId,
+            colorSystemId: template.colorSystemId ?? undefined,
+          },
+        },
+      };
+    }),
   },
-])(
-  "$commandLabel adds multiple templates, edits only the clicked chip, and sends every reference",
-  async ({
-    mode,
-    commandLabel,
-    pickerLabel,
-    selectLabel,
-    previewLabel,
-    templates,
-  }) => {
+] as const;
+
+test.each(createTemplateScenarios)(
+  "$commandLabel adds multiple templates without replacing the existing text or chip",
+  async ({ mode, commandLabel, pickerLabel, selectLabel, templates }) => {
     setupModels();
-    const submissions: UserMessageDocument[] = [];
-    mockChatLifecycle(context, {
-      onRunCreate: (body) => {
-        if (body.userMessage) {
-          submissions.push(body.userMessage);
-        }
-      },
-    });
+    mockChatLifecycle(context);
     const editor = await setupComposer();
     const user = userEvent.setup({ delay: null });
-    const [first, second, replacement] = templates;
-    if (!first || !second || !replacement) {
-      throw new Error(`Expected three ${mode} templates`);
+    const [first, second] = templates;
+    if (!first || !second) {
+      throw new Error(`Expected two ${mode} templates`);
     }
     await chooseCommand(editor, `Our launch /create ${mode}`, commandLabel);
     click(button(pickerLabel));
@@ -435,6 +451,71 @@ test.each([
       expect(chips).toHaveLength(2);
       expect(chips[0]).toHaveTextContent(first.title);
       expect(chips[1]).toHaveTextContent(second.title);
+    });
+    expect(editor).toHaveTextContent("Our launch");
+    expect(editor).toHaveTextContent("for the cover.");
+    expect(button(pickerLabel)).toBeInTheDocument();
+  },
+);
+
+test.each(createTemplateScenarios)(
+  "$commandLabel edits only the clicked draft template and sends every reference",
+  async ({
+    mode,
+    commandLabel,
+    pickerLabel,
+    selectLabel,
+    previewLabel,
+    templates,
+  }) => {
+    setupModels();
+    const submissions: UserMessageDocument[] = [];
+    mockChatLifecycle(context, {
+      onRunCreate: (body) => {
+        if (body.userMessage) {
+          submissions.push(body.userMessage);
+        }
+      },
+    });
+    const [first, second, replacement] = templates;
+    if (!first || !second || !replacement) {
+      throw new Error(`Expected three ${mode} templates`);
+    }
+    context.mocks.api(agentDraftContract.get, ({ respond }) => {
+      return respond(200, {
+        draftUserMessage: {
+          version: 1,
+          parts: [
+            { type: "text", text: "Our launch " },
+            {
+              type: "template",
+              titleSnapshot: first.title,
+              template: first.request,
+            },
+            { type: "text", text: " for the cover. " },
+            {
+              type: "template",
+              titleSnapshot: second.title,
+              template: second.request,
+            },
+          ],
+        },
+        draftAttachments: null,
+      });
+    });
+    const editor = await setupComposer();
+    await waitFor(() => {
+      expect(composerInlineTemplates()).toHaveLength(2);
+    });
+    const user = userEvent.setup({ delay: null });
+    await user.click(editor);
+    await user.paste(` /create ${mode}`);
+    const menu = await screen.findByTestId("slash-workflow-menu");
+    click(button(commandLabel, menu));
+    await waitFor(() => {
+      expect(screen.getByTestId("composer-create-mode")).toHaveTextContent(
+        commandLabel,
+      );
     });
 
     const firstChip = composerInlineTemplates()[0];

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-keyboard.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-keyboard.test.tsx
@@ -146,7 +146,7 @@ test("Send with the Enter key preference", async () => {
     path: `/agents/${MESSAGE_EXPERIENCE_AGENT_ID}/chat`,
   });
 
-  let editor = await loadNewChatComposer();
+  const editor = await loadNewChatComposer();
   await fill(editor, "Prepare the launch summary");
   await user.keyboard("{Enter}");
   await waitFor(() => {
@@ -154,14 +154,39 @@ test("Send with the Enter key preference", async () => {
   });
   await expectSentPrompt("Prepare the launch summary");
   await expectAgentWorking();
+});
 
-  editor = await findComposer();
+test("Shift-Enter keeps an active chat's follow-up draft on two lines without sending", async () => {
+  const user = userEvent.setup({ delay: null });
+  const sentPrompts: string[] = [];
+  const threadId = "c0000000-0000-4000-a000-000000000055";
+  const runId = "c0000000-0000-4000-a000-000000000056";
+  context.mocks.data.userPreferences({ sendMode: "enter" });
+  installMessageExperienceChat({
+    threadId,
+    chatEvents: [
+      {
+        id: "active-keyboard-prompt",
+        role: "user",
+        content: "Prepare the launch summary",
+        runId,
+        createdAt: "2026-08-01T00:00:00Z",
+      },
+    ],
+    activeRunIds: [runId],
+    onSendRequest: ({ prompt }) => {
+      sentPrompts.push(prompt);
+    },
+  });
+  await setupPage({ context, path: `/chats/${threadId}` });
+  await expectAgentWorking();
+  const editor = await findComposer();
   await fill(editor, "Keep this draft");
   await user.keyboard("{Shift>}{Enter}{/Shift}");
   await user.keyboard("on two lines");
   expect(draftLines(editor)).toStrictEqual(["Keep this draft", "on two lines"]);
   expect(editor).toHaveFocus();
-  expect(sentPrompts).toStrictEqual(["Prepare the launch summary"]);
+  expect(sentPrompts).toStrictEqual([]);
 });
 
 test("Send with the command-key preference", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-mentions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-mentions.test.tsx
@@ -9,6 +9,7 @@ import type { ChatThreadSnapshotProjection } from "@okouai/api-contracts/contrac
 import { expect, test } from "vitest";
 
 import {
+  fill,
   click,
   queryAllByRoleFast,
   setupPage,
@@ -175,7 +176,7 @@ test("Hide mention suggestions when nothing useful matches", async () => {
   });
 });
 
-test("Mention another agent in a message", async () => {
+async function openAgentMentionWorkspace() {
   const current = withAgent(
     continuityThread(62, 1, "Scout planning"),
     AGENT_ID,
@@ -219,9 +220,13 @@ test("Mention another agent in a message", async () => {
     path: `/chats/${current.id}`,
     ...workspace.pageOptions,
   });
+  return { current, savedMentionThread, workspace };
+}
 
-  const user = userEvent.setup();
+test("Suggest other agents before matching chats", async () => {
+  await openAgentMentionWorkspace();
   const composer = await screen.findByRole("textbox", { name: "Message" });
+  const user = userEvent.setup({ delay: null });
   await user.click(composer);
   await user.keyboard("@");
   const menu = await screen.findByTestId("chat-thread-suggestion-menu");
@@ -248,8 +253,14 @@ test("Mention another agent in a message", async () => {
   ]);
   expect(within(menu).queryByText("Scout")).toBeNull();
   expect(within(menu).getByText("Zeta launch notes")).toBeVisible();
+});
 
-  await user.keyboard("zeta");
+test("Save a selected agent mention and retain it when returning to the chat", async () => {
+  const { current, savedMentionThread, workspace } =
+    await openAgentMentionWorkspace();
+  const user = userEvent.setup({ delay: null });
+  const composer = await screen.findByRole("textbox", { name: "Message" });
+  await fill(composer, "@zeta");
   const zetaSuggestion = await waitFor(() => {
     return menuButton("Zeta Agent");
   });
@@ -275,7 +286,19 @@ test("Mention another agent in a message", async () => {
       }),
     ).toBeTruthy();
   });
+  await openConversation(savedMentionThread.id);
+  await screen.findByRole("textbox", { name: "Message" });
+  await openConversation(current.id);
+  const retainedComposer = await screen.findByRole("textbox", {
+    name: "Message",
+  });
+  await waitFor(() => {
+    expect(agentMention(retainedComposer, ZETA_ID)).toBeVisible();
+  });
+});
 
+test("A saved agent mention uses the current avatar when opened", async () => {
+  const { savedMentionThread } = await openAgentMentionWorkspace();
   await openConversation(savedMentionThread.id);
   const restoredComposer = await screen.findByRole("textbox", {
     name: "Message",
@@ -287,14 +310,6 @@ test("Mention another agent in a message", async () => {
       "data-agent-avatar-url",
       ZETA_CURRENT_AVATAR,
     );
-  });
-
-  await openConversation(current.id);
-  const retainedComposer = await screen.findByRole("textbox", {
-    name: "Message",
-  });
-  await waitFor(() => {
-    expect(agentMention(retainedComposer, ZETA_ID)).toBeVisible();
   });
 });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-presentation-gallery.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-presentation-gallery.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, test, vi } from "vitest";
 
-import { setupPage } from "../../../__tests__/page-helper.ts";
+import { click, setupPage } from "../../../__tests__/page-helper.ts";
 import { PRESENTATION_TEMPLATE_PICKER_ITEMS } from "@okouai/core/presentation-template-items";
 import { VIDEO_TEMPLATE_ITEMS } from "@okouai/core/video-template-items";
 import { WEBSITE_TEMPLATE_ITEMS } from "@okouai/core/website-template-items";
@@ -49,7 +49,7 @@ function installImmediateAnimationFrames(): void {
   );
 }
 
-test("Choose a presentation template theme", async () => {
+async function openPresentationThemePreview() {
   const capture = mockTemplateChat();
   const template = builtInTemplate();
   mockTemplateObjectUrls();
@@ -64,27 +64,33 @@ test("Choose a presentation template theme", async () => {
   });
 
   await openTemplatePicker(user, "Presentation");
-  await user.click(
-    screen.getByLabelText(`Preview ${template.title} at current slide`),
-  );
+  click(screen.getByLabelText(`Preview ${template.title} at current slide`));
   await waitFor(() => {
     expect(detailGroup(template.title)).toBeVisible();
   });
-  const detail = detailGroup(template.title);
+  return { capture, template, user, detail: detailGroup(template.title) };
+}
+
+test("Changing a presentation theme refreshes its visible preview", async () => {
+  const { template, detail } = await openPresentationThemePreview();
   const firstFrame = await waitFor(() => {
     return within(detail).getByTitle(`${template.title} HTML preview`);
   });
   const firstFrameUrl = firstFrame.getAttribute("src");
 
-  await user.click(screen.getByLabelText("Select style Deep dive"));
+  click(screen.getByLabelText("Select style Deep dive"));
   const themedFrame = await waitFor(() => {
     const frame = within(detail).getByTitle(`${template.title} HTML preview`);
     expect(frame.getAttribute("src")).not.toBe(firstFrameUrl);
     return frame;
   });
   expect(themedFrame).toBeVisible();
+});
 
-  await user.click(
+test("Send the selected presentation theme from its preview", async () => {
+  const { capture, template, user } = await openPresentationThemePreview();
+  click(screen.getByLabelText("Select style Deep dive"));
+  click(
     within(screen.getByRole("dialog")).getByLabelText(
       `Select template ${template.title}`,
     ),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-presentation-options.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-presentation-options.test.tsx
@@ -81,14 +81,9 @@ function visibleText(message: SubmittedMessage | undefined): string {
   );
 }
 
-test("Presentation sends Auto as hidden additional info while keeping the message unchanged", async () => {
+test("Presentation offers the documented slide counts and selects Auto", async () => {
   setupModels();
-  const submissions: SubmittedMessage[] = [];
-  mockChatLifecycle(context, {
-    onRunCreate: (body) => {
-      submissions.push(body);
-    },
-  });
+  mockChatLifecycle(context);
   const editor = await setupComposer();
   expect(screen.queryByRole("combobox", { name: "Slide count" })).toBeNull();
   const picker = await enterPresentation(editor);
@@ -112,6 +107,24 @@ test("Presentation sends Auto as hidden additional info while keeping the messag
   expect(
     within(menu).getByRole("option", { name: "8–12 slides" }),
   ).toHaveAttribute("aria-selected", "true");
+  click(within(menu).getByRole("option", { name: "Auto" }));
+  await waitFor(() => {
+    return expect(picker).toHaveTextContent("Auto");
+  });
+});
+
+test("Presentation sends Auto as hidden additional info while keeping the message unchanged", async () => {
+  setupModels();
+  const submissions: SubmittedMessage[] = [];
+  mockChatLifecycle(context, {
+    onRunCreate: (body) => {
+      submissions.push(body);
+    },
+  });
+  const editor = await setupComposer();
+  const picker = await enterPresentation(editor);
+  click(picker);
+  const menu = await screen.findByRole("listbox");
   click(within(menu).getByRole("option", { name: "Auto" }));
   await waitFor(() => {
     expect(picker).toHaveTextContent("Auto");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-uploaded-presentation-templates.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-uploaded-presentation-templates.test.tsx
@@ -162,7 +162,7 @@ test("A closed composer does not load uploaded template covers", async () => {
   });
 });
 
-test("Use an uploaded presentation template", async () => {
+async function openUploadedPresentationPicker() {
   mockNow(UPLOADED_TEMPLATE_NOW_MS, context.signal);
   const capture = mockTemplateChat();
   const uploaded = createUploadedTemplate({
@@ -185,7 +185,11 @@ test("Use an uploaded presentation template", async () => {
     expect(screen.getByText(uploaded.title)).toBeVisible();
   });
   expectTextBefore(uploaded.title, firstBuiltInTitle());
+  return { capture, uploaded, user, picker };
+}
 
+test("Hovering an uploaded presentation opens the currently previewed slide", async () => {
+  const { uploaded, user, picker } = await openUploadedPresentationPicker();
   const media = importedTemplateMedia(uploaded.id);
   Object.defineProperty(media, "getBoundingClientRect", {
     configurable: true,
@@ -213,6 +217,17 @@ test("Use an uploaded presentation template", async () => {
     "true",
   );
   expect(detail).toBeVisible();
+});
+
+test("Select and send an uploaded presentation template from its detail preview", async () => {
+  const { capture, uploaded, user } = await openUploadedPresentationPicker();
+  click(
+    buttonNamed(
+      `Preview ${uploaded.title} at current slide`,
+      importedTemplateMedia(uploaded.id),
+    ),
+  );
+  await screen.findByRole("group", { name: `${uploaded.title} slide preview` });
   click(buttonNamed(`Select template ${uploaded.title}`));
   await sendComposerMessage(user, "Use this deck for the launch review");
   await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-video-options.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-video-options.test.tsx
@@ -198,9 +198,27 @@ function installVideoSubmissionCapture(): SubmittedMessage[] {
 }
 
 test.each([false, true])(
+  "Show default video option controls with Create enabled: %s",
+  async (enabled) => {
+    installVideoSubmissionCapture();
+    await setupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.ComposerCreateCommands]: enabled },
+    });
+    await enterText("Generate the first cinematic clip.");
+    await enterVideoMode("Claude Fable 5.1");
+    await selectVideoTemplate();
+    await expect(
+      openVideoOptions("16:9 · 8s · 720p"),
+    ).resolves.toBeInTheDocument();
+    await userEvent.setup({ delay: null }).keyboard("{Escape}");
+  },
+);
+
+test.each([false, true])(
   "Submit default video options with Create enabled: %s",
   async (enabled) => {
-    const user = userEvent.setup({ delay: null });
     const submissions = installVideoSubmissionCapture();
     await setupPage({
       context,
@@ -212,10 +230,6 @@ test.each([false, true])(
     const editor = await enterText(prompt);
     await enterVideoMode("Claude Fable 5.1");
     const template = await selectVideoTemplate();
-    await expect(
-      openVideoOptions("16:9 · 8s · 720p"),
-    ).resolves.toBeInTheDocument();
-    await user.keyboard("{Escape}");
     await sendCurrent(editor, prompt);
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-workflows.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-workflows.test.tsx
@@ -11,6 +11,7 @@ import {
   WORKFLOW_TEMPLATE_ITEMS,
 } from "@okouai/core";
 import { expect, test } from "vitest";
+import { chatThreadDraftContract } from "@okouai/api-contracts/contracts/chat-threads";
 
 import {
   click,
@@ -206,53 +207,83 @@ function installOffsetVisualViewport(): void {
   );
 }
 
-test("Send a message with multiple inline templates", async () => {
-  const first = PRESENTATION_TEMPLATE_PICKER_ITEMS[0];
-  const second = PRESENTATION_TEMPLATE_PICKER_ITEMS[1];
-  if (!first || !second) {
-    throw new Error("Expected at least two presentation templates");
-  }
-  let sentTemplateTitles: string[] = [];
-  mockAgent();
-  mockChatLifecycle(context, {
-    threadId: THREAD_ID,
-    threadTitle: "My thread",
-    onSendRequest: (body) => {
-      sentTemplateTitles =
-        body.userMessage?.parts.flatMap((part) => {
-          return part.type === "template" ? [part.titleSnapshot] : [];
-        }) ?? [];
-    },
-  });
-  installWorkflows(() => {
-    return [];
-  });
+test.each(["insert", "send"])(
+  "Multiple inline templates preserve every reference when you %s",
+  async (action) => {
+    const first = PRESENTATION_TEMPLATE_PICKER_ITEMS[0];
+    const second = PRESENTATION_TEMPLATE_PICKER_ITEMS[1];
+    if (!first || !second) {
+      throw new Error("Expected at least two presentation templates");
+    }
+    let sentTemplateTitles: string[] = [];
+    mockAgent();
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      threadTitle: "My thread",
+      onSendRequest: (body) => {
+        sentTemplateTitles =
+          body.userMessage?.parts.flatMap((part) => {
+            return part.type === "template" ? [part.titleSnapshot] : [];
+          }) ?? [];
+      },
+    });
+    installWorkflows(() => {
+      return [];
+    });
+    if (action === "send") {
+      context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
+        return respond(200, {
+          draftUserMessage: {
+            version: 1,
+            parts: [first, second].map((template) => {
+              return {
+                type: "template" as const,
+                titleSnapshot: template.title,
+                template: {
+                  type: "presentation" as const,
+                  selection: { templateId: template.templateId },
+                },
+              };
+            }),
+          },
+          draftAttachments: null,
+        });
+      });
+    }
 
-  await setupPage({ context, path: `/chats/${THREAD_ID}` });
+    await setupPage({ context, path: `/chats/${THREAD_ID}` });
 
-  const user = userEvent.setup();
-  const editor = await findComposerEditor();
-  await expect(screen.findByLabelText("Template")).resolves.toBeVisible();
+    const user = userEvent.setup();
+    const editor = await findComposerEditor();
+    await expect(screen.findByLabelText("Template")).resolves.toBeVisible();
 
-  await selectTemplate(user, first);
-  await selectTemplate(user, second);
-  expect(composerInlineTemplates()).toHaveLength(2);
-  expect(editor.textContent).not.toContain("Ask me to automate");
+    if (action === "insert") {
+      await selectTemplate(user, first);
+      await selectTemplate(user, second);
+    }
+    await waitFor(() => {
+      return expect(composerInlineTemplates()).toHaveLength(2);
+    });
+    expect(editor.textContent).not.toContain("Ask me to automate");
+    if (action === "insert") {
+      return;
+    }
 
-  await user.click(editor);
-  await user.keyboard("{Enter}");
+    await user.click(editor);
+    await user.keyboard("{Enter}");
 
-  await waitFor(() => {
-    expect(sentTemplateTitles).toStrictEqual([first.title, second.title]);
-    expect(structuredTemplateReferences()).toHaveLength(2);
-  });
-  expect(
-    structuredTemplateReferences().map((reference) => {
-      return reference.textContent;
-    }),
-  ).toStrictEqual([first.title, second.title]);
-  expect(composerInlineTemplates()).toHaveLength(0);
-});
+    await waitFor(() => {
+      expect(sentTemplateTitles).toStrictEqual([first.title, second.title]);
+      expect(structuredTemplateReferences()).toHaveLength(2);
+    });
+    expect(
+      structuredTemplateReferences().map((reference) => {
+        return reference.textContent;
+      }),
+    ).toStrictEqual([first.title, second.title]);
+    expect(composerInlineTemplates()).toHaveLength(0);
+  },
+);
 
 test("Replace an inline template after sending a message", async () => {
   const first = PRESENTATION_TEMPLATE_PICKER_ITEMS[0];
@@ -342,8 +373,8 @@ test("Dismiss workflow suggestions without losing the query", async () => {
   });
 });
 
-test("Refresh workflow suggestions without disrupting the draft", async () => {
-  let workflows: WorkflowFixture[] = [];
+async function openWorkflowRefreshChat(initialWorkflows: WorkflowFixture[]) {
+  let workflows = initialWorkflows;
   const primaryThread = {
     id: THREAD_ID,
     agentId: AGENT_ID,
@@ -377,7 +408,6 @@ test("Refresh workflow suggestions without disrupting the draft", async () => {
   await user.keyboard("/release-report");
   await waitFor(() => {
     expect(primaryEditor).toHaveTextContent("/release-report");
-    expect(workflowHighlights(primaryEditor)).toHaveLength(0);
   });
   await waitFor(() => {
     expect(
@@ -391,26 +421,48 @@ test("Refresh workflow suggestions without disrupting the draft", async () => {
       ),
     ).toBeTruthy();
   });
+  return {
+    primaryEditor,
+    splitEditor,
+    user,
+    traffic,
+    updateWorkflows(next: WorkflowFixture[]) {
+      workflows = next;
+      context.mocks.ably.trigger(`chatThreadWorkflowsChanged:${THREAD_ID}`);
+      context.mocks.ably.trigger(
+        `chatThreadWorkflowsChanged:${SPLIT_THREAD_ID}`,
+      );
+    },
+  };
+}
 
-  workflows = [workflow("release-report")];
-  context.mocks.ably.trigger(`chatThreadWorkflowsChanged:${THREAD_ID}`);
-  context.mocks.ably.trigger(`chatThreadWorkflowsChanged:${SPLIT_THREAD_ID}`);
+test("A newly available workflow highlights the existing draft without changing its text", async () => {
+  const { primaryEditor, updateWorkflows } = await openWorkflowRefreshChat([]);
+  expect(workflowHighlights(primaryEditor)).toHaveLength(0);
+  updateWorkflows([workflow("release-report")]);
 
   await waitFor(() => {
     expect(primaryEditor).toHaveTextContent("/release-report");
     expect(workflowHighlights(primaryEditor)).toHaveLength(1);
     expect(slashButton("/release-report")).toBeVisible();
   });
+});
 
-  workflows = [...workflows, workflow("first-live-change")];
-  context.mocks.ably.trigger(`chatThreadWorkflowsChanged:${THREAD_ID}`);
-  context.mocks.ably.trigger(`chatThreadWorkflowsChanged:${SPLIT_THREAD_ID}`);
+test("Successive workflow updates reach both open composers without disrupting their drafts", async () => {
+  const { primaryEditor, splitEditor, user, traffic, updateWorkflows } =
+    await openWorkflowRefreshChat([workflow("release-report")]);
+  await waitFor(() => {
+    return expect(workflowHighlights(primaryEditor)).toHaveLength(1);
+  });
+  updateWorkflows([workflow("release-report"), workflow("first-live-change")]);
   await waitFor(() => {
     expect(traffic.requests.length).toBeGreaterThanOrEqual(4);
   });
-  workflows = [...workflows, workflow("latest-attached")];
-  context.mocks.ably.trigger(`chatThreadWorkflowsChanged:${THREAD_ID}`);
-  context.mocks.ably.trigger(`chatThreadWorkflowsChanged:${SPLIT_THREAD_ID}`);
+  updateWorkflows([
+    workflow("release-report"),
+    workflow("first-live-change"),
+    workflow("latest-attached"),
+  ]);
 
   await user.click(primaryEditor);
   await user.keyboard(" /latest");
@@ -763,52 +815,63 @@ test("Send a template while the current run is active", async () => {
   expect((await findComposerEditor()).textContent).toBe("");
 });
 
-test("Find and send a workflow template", async () => {
-  const template = WORKFLOW_TEMPLATE_ITEMS.find((item) => {
-    return item.id === "workflow-template:github-pr-summarizer";
-  });
-  if (!template) {
-    throw new Error("Expected the GitHub PR summarizer workflow template");
-  }
-  let sentTemplateTitle: string | undefined;
-  mockAgent();
-  mockChatLifecycle(context, {
-    threadId: THREAD_ID,
-    threadTitle: "Workflow templates",
-    onSendRequest: (body) => {
-      sentTemplateTitle = body.userMessage?.parts.find((part) => {
-        return part.type === "template";
-      })?.titleSnapshot;
-    },
-  });
-  installWorkflows(() => {
-    return [];
-  });
+test.each(["find", "send"])(
+  "Use the workflow template picker to %s a workflow template",
+  async (action) => {
+    const template = WORKFLOW_TEMPLATE_ITEMS.find((item) => {
+      return item.id === "workflow-template:github-pr-summarizer";
+    });
+    if (!template) {
+      throw new Error("Expected the GitHub PR summarizer workflow template");
+    }
+    let sentTemplateTitle: string | undefined;
+    mockAgent();
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      threadTitle: "Workflow templates",
+      onSendRequest: (body) => {
+        sentTemplateTitle = body.userMessage?.parts.find((part) => {
+          return part.type === "template";
+        })?.titleSnapshot;
+      },
+    });
+    installWorkflows(() => {
+      return [];
+    });
 
-  await setupPage({ context, path: `/chats/${THREAD_ID}` });
+    await setupPage({ context, path: `/chats/${THREAD_ID}` });
 
-  const user = userEvent.setup();
-  const editor = await findComposerEditor();
-  await openTemplateCategory("Workflow");
-  const search = screen.getByRole("textbox", { name: "Search templates" });
-  await user.type(search, "merged pull requests");
-  click(
-    await screen.findByLabelText(`Select workflow template ${template.title}`),
-  );
+    const user = userEvent.setup();
+    const editor = await findComposerEditor();
+    await openTemplateCategory("Workflow");
+    const search = screen.getByRole("textbox", { name: "Search templates" });
+    await fill(
+      search,
+      action === "find" ? "merged pull requests" : template.title,
+    );
+    click(
+      await screen.findByLabelText(
+        `Select workflow template ${template.title}`,
+      ),
+    );
 
-  await expectInlineTemplateInComposer(template.title);
-  await user.click(editor);
-  await user.keyboard("{Enter}");
+    await expectInlineTemplateInComposer(template.title);
+    if (action === "find") {
+      return;
+    }
+    await user.click(editor);
+    await user.keyboard("{Enter}");
 
-  await waitFor(() => {
-    expect(sentTemplateTitle).toBe(template.title);
-    expect(
-      structuredTemplateReferences().some((reference) => {
-        return reference.textContent === template.title;
-      }),
-    ).toBeTruthy();
-  });
-});
+    await waitFor(() => {
+      expect(sentTemplateTitle).toBe(template.title);
+      expect(
+        structuredTemplateReferences().some((reference) => {
+          return reference.textContent === template.title;
+        }),
+      ).toBeTruthy();
+    });
+  },
+);
 
 test("Continue from empty slash suggestions to all workflows", async () => {
   mockAgent();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-drafts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-drafts.test.tsx
@@ -65,7 +65,7 @@ function composerFileInput(): HTMLInputElement {
   return input;
 }
 
-test("Keep each conversation's draft separate while navigating", async () => {
+async function editSeparateConversationDrafts() {
   const first = continuityThread(1, 1, "First draft conversation");
   const second = continuityThread(1, 2, "Second draft conversation");
   const secondServerDraft = continuityDraft([
@@ -88,7 +88,7 @@ test("Keep each conversation's draft separate while navigating", async () => {
   });
 
   const firstComposer = await messageComposer();
-  await userEvent.type(firstComposer, "First conversation follow-up");
+  await fill(firstComposer, "First conversation follow-up");
   expect(firstComposer).toHaveTextContent("First conversation follow-up");
 
   await openConversation(second.id);
@@ -101,13 +101,21 @@ test("Keep each conversation's draft separate while navigating", async () => {
   await userEvent.type(secondComposer, " and a separate note");
 
   await openConversation(first.id);
+  return { second };
+}
+
+test("Restore the first edited draft without leaking the other conversation's draft", async () => {
+  await editSeparateConversationDrafts();
   await waitFor(() => {
     expect(currentMessageComposer()).toHaveTextContent(
       "First conversation follow-up",
     );
   });
   expect(currentMessageComposer()).not.toHaveTextContent("a separate note");
+});
 
+test("Restore the second edited draft without leaking the other conversation's draft", async () => {
+  const { second } = await editSeparateConversationDrafts();
   await openConversation(second.id);
   await waitFor(() => {
     expect(currentMessageComposer()).toHaveTextContent("a separate note");
@@ -243,7 +251,7 @@ test("Restore a rich saved draft when a chat opens", async () => {
   expect(composer).toHaveTextContent("Preserve the launch date");
 });
 
-test("Save and clear typed drafts consistently", async () => {
+async function typePersistentDraft() {
   const target = continuityThread(4, 1, "Draft persistence target");
   const neighbor = continuityThread(4, 2, "Draft persistence neighbor");
   const workspace = installContinuityWorkspace(context, {
@@ -268,7 +276,11 @@ test("Save and clear typed drafts consistently", async () => {
       }),
     ).toBeTruthy();
   });
+  return { target, neighbor, workspace, composer };
+}
 
+test("Save a typed draft and restore it after navigating away", async () => {
+  const { target, neighbor } = await typePersistentDraft();
   await openConversation(neighbor.id);
   await openConversation(target.id);
   await waitFor(() => {
@@ -276,8 +288,15 @@ test("Save and clear typed drafts consistently", async () => {
       "Unsent launch checklist",
     );
   });
+});
 
-  const restoredComposer = await messageComposer();
+test("Clear a saved typed draft without restoring it on the next visit", async () => {
+  const {
+    target,
+    neighbor,
+    workspace,
+    composer: restoredComposer,
+  } = await typePersistentDraft();
   await userEvent.click(restoredComposer);
   await userEvent.keyboard("{Control>}a{/Control}{Backspace}");
   await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-optimistic.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-optimistic.test.tsx
@@ -1,5 +1,4 @@
 import { screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import {
   chatEventsContract,
   chatThreadDraftContract,
@@ -7,7 +6,7 @@ import {
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { expect, test } from "vitest";
 
-import { setupPage } from "../../../__tests__/page-helper.ts";
+import { click, fill, setupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
   CHAT_LIST_AGENT_ID,
@@ -27,7 +26,7 @@ import {
 const context = testContext();
 
 async function selectClaudeSonnet(): Promise<void> {
-  await userEvent.click(await screen.findByRole("combobox"));
+  click(await screen.findByRole("combobox"));
   let option: HTMLElement | undefined;
   await waitFor(() => {
     option = Array.from(
@@ -37,16 +36,16 @@ async function selectClaudeSonnet(): Promise<void> {
     });
     expect(option).toBeDefined();
   });
-  await userEvent.click(option!);
+  click(option!);
 }
 
 async function sendComposerMessage(message: string): Promise<void> {
   const composer = await screen.findByRole("textbox", { name: "Message" });
-  await userEvent.type(composer, message);
+  await fill(composer, message);
   await waitFor(() => {
     expect(fastButton("Send")).toBeEnabled();
   });
-  await userEvent.click(fastButton("Send"));
+  click(fastButton("Send"));
 }
 
 function installNewThreadDefaults(): void {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-status-tail.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-status-tail.test.tsx
@@ -85,7 +85,7 @@ async function expectRetainedResult(): Promise<HTMLElement> {
   return main;
 }
 
-test("Retire the previous error as soon as a new message is sent, before acknowledgement or output", async () => {
+async function sendAfterPreviousFailure() {
   const sendGate = context.mocks.deferred<void>();
   const runCreated = context.mocks.deferred<void>();
   const chat = installRunChat({
@@ -109,7 +109,16 @@ test("Retire the previous error as soon as a new message is sent, before acknowl
     expect(screen.queryByText(OLD_ERROR)).toBeNull();
   });
   await expectRetainedResult();
+  return { chat, sendGate, runCreated };
+}
 
+test("Retire the previous error as soon as a new message is sent, before acknowledgement or output", async () => {
+  await sendAfterPreviousFailure();
+  expect(screen.queryByText(OLD_ERROR)).toBeNull();
+});
+
+test("A subsequent failed response replaces the previous error while retaining its result", async () => {
+  const { chat, sendGate, runCreated } = await sendAfterPreviousFailure();
   sendGate.resolve();
   await runCreated.promise;
   chat.failRun(NEW_ERROR);
@@ -120,7 +129,24 @@ test("Retire the previous error as soon as a new message is sent, before acknowl
   expect(document.querySelector("[data-thinking-indicator]")).toBeNull();
   expect(screen.getAllByTestId("chat-event-actions")).toHaveLength(1);
   await expectRetainedResult();
+});
 
+test("Retrying the latest recorded failure retires it while retaining the earlier result", async () => {
+  installRunChat({
+    chatEvents: [
+      ...resultEvents(),
+      failedEvent(),
+      promptEvent({
+        id: "next-input",
+        runId: RUN_B,
+        seqId: 5,
+        text: "Continue checking",
+      }),
+      failedEvent(RUN_B, NEW_ERROR, 6),
+    ],
+  });
+  await openChat();
+  await screen.findByText(NEW_ERROR);
   await sendText("Try the next check");
 
   await expect(screen.findByText("Try the next check")).resolves.toBeVisible();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
@@ -888,7 +888,7 @@ test("Complete OAuth only after the current attempt succeeds", async () => {
   });
 });
 
-test("Name a newly added manual account", async () => {
+async function addManualAccountForNaming() {
   mockConnectors(context, []);
   const connectionId = crypto.randomUUID();
   let renamed: { readonly id: string; readonly name: string | null } | null =
@@ -946,14 +946,30 @@ test("Name a newly added manual account", async () => {
     name: "Name your Ahrefs account",
   });
   const input = within(naming).getByLabelText("Account name");
+  return {
+    input,
+    naming,
+    connectionId,
+    getRenamed: () => {
+      return renamed;
+    },
+  };
+}
+
+test("A newly added manual account suggests its external identity without prefilling a name", async () => {
+  const { input } = await addManualAccountForNaming();
   expect(input).toHaveValue("");
   expect(input).toHaveAttribute("placeholder", "owner@example.com");
+});
 
+test("Save a name for the exact newly added manual account", async () => {
+  const { input, naming, connectionId, getRenamed } =
+    await addManualAccountForNaming();
   await fill(input, "Work");
   click(getConnectorAction("button", "Save", naming));
 
   await waitFor(() => {
-    expect(renamed).toStrictEqual({ id: connectionId, name: "Work" });
+    expect(getRenamed()).toStrictEqual({ id: connectionId, name: "Work" });
   });
 });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
@@ -220,7 +220,7 @@ test("Update connector visibility when availability changes", async () => {
   expect(locationSearch()).toBe("?keywords=mailchimp");
 });
 
-test("Filter connectors by connection state and agent", async () => {
+async function openConnectorFilterCatalog() {
   const researchId = "c0000000-0000-4000-a000-000000000010";
   mockConnectors(context, [
     { connectorSlug: "github", externalUsername: "octocat" },
@@ -235,7 +235,11 @@ test("Filter connectors by connection state and agent", async () => {
   });
   await setupPage({ context, path: "/connectors" });
   await expectCards({ github: true, asana: true });
+  return { researchId };
+}
 
+test("Filter connected and disconnected connectors without losing a text search", async () => {
+  await openConnectorFilterCatalog();
   click(getConnectorAction("button", "Filter connectors"));
   click(getConnectorAction("menuitem", "Connected"));
   await expectCards({ github: true, asana: false });
@@ -253,7 +257,12 @@ test("Filter connectors by connection state and agent", async () => {
   await expectCards({ github: true, asana: false });
   expect(new URLSearchParams(locationSearch()).get("keywords")).toBe("git");
   expect(new URLSearchParams(locationSearch()).has("connection")).toBeFalsy();
+});
 
+test("Filter connectors by an agent after clearing the text search", async () => {
+  const { researchId } = await openConnectorFilterCatalog();
+  await fill(screen.getByPlaceholderText("Find connectors"), "git");
+  await expectCards({ github: true, asana: false });
   await fill(screen.getByPlaceholderText("Find connectors"), "");
   click(getConnectorAction("button", "Filter connectors"));
   click(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/markdown-interactions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/markdown-interactions.test.tsx
@@ -64,7 +64,7 @@ function getLinkByName(
   return link;
 }
 
-test("Code-copy confirmations belong to the selected block", async () => {
+async function openCodeCopyBlocks() {
   const chat = createMarkdownChatFixture(context);
   const source = [
     "```typescript",
@@ -107,15 +107,34 @@ test("Code-copy confirmations belong to the selected block", async () => {
   });
   const firstCopy = getButtonByName("Copy to clipboard", firstBlock);
   const secondCopy = getButtonByName("Copy to clipboard", secondBlock);
+  return { firstCopy, secondCopy, clipboard };
+}
 
+test.each(["first", "second"])(
+  "Copying the %s code block confirms only that block",
+  async (selected) => {
+    const { firstCopy, secondCopy, clipboard } = await openCodeCopyBlocks();
+    const [copy, other] =
+      selected === "first" ? [firstCopy, secondCopy] : [secondCopy, firstCopy];
+    click(copy);
+    await waitFor(() => {
+      expect(copy).toHaveAttribute("aria-label", "Copied");
+    });
+    expect(other).toHaveAttribute("aria-label", "Copy to clipboard");
+    expect(clipboard.writes).toStrictEqual([
+      selected === "first"
+        ? 'const first = "alpha";\n'
+        : 'const second = "beta";\n',
+    ]);
+  },
+);
+
+test("Copied code blocks reset their confirmations after returning to the chat", async () => {
+  const { firstCopy, secondCopy, clipboard } = await openCodeCopyBlocks();
   click(firstCopy);
-
   await waitFor(() => {
-    expect(firstCopy).toHaveAttribute("aria-label", "Copied");
+    return expect(firstCopy).toHaveAttribute("aria-label", "Copied");
   });
-  expect(secondCopy).toHaveAttribute("aria-label", "Copy to clipboard");
-  expect(clipboard.writes).toStrictEqual(['const first = "alpha";\n']);
-
   click(secondCopy);
 
   await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/markdown-mermaid.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/markdown-mermaid.test.tsx
@@ -54,7 +54,7 @@ function diagramButtons(container: ParentNode = document.body): HTMLElement[] {
   });
 }
 
-test("A Mermaid diagram can move from chat into artifact split view", async () => {
+async function openMermaidSplitView() {
   vi.spyOn(HTMLImageElement.prototype, "naturalWidth", "get").mockReturnValue(
     900,
   );
@@ -124,7 +124,12 @@ test("A Mermaid diagram can move from chat into artifact split view", async () =
   });
   const firstSidebarSource = firstSidebarImage.getAttribute("src");
   await dialogRemoved;
+  return { sidebar, firstSidebarSource, secondExpand };
+}
 
+test("Opening another Mermaid diagram replaces the current artifact split view", async () => {
+  const { sidebar, firstSidebarSource, secondExpand } =
+    await openMermaidSplitView();
   click(secondExpand);
 
   await waitFor(() => {
@@ -136,7 +141,10 @@ test("A Mermaid diagram can move from chat into artifact split view", async () =
   expect(
     screen.queryByRole("dialog", { name: "diagram.svg preview" }),
   ).toBeNull();
+});
 
+test("Closing a Mermaid artifact split view preserves both inline diagrams and sources", async () => {
+  const { sidebar } = await openMermaidSplitView();
   const sidebarRemoved = waitForElementToBeRemoved(sidebar);
   click(getButtonByName("Close artifact", sidebar));
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-billing-tab.test.tsx
@@ -1272,14 +1272,27 @@ test("Manage member packages on an Atom-granted plan", async () => {
   ).not.toBeInTheDocument();
 });
 
-test("Schedule and revise a legacy Team conversion", async () => {
+async function openLegacyTeamConversion(scheduled = false): Promise<void> {
   let migrationState: UsagePackMigrationStateResponse = {
     tier: "team",
-    targetTier: null,
-    status: "eligible",
-    migrationId: null,
+    targetTier: scheduled ? "team" : null,
+    status: scheduled ? "scheduled" : "eligible",
+    migrationId: scheduled ? "3ea4b7cf-d71e-45dc-8273-8bc8b9712490" : null,
     effectiveAt: "2026-09-01T00:00:00.000Z",
     hostedInvoiceUrl: null,
+    ...(scheduled
+      ? {
+          configuration: {
+            tier: "team" as const,
+            memberUsagePacks: [
+              { memberId: "user_1", usagePackUsd: 20 },
+              { memberId: "invitation_1", usagePackUsd: 50 },
+            ],
+            recurringAmountCents: 22_950,
+            currency: "usd",
+          },
+        }
+      : {}),
   };
   context.mocks.data.org({
     id: "org_1",
@@ -1458,6 +1471,10 @@ test("Schedule and revise a legacy Team conversion", async () => {
   });
 
   await screen.findByText("Team plan");
+}
+
+test("Schedule a legacy Team conversion after reviewing member packages", async () => {
+  await openLegacyTeamConversion();
   click(buttonByText("Compare all plans"));
   const choosePlanDialog = await screen.findByRole("dialog", {
     name: "Choose a plan",
@@ -1616,7 +1633,11 @@ test("Schedule and revise a legacy Team conversion", async () => {
     ),
   ).not.toBeInTheDocument();
   expect(screen.getByText("Legacy")).toBeInTheDocument();
+});
 
+test("Review and revise an already scheduled legacy Team conversion", async () => {
+  await openLegacyTeamConversion(true);
+  await screen.findByText("Switches to Team on Sep 1, 2026");
   click(buttonByText("Downgrade"));
   const unchangedChoosePlanDialog = await screen.findByRole("dialog", {
     name: "Choose a plan",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-general-tab.test.tsx
@@ -358,48 +358,44 @@ test.each(["Cancel", "Close", "Escape", "backdrop"] as const)(
   },
 );
 
-test("Require fresh workspace confirmation after closing Settings or navigating back", async () => {
-  context.mocks.data.org({ id: "org_1", name: "Acme", role: "admin" });
-  await openGeneralTab();
+test.each(["closing Settings", "navigating back"])(
+  "Require fresh workspace confirmation after %s",
+  async (exit) => {
+    context.mocks.data.org({ id: "org_1", name: "Acme", role: "admin" });
+    await setupPage({ context, path: "/" });
+    await reopenSettings();
 
-  const dialog = await openDeleteDialog();
-  await fill(within(dialog).getByPlaceholderText("confirm"), "confirm");
-  expect(buttonWithText(dialog, "Delete workspace")).toBeEnabled();
-  click(buttonWithText(dialog, "Cancel"));
-  const settings = await screen.findByRole("dialog", { name: "Settings" });
-  click(within(settings).getByLabelText("Close"));
-  await waitFor(() => {
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-  });
+    const dialog = await openDeleteDialog();
+    await fill(within(dialog).getByPlaceholderText("confirm"), "confirm");
+    expect(buttonWithText(dialog, "Delete workspace")).toBeEnabled();
+    if (exit === "closing Settings") {
+      click(buttonWithText(dialog, "Cancel"));
+      const settings = await screen.findByRole("dialog", { name: "Settings" });
+      click(within(settings).getByLabelText("Close"));
+    } else {
+      act(() => {
+        window.history.back();
+      });
+      await screen.findByRole("heading", { name: "Preference" });
+      act(() => {
+        window.history.back();
+      });
+    }
+    await waitFor(() => {
+      expect(
+        new URLSearchParams(window.location.search).has("settings"),
+      ).toBeFalsy();
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
 
-  await reopenSettings();
-  const reopened = await openDeleteDialog();
-  expect(within(reopened).getByPlaceholderText("confirm")).toHaveValue("");
-  expect(buttonWithText(reopened, "Delete workspace")).toBeDisabled();
-
-  await fill(within(reopened).getByPlaceholderText("confirm"), "confirm");
-  expect(buttonWithText(reopened, "Delete workspace")).toBeEnabled();
-  act(() => {
-    window.history.back();
-  });
-  await screen.findByRole("heading", { name: "Preference" });
-  act(() => {
-    window.history.back();
-  });
-  await waitFor(() => {
-    expect(
-      new URLSearchParams(window.location.search).has("settings"),
-    ).toBeFalsy();
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-  });
-
-  await reopenSettings();
-  const afterNavigation = await openDeleteDialog();
-  expect(within(afterNavigation).getByPlaceholderText("confirm")).toHaveValue(
-    "",
-  );
-  expect(buttonWithText(afterNavigation, "Delete workspace")).toBeDisabled();
-});
+    await reopenSettings();
+    const afterNavigation = await openDeleteDialog();
+    expect(within(afterNavigation).getByPlaceholderText("confirm")).toHaveValue(
+      "",
+    );
+    expect(buttonWithText(afterNavigation, "Delete workspace")).toBeDisabled();
+  },
+);
 
 test("Require fresh confirmation after workspace details finish saving", async () => {
   const saveReady = createDeferredPromise<void>(context.signal);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-members-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-members-tab.test.tsx
@@ -1029,42 +1029,36 @@ test("Explain package and credit effects before removing a member", async () => 
   expect(screen.getByText("bob@example.com")).toBeInTheDocument();
 });
 
-test("Revoke a pending workspace invitation", async () => {
-  mockMembersStory();
-  await openMembersTab();
+test.each(["Cancel", "Revoke"] as const)(
+  "%s a pending workspace invitation revocation",
+  async (action) => {
+    mockMembersStory();
+    await openMembersTab();
 
-  await fill(screen.getByPlaceholderText("Search"), "pending");
-  await waitFor(() => {
-    expect(screen.getByText("pending@example.com")).toBeInTheDocument();
-  });
+    await fill(screen.getByPlaceholderText("Search"), "pending");
+    await waitFor(() => {
+      expect(screen.getByText("pending@example.com")).toBeInTheDocument();
+    });
 
-  click(screen.getByLabelText("Actions for pending@example.com"));
-  click(menuItemByText("Revoke invitation"));
+    click(screen.getByLabelText("Actions for pending@example.com"));
+    click(menuItemByText("Revoke invitation"));
 
-  const cancelRevokeDialog = await screen.findByRole("dialog", {
-    name: "Revoke invitation?",
-  });
-  expect(
-    within(cancelRevokeDialog).getByText(
-      /will no longer be able to join using this invitation/i,
-    ),
-  ).toBeInTheDocument();
-  click(buttonByText("Cancel", cancelRevokeDialog));
-
-  await waitFor(() => {
-    expect(screen.getByText("pending@example.com")).toBeInTheDocument();
-  });
-
-  click(screen.getByLabelText("Actions for pending@example.com"));
-  click(menuItemByText("Revoke invitation"));
-
-  const revokeDialog = await screen.findByRole("dialog", {
-    name: "Revoke invitation?",
-  });
-  click(buttonByText("Revoke", revokeDialog));
-
-  await waitFor(() => {
-    expect(screen.getByText("Invitation revoked")).toBeInTheDocument();
-    expect(screen.queryByText("pending@example.com")).not.toBeInTheDocument();
-  });
-});
+    const cancelRevokeDialog = await screen.findByRole("dialog", {
+      name: "Revoke invitation?",
+    });
+    expect(
+      within(cancelRevokeDialog).getByText(
+        /will no longer be able to join using this invitation/i,
+      ),
+    ).toBeInTheDocument();
+    click(buttonByText(action, cancelRevokeDialog));
+    await waitFor(() => {
+      expect(screen.queryAllByText("pending@example.com")).toHaveLength(
+        action === "Cancel" ? 1 : 0,
+      );
+      expect(screen.queryAllByText("Invitation revoked")).toHaveLength(
+        action === "Revoke" ? 1 : 0,
+      );
+    });
+  },
+);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx
@@ -260,8 +260,10 @@ function gatewayConnectionResponse(
   };
 }
 
-function mockGatewayConnectionLifecycle() {
-  let connections: ModelProviderConnectionResponse[] = [];
+function mockGatewayConnectionLifecycle(
+  initialConnections: ModelProviderConnectionResponse[] = [],
+) {
+  let connections = initialConnections;
   let updateSecret: string | undefined;
 
   context.mocks.api(
@@ -300,6 +302,57 @@ function mockGatewayConnectionLifecycle() {
       return updateSecret;
     },
   };
+}
+
+async function openExistingGateway(displayName: string, routed = false) {
+  mockAdminOrg();
+  context.mocks.data.orgModelProviders([]);
+  context.mocks.data.orgModelPolicies([
+    builtInPolicy(
+      "00000000-0000-4000-a000-000000000211",
+      "gpt-5.6-luna",
+      "GPT 5.6 Luna",
+      true,
+    ),
+    ...(routed
+      ? [
+          {
+            ...builtInPolicy(
+              "00000000-0000-4000-a000-000000000212",
+              "claude-sonnet-5",
+              "Claude Sonnet 5",
+              false,
+            ),
+            defaultProviderType: "custom-anthropic-messages" as const,
+            modelProviderSurfaceId: "00000000-0000-4000-a000-000000000301",
+          },
+        ]
+      : []),
+  ]);
+  const lifecycle = mockGatewayConnectionLifecycle([
+    gatewayConnectionResponse({
+      displayName,
+      surfaces: [
+        {
+          protocol: "anthropic-messages",
+          apiBaseUrl: "https://ai-gateway.vercel.sh",
+          authHeaderName: "Authorization",
+          authHeaderTemplate: "Bearer {{secret}}",
+          modelMappings: { "claude-sonnet-5": "anthropic/claude-sonnet-5" },
+        },
+      ],
+    }),
+  ]);
+  await openProvidersTab();
+  const heading = await screen.findByRole("heading", {
+    name: "Provider connections",
+  });
+  const section = heading.closest("section");
+  if (!(section instanceof HTMLElement)) {
+    throw new Error("Provider connections section not found");
+  }
+  await expect(within(section).findByText(displayName)).resolves.toBeVisible();
+  return { lifecycle, connectionsSection: section };
 }
 
 async function openProvidersTab(): Promise<void> {
@@ -563,7 +616,7 @@ test("Discard sensitive provider-connection drafts when Settings closes", async 
   expect(within(reopenedAddDialog).getByLabelText("API key")).toHaveValue("");
 });
 
-test("Add, edit, route through, and delete a workspace model gateway", async () => {
+async function openAddGatewayDialog() {
   mockAdminOrg();
   context.mocks.data.orgModelProviders([]);
   context.mocks.data.orgModelPolicies([
@@ -574,7 +627,7 @@ test("Add, edit, route through, and delete a workspace model gateway", async () 
       true,
     ),
   ]);
-  const lifecycle = mockGatewayConnectionLifecycle();
+  mockGatewayConnectionLifecycle();
 
   await openProvidersTab();
 
@@ -591,6 +644,11 @@ test("Add, edit, route through, and delete a workspace model gateway", async () 
   const addDialog = await screen.findByRole("dialog", {
     name: "Add model provider",
   });
+  return { addDialog, connectionsSection };
+}
+
+test("The workspace gateway form describes both supported request surfaces", async () => {
+  const { addDialog } = await openAddGatewayDialog();
   expect(
     within(addDialog).getByText(
       "Requests: https://ai-gateway.vercel.sh/v1/messages",
@@ -601,6 +659,10 @@ test("Add, edit, route through, and delete a workspace model gateway", async () 
       "Requests: https://ai-gateway.vercel.sh/v1/responses",
     ),
   ).toBeInTheDocument();
+});
+
+test("Add a workspace gateway without exposing its private key", async () => {
+  const { addDialog, connectionsSection } = await openAddGatewayDialog();
   await fill(within(addDialog).getByLabelText("API key"), "vck-test");
   click(buttonByText("Save changes", addDialog));
 
@@ -608,7 +670,11 @@ test("Add, edit, route through, and delete a workspace model gateway", async () 
     within(connectionsSection).findByText("Vercel AI Gateway"),
   ).resolves.toBeInTheDocument();
   expect(screen.queryByText("vck-test")).not.toBeInTheDocument();
+});
 
+test("Rename a workspace gateway and rotate its private API key", async () => {
+  const { lifecycle, connectionsSection } =
+    await openExistingGateway("Vercel AI Gateway");
   click(within(connectionsSection).getByLabelText("Gateway actions"));
   click(menuItemByText("Edit"));
   const editDialog = await screen.findByRole("dialog", {
@@ -635,7 +701,10 @@ test("Add, edit, route through, and delete a workspace model gateway", async () 
   expect(
     screen.getByTestId("org-model-policy-row-gpt-5.6-luna"),
   ).toBeInTheDocument();
+});
 
+test("Route a workspace model through an existing custom gateway", async () => {
+  await openExistingGateway("Vercel Edge Gateway");
   click(buttonByText("Add model"));
   await selectDialogModel("Claude Sonnet 5");
   const policyDialog = screen.getByRole("dialog", { name: "Add model" });
@@ -653,7 +722,17 @@ test("Add, edit, route through, and delete a workspace model gateway", async () 
       within(policyRow).getByText("Vercel Edge Gateway"),
     ).toBeInTheDocument();
   });
+});
 
+test("Deleting a gateway removes it from an already routed workspace model", async () => {
+  const { connectionsSection } = await openExistingGateway(
+    "Vercel Edge Gateway",
+    true,
+  );
+  const policyRow = await screen.findByTestId(
+    "org-model-policy-row-claude-sonnet-5",
+  );
+  await within(policyRow).findByText("Vercel Edge Gateway");
   click(within(connectionsSection).getByLabelText("Gateway actions"));
   click(menuItemByText("Delete"));
   const deleteDialog = await screen.findByRole("dialog", {
@@ -674,41 +753,33 @@ test("Add, edit, route through, and delete a workspace model gateway", async () 
   });
 });
 
-test("Offer only active models when adding a workspace route", async () => {
-  mockAdminOrg();
-  context.mocks.data.orgModelProviders([]);
-  context.mocks.data.orgModelPolicies([]);
-  await openProvidersTab();
+test.each([
+  { model: "GPT 5.6 Sol", active: true },
+  { model: "GPT 5.5", active: true },
+  { model: "Claude Sonnet 4.6", active: true },
+  { model: "Claude Opus 4.8", active: true },
+  { model: "DeepSeek V4 Flash", active: true },
+  { model: "DeepSeek V4 Pro", active: true },
+  { model: "Kimi K2.7 Code", active: false },
+  { model: "Claude Opus 4.7", active: false },
+])(
+  "Offer $model only when active while adding a workspace route",
+  async ({ model, active }) => {
+    mockAdminOrg();
+    context.mocks.data.orgModelProviders([]);
+    context.mocks.data.orgModelPolicies([]);
+    await openProvidersTab();
 
-  click(buttonByText("Add model"));
-  const dialog = screen.getByRole("dialog", { name: "Add model" });
-  click(within(dialog).getByRole("combobox"));
+    click(buttonByText("Add model"));
+    const dialog = screen.getByRole("dialog", { name: "Add model" });
+    click(within(dialog).getByRole("combobox"));
 
-  await expect(
-    screen.findByRole("option", { name: "GPT 5.6 Sol" }),
-  ).resolves.toBeInTheDocument();
-  await expect(
-    screen.findByRole("option", { name: "GPT 5.5" }),
-  ).resolves.toBeInTheDocument();
-  await expect(
-    screen.findByRole("option", { name: "Claude Sonnet 4.6" }),
-  ).resolves.toBeInTheDocument();
-  await expect(
-    screen.findByRole("option", { name: "Claude Opus 4.8" }),
-  ).resolves.toBeInTheDocument();
-  await expect(
-    screen.findByRole("option", { name: "DeepSeek V4 Flash" }),
-  ).resolves.toBeInTheDocument();
-  await expect(
-    screen.findByRole("option", { name: "DeepSeek V4 Pro" }),
-  ).resolves.toBeInTheDocument();
-  expect(
-    screen.queryByRole("option", { name: "Kimi K2.7 Code" }),
-  ).not.toBeInTheDocument();
-  expect(
-    screen.queryByRole("option", { name: "Claude Opus 4.7" }),
-  ).not.toBeInTheDocument();
-});
+    await screen.findByRole("option", { name: "GPT 5.6 Sol" });
+    expect(screen.queryAllByRole("option", { name: model })).toHaveLength(
+      active ? 1 : 0,
+    );
+  },
+);
 
 test("Limit free workspaces to eligible built-in models", async () => {
   mockAdminOrg();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/personal-usage-tab.test.tsx
@@ -289,8 +289,7 @@ async function openUsageSettings(
   });
 }
 
-test("Review your member-package credit balance", async () => {
-  const user = userEvent.setup();
+async function openMemberPackageCredits(): Promise<HTMLElement> {
   mockPersonalUsageStory(usageRows(), "pro", false, "member");
   context.mocks.api(billingUsagePackCreditsContract.get, ({ respond }) => {
     return respond(200, {
@@ -322,6 +321,11 @@ test("Review your member-package credit balance", async () => {
   await openUsageSettings();
 
   const card = await screen.findByTestId("usage-pack-credit-card");
+  return card;
+}
+
+test("Review your member-package credit balance and grant rows", async () => {
+  const card = await openMemberPackageCredits();
   expect(within(card).getByText("Usage pack credits")).toBeInTheDocument();
   expect(
     within(card).getByTestId("usage-pack-credit-purchased"),
@@ -350,7 +354,12 @@ test("Review your member-package credit balance", async () => {
       return button.textContent?.trim() === "Configure member packages";
     }),
   ).toBeFalsy();
+});
 
+test("Review purchased member-package credit expiry and grant details", async () => {
+  const card = await openMemberPackageCredits();
+  const grants = within(card).getByTestId("usage-pack-credit-grants-section");
+  const user = userEvent.setup();
   await user.hover(within(card).getByTestId("usage-pack-credit-purchased"));
   await expect(
     screen.findByText("Purchased — 20,000"),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/preferences-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/preferences-page.test.tsx
@@ -20,7 +20,7 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
 
-test("Debug preferences restore, change, and reset the voice input model", async () => {
+test("Debug preferences restore and change the voice input model", async () => {
   const updates = mockPreferences({
     voiceInputModel: "google/gemini-3.6-flash",
   });
@@ -29,9 +29,7 @@ test("Debug preferences restore, change, and reset the voice input model", async
     path: "/?settings=debug",
     featureSwitches: { [FeatureSwitchKey.OkouDebug]: true },
   });
-  const picker = await screen.findByRole("combobox", {
-    name: "Voice input model",
-  });
+  const picker = await screen.findByLabelText("Voice input model");
   await waitFor(() => {
     return expect(picker).toHaveTextContent("Gemini 3.6 Flash");
   });
@@ -42,6 +40,21 @@ test("Debug preferences restore, change, and reset the voice input model", async
   });
   expect(updates).toContainEqual({
     voiceInputModel: "fal-ai/elevenlabs/speech-to-text/scribe-v2",
+  });
+});
+
+test("Debug preferences reset a saved voice input model to the default", async () => {
+  const updates = mockPreferences({
+    voiceInputModel: "fal-ai/elevenlabs/speech-to-text/scribe-v2",
+  });
+  await setupPage({
+    context,
+    path: "/?settings=debug",
+    featureSwitches: { [FeatureSwitchKey.OkouDebug]: true },
+  });
+  const picker = await screen.findByLabelText("Voice input model");
+  await waitFor(() => {
+    expect(picker).toHaveTextContent("ElevenLabs Scribe v2");
   });
   click(picker);
   click(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-dialog.test.tsx
@@ -144,7 +144,7 @@ function buttonWithText(
   return button;
 }
 
-test("Offer only languages supported by the workspace", async () => {
+async function openSupportedLanguagePicker() {
   let preferences = createPreferences("pt-BR", ["en-US", "pt-BR", "de-DE"]);
   context.mocks.api(userPreferencesContract.get, ({ respond }) => {
     return respond(200, preferences);
@@ -157,7 +157,10 @@ test("Offer only languages supported by the workspace", async () => {
   await openDialog("admin", "preference");
 
   click(await screen.findByRole("combobox", { name: "Idioma" }));
+}
 
+test("Offer only the workspace's supported languages", async () => {
+  await openSupportedLanguagePicker();
   const languageOptions = within(screen.getByRole("listbox")).getAllByRole(
     "option",
   );
@@ -168,6 +171,10 @@ test("Offer only languages supported by the workspace", async () => {
     }),
   ).toStrictEqual(["English", "Português (Brasil)", "Deutsch"]);
   expect(screen.queryByRole("option", { name: "Italiano" })).toBeNull();
+});
+
+test("Keep a saved single-language preference after closing and reopening Settings", async () => {
+  await openSupportedLanguagePicker();
   click(screen.getByRole("option", { name: "English" }));
 
   await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/thread-list-number-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/thread-list-number-shortcuts.test.tsx
@@ -129,10 +129,10 @@ async function openNumberShortcutPage(
 }
 
 test.each(NUMBER_SHORTCUT_PLATFORMS)(
-  "Reveal the first nine hints after a 500 ms hold and open the ninth chat on $platform",
+  "Reveal only the first nine hints after a 500 ms hold on $platform",
   async (platform) => {
     const { modifier, additionalModifier, releaseModifiers, label } = platform;
-    const { threads, list } = await openNumberShortcutPage(platform, "new");
+    const { list } = await openNumberShortcutPage(platform, "new");
     const user = userEvent.setup();
     await user.hover(sidebarThreadLinks()[0]!);
     expect(hintKeys(list)).toStrictEqual([]);
@@ -152,6 +152,24 @@ test.each(NUMBER_SHORTCUT_PLATFORMS)(
       await user.keyboard(additionalModifier);
     }
     expect(hintKeys(list)).toHaveLength(9);
+    await user.keyboard(releaseModifiers);
+    expect(hintKeys(list)).toStrictEqual([]);
+  },
+);
+
+test.each(NUMBER_SHORTCUT_PLATFORMS)(
+  "Open the ninth chat using its visible hint on $platform",
+  async (platform) => {
+    const { modifier, additionalModifier, releaseModifiers } = platform;
+    const { threads, list } = await openNumberShortcutPage(platform, "new");
+    const user = userEvent.setup();
+    await user.keyboard(`{${modifier}>}`);
+    await waitFor(() => {
+      expect(hintKeys(list)).toHaveLength(9);
+    });
+    if (additionalModifier) {
+      await user.keyboard(additionalModifier);
+    }
     await user.keyboard(`9${releaseModifiers}`);
     await waitFor(() => {
       expect(pathname()).toBe(`/chats/${threads[4]!.id}`);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/workspace-agent-search.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/workspace-agent-search.test.tsx
@@ -76,7 +76,7 @@ async function openSearch() {
   };
 }
 
-test("Find workspace agents by name and open their chat", async () => {
+test("Find workspace agents by name with case and whitespace normalization", async () => {
   prepareAgents();
   await setupPage({
     context,
@@ -102,7 +102,12 @@ test("Find workspace agents by name and open their chat", async () => {
   expect(
     within(dialog).getByRole("option", { name: "Research Agent" }),
   ).toBeVisible();
+});
 
+test("Agent search excludes IDs and blank queries but includes Zero", async () => {
+  prepareAgents();
+  await setupPage({ context, path: `/agents/${DEFAULT_AGENT_ID}/chat` });
+  const { dialog, search } = await openSearch();
   await fill(search, RESEARCH_AGENT_ID);
   await expect(
     within(dialog).findByText("No results found"),
@@ -119,7 +124,12 @@ test("Find workspace agents by name and open their chat", async () => {
     within(dialog).findByText("No results found"),
   ).resolves.toBeVisible();
   expect(within(dialog).queryByRole("option")).toBeNull();
+});
 
+test("Selecting a workspace agent search result opens its chat", async () => {
+  prepareAgents();
+  await setupPage({ context, path: `/agents/${DEFAULT_AGENT_ID}/chat` });
+  const { dialog, search } = await openSearch();
   await fill(search, "Support");
   const result = await within(dialog).findByRole("option", {
     name: "Support Agent",

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -483,27 +483,24 @@ test("Built-in workflows can start without connector setup", async () => {
   expect(preview.querySelector('path[d="M170 81H277"]')).toBeNull();
 });
 
-test("Every onboarding role has a curated workflow set", async () => {
-  await openMakePage();
-  chooseMakeOption("Workflow automation");
-
-  await expect(
-    screen.findByRole("heading", { name: "What do you work on?" }),
-  ).resolves.toBeInTheDocument();
-
-  const roles = [
-    "Everyone",
-    "Engineer",
-    "Product",
-    "Data",
-    "Marketing",
-    "Sales",
-    "Support",
-    "CEO",
-    "Operations",
-  ] as const;
-  let workflowCount = 0;
-  for (const role of roles) {
+test.each([
+  "Everyone",
+  "Engineer",
+  "Product",
+  "Data",
+  "Marketing",
+  "Sales",
+  "Support",
+  "CEO",
+  "Operations",
+] as const)(
+  "The %s onboarding role has six curated workflows and returns to role selection",
+  async (role) => {
+    await openMakePage();
+    chooseMakeOption("Workflow automation");
+    await expect(
+      screen.findByRole("heading", { name: "What do you work on?" }),
+    ).resolves.toBeInTheDocument();
     click(buttonByText(role));
     await expect(
       screen.findByRole("heading", { name: `${role} workflows` }),
@@ -511,15 +508,13 @@ test("Every onboarding role has a curated workflow set", async () => {
 
     const workflowCards = screen.getAllByRole("article");
     expect(workflowCards).toHaveLength(6);
-    workflowCount += workflowCards.length;
 
     click(buttonByText("Back"));
     await expect(
       screen.findByRole("heading", { name: "What do you work on?" }),
     ).resolves.toBeInTheDocument();
-  }
-  expect(workflowCount).toBe(54);
-});
+  },
+);
 
 test("A workflow preview can be selected as the first draft", async () => {
   await openMakePage();

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-connectors.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-connectors.test.tsx
@@ -230,7 +230,7 @@ async function navigateToAgent(name: string): Promise<void> {
   await screen.findByRole("heading", { name });
 }
 
-test("Connector changes for one agent never appear on another agent", async () => {
+async function openAgentConnectorIsolationStory() {
   const customSaves: string[] = [];
   mockConnectorSurface(context, {
     catalog: [catalogConnectorFixture("github", "GitHub")],
@@ -261,6 +261,11 @@ test("Connector changes for one agent never appear on another agent", async () =
   });
 
   await screen.findByRole("heading", { name: "Research Agent" });
+  return { customSaves };
+}
+
+test("Cancelled custom connector permission edits do not appear on another agent", async () => {
+  const { customSaves } = await openAgentConnectorIsolationStory();
   await screen.findByText("Acme Search");
   click(connectorAccessSwitch("Grant Acme Search access"));
   await screen.findByRole("heading", { name: /Acme Search permissions/i });
@@ -282,8 +287,10 @@ test("Connector changes for one agent never appear on another agent", async () =
   ).not.toBeInTheDocument();
   expect(connectorAccessSwitch("Grant Acme Search access")).toBeVisible();
   expect(customSaves).toStrictEqual([]);
+});
 
-  await navigateToAgent("Research Agent");
+test("A failed built-in connector grant does not appear on another agent", async () => {
+  await openAgentConnectorIsolationStory();
   await screen.findByText("GitHub");
   click(connectorAccessSwitch("Grant GitHub access"));
   await waitFor(() => {


### PR DESCRIPTION
The September 10 CI audit found TypeScript tests exhausting, or approaching, their effective timeout. Split the independent scenarios for 40 historical Vitest findings across one consolidated change, plus the compound Playwright viewport/dialog/password scenarios. Reduce the optimistic-chat test's input preparation overhead while keeping its unconfirmed-server race intact.

Each case owns its fixtures and retains the original observable assertions. Cross-step contracts remain together where required, including repeated voice retries, draft isolation across navigation, workflow provenance and result-email routing, gateway deletion after routing, and pagination over 101 real API-created accounts. Timeout budgets, retries, skips, product behavior and repository protections are unchanged.

Validation:
- All 123 changed Vitest cases passed their latest targeted local verification at 354–3589ms. The three API files also passed all 156 tests. Four frontend helper files were checked in full (53/54 initially passed); the failed mention case passed after correcting its keyboard setup. Initial failures and their subsequent code fixes are retained in the issue's evidence record.
- Historical-repair baseline: 162 tests in 12 relevant frontend files; four Desktop delayed-registration cases passed at 14–95ms. Cases still near the limit were retained and included in the repair when a valid split existed.
- Changed-file Prettier, ESLint, Oxlint including type-aware checks, affected TypeScript checks and Knip. Playwright type checking and test discovery passed; the browser scenarios were exercised by PR CI.

Relates to #33319. The complete audit ledger remains open for atomic timing risks and browser prerequisite/transition failures that cannot be repaired by dividing assertions across unrelated test lifetimes. Its per-finding record distinguishes verified historical repairs, obsolete scenarios, this PR's changes and unresolved evidence; one fast result is not treated as proof that a flake is fixed.

Current-head CI: 122 changed cases have exact timings of 484–3366ms; the remaining unfinished-segment case is below the 300ms reporter threshold, and all 123 passed. The six feature-browser cases passed at 2.2–5.5s. All six changed auth scenarios passed the bounded same-head recheck at 1.8–6.0s after one initial failure in unchanged login-page bootstrap. That initial failure remains recorded. All three required gates passed.

Final merge-group validation also passed all 123 changed Vitest cases: 122 exact timings of **411–3716ms**, with the remaining case below the 300ms reporter threshold. All 12 changed browser cases passed in this run (feature scenarios 2.3–4.8s; auth scenarios 1.9–2.9s). [Verified merge and final validation](https://github.com/vm0-ai/vm0/issues/33319#issuecomment-5629763227).

[Complete 160-finding revalidation and evidence](https://github.com/vm0-ai/vm0/issues/33319#issuecomment-5629466964) · [remaining current CI risks](https://github.com/vm0-ai/vm0/issues/33319#issuecomment-5629482368).
