### PR TITLE
fix(runner): retry transient builtin catalog read failures

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -107,34 +107,43 @@ class BuiltinFirewallCatalogSnapshot:
       uses `cache_path_missing`.
     - Open or trust failure has no dependency or catalog, retains the absolute
       cache path, and uses the corresponding open-failure reason.
-    - Read, decode, schema, or validation failure has the opened file key and
-      absolute cache path, no catalog, and uses `cache_invalid`.
+    - Read, size, decode, schema, or validation failure has the opened file key
+      and absolute cache path, no catalog, and uses `cache_invalid`.
 
     `dependency_file_key` comes from the descriptor actually opened for this
-    snapshot, not a preliminary path stat. Registry snapshots compare it with
-    the current path identity to decide whether cached resolution remains valid.
+    snapshot, not a preliminary path stat. `reuse_by_identity` is true only for
+    success or deterministic size/decode/schema/validation rejection. I/O and
+    open/trust failures must be retried even if the identity is unchanged.
+    Both the loader and dependent registry snapshots use `can_reuse()`; the
+    diagnostic reason alone does not establish reuse eligibility.
     """
 
     dependency_file_key: CatalogFileKey | None
     catalog: BuiltinFirewallCatalog | None
     cache_path: str | None = None
     unavailable_reason: CatalogUnavailableReason | None = None
+    reuse_by_identity: bool = False
+
+    def can_reuse(self, file_key: CatalogFileKey | None) -> bool:
+        """Whether this result remains valid for the supplied file identity."""
+        return (
+            self.reuse_by_identity
+            and self.dependency_file_key is not None
+            and self.dependency_file_key == file_key
+        )
 
 
 @dataclass
 class _CatalogCacheState:
     path_key: str | None = None
-    loaded_key: CatalogFileKey | None = None
-    failed_key: CatalogFileKey | None = None
-    failed_reason: CatalogUnavailableReason | None = None
-    catalog: BuiltinFirewallCatalog | None = None
+    snapshot: BuiltinFirewallCatalogSnapshot | None = None
+    # Retry unchanged read failures, suppressing only their duplicate warnings.
+    read_error_key: CatalogFileKey | None = None
 
     def reset(self, path_key: str | None = None) -> None:
         self.path_key = path_key
-        self.loaded_key = None
-        self.failed_key = None
-        self.failed_reason = None
-        self.catalog = None
+        self.snapshot = None
+        self.read_error_key = None
 
 
 _cache_state = _CatalogCacheState()
@@ -224,41 +233,44 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
 
     with opened_file:
         key = opened_file.identity
-        if key == state.loaded_key:
-            return BuiltinFirewallCatalogSnapshot(key, state.catalog, cache_path=path_key)
-        if key == state.failed_key:
-            return BuiltinFirewallCatalogSnapshot(
-                key,
-                None,
-                cache_path=path_key,
-                unavailable_reason=state.failed_reason or "cache_invalid",
-            )
+        if state.snapshot is not None and state.snapshot.can_reuse(key):
+            return state.snapshot
+        reuse_by_identity = True
+        unavailable_reason: CatalogUnavailableReason | None = None
         try:
             catalog = _read_catalog(
                 opened_file.read_bytes(BUILTIN_FIREWALL_CATALOG_MAX_BYTES),
                 key,
             )
-        except (BuiltinFirewallCatalogCacheError, OSError, ValueError, RecursionError) as exc:
-            state.failed_key = key
-            state.failed_reason = "cache_invalid"
-            state.loaded_key = None
-            state.catalog = None
+        except (state_file.StateFileTooLargeError, ValueError, RecursionError) as exc:
+            catalog = None
+            unavailable_reason = "cache_invalid"
+            state.read_error_key = None
             addon_process_logging.emit_addon_process_event(
                 "warn",
                 f"Failed to read builtin firewall catalog cache: {exc}",
             )
-            return BuiltinFirewallCatalogSnapshot(
-                key,
-                None,
-                cache_path=path_key,
-                unavailable_reason=state.failed_reason,
-            )
+        except OSError as exc:
+            catalog = None
+            unavailable_reason = "cache_invalid"
+            reuse_by_identity = False
+            if state.read_error_key != key:
+                addon_process_logging.emit_addon_process_event(
+                    "warn",
+                    f"Failed to read builtin firewall catalog cache: {exc}",
+                )
+            state.read_error_key = key
+        else:
+            state.read_error_key = None
 
-    state.loaded_key = key
-    state.failed_key = None
-    state.failed_reason = None
-    state.catalog = catalog
-    return BuiltinFirewallCatalogSnapshot(key, catalog, cache_path=path_key)
+    state.snapshot = BuiltinFirewallCatalogSnapshot(
+        key,
+        catalog,
+        cache_path=path_key,
+        unavailable_reason=unavailable_reason,
+        reuse_by_identity=reuse_by_identity,
+    )
+    return state.snapshot
 
 
 def _open_error_unavailable_reason(exc: OSError) -> CatalogUnavailableReason:

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -502,6 +502,8 @@ def load_registry_state(registry_path: str) -> RegistryState:
     successful snapshot while valid entries remain in ``sandboxes`` and stay
     available for enforcement. They do not make the whole registry unavailable;
     requests for an invalid entry are blocked as ``invalid_registry_sandbox``.
+    A catalog dependency also owns its reuse eligibility: retryable catalog
+    failures rebuild the registry even when neither file identity has changed.
 
     ``stat_failed`` covers failures before a file identity is available, and
     later calls retry opening the path while the stat warning guard suppresses
@@ -535,8 +537,9 @@ def load_registry_state(registry_path: str) -> RegistryState:
         loaded_catalog_snapshot = state.snapshot.builtin_firewall_catalog_snapshot
         if key == state.snapshot.loaded_key and (
             loaded_catalog_snapshot is None
-            or registry_firewalls.catalog_file_key(builtin_catalog_cache_path)
-            == loaded_catalog_snapshot.dependency_file_key
+            or loaded_catalog_snapshot.can_reuse(
+                registry_firewalls.catalog_file_key(builtin_catalog_cache_path)
+            )
         ):
             state.unavailable = None
             state.stat_error_logged = False
@@ -582,7 +585,9 @@ def load_registry_state(registry_path: str) -> RegistryState:
         raw_registry,
         builtin_firewall_catalog_cache_path=builtin_catalog_cache_path,
     )
-    if invalid_sandboxes:
+    if invalid_sandboxes and (
+        key != state.snapshot.loaded_key or invalid_sandboxes != state.snapshot.invalid_sandboxes
+    ):
         addon_process_logging.emit_addon_process_event(
             "warn",
             f"Rejected {len(invalid_sandboxes)} invalid proxy registry sandbox entries",

--- a/crates/runner/mitm-addon/src/state_file.py
+++ b/crates/runner/mitm-addon/src/state_file.py
@@ -65,6 +65,10 @@ class StateFileNotRegularError(OSError):
     """The opened state-file path does not identify a regular file."""
 
 
+class StateFileTooLargeError(OSError):
+    """The opened state file exceeds the caller's bounded-read limit."""
+
+
 @dataclass(frozen=True)
 class OpenedStateFile:
     """State-file descriptor that passed the helper's baseline checks.
@@ -98,10 +102,13 @@ class OpenedStateFile:
         is rejected before any bytes are consumed. The method then probes one
         byte beyond the limit, so underreported or growing content is also
         rejected. Success returns at most ``max_bytes`` bytes; excess content
-        raises ``OSError``.
+        raises ``StateFileTooLargeError``. Other ``OSError`` failures report
+        actual I/O errors, allowing callers to choose a separate retry policy.
         """
         if self.identity.st_size > max_bytes:
