### PR TITLE
perf(python): bound json nesting guard string scanning

### DIFF
--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -88,7 +88,8 @@ _SLOW_SCALAR_BYTES_PER_WORK_UNIT = 32
 _DISCARDED_STRING_BULK_BYTES_PER_WORK_UNIT = 64 * 1024
 JSON_WORK_LIMIT_EXCEEDED = "work limit exceeded"
 JSON_INTEGER_VALUE_LIMIT_EXCEEDED = "integer value limit exceeded"
-_JSON_STRING_OR_CONTAINER_RE = re.compile(rb'"(?:\\.|[^"\\])*"|[{}\[\]]', re.DOTALL)
+_JSON_CONTAINER_OR_QUOTE_RE = re.compile(rb'["{}\[\]]')
+_JSON_STRING_ESCAPE_OR_QUOTE_RE = re.compile(rb'["\\]')
 
 
 def _validate_positive_int(name: str, value: int) -> None:
@@ -103,19 +104,32 @@ def json_nesting_within_limit(body: bytes, *, max_depth: int = _DEFAULT_MAX_DEPT
 
     This is a boundedness guard, not a JSON validator. The fast path accepts
     payloads with at most ``max_depth`` opening delimiters. The slow path
-    ignores delimiters inside complete strings before tracking structural
-    object and array depth. Callers must still parse the body to validate it.
+    ignores delimiters inside strings before tracking structural object and
+    array depth, rejecting unterminated strings. Both paths take linear work
+    and constant auxiliary memory. Callers must still parse the body to
+    validate it.
     """
     _validate_positive_int("max_depth", max_depth)
     if body.count(b"{") + body.count(b"[") <= max_depth:
         return True
 
     depth = 0
-    for match in _JSON_STRING_OR_CONTAINER_RE.finditer(body):
+    position = 0
+    while match := _JSON_CONTAINER_OR_QUOTE_RE.search(body, position):
         token = body[match.start()]
+        position = match.end()
         if token == ord('"'):
-            continue
-        if token in (ord("{"), ord("[")):
+            # Search only unconsumed spans. Single-byte matches avoid retaining
+            # a long string's backtracking state or retrying a failed string
+            # from each escaped quote.
+            while string_match := _JSON_STRING_ESCAPE_OR_QUOTE_RE.search(body, position):
+                position = string_match.end()
+                if body[string_match.start()] == ord('"'):
+                    break
+                position += 1  # A backslash consumes the next byte, even a quote.
+            else:
+                return False
+        elif token in (ord("{"), ord("[")):
             depth += 1
             if depth > max_depth:
                 return False

--- a/crates/runner/mitm-addon/tests/test_x_tweet_create_nesting.py
+++ b/crates/runner/mitm-addon/tests/test_x_tweet_create_nesting.py
@@ -1,0 +1,147 @@
+"""Tweet-create nesting bounds through the response hook and usage webhook."""
+
+import json
+import tracemalloc
+
+import pytest
+
+import mitm_addon
+import usage
+from tests.x_flow_helpers import make_x_pipeline_flow
+
+
+@pytest.fixture
+def tweet_create_response(tmp_path, real_flow, usage_webhook_api, sync_usage_executor):
+    def run(request_body: bytes, *, status: int = 201):
+        flow = make_x_pipeline_flow(
+            real_flow,
+            tmp_path,
+            permission="tweet.write",
+            rule="POST /2/tweets",
+            response_status=status,
+        )
+        flow.request.method = "POST"
+        flow.request.content = request_body
+        assert flow.response is not None
+        flow.response.content = b'{"data":{"id":"1"}}'
+
+        with usage_webhook_api() as webhook:
+            tracemalloc.start()
+            try:
+                mitm_addon.response(flow)
+                peak_bytes = tracemalloc.get_traced_memory()[1]
+            finally:
+                tracemalloc.stop()
+            usage.flush_usage_events(trigger="test")
+
+        return webhook.usage_events(), peak_bytes
+
+    return run
+
+
+@pytest.mark.parametrize("quoted_brackets", [255, 256])
+def test_same_size_utf8_tweet_bounds_response_allocation(tweet_create_response, quoted_brackets):
+    body = (
+        b'{"text":"'
+        + b"[" * quoted_brackets
+        + b"a" * (256 - quoted_brackets)
+        + "中".encode() * 21756
+        + b'"}'
+    )
+    assert len(body) == 65535
+
+    events, peak_bytes = tweet_create_response(body)
+
+    [event] = events
+    assert event["category"] == "content.create"
+    assert event["quantity"] == 1
+    # Allow normal hook/JSON allocations, but not multi-MiB string-scan state.
+    assert peak_bytes < 1024 * 1024
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        pytest.param("[" * 256 + "a" * 65268, id="long-ascii"),
+        pytest.param("[" * 256 + '"' * 16384, id="escaped-quotes"),
+        pytest.param("[" * 256 + "\\" * 16384, id="escaped-backslashes"),
+    ],
+)
+def test_long_tweet_strings_keep_bounded_billing(tweet_create_response, text):
+    body = json.dumps({"text": text}, separators=(",", ":")).encode()
+
+    events, peak_bytes = tweet_create_response(body)
+
+    [event] = events
+    assert event["category"] == "content.create"
+    assert event["quantity"] == 1
+    assert peak_bytes < 1024 * 1024
+
+
+@pytest.mark.parametrize("nested_depth", [254, 255, 256])
+@pytest.mark.parametrize("ensure_ascii", [True, False])
+def test_quoted_delimiters_and_escapes_preserve_exact_depth(
+    tweet_create_response, nested_depth, ensure_ascii
+):
+    text = "[]{}" * 256 + '中☃\\"[\\\\]"{' + "\\"
+    prefix = json.dumps({"text": text}, ensure_ascii=ensure_ascii).encode()[:-1]
+    opens = [b"[" if index % 2 == 0 else b'{"x":' for index in range(nested_depth)]
+    closes = [b"]" if index % 2 == 0 else b"}" for index in reversed(range(nested_depth))]
+    body = prefix + b',"nested":' + b"".join(opens) + b"0" + b"".join(closes) + b"}"
+
+    events, _ = tweet_create_response(body)
+
+    [event] = events
+    # The root tweet object adds one level to the nested value.
+    expected = "content.create" if nested_depth <= 255 else "content.create_with_url"
+    assert event["category"] == expected
+    assert event["quantity"] == 1
+
+
+def test_many_shallow_containers_do_not_exhaust_depth(tweet_create_response):
+    body = b'{"text":"hello","items":[' + b",".join([b"{}"] * 512) + b"]}"
+
+    events, _ = tweet_create_response(body)
+
+    [event] = events
+    assert event["category"] == "content.create"
+    assert event["quantity"] == 1
+
+
+@pytest.mark.parametrize("pairs", [4096, 8192, 16384])
+@pytest.mark.parametrize("status", [201, 400])
+def test_unterminated_escaped_quotes_preserve_billing_gate(tweet_create_response, pairs, status):
+    body = b'{"text":"' + b'\\"' * pairs + b"[" * 256
+
+    events, peak_bytes = tweet_create_response(body, status=status)
+
+    if status == 201:
+        [event] = events
+        assert event["category"] == "content.create_with_url"
+        assert event["quantity"] == 1
+    else:
+        assert events == []
+    assert peak_bytes < 1024 * 1024
+
+
+@pytest.mark.parametrize("ending", [b"\\", b'\\"', b"\\\\"])
+def test_unterminated_string_endings_stay_conservative(tweet_create_response, ending):
+    events, _ = tweet_create_response(b'{"text":"' + b"[" * 256 + ending)
+
+    [event] = events
+    assert event["category"] == "content.create_with_url"
+    assert event["quantity"] == 1
+
+
+@pytest.mark.parametrize("body_size", [64 * 1024, 64 * 1024 + 1])
+def test_tweet_create_retains_request_inspection_byte_limit(tweet_create_response, body_size):
+    prefix = b'{"text":"' + b"[" * 256
+    suffix = b'"}'
+    body = prefix + b"a" * (body_size - len(prefix) - len(suffix)) + suffix
+
+    events, _ = tweet_create_response(body)
+
+    [event] = events
+    expected = "content.create" if body_size == 64 * 1024 else "content.create_with_url"
+    assert event["category"] == expected
+    assert event["quantity"] == 1


### PR DESCRIPTION
## Summary

A shallow 65,535-byte tweet-create request can force the JSON nesting guard to allocate about 8.4 MB while matching its string. Unterminated strings containing escaped quotes also trigger repeated suffix scans. Replace the complete-string regex with forward-only single-byte searches, preserving the raw-delimiter fast path and using constant auxiliary memory.

Add 23 response-hook/webhook regressions for quoted delimiters, escape parity, UTF-8, exact mixed-container depth, many shallow containers, long and unterminated strings, and the request byte limit. The existing 64 KiB admission limits, JSON validation, conservative billing and 2xx response gate remain intact. No schema, dependency or billing-policy change is included.

Closes #33445

## Measurements

Same locked CPython 3.14.0 environment, baseline `8c455bee21f6ab9fe34e952741f62cc00bc0ce1b`. Guard-only peak allocation uses tracemalloc; timings are independent, untraced medians of three calls. Inputs are constructed beforehand, using the issue's reproducer.

| Input | Peak bytes, before → after | Milliseconds, before → after |
| --- | ---: | ---: |
| 65,535-byte UTF-8, 255 quoted brackets | 0 → 0 | 0.058 → 0.064 |
| Same size, 256 quoted brackets | 8,426,223 → 1,582 | 3.393 → 0.294 |
| 65,535-byte ASCII string | 8,426,223 → 1,582 | 2.167 → 0.315 |
| Valid string, 16,384 escaped quotes | 2,206,403 → 1,582 | 0.433 → 3.228 |
| Unterminated, 4,096 escaped quotes | 575,903 → 1,582 | 272.721 → 0.808 |
| Unterminated, 8,192 escaped quotes | 1,128,053 → 1,582 | 1,096.488 → 1.645 |
| Unterminated, 16,384 escaped quotes | 2,206,403 → 1,582 | 4,266.597 → 3.205 |

Dense valid escapes trade native regex repetition for one Python step per escape, so that synthetic case is slower. Long ordinary strings improve, and malformed escaped strings now scale approximately linearly. These are local measurements, not production observations or evidence that X accepts malformed JSON.

## Validation

- The whole-response-hook allocation regression failed against the old implementation at 8,431,139 bytes while the same-size fast-path control passed; it passes after the change with a generous 1 MiB budget. CI has no wall-clock assertions.
- 23 new integration regressions passed: `uv run --no-sync python -m pytest tests/test_x_tweet_create_nesting.py -q`.
- 906 existing tests passed: `uv run --no-sync python -m pytest tests/test_json_selective_*.py tests/x_connector_usage/ tests/test_x_connector_pipeline.py tests/test_openai_chat_completions_usage.py -q`.
- Locked environment and static checks passed: `uv lock --check`, `uv sync --locked`, `uv run --no-sync ruff format --check .`, `uv run --no-sync ruff check .`, `uv run --no-sync basedpyright -p .`; the final added regression also passed targeted format/lint/type checks.
- Full addon and broader repository checks are left to PR CI. No local Vitest run or dev server was started.
