### PR TITLE
test(guest-agent): synchronize oom evidence disconnect checks

### DIFF
--- a/crates/guest-agent/src/workload_containment/evidence_tests.rs
+++ b/crates/guest-agent/src/workload_containment/evidence_tests.rs
@@ -63,9 +63,9 @@ async fn expect_request<F: Future>(capture: Pin<&mut F>, peer: &mut AsyncUnixStr
 }
 
 async fn expect_disconnect(peer: &mut AsyncUnixStream) {
-    let result = tokio::time::timeout(Duration::from_secs(1), peer.read(&mut [0]))
-        .await
-        .expect("cancelled or failed exchange must close its socket");
+    // The paused clock can expire a timeout before Tokio observes the close.
+    // Use the same bounded I/O readiness wait as the request and response checks.
+    let result = ready_io(peer.read(&mut [0])).await;
     assert!(
         matches!(result, Ok(0))
             || matches!(result, Err(error) if error.kind() == io::ErrorKind::ConnectionReset)


### PR DESCRIPTION
`evidence_rejects_invalid_frames_and_closes_the_connection` intermittently fails at `expect_disconnect` in the [Crates coverage job](https://github.com/vm0-ai/vm0/actions/runs/34562807394/job/103148876218). The test runs with Tokio's clock paused: its one-second timeout can auto-advance before the reactor observes socket closure. The same source passed the [preceding PR coverage job](https://github.com/vm0-ai/vm0/actions/runs/34555323736/job/103126742247). The missing coverage report and failed gate are consequences of the test failure.

Use the existing bounded `ready_io` helper for the disconnect read, as the suite already does for requests and responses. This lets socket readiness progress without advancing virtual time, while preserving the EOF/connection-reset assertion and permanent-disconnection checks after invalid responses, deadlines, cancellation, and metrics shutdown. Production behavior and timeout budgets are unchanged.

This PR targets `fix/issue-33316-async-oom-evidence` from #33396, which introduces these tests and is not yet merged into `main`. Its diff contains only the disconnect-check fix.

## Validation

- `cargo test --manifest-path crates/Cargo.toml --profile local --locked -p guest-agent --lib workload_containment::evidence_tests` — all 8 tests passed; the compiled suite then passed 100 consecutive runs (800 test executions).
- `cargo fmt --manifest-path crates/guest-agent/Cargo.toml -- --check` and `git diff --check` passed.
- `cargo clippy --manifest-path crates/Cargo.toml --profile local --locked -p guest-agent --all-targets --all-features` passed.
- `cargo doc --manifest-path crates/Cargo.toml --profile local --locked -p guest-agent --all-features --no-deps` passed.
- Before the fix, 500 runs of the exact failing test and 100 suite runs passed locally; the intermittent CI failure was not reproduced locally. Full workspace coverage remains for the PR pipeline.
