### PR TITLE
test(sandbox): declare tokio features for standalone tests

### DIFF
--- a/crates/sandbox/Cargo.toml
+++ b/crates/sandbox/Cargo.toml
@@ -13,6 +13,7 @@ uuid = { workspace = true, features = ["serde", "std", "v4"] }
 
 [dev-dependencies]
 serde_json = { workspace = true, features = ["std"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 trybuild = { workspace = true }
 
 [lints]


### PR DESCRIPTION
## Summary

- Declare workspace-inherited Tokio `macros` and `rt` as `sandbox` development features so its existing async test compiles when the package is selected alone.
- Keep production dependency features, test behavior, CI configuration, and `Cargo.lock` unchanged.

Closes #33482

## Validation

On main `54efc258e9`, the exact package-scoped command failed with E0433 (`tokio::test` missing at `sandbox/src/types.rs:1593`). After this change, on Linux with Rust/Cargo 1.98.0, the same command passes all 43 tests (33 unit, 9 integration, 1 trybuild; doctests also pass with 0 cases).

Passed sequentially, using `CARGO_BUILD_JOBS=1` for compilation:

- `cargo test --locked --manifest-path crates/Cargo.toml --profile local -p sandbox`
- `cargo check --locked --manifest-path crates/Cargo.toml --profile local -p sandbox --lib`
- `cargo fmt --manifest-path crates/Cargo.toml -p sandbox -- --check`
- `cargo clippy --locked --manifest-path crates/Cargo.toml --profile local -p sandbox --all-targets --all-features -- -D warnings`
- `cargo doc --locked --manifest-path crates/Cargo.toml --profile local -p sandbox --no-deps`
- `git diff --check`

The normal/build dependency tree from `cargo tree --locked --manifest-path crates/Cargo.toml -p sandbox -e normal,build -f '{p} features=[{f}]'` is identical before and after. Tokio `rt` was already provided transitively; this change explicitly owns the async test's requirements without enabling test macros in normal builds. No extra package selection or dependency feature flags were used for the passing test command.

Workspace-wide/deployed CI is not represented by these local results; required checks must pass before merge. No runtime behavior or performance change is intended.
