### PR TITLE
ci: deduplicate selected runner image waiting

### DIFF
--- a/.github/scripts/runner-host-architecture-groups.sh
+++ b/.github/scripts/runner-host-architecture-groups.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
   cat <<'USAGE'
-Usage: runner-host-architecture-groups.sh [matrix|target-matrix|has-groups|hosts ID|select-context KEY|select-host ID KEY [HOSTS]]
+Usage: runner-host-architecture-groups.sh [matrix|validation-plan KEY|target-matrix|has-groups|hosts ID|select-context KEY|select-host ID KEY [HOSTS]]
 
 Emits compact JSON for configured runner host architecture groups.
 Inputs:
@@ -16,6 +16,7 @@ Inputs:
 Commands:
   <none>      Emit the full local contract, including hosts.
   matrix      Emit the cross-job matrix contract, excluding hosts.
+  validation-plan KEY  Emit the full matrix, selected target, and remaining validation matrix.
   target-matrix  Emit the deploy/rollback matrix contract: id, label, target.
   has-groups  Emit true when at least one host group is configured.
   hosts ID            Emit comma-separated hosts for the given architecture group.
@@ -167,6 +168,11 @@ emit_groups() {
 emit_matrix() {
   local groups
   groups=$(emit_groups) || return $?
+  matrix_from_groups "$groups"
+}
+
+matrix_from_groups() {
+  local groups=$1
   jq -c 'map({
     id,
     label,
@@ -222,15 +228,17 @@ emit_hosts() {
   jq -r --arg id "$group_id" '.[] | select(.id == $id) | .hosts' <<<"$groups"
 }
 
-emit_selected_context() {
+validate_selection_key() {
   local selection_key=${1:-}
   if [ -z "$selection_key" ]; then
     echo "missing runner host context selection key" >&2
     return 2
   fi
+}
 
-  local groups contexts context_count
-  groups=$(emit_groups) || return $?
+selected_context_from_groups() {
+  local selection_key=$1 groups=$2
+  local contexts context_count
   contexts=$(jq -c '[.[] as $group | $group.hosts | split(",")[] | {
     host: .,
     groupId: $group.id,
@@ -247,6 +255,27 @@ emit_selected_context() {
   hash=$(printf '%s' "$selection_key" | md5sum | cut -c1-8)
   context_index=$(( 0x$hash % context_count ))
   jq -c --argjson context_index "$context_index" '.[$context_index]' <<<"$contexts"
+}
+
+emit_selected_context() {
+  validate_selection_key "${1:-}" || return $?
+  local groups
+  groups=$(emit_groups) || return $?
+  selected_context_from_groups "${1:-}" "$groups"
+}
+
+emit_validation_plan() {
+  validate_selection_key "${1:-}" || return $?
+  local groups context matrix target
+  groups=$(emit_groups) || return $?
+  context=$(selected_context_from_groups "${1:-}" "$groups") || return $?
+  target=$(jq -r '.target' <<<"$context")
+  matrix=$(matrix_from_groups "$groups") || return $?
+  jq -cn --argjson matrix "$matrix" --arg target "$target" '{
+    matrix: $matrix,
+    selectedTarget: $target,
+    validationMatrix: ($matrix | map(select(.target != $target)))
+  }'
 }
 
 emit_selected_host() {
@@ -294,6 +323,9 @@ case "$cmd" in
     ;;
   matrix)
     emit_matrix
+    ;;
+  validation-plan)
+    emit_validation_plan "${2:-}"
     ;;
   target-matrix)
     emit_target_matrix

--- a/.github/scripts/tests/crates-runner-image-waiters-test.sh
+++ b/.github/scripts/tests/crates-runner-image-waiters-test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+repo_root="$(cd "$repo_root/.." && pwd)"
+
+ruby -ryaml -rjson -ropen3 -rtmpdir -rfileutils - "$repo_root" <<'RUBY'
+root = ARGV.fetch(0)
+workflow = YAML.load_file(File.join(root, ".github/workflows/crates.yml"))
+jobs = workflow.fetch("jobs")
+groups = jobs.fetch("runner-host-groups")
+selected = jobs.fetch("runner-build")
+remaining = jobs.fetch("runner-image-architecture-manifest")
+gate = jobs.fetch("ci-gate-crates")
+group_step = groups.fetch("steps").find { |step| step["id"] == "groups" }
+select_step = selected.fetch("steps").find { |step| step["id"] == "selected-host" }
+gate_step = gate.fetch("steps").find { |step| step["name"] == "Validate CI results" }
+
+unless selected.fetch("needs") == ["detect", "runner-host-groups"] &&
+    remaining.fetch("needs") == ["detect", "runner-host-groups"] &&
+    remaining.dig("strategy", "fail-fast") == false &&
+    remaining.dig("strategy", "matrix", "include") == '${{ fromJSON(needs.runner-host-groups.outputs.validation-matrix || \'[]\') }}' &&
+    remaining.fetch("if").include?("needs.runner-host-groups.outputs.validation-matrix != '[]'")
+  raise "selected and complementary validation must start independently, with empty complements omitted"
+end
+%w[nbd-cow-test runner-rootfs-process-test].each do |name|
+  unless jobs.fetch(name).dig("strategy", "matrix", "include").include?("needs.runner-host-groups.outputs.matrix")
+    raise "#{name} must retain the full architecture matrix"
+  end
+end
+%w[runner-behavior-lane-a runner-behavior-lane-b runner-behavior-lane-c runner-behavior-lane-d guest-rpc-firecracker-test].each do |name|
+  raise "#{name} must depend only on selected target readiness" unless jobs.fetch(name).fetch("needs") == ["runner-build"]
+end
+unless group_step.dig("env", "SELECTION_KEY") == '${{ needs.detect.outputs.runner-image-job-ref }}' &&
+    select_step.dig("env", "EXPECTED_TARGET") == '${{ needs.runner-host-groups.outputs.selected-target }}' &&
+    gate_step.dig("env", "IMAGE_VALIDATION_MATRIX") == '${{ needs.runner-host-groups.outputs.validation-matrix }}' &&
+    gate_step.dig("env", "RUNNER_IMAGE_NEEDED") == "${{ needs.detect.outputs.metal-job-ref != '' && needs.detect.outputs.crates-runner-consumer-needed == 'true' }}"
+  raise "planning, validation, and gate must share the original image selection context"
+end
+
+def run_step(root, env, step, success: true)
+  output, error, status = Open3.capture3(env, "bash", "-euo", "pipefail", "-c", step, chdir: root)
+  raise "unexpected step status #{status.exitstatus}: #{output}#{error}" unless status.success? == success
+  output + error
+end
+
+def check_gate(root, gate, step, matrix:, needed: "true", release: "false", results: {}, success: true)
+  values = gate.fetch("needs").to_h { |name| [name, "success"] }.merge(results)
+  script = step.fetch("run").gsub(/\$\{\{ needs\.([a-z-]+)\.result \}\}/) { values.fetch(Regexp.last_match(1)) }
+  raise "unresolved gate expression" if script.include?("${{")
+  env = {"IS_RELEASE" => release, "RUNNER_IMAGE_NEEDED" => needed, "IMAGE_VALIDATION_MATRIX" => matrix}
+  run_step(root, env, script, success: success)
+end
+
+Dir.mktmpdir("crates-image-waiters") do |dir|
+  bin = File.join(dir, "bin")
+  FileUtils.mkdir_p(bin)
+  ssh = File.join(bin, "ssh")
+  File.write(ssh, <<~SH)
+    #!/usr/bin/env bash
+    set -euo pipefail
+    [ "$1" = "-n" ]
+    case "$2" in
+      ci@arm-*) echo aarch64 ;;
+      ci@x86-*) echo x86_64 ;;
+      *) exit 1 ;;
+    esac
+  SH
+  File.chmod(0o755, ssh)
+
+  ["arm-1,x86-1,x86-2", "arm-1", "x86-1"].each do |hosts|
+    %w[pr-1 pr-2].each do |key|
+      output_file = File.join(dir, "#{hosts}-#{key}.out")
+      env = {"PATH" => "#{bin}:#{ENV.fetch('PATH')}", "METAL_USER" => "ci",
+             "AWS_METAL_RUNNER_HOSTS" => hosts, "RUNNER_CONSUMER_NEEDED" => "true",
+             "SELECTION_KEY" => key, "GITHUB_OUTPUT" => output_file}
+      run_step(root, env, group_step.fetch("run"))
+      outputs = File.readlines(output_file, chomp: true).to_h { |line| line.split("=", 2) }
+      full = JSON.parse(outputs.fetch("matrix"))
+      other = JSON.parse(outputs.fetch("validation-matrix"))
+      target = outputs.fetch("selected-target")
+      raise "image validation must partition the full matrix" unless other == full.reject { |entry| entry.fetch("target") == target }
+      raise "one selected target must be covered by runner-build" unless full.count { |entry| entry.fetch("target") == target } == 1
+      env["EXPECTED_TARGET"] = target
+      env["GITHUB_OUTPUT"] = File.join(dir, "selected.out")
+      run_step(root, env, select_step.fetch("run"))
+      mismatch = run_step(root, env.merge("EXPECTED_TARGET" => "different-target"), select_step.fetch("run"), success: false)
+      raise "inventory drift must report target mismatch" unless mismatch.include?("Selected runner target changed")
+      matrix_result = other.empty? ? "skipped" : "success"
+      check_gate(root, gate, gate_step, matrix: outputs.fetch("validation-matrix"), results: {"runner-image-architecture-manifest" => matrix_result})
+    end
+  end
+
+  # Host-only tests still receive the complete matrix without image selection.
+  output_file = File.join(dir, "host-only.out")
+  env = {"PATH" => "#{bin}:#{ENV.fetch('PATH')}", "METAL_USER" => "ci",
+         "AWS_METAL_RUNNER_HOSTS" => "arm-1,x86-1", "RUNNER_CONSUMER_NEEDED" => "false",
+         "SELECTION_KEY" => "", "GITHUB_OUTPUT" => output_file}
+  run_step(root, env, group_step.fetch("run"))
+  outputs = File.readlines(output_file, chomp: true).to_h { |line| line.split("=", 2) }
+  raise "host-only tests need both targets" unless JSON.parse(outputs.fetch("matrix")).length == 2
+end
+
+%w[runner-host-groups runner-build runner-image-architecture-manifest].each do |job|
+  %w[failure cancelled skipped].each do |result|
+    check_gate(root, gate, gate_step, matrix: '[{"target":"other"}]', results: {job => result}, success: false)
+  end
+end
+check_gate(root, gate, gate_step, matrix: "[]", results: {"runner-build" => "skipped", "runner-image-architecture-manifest" => "skipped"}, success: false)
+check_gate(root, gate, gate_step, matrix: "", results: {"runner-image-architecture-manifest" => "skipped"}, success: false)
+unselected = %w[runner-host-groups runner-build runner-image-architecture-manifest guest-rpc-firecracker-test].to_h { |name| [name, "skipped"] }
+check_gate(root, gate, gate_step, matrix: "", needed: "false", results: unselected)
+check_gate(root, gate, gate_step, matrix: "", release: "true", results: gate.fetch("needs").to_h { |name| [name, "skipped"] })
+
+puts "crates-runner-image-waiters-test: ok"
+RUBY

