### PR TITLE
perf(ci): move runner artifact transport and readiness to r2

### DIFF
--- a/.github/scripts/runner-binary-cache-plan.sh
+++ b/.github/scripts/runner-binary-cache-plan.sh
@@ -33,6 +33,12 @@ output_value() {
 require_env RUNNER_HOST_GROUPS_MATRIX
 require_env RESOLVE_OUTPUT_DIR
 
+case "${RUNNER_BINARY_RESOLVE_MODE:=download}" in
+  download) resolve_command=active-resolve ;;
+  reference) resolve_command=reference-resolve ;;
+  *) echo "invalid Runner binary resolve mode: ${RUNNER_BINARY_RESOLVE_MODE}" >&2; exit 2 ;;
+esac
+
 case "${RUNNER_BINARY_CACHE_FORCE_MISS:-false}" in
   true|false|"") ;;
   *)
@@ -96,13 +102,14 @@ while IFS= read -r encoded_entry; do
       EXPECTED_TARGET="$target" \
       EXPECTED_BINARY_INPUT_DIGEST="$digest" \
       RESOLVE_OUTPUT_DIR="${RESOLVE_OUTPUT_DIR}/${target}" \
-      "$CACHE" active-resolve \
+      "$CACHE" "$resolve_command" \
       >"$result_file" 2>"$error_file" &
   pids+=("$!")
 done < <(jq -cr '.[] | @base64' <<<"$RUNNER_HOST_GROUPS_MATRIX")
 
 miss_matrix='[]'
 hit_targets='[]'
+hit_manifests='{}'
 resolution_json='[]'
 hit_count=0
 miss_count=0
@@ -151,7 +158,11 @@ for index in "${!targets[@]}"; do
   fi
 
   if [ "$outcome" = "hit" ]; then
-    if [ ! -f "${RESOLVE_OUTPUT_DIR}/${target}/runner" ] ||
+    if [ "$RUNNER_BINARY_RESOLVE_MODE" = reference ]; then
+      hit_manifests=$(jq -c --arg target "$target" \
+        --slurpfile manifest "${RESOLVE_OUTPUT_DIR}/${target}/manifest.json" \
+        '. + {($target): $manifest[0]}' <<<"$hit_manifests")
+    elif [ ! -f "${RESOLVE_OUTPUT_DIR}/${target}/runner" ] ||
       [ ! -f "${RESOLVE_OUTPUT_DIR}/${target}/metadata.json" ]; then
       echo "runner binary hit transport is incomplete for ${target}" >&2
       hard_failure=true
@@ -199,6 +210,7 @@ fi
 
 emit "compile-matrix" "$miss_matrix"
 emit "hit-targets" "$hit_targets"
+if [ "$RUNNER_BINARY_RESOLVE_MODE" = reference ]; then emit "hit-manifests" "$hit_manifests"; fi
 emit "hit-count" "$hit_count"
 emit "miss-count" "$miss_count"
 printf 'resolution-json=%s\n' "$resolution_json"

--- a/.github/scripts/runner-binary-cache.sh
+++ b/.github/scripts/runner-binary-cache.sh
@@ -199,17 +199,6 @@ reusable_record_name() {
   printf 'runner-binary-asset-%s-%s\n' "$target" "$digest"
 }
 
-record_name() {
-  require_env EXPECTED_TARGET
-  require_env EXPECTED_BINARY_INPUT_DIGEST
-  runner_image_validate_target "$EXPECTED_TARGET"
-  if [[ ! "$EXPECTED_BINARY_INPUT_DIGEST" =~ ^[0-9a-f]{64}$ ]]; then
-    echo "invalid runner binary input digest: ${EXPECTED_BINARY_INPUT_DIGEST}" >&2
-    exit 2
-  fi
-  emit "record-name" "$(reusable_record_name "$EXPECTED_TARGET" "$EXPECTED_BINARY_INPUT_DIGEST")"
-}
-
 publish_failure() {
   local reason=$1 message=$2
   echo "::error::Runner binary publication failed (${reason}): ${message}" >&2
@@ -903,13 +892,12 @@ download_current() {
 
 usage() {
   cat <<'USAGE'
-Usage: runner-binary-cache.sh <fresh-validate|record-name|manifest-validate|publish|shadow-resolve|active-resolve|reference-resolve|download|download-current>
+Usage: runner-binary-cache.sh <fresh-validate|manifest-validate|publish|shadow-resolve|active-resolve|reference-resolve|download|download-current>
 USAGE
 }
 
 case "${1:-}" in
   fresh-validate) fresh_validate ;;
-  record-name) record_name ;;
   manifest-validate) manifest_validate ;;
   publish) publish ;;
   shadow-resolve) shadow_resolve ;;

--- a/.github/scripts/runner-binary-cache.sh
+++ b/.github/scripts/runner-binary-cache.sh
@@ -509,7 +509,7 @@ validate_resolution_context() {
 
 producer_is_main_reachable() {
   local ancestor_sha=$1 comparison_json
-  if ! comparison_json=$(timeout --kill-after=5s 60s gh api \
+  if ! comparison_json=$(timeout --foreground --kill-after=5s 60s gh api \
     "repos/${REPO}/compare/${ancestor_sha}...${DEFAULT_BRANCH}" 2>/dev/null); then
     return 1
   fi
@@ -572,7 +572,7 @@ collect_trusted_candidates() {
     [ "$run_id" != "$CURRENT_RUN_ID" ] || continue
     inspected=$((inspected + 1))
 
-    run_json=$(timeout --kill-after=5s 60s gh api "repos/${REPO}/actions/runs/${run_id}" 2>/dev/null) || continue
+    run_json=$(timeout --foreground --kill-after=5s 60s gh api "repos/${REPO}/actions/runs/${run_id}" 2>/dev/null) || continue
     if ! jq -e --arg repo "$REPO" --arg workflow "$RUNNER_BINARY_WORKFLOW_PATH" \
       --argjson run "$run_id" --argjson attempt "$attempt" '
       .id == $run and .repository.full_name == $repo and .path == $workflow and
@@ -875,7 +875,7 @@ download_current() {
   require_env EXPECTED_PRODUCER_HEAD_SHA
   runner_ci_config
   local run jobs name manifest status=0
-  run=$(timeout --kill-after=5s 60s gh api "repos/${REPO}/actions/runs/${CURRENT_RUN_ID}")
+  run=$(timeout --foreground --kill-after=5s 60s gh api "repos/${REPO}/actions/runs/${CURRENT_RUN_ID}")
   jq -e --arg repo "$REPO" --arg head "$EXPECTED_PRODUCER_HEAD_SHA" \
     --arg workflow "$RUNNER_BINARY_WORKFLOW_PATH" --argjson run "$CURRENT_RUN_ID" '
     .id == $run and .repository.full_name == $repo and .path == $workflow and .head_sha == $head

--- a/.github/scripts/runner-binary-cache.sh
+++ b/.github/scripts/runner-binary-cache.sh
@@ -5,11 +5,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 . "${SCRIPT_DIR}/runner-image-target.sh"
 . "${SCRIPT_DIR}/runner-guest-binaries.sh"
+. "${SCRIPT_DIR}/runner-ci-record.sh"
 . "${REPO_ROOT}/.github/scripts/runner-binary-build/contract.env"
 
 RUNNER_BINARY_MAX_SIZE_BYTES=$((128 * 1024 * 1024))
 RUNNER_BINARY_MAX_COMPRESSED_BYTES=$((64 * 1024 * 1024))
-RUNNER_BINARY_MAX_MANIFEST_ARTIFACT_BYTES=$((1024 * 1024))
 RUNNER_BINARY_MAX_CANDIDATE_INSPECTIONS=8
 RUNNER_BINARY_MAX_TRUSTED_IDENTITIES=2
 RUNNER_BINARY_WORKFLOW_PATH=".github/workflows/runner-image.yml"
@@ -194,12 +194,12 @@ manifest_validate() {
   emit "object-size-bytes" "$REUSABLE_OBJECT_SIZE"
 }
 
-reusable_artifact_name() {
+reusable_record_name() {
   local target=$1 digest=$2
   printf 'runner-binary-asset-%s-%s\n' "$target" "$digest"
 }
 
-artifact_name() {
+record_name() {
   require_env EXPECTED_TARGET
   require_env EXPECTED_BINARY_INPUT_DIGEST
   runner_image_validate_target "$EXPECTED_TARGET"
@@ -207,14 +207,13 @@ artifact_name() {
     echo "invalid runner binary input digest: ${EXPECTED_BINARY_INPUT_DIGEST}" >&2
     exit 2
   fi
-  emit "artifact-name" "$(reusable_artifact_name "$EXPECTED_TARGET" "$EXPECTED_BINARY_INPUT_DIGEST")"
+  emit "record-name" "$(reusable_record_name "$EXPECTED_TARGET" "$EXPECTED_BINARY_INPUT_DIGEST")"
 }
 
-publish_soft_failure() {
+publish_failure() {
   local reason=$1 message=$2
-  echo "::warning::Runner binary cache publication skipped (${reason}): ${message}"
-  emit "published" "false"
-  emit "publish-reason" "$reason"
+  echo "::error::Runner binary publication failed (${reason}): ${message}" >&2
+  return 1
 }
 
 fetch_verified_r2_runner() {
@@ -223,8 +222,8 @@ fetch_verified_r2_runner() {
   local expected_runner_size=$3
   local expected_runner_sha=$4
   local compressed_path=$5
-  local runner_path=$6
-  local endpoint head_json observed_object_size downloaded_size decompressed_size actual_sha
+  local verified_runner_path=$6
+  local head_json observed_object_size downloaded_size decompressed_size actual_sha
   local get_status=0 decompress_status=0
   local aws_error_log="${compressed_path}.aws.err"
   local zstd_error_log="${compressed_path}.zstd.err"
@@ -232,15 +231,9 @@ fetch_verified_r2_runner() {
   R2_VERIFICATION_REASON=""
   R2_VERIFICATION_MESSAGE=""
   R2_VERIFIED_OBJECT_SIZE=""
-  endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
-
-  if ! head_json=$(aws s3api head-object \
-    --endpoint-url "$endpoint" \
-    --bucket "$R2_BUCKET_NAME" \
+  if ! head_json=$(runner_ci_aws head-object \
     --key "$object_key" \
-    --output json \
-    --cli-connect-timeout 5 \
-    --cli-read-timeout 30 2>"$aws_error_log"); then
+    --output json 2>"$aws_error_log"); then
     R2_VERIFICATION_REASON="head-failed"
     R2_VERIFICATION_MESSAGE="the R2 object could not be inspected"
     return 1
@@ -263,13 +256,9 @@ fetch_verified_r2_runner() {
     return 1
   fi
 
-  aws s3api get-object \
-    --endpoint-url "$endpoint" \
-    --bucket "$R2_BUCKET_NAME" \
+  runner_ci_aws get-object \
     --key "$object_key" \
     --range "bytes=0-${RUNNER_BINARY_MAX_COMPRESSED_BYTES}" \
-    --cli-connect-timeout 5 \
-    --cli-read-timeout 30 \
     "$compressed_path" \
     >/dev/null 2>"$aws_error_log" || get_status=$?
   if [ "$get_status" -ne 0 ]; then
@@ -287,15 +276,15 @@ fetch_verified_r2_runner() {
   zstd -q -d -c "$compressed_path" \
     2>"$zstd_error_log" \
     | head -c "$((RUNNER_BINARY_MAX_SIZE_BYTES + 1))" \
-      > "$runner_path" || decompress_status=$?
-  decompressed_size=$(stat -c '%s' "$runner_path")
+      > "$verified_runner_path" || decompress_status=$?
+  decompressed_size=$(stat -c '%s' "$verified_runner_path")
   if [ "$decompress_status" -ne 0 ] ||
     [ "$decompressed_size" -gt "$RUNNER_BINARY_MAX_SIZE_BYTES" ]; then
     R2_VERIFICATION_REASON="decompression-invalid"
     R2_VERIFICATION_MESSAGE="the R2 object is not a bounded zstd runner"
     return 1
   fi
-  actual_sha=$(sha256sum "$runner_path" | awk '{print $1}')
+  actual_sha=$(sha256sum "$verified_runner_path" | awk '{print $1}')
   if [ "$decompressed_size" != "$expected_runner_size" ] ||
     [ "$actual_sha" != "$expected_runner_sha" ]; then
     R2_VERIFICATION_REASON="content-mismatch"
@@ -350,19 +339,20 @@ publish() {
     exit 2
   fi
   mkdir -p "$OUTPUT_DIR"
+  REPO=$PRODUCER_REPOSITORY
 
   if [ -z "${R2_ACCOUNT_ID:-}" ] || [ -z "${R2_BUCKET_NAME:-}" ] ||
     [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
-    publish_soft_failure "missing-r2-config" "required R2 configuration is unavailable"
-    return 0
+    publish_failure "missing-r2-config" "required R2 configuration is unavailable"
+    return 1
   fi
   if ! command -v aws >/dev/null; then
-    publish_soft_failure "aws-unavailable" "AWS CLI is unavailable"
-    return 0
+    publish_failure "aws-unavailable" "AWS CLI is unavailable"
+    return 1
   fi
   if ! command -v zstd >/dev/null; then
-    publish_soft_failure "zstd-unavailable" "zstd is unavailable"
-    return 0
+    publish_failure "zstd-unavailable" "zstd is unavailable"
+    return 1
   fi
 
   local temp_root compressed retained decompressed error_log
@@ -375,23 +365,21 @@ publish() {
   trap 'rm -rf "$PUBLISH_TEMP_ROOT"' EXIT
 
   if ! zstd -q -3 -T0 -f -o "$compressed" "$RUNNER_PATH"; then
-    publish_soft_failure "compression-failed" "runner compression failed"
-    return 0
+    publish_failure "compression-failed" "runner compression failed"
+    return 1
   fi
   local compressed_size
   compressed_size=$(stat -c '%s' "$compressed")
   if [ "$compressed_size" -le 0 ] || [ "$compressed_size" -gt "$RUNNER_BINARY_MAX_COMPRESSED_BYTES" ]; then
-    publish_soft_failure "compressed-size-invalid" "compressed runner is outside the configured bound"
-    return 0
+    publish_failure "compressed-size-invalid" "compressed runner is outside the configured bound"
+    return 1
   fi
 
-  local object_key endpoint put_status
+  local object_key put_status
   object_key="runner-binaries/${FRESH_TARGET}/${FRESH_RUNNER_SHA}.zst"
-  endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+  runner_ci_config
   put_status=0
-  aws s3api put-object \
-    --endpoint-url "$endpoint" \
-    --bucket "$R2_BUCKET_NAME" \
+  runner_ci_aws put-object \
     --key "$object_key" \
     --body "$compressed" \
     --content-type application/zstd \
@@ -399,8 +387,8 @@ publish() {
     --if-none-match '*' \
     >/dev/null 2>"$error_log" || put_status=$?
   if [ "$put_status" -ne 0 ] && ! grep -Eq 'PreconditionFailed|precondition|412' "$error_log"; then
-    publish_soft_failure "put-failed" "R2 rejected the runner object upload"
-    return 0
+    publish_failure "put-failed" "R2 rejected the runner object upload"
+    return 1
   fi
 
   local retained_size publish_reason
@@ -413,8 +401,8 @@ publish() {
       content-mismatch) publish_reason="retained-content-mismatch" ;;
       *) publish_reason="$R2_VERIFICATION_REASON" ;;
     esac
-    publish_soft_failure "$publish_reason" "$R2_VERIFICATION_MESSAGE"
-    return 0
+    publish_failure "$publish_reason" "$R2_VERIFICATION_MESSAGE"
+    return 1
   fi
   retained_size="$R2_VERIFIED_OBJECT_SIZE"
 
@@ -473,6 +461,8 @@ publish() {
     EXPECTED_WORKFLOW_PATH="${PRODUCER_WORKFLOW_PATH:-$RUNNER_BINARY_WORKFLOW_PATH}" \
     "$0" manifest-validate >/dev/null
 
+  runner_ci_record_publish "$(reusable_record_name "$FRESH_TARGET" "$FRESH_BINARY_INPUT_DIGEST")" \
+    "${OUTPUT_DIR}/manifest.json" "$PRODUCER_RUN_ID" "$PRODUCER_RUN_ATTEMPT"
   emit "published" "true"
   emit "publish-reason" "$([ "$put_status" -eq 0 ] && echo uploaded || echo existing-validated)"
   emit "manifest-path" "${OUTPUT_DIR}/manifest.json"
@@ -518,13 +508,13 @@ validate_resolution_context() {
 }
 
 producer_is_main_reachable() {
-  local producer_head_sha=$1 comparison_json
-  if ! comparison_json=$(gh api \
-    "repos/${REPO}/compare/${producer_head_sha}...${DEFAULT_BRANCH}" 2>/dev/null); then
+  local ancestor_sha=$1 comparison_json
+  if ! comparison_json=$(timeout --kill-after=5s 60s gh api \
+    "repos/${REPO}/compare/${ancestor_sha}...${DEFAULT_BRANCH}" 2>/dev/null); then
     return 1
   fi
   jq -e \
-    --arg producer_head_sha "$producer_head_sha" '
+    --arg producer_head_sha "$ancestor_sha" '
       (.base_commit | type == "object") and
       .base_commit.sha == $producer_head_sha and
       (.merge_base_commit | type == "object") and
@@ -549,274 +539,125 @@ producer_is_main_reachable() {
 collect_trusted_candidates() {
   local expected_target=$1 expected_digest=$2 output_dir=$3
   mkdir -p "$output_dir"
-
-  local artifact_name_value artifacts_json
-  artifact_name_value=$(reusable_artifact_name "$expected_target" "$expected_digest")
-  if ! artifacts_json=$(gh api --paginate --slurp \
-    "repos/${REPO}/actions/artifacts?name=${artifact_name_value}&per_page=100" 2>/dev/null); then
-    CANDIDATE_DISCOVERY_REASON="artifact-api-unavailable"
-    return 1
-  fi
-  if ! jq -e 'type == "array" and all(.[]; type == "object" and (.artifacts | type == "array"))' \
-    <<<"$artifacts_json" >/dev/null; then
-    CANDIDATE_DISCOVERY_REASON="artifact-api-malformed"
+  runner_ci_config
+  local name records
+  name=$(reusable_record_name "$expected_target" "$expected_digest")
+  if ! records=$(runner_ci_records "$name" 2>/dev/null); then
+    CANDIDATE_DISCOVERY_REASON="record-index-unavailable"
     return 1
   fi
 
-  local potential_file sorted_potential trusted_unsorted trusted_file identities_file
-  potential_file="${output_dir}/potential-candidates.tsv"
-  sorted_potential="${output_dir}/potential-candidates-sorted.tsv"
-  trusted_unsorted="${output_dir}/trusted-candidates-unsorted.tsv"
-  trusted_file="${output_dir}/trusted-candidates.tsv"
-  identities_file="${output_dir}/trusted-identities.tsv"
-  : > "$potential_file"
-  : > "$trusted_unsorted"
+  local trusted_file="${output_dir}/trusted-candidates.tsv"
+  local unsorted="${output_dir}/trusted-unsorted.tsv"
+  local identities="${output_dir}/identities"
   : > "$trusted_file"
-  : > "$identities_file"
-  while IFS= read -r artifact_encoded; do
-    [ -n "$artifact_encoded" ] || continue
-    local artifact_json artifact_run_id artifact_id artifact_size artifact_created artifact_branch artifact_head_sha
-    artifact_json=$(base64 -d <<<"$artifact_encoded")
-    artifact_run_id=$(jq -r '.workflow_run.id // empty' <<<"$artifact_json")
-    artifact_id=$(jq -r '.id // empty' <<<"$artifact_json")
-    artifact_size=$(jq -r '.size_in_bytes // empty' <<<"$artifact_json")
-    artifact_created=$(jq -r '.created_at // empty' <<<"$artifact_json")
-    artifact_branch=$(jq -r '.workflow_run.head_branch // empty' <<<"$artifact_json")
-    artifact_head_sha=$(jq -r '.workflow_run.head_sha // empty' <<<"$artifact_json")
-    if [[ ! "$artifact_run_id" =~ ^[1-9][0-9]*$ ]] ||
-      [[ ! "$artifact_id" =~ ^[1-9][0-9]*$ ]] ||
-      [[ ! "$artifact_size" =~ ^[1-9][0-9]*$ ]] ||
-      [ "$artifact_size" -gt "$RUNNER_BINARY_MAX_MANIFEST_ARTIFACT_BYTES" ] ||
-      [[ ! "$artifact_head_sha" =~ ^[0-9a-f]{40}$ ]] ||
-      [ "$artifact_run_id" = "$CURRENT_RUN_ID" ]; then
-      continue
-    fi
+  : > "$unsorted"
+  : > "$identities"
+  local inspected=0 trusted_count=0 identity_count=0
+  local record key suffix run_id attempt sha modified manifest_path run_json jobs_json
+  local source event branch head producer_prs source_rank identity_key
 
-    local discovery_rank="" discovery_source_rank=""
-    if [ "$artifact_branch" = "$DEFAULT_BRANCH" ]; then
-      discovery_rank=0
-      case "$CURRENT_EVENT" in
-        pull_request|push) discovery_source_rank=0 ;;
-        merge_group) discovery_source_rank=1 ;;
-      esac
-    elif [ -n "${CURRENT_PR_HEAD_REF:-}" ] && [ "$artifact_branch" = "$CURRENT_PR_HEAD_REF" ]; then
-      discovery_rank=0
-      case "$CURRENT_EVENT" in
-        pull_request) discovery_source_rank=2 ;;
-        merge_group) discovery_source_rank=0 ;;
-        push) continue ;;
-      esac
-    elif [ -n "${CURRENT_PR_NUMBER:-}" ] && [[ "$artifact_branch" =~ (^|/)pr-${CURRENT_PR_NUMBER}- ]]; then
-      discovery_rank=0
-      case "$CURRENT_EVENT" in
-        pull_request) discovery_source_rank=2 ;;
-        merge_group) discovery_source_rank=0 ;;
-        push) continue ;;
-      esac
-    else
-      discovery_rank=1
-      case "$CURRENT_EVENT" in
-        pull_request) discovery_source_rank=1 ;;
-        merge_group) discovery_source_rank=2 ;;
-        push) discovery_source_rank=1 ;;
-      esac
-    fi
-
-    printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
-      "$discovery_rank" "$discovery_source_rank" "$artifact_created" \
-      "$artifact_id" "$artifact_run_id" "$artifact_head_sha" >> "$potential_file"
-  done < <(jq -r \
-    --arg name "$artifact_name_value" '
-      .[] | .artifacts[]? |
-      select(.name == $name and .expired == false) |
-      @base64
-    ' <<<"$artifacts_json")
-
-  # Inspect direct source hints before candidates that need an ancestry query.
-  sort -t $'\t' -k1,1n -k2,2n -k3,3r "$potential_file" > "$sorted_potential"
-
-  local inspected=0 trusted_count=0 identity_count=0 limit_reached=false
-  local potential_count
-  potential_count=$(wc -l < "$sorted_potential" | tr -d ' ')
-  while IFS=$'\t' read -r _ _ artifact_created artifact_id artifact_run_id artifact_head_sha; do
-    [ -n "$artifact_run_id" ] || continue
-    if [ "$inspected" -ge "$RUNNER_BINARY_MAX_CANDIDATE_INSPECTIONS" ]; then
-      break
-    fi
+  while IFS= read -r record; do
+    [ "$inspected" -lt "$RUNNER_BINARY_MAX_CANDIDATE_INSPECTIONS" ] || break
+    key=$(jq -r '.Key' <<<"$record")
+    modified=$(jq -r '.LastModified' <<<"$record")
+    runner_ci_record_key_valid "$key" || continue
+    runner_ci_record_fresh "$modified" || continue
+    suffix=${key#"${RUNNER_CI_RECORD_PREFIX}${name}/"}
+    run_id=${suffix%%/*}
+    suffix=${suffix#*/}
+    attempt=${suffix%%/*}
+    sha=${suffix##*/}
+    sha=${sha%.json}
+    [ "$run_id" != "$CURRENT_RUN_ID" ] || continue
     inspected=$((inspected + 1))
 
-    local run_json
-    if ! run_json=$(gh api "repos/${REPO}/actions/runs/${artifact_run_id}" 2>/dev/null); then
+    run_json=$(timeout --kill-after=5s 60s gh api "repos/${REPO}/actions/runs/${run_id}" 2>/dev/null) || continue
+    if ! jq -e --arg repo "$REPO" --arg workflow "$RUNNER_BINARY_WORKFLOW_PATH" \
+      --argjson run "$run_id" --argjson attempt "$attempt" '
+      .id == $run and .repository.full_name == $repo and .path == $workflow and
+      .status == "completed" and .run_attempt >= $attempt and
+      (.head_sha | type == "string" and test("^[0-9a-f]{40}$"))
+    ' <<<"$run_json" >/dev/null; then
       continue
     fi
-    if ! jq -e \
-      --arg repo "$REPO" \
-      --arg workflow "$RUNNER_BINARY_WORKFLOW_PATH" \
-      --argjson run_id "$artifact_run_id" \
-      --arg artifact_head_sha "$artifact_head_sha" '
-        .id == $run_id and
-        .repository.full_name == $repo and
-        .path == $workflow and
-        .status == "completed" and
-        .head_sha == $artifact_head_sha and
-        (.run_attempt | type == "number" and . > 0)
-      ' <<<"$run_json" >/dev/null; then
-      continue
-    fi
-
-    local actual_source="" run_event run_branch producer_pr_numbers
-    run_event=$(jq -r '.event' <<<"$run_json")
-    run_branch=$(jq -r '.head_branch' <<<"$run_json")
-    case "$run_event" in
-      push)
-        producer_pr_numbers='[]'
-        if [ "$run_branch" = "$DEFAULT_BRANCH" ]; then
-          actual_source="protected-main"
-        fi
-        ;;
+    event=$(jq -r '.event' <<<"$run_json")
+    branch=$(jq -r '.head_branch' <<<"$run_json")
+    head=$(jq -r '.head_sha' <<<"$run_json")
+    source=""
+    producer_prs='[]'
+    case "$event" in
+      push) [ "$branch" != "$DEFAULT_BRANCH" ] || source=protected-main ;;
       pull_request)
-        if ! producer_pr_numbers=$(jq -ce '
-          [.pull_requests[]?.number] |
-          select(
-            length > 0 and
-            all(.[]; type == "number" and floor == . and . > 0)
-          )
-        ' <<<"$run_json"); then
-          continue
-        fi
+        producer_prs=$(jq -ce '[.pull_requests[]?.number] |
+          select(length > 0 and all(.[]; type == "number" and floor == . and . > 0))' <<<"$run_json") || continue
         if [ -n "${CURRENT_PR_NUMBER:-}" ] &&
-          jq -e --argjson pr "$CURRENT_PR_NUMBER" 'index($pr) != null' \
-            <<<"$producer_pr_numbers" >/dev/null; then
-          actual_source="same-pr"
+          jq -e --argjson pr "$CURRENT_PR_NUMBER" 'index($pr) != null' <<<"$producer_prs" >/dev/null; then
+          source=same-pr
         fi
         ;;
       merge_group)
-        if [[ ! "$run_branch" =~ (^|/)pr-([1-9][0-9]*)- ]]; then
-          continue
-        fi
-        producer_pr_numbers="[${BASH_REMATCH[2]}]"
-        if [ -n "${CURRENT_PR_NUMBER:-}" ] &&
-          [ "${BASH_REMATCH[2]}" = "$CURRENT_PR_NUMBER" ]; then
-          actual_source="same-pr"
-        fi
+        [[ "$branch" =~ (^|/)pr-([1-9][0-9]*)- ]] || continue
+        producer_prs="[${BASH_REMATCH[2]}]"
+        [ "${BASH_REMATCH[2]}" != "${CURRENT_PR_NUMBER:-}" ] || source=same-pr
         ;;
       *) continue ;;
     esac
-    if [ -z "$actual_source" ]; then
-      if producer_is_main_reachable "$artifact_head_sha"; then
-        actual_source="main-reachable"
-      else
-        continue
-      fi
+    if [ -z "$source" ]; then
+      producer_is_main_reachable "$head" || continue
+      source=main-reachable
     fi
-    local source_rank
-    case "${CURRENT_EVENT}:${actual_source}" in
-      pull_request:protected-main) source_rank=0 ;;
-      pull_request:main-reachable) source_rank=1 ;;
-      pull_request:same-pr) source_rank=2 ;;
-      merge_group:same-pr) source_rank=0 ;;
-      merge_group:protected-main) source_rank=1 ;;
-      merge_group:main-reachable) source_rank=2 ;;
-      push:protected-main) source_rank=0 ;;
-      push:main-reachable) source_rank=1 ;;
+    case "${CURRENT_EVENT}:${source}" in
+      pull_request:protected-main|merge_group:same-pr|push:protected-main) source_rank=0 ;;
+      pull_request:main-reachable|merge_group:protected-main|push:main-reachable) source_rank=1 ;;
+      pull_request:same-pr|merge_group:main-reachable) source_rank=2 ;;
       *) continue ;;
     esac
 
