### PR TITLE
fix(app): contain long connector account names

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/add-connection-dialog.tsx
@@ -1578,8 +1578,8 @@ export function ConnectModal({
         </DialogHeader>
 
         {item.connected && !accountMode && (
-          <p className="flex items-center gap-2 text-sm text-muted-foreground">
-            <span>{connectedStatusText(item)}</span>
+          <p className="wrap-anywhere text-sm text-muted-foreground">
+            {connectedStatusText(item)}
           </p>
         )}
 

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
@@ -785,7 +785,10 @@ function PermissionConnectorCard({
       label={connector.label}
       labelSuffix={
         connector.connection?.externalUsername ? (
-          <span className="text-xs text-muted-foreground">
+          <span
+            className="min-w-0 truncate text-xs text-muted-foreground"
+            title={`@${connector.connection.externalUsername}`}
+          >
             @{connector.connection.externalUsername}
           </span>
         ) : undefined

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-permission-row.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-permission-row.tsx
@@ -45,7 +45,7 @@ export function ConnectorPermissionRow({
           <div className="flex items-center gap-2">
             <span
               data-testid="connector-card-label"
-              className="truncate text-sm font-medium text-foreground"
+              className="max-w-full shrink-0 truncate text-sm font-medium text-foreground"
             >
               {label}
             </span>


### PR DESCRIPTION
Long connector account names, such as AWS assumed-role ARNs, overflow the Agent Authorization list on narrow screens and can squeeze the connector name out of view. Keep the service label visible and truncate the account identity with its full value available on hover. Allow the connected-account status in the connection dialog to wrap, including identifiers without spaces.

Validation:

- Passed formatting, targeted Oxlint/ESLint, Tailwind style lint, and style policy checks.
- Passed App TypeScript checks and App-scoped Knip.
- PR CI passed, including App tests, type/style/lint checks, and required CI gates.
- PASS: Agent Authorization with a 137-character AWS assumed-role identity at 320px, 393px, and 1280px widths. The service label and switches stay visible, the identity truncates, and neither the document nor scrollable content overflows horizontally. The complete identity is retained in the native title.
- PASS: AWS connection dialog at `/connectors/aws/connect` wraps the complete identity at mobile and desktop widths. The 393px viewport has a 343px dialog, with no horizontal scrolling. The 320px viewport also passes.
- PASS: Connectors directory and AWS account manager at 393px; account menu remains accessible. Agent authorization toggles work with the fixture responses.
- Full local Vitest and a local dev server were not run, per project instructions.

Browser verification used the deployed PR head `f7c291bb2f7cd9435419415eff83a6eff9b9896d`, local agent-browser with Chromium 152, a dedicated Clerk test workspace, and API response fixtures containing synthetic AWS/Axiom/Dropbox identities plus live catalog metadata. Onboarding was completed through the preview API. No Lab overrides were changed; `connectorDirectory` and `_realAgentInPreview` were both off. Screenshots render the deployed App without DOM or CSS overrides; no real AWS credentials are involved.

App preview: https://pr-33437-app-okou-app-preview.vm0.workers.dev

API preview: https://pr-33437-api.vm6.ai
