### PR TITLE
feat(ssh): support password authentication in runner execution

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -1406,6 +1406,21 @@ pub mod runners {
                 /// Bounded zeroizing passphrase, preserving whitespace.
                 passphrase: Option<crate::SecretText<4096>>,
             },
+            /// Authorized current password credential handoff.
+            ResolvedPassword {
+                /// Current destination, private to Runner.
+                host: String,
+                /// Current destination port.
+                port: u64,
+                /// Current login identity.
+                username: String,
+                /// Current configuration generation.
+                generation: i64,
+                /// Existing pin, or first-use trust required.
+                learned_host_key: Option<ResolveResponseResolvedLearnedHostKey>,
+                /// Bounded zeroizing login password, preserving whitespace.
+                password: crate::SecretText<4096>,
+            },
         }
 
         impl<'de> serde::Deserialize<'de> for ResolveResponse {
@@ -1417,6 +1432,8 @@ pub mod runners {
                     Unavailable,
                     #[serde(rename = "resolved")]
                     Resolved,
+                    #[serde(rename = "resolved_password")]
+                    ResolvedPassword,
                 }
                 #[derive(serde::Deserialize)]
                 #[serde(field_identifier)]
@@ -1437,6 +1454,8 @@ pub mod runners {
                     PrivateKey,
                     #[serde(rename = "passphrase")]
                     Passphrase,
+                    #[serde(rename = "password")]
+                    Password,
                 }
                 struct Visitor;
                 impl<'de> serde::de::Visitor<'de> for Visitor {
@@ -1460,6 +1479,7 @@ pub mod runners {
                             None::<Option<ResolveResponseResolvedLearnedHostKey>>;
                         let mut private_key = None::<crate::SecretText<65536>>;
                         let mut passphrase = None::<Option<crate::SecretText<4096>>>;
+                        let mut password = None::<crate::SecretText<4096>>;
                         while let Some(field) = map.next_key::<Field>()? {
                             match field {
                                 Field::Outcome => {
@@ -1526,6 +1546,14 @@ pub mod runners {
                                     }
                                     passphrase = Some(map.next_value()?);
                                 }
+                                Field::Password => {
+                                    if password.is_some() {
+                                        return Err(serde::de::Error::custom(
+                                            "duplicate authority field",
+                                        ));
+                                    }
+                                    password = Some(map.next_value()?);
+                                }
                             }
                         }
                         match (
@@ -1537,10 +1565,19 @@ pub mod runners {
                             learned_host_key,
                             private_key,
                             passphrase,
+                            password,
                         ) {
-                            (Some(Kind::Unavailable), None, None, None, None, None, None, None) => {
-                                Ok(ResolveResponse::Unavailable)
-                            }
+                            (
+                                Some(Kind::Unavailable),
+                                None,
+                                None,
+                                None,
+                                None,
+                                None,
+                                None,
+                                None,
+                                None,
+                            ) => Ok(ResolveResponse::Unavailable),
                             (
                                 Some(Kind::Resolved),
                                 Some(host),
@@ -1550,6 +1587,7 @@ pub mod runners {
                                 Some(learned_host_key),
                                 Some(private_key),
                                 Some(passphrase),
+                                None,
                             ) => Ok(ResolveResponse::Resolved {
                                 host,
                                 port,
@@ -1558,6 +1596,24 @@ pub mod runners {
                                 learned_host_key,
                                 private_key,
                                 passphrase,
+                            }),
+                            (
+                                Some(Kind::ResolvedPassword),
+                                Some(host),
+                                Some(port),
+                                Some(username),
+                                Some(generation),
+                                Some(learned_host_key),
+                                None,
+                                None,
+                                Some(password),
+                            ) => Ok(ResolveResponse::ResolvedPassword {
+                                host,
+                                port,
+                                username,
+                                generation,
+                                learned_host_key,
+                                password,
                             }),
                             _ => Err(serde::de::Error::custom("invalid authority outcome fields")),
                         }

--- a/crates/api-contracts/tests/ssh.rs
+++ b/crates/api-contracts/tests/ssh.rs
@@ -2,6 +2,61 @@ use api_contracts::generated::types::runners::ssh::ResolveResponse;
 use serde_json::json;
 
 #[test]
+fn password_handoff_requires_exact_variant_fields_and_bounded_secrets() {
+    let password = format!(" {}  \n", "😀".repeat(2046));
+    assert_eq!(password.encode_utf16().count(), 4096);
+    let body = json!({"outcome":"resolved_password","host":"example.com","port":22,"username":"user","generation":1,"learnedHostKey":null,"password":password});
+    let decoded: ResolveResponse = serde_json::from_str(&body.to_string()).unwrap();
+    let ResolveResponse::ResolvedPassword {
+        password: decoded, ..
+    } = decoded
+    else {
+        panic!("expected password");
+    };
+    assert_eq!(decoded.expose(), password);
+    for password in ["".to_owned(), "😀".repeat(2049)] {
+        let mut invalid = body.clone();
+        invalid["password"] = json!(password);
+        assert!(serde_json::from_str::<ResolveResponse>(&invalid.to_string()).is_err());
+    }
+    for field in [
+        "host",
+        "port",
+        "username",
+        "generation",
+        "learnedHostKey",
+        "password",
+    ] {
+        let mut invalid = body.clone();
+        invalid.as_object_mut().unwrap().remove(field);
+        assert!(
+            serde_json::from_str::<ResolveResponse>(&invalid.to_string()).is_err(),
+            "missing {field}"
+        );
+    }
+    for field in ["privateKey", "passphrase", "unknown"] {
+        let mut invalid = body.clone();
+        invalid[field] = json!("secret-canary");
+        let error = serde_json::from_str::<ResolveResponse>(&invalid.to_string())
+            .err()
+            .unwrap();
+        assert!(!error.to_string().contains("secret-canary"));
+    }
+    for field in ["outcome", "host", "password", "learnedHostKey"] {
+        let duplicate = format!("{{\"{field}\":{},{}", body[field], &body.to_string()[1..]);
+        assert!(
+            serde_json::from_str::<ResolveResponse>(&duplicate).is_err(),
+            "duplicate {field}"
+        );
+    }
+    let mut mixed = body;
+    mixed["outcome"] = json!("resolved");
+    mixed["privateKey"] = json!("secret-key");
+    mixed["passphrase"] = serde_json::Value::Null;
+    assert!(serde_json::from_str::<ResolveResponse>(&mixed.to_string()).is_err());
+}
+
+#[test]
 fn credential_handoff_obeys_utf16_bounds_and_preserves_secret_whitespace() {
     let body = json!({"outcome":"resolved","host":"example.com","port":22,"username":"user","generation":1,"learnedHostKey":null,"privateKey":"😀".repeat(32768),"passphrase":" passphrase\n"});
     let decoded: ResolveResponse = serde_json::from_value(body.clone()).unwrap();

--- a/crates/runner/src/ssh/authority.rs
+++ b/crates/runner/src/ssh/authority.rs
@@ -25,8 +25,15 @@ pub(super) struct Credential {
     pub(super) username: String,
     pub(super) generation: i64,
     pub(super) pin: Option<ResolveResponseResolvedLearnedHostKey>,
-    pub(super) private_key: api_contracts::SecretText<65536>,
-    pub(super) passphrase: Option<api_contracts::SecretText<4096>>,
+    pub(super) auth: CredentialAuth,
+}
+
+pub(super) enum CredentialAuth {
+    PrivateKey {
+        private_key: api_contracts::SecretText<65536>,
+        passphrase: Option<api_contracts::SecretText<4096>>,
+    },
+    Password(api_contracts::SecretText<4096>),
 }
 
 pub(super) struct PreparedCredential {
@@ -34,7 +41,12 @@ pub(super) struct PreparedCredential {
     pub(super) port: u16,
     pub(super) username: String,
     pub(super) trust: Mutex<Trust>,
-    pub(super) key: SigningKey,
+    pub(super) auth: PreparedAuth,
+}
+
+pub(super) enum PreparedAuth {
+    PrivateKey(SigningKey),
+    Password(api_contracts::SecretText<4096>),
 }
 
 pub(super) struct Trust {
@@ -161,17 +173,42 @@ impl Authority {
                 &body,
             )
             .await?;
-        let ResolveResponse::Resolved {
-            host,
-            port,
-            username,
-            generation,
-            learned_host_key,
-            private_key,
-            passphrase,
-        } = response
-        else {
-            return Err(FailureReason::Unavailable);
+        let (host, port, username, generation, learned_host_key, auth) = match response {
+            ResolveResponse::Unavailable => return Err(FailureReason::Unavailable),
+            ResolveResponse::Resolved {
+                host,
+                port,
+                username,
+                generation,
+                learned_host_key,
+                private_key,
+                passphrase,
+            } => (
+                host,
+                port,
+                username,
+                generation,
+                learned_host_key,
+                CredentialAuth::PrivateKey {
+                    private_key,
+                    passphrase,
+                },
+            ),
+            ResolveResponse::ResolvedPassword {
+                host,
+                port,
+                username,
+                generation,
+                learned_host_key,
+                password,
+            } => (
+                host,
+                port,
+                username,
+                generation,
+                learned_host_key,
+                CredentialAuth::Password(password),
+            ),
         };
         let port = u16::try_from(port).map_err(|_| FailureReason::AuthorityFailure)?;
         if port == 0
@@ -192,8 +229,7 @@ impl Authority {
             username,
             generation,
             pin: learned_host_key,
-            private_key,
-            passphrase,
+            auth,
         })
     }
 

--- a/crates/runner/src/ssh/engine.rs
+++ b/crates/runner/src/ssh/engine.rs
@@ -16,7 +16,7 @@ use tokio::net::TcpStream;
 
 use super::{
     FailureReason, Scope,
-    authority::{Authority, PreparedCredential},
+    authority::{Authority, PreparedAuth, PreparedCredential},
     io::{GuestIo, Lease, SshSocket},
     output::{Output, RemoteExit, Stream},
 };
@@ -62,26 +62,38 @@ impl Execution {
                 .unwrap_or(FailureReason::Protocol)
         })?;
         let result = async {
-            let hash = if matches!(self.credential.key.0.algorithm(), Algorithm::Rsa { .. }) {
-                match scope
-                    .wait(session.best_supported_rsa_hash())
-                    .await?
-                    .map_err(|_| FailureReason::Protocol)?
-                {
-                    Some(Some(hash)) => Some(hash),
-                    None => Some(HashAlg::Sha512),
-                    Some(None) => return Err(FailureReason::AuthenticationFailed),
-                }
-            } else {
-                None
-            };
-            let authentication = scope
-                .wait(session.authenticate_publickey(
-                    self.credential.username.clone(),
-                    PrivateKeyWithHashAlg::new(Arc::clone(&self.credential.key.0), hash),
-                ))
-                .await?
-                .map_err(|_| FailureReason::AuthenticationFailed)?;
+            let authentication =
+                match &self.credential.auth {
+                    PreparedAuth::Password(password) => scope
+                        .wait(session.authenticate_password(
+                            self.credential.username.clone(),
+                            password.expose(),
+                        ))
+                        .await?
+                        .map_err(|_| FailureReason::AuthenticationFailed)?,
+                    PreparedAuth::PrivateKey(key) => {
+                        let hash = if matches!(key.0.algorithm(), Algorithm::Rsa { .. }) {
+                            match scope
+                                .wait(session.best_supported_rsa_hash())
+                                .await?
+                                .map_err(|_| FailureReason::Protocol)?
+                            {
+                                Some(Some(hash)) => Some(hash),
+                                None => Some(HashAlg::Sha512),
+                                Some(None) => return Err(FailureReason::AuthenticationFailed),
+                            }
+                        } else {
+                            None
+                        };
+                        scope
+                            .wait(session.authenticate_publickey(
+                                self.credential.username.clone(),
+                                PrivateKeyWithHashAlg::new(Arc::clone(&key.0), hash),
+                            ))
+                            .await?
+                            .map_err(|_| FailureReason::AuthenticationFailed)?
+                    }
+                };
             if !authentication.success() {
                 return Err(FailureReason::AuthenticationFailed);
             }

--- a/crates/runner/src/ssh/mod.rs
+++ b/crates/runner/src/ssh/mod.rs
@@ -26,7 +26,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 
 use crate::{http::HttpClient, ids::RunId, runner_process_identity::RunnerProcessIdentity};
-use authority::{Authority, PreparedCredential, Trust};
+use authority::{Authority, CredentialAuth, PreparedAuth, PreparedCredential, Trust};
 use io::{GuestIo, Lease};
 use network::{Network, PublicNetwork};
 
@@ -391,6 +391,26 @@ impl SshRuntime {
         let credential = scope
             .wait(self.authority.resolve(run, connection))
             .await??;
+        let (private_key, passphrase) = match credential.auth {
+            CredentialAuth::PrivateKey {
+                private_key,
+                passphrase,
+            } => (private_key, passphrase),
+            CredentialAuth::Password(password) => {
+                scope.check()?;
+                observation.generation = Some(credential.generation);
+                return Ok(PreparedCredential {
+                    host: credential.host,
+                    port: credential.port,
+                    username: credential.username,
+                    trust: Mutex::new(Trust {
+                        generation: credential.generation,
+                        pin: credential.pin,
+                    }),
+                    auth: PreparedAuth::Password(password),
+                });
+            }
+        };
         let cpu = Arc::clone(&self.cpu)
             .try_acquire_owned()
             .map_err(|_| FailureReason::ResourceExhausted)?;
@@ -402,8 +422,8 @@ impl SshRuntime {
             let _lease = worker_lease;
             worker_scope.check()?;
             let key = keys::decode(
-                credential.private_key.expose(),
-                credential.passphrase.as_ref().map(|value| value.expose()),
+                private_key.expose(),
+                passphrase.as_ref().map(|value| value.expose()),
             )?;
             worker_scope.check()?;
             Ok::<_, FailureReason>(PreparedCredential {
@@ -414,7 +434,7 @@ impl SshRuntime {
                     generation: credential.generation,
                     pin: credential.pin,
                 }),
-                key,
+                auth: PreparedAuth::PrivateKey(key),
             })
         });
         let result = scope

--- a/crates/runner/src/ssh/tests/harness.rs
+++ b/crates/runner/src/ssh/tests/harness.rs
@@ -450,6 +450,9 @@ pub(super) async fn frames(mut guest: DuplexStream) -> Vec<Value> {
         .unwrap()
 }
 
+pub(super) const PASSWORD: &str = " password-😀-canary \n";
+pub(super) const PARTIAL_PASSWORD: &str = "partial-password-canary";
+
 struct Peer {
     key: PublicKey,
     observed: Arc<Observed>,
@@ -508,6 +511,21 @@ impl Peer {
 }
 impl server::Handler for Peer {
     type Error = russh::Error;
+    async fn auth_password(
+        &mut self,
+        user: &str,
+        password: &str,
+    ) -> Result<server::Auth, Self::Error> {
+        self.observed.auth.fetch_add(1, Ordering::SeqCst);
+        Ok(if user == "test-user" && password == PASSWORD {
+            server::Auth::Accept
+        } else {
+            server::Auth::Reject {
+                proceed_with_methods: None,
+                partial_success: password == PARTIAL_PASSWORD,
+            }
+        })
+    }
     async fn auth_publickey(
         &mut self,
         user: &str,

--- a/crates/runner/src/ssh/tests/mod.rs
+++ b/crates/runner/src/ssh/tests/mod.rs
@@ -4,6 +4,7 @@ mod framing;
 mod harness;
 mod lifecycle;
 mod observations;
+mod passwords;
 mod proof;
 mod telemetry;
 

--- a/crates/runner/src/ssh/tests/passwords.rs
+++ b/crates/runner/src/ssh/tests/passwords.rs
@@ -1,0 +1,190 @@
+use super::{
+    harness::{CONNECTION, Harness, PARTIAL_PASSWORD, PASSWORD, Reply, key, params},
+    output, terminal,
+};
+use russh::keys::{Algorithm, HashAlg};
+use serde_json::{Value, json};
+use std::sync::atomic::Ordering;
+
+fn credential(h: &Harness, pinned: bool, password: &str) -> Value {
+    json!({
+        "outcome": "resolved_password", "host": "ssh.example.com", "port": 22,
+        "username": "test-user", "generation": 7, "password": password,
+        "learnedHostKey": pinned.then(|| json!({
+            "algorithm": h.host_key.algorithm().as_str(),
+            "fingerprint": h.host_key.fingerprint(HashAlg::Sha256).to_string(),
+        })),
+    })
+}
+
+#[tokio::test]
+async fn password_preserves_whitespace_and_binary_output_with_nonzero_exit() {
+    let h = Harness::new(Reply::default()).await;
+    let resolve = h.resolve(credential(&h, true, PASSWORD)).await;
+    let frames = h.request(params()).await;
+    assert_eq!(
+        frames[0],
+        json!({"type":"event","data":{"type":"accepted"}})
+    );
+    assert_eq!(terminal(&frames)["type"], "finished");
+    assert_eq!(terminal(&frames)["exit"], json!({"type":"status","code":7}));
+    assert_eq!(terminal(&frames)["effects"], "completed");
+    assert_eq!(output(&frames, "stdout"), b"hello\0\xff");
+    assert_eq!(output(&frames, "stderr"), b"warning\n");
+    assert!(!serde_json::to_string(&frames).unwrap().contains("canary"));
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        *h.observed.commands.lock().unwrap(),
+        vec![b"printf test-command".to_vec()]
+    );
+    resolve.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn rejected_or_partial_password_never_falls_back_and_reports_recovery() {
+    for password in ["wrong-password-canary", PARTIAL_PASSWORD] {
+        let mut h = Harness::new(Reply::default()).await;
+        let dispatcher = h.take_dispatcher();
+        h.runtime.ably_connected(true);
+        let resolve = h.resolve(credential(&h, true, password)).await;
+        let failure = h
+            .api
+            .mock_async(|when, then| {
+                when.method("POST")
+                    .path(format!("/api/runners/runs/{}/ssh/observations", h.run))
+                    .json_body_includes(
+                        json!({"expectedGeneration":7,"failureReason":"authentication_failed"})
+                            .to_string(),
+                    )
+                    .body_excludes("canary")
+                    .body_excludes("password");
+                then.status(200).json_body(json!({"outcome":"recorded"}));
+            })
+            .await;
+        let recovered = h
+            .api
+            .mock_async(|when, then| {
+                when.method("POST")
+                    .path(format!("/api/runners/runs/{}/ssh/observations", h.run))
+                    .json_body_includes(
+                        json!({"expectedGeneration":7,"failureReason":null}).to_string(),
+                    )
+                    .body_excludes("canary")
+                    .body_excludes("password");
+                then.status(200).json_body(json!({"outcome":"recorded"}));
+            })
+            .await;
+        let frames = h.request(params()).await;
+        assert_eq!(terminal(&frames)["failure_reason"], "authentication_failed");
+        assert_eq!(terminal(&frames)["effects"], "not_started");
+        assert!(!serde_json::to_string(&frames).unwrap().contains("canary"));
+        assert_eq!(h.observed.auth.load(Ordering::SeqCst), 1);
+        assert!(h.observed.commands.lock().unwrap().is_empty());
+        resolve.assert_calls_async(1).await;
+        resolve.delete_async().await;
+        let resolve = h.resolve(credential(&h, true, PASSWORD)).await;
+        assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
+        dispatcher.shutdown().await;
+        failure.assert_calls_async(1).await;
+        recovered.assert_calls_async(1).await;
+        resolve.assert_calls_async(1).await;
+        assert_eq!(h.observed.commands.lock().unwrap().len(), 1);
+    }
+}
+
+#[tokio::test]
+async fn password_is_not_sent_to_a_mismatched_host() {
+    let h = Harness::new(Reply::default()).await;
+    let mut body = credential(&h, true, PASSWORD);
+    body["learnedHostKey"]["fingerprint"] = json!(
+        key(Algorithm::Ed25519)
+            .fingerprint(HashAlg::Sha256)
+            .to_string()
+    );
+    let _resolve = h.resolve(body).await;
+    let frames = h.request(params()).await;
+    assert_eq!(terminal(&frames)["failure_reason"], "host_key_mismatch");
+    assert_eq!(terminal(&frames)["effects"], "not_started");
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 0);
+    assert!(h.observed.commands.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn password_waits_for_confirmed_tofu_and_reports_its_generation() {
+    for outcome in ["pinned", "configuration_changed"] {
+        let mut h = Harness::new(Reply::default()).await;
+        let dispatcher = h.take_dispatcher();
+        let _resolve = h.resolve(credential(&h, false, PASSWORD)).await;
+        let pin = h
+            .api
+            .mock_async(|when, then| {
+                when.method("POST")
+                    .path(format!("/api/runners/runs/{}/ssh/pin", h.run))
+                    .json_body_includes(json!({"expectedGeneration":7}).to_string());
+                then.status(200).json_body(if outcome == "pinned" {
+                    json!({"outcome":outcome,"generation":8})
+                } else {
+                    json!({"outcome":outcome})
+                });
+            })
+            .await;
+        let report = h
+            .api
+            .mock_async(|when, then| {
+                when.method("POST")
+                    .path(format!("/api/runners/runs/{}/ssh/observations", h.run))
+                    .json_body_includes(
+                        json!({"expectedGeneration":8,"failureReason":null}).to_string(),
+                    )
+                    .body_excludes("canary");
+                then.status(200).json_body(json!({"outcome":"recorded"}));
+            })
+            .await;
+        let frames = h.request(params()).await;
+        dispatcher.shutdown().await;
+        pin.assert_calls_async(1).await;
+        if outcome == "pinned" {
+            assert_eq!(terminal(&frames)["type"], "finished");
+            assert_eq!(h.observed.auth.load(Ordering::SeqCst), 1);
+            report.assert_calls_async(1).await;
+        } else {
+            assert_eq!(terminal(&frames)["failure_reason"], outcome);
+            assert_eq!(h.observed.auth.load(Ordering::SeqCst), 0);
+            assert!(h.observed.commands.lock().unwrap().is_empty());
+            report.assert_calls_async(0).await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn invalidation_replaces_cached_key_with_password_and_disconnect_evicts_it() {
+    let h = Harness::new(Reply::default()).await;
+    h.runtime.ably_connected(true);
+    let resolve = h.resolve(h.credential(true)).await;
+    assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
+    resolve.assert_calls_async(1).await;
+    resolve.delete_async().await;
+    let resolve = h.resolve(credential(&h, true, PASSWORD)).await;
+    assert!(h.runtime.ably_message(&ably_subscriber::Message {
+        name: Some("ssh-authority-invalidated".into()),
+        data: json!({"runId":h.run,"connectionId":CONNECTION}),
+        id: None,
+        client_id: None,
+        timestamp: None,
+    }));
+    for _ in 0..2 {
+        assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
+    }
+    resolve.assert_calls_async(1).await;
+    resolve.delete_async().await;
+    h.runtime.ably_connected(false);
+    let resolve = h
+        .resolve(credential(&h, true, "rotated-password-canary"))
+        .await;
+    assert_eq!(
+        terminal(&h.request(params()).await)["failure_reason"],
+        "authentication_failed"
+    );
+    resolve.assert_calls_async(1).await;
+    assert_eq!(h.observed.commands.lock().unwrap().len(), 3);
+}

--- a/docs/runner-ssh-execution.md
+++ b/docs/runner-ssh-execution.md
@@ -20,7 +20,8 @@ Run, owner, Agent, endpoint, username, private key, pin, timeout or SSH options.
 Unknown methods and invalid params are rejected before credential resolution.
 
 The Runner resolves or reuses its Run-owned credentials, validates the destination, makes one
-TCP connection, verifies host trust, authenticates using the private key, opens
+TCP connection, verifies host trust, authenticates using the selected private key
+or password, opens
 one session channel and requests one non-PTY exec with acknowledgement. It sends
 EOF on stdin. It never requests shell, environment, PTY, agent forwarding, port
 forwarding or subsystems, and rejects unsolicited server channels. There is no
@@ -69,12 +70,13 @@ or pin is required, without affecting normal Agent execution. Cache hits make no
 API request. In-flight handoffs cannot be retracted; missed invalidations may
 additionally preserve an authorized snapshot until Run end.
 
-### Run-scoped authority and key cache
+### Run-scoped authority and credential cache
 
-The first use of a connection resolves current authority and parses the private
-key under the existing CPU/admission limits. While the Runner's Ably subscription
+The first use of a connection resolves current authority and prepares exactly one
+authentication method. Private keys are parsed under the existing CPU/admission
+limits; passwords require no key-decoding slot. While the Runner's Ably subscription
 is connected, later commands in the same Run reuse that prepared configuration,
-generation, host trust and parsed key. There is no TTL, periodic refresh,
+generation, host trust and parsed key or bounded zeroizing password. There is no TTL, periodic refresh,
 connection pooling, disk persistence or cross-Run credential sharing. Raw private
 key/passphrase text is released after preparation rather than retained alongside
 the parsed key. Every connection still validates its public destination and the
@@ -164,6 +166,19 @@ deserialize fields directly rather than through tagged generic-value buffers.
 Application-owned response, PEM and decrypted buffers are bounded and zeroizing;
 this is not a claim that serde/HTTP/crypto libraries eliminate every internal
 plaintext copy. Credentials are never written to guest files or checkpoints.
+
+The private `resolved_password` response supplies a login password (1..4096 UTF-16
+code units, preserving whitespace), distinct from a private-key passphrase. The
+Runner sends it only after host proof and pin/TOFU succeed. The destination receives
+the password over encrypted SSH; unlike private-key authentication, a malicious
+destination can learn and reuse it. Partial authentication or rejection fails
+without exec, another authentication method or command replay. Keyboard-interactive,
+OTP/MFA and forced password-change exchanges are not supported.
+
+#33467 adds this contract and execution capability only. Owner configuration and
+API credential writers remain key-only until #33468 delivers reusable credentials.
+SSH is staff-only, so this work adds no legacy compatibility or reader-drain gate;
+see [fallback policy](fallback.md#2-features-behind-a-feature-switch-need-no-fallback).
 
 Per-sandbox admission is 2 requests and per-Runner admission is 16, before request
 parsing and JIT. Expensive key decoding uses 2 process-wide blocking slots.

--- a/turbo/apps/api/src/signals/routes/__tests__/ssh-connections.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ssh-connections.test.ts
@@ -455,16 +455,17 @@ describe("SSH connection routes", () => {
         "/api/ssh/connections",
         "POST",
         {
-          displayName: "Password",
-          host: "password.example.com",
-          username: "user",
+          ...createBody("password.example.com"),
           password: "password-canary",
         },
       ],
       [
         `/api/ssh/connections/${created.body.id}`,
         "PATCH",
-        { password: "password-canary" },
+        {
+          expectedGeneration: created.body.generation,
+          password: "password-canary",
+        },
       ],
     ] as const) {
       const response = await rawRequest(path, {

--- a/turbo/apps/api/src/signals/routes/__tests__/ssh-connections.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ssh-connections.test.ts
@@ -450,6 +450,33 @@ describe("SSH connection routes", () => {
       context,
       routes: sshConnectionsRoutes,
     });
+    for (const [path, method, body] of [
+      [
+        "/api/ssh/connections",
+        "POST",
+        {
+          displayName: "Password",
+          host: "password.example.com",
+          username: "user",
+          password: "password-canary",
+        },
+      ],
+      [
+        `/api/ssh/connections/${created.body.id}`,
+        "PATCH",
+        { password: "password-canary" },
+      ],
+    ] as const) {
+      const response = await rawRequest(path, {
+        method,
+        headers: { ...authHeaders(), "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      expect(response.status).toBe(400);
+      expect(JSON.stringify(response.body)).not.toContain("password-canary");
+    }
+    expect(kms.generateDataKeyCalls).toBe(1);
+
     const unknownField = await rawRequest("/api/ssh/connections", {
       method: "POST",
       headers: { ...authHeaders(), "content-type": "application/json" },

--- a/turbo/packages/api-contracts/src/contracts/runner-ssh.ts
+++ b/turbo/packages/api-contracts/src/contracts/runner-ssh.ts
@@ -12,6 +12,7 @@ import {
 } from "./ssh-connections";
 
 const c = initContract();
+export const SSH_PASSWORD_MAX_LENGTH = 4096;
 const generationSchema = z.int().positive().max(2_147_483_647);
 
 /** Identifier-only invalidation; null connectionId invalidates the whole Run. */
@@ -55,18 +56,28 @@ const resolveRequestSchema = z
 const unavailableSchema = z
   .object({ outcome: z.literal("unavailable") })
   .strict();
+const resolvedFields = {
+  host: z.string().min(1).max(SSH_HOST_MAX_LENGTH),
+  port: z.int().min(1).max(65_535),
+  username: z.string().min(1).max(SSH_USERNAME_MAX_LENGTH),
+  generation: generationSchema,
+  learnedHostKey: sshHostKeySchema.nullable(),
+};
 const resolveResponseSchema = z.discriminatedUnion("outcome", [
   unavailableSchema,
   z
     .object({
       outcome: z.literal("resolved"),
-      host: z.string().min(1).max(SSH_HOST_MAX_LENGTH),
-      port: z.int().min(1).max(65_535),
-      username: z.string().min(1).max(SSH_USERNAME_MAX_LENGTH),
-      generation: generationSchema,
-      learnedHostKey: sshHostKeySchema.nullable(),
+      ...resolvedFields,
       privateKey: z.string().min(1).max(SSH_PRIVATE_KEY_MAX_LENGTH),
       passphrase: z.string().min(1).max(SSH_PASSPHRASE_MAX_LENGTH).nullable(),
+    })
+    .strict(),
+  z
+    .object({
+      outcome: z.literal("resolved_password"),
+      ...resolvedFields,
+      password: z.string().min(1).max(SSH_PASSWORD_MAX_LENGTH),
     })
     .strict(),
 ]);

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -280,6 +280,11 @@ describe("Rust type bindings", () => {
     expect(source).toContain("pub enum ResolveResponse {");
     expect(source).toContain("private_key: crate::SecretText<65536>");
     expect(source).toContain("passphrase: Option<crate::SecretText<4096>>");
+    expect(source).toContain("password: crate::SecretText<4096>");
+    expect(source).toContain("ResolvedPassword {");
+    expect(
+      source.match(/pub struct ResolveResponseResolvedLearnedHostKey \{/gu),
+    ).toHaveLength(1);
     expect(source).toContain(
       "impl<'de> serde::Deserialize<'de> for ResolveResponse",
     );
@@ -289,6 +294,28 @@ describe("Rust type bindings", () => {
     expect(source).not.toMatch(
       /#\[derive\([^\]]*(Debug|Clone|Serialize)[^\]]*\)\]\s*(#\[[^\]]*\]\s*)*pub enum ResolveResponse\s*\{/,
     );
+  });
+  it("rejects incompatible shared fields in sensitive variants", () => {
+    const binding = validBinding({
+      sensitive: true,
+      schema: z.discriminatedUnion("outcome", [
+        z.object({ outcome: z.literal("key"), shared: z.string() }).strict(),
+        z
+          .object({ outcome: z.literal("password"), shared: z.number() })
+          .strict(),
+      ]),
+      declarations: [
+        {
+          rustTypeName: "Request",
+          rustDoc: ["Sensitive test response."],
+          fields: { shared: ["Incompatible shared field."] },
+          variants: { key: ["Key."], password: ["Password."] },
+        },
+      ],
+    });
+    expect(() => {
+      return renderExampleRustTypes([binding]);
+    }).toThrow("sensitive shared field shared has incompatible schemas");
   });
   it("contains exactly the supported Rust DTO set", () => {
     const actualBindings = normalizeTypeBindings(rustTypeBindings).map(

--- a/turbo/packages/api-contracts/src/rust-bindings/generate.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/generate.ts
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { execFileSync } from "node:child_process";
 import { dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { isDeepStrictEqual } from "node:util";
 import { z } from "zod";
 import {
   type RustConstantValue,
@@ -1792,7 +1793,10 @@ function renderSensitiveTaggedEnum(
   }
   context.declarationNames.add(typeName);
   const doc = typeDeclarationDoc(context, typeName);
-  const fields = new Map<string, { rustName: string; rustType: string }>();
+  const fields = new Map<
+    string,
+    { rustName: string; rustType: string; schema: JsonObject }
+  >();
   const lines = [
     ...renderOuterRustDoc(doc.rustDoc, ""),
     `pub enum ${typeName} {`,
@@ -1812,24 +1816,27 @@ function renderSensitiveTaggedEnum(
     }
     lines.push(`    ${name} {`);
     for (const [wireName, schema] of entries) {
-      if (
-        !isJsonObject(schema) ||
-        fields.has(wireName) ||
-        !variant.required.includes(wireName)
-      ) {
+      if (!isJsonObject(schema) || !variant.required.includes(wireName)) {
         throw new Error(
-          `${context.label}: sensitive variants require distinct, required fields`,
+          `${context.label}: sensitive variants require required object schemas`,
         );
       }
       const rustName = toRustFieldName(wireName);
+      const existing = fields.get(wireName);
+      if (existing && !isDeepStrictEqual(existing.schema, schema)) {
+        throw new Error(
+          `${context.label}: sensitive shared field ${wireName} has incompatible schemas`,
+        );
+      }
       const rustType =
+        existing?.rustType ??
         context.fieldTypeOverrides[wireName] ??
         rustTypeForSchema(
           schema,
           nestedTypeNameForField(`${typeName}${name}`, wireName, schema),
           context,
         );
-      fields.set(wireName, { rustName, rustType });
+      fields.set(wireName, { rustName, rustType, schema });
       lines.push(
         ...renderOuterRustDoc(
           typeFieldDoc(context, typeName, wireName, doc),

--- a/turbo/packages/api-contracts/src/rust-bindings/ssh-types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/ssh-types.ts
@@ -1,6 +1,7 @@
 import {
   runnerSshContract,
   runnerSshInvalidateSchema,
+  SSH_PASSWORD_MAX_LENGTH,
 } from "../contracts/runner-ssh";
 import {
   SSH_PRIVATE_KEY_MAX_LENGTH,
@@ -192,6 +193,7 @@ export const sshTypeBindings = [
     fieldTypeOverrides: {
       privateKey: `crate::SecretText<${SSH_PRIVATE_KEY_MAX_LENGTH}>`,
       passphrase: `Option<crate::SecretText<${SSH_PASSPHRASE_MAX_LENGTH}>>`,
+      password: `crate::SecretText<${SSH_PASSWORD_MAX_LENGTH}>`,
     },
     declarations: [
       {
@@ -207,10 +209,16 @@ export const sshTypeBindings = [
           learnedHostKey: ["Existing pin, or first-use trust required."],
           privateKey: ["Bounded zeroizing private key text."],
           passphrase: ["Bounded zeroizing passphrase, preserving whitespace."],
+          password: [
+            "Bounded zeroizing login password, preserving whitespace.",
+          ],
         },
         variants: {
           unavailable: ["Current authority not available; no secrets."],
           resolved: ["Authorized current credential handoff."],
+          resolved_password: [
+            "Authorized current password credential handoff.",
+          ],
         },
       },
       ...hostKeyDocs("ResolveResponseResolvedLearnedHostKey"),


### PR DESCRIPTION
## Summary

- Add a strict private `resolved_password` handoff with bounded, whitespace-preserving, zeroizing Rust secrets. The sensitive DTO generator reuses only identically shaped required fields and still rejects duplicate/missing/unknown/mixed fields without a generic secret buffer.
- Prepare and authenticate exactly one method (private key or password), after existing host proof and pin/TOFU checks. Password preparation does not consume key-decoding slots. Preserve Run-scoped caching, invalidation, cancellation, structured observations and no command replay.
- Exercise password success, rejection/partial auth, trust fencing, key-to-password cache changes and recovery against a real SSH peer through the guest RPC boundary.

Closes #33467. Parent: #33456. Next: #33468 (canonical reusable credential model, APIs and UI).

## Scope and safety

No UI, owner configuration, database, feature-switch or deployment changes. Production owner APIs and resolve writers remain key-only in this execution slice; route tests reject attempted password configuration. SSH remains staff-only. No legacy compatibility bridge, version negotiation or reader-drain gate is introduced.

Passwords are sent to the verified destination inside encrypted SSH, so a compromised receiving host can reuse them. Passwords remain bounded in Run-owned memory; missed best-effort invalidations retain the existing Run-lifetime window. No keyboard-interactive, MFA/chained authentication, forced password change, new secret fallback or per-command authority request.

## Validation

All passed locally:

- `pnpm -F @okouai/api-contracts exec vitest run --maxWorkers=4 --silent=passed-only`: 824 tests; focused generator rerun: 35 tests.
- `pnpm -F api exec vitest run src/signals/routes/__tests__/runner-ssh.test.ts src/signals/routes/__tests__/ssh-connections.test.ts --maxWorkers=2 --silent=passed-only`: 54 tests.
- `cargo test --profile local -p runner ssh::tests`: 52 tests, including all five new password integration tests.
- `cargo test --profile local -p api-contracts`: 41 tests.
- `cargo fmt --all --check`; `cargo clippy --profile local -p runner -p api-contracts --all-targets --all-features`; `cargo doc --profile local -p runner -p api-contracts --all-features --no-deps`.
- api-contracts lint/types/Knip; changed API test lint plus API type checks/Knip; Prettier and diff checks.
- `generate:rust` and `generate:python` reproduce identical generated output (SHA-256 comparison).

No deployed password Run was tested: this slice intentionally has no owner password writer. No screenshots are needed because no UI changes.

## Rebase verification

Rebased onto main `3e4a5d0c1957d0673d3774dd585630bcde0f2833`, preserving #33473's support for multiple configurations at one endpoint. The only conflict was API test placement. Strengthened password-field rejection requests with valid required fields so rejection cannot be caused by a missing generation/private key. Re-ran the contract/API/Rust suites and affected static checks after integration; authentication implementation is unchanged.