-    local candidate_dir manifest_path
-    candidate_dir="${output_dir}/candidate-${artifact_id}"
-    rm -rf "$candidate_dir"
-    mkdir -p "$candidate_dir"
-    if ! gh run download "$artifact_run_id" -n "$artifact_name_value" -D "$candidate_dir" \
-      >/dev/null 2>&1; then
+    jobs_json=$(runner_ci_jobs "$run_id" 2>/dev/null) || continue
+    runner_ci_receipt_valid "$jobs_json" "$run_id" "$attempt" "$sha" || continue
+    manifest_path="${output_dir}/${sha}.json"
+    runner_ci_record_get "$key" "$manifest_path" >/dev/null 2>&1 || continue
+    if ! env GITHUB_OUTPUT= MANIFEST_PATH="$manifest_path" EXPECTED_TARGET="$expected_target" \
+      EXPECTED_BINARY_INPUT_DIGEST="$expected_digest" EXPECTED_REPOSITORY="$REPO" \
+      EXPECTED_WORKFLOW_PATH="$RUNNER_BINARY_WORKFLOW_PATH" "$0" manifest-validate >/dev/null 2>&1; then
       continue
     fi
-    mapfile -t manifest_candidates < <(find "$candidate_dir" -type f -name manifest.json | sort)
-    if [ "${#manifest_candidates[@]}" -ne 1 ]; then
+    if ! jq -e --argjson run "$run_id" --argjson attempt "$attempt" --arg event "$event" \
+      --arg head "$head" --argjson prs "$producer_prs" --arg source "$source" \
+      --argjson current_pr "${CURRENT_PR_NUMBER:-null}" '
+      .producer.runId == $run and .producer.runAttempt == $attempt and
+      .producer.event == $event and .producer.headSha == $head and
+      (if $event == "push" then .producer.prNumber == null
+       else .producer.prNumber as $pr | ($prs | index($pr)) != null end) and
+      ($source != "same-pr" or .producer.prNumber == $current_pr)
+    ' "$manifest_path" >/dev/null; then
       continue
     fi
-    manifest_path="${manifest_candidates[0]}"
-    if ! env GITHUB_OUTPUT= \
-      MANIFEST_PATH="$manifest_path" \
-      EXPECTED_TARGET="$expected_target" \
-      EXPECTED_BINARY_INPUT_DIGEST="$expected_digest" \
-      EXPECTED_REPOSITORY="$REPO" \
-      EXPECTED_WORKFLOW_PATH="$RUNNER_BINARY_WORKFLOW_PATH" \
-        "$0" manifest-validate >/dev/null 2>&1; then
-      continue
-    fi
-
-    local run_attempt current_pr_json
-    run_attempt=$(jq -r '.run_attempt' <<<"$run_json")
-    current_pr_json="${CURRENT_PR_NUMBER:-null}"
-    if ! jq -e \
-      --argjson run_id "$artifact_run_id" \
-      --argjson run_attempt "$run_attempt" \
-      --arg event "$run_event" \
-      --arg head_sha "$artifact_head_sha" \
-      --arg source "$actual_source" \
-      --argjson producer_pr_numbers "$producer_pr_numbers" \
-      --argjson current_pr_number "$current_pr_json" '
-        .producer.runId == $run_id and
-        .producer.runAttempt == $run_attempt and
-        .producer.event == $event and
-        .producer.headSha == $head_sha and
-        (
-          if $event == "push" then
-            .producer.prNumber == null
-          else
-            .producer.prNumber as $producer_pr_number |
-            ($producer_pr_numbers | index($producer_pr_number)) != null
-          end
-        ) and
-        (
-          if $source == "same-pr" then
-            .producer.prNumber == $current_pr_number
-          else
-            true
-          end
-        )
-      ' "$manifest_path" >/dev/null; then
-      continue
-    fi
-
-    local identity identity_key
-    identity=$(jq -cS '{runner, guests}' "$manifest_path")
-    identity_key=$(sha256sum <<<"$identity" | awk '{print $1}')
-    if ! grep -qxF "$identity_key" "$identities_file"; then
-      printf '%s\n' "$identity_key" >> "$identities_file"
+    identity_key=$(jq -cS '{runner, guests}' "$manifest_path" | sha256sum | awk '{print $1}')
+    if ! grep -qxF "$identity_key" "$identities"; then
+      printf '%s\n' "$identity_key" >> "$identities"
       identity_count=$((identity_count + 1))
     fi
     printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
-      "$source_rank" "$artifact_created" "$artifact_id" "$artifact_run_id" \
-      "$actual_source" "$manifest_path" >> "$trusted_unsorted"
+      "$source_rank" "$modified" "$sha" "$run_id" "$source" "$manifest_path" >> "$unsorted"
     trusted_count=$((trusted_count + 1))
-    if [ "$identity_count" -ge "$RUNNER_BINARY_MAX_TRUSTED_IDENTITIES" ]; then
-      break
-    fi
-  done < "$sorted_potential"
+    [ "$identity_count" -lt "$RUNNER_BINARY_MAX_TRUSTED_IDENTITIES" ] || break
+  done < <(jq -c '.[]' <<<"$records")
 
-  # Select by the source proven from canonical run metadata, not the hint.
-  sort -t $'\t' -k1,1n -k2,2r "$trusted_unsorted" > "$trusted_file"
-
-  if [ "$inspected" -ge "$RUNNER_BINARY_MAX_CANDIDATE_INSPECTIONS" ] &&
-    [ "$potential_count" -gt "$inspected" ]; then
-    limit_reached=true
-  fi
-
+  sort -t $'\t' -k1,1n -k2,2r "$unsorted" > "$trusted_file"
   TRUSTED_CANDIDATES_FILE="$trusted_file"
-  TRUSTED_CANDIDATE_COUNT="$trusted_count"
-  TRUSTED_IDENTITY_COUNT="$identity_count"
-  TRUSTED_INSPECTION_COUNT="$inspected"
+  TRUSTED_CANDIDATE_COUNT=$trusted_count
+  TRUSTED_IDENTITY_COUNT=$identity_count
+  TRUSTED_INSPECTION_COUNT=$inspected
+  CANDIDATE_DISCOVERY_REASON=trusted-candidate
   if [ "$trusted_count" -eq 0 ]; then
-    if [ "$limit_reached" = "true" ]; then
-      CANDIDATE_DISCOVERY_REASON="candidate-limit-exhausted"
-    else
-      CANDIDATE_DISCOVERY_REASON="no-trusted-candidate"
+    CANDIDATE_DISCOVERY_REASON=no-trusted-candidate
+    if [ "$inspected" -ge "$RUNNER_BINARY_MAX_CANDIDATE_INSPECTIONS" ]; then
+      CANDIDATE_DISCOVERY_REASON=candidate-limit-exhausted
     fi
   elif [ "$identity_count" -gt 1 ]; then
-    CANDIDATE_DISCOVERY_REASON="trusted-output-conflict"
-  else
-    CANDIDATE_DISCOVERY_REASON="trusted-candidate"
+    CANDIDATE_DISCOVERY_REASON=trusted-output-conflict
   fi
 }
 
@@ -879,6 +720,7 @@ resolve_result() {
 }
 
 active_resolve() {
+  local mode=${1:-download}
   require_env EXPECTED_TARGET
   require_env EXPECTED_BINARY_INPUT_DIGEST
   require_env RESOLVE_OUTPUT_DIR
@@ -943,6 +785,21 @@ active_resolve() {
   fi
   first_trusted_candidate
 
+  if [ "$mode" = reference ]; then
+    local head
+    if ! head=$(runner_ci_aws head-object --key "$(jq -r '.object.key' "$TRUSTED_MANIFEST_PATH")" --output json 2>/dev/null) ||
+      ! jq -e --argjson size "$(jq '.object.sizeBytes' "$TRUSTED_MANIFEST_PATH")" '.ContentLength == $size' <<<"$head" >/dev/null; then
+      resolve_result miss "$TRUSTED_SOURCE" r2-head-failed "$TRUSTED_RUN_ID"
+      return 0
+    fi
+    mkdir -p "$RESOLVE_OUTPUT_DIR"
+    cp "$TRUSTED_MANIFEST_PATH" "${RESOLVE_OUTPUT_DIR}/manifest.json"
+    emit "runner-size-bytes" "$(jq '.runner.sizeBytes' "$TRUSTED_MANIFEST_PATH")"
+    emit "object-size-bytes" "$(jq '.object.sizeBytes' "$TRUSTED_MANIFEST_PATH")"
+    resolve_result hit "$TRUSTED_SOURCE" reference "$TRUSTED_RUN_ID"
+    return 0
+  fi
+
   local object_key object_size runner_sha runner_size
   object_key=$(jq -r '.object.key' "$TRUSTED_MANIFEST_PATH")
   object_size=$(jq -r '.object.sizeBytes' "$TRUSTED_MANIFEST_PATH")
@@ -985,19 +842,81 @@ active_resolve() {
   resolve_result "hit" "$TRUSTED_SOURCE" "validated" "$TRUSTED_RUN_ID"
 }
 
+download_manifest() {
+  require_env MANIFEST_PATH
+  require_env RESOLVE_OUTPUT_DIR
+  validate_reusable_manifest
+  runner_ci_config
+  [ ! -e "$RESOLVE_OUTPUT_DIR" ] && [ ! -L "$RESOLVE_OUTPUT_DIR" ] || return 2
+  local work_dir status=0
+  mkdir -p "$(dirname "$RESOLVE_OUTPUT_DIR")"
+  work_dir=$(mktemp -d "${RESOLVE_OUTPUT_DIR}.XXXXXX")
+  if ! fetch_verified_r2_runner "$REUSABLE_OBJECT_KEY" "$REUSABLE_OBJECT_SIZE" \
+    "$REUSABLE_RUNNER_SIZE" "$REUSABLE_RUNNER_SHA" "${work_dir}/runner.zst" "${work_dir}/runner"; then
+    echo "::error::Required Runner binary retrieval failed: ${R2_VERIFICATION_REASON}" >&2
+    rm -rf "$work_dir"
+    return 1
+  fi
+  chmod 755 "${work_dir}/runner"
+  jq '{schemaVersion, binaryInputDigest, target, toolchainImage,
+    runnerSha256: .runner.sha256, runnerSizeBytes: .runner.sizeBytes, guestSha256: .guests
+  }' "$MANIFEST_PATH" > "${work_dir}/metadata.json"
+  env GITHUB_OUTPUT= FRESH_METADATA_PATH="${work_dir}/metadata.json" RUNNER_PATH="${work_dir}/runner" \
+    "$0" fresh-validate >/dev/null || status=$?
+  if [ "$status" -ne 0 ]; then rm -rf "$work_dir"; return "$status"; fi
+  rm -f "${work_dir}/runner.zst" "${work_dir}/runner.zst.aws.err" "${work_dir}/runner.zst.zstd.err"
+  mv "$work_dir" "$RESOLVE_OUTPUT_DIR"
+}
+
+download_current() {
+  require_env CURRENT_RUN_ID
+  require_env EXPECTED_TARGET
+  require_env EXPECTED_BINARY_INPUT_DIGEST
+  require_env EXPECTED_PRODUCER_HEAD_SHA
+  runner_ci_config
+  local run jobs name manifest status=0
+  run=$(timeout --kill-after=5s 60s gh api "repos/${REPO}/actions/runs/${CURRENT_RUN_ID}")
+  jq -e --arg repo "$REPO" --arg head "$EXPECTED_PRODUCER_HEAD_SHA" \
+    --arg workflow "$RUNNER_BINARY_WORKFLOW_PATH" --argjson run "$CURRENT_RUN_ID" '
+    .id == $run and .repository.full_name == $repo and .path == $workflow and .head_sha == $head
+  ' <<<"$run" >/dev/null
+  jobs=$(runner_ci_jobs "$CURRENT_RUN_ID")
+  name=$(reusable_record_name "$EXPECTED_TARGET" "$EXPECTED_BINARY_INPUT_DIGEST")
+  manifest=$(mktemp "${RUNNER_TEMP:-$(dirname "$RESOLVE_OUTPUT_DIR")}/runner-manifest.XXXXXX")
+  if ! runner_ci_record_fetch "$name" "$CURRENT_RUN_ID" "$jobs" "$manifest"; then
+    rm -f "$manifest"
+    echo "::error::Current Runner binary has no authenticated R2 record" >&2
+    return 1
+  fi
+  if ! jq -e --argjson run "$CURRENT_RUN_ID" --argjson attempt "$RUNNER_CI_RECORD_ATTEMPT" \
+    --arg head "$EXPECTED_PRODUCER_HEAD_SHA" '
+    .producer.runId == $run and .producer.runAttempt == $attempt and .producer.headSha == $head
+  ' "$manifest" >/dev/null; then
+    rm -f "$manifest"
+    echo "::error::Current Runner binary record has inconsistent producer identity" >&2
+    return 1
+  fi
+  MANIFEST_PATH="$manifest" EXPECTED_REPOSITORY="$REPO" download_manifest || status=$?
+  rm -f "$manifest"
+  return "$status"
+}
+
 usage() {
   cat <<'USAGE'
-Usage: runner-binary-cache.sh <fresh-validate|artifact-name|manifest-validate|publish|shadow-resolve|active-resolve>
+Usage: runner-binary-cache.sh <fresh-validate|record-name|manifest-validate|publish|shadow-resolve|active-resolve|reference-resolve|download|download-current>
 USAGE
 }
 
 case "${1:-}" in
   fresh-validate) fresh_validate ;;
-  artifact-name) artifact_name ;;
+  record-name) record_name ;;
   manifest-validate) manifest_validate ;;
   publish) publish ;;
   shadow-resolve) shadow_resolve ;;
   active-resolve) active_resolve ;;
+  reference-resolve) active_resolve reference ;;
+  download) download_manifest ;;
+  download-current) download_current ;;
   -h|--help|help) usage ;;
   *) usage >&2; exit 2 ;;
 esac