--- a/.github/scripts/tests/runner-host-architecture-groups-test.sh
+++ b/.github/scripts/tests/runner-host-architecture-groups-test.sh
@@ -27,6 +27,9 @@ fi
 remote=$1
 shift
 host=${remote#*@}
+if [ -n "${SSH_LOG:-}" ]; then
+  printf '%s\n' "$host" >> "$SSH_LOG"
+fi
 
 if [ "$#" -ne 2 ] || [ "$1" != "uname" ] || [ "$2" != "-m" ]; then
   echo "unexpected ssh command for ${host}: $*" >&2
@@ -185,6 +188,26 @@ assert_json_eq "$selected" '{"host":"x86-1","groupId":"x86_64","target":"x86_64-
 
 retry_selected=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1,x86-1,x86-2' "$HOST_GROUPS" select-context pr-1)
 assert_json_eq "$retry_selected" "$selected"
+
+for selection_key in pr-1 pr-2 pr-9; do
+  plan=$(run_clean SSH_LOG="${TMPDIR}/${selection_key}.ssh" AWS_METAL_RUNNER_HOSTS='arm-1,x86-1,x86-2' "$HOST_GROUPS" validation-plan "$selection_key")
+  [ "$(wc -l <"${TMPDIR}/${selection_key}.ssh")" -eq 3 ] || fail "validation planning must probe each host only once"
+  context=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1,x86-1,x86-2' "$HOST_GROUPS" select-context "$selection_key")
+  assert_json_eq "$(jq '.selectedTarget' <<<"$plan")" "$(jq '.target' <<<"$context")"
+  assert_json_eq "$(jq '.matrix' <<<"$plan")" "$out"
+  jq -e '
+    (keys | sort) == ["matrix", "selectedTarget", "validationMatrix"] and
+    (.selectedTarget as $target | .validationMatrix == (.matrix | map(select(.target != $target)))) and
+    (.validationMatrix | length) == 1
+  ' <<<"$plan" >/dev/null || fail "expected full and complementary validation matrices"
+  assert_no_hosts_field "$(jq '.matrix' <<<"$plan")"
+  assert_no_hosts_field "$(jq '.validationMatrix' <<<"$plan")"
+done
+
+for host in arm-1 x86-1; do
+  plan=$(run_clean AWS_METAL_RUNNER_HOSTS="$host" "$HOST_GROUPS" validation-plan pr-1)
+  jq -e '.validationMatrix == [] and (.matrix | length) == 1 and .selectedTarget == .matrix[0].target' <<<"$plan" >/dev/null || fail "one target must be fully covered by runner-build"
+done
 
 selected=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1,x86-1,x86-2' "$HOST_GROUPS" select-context pr-2)
 assert_json_eq "$selected" '{"host":"arm-1","groupId":"arm64","target":"aarch64-unknown-linux-musl","groupHosts":"arm-1"}'

--- a/.github/scripts/tests/runner-image-manifest-test.sh
+++ b/.github/scripts/tests/runner-image-manifest-test.sh
@@ -89,6 +89,19 @@ if MANIFEST_PATH="${TMPDIR}/manifest.json" \
 fi
 grep -q "manifest missing rootfsHash for dev-3" "${TMPDIR}/manifest-test.err" || fail "expected missing host message"
 
+# Selecting an existing host must not bypass validation of its whole group.
+if MANIFEST_PATH="${TMPDIR}/manifest.json" \
+  HEAD_SHA=abc \
+  JOB_REF=pr-123 \
+  TARGET=aarch64-unknown-linux-musl \
+  PROFILE=vm0/default \
+  METAL_HOSTS=dev-1,dev-3 \
+  SELECTED_HOST=dev-1 \
+  "$MANIFEST" validate >"${TMPDIR}/selected-group.out" 2>"${TMPDIR}/selected-group.err"; then
+  fail "expected missing unselected host in selected group to fail"
+fi
+grep -q "manifest missing rootfsHash for dev-3" "${TMPDIR}/selected-group.err" || fail "expected whole selected group validation"
+
 if MANIFEST_PATH="${TMPDIR}/manifest.json" \
   HEAD_SHA=abc \
   JOB_REF=pr-123 \

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -265,6 +265,8 @@ jobs:
       # Keep cross-job architecture metadata sanitized. Jobs that need hosts
       # resolve host data locally from the secret-backed configuration.
       matrix: ${{ steps.groups.outputs.matrix }}
+      selected-target: ${{ steps.groups.outputs.selected-target }}
+      validation-matrix: ${{ steps.groups.outputs.validation-matrix }}
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -282,8 +284,17 @@ jobs:
         env:
           AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          RUNNER_CONSUMER_NEEDED: ${{ needs.detect.outputs.crates-runner-consumer-needed }}
+          SELECTION_KEY: ${{ needs.detect.outputs.runner-image-job-ref }}
         run: |
-          MATRIX=$(.github/scripts/runner-host-architecture-groups.sh matrix)
+          if [ "$RUNNER_CONSUMER_NEEDED" = "true" ]; then
+            PLAN=$(.github/scripts/runner-host-architecture-groups.sh validation-plan "$SELECTION_KEY")
+            MATRIX=$(jq -c '.matrix' <<<"$PLAN")
+            echo "selected-target=$(jq -r '.selectedTarget' <<<"$PLAN")" >> "$GITHUB_OUTPUT"
+            echo "validation-matrix=$(jq -c '.validationMatrix' <<<"$PLAN")" >> "$GITHUB_OUTPUT"
+          else
+            MATRIX=$(.github/scripts/runner-host-architecture-groups.sh matrix)
+          fi
           GROUP_COUNT=$(jq -r 'length' <<<"$MATRIX")
           if [ "$GROUP_COUNT" -lt 1 ]; then
             echo "::error::No runner host architecture groups found"
@@ -752,12 +763,17 @@ jobs:
           AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           SELECTION_KEY: ${{ needs.detect.outputs.runner-image-job-ref }}
+          EXPECTED_TARGET: ${{ needs.runner-host-groups.outputs.selected-target }}
         run: |
           CONTEXT=$(.github/scripts/runner-host-architecture-groups.sh select-context "$SELECTION_KEY")
           HOST=$(jq -r '.host' <<<"$CONTEXT")
           GROUP_ID=$(jq -r '.groupId' <<<"$CONTEXT")
           TARGET=$(jq -r '.target' <<<"$CONTEXT")
           HOSTS=$(jq -r '.groupHosts' <<<"$CONTEXT")
+          if [ "$TARGET" != "$EXPECTED_TARGET" ]; then
+            echo "::error::Selected runner target changed after architecture validation planning: $EXPECTED_TARGET != $TARGET"
+            exit 1
+          fi
           {
             echo "host=${HOST}"
             echo "hosts=${HOSTS}"
@@ -787,11 +803,13 @@ jobs:
     needs: [detect, runner-host-groups]
     if: |
       needs.detect.outputs.metal-job-ref != '' &&
-      needs.detect.outputs.crates-runner-consumer-needed == 'true'
+      needs.detect.outputs.crates-runner-consumer-needed == 'true' &&
+      needs.runner-host-groups.outputs.validation-matrix != '[]'
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.runner-host-groups.outputs.matrix || '[]') }}
+        # runner-build validates every host in the selected target's group.
+        include: ${{ fromJSON(needs.runner-host-groups.outputs.validation-matrix || '[]') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
@@ -1125,6 +1143,8 @@ jobs:
       - name: Validate CI results
         env:
           IS_RELEASE: ${{ needs.detect-release.outputs.skip }}
+          RUNNER_IMAGE_NEEDED: ${{ needs.detect.outputs.metal-job-ref != '' && needs.detect.outputs.crates-runner-consumer-needed == 'true' }}
+          IMAGE_VALIDATION_MATRIX: ${{ needs.runner-host-groups.outputs.validation-matrix }}
         run: |
           # Auto-pass for release-please PRs, commits, and merge queue entries
           if [[ "$IS_RELEASE" == "true" ]]; then
@@ -1155,15 +1175,24 @@ jobs:
           # Must-succeed: only 'success' is acceptable
           check_result "detect" "${{ needs.detect.result }}" ""
 
+          RUNNER_IMAGE_ALLOW_SKIP=true
+          OTHER_TARGETS_ALLOW_SKIP=true
+          if [ "$RUNNER_IMAGE_NEEDED" = "true" ]; then
+            RUNNER_IMAGE_ALLOW_SKIP=""
+            if [ "$IMAGE_VALIDATION_MATRIX" != "[]" ]; then
+              OTHER_TARGETS_ALLOW_SKIP=""
+            fi
+          fi
+
           # May-skip: only run when relevant crates change
           check_result "check" "${{ needs.check.result }}" "true"
           check_result "coverage" "${{ needs.coverage.result }}" "true"
           check_result "api-contracts-rust-bindings" "${{ needs.api-contracts-rust-bindings.result }}" "true"
           check_result "runner-firewall-contract-test" "${{ needs.runner-firewall-contract-test.result }}" "true"
           check_result "mitm-addon-test" "${{ needs.mitm-addon-test.result }}" "true"
-          check_result "runner-host-groups" "${{ needs.runner-host-groups.result }}" "true"
-          check_result "runner-build" "${{ needs.runner-build.result }}" "true"
-          check_result "runner-image-architecture-manifest" "${{ needs.runner-image-architecture-manifest.result }}" "true"
+          check_result "runner-host-groups" "${{ needs.runner-host-groups.result }}" "$RUNNER_IMAGE_ALLOW_SKIP"
+          check_result "runner-build" "${{ needs.runner-build.result }}" "$RUNNER_IMAGE_ALLOW_SKIP"
+          check_result "runner-image-architecture-manifest" "${{ needs.runner-image-architecture-manifest.result }}" "$OTHER_TARGETS_ALLOW_SKIP"
           check_result "runner-behavior-lane-a" "${{ needs.runner-behavior-lane-a.result }}" "true"
           check_result "runner-behavior-lane-b" "${{ needs.runner-behavior-lane-b.result }}" "true"
           check_result "runner-behavior-lane-c" "${{ needs.runner-behavior-lane-c.result }}" "true"

--- a/docs/runner-multi-architecture.md
+++ b/docs/runner-multi-architecture.md
@@ -93,6 +93,12 @@ specific checks, including NBD COW tests, on matching metal. Jobs that need an
 actual host resolve the host subset inside the job instead of reading hosts from
 the matrix.
 
+Crates plans image validation with `validation-plan KEY` using the same
+deterministic host selection as `runner-build`. That job validates the entire
+selected architecture group; a parallel manifest matrix validates only the
+remaining groups. The full matrix still drives NBD COW and rootfs process tests.
+The CI gate requires both validation paths when applicable, including on reruns.
+
 Playwright uses the same metal inventory to bootstrap the runner exercised by
 the deployed product chat flow. Architecture-specific runner behavior remains
 in the host-bound crates checks instead of being duplicated in product E2E.


### PR DESCRIPTION
## Summary

- Keep Crates and Turbo as independent entry workflows in their original runs, while removing the Crates manifest-matrix waiter for the architecture already validated by `runner-build`.
- Compute the full matrix, selected target, and complementary image-validation matrix from one host-inventory probe. Preserve the existing host-weighted deterministic selection and sanitized cross-job metadata.
- Validate the entire selected host group in `runner-build`, validate remaining targets in parallel, and require every applicable validation path at `ci-gate-crates`. Reject a changed selected target; allow an empty complementary matrix only when there is no other target.

The full architecture matrix still drives NBD COW and rootfs process tests. Behavior lanes and their early selected-target readiness, polling intervals/deadlines, retries, artifact identity, cleanup, and binary transport are unchanged. No continuation workflows, new services, or runtime changes are introduced; Turbo is unchanged.

## Expected effect and risks

With two architectures and both consumers active, independently allocated waiter jobs fall from **4 to 3**; with one architecture, from **3 to 2**. This is not a claim of a 25% reduction in total CI time or cost.

In the existing controlled 90-second artifact-readiness fixture, one real waiter made **4 artifact lookups, 2 producer lookups, and 1 download invocation**. Removing the duplicate waiter removes that entire request sequence under equivalent conditions. The planning regression also verifies exactly one SSH probe per configured host.

The primary risks are a validation coverage gap, a changed selection, or accidentally delaying selected-target tests. Regression coverage exercises the actual workflow shell, single/mixed inventories, unchanged selection, target drift, full-group manifest rejection, independent dependencies, and failed/cancelled/unexpectedly skipped gate inputs. Live hosted scheduling and wall-clock savings remain to be confirmed by CI; no production timing claim is made.

## Validation

- All **88** `.github/scripts/tests/*.sh` scripts passed, sequentially, including the new Crates workflow test and existing manifest/waiter/host-selection/deploy consumers.
- `bash -n` passed for `.github/actions/report-memory-peak/*.sh`, `.github/scripts/*.sh`, and `.github/scripts/tests/*.sh`.
- `shellcheck -x -P SCRIPTDIR .github/scripts/runner-host-architecture-groups.sh .github/scripts/tests/runner-host-architecture-groups-test.sh .github/scripts/tests/runner-image-manifest-test.sh .github/scripts/tests/crates-runner-image-waiters-test.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh`
- Repository-pinned `actionlint` 1.7.12 across all workflows.
- `pnpm -C turbo exec prettier --check ../.github/workflows/crates.yml ../docs/runner-multi-architecture.md`
- `git diff --check`; pre-commit file-size and commit-message hooks passed.

Closes #33479
