### PR TITLE
ci: fix runner retirement process inspection

### DIFF
--- a/.github/scripts/kms-production-exit-check.py
+++ b/.github/scripts/kms-production-exit-check.py
@@ -178,7 +178,6 @@ SERVICE_STATES = {
     },
     "UnitFileState": {
         "",
-        "not-found",
         "enabled",
         "enabled-runtime",
         "linked",
@@ -244,7 +243,7 @@ def missing_registry_evidence(directory):
         # Command lines may contain credentials: keep them in host memory and
         # export only a count. This does not prove absence of all retained state.
         processes = subprocess.run(
-            ["ps", "-C", "runner", "-o", "args=", "--ww"],
+            ["ps", "-C", "runner", "-o", "args=", "-ww"],
             capture_output=True,
             text=True,
             timeout=15,
@@ -280,7 +279,7 @@ def missing_registry_evidence(directory):
             serviceReturnCode=child.returncode, serviceStderrPresent=bool(child.stderr)
         )
         require(
-            child.returncode in (0, 1, 4) and len(child.stdout) <= 4096,
+            child.returncode in (0, 1) and len(child.stdout) <= 4096,
             "service_state_unavailable",
         )
         diagnostics["stage"] = "service_properties"

--- a/.github/scripts/kms-production-exit-check.py
+++ b/.github/scripts/kms-production-exit-check.py
@@ -178,6 +178,7 @@ SERVICE_STATES = {
     },
     "UnitFileState": {
         "",
+        "not-found",
         "enabled",
         "enabled-runtime",
         "linked",
@@ -216,6 +217,15 @@ def validate_service_state(service):
 def missing_registry_evidence(directory):
     """Read metadata only. Runner maintenance commands can clean state."""
     evidence = {"runnerVersion": directory.name, "collectionComplete": False}
+    diagnostics = {
+        "stage": "directory",
+        "directoryEntryCount": None,
+        "configFileOnly": None,
+        "serviceReturnCode": None,
+        "serviceStderrPresent": None,
+        "serviceProperties": {},
+        "matchingRunnerCommandLines": None,
+    }
     try:
         before = directory.stat(follow_symlinks=False)
         require(stat.S_ISDIR(before.st_mode), "invalid_runner_directory")
@@ -226,36 +236,10 @@ def missing_registry_evidence(directory):
             and entries[0].name == "runner.yaml"
             and stat.S_ISREG(entries[0].stat(follow_symlinks=False).st_mode)
         )
-        command = [
-            "systemctl",
-            "show",
-            "--all",
-            "--no-pager",
-            "--property=" + ",".join([*SERVICE_STATES, "MainPID", "ControlPID"]),
-            "vm0-runner-" + directory.name + ".service",
-        ]
-        child = subprocess.run(command, capture_output=True, text=True, timeout=15)
-        require(
-            child.returncode in (0, 1) and len(child.stdout) <= 4096,
-            "service_state_unavailable",
-        )
-        pairs = [line.split("=", 1) for line in child.stdout.splitlines()]
-        require(all(len(pair) == 2 for pair in pairs), "invalid_service_state")
-        service = strict_object(pairs)
-        for key in ("MainPID", "ControlPID"):
-            require(
-                isinstance(service.get(key), str)
-                and service[key].isascii()
-                and service[key].isdigit(),
-                "invalid_service_state",
-            )
-            service[key] = int(service[key])
-        validate_service_state(service)
-        require(
-            child.returncode == 0
-            or service["LoadState"] == "not-found"
-            and service["MainPID"] == service["ControlPID"] == 0,
-            "service_state_unavailable",
+        diagnostics.update(
+            directoryEntryCount=len(entries),
+            configFileOnly=config_only,
+            stage="process_command",
         )
         # Command lines may contain credentials: keep them in host memory and
         # export only a count. This does not prove absence of all retained state.
@@ -281,6 +265,50 @@ def missing_registry_evidence(directory):
         matches = sum(
             bool(version.search(line)) for line in processes.stdout.splitlines()
         )
+        diagnostics["matchingRunnerCommandLines"] = matches
+        diagnostics["stage"] = "service_command"
+        command = [
+            "systemctl",
+            "show",
+            "--all",
+            "--no-pager",
+            "--property=" + ",".join([*SERVICE_STATES, "MainPID", "ControlPID"]),
+            "vm0-runner-" + directory.name + ".service",
+        ]
+        child = subprocess.run(command, capture_output=True, text=True, timeout=15)
+        diagnostics.update(
+            serviceReturnCode=child.returncode, serviceStderrPresent=bool(child.stderr)
+        )
+        require(
+            child.returncode in (0, 1, 4) and len(child.stdout) <= 4096,
+            "service_state_unavailable",
+        )
+        diagnostics["stage"] = "service_properties"
+        pairs = [line.split("=", 1) for line in child.stdout.splitlines()]
+        require(all(len(pair) == 2 for pair in pairs), "invalid_service_state")
+        service = strict_object(pairs)
+        # Retain only known state values on failure, never raw command output.
+        diagnostics["serviceProperties"] = {
+            key: value
+            for key, value in service.items()
+            if key in SERVICE_STATES and value in SERVICE_STATES[key]
+        }
+        for key in ("MainPID", "ControlPID"):
+            require(
+                isinstance(service.get(key), str)
+                and service[key].isascii()
+                and service[key].isdigit(),
+                "invalid_service_state",
+            )
+            service[key] = int(service[key])
+        validate_service_state(service)
+        require(
+            child.returncode == 0
+            or service["LoadState"] == "not-found"
+            and service["MainPID"] == service["ControlPID"] == 0,
+            "service_state_unavailable",
+        )
+        diagnostics["stage"] = "directory_readback"
         after = directory.stat(follow_symlinks=False)
         unchanged = (before.st_dev, before.st_ino, before.st_mtime_ns) == (
             after.st_dev,
@@ -297,7 +325,11 @@ def missing_registry_evidence(directory):
             "matchingRunnerCommandLines": matches,
         }
     except (CheckError, OSError, ValueError, subprocess.TimeoutExpired):
-        return {**evidence, "error": "runner_state_unavailable"}
+        return {
+            **evidence,
+            "error": "runner_state_unavailable",
+            "diagnostics": diagnostics,
+        }
 
 
 def validate_missing_evidence(evidence):
@@ -310,11 +342,63 @@ def validate_missing_evidence(evidence):
     )
     if "error" in evidence:
         require(
-            set(evidence) == {"runnerVersion", "collectionComplete", "error"}
+            set(evidence)
+            == {"runnerVersion", "collectionComplete", "error", "diagnostics"}
             and evidence["collectionComplete"] is False
             and evidence["error"] == "runner_state_unavailable",
             "invalid_remote_report",
         )
+        diagnostics = evidence["diagnostics"]
+        require(
+            isinstance(diagnostics, dict)
+            and set(diagnostics)
+            == {
+                "stage",
+                "directoryEntryCount",
+                "configFileOnly",
+                "serviceReturnCode",
+                "serviceStderrPresent",
+                "serviceProperties",
+                "matchingRunnerCommandLines",
+            },
+            "invalid_remote_report",
+        )
+        require(
+            diagnostics["stage"]
+            in {
+                "directory",
+                "service_command",
+                "service_properties",
+                "process_command",
+                "directory_readback",
+            },
+            "invalid_remote_report",
+        )
+        for key, minimum, maximum in [
+            ("directoryEntryCount", 0, 10000),
+            ("matchingRunnerCommandLines", 0, 10000),
+            ("serviceReturnCode", -255, 255),
+        ]:
+            value = diagnostics[key]
+            require(
+                value is None or type(value) is int and minimum <= value <= maximum,
+                "invalid_remote_report",
+            )
+        for key in ["configFileOnly", "serviceStderrPresent"]:
+            require(
+                diagnostics[key] is None or type(diagnostics[key]) is bool,
+                "invalid_remote_report",
+            )
+        properties = diagnostics["serviceProperties"]
+        require(
+            isinstance(properties, dict) and set(properties) <= set(SERVICE_STATES),
+            "invalid_remote_report",
+        )
+        for key, value in properties.items():
+            require(
+                isinstance(value, str) and value in SERVICE_STATES[key],
+                "invalid_remote_report",
+            )
         return
     require(
         set(evidence)

--- a/.github/scripts/tests/kms-production-exit-check-test.py
+++ b/.github/scripts/tests/kms-production-exit-check-test.py
@@ -71,7 +71,7 @@ print("LoadState=not-found\\nActiveState=inactive\\nSubState=dead\\nUnitFileStat
         )
         self.tool(
             "ps",
-            "import sys\nassert sys.argv[1:]==['-C','runner','-o','args=','--ww']\nsys.exit(1)\n",
+            "import sys\nassert sys.argv[1:]==['-C','runner','-o','args=','-ww']\nsys.exit(1)\n",
         )
 
     def run_script(self, *args):
@@ -272,22 +272,18 @@ print(json.dumps(data)+"\\n200", end="")
         self.assertTrue(evidence["diagnostics"]["serviceStderrPresent"])
         self.assertEqual(evidence["diagnostics"]["serviceProperties"], {})
 
-    def test_not_found_service_exit_preserves_evidence_without_clearing_missing_registry(
-        self,
-    ):
+    def test_real_ps_accepts_wide_process_query(self):
         release = self.root / "runners" / "v1.2.3"
         release.mkdir(parents=True)
         (release / "runner.yaml").write_text(SECRET)
-        self.tool(
-            "systemctl",
-            'import sys\nprint("LoadState=not-found\\nActiveState=inactive\\nSubState=dead\\nUnitFileState=not-found\\nMainPID=0\\nControlPID=0")\nsys.exit(4)\n',
-        )
+        # Exercise the installed procps parser instead of teaching a fixture
+        # to accept the same invalid option as the production command.
+        (self.bin / "ps").unlink()
         result = self.run_script("runner-local", str(release.parent))
         inventory = json.loads(result.stdout)
         evidence = inventory["missingRegistryEvidence"][0]
         self.assertTrue(evidence["collectionComplete"])
         self.assertTrue(evidence["configFileOnly"])
-        self.assertEqual(evidence["service"]["LoadState"], "not-found")
         self.assertEqual(inventory["counts"]["unreadable"], 1)
 
     def test_invalid_service_values_preserve_directory_evidence_without_leaking(self):

--- a/.github/scripts/tests/kms-production-exit-check-test.py
+++ b/.github/scripts/tests/kms-production-exit-check-test.py
@@ -265,14 +265,45 @@ print(json.dumps(data)+"\\n200", end="")
         result = self.run_script("runner-local", str(release.parent))
         self.assertEqual(result.returncode, 0)
         evidence = json.loads(result.stdout)["missingRegistryEvidence"][0]
-        self.assertEqual(
-            evidence,
-            {
-                "runnerVersion": "v1.2.3",
-                "collectionComplete": False,
-                "error": "runner_state_unavailable",
-            },
+        self.assertFalse(evidence["collectionComplete"])
+        self.assertEqual(evidence["error"], "runner_state_unavailable")
+        self.assertEqual(evidence["diagnostics"]["directoryEntryCount"], 0)
+        self.assertEqual(evidence["diagnostics"]["serviceReturnCode"], 1)
+        self.assertTrue(evidence["diagnostics"]["serviceStderrPresent"])
+        self.assertEqual(evidence["diagnostics"]["serviceProperties"], {})
+
+    def test_not_found_service_exit_preserves_evidence_without_clearing_missing_registry(
+        self,
+    ):
+        release = self.root / "runners" / "v1.2.3"
+        release.mkdir(parents=True)
+        (release / "runner.yaml").write_text(SECRET)
+        self.tool(
+            "systemctl",
+            'import sys\nprint("LoadState=not-found\\nActiveState=inactive\\nSubState=dead\\nUnitFileState=not-found\\nMainPID=0\\nControlPID=0")\nsys.exit(4)\n',
         )
+        result = self.run_script("runner-local", str(release.parent))
+        inventory = json.loads(result.stdout)
+        evidence = inventory["missingRegistryEvidence"][0]
+        self.assertTrue(evidence["collectionComplete"])
+        self.assertTrue(evidence["configFileOnly"])
+        self.assertEqual(evidence["service"]["LoadState"], "not-found")
+        self.assertEqual(inventory["counts"]["unreadable"], 1)
+
+    def test_invalid_service_values_preserve_directory_evidence_without_leaking(self):
+        release = self.root / "runners" / "v1.2.3"
+        release.mkdir(parents=True)
+        (release / "runner.yaml").write_text(SECRET)
+        self.tool(
+            "systemctl",
+            'print("LoadState=not-found\\nActiveState=inactive\\nSubState=dead\\nUnitFileState=must-not-leak-secret\\nMainPID=0\\nControlPID=0")\n',
+        )
+        result = self.run_script("runner-local", str(release.parent))
+        evidence = json.loads(result.stdout)["missingRegistryEvidence"][0]
+        self.assertFalse(evidence["collectionComplete"])
+        self.assertTrue(evidence["diagnostics"]["configFileOnly"])
+        self.assertEqual(evidence["diagnostics"]["stage"], "service_properties")
+        self.assertNotIn("UnitFileState", evidence["diagnostics"]["serviceProperties"])
 
     def test_duplicate_registry_keys_cannot_silently_hide_source_values(self):
         release = self.root / "runners" / "v1.2.3"


### PR DESCRIPTION
The production exit check reported `runner_state_unavailable` for all three missing registries because its process query used `ps --ww`, which GNU procps rejects as an unknown long option. Use the valid `-ww` option and cover the production entry point with the installed `ps` parser.

Retain sanitized partial directory/process evidence, service exit status, and allowlisted state properties if another inspection step fails. Missing registries remain unreadable; this change does not relax systemd validation or grant retirement clearance. The remote program and strict report reader ship together from the same Actions checkout. Raw config, command lines and error text remain excluded.

Validation: 19 targeted CLI tests passed, including the real procps regression, partial failure evidence, invalid service values and secret non-disclosure. Ruff, diff and repository file-size checks passed. PR CI supplies repository checks.

Observed failure: https://github.com/vm0-ai/vm0/actions/runs/34566713893

Refs #32264.
