### PR TITLE
fix(platform): let flyout rows clip at the panel's own edge

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
@@ -787,6 +787,14 @@ function ModelPickerFlyoutPanel({
   const savedEffort = switches[FeatureSwitchKey.ChatReasoningEffort]
     ? props.value?.reasoningEffort
     : undefined;
+  const showSettingsRow =
+    !activeMedia &&
+    Boolean(props.value) &&
+    Boolean(selectedOption) &&
+    canAdjustChatSettings(
+      selectedOption,
+      efforts.length > 0 || Boolean(savedEffort),
+    );
   if (!activeMedia && page.kind === "settings" && props.value) {
     return (
       <div
@@ -807,7 +815,19 @@ function ModelPickerFlyoutPanel({
         ref={panelRef}
         role="listbox"
         aria-label={panelLabel}
-        className="flex max-h-[244px] flex-col gap-0.5 overflow-y-auto overscroll-contain"
+        className={cn(
+          // Rows have to appear and disappear at the card's own edge. The card
+          // insets this box by `p-1`, which left a blank band where a row was
+          // cut short of the border, so pull the box back over that inset and
+          // restate it as scroll padding: the list still rests clear of the
+          // border at either end, but a row mid-scroll runs to the edge.
+          // The heights keep the visible area at 244px either way.
+          "-mt-1 flex flex-col gap-0.5 overflow-y-auto overscroll-contain pt-1",
+          showSettingsRow
+            ? "max-h-[248px]"
+            : // Nothing follows, so the bottom reaches the card's edge too.
+              "-mb-1 max-h-[252px] pb-1",
+        )}
       >
         <ModelPickerFlyoutOptions
           {...props}
@@ -822,30 +842,24 @@ function ModelPickerFlyoutPanel({
           </p>
         )}
       </div>
-      {!activeMedia &&
-        props.value &&
-        selectedOption &&
-        canAdjustChatSettings(
-          selectedOption,
-          efforts.length > 0 || Boolean(savedEffort),
-        ) && (
-          <Button
-            variant="ghost"
-            className="h-9 shrink-0 justify-start gap-2 border-t border-border/60 px-2 text-xs text-muted-foreground"
-            aria-label={t(
-              ($) => {
-                return $.settings.models.picker.menu.adjustSettings;
-              },
-              { model: selectedOption.label },
-            )}
-            onClick={editSettings}
-          >
-            <SlidersHorizontal size={14} aria-hidden="true" />
-            {t(($) => {
-              return $.settings.models.picker.menu.chatSettings;
-            })}
-          </Button>
-        )}
+      {showSettingsRow && selectedOption && (
+        <Button
+          variant="ghost"
+          className="h-9 shrink-0 justify-start gap-2 border-t border-border/60 px-2 text-xs text-muted-foreground"
+          aria-label={t(
+            ($) => {
+              return $.settings.models.picker.menu.adjustSettings;
+            },
+            { model: selectedOption.label },
+          )}
+          onClick={editSettings}
+        >
+          <SlidersHorizontal size={14} aria-hidden="true" />
+          {t(($) => {
+            return $.settings.models.picker.menu.chatSettings;
+          })}
+        </Button>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Problem

A row scrolling out of the model panel is cut short of the card, leaving a blank
band between the cut and the border, so rows appear and disappear inside the
panel instead of at its edge.

The list is inset by the card's `p-1`, and overflow clips at the scroll
container's own box — that inset — not at the card's rounded edge. Measured on
the reported 2x screenshot: the glyphs stop at device `y=50`, then 8 rows of
white, then the border at `y=59`. That is the `4px` padding plus the `0.5px`
hairline.

## Change

Pull the list back over the inset with `-mt-1` / `-mb-1` and restate it as
scroll padding (`pt-1` / `pb-1`). The first and last rows still rest clear of
the border at the scroll extremes, but a row mid-scroll now runs to the edge.

The bottom bleeds only when nothing follows the list. With the chat-settings row
present, its `border-t` is the boundary, so only the top bleeds and the height
compensates. Both branches keep the visible area at `244px` and the card's
height unchanged, so nothing else moves.

The settings-row condition moves into `showSettingsRow` because the list's
class now depends on it; previously it was inlined in the JSX and could drift
from the geometry that assumes it.

`overflow-hidden` is deliberately not added: a row's own `rounded-lg` keeps its
hover fill inside the card's `12px` corner (verified below), and clipping the
card would also cut row focus rings.

## Verification

Rebuilt the panel from the production class strings against the App's real
Tailwind entry (`apps/platform/src/views/css/index.css`, v4.3.3) and measured in
Chromium at 2x:

| | card height | dead band, top | dead band, bottom | scrollable area |
| --- | --- | --- | --- | --- |
| before | 254px | 5px | 5px | 244px |
| after | 254px | **1px** (the hairline) | **1px** | 244px |

With the chat-settings row: card height 292px before and after, top band 5px ->
1px, list-to-divider gap 2px in both.

A hovered row clipped at the top edge stays inside the rounded corner with no
`overflow-hidden`, checked at 7x.

- `chat-composer-media-models.test.tsx` — 23 passed.
- `chat-composer-model-selection.test.tsx` — 21 passed.
- `pnpm lint:style` exits 0, plus `check-types`, `oxlint`, `prettier --check`.

## Not covered

The drill-in menu layout (`modelPickerMenu`) has the same artifact from
`PopoverContent`'s padding. It is a separate switch and a different fix, so it
is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)