-            raise OSError(f"{self.description} {self.path} exceeds {max_bytes} bytes")
+            raise StateFileTooLargeError(
+                f"{self.description} {self.path} exceeds {max_bytes} bytes"
+            )
 
         chunks: list[bytes] = []
         total = 0
@@ -114,7 +121,9 @@ class OpenedStateFile:
             total += len(chunk)
 
         if total > max_bytes:
-            raise OSError(f"{self.description} {self.path} exceeds {max_bytes} bytes")
+            raise StateFileTooLargeError(
+                f"{self.description} {self.path} exceeds {max_bytes} bytes"
+            )
         return b"".join(chunks)
 
 

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_core_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_core_cache.py
@@ -1,6 +1,7 @@
 """Tests for compiled built-in registry core-cache behavior and lifecycle."""
 
 import os
+from unittest.mock import patch
 
 import pytest
 
@@ -455,7 +456,7 @@ class TestRegistryBuiltinCoreCache:
             context = registry.get_sandbox_context("10.200.0.1", str(path))
             assert context is not None
             assert len(registry._registry_state.builtin_firewall_core_cache) == 1
-            retained_catalog = builtin_firewall_cache._cache_state.catalog
+            retained_catalog = builtin_firewall_cache.load_catalog_snapshot(str(cache_path)).catalog
             assert retained_catalog is not None
 
             path.write_text("{ broken")
