### PR TITLE
fix(rust): unify guest restore timezone validation

### DIFF
--- a/crates/guest-control-client/src/tests/guest_state_restore.rs
+++ b/crates/guest-control-client/src/tests/guest_state_restore.rs
@@ -11,6 +11,7 @@ use tokio::sync::oneshot;
 use crate::operation_tracker::NormalOperationReadiness;
 use crate::tests::support::{
     MockGuest, host_from_stream, make_pair, normal_operation_readiness, pending_request_count,
+    setup_host_and_mock_guest,
 };
 
 fn entropy() -> [u8; 256] {
@@ -82,6 +83,50 @@ async fn guest_state_restore_sends_fixed_request_and_decodes_result() {
     );
     release_tx.send(()).unwrap();
     guest.await.unwrap();
+}
+
+#[tokio::test]
+async fn guest_state_restore_rejects_empty_named_timezones_without_sending_request() {
+    let (host, mut guest) = setup_host_and_mock_guest().await;
+    let entropy = entropy();
+    for timezone in [
+        GuestStateRestoreTimezone::BestEffort(""),
+        GuestStateRestoreTimezone::Required(""),
+    ] {
+        let error = host
+            .guest_state_restore(1, 0, &entropy, timezone, 1, Duration::from_secs(1))
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    let (result, ()) = tokio::join!(
+        host.guest_state_restore(
+            1,
+            0,
+            &entropy,
+            GuestStateRestoreTimezone::Required("UTC"),
+            1,
+            Duration::from_secs(1),
+        ),
+        async {
+            let request = guest.expect_message(MSG_GUEST_STATE_RESTORE).await;
+            let decoded =
+                guest_control_proto::decode_guest_state_restore_request(&request.payload).unwrap();
+            assert_eq!(decoded.timezone, GuestStateRestoreTimezone::Required("UTC"));
+            guest
+                .send_response(
+                    MSG_GUEST_STATE_RESTORE_RESULT,
+                    request.seq,
+                    &success_payload(),
+                )
+                .await;
+        },
+    );
+    assert_eq!(
+        result.unwrap().termination,
+        ExecTermination::Exited { exit_code: 0 }
+    );
 }
 
 #[tokio::test]

--- a/crates/guest-control-proto/src/payloads/guest_state_restore.rs
+++ b/crates/guest-control-proto/src/payloads/guest_state_restore.rs
@@ -21,6 +21,9 @@ const TIMEZONE_BEST_EFFORT: u8 = 1;
 const TIMEZONE_REQUIRED: u8 = 2;
 
 /// Typed timezone behavior for the fixed guest-state restore operation.
+///
+/// Named modes require a non-empty name containing only ASCII letters, digits,
+/// `/`, `_`, `-`, and `+`, bounded by [`GUEST_STATE_RESTORE_MAX_TIMEZONE_BYTES`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GuestStateRestoreTimezone<'a> {
     /// Do not change timezone state.
@@ -267,6 +270,11 @@ fn validate_request(
         ));
     }
     let timezone_name = timezone_name(timezone);