--- a/.github/scripts/runner-ci-record.sh
+++ b/.github/scripts/runner-ci-record.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Private transport for Runner CI manifests. A content hash checks integrity;
+# the successful GitHub job step carrying that hash establishes its producer.
+RUNNER_CI_RECORD_MAX_BYTES=65536
+RUNNER_CI_RECORD_MAX_AGE_SECONDS=$((7 * 86400))
+
+runner_ci_config() {
+  : "${REPO:=${GITHUB_REPOSITORY:-}}"
+  : "${REPO:?missing REPO}"
+  : "${R2_ACCOUNT_ID:?missing R2_ACCOUNT_ID}"
+  : "${R2_BUCKET_NAME:?missing R2_BUCKET_NAME}"
+  : "${AWS_ACCESS_KEY_ID:?missing AWS_ACCESS_KEY_ID}"
+  : "${AWS_SECRET_ACCESS_KEY:?missing AWS_SECRET_ACCESS_KEY}"
+  [[ "$REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || return 2
+  RUNNER_CI_RECORD_PREFIX="runner-ci/v1/${REPO}/"
+}
+
+runner_ci_aws() {
+  # Bound the whole client process, including SDK retries. Cache planning has
+  # its own shorter owner deadline; required transfers get at most 120s.
+  local seconds=120
+  if [ -n "${RUNNER_CI_DEADLINE:-}" ]; then
+    local remaining=$((RUNNER_CI_DEADLINE - $(date +%s)))
+    [ "$remaining" -gt 0 ] || return 124
+    if [ "$remaining" -lt "$seconds" ]; then seconds=$remaining; fi
+  fi
+  timeout --kill-after=5s "${seconds}s" env AWS_RETRY_MODE=standard AWS_MAX_ATTEMPTS=3 \
+    aws s3api "$@" --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+    --bucket "$R2_BUCKET_NAME" --cli-connect-timeout 5 --cli-read-timeout 30
+}
+
+runner_ci_record_name_valid() {
+  [[ "$1" =~ ^runner-(binary-asset|image-manifest)-[A-Za-z0-9_-]+$ ]]
+}
+
+runner_ci_record_key_valid() {
+  local key=$1 suffix
+  [[ "$key" == "$RUNNER_CI_RECORD_PREFIX"* ]] || return 1
+  suffix=${key#"$RUNNER_CI_RECORD_PREFIX"}
+  [[ "$suffix" =~ ^(runner-(binary-asset|image-manifest)-[A-Za-z0-9_-]+)/([1-9][0-9]*)/([1-9][0-9]*)/([0-9a-f]{64})\.json$ ]]
+}
+
+runner_ci_record_get() {
+  local key=$1 destination=$2 expected_sha actual_sha size
+  runner_ci_record_key_valid "$key" || return 2
+  expected_sha=${key##*/}
+  expected_sha=${expected_sha%.json}
+  runner_ci_aws get-object --key "$key" \
+    --range "bytes=0-${RUNNER_CI_RECORD_MAX_BYTES}" "$destination" >/dev/null || return $?
+  size=$(stat -c '%s' "$destination")
+  [ "$size" -le "$RUNNER_CI_RECORD_MAX_BYTES" ] || return 1
+  actual_sha=$(sha256sum "$destination" | awk '{print $1}')
+  if [ "$actual_sha" != "$expected_sha" ]; then
+    echo "Runner CI record SHA mismatch: ${key}" >&2
+    return 1
+  fi
+  jq empty "$destination"
+}
+
+runner_ci_record_publish() {
+  local name=$1 manifest=$2 run_id=$3 attempt=$4 size sha key status=0
+  runner_ci_config
+  runner_ci_record_name_valid "$name" || return 2
+  [[ "$run_id" =~ ^[1-9][0-9]*$ && "$attempt" =~ ^[1-9][0-9]*$ ]] || return 2
+  [ -f "$manifest" ] && [ ! -L "$manifest" ] || return 2
+  size=$(stat -c '%s' "$manifest")
+  [ "$size" -gt 0 ] && [ "$size" -le "$RUNNER_CI_RECORD_MAX_BYTES" ] || return 2
+  jq empty "$manifest" || return $?
+  sha=$(sha256sum "$manifest" | awk '{print $1}')
+  key="${RUNNER_CI_RECORD_PREFIX}${name}/${run_id}/${attempt}/${sha}.json"
+  local error_file retained
+  error_file=$(mktemp "${manifest}.put.XXXXXX")
+  retained=$(mktemp "${manifest}.retained.XXXXXX")
+  runner_ci_aws put-object --key "$key" --body "$manifest" \
+    --content-type application/json --cache-control 'private, no-store' \
+    --if-none-match '*' >/dev/null 2>"$error_file" || status=$?
+  if [ "$status" -ne 0 ] && ! grep -q 'PreconditionFailed' "$error_file"; then
+    echo "Runner CI record publication failed: name=${name} status=${status}" >&2
+    rm -f "$error_file" "$retained"
+    return "$status"
+  fi
+  status=0
+  runner_ci_record_get "$key" "$retained" || status=$?
+  rm -f "$error_file" "$retained"
+  [ "$status" -eq 0 ] || return "$status"
+  printf 'record-sha=%s\n' "$sha"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf 'record-sha=%s\n' "$sha" >>"$GITHUB_OUTPUT"
+  fi
+}
+
+runner_ci_records() {
+  local name=$1 run_id=${2:-} prefix json
+  runner_ci_record_name_valid "$name" || return 2
+  prefix="${RUNNER_CI_RECORD_PREFIX}${name}/"
+  if [ -n "$run_id" ]; then
+    [[ "$run_id" =~ ^[1-9][0-9]*$ ]] || return 2
+    prefix+="${run_id}/"
+  fi
+  json=$(runner_ci_aws list-objects-v2 --prefix "$prefix" --max-items 1000 --output json) || return $?
+  # Do not turn a truncated index into a trusted, conflict-free candidate set.
+  jq -ce --arg prefix "$prefix" --argjson max "$RUNNER_CI_RECORD_MAX_BYTES" '
+    select(.NextToken == null) |
+    [.Contents[]? | select(.Key | startswith($prefix)) |
+      select(.Size > 0 and .Size <= $max)] | sort_by(.LastModified) | reverse
+  ' <<<"$json"
+}
+
+runner_ci_record_fresh() {
+  local modified=$1 timestamp now
+  timestamp=$(date -d "$modified" +%s 2>/dev/null) || return 1
+  now=$(date +%s)
+  [ "$timestamp" -le "$now" ] && [ "$timestamp" -gt "$((now - RUNNER_CI_RECORD_MAX_AGE_SECONDS))" ]
+}
+
+runner_ci_jobs() {
+  local run_id=$1
+  timeout --kill-after=5s 60s gh api --paginate --slurp \
+    "repos/${REPO}/actions/runs/${run_id}/jobs?filter=all&per_page=100"
+}
+
+runner_ci_receipt_valid() {
+  local jobs=$1 run_id=$2 attempt=$3 sha=$4 now
+  now=$(date +%s)
+  # A failed-only rerun can retain a successful producer from an older attempt.
+  # But once that job is rerun, its older receipt cannot authorize new readers.
+  jq -e --argjson run "$run_id" --argjson attempt "$attempt" --arg name "R2 record ${sha}" \
+    --argjson now "$now" --argjson age "$RUNNER_CI_RECORD_MAX_AGE_SECONDS" '
+    [.[].jobs[] | select(.run_id == $run)] |
+    group_by(.name) | map(max_by([.run_attempt, .id])) |
+    any(.[];
+      .run_attempt == $attempt and
+      any(.steps[]?; .name == $name and .status == "completed" and .conclusion == "success" and
+        # Storage timestamps can be refreshed by a writer; only GitHub can
+        # establish when this producer actually acknowledged the record.
+        ((.completed_at | fromdateiso8601?) as $time | $time <= $now and $time > ($now - $age)))
+    )
+  ' <<<"$jobs" >/dev/null
+}
+
+runner_ci_record_fetch() {
+  local name=$1 run_id=$2 jobs=$3 destination=$4 records record key suffix attempt sha modified
+  records=$(runner_ci_records "$name" "$run_id") || return $?
+  while IFS= read -r record; do
+    key=$(jq -r '.Key' <<<"$record")
+    modified=$(jq -r '.LastModified' <<<"$record")
+    runner_ci_record_key_valid "$key" || continue
+    runner_ci_record_fresh "$modified" || continue
+    suffix=${key#"${RUNNER_CI_RECORD_PREFIX}${name}/${run_id}/"}
+    attempt=${suffix%%/*}
+    sha=${suffix##*/}
+    sha=${sha%.json}
+    if runner_ci_receipt_valid "$jobs" "$run_id" "$attempt" "$sha"; then
+      export RUNNER_CI_RECORD_ATTEMPT=$attempt
+      runner_ci_record_get "$key" "$destination"
+      return $?
+    fi
+  done < <(jq -c '.[]' <<<"$records")
+  return 1
+}
+
+runner_ci_record_cleanup() {
+  runner_ci_config
+  case "${DRY_RUN:-false}" in true|false) ;; *) return 2 ;; esac
+  local listing record key modified timestamp cutoff count=0 token=""
+  local -a pagination=()
+  cutoff=$(($(date +%s) - 14 * 86400))
+  CLEANUP_TEMP_DIR=$(mktemp -d)
+  trap 'rm -rf "$CLEANUP_TEMP_DIR"' EXIT
+  local keys="${CLEANUP_TEMP_DIR}/keys" payload="${CLEANUP_TEMP_DIR}/delete.json" result
+  : >"$keys"
+  while true; do
+    listing=$(runner_ci_aws list-objects-v2 --prefix "$RUNNER_CI_RECORD_PREFIX" \
+      --no-paginate --max-keys 1000 "${pagination[@]}" --output json) || return $?
+    while IFS= read -r record; do
+      key=$(jq -r '.Key' <<<"$record")
+      runner_ci_record_key_valid "$key" || continue
+      modified=$(jq -r '.LastModified' <<<"$record")
+      timestamp=$(date -d "$modified" +%s) || return $?
+      [ "$timestamp" -lt "$cutoff" ] || continue
+      printf '%s\n' "$key" >>"$keys"
+      count=$((count + 1))
+      [ "$count" -lt 1000 ] || break 2
+    done < <(jq -c '.Contents[]?' <<<"$listing")
+    token=$(jq -er 'if .IsTruncated then .NextContinuationToken | select(type == "string" and length > 0) else "" end' <<<"$listing") || return $?
+    [ -n "$token" ] || break
+    pagination=(--continuation-token "$token")
+  done
+  if [ "$count" -gt 0 ]; then
+    if [ "${DRY_RUN:-false}" = true ]; then
+      sed 's/^/Would delete expired Runner CI record: /' "$keys"
+    else
+      # One bounded S3 batch avoids a client startup/network round trip per key.
+      jq -Rn '{Objects:[inputs | {Key:.}],Quiet:true}' <"$keys" >"$payload"
+      result=$(runner_ci_aws delete-objects --delete "file://${payload}" --output json) || return $?
+      if ! jq -e '(.Errors // [] | length) == 0' <<<"$result" >/dev/null; then
+        echo "Runner CI record cleanup had per-object failures: ${result}" >&2
+        return 1
+      fi
+      echo "Deleted expired Runner CI records: ${count}"
+    fi
+  fi
+  echo "Expired Runner CI records processed: ${count}"
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  runner_ci_config
+  case "${1:-}" in
+    publish)
+      runner_ci_record_publish "${RECORD_NAME:?}" "${MANIFEST_PATH:?}" \
+        "${PRODUCER_RUN_ID:?}" "${PRODUCER_RUN_ATTEMPT:?}"
+      ;;
+    fetch)
+      jobs=$(runner_ci_jobs "${PRODUCER_RUN_ID:?}")
+      runner_ci_record_fetch "${RECORD_NAME:?}" "$PRODUCER_RUN_ID" "$jobs" "${MANIFEST_PATH:?}"
+      ;;
+    cleanup) runner_ci_record_cleanup ;;
+    *) echo 'Usage: runner-ci-record.sh <publish|fetch|cleanup>' >&2; exit 2 ;;
+  esac
+fi

--- a/.github/scripts/runner-ci-record.sh
+++ b/.github/scripts/runner-ci-record.sh
@@ -20,13 +20,15 @@ runner_ci_config() {
 runner_ci_aws() {
   # Bound the whole client process, including SDK retries. Cache planning has
   # its own shorter owner deadline; required transfers get at most 120s.
+  # Foreground mode keeps nested clients in that owner's process group so its
+  # cancellation reaches them instead of leaving detached transfers behind.
   local seconds=120
   if [ -n "${RUNNER_CI_DEADLINE:-}" ]; then
     local remaining=$((RUNNER_CI_DEADLINE - $(date +%s)))
     [ "$remaining" -gt 0 ] || return 124
     if [ "$remaining" -lt "$seconds" ]; then seconds=$remaining; fi
   fi
-  timeout --kill-after=5s "${seconds}s" env AWS_RETRY_MODE=standard AWS_MAX_ATTEMPTS=3 \
+  timeout --foreground --kill-after=5s "${seconds}s" env AWS_RETRY_MODE=standard AWS_MAX_ATTEMPTS=3 \
     aws s3api "$@" --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" \
     --bucket "$R2_BUCKET_NAME" --cli-connect-timeout 5 --cli-read-timeout 30
 }
@@ -117,7 +119,7 @@ runner_ci_record_fresh() {
 
 runner_ci_jobs() {
   local run_id=$1
-  timeout --kill-after=5s 60s gh api --paginate --slurp \
+  timeout --foreground --kill-after=5s 60s gh api --paginate --slurp \
     "repos/${REPO}/actions/runs/${run_id}/jobs?filter=all&per_page=100"
 }
 

--- a/.github/scripts/runner-image-context.sh
+++ b/.github/scripts/runner-image-context.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
   cat <<'USAGE'
-Usage: runner-image-context.sh <resolve|turbo-consumer|playwright-consumer|crates-consumer|image-inputs|needed|artifact-name>
+Usage: runner-image-context.sh <resolve|turbo-consumer|playwright-consumer|crates-consumer|image-inputs|needed|record-name>
 
 resolve:
   Computes release skip, canonical job ref, and head SHA from GitHub event env.
@@ -29,8 +29,8 @@ crates-consumer:
 image-inputs:
   Computes whether current commit inputs can change the produced runner image.
 
-artifact-name:
-  Computes the GitHub artifact name for a runner image manifest.
+record-name:
+  Computes the R2 record name for a runner image manifest.
 USAGE
 }
 
@@ -313,7 +313,7 @@ image_inputs() {
   emit "runner-image-inputs-changed" "$runner_image_inputs_changed"
 }
 
-artifact_name() {
+record_name() {
   require_env HEAD_SHA
   require_env JOB_REF
   require_env TARGET
@@ -321,9 +321,9 @@ artifact_name() {
   head_sha=$(env_value HEAD_SHA)
   job_ref=$(env_value JOB_REF)
   target=$(env_value TARGET)
-  local artifact_name
-  artifact_name=$(runner_image_artifact_name "$target" "$head_sha" "$job_ref")
-  emit "artifact-name" "$artifact_name"
+  local record_name
+  record_name=$(runner_image_record_name "$target" "$head_sha" "$job_ref")
+  emit "record-name" "$record_name"
 }
 
 cmd="${1:-}"
@@ -334,7 +334,7 @@ case "$cmd" in
   crates-consumer) crates_consumer ;;
   image-inputs) image_inputs ;;
   needed) needed ;;
-  artifact-name) artifact_name ;;
+  record-name) record_name ;;
   -h|--help|help) usage ;;
   *) usage >&2; exit 2 ;;
 esac

--- a/.github/scripts/runner-image-target.sh
+++ b/.github/scripts/runner-image-target.sh
@@ -47,7 +47,7 @@ runner_image_target_for_uname_m() {
   esac
 }
 