@@ -464,7 +465,9 @@ class TestRegistryBuiltinCoreCache:
         assert isinstance(unavailable, registry.RegistryUnavailable)
         assert unavailable.reason == "parse_failed"
         assert registry._registry_state.builtin_firewall_core_cache == {}
-        assert builtin_firewall_cache._cache_state.catalog is retained_catalog
+        with patch.object(os, "read", side_effect=AssertionError("unexpected catalog reread")):
+            cached = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+        assert cached.catalog is retained_catalog
 
     def test_registry_dropping_builtin_entries_retains_shared_catalog(self, tmp_path, mitm_ctx):
         path = tmp_path / "registry.json"
@@ -486,7 +489,7 @@ class TestRegistryBuiltinCoreCache:
         ):
             context = registry.get_sandbox_context("10.200.0.1", str(path))
             assert context is not None
-            retained_catalog = builtin_firewall_cache._cache_state.catalog
+            retained_catalog = builtin_firewall_cache.load_catalog_snapshot(str(cache_path)).catalog
             assert retained_catalog is not None
 
             write_multi_sandbox_registry(path, {"10.200.0.1": inline_sandbox("run-inline")})
@@ -494,7 +497,9 @@ class TestRegistryBuiltinCoreCache:
             inline_context = registry.get_sandbox_context("10.200.0.1", str(path))
 
         assert inline_context is not None
-        assert builtin_firewall_cache._cache_state.catalog is retained_catalog
+        with patch.object(os, "read", side_effect=AssertionError("unexpected catalog reread")):
+            cached = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+        assert cached.catalog is retained_catalog
 
     def test_no_builtin_registry_fast_path_retains_shared_catalog(self, tmp_path, mitm_ctx):
         path = tmp_path / "registry.json"
@@ -513,7 +518,6 @@ class TestRegistryBuiltinCoreCache:
         ):
             first_context = registry.get_sandbox_context("10.200.0.1", str(path))
             assert first_context is not None
-            assert builtin_firewall_cache._cache_state.catalog is None
 
             snapshot = registry_firewalls.load_catalog_snapshot(str(cache_path))
             assert snapshot.catalog is not None
@@ -522,10 +526,10 @@ class TestRegistryBuiltinCoreCache:
             assert snapshot.catalog.identity.source == "cache"
             assert snapshot.catalog.identity.catalog_version == "catalog-a"
             assert snapshot.catalog.identity.file_key == snapshot.dependency_file_key
-            retained_catalog = builtin_firewall_cache._cache_state.catalog
-            assert retained_catalog is snapshot.catalog
 
             second_context = registry.get_sandbox_context("10.200.0.1", str(path))
 
         assert second_context is not None
