### PR TITLE
chore(runner): add session history sidecar export stage timings

### DIFF
--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -172,6 +172,28 @@ impl ResolvedSessionHistory {
     fn into_zstd_bytes(self, max_encoded_bytes: u64) -> Result<Vec<u8>, AgentError> {
         read_zstd_encoded_session_history(self.file, &self.path, max_encoded_bytes)
     }
+
+    pub(crate) fn prepare_sidecar(
+        self,
+        max_decoded_bytes: u64,
+        max_encoded_bytes: u64,
+    ) -> Result<PreparedSessionHistorySidecar, SessionHistoryDigestError> {
+        if self.is_zstd {
+            if self.encoded_len()? <= max_encoded_bytes {
+                let encoded = self.into_zstd_bytes(max_encoded_bytes)?;
+                let digest = digest_zstd_session_history_bytes(&encoded, max_decoded_bytes)?;
+                return Ok(PreparedSessionHistorySidecar {
+                    digest,
+                    source: SessionHistoryCheckpointSource::CodexZstd { encoded },
+                });
+            }
+            return self
+                .into_decoded_reader()?
+                .prepare_sidecar(max_decoded_bytes);
+        }
+        self.into_decoded_reader()?
+            .prepare_sidecar(max_decoded_bytes)
+    }
 }
 
 impl PreparedSessionHistorySidecar {
@@ -258,30 +280,6 @@ pub(crate) fn digest_session_history_from_source_bounded(
     resolve_session_history_from_source(source)?
         .into_decoded_reader()?
         .digest(max_bytes)
-}
-
-pub(crate) fn prepare_session_history_sidecar_from_source_bounded(
-    source: &SessionHistorySourceRef,
-    max_decoded_bytes: u64,
-    max_encoded_bytes: u64,
-) -> Result<PreparedSessionHistorySidecar, SessionHistoryDigestError> {
-    let resolved = resolve_session_history_from_source(source)?;
-    if resolved.is_zstd {
-        if resolved.encoded_len()? <= max_encoded_bytes {
-            let encoded = resolved.into_zstd_bytes(max_encoded_bytes)?;
-            let digest = digest_zstd_session_history_bytes(&encoded, max_decoded_bytes)?;
-            return Ok(PreparedSessionHistorySidecar {
-                digest,
-                source: SessionHistoryCheckpointSource::CodexZstd { encoded },
-            });
-        }
-        return resolved
-            .into_decoded_reader()?
-            .prepare_sidecar(max_decoded_bytes);
-    }
-    resolved
-        .into_decoded_reader()?
-        .prepare_sidecar(max_decoded_bytes)
 }
 
 fn validated_absolute_source_path(value: &str) -> Result<PathBuf, AgentError> {
@@ -1388,12 +1386,10 @@ mod tests {
         std::fs::write(path, &compressed).unwrap();
         let source = codex_source(&sessions_dir, thread_id);
 
-        let prepared = prepare_session_history_sidecar_from_source_bounded(
-            &source,
-            history.len() as u64,
-            compressed.len() as u64,
-        )
-        .unwrap();
+        let prepared = resolve_session_history_from_source(&source)
+            .unwrap()
+            .prepare_sidecar(history.len() as u64, compressed.len() as u64)
+            .unwrap();
         match prepared.into_source() {
             SessionHistoryCheckpointSource::CodexZstd { encoded } => {
                 assert_eq!(encoded, compressed)
@@ -1403,12 +1399,10 @@ mod tests {
             }
         }
 
-        let prepared = prepare_session_history_sidecar_from_source_bounded(
-            &source,
-            history.len() as u64,
-            history.len() as u64,
-        )
-        .unwrap();
+        let prepared = resolve_session_history_from_source(&source)
+            .unwrap()
+            .prepare_sidecar(history.len() as u64, history.len() as u64)
+            .unwrap();
 
         assert_eq!(prepared.digest.size_bytes, history.len() as u64);
         assert_eq!(
@@ -1438,11 +1432,9 @@ mod tests {
         std::fs::write(path, compressed).unwrap();
         let source = codex_source(&sessions_dir, thread_id);
 
-        let result = prepare_session_history_sidecar_from_source_bounded(
-            &source,
-            history.len() as u64,
-            encoded_limit,
-        );
+        let result = resolve_session_history_from_source(&source)
+            .unwrap()
+            .prepare_sidecar(history.len() as u64, encoded_limit);
 
         assert!(matches!(result, Err(SessionHistoryDigestError::Read(_))));
     }

--- a/crates/guest-agent/src/session_history_identity.rs
+++ b/crates/guest-agent/src/session_history_identity.rs
@@ -18,13 +18,14 @@ use guest_contracts::session_history_identity::{
     SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistoryFramework,
     SessionHistoryIdentity, SessionHistoryIdentityError, SessionHistoryIdentityExpectation,
     SessionHistoryRefKind, SessionHistorySidecarExportFailure, SessionHistorySidecarExportMetadata,
-    SessionHistorySidecarIoErrorClass, SessionHistorySidecarRepresentation,
-    SessionHistorySourceRef,
+    SessionHistorySidecarExportTimings, SessionHistorySidecarIoErrorClass,
+    SessionHistorySidecarRepresentation, SessionHistorySourceRef,
 };
 use sha2::{Digest, Sha256};
 use std::fmt;
 use std::io;
 use std::path::Path;
+use std::time::{Duration, Instant};
 
 /// Build final session-history identity metadata for a successful checkpoint.
 pub(crate) fn build_final_session_history_identity(
@@ -105,8 +106,9 @@ pub fn verify_final_session_history_identity_file(
 ///
 /// # Returns
 ///
-/// On success, returns the representation and exact byte length written to
-/// `export_path`.
+/// On success, returns the representation, exact byte length written to
+/// `export_path`, and phase timings. Timings exclude helper process startup,
+/// result serialization, exit, and subsequent host copying.
 ///
 /// # Errors
 ///
@@ -118,16 +120,22 @@ pub fn export_final_session_history_sidecar_file(
     metadata_path: impl AsRef<Path>,
     export_path: impl AsRef<Path>,
 ) -> Result<SessionHistorySidecarExportMetadata, SessionHistorySidecarExportError> {
+    let started = Instant::now();
     let identity = read_final_session_history_identity(metadata_path)?;
     let history_source = validated_history_source(&identity)?;
     verify_final_session_history_identity_constraints(&identity)?;
-    let prepared = session_history::prepare_session_history_sidecar_from_source_bounded(
-        history_source,
-        identity.history_size_bytes,
-        RESUME_SESSION_HISTORY_MAX_BYTES,
-    )
-    .map_err(map_session_history_digest_error)?;
+    let metadata_done = Instant::now();
+    let resolved = session_history::resolve_session_history_from_source(history_source)
+        .map_err(SessionHistoryIdentityVerifyError::HistoryRead)?;
+    let resolve_done = Instant::now();
+    let prepared = resolved
+        .prepare_sidecar(
+            identity.history_size_bytes,
+            RESUME_SESSION_HISTORY_MAX_BYTES,
+        )
+        .map_err(map_session_history_digest_error)?;
     verify_final_session_history_digest(&identity, &prepared.digest)?;
+    let read_verify_done = Instant::now();
     let source = prepared.into_source();
     let (representation, bytes) = match source {
         session_history::SessionHistoryCheckpointSource::Decoded(bytes) => {
@@ -139,10 +147,22 @@ pub fn export_final_session_history_sidecar_file(
     };
     crate::paths::write_private(export_path.as_ref(), &bytes)
         .map_err(SessionHistorySidecarExportError::OutputWrite)?;
+    let finished = Instant::now();
     Ok(SessionHistorySidecarExportMetadata {
         representation,
         encoded_size: bytes.len() as u64,
+        timings: SessionHistorySidecarExportTimings {
+            metadata_us: duration_us(metadata_done.duration_since(started)),
+            resolve_us: duration_us(resolve_done.duration_since(metadata_done)),
+            read_verify_us: duration_us(read_verify_done.duration_since(resolve_done)),
+            write_us: duration_us(finished.duration_since(read_verify_done)),
+            total_us: duration_us(finished.duration_since(started)),
+        },
     })
+}
+
+fn duration_us(duration: Duration) -> u64 {
+    u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
 }
 
 fn read_final_session_history_identity(

--- a/crates/guest-agent/tests/session_history_identity_helper.rs
+++ b/crates/guest-agent/tests/session_history_identity_helper.rs
@@ -29,6 +29,23 @@ type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 const SESSION_HISTORY_HELPER_TIMEOUT: Duration = Duration::from_secs(10);
 
+fn assert_export_timings(output: &Output, metadata: &SessionHistorySidecarExportMetadata) {
+    let timings = &metadata.timings;
+    let stages_us =
+        timings.metadata_us + timings.resolve_us + timings.read_verify_us + timings.write_us;
+    // Four adjacent intervals lose at most three microseconds to rounding.
+    assert!(timings.total_us >= stages_us);
+    assert!(timings.total_us - stages_us <= 3);
+    assert!(
+        output.stdout.len() < 1024,
+        "helper result must remain bounded"
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "timings must not add stderr output"
+    );
+}
+
 fn claude_history_fixture(
     root: &Path,
     session_id: &str,
@@ -314,6 +331,7 @@ async fn export_session_history_sidecar_reads_raw_source_once() -> TestResult {
         SessionHistorySidecarRepresentation::Raw
     );
     assert_eq!(export_metadata.encoded_size, history.len() as u64);
+    assert_export_timings(&output, &export_metadata);
     assert_eq!(std::fs::read(export_path)?, history);
     Ok(())
 }
@@ -449,6 +467,7 @@ async fn export_session_history_sidecar_reads_native_codex_zstd_once() -> TestRe
         SessionHistorySidecarRepresentation::CodexZstd
     );
     assert_eq!(export_metadata.encoded_size, encoded.len() as u64);
+    assert_export_timings(&output, &export_metadata);
     assert_eq!(std::fs::read(export_path)?, encoded);
     Ok(())
 }

--- a/crates/guest-contracts/src/session_history_identity.rs
+++ b/crates/guest-contracts/src/session_history_identity.rs
@@ -150,6 +150,27 @@ pub struct SessionHistorySidecarExportMetadata {
     pub representation: SessionHistorySidecarRepresentation,
     /// Exact byte length of the exported sidecar file.
     pub encoded_size: u64,
+    /// Guest helper timings, not persisted in workspace-cache metadata.
+    pub timings: SessionHistorySidecarExportTimings,
+}
+
+/// Monotonic wall-clock durations for one successful sidecar export.
+///
+/// Runner and the helper ship together. These fields are private helper output,
+/// not a workspace-cache format or independently deployed API contract.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionHistorySidecarExportTimings {
+    /// Read and validate final identity metadata and its size/identity constraints.
+    pub metadata_us: u64,
+    /// Locate and safely open the unique history source.
+    pub resolve_us: u64,
+    /// Read, optionally decode, buffer and hash the source, then verify its digest.
+    pub read_verify_us: u64,
+    /// Create and write the verified export file; does not include host copying.
+    pub write_us: u64,
+    /// Total helper work; excludes process startup, result serialization and exit.
+    pub total_us: u64,
 }
 
 /// Safe low-cardinality I/O class emitted for a sidecar output failure.

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -2566,6 +2566,7 @@ mod tests {
         sandbox.push_exec_result(Ok(ExecResult::new(
             0,
             serde_json::to_vec(&SessionHistorySidecarExportMetadata {
+                timings: Default::default(),
                 representation: WorkspaceSessionHistorySidecarRepresentation::Raw,
                 encoded_size: next_history.len() as u64,
             })

--- a/crates/runner/src/idle_pool/reclamation_tests.rs
+++ b/crates/runner/src/idle_pool/reclamation_tests.rs
@@ -59,6 +59,7 @@ async fn idle_reclamation_holds_from_terminal_unpark_through_kill_but_not_host_d
         ExecResult::new(
             0,
             serde_json::to_vec(&SessionHistorySidecarExportMetadata {
+                timings: Default::default(),
                 representation: SessionHistorySidecarRepresentation::Raw,
                 encoded_size: history.len() as u64,
             })
@@ -379,6 +380,7 @@ async fn idle_reclamation_admission_does_not_block_bypass_or_active_promotion() 
     sandbox.push_exec_result(Ok(ExecResult::new(
         0,
         serde_json::to_vec(&SessionHistorySidecarExportMetadata {
+            timings: Default::default(),
             representation: SessionHistorySidecarRepresentation::Raw,
             encoded_size: history.len() as u64,
         })

--- a/crates/runner/src/workspace_promotion.rs
+++ b/crates/runner/src/workspace_promotion.rs
@@ -1,6 +1,6 @@
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use futures_util::FutureExt;
@@ -25,6 +25,7 @@ use crate::workspace_mount::freeze_workspace_drive;
 
 const SESSION_HISTORY_SIDECAR_EXPORT_TIMEOUT: Duration = Duration::from_secs(30);
 const SESSION_HISTORY_SIDECAR_COPY_TIMEOUT: Duration = Duration::from_secs(30);
+const SESSION_HISTORY_SIDECAR_SLOW_EXPORT: Duration = Duration::from_secs(5);
 
 enum WorkspacePromotionAction {
     Promoted,
@@ -256,6 +257,52 @@ impl PreparedWorkspaceImagePromotion {
     }
 }
 
+fn log_session_history_sidecar_export_timing(
+    promotion: &WorkspaceImagePromotionContext,
+    reason: &'static str,
+    metadata: &SessionHistorySidecarExportMetadata,
+    admission_duration: Duration,
+    exec_duration: Duration,
+    guest_duration_ms: Option<u32>,
+) {
+    let timings = &metadata.timings;
+    macro_rules! emit {
+        ($level:expr) => {
+            tracing::event!(
+                $level,
+                run_id = %promotion.run_id(),
+                sandbox_id = %promotion.sandbox_id(),
+                profile_name = promotion.profile_name(),
+                reason,
+                representation = ?metadata.representation,
+                history_size_bytes = promotion
+                    .restored_session_identity()
+                    .and_then(|identity| identity.cache_fields())
+                    .map(|identity| identity.history_size_bytes),
+                encoded_size = metadata.encoded_size,
+                export_admission_ms = admission_duration.as_millis() as u64,
+                export_exec_ms = exec_duration.as_millis() as u64,
+                guest_duration_ms,
+                helper_metadata_us = timings.metadata_us,
+                helper_resolve_us = timings.resolve_us,
+                helper_read_verify_us = timings.read_verify_us,
+                helper_write_us = timings.write_us,
+                helper_total_us = timings.total_us,
+                "workspace image cache session history sidecar export completed"
+            );
+        };
+    }
+    if exec_duration >= SESSION_HISTORY_SIDECAR_SLOW_EXPORT
+        || guest_duration_ms.is_some_and(|ms| {
+            Duration::from_millis(u64::from(ms)) >= SESSION_HISTORY_SIDECAR_SLOW_EXPORT
+        })
+    {
+        emit!(Level::WARN);
+    } else {
+        emit!(Level::INFO);
+    }
+}
+
 async fn export_session_history_sidecar(
     sandbox: &dyn Sandbox,
     promotion: &WorkspaceImagePromotionContext,
@@ -288,6 +335,7 @@ async fn export_session_history_sidecar(
         stdin_bytes: None,
         output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
     };
+    let admission_started = Instant::now();
     let export_permit = match promotion
         .acquire_session_history_sidecar_export_permit()
         .await
@@ -307,9 +355,12 @@ async fn export_session_history_sidecar(
             return None;
         }
     };
+    let exec_started = Instant::now();
+    let admission_duration = exec_started.duration_since(admission_started);
     let result = sandbox
         .exec_with_diagnostic_label(&request, "session-history-sidecar-export")
         .await;
+    let exec_duration = exec_started.elapsed();
     drop(export_permit);
     let result = match result {
         Ok(result) => result,
@@ -394,6 +445,15 @@ async fn export_session_history_sidecar(
             return None;
         }
     };
+    // Report helper completion independently of subsequent host copying and publication.
+    log_session_history_sidecar_export_timing(
+        promotion,
+        reason,
+        &metadata,
+        admission_duration,
+        exec_duration,
+        result.guest_duration_ms,
+    );
     let entry_guard = promotion
         .try_acquire_session_history_sidecar_entry_guard()
         .await?;

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -16,8 +16,8 @@ use async_trait::async_trait;
 use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
     SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistorySidecarExportFailure,
-    SessionHistorySidecarExportMetadata, SessionHistorySidecarIoErrorClass,
-    SessionHistorySidecarRepresentation,
+    SessionHistorySidecarExportMetadata, SessionHistorySidecarExportTimings,
+    SessionHistorySidecarIoErrorClass, SessionHistorySidecarRepresentation,
 };
 use sandbox::{
     CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestAgentProcessHandle,
@@ -353,6 +353,13 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
     assert!(fixture.promotion.restored_session_identity().is_some());
     let sandbox = sandbox_mock::MockSandbox::new(fixture.sandbox_id.to_string());
     let export_metadata = SessionHistorySidecarExportMetadata {
+        timings: SessionHistorySidecarExportTimings {
+            metadata_us: 101,
+            resolve_us: 202,
+            read_verify_us: 303,
+            write_us: 404,
+            total_us: 1010,
+        },
         representation: SessionHistorySidecarRepresentation::Raw,
         encoded_size: history.len() as u64,
     };
@@ -373,6 +380,25 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
     .await;
 
     assert!(promoted);
+    let export_event = captured_event(
+        &events,
+        "workspace image cache session history sidecar export completed",
+    );
+    assert_eq!(export_event.level, Level::INFO);
+    for (field, expected) in [
+        ("helper_metadata_us", 101),
+        ("helper_resolve_us", 202),
+        ("helper_read_verify_us", 303),
+        ("helper_write_us", 404),
+        ("helper_total_us", 1010),
+        ("history_size_bytes", history.len() as u64),
+        ("encoded_size", history.len() as u64),
+    ] {
+        assert_eq!(export_event.fields[field].parse::<u64>().unwrap(), expected);
+    }
+    for field in ["export_admission_ms", "export_exec_ms"] {
+        export_event.fields[field].parse::<u64>().unwrap();
+    }
     let promotion_event = captured_event(&events, "workspace image cache promoted");
     assert_eq!(
         promotion_event
@@ -425,6 +451,9 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
             .collect::<Vec<_>>();
         panic!("missing sidecar metadata; entries={entries:?}; events={events:#?}");
     }
+    let persisted: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(sidecar_metadata_path).unwrap()).unwrap();
+    assert!(persisted.get("timings").is_none());
 
     let lease = fixture
         .cache
@@ -449,6 +478,56 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
 }
 
 #[tokio::test]
+async fn successful_slow_sidecar_export_reports_timings_at_warn() {
+    for (guest_duration_ms, expected_level) in [(4999, Level::INFO), (5000, Level::WARN)] {
+        let history = b"cached history";
+        let restored_identity = test_restored_session_identity("sess-export-timing", history);
+        let fixture = WorkspacePromotionFixture::new_with_restored_session_identity(
+            "thread:export-timing",
+            Some(&restored_identity),
+        )
+        .await;
+        let sandbox = MockSandbox::new(fixture.sandbox_id.to_string());
+        let metadata = SessionHistorySidecarExportMetadata {
+            representation: SessionHistorySidecarRepresentation::Raw,
+            encoded_size: history.len() as u64,
+            timings: SessionHistorySidecarExportTimings {
+                metadata_us: 100,
+                resolve_us: 200,
+                read_verify_us: 3_000_000,
+                write_us: 1_000_000,
+                total_us: 4_000_300,
+            },
+        };
+        let mut result = ExecResult::new(0, serde_json::to_vec(&metadata).unwrap(), Vec::new());
+        result.guest_duration_ms = Some(guest_duration_ms);
+        sandbox.push_exec_result(Ok(result));
+        sandbox.push_copy_file_result(Ok(history.to_vec()));
+
+        let (promoted, events) = capture_promotion_events(prepare_and_publish_workspace_image(
+            &sandbox,
+            fixture.promotion,
+        ))
+        .await;
+
+        assert!(promoted, "slow success must still publish the sidecar");
+        let event = captured_event(
+            &events,
+            "workspace image cache session history sidecar export completed",
+        );
+        assert_eq!(event.level, expected_level);
+        assert_eq!(
+            event.fields["guest_duration_ms"],
+            guest_duration_ms.to_string()
+        );
+        assert_eq!(event.fields["helper_read_verify_us"], "3000000");
+        assert_eq!(event.fields["helper_write_us"], "1000000");
+        assert_eq!(event.fields["helper_total_us"], "4000300");
+        assert_eq!(sandbox.copy_file_calls().len(), 1);
+    }
+}
+
+#[tokio::test]
 async fn session_history_sidecar_export_admission_queues_before_guest_exec() {
     let history = br#"{"type":"message","content":"bounded export"}"#;
     let first_identity = test_restored_session_identity("sess-export-first", history);
@@ -468,6 +547,7 @@ async fn session_history_sidecar_export_admission_queues_before_guest_exec() {
     )
     .await;
     let export_metadata = SessionHistorySidecarExportMetadata {
+        timings: Default::default(),
         representation: SessionHistorySidecarRepresentation::Raw,
         encoded_size: history.len() as u64,
     };
@@ -553,6 +633,7 @@ async fn session_history_sidecar_export_admission_releases_before_host_copy() {
     )
     .await;
     let export_metadata = SessionHistorySidecarExportMetadata {
+        timings: Default::default(),
         representation: SessionHistorySidecarRepresentation::Raw,
         encoded_size: history.len() as u64,
     };
@@ -657,6 +738,7 @@ async fn session_history_sidecar_export_admission_releases_after_panic() {
 
     let second_sandbox = MockSandbox::new(second_fixture.sandbox_id.to_string());
     let export_metadata = SessionHistorySidecarExportMetadata {
+        timings: Default::default(),
         representation: SessionHistorySidecarRepresentation::Raw,
         encoded_size: history.len() as u64,
     };
@@ -688,6 +770,7 @@ async fn active_workspace_promotion_rejects_invalid_sidecar_metadata() {
         (
             "zero-size",
             serde_json::to_vec(&SessionHistorySidecarExportMetadata {
+                timings: Default::default(),
                 representation: SessionHistorySidecarRepresentation::Raw,
                 encoded_size: 0,
             })
@@ -696,6 +779,7 @@ async fn active_workspace_promotion_rejects_invalid_sidecar_metadata() {
         (
             "over-max",
             serde_json::to_vec(&SessionHistorySidecarExportMetadata {
+                timings: Default::default(),
                 representation: SessionHistorySidecarRepresentation::Raw,
                 encoded_size: RESUME_SESSION_HISTORY_MAX_BYTES + 1,
             })
@@ -765,6 +849,7 @@ async fn active_workspace_promotion_discards_sidecar_source_on_copy_error() {
     let cache = fixture.cache.clone();
     let sandbox = MockSandbox::new(fixture.sandbox_id.to_string());
     let export_metadata = SessionHistorySidecarExportMetadata {
+        timings: Default::default(),
         representation: SessionHistorySidecarRepresentation::Raw,
         encoded_size: history.len() as u64,
     };
@@ -817,6 +902,7 @@ async fn cancelled_workspace_promotion_preserves_session_history_sidecar() {
     sandbox.push_exec_result(Ok(ExecResult::new(
         0,
         serde_json::to_vec(&SessionHistorySidecarExportMetadata {
+            timings: Default::default(),
             representation: SessionHistorySidecarRepresentation::Raw,
             encoded_size: history.len() as u64,
         })
@@ -907,6 +993,7 @@ async fn workspace_promotion_classifies_cancelled_sidecar_admission_rejections()
             sandbox.push_exec_result(Ok(ExecResult::new(
                 0,
                 serde_json::to_vec(&SessionHistorySidecarExportMetadata {
+                    timings: Default::default(),
                     representation: SessionHistorySidecarRepresentation::Raw,
                     encoded_size: history.len() as u64,
                 })
@@ -967,6 +1054,7 @@ async fn active_workspace_promotion_discards_sidecar_source_on_copy_size_mismatc
     let cache = fixture.cache.clone();
     let sandbox = MockSandbox::new(fixture.sandbox_id.to_string());
     let export_metadata = SessionHistorySidecarExportMetadata {
+        timings: Default::default(),
         representation: SessionHistorySidecarRepresentation::Raw,
         encoded_size: history.len() as u64 + 1,
     };
@@ -990,6 +1078,16 @@ async fn active_workspace_promotion_discards_sidecar_source_on_copy_size_mismatc
     let event = captured_event(
         &events,
         "workspace image cache session history sidecar copy size mismatch",
+    );
+    assert_eq!(event.level, Level::WARN);
+    assert_eq!(
+        captured_event(
+            &events,
+            "workspace image cache session history sidecar export completed",
+        )
+        .level,
+        Level::INFO,
+        "successful export timing must not hide subsequent copy failure"
     );
     let copied_bytes = history.len().to_string();
     let encoded_size = (history.len() as u64 + 1).to_string();
@@ -1184,6 +1282,7 @@ async fn session_history_sidecar_staging_is_protected_from_gc() {
     let cache = fixture.cache.clone();
     let sandbox = PostCopyGateSandbox::new(fixture.sandbox_id.to_string());
     let export_metadata = SessionHistorySidecarExportMetadata {
+        timings: Default::default(),
         representation: SessionHistorySidecarRepresentation::Raw,
         encoded_size: history.len() as u64,
     };
@@ -1257,6 +1356,7 @@ async fn session_history_sidecar_staging_cleans_source_and_unlocks_when_cancelle
     let cache = fixture.cache.clone();
     let sandbox = Arc::new(PostCopyGateSandbox::new(fixture.sandbox_id.to_string()));
     let export_metadata = SessionHistorySidecarExportMetadata {
+        timings: Default::default(),
         representation: SessionHistorySidecarRepresentation::Raw,
         encoded_size: history.len() as u64,
     };
@@ -1325,6 +1425,7 @@ async fn session_history_sidecar_staging_cleans_source_and_unlocks_after_freeze_
     let sandbox =
         MockSandbox::with_overrides(fixture.sandbox_id.to_string(), Arc::clone(&overrides));
     let export_metadata = SessionHistorySidecarExportMetadata {
+        timings: Default::default(),
         representation: SessionHistorySidecarRepresentation::Raw,
         encoded_size: history.len() as u64,
     };


### PR DESCRIPTION
## Summary

Relates to #33371. This is the instrumentation slice; the issue stays open for production observation and a subsequent decision about optimization or warning classification.

Successful session-history sidecar exports can take 5–10 seconds, but the existing terminal log cannot attribute that time to individual helper stages.

- Return monotonic microsecond timings for metadata validation, source resolution/open, read/decode/hash verification, output writing, and total helper work through the existing helper result.
- Log one bounded completion summary with export-permit wait, host-observed exec time, guest-reported process time, representation, sizes, and the helper stages.
- Emit normal completion at INFO and successful exports taking at least 5 seconds at WARN so slow-stage evidence reaches the existing Axiom ingestion path.
- Exercise real helper processes and files, verify single source opens and phase accounting, and cover timing propagation, slow-success logging, unchanged persisted metadata, and a subsequent genuine copy failure.

## Scope, compatibility, and performance

- No changes to run startup, reclamation/export concurrency, the 30-second export/copy timeouts, or existing failure/cancellation handling.
- No additional RPC, history read, per-block timing/logging, or compression pass. The additional work is a fixed number of clock reads, a small numeric result, and one summary event per successful export.
- Timings are private helper output within one bundled Runner/Guest artifact, not API or persisted workspace-cache fields. Existing cached sidecars retain their format.
- The completion event describes helper export only, before host copying and cache publication. Failed or timed-out helpers retain their existing diagnostics without fabricated partial timings.
- Existing generic slow-operation warnings are unchanged; a slow export gains one additional detailed WARN event. This does not yet identify the underlying bottleneck or claim a measured production performance improvement.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml --profile local -j 2 -p guest-agent --test session_history_identity_helper`
- `cargo test --manifest-path crates/Cargo.toml --profile local -j 2 -p guest-contracts -p guest-agent -p runner --all-targets -- --test-threads=4 --quiet`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -j 2 -p guest-contracts -p guest-agent -p runner --all-targets -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml --profile local -j 2 -p guest-contracts -p guest-agent -p runner --no-deps`
- `git diff --check`

The final full test run passed, including 3,669 Runner tests (30 pre-existing ignored tests; no new skips). Repository hooks also passed workspace-wide all-feature Clippy and documentation checks, formatting, file-size checks, and commitlint.

No production deployment or performance benchmark was performed.