-runner_image_artifact_name() {
+runner_image_record_name() {
   local target="${1:-}"
   local head_sha="${2:-}"
   local job_ref="${3:-}"

--- a/.github/scripts/tests/fixtures/runner-ci-aws.sh
+++ b/.github/scripts/tests/fixtures/runner-ci-aws.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# External S3 boundary backed by real files. Tests own the listing/timeline
+# fixtures independently of the bytes that the production scripts publish.
+set -euo pipefail
+printf '%s\n' "$*" >>"$AWS_LOG"
+[ "$1" = s3api ] || exit 2
+operation=$2
+shift 2
+key="" prefix="" body="" destination="" token="" delete_payload=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --key) key=$2; shift 2 ;;
+    --prefix) prefix=$2; shift 2 ;;
+    --body) body=$2; shift 2 ;;
+    --delete) delete_payload=${2#file://}; shift 2 ;;
+    --continuation-token) token=$2; shift 2 ;;
+    --endpoint-url|--bucket|--content-type|--cache-control|--if-none-match|--output|--range|--cli-connect-timeout|--cli-read-timeout|--max-items|--max-keys) shift 2 ;;
+    --no-paginate) shift ;;
+    --*) echo "unexpected option: $1" >&2; exit 2 ;;
+    *) destination=$1; shift ;;
+  esac
+done
+object="${AWS_STORE}/${key}"
+case "$operation" in
+  list-objects-v2)
+    [ "${AWS_MODE:-}" != list-fail ] || exit 8
+    jq --arg prefix "$prefix" '.Contents |= map(select(.Key | startswith($prefix)))' \
+      "${AWS_STORE}/index${token}.json"
+    ;;
+  put-object)
+    if [ "${AWS_MODE:-}" = put-fail ]; then
+      echo 'request failed X-Amz-Signature=supersecret' >&2
+      exit 9
+    fi
+    if [ -f "$object" ]; then echo PreconditionFailed >&2; exit 1; fi
+    mkdir -p "$(dirname "$object")"
+    cp "$body" "$object"
+    printf '{}\n'
+    ;;
+  head-object)
+    [ -f "$object" ] || exit 1
+    case "${AWS_MODE:-}" in
+      head-fail) exit 6 ;;
+      malformed-head) printf 'not-json\n' ;;
+      oversized-head) printf '{"ContentLength":67108865}\n' ;;
+      size-mismatch) printf '{"ContentLength":1}\n' ;;
+      *) printf '{"ContentLength":%s}\n' "$(stat -c '%s' "$object")" ;;
+    esac
+    ;;
+  get-object)
+    if [[ "$key" == runner-binaries/* ]] && [ "${AWS_MODE:-}" = get-fail ]; then exit 7; fi
+    [ "${AWS_MODE:-}" != record-get-fail ] || exit 7
+    cp "$object" "$destination"
+    printf '{}\n'
+    ;;
+  delete-objects)
+    if [ "${AWS_MODE:-}" = partial-delete ]; then
+      printf '{"Errors":[{"Code":"AccessDenied"}]}\n'
+    else
+      while IFS= read -r key; do rm "${AWS_STORE}/${key}"; done < <(jq -r '.Objects[].Key' "$delete_payload")
+      printf '{}\n'
+    fi
+    ;;
+  *) exit 2 ;;
+esac

--- a/.github/scripts/tests/runner-binary-cache-plan-test.sh
+++ b/.github/scripts/tests/runner-binary-cache-plan-test.sh
@@ -137,10 +137,9 @@ run_plan() {
     mixed) jq -n --argjson index "$index" --arg arm "$arm_record" '{Contents:[$index[] | select(.Key | contains($arm))]}' >"${TMPDIR}/store/index.json" ;;
     all-hit) jq -n --argjson index "$index" '{Contents:$index}' >"${TMPDIR}/store/index.json" ;;
   esac
-  local pr_number=123 pr_head_ref=feature
+  local pr_number=123
   if [ "$event" = "push" ]; then
     pr_number=""
-    pr_head_ref=""
   fi
   PATH="${TMPDIR}/bin:${PATH}" \
   GH_LOG="${TMPDIR}/gh.log" \
@@ -160,7 +159,6 @@ run_plan() {
   CURRENT_RUN_ID=99 \
   CURRENT_EVENT="$event" \
   CURRENT_PR_NUMBER="$pr_number" \
-  CURRENT_PR_HEAD_REF="$pr_head_ref" \
   DEFAULT_BRANCH=main \
   RUNNER_HOST_GROUPS_MATRIX="$matrix" \
   RESOLVE_OUTPUT_DIR="$output_dir" \
@@ -242,7 +240,6 @@ timed_out=$(PATH="${TMPDIR}/timeout-bin:${TMPDIR}/bin:${PATH}" \
   CURRENT_RUN_ID=99 \
   CURRENT_EVENT=pull_request \
   CURRENT_PR_NUMBER=123 \
-  CURRENT_PR_HEAD_REF=feature \
   DEFAULT_BRANCH=main \
   "$PLAN")
 assert_contains "$timed_out" 'hit-count=0'
@@ -258,7 +255,6 @@ killed=$(TIMEOUT_STATUS=137 \
   CURRENT_RUN_ID=99 \
   CURRENT_EVENT=pull_request \
   CURRENT_PR_NUMBER=123 \
-  CURRENT_PR_HEAD_REF=feature \
   DEFAULT_BRANCH=main \
   "$PLAN")
 assert_contains "$killed" 'hit-count=0'

--- a/.github/scripts/tests/runner-binary-cache-plan-test.sh
+++ b/.github/scripts/tests/runner-binary-cache-plan-test.sh
@@ -23,8 +23,8 @@ arm_target=aarch64-unknown-linux-musl
 x86_target=x86_64-unknown-linux-musl
 arm_digest=$("${SCRIPT_DIR}/runner-binary-build/digest.sh" "$arm_target" | sed -n 's/^binary-input-digest=//p')
 x86_digest=$("${SCRIPT_DIR}/runner-binary-build/digest.sh" "$x86_target" | sed -n 's/^binary-input-digest=//p')
-arm_artifact="runner-binary-asset-${arm_target}-${arm_digest}"
-x86_artifact="runner-binary-asset-${x86_target}-${x86_digest}"
+arm_record="runner-binary-asset-${arm_target}-${arm_digest}"
+x86_record="runner-binary-asset-${x86_target}-${x86_digest}"
 matrix=$(jq -cn \
   --arg arm_target "$arm_target" \
   --arg x86_target "$x86_target" '[
@@ -91,81 +91,52 @@ create_fixture() {
     ' > "${TMPDIR}/fixtures/${name}.json"
 }
 
-create_fixture "$arm_target" "$arm_digest" "$arm_artifact"
-create_fixture "$x86_target" "$x86_digest" "$x86_artifact"
+create_fixture "$arm_target" "$arm_digest" "$arm_record"
+create_fixture "$x86_target" "$x86_digest" "$x86_record"
 
 cat > "${TMPDIR}/fixtures/run-20.json" <<JSON
 {"id":20,"run_attempt":1,"event":"push","status":"completed","conclusion":"success","head_branch":"main","head_sha":"${main_head}","path":".github/workflows/runner-image.yml","repository":{"full_name":"vm0-ai/vm0"},"pull_requests":[]}
 JSON
 
+mkdir -p "${TMPDIR}/store"
+index='[]'
+steps='[]'
+now=$(date -u +%FT%TZ)
+for name in "$arm_record" "$x86_record"; do
+  manifest="${TMPDIR}/fixtures/${name}.json"
+  sha=$(sha256sum "$manifest" | awk '{print $1}')
+  key="runner-ci/v1/vm0-ai/vm0/${name}/20/1/${sha}.json"
+  object=$(jq -r '.object.key' "$manifest")
+  target=$(jq -r '.target' "$manifest")
+  mkdir -p "${TMPDIR}/store/$(dirname "$key")" "${TMPDIR}/store/$(dirname "$object")"
+  cp "$manifest" "${TMPDIR}/store/${key}"
+  cp "${TMPDIR}/objects/${target}.zst" "${TMPDIR}/store/${object}"
+  index=$(jq -c --arg key "$key" --arg time "$now" '. + [{Key:$key,Size:2000,LastModified:$time}]' <<<"$index")
+  steps=$(jq -c --arg sha "$sha" --arg time "$now" \
+    '. + [{name:("R2 record " + $sha),status:"completed",conclusion:"success",completed_at:$time}]' <<<"$steps")
+done
+jq -n --argjson steps "$steps" '{jobs:[{id:20,run_id:20,run_attempt:1,name:"Compile",steps:$steps}]}' >"${TMPDIR}/fixtures/jobs-20.json"
 cat > "${TMPDIR}/bin/gh" <<'BASH'
 #!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n' "$*" >> "$GH_LOG"
-if [ "$1" = "api" ]; then
-  endpoint="${*: -1}"
-  if [[ "$endpoint" == *'/actions/artifacts?'* ]]; then
-    name=${endpoint#*name=}
-    name=${name%%&*}
-    if [ "${GH_SCENARIO:-all-hit}" = "all-miss" ] ||
-      { [ "${GH_SCENARIO:-all-hit}" = "mixed" ] && [ "$name" = "$X86_ARTIFACT" ]; }; then
-      printf '[{"artifacts":[]}]\n'
-    else
-      printf '[{"artifacts":[{"id":120,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-22T00:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' \
-        "$name" "$MAIN_HEAD"
-    fi
-    exit 0
-  fi
-  cp "${FIXTURES}/run-20.json" /dev/stdout
-  exit 0
+printf '%s\n' "$*" >>"$GH_LOG"
+endpoint="${*: -1}"
+if [[ "$endpoint" == *'/jobs?'* ]]; then
+  jq -s '.' "${FIXTURES}/jobs-20.json"
+else
+  cat "${FIXTURES}/run-20.json"
 fi
-if [ "$1" = "run" ] && [ "$2" = "download" ]; then
-  artifact_name=""
-  output_dir=""
-  while [ "$#" -gt 0 ]; do
-    case "$1" in
-      -n) artifact_name=$2; shift 2 ;;
-      -D) output_dir=$2; shift 2 ;;
-      *) shift ;;
-    esac
-  done
-  mkdir -p "$output_dir"
-  cp "${FIXTURES}/${artifact_name}.json" "${output_dir}/manifest.json"
-  exit 0
-fi
-exit 2
 BASH
 chmod +x "${TMPDIR}/bin/gh"
-
-cat > "${TMPDIR}/bin/aws" <<'BASH'
-#!/usr/bin/env bash
-set -euo pipefail
-[ "$1" = "s3api" ] || exit 2
-operation=$2
-shift 2
-key=""
-destination=""
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --key) key=$2; shift 2 ;;
-    --endpoint-url|--bucket|--output|--range|--cli-connect-timeout|--cli-read-timeout) shift 2 ;;
-    --*) shift ;;
-    *) destination=$1; shift ;;
-  esac
-done
-target=${key#runner-binaries/}
-target=${target%%/*}
-object="${OBJECTS}/${target}.zst"
-case "$operation" in
-  head-object) printf '{"ContentLength":%s}\n' "$(stat -c '%s' "$object")" ;;
-  get-object) cp "$object" "$destination"; printf '{}\n' ;;
-  *) exit 2 ;;
-esac
-BASH
-chmod +x "${TMPDIR}/bin/aws"
+ln -s "${SCRIPT_DIR}/tests/fixtures/runner-ci-aws.sh" "${TMPDIR}/bin/aws"
 
 run_plan() {
   local scenario=$1 output_dir=$2 event=${3:-pull_request}
+  case "$scenario" in
+    all-miss) printf '{"Contents":[]}\n' >"${TMPDIR}/store/index.json" ;;
+    mixed) jq -n --argjson index "$index" --arg arm "$arm_record" '{Contents:[$index[] | select(.Key | contains($arm))]}' >"${TMPDIR}/store/index.json" ;;
+    all-hit) jq -n --argjson index "$index" '{Contents:$index}' >"${TMPDIR}/store/index.json" ;;
+  esac
   local pr_number=123 pr_head_ref=feature
   if [ "$event" = "push" ]; then
     pr_number=""
@@ -175,9 +146,10 @@ run_plan() {
   GH_LOG="${TMPDIR}/gh.log" \
   GH_SCENARIO="$scenario" \
   FIXTURES="${TMPDIR}/fixtures" \
-  OBJECTS="${TMPDIR}/objects" \
-  ARM_ARTIFACT="$arm_artifact" \
-  X86_ARTIFACT="$x86_artifact" \
+  AWS_STORE="${TMPDIR}/store" \
+  AWS_LOG="${TMPDIR}/aws.log" \
+  ARM_RECORD="$arm_record" \
+  X86_RECORD="$x86_record" \
   MAIN_HEAD="$main_head" \
   AWS_ACCESS_KEY_ID=test-access \
   AWS_SECRET_ACCESS_KEY=test-secret \
@@ -293,4 +265,14 @@ assert_contains "$killed" 'hit-count=0'
 assert_contains "$killed" 'miss-count=2'
 assert_contains "$killed" '"reason":"resolve-timeout"'
 
+: >"${TMPDIR}/aws.log"
+references=$(RUNNER_BINARY_RESOLVE_MODE=reference run_plan all-hit "${TMPDIR}/references")
+assert_contains "$references" 'hit-count=2'
+assert_contains "$references" 'hit-manifests={'
+for target in "$arm_target" "$x86_target"; do
+  [ -f "${TMPDIR}/references/${target}/manifest.json" ] || fail "reference plan must carry a per-target manifest"
+done
+if grep 'get-object' "${TMPDIR}/aws.log" | grep -q 'runner-binaries/'; then
+  fail "reference-only planning must not download runner bytes"
+fi
 echo "runner-binary-cache-plan-test: ok"

--- a/.github/scripts/tests/runner-binary-cache-test.sh
+++ b/.github/scripts/tests/runner-binary-cache-test.sh
@@ -78,16 +78,6 @@ fresh_out=$(FRESH_METADATA_PATH="$fresh" \
 assert_contains "$fresh_out" "runner-sha=${runner_sha}"
 assert_contains "$fresh_out" "runner-size-bytes=${runner_size}"
 
-record_out=$(EXPECTED_TARGET="$target" \
-  EXPECTED_BINARY_INPUT_DIGEST="$input_digest" \
-  "$CACHE" record-name)
-assert_contains "$record_out" \
-  "record-name=runner-binary-asset-${target}-${input_digest}"
-assert_fails "record name rejects an invalid input digest" \
-  env EXPECTED_TARGET="$target" \
-  EXPECTED_BINARY_INPUT_DIGEST=invalid \
-  "$CACHE" record-name
-
 jq '.unexpected = true' "$fresh" > "${TMPDIR}/fresh-extra.json"
 assert_fails "fresh metadata rejects unknown fields" \
   env FRESH_METADATA_PATH="${TMPDIR}/fresh-extra.json" \
@@ -443,10 +433,9 @@ prepare_candidates() {
 run_shadow() {
   local current_event=$1 scenario=$2 output_dir=$3
   prepare_candidates "$scenario"
-  local current_pr_number=123 current_pr_head_ref=feature
+  local current_pr_number=123
   if [ "$current_event" = "push" ]; then
     current_pr_number=""
-    current_pr_head_ref=""
   fi
   PATH="${TMPDIR}/bin:${PATH}" \
   GH_LOG="${TMPDIR}/gh.log" \
@@ -465,7 +454,6 @@ run_shadow() {
   CURRENT_RUN_ID=99 \
   CURRENT_EVENT="$current_event" \
   CURRENT_PR_NUMBER="$current_pr_number" \
-  CURRENT_PR_HEAD_REF="$current_pr_head_ref" \
   DEFAULT_BRANCH=main \
   AWS_LOG="${TMPDIR}/aws.log" \
   AWS_STORE="${TMPDIR}/store" \
@@ -549,10 +537,9 @@ grep -q 'equal runner binary input digest produced conflicting output identity' 
 run_active() {
   local current_event=$1 scenario=$2 output_dir=$3 aws_mode=${4:-success}
   prepare_candidates "$scenario"
-  local current_pr_number=123 current_pr_head_ref=feature
+  local current_pr_number=123
   if [ "$current_event" = "push" ]; then
     current_pr_number=""
-    current_pr_head_ref=""
   fi
   PATH="${TMPDIR}/bin:${PATH}" \
   GH_LOG="${TMPDIR}/gh.log" \
@@ -578,7 +565,6 @@ run_active() {
   CURRENT_RUN_ID=99 \
   CURRENT_EVENT="$current_event" \
   CURRENT_PR_NUMBER="$current_pr_number" \
-  CURRENT_PR_HEAD_REF="$current_pr_head_ref" \
   DEFAULT_BRANCH=main \
     "$CACHE" "${CACHE_RESOLVE_COMMAND:-active-resolve}"
 }

--- a/.github/scripts/tests/runner-binary-cache-test.sh
+++ b/.github/scripts/tests/runner-binary-cache-test.sh
@@ -78,15 +78,15 @@ fresh_out=$(FRESH_METADATA_PATH="$fresh" \
 assert_contains "$fresh_out" "runner-sha=${runner_sha}"
 assert_contains "$fresh_out" "runner-size-bytes=${runner_size}"
 
-artifact_out=$(EXPECTED_TARGET="$target" \
+record_out=$(EXPECTED_TARGET="$target" \
   EXPECTED_BINARY_INPUT_DIGEST="$input_digest" \
-  "$CACHE" artifact-name)
-assert_contains "$artifact_out" \
-  "artifact-name=runner-binary-asset-${target}-${input_digest}"
-assert_fails "artifact name rejects an invalid input digest" \
+  "$CACHE" record-name)
+assert_contains "$record_out" \
+  "record-name=runner-binary-asset-${target}-${input_digest}"
+assert_fails "record name rejects an invalid input digest" \
   env EXPECTED_TARGET="$target" \
   EXPECTED_BINARY_INPUT_DIGEST=invalid \
-  "$CACHE" artifact-name
+  "$CACHE" record-name
 
 jq '.unexpected = true' "$fresh" > "${TMPDIR}/fresh-extra.json"
 assert_fails "fresh metadata rejects unknown fields" \
@@ -105,59 +105,7 @@ assert_fails "fresh metadata verifies runner bytes" \
   "$CACHE" fresh-validate
 
 mkdir -p "${TMPDIR}/bin" "${TMPDIR}/store" "${TMPDIR}/runner-temp"
-cat > "${TMPDIR}/bin/aws" <<'BASH'
-#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\n' "$*" >> "$AWS_LOG"
-[ "$1" = "s3api" ] || exit 2
-operation=$2
-shift 2
-body=""
-destination=""
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --body) body=$2; shift 2 ;;
-    --endpoint-url|--bucket|--key|--content-type|--cache-control|--if-none-match|--output|--range|--cli-connect-timeout|--cli-read-timeout)
-      shift 2
-      ;;
-    --*) shift ;;
-    *) destination=$1; shift ;;
-  esac
-done
-object="${AWS_STORE}/object.zst"
-case "$operation" in
-  put-object)
-    if [ "${AWS_MODE:-success}" = "put-fail" ]; then
-      echo 'request failed X-Amz-Signature=supersecret' >&2
-      exit 9
-    fi
-    if [ -f "$object" ]; then
-      echo 'PreconditionFailed: 412' >&2
-      exit 1
-    fi
-    cp "$body" "$object"
-    printf '{}\n'
-    ;;
-  head-object)
-    [ -f "$object" ] || exit 1
-    case "${AWS_MODE:-success}" in
-      head-fail) exit 6 ;;
-      malformed-head) printf 'not-json\n' ;;
-      oversized-head) printf '{"ContentLength":67108865}\n' ;;
-      size-mismatch) printf '{"ContentLength":1}\n' ;;
-      *) printf '{"ContentLength":%s}\n' "$(stat -c '%s' "$object")" ;;
-    esac
-    ;;
-  get-object)
-    [ "${AWS_MODE:-success}" != "get-fail" ] || exit 7
-    [ -f "$object" ] || exit 1
-    cp "$object" "$destination"
-    printf '{}\n'
-    ;;
-  *) exit 2 ;;
-esac
-BASH
-chmod +x "${TMPDIR}/bin/aws"
+ln -s "${SCRIPT_DIR}/tests/fixtures/runner-ci-aws.sh" "${TMPDIR}/bin/aws"
 
 run_publish() {
   local output_dir=$1 mode=${2:-success}
@@ -191,9 +139,9 @@ publish_out=$(GITHUB_OUTPUT="$publish_output" run_publish "${TMPDIR}/published")
 assert_contains "$publish_out" "published=true"
 assert_contains "$publish_out" "publish-reason=uploaded"
 assert_output_keys "$publish_output" \
-  "manifest-path,object-key,object-size-bytes,publish-reason,published"
+  "manifest-path,object-key,object-size-bytes,publish-reason,published,record-sha"
 [ -f "${TMPDIR}/published/manifest.json" ] || fail "expected reusable manifest"
-zstd -q -d -c "${TMPDIR}/store/object.zst" > "${TMPDIR}/stored-runner"
+zstd -q -d -c "${TMPDIR}/store/runner-binaries/${target}/${runner_sha}.zst" > "${TMPDIR}/stored-runner"
 cmp -s "$runner" "${TMPDIR}/stored-runner" || fail "R2 object must contain the fresh runner"
 if ! grep -F 's3api head-object' "${TMPDIR}/aws.log" |
   grep -qF -- '--cli-connect-timeout 5 --cli-read-timeout 30'; then
@@ -302,39 +250,34 @@ existing_out=$(run_publish "${TMPDIR}/existing")
 assert_contains "$existing_out" "published=true"
 assert_contains "$existing_out" "publish-reason=existing-validated"
 
-printf 'not zstd\n' > "${TMPDIR}/store/object.zst"
-corrupt_out=$(run_publish "${TMPDIR}/corrupt")
-assert_contains "$corrupt_out" "published=false"
-assert_contains "$corrupt_out" "publish-reason=decompression-invalid"
+printf 'not zstd\n' > "${TMPDIR}/store/runner-binaries/${target}/${runner_sha}.zst"
+if corrupt_out=$(run_publish "${TMPDIR}/corrupt" 2>&1); then fail "required publication accepted decompression-invalid"; fi
+assert_contains "$corrupt_out" "(decompression-invalid)"
 [ ! -e "${TMPDIR}/corrupt/manifest.json" ] || fail "corrupt R2 bytes must not be advertised"
 
 printf 'different runner binary fixture\n' > "${TMPDIR}/different-runner"
-zstd -q -3 -f -o "${TMPDIR}/store/object.zst" "${TMPDIR}/different-runner"
-content_mismatch_out=$(run_publish "${TMPDIR}/publish-content-mismatch")
-assert_contains "$content_mismatch_out" "published=false"
-assert_contains "$content_mismatch_out" "publish-reason=retained-content-mismatch"
+zstd -q -3 -f -o "${TMPDIR}/store/runner-binaries/${target}/${runner_sha}.zst" "${TMPDIR}/different-runner"
+if content_mismatch_out=$(run_publish "${TMPDIR}/publish-content-mismatch" 2>&1); then fail "required publication accepted retained-content-mismatch"; fi
+assert_contains "$content_mismatch_out" "(retained-content-mismatch)"
 [ ! -e "${TMPDIR}/publish-content-mismatch/manifest.json" ] ||
   fail "mismatched R2 bytes must not be advertised"
 
-rm -f "${TMPDIR}/store/object.zst"
-put_failure=$(run_publish "${TMPDIR}/put-failure" put-fail 2>&1)
-assert_contains "$put_failure" "published=false"
-assert_contains "$put_failure" "publish-reason=put-failed"
+rm -f "${TMPDIR}/store/runner-binaries/${target}/${runner_sha}.zst"
+if put_failure=$(run_publish "${TMPDIR}/put-failure" put-fail 2>&1); then fail "required publication accepted put-failed"; fi
+assert_contains "$put_failure" "(put-failed)"
 if grep -q 'supersecret' <<<"$put_failure"; then
   fail "cache diagnostics leaked AWS error query material"
 fi
 [ ! -e "${TMPDIR}/put-failure/manifest.json" ] || fail "failed upload must not advertise a manifest"
 
-zstd -q -3 -f -o "${TMPDIR}/store/object.zst" "$runner"
-oversized_out=$(run_publish "${TMPDIR}/oversized" oversized-head)
-assert_contains "$oversized_out" "published=false"
-assert_contains "$oversized_out" "publish-reason=retained-size-invalid"
+zstd -q -3 -f -o "${TMPDIR}/store/runner-binaries/${target}/${runner_sha}.zst" "$runner"
+if oversized_out=$(run_publish "${TMPDIR}/oversized" oversized-head 2>&1); then fail "required publication accepted retained-size-invalid"; fi
+assert_contains "$oversized_out" "(retained-size-invalid)"
 
-malformed_head_out=$(run_publish "${TMPDIR}/malformed-head" malformed-head)
-assert_contains "$malformed_head_out" "published=false"
-assert_contains "$malformed_head_out" "publish-reason=head-malformed"
+if malformed_head_out=$(run_publish "${TMPDIR}/malformed-head" malformed-head 2>&1); then fail "required publication accepted head-malformed"; fi
+assert_contains "$malformed_head_out" "(head-malformed)"
 
-missing_config=$(FRESH_METADATA_PATH="$fresh" \
+if missing_config=$(FRESH_METADATA_PATH="$fresh" \
   RUNNER_PATH="$runner" \
   EXPECTED_TARGET="$target" \
   EXPECTED_BINARY_INPUT_DIGEST="$input_digest" \
@@ -345,9 +288,8 @@ missing_config=$(FRESH_METADATA_PATH="$fresh" \
   PRODUCER_EVENT=pull_request \
   PRODUCER_HEAD_SHA="$head_sha" \
   PRODUCER_PR_NUMBER=123 \
-    "$CACHE" publish)
-assert_contains "$missing_config" "published=false"
-assert_contains "$missing_config" "publish-reason=missing-r2-config"
+    "$CACHE" publish 2>&1); then fail "required publication accepted missing configuration"; fi
+assert_contains "$missing_config" "(missing-r2-config)"
 
 main_head=$(printf 'c%.0s' {1..40})
 pr_head=$(printf 'd%.0s' {1..40})
@@ -417,66 +359,8 @@ cat > "${TMPDIR}/bin/gh" <<'BASH'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$GH_LOG"
-if [ "$1" = "api" ]; then
-  endpoint="${*: -1}"
-  if [[ "$endpoint" == *'/actions/artifacts?'* ]]; then
-    [ "${GH_SCENARIO:-rank}" != "api-fail" ] || exit 8
-    case "${GH_SCENARIO:-rank}" in
-      failed)
-        printf '[{"artifacts":[{"id":122,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":22,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
-        ;;
-      failed-valid)
-        printf '[{"artifacts":[{"id":122,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":22,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
-        ;;
-      in-progress)
-        printf '[{"artifacts":[{"id":123,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":23,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
-        ;;
-      reachable|reachable-identical|compare-fail|compare-malformed|compare-mismatch|compare-behind|compare-diverged|pr-mismatch)
-        printf '[{"artifacts":[{"id":124,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":24,"head_branch":"gh-readonly-queue/main/pr-456-deadbeef","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$REACHABLE_HEAD"
-        ;;
-      ranking-reachable)
-        printf '[{"artifacts":[{"id":124,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T02:00:00Z","workflow_run":{"id":24,"head_branch":"gh-readonly-queue/main/pr-456-deadbeef","head_sha":"%s"}},{"id":121,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T01:00:00Z","workflow_run":{"id":21,"head_branch":"feature","head_sha":"%s"}}]}]\n' \
-          "$EXPECTED_ARTIFACT_NAME" "$REACHABLE_HEAD" \
-          "$EXPECTED_ARTIFACT_NAME" "$PR_HEAD"
-        ;;
-      invalid-head)
-        printf '[{"artifacts":[{"id":126,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":26,"head_branch":"other","head_sha":"not-a-sha"}}]}]\n' "$EXPECTED_ARTIFACT_NAME"
-        ;;
-      untrusted)
-        printf '[{"artifacts":[{"id":120,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
-        ;;
-      empty)
-        printf '[{"artifacts":[]}]\n'
-        ;;
-      expired)
-        printf '[{"artifacts":[{"id":120,"name":"%s","expired":true,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
-        ;;
-      oversized-artifact)
-        printf '[{"artifacts":[{"id":120,"name":"%s","expired":false,"size_in_bytes":1048577,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
-        ;;
-      content-mismatch)
-        printf '[{"artifacts":[{"id":120,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
-        ;;
-      many-invalid)
-        printf '[{"artifacts":['
-        separator=""
-        for run_id in $(seq 30 38); do
-          printf '%s{"id":%s,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T%02d:00:00Z","workflow_run":{"id":%s,"head_branch":"main","head_sha":"%s"}}' \
-            "$separator" "$((run_id + 100))" "$EXPECTED_ARTIFACT_NAME" "$((run_id - 30))" "$run_id" "$MAIN_HEAD"
-          separator=,
-        done
-        printf ']}]\n'
-        ;;
-      *)
-        printf '[{"artifacts":[{"id":199,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T03:00:00Z","workflow_run":{"id":99,"head_branch":"feature","head_sha":"%s"}},{"id":130,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T02:30:00Z","workflow_run":{"id":30,"head_branch":"other","head_sha":"%s"}},{"id":121,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T02:00:00Z","workflow_run":{"id":21,"head_branch":"feature","head_sha":"%s"}}]},{"artifacts":[{"id":120,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T01:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' \
-          "$EXPECTED_ARTIFACT_NAME" "$PR_HEAD" \
-          "$EXPECTED_ARTIFACT_NAME" "$UNREACHABLE_HEAD" \
-          "$EXPECTED_ARTIFACT_NAME" "$PR_HEAD" \
-          "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
-        ;;
-    esac
-    exit 0
-  fi
+[ "$1" = api ] || exit 2
+endpoint="${*: -1}"
   if [[ "$endpoint" == *'/compare/'* ]]; then
     case "${GH_SCENARIO:-rank}" in
       compare-fail) exit 8 ;;
@@ -500,50 +384,65 @@ if [ "$1" = "api" ]; then
     esac
     exit 0
   fi
+
+if [[ "$endpoint" == *'/jobs?'* ]]; then
+  run_id=${endpoint%/jobs?*}
+  run_id=${run_id##*/}
+  jq -s '.' "${GH_FIXTURES}/jobs-${run_id}.json"
+else
   run_id=${endpoint##*/}
-  cp "${GH_FIXTURES}/run-${run_id}.json" /dev/stdout
-  exit 0
+  cat "${GH_FIXTURES}/run-${run_id}.json"
 fi
-if [ "$1" = "run" ] && [ "$2" = "download" ]; then
-  run_id=$3
-  output_dir=""
-  while [ "$#" -gt 0 ]; do
-    case "$1" in
-      -D) output_dir=$2; shift 2 ;;
-      *) shift ;;
-    esac
-  done
-  mkdir -p "$output_dir"
-  if [ "$run_id" = "20" ] && [ "${GH_SCENARIO:-rank}" = "untrusted" ]; then
-    cp "${GH_FIXTURES}/untrusted-manifest.json" "${output_dir}/manifest.json"
-  elif [ "$run_id" = "20" ] && [ "${GH_SCENARIO:-rank}" = "content-mismatch" ]; then
-    cp "${GH_FIXTURES}/content-mismatch-manifest.json" "${output_dir}/manifest.json"
-  elif [ "$run_id" = "20" ] && [ "${GH_SCENARIO:-rank}" = "conflict" ]; then
-    cp "${GH_FIXTURES}/conflict-manifest.json" "${output_dir}/manifest.json"
-  elif [ "$run_id" = "20" ] && [ "${GH_SCENARIO:-rank}" = "guest-conflict" ]; then
-    cp "${GH_FIXTURES}/guest-conflict-manifest.json" "${output_dir}/manifest.json"
-  elif [ "$run_id" = "20" ]; then
-    cp "${GH_FIXTURES}/main-manifest.json" "${output_dir}/manifest.json"
-  elif [ "$run_id" = "21" ]; then
-    cp "${GH_FIXTURES}/pr-manifest.json" "${output_dir}/manifest.json"
-  elif [ "$run_id" = "22" ] && [ "${GH_SCENARIO:-rank}" = "failed-valid" ]; then
-    cp "${GH_FIXTURES}/failed-main-manifest.json" "${output_dir}/manifest.json"
-  elif [ "$run_id" = "24" ] && [ "${GH_SCENARIO:-rank}" = "pr-mismatch" ]; then
-    cp "${GH_FIXTURES}/reachable-pr-mismatch-manifest.json" "${output_dir}/manifest.json"
-  elif [ "$run_id" = "24" ]; then
-    cp "${GH_FIXTURES}/reachable-manifest.json" "${output_dir}/manifest.json"
-  else
-    exit 1
-  fi
-  exit 0
-fi
-exit 2
 BASH
 chmod +x "${TMPDIR}/bin/gh"
 
