### PR TITLE
fix(platform): align pinned agent collars with okou

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/avatar-svg-preview.tsx
+++ b/turbo/apps/platform/src/views/okou-page/avatar-svg-preview.tsx
@@ -1,4 +1,5 @@
 import { useGet } from "ccstate-react";
+import { cn } from "@okouai/ui";
 import {
   avatarFramingEnabled$,
   avatarNeckSweaterEnabled$,
@@ -8,6 +9,7 @@ import {
   AVATAR_HEAD_SLOT,
   avatarSvgComposition,
   avatarSvgContentTransform,
+  isLegacyAvatarSvgConfig,
   type ResolvedAvatarSvgConfig,
 } from "./avatar-svg-utils.ts";
 
@@ -16,6 +18,8 @@ interface AvatarSvgPreviewProps {
   size?: number;
   className?: string;
   centerContent?: boolean;
+  /** Keep the shared chin and collar aligned with adjacent brand avatars. */
+  preserveChinBaseline?: boolean;
   alt?: string;
   "data-testid"?: string;
 }
@@ -28,18 +32,22 @@ export function AvatarSvgPreview({
   size,
   className,
   centerContent = false,
+  preserveChinBaseline = false,
   alt,
   "data-testid": testId,
 }: AvatarSvgPreviewProps) {
   const neckSweater = useGet(avatarNeckSweaterEnabled$);
-  const framing = useGet(avatarFramingEnabled$);
+  const preserveBaseline =
+    preserveChinBaseline && neckSweater && !isLegacyAvatarSvgConfig(config);
+  const framing = useGet(avatarFramingEnabled$) && !preserveBaseline;
   const { behind, head, front, headOffsetY, contentOffsetY, contentScale } =
     avatarSvgComposition(config, { neckSweater, framing });
   // `centerContent` is the avatar maker asking for centering on its own while
-  // the framing switch is off; the rule centers every avatar once it ships, and
-  // the prop goes with the switch.
+  // the framing switch is off. Pinned rows keep the shared chin baseline instead
+  // of letting hair height move each collar to a different position.
   const transform = avatarSvgContentTransform({
-    contentOffsetY: framing || centerContent ? contentOffsetY : 0,
+    contentOffsetY:
+      !preserveBaseline && (framing || centerContent) ? contentOffsetY : 0,
     contentScale,
   });
   const layerClassName = "absolute inset-0 h-full w-full object-cover";
@@ -49,7 +57,12 @@ export function AvatarSvgPreview({
 
   return (
     <div
-      className={`relative overflow-hidden ${className ?? ""}`}
+      className={cn(
+        "relative overflow-hidden",
+        className,
+        // A circular mask would trim the collar at the shared canvas bottom.
+        preserveBaseline && "rounded-none",
+      )}
       style={size ? { width: size, height: size } : undefined}
       {...(alt ? { role: "img", "aria-label": alt } : undefined)}
       data-testid={testId}

--- a/turbo/apps/platform/src/views/okou-page/avatar-svg-preview.tsx
+++ b/turbo/apps/platform/src/views/okou-page/avatar-svg-preview.tsx
@@ -60,8 +60,9 @@ export function AvatarSvgPreview({
       className={cn(
         "relative overflow-hidden",
         className,
-        // A circular mask would trim the collar at the shared canvas bottom.
-        preserveBaseline && "rounded-none",
+        // Keep collars and tall hair intact when the shared chin baseline puts
+        // the top of a hairstyle just beyond the composition canvas.
+        preserveBaseline && "overflow-visible rounded-none",
       )}
       style={size ? { width: size, height: size } : undefined}
       {...(alt ? { role: "img", "aria-label": alt } : undefined)}

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -339,6 +339,7 @@ function PinnedAgentGridCard({
         <AgentAvatarImg
           name={agent.agentId}
           alt=""
+          preserveChinBaseline
           className={`block h-full w-full object-cover object-top ${
             isDefaultAgent ? "" : "rounded-full"
           }`}

--- a/turbo/apps/platform/src/views/okou-page/sidebar-shared.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-shared.tsx
@@ -108,12 +108,14 @@ export function AgentAvatarImg({
   alt,
   className,
   size,
+  preserveChinBaseline = false,
   "data-testid": testId,
 }: {
   name: string;
   alt: string;
   className: string;
   size?: number;
+  preserveChinBaseline?: boolean;
   "data-testid"?: string;
 }) {
   const { src, rawAvatarUrl } = useAgentAvatarState(name);
@@ -125,6 +127,7 @@ export function AgentAvatarImg({
       <AvatarSvgPreview
         config={svgConfig}
         size={size}
+        preserveChinBaseline={preserveChinBaseline}
         className={className}
         alt={alt}
         data-testid={testId}


### PR DESCRIPTION
When avatar framing is enabled, the pinned grid scales and centers composer avatars according to hair height while the fixed Okou image stays at its native position. Their necks and collars consequently appear at different heights.

Keep modern composer avatars on the shared chin baseline in the pinned grid. Preserve complete collars and tall hairstyles without a circular crop or container clipping. Other avatar surfaces, legacy avatars, and uploaded images retain their existing rendering.

## Verification

Tested commit: `e6099443ac73490d8e518bc784cc529efac1aa76`.

- Scoped Prettier, Oxlint, ESLint, style validation, commitlint, and Platform type checks passed.
- All eight App test shards and all three required CI gates passed on this head.
- Real deployed preview: https://pr-33453-app-okou-app-preview.vm0.workers.dev
- Deployment evidence: [Turbo run](https://github.com/vm0-ai/vm0/actions/runs/34571264453), App merge commit `b4596b5` includes this PR head; loaded App asset `index-DGBhAQ4k.js` matches deploy-app output.

| Browser checkpoint | Result | Evidence |
| --- | --- | --- |
| Okou and three composer avatars share chin/collar placement at 1440×1000 | PASS | [Light](https://a.okou.io/x0fsqs0mvn.png), [Dark](https://a.okou.io/qojhok2t6r.png) |
| Tall face/topknot retains its complete top; legacy and image avatars render | PASS | [Compatibility](https://a.okou.io/5zkqqu4ky6.png) |
| Hover tooltip, keyboard focus, Enter navigation, and selected state | PASS | [Focus and tooltip](https://a.okou.io/z3xczpogud.png) |
| Pin/unpin and drag reorder; order retained after reload; normal opacity restored | PASS | Exercised using real Pin dialog and browser drag action |
| Framing on/off with neck+sweater on retains the pinned baseline; neck+sweater off retains the existing head-only path | PASS | Lab controls and effective API switches verified; restored both on |
| Agents page retains ordinary avatar framing | PASS | Live DOM retains per-avatar transforms outside the pinned grid |
| iPhone 15 emulation at 393×852, DPR 3: menu, agent selection, auto-close, no horizontal overflow | PASS | [Mobile](https://a.okou.io/13zy704rgn.png) |

Setup: local Chromium 152; fresh `avatar-33453-0911a+clerk_test@example.com` test account. Preview protection and onboarding were bypassed because onboarding is outside this check. Six disposable avatar records were created through the preview API; all assessed components and styling came from the deployed PR. `avatarNeckSweater=true`, `avatarFraming=true`, `_realAgentInPreview=false` after testing. No chat run, local dev server, or full local Vitest run was needed. Native OS drag-image pixels are not included in Chromium page screenshots; drag completion and persistence were verified separately.
