### PR TITLE
refactor(desktop): rename renderer-local bridge globals to okou prefix

### DIFF
--- a/docs/testing/desktop-testing.md
+++ b/docs/testing/desktop-testing.md
@@ -23,7 +23,7 @@ Use this boundary for behavior in:
 
 Mock the external bridge objects on `window`:
 
-- `window.vm0DesktopComputerUse`
+- `window.okouDesktopComputerUse`
 - `window.vm0DesktopAuth`
 
 Keep renderer modules real. Assert visible user behavior and bridge outcomes:

--- a/turbo/apps/desktop/src/desktop-bridge.ts
+++ b/turbo/apps/desktop/src/desktop-bridge.ts
@@ -144,10 +144,10 @@ export type DesktopIdentityInfo = Pick<
 declare global {
   interface Window {
     vm0DesktopAuth?: DesktopAuthApi;
-    vm0DesktopComputerUse?: DesktopComputerUseApi;
-    vm0DesktopDeveloperTools?: DesktopDeveloperToolsApi;
-    vm0DesktopIdentity: DesktopIdentityInfo;
-    vm0DesktopRecorder?: DesktopRecorderApi;
+    okouDesktopComputerUse?: DesktopComputerUseApi;
+    okouDesktopDeveloperTools?: DesktopDeveloperToolsApi;
+    okouDesktopIdentity: DesktopIdentityInfo;
+    okouDesktopRecorder?: DesktopRecorderApi;
   }
 }
 

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -1420,11 +1420,11 @@ async function verifyDesktopSmokeBridge() {
     `(async () => ({
       auth: typeof window.vm0DesktopAuth === "object",
       authCompletionRejected: await window.vm0DesktopAuth.completeSignIn({ token: "smoke-test-token" }).then(() => false, () => true),
-      computerUse: typeof window.vm0DesktopComputerUse === "object",
-      developerTools: typeof window.vm0DesktopDeveloperTools === "object",
-      driverControls: ["setExperimentalCuaEnabled", "selectDriver", "start", "stop"].every(name => typeof window.vm0DesktopComputerUse[name] === "function"),
-      driver: (await window.vm0DesktopComputerUse.getState()).driver,
-      identity: window.vm0DesktopIdentity ?? null,
+      computerUse: typeof window.okouDesktopComputerUse === "object",
+      developerTools: typeof window.okouDesktopDeveloperTools === "object",
+      driverControls: ["setExperimentalCuaEnabled", "selectDriver", "start", "stop"].every(name => typeof window.okouDesktopComputerUse[name] === "function"),
+      driver: (await window.okouDesktopComputerUse.getState()).driver,
+      identity: window.okouDesktopIdentity ?? null,
     }))()`,
     true,
   );
@@ -1452,7 +1452,7 @@ async function verifyDesktopSmokeBridge() {
   // Neither read authorizes an experiment or starts a driver.
   await refreshComputerUsePermissions();
   const settledDriver: unknown = await window.webContents.executeJavaScript(
-    "window.vm0DesktopComputerUse.getState().then(state => state.driver)",
+    "window.okouDesktopComputerUse.getState().then(state => state.driver)",
     true,
   );
   assertCuaDormant();

--- a/turbo/apps/desktop/src/preload.test.ts
+++ b/turbo/apps/desktop/src/preload.test.ts
@@ -87,19 +87,19 @@ describe("Desktop preload bridge", () => {
       }),
     ).toStrictEqual([
       "vm0DesktopAuth",
-      "vm0DesktopComputerUse",
-      "vm0DesktopDeveloperTools",
-      "vm0DesktopIdentity",
-      "vm0DesktopRecorder",
+      "okouDesktopComputerUse",
+      "okouDesktopDeveloperTools",
+      "okouDesktopIdentity",
+      "okouDesktopRecorder",
     ]);
     expect(exposedApi<DesktopAuthApi>("vm0DesktopAuth")).toBeTruthy();
     expect(
-      exposedApi<DesktopComputerUseApi>("vm0DesktopComputerUse"),
+      exposedApi<DesktopComputerUseApi>("okouDesktopComputerUse"),
     ).toBeTruthy();
     expect(
-      exposedApi<DesktopDeveloperToolsApi>("vm0DesktopDeveloperTools"),
+      exposedApi<DesktopDeveloperToolsApi>("okouDesktopDeveloperTools"),
     ).toBeTruthy();