-expected_artifact="runner-binary-asset-${target}-${input_digest}"
+expected_record="runner-binary-asset-${target}-${input_digest}"
+prepare_candidates() {
+  local scenario=$1 candidate run_id sha key modified index='[]' receipt manifest
+  local -a candidates=()
+  case "$scenario" in
+    failed) candidates=("22:main-manifest") ;;
+    failed-valid) candidates=("22:failed-main-manifest") ;;
+    in-progress) candidates=("23:main-manifest") ;;
+    reachable|reachable-identical|compare-*) candidates=("24:reachable-manifest") ;;
+    pr-mismatch) candidates=("24:reachable-pr-mismatch-manifest") ;;
+    ranking-reachable) candidates=("24:reachable-manifest" "21:pr-manifest") ;;
+    invalid-head) candidates=("26:main-manifest") ;;
+    untrusted) candidates=("20:untrusted-manifest") ;;
+    content-mismatch) candidates=("20:content-mismatch-manifest") ;;
+    conflict) candidates=("20:conflict-manifest" "21:pr-manifest") ;;
+    guest-conflict) candidates=("20:guest-conflict-manifest" "21:pr-manifest") ;;
+    empty|api-fail) ;;
+    expired|oversized-record) candidates=("20:main-manifest") ;;
+    many-invalid)
+      for run_id in {30..38}; do candidates+=("${run_id}:main-manifest"); done
+      ;;
+    *) candidates=("99:pr-manifest" "30:pr-manifest" "21:pr-manifest" "20:main-manifest") ;;
+  esac
+  modified=$(date -u +%FT%TZ)
+  receipt=$modified
+  if [ "$scenario" = expired ]; then modified=$(date -u -d '8 days ago' +%FT%TZ); fi
+  for candidate in "${candidates[@]}"; do
+    run_id=${candidate%%:*}
+    manifest="${TMPDIR}/${candidate#*:}.json"
+    sha=$(sha256sum "$manifest" | awk '{print $1}')
+    key="runner-ci/v1/vm0-ai/vm0/${expected_record}/${run_id}/1/${sha}.json"
+    mkdir -p "${TMPDIR}/store/$(dirname "$key")"
+    cp "$manifest" "${TMPDIR}/store/${key}"
+    index=$(jq -c --arg key "$key" --arg time "$modified" --argjson size "$(stat -c '%s' "$manifest")" \
+      '. + [{Key:$key,LastModified:$time,Size:$size}]' <<<"$index")
+    jq -n --argjson run "$run_id" --arg sha "$sha" --arg time "$receipt" '{
+      jobs:[{id:$run,run_id:$run,run_attempt:1,name:"Compile arm64",
+      steps:[{name:("R2 record " + $sha),status:"completed",conclusion:"success",completed_at:$time}]}]
+    }' >"${TMPDIR}/jobs-${run_id}.json"
+  done
+  if [ "$scenario" = oversized-record ]; then index=$(jq 'map(.Size=65537)' <<<"$index"); fi
+  jq -n --argjson contents "$index" '{Contents:$contents}' >"${TMPDIR}/store/index.json"
+}
+
 run_shadow() {
   local current_event=$1 scenario=$2 output_dir=$3
+  prepare_candidates "$scenario"
   local current_pr_number=123 current_pr_head_ref=feature
   if [ "$current_event" = "push" ]; then
     current_pr_number=""
@@ -553,7 +452,7 @@ run_shadow() {
   GH_LOG="${TMPDIR}/gh.log" \
   GH_SCENARIO="$scenario" \
   GH_FIXTURES="$TMPDIR" \
-  EXPECTED_ARTIFACT_NAME="$expected_artifact" \
+  EXPECTED_RECORD_NAME="$expected_record" \
   MAIN_HEAD="$main_head" \
   PR_HEAD="$pr_head" \
   REACHABLE_HEAD="$reachable_head" \
@@ -568,6 +467,13 @@ run_shadow() {
   CURRENT_PR_NUMBER="$current_pr_number" \
   CURRENT_PR_HEAD_REF="$current_pr_head_ref" \
   DEFAULT_BRANCH=main \
+  AWS_LOG="${TMPDIR}/aws.log" \
+  AWS_STORE="${TMPDIR}/store" \
+  AWS_MODE="$([ "$scenario" = api-fail ] && echo list-fail || echo success)" \
+  AWS_ACCESS_KEY_ID=test-access \
+  AWS_SECRET_ACCESS_KEY=test-secret \
+  R2_ACCOUNT_ID=test-account \
+  R2_BUCKET_NAME=test-bucket \
   SHADOW_OUTPUT_DIR="$output_dir" \
     "$CACHE" shadow-resolve
 }
@@ -609,7 +515,7 @@ assert_contains "$push_shadow" "shadow-source=protected-main"
 
 api_failure=$(run_shadow pull_request api-fail "${TMPDIR}/shadow-api-failure")
 assert_contains "$api_failure" "shadow-outcome=error"
-assert_contains "$api_failure" "shadow-reason=artifact-api-unavailable"
+assert_contains "$api_failure" "shadow-reason=record-index-unavailable"
 
 failed_candidate=$(run_shadow pull_request failed "${TMPDIR}/shadow-failed")
 assert_contains "$failed_candidate" "shadow-outcome=miss"
@@ -642,6 +548,7 @@ grep -q 'equal runner binary input digest produced conflicting output identity' 
 
 run_active() {
   local current_event=$1 scenario=$2 output_dir=$3 aws_mode=${4:-success}
+  prepare_candidates "$scenario"
   local current_pr_number=123 current_pr_head_ref=feature
   if [ "$current_event" = "push" ]; then
     current_pr_number=""
@@ -651,13 +558,13 @@ run_active() {
   GH_LOG="${TMPDIR}/gh.log" \
   GH_SCENARIO="$scenario" \
   GH_FIXTURES="$TMPDIR" \
-  EXPECTED_ARTIFACT_NAME="$expected_artifact" \
+  EXPECTED_RECORD_NAME="$expected_record" \
   MAIN_HEAD="$main_head" \
   PR_HEAD="$pr_head" \
   REACHABLE_HEAD="$reachable_head" \
   UNREACHABLE_HEAD="$unreachable_head" \
   AWS_LOG="${TMPDIR}/aws.log" \
-  AWS_MODE="$aws_mode" \
+  AWS_MODE="$([ "$scenario" = api-fail ] && echo list-fail || echo "$aws_mode")" \
   AWS_STORE="${TMPDIR}/store" \
   AWS_ACCESS_KEY_ID=test-access \
   AWS_SECRET_ACCESS_KEY=test-secret \
@@ -673,10 +580,11 @@ run_active() {
   CURRENT_PR_NUMBER="$current_pr_number" \
   CURRENT_PR_HEAD_REF="$current_pr_head_ref" \
   DEFAULT_BRANCH=main \
-    "$CACHE" active-resolve
+    "$CACHE" "${CACHE_RESOLVE_COMMAND:-active-resolve}"
 }
 
-zstd -q -3 -f -o "${TMPDIR}/store/object.zst" "$runner"
+zstd -q -3 -f -o "${TMPDIR}/store/runner-binaries/${target}/${runner_sha}.zst" "$runner"
+cp "${TMPDIR}/store/runner-binaries/${target}/${runner_sha}.zst" "${TMPDIR}/store/runner-binaries/${target}/${conflict_sha}.zst"
 : > "${TMPDIR}/gh.log"
 active_output="${TMPDIR}/active.output"
 active_hit=$(GITHUB_OUTPUT="$active_output" run_active pull_request rank "${TMPDIR}/active-hit")
@@ -740,13 +648,13 @@ grep -qF 'unsupported current event: unsupported' \
 
 api_miss=$(run_active pull_request api-fail "${TMPDIR}/active-api-fail")
 assert_contains "$api_miss" "resolve-outcome=miss"
-assert_contains "$api_miss" "resolve-reason=artifact-api-unavailable"
+assert_contains "$api_miss" "resolve-reason=record-index-unavailable"
 
 expired_miss=$(run_active pull_request expired "${TMPDIR}/active-expired")
 assert_contains "$expired_miss" "resolve-reason=no-trusted-candidate"
 
-oversized_artifact_miss=$(run_active pull_request oversized-artifact "${TMPDIR}/active-oversized-artifact")
-assert_contains "$oversized_artifact_miss" "resolve-reason=no-trusted-candidate"
+oversized_record_miss=$(run_active pull_request oversized-record "${TMPDIR}/active-oversized-record")
+assert_contains "$oversized_record_miss" "resolve-reason=no-trusted-candidate"
 
 conflict_miss=$(run_active pull_request conflict "${TMPDIR}/active-conflict")
 assert_contains "$conflict_miss" "resolve-outcome=miss"
@@ -770,12 +678,12 @@ assert_contains "$get_failure_miss" "resolve-reason=r2-get-failed"
 content_mismatch_miss=$(run_active pull_request content-mismatch "${TMPDIR}/active-content-mismatch")
 assert_contains "$content_mismatch_miss" "resolve-reason=r2-content-mismatch"
 
-compressed_size=$(stat -c '%s' "${TMPDIR}/store/object.zst")
-dd if=/dev/zero of="${TMPDIR}/store/object.zst" bs="$compressed_size" count=1 status=none
+compressed_size=$(stat -c '%s' "${TMPDIR}/store/runner-binaries/${target}/${runner_sha}.zst")
+dd if=/dev/zero of="${TMPDIR}/store/runner-binaries/${target}/${runner_sha}.zst" bs="$compressed_size" count=1 status=none
 corrupt_miss=$(run_active pull_request rank "${TMPDIR}/active-corrupt")
 assert_contains "$corrupt_miss" "resolve-outcome=miss"
 assert_contains "$corrupt_miss" "resolve-reason=r2-decompression-invalid"
-zstd -q -3 -f -o "${TMPDIR}/store/object.zst" "$runner"
+zstd -q -3 -f -o "${TMPDIR}/store/runner-binaries/${target}/${runner_sha}.zst" "$runner"
 
 : > "${TMPDIR}/gh.log"
 bounded_miss=$(run_active pull_request many-invalid "${TMPDIR}/active-bounded")
@@ -783,5 +691,42 @@ assert_contains "$bounded_miss" "resolve-outcome=miss"
 assert_contains "$bounded_miss" "resolve-reason=candidate-limit-exhausted"
 run_queries=$(grep -c 'actions/runs/' "${TMPDIR}/gh.log")
 [ "$run_queries" -eq 8 ] || fail "active resolution must inspect at most eight candidate runs"
+
+: >"${TMPDIR}/aws.log"
+reference=$(CACHE_RESOLVE_COMMAND=reference-resolve \
+  run_active pull_request rank "${TMPDIR}/reference")
+assert_contains "$reference" 'resolve-outcome=hit'
+assert_contains "$reference" 'resolve-reason=reference'
+if grep 'get-object' "${TMPDIR}/aws.log" | grep -q 'runner-binaries/'; then
+  fail "reference lookup downloaded binary bytes"
+fi
+
+download_binary() {
+  local command=$1 destination=$2
+  env PATH="${TMPDIR}/bin:$PATH" REPO=vm0-ai/vm0 \
+    AWS_STORE="${TMPDIR}/store" AWS_LOG="${TMPDIR}/aws.log" \
+    AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test R2_ACCOUNT_ID=test R2_BUCKET_NAME=test \
+    GH_LOG="${TMPDIR}/gh.log" GH_FIXTURES="$TMPDIR" RUNNER_TEMP="${TMPDIR}/runner-temp" \
+    CURRENT_RUN_ID=20 EXPECTED_PRODUCER_HEAD_SHA="$main_head" EXPECTED_REPOSITORY=vm0-ai/vm0 \
+    EXPECTED_TARGET="$target" EXPECTED_BINARY_INPUT_DIGEST="$input_digest" \
+    MANIFEST_PATH="${TMPDIR}/reference/manifest.json" RESOLVE_OUTPUT_DIR="$destination" \
+    "$CACHE" "$command"
+}
+
+download_binary download "${TMPDIR}/required-hit"
+cmp "$runner" "${TMPDIR}/required-hit/runner"
+jq '.run_attempt=2 | .status="in_progress"' "${TMPDIR}/run-20.json" >"${TMPDIR}/run-20.next"
+mv "${TMPDIR}/run-20.next" "${TMPDIR}/run-20.json"
+download_binary download-current "${TMPDIR}/required-current"
+cmp "$runner" "${TMPDIR}/required-current/runner"
+jq '.jobs += [{id:200,run_id:20,run_attempt:2,name:"Compile arm64",steps:[]}]' \
+  "${TMPDIR}/jobs-20.json" >"${TMPDIR}/jobs-20.next"
+mv "${TMPDIR}/jobs-20.next" "${TMPDIR}/jobs-20.json"
+assert_fails "new producer attempt invalidates required binary receipt" \
+  download_binary download-current "${TMPDIR}/required-stale"
+# A selected hit is no longer an optional cache probe: missing storage fails.
+if AWS_MODE=get-fail download_binary download "${TMPDIR}/required-missing"; then
+  fail "required hit download accepted unavailable bytes"
+fi
 
 echo "runner-binary-cache-test: ok"

--- a/.github/scripts/tests/runner-ci-record-test.sh
+++ b/.github/scripts/tests/runner-ci-record-test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RECORD="${SCRIPT_DIR}/runner-ci-record.sh"
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+expect_failure() { if "$@" >"${TEST_DIR}/failure.out" 2>&1; then fail "expected failure: $*"; fi; }
+mkdir -p "${TEST_DIR}/bin" "${TEST_DIR}/store"
+ln -s "${SCRIPT_DIR}/tests/fixtures/runner-ci-aws.sh" "${TEST_DIR}/bin/aws"
+cat >"${TEST_DIR}/bin/gh" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "$*" == *'/jobs?filter=all&per_page=100' ]] || exit 2
+jq -s '.' "$JOBS_FILE"
+BASH
+chmod +x "${TEST_DIR}/bin/gh"
+export PATH="${TEST_DIR}/bin:$PATH" AWS_STORE="${TEST_DIR}/store" AWS_LOG="${TEST_DIR}/aws.log"
+export AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test R2_ACCOUNT_ID=test R2_BUCKET_NAME=test
+export REPO=vm0-ai/vm0 RECORD_NAME=runner-image-manifest-arm64-test-pr-123
+export PRODUCER_RUN_ID=42 PRODUCER_RUN_ATTEMPT=1 JOBS_FILE="${TEST_DIR}/jobs.json"
+export GITHUB_OUTPUT="${TEST_DIR}/outputs"
+prefix="runner-ci/v1/${REPO}/${RECORD_NAME}/42"
+printf '{"ready":true}\n' >"${TEST_DIR}/manifest.json"
+sha=$(sha256sum "${TEST_DIR}/manifest.json" | awk '{print $1}')
+key="${prefix}/1/${sha}.json"
+MANIFEST_PATH="${TEST_DIR}/manifest.json" "$RECORD" publish >/dev/null
+grep -qxF "record-sha=${sha}" "$GITHUB_OUTPUT" || fail "publication must expose verified hash"
+cmp "${TEST_DIR}/manifest.json" "${AWS_STORE}/${key}"
+# Conditional publication accepts an existing object only after readback.
+MANIFEST_PATH="${TEST_DIR}/manifest.json" "$RECORD" publish >/dev/null
+
+now=$(date -u +%FT%TZ)
+jq -n --arg key "$key" --arg now "$now" \
+  '{Contents:[{Key:$key,Size:15,LastModified:$now}]}' >"${AWS_STORE}/index.json"
+jq -n --arg sha "$sha" --arg now "$now" '{jobs:[{
+  id:1,run_id:42,run_attempt:1,name:"Build arm64",steps:[{
+    name:("R2 record " + $sha),status:"completed",conclusion:"success",completed_at:$now
+  }]
+}]}' >"$JOBS_FILE"
+MANIFEST_PATH="${TEST_DIR}/download.json" "$RECORD" fetch
+cmp "${TEST_DIR}/manifest.json" "${TEST_DIR}/download.json"
+
+# Failed-only reruns may leave this successful producer on the first attempt.
+jq '.jobs += [{id:2,run_id:42,run_attempt:2,name:"Build x86",steps:[]}]' "$JOBS_FILE" >"${TEST_DIR}/other-rerun.json"
+JOBS_FILE="${TEST_DIR}/other-rerun.json" MANIFEST_PATH="${TEST_DIR}/download.json" "$RECORD" fetch
+# Rerunning this producer invalidates its previous receipt, even on failure.
+jq '.jobs += [{id:3,run_id:42,run_attempt:2,name:"Build arm64",steps:[]}]' "$JOBS_FILE" >"${TEST_DIR}/producer-rerun.json"
+expect_failure env JOBS_FILE="${TEST_DIR}/producer-rerun.json" MANIFEST_PATH="${TEST_DIR}/download.json" "$RECORD" fetch
+
+for change in '.jobs[0].steps[0].conclusion="failure"' \
+  '.jobs[0].steps[0].status="in_progress"' '.jobs[0].run_id=43' \
+  '.jobs[0].steps[0].name="R2 record forged"' \
+  '.jobs[0].steps[0].completed_at="2000-01-01T00:00:00Z"'; do
+  jq "$change" "$JOBS_FILE" >"${TEST_DIR}/invalid-jobs.json"
+  expect_failure env JOBS_FILE="${TEST_DIR}/invalid-jobs.json" MANIFEST_PATH="${TEST_DIR}/download.json" "$RECORD" fetch
+done
+
+# Replacing bytes under an attested key must not authorize the replacement.
+printf '{"ready":false}\n' >"${AWS_STORE}/${key}"
+expect_failure env MANIFEST_PATH="${TEST_DIR}/download.json" "$RECORD" fetch
+: >"$GITHUB_OUTPUT"
+expect_failure env MANIFEST_PATH="${TEST_DIR}/manifest.json" "$RECORD" publish
+[ ! -s "$GITHUB_OUTPUT" ] || fail "failed readback must not advertise readiness"
+cp "${TEST_DIR}/manifest.json" "${AWS_STORE}/${key}"
+expect_failure env AWS_MODE=record-get-fail MANIFEST_PATH="${TEST_DIR}/manifest.json" "$RECORD" publish
+expect_failure env AWS_MODE=put-fail PRODUCER_RUN_ATTEMPT=2 MANIFEST_PATH="${TEST_DIR}/manifest.json" "$RECORD" publish
+if grep -q supersecret "${TEST_DIR}/failure.out"; then fail "publication leaked request material"; fi
+
+jq '.Contents[0].LastModified="2000-01-01T00:00:00Z"' "${AWS_STORE}/index.json" >"${TEST_DIR}/old-index.json"
+cp "${TEST_DIR}/old-index.json" "${AWS_STORE}/index.json"
+expect_failure env MANIFEST_PATH="${TEST_DIR}/download.json" "$RECORD" fetch
+
+# Cleanup reads successive pages (recent entries must not hide old keys),
+# removes only scoped old metadata, and leaves binaries/unrelated keys intact.
+old_key="runner-ci/v1/${REPO}/runner-binary-asset-arm64-test/41/1/${sha}.json"
+outside_key="runner-ci/v1/another/repo/runner-image-manifest-arm64/41/1/${sha}.json"
+invalid_key="runner-ci/v1/${REPO}/unrelated/41/1/${sha}.json"
+for object in "$old_key" "$outside_key" "$invalid_key"; do
+  mkdir -p "${AWS_STORE}/$(dirname "$object")"
+  cp "${TEST_DIR}/manifest.json" "${AWS_STORE}/${object}"
+done
+jq -n --arg key "$key" --arg now "$now" '{Contents:[{Key:$key,LastModified:$now}],IsTruncated:true,NextContinuationToken:"2"}' >"${AWS_STORE}/index.json"
+jq -n --arg old "$old_key" --arg outside "$outside_key" --arg invalid "$invalid_key" \
+  '{Contents:[$old,$outside,$invalid] | map({Key:.,LastModified:"2000-01-01T00:00:00Z"}),IsTruncated:false}' >"${AWS_STORE}/index2.json"
+DRY_RUN=true "$RECORD" cleanup >"${TEST_DIR}/cleanup.out"
+[ -f "${AWS_STORE}/${old_key}" ] || fail "dry-run deleted metadata"
+grep -q 'Would delete expired Runner CI record' "${TEST_DIR}/cleanup.out" || fail "dry-run must report expired metadata"
+expect_failure env AWS_MODE=partial-delete DRY_RUN=false "$RECORD" cleanup
+DRY_RUN=false "$RECORD" cleanup >"${TEST_DIR}/cleanup.out"
+[ ! -e "${AWS_STORE}/${old_key}" ] || fail "expired metadata was retained"
+for object in "$key" "$outside_key" "$invalid_key"; do
+  [ -f "${AWS_STORE}/${object}" ] || fail "cleanup exceeded its scope: $object"
+done
+expect_failure env AWS_MODE=list-fail "$RECORD" cleanup
+echo "runner-ci-record-test: ok"

--- a/.github/scripts/tests/runner-ci-record-test.sh
+++ b/.github/scripts/tests/runner-ci-record-test.sh
@@ -94,4 +94,36 @@ for object in "$key" "$outside_key" "$invalid_key"; do
   [ -f "${AWS_STORE}/${object}" ] || fail "cleanup exceeded its scope: $object"
 done
 expect_failure env AWS_MODE=list-fail "$RECORD" cleanup
+
+# The cache planner owns a shorter process-group deadline than individual
+# transfers. Cancelling that owner must also interrupt a nested AWS operation.
+mkdir "${TEST_DIR}/cancel-bin"
+mkfifo "${TEST_DIR}/ready" "${TEST_DIR}/terminated" "${TEST_DIR}/block"
+export CANCEL_READY="${TEST_DIR}/ready" CANCEL_TERMINATED="${TEST_DIR}/terminated" CANCEL_BLOCK="${TEST_DIR}/block"
+exec {ready_fd}<>"$CANCEL_READY" {terminated_fd}<>"$CANCEL_TERMINATED"
+cat >"${TEST_DIR}/cancel-bin/aws" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+trap 'printf "terminated\n" >"$CANCEL_TERMINATED"; exit 143' TERM
+exec 3<>"$CANCEL_BLOCK"
+printf '%s\n' "$BASHPID" >"$CANCEL_READY"
+read -r blocked <&3
+BASH
+chmod +x "${TEST_DIR}/cancel-bin/aws"
+timeout --kill-after=5s 60s env PATH="${TEST_DIR}/cancel-bin:$PATH" \
+  MANIFEST_PATH="${TEST_DIR}/manifest.json" "$RECORD" publish >"${TEST_DIR}/cancel.out" 2>&1 &
+owner_pid=$!
+if ! read -r -t 10 aws_pid <&"$ready_fd"; then
+  kill -TERM "$owner_pid"
+  wait "$owner_pid" || true
+  fail "AWS operation did not reach the cancellation boundary"
+fi
+kill -TERM "$owner_pid"
+if ! read -r -t 5 state <&"$terminated_fd"; then
+  kill -TERM "$aws_pid"
+  wait "$owner_pid" || true
+  fail "owner cancellation left the nested AWS operation running"
+fi
+wait "$owner_pid" && fail "cancelled owner unexpectedly succeeded"
+[ "$state" = terminated ] || fail "AWS operation did not acknowledge termination"
 echo "runner-ci-record-test: ok"

--- a/.github/scripts/tests/runner-image-context-test.sh
+++ b/.github/scripts/tests/runner-image-context-test.sh
@@ -317,22 +317,22 @@ assert_contains "$out" "crates-runner-consumer-needed=true"
 assert_contains "$out" "runner-image-inputs-changed=true"
 assert_contains "$out" "current-runner-image-needed=true"
 
-assert_fails "artifact-name requires TARGET" \
+assert_fails "record-name requires TARGET" \
   HEAD_SHA=abc \
   JOB_REF=pr-123 \
-  "$CONTEXT" artifact-name
+  "$CONTEXT" record-name
 
-assert_fails "artifact-name rejects unsupported TARGET" \
+assert_fails "record-name rejects unsupported TARGET" \
   HEAD_SHA=abc \
   JOB_REF=pr-123 \
   TARGET=powerpc-unknown-linux-musl \
-  "$CONTEXT" artifact-name
+  "$CONTEXT" record-name
 
-out=$(run_clean HEAD_SHA=abc JOB_REF=pr-123 TARGET=aarch64-unknown-linux-musl "$CONTEXT" artifact-name)
-assert_contains "$out" "artifact-name=runner-image-manifest-aarch64-unknown-linux-musl-abc-pr-123"
+out=$(run_clean HEAD_SHA=abc JOB_REF=pr-123 TARGET=aarch64-unknown-linux-musl "$CONTEXT" record-name)
+assert_contains "$out" "record-name=runner-image-manifest-aarch64-unknown-linux-musl-abc-pr-123"
 
-out=$(run_clean HEAD_SHA=abc JOB_REF=pr-123 TARGET=x86_64-unknown-linux-musl "$CONTEXT" artifact-name)
-assert_contains "$out" "artifact-name=runner-image-manifest-x86_64-unknown-linux-musl-abc-pr-123"
+out=$(run_clean HEAD_SHA=abc JOB_REF=pr-123 TARGET=x86_64-unknown-linux-musl "$CONTEXT" record-name)
+assert_contains "$out" "record-name=runner-image-manifest-x86_64-unknown-linux-musl-abc-pr-123"
 
 grep -qF "SOURCE_HEAD_SHA: \${{ github.event.pull_request.head.sha || github.sha }}" \
   "${REPO_ROOT}/.github/workflows/runner-image.yml" \

