### PR TITLE
ci: inspect isolated snapshots before kms retirement

### DIFF
--- a/.github/kms-migration-32264/README.md
+++ b/.github/kms-migration-32264/README.md
@@ -4,6 +4,10 @@ The production application remains the existing `vm0-kms-prod` IAM user.
 GitHub Actions uses a separate OIDC role for ciphertext rewrap. No new access
 keys or static operator credentials are required.
 
+The production backfill is complete. Follow the
+[permanent retirement plan](permanent-retirement.md) for retained recovery
+dependencies and isolated snapshot inspection before scheduling old-key deletion.
+
 ## One-time IAM prerequisite
 
 An AWS administrator must provision or reconcile this exact role in account

--- a/.github/kms-migration-32264/permanent-retirement.md
+++ b/.github/kms-migration-32264/permanent-retirement.md
@@ -1,0 +1,116 @@
+# Permanent production KMS retirement
+
+The requested end state is permanent deletion of the old **production** key:
+`arn:aws:kms:us-west-2:072707626411:key/a1b3922b-fab1-4ed3-aa9e-40f86f92a7a8`.
+Its replacement is
+`arn:aws:kms:us-west-2:251964670836:key/e68917e2-5541-4597-b6ef-7e9eb5670947`.
+Keep the old key enabled while retained recovery paths still need it. This plan
+does not retire staging, the old account, historical audit logs, CloudTrail, or
+AWS Config.
+
+## Accepted evidence and remaining dependencies
+
+- [Full verification 34449151278](https://github.com/vm0-ai/vm0/actions/runs/34449151278)
+  completed at `2026-09-10T07:38:23.484Z`: 77,331 verified fields with no source
+  or nested source references. The backfill is complete; do not repeat it.
+- [Target audit 34556455859, attempt 2](https://github.com/vm0-ai/vm0/actions/runs/34556455859/attempts/2)
+  verified actual CloudTrail and Config delivery into the new S3 buckets.
+- [Dependency inspection 34569228115](https://github.com/vm0-ai/vm0/actions/runs/34569228115)
+  read 59 target headers and no source headers from 15 runner registries.
+  Three missing registries are stable configuration-only `v0.190.0` directories,
+  without a loaded service, service PID, or matching runner process. The automated
+  inventory remains incomplete; its gate has not been weakened.
+- The same inspection listed 14 daily Neon snapshots with 14-day retention and
+  one manual snapshot without reported expiration. Snapshot timestamps/LSNs were
+  absent. Creation dates alone do not prove which historical data is stored.
+  The latest reported expiration was `2026-09-25T00:00:14Z`; actual disappearance
+  must be checked later.
+- The configured 24-hour PITR window clears the accepted verification timestamp
+  at `2026-09-11T07:38:23.484Z`. This arithmetic does not verify the earliest
+  actually restorable point or remove independent snapshot history.
+- [Source audit 34567634207](https://github.com/vm0-ai/vm0/actions/runs/34567634207)
+  verified the old IAM identity, then failed with `AccessDeniedException` on
+  `cloudtrail:LookupEvents`. No event pages were collected. The temporary read
+  grant remains required on `arn:aws:iam::072707626411:user/vm0-kms-prod`, scoped
+  to `us-west-2`; this is not a zero-usage result.
+
+## Isolated snapshot inspection
+
+Run **KMS Recovery Snapshot Inspect** from `main` through the protected
+`production` environment. Select the exact snapshot ID SHA-256 and creation
+timestamp from a reviewed **KMS Production Exit Dependencies** artifact. The
+defaults identify the manual snapshot created `2026-02-16T05:57:00Z`:
+`02762df9fab6d6f04a398d5ff4e1afd10bf5fa0a6e270855fff4e7df2bbcbe37`.
+
+The workflow pins the project and uniquely resolves production. It records the
+production branch/endpoint identities and snapshot metadata, then restores one
+snapshot to a new deterministic preview with `finalize_restore: false`.
+It never calls the finalize endpoint. Existing inspection previews block a new
+run, including after an uncertain request.
+
+The new branch must have the exact snapshot provenance and must not be an
+existing, default, or protected branch. If needed, one 0.25-CU preview compute is
+created with 60-second idle suspend. Connection discovery pins both the branch
+and endpoint; production endpoints and pooled connections are rejected.
+
+The workflow reads every database returned for the preview in PostgreSQL
+read-only, repeatable-read transactions. It scans physical user tables, partition
+leaves, and materialized views for `vm0secret:` and the old key UUID. Only counts
+and operational identifiers leave the database. Foreign tables, large objects,
+and binary fields are reported as coverage limitations. Provider and SQL errors
+never export their bodies.
+
+Finally, it deletes only the newly created and revalidated preview, checks that
+it is no longer live, and separately inspects its provider recovery window.
+A deleted but recoverable copy still belongs in the retirement inventory.
+Production branch/endpoint identities and the original snapshot set are read
+back; cleanup or preservation uncertainty makes the run incomplete. Cancellation
+or an uncertain provider response can leave a preview: inspect the deterministic
+name before cleanup, and never blindly retry a restore.
+
+This operation creates a temporary recovery copy and compute. It does not write
+production data, modify existing snapshots, change credentials or deployments,
+call KMS, finalize a restore, or schedule key deletion. `collectionComplete`
+only means the declared scan completed. It does not authenticate ciphertext,
+inspect plaintext nested inside encryption, decode arbitrary opaque formats, or
+prove application-level recovery. `retirementCleared` is always false.
+
+The provider contract is documented in
+[Neon's snapshot restore API](https://neon.com/docs/reference/api/snapshots/restore-snapshot).
+Run `bash .github/scripts/tests/kms-recovery-snapshot-inspect-test.sh` for the
+external-boundary CLI scenarios and real isolated PostgreSQL aggregate tests.
+
+## Resolve recovery paths before scheduling deletion
+
+1. Inspect the non-expiring manual snapshot. If it contains KMS envelopes,
+   verify its historical schema and ciphertext in isolation, re-encrypt source
+   and nested source values under the target key, then create and restore a
+   replacement backup and verify the target-only result. A separate reviewed
+   operation must pin the isolated branch; do not bypass the existing production
+   migration workflow's branch guards.
+2. Preserve daily backups through their configured retention. Wait for the
+   identified snapshots to actually expire, or preserve each required recovery
+   point through the same verified replacement process for an earlier retirement.
+   Do not delete historical recovery points merely to reduce the count.
+3. Refresh snapshot, PITR, live branch, and recoverable-deleted-branch inventories.
+   Perform target-only restore verification against a retained recovery point.
+   Resolve any other concrete backup locations in the operational inventory.
+   Metadata counts alone do not certify recovery.
+4. Complete the source CloudTrail audit after its read permission is granted.
+   Review the full paginated interval, visibility buffer and late arrival, and
+   classify every old-key call. Do not generate old-key canaries during the quiet
+   observation.
+5. Retire the old-key configuration rollback path in the operational runbook.
+   After permanent retirement, approved code rollbacks must retain current target
+   KMS configuration. The immutable Doppler pre-cutover configuration remains
+   historical evidence, not an executable restoration procedure. Preserve it
+   without recreating or exposing credentials.
+6. Only after accepted live, retained-state, backup, and rollback evidence is
+   complete, prepare an exact-key `ScheduleKeyDeletion` operation. Verify identity,
+   state, waiting period, and returned deletion date. KMS requires a 7–30 day wait
+   and the key is unusable while pending deletion. Maintain a tested cancellation
+   and re-enable procedure during that period, and observe failures before the
+   irreversible deadline.
+
+Do not substitute `DisableKey`, a successful metadata job, configured expiration,
+or an empty denied query for these dependency checks.

--- a/.github/scripts/kms-recovery-snapshot-inspect.py
+++ b/.github/scripts/kms-recovery-snapshot-inspect.py
@@ -248,6 +248,7 @@ def inspect_database(database, endpoint, branch_id):
             "PGUSER": owner,
             "PGPASSWORD": urllib.parse.unquote(parsed.password),
             "PGSSLMODE": "verify-full",
+            "PGSSLROOTCERT": "/etc/ssl/certs/ca-certificates.crt",
             "PGCONNECT_TIMEOUT": "30",
             "PGOPTIONS": "-c default_transaction_read_only=on -c statement_timeout=120000 -c lock_timeout=5000",
         }

--- a/.github/scripts/kms-recovery-snapshot-inspect.py
+++ b/.github/scripts/kms-recovery-snapshot-inspect.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""Inspect one isolated snapshot preview; never finalize, migrate, or retire KMS."""
+
+import datetime as dt
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import time
+import urllib.parse
+
+PROJECT = "hidden-lab-39609750"
+BASE = f"https://console.neon.tech/api/v2/projects/{PROJECT}"
+WORKFLOW = (
+    "vm0-ai/vm0/.github/workflows/kms-recovery-snapshot-inspect.yml@refs/heads/main"
+)
+PREFIX = "kms-recovery-32264-"
+DEADLINE = time.monotonic() + 20 * 60
+
+
+class InspectionError(Exception):
+    """Only fixed codes, never provider or database text, reach reports."""
+
+
+def require(condition, code):
+    if not condition:
+        raise InspectionError(code)
+
+
+def digest(value):
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def timestamp(value):
+    require(isinstance(value, str), "invalid_timestamp")
+    result = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    require(result.tzinfo is not None, "timestamp_timezone_missing")
+    return result.astimezone(dt.timezone.utc)
+
+
+def identifier(value, prefix=""):
+    require(
+        isinstance(value, str)
+        and re.fullmatch(r"[a-z0-9-]{1,80}", value)
+        and value.startswith(prefix),
+        "invalid_resource_id",
+    )
+    return value
+
+
+def api(suffix, method="GET", body=None, allow_missing=False):
+    # Call sites provide all paths; no user-supplied URL or redirect is accepted.
+    require(suffix.startswith("/"), "invalid_api_path")
+    seconds = min(45, int(DEADLINE - time.monotonic()))
+    require(seconds > 0, "inspection_time_budget_exhausted")
+    command = [
+        "curl",
+        "--silent",
+        "--show-error",
+        "--max-time",
+        str(seconds),
+        "--max-filesize",
+        "8388608",
+        "--proto",
+        "=https",
+        "--request",
+        method,
+        "--header",
+        "Authorization: Bearer " + os.environ["NEON_API_KEY"],
+        "--header",
+        "Content-Type: application/json",
+        "--write-out",
+        "\n%{http_code}",
+    ]
+    if body is not None:
+        command.extend(["--data-binary", "@-"])
+    command.append(BASE + suffix)
+    response = subprocess.run(
+        command,
+        input=json.dumps(body) if body is not None else None,
+        capture_output=True,
+        text=True,
+        timeout=seconds + 5,
+    )
+    require(response.returncode == 0, "neon_request_outcome_unconfirmed")
+    content, status = response.stdout.rsplit("\n", 1)
+    if allow_missing and status == "404":
+        return None
+    require(
+        status in {"200", "201", "202"},
+        "neon_http_" + status
+        if re.fullmatch(r"\d{3}", status)
+        else "invalid_neon_status",
+    )
+    data = json.loads(content)
+    require(isinstance(data, dict), "invalid_neon_response")
+    return data
+
+
+def listing(collection, query=None):
+    items, seen = [], set()
+    query = dict(query or {})
+    for _ in range(100):
+        suffix = "/" + collection
+        if query:
+            suffix += "?" + urllib.parse.urlencode(query)
+        data = api(suffix)
+        page = data.get(collection)
+        require(
+            isinstance(page, list) and all(isinstance(x, dict) for x in page),
+            "invalid_listing",
+        )
+        items.extend(page)
+        require(len(items) <= 10000, "listing_limit")
+        pagination = data.get("pagination", {})
+        require(isinstance(pagination, dict), "invalid_pagination")
+        next_cursor = pagination.get("next") or pagination.get("cursor")
+        if not next_cursor:
+            require(
+                not pagination.get("has_more") and not data.get("has_more"),
+                "incomplete_listing",
+            )
+            ids = [identifier(x.get("id")) for x in items]
+            require(len(ids) == len(set(ids)), "duplicate_resource_id")
+            return items
+        require(
+            collection == "branches"
+            and isinstance(next_cursor, str)
+            and next_cursor not in seen,
+            "unsupported_pagination",
+        )
+        seen.add(next_cursor)
+        query["cursor"] = next_cursor
+    raise InspectionError("pagination_limit")
+
+
+def wait_operations(data):
+    operations = data.get("operations")
+    require(isinstance(operations, list), "operations_missing")
+    for operation in operations:
+        operation_id = identifier(operation.get("id"))
+        for _ in range(60):
+            current = api(f"/operations/{operation_id}")["operation"]
+            require(current.get("id") == operation_id, "operation_identity_mismatch")
+            status = current.get("status")
+            if status in {"finished", "skipped"}:
+                break
+            require(status in {"running", "scheduling"}, "neon_operation_failed")
+            time.sleep(5)
+        else:
+            raise InspectionError("operation_wait_limit")
+
+
+def branch_identity(branch):
+    return {
+        k: branch.get(k) for k in ("id", "project_id", "name", "default", "protected")
+    }
+
+
+def production_endpoints(branch_id):
+    return sorted(
+        [
+            {k: endpoint.get(k) for k in ("id", "branch_id", "host", "type")}
+            for endpoint in listing("endpoints")
+            if endpoint.get("branch_id") == branch_id
+        ],
+        key=lambda x: x["id"],
+    )
+
+
+def snapshot_state(snapshots):
+    return sorted(
+        [
+            {
+                k: item.get(k)
+                for k in (
+                    "id",
+                    "source_branch_id",
+                    "created_at",
+                    "expires_at",
+                    "timestamp",
+                    "lsn",
+                    "manual",
+                )
+            }
+            for item in snapshots
+        ],
+        key=lambda x: x["id"],
+    )
+
+
+def validate_preview(branch, name, snapshot_id, existing_ids):
+    branch_id = identifier(branch.get("id"), "br-")
+    require(branch_id not in existing_ids, "preview_is_existing_branch")
+    require(
+        branch.get("project_id") == PROJECT
+        and branch.get("name") == name
+        and branch.get("default") is False
+        and branch.get("protected") is False
+        and branch.get("restored_from") == snapshot_id
+        and branch.get("restore_status") == "restored",
+        "preview_identity_mismatch",
+    )
+    return branch_id
+
+
+def inspect_database(database, endpoint, branch_id):
+    name, owner = database.get("name"), database.get("owner_name")
+    require(database.get("branch_id") == branch_id, "database_branch_mismatch")
+    require(
+        all(
+            isinstance(x, str) and re.fullmatch(r"[A-Za-z0-9_-]{1,63}", x)
+            for x in (name, owner)
+        ),
+        "invalid_database_identity",
+    )
+    query = urllib.parse.urlencode(
+        {
+            "branch_id": branch_id,
+            "endpoint_id": endpoint["id"],
+            "database_name": name,
+            "role_name": owner,
+            "pooled": "false",
+        }
+    )
+    parsed = urllib.parse.urlsplit(api("/connection_uri?" + query)["uri"])
+    require(
+        parsed.scheme in {"postgres", "postgresql"}
+        and parsed.hostname == endpoint["host"]
+        and parsed.port in {None, 5432}
+        and parsed.hostname.endswith(".neon.tech")
+        and "-pooler" not in parsed.hostname
+        and urllib.parse.unquote(parsed.path) == "/" + name
+        and urllib.parse.unquote(parsed.username or "") == owner
+        and parsed.password,
+        "isolated_connection_identity_mismatch",
+    )
+    environment = {
+        k: v for k, v in os.environ.items() if not k.startswith(("PG", "NEON_"))
+    }
+    environment.update(
+        {
+            "PGHOST": parsed.hostname,
+            "PGPORT": "5432",
+            "PGDATABASE": name,
+            "PGUSER": owner,
+            "PGPASSWORD": urllib.parse.unquote(parsed.password),
+            "PGSSLMODE": "verify-full",
+            "PGCONNECT_TIMEOUT": "30",
+            "PGOPTIONS": "-c default_transaction_read_only=on -c statement_timeout=120000 -c lock_timeout=5000",
+        }
+    )
+    seconds = min(900, int(DEADLINE - time.monotonic()))
+    require(seconds > 0, "inspection_time_budget_exhausted")
+    result = subprocess.run(
+        [
+            "psql",
+            "-X",
+            "-qAt",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-f",
+            str(Path(__file__).with_name("kms-recovery-snapshot-inventory.sql")),
+        ],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=seconds,
+    )
+    require(result.returncode == 0, "snapshot_database_scan_failed")
+    records = [json.loads(line) for line in result.stdout.splitlines() if line]
+    headers = [r for r in records if r.get("kind") == "database"]
+    require(
+        len(headers) == 1
+        and headers[0].get("readOnly") is True
+        and headers[0].get("isolation") == "repeatable read",
+        "read_only_transaction_unverified",
+    )
+    safe = []
+    fields = {
+        "database": {"largeObjects", "foreignTables"},
+        "table": {
+            "relationOid",
+            "rows",
+            "rowsWithEnvelopeMarker",
+            "rowsWithSourceReference",
+        },
+        "binary": {"relationOid", "columnNumber", "nonNullValues"},
+    }
+    for record in records:
+        kind = record.get("kind")
+        require(kind in fields, "unknown_scan_record")
+        item = {"kind": kind}
+        for field in fields[kind]:
+            value = record.get(field)
+            require(type(value) is int and value >= 0, "invalid_scan_counter")
+            item[field] = value
+        safe.append(item)
+    return {"databaseNameSha256": digest(name), "readOnly": True, "records": safe}
+
+
+def main():
+    global DEADLINE
+    report_path = Path(os.environ["RUNNER_TEMP"]) / "kms-recovery-snapshot.json"
+    report = {
+        "version": 1,
+        "runId": os.environ.get("GITHUB_RUN_ID"),
+        "attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
+        "commit": os.environ.get("GITHUB_SHA"),
+        "startedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "collectionComplete": False,
+        "retirementCleared": False,
+        "cryptographicVerification": False,
+        "nestedPayloadInspection": False,
+        "kmsCallsMade": False,
+        "existingSnapshotsChanged": False,
+        "productionDatabaseConnected": False,
+        "restoreFinalized": False,
+        "previewCreated": False,
+        "cleanupComplete": False,
+        "databases": [],
+    }
+
+    def checkpoint():
+        report_path.write_text(json.dumps(report, indent=2) + "\n")
+
+    preview_id = None
+    production = None
+    before_endpoints = None
+    before_snapshots = None
+    existing_ids = set()
+    snapshot_id = None
+    checkpoint()
+    try:
+        require(
+            os.environ.get("GITHUB_REPOSITORY") == "vm0-ai/vm0"
+            and os.environ.get("GITHUB_REF") == "refs/heads/main"
+            and os.environ.get("GITHUB_EVENT_NAME") == "workflow_dispatch"
+            and os.environ.get("GITHUB_WORKFLOW_REF") == WORKFLOW,
+            "unprotected_invocation",
+        )
+        require(
+            os.environ.get("NEON_PROJECT_ID") == PROJECT
+            and os.environ.get("NEON_API_KEY"),
+            "project_or_credential_missing",
+        )
+        require(
+            re.fullmatch(r"[0-9a-f]{40}", os.environ.get("GITHUB_SHA", "")),
+            "invalid_commit",
+        )
+        run_id = identifier(os.environ.get("GITHUB_RUN_ID"))
+        attempt = identifier(os.environ.get("GITHUB_RUN_ATTEMPT"))
+        require(run_id.isdigit() and attempt.isdigit(), "invalid_run_identity")
+        name = PREFIX + run_id + "-" + attempt
+        report["previewName"] = name
+        expected_hash = os.environ.get("SNAPSHOT_SHA256", "")
+        require(re.fullmatch(r"[0-9a-f]{64}", expected_hash), "invalid_snapshot_hash")
+        created_at = timestamp(os.environ.get("EXPECTED_CREATED_AT"))
+        branches = listing("branches")
+        existing_ids = {branch["id"] for branch in branches}
+        require(
+            not any(branch.get("name", "").startswith(PREFIX) for branch in branches),
+            "existing_inspection_preview_requires_review",
+        )
+        candidates = [b for b in branches if b.get("name") == "production"]
+        require(
+            len(candidates) == 1 and candidates[0].get("project_id") == PROJECT,
+            "production_branch_not_unique",
+        )
+        production = branch_identity(candidates[0])
+        before_endpoints = production_endpoints(production["id"])
+        require(bool(before_endpoints), "production_endpoints_missing")
+        snapshots = listing("snapshots")
+        before_snapshots = snapshot_state(snapshots)
+        candidates = [s for s in snapshots if digest(s["id"]) == expected_hash]
+        require(len(candidates) == 1, "snapshot_not_unique")
+        snapshot = candidates[0]
+        require(
+            snapshot.get("source_branch_id") == production["id"]
+            and timestamp(snapshot.get("created_at")) == created_at,
+            "snapshot_identity_mismatch",
+        )
+        snapshot_id = snapshot["id"]
+        report.update(
+            {
+                "snapshotIdSha256": expected_hash,
+                "snapshotCreatedAt": created_at.isoformat(),
+                "restoreRequestStarted": True,
+            }
+        )
+        checkpoint()
+        # The API creates a new branch. Never call finalize_restore or branch restore.
+        restored = api(
+            f"/snapshots/{snapshot_id}/restore",
+            "POST",
+            {"name": name, "finalize_restore": False},
+        )
+        candidate_id = validate_preview(
+            restored["branch"], name, snapshot_id, existing_ids
+        )
+        preview_id = candidate_id
+        report.update({"previewCreated": True, "previewBranchId": preview_id})
+        checkpoint()
+        wait_operations(restored)
+        validate_preview(
+            api(f"/branches/{preview_id}")["branch"], name, snapshot_id, existing_ids
+        )
+        endpoints = [
+            e for e in listing("endpoints") if e.get("branch_id") == preview_id
+        ]
+        if not endpoints:
+            created = api(
+                "/endpoints",
+                "POST",
+                {
+                    "endpoint": {
+                        "branch_id": preview_id,
+                        "type": "read_write",
+                        "autoscaling_limit_min_cu": 0.25,
+                        "autoscaling_limit_max_cu": 0.25,
+                        "suspend_timeout_seconds": 60,
+                    }
+                },
+            )
+            require(
+                created["endpoint"].get("branch_id") == preview_id,
+                "created_endpoint_branch_mismatch",
+            )
+            wait_operations(created)
+            endpoints = [
+                e for e in listing("endpoints") if e.get("branch_id") == preview_id
+            ]
+        require(len(endpoints) == 1, "preview_endpoint_not_unique")
+        endpoint = endpoints[0]
+        identifier(endpoint.get("id"), "ep-")
+        require(
+            isinstance(endpoint.get("host"), str)
+            and endpoint["host"].startswith(endpoint["id"] + ".")
+            and endpoint["host"].endswith(".neon.tech")
+            and endpoint["id"] not in {e["id"] for e in before_endpoints},
+            "preview_endpoint_identity_mismatch",
+        )
+        databases = api(f"/branches/{preview_id}/databases")["databases"]
+        require(
+            isinstance(databases, list)
+            and 0 < len(databases) <= 20
+            and len({d.get("name") for d in databases}) == len(databases),
+            "invalid_database_listing",
+        )
+        for database in databases:
+            report["databases"].append(inspect_database(database, endpoint, preview_id))
+            checkpoint()
+        report["collectionComplete"] = True
+    except (
+        InspectionError,
+        KeyError,
+        ValueError,
+        TypeError,
+        OSError,
+        subprocess.TimeoutExpired,
+    ) as error:
+        report["failure"] = (
+            str(error) if isinstance(error, InspectionError) else "inspection_failed"
+        )
+    finally:
+        # Reserve cleanup and preservation read-back time inside the 30-minute job.
+        DEADLINE = time.monotonic() + 5 * 60
+        if preview_id is not None:
+            try:
+                validate_preview(
+                    api(f"/branches/{preview_id}")["branch"],
+                    name,
+                    snapshot_id,
+                    existing_ids,
+                )
+                wait_operations(api(f"/branches/{preview_id}", "DELETE"))
+                require(
+                    api(f"/branches/{preview_id}", allow_missing=True) is None,
+                    "preview_still_live",
+                )
+                report["cleanupComplete"] = True
+                # Deletion can leave a recoverable copy. Never equate DELETE with
+                # permanent removal of the restored historical ciphertext.
+                report["deletedPreviewRecoveryVerified"] = False
+                try:
+                    deleted = [
+                        b
+                        for b in listing("branches", {"include_deleted": "true"})
+                        if b["id"] == preview_id
+                    ]
+                    report["deletedPreviewRecoveryVerified"] = True
+                    report["deletedPreviewStillListed"] = bool(deleted)
+                    if deleted:
+                        recovery = deleted[0].get("recovery") or {}
+                        until = recovery.get("recoverable_until")
+                        report["deletedPreviewRecoverableUntil"] = (
+                            timestamp(until).isoformat() if until else None
+                        )
+                except (
+                    InspectionError,
+                    KeyError,
+                    ValueError,
+                    TypeError,
+                    OSError,
+                    subprocess.TimeoutExpired,
+                ):
+                    report["deletedPreviewRecoveryFailure"] = (
+                        "recovery_metadata_unavailable"
+                    )
+            except (
+                InspectionError,
+                KeyError,
+                ValueError,
+                TypeError,
+                OSError,
+                subprocess.TimeoutExpired,
+            ):
+                report["cleanupFailure"] = "preview_cleanup_unconfirmed"
+        if production is not None:
+            DEADLINE = time.monotonic() + 2 * 60
+            try:
+                report["productionBranchUnchanged"] = (
+                    branch_identity(api(f"/branches/{production['id']}")["branch"])
+                    == production
+                )
+                report["productionEndpointsUnchanged"] = (
+                    before_endpoints is not None
+                    and production_endpoints(production["id"]) == before_endpoints
+                )
+                report["snapshotSetUnchanged"] = (
+                    before_snapshots is not None
+                    and snapshot_state(listing("snapshots")) == before_snapshots
+                )
+            except (
+                InspectionError,
+                KeyError,
+                ValueError,
+                TypeError,
+                OSError,
+                subprocess.TimeoutExpired,
+            ):
+                report["preservationReadbackFailure"] = (
+                    "preservation_readback_unconfirmed"
+                )
+        report["finishedAt"] = dt.datetime.now(dt.timezone.utc).isoformat()
+        report["result"] = (
+            "collected"
+            if report["collectionComplete"]
+            and report["cleanupComplete"]
+            and all(
+                report.get(k) is True
+                for k in (
+                    "productionBranchUnchanged",
+                    "productionEndpointsUnchanged",
+                    "snapshotSetUnchanged",
+                )
+            )
+            else "incomplete"
+        )
+        checkpoint()
+    print("Snapshot inspection " + report["result"] + "; sanitized report retained.")
+    return 0 if report["result"] == "collected" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/kms-recovery-snapshot-inventory.sql
+++ b/.github/scripts/kms-recovery-snapshot-inventory.sql
@@ -1,0 +1,51 @@
+\set ON_ERROR_STOP on
+BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;
+SET LOCAL statement_timeout = '120s';
+SET LOCAL lock_timeout = '5s';
+SET LOCAL row_security = off;
+
+SELECT json_build_object(
+  'kind', 'database',
+  'readOnly', current_setting('transaction_read_only') = 'on',
+  'isolation', current_setting('transaction_isolation'),
+  'largeObjects', (SELECT count(*) FROM pg_largeobject_metadata),
+  'foreignTables', (
+    SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'f' AND n.nspname NOT LIKE 'pg\_%' ESCAPE '\'
+      AND n.nspname <> 'information_schema'
+  )
+);
+
+-- Scan physical tables, including partition leaves, and materialized views.
+-- Identifiers are quoted by PostgreSQL; gexec executes SQL, not psql commands.
+-- Only aggregates leave the database. No rows, ciphertext or primary keys do.
+SELECT format(
+  'SELECT json_build_object(''kind'', ''table'', ''relationOid'', %s,
+    ''rows'', count(*),
+    ''rowsWithEnvelopeMarker'', count(*) FILTER (WHERE row_to_json(t)::text LIKE ''%%vm0secret:%%''),
+    ''rowsWithSourceReference'', count(*) FILTER (WHERE row_to_json(t)::text LIKE ''%%a1b3922b-fab1-4ed3-aa9e-40f86f92a7a8%%''))
+   FROM %I.%I t;', c.oid, n.nspname, c.relname
+)
+FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relkind IN ('r', 'm') AND n.nspname NOT LIKE 'pg\_%' ESCAPE '\'
+  AND n.nspname <> 'information_schema'
+ORDER BY c.oid
+\gexec
+
+-- Binary values may hide encodings that row_to_json renders as hex. Their
+-- presence is a coverage limitation, never evidence of key independence.
+SELECT format(
+  'SELECT json_build_object(''kind'', ''binary'', ''relationOid'', %s,
+    ''columnNumber'', %s, ''nonNullValues'', count(%I)) FROM %I.%I;',
+  c.oid, a.attnum, a.attname, n.nspname, c.relname
+)
+FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+JOIN pg_attribute a ON a.attrelid = c.oid
+JOIN pg_type ty ON ty.oid = a.atttypid
+WHERE c.relkind IN ('r', 'm') AND n.nspname NOT LIKE 'pg\_%' ESCAPE '\'
+  AND n.nspname <> 'information_schema' AND a.attnum > 0 AND NOT a.attisdropped
+  AND (ty.oid = 'bytea'::regtype OR ty.typbasetype = 'bytea'::regtype
+    OR ty.typelem = 'bytea'::regtype)
+ORDER BY c.oid, a.attnum
+\gexec
+ROLLBACK;

--- a/.github/scripts/tests/fixtures/kms-recovery-snapshot-tools.py
+++ b/.github/scripts/tests/fixtures/kms-recovery-snapshot-tools.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""External Neon and PostgreSQL boundaries for the recovery inspection CLI."""
+
+import json
+import os
+from pathlib import Path
+import sys
+import urllib.parse
+
+state_path = Path(os.environ["FIXTURE_STATE"])
+state = json.loads(state_path.read_text())
+scenario = state["scenario"]
+project = "hidden-lab-39609750"
+name = "kms-recovery-32264-12345-1"
+production = {
+    "id": "br-production",
+    "project_id": project,
+    "name": "production",
+    "default": True,
+    "protected": True,
+}
+preview = {
+    "id": "br-preview",
+    "project_id": project,
+    "name": name,
+    "default": False,
+    "protected": False,
+    "restored_from": "snapshot-manual",
+    "restore_status": "restored",
+}
+endpoint = {
+    "id": "ep-preview",
+    "branch_id": "br-preview",
+    "host": "ep-preview.us-west-2.aws.neon.tech",
+    "type": "read_write",
+}
+snapshot = {
+    "id": "snapshot-manual",
+    "source_branch_id": "br-production",
+    "created_at": "2026-02-16T05:57:00Z",
+    "manual": True,
+}
+
+
+def save():
+    state_path.write_text(json.dumps(state))
+
+
+def respond(data, status=200):
+    save()
+    print(json.dumps(data) + "\n" + str(status), end="")
+    raise SystemExit(0)
+
+
+if Path(sys.argv[0]).name == "psql":
+    state["sqlCalls"] = state.get("sqlCalls", 0) + 1
+    save()
+    assert os.environ["PGHOST"] == endpoint["host"]
+    assert os.environ["PGDATABASE"] == "neondb"
+    assert os.environ["PGPASSWORD"] == "fixture-private-password"
+    assert os.environ["PGSSLMODE"] == "verify-full"
+    assert "default_transaction_read_only=on" in os.environ["PGOPTIONS"]
+    assert "-X" in sys.argv and "NEON_API_KEY" not in os.environ
+    if scenario == "sql-failure":
+        sys.stderr.write("fixture-private-password")
+        raise SystemExit(1)
+    print(
+        json.dumps(
+            {
+                "kind": "database",
+                "readOnly": True,
+                "isolation": "repeatable read",
+                "largeObjects": 0,
+                "foreignTables": 0,
+            }
+        )
+    )
+    print(
+        json.dumps(
+            {
+                "kind": "table",
+                "relationOid": 123,
+                "rows": 20,
+                "rowsWithEnvelopeMarker": 3,
+                "rowsWithSourceReference": 0,
+                "private": "fixture-private-password",
+            }
+        )
+    )
+    raise SystemExit(0)
+
+assert Path(sys.argv[0]).name == "curl"
+method = sys.argv[sys.argv.index("--request") + 1]
+url = urllib.parse.urlsplit(sys.argv[-1])
+assert url.netloc == "console.neon.tech"
+assert "--location" not in sys.argv
+path = url.path.removeprefix("/api/v2/projects/" + project)
+query = urllib.parse.parse_qs(url.query)
+body = json.load(sys.stdin) if "--data-binary" in sys.argv else None
+state["calls"].append({"method": method, "path": path, "query": query, "body": body})
+save()
+if path == "/snapshots" and method == "GET":
+    respond({"snapshots": [snapshot]})
+if path == "/branches" and method == "GET":
+    branches = [production]
+    if (
+        scenario == "existing-preview"
+        or state.get("restored")
+        and not state.get("deleted")
+    ):
+        branches.append(preview)
+    if state.get("deleted") and query.get("include_deleted") == ["true"]:
+        branches.append(
+            {**preview, "recovery": {"recoverable_until": "2026-09-18T00:00:00Z"}}
+        )
+    if scenario == "repeated-page":
+        respond({"branches": branches, "pagination": {"next": "repeat"}})
+    respond({"branches": branches})
+if path == "/branches/br-production" and method == "GET":
+    respond({"branch": production})
+if path == "/endpoints" and method == "GET":
+    endpoints = [
+        {
+            "id": "ep-production",
+            "branch_id": "br-production",
+            "host": "ep-production.us-west-2.aws.neon.tech",
+            "type": "read_write",
+        }
+    ]
+    if state.get("endpointCreated") and not state.get("deleted"):
+        endpoints.append(endpoint)
+    respond({"endpoints": endpoints})
+if path == "/snapshots/snapshot-manual/restore" and method == "POST":
+    assert body == {"name": name, "finalize_restore": False}
+    state["restored"] = True
+    save()
+    if scenario == "unknown-restore-outcome":
+        sys.stderr.write("fixture-private-password")
+        raise SystemExit(28)
+    if scenario == "production-returned":
+        respond({"branch": production, "operations": []})
+    respond({"branch": preview, "operations": [{"id": "op-restore"}]})
+if path.startswith("/operations/") and method == "GET":
+    respond({"operation": {"id": path.rsplit("/", 1)[1], "status": "finished"}})
+if path == "/branches/br-preview" and method == "GET":
+    respond({"message": "fixture-private-password"}, 404) if state.get(
+        "deleted"
+    ) else respond({"branch": preview})
+if path == "/branches/br-preview" and method == "DELETE":
+    if scenario == "cleanup-denied":
+        respond({"message": "fixture-private-password"}, 403)
+    state["deleted"] = True
+    respond({"operations": [{"id": "op-delete"}]})
+if path == "/endpoints" and method == "POST":
+    assert body["endpoint"]["branch_id"] == "br-preview"
+    assert body["endpoint"]["suspend_timeout_seconds"] == 60
+    state["endpointCreated"] = True
+    respond({"endpoint": endpoint, "operations": [{"id": "op-endpoint"}]})
+if path == "/branches/br-preview/databases" and method == "GET":
+    respond(
+        {
+            "databases": [
+                {
+                    "branch_id": "br-preview",
+                    "name": "neondb",
+                    "owner_name": "neondb_owner",
+                }
+            ]
+        }
+    )
+if path == "/connection_uri" and method == "GET":
+    assert query["branch_id"] == ["br-preview"] and query["endpoint_id"] == [
+        "ep-preview"
+    ]
+    host = (
+        "ep-production.us-west-2.aws.neon.tech"
+        if scenario == "production-uri"
+        else endpoint["host"]
+    )
+    respond(
+        {
+            "uri": "postgresql://neondb_owner:fixture-private-password@"
+            + host
+            + "/neondb?sslmode=require"
+        }
+    )
+raise AssertionError("unexpected external operation")

--- a/.github/scripts/tests/fixtures/kms-recovery-snapshot-tools.py
+++ b/.github/scripts/tests/fixtures/kms-recovery-snapshot-tools.py
@@ -59,6 +59,7 @@ if Path(sys.argv[0]).name == "psql":
     assert os.environ["PGDATABASE"] == "neondb"
     assert os.environ["PGPASSWORD"] == "fixture-private-password"
     assert os.environ["PGSSLMODE"] == "verify-full"
+    assert os.environ["PGSSLROOTCERT"] == "/etc/ssl/certs/ca-certificates.crt"
     assert "default_transaction_read_only=on" in os.environ["PGOPTIONS"]
     assert "-X" in sys.argv and "NEON_API_KEY" not in os.environ
     if scenario == "sql-failure":

--- a/.github/scripts/tests/kms-recovery-snapshot-inspect-test.py
+++ b/.github/scripts/tests/kms-recovery-snapshot-inspect-test.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Exercise preview isolation, failure cleanup and sanitized CLI reports."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "kms-recovery-snapshot-inspect.py"
+TOOLS = HERE / "fixtures/kms-recovery-snapshot-tools.py"
+
+
+class SnapshotInspectionTest(unittest.TestCase):
+    def invoke(self, scenario="normal", overrides=None):
+        with tempfile.TemporaryDirectory(
+            prefix="snapshot-inspection-test-"
+        ) as directory:
+            root = Path(directory)
+            binary = root / "bin"
+            binary.mkdir()
+            for name in ["curl", "psql"]:
+                tool = binary / name
+                tool.write_text(TOOLS.read_text())
+                tool.chmod(0o700)
+            state_path = root / "fixture.json"
+            state_path.write_text(json.dumps({"scenario": scenario, "calls": []}))
+            environment = {
+                **os.environ,
+                "PATH": str(binary) + os.pathsep + os.environ["PATH"],
+                "FIXTURE_STATE": str(state_path),
+                "RUNNER_TEMP": str(root),
+                "GITHUB_REPOSITORY": "vm0-ai/vm0",
+                "GITHUB_REF": "refs/heads/main",
+                "GITHUB_EVENT_NAME": "workflow_dispatch",
+                "GITHUB_RUN_ID": "12345",
+                "GITHUB_RUN_ATTEMPT": "1",
+                "GITHUB_SHA": "a" * 40,
+                "GITHUB_WORKFLOW_REF": "vm0-ai/vm0/.github/workflows/kms-recovery-snapshot-inspect.yml@refs/heads/main",
+                "NEON_PROJECT_ID": "hidden-lab-39609750",
+                "NEON_API_KEY": "fixture-private-token",
+                "SNAPSHOT_SHA256": hashlib.sha256(b"snapshot-manual").hexdigest(),
+                "EXPECTED_CREATED_AT": "2026-02-16T05:57:00Z",
+                **(overrides or {}),
+            }
+            result = subprocess.run(
+                ["python3", str(SCRIPT)],
+                env=environment,
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+            raw = (root / "kms-recovery-snapshot.json").read_text()
+            for value in (raw, result.stdout, result.stderr):
+                for secret in ("fixture-private-password", "fixture-private-token"):
+                    self.assertNotIn(secret, value)
+            report = json.loads(raw)
+            state = json.loads(state_path.read_text())
+            self.assertFalse(report["retirementCleared"])
+            self.assertFalse(report["kmsCallsMade"])
+            self.assertFalse(report["restoreFinalized"])
+            self.assertFalse(report["productionDatabaseConnected"])
+            for call in state["calls"]:
+                if call["method"] != "GET":
+                    self.assertIn(
+                        (call["method"], call["path"]),
+                        {
+                            ("POST", "/snapshots/snapshot-manual/restore"),
+                            ("POST", "/endpoints"),
+                            ("DELETE", "/branches/br-preview"),
+                        },
+                    )
+            return result, report, state
+
+    def test_inspects_snapshot_and_records_recoverable_cleanup_without_clearance(self):
+        result, report, state = self.invoke()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(report["collectionComplete"])
+        self.assertTrue(report["cleanupComplete"])
+        self.assertTrue(report["snapshotSetUnchanged"])
+        self.assertTrue(report["productionEndpointsUnchanged"])
+        self.assertTrue(report["deletedPreviewStillListed"])
+        self.assertEqual(
+            report["deletedPreviewRecoverableUntil"], "2026-09-18T00:00:00+00:00"
+        )
+        self.assertEqual(
+            report["databases"][0]["records"][1]["rowsWithEnvelopeMarker"], 3
+        )
+        self.assertEqual(state["sqlCalls"], 1)
+
+    def test_wrong_snapshot_time_stops_before_any_mutation(self):
+        result, report, state = self.invoke(
+            overrides={"EXPECTED_CREATED_AT": "2026-02-17T05:57:00Z"}
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(report["failure"], "snapshot_identity_mismatch")
+        self.assertTrue(all(c["method"] == "GET" for c in state["calls"]))
+
+    def test_production_returned_as_preview_never_connects_or_deletes(self):
+        result, report, state = self.invoke("production-returned")
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(report["failure"], "preview_is_existing_branch")
+        self.assertNotIn("sqlCalls", state)
+        self.assertFalse(any(c["method"] == "DELETE" for c in state["calls"]))
+
+    def test_wrong_database_endpoint_is_rejected_and_preview_removed(self):
+        result, report, state = self.invoke("production-uri")
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(report["failure"], "isolated_connection_identity_mismatch")
+        self.assertNotIn("sqlCalls", state)
+        self.assertTrue(report["cleanupComplete"])
+
+    def test_database_failure_keeps_aggregate_error_and_cleans_up(self):
+        result, report, _ = self.invoke("sql-failure")
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(report["failure"], "snapshot_database_scan_failed")
+        self.assertTrue(report["cleanupComplete"])
+        self.assertFalse(report["collectionComplete"])
+
+    def test_cleanup_denial_is_incomplete_even_after_successful_scan(self):
+        result, report, _ = self.invoke("cleanup-denied")
+        self.assertEqual(result.returncode, 1)
+        self.assertTrue(report["collectionComplete"])
+        self.assertFalse(report["cleanupComplete"])
+        self.assertEqual(report["cleanupFailure"], "preview_cleanup_unconfirmed")
+
+    def test_uncertain_restore_is_not_retried_or_blindly_deleted(self):
+        result, report, state = self.invoke("unknown-restore-outcome")
+        self.assertEqual(result.returncode, 1)
+        self.assertTrue(report["restoreRequestStarted"])
+        self.assertEqual(report["failure"], "neon_request_outcome_unconfirmed")
+        self.assertEqual(sum(c["method"] == "POST" for c in state["calls"]), 1)
+        self.assertFalse(any(c["method"] == "DELETE" for c in state["calls"]))
+
+    def test_existing_preview_and_incomplete_pagination_block_new_restore(self):
+        for scenario in ("existing-preview", "repeated-page"):
+            with self.subTest(scenario=scenario):
+                result, _, state = self.invoke(scenario)
+                self.assertEqual(result.returncode, 1)
+                self.assertTrue(all(c["method"] == "GET" for c in state["calls"]))
+
+    def test_non_main_invocation_never_calls_neon(self):
+        result, report, state = self.invoke(
+            overrides={"GITHUB_REF": "refs/heads/feature"}
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(report["failure"], "unprotected_invocation")
+        self.assertEqual(state["calls"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/kms-recovery-snapshot-inspect-test.sh
+++ b/.github/scripts/tests/kms-recovery-snapshot-inspect-test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+python3 "$repo_root/.github/scripts/tests/kms-recovery-snapshot-inspect-test.py"
+python3 "$repo_root/.github/scripts/tests/kms-recovery-snapshot-sql-test.py"

--- a/.github/scripts/tests/kms-recovery-snapshot-sql-test.py
+++ b/.github/scripts/tests/kms-recovery-snapshot-sql-test.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Run the actual aggregate SQL in an isolated local PostgreSQL cluster."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+SQL = Path(__file__).resolve().parents[1] / "kms-recovery-snapshot-inventory.sql"
+
+
+class SnapshotSqlTest(unittest.TestCase):
+    def test_aggregate_inventory_preserves_data_and_handles_partition_and_binary_values(
+        self,
+    ):
+        binary = Path(
+            subprocess.check_output(["pg_config", "--bindir"], text=True).strip()
+        )
+        with tempfile.TemporaryDirectory(prefix="kms-snapshot-sql-") as directory:
+            root = Path(directory)
+            data = root / "data"
+            subprocess.run(
+                [str(binary / "initdb"), "-D", str(data), "-A", "trust", "--no-locale"],
+                check=True,
+                capture_output=True,
+            )
+            with (data / "postgresql.conf").open("a") as stream:
+                stream.write(
+                    "\nlisten_addresses = ''\nunix_socket_directories = '"
+                    + str(root)
+                    + "'\n"
+                )
+            subprocess.run(
+                [
+                    str(binary / "pg_ctl"),
+                    "-D",
+                    str(data),
+                    "-l",
+                    str(root / "server.log"),
+                    "start",
+                    "-w",
+                ],
+                check=True,
+                capture_output=True,
+            )
+            environment = {
+                k: v for k, v in os.environ.items() if not k.startswith("PG")
+            }
+            environment.update(
+                {"PGHOST": str(root), "PGPORT": "5432", "PGDATABASE": "postgres"}
+            )
+
+            def psql(*args, sql=None):
+                return subprocess.run(
+                    ["psql", "-X", "-qAt", "-v", "ON_ERROR_STOP=1", *args],
+                    input=sql,
+                    env=environment,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+
+            try:
+                fixture = psql(
+                    sql="""
+                    CREATE TABLE public.secret_probe(id int, value text, payload jsonb, binary_value bytea);
+                    INSERT INTO public.secret_probe VALUES
+                      (1, 'vm0secret:v1:test-only', '{"nested":"vm0secret:v1:synthetic"}', NULL),
+                      (2, 'synthetic a1b3922b-fab1-4ed3-aa9e-40f86f92a7a8', '{}', decode('abc0','hex')),
+                      (3, 'private-plaintext-must-stay-in-db', '{}', NULL);
+                    CREATE TABLE public.part_probe(id int, value text) PARTITION BY RANGE(id);
+                    CREATE TABLE public.part_leaf PARTITION OF public.part_probe FOR VALUES FROM(0) TO(10);
+                    INSERT INTO public.part_probe VALUES(1, 'vm0secret:v1:partition');
+                    CREATE MATERIALIZED VIEW public.mat_probe AS SELECT id,value FROM public.secret_probe WHERE id=1;
+                    CREATE SCHEMA "odd-schema";
+                    CREATE TABLE "odd-schema"."quoted'name"(val text);
+                    INSERT INTO "odd-schema"."quoted'name" VALUES('vm0secret:v1:quoted');
+                """
+                )
+                self.assertEqual(fixture.returncode, 0, fixture.stderr)
+                result = psql("-f", str(SQL))
+                self.assertEqual(result.returncode, 0, result.stderr)
+                records = [
+                    json.loads(line) for line in result.stdout.splitlines() if line
+                ]
+                tables = [r for r in records if r["kind"] == "table"]
+                self.assertEqual(len(tables), 4)
+                self.assertEqual(sum(r["rows"] for r in tables), 6)
+                self.assertEqual(sum(r["rowsWithEnvelopeMarker"] for r in tables), 4)
+                self.assertEqual(sum(r["rowsWithSourceReference"] for r in tables), 1)
+                self.assertEqual(
+                    sum(r["nonNullValues"] for r in records if r["kind"] == "binary"), 1
+                )
+                self.assertTrue(records[0]["readOnly"])
+                self.assertEqual(records[0]["isolation"], "repeatable read")
+                self.assertNotIn("private-plaintext", result.stdout)
+                self.assertNotIn("vm0secret", result.stdout)
+                self.assertEqual(
+                    psql(
+                        "-c", "SELECT count(*) FROM public.secret_probe"
+                    ).stdout.strip(),
+                    "3",
+                )
+            finally:
+                subprocess.run(
+                    [
+                        str(binary / "pg_ctl"),
+                        "-D",
+                        str(data),
+                        "stop",
+                        "-m",
+                        "fast",
+                        "-w",
+                    ],
+                    check=True,
+                    capture_output=True,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/kms-recovery-snapshot-inspect.yml
+++ b/.github/workflows/kms-recovery-snapshot-inspect.yml
@@ -1,0 +1,48 @@
+name: KMS Recovery Snapshot Inspect
+
+on:
+  workflow_dispatch:
+    inputs:
+      snapshot_sha256:
+        description: "Snapshot ID hash from the reviewed recovery inventory"
+        required: true
+        type: string
+        default: "02762df9fab6d6f04a398d5ff4e1afd10bf5fa0a6e270855fff4e7df2bbcbe37"
+      expected_created_at:
+        description: "Exact snapshot creation time from the reviewed inventory"
+        required: true
+        type: string
+        default: "2026-02-16T05:57:00Z"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kms-production-operation-32264
+  cancel-in-progress: false
+
+jobs:
+  inspect:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: production
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Restore an isolated preview, inspect aggregate markers, and remove the preview
+        env:
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          SNAPSHOT_SHA256: ${{ inputs.snapshot_sha256 }}
+          EXPECTED_CREATED_AT: ${{ inputs.expected_created_at }}
+        run: python3 .github/scripts/kms-recovery-snapshot-inspect.py
+      - name: Retain sanitized recovery evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kms-recovery-snapshot-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/kms-recovery-snapshot.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/kms-recovery-snapshot-inspect.yml
+++ b/.github/workflows/kms-recovery-snapshot-inspect.yml
@@ -1,5 +1,8 @@
 name: KMS Recovery Snapshot Inspect
 
+env:
+  npm_config_audit: "false"
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Production backfill is complete, but retained Neon snapshots can still require the retiring KMS key. Add a protected manual workflow that restores one reviewed snapshot into an isolated preview, scans read-only aggregate envelope markers, removes that preview, and verifies production branch, endpoints, and existing snapshots are unchanged.

The first target is the non-expiring manual snapshot identified in run 34569228115. The report preserves coverage gaps and any recoverable deleted preview; it never certifies key retirement. The accompanying runbook tracks snapshot/PITR, old-key audit, rollback, and the final KMS deletion waiting period for #32264.

Validation: nine CLI integration scenarios passed, covering wrong snapshot/production identities, ambiguous restore outcomes, SQL failure, cleanup denial, pagination, and secret exclusion. The aggregate SQL also passed against a real isolated PostgreSQL 18 cluster, including partition leaves, materialized views, quoted identifiers, binary values, and data preservation. Ruff, Prettier, shell syntax, file-size, and diff checks passed. No full local Vitest or live database operation was run.

Operational scope: the workflow creates and deletes only its own temporary preview and compute. It has no AWS credentials and makes no KMS calls, existing-backup mutations, deployment changes, or production data writes. Live execution follows merge and the protected production environment gate.