-    expect(exposedApi("vm0DesktopIdentity")).toStrictEqual({
+    expect(exposedApi("okouDesktopIdentity")).toStrictEqual({
       product: "okou",
       brandName: "Okou",
       displayName: "Okou",
@@ -131,7 +131,7 @@ describe("Desktop preload bridge", () => {
   it("routes computer use API calls through IPC channels", async () => {
     await loadPreload();
     const computerUse = exposedApi<DesktopComputerUseApi>(
-      "vm0DesktopComputerUse",
+      "okouDesktopComputerUse",
     );
 
     await computerUse.getState();
@@ -183,7 +183,7 @@ describe("Desktop preload bridge", () => {
   it("routes developer tools API calls through IPC channels", async () => {
     await loadPreload();
     const developerTools = exposedApi<DesktopDeveloperToolsApi>(
-      "vm0DesktopDeveloperTools",
+      "okouDesktopDeveloperTools",
     );
 
     await developerTools.getState();
@@ -199,10 +199,10 @@ describe("Desktop preload bridge", () => {
     await loadPreload();
     const auth = exposedApi<DesktopAuthApi>("vm0DesktopAuth");
     const computerUse = exposedApi<DesktopComputerUseApi>(
-      "vm0DesktopComputerUse",
+      "okouDesktopComputerUse",
     );
     const developerTools = exposedApi<DesktopDeveloperToolsApi>(
-      "vm0DesktopDeveloperTools",
+      "okouDesktopDeveloperTools",
     );
     const authChanged = vi.fn<() => void>();
     const computerUseChanged = vi.fn<() => void>();

--- a/turbo/apps/desktop/src/preload.ts
+++ b/turbo/apps/desktop/src/preload.ts
@@ -229,10 +229,13 @@ const desktopIdentity = ipcRenderer.sendSync(
 ) as DesktopIdentityInfo;
 
 contextBridge.exposeInMainWorld("vm0DesktopAuth", desktopAuthApi);
-contextBridge.exposeInMainWorld("vm0DesktopComputerUse", desktopComputerUseApi);
 contextBridge.exposeInMainWorld(
-  "vm0DesktopDeveloperTools",
+  "okouDesktopComputerUse",
+  desktopComputerUseApi,
+);
+contextBridge.exposeInMainWorld(
+  "okouDesktopDeveloperTools",
   desktopDeveloperToolsApi,
 );
-contextBridge.exposeInMainWorld("vm0DesktopIdentity", desktopIdentity);
-contextBridge.exposeInMainWorld("vm0DesktopRecorder", desktopRecorderApi);
+contextBridge.exposeInMainWorld("okouDesktopIdentity", desktopIdentity);
+contextBridge.exposeInMainWorld("okouDesktopRecorder", desktopRecorderApi);

--- a/turbo/apps/desktop/src/renderer/App.test.tsx
+++ b/turbo/apps/desktop/src/renderer/App.test.tsx
@@ -410,8 +410,8 @@ function installDesktopBridges({
   const computerUse = createComputerUseBridge(computerUseState);
   const developerTools = createDeveloperToolsBridge(developerToolsState);
   window.vm0DesktopAuth = auth.api;
-  window.vm0DesktopComputerUse = computerUse.api;
-  window.vm0DesktopDeveloperTools = developerTools.api;
+  window.okouDesktopComputerUse = computerUse.api;
+  window.okouDesktopDeveloperTools = developerTools.api;
   return {
     auth,
     computerUse,
@@ -428,7 +428,7 @@ function buttonForText(text: string): HTMLButtonElement {
 }
 
 function renderDesktopApp(): void {
-  window.vm0DesktopIdentity = {
+  window.okouDesktopIdentity = {
     product: "okou",
     brandName: "Okou",
     displayName: "Okou",
@@ -444,8 +444,8 @@ afterEach(async () => {
   await settleDesktopActions();
   cleanup();
   delete window.vm0DesktopAuth;
-  delete window.vm0DesktopComputerUse;
-  delete window.vm0DesktopDeveloperTools;
+  delete window.okouDesktopComputerUse;
+  delete window.okouDesktopDeveloperTools;
   vi.clearAllMocks();
 });
 

--- a/turbo/apps/desktop/src/renderer/computer-use-state.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.ts
@@ -21,7 +21,7 @@ const reloadDesktopAuthState$ = state(0);
 const reloadDeveloperToolsState$ = state(0);
 
 function desktopComputerUseApi(): DesktopComputerUseApi {
-  const api = window.vm0DesktopComputerUse;
+  const api = window.okouDesktopComputerUse;
   if (!api) {
     throw new Error("Desktop Computer Use bridge is unavailable");
   }
@@ -37,11 +37,11 @@ function desktopAuthApi(): DesktopAuthApi {
 }
 
 function desktopDeveloperToolsApi(): DesktopDeveloperToolsApi | null {
-  return window.vm0DesktopDeveloperTools ?? null;
+  return window.okouDesktopDeveloperTools ?? null;
 }
 
 export function hasDesktopComputerUseBridge(): boolean {
-  return Boolean(window.vm0DesktopComputerUse);
+  return Boolean(window.okouDesktopComputerUse);
 }
 
 export function hasDesktopAuthBridge(): boolean {
@@ -49,7 +49,7 @@ export function hasDesktopAuthBridge(): boolean {
 }
 
 export function hasDesktopDeveloperToolsBridge(): boolean {
-  return Boolean(window.vm0DesktopDeveloperTools);
+  return Boolean(window.okouDesktopDeveloperTools);
 }
 
 export const computerUseData$ = computed(

--- a/turbo/apps/desktop/src/renderer/desktop-identity.ts
+++ b/turbo/apps/desktop/src/renderer/desktop-identity.ts
@@ -1,5 +1,5 @@
 import type { DesktopIdentityInfo } from "../desktop-bridge";
 
 export function currentDesktopIdentity(): DesktopIdentityInfo {
-  return window.vm0DesktopIdentity;
+  return window.okouDesktopIdentity;
 }

--- a/turbo/apps/desktop/src/renderer/recorder/area-selector.tsx
+++ b/turbo/apps/desktop/src/renderer/recorder/area-selector.tsx
@@ -8,7 +8,7 @@ interface DragPoint {
   readonly y: number;
 }
 
-const recorder = window.vm0DesktopRecorder;
+const recorder = window.okouDesktopRecorder;
 /**
  * Which screen this overlay covers.
  *

--- a/turbo/apps/desktop/src/renderer/recorder/recorder-bar.test.tsx
+++ b/turbo/apps/desktop/src/renderer/recorder/recorder-bar.test.tsx
@@ -40,7 +40,7 @@ function installRecorder(): RecorderStub {
       return await Promise.resolve();
     },
   } as unknown as DesktopRecorderApi;
-  vi.stubGlobal("vm0DesktopRecorder", api);
+  vi.stubGlobal("okouDesktopRecorder", api);
   return {
     api,
     completeWindowSelection,

--- a/turbo/apps/desktop/src/renderer/recorder/recorder-bar.tsx
+++ b/turbo/apps/desktop/src/renderer/recorder/recorder-bar.tsx
@@ -18,7 +18,7 @@ type CaptureChoice =
       readonly title: string;
     };
 
-const recorder = window.vm0DesktopRecorder;
+const recorder = window.okouDesktopRecorder;
 
 export function RecorderBar(): React.ReactElement {
   const [choice, setChoice] = useState<CaptureChoice>({ kind: "display" });

--- a/turbo/apps/desktop/src/renderer/recorder/recording-controller.test.tsx
+++ b/turbo/apps/desktop/src/renderer/recorder/recording-controller.test.tsx
@@ -41,7 +41,7 @@ function installRecorder(initial: DesktopRecorderStatus): {
       return await Promise.resolve();
     },
   } as unknown as DesktopRecorderApi;
-  vi.stubGlobal("vm0DesktopRecorder", api);
+  vi.stubGlobal("okouDesktopRecorder", api);
   return {
     setStatus: (next) => {
       status = next;

--- a/turbo/apps/desktop/src/renderer/recorder/recording-controller.tsx
+++ b/turbo/apps/desktop/src/renderer/recorder/recording-controller.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Pause, Play, Square, Trash2 } from "lucide-react";
 
-const recorder = window.vm0DesktopRecorder;
+const recorder = window.okouDesktopRecorder;
 
 function formatElapsed(elapsedMs: number): string {
   const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));

--- a/turbo/apps/desktop/src/renderer/recorder/window-picker.tsx
+++ b/turbo/apps/desktop/src/renderer/recorder/window-picker.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { X } from "lucide-react";
 import type { DesktopRecorderWindowOption } from "../../desktop-recorder-types";
 
-const recorder = window.vm0DesktopRecorder;
+const recorder = window.okouDesktopRecorder;
 
 /**
  * Picks the window to record by sight.


### PR DESCRIPTION
Closes #33476.

## What

Renames the four preload bridge globals that are read only inside `turbo/apps/desktop`:

| before | after |
| --- | --- |
| `vm0DesktopComputerUse` | `okouDesktopComputerUse` |
| `vm0DesktopDeveloperTools` | `okouDesktopDeveloperTools` |
| `vm0DesktopIdentity` | `okouDesktopIdentity` |
| `vm0DesktopRecorder` | `okouDesktopRecorder` |

Sites updated: `preload.ts` (the `contextBridge.exposeInMainWorld` calls), the `Window` interface declaration in `desktop-bridge.ts`, the `executeJavaScript` **string literals** in `main.ts` (`verifyDesktopSmokeBridge`, plus the settled-driver read — a symbol rename does not reach these), `renderer/computer-use-state.ts`, `renderer/desktop-identity.ts`, `renderer/recorder/{area-selector,recorder-bar,recording-controller,window-picker}.tsx`, the matching tests, and `docs/testing/desktop-testing.md`.

No behavior change: bridge APIs, IPC channel names, argument and return shapes, `contextIsolation` / `sandbox` / `partition`, `preloadPath()`, `browserWindowOptions`, the auth-window navigation policy, bundle identifiers, auth schemes, `sessionPartition` values and `desktop-identities.json` are all untouched. `preload.ts` picked up a Prettier line-wrap on two exposure calls because the new names are longer.

## `vm0DesktopAuth` is deliberately untouched

`vm0DesktopAuth` is a cross-version contract and stays byte-identical, with no alias, dual exposure or deprecation shim.

The preload **does** meet remote code: `main.ts` builds `DesktopAuthWindow` with `windowOptions: () => browserWindowOptions()`, `browserWindowOptions` attaches `preloadPath()` by default, and that window then loads `config.authUrl.origin`. The deployed web app — `turbo/apps/platform/src/signals/desktop-auth/protocol.ts` — declares the global at line 16 and reads `window.vm0DesktopAuth?.completeSignIn` at line 173. Renaming it would break sign-in for already-installed Desktop builds. Its migration is a separate decision.

The four globals in this PR are safe not because the preload is local-only, but because no remote-served code reads them.

## Verification, re-run at implementation time

Searches re-run against `origin/main` at `f222d69` rather than trusting the issue's snapshot.

Pre-change, each old name across both remote-served trees:

```
$ for n in vm0DesktopComputerUse vm0DesktopDeveloperTools vm0DesktopIdentity vm0DesktopRecorder; do
    git grep -n "$n" origin/main -- turbo/apps/platform turbo/packages
  done
vm0DesktopComputerUse: 0 matches in turbo/apps/platform + turbo/packages
vm0DesktopDeveloperTools: 0 matches in turbo/apps/platform + turbo/packages
vm0DesktopIdentity: 0 matches in turbo/apps/platform + turbo/packages
vm0DesktopRecorder: 0 matches in turbo/apps/platform + turbo/packages
```

Post-change, each new name across the same trees:

```
$ for n in okouDesktopComputerUse okouDesktopDeveloperTools okouDesktopIdentity okouDesktopRecorder; do
    grep -rn "$n" turbo/apps/platform turbo/packages
  done
(no matches for any of the four)
```

Old names gone from the tracked tree, including the `main.ts` string literals and the docs:

```
$ grep -rn "vm0DesktopComputerUse\|vm0DesktopDeveloperTools\|vm0DesktopIdentity\|vm0DesktopRecorder" . --exclude-dir=.git --exclude-dir=node_modules
(none)
```

`vm0DesktopAuth` unchanged — no added or removed line in this PR mentions it:

```
$ git diff origin/main | grep -E "^[+-].*vm0DesktopAuth"
(no changed line touches vm0DesktopAuth)
```

Its four platform occurrences (`protocol.ts:16`, `protocol.ts:173`, `desktop-auth.test.tsx:49`, `desktop-auth.test.tsx:58`) and its `desktop-bridge.ts:146` declaration, `preload.ts:231` exposure and `main.ts:1421-1422` diagnostic are all as on `main`.

## Checks

Scoped to the affected area, per repository guidance — no full local suite, no dev server:

- `pnpm -F @okouai/desktop check-types` — clean
- `pnpm -F @okouai/desktop lint` (`oxlint src --deny-warnings`) — clean
- `pnpm -F @okouai/desktop test` — 59 files, 870 tests passed
- `prettier --check` on all 14 changed files — clean

## Open-PR overlap

Re-checked at implementation time: of the 28 open PRs, none touches `turbo/apps/desktop/**` or `docs/testing/desktop-testing.md`. Recorded as inventory only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
