### PR TITLE
ci: collect kms retirement dependency evidence

### DIFF
--- a/.github/kms-migration-32264/README.md
+++ b/.github/kms-migration-32264/README.md
@@ -149,13 +149,26 @@ The two independent jobs reuse existing production credentials:
   `/var/lib/vm0-runner/runners/v{version}/proxy-registry.json`, including retained
   production release directories. It does not install a program, restart a
   service, unregister a sandbox, or decrypt a secret. Only aggregate outer-key
-  counts leave each host. PR and staging directories are excluded.
+  counts and sanitized failure metadata leave each host. PR and staging
+  directories are excluded. A missing registry also collects directory-entry
+  count, whether only a regular `runner.yaml` remains, exact systemd service
+  properties, and a count of `runner` command lines mentioning the version.
+  Config contents and process command lines never leave the host. The check
+  uses `systemctl show` and `ps`; it does not invoke runner maintenance commands
+  that can clean state. These observations aid review and do not convert a
+  missing registry into a successful or zero-key inventory.
 - Recovery inventory makes GET requests to the production Neon project's
   metadata, branch list, snapshot list and production backup schedule. It does
   not request a database connection URI or connect to PostgreSQL. It reports
   configured history-window overlap and counts every retained snapshot as
   requiring key review: snapshot creation time does not prove which historical
-  LSN was captured. Other branches are counted without inspecting their data.
+  LSN was captured. Snapshot evidence contains an ID fingerprint, production
+  branch match, reported snapshot timestamp/LSN, creation time, expiration, and
+  sanitized backup schedule. Names and raw snapshot IDs are omitted. Missing
+  snapshot points and expirations remain explicitly unreported; an expiration
+  in the past does not prove deletion while the snapshot is still listed.
+  These fields describe recovery metadata, not successful decryption or a
+  tested restore. Other branches are counted without inspecting their data.
 
 The workflow needs no new AWS credentials, IAM roles or KMS grants. It retains
 sanitized reports for 30 days. Failed SSH, unreadable or changing files, unknown

--- a/.github/scripts/kms-production-exit-check.py
+++ b/.github/scripts/kms-production-exit-check.py
@@ -5,6 +5,7 @@ import base64
 import binascii
 import datetime as dt
 import errno
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -132,9 +133,220 @@ def key_category(value):
         return "invalid"
 
 
