### PR TITLE
fix(ci): retry transient desktop notarization failures

### DIFF
--- a/.github/scripts/tests/deploy-desktop-workflow-test.sh
+++ b/.github/scripts/tests/deploy-desktop-workflow-test.sh
@@ -144,6 +144,12 @@ ruby -e '
     "--issuer \"#{dollar}OKOU_DESKTOP_NOTARIZE_API_ISSUER\"",
   ]
   raise "Desktop DMG notarization must consume the canonical API credential triple" unless canonical_notarytool_arguments.all? { |argument| notarize_run.include?(argument) }
+  raise "Desktop DMG notarization must submit through a single canonical invocation" unless notarize_run.scan("xcrun notarytool submit").length == 1
+  raise "Desktop DMG notarization must survive a transient notary poll failure" unless notarize_run.include?("for attempt in 1 2 3")
+  raise "Desktop DMG notarization must bound notary retries" unless notarize_run.include?("Notarization did not complete after 3 attempts")
+  raise "Desktop DMG notarization must not retry a terminal Apple verdict" unless notarize_run.include?("status: (Invalid|Rejected)")
+  raise "Desktop DMG notarization must not let tee mask a notarytool failure" unless notarize_run.include?("set -o pipefail")
+  raise "Desktop DMG stapling must follow a successful notarization" unless notarize_run.index("stapler staple") > notarize_run.index("notarize_status")
   raise "Desktop promotion must not rebuild the app" if promote_text.include?("pnpm -F @okouai/desktop build")
   raise "Desktop promotion must sign the downloaded app" unless promote_text.include?("sign-and-notarize-packaged-app.mjs")
   raise "Desktop promotion must publish an independent Okou release" unless promote_text.include?("OKOU_RELEASE_TAG: okou-desktop-v")

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -576,6 +576,8 @@ jobs:
           OKOU_DESKTOP_NOTARIZE_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           OKOU_DESKTOP_NOTARIZE_API_ISSUER: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
         run: |
+          set -o pipefail
+
           app_dir="${{ steps.desktop-app.outputs.okou_app_dir }}"
           zip_artifact_path="apps/desktop/out/Okou-darwin-arm64-$DESKTOP_VERSION.zip"
           dmg_artifact_path="apps/desktop/out/Okou-darwin-arm64-$DESKTOP_VERSION.dmg"
@@ -591,11 +593,37 @@ jobs:
             --volume-name "Okou" \
             --background-svg apps/desktop/assets/dmg-background-okou.svg
           codesign --force --sign "$OKOU_DESKTOP_SIGNING_IDENTITY" --timestamp "$dmg_artifact_path"
-          xcrun notarytool submit "$dmg_artifact_path" \
-            --key "$OKOU_DESKTOP_NOTARIZE_API_KEY_PATH" \
-            --key-id "$OKOU_DESKTOP_NOTARIZE_API_KEY_ID" \
-            --issuer "$OKOU_DESKTOP_NOTARIZE_API_ISSUER" \
-            --wait
+          # A single timed-out status poll makes notarytool exit non-zero while the
+          # submission itself is still healthy, which loses the whole release. Retry
+          # the submission twice; a terminal Apple verdict is never retried.
+          notarize_log="$(mktemp)"
+          notarize_status=1
+          for attempt in 1 2 3; do
+            if xcrun notarytool submit "$dmg_artifact_path" \
+              --key "$OKOU_DESKTOP_NOTARIZE_API_KEY_PATH" \
+              --key-id "$OKOU_DESKTOP_NOTARIZE_API_KEY_ID" \
+              --issuer "$OKOU_DESKTOP_NOTARIZE_API_ISSUER" \
+              --wait 2>&1 | tee "$notarize_log"; then
+              notarize_status=0
+              break
+            fi
+
+            if grep -Eq '^[[:space:]]+status: (Invalid|Rejected)$' "$notarize_log"; then
+              echo "::error::Apple rejected notarization of ${dmg_artifact_path}"
+              exit 1
+            fi
+
+            echo "::warning::Notarization did not complete (attempt ${attempt}/3)"
+            if [ "$attempt" -lt 3 ]; then
+              sleep 30
+            fi
+          done
+
+          if [ "$notarize_status" -ne 0 ]; then
+            echo "::error::Notarization did not complete after 3 attempts"
+            exit 1
+          fi
+
           xcrun stapler staple "$dmg_artifact_path"
 
           {


### PR DESCRIPTION
## Problem

Desktop release `0.48.32` failed in [run 34560910027](https://github.com/vm0-ai/vm0/actions/runs/34560910027), job `promote-desktop-release`, step *Sign and notarize macOS artifacts*:

```
Submission ID received  id: e1ab3d80-ee41-48d2-a3a8-e5f110883b9e
Successfully uploaded file
Waiting for processing to complete.
Current status: In Progress.......
Error: HTTPError(statusCode: nil, error: NSURLErrorDomain Code=-1001 "The request timed out."
       URL=https://appstoreconnect.apple.com/notary/v2/submissions/e1ab3d80-...)
##[error]Process completed with exit code 1
```

Signing, the DMG build, and the upload to Apple all succeeded. One status poll inside `xcrun notarytool submit --wait` hit the CFNetwork 60s timeout, notarytool exited 1, and under `bash -e` that ended the job — while Apple still reported the submission as `In Progress`. `okou-desktop-v0.48.32` was never created and `publish-desktop-update-manifest` was skipped, so users stayed on `0.48.31`.

The step had no retry protection of any kind. This is the same class of failure as #33411 (interrupted runner binary uploads).

## Change

Retry the DMG notarization twice (3 attempts total) before failing, with a 30s pause between attempts.

A terminal Apple verdict short-circuits the loop: when notarytool reports `status: Invalid` or `status: Rejected`, the artifact itself is the problem, so the step fails on the first attempt rather than re-uploading a 163MB DMG two more times.

`set -o pipefail` is added to the step because the submission is now piped to `tee` to keep the notary log inspectable. Without it, `tee` would return 0 and mask every notarytool failure.

Out of scope: the `.app` notarization in `sign-and-notarize-packaged-app.mjs` goes through `@electron/notarize` and has its own retry behavior; it is untouched here.

## Verification

- `.github/scripts/tests/deploy-desktop-workflow-test.sh` extended with the retry contract (single canonical `notarytool submit` invocation, bounded at 3 attempts, no retry on a terminal verdict, `pipefail` present, stapling only after success) — passes.
- The extracted step body was executed against a stubbed `xcrun` across every path:

  | scenario | exit | submits | stapled |
  | --- | --- | --- | --- |
  | accepted immediately | 0 | 1 | yes |
  | 1 timeout, then accepted | 0 | 2 | yes |
  | 2 timeouts, then accepted | 0 | 3 | yes |
  | 3 timeouts | 1 | 3 | no |
  | rejected | 1 | 1 | no |
  | 1 timeout, then rejected | 1 | 2 | no |

- `shellcheck --shell=bash` clean on the rendered step body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