--- a/.github/scripts/tests/runner-image-workflow-test.sh
+++ b/.github/scripts/tests/runner-image-workflow-test.sh
@@ -47,14 +47,13 @@ jq -e '
 ' <<<"$workflow_json" >/dev/null || fail "merge-group consumers must stop before shared runner resources are rebuilt"
 
 jq -e '
-  [.jobs | to_entries[] | .value.steps[]? |
-    .with.name? // empty |
-    select(startswith("runner-binary-hits-") or startswith("runner-binary-compiled-"))
-  ] as $transport_names |
-  ($transport_names | length) == 5 and
-  all($transport_names[]; contains("${{ github.run_id }}")) and
-  all($transport_names[]; contains("${{ github.run_attempt }}") | not)
-' <<<"$workflow_json" >/dev/null || fail "runner binary transport identity must survive producer and consumer attempt mismatch"
+  all([.jobs.compile, .jobs.build][];
+    .env.R2_BUCKET_NAME == "${{ vars.R2_USER_STORAGES_BUCKET_NAME }}" and
+    .permissions.actions == "read" and
+    any(.steps[]; .name == "R2 record ${{ steps.publish.outputs.record-sha }}" and
+      .env.RECORD_SHA == "${{ steps.publish.outputs.record-sha }}" and
+      (. | has("continue-on-error") | not)))
+' <<<"$workflow_json" >/dev/null || fail "required R2 publication needs canonical hash receipts"
 
 jq -e '
   .jobs.prepare["runs-on"] == "ubuntu-latest" and
@@ -68,15 +67,9 @@ jq -e '
     .run == ".github/scripts/runner-binary-cache-plan.sh" and
     .env.RUNNER_BINARY_CACHE_FORCE_MISS == "${{ vars.RUNNER_BINARY_CACHE_FORCE_MISS }}"
   ) and
-  any(.jobs.prepare.steps[];
-    .uses == "actions/upload-artifact@v7" and
-    .with.name == "runner-binary-hits-${{ github.run_id }}" and
-    .with.overwrite == true and
-    .if == "steps.binary-plan.outputs.hit-count != '\''0'\''" and
-    .with["compression-level"] == 1 and
-    (. | has("continue-on-error") | not)
-  )
-' <<<"$workflow_json" >/dev/null || fail "prepare must own bounded pre-container hit planning and required transport upload"
+  .jobs.prepare.outputs["runner-binary-hit-manifests"] == "${{ steps.binary-plan.outputs.hit-manifests }}" and
+  any(.jobs.prepare.steps[]; .id == "binary-plan" and .env.RUNNER_BINARY_RESOLVE_MODE == "reference")
+' <<<"$workflow_json" >/dev/null || fail "prepare must own bounded pre-container hit planning and per-target reference transport"
 
 jq -e '
   .jobs.compile["runs-on"] == "ubuntu-latest-8-cores" and
@@ -95,12 +88,12 @@ jq -e '
   any(.jobs.compile.steps[]; .uses == "mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba") and
   any(.jobs.compile.steps[]; .uses == "Swatinem/rust-cache@v2") and
   any(.jobs.compile.steps[]; .run == ".github/scripts/runner-binary-build/build.sh build") and
-  any(.jobs.compile.steps[];
-    .uses == "actions/upload-artifact@v7" and
-    .with.name == "runner-binary-compiled-${{ github.run_id }}-${{ matrix.target }}" and
-    .with.overwrite == true and
-    (. | has("continue-on-error") | not)
-  )
+  .jobs.compile.defaults.run.shell == "bash" and
+  any(.jobs.compile.steps[]; .name == "Install Runner transport clients") and
+  any(.jobs.compile.steps[]; .id == "shadow" and (.run | contains("runner-binary-cache.sh shadow-resolve"))) and
+  any(.jobs.compile.steps[]; .id == "publish" and (.run | contains("runner-binary-cache.sh publish")) and
+    .env.PRODUCER_RUN_ATTEMPT == "${{ github.run_attempt }}" and
+    (. | has("continue-on-error") | not))
 ' <<<"$workflow_json" >/dev/null || fail "compile must be a required miss-only Rust/cache/build matrix"
 
 jq -e '
@@ -120,14 +113,13 @@ jq -e '
   (.jobs.build.if | contains("needs.compile.result == '\''skipped'\''")) and
   (.jobs.build.if | contains("needs.compile.result == '\''success'\''")) and
   any(.jobs.build.steps[];
-    .name == "Download validated runner binary hit" and
-    (.if | contains("runner-binary-hit-targets")) and
-    .with.name == "runner-binary-hits-${{ github.run_id }}"
+    .name == "Download runner binary from R2" and
+    .env.HIT_MANIFEST == "${{ toJSON(fromJSON(needs.prepare.outputs.runner-binary-hit-manifests)[matrix.target]) }}" and
+    .env.CURRENT_RUN_ID == "${{ github.run_id }}" and
+    (.run | contains("runner-binary-cache.sh download-current")) and
+    (.run | contains("runner-binary-cache.sh download"))
   ) and
-  any(.jobs.build.steps[];
-    .name == "Download compiled runner binary" and
-    .with.name == "runner-binary-compiled-${{ github.run_id }}-${{ matrix.target }}"
-  ) and
+  any(.jobs.build.steps[]; .id == "publish" and .run == ".github/scripts/runner-ci-record.sh publish") and
   any(.jobs.build.steps[];
     .run == ".github/scripts/prepare-runner-image.sh" and
     .env.RUNNER_PATH == "runner-binary-transport/${{ matrix.target }}/runner" and
@@ -135,37 +127,21 @@ jq -e '
   )
 ' <<<"$workflow_json" >/dev/null || fail "build must preserve the all-target host readiness contract for hits and misses"
 
-jq -e '
-  (.jobs.asset.needs | sort) == ["compile", "prepare"] and
-  (.jobs.asset.if | contains("runner-binary-miss-count != '\''0'\''")) and
-  .jobs.asset.strategy.matrix.include == "${{ fromJSON(needs.prepare.outputs.runner-binary-compile-matrix) }}" and
-  any(.jobs.asset.steps[];
-    .name == "Download compiled runner binary" and
-    .with.name == "runner-binary-compiled-${{ github.run_id }}-${{ matrix.target }}"
-  ) and
-  any(.jobs.asset.steps[];
-    .name == "Validate fresh runner binary" and
-    (. | has("if") | not) and
-    (. | has("continue-on-error") | not)
-  ) and
-  any(.jobs.asset.steps[];
-    .name == "Resolve reusable candidate in shadow mode" and
-    (. | has("if") | not)
-  ) and
-  any(.jobs.asset.steps[];
-    .name == "Publish runner binary cache object" and
-    (. | has("if") | not)
-  ) and
-  any(.jobs.asset.steps[];
-    .name == "Upload reusable runner binary manifest" and
-    .with.path == "runner-binary-asset/manifest.json" and
-    .with["retention-days"] == 7
-  )
-' <<<"$workflow_json" >/dev/null || fail "reusable publication must run only for compiled misses"
-
 prepare_consumers=$(jq -r '[.jobs | to_entries[] |
   select(any(.value.steps[]?; .run == ".github/scripts/prepare-runner-image.sh")) |
   .key] | join(",")' <<<"$workflow_json")
 [ "$prepare_consumers" = "build" ] || fail "host preparation must run only in the all-target build job"
 
 echo "runner-image-workflow-test: ok"
+
+for consumer in crates turbo; do
+  yq -o=json '.' "${REPO_ROOT}/.github/workflows/${consumer}.yml" | jq -e '
+    [.jobs[].steps[]? | select(.run? | strings | test("wait-runner-image(-groups)?\\.sh$"))] |
+    length > 0 and all(.[];
+      .env.AWS_ACCESS_KEY_ID == "${{ secrets.R2_ACCESS_KEY_ID }}" and
+      .env.AWS_SECRET_ACCESS_KEY == "${{ secrets.R2_SECRET_ACCESS_KEY }}" and
+      .env.R2_ACCOUNT_ID == "${{ vars.R2_ACCOUNT_ID }}" and
+      .env.R2_BUCKET_NAME == "${{ vars.R2_USER_STORAGES_BUCKET_NAME }}"
+    )
+  ' >/dev/null || fail "all ${consumer} readiness consumers need private R2 access"
+done

--- a/.github/scripts/tests/wait-runner-image-groups-test.sh
+++ b/.github/scripts/tests/wait-runner-image-groups-test.sh
@@ -34,77 +34,57 @@ chmod +x "$FAKE_BIN/ssh"
 cat >"$FAKE_BIN/gh" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
-
-if [ "$1" = "api" ]; then
-  request="$2"
-  artifact_name="${request#*name=}"
-  artifact_name="${artifact_name%%&*}"
-  printf 'HTTP/2.0 200 OK\r\n\r\n'
-  cat <<JSON
-{
-  "artifacts": [
-    {
-      "name": "$artifact_name",
-      "expired": false,
-      "workflow_run": {
-        "id": 42,
-        "head_sha": "$HEAD_SHA"
-      }
-    }
-  ]
-}
-JSON
-  exit 0
-fi
-
-if [ "$1" = "run" ] && [ "$2" = "view" ]; then
-  echo "https://github.com/vm0-ai/vm0/actions/runs/42"
-  exit 0
-fi
-
-if [ "$1" = "run" ] && [ "$2" = "download" ]; then
-  artifact_name=""
-  output_dir=""
-  while [ "$#" -gt 0 ]; do
-    case "$1" in
-      -n)
-        artifact_name="$2"
-        shift 2
-        ;;
-      -D)
-        output_dir="$2"
-        shift 2
-        ;;
-      *)
-        shift
-        ;;
-    esac
+printf 'HTTP/2.0 200 OK\r\n\r\n'
+if [[ "$2" == *'/actions/workflows/'* ]]; then
+  jq -cn --arg head "$HEAD_SHA" '{
+    workflow_runs:[{id:42,head_sha:$head,path:".github/workflows/runner-image.yml",
+      repository:{full_name:"vm0-ai/vm0"},status:"in_progress",created_at:"2026-05-11T00:00:00Z",
+      html_url:"https://github.com/vm0-ai/vm0/actions/runs/42"}]}'
+else
+  steps='[]'
+  for arch in arm64 x86_64; do
+    file="$MANIFEST_DIR/${arch}.json"
+    if [ "$arch" = x86_64 ] && [ "${FAKE_X86_MISMATCH:-}" = 1 ]; then file="$MANIFEST_DIR/x86_64-mismatch.json"; fi
+    sha=$(sha256sum "$file" | awk '{print $1}')
+    steps=$(jq -c --arg sha "$sha" --arg now "$(date -u +%FT%TZ)" \
+      '. + [{name:("R2 record " + $sha),status:"completed",conclusion:"success",completed_at:$now}]' <<<"$steps")
   done
-
-  mkdir -p "$output_dir"
-  case "$artifact_name" in
-    *aarch64-unknown-linux-musl*)
-      cp "$MANIFEST_DIR/arm64.json" "$output_dir/manifest.json"
-      ;;
-    *x86_64-unknown-linux-musl*)
-      if [ "${FAKE_X86_MISMATCH:-}" = "1" ]; then
-        cp "$MANIFEST_DIR/x86_64-mismatch.json" "$output_dir/manifest.json"
-      else
-        cp "$MANIFEST_DIR/x86_64.json" "$output_dir/manifest.json"
-      fi
-      ;;
-    *)
-      echo "unexpected artifact: $artifact_name" >&2
-      exit 1
-      ;;
-  esac
-  exit 0
+  jq -cn --argjson steps "$steps" '{jobs:[{id:1,run_id:42,run_attempt:1,name:"Build",steps:$steps}]}'
 fi
-
-echo "unexpected gh command: $*" >&2
-exit 1
 SH
-chmod +x "$FAKE_BIN/gh"
+cat >"$FAKE_BIN/aws" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+operation=$2
+prefix="" key="" destination=""
+shift 2
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --prefix) prefix=$2; shift 2 ;;
+    --key) key=$2; shift 2 ;;
+    --*) shift 2 ;;
+    *) destination=$1; shift ;;
+  esac
+done
+if [[ "${prefix}${key}" == *aarch64* ]]; then
+  file="$MANIFEST_DIR/arm64.json"
+elif [ "${FAKE_X86_MISMATCH:-}" = 1 ]; then
+  file="$MANIFEST_DIR/x86_64-mismatch.json"
+else
+  file="$MANIFEST_DIR/x86_64.json"
+fi
+case "$operation" in
+  list-objects-v2)
+    sha=$(sha256sum "$file" | awk '{print $1}')
+    jq -cn --arg key "${prefix}1/${sha}.json" --arg now "$(date -u +%FT%TZ)" \
+      '{Contents:[{Key:$key,Size:1000,LastModified:$now}]}'
+    ;;
+  get-object) cp "$file" "$destination" ;;
+  *) exit 2 ;;
+esac
+SH
+chmod +x "$FAKE_BIN/gh" "$FAKE_BIN/aws"
+export AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test R2_ACCOUNT_ID=test R2_BUCKET_NAME=test
 
 make_manifest() {
   local file="$1"

--- a/.github/scripts/tests/wait-runner-image-test.sh
+++ b/.github/scripts/tests/wait-runner-image-test.sh
@@ -62,7 +62,7 @@ respond_error() {
 
 if [ "$1" = "api" ]; then
   [[ "$*" == *' --include' ]] || exit 1
-  case "${FAKE_MODE:-artifact}" in
+  case "${FAKE_MODE:-record}" in
     primary)
       if [ "$now" -lt 1007 ]; then
         respond_error 403 'X-RateLimit-Remaining: 0\r\nX-RateLimit-Reset: 1006\r\n' 'API rate limit exceeded for installation'
@@ -100,69 +100,32 @@ if [ "$1" = "api" ]; then
   esac
 
   if [[ "$2" == *'/actions/workflows/'* ]]; then
-    if [[ "${FAKE_MODE:-artifact}" == workflow-rate* ]] && [ "$now" -lt 1007 ]; then
+    if [[ "${FAKE_MODE:-record}" == workflow-rate* ]] && [ "$now" -lt 1007 ]; then
       respond_error 403 'Retry-After: 7\r\n' 'secondary rate limit'
     fi
     printf 'HTTP/2.0 200 OK\r\n\r\n'
-    if [ "${FAKE_MODE:-artifact}" = "no-producer" ]; then
+    if [ "${FAKE_MODE:-record}" = "no-producer" ]; then
       printf '{"workflow_runs":[]}\n'
     else
       status=in_progress
       conclusion=null
-      if [ "${FAKE_MODE:-artifact}" = "failed-run" ] ||
-        [ "${FAKE_MODE:-artifact}" = "workflow-rate-failure" ] || {
-        [ "${FAKE_MODE:-artifact}" = "later-failure" ] && [ "$now" -ge 1060 ]
+      if [ "${FAKE_MODE:-record}" = "failed-run" ] ||
+        [ "${FAKE_MODE:-record}" = "workflow-rate-failure" ] || {
+        [ "${FAKE_MODE:-record}" = "later-failure" ] && [ "$now" -ge 1060 ]
       }; then
         status=completed
         conclusion='"failure"'
       fi
-      printf '{"workflow_runs":[{"id":42,"status":"%s","conclusion":%s,"created_at":"2026-05-11T00:00:00Z","html_url":"https://example.test/run/42","head_sha":"head-sha"}]}\n' "$status" "$conclusion"
+      printf '{"workflow_runs":[{"id":42,"status":"%s","conclusion":%s,"created_at":"2026-05-11T00:00:00Z","html_url":"https://example.test/run/42","head_sha":"head-sha","path":".github/workflows/runner-image.yml","repository":{"full_name":"vm0-ai/vm0"}}]}\n' "$status" "$conclusion"
     fi
     exit 0
   fi
 
-  [[ "$2" == *'/actions/artifacts?name='* ]] || exit 1
+  [[ "$2" == *'/jobs?filter=all&per_page=100&page='* ]] || exit 1
   printf 'HTTP/2.0 200 OK\r\n\r\n'
-  if [ "${FAKE_MODE:-artifact}" = "failed-run" ] ||
-    [ "${FAKE_MODE:-artifact}" = "later-failure" ] ||
-    [ "${FAKE_MODE:-artifact}" = "no-producer" ] ||
-    [ "$now" -lt "${AVAILABLE_AT:-0}" ]; then
-    printf '{"artifacts":[]}\n'
-    exit 0
-  fi
-  printf '{"artifacts":[{"id":123,"name":"%s","expired":false,"created_at":"2026-05-11T00:00:00Z","workflow_run":{"id":42,"head_sha":"head-sha"}}]}\n' "${EXPECTED_ARTIFACT_NAME}"
-  exit 0
-fi
-
-if [ "$1" = "run" ] && [ "$2" = "download" ]; then
-  if [ "${FAKE_MODE:-artifact}" = "download-rate" ] && [ "$now" -lt 1060 ]; then
-    echo 'gh: API rate limit exceeded for installation (HTTP 403)' >&2
-    exit 1
-  fi
-  if [ "${FAKE_MODE:-artifact}" = "download-unavailable" ]; then
-    echo 'artifact is not downloadable yet' >&2
-    exit 1
-  fi
-  artifact=""
-  output_dir=""
-  while [ "$#" -gt 0 ]; do
-    case "$1" in
-      -n)
-        artifact=$2
-        shift 2
-        ;;
-      -D)
-        output_dir=$2
-        shift 2
-        ;;
-      *)
-        shift
-        ;;
-    esac
-  done
-  [ "$artifact" = "${EXPECTED_ARTIFACT_NAME}" ] || exit 1
-  mkdir -p "$output_dir"
-  cp "${FAKE_MANIFEST}" "${output_dir}/manifest.json"
+  sha=$(sha256sum "$FAKE_MANIFEST" | awk '{print $1}')
+  jq -cn --arg sha "$sha" '{jobs:[{id:1,run_id:42,run_attempt:1,name:"Build image",
+    steps:[{name:("R2 record " + $sha),status:"completed",conclusion:"success",completed_at:"1970-01-01T00:16:40Z"}]}]}'
   exit 0
 fi
 
@@ -170,14 +133,51 @@ echo "unexpected gh call: $*" >&2
 exit 1
 BASH
 chmod +x "${TMPDIR}/bin/gh"
+cat >"${TMPDIR}/bin/aws" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+now=$(date +%s)
+printf '%s %s\n' "$now" "$*" >>"$AWS_ARGS_LOG"
+key="" prefix="" destination=""
+operation=$2
+shift 2
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --key) key=$2; shift 2 ;;
+    --prefix) prefix=$2; shift 2 ;;
+    --*) shift 2 ;;
+    *) destination=$1; shift ;;
+  esac
+done
+case "$operation" in
+  list-objects-v2)
+    if [ "${FAKE_MODE:-}" = failed-run ] || [ "${FAKE_MODE:-}" = later-failure ] ||
+      [ "$now" -lt "${AVAILABLE_AT:-0}" ]; then
+      printf '{"Contents":[]}\n'
+    else
+      sha=$(sha256sum "$FAKE_MANIFEST" | awk '{print $1}')
+      jq -cn --arg key "${prefix}1/${sha}.json" \
+        '{Contents:[{Key:$key,Size:1000,LastModified:"1970-01-01T00:16:40Z"}]}'
+    fi
+    ;;
+  get-object)
+    if [ "${FAKE_MODE:-}" = download-unavailable ]; then exit 1; fi
+    if [ "${FAKE_MODE:-}" = download-transient ] && [ "$now" -lt 1060 ]; then exit 1; fi
+    cp "$FAKE_MANIFEST" "$destination"
+    ;;
+  *) exit 2 ;;
+esac
+BASH
+chmod +x "${TMPDIR}/bin/aws"
+export AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test R2_ACCOUNT_ID=test R2_BUCKET_NAME=test
+export AWS_ARGS_LOG="${TMPDIR}/aws-args.log"
 
 # Control the external clock and sleep commands so real cooldowns can be tested
 # without waiting minutes or replacing any production script functions.
 cat > "${TMPDIR}/bin/date" <<'BASH'
 #!/usr/bin/env bash
 set -euo pipefail
-[ "$*" = '+%s' ]
-cat "$CLOCK_FILE"
+if [ "$*" = '+%s' ]; then cat "$CLOCK_FILE"; else /usr/bin/date "$@"; fi
 BASH
 cat > "${TMPDIR}/bin/sleep" <<'BASH'
 #!/usr/bin/env bash