+SERVICE_STATES = {
+    "LoadState": {
+        "stub",
+        "loaded",
+        "not-found",
+        "bad-setting",
+        "error",
+        "merged",
+        "masked",
+    },
+    "ActiveState": {
+        "active",
+        "reloading",
+        "inactive",
+        "failed",
+        "activating",
+        "deactivating",
+        "maintenance",
+        "refreshing",
+    },
+    "SubState": {
+        "dead",
+        "running",
+        "exited",
+        "failed",
+        "start-pre",
+        "start",
+        "start-post",
+        "auto-restart",
+        "stop",
+        "stop-sigterm",
+        "stop-sigkill",
+        "stop-post",
+        "condition",
+        "final-sigterm",
+        "final-sigkill",
+        "cleaning",
+        "reload",
+        "reload-signal",
+        "reload-notify",
+        "dead-before-auto-restart",
+        "failed-before-auto-restart",
+    },
+    "UnitFileState": {
+        "",
+        "enabled",
+        "enabled-runtime",
+        "linked",
+        "linked-runtime",
+        "alias",
+        "static",
+        "disabled",
+        "masked",
+        "masked-runtime",
+        "indirect",
+        "generated",
+        "transient",
+        "bad",
+    },
+}
+
+
+def validate_service_state(service):
+    require(
+        isinstance(service, dict)
+        and set(service) == set(SERVICE_STATES) | {"MainPID", "ControlPID"},
+        "invalid_service_state",
+    )
+    for key, choices in SERVICE_STATES.items():
+        require(
+            isinstance(service[key], str) and service[key] in choices,
+            "invalid_service_state",
+        )
+    for key in ("MainPID", "ControlPID"):
+        require(
+            type(service[key]) is int and 0 <= service[key] < 2**31,
+            "invalid_service_state",
+        )
+
+
+def missing_registry_evidence(directory):
+    """Read metadata only. Runner maintenance commands can clean state."""
+    evidence = {"runnerVersion": directory.name, "collectionComplete": False}
+    try:
+        before = directory.stat(follow_symlinks=False)
+        require(stat.S_ISDIR(before.st_mode), "invalid_runner_directory")
+        entries = list(directory.iterdir())
+        require(len(entries) <= 10000, "directory_evidence_limit")
+        config_only = (
+            len(entries) == 1
+            and entries[0].name == "runner.yaml"
+            and stat.S_ISREG(entries[0].stat(follow_symlinks=False).st_mode)
+        )
+        command = [
+            "systemctl",
+            "show",
+            "--all",
+            "--no-pager",
+            "--property=" + ",".join([*SERVICE_STATES, "MainPID", "ControlPID"]),
+            "vm0-runner-" + directory.name + ".service",
+        ]
+        child = subprocess.run(command, capture_output=True, text=True, timeout=15)
+        require(
+            child.returncode in (0, 1) and len(child.stdout) <= 4096,
+            "service_state_unavailable",
+        )
+        pairs = [line.split("=", 1) for line in child.stdout.splitlines()]
+        require(all(len(pair) == 2 for pair in pairs), "invalid_service_state")
+        service = strict_object(pairs)
+        for key in ("MainPID", "ControlPID"):
+            require(
+                isinstance(service.get(key), str)
+                and service[key].isascii()
+                and service[key].isdigit(),
+                "invalid_service_state",
+            )
+            service[key] = int(service[key])
+        validate_service_state(service)
+        require(
+            child.returncode == 0
+            or service["LoadState"] == "not-found"
+            and service["MainPID"] == service["ControlPID"] == 0,
+            "service_state_unavailable",
+        )
+        # Command lines may contain credentials: keep them in host memory and
+        # export only a count. This does not prove absence of all retained state.
+        processes = subprocess.run(
+            ["ps", "-C", "runner", "-o", "args=", "--ww"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        require(
+            len(processes.stdout) <= 1024 * 1024
+            and (
+                processes.returncode == 0
+                or processes.returncode == 1
+                and not processes.stdout
+                and not processes.stderr
+            ),
+            "process_evidence_unavailable",
+        )
+        version = re.compile(
+            r"(?<![A-Za-z0-9_.-])" + re.escape(directory.name) + r"(?![A-Za-z0-9_.-])"
+        )
+        matches = sum(
+            bool(version.search(line)) for line in processes.stdout.splitlines()
+        )
+        after = directory.stat(follow_symlinks=False)
+        unchanged = (before.st_dev, before.st_ino, before.st_mtime_ns) == (
+            after.st_dev,
+            after.st_ino,
+            after.st_mtime_ns,
+        )
+        return {
+            **evidence,
+            "collectionComplete": unchanged,
+            "directoryEntryCount": len(entries),
+            "configFileOnly": config_only,
+            "directoryChangedDuringRead": not unchanged,
+            "service": service,
+            "matchingRunnerCommandLines": matches,
+        }
+    except (CheckError, OSError, ValueError, subprocess.TimeoutExpired):
+        return {**evidence, "error": "runner_state_unavailable"}
+
+
+def validate_missing_evidence(evidence):
+    require(
+        isinstance(evidence, dict)
+        and isinstance(evidence.get("runnerVersion"), str)
+        and bool(PRODUCTION_VERSION.fullmatch(evidence["runnerVersion"]))
+        and type(evidence.get("collectionComplete")) is bool,
+        "invalid_remote_report",
+    )
+    if "error" in evidence:
+        require(
+            set(evidence) == {"runnerVersion", "collectionComplete", "error"}
+            and evidence["collectionComplete"] is False
+            and evidence["error"] == "runner_state_unavailable",
+            "invalid_remote_report",
+        )
+        return
+    require(
+        set(evidence)
+        == {
+            "runnerVersion",
+            "collectionComplete",
+            "directoryEntryCount",
+            "configFileOnly",
+            "directoryChangedDuringRead",
+            "service",
+            "matchingRunnerCommandLines",
+        },
+        "invalid_remote_report",
+    )
+    for key in ("directoryEntryCount", "matchingRunnerCommandLines"):
+        require(
+            type(evidence[key]) is int and 0 <= evidence[key] <= 10000,
+            "invalid_remote_report",
+        )
+    for key in ("configFileOnly", "directoryChangedDuringRead"):
+        require(type(evidence[key]) is bool, "invalid_remote_report")
+    require(
+        evidence["collectionComplete"] is not evidence["directoryChangedDuringRead"],
+        "invalid_remote_report",
+    )
+    validate_service_state(evidence["service"])
+
+
 def registry_inventory(root):
     counts = dict.fromkeys(COUNTERS, 0)
     failures = []
+    missing_evidence = []
     require(not root.is_symlink() and root.is_dir(), "runner_root_unavailable")
     directories = list(root.iterdir())
     require(len(directories) <= 1000, "runner_directory_limit")
@@ -204,7 +416,13 @@ def registry_inventory(root):
             failures.append(
                 {"runnerVersion": directory.name, "reason": reason, "sizeBytes": size}
             )
-    return {"counts": counts, "failures": failures}
+            if reason == "missing_registry":
+                missing_evidence.append(missing_registry_evidence(directory))
+    return {
+        "counts": counts,
+        "failures": failures,
+        "missingRegistryEvidence": missing_evidence,
+    }
 
 
 def runner_fleet():
@@ -245,7 +463,7 @@ def runner_fleet():
             inventory = decode_json(child.stdout)
             require(
                 isinstance(inventory, dict)
-                and set(inventory) == {"counts", "failures"},
+                and set(inventory) == {"counts", "failures", "missingRegistryEvidence"},
                 "invalid_remote_report",
             )
             counts = inventory["counts"]
@@ -282,8 +500,27 @@ def runner_fleet():
                     ),
                     "invalid_remote_report",
                 )