+    if timezone_name.is_empty() && !matches!(timezone, GuestStateRestoreTimezone::None) {
+        return Err(ProtocolError::InvalidPayload(
+            "guest_state_restore timezone must not be empty",
+        ));
+    }
     if timezone_name.len() > GUEST_STATE_RESTORE_MAX_TIMEZONE_BYTES {
         return Err(ProtocolError::PayloadTooLarge(
             "timezone",
@@ -326,9 +334,6 @@ fn timezone_name(timezone: GuestStateRestoreTimezone<'_>) -> &str {
 fn decode_timezone(mode: u8, name: &str) -> Result<GuestStateRestoreTimezone<'_>, ProtocolError> {
     match (mode, name) {
         (TIMEZONE_NONE, "") => Ok(GuestStateRestoreTimezone::None),
-        (TIMEZONE_BEST_EFFORT, "") | (TIMEZONE_REQUIRED, "") => Err(ProtocolError::InvalidPayload(
-            "guest_state_restore timezone must not be empty",
-        )),
         (TIMEZONE_BEST_EFFORT, name) => Ok(GuestStateRestoreTimezone::BestEffort(name)),
         (TIMEZONE_REQUIRED, name) => Ok(GuestStateRestoreTimezone::Required(name)),
         (TIMEZONE_NONE, _) => Err(ProtocolError::InvalidPayload(

--- a/crates/guest-control-proto/tests/guest_state_restore_properties.rs
+++ b/crates/guest-control-proto/tests/guest_state_restore_properties.rs
@@ -25,6 +25,7 @@ const TIMEZONE_LENGTH_OFFSET: usize = 17;
 const TIMEZONE_NAME_OFFSET: usize = 19;
 
 const TIMEZONE_NONE: u8 = 0;
+const TIMEZONE_BEST_EFFORT: u8 = 1;
 const TIMEZONE_REQUIRED: u8 = 2;
 
 #[derive(Clone, Debug)]
@@ -592,6 +593,59 @@ proptest! {
             decode_guest_state_restore_result(&discarded_stderr_payload.unwrap()).is_err(),
             "accepted guest-state result with discarded stderr",
         );
+    }
+}
+
+#[test]
+fn payload_encoder_rejects_empty_named_timezones() {
+    let entropy = [0; GUEST_STATE_RESTORE_ENTROPY_BYTES];
+    for timezone in [
+        GuestStateRestoreTimezone::BestEffort(""),
+        GuestStateRestoreTimezone::Required(""),
+    ] {
+        assert!(matches!(
+            encode_guest_state_restore_request(1, 1, 0, &entropy, timezone),
+            Err(ProtocolError::InvalidPayload(
+                "guest_state_restore timezone must not be empty"
+            ))
+        ));
+    }
+}
+
+#[test]
+fn frame_encoder_rejects_empty_named_timezones_without_changing_buffer() {
+    let entropy = [0; GUEST_STATE_RESTORE_ENTROPY_BYTES];
+    for timezone in [
+        GuestStateRestoreTimezone::BestEffort(""),
+        GuestStateRestoreTimezone::Required(""),
+    ] {
+        let mut frame = vec![0xA5, 0x5A];
+        assert!(matches!(
+            encode_guest_state_restore_request_frame_into(
+                &mut frame, 42, 1, 1, 0, &entropy, timezone,
+            ),
+            Err(ProtocolError::InvalidPayload(
+                "guest_state_restore timezone must not be empty"
+            ))
+        ));
+        assert_eq!(frame, [0xA5, 0x5A]);
+    }
+}
+
+#[test]
+fn decoder_rejects_empty_named_timezones() {
+    let entropy = [0; GUEST_STATE_RESTORE_ENTROPY_BYTES];
+    let mut payload =
+        encode_guest_state_restore_request(1, 1, 0, &entropy, GuestStateRestoreTimezone::None)
+            .unwrap();
+    for mode in [TIMEZONE_BEST_EFFORT, TIMEZONE_REQUIRED] {
+        payload[TIMEZONE_MODE_OFFSET] = mode;
+        assert!(matches!(
+            decode_guest_state_restore_request(&payload),
+            Err(ProtocolError::InvalidPayload(
+                "guest_state_restore timezone must not be empty"
+            ))
+        ));
     }
 }
 


### PR DESCRIPTION
Empty `BestEffort` and `Required` timezone names previously passed both guest-state restore encoders but were rejected by the decoder, allowing the client to write an invalid request. Move the non-empty invariant into the existing shared request validator so these inputs fail locally with `InvalidInput`.

Add public-codec regressions for both named modes, frame-buffer preservation, and decoder rejection, plus a Unix socket client test proving no invalid request precedes a successful valid restore. Document the named-timezone contract. Public signatures, valid wire bytes, character/length limits, dependencies, and deployment configuration remain unchanged.

Closes #33441

### Validation

The new client and encoder regressions failed against the original production code; the decoder regression already passed. After the fix, all of the following passed:

- `cargo test --manifest-path crates/Cargo.toml --profile local -p guest-control-proto -p guest-control-client`
- `cargo fmt --manifest-path crates/guest-control-proto/Cargo.toml -p guest-control-proto -p guest-control-client --check`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p guest-control-proto -p guest-control-client --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml --profile local -p guest-control-proto -p guest-control-client --no-deps`

Validation used stable Rust 1.98.1. Live guest-helper/Firecracker execution was not run; the changed behavior is validated at the codec and real Unix socket client boundaries.