@@ -193,7 +193,7 @@ echo 1000 >"$CLOCK_FILE"
 out=$(PATH="${TMPDIR}/bin:${PATH}" \
   GH_ARGS_LOG="${TMPDIR}/gh-args.log" \
   FAKE_MANIFEST="${TMPDIR}/manifest.json" \
-  EXPECTED_ARTIFACT_NAME=runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123 \
+  EXPECTED_RECORD_NAME=runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123 \
   REPO=vm0-ai/vm0 \
   HEAD_SHA=build-sha \
   LOOKUP_SHA=head-sha \
@@ -205,11 +205,9 @@ out=$(PATH="${TMPDIR}/bin:${PATH}" \
   POLL_SECONDS=0 \
   "$WAIT")
 
-grep -q -- 'api repos/vm0-ai/vm0/actions/artifacts?name=runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123&per_page=100 --include' "${TMPDIR}/gh-args.log" || fail "expected artifact lookup by exact name"
-if grep -q -- '/actions/workflows/' "${TMPDIR}/gh-args.log"; then
-  fail "expected artifact-first path to skip producer lookup after artifact is found"
-fi
-grep -q -- 'run download 42 -n runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123' "${TMPDIR}/gh-args.log" || fail "expected artifact name to include target and HEAD_SHA"
+grep -q -- '/actions/workflows/runner-image.yml/runs?head_sha=head-sha' "${TMPDIR}/gh-args.log" || fail "must verify the canonical producer"
+grep -q -- '/jobs?filter=all' "${TMPDIR}/gh-args.log" || fail "must authenticate the record hash against all job attempts"
+grep -q -- 'runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123/42/' "$AWS_ARGS_LOG" || fail "must read the exact target and run prefix"
 grep -qxF 'producer-run-id=42' <<<"$out" || fail "expected producer-run-id output"
 grep -qxF 'bin-dir=/var/lib/vm0-runner/bin/pr-123' <<<"$out" || fail "expected manifest outputs"
 
@@ -217,7 +215,7 @@ grep -qxF 'bin-dir=/var/lib/vm0-runner/bin/pr-123' <<<"$out" || fail "expected m
 out=$(PATH="${TMPDIR}/bin:${PATH}" \
   GH_ARGS_LOG="${TMPDIR}/gh-args.log" \
   FAKE_MANIFEST="${TMPDIR}/manifest-x86.json" \
-  EXPECTED_ARTIFACT_NAME=runner-image-manifest-x86_64-unknown-linux-musl-build-sha-pr-123 \
+  EXPECTED_RECORD_NAME=runner-image-manifest-x86_64-unknown-linux-musl-build-sha-pr-123 \
   REPO=vm0-ai/vm0 \
   HEAD_SHA=build-sha \
   LOOKUP_SHA=head-sha \
@@ -228,8 +226,7 @@ out=$(PATH="${TMPDIR}/bin:${PATH}" \
   OUTPUT_DIR="${TMPDIR}/out-x86" \
   POLL_SECONDS=0 \
   "$WAIT")
-grep -q -- 'api repos/vm0-ai/vm0/actions/artifacts?name=runner-image-manifest-x86_64-unknown-linux-musl-build-sha-pr-123&per_page=100 --include' "${TMPDIR}/gh-args.log" || fail "expected x86 artifact lookup by exact name"
-grep -q -- 'run download 42 -n runner-image-manifest-x86_64-unknown-linux-musl-build-sha-pr-123' "${TMPDIR}/gh-args.log" || fail "expected x86 artifact download by exact name"
+grep -q -- "runner-image-manifest-x86_64-unknown-linux-musl-build-sha-pr-123/42/" "$AWS_ARGS_LOG" || fail "expected x86 record lookup"
 grep -qxF 'producer-run-id=42' <<<"$out" || fail "expected x86 producer-run-id output"
 
 : > "${TMPDIR}/gh-args.log"
@@ -255,7 +252,8 @@ grep -q -- 'unsupported runner image target: powerpc-unknown-linux-musl' "${TMPD
 if PATH="${TMPDIR}/bin:${PATH}" \
   GH_ARGS_LOG="${TMPDIR}/gh-args.log" \
   FAKE_MODE=failed-run \
-  EXPECTED_ARTIFACT_NAME=runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123 \
+  FAKE_MANIFEST="${TMPDIR}/manifest.json" \
+  EXPECTED_RECORD_NAME=runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123 \
   REPO=vm0-ai/vm0 \
   HEAD_SHA=build-sha \
   LOOKUP_SHA=head-sha \
@@ -266,7 +264,7 @@ if PATH="${TMPDIR}/bin:${PATH}" \
   OUTPUT_DIR="${TMPDIR}/failed-out" \
   POLL_SECONDS=0 \
   "$WAIT" >"${TMPDIR}/failed.out" 2>"${TMPDIR}/failed.err"; then
-  fail "expected failed producer run without artifact to fail"
+  fail "expected failed producer run without record to fail"
 fi
 grep -q -- '/actions/workflows/runner-image.yml/runs?head_sha=head-sha&per_page=20' "${TMPDIR}/gh-args.log" || fail "expected failed path to query producer run by LOOKUP_SHA"
 grep -q -- 'runner image workflow completed with conclusion=failure' "${TMPDIR}/failed.err" || fail "expected producer failure message"
@@ -275,10 +273,11 @@ run_wait() {
   echo 1000 >"$CLOCK_FILE"
   : >"$SLEEP_LOG"
   : >"${TMPDIR}/gh-args.log"
+  : >"$AWS_ARGS_LOG"
   env PATH="${TMPDIR}/bin:${PATH}" \
     GH_ARGS_LOG="${TMPDIR}/gh-args.log" \
     FAKE_MANIFEST="${TMPDIR}/manifest.json" \
-    EXPECTED_ARTIFACT_NAME=runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123 \
+    EXPECTED_RECORD_NAME=runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123 \
     REPO=vm0-ai/vm0 HEAD_SHA=build-sha LOOKUP_SHA=head-sha JOB_REF=pr-123 \
     METAL_HOSTS=dev-1 TARGET=aarch64-unknown-linux-musl PROFILE=vm0/default \
     OUTPUT_DIR="${TMPDIR}/out" "$@" "$WAIT" >"${TMPDIR}/case.out" 2>"${TMPDIR}/case.err"
@@ -299,7 +298,7 @@ expect_failure() {
 
 expect_success FAKE_MODE=primary
 [ "$(cat "$SLEEP_LOG")" = 7 ] || fail "expected primary quota reset plus boundary second"
-grep -q '^1007 run download ' "${TMPDIR}/gh-args.log" || fail "expected download after primary reset"
+grep -q '^1007 s3api get-object ' "$AWS_ARGS_LOG" || fail "expected download after primary reset"
 
 expect_success FAKE_MODE=retry-after
 [ "$(cat "$SLEEP_LOG")" = 12 ] || fail "expected later of Retry-After and quota reset"
@@ -314,10 +313,10 @@ expect_success FAKE_MODE=workflow-rate AVAILABLE_AT=1007
 grep -q '^1007 api .*workflows/' "${TMPDIR}/gh-args.log" || fail "expected producer request after Retry-After"
 
 expect_success FAKE_MODE=workflow-rate-failure AVAILABLE_AT=1007
-grep -q '^1007 run download ' "${TMPDIR}/gh-args.log" || fail "expected artifact uploaded during status cooldown to take priority"
+grep -q '^1007 s3api get-object ' "$AWS_ARGS_LOG" || fail "expected record uploaded during status cooldown to take priority"
 
-expect_success FAKE_MODE=download-rate
-[ "$(cat "$SLEEP_LOG")" = 60 ] || fail "expected conservative download cooldown"
+expect_success FAKE_MODE=download-transient
+[ "$(paste -sd, "$SLEEP_LOG")" = "30,30" ] || fail "expected bounded R2 delivery recovery"
 
 expect_success FAKE_MODE=transient
 [ "$(paste -sd, "$SLEEP_LOG")" = '30,30' ] || fail "expected transient metadata recovery"
@@ -341,18 +340,18 @@ grep -q 'cannot retry within runner image wait deadline' "${TMPDIR}/case.err" ||
 expect_failure TIMEOUT_SECONDS=0
 [ ! -s "${TMPDIR}/gh-args.log" ] || fail "must not start requests after deadline"
 
-expect_failure FAKE_MODE=download-unavailable TIMEOUT_SECONDS=10
+expect_failure FAKE_MODE=download-unavailable TIMEOUT_SECONDS=10 POLL_SECONDS=5
 [ "$(cat "$SLEEP_LOG")" = 5 ] || fail "expected download retry budget bounded by deadline"
 
 expect_success AVAILABLE_AT=1090
 [ "$(grep -c '/actions/workflows/' "${TMPDIR}/gh-args.log")" -eq 2 ] || fail "expected fewer producer status requests"
 grep -q '^1060 api .*workflows/' "${TMPDIR}/gh-args.log" || fail "expected producer refresh after 60 seconds"
-grep -q '^1090 run download ' "${TMPDIR}/gh-args.log" || fail "expected artifact readiness between producer checks"
+grep -q '^1090 s3api get-object ' "$AWS_ARGS_LOG" || fail "expected record readiness between producer checks"
 
 expect_failure FAKE_MODE=later-failure
 grep -q 'workflow completed with conclusion=failure' "${TMPDIR}/case.err" || fail "expected refreshed producer failure"
 
-expect_failure HEAD_SHA=wrong-sha EXPECTED_ARTIFACT_NAME=runner-image-manifest-aarch64-unknown-linux-musl-wrong-sha-pr-123
+expect_failure HEAD_SHA=wrong-sha EXPECTED_RECORD_NAME=runner-image-manifest-aarch64-unknown-linux-musl-wrong-sha-pr-123
 grep -q 'headSha mismatch' "${TMPDIR}/case.err" || fail "expected exact manifest identity validation"
 
 echo "wait-runner-image-test: ok"

--- a/.github/scripts/wait-runner-image.sh
+++ b/.github/scripts/wait-runner-image.sh
@@ -53,7 +53,8 @@ RUNNER_CI_DEADLINE=$(( $(date +%s) + TIMEOUT_SECONDS ))
 deadline=$RUNNER_CI_DEADLINE
 
 check_deadline() {
-  if [ "$(date +%s)" -ge "$deadline" ]; then
+  WAIT_REMAINING_SECONDS=$((deadline - $(date +%s)))
+  if [ "$WAIT_REMAINING_SECONDS" -le 0 ]; then
     echo "timed out waiting for runner image workflow ${WORKFLOW} at ${LOOKUP_SHA} with record ${RECORD_NAME}" >&2
     exit 1
   fi
@@ -81,7 +82,7 @@ api_get() {
   local status retry_after remaining reset delay now
   while true; do
     check_deadline
-    if timeout --kill-after=5s "$((deadline - $(date +%s)))s" gh api "$endpoint" --include >"$GH_RESPONSE" 2>"$GH_ERR"; then
+    if timeout --foreground --kill-after=5s "${WAIT_REMAINING_SECONDS}s" gh api "$endpoint" --include >"$GH_RESPONSE" 2>"$GH_ERR"; then
       sed '1,/^\r\{0,1\}$/d' "$GH_RESPONSE"
       return
     fi

--- a/.github/scripts/wait-runner-image.sh
+++ b/.github/scripts/wait-runner-image.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${SCRIPT_DIR}/runner-image-target.sh"
+. "${SCRIPT_DIR}/runner-ci-record.sh"
 
 emit() {
   local key=$1 value=$2
@@ -25,8 +26,8 @@ WORKFLOW="${WORKFLOW:-runner-image.yml}"
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-1800}"
 POLL_SECONDS="${POLL_SECONDS:-30}"
 OUTPUT_DIR="${OUTPUT_DIR:-/tmp/runner-image-manifest}"
-DEFAULT_ARTIFACT_NAME=$(runner_image_artifact_name "$TARGET" "$HEAD_SHA" "$JOB_REF")
-ARTIFACT_NAME="${ARTIFACT_NAME:-$DEFAULT_ARTIFACT_NAME}"
+DEFAULT_RECORD_NAME=$(runner_image_record_name "$TARGET" "$HEAD_SHA" "$JOB_REF")
+RECORD_NAME="${RECORD_NAME:-$DEFAULT_RECORD_NAME}"
 LOOKUP_SHA="${LOOKUP_SHA:-$HEAD_SHA}"
 
 if [ -z "$REPO" ]; then
@@ -47,11 +48,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
-deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+runner_ci_config
+RUNNER_CI_DEADLINE=$(( $(date +%s) + TIMEOUT_SECONDS ))
+deadline=$RUNNER_CI_DEADLINE
 
 check_deadline() {
   if [ "$(date +%s)" -ge "$deadline" ]; then
-    echo "timed out waiting for runner image workflow ${WORKFLOW} at ${LOOKUP_SHA} with artifact ${ARTIFACT_NAME}" >&2
+    echo "timed out waiting for runner image workflow ${WORKFLOW} at ${LOOKUP_SHA} with record ${RECORD_NAME}" >&2
     exit 1
   fi
 }
@@ -60,7 +63,7 @@ wait_with_deadline() {
   local seconds=$1
   check_deadline
   if [ "$seconds" -ge "$((deadline - $(date +%s)))" ]; then
-    echo "cannot retry within runner image wait deadline: required delay=${seconds}s artifact=${ARTIFACT_NAME}" >&2
+    echo "cannot retry within runner image wait deadline: required delay=${seconds}s record=${RECORD_NAME}" >&2
     exit 1
   fi
   sleep "$seconds"
@@ -78,7 +81,7 @@ api_get() {
   local status retry_after remaining reset delay now
   while true; do
     check_deadline
-    if gh api "$endpoint" --include >"$GH_RESPONSE" 2>"$GH_ERR"; then
+    if timeout --kill-after=5s "$((deadline - $(date +%s)))s" gh api "$endpoint" --include >"$GH_RESPONSE" 2>"$GH_ERR"; then
       sed '1,/^\r\{0,1\}$/d' "$GH_RESPONSE"
       return
     fi
@@ -128,103 +131,59 @@ api_get() {
 selected_run=""
 selected_url=""
 selected_run_id=""
-selected_artifact=""
 next_run_check=0
 producer_failure_url=""
 
 while true; do
-  artifacts_json=$(api_get "repos/${REPO}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100")
-
-  selected_artifact=$(jq -c \
-    --arg name "$ARTIFACT_NAME" \
-    '.artifacts
-      | map(select(.name == $name and .expired == false))
-      | sort_by(.created_at)
-      | reverse
-      | .[0] // empty' <<<"$artifacts_json")
-
-  if [ -n "$selected_artifact" ]; then
-    selected_run_id=$(jq -r '.workflow_run.id' <<<"$selected_artifact")
-    echo "runner image artifact found: name=${ARTIFACT_NAME} run_id=${selected_run_id} head_sha=${HEAD_SHA}"
-    rm -rf "${OUTPUT_DIR:?}"/*
-    download_ok=false
-    download_attempts=0
-    download_backoff=60
-    while [ "$download_attempts" -lt 5 ]; do
-      check_deadline
-      if gh run download "$selected_run_id" -n "$ARTIFACT_NAME" -D "$OUTPUT_DIR" 2>"$GH_ERR"; then
-        download_ok=true
-        break
-      fi
-      cat "$GH_ERR" >&2
-      # gh run download does not expose response headers. Use GitHub's
-      # conservative headerless cooldown rather than five-second retries.
-      if grep -qi 'rate limit\|HTTP 429' "$GH_ERR"; then
-        echo "GitHub artifact download rate limited; retrying in ${download_backoff}s" >&2
-        wait_with_deadline "$download_backoff"
-        download_backoff=$((download_backoff * 2))
-        if [ "$download_backoff" -gt 300 ]; then download_backoff=300; fi
-        continue
-      fi
-      if grep -qE 'HTTP (401|403)' "$GH_ERR"; then exit 1; fi
-      download_attempts=$((download_attempts + 1))
-      echo "artifact ${ARTIFACT_NAME} is listed but not downloadable yet from run ${selected_run_id}; retrying"
-      wait_with_deadline 5
-    done
-    if [ "$download_ok" = "true" ]; then
-      break
-    fi
-    echo "artifact ${ARTIFACT_NAME} could not be downloaded from run ${selected_run_id}; continuing to wait"
-  fi
-
-  if [ -n "$producer_failure_url" ]; then
-    echo "runner image workflow completed with conclusion=${conclusion}: ${producer_failure_url}" >&2
-    exit 1
-  fi
-
-  # Artifact readiness is checked more often than producer failure. A direct
-  # workflow endpoint also avoids resolving the workflow on every gh run list.
+  check_deadline
   if [ "$(date +%s)" -ge "$next_run_check" ]; then
     runs_json=$(api_get "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?head_sha=${LOOKUP_SHA}&per_page=20")
-    selected_run=$(jq -c '.workflow_runs | sort_by(.created_at) | reverse | .[0] // empty' <<<"$runs_json")
+    selected_run=$(jq -c --arg repo "$REPO" --arg workflow ".github/workflows/${WORKFLOW}" \
+      --arg head "$LOOKUP_SHA" '
+      [.workflow_runs[] | select(.repository.full_name == $repo and .path == $workflow and .head_sha == $head)] |
+      sort_by(.created_at, .id) | reverse | .[0] // empty
+    ' <<<"$runs_json")
     next_run_check=$(( $(date +%s) + 60 ))
   fi
 
   if [ -n "$selected_run" ]; then
+    selected_run_id=$(jq -r '.id' <<<"$selected_run")
+    selected_url=$(jq -r '.html_url' <<<"$selected_run")
+    # Resolve the latest execution of each job, not just the workflow's latest
+    # attempt: failed-only reruns need the successful, untouched producer jobs.
+    jobs='[]'
+    page=1
+    while true; do
+      response=$(api_get "repos/${REPO}/actions/runs/${selected_run_id}/jobs?filter=all&per_page=100&page=${page}")
+      jobs=$(jq -c --argjson response "$response" '. + [$response]' <<<"$jobs")
+      [ "$(jq '.jobs | length' <<<"$response")" -eq 100 ] || break
+      page=$((page + 1))
+    done
+    if runner_ci_record_fetch "$RECORD_NAME" "$selected_run_id" "$jobs" "${OUTPUT_DIR}/manifest.json"; then
+      echo "runner image record ready: name=${RECORD_NAME} run_id=${selected_run_id} head_sha=${HEAD_SHA}"
+      break
+    fi
+
     status=$(jq -r '.status' <<<"$selected_run")
     conclusion=$(jq -r '.conclusion // empty' <<<"$selected_run")
-    run_id=$(jq -r '.id' <<<"$selected_run")
-    selected_url=$(jq -r '.html_url' <<<"$selected_run")
-    selected_run_id="$run_id"
-    echo "waiting for runner image artifact: name=${ARTIFACT_NAME} lookup_sha=${LOOKUP_SHA} producer_run=${run_id} status=${status} conclusion=${conclusion} url=${selected_url}"
-
-    if [ "$status" = "completed" ]; then
-      if [ "$conclusion" != "success" ]; then
-        # The requested architecture may have uploaded its artifact during a
-        # status-request cooldown even if another producer job failed. Recheck
-        # artifact readiness once before reporting the producer failure.
-        producer_failure_url="$selected_url"
-        continue
-      fi
+    if [ -n "$producer_failure_url" ]; then
+      echo "runner image workflow completed with conclusion=${conclusion}: ${producer_failure_url}" >&2
+      exit 1
     fi
+    if [ "$status" = completed ] && [ "$conclusion" != success ]; then
+      # A sibling architecture can fail while this target's receipt becomes
+      # visible. Recheck its readiness once before reporting producer failure.
+      producer_failure_url=$selected_url
+      continue
+    fi
+    echo "waiting for runner image record: name=${RECORD_NAME} producer_run=${selected_run_id} status=${status} url=${selected_url}"
   else
-    echo "waiting for runner image artifact ${ARTIFACT_NAME}; no ${WORKFLOW} run found at ${LOOKUP_SHA} yet"
+    echo "waiting for runner image record ${RECORD_NAME}; no ${WORKFLOW} run found at ${LOOKUP_SHA} yet"
   fi
-
   wait_with_deadline "$POLL_SECONDS"
 done
 
 MANIFEST_PATH="${OUTPUT_DIR}/manifest.json"
-if [ ! -f "$MANIFEST_PATH" ]; then
-  mapfile -t candidates < <(find "$OUTPUT_DIR" -name manifest.json -type f | sort)
-  if [ "${#candidates[@]}" -eq 1 ]; then
-    MANIFEST_PATH="${candidates[0]}"
-  else
-    echo "expected one manifest.json in ${OUTPUT_DIR}, found ${#candidates[@]}" >&2
-    exit 1
-  fi
-fi
-
 MANIFEST_PATH="$MANIFEST_PATH" \
 HEAD_SHA="$HEAD_SHA" \
 JOB_REF="$JOB_REF" \

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
       - name: Clean private Runner transport metadata

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -15,6 +15,26 @@ env:
   DRY_RUN: ${{ inputs.dry-run || false }}
 
 jobs:
+  cleanup-runner-ci-records:
+    name: Clean expired Runner CI records
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Clean private Runner transport metadata
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_DEFAULT_REGION: auto
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
+          R2_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
+          REPO: ${{ github.repository }}
+        run: .github/scripts/runner-ci-record.sh cleanup
+
   cleanup-neon-branches:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -768,6 +768,11 @@ jobs:
       - name: Wait for runner image manifest
         id: manifest
         env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_DEFAULT_REGION: auto
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
+          R2_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.sha }}
           LOOKUP_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -825,6 +830,11 @@ jobs:
 
       - name: Wait for runner image manifest for ${{ matrix.label }}
         env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_DEFAULT_REGION: auto
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
+          R2_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.sha }}
           LOOKUP_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -73,7 +73,7 @@ jobs:
       runner-host-groups-matrix: ${{ steps.host-groups.outputs.matrix }}
       runner-host-groups-configured: ${{ steps.host-group-presence.outputs.configured }}
       runner-binary-compile-matrix: ${{ steps.binary-plan.outputs.compile-matrix }}
-      runner-binary-hit-targets: ${{ steps.binary-plan.outputs.hit-targets }}
+      runner-binary-hit-manifests: ${{ steps.binary-plan.outputs.hit-manifests }}
       runner-binary-miss-count: ${{ steps.binary-plan.outputs.miss-count }}
     steps:
       - uses: actions/checkout@v7.0.1
@@ -202,7 +202,7 @@ jobs:
           set -euo pipefail
 
           runner_image_ci_changed=false
-          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(turbo|crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/runner-binary-build/|^\.github/scripts/(prepare-runner-image|runner-binary-cache|runner-binary-cache-plan|runner-host-architecture-groups|runner-image-context|runner-image-manifest|runner-image-target|wait-runner-image)\.sh$|^ansible/(ansible\.cfg|playbooks/(build-runner|provision-runner|promote-runner|rollback-runner)\.yml)$"; then
+          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(turbo|crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/runner-binary-build/|^\.github/scripts/(prepare-runner-image|runner-binary-cache|runner-binary-cache-plan|runner-ci-record|runner-host-architecture-groups|runner-image-context|runner-image-manifest|runner-image-target|wait-runner-image)\.sh$|^ansible/(ansible\.cfg|playbooks/(build-runner|provision-runner|promote-runner|rollback-runner)\.yml)$"; then
             runner_image_ci_changed=true
           fi
 
@@ -278,7 +278,6 @@ jobs:
           AWS_DEFAULT_REGION: auto
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           CURRENT_EVENT: ${{ github.event_name }}
-          CURRENT_PR_HEAD_REF: ${{ steps.identity.outputs.pr-head-ref }}
           CURRENT_PR_NUMBER: ${{ steps.identity.outputs.pr-number }}
           CURRENT_RUN_ID: ${{ github.run_id }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -286,28 +285,22 @@ jobs:
           REPO: ${{ github.repository }}
           R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
           R2_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
+          RUNNER_BINARY_RESOLVE_MODE: reference
           RESOLVE_OUTPUT_DIR: runner-binary-hits
           RUNNER_BINARY_CACHE_FORCE_MISS: ${{ vars.RUNNER_BINARY_CACHE_FORCE_MISS }}
           RUNNER_HOST_GROUPS_MATRIX: ${{ steps.host-groups.outputs.matrix }}
         run: .github/scripts/runner-binary-cache-plan.sh
-
-      - name: Upload validated runner binary hits
-        if: steps.binary-plan.outputs.hit-count != '0'
-        uses: actions/upload-artifact@v7
-        with:
-          name: runner-binary-hits-${{ github.run_id }}
-          overwrite: true
-          path: runner-binary-hits/
-          if-no-files-found: error
-          retention-days: 1
-          compression-level: 1
 
   compile:
     name: Compile runner binary (${{ matrix.label }})
     runs-on: ubuntu-latest-8-cores
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260825
+    defaults:
+      run:
+        shell: bash
     permissions:
+      actions: read
       contents: read
     needs: [prepare]
     if: >-
@@ -324,6 +317,13 @@ jobs:
         include: ${{ fromJSON(needs.prepare.outputs.runner-binary-compile-matrix) }}
     env:
       TARGET_TRIPLE: ${{ matrix.target }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      AWS_DEFAULT_REGION: auto
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
+      R2_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
+      REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
       RUNNER_BINARY_ACTUAL_TOOLCHAIN_IMAGE: ghcr.io/vm0-ai/vm0-toolchain-rust:20260825
     steps:
       - uses: actions/checkout@v7.0.1
@@ -379,15 +379,56 @@ jobs:
             "$RUNNER_PATH"
           .github/scripts/runner-binary-cache.sh fresh-validate
 
-      - name: Upload compiled runner binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: runner-binary-compiled-${{ github.run_id }}-${{ matrix.target }}
-          overwrite: true
-          path: runner-binary-fresh/
-          if-no-files-found: error
-          retention-days: 1
-          compression-level: 1
+      - name: Install Runner transport clients
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends gh
+          client_dir=$(mktemp -d)
+          curl -fsSL --retry 3 --connect-timeout 10 --max-time 120 \
+            https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip \
+            --output "${client_dir}/aws.zip"
+          python3 -m zipfile -e "${client_dir}/aws.zip" "$client_dir"
+          chmod +x "${client_dir}/aws/install" "${client_dir}/aws/dist/aws"
+          "${client_dir}/aws/install"
+          aws --version
+          gh --version
+
+      - name: Resolve reusable candidate in shadow mode
+        id: shadow
+        env:
+          CURRENT_EVENT: ${{ github.event_name }}
+          CURRENT_PR_NUMBER: ${{ needs.prepare.outputs.pr-number }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EXPECTED_BINARY_INPUT_DIGEST: ${{ steps.build.outputs.binary-input-digest }}
+          EXPECTED_TARGET: ${{ matrix.target }}
+          FRESH_METADATA_PATH: runner-binary-fresh/metadata.json
+          RUNNER_PATH: runner-binary-fresh/runner
+          SHADOW_OUTPUT_DIR: runner-binary-shadow
+        run: .github/scripts/runner-binary-cache.sh shadow-resolve
+
+      - name: Publish runner binary cache object
+        id: publish
+        env:
+          EXPECTED_BINARY_INPUT_DIGEST: ${{ steps.build.outputs.binary-input-digest }}
+          EXPECTED_TARGET: ${{ matrix.target }}
+          FRESH_METADATA_PATH: runner-binary-fresh/metadata.json
+          OUTPUT_DIR: runner-binary-asset
+          PRODUCER_EVENT: ${{ github.event_name }}
+          PRODUCER_HEAD_SHA: ${{ needs.prepare.outputs.source-head-sha }}
+          PRODUCER_PR_NUMBER: ${{ needs.prepare.outputs.pr-number }}
+          PRODUCER_REPOSITORY: ${{ github.repository }}
+          PRODUCER_RUN_ATTEMPT: ${{ github.run_attempt }}
+          PRODUCER_RUN_ID: ${{ github.run_id }}
+          PRODUCER_WORKFLOW_PATH: .github/workflows/runner-image.yml
+          RUNNER_PATH: runner-binary-fresh/runner
+        run: .github/scripts/runner-binary-cache.sh publish
+
+      # The canonical job timeline binds these exact R2 bytes to this producer.
+      - name: R2 record ${{ steps.publish.outputs.record-sha }}
+        env:
+          RECORD_SHA: ${{ steps.publish.outputs.record-sha }}
+        run: '[[ "$RECORD_SHA" =~ ^[0-9a-f]{64}$ ]]'
 
       - name: Report peak memory
         if: always()
@@ -419,6 +460,13 @@ jobs:
     env:
       TARGET_TRIPLE: ${{ matrix.target }}
       PROFILE: vm0/default
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      AWS_DEFAULT_REGION: auto
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
+      R2_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
+      REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -428,19 +476,23 @@ jobs:
           TARGET_TRIPLE: ${{ matrix.target }}
         run: .github/scripts/runner-binary-build/digest.sh "$TARGET_TRIPLE"
 
-      - name: Download validated runner binary hit
-        if: contains(fromJSON(needs.prepare.outputs.runner-binary-hit-targets), matrix.target)
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: runner-binary-hits-${{ github.run_id }}
-          path: runner-binary-transport
-
-      - name: Download compiled runner binary
-        if: ${{ !contains(fromJSON(needs.prepare.outputs.runner-binary-hit-targets), matrix.target) }}
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: runner-binary-compiled-${{ github.run_id }}-${{ matrix.target }}
-          path: runner-binary-transport/${{ matrix.target }}
+      - name: Download runner binary from R2
+        env:
+          EXPECTED_BINARY_INPUT_DIGEST: ${{ steps.binary-input.outputs.binary-input-digest }}
+          EXPECTED_TARGET: ${{ matrix.target }}
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+          EXPECTED_PRODUCER_HEAD_SHA: ${{ needs.prepare.outputs.source-head-sha }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
+          HIT_MANIFEST: ${{ toJSON(fromJSON(needs.prepare.outputs.runner-binary-hit-manifests)[matrix.target]) }}
+          MANIFEST_PATH: runner-binary-hit.json
+          RESOLVE_OUTPUT_DIR: runner-binary-transport/${{ matrix.target }}
+        run: |
+          if [ "$HIT_MANIFEST" != null ]; then
+            printf '%s\n' "$HIT_MANIFEST" > "$MANIFEST_PATH"
+            .github/scripts/runner-binary-cache.sh download
+          else
+            .github/scripts/runner-binary-cache.sh download-current
+          fi
 
       - name: Validate runner binary transport
         env:
@@ -514,162 +566,24 @@ jobs:
           METAL_HOSTS: ${{ steps.matrix-hosts.outputs.hosts }}
         run: .github/scripts/runner-image-manifest.sh validate
 
-      - name: Resolve manifest artifact name
-        id: artifact
+      - name: Resolve manifest record name
+        id: record
         env:
           HEAD_SHA: ${{ needs.prepare.outputs.head-sha }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           TARGET: ${{ matrix.target }}
-        run: .github/scripts/runner-image-context.sh artifact-name
+        run: .github/scripts/runner-image-context.sh record-name
 
-      - name: Upload runner image manifest
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ steps.artifact.outputs.artifact-name }}
-          path: runner-image-manifest/manifest.json
-          retention-days: 7
-
-  asset:
-    name: Publish runner binary asset (${{ matrix.label }})
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-    needs: [prepare, compile]
-    if: >-
-      ${{
-        always() &&
-        needs.prepare.result == 'success' &&
-        needs.prepare.outputs.current-runner-image-needed == 'true' &&
-        needs.prepare.outputs.runner-binary-miss-count != '0' &&
-        needs.compile.result == 'success'
-      }}
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.prepare.outputs.runner-binary-compile-matrix) }}
-    steps:
-      - uses: actions/checkout@v7.0.1
-
-      - name: Resolve runner binary input
-        id: binary-input
-        env:
-          TARGET_TRIPLE: ${{ matrix.target }}
-        run: .github/scripts/runner-binary-build/digest.sh "$TARGET_TRIPLE"
-
-      - name: Download compiled runner binary
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: runner-binary-compiled-${{ github.run_id }}-${{ matrix.target }}
-          path: runner-binary-fresh
-
-      - name: Validate fresh runner binary
-        id: fresh
-        env:
-          EXPECTED_BINARY_INPUT_DIGEST: ${{ steps.binary-input.outputs.binary-input-digest }}
-          EXPECTED_TARGET: ${{ matrix.target }}
-          FRESH_METADATA_PATH: runner-binary-fresh/metadata.json
-          RUNNER_PATH: runner-binary-fresh/runner
-        run: .github/scripts/runner-binary-cache.sh fresh-validate
-
-      - name: Resolve reusable candidate in shadow mode
-        id: shadow
-        env:
-          CURRENT_EVENT: ${{ github.event_name }}
-          CURRENT_PR_HEAD_REF: ${{ needs.prepare.outputs.pr-head-ref }}
-          CURRENT_PR_NUMBER: ${{ needs.prepare.outputs.pr-number }}
-          CURRENT_RUN_ID: ${{ github.run_id }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          EXPECTED_BINARY_INPUT_DIGEST: ${{ steps.binary-input.outputs.binary-input-digest }}
-          EXPECTED_TARGET: ${{ matrix.target }}
-          FRESH_METADATA_PATH: runner-binary-fresh/metadata.json
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          RUNNER_PATH: runner-binary-fresh/runner
-          SHADOW_OUTPUT_DIR: runner-binary-shadow
-        run: |
-          started_at=$(date +%s)
-          .github/scripts/runner-binary-cache.sh shadow-resolve
-          echo "duration-seconds=$(($(date +%s) - started_at))" >> "$GITHUB_OUTPUT"
-
-      - name: Publish runner binary cache object
+      - name: Publish runner image manifest
         id: publish
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_DEFAULT_REGION: auto
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          EXPECTED_BINARY_INPUT_DIGEST: ${{ steps.binary-input.outputs.binary-input-digest }}
-          EXPECTED_TARGET: ${{ matrix.target }}
-          FRESH_METADATA_PATH: runner-binary-fresh/metadata.json
-          OUTPUT_DIR: runner-binary-asset
-          PRODUCER_EVENT: ${{ github.event_name }}
-          PRODUCER_HEAD_SHA: ${{ needs.prepare.outputs.source-head-sha }}
-          PRODUCER_PR_NUMBER: ${{ needs.prepare.outputs.pr-number }}
-          PRODUCER_REPOSITORY: ${{ github.repository }}
-          PRODUCER_RUN_ATTEMPT: ${{ github.run_attempt }}
+          RECORD_NAME: ${{ steps.record.outputs.record-name }}
+          MANIFEST_PATH: runner-image-manifest/manifest.json
           PRODUCER_RUN_ID: ${{ github.run_id }}
-          PRODUCER_WORKFLOW_PATH: .github/workflows/runner-image.yml
-          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
-          R2_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
-          RUNNER_PATH: runner-binary-fresh/runner
-        run: |
-          started_at=$(date +%s)
-          .github/scripts/runner-binary-cache.sh publish
-          echo "duration-seconds=$(($(date +%s) - started_at))" >> "$GITHUB_OUTPUT"
+          PRODUCER_RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: .github/scripts/runner-ci-record.sh publish
 
-      - name: Resolve reusable artifact name
-        id: artifact
-        if: steps.publish.outputs.published == 'true'
+      - name: R2 record ${{ steps.publish.outputs.record-sha }}
         env:
-          EXPECTED_BINARY_INPUT_DIGEST: ${{ steps.binary-input.outputs.binary-input-digest }}
-          EXPECTED_TARGET: ${{ matrix.target }}
-        run: .github/scripts/runner-binary-cache.sh artifact-name
-
-      - name: Upload reusable runner binary manifest
-        id: manifest-upload
-        if: steps.publish.outputs.published == 'true'
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ steps.artifact.outputs.artifact-name }}
-          path: runner-binary-asset/manifest.json
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Summarize runner binary asset
-        if: always()
-        env:
-          BINARY_INPUT_DIGEST: ${{ steps.binary-input.outputs.binary-input-digest }}
-          FRESH_VALIDATION: ${{ steps.fresh.outcome }}
-          MANIFEST_UPLOAD: ${{ steps.manifest-upload.outcome }}
-          OBJECT_SIZE_BYTES: ${{ steps.publish.outputs.object-size-bytes }}
-          PUBLISHED: ${{ steps.publish.outputs.published }}
-          PUBLISH_REASON: ${{ steps.publish.outputs.publish-reason }}
-          PUBLISH_SECONDS: ${{ steps.publish.outputs.duration-seconds }}
-          RUNNER_SIZE_BYTES: ${{ steps.fresh.outputs.runner-size-bytes }}
-          SHADOW_OUTCOME: ${{ steps.shadow.outputs.shadow-outcome }}
-          SHADOW_REASON: ${{ steps.shadow.outputs.shadow-reason }}
-          SHADOW_SECONDS: ${{ steps.shadow.outputs.duration-seconds }}
-          SHADOW_SOURCE: ${{ steps.shadow.outputs.shadow-source }}
-          TARGET_TRIPLE: ${{ matrix.target }}
-        run: |
-          {
-            echo "### Runner binary asset"
-            echo
-            echo "- Target: \`${TARGET_TRIPLE}\`"
-            echo "- Input digest: \`${BINARY_INPUT_DIGEST}\`"
-            echo "- Fresh runner bytes: \`${RUNNER_SIZE_BYTES}\`"
-            echo "- Fresh validation: \`${FRESH_VALIDATION:-not-run}\`"
-            echo "- Shadow outcome: \`${SHADOW_OUTCOME:-not-run}\`"
-            echo "- Shadow source: \`${SHADOW_SOURCE:-none}\`"
-            echo "- Shadow reason: \`${SHADOW_REASON:-not-run}\`"
-            echo "- Shadow duration: \`${SHADOW_SECONDS:-0}s\`"
-            echo "- Published: \`${PUBLISHED:-false}\`"
-            echo "- Publish reason: \`${PUBLISH_REASON:-not-run}\`"
-            echo "- Publish duration: \`${PUBLISH_SECONDS:-0}s\`"
-            echo "- Manifest upload: \`${MANIFEST_UPLOAD:-not-run}\`"
-            if [ -n "$OBJECT_SIZE_BYTES" ]; then
-              echo "- R2 object bytes: \`${OBJECT_SIZE_BYTES}\`"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+          RECORD_SHA: ${{ steps.publish.outputs.record-sha }}
+        run: '[[ "$RECORD_SHA" =~ ^[0-9a-f]{64}$ ]]'

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -61,7 +61,6 @@ jobs:
       head-sha: ${{ steps.identity.outputs.head-sha }}
       source-head-sha: ${{ steps.identity.outputs.source-head-sha }}
       pr-number: ${{ steps.identity.outputs.pr-number }}
-      pr-head-ref: ${{ steps.identity.outputs.pr-head-ref }}
       turbo-runner-consumer-needed: ${{ steps.needed.outputs.turbo-runner-consumer-needed }}
       playwright-runner-consumer-needed: ${{ steps.needed.outputs.playwright-runner-consumer-needed }}
       crates-runner-consumer-needed: ${{ steps.needed.outputs.crates-runner-consumer-needed }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -263,6 +263,9 @@ jobs:
             .github/scripts/verify-okou-app-assets.sh \
             .github/scripts/verify-okou-app-runtime.sh \
             .github/scripts/reconcile-and-start-runner-groups.sh \
+            .github/scripts/runner-ci-record.sh \
+            .github/scripts/tests/runner-ci-record-test.sh \
+            .github/scripts/tests/fixtures/runner-ci-aws.sh \
             .github/scripts/prune-runner-idle.sh \
             .github/scripts/reconcile-runner-binary-groups.sh \
             .github/actions/report-memory-peak/report.sh \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2521,7 +2521,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
           CURRENT_EVENT: ${{ github.event_name }}
-          CURRENT_PR_HEAD_REF: ${{ github.head_ref || '' }}
           CURRENT_RUN_ID: ${{ github.run_id }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2455,6 +2455,11 @@ jobs:
       - name: Wait for runner image manifest
         id: manifest
         env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_DEFAULT_REGION: auto
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
+          R2_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.sha }}
           LOOKUP_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -51,6 +51,8 @@ surface; the index does not replace their detailed rules.
   verify host-local concurrency and I/O capacity overrides.
 - [Runner multi-architecture rollout](./runner-multi-architecture.md): build,
   deploy, and validate runner artifacts for supported host architectures.
+- [Runner CI transport](./runner-ci-transport.md): private binary delivery,
+  authenticated image readiness, reruns, and metadata retention.
 - [Testing catalog](./testing/anti-patterns.md): detailed testing anti-patterns.
 - [Addon runtime contracts](./mitm-addon-contracts.md): logging ownership,
   WebSocket framing and handshake limits, and path normalization boundaries.

--- a/docs/runner-ci-transport.md
+++ b/docs/runner-ci-transport.md
@@ -61,6 +61,8 @@ retrieval fail if they cannot be verified; they do not silently fall back to
 GitHub artifacts. Each R2 client operation has a 120-second total bound and three
 SDK attempts. Cache planning has a shorter 60-second per-target owner deadline;
 image waiting preserves its existing deadline and GitHub rate-limit cooldowns.
+Nested client timers stay in their owner's process group so cancelling a cache
+lookup also interrupts its active network operations.
 
 Records expire for readers after seven days, based on both storage metadata and
 the independently recorded GitHub receipt time. Refreshing an R2 timestamp cannot

--- a/docs/runner-ci-transport.md
+++ b/docs/runner-ci-transport.md
@@ -1,0 +1,89 @@
+# Runner CI transport
+
+The Runner Image workflow uses private R2 for binary delivery and image readiness.
+GitHub Actions still owns scheduling, producer identity, permissions, and job
+status. Other workflows' reports, credentials, and CLI artifacts are unchanged.
+
+## Delivery
+
+1. The hosted `prepare` job computes each target's binary input digest and looks
+   for a trusted reusable manifest. It checks the object's size with HEAD but
+   does not download binaries. Its output contains only small per-target binary
+   manifests; host maps remain in private storage.
+2. Only cache misses start the Rust `compile` matrix. Each compiler validates the
+   fresh Runner and Guest metadata, checks historical equal-input conflicts,
+   compresses and publishes the binary to R2, and publishes its reusable record.
+3. The hosted `build` matrix downloads only its target's selected binary. It
+   verifies compressed size, decompressed size, and SHA-256 before using it. It
+   then prepares images on all hosts of that architecture and publishes the
+   validated image manifest.
+4. Crates and Turbo wait for their target's authenticated image record and
+   validate the exact build SHA, job reference, profile, target, and host set.
+   An independently ready target remains usable if a sibling producer fails.
+
+There is no separate binary asset job or GitHub artifact hop in this chain.
+Recovery through `runner-binary-cache-plan.sh` still downloads and validates the
+binary by default; only `RUNNER_BINARY_RESOLVE_MODE=reference` selects the
+metadata-only planning path used by Runner Image.
+
+## Integrity and producer authority
+
+Compressed binaries retain their content-addressed key:
+`runner-binaries/<target>/<runner-sha>.zst`. Conditional publication must verify
+the retained object even when another producer has already written that key.
+
+Manifests use the repository-scoped namespace:
+`runner-ci/v1/<owner>/<repo>/<record-name>/<run-id>/<attempt>/<manifest-sha>.json`.
+Records are bounded to 64 KiB, conditionally written, and read back before the
+publisher exposes the SHA. A successful subsequent step named
+`R2 record <manifest-sha>` records that exact hash in GitHub's canonical job
+timeline. Readers verify those bytes against that receipt as well as the
+canonical repository, workflow path, source SHA, run, and attempt.
+
+R2 writer access or a self-declared `producer` field is not proof of origin.
+Cache candidates must also satisfy the existing protected-main, same-PR, or
+main-ancestry rules. Conflicting Runner or Guest identities for equal inputs
+cause a cache miss; the fresh compiler's shadow comparison fails on a trusted
+conflict. Historical discovery inspects at most eight records and ranks the
+authenticated candidates according to the consumer event. Missing or unavailable
+historical cache data allows fresh compilation, not unverified reuse.
+
+Readers request all job attempts and use the newest execution of each job name.
+A failed-only downstream rerun can reuse a successful producer that was not
+rerun. Once that producer itself has a newer execution, its earlier receipt is
+invalid even if the newer execution failed. Workflow-wide attempt equality would
+incorrectly reject the first case.
+
+## Failure and retention
+
+R2 is a required delivery dependency. Fresh publication and selected binary
+retrieval fail if they cannot be verified; they do not silently fall back to
+GitHub artifacts. Each R2 client operation has a 120-second total bound and three
+SDK attempts. Cache planning has a shorter 60-second per-target owner deadline;
+image waiting preserves its existing deadline and GitHub rate-limit cooldowns.
+
+Records expire for readers after seven days, based on both storage metadata and
+the independently recorded GitHub receipt time. Refreshing an R2 timestamp cannot
+renew an old producer receipt. The scheduled `cleanup-stale.yml` metadata job
+deletes records older than fourteen days in batches of at most 1,000, with a
+dry-run mode. It paginates past recent records and only accepts keys matching
+this repository's new namespace and record grammar. Cleanup failures remain
+visible. Bucket lifecycle administration is not required.
+
+This cleanup does not delete `runner-binaries/` objects or change their existing
+retention ownership. `Cache-Control` is a caching header, not a deletion policy.
+Host-side binary and image cleanup also remains unchanged.
+
+## Rollout and validation
+
+Producer and consumer changes ship together in one workflow revision. Older
+revisions continue their own GitHub artifact transport. New readers do not reuse
+old artifact manifests, so their first lookup can compile from a cold cache.
+There are no application, API, or Guest/Runner protocol changes.
+
+Local shell integration tests exercise real files, hashes, and zstd bytes with
+external GitHub/S3 fixtures. PR CI must additionally validate real private R2
+access, resolved receipt step names in the GitHub jobs API, both architectures,
+and downstream manifest delivery. Removing duplicate transfers is not itself a
+measurement of end-to-end speedup; client installation and verification costs
+must be included when comparing actual runs.


### PR DESCRIPTION
## Summary

Move the Runner Image workflow's binary transport, reusable manifests, and image-readiness manifests from GitHub artifacts to private R2. This removes the post-compilation artifact finalization dependency observed in #33431 and the redundant R2/GitHub binary hops.

- Keep hosted, reference-only cache planning and miss-only Rust compilation. Pass small per-target binary manifests through job outputs; download only the selected target's bytes in each build job.
- Publish fresh zstd binaries directly from compile, retaining conditional writes, retained-object validation, and equal-input Runner/Guest conflict checks. Remove the independent asset job.
- Authenticate immutable R2 records with successful GitHub job-timeline steps named `R2 record <manifest-sha>`, plus canonical repository/workflow/source/run/attempt checks. Preserve failed-only reruns by selecting each producer job's newest execution across all attempts.
- Move Crates/Turbo image waits to private R2 while preserving exact manifest identity validation, deadlines, rate-limit cooldowns, and independently ready architecture behavior.
- Add seven-day reader expiry and scoped fourteen-day metadata cleanup, with dry-run support, pagination, and a bounded 1,000-object S3 deletion batch.

Closes #33431

## Scope and compatibility

Only the Runner binary/cache/readiness chain changes. Other GitHub artifacts, application/UI/API behavior, runtime protocols, selected-host deployment, all-host architecture image preparation, and #33411's SSH upload recovery are unchanged.

Producer and consumer workflow revisions switch together to `runner-ci/v1/<repository>/...`. Older revisions continue using their own GitHub artifact implementation; new readers initially compile rather than reusing old artifact manifests. Existing `runner-binaries/` object retention and bucket lifecycle configuration are unchanged. No live cleanup or bucket administration was performed.

## Fallbacks

Historical binary cache discovery remains an optional optimization: unavailable, expired, unauthenticated, conflicting, or timed-out candidates produce a cache miss and fresh compilation. The existing 60-second per-target planning deadline remains. This is the existing cache-miss contract carried over to R2, not a rollout fallback. Required publication and selected-object retrieval fail if validation cannot complete; there is no GitHub artifact fallback or dual write.

## Validation

- Bash syntax for every changed shell script.
- ShellCheck for the transport/cache/wait/context scripts and affected shell tests.
- Prettier for all changed workflow/documentation files.
- actionlint for Runner Image, Crates, Turbo, Security, and stale cleanup workflows.
- 18 shell integration suites: `runner-ci-record`, `runner-binary-cache`, `runner-binary-cache-plan`, `runner-binary-build`, `runner-image-context`, `runner-image-workflow`, `runner-image-manifest`, `wait-runner-image`, `wait-runner-image-groups`, `prepare-runner-image`, `reconcile-runner-binary-groups`, `reconcile-and-start-runner-groups`, `runner-host-architecture-groups`, `check-workflow-shell-compatibility`, `turbo-playwright-runner-workflow`, `runner-lifecycle-ownership-workflow`, `rust-ci-memory-workflow`, and `checkout-depth` (all `.github/scripts/tests/<name>-test.sh`).

Tests exercise actual entry points with real files, hashes, and zstd data; only external GitHub/S3/SSH and existing wait-test clock boundaries are controlled. Coverage includes both architectures, corrupt/missing objects, forged/expired/stale receipts, previous-attempt reuse, newer producer invalidation, required transport failure, source ranking, conflicts, rate limits, and cleanup scope/partial deletion errors.

Self-review also reproduced and fixed nested timeout cancellation ownership with a real process/FIFO regression test, pinned the new cleanup checkout to its canonical release commit, and removed retired transport bindings.

Real CI validated fresh publication and target-local image preparation for both architectures in [34564390556](https://github.com/vm0-ai/vm0/actions/runs/34564390556), then cache-hit delivery for both in [34564724248](https://github.com/vm0-ai/vm0/actions/runs/34564724248). The GitHub jobs API exposed the successful dynamic hash receipt names. These runs precede the final cancellation/cleanup commits; current-head CI remains the merge gate.

No measured end-to-end speedup is claimed: compiler client installation and verification overhead must be included in the comparison. No merge is requested.
