### PR TITLE
refactor(test): replace residual retired-brand fixtures and a missed comment

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
@@ -655,7 +655,7 @@ describe("okou browser route", () => {
     expect(created.body.browser).toMatchObject({
       name: "booking",
       status: "active",
-      // Zero always requests the provider's longest lifetime and manages
+      // The API always requests the provider's longest lifetime and manages
       // reclamation through the idle lease instead.
       timeoutMinutes: 240,
       idleExpiresAt: isoAt(10 * MINUTE_MS),

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -25801,17 +25801,17 @@ describe("CHAT-02: default assistant identity", () => {
     await cancelChatRun(actor, promoted.runId);
 
     mockEnv("APP_URL", "https://preview.example.test");
-    const customZero = await bdd.createAgent(actor, {
-      displayName: "Zero",
+    const customAgent = await bdd.createAgent(actor, {
+      displayName: "Nova",
       visibility: "private",
     });
     const customRun = await sendChatRun(actor, {
-      agentId: customZero.agentId,
+      agentId: customAgent.agentId,
       prompt: "keep my custom name",
     });
     const customPrompt = (await api.readRun(actor, customRun.runId))
       .appendSystemPrompt;
-    expect(customPrompt).toContain("Your name is Zero.");
+    expect(customPrompt).toContain("Your name is Nova.");
     expect(customPrompt).not.toContain("Your name is Okou.");
     const customClaim = await claimChatRun(runnerGroup, customRun.runId);
     await expectRunAppContext({
@@ -26092,7 +26092,7 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
     const grantedRun = await api.readRun(actor, granted.runId);
     expect(grantedRun.appendSystemPrompt).toContain("# Computer Use");
     expect(grantedRun.appendSystemPrompt).toContain(
-      "Computer Use is enabled for this run on Zero Desktop.",
+      "Computer Use is enabled for this run on BDD Desktop.",
     );
     expect(grantedRun.appendSystemPrompt).not.toContain(hostId);
     const grantedClaim = await claimChatRun(runnerGroup, granted.runId);
@@ -26142,7 +26142,7 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
     });
     const staleRun = await api.readRun(actor, staleGranted.runId);
     expect(staleRun.appendSystemPrompt).toContain(
-      "Computer Use is enabled for this run on Zero Desktop.",
+      "Computer Use is enabled for this run on BDD Desktop.",
     );
     clearMockNow();
     const staleClaim = await claimChatRun(runnerGroup, staleGranted.runId);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
@@ -727,7 +727,7 @@ describe("CHAT-02 chat messages and visible validation", () => {
     const agent = await api.createAgentForChatThread(owner);
     const thread = await api.createThread(owner, {
       agentId: agent.agentId,
-      title: "Zero message boundary",
+      title: "Empty message boundary",
     });
 
     const ownerMessages = await api.listThreadEvents(owner, thread.id, {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -3387,7 +3387,7 @@ describe("CHAT-03 run usage events", () => {
 
   it("emits zero-credit usage events and skips runs without usage", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor(
-      "Zero usage message agent",
+      "Zero-credit usage message agent",
     );
 
     const agentRun = await sendChatRun(actor, {

--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -518,9 +518,13 @@ describe("FILE-03 desktop computer-use runtime", () => {
     mockNow(base);
 
     const first = await api.startComputerUseHost(actor, {
-      hostName: "Zero Desktop",
+      hostName: "Office Mac",
     });
-    const heartbeat = await api.heartbeatComputerUseHost(first.hostToken);
+    // Every heartbeat carries the full runtime body, so it also rewrites the
+    // host name. Repeat this host's own name to keep its identity stable.
+    const heartbeat = await api.heartbeatComputerUseHost(first.hostToken, {
+      hostName: "Office Mac",
+    });
     expect(heartbeat).toStrictEqual({ ok: true, hostId: first.hostId });
 
     mockNow(base + 120_000);
@@ -529,7 +533,9 @@ describe("FILE-03 desktop computer-use runtime", () => {
     });
     expect(second.hostId).not.toBe(first.hostId);
 
-    const staleHeartbeat = await api.heartbeatComputerUseHost(first.hostToken);
+    const staleHeartbeat = await api.heartbeatComputerUseHost(first.hostToken, {
+      hostName: "Office Mac",
+    });
     expect(staleHeartbeat).toStrictEqual({ ok: true, hostId: first.hostId });
 
     const visibleHosts = await api.listComputerUseHosts(actor);
@@ -538,7 +544,7 @@ describe("FILE-03 desktop computer-use runtime", () => {
       expect.arrayContaining([
         expect.objectContaining({
           id: first.hostId,
-          hostName: "Zero Desktop",
+          hostName: "Office Mac",
           status: "online",
         }),
         expect.objectContaining({

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
@@ -237,7 +237,7 @@ function hostRuntimeBody(options: ComputerUseHostStartOptions = {}) {
     ...(options.installationId
       ? { installationId: options.installationId }
       : {}),
-    hostName: options.hostName ?? "Zero Desktop",
+    hostName: options.hostName ?? "BDD Desktop",
     appVersion: "0.1.0",
     osVersion: "macOS 15",
     supportedCapabilities: [

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-post.test.ts
@@ -932,11 +932,11 @@ describe("POST /api/telegram/register", () => {
       expectedAgentName: "Okou",
     },
     {
-      caseName: "a non-canonical Okou agent named Zero",
-      displayName: "Zero",
+      caseName: "a non-canonical Okou agent named Nova",
+      displayName: "Nova",
       seedDefaultAgent: false,
       expectedUpdateStatus: 200,
-      expectedAgentName: "Zero",
+      expectedAgentName: "Nova",
     },
   ] as const)(
     "brands Telegram command descriptions for $caseName",

--- a/turbo/apps/cli/src/commands/connector/account/__tests__/switch-request.test.ts
+++ b/turbo/apps/cli/src/commands/connector/account/__tests__/switch-request.test.ts
@@ -58,7 +58,7 @@ function stubAgent(): ReturnType<typeof http.get> {
     return HttpResponse.json({
       agentId: AGENT_ID,
       ownerId: "owner-1",
-      displayName: "Zero",
+      displayName: "Nova",
       description: null,
       sound: null,
       avatarUrl: null,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/billing-plans-entry.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/billing-plans-entry.test.tsx
@@ -22,7 +22,7 @@ function prepareUpgradeFlow(): void {
     {
       agentId: AGENT_ID,
       ownerId: "test-user-123",
-      displayName: "Zero",
+      displayName: "Nova",
       description: null,
       sound: null,
       avatarUrl: null,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
@@ -150,7 +150,7 @@ function prepareAgentProfile(
     {
       agentId: DEFAULT_AGENT_ID,
       ownerId: "test-user-123",
-      displayName: "Zero",
+      displayName: "Nova",
       description: null,
       sound: null,
       avatarUrl: null,
@@ -1107,7 +1107,7 @@ test.each(["copy", "delete"])(
     click(screen.getByText("Delete agent"));
     const dialog = await screen.findByRole("dialog");
     click(await within(dialog).findByRole("combobox"));
-    click(await screen.findByRole("option", { name: "Copy to Zero" }));
+    click(await screen.findByRole("option", { name: "Copy to Nova" }));
     click(within(dialog).getByText("Delete agent"));
 
     const copyingButton = await within(dialog).findByText("Copying…");
@@ -1137,7 +1137,7 @@ test.each(["copy", "delete"])(
     const select = within(reopened).getByRole("combobox");
     expect(select).toHaveTextContent("Delete with agent");
     click(select);
-    click(await screen.findByRole("option", { name: "Copy to Zero" }));
+    click(await screen.findByRole("option", { name: "Copy to Nova" }));
 
     canSubmit = true;
     click(within(reopened).getByText("Delete agent"));
@@ -1163,7 +1163,7 @@ async function chooseWorkflowCopy(
   await user.click(
     within(dialog).getByRole("combobox", { name: `Handle workflow ${title}` }),
   );
-  await user.click(await screen.findByRole("option", { name: "Copy to Zero" }));
+  await user.click(await screen.findByRole("option", { name: "Copy to Nova" }));
 }
 
 function dialogBackdrop(): HTMLElement {
@@ -1260,8 +1260,8 @@ test.each([false, true])(
           ...source,
           id: crypto.randomUUID(),
           agentId: body.toAgentId,
-          agentName: "zero",
-          agentDisplayName: "Zero",
+          agentName: "nova",
+          agentDisplayName: "Nova",
         };
         workflows.push(copied);
         return respond(201, copied);
@@ -1288,10 +1288,10 @@ test.each([false, true])(
     expect(within(dialog).getByText("Delete agent")).toBeEnabled();
     expect(screen.getByDisplayValue("Research Agent")).toBeInTheDocument();
     expect(
-      within(dialog).getByText("Daily research copied to Zero"),
+      within(dialog).getByText("Daily research copied to Nova"),
     ).toBeInTheDocument();
     expect(
-      within(dialog).queryByText("Weekly research copied to Zero"),
+      within(dialog).queryByText("Weekly research copied to Nova"),
     ).not.toBeInTheDocument();
     for (const select of within(dialog).getAllByRole("combobox")) {
       expect(select).toHaveTextContent("Delete with agent");
@@ -1307,7 +1307,7 @@ test.each([false, true])(
       expect(select).toHaveTextContent("Delete with agent");
     }
     expect(
-      within(dialog).getByText("Daily research copied to Zero"),
+      within(dialog).getByText("Daily research copied to Nova"),
     ).toBeInTheDocument();
     await chooseWorkflowCopy(dialog);
     await chooseWorkflowCopy(dialog, "Weekly research");
@@ -1338,7 +1338,7 @@ test.each(["copy", "delete"])(
       displayName: "Weekly research",
     };
     const agents = [
-      copyTarget(DEFAULT_AGENT_ID, "Zero"),
+      copyTarget(DEFAULT_AGENT_ID, "Nova"),
       copyTarget(AGENT_ID, "Research Agent"),
       copyTarget(secondAgentId, "Second Agent"),
     ];
@@ -1445,7 +1445,7 @@ test.each(["copy", "delete"])(
     await user.keyboard("{Escape}");
     expect(within(currentDialog).getByText("Copying…")).toBeDisabled();
     expect(within(currentDialog).getByRole("combobox")).toHaveTextContent(
-      "Copy to Zero",
+      "Copy to Nova",
     );
     currentResponse.resolve();
     await expect(
@@ -1535,7 +1535,7 @@ test("Keep the source agent when its workflow refresh fails after copying", asyn
   click(screen.getByText("Delete agent"));
   const dialog = await screen.findByRole("dialog");
   click(await within(dialog).findByRole("combobox"));
-  click(await screen.findByRole("option", { name: "Copy to Zero" }));
+  click(await screen.findByRole("option", { name: "Copy to Nova" }));
   click(within(dialog).getByText("Delete agent"));
 
   await expect(within(dialog).findByRole("alert")).resolves.toHaveTextContent(
@@ -1549,7 +1549,7 @@ test("Keep the source agent when its workflow refresh fails after copying", asyn
   );
   expect(within(dialog).getByRole("combobox")).toBeDisabled();
   expect(
-    within(dialog).getByText("Daily research copied to Zero"),
+    within(dialog).getByText("Daily research copied to Nova"),
   ).toBeInTheDocument();
   click(within(dialog).getByText("Cancel"));
   await waitFor(() => {
@@ -1612,5 +1612,5 @@ test("Load the agent's workflows before enabling deletion after an initial list 
   expect(within(dialog).getByText("Delete agent")).toBeEnabled();
   expect(within(dialog).queryByRole("alert")).not.toBeInTheDocument();
   await chooseWorkflowCopy(dialog);
-  expect(select).toHaveTextContent("Copy to Zero");
+  expect(select).toHaveTextContent("Copy to Nova");
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -121,7 +121,7 @@ function prepareDefaultAgent(targetContext = context): void {
     {
       agentId: AGENT_ID,
       ownerId: "test-user-123",
-      displayName: "Zero",
+      displayName: "Nova",
       description: null,
       sound: null,
       avatarUrl: null,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-mac-shortcut.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-mac-shortcut.test.tsx
@@ -35,7 +35,7 @@ function prepareDefaultAgent(): void {
     {
       agentId: AGENT_ID,
       ownerId: "test-user-123",
-      displayName: "Zero",
+      displayName: "Nova",
       description: null,
       sound: null,
       avatarUrl: null,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
@@ -36,7 +36,7 @@ function mockThreads(count: number): void {
     {
       agentId: AGENT_ID,
       ownerId: "test-user-123",
-      displayName: "Zero",
+      displayName: "Nova",
       description: null,
       sound: null,
       avatarUrl: null,
@@ -380,7 +380,7 @@ function mockPinnedGrid(): string {
     return {
       agentId: `c0000000-0000-4000-a000-${String(index + 1).padStart(12, "0")}`,
       ownerId: "test-user-123",
-      displayName: index === 0 ? "Zero" : `Agent ${index + 1}`,
+      displayName: index === 0 ? "Nova" : `Agent ${index + 1}`,
       description: null,
       sound: null,
       avatarUrl: null,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -108,7 +108,7 @@ function prepareDefaultAgent(
     {
       agentId: AGENT_ID,
       ownerId: "test-user-123",
-      displayName: "Zero",
+      displayName: "Nova",
       description: null,
       sound: null,
       avatarUrl,
@@ -123,7 +123,7 @@ function prepareAgents(targetContext = context): AgentResponse[] {
       isDefaultAgent: false,
       agentId: AGENT_ID,
       ownerId: "test-user-123",
-      displayName: "Zero",
+      displayName: "Nova",
       description: null,
       sound: null,
       avatarUrl: null,
@@ -162,7 +162,7 @@ function prepareAgents(targetContext = context): AgentResponse[] {
   targetContext.mocks.data.agents(agents);
   targetContext.mocks.api(agentsByIdContract.get, ({ params, respond }) => {
     const displayNameById: Record<string, string> = {
-      [AGENT_ID]: "Zero",
+      [AGENT_ID]: "Nova",
       [RESEARCH_AGENT_ID]: "Research Agent",
       [SUPPORT_AGENT_ID]: "Support Agent",
     };
@@ -1351,7 +1351,7 @@ test("Keep pin management usable with many pinned agents", async () => {
       return link.textContent?.trim();
     }),
   ).toStrictEqual([
-    "Zero",
+    "Nova",
     "Research Agent",
     "Support Agent",
     "Operations Agent",
@@ -1365,7 +1365,7 @@ test("Keep pin management usable with many pinned agents", async () => {
   if (!pinAgent) {
     throw new Error("Pin agent button not found");
   }
-  // Cards render as Zero, Research, Support, Operations, Pin, Analytics,
+  // Cards render as Nova, Research, Support, Operations, Pin, Analytics,
   // Billing, so Pin closes the first row and the rest wrap after it.
   const fourthAgent = pinnedAgentLink(grid, "Operations Agent");
   const fifthAgent = pinnedAgentLink(grid, "Analytics Agent");
@@ -1417,7 +1417,7 @@ test("Keep pinned agents and the chat heading visible while conversations scroll
     "pinned-agents-horizontal",
   );
   const pinnedAgent = within(pinnedHeader).getByText("Research Agent");
-  const chatTitle = within(sidebar()).getByText("Chats with Zero");
+  const chatTitle = within(sidebar()).getByText("Chats with Nova");
   expect(scrollArea).not.toContainElement(pinnedHeader);
   expect(scrollArea).not.toContainElement(pinnedAgent);
   expect(scrollArea).not.toContainElement(chatTitle);
@@ -1921,7 +1921,7 @@ test("Navigate pinned agents from the mobile sidebar", async () => {
     expect(mobileSidebar()).toHaveAttribute("data-sidebar-expanded", "true");
   });
 
-  click(pinnedAgentLink(mobileSidebar(), "Zero"));
+  click(pinnedAgentLink(mobileSidebar(), "Nova"));
   await waitFor(() => {
     expect(pathname()).toBe(`/agents/${AGENT_ID}/chat`);
     expect(mobileSidebar()).not.toHaveAttribute("data-sidebar-expanded");
@@ -2130,7 +2130,7 @@ test("Pin and unpin agents without closing the pin manager", async () => {
 
   await waitFor(() => {
     expect(pinnedAgentNames(grid)).toStrictEqual([
-      "Zero",
+      "Nova",
       "Research Agent",
       "Support Agent",
     ]);
@@ -2146,7 +2146,7 @@ test("Pin and unpin agents without closing the pin manager", async () => {
   click(buttonByText("Unpin", commandItemByText(dialogList, "Support Agent")));
 
   await waitFor(() => {
-    expect(pinnedAgentNames(grid)).toStrictEqual(["Zero", "Research Agent"]);
+    expect(pinnedAgentNames(grid)).toStrictEqual(["Nova", "Research Agent"]);
   });
   expect(dialogList).toBeInTheDocument();
   expect(
@@ -2183,13 +2183,13 @@ test("Show pinned agents before unread indicators finish loading", async () => {
 
   const grid = await screen.findByTestId("pinned-agents-grid");
   await waitFor(() => {
-    expect(pinnedAgentNames(grid)).toStrictEqual(["Zero", "Research Agent"]);
+    expect(pinnedAgentNames(grid)).toStrictEqual(["Nova", "Research Agent"]);
   });
 
   releaseIndicators.resolve(undefined);
   await waitFor(() => {
     expect(pinnedAgentNames(grid)).toStrictEqual([
-      "Zero",
+      "Nova",
       "Research Agent",
       "Support Agent",
     ]);
@@ -2210,7 +2210,7 @@ test("Preserve the user’s pinned-agent order", async () => {
   const grid = await screen.findByTestId("pinned-agents-grid");
   await waitFor(() => {
     expect(pinnedAgentNames(grid)).toStrictEqual([
-      "Zero",
+      "Nova",
       "Support Agent",
       "Research Agent",
     ]);
@@ -2247,7 +2247,7 @@ test("Highlight the current thread’s agent in the pinned grid", async () => {
       "page",
     );
   });
-  expect(pinnedAgentLink(grid, "Zero")).not.toHaveAttribute("aria-current");
+  expect(pinnedAgentLink(grid, "Nova")).not.toHaveAttribute("aria-current");
 });
 
 test("Recognize and pin sidebar conversation states", async () => {
@@ -2403,10 +2403,10 @@ test("Refresh agent and thread unread indicators", async () => {
 
   const nav = await waitFor(() => {
     const current = mobileSidebar();
-    expect(within(current).getByText("Zero")).toBeInTheDocument();
+    expect(within(current).getByText("Nova")).toBeInTheDocument();
     return current;
   });
-  const agentRow = agentRowByName(nav, "Zero");
+  const agentRow = agentRowByName(nav, "Nova");
   const threadRow = await waitFor(() => {
     return threadRowByTitle("Remote unread conversation", nav);
   });
@@ -2495,7 +2495,7 @@ test("Rename a conversation from the sidebar", async () => {
   );
 });
 
-test("Reorder pinned agents while keeping Zero first", async () => {
+test("Reorder pinned agents while keeping Nova first", async () => {
   const pinnedAgentIds = prepareOverflowingPinnedAgents();
   context.mocks.data.userPreferences({ pinnedAgentIds });
 
@@ -2509,7 +2509,7 @@ test("Reorder pinned agents while keeping Zero first", async () => {
     expect(within(grid).getAllByTestId("pinned-agent-card")).toHaveLength(6);
   });
   expect(pinnedAgentNames(grid)).toStrictEqual([
-    "Zero",
+    "Nova",
     "Research Agent",
     "Support Agent",
     "Operations Agent",
@@ -2542,7 +2542,7 @@ test("Reorder pinned agents while keeping Zero first", async () => {
 
   await waitFor(() => {
     expect(pinnedAgentNames(grid)).toStrictEqual([
-      "Zero",
+      "Nova",
       "Research Agent",
       "Operations Agent",
       "Analytics Agent",
@@ -2552,7 +2552,7 @@ test("Reorder pinned agents while keeping Zero first", async () => {
   });
 
   const orderAfterReorder = pinnedAgentNames(grid);
-  const lead = pinnedAgentLink(grid, "Zero");
+  const lead = pinnedAgentLink(grid, "Nova");
   const leadDropTransfer = createDataTransferStub();
   fireEvent.dragStart(pinnedAgentLink(grid, "Research Agent"), {
     dataTransfer: leadDropTransfer,
@@ -2565,7 +2565,7 @@ test("Reorder pinned agents while keeping Zero first", async () => {
     dataTransfer: leadDropTransfer,
   });
   expect(pinnedAgentNames(grid)).toStrictEqual(orderAfterReorder);
-  expect(pinnedAgentLink(grid, "Zero")).toBeInTheDocument();
+  expect(pinnedAgentLink(grid, "Nova")).toBeInTheDocument();
 });
 
 test("Keep the default Okou sweater outside a circular mask", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/workspace-agent-search.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/workspace-agent-search.test.tsx
@@ -24,7 +24,7 @@ const MAC_USER_AGENT =
 function prepareAgents() {
   context.mocks.browser.userAgent(MAC_USER_AGENT);
   const agents: AgentResponse[] = [
-    { agentId: DEFAULT_AGENT_ID, displayName: "Zero" },
+    { agentId: DEFAULT_AGENT_ID, displayName: "Nova" },
     { agentId: RESEARCH_AGENT_ID, displayName: "Research Agent" },
     {
       agentId: SUPPORT_AGENT_ID,
@@ -104,7 +104,7 @@ test("Find workspace agents by name with case and whitespace normalization", asy
   ).toBeVisible();
 });
 
-test("Agent search excludes IDs and blank queries but includes Zero", async () => {
+test("Agent search excludes IDs and blank queries but includes Nova", async () => {
   prepareAgents();
   await setupPage({ context, path: `/agents/${DEFAULT_AGENT_ID}/chat` });
   const { dialog, search } = await openSearch();
@@ -114,9 +114,9 @@ test("Agent search excludes IDs and blank queries but includes Zero", async () =
   ).resolves.toBeVisible();
   expect(within(dialog).getByText("0 results")).toBeVisible();
 
-  await fill(search, "zero");
+  await fill(search, "nova");
   await expect(
-    within(dialog).findByRole("option", { name: "Zero" }),
+    within(dialog).findByRole("option", { name: "Nova" }),
   ).resolves.toBeVisible();
 
   await fill(search, " ");
@@ -147,7 +147,7 @@ test("Selecting a workspace agent search result opens its chat", async () => {
 test("Limit matching agents to the workspace search result size", async () => {
   context.mocks.browser.userAgent(MAC_USER_AGENT);
   context.mocks.data.agents([
-    { agentId: DEFAULT_AGENT_ID, displayName: "Zero" },
+    { agentId: DEFAULT_AGENT_ID, displayName: "Nova" },
     ...Array.from({ length: 30 }, (_, index) => {
       return {
         agentId: `c1000000-0000-4000-a000-${(index + 1).toString().padStart(12, "0")}`,


### PR DESCRIPTION
## Summary

Closes #33475. Production source carries no retired brand literal outside the retained #26368 surfaces, so the fixtures listed in the issue named something that no longer exists. This replaces each with a neutral value, rewrites the comment #32946 missed, and moves every assertion that consumes a changed fixture in the same step.

Test-only change. No production source, no release needed.

## Changes

1. **`browser.test.ts:658`** — `// Zero always requests the provider's longest lifetime ...` now says `// The API always requests ...`, matching how #32946 handled the identical-class comment at line 138 of the same file. Comment text only.

2. **Shared BDD default** (`helpers/api-bdd-computer-use.ts:240`) — `hostName: options.hostName ?? "Zero Desktop"` → `"BDD Desktop"`. I traced every consumer of this default rather than assuming only the two explicit `computer-use.bdd.test.ts` sites were affected:

   | Caller | Passes `hostName`? | Asserts on it? |
   |---|---|---|
   | `workflow-automation-scheduler.test.ts:372` | yes (`"Automation Desktop"`) | yes, unaffected |
   | `teams-bot.test.ts:3192` | yes (`"Teams authorized host"`) | no |
   | `browser.test.ts:423` | no | no |
   | `chat-threads.bdd.test.ts:2145` | no | no |
   | `chat-events.bdd.test.ts` ×5 | no | **yes** — two prompt assertions |

   The two `chat-events.bdd.test.ts` assertions on `Computer Use is enabled for this run on ${displayName}.` are updated to `BDD Desktop`. `requestStartComputerUseHost` and `requestComputerUseHeartbeat` also hardcode the default, but assert only status codes.

3. **A latent coupling the rename exposed** — `computer-use.bdd.test.ts` > `keeps multiple active hosts and lets stale heartbeats recover` started the first host as `"Zero Desktop"` and then asserted `hostName: "Zero Desktop"`. That passed only because the explicit fixture and the helper default were the same literal. Every heartbeat sends the full runtime body, so the two untouched `heartbeatComputerUseHost(first.hostToken)` calls were silently renaming the host to the default before the assertion ran — the assertion was observing the default, not the value the test set up.

   Splitting the two literals turned this into a real failure. Rather than relax the assertion or realign the fixture back onto the default (which would re-hide the coupling), both heartbeats now repeat that host's own name, with a comment recording why. The assertion stays exact and now observes the identity the test actually establishes. Host renaming through the runtime body keeps its own dedicated coverage in the `"Renamed Studio Mac"` case.

4. **Remaining fixtures** — a neutral `Nova` display name for the agent fixtures, with the assertions built from them updated together:
   - `chat-events.bdd.test.ts` — `displayName: "Zero"` → `"Nova"`, local `customZero` → `customAgent`, and `expect(customPrompt).toContain("Your name is Zero.")` → `"Your name is Nova."`. The adjacent `not.toContain("Your name is Okou.")` is unchanged, so the test still proves a custom agent keeps its own name.
   - `workspace-agent-search.test.tsx` — the fixture, the `"zero"` → `"nova"` search query, the `option` name assertion, and the test title. Case-insensitive matching is still exercised by the lowercase query against the capitalized name.
   - `sidebar.test.tsx`, `settings-tab.test.tsx`, `sidebar-account-menu`, `sidebar-mac-shortcut`, `sidebar-virtualization`, `billing-plans-entry` — the fixtures plus every `Chats with …`, `Copy to …`, `… copied to …`, pinned-grid order, and `agentRowByName` assertion built from them.
   - `integrations-telegram-post.test.ts` — the `it.each` case's `displayName`, its `expectedAgentName`, and the case label. The two canonical-default cases are untouched.
   - `switch-request.test.ts` — stub response field; no assertion consumes it.

5. **Two numeric-zero titles** — `"Zero message boundary"` → `"Empty message boundary"` and `"Zero usage message agent"` → `"Zero-credit usage message agent"`. Both were listed in the issue, but both read as numeric zero rather than the brand (their tests assert `events: []` and zero-credit usage). These wordings drop the ambiguous standalone token while keeping the numeric meaning the tests actually exercise, consistent with the EPIC's "leave numeric-zero vocabulary alone" boundary. Neither value is asserted.

No assertion is weakened, deleted, or inverted, and no test asserts that a retired name is absent.

## Not touched

Byte-identical, as required by the issue: the retained #26368 surfaces (`desktop-updates.ts`, `desktop-updates.test.ts`, `app-factory.test.ts`, `auth-device.bdd.test.ts`), `scripts/tunnel-access.sh` ("Zero Trust" is Cloudflare's product name), the `it-IT` / `pt-BR` `da zero` / `do zero` locale strings, `scripts/sync-env.sh:84`, and every `vm0*` identifier. No repository-wide substitution was used.

## Scope notes

- `sidebar-virtualization.test.tsx` has a second occurrence at line 383 (`displayName: index === 0 ? "Zero" : ...`) that the issue's exact-literal listing did not count. It is the same fixture class in a listed file, so it is included.
- `settings-tab.test.tsx:1263` carries `agentName: "zero"` on the same copied-workflow fixture object as the `agentDisplayName` being changed; it moves to `"nova"` so the fixture stays coherent. It is not asserted.
- **`connectors-auth-methods.test.tsx` and `telegram-settings.test.tsx` are deliberately left out.** They hold `listAgent(..., "Zero")` and `agent: { name: "Zero" }`, which are the same residue class, but the issue enumerates `displayName: "Zero"` sites specifically and says "Nothing else." Left for a follow-up rather than pulled in as unscoped drive-by renames.

## Verification

- `prettier --check` on all 15 changed files — pass
- ESLint (`--max-warnings 0`) and oxlint on the changed API, CLI, and platform files — pass
- `apps/api` full `check-types`, `apps/platform` `tsconfig.tests.json`, `apps/cli` `check-types` — pass
- Platform Vitest, all 7 changed files — 122 passed
- CLI Vitest `switch-request.test.ts` — 14 passed
- API Vitest, every changed suite plus every consumer of the shared helper default: `chat-events.bdd` (535), `run-lifecycle.bdd` (252), `chat-threads.bdd` + `teams-bot` (78), `browser` + `computer-use.bdd` + `chat-files.bdd` + `integrations-telegram-post` + `workflow-automation-scheduler` (111) — all passed

A local Postgres instance initialized in a non-UTC timezone made the runner-claim path fail across these suites on unmodified `main` too; the suites above were run after correcting the cluster to UTC, which is what the timezone-naive `runner_job_queue.expires_at` comparison expects.

## Overlap

No open PR touches any of the 15 files. Normal merge precedence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