+            missing_evidence = inventory["missingRegistryEvidence"]
+            require(
+                isinstance(missing_evidence, list)
+                and len(missing_evidence)
+                == sum(f["reason"] == "missing_registry" for f in failures),
+                "invalid_remote_report",
+            )
+            for evidence in missing_evidence:
+                validate_missing_evidence(evidence)
+            require(
+                sorted(e["runnerVersion"] for e in missing_evidence)
+                == sorted(
+                    f["runnerVersion"]
+                    for f in failures
+                    if f["reason"] == "missing_registry"
+                ),
+                "invalid_remote_report",
+            )
             result["counts"] = counts
             result["registryFailures"] = failures
+            result["missingRegistryEvidence"] = missing_evidence
         except (CheckError, OSError, ValueError, subprocess.TimeoutExpired):
             result["error"] = "remote_inventory_failed"
         results.append(result)
@@ -371,6 +608,102 @@ def neon_list(collection):
     raise CheckError("neon_pagination_limit")
 
 
+def metadata_timestamp(value):
+    if value is None:
+        return None
+    require(
+        isinstance(value, str)
+        and bool(
+            re.fullmatch(
+                r"\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d{1,9})?(?:Z|[+-]\d\d:\d\d)",
+                value,
+            )
+        ),
+        "invalid_metadata_timestamp",
+    )
+    try:
+        return dt.datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(
+            dt.timezone.utc
+        )
+    except ValueError:
+        raise CheckError("invalid_metadata_timestamp") from None
+
+
+def snapshot_evidence(snapshots, branch_id, cutoff):
+    evidence, seen = [], set()
+    for snapshot in snapshots:
+        snapshot_id = snapshot.get("id")
+        require(
+            isinstance(snapshot_id, str)
+            and bool(re.fullmatch(r"[a-z0-9-]{1,60}", snapshot_id))
+            and snapshot_id not in seen,
+            "invalid_snapshot_id",
+        )
+        seen.add(snapshot_id)
+        created = metadata_timestamp(snapshot.get("created_at"))
+        require(created is not None, "missing_snapshot_created_at")
+        point = metadata_timestamp(snapshot.get("timestamp"))
+        expires = metadata_timestamp(snapshot.get("expires_at"))
+        lsn = snapshot.get("lsn")
+        require(
+            lsn is None
+            or isinstance(lsn, str)
+            and bool(re.fullmatch(r"[0-9A-Fa-f]{1,8}/[0-9A-Fa-f]{1,8}", lsn)),
+            "invalid_snapshot_lsn",
+        )
+        source_branch = snapshot.get("source_branch_id")
+        require(
+            source_branch is None
+            or isinstance(source_branch, str)
+            and bool(re.fullmatch(r"br-[a-z0-9-]+", source_branch)),
+            "invalid_snapshot_branch",
+        )
+        manual = snapshot.get("manual")
+        require(manual is None or type(manual) is bool, "invalid_snapshot_manual_flag")
+        evidence.append(
+            {
+                "snapshotIdSha256": hashlib.sha256(snapshot_id.encode()).hexdigest(),
+                "createdAt": created.isoformat(),
+                "snapshotPoint": point.isoformat() if point else None,
+                "reportedLsn": lsn,
+                "expiresAt": expires.isoformat() if expires else None,
+                "expirationReported": expires is not None,
+                "sourceBranchIsProduction": source_branch == branch_id
+                if source_branch
+                else None,
+                "manual": manual,
+                "pointBeforeMigrationVerification": point < cutoff if point else None,
+            }
+        )
+    return sorted(evidence, key=lambda item: item["snapshotIdSha256"])
+
+
+def backup_schedule_evidence(schedule):
+    evidence = []
+    for entry in schedule:
+        require(
+            isinstance(entry, dict)
+            and entry.get("frequency")
+            in {"hourly", "daily", "weekly", "monthly", "yearly"},
+            "invalid_backup_schedule",
+        )
+        item = {"frequency": entry["frequency"]}
+        for key, minimum, maximum in [
+            ("hour", 0, 23),
+            ("day", 1, 31),
+            ("month", 1, 12),
+            ("retention_seconds", 3600, 2**53 - 1),
+        ]:
+            value = entry.get(key)
+            require(
+                value is None or type(value) is int and minimum <= value <= maximum,
+                "invalid_backup_schedule",
+            )
+            item[key] = value
+        evidence.append(item)
+    return evidence
+
+
 def recovery_history():
     require(os.environ.get("NEON_PROJECT_ID") == PROJECT, "production_project_mismatch")
     cutoff = timestamp(os.environ.get("MIGRATION_VERIFIED_AT"))
