### PR TITLE
ci: audit source kms usage without canary calls

### DIFF
--- a/.github/kms-migration-32264/source-audit.md
+++ b/.github/kms-migration-32264/source-audit.md
@@ -1,0 +1,29 @@
+# Read-only source-key usage evidence
+
+Dispatch **KMS Production Preflight** on protected `main` with
+`operation=source-audit`. Its existing production environment approval and
+Doppler OIDC identity apply. This operation does not need a deployment ID;
+the default `verify` operation still requires one in the script.
+
+The audit reads the existing checksum- and provenance-verified rollback snapshot
+in memory, verifies the source account and runtime principal through STS, then
+calls only `cloudtrail:LookupEvents` in `us-west-2`. It does not run KMS canaries,
+connect to a database, fetch a Vercel deployment, change credentials or modify
+resources. The retained source principal must already have permission to read
+CloudTrail event history; an access denial produces an incomplete report.
+
+Both full key ARN and short key ID queries cover the accepted migration
+verification time, `2026-09-10T07:38:23.484Z`, through 15 minutes before the audit.
+Each query uses explicit bounded pagination and the combined result deduplicates
+event IDs. The visibility buffer does not guarantee that all delayed events have
+arrived. The command fails closed when its start falls outside CloudTrail's
+90-day event-history window.
+
+The existing sanitized verification artifact contains `source-audit.json` with
+query coverage, event counts, allowlisted operation names, event times, error
+presence, hashed principal identifiers, and whether an event used the retained
+source credential. Provider payloads, access keys, names, request parameters and
+pagination tokens are not exported. A successful collection does not establish
+retirement clearance: recent cryptographic or unclassified calls still need
+review, along with current production ciphertext, runner state and retained
+backup/recovery dependencies. `retirementCleared` remains false.

--- a/.github/scripts/kms-production-migration.py
+++ b/.github/scripts/kms-production-migration.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 import urllib.parse
 
 
@@ -143,6 +144,7 @@ def aws(arguments, environment, payload=None):
     operation = {
         ("sts", "get-caller-identity"): "sts:GetCallerIdentity",
         ("sts", "assume-role-with-web-identity"): "sts:AssumeRoleWithWebIdentity",
+        ("cloudtrail", "lookup-events"): "cloudtrail:LookupEvents",
     }[tuple(arguments[:2])]
     with ExitStack() as resources:
         descriptors = ()
@@ -407,13 +409,259 @@ def read_verification(path):
     return report
 
 