-        assert builtin_firewall_cache._cache_state.catalog is retained_catalog
+        with patch.object(os, "read", side_effect=AssertionError("unexpected catalog reread")):
+            cached = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+        assert cached.catalog is snapshot.catalog

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_recovery.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_recovery.py
@@ -1,0 +1,217 @@
+"""Recovery contracts for catalog reads and dependent registry snapshots."""
+
+import errno
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import builtin_firewall_cache
+import matching
+import mitm_addon
+import registry
+import state_file
+from tests.registry_builtin_helpers import cache_firewall, write_registry_with_cache
+from tests.registry_helpers import builtin_sandbox, inline_sandbox
+
+
+def _write_recovery_files(tmp_path: Path) -> tuple[Path, Path]:
+    firewall = cache_firewall("example", "https://cache.example.com")
+    firewall["apis"][0]["auth"] = {"headers": {"Authorization": "Bearer ${{ secrets.TEST_TOKEN }}"}}
+    sandboxes = {
+        client_ip: {
+            **builtin_sandbox(f"run-{suffix}", "example"),
+            "sandboxToken": "test-token",
+            "encryptedSecrets": "iv:tag:data",
+            "networkPolicies": {
+                "example": {"allow": ["read"], "deny": [], "unknownPolicy": "deny"}
+            },
+        }
+        for client_ip, suffix in [("10.200.0.1", "one"), ("10.200.0.2", "two")]
+    }
+    sandboxes["10.200.0.3"] = inline_sandbox("run-inline")
+    return write_registry_with_cache(tmp_path, sandboxes, {"example": firewall})
+
+
+@contextmanager
+def _fail_catalog_reads(cache_path: Path) -> Iterator[None]:
+    catalog_stat = cache_path.stat()
+    real_read = os.read
+
+    def read(fd: int, size: int) -> bytes:
+        opened_stat = os.fstat(fd)
+        if (opened_stat.st_dev, opened_stat.st_ino) == (
+            catalog_stat.st_dev,
+            catalog_stat.st_ino,
+        ):
+            raise OSError(errno.EIO, "injected catalog read failure")
+        return real_read(fd, size)
+
+    with patch.object(state_file.os, "read", side_effect=read):
+        yield
+
+
+def test_catalog_recovers_after_same_identity_read_error(tmp_path, mitm_ctx):
+    _, cache_path = _write_recovery_files(tmp_path)
+
+    with mitm_ctx() as log:
+        with _fail_catalog_reads(cache_path):
+            failed = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+            for _ in range(3):
+                repeated = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+                assert repeated.catalog is None
+                assert repeated.unavailable_reason == "cache_invalid"
+
+        recovered = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+        assert recovered.catalog is not None
+        assert recovered.catalog.firewalls["example"]["apis"][0]["base"] == (
+            "https://cache.example.com"
+        )
+        assert recovered.dependency_file_key == failed.dependency_file_key
+        assert recovered.unavailable_reason is None
+        assert log.warn.call_count == 1
+
+        with patch.object(state_file.os, "read", side_effect=AssertionError("unexpected reread")):
+            cached = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+        assert cached.catalog is recovered.catalog
+
+
+@pytest.mark.parametrize("recover_catalog_first", [False, True])
+def test_registry_recovers_after_same_identity_catalog_read_error(
+    tmp_path, mitm_ctx, recover_catalog_first
+):
+    registry_path, cache_path = _write_recovery_files(tmp_path)
+
+    with mitm_ctx(registry_path=str(registry_path)) as log:
+        with _fail_catalog_reads(cache_path):
+            for _ in range(3):
+                failed = registry.load_registry_state(str(registry_path))
+                assert not isinstance(failed, registry.RegistryUnavailable)
+                assert set(failed.invalid_sandboxes) == {"10.200.0.1", "10.200.0.2"}
+                assert set(failed.sandboxes) == {"10.200.0.3"}
+                assert "10.200.0.1" not in failed.compiled_firewalls
+                assert "10.200.0.2" not in failed.compiled_firewalls
+            assert log.warn.call_count == 2
+
+        if recover_catalog_first:
+            # Isolate the outer cache even when the inner loader already recovered.
+            builtin_firewall_cache.clear_cache()
+            catalog = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+            assert catalog.catalog is not None
+
+        recovered = registry.load_registry_state(str(registry_path))
+        assert not isinstance(recovered, registry.RegistryUnavailable)
+        assert recovered.invalid_sandboxes == {}
+        assert recovered.loaded_key == failed.loaded_key
+        assert recovered.builtin_firewall_catalog_snapshot is not None
+        assert failed.builtin_firewall_catalog_snapshot is not None
+        assert recovered.builtin_firewall_catalog_snapshot.dependency_file_key == (
+            failed.builtin_firewall_catalog_snapshot.dependency_file_key
+        )
+        for client_ip in ("10.200.0.1", "10.200.0.2"):
+            compiled = recovered.compiled_firewalls[client_ip]
+            policies = recovered.compiled_network_policies[client_ip]
+            allowed = matching.match_compiled_firewall_request(
+                "https://cache.example.com/items", "GET", compiled, policies
+            )
+            blocked = matching.match_compiled_firewall_request(
+                "https://cache.example.com/items", "POST", compiled, policies
+            )
+            assert isinstance(allowed, matching.FirewallAllow)
+            assert isinstance(blocked, matching.FirewallBlock)
+            assert blocked.reason == "unknown_endpoint"
+        assert log.warn.call_count == 2
+
+
+async def test_request_recovers_after_catalog_read_error(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers
+):
+    registry_path, cache_path = _write_recovery_files(tmp_path)
+    failed_flow = real_flow(
+        with_response=False, client_ip="10.200.0.1", host="cache.example.com", path="/items"
+    )
+    recovered_flow = real_flow(
+        with_response=False, client_ip="10.200.0.1", host="cache.example.com", path="/items"
+    )
+
+    with (
+        mitm_ctx(registry_path=str(registry_path)),
+        fake_firewall_headers(headers={"Authorization": "Bearer recovered"}) as auth_fetch,
+    ):
+        with _fail_catalog_reads(cache_path):
+            await mitm_addon.request(failed_flow)
+        assert failed_flow.response is not None
+        assert failed_flow.response.status_code == 503
+        assert failed_flow.response.json()["error"] == "invalid_registry_sandbox"
+        assert failed_flow.request.headers.get("Authorization") is None
+        auth_fetch.assert_not_called()
+
+        await mitm_addon.request(recovered_flow)
+
+    assert recovered_flow.response is None
+    assert recovered_flow.request.headers["Authorization"] == "Bearer recovered"
+
+
+@pytest.mark.parametrize("invalid_content", ["json", "schema", "oversized"])
+def test_invalid_catalog_content_keeps_negative_cache(tmp_path, mitm_ctx, invalid_content):
+    registry_path, cache_path = _write_recovery_files(tmp_path)
+    if invalid_content == "json":
+        cache_path.write_text("{ broken")
+    elif invalid_content == "schema":
+        cache_path.write_text('{"schemaVersion": -1}')
+    limit = cache_path.stat().st_size - (invalid_content == "oversized")
+
+    with (
+        mitm_ctx(registry_path=str(registry_path)) as log,
+        patch.object(builtin_firewall_cache, "BUILTIN_FIREWALL_CATALOG_MAX_BYTES", limit),
+    ):
+        first_catalog = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+        first_registry = registry.load_registry_state(str(registry_path))
+        assert first_catalog.catalog is None
+        assert first_catalog.unavailable_reason == "cache_invalid"
+        assert not isinstance(first_registry, registry.RegistryUnavailable)
+        assert set(first_registry.invalid_sandboxes) == {"10.200.0.1", "10.200.0.2"}
+
+        with patch.object(state_file.os, "read", side_effect=AssertionError("unexpected reread")):
+            for _ in range(3):
+                cached_catalog = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+                cached_registry = registry.load_registry_state(str(registry_path))
+                assert cached_catalog.catalog is None
+                assert cached_registry is first_registry
+        assert log.warn.call_count == 2
+
+
+@pytest.mark.parametrize("unavailable", ["missing", "untrusted"])
+def test_unavailable_catalog_recovers_without_rewriting_registry(tmp_path, mitm_ctx, unavailable):
+    registry_path, cache_path = _write_recovery_files(tmp_path)
+    saved_path = cache_path.with_suffix(".saved")
+    if unavailable == "missing":
+        cache_path.rename(saved_path)
+    else:
+        cache_path.chmod(0o620)
+
+    with mitm_ctx(registry_path=str(registry_path)) as log:
+        for _ in range(3):
+            failed = registry.load_registry_state(str(registry_path))
+            assert not isinstance(failed, registry.RegistryUnavailable)
+            assert set(failed.invalid_sandboxes) == {"10.200.0.1", "10.200.0.2"}
+        assert log.warn.call_count == 1
+
+        if unavailable == "missing":
+            saved_path.rename(cache_path)
+        else:
+            cache_path.chmod(0o600)
+        recovered = registry.load_registry_state(str(registry_path))
+        assert not isinstance(recovered, registry.RegistryUnavailable)
+        assert recovered.invalid_sandboxes == {}
+        assert recovered.loaded_key == failed.loaded_key
+
+        # A new failure following recovery must still produce a rejection warning.
+        cache_path.rename(saved_path)
+        failed_again = registry.load_registry_state(str(registry_path))
+        assert not isinstance(failed_again, registry.RegistryUnavailable)
+        assert set(failed_again.invalid_sandboxes) == {"10.200.0.1", "10.200.0.2"}
+        assert log.warn.call_count == 2

