### PR TITLE
test: split projection, workflow, and connector timeout scenarios

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3017,15 +3017,16 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, filteredRun.runId, [200]);
   });
 
-  it("loads, deduplicates, and reuses an exact scoped runtime projection", async () => {
+  async function exactRuntimeProjection() {
     const api = createRunsApi(context);
     const fw = createFirewallApi(context);
     mockEnv(
       "R2_USER_STORAGES_BUCKET_NAME",
       `test-run-lifecycle-runtime-projection-${randomUUID()}`,
     );
+    const catalogVersion = `api-test-runtime-projection-${randomUUID()}`;
     await installApiTestConnectorCatalog({
-      catalogVersion: `api-test-runtime-projection-${randomUUID()}`,
+      catalogVersion,
       runtimeProjection: true,
     });
     await corruptApiTestConnectorCatalogRuntimeProjectionDigest("slack");
@@ -3049,6 +3050,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       });
     };
 
+    return { api, actor, runnerGroup, catalogVersion, createProjectedRun };
+  }
+
+  it("deduplicates concurrent scoped runtime projection loads and reuses the warm result", async () => {
+    const { api, actor, runnerGroup, createProjectedRun } =
+      await exactRuntimeProjection();
     const concurrentRuns = await Promise.all(
       Array.from({ length: 2 }, async (_, index) => {
         return await createProjectedRun(
@@ -3185,6 +3192,14 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       }),
     );
     await api.requestCancelRun(actor, repeatedRun.runId, [200]);
+  });
+
+  it("invalidates scoped runtime projection history when the catalog version changes", async () => {
+    const { api, actor, createProjectedRun } = await exactRuntimeProjection();
+    const initialRun = await createProjectedRun(
+      "warm the previous catalog identity",
+    );
+    await api.requestCancelRun(actor, initialRun.runId, [200]);
 
     const rotatedVersion = `api-test-projection-observation-${randomUUID()}`;
     await installApiTestConnectorCatalog({
@@ -3222,10 +3237,19 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       }),
     );
     await api.requestCancelRun(actor, resetRun.runId, [200]);
+  });
+
+  it("invalidates a scoped runtime projection when capabilities change at the same catalog version", async () => {
+    const { api, actor, catalogVersion, createProjectedRun } =
+      await exactRuntimeProjection();
+    const initialRun = await createProjectedRun(
+      "warm the previous capability identity",
+    );
+    await api.requestCancelRun(actor, initialRun.runId, [200]);
 
     mockOptionalEnv("CALCOM_OAUTH_CLIENT_ID", undefined);
     await installApiTestConnectorCatalog({
-      catalogVersion: rotatedVersion,
+      catalogVersion,
       runtimeProjection: true,
     });
     const capabilityRun = await createProjectedRun(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-mentions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-mentions.test.tsx
@@ -159,7 +159,7 @@ test("Hide mention suggestions when nothing useful matches", async () => {
     ...workspace.pageOptions,
   });
 
-  const user = userEvent.setup();
+  const user = userEvent.setup({ delay: null });
   const composer = await screen.findByRole("textbox", { name: "Message" });
   await user.click(composer);
   await user.keyboard("@beta");
@@ -278,6 +278,8 @@ test("Save a selected agent mention and retain it when returning to the chat", a
       "data-agent-avatar-url",
       ZETA_CURRENT_AVATAR,
     );
+  });
+  await waitFor(() => {
     expect(
       workspace.draftPatches.some((patch) => {
         return patch.draftUserMessage?.parts.some((part) => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-workflows.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-workflows.test.tsx
@@ -1,5 +1,5 @@
 import { HttpResponse } from "msw";
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   uploadsContract,
@@ -112,10 +112,22 @@ function templateTab(name: string): HTMLElement {
 async function openTemplateCategory(
   category: string,
   templateLabel = "Template",
-): Promise<void> {
+): Promise<HTMLElement> {
   click(await screen.findByLabelText(templateLabel));
-  await expect(screen.findByRole("dialog")).resolves.toBeVisible();
-  click(templateTab(category));
+  const dialog = await waitFor(() => {
+    const element = document.querySelector<HTMLElement>('[role="dialog"]');
+    if (!element) {
+      throw new Error("Expected the template picker dialog");
+    }
+    expect(element).toBeVisible();
+    return element;
+  });
+  const tab = templateTab(category);
+  click(tab);
+  await waitFor(() => {
+    expect(tab).toHaveAttribute("aria-selected", "true");
+  });
+  return dialog;
 }
 
 function structuredTemplateReferences(): HTMLElement[] {
@@ -397,7 +409,7 @@ async function openWorkflowRefreshChat(initialWorkflows: WorkflowFixture[]) {
     path: `/chats/${THREAD_ID}?sidebar=${SPLIT_THREAD_ID}`,
   });
 
-  const user = userEvent.setup();
+  const user = userEvent.setup({ delay: null });
   await waitFor(() => {
     expect(composerForThread(THREAD_ID)).toBeVisible();
     expect(composerForThread(SPLIT_THREAD_ID)).toBeVisible();
@@ -448,45 +460,45 @@ test("A newly available workflow highlights the existing draft without changing 
   });
 });
 
-test("Successive workflow updates reach both open composers without disrupting their drafts", async () => {
-  const { primaryEditor, splitEditor, user, traffic, updateWorkflows } =
-    await openWorkflowRefreshChat([workflow("release-report")]);
-  await waitFor(() => {
-    return expect(workflowHighlights(primaryEditor)).toHaveLength(1);
-  });
-  updateWorkflows([workflow("release-report"), workflow("first-live-change")]);
-  await waitFor(() => {
-    expect(traffic.requests.length).toBeGreaterThanOrEqual(4);
-  });
-  updateWorkflows([
-    workflow("release-report"),
-    workflow("first-live-change"),
-    workflow("latest-attached"),
-  ]);
+test.each([
+  { pane: "primary", threadId: THREAD_ID, input: " /latest", highlights: 2 },
+  { pane: "split", threadId: SPLIT_THREAD_ID, input: "/latest", highlights: 1 },
+])(
+  "Successive workflow updates reach the $pane composer while both panes are open",
+  async ({ threadId, input, highlights }) => {
+    const { primaryEditor, user, traffic, updateWorkflows } =
+      await openWorkflowRefreshChat([workflow("release-report")]);
+    await waitFor(() => {
+      return expect(workflowHighlights(primaryEditor)).toHaveLength(1);
+    });
+    updateWorkflows([
+      workflow("release-report"),
+      workflow("first-live-change"),
+    ]);
+    await waitFor(() => {
+      expect(traffic.requests.length).toBeGreaterThanOrEqual(4);
+    });
+    updateWorkflows([
+      workflow("release-report"),
+      workflow("first-live-change"),
+      workflow("latest-attached"),
+    ]);
 
-  await user.click(primaryEditor);
-  await user.keyboard(" /latest");
-  await waitFor(() => {
-    expect(slashButton("/latest-attached")).toBeVisible();
-  });
-  await user.keyboard("{Enter}");
-  await waitFor(() => {
-    expect(primaryEditor).toHaveTextContent("/latest-attached");
-  });
+    const editor = composerForThread(threadId);
+    await user.click(editor);
+    await user.keyboard(input);
+    await waitFor(() => {
+      expect(slashButton("/latest-attached")).toBeVisible();
+    });
+    await user.keyboard("{Enter}");
 
-  await user.click(splitEditor);
-  await user.keyboard("/latest");
-  await waitFor(() => {
-    expect(slashButton("/latest-attached")).toBeVisible();
-  });
-  await user.keyboard("{Enter}");
-
-  await waitFor(() => {
-    expect(workflowHighlights(primaryEditor)).toHaveLength(2);
-    expect(workflowHighlights(splitEditor)).toHaveLength(1);
-    expect(splitEditor).toHaveTextContent("/latest-attached");
-  });
-});
+    await waitFor(() => {
+      expect(workflowHighlights(editor)).toHaveLength(highlights);
+      expect(editor).toHaveTextContent("/latest-attached");
+      expect(primaryEditor).toHaveTextContent("/release-report");
+    });
+  },
+);
 
 test("Insert an attached workflow with slash suggestions", async () => {
   mockAgent();
@@ -841,16 +853,17 @@ test.each(["find", "send"])(
 
     await setupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     const editor = await findComposerEditor();
-    await openTemplateCategory("Workflow");
-    const search = screen.getByRole("textbox", { name: "Search templates" });
+    const dialog = await openTemplateCategory("Workflow");
+    const search = within(dialog).getByLabelText("Search templates");
+    expect(search).toBeVisible();
     await fill(
       search,
       action === "find" ? "merged pull requests" : template.title,
     );
     click(
-      await screen.findByLabelText(
+      await within(dialog).findByLabelText(
         `Select workflow template ${template.title}`,
       ),
     );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-drafts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-drafts.test.tsx
@@ -98,7 +98,9 @@ async function editSeparateConversationDrafts() {
     expect(document.body).toHaveTextContent("Keep this quoted requirement");
   });
   expect(secondComposer).not.toHaveTextContent("First conversation follow-up");
-  await userEvent.type(secondComposer, " and a separate note");
+  await userEvent
+    .setup({ delay: null })
+    .type(secondComposer, " and a separate note");
 
   await openConversation(first.id);
   return { second };

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
@@ -238,7 +238,7 @@ async function openConnectorFilterCatalog() {
   return { researchId };
 }
 
-test("Filter connected and disconnected connectors without losing a text search", async () => {
+test("Switch between connected and disconnected connector filters", async () => {
   await openConnectorFilterCatalog();
   click(getConnectorAction("button", "Filter connectors"));
   click(getConnectorAction("menuitem", "Connected"));
@@ -247,6 +247,13 @@ test("Filter connected and disconnected connectors without losing a text search"
     "connected",
   );
 
+  click(getConnectorAction("button", "Filter connectors"));
+  click(getConnectorAction("menuitem", "Not connected"));
+  await expectCards({ github: false, asana: true });
+});
+
+test("Retain a text search when clearing the connector connection filter", async () => {
+  await openConnectorFilterCatalog();
   click(getConnectorAction("button", "Filter connectors"));
   click(getConnectorAction("menuitem", "Not connected"));
   await expectCards({ github: false, asana: true });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/preferences-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/preferences-page.test.tsx
@@ -34,7 +34,12 @@ test("Debug preferences restore and change the voice input model", async () => {
     return expect(picker).toHaveTextContent("Gemini 3.6 Flash");
   });
   click(picker);
-  click(await screen.findByRole("option", { name: "ElevenLabs Scribe v2" }));
+  const option = await waitFor(() => {
+    const element = getFastRole("option", "ElevenLabs Scribe v2");
+    expect(element).toBeVisible();
+    return element;
+  });
+  click(option);
   await waitFor(() => {
     return expect(picker).toHaveTextContent("ElevenLabs Scribe v2");
   });
@@ -57,11 +62,12 @@ test("Debug preferences reset a saved voice input model to the default", async (
     expect(picker).toHaveTextContent("ElevenLabs Scribe v2");
   });
   click(picker);
-  click(
-    await screen.findByRole("option", {
-      name: "Default (Gemini 3.1 Flash-Lite)",
-    }),
-  );
+  const option = await waitFor(() => {
+    const element = getFastRole("option", "Default (Gemini 3.1 Flash-Lite)");
+    expect(element).toBeVisible();
+    return element;
+  });
+  click(option);
   await waitFor(() => {
     return expect(picker).toHaveTextContent("Default (Gemini 3.1 Flash-Lite)");
   });


### PR DESCRIPTION
The September 10 timeout audit missed an API scenario reported at exactly 4000ms, and current-main verification found additional slow or failing mapped cases. Split scoped projection reuse/invalidation, workflow refresh per composer pane, and connector filtering into seven independent cases. Each case retains its own real setup and the original observable contracts.

Reduce test interaction and query overhead for draft restoration, mention persistence/filtering, voice preferences, and workflow-template selection. Preserve actual keyboard events, rich draft content, debounce completion, visible controls, all assertions, and the existing 5000ms limits.

Relates to #33319. This consolidated follow-up covers T020, T022, T062, T070, T082, T117, T159 and the newly recorded T161. The audit stays open for the separately documented indivisible contracts and browser prerequisites.

Validation:
- All 63 tests across the five affected Platform files passed after the relevant fixes; all three API replacements passed against the owned local PostgreSQL database.
- Final targeted verification covers all 16 changed/helper-affected cases. Maximum measured duration on the final relevant code is 3241.294ms, leaving 1758.706ms before the unchanged default timeout. First failures and intermediate failures remain in the audit evidence.
- Scoped Prettier, Oxlint, type-aware Oxlint, ESLint, Platform/API test type checks and both workspace Knip checks passed. Missing local API core declarations were rebuilt through the existing typecheck script.
- Full suites and submitted-head timing are left to PR CI; no full local Vitest run or local dev server was used.