+def source_audit():
+    """Read source-key event history without generating KMS canary calls."""
+    output = Path(required_env("RUNNER_TEMP")) / "kms-production-reports"
+    output.mkdir(mode=0o700)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    start = datetime.datetime.fromisoformat(
+        required_env("SOURCE_AUDIT_WINDOW_START").replace("Z", "+00:00")
+    )
+    end = now - datetime.timedelta(minutes=15)
+    report = {
+        "version": 1,
+        "operation": "source-audit",
+        "runId": required_env("GITHUB_RUN_ID"),
+        "commit": required_env("GITHUB_SHA"),
+        "startedAt": now.isoformat(),
+        "sourceKeyArn": SOURCE,
+        "account": "072707626411",
+        "region": "us-west-2",
+        "windowStart": start.isoformat(),
+        "windowEnd": end.isoformat(),
+        "visibilityBufferSeconds": 900,
+        "lateArrivalExcluded": False,
+        "backupSnapshotSha256": required_env("EXPECTED_BACKUP_SHA256"),
+        "result": "running",
+        "collectionComplete": False,
+        "retirementCleared": False,
+        "productionConfigurationChanged": False,
+        "staticCredentialsCreated": False,
+        "kmsCallsMade": False,
+        "queries": [],
+        "events": [],
+    }
+    try:
+        require(
+            start.utcoffset() == datetime.timedelta(0) and start < end < now,
+            "invalid_audit_window",
+        )
+        # LookupEvents retains only 90 days. Never report a complete historical
+        # window after its beginning falls outside that service boundary.
+        require(now - start < datetime.timedelta(days=90), "audit_window_expired")
+        environment = runtime_environment(backup_configuration())
+        identity = aws(["sts", "get-caller-identity"], environment)
+        require(
+            identity.get("Account") == "072707626411"
+            and identity.get("Arn") == "arn:aws:iam::072707626411:user/vm0-kms-prod",
+            "source_audit_principal_mismatch",
+        )
+        report["sourcePrincipalVerified"] = True
+        crypto = {
+            "Decrypt",
+            "Encrypt",
+            "ReEncrypt",
+            "GenerateDataKey",
+            "GenerateDataKeyWithoutPlaintext",
+            "GenerateDataKeyPair",
+            "GenerateDataKeyPairWithoutPlaintext",
+            "Sign",
+            "Verify",
+            "GenerateMac",
+            "VerifyMac",
+            "DeriveSharedSecret",
+        }
+        management = {
+            "DescribeKey",
+            "GetKeyPolicy",
+            "GetKeyRotationStatus",
+            "ListGrants",
+            "ListKeyPolicies",
+            "ListResourceTags",
+            "CreateGrant",
+            "RevokeGrant",
+            "RetireGrant",
+            "PutKeyPolicy",
+            "EnableKey",
+            "DisableKey",
+            "ScheduleKeyDeletion",
+            "CancelKeyDeletion",
+            "EnableKeyRotation",
+            "DisableKeyRotation",
+            "TagResource",
+            "UntagResource",
+            "UpdateKeyDescription",
+            "RotateKeyOnDemand",
+            "ListKeyRotations",
+        }
+        seen = {}
+        for resource in [SOURCE, SOURCE.rsplit("/", 1)[1]]:
+            query = {
+                "resourceForm": "arn" if resource == SOURCE else "key-id",
+                "pages": 0,
+                "returnedEvents": 0,
+                "complete": False,
+            }
+            report["queries"].append(query)
+            tokens = set()
+            token = None
+            for _ in range(100):
+                # CloudTrail permits two LookupEvents requests per second.
+                time.sleep(0.6)
+                payload = {
+                    "LookupAttributes": [
+                        {"AttributeKey": "ResourceName", "AttributeValue": resource}
+                    ],
+                    "StartTime": start.isoformat(),
+                    "EndTime": end.isoformat(),
+                    "MaxResults": 50,
+                }
+                if token is not None:
+                    payload["NextToken"] = token
+                page = aws(
+                    ["cloudtrail", "lookup-events", "--no-paginate"],
+                    environment,
+                    payload,
+                )
+                require(isinstance(page, dict), "invalid_audit_page")
+                events = page.get("Events")
+                require(
+                    isinstance(events, list) and len(events) <= 50,
+                    "invalid_audit_events",
+                )
+                query["pages"] += 1
+                query["returnedEvents"] += len(events)
+                for event in events:
+                    require(isinstance(event, dict), "invalid_audit_event")
+                    event_id = event.get("EventId", "")
+                    require(
+                        isinstance(event_id, str)
+                        and re.fullmatch(
+                            r"[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}", event_id
+                        ),
+                        "invalid_audit_event_id",
+                    )
+                    raw = json.loads(event["CloudTrailEvent"])
+                    require(
+                        isinstance(raw, dict)
+                        and raw.get("eventID") == event_id
+                        and raw.get("eventSource") == "kms.amazonaws.com"
+                        and raw.get("awsRegion") == "us-west-2"
+                        and raw.get("recipientAccountId") == "072707626411",
+                        "audit_event_scope_mismatch",
+                    )
+                    occurred = datetime.datetime.fromisoformat(
+                        raw["eventTime"].replace("Z", "+00:00")
+                    )
+                    require(
+                        occurred.utcoffset() == datetime.timedelta(0)
+                        and start <= occurred <= end,
+                        "audit_event_time_mismatch",
+                    )
+                    resources = event.get("Resources")
+                    require(
+                        isinstance(resources, list)
+                        and any(
+                            isinstance(value, dict)
+                            and value.get("ResourceName")
+                            in {SOURCE, SOURCE.rsplit("/", 1)[1]}
+                            for value in resources
+                        ),
+                        "audit_resource_mismatch",
+                    )
+                    name = raw.get("eventName")
+                    require(
+                        isinstance(name, str) and name == event.get("EventName"),
+                        "audit_event_name_mismatch",
+                    )
+                    principal = raw.get("userIdentity")
+                    require(isinstance(principal, dict), "invalid_audit_identity")
+                    digest = hashlib.sha256(
+                        json.dumps(raw, sort_keys=True).encode()
+                    ).hexdigest()
+                    if event_id in seen:
+                        require(seen[event_id] == digest, "audit_duplicate_changed")
+                        continue
+                    seen[event_id] = digest
+                    report["events"].append(
+                        {
+                            "eventTime": occurred.isoformat(),
+                            "eventName": name
+                            if name in crypto | management
+                            else "other_kms_event",
+                            "cryptographicOperation": name in crypto,
+                            "unclassifiedOperation": name not in crypto | management,
+                            "reportedError": bool(
+                                raw.get("errorCode") or raw.get("errorMessage")
+                            ),
+                            "matchesRetainedSourceCredential": (
+                                principal["accessKeyId"]
+                                == environment["AWS_ACCESS_KEY_ID"]
+                                if "accessKeyId" in principal
+                                else None
+                            ),
+                            "principalSha256": hashlib.sha256(
+                                json.dumps(
+                                    {
+                                        key: principal.get(key)
+                                        for key in ["type", "arn", "principalId"]
+                                    },
+                                    sort_keys=True,
+                                ).encode()
+                            ).hexdigest(),
+                        }
+                    )
+                token = page.get("NextToken")
+                if token is None:
+                    query["complete"] = True
+                    break
+                require(
+                    isinstance(token, str)
+                    and 0 < len(token) <= 16384
+                    and token not in tokens,
+                    "invalid_audit_pagination",
+                )
+                tokens.add(token)
+            require(query["complete"], "audit_page_limit_reached")
+        report["events"].sort(
+            key=lambda event: (event["eventTime"], event["eventName"])
+        )
+        report["totals"] = {
+            "uniqueEvents": len(report["events"]),
+            "cryptographicOperations": sum(
+                event["cryptographicOperation"] for event in report["events"]
+            ),
+            "unclassifiedOperations": sum(
+                event["unclassifiedOperation"] for event in report["events"]
+            ),
+            "reportedErrors": sum(event["reportedError"] for event in report["events"]),
+        }
+        report["collectionComplete"] = True
+        report["result"] = "collected"
+    except BaseException as error:
+        report["result"] = "failed"
+        report["failure"] = (
+            str(error) if isinstance(error, MigrationError) else "unexpected_error"
+        )
+        if isinstance(error, AwsOperationError):
+            report["awsFailure"] = error.details
+        raise
+    finally:
+        report["finishedAt"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        (output / "source-audit.json").write_text(json.dumps(report, indent=2) + "\n")
+
+
 def main():
     mode = required_env("KMS_OPERATION")
-    require(mode in {"verify", "verify-business", "migrate"}, "invalid_operation")
+    require(
+        mode in {"verify", "verify-business", "migrate", "source-audit"},
+        "invalid_operation",
+    )
     workflow = {
         "verify": "kms-production-preflight.yml",
         "verify-business": "kms-production-business-verify.yml",
         "migrate": "kms-production-migrate.yml",
+        "source-audit": "kms-production-preflight.yml",
     }[mode]
     require(
         required_env("GITHUB_REPOSITORY") == "vm0-ai/vm0"
@@ -435,6 +683,9 @@ def main():
         re.fullmatch(r"[0-9a-f]{64}", required_env("EXPECTED_BACKUP_SHA256")),
         "invalid_backup_digest",
     )
+    if mode == "source-audit":
+        source_audit()
+        return
     expected = required_env("EXPECTED_DEPLOYMENT_ID")
     require(re.fullmatch(r"dpl_[A-Za-z0-9]+", expected), "invalid_expected_deployment")
     cursor = os.environ.get("CURSOR", "")

--- a/.github/scripts/tests/fixtures/kms-production-source-audit-tools.py
+++ b/.github/scripts/tests/fixtures/kms-production-source-audit-tools.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Fixed read-only provider boundaries for the production source audit CLI."""
+
+import json
+import os
+from pathlib import Path
+import sys
+
+
+binary = Path(sys.argv[0])
+state_path = binary.parent.parent / "provider.json"
+state = json.loads(state_path.read_text())
+arguments = sys.argv[1:]
+scenario = state["scenario"]
+source = state["snapshot"]["sourceKeyArn"]
+result = None
+status = 200
+
+if binary.name == "curl":
+    url = next(value for value in arguments if value.startswith("https://"))
+    if ".actions.githubusercontent.com/" in url:
+        state["calls"].append("oidc")
+        result = {"value": "synthetic-oidc-secret"}
+    elif url == "https://api.doppler.com/v3/auth/oidc":
+        state["calls"].append("doppler-auth")
+        assert json.loads(sys.stdin.read())["token"] == "synthetic-oidc-secret"
+        result = {"token": "synthetic-doppler-secret"}
+    else:
+        assert url == (
+            "https://api.doppler.com/v3/configs/config/secrets?"
+            "project=vm0-kms-rollback-32264&config=prd&include_managed_secrets=false"
+        )
+        assert arguments[arguments.index("--request") + 1] == "GET"
+        state["calls"].append("backup-read")
+        raw = json.dumps(state["snapshot"], separators=(",", ":"))
+        if scenario == "backup-changed":
+            raw += " "
+        result = {
+            "secrets": {
+                "KMS_BACKUP_JSON": {
+                    "raw": raw,
+                    "computed": raw,
+                    "rawVisibility": "masked",
+                    "computedVisibility": "masked",
+                }
+            }
+        }
+    state_path.write_text(json.dumps(state))
+    print(json.dumps(result) + "\n" + str(status), end="")
+    sys.exit(0)
+
+assert binary.name == "aws"
+assert os.environ["AWS_ACCESS_KEY_ID"] == "synthetic-source-access-key"
+assert not os.environ.get("AWS_SESSION_TOKEN")
+for name in [
+    "VERCEL_TOKEN",
+    "NEON_API_KEY",
+    "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+    "DOPPLER_SERVICE_IDENTITY_ID",
+    "AWS_ENDPOINT_URL",
+]:
+    assert name not in os.environ
+assert arguments[-4:] == ["--region", "us-west-2", "--output", "json"]
+if arguments[:2] == ["sts", "get-caller-identity"]:
+    state["calls"].append("source-sts")
+    result = {
+        "Account": "072707626411",
+        "Arn": "arn:aws:iam::072707626411:user/vm0-kms-prod",
+    }
+    if scenario == "wrong-account":
+        result["Account"] = "251964670836"
+else:
+    assert arguments[:3] == ["cloudtrail", "lookup-events", "--no-paginate"]
+    file = Path(
+        arguments[arguments.index("--cli-input-json") + 1].removeprefix("file://")
+    )
+    payload = json.loads(file.read_text())
+    assert json.loads(file.read_text()) == payload
+    assert payload["MaxResults"] == 50
+    assert payload["StartTime"] == state["windowStart"]
+    assert payload["LookupAttributes"][0]["AttributeKey"] == "ResourceName"
+    resource = payload["LookupAttributes"][0]["AttributeValue"]
+    assert resource in {source, source.rsplit("/", 1)[1]}
+    state["calls"].append("lookup-arn" if resource == source else "lookup-id")
+    if scenario == "denied" or (scenario == "partial-denied" and resource != source):
+        state_path.write_text(json.dumps(state))
+        print("synthetic-provider-secret-must-not-leak")
+        print(
+            "An error occurred (AccessDeniedException) when calling the LookupEvents operation: synthetic-provider-secret-must-not-leak",
+            file=sys.stderr,
+        )
+        sys.exit(255)
+    event_id = "11111111-2222-3333-4444-555555555555"
+    name = "Decrypt" if scenario in {"crypto", "partial-denied"} else "DescribeKey"
+    if scenario == "unknown-event":
+        name = "synthetic-provider-secret-must-not-leak"
+    raw = {
+        "eventID": event_id,
+        "eventSource": "kms.amazonaws.com",
+        "awsRegion": "us-west-2",
+        "recipientAccountId": "072707626411",
+        "eventTime": state["eventTime"],
+        "eventName": name,
+        "userIdentity": {
+            "type": "IAMUser",
+            "arn": "synthetic-private-identity",
+            "principalId": "synthetic-private-principal",
+            "accessKeyId": "synthetic-source-access-key",
+        },
+        "requestParameters": {"secret": "synthetic-provider-secret-must-not-leak"},
+    }
+    if scenario == "wrong-event-scope":
+        raw["recipientAccountId"] = "251964670836"
+    if scenario == "duplicate-changed" and resource != source:
+        raw["requestParameters"] = {
+            "different": "synthetic-provider-secret-must-not-leak"
+        }
+    event = {
+        "EventId": event_id,
+        "EventName": name,
+        "Resources": [{"ResourceName": source}],
+        "CloudTrailEvent": json.dumps(raw),
+    }
+    result = {"Events": [] if scenario == "empty" else [event]}
+    if scenario == "pagination" and not payload.get("NextToken"):
+        result["NextToken"] = "synthetic-next-page-secret"
+    if scenario == "repeated-token":
+        result["NextToken"] = "synthetic-next-page-secret"
+state_path.write_text(json.dumps(state))
+print(json.dumps(result))

--- a/.github/scripts/tests/kms-production-source-audit-test.py
+++ b/.github/scripts/tests/kms-production-source-audit-test.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Exercise the real protected CLI with isolated AWS and Doppler commands."""
+
+import hashlib
+import datetime
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "kms-production-migration.py"
+TOOLS = HERE / "fixtures/kms-production-source-audit-tools.py"
+SOURCE = "arn:aws:kms:us-west-2:072707626411:key/a1b3922b-fab1-4ed3-aa9e-40f86f92a7a8"
+
+
+class SourceAuditCliTest(unittest.TestCase):
+    def invoke(self, scenario="empty", overrides=None):
+        with tempfile.TemporaryDirectory(prefix="kms-source-audit-test-") as directory:
+            root = Path(directory)
+            binary = root / "bin"
+            binary.mkdir()
+            for name in ["aws", "curl"]:
+                wrapper = binary / name
+                wrapper.write_text(TOOLS.read_text())
+                wrapper.chmod(0o700)
+            snapshot = {
+                "version": 1,
+                "sourceKeyArn": SOURCE,
+                "sourcePrincipal": "arn:aws:iam::072707626411:user/vm0-kms-prod",
+                "workflow": {
+                    "repository": "vm0-ai/vm0",
+                    "commit": "594d907ca844e845f674c04640a58ae8cebcdc8a",
+                    "runId": "34324494642",
+                },
+                "configuration": {
+                    "AWS_ACCESS_KEY_ID": "synthetic-source-access-key",
+                    "AWS_SECRET_ACCESS_KEY": "synthetic-source-secret",
+                    "AWS_REGION": "us-west-2",
+                    "SECRETS_KMS_KEY_ID": "alias/vm0-secrets-prod",
+                },
+            }
+            raw = json.dumps(snapshot, separators=(",", ":"))
+            start = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+                hours=2
+            )
+            state_path = root / "provider.json"
+            state_path.write_text(
+                json.dumps(
+                    {
+                        "scenario": scenario,
+                        "snapshot": snapshot,
+                        "calls": [],
+                        "windowStart": start.isoformat(),
+                        "eventTime": (
+                            start + datetime.timedelta(minutes=15)
+                        ).isoformat(),
+                    }
+                )
+            )
+            env = {
+                **os.environ,
+                "PATH": str(binary) + os.pathsep + os.environ["PATH"],
+                "KMS_OPERATION": "source-audit",
+                "SOURCE_AUDIT_WINDOW_START": start.isoformat(),
+                "RUNNER_TEMP": str(root),
+                "GITHUB_REPOSITORY": "vm0-ai/vm0",
+                "GITHUB_REF": "refs/heads/main",
+                "GITHUB_EVENT_NAME": "workflow_dispatch",
+                "GITHUB_RUN_ID": "12345",
+                "GITHUB_SHA": "a" * 40,
+                "GITHUB_WORKFLOW_REF": "vm0-ai/vm0/.github/workflows/kms-production-preflight.yml@refs/heads/main",
+                "EXPECTED_BACKUP_SHA256": hashlib.sha256(raw.encode()).hexdigest(),
+                "DOPPLER_SERVICE_IDENTITY_ID": "c0c87790-e651-45dd-b7fa-c5ed07bb990f",
+                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://pipelines.actions.githubusercontent.com/oidc",
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "synthetic-github-secret",
+                "VERCEL_TOKEN": "synthetic-vercel-secret",
+                "NEON_API_KEY": "synthetic-neon-secret",
+                "AWS_ENDPOINT_URL": "https://must-not-propagate.invalid",
+            }
+            env.pop("EXPECTED_DEPLOYMENT_ID", None)
+            env.update(overrides or {})
+            result = subprocess.run(
+                ["python3", str(SCRIPT)],
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=20,
+                check=False,
+            )
+            state = json.loads(state_path.read_text())
+            report_path = root / "kms-production-reports/source-audit.json"
+            report = (
+                json.loads(report_path.read_text()) if report_path.exists() else None
+            )
+            emitted = result.stdout + result.stderr + json.dumps(report)
+            for secret in [
+                "synthetic-source-access-key",
+                "synthetic-source-secret",
+                "synthetic-github-secret",
+                "synthetic-oidc-secret",
+                "synthetic-doppler-secret",
+                "synthetic-private-identity",
+                "synthetic-private-principal",
+                "synthetic-next-page-secret",
+                "synthetic-provider-secret-must-not-leak",
+            ]:
+                self.assertNotIn(secret, emitted)
+            self.assertEqual(state["snapshot"], snapshot)
+            self.assertFalse((root / "kms-production-canary").exists())
+            if report:
+                self.assertFalse(report["retirementCleared"])
+                self.assertFalse(report["kmsCallsMade"])
+                self.assertFalse(report["productionConfigurationChanged"])
+                self.assertFalse(report["staticCredentialsCreated"])
+                self.assertFalse(report["lateArrivalExcluded"])
+            return result, state, report
+
+    def test_empty_complete_window_makes_only_two_lookup_queries(self):
+        result, state, report = self.invoke()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(report["collectionComplete"])
+        self.assertEqual(report["totals"]["uniqueEvents"], 0)
+        self.assertEqual(
+            state["calls"],
+            [
+                "oidc",
+                "doppler-auth",
+                "backup-read",
+                "source-sts",
+                "lookup-arn",
+                "lookup-id",
+            ],
+        )
+
+    def test_pagination_and_duplicate_queries_count_an_event_once(self):
+        result, state, report = self.invoke("pagination")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual([query["pages"] for query in report["queries"]], [2, 2])
+        self.assertEqual(report["totals"]["uniqueEvents"], 1)
+        self.assertEqual(report["totals"]["cryptographicOperations"], 0)
+        self.assertTrue(report["events"][0]["matchesRetainedSourceCredential"])
+
+    def test_crypto_and_unclassified_events_remain_visible_without_raw_payloads(self):
+        for scenario, category in [
+            ("crypto", "cryptographicOperations"),
+            ("unknown-event", "unclassifiedOperations"),
+        ]:
+            with self.subTest(scenario=scenario):
+                result, _, report = self.invoke(scenario)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(report["totals"][category], 1)
+
+    def test_denied_or_incomplete_pages_never_report_a_complete_window(self):
+        for scenario in [
+            "denied",
+            "partial-denied",
+            "repeated-token",
+            "wrong-event-scope",
+            "duplicate-changed",
+        ]:
+            with self.subTest(scenario=scenario):
+                result, _, report = self.invoke(scenario)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse(report["collectionComplete"])
+                self.assertEqual(report["result"], "failed")
+                if "denied" in scenario:
+                    self.assertEqual(
+                        report["awsFailure"]["operation"], "cloudtrail:LookupEvents"
+                    )
+                    self.assertEqual(
+                        report["awsFailure"]["errorCode"], "AccessDeniedException"
+                    )
+                if scenario == "partial-denied":
+                    self.assertEqual(len(report["events"]), 1)
+
+    def test_bad_identity_and_changed_backup_stop_before_cloudtrail(self):
+        for scenario in ["wrong-account", "backup-changed"]:
+            with self.subTest(scenario=scenario):
+                result, state, report = self.invoke(scenario)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse(report["collectionComplete"])
+                self.assertFalse(
+                    any(call.startswith("lookup") for call in state["calls"])
+                )
+
+    def test_unprotected_context_and_verify_without_deployment_stop_before_providers(
+        self,
+    ):
+        for overrides in [
+            {"GITHUB_REF": "refs/heads/feature"},
+            {"GITHUB_EVENT_NAME": "pull_request"},
+            {"GITHUB_WORKFLOW_REF": "other-workflow"},
+            {"KMS_OPERATION": "verify"},
+        ]:
+            with self.subTest(overrides=overrides):
+                result, state, report = self.invoke(overrides=overrides)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(state["calls"], [])
+                self.assertIsNone(report)
+
+    def test_expired_history_window_stops_before_reading_credentials(self):
+        start = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+            days=91
+        )
+        result, state, report = self.invoke(
+            overrides={"SOURCE_AUDIT_WINDOW_START": start.isoformat()}
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(state["calls"], [])
+        self.assertEqual(report["failure"], "audit_window_expired")
+        self.assertFalse(report["collectionComplete"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/kms-production-source-audit-test.sh
+++ b/.github/scripts/tests/kms-production-source-audit-test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+python3 "$repo_root/.github/scripts/tests/kms-production-source-audit-test.py"

--- a/.github/workflows/kms-production-preflight.yml
+++ b/.github/workflows/kms-production-preflight.yml
@@ -6,9 +6,17 @@ env:
 on:
   workflow_dispatch:
     inputs:
-      expected_deployment_id:
-        description: "Current production API deployment ID, recorded before approval"
+      operation:
+        description: "Full production verification or read-only old-key CloudTrail audit"
         required: true
+        default: verify
+        type: choice
+        options:
+          - verify
+          - source-audit
+      expected_deployment_id:
+        description: "Required for verify: current production API deployment ID, recorded before approval"
+        required: false
         type: string
 
 concurrency:
@@ -32,18 +40,21 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        if: inputs.operation != 'source-audit'
         with:
           node-version: 22
       - name: Install migration dependencies
+        if: inputs.operation != 'source-audit'
         working-directory: turbo
         run: |
           corepack enable pnpm
           pnpm install --frozen-lockfile --ignore-scripts --filter @okouai/db...
           command -v aws
       - name: Verify target runtime, rollback reads, and all production ciphertext
+        if: inputs.operation != 'source-audit'
         working-directory: turbo/packages/db
         env:
-          KMS_OPERATION: verify
+          KMS_OPERATION: ${{ inputs.operation }}
           EXPECTED_BACKUP_SHA256: 60d1500d90c83a8b40996c3e9e6fbb9453ffbf598a9ae1c670d38f60b340e9f8
           EXPECTED_DEPLOYMENT_ID: ${{ inputs.expected_deployment_id }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -56,6 +67,14 @@ jobs:
           NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: python3 ../../../.github/scripts/kms-production-migration.py
+      - name: Read source-key CloudTrail history without KMS calls
+        if: inputs.operation == 'source-audit'
+        env:
+          KMS_OPERATION: source-audit
+          SOURCE_AUDIT_WINDOW_START: "2026-09-10T07:38:23.484Z"
+          EXPECTED_BACKUP_SHA256: 60d1500d90c83a8b40996c3e9e6fbb9453ffbf598a9ae1c670d38f60b340e9f8
+          DOPPLER_SERVICE_IDENTITY_ID: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+        run: python3 .github/scripts/kms-production-migration.py
       - name: Retain sanitized verification and operation checkpoint
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
Production KMS retirement needs a fresh source-key usage window without introducing synthetic KMS calls into that window. Add a read-only `source-audit` choice to the existing protected KMS Production Preflight workflow, reusing its reviewed Doppler rollback snapshot and verifying the source AWS identity before paginated CloudTrail queries.

The default full verification still requires a production deployment ID in the script. Source audit uses no database, deployment or target runtime secrets, and changes no credentials, KMS state or resources. It records coverage and sanitized evidence only; access denial, invalid scope and incomplete pagination fail closed, and retirement clearance remains false.

## Validation

- Seven targeted CLI tests passed with isolated AWS/Doppler process boundaries, covering pagination/deduplication, crypto and unknown operations, partial denial, corrupt scope, changed backup, wrong account, protected context, expired history and no secret export.
- Ruff, workflow/document Prettier, staged diff and repository file-size checks passed. Full repository verification runs through PR CI.

## Fallbacks

- `kms-production-migration.py:source_audit` uses the fixed `other_kms_event` label for provider operation names outside its output allowlist and records them as unclassified. Optional CloudTrail identity fields remain unavailable when absent; a missing access-key identifier is reported as unknown. These are external metadata/sanitization boundaries, not migration compatibility paths; they must not grant retirement clearance. They leave with the temporary retirement audit tooling after #32264.

Refs #32264.