--- a/crates/runner/mitm-addon/tests/test_state_file.py
+++ b/crates/runner/mitm-addon/tests/test_state_file.py
@@ -65,7 +65,7 @@ def test_rejects_initially_oversized_file(tmp_path: Path) -> None:
 
     with (
         state_file.open_state_file(path, description="test state") as opened_file,
-        pytest.raises(OSError, match=r"test state .* exceeds 3 bytes"),
+        pytest.raises(state_file.StateFileTooLargeError, match=r"test state .* exceeds 3 bytes"),
     ):
         opened_file.read_bytes(3)
 
@@ -76,7 +76,7 @@ def test_rejects_bytes_beyond_underreported_size() -> None:
 
     with (
         state_file.open_state_file(path, description="test state") as opened_file,
-        pytest.raises(OSError, match=r"test state .* exceeds 1 bytes"),
+        pytest.raises(state_file.StateFileTooLargeError, match=r"test state .* exceeds 1 bytes"),
     ):
         opened_file.read_bytes(1)
 


### PR DESCRIPTION
A transient catalog read error can leave valid built-in firewall entries rejected indefinitely, even after the same files become readable. Give catalog snapshots one identity-reuse predicate shared by the catalog loader and registry, so later requests retry failed reads and rebuild the affected compiled state.

Keep deterministic malformed/oversized content negatively cached, distinguish size-limit rejection with an `OSError` subtype, and suppress duplicate warnings during repeated failures. File formats, diagnostic categories, descriptor trust checks, and fail-closed enforcement remain unchanged.

Closes #33429.

## Validation

- The new recovery tests produced **4 expected failures and 5 passing controls** against unchanged source: direct catalog recovery, both registry recovery paths, and HTTP 503 recovery failed before the fix.
- **529 passed** with `uv run --no-sync python -m pytest tests/test_registry_*.py tests/test_state_file.py tests/test_request_handler_registry_admission.py tests/test_request_handler_builtin_host_policy.py tests/test_builtin_connector_diagnostics.py tests/test_builtin_host_policy_contract.py tests/test_firewall_base_url_validation_contract.py tests/test_runner_flush_request.py -q`.
- `uv lock --check`, `uv sync --locked`, `uv run --no-sync ruff format --check .`, `uv run --no-sync ruff check .`, and `uv run --no-sync basedpyright -p .` passed.

Sustained I/O failures are retried on later requests and can rebuild registry state until recovery; repeated identical rejection warnings stay bounded. No live Runner deployment was exercised.