@@ -398,6 +731,8 @@ def recovery_history():
         isinstance(schedule, dict) and isinstance(schedule.get("schedule"), list),
         "invalid_backup_schedule",
     )
+    snapshot_details = snapshot_evidence(snapshots, branch_id, cutoff)
+    schedule_details = backup_schedule_evidence(schedule["schedule"])
     return {
         "collectionComplete": True,
         "project": PROJECT,
@@ -410,10 +745,24 @@ def recovery_history():
         "configuredHistoryWindowOverlapsMigration": checked
         - dt.timedelta(seconds=retention)
         < cutoff,
+        "configuredHistoryWindowClearsMigrationAt": (
+            cutoff + dt.timedelta(seconds=retention)
+        ).isoformat(),
         "productionBranchFound": True,
         "otherBranchesNotInspected": len(branches) - 1,
         "retainedSnapshotsRequiringKeyReview": len(snapshots),
         "backupScheduleEntries": len(schedule["schedule"]),
+        "snapshots": snapshot_details,
+        "snapshotsWithReportedPreMigrationPoint": sum(
+            s["pointBeforeMigrationVerification"] is True for s in snapshot_details
+        ),
+        "snapshotsWithUnreportedPoint": sum(
+            s["snapshotPoint"] is None for s in snapshot_details
+        ),
+        "snapshotsWithoutReportedExpiration": sum(
+            not s["expirationReported"] for s in snapshot_details
+        ),
+        "backupSchedule": schedule_details,
         "actualEarliestRestorableTimeVerified": False,
         "backupCiphertextVerified": False,
         "externalBackupsInspected": False,

--- a/.github/scripts/tests/kms-production-exit-check-test.py
+++ b/.github/scripts/tests/kms-production-exit-check-test.py
@@ -61,6 +61,18 @@ class ExitCheckTests(unittest.TestCase):
         self.bin = self.root / "bin"
         self.bin.mkdir()
         self.env["PATH"] = str(self.bin) + os.pathsep + self.env["PATH"]
+        self.tool(
+            "systemctl",
+            """import sys
+assert sys.argv[1:3] == ["show", "--all"]
+assert sys.argv[-1].startswith("vm0-runner-v") and sys.argv[-1].endswith(".service")
+print("LoadState=not-found\\nActiveState=inactive\\nSubState=dead\\nUnitFileState=\\nMainPID=0\\nControlPID=0")
+""",
+        )
+        self.tool(
+            "ps",
+            "import sys\nassert sys.argv[1:]==['-C','runner','-o','args=','--ww']\nsys.exit(1)\n",
+        )
 
     def run_script(self, *args):
         result = subprocess.run(
@@ -104,7 +116,7 @@ elif path.endswith("/snapshots"):
         print(json.dumps({"message":"must-not-leak-secret"})+"\\n403", end="")
         sys.stderr.write("must-not-leak-secret")
         sys.exit(0)
-    data={"snapshots":[{"id":"old","created_at":"2025-01-01T00:00:00Z"},{"id":"new-historical-lsn","created_at":"2099-01-01T00:00:00Z"}]}
+    data={"snapshots":json.loads(os.environ["SNAPSHOTS_FIXTURE"]) if "SNAPSHOTS_FIXTURE" in os.environ else [{"id":"old","created_at":"2025-01-01T00:00:00Z"},{"id":"new-historical-lsn","created_at":"2099-01-01T00:00:00Z"}]}
 elif path.endswith("/backup_schedule"):
     data={"schedule":[{"frequency":"daily","hour":3,"retention_seconds":604800}]}
 else:
@@ -208,6 +220,60 @@ print(json.dumps(data)+"\\n200", end="")
         self.assertEqual(path.stat().st_size, before.st_size)
         self.assertEqual(path.stat().st_mtime_ns, before.st_mtime_ns)
 
+    def test_unstarted_directory_evidence_does_not_turn_missing_registry_into_zero(
+        self,
+    ):
+        release = self.root / "runners" / "v1.2.3"
+        release.mkdir(parents=True)
+        config = release / "runner.yaml"
+        config.write_text(SECRET)
+        before = config.stat()
+        result = self.run_script("runner-local", str(release.parent))
+        self.assertEqual(result.returncode, 0)
+        inventory = json.loads(result.stdout)
+        evidence = inventory["missingRegistryEvidence"][0]
+        self.assertTrue(evidence["collectionComplete"])
+        self.assertTrue(evidence["configFileOnly"])
+        self.assertEqual(evidence["service"]["LoadState"], "not-found")
+        self.assertEqual(evidence["matchingRunnerCommandLines"], 0)
+        self.assertEqual(inventory["counts"]["unreadable"], 1)
+        self.assertEqual(inventory["counts"]["registriesRead"], 0)
+        self.assertEqual(config.read_text(), SECRET)
+        self.assertEqual(config.stat().st_mtime_ns, before.st_mtime_ns)
+
+    def test_manual_runner_match_is_counted_without_exporting_command_line(self):
+        release = self.root / "runners" / "v1.2.3"
+        release.mkdir(parents=True)
+        (release / "status.json").write_text(SECRET)
+        self.tool(
+            "ps",
+            "print('/var/lib/vm0-runner/bin/v1.2.3/runner start --token must-not-leak-secret')\nprint('/var/lib/vm0-runner/bin/v1.2.30/runner start')\n",
+        )
+        result = self.run_script("runner-local", str(release.parent))
+        self.assertEqual(result.returncode, 0)
+        evidence = json.loads(result.stdout)["missingRegistryEvidence"][0]
+        self.assertFalse(evidence["configFileOnly"])
+        self.assertEqual(evidence["matchingRunnerCommandLines"], 1)
+
+    def test_denied_service_inspection_stays_unknown_and_sanitized(self):
+        release = self.root / "runners" / "v1.2.3"
+        release.mkdir(parents=True)
+        self.tool(
+            "systemctl",
+            "import sys\nsys.stderr.write('must-not-leak-secret')\nsys.exit(1)\n",
+        )
+        result = self.run_script("runner-local", str(release.parent))
+        self.assertEqual(result.returncode, 0)
+        evidence = json.loads(result.stdout)["missingRegistryEvidence"][0]
+        self.assertEqual(
+            evidence,
+            {
+                "runnerVersion": "v1.2.3",
+                "collectionComplete": False,
+                "error": "runner_state_unavailable",
+            },
+        )
+
     def test_duplicate_registry_keys_cannot_silently_hide_source_values(self):
         release = self.root / "runners" / "v1.2.3"
         release.mkdir(parents=True)
@@ -250,6 +316,65 @@ print(json.dumps(data)+"\\n200", end="")
         report = json.loads((self.root / "kms-exit-backups.json").read_text())
         self.assertEqual(report["result"], "incomplete")
         self.assertEqual(report["failure"], "neon_metadata_request_failed")
+
+    def test_snapshot_points_and_expirations_are_reported_independently_of_creation(
+        self,
+    ):
+        self.fake_neon()
+        cutoff = dt.datetime.fromisoformat(
+            self.env["MIGRATION_VERIFIED_AT"].replace("Z", "+00:00")
+        )
+        created = (cutoff + dt.timedelta(minutes=1)).isoformat()
+        self.env["SNAPSHOTS_FIXTURE"] = json.dumps(
+            [
+                {
+                    "id": "old-point",
+                    "name": SECRET,
+                    "created_at": created,
+                    "timestamp": (cutoff - dt.timedelta(days=1)).isoformat(),
+                    "expires_at": (cutoff + dt.timedelta(days=7)).isoformat(),
+                    "manual": False,
+                    "source_branch_id": "br-prod",
+                },
+                {
+                    "id": "new-point",
+                    "name": SECRET,
+                    "created_at": created,
+                    "timestamp": (cutoff + dt.timedelta(seconds=10)).isoformat(),
+                    "lsn": "AB/CD",
+                    "manual": True,
+                    "source_branch_id": "br-prod",
+                },
+            ]
+        )
+        self.assertEqual(self.run_script("backups").returncode, 0)
+        inventory = json.loads((self.root / "kms-exit-backups.json").read_text())[
+            "inventory"
+        ]
+        self.assertEqual(inventory["snapshotsWithReportedPreMigrationPoint"], 1)
+        self.assertEqual(inventory["snapshotsWithUnreportedPoint"], 0)
+        self.assertEqual(inventory["snapshotsWithoutReportedExpiration"], 1)
+        self.assertEqual(inventory["retainedSnapshotsRequiringKeyReview"], 2)
+        self.assertTrue(
+            all(s["sourceBranchIsProduction"] for s in inventory["snapshots"])
+        )
+        self.assertFalse(inventory["backupCiphertextVerified"])
+        self.assertEqual(inventory["backupSchedule"][0]["retention_seconds"], 604800)
+        self.assertNotIn("old-point", json.dumps(inventory))
+
+    def test_invalid_snapshot_metadata_and_duplicate_ids_fail_closed(self):
+        self.fake_neon()
+        snapshot = {"id": "snapshot", "created_at": "2025-01-01T00:00:00Z"}
+        for snapshots, failure in [
+            ([{**snapshot, "lsn": SECRET}], "invalid_snapshot_lsn"),
+            ([snapshot, snapshot], "invalid_snapshot_id"),
+        ]:
+            with self.subTest(failure=failure):
+                self.env["SNAPSHOTS_FIXTURE"] = json.dumps(snapshots)
+                self.assertEqual(self.run_script("backups").returncode, 1)
+                report = json.loads((self.root / "kms-exit-backups.json").read_text())
+                self.assertEqual(report["result"], "incomplete")
+                self.assertEqual(report["failure"], failure)
 
     def test_nonproduction_context_never_contacts_neon(self):
         self.fake_neon()
@@ -322,6 +447,28 @@ print(open(os.environ["HOST_REPORT_FIXTURE"]).read())
         report = json.loads((self.root / "kms-exit-runners.json").read_text())
         self.assertFalse(report["inventory"]["collectionComplete"])
         self.assertTrue(all("error" in h for h in report["inventory"]["hosts"]))
+
+    def test_untrusted_service_metadata_cannot_leak_or_preserve_a_partial_success(self):
+        release = self.root / "runners" / "v1.2.3"
+        release.mkdir(parents=True)
+        local = self.run_script("runner-local", str(release.parent))
+        inventory = json.loads(local.stdout)
+        inventory["missingRegistryEvidence"][0]["service"]["UnitFileState"] = SECRET
+        fixture = self.root / "host-report.json"
+        fixture.write_text(json.dumps(inventory))
+        self.env["HOST_REPORT_FIXTURE"] = str(fixture)
+        self.tool(
+            "ssh",
+            "import os,sys\nsys.stdin.read()\nprint(open(os.environ['HOST_REPORT_FIXTURE']).read())\n",
+        )
+        self.assertEqual(self.run_script("runners").returncode, 1)
+        report = json.loads((self.root / "kms-exit-runners.json").read_text())
+        self.assertFalse(report["inventory"]["collectionComplete"])
+        self.assertTrue(
+            all(
+                "error" in h and "counts" not in h for h in report["inventory"]["hosts"]
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Production exit run 34563374697 found one missing registry on each host for runner v0.190.0, whose release built successfully but never reached runner promotion. The backup report also counted 15 retained snapshots without their recovery points or expiration dates.

Add read-only directory metadata, exact systemd service properties, and sanitized runner process match counts for missing registries. Include Neon snapshot ID fingerprints, reported snapshot times/LSNs, expirations, production-branch matches, and the backup schedule. Missing registries remain incomplete, and these observations do not grant key retirement clearance or certify a restore.

The workflow keeps its existing main/production gates and credentials. It does not invoke runner maintenance commands, read configuration contents, export process command lines or snapshot names, restore backups, decrypt data, or change production resources. The SSH report change is consumed by the same checked-out script sent over stdin, with no independently deployed protocol consumer.

Validation: 17 CLI/file/process-boundary tests; Ruff lint and formatting; Prettier for the runbook; whitespace and file-size checks. Tests cover prepared directories, manual process matches, permission failures, untrusted remote metadata, historical snapshot points created later, absent expirations, malformed metadata, and unchanged fail-closed behavior.

Refs #32264.
