### PR TITLE
perf(runner): bound response decoder header inspection

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -43,6 +43,11 @@ INVALID_COMPRESSED_BODY = "invalid compressed body"
 INCOMPLETE_COMPRESSED_BODY = "incomplete compressed body"
 DECODED_BODY_LIMIT_EXCEEDED = "decoded body limit exceeded"
 COMPRESSED_FRAME_LIMIT_EXCEEDED = "compressed frame limit exceeded"
+_CONTENT_ENCODING_HEADER_LIMIT_EXCEEDED = "content encoding header inspection limit exceeded"
+_CONTENT_ENCODING_NAME = b"content-encoding"
+_MAX_CONTENT_ENCODING_FIELDS = 8 * 1024
+_MAX_CONTENT_ENCODING_VALUE_BYTES = 8 * 1024
+_HEADER_VALUE_SEPARATOR = ", "
 _STREAM_ZLIB_WBITS_BY_ENCODING = {
     "gzip": 16 + zlib.MAX_WBITS,
     "deflate": zlib.MAX_WBITS,
@@ -270,7 +275,38 @@ def stream_decodable_content_encodings() -> tuple[str, ...]:
     return _STREAM_DECODABLE_CONTENT_ENCODINGS
 
 
-def _stream_decode_skip_reason(encoding: str) -> str | None:
+def _content_encoding(headers: http.Headers) -> str | None:
+    """Read a bounded folded encoding, or None when header inspection is exhausted.
+
+    Missing fields return an empty encoding. Check raw field count, name length,
+    and aggregate value bytes before normalization or conversion. In-budget
+    values retain mitmproxy's UTF-8/surrogateescape and comma-folding semantics.
+    """
+    fields = headers.fields
+    if len(fields) > _MAX_CONTENT_ENCODING_FIELDS:
+        return None
+
+    values: list[bytes] = []
+    value_bytes = 0
+    for name, value in fields:
+        if len(name) != len(_CONTENT_ENCODING_NAME) or name.lower() != _CONTENT_ENCODING_NAME:
+            continue
+        value_bytes += len(value)
+        if values:
+            value_bytes += len(_HEADER_VALUE_SEPARATOR)
+        if value_bytes > _MAX_CONTENT_ENCODING_VALUE_BYTES:
+            return None
+        values.append(value)
+    return (
+        _HEADER_VALUE_SEPARATOR.join(value.decode("utf-8", "surrogateescape") for value in values)
+        .strip()
+        .lower()
+    )
+
+
+def _stream_decode_skip_reason(encoding: str | None) -> str | None:
+    if encoding is None:
+        return _CONTENT_ENCODING_HEADER_LIMIT_EXCEEDED
     if not encoding or encoding in stream_decodable_content_encodings():
         return None
     if encoding == "zstd":
@@ -280,7 +316,7 @@ def _stream_decode_skip_reason(encoding: str) -> str | None:
 
 def stream_decode_skip_reason(headers: http.Headers) -> str | None:
     """Return a fixed reason when usage streams cannot decode the response."""
-    encoding = headers.get("content-encoding", "").strip().lower()
+    encoding = _content_encoding(headers)
     return _stream_decode_skip_reason(encoding)
 
 
@@ -291,8 +327,10 @@ def can_stream_decode_usage(headers: http.Headers) -> bool:
 
 def can_decode_json_usage_body(headers: http.Headers) -> bool:
     """Return whether bounded terminal JSON usage decoding supports the response."""
-    encoding = headers.get("content-encoding", "").strip().lower()
-    return not encoding or encoding == "identity" or encoding in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS
+    encoding = _content_encoding(headers)
+    return encoding is not None and (
+        not encoding or encoding == "identity" or encoding in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS
+    )
 
 
 def create_stream_decode_session(
@@ -319,7 +357,8 @@ def create_stream_decode_session(
     expansion budget, but this helper does not promise a byte-exact bound on
     the Brotli binding's temporary output allocation.
 
-    Returns None when a content encoding cannot be decoded incrementally.
+    Returns None when a content encoding cannot be decoded incrementally or
+    its raw headers exceed the inspection budget.
 
     The returned session exposes ``finish_error()`` so billing paths can reject
     parser state from compressed streams that never reached a valid frame/member
@@ -333,8 +372,8 @@ def create_stream_decode_session(
     """
     if max_decoded_chunk <= 0:
         raise ValueError("max_decoded_chunk must be positive")
-    encoding = headers.get("content-encoding", "").strip().lower()
-    if not can_stream_decode_usage(headers):
+    encoding = _content_encoding(headers)
+    if _stream_decode_skip_reason(encoding) is not None:
         return None
     if not encoding or encoding == "identity":
         if should_continue is None:
@@ -390,11 +429,11 @@ def decompress_body(
       exceed that soft threshold and are sliced to the exact cap.
 
     Returns the original data unchanged when the encoding is missing,
-    ``identity``, unrecognised, or invalid before any compressed member
-    completes. Once a member has completed, later invalid trailing data is
-    ignored on this best-effort path. A valid frame that decodes to an empty
-    body returns ``b""`` — callers that short-circuit via ``if not body`` rely
-    on that (see #10287).
+    ``identity``, unrecognised, beyond the header inspection budget, or invalid
+    before any compressed member completes. Once a member has completed, later
+    invalid trailing data is ignored on this best-effort path. A valid frame
+    that decodes to an empty body returns ``b""`` — callers that short-circuit
+    via ``if not body`` rely on that (see #10287).
     """
     return _decode_body_bounded(data, headers, max_output=max_output).body
 
@@ -483,7 +522,9 @@ def decode_response_body_for_network_log_capture(
     retained streaming buffers, which can preserve original wire bytes or
     partial decoded output after a decode problem.
     """
-    encoding = headers.get("content-encoding", "").strip().lower()
+    encoding = _content_encoding(headers)
+    if encoding is None:
+        return None
     if not encoding or encoding == "identity":
         return data
     if encoding == "gzip":
@@ -582,7 +623,7 @@ def _decode_body_bounded(
     Valid empty compressed frames return ``b""``. ``max_output`` caps decoded
     output and may return a truncated decoded prefix without marking failure.
     """
-    encoding = headers.get("content-encoding", "").strip().lower()
+    encoding = _content_encoding(headers)
     if not encoding or encoding == "identity":
         return _BodyDecodeResult(data, False)
     try:
@@ -774,7 +815,9 @@ def decode_request_body_for_network_log_capture(
     intentionally separate from billing inspection, which has a stricter
     fail-closed policy.
     """
-    encoding = headers.get("content-encoding", "").strip().lower()
+    encoding = _content_encoding(headers)
+    if encoding is None:
+        return None
     if not encoding or encoding == "identity":
         return data
     if encoding not in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS:
@@ -801,7 +844,9 @@ def decompress_json_usage_body(
     rejects bodies that exceed its per-body frame budget.
 
     """
-    encoding = headers.get("content-encoding", "").strip().lower()
+    encoding = _content_encoding(headers)
+    if encoding is None:
+        return b"", _CONTENT_ENCODING_HEADER_LIMIT_EXCEEDED
     if encoding in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS:
         return _decode_supported_body_with_complete_status(
             data,
@@ -810,4 +855,4 @@ def decompress_json_usage_body(
         )
     if encoding and encoding != "identity" and data:
         return b"", "unsupported content encoding"
-    return decompress_body(data, headers, max_output=max_output), None
+    return data, None

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -1115,7 +1115,7 @@ def test_retry_after_checks_late_duplicate_before_inspection(
 
 
 @pytest.mark.parametrize("excess_fields", [False, True], ids=["oversized-name", "excess-fields"])
-def test_retry_after_observer_checks_budgets_before_normalizing_names(
+def test_retry_after_response_hook_checks_budgets_before_normalizing_names(
     tmp_path, real_flow, model_provider_failure_api, *, excess_fields
 ):
     fields = (
@@ -1133,14 +1133,12 @@ def test_retry_after_observer_checks_budgets_before_normalizing_names(
     if not excess_fields:
         expected["retryAfterSeconds"] = 120
 
-    # Guard the reporting observer itself: later body decoding independently reads
-    # Content-Encoding through mitmproxy's general header lookup.
-    model_provider_failure.admit_flow(flow)
-    model_provider_failure.configure_response_observer(flow)
+    _assert_retry_after_header_report(flow, model_provider_failure_api, expected)
 
-    assert _reported_payloads(model_provider_failure_api) == [expected]
+    assert flow.response.status_code == 429
     assert flow.response.headers.fields == fields
-    model_provider_failure.release_flow(flow)
+    assert response_stream(flow)(b"upstream-error") == b"upstream-error"
+    assert response_stream(flow)(b"") == b""
 
 
 def test_later_success_does_not_retract_report(

--- a/crates/runner/mitm-addon/tests/test_response_content_encoding_budget.py
+++ b/crates/runner/mitm-addon/tests/test_response_content_encoding_budget.py
@@ -1,0 +1,270 @@
+"""Decoder header work limits through response hooks and observable usage delivery."""
+
+import gzip
+import zlib
+
+import brotli
+import pytest
+import zstandard
+from mitmproxy import http
+
+import body_decoding
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+from tests.flow_helpers import response_stream
+from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
+from tests.model_provider_response_helpers import (
+    OPENAI_RESPONSES_CASE,
+    expected_event_quantities,
+    model_provider_flow,
+    run_response,
+    standard_success_payload,
+)
+from tests.x_flow_helpers import make_x_pipeline_flow
+
+pytestmark = pytest.mark.usefixtures("sync_usage_executor")
+
+_FIELD_LIMIT = 8 * 1024
+_VALUE_LIMIT = 8 * 1024
+_BUDGET_REASON = "content encoding header inspection limit exceeded"
+
+
+class _UnnormalizedName(bytes):
+    def lower(self) -> bytes:
+        raise AssertionError("normalized a raw name before checking its budget")
+
+
+class _UninspectedValue(bytes):
+    def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
+        raise AssertionError("decoded a raw value before checking its budget")
+
+    def strip(self, chars: bytes | None = None) -> bytes:
+        raise AssertionError("stripped a raw value before checking its budget")
+
+    def lower(self) -> bytes:
+        raise AssertionError("normalized a raw value before checking its budget")
+
+
+def _model_flow(real_flow, tmp_path, fields) -> http.HTTPFlow:
+    flow = model_provider_flow(
+        real_flow,
+        tmp_path,
+        OPENAI_RESPONSES_CASE,
+        proxy_log_path=tmp_path / "proxy.jsonl",
+    )
+    flow.request.method = "POST"
+    flow.request.path = "/v1/responses"
+    flow.response = http.Response.make(200)
+    flow.response.headers = http.Headers(fields)
+    flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] = "already_stream_decodable"
+    return flow
+
+
+def _assert_model_usage(flow, body: bytes, usage_webhook_api) -> None:
+    assert flow.response is not None
+    upstream_response = flow.response
+    fields = upstream_response.headers.fields
+    request_fields = flow.request.headers.fields
+
+    mitm_addon.responseheaders(flow)
+    assert flow.response.status_code == 200
+    stream = response_stream(flow)
+    for offset in range(0, len(body), 17):
+        chunk = body[offset : offset + 17]
+        assert stream(chunk) == chunk
+    assert stream(b"") == b""
+    webhook = run_response(flow, usage_webhook_api)
+
+    assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == (
+        expected_event_quantities(OPENAI_RESPONSES_CASE)
+    )
+    assert flow.response is upstream_response
+    assert flow.response.headers.fields == fields
+    assert flow.request.headers.fields == request_fields
+
+
+@pytest.mark.parametrize("encoding", ["", "identity", "gzip", "deflate", "br", "zstd"])
+def test_oversized_unrelated_fields_preserve_codecs_and_usage(
+    real_flow, tmp_path, usage_webhook_api, encoding
+):
+    body = standard_success_payload(OPENAI_RESPONSES_CASE)
+    if encoding == "gzip":
+        body = gzip.compress(body)
+    elif encoding == "deflate":
+        body = zlib.compress(body)
+    elif encoding == "br":
+        body = brotli.compress(body)
+    elif encoding == "zstd":
+        body = zstandard.ZstdCompressor().compress(body)
+    fields = (
+        (_UnnormalizedName(b"X" * (1024 * 1024)), _UninspectedValue(b"x" * (1024 * 1024))),
+        (b"Content-Type", b"application/json"),
+        (b"cOnTeNt-EnCoDiNg", b" \t" + encoding.upper().encode() + b"\t "),
+    )
+
+    _assert_model_usage(_model_flow(real_flow, tmp_path, fields), body, usage_webhook_api)
+
+
+@pytest.mark.parametrize("is_sse", [False, True], ids=["json", "sse"])
+def test_exact_field_and_value_limits_preserve_usage(
+    real_flow, tmp_path, usage_webhook_api, *, is_sse
+):
+    body = standard_success_payload(OPENAI_RESPONSES_CASE)
+    if is_sse:
+        body = b'event: response.completed\ndata: {"response":' + body + b"}\n\n"
+    fields = (
+        ((b"X-Padding", b""),) * (_FIELD_LIMIT - 2)
+        + ((b"Content-Type", b"text/event-stream" if is_sse else b"application/json"),)
+        + ((b"Content-Encoding", b" " * (_VALUE_LIMIT - len(b"gzip")) + b"gzip"),)
+    )
+
+    _assert_model_usage(
+        _model_flow(real_flow, tmp_path, fields), gzip.compress(body), usage_webhook_api
+    )
+
+
+_OVER_BUDGET_FIELDS = [
+    pytest.param(
+        ((_UnnormalizedName(b"Content-Encoding"), _UninspectedValue(b"identity")),)
+        * (_FIELD_LIMIT + 1),
+        id="excess-fields-before-normalization",
+    ),
+    pytest.param(
+        ((_UnnormalizedName(b"X-Unrelated"), b""),) * (_FIELD_LIMIT + 1),
+        id="excess-fields-without-encoding",
+    ),
+    pytest.param(
+        ((b"Content-Encoding", _UninspectedValue(b" " * (_VALUE_LIMIT + 1))),),
+        id="oversized-blank-value",
+    ),
+    pytest.param(
+        ((b"Content-Encoding", _UninspectedValue(b"gzip" + b" " * _VALUE_LIMIT)),),
+        id="oversized-supported-prefix",
+    ),
+    pytest.param(
+        (
+            (b"Content-Encoding", _UninspectedValue(b" " * (_VALUE_LIMIT // 2))),
+            (b"CONTENT-ENCODING", _UninspectedValue(b" " * (_VALUE_LIMIT // 2))),
+        ),
+        id="aggregate-values-plus-folding",
+    ),
+]
+
+
+@pytest.mark.parametrize("fields", _OVER_BUDGET_FIELDS)
+@pytest.mark.parametrize("consumer", ["model-json", "model-sse", "connector"])
+def test_over_budget_billable_response_is_rejected_without_upstream_body(
+    real_flow, tmp_path, mitm_ctx, usage_webhook_api, fields, consumer
+):
+    if consumer == "connector":
+        flow = make_x_pipeline_flow(real_flow, tmp_path)
+        flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] = "already_stream_decodable"
+    else:
+        flow = _model_flow(real_flow, tmp_path, ())
+    assert flow.response is not None
+    flow.response.headers = http.Headers(
+        (
+            (
+                b"Content-Type",
+                b"text/event-stream" if consumer == "model-sse" else b"application/json",
+            ),
+            *fields,
+        )
+    )
+    upstream_response = flow.response
+    upstream_fields = upstream_response.headers.fields
+
+    with mitm_ctx():
+        mitm_addon.responseheaders(flow)
+
+    assert flow.response.status_code == 502
+    assert flow.response.raw_content == b""
+    assert response_stream(flow)(b"uninspectable-upstream") == b""
+    assert response_stream(flow)(b"") == b""
+    assert upstream_response.headers.fields == upstream_fields
+    [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+    assert entry["reason"] == "response_encoding_not_stream_decodable"
+    assert entry["inspection_disposition"] == "fail_closed"
+    assert entry["decode_skip_reason"] == _BUDGET_REASON
+    assert run_response(flow, usage_webhook_api).usage_events() == []
+
+
+@pytest.mark.parametrize("fields", _OVER_BUDGET_FIELDS)
+def test_terminal_and_capture_decoders_keep_their_uninspectable_policies(fields):
+    headers = http.Headers(fields)
+    body = b'{"usage":{"input_tokens":123}}'
+
+    assert not body_decoding.can_stream_decode_usage(headers)
+    assert not body_decoding.can_decode_json_usage_body(headers)
+    assert body_decoding.decompress_json_usage_body(body, headers) == (b"", _BUDGET_REASON)
+    assert body_decoding.decode_response_body_for_network_log_capture(body, headers) is None
+    assert body_decoding.decode_request_body_for_network_log_capture(body, headers) is None
+    assert body_decoding.decompress_body(body, headers) == body
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param((), id="missing"),
+        pytest.param((b"",), id="empty"),
+        pytest.param((b"\xc2\xa0IdEnTiTy\xc2\xa0",), id="existing-unicode-whitespace"),
+    ],
+)
+def test_in_budget_identity_semantics_preserve_usage(
+    real_flow, tmp_path, usage_webhook_api, values
+):
+    flow = _model_flow(real_flow, tmp_path, tuple((b"Content-Encoding", value) for value in values))
+
+    _assert_model_usage(flow, standard_success_payload(OPENAI_RESPONSES_CASE), usage_webhook_api)
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param((b"identity", b"identity"), id="duplicate"),
+        pytest.param((b"", b""), id="empty-duplicates"),
+        pytest.param((b"gzip, br",), id="coding-list"),
+        pytest.param((b"\xff",), id="non-utf8"),
+        pytest.param(
+            (b" " * (_VALUE_LIMIT // 2 - 1), b" " * (_VALUE_LIMIT // 2 - 1)),
+            id="folded-value-exact-limit",
+        ),
+    ],
+)
+def test_in_budget_unsupported_encodings_remain_rejected(real_flow, tmp_path, mitm_ctx, values):
+    fields = tuple((b"Content-Encoding", value) for value in values)
+    flow = _model_flow(real_flow, tmp_path, fields)
+
+    with mitm_ctx():
+        mitm_addon.responseheaders(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert response_stream(flow)(b"upstream-body") == b""
+    [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+    assert entry["decode_skip_reason"] == "unsupported content encoding"
+
+
+@pytest.mark.parametrize(
+    ("billable", "status"),
+    [(False, 200), (True, 429), (True, 204)],
+)
+def test_over_budget_uninspected_responses_keep_pass_through(
+    real_flow, tmp_path, mitm_ctx, *, billable, status
+):
+    fields = ((b"Content-Encoding", _UninspectedValue(b" " * (_VALUE_LIMIT + 1))),)
+    flow = _model_flow(real_flow, tmp_path, fields)
+    flow.metadata[metadata_keys.FIREWALL_BILLABLE] = billable
+    assert flow.response is not None
+    flow.response.status_code = status
+    upstream_response = flow.response
+
+    with mitm_ctx():
+        mitm_addon.responseheaders(flow)
+
+    assert flow.response is upstream_response
+    assert flow.response.status_code == status
+    assert flow.response.headers.fields == fields
+    if status != 204:
+        assert response_stream(flow)(b"upstream-body") == b"upstream-body"
+    assert response_stream(flow)(b"") == b""

--- a/crates/runner/mitm-addon/tests/test_response_content_type_budget.py
+++ b/crates/runner/mitm-addon/tests/test_response_content_type_budget.py
@@ -29,6 +29,7 @@ def _make_flow(real_flow, fields: tuple[tuple[bytes, bytes], ...]) -> http.HTTPF
             metadata_keys.FIREWALL_BILLABLE: True,
             metadata_keys.CLI_AGENT_TYPE: "codex",
             metadata_keys.MODEL_USAGE_PROVIDER: "gpt-5.5",
+            metadata_keys.RESPONSE_ENCODING_NEGOTIATION: "already_stream_decodable",
         }
     )
     return flow
@@ -128,14 +129,22 @@ def test_response_hook_uses_complete_bounded_singleton(real_flow, values, *, is_
 
 
 @pytest.mark.parametrize(
-    ("field_count", "is_sse"),
-    [(_FIELD_LIMIT, True), (_FIELD_LIMIT + 1, False)],
+    "field_count",
+    [_FIELD_LIMIT, _FIELD_LIMIT + 1],
 )
-def test_response_hook_bounds_field_count(real_flow, field_count: int, *, is_sse: bool):
+def test_response_hook_bounds_field_count(real_flow, mitm_ctx, field_count: int):
     fields = ((b"X-Padding", b""),) * (field_count - 1) + ((b"Content-Type", b"text/event-stream"),)
     flow = _make_flow(real_flow, fields)
 
-    _assert_stream_classification(flow, is_sse=is_sse)
+    if field_count == _FIELD_LIMIT:
+        _assert_stream_classification(flow, is_sse=True)
+    else:
+        # Excess fields also prevent the decoder from establishing identity.
+        with mitm_ctx():
+            mitm_addon.responseheaders(flow)
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert response_stream(flow)(_SSE_USAGE) == b""
 
 
 def test_response_hook_checks_duplicates_after_early_sse_match(real_flow):

--- a/docs/mitm-addon-contracts.md
+++ b/docs/mitm-addon-contracts.md
@@ -243,6 +243,44 @@ copies, name normalization, and truncated-prefix matches. The shared failure
 reporting suite also verifies the same classification for usage and failure
 observers without timing or allocation thresholds.
 
+## Content-Encoding decoder inspection boundary
+
+Shared body decoders inspect at most 8,192 raw header fields and 8,192 total
+Content-Encoding value bytes per call, including comma-space separators for
+repeated fields. Field count is checked before traversal, and raw names are
+length-checked before case normalization. All matching values must fit the
+budget before any value is decoded, joined, stripped, or lowercased. Oversized
+unrelated names and values are skipped without copying or normalization.
+
+Within budget, decoding preserves mitmproxy's UTF-8/surrogateescape conversion,
+comma folding, and existing whitespace/case normalization. Missing and empty
+encoding remain identity; gzip, deflate, and br keep streaming support, while
+zstd keeps its bounded terminal JSON path. Repeated fields and coding lists
+retain their unsupported-encoding behavior.
+
+Budget exhaustion is uninspectable, not proof of identity encoding. Capability
+checks decline both streaming and terminal JSON fallback. Successful billable
+model responses and registered connector response parsers therefore use the
+existing empty 502 response and discard upstream body bytes. The fixed
+`content encoding header inspection limit exceeded` diagnostic contains no raw
+header data. Upstream errors, non-billable flows, and bodyless responses retain
+their existing pass-through policy; status-level provider failure reports remain
+available. Accepted and pass-through responses preserve wire headers and bytes.
+
+Direct terminal JSON decoding returns an error for exhaustion, strict capture
+decoders hide the body, and best-effort capture decompression retains wire bytes
+as it does for unsupported encoding. These local decoder limits do not bound
+mitmproxy's initial HTTP-head buffer, separate request-billing inspection, or
+other header consumers. Old runners retain their previous local behavior until
+updated; no wire protocol or persisted state changes.
+
+`test_response_content_encoding_budget.py` exercises guarded raw inputs through
+the real response hooks and verifies usage delivery, exact limits, and 502/body
+discard behavior. The provider failure suite covers the real 429 response hook
+with oversized unrelated names and excess fields while verifying HTTP reports
+and pass-through traffic. The regressions use structural work assertions, not
+wall-clock thresholds.
+
 ## Path normalization work boundary
 
 Path safety validation accepts at most 65,536 input characters and five percent


### PR DESCRIPTION
## Summary

Response decoder setup used mitmproxy's general Content-Encoding lookup, which traversed every raw header and normalized complete names before applying any work limit. Bound the shared decoder reads to 8,192 fields and 8,192 folded value bytes, checking name lengths and aggregate value size before normalization or conversion.

Supported in-budget encodings, wire headers, and streamed bytes retain their existing behavior. Budget exhaustion is explicitly uninspectable: successful billable responses without a bounded accounting path use the existing empty 502/body-discard policy, while upstream errors still pass through and produce status-based failure reports. Streaming capability checks, terminal JSON decoding, and capture helpers share the same bound and retain their respective failure policies.

The limits apply to decoder inspection; initial mitmproxy HTTP-head buffering and separate request-billing inspection are outside this change. No dependency, protocol, schema, or migration changes.

Closes #33459

## Validation

- Verified the new structural regressions on unchanged main: 24 expected failures at unbounded header normalization/conversion; the exact-boundary cases passed.
- Real response hooks now cover oversized unrelated names/values, field and aggregate-value exhaustion, exact boundaries, duplicate/non-UTF-8 values, normal codecs including zstd fallback, usage webhook delivery, 502/body discard, and preserved 429 failure reports.
- Locked uv 0.11.32 / CPython 3.14.0 / mitmproxy 12.2.3 environment: `uv lock --check`, `uv sync --locked`.
- `uv run --no-sync python -m pytest -q tests/ --tb=short`: **7,727 passed**.
- `uv run --no-sync ruff format --check .`, `uv run --no-sync ruff check .`, `uv run --no-sync basedpyright -p .`: passed.
- `npx --yes prettier@3.8.1 --check docs/mitm-addon-contracts.md`, `git diff --check`: passed.
