### PR TITLE
docs(runner): clarify oversized background fill failure boundary

### DIFF
--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -24,9 +24,11 @@
 //!
 //! Entries above [`CACHE_MAX_SIZE`], entries without a content key, and
 //! reuse/repair actions pass through untouched.
-//! If the probe says an entry is cache-eligible but the full response exceeds
-//! [`CACHE_MAX_SIZE`], the cache fails closed instead of handing the same
-//! inconsistent URL to the guest.
+//! For a post-spawn background fill, if the probe says an entry is cache-eligible
+//! but the full response exceeds [`CACHE_MAX_SIZE`], the cache rejects publication
+//! and reports a background-fill failure. The original URL has already been handed
+//! to the guest; this failure does not revoke it or retroactively fail storage
+//! application.
 //!
 //! Runtime contract: `file://` URLs produced here point to guest-local archives
 //! staged under [`GUEST_STAGE_DIR`]. `guest-storage-apply` supports that scheme and


### PR DESCRIPTION
When a post-spawn background fill receives an oversized response after an eligible probe, the guest has already received the original download URL. Correct the storage-cache module documentation to describe cache publication rejection and failed-fill telemetry without promising that guest access is prevented or storage application fails retroactively.

This changes only module documentation. The separate pre-spawn owner/drain contract, runtime behavior, and existing regression assertions remain unchanged.

Closes #33439.

Validation:

- `cargo fmt --manifest-path crates/runner/Cargo.toml -- --check`
- `CARGO_BUILD_JOBS=2 cargo doc --manifest-path crates/Cargo.toml --profile local -p runner --no-deps --document-private-items`
- `git diff --check` and the repository file-size check
- Verified that runtime code, tests, and the pre-spawn documentation are byte-for-byte unchanged; reviewed the production caller and existing `full_download_over_probe_limit_fails_closed` assertions. Behavioral tests were not run for this documentation-only change.
