### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -4547,9 +4547,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.5+spec-1.1.0"
+version = "1.1.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+checksum = "920602543f0911ab71da12c50d59701da54c196d1a2bf5cb4b75667f137a406a"
 dependencies = [
  "indexmap",
  "serde_core",


### PR DESCRIPTION
## Summary

- Refresh the Rust workspace lockfile with `cargo update`.
- Update `toml` from `1.1.5+spec-1.1.0` to `1.1.6+spec-1.1.0`.
- Keep the change lockfile-only; `toml` is used transitively by `trybuild` for `sandbox` development tests.
- Review the published patch: features and MSRV are unchanged, and the source change avoids cloning a parsed table key.

## Deferred updates

- `generic-array` 0.14.9 remains blocked because `crypto-common` 0.1.7 requires exactly 0.14.7 through `digest` / `crc-fast` / `aws-smithy-checksums` / `aws-sdk-s3`.
- `zstd` 0.14.0 is a major update outside the workspace's current `^0.13` requirement and is deferred for dedicated compatibility work.

## Manual manifest changes

- None.

## Validation

- `cargo +stable test --locked --workspace --exclude runner --profile local` (passed)
- `cargo +stable check --locked --profile local -p runner --tests` (passed)
- The affected `sandbox` trybuild test passed as part of the workspace suite.
- Runner tests were compile-checked separately to stay within the local 3.8 GiB, no-swap memory limit; CI will execute the full runner suite.
