### PR TITLE
feat(app-worker): serve static posthog oauth client metadata

### DIFF
--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -539,6 +539,62 @@ async function requestAppPage(origin) {
   return { html, response };
 }
 
+const posthogMetadataUrl =
+  "https://app.okou.ai/connectors/posthog/metadata.json";
+const posthogMetadataResponse = await worker.fetch(
+  new Request(posthogMetadataUrl),
+  {},
+);
+assert.equal(posthogMetadataResponse.status, 200);
+assert.equal(
+  posthogMetadataResponse.headers.get("content-type"),
+  "application/json; charset=UTF-8",
+);
+assert.equal(
+  posthogMetadataResponse.headers.get("cache-control"),
+  "public, max-age=300",
+);
+assert.equal(posthogMetadataResponse.headers.get("set-cookie"), null);
+assert.equal(
+  posthogMetadataResponse.headers.get("x-content-type-options"),
+  "nosniff",
+);
+const posthogMetadata = await posthogMetadataResponse.json();
+assert.equal(posthogMetadata.client_id, posthogMetadataUrl);
+assert.deepEqual(posthogMetadata.redirect_uris, [
+  "https://app.okou.ai/connectors/posthog/callback",
+]);
+assert.equal(posthogMetadata.token_endpoint_auth_method, "none");
+
+const posthogMetadataHead = await worker.fetch(
+  new Request(posthogMetadataUrl, { method: "HEAD" }),
+  {},
+);
+assert.equal(posthogMetadataHead.status, 200);
+assert.deepEqual(
+  [...posthogMetadataHead.headers],
+  [...posthogMetadataResponse.headers],
+);
+assert.equal(await posthogMetadataHead.text(), "");
+
+const posthogMetadataPost = await worker.fetch(
+  new Request(posthogMetadataUrl, { method: "POST" }),
+  {},
+);
+assert.equal(posthogMetadataPost.status, 405);
+assert.equal(posthogMetadataPost.headers.get("allow"), "GET, HEAD");
+
+const posthogCallbackResponse = await worker.fetch(
+  new Request("https://app.okou.ai/connectors/posthog/callback?code=test"),
+  {},
+);
+assert.equal(posthogCallbackResponse.status, 200);
+assert.equal(
+  posthogCallbackResponse.headers.get("content-type"),
+  "text/html; charset=UTF-8",
+);
+assert.equal(documentTitle(await posthogCallbackResponse.text()), okouTitle);
+
 const okouPage = await requestAppPage("https://app.okou.ai");
 assert.equal(okouPage.response.status, 200);
 assert.equal(

--- a/.github/scripts/tests/okou-app-worker-test.sh
+++ b/.github/scripts/tests/okou-app-worker-test.sh
@@ -44,10 +44,13 @@ printf '%s\n' \
 core_scope_dir="${tmp_dir}/node_modules/@okouai"
 mkdir -p "$core_scope_dir"
 ln -s "${repo_root}/turbo/packages/core" "${core_scope_dir}/core"
-cp "${repo_root}/turbo/apps/app-worker/src/worker.js" "${tmp_dir}/worker.mjs"
+mkdir -p "${tmp_dir}/src" "${tmp_dir}/assets"
+cp "${repo_root}/turbo/apps/app-worker/src/worker.js" "${tmp_dir}/src/worker.mjs"
+cp "${repo_root}/turbo/apps/app-worker/assets/posthog-metadata.json" \
+  "${tmp_dir}/assets/posthog-metadata.json"
 
 node "${repo_root}/.github/scripts/tests/okou-app-worker-test.mjs" \
-  "${tmp_dir}/worker.mjs" \
+  "${tmp_dir}/src/worker.mjs" \
   "${repo_root}/turbo/apps/platform/index.html" \
   "${repo_root}/turbo/apps/platform/public/manifest.webmanifest" \
   "${repo_root}/turbo/apps/app-worker/assets/favicon.ico.bin"

--- a/turbo/apps/app-worker/assets/posthog-metadata.json
+++ b/turbo/apps/app-worker/assets/posthog-metadata.json
@@ -1,0 +1,39 @@
+{
+  "client_id": "https://app.okou.ai/connectors/posthog/metadata.json",
+  "client_name": "Okou",
+  "client_uri": "https://okou.ai",
+  "logo_uri": "https://app.okou.ai/icons/icon-192.png",
+  "redirect_uris": ["https://app.okou.ai/connectors/posthog/callback"],
+  "grant_types": ["authorization_code", "refresh_token"],
+  "response_types": ["code"],
+  "application_type": "web",
+  "token_endpoint_auth_method": "none",
+  "com.posthog": {
+    "scopes": [
+      "openid",
+      "profile",
+      "email",
+      "user:read",
+      "project:read",
+      "feature_flag:read",
+      "feature_flag:write",
+      "experiment:read",
+      "experiment:write",
+      "insight:read",
+      "insight:write",
+      "dashboard:read",
+      "dashboard:write",
+      "action:read",
+      "action:write",
+      "annotation:read",
+      "annotation:write",
+      "cohort:read",
+      "cohort:write",
+      "event_definition:read",
+      "query:read",
+      "survey:read",
+      "survey:write",
+      "error_tracking:read"
+    ]
+  }
+}

--- a/turbo/apps/app-worker/src/worker.js
+++ b/turbo/apps/app-worker/src/worker.js
@@ -1,6 +1,10 @@
 import { createClerkClient } from "@clerk/backend";
 import { derivePlatformServiceOrigin } from "@okouai/core/platform-service-origin";
 
+import posthogClientMetadata from "../assets/posthog-metadata.json" with { type: "json" };
+
+const POSTHOG_CLIENT_METADATA_PATH = "/connectors/posthog/metadata.json";
+const POSTHOG_CLIENT_METADATA_BODY = JSON.stringify(posthogClientMetadata);
 const SHARED_THREAD_PATH =
   /^\/share\/threads\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/?$/iu;
 const PREVIEW_API_ORIGIN_PATTERN =
@@ -44,6 +48,7 @@ const EMBEDDED_SHELL_CONTENT_TYPES = new Map([
   ["/icons/icon-192.png", "image/png"],
   ["/icons/icon-512.png", "image/png"],
   ["/icons/icon-512-maskable.png", "image/png"],
+  [POSTHOG_CLIENT_METADATA_PATH, "application/json; charset=UTF-8"],
 ]);
 
 const OKOU_APP_METADATA = {
@@ -641,6 +646,8 @@ function embeddedShellAsset(pathname, embeddedShell) {
       return embeddedShell.icon512;
     case "/icons/icon-512-maskable.png":
       return embeddedShell.icon512Maskable;
+    case POSTHOG_CLIENT_METADATA_PATH:
+      return POSTHOG_CLIENT_METADATA_BODY;
     default:
       return embeddedShell.indexHtml;
   }
@@ -769,7 +776,9 @@ function withAppHeaders(response, requestUrl) {
   for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
     headers.set(name, value);
   }
-  if (requestUrl.pathname === "/sw.js") {
+  if (requestUrl.pathname === POSTHOG_CLIENT_METADATA_PATH && response.ok) {
+    headers.set("Cache-Control", "public, max-age=300");
+  } else if (requestUrl.pathname === "/sw.js") {
     headers.set("Cache-Control", "public, max-age=0, must-revalidate");
     headers.set("Service-Worker-Allowed", "/");
   } else if (requestUrl.pathname === "/robots.txt") {


### PR DESCRIPTION
## Summary

Requests to `https://app.okou.ai/connectors/posthog/metadata.json` currently return the App shell. Serve a committed PostHog Client ID Metadata Document (CIMD) through the App Worker's existing static resource handling, with `application/json`, GET/HEAD support, and a five-minute public cache.

The document declares Okou's production callback, logo, public-client authentication, and the 24 scopes currently requested by the PostHog connector. It is bundled into the Worker and needs no API service, proxy, or runtime credentials. The OAuth provider migration and connector rollout remain separate work tracked in #30508.

## Verification

- App Worker regression suite passed, including anonymous metadata retrieval, HEAD headers and empty body, unsupported methods, and the existing callback page.
- App Worker lint, TypeScript checks, and scoped Knip passed; changed files pass Prettier and shell syntax checks.
- Production Wrangler dry-run bundled the metadata successfully, using local shell fixtures from tracked App sources; nothing was deployed.
- All 24 declared scopes match the current connector catalog and PostHog's live OAuth discovery response.
