### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -113,7 +113,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.27.1"
-CLAUDE_CODE_VERSION="2.1.267"
+CLAUDE_CODE_VERSION="2.1.268"
 CODEX_CLI_VERSION="0.154.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.3.1"


### PR DESCRIPTION
## Summary

- Update Claude Code from `2.1.267` to `2.1.268`.
- Keep the remaining rootfs package and tool pins unchanged after checking their current upstream release channels.

## Validation

- Confirmed the Claude Code 2.1.268 manifest and both Linux binaries (`linux-x64` and `linux-arm64`) are available with published checksums.
- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 cargo check --manifest-path crates/Cargo.toml --profile local -p runner --tests`