### PR TITLE
perf(ci): download cached runner binaries directly from r2

### DIFF
--- a/.github/scripts/reconcile-and-start-runner-groups.sh
+++ b/.github/scripts/reconcile-and-start-runner-groups.sh
@@ -83,7 +83,7 @@ if [ "$recovery_needed" = "true" ]; then
   plan_output="${work_dir}/plan.out"
   export CURRENT_PR_NUMBER=$current_pr_number
   GITHUB_OUTPUT="$plan_output" \
-    RESOLVE_OUTPUT_DIR="$recovery_dir" \
+    RESOLVE_OUTPUT_DIR="${work_dir}/references" \
     RUNNER_HOST_GROUPS_MATRIX="$runner_host_groups_matrix" \
     "${SCRIPT_DIR}/runner-binary-cache-plan.sh"
 
@@ -92,6 +92,17 @@ if [ "$recovery_needed" = "true" ]; then
     echo "::error::Validated runner binary recovery was unavailable for ${recovery_miss_count} target(s)" >&2
     exit 1
   fi
+
+  recovery_references=$(output_value hit-references "$plan_output")
+  while IFS= read -r reference; do
+    target=$(jq -r '.target' <<<"$reference")
+    env GITHUB_OUTPUT= \
+      EXPECTED_TARGET="$target" \
+      EXPECTED_BINARY_INPUT_DIGEST="$(jq -r '.binaryInputDigest' <<<"$reference")" \
+      CACHE_REFERENCE="$reference" \
+      RESOLVE_OUTPUT_DIR="${recovery_dir}/${target}" \
+      "${SCRIPT_DIR}/runner-binary-cache.sh" download-reference
+  done < <(jq -c '.[]' <<<"$recovery_references")
 
   RECOVERY_DIR="$recovery_dir" \
     "${SCRIPT_DIR}/reconcile-runner-binary-groups.sh" restore

--- a/.github/scripts/runner-binary-cache-plan.sh
+++ b/.github/scripts/runner-binary-cache-plan.sh
@@ -96,13 +96,14 @@ while IFS= read -r encoded_entry; do
       EXPECTED_TARGET="$target" \
       EXPECTED_BINARY_INPUT_DIGEST="$digest" \
       RESOLVE_OUTPUT_DIR="${RESOLVE_OUTPUT_DIR}/${target}" \
-      "$CACHE" active-resolve \
+      "$CACHE" resolve-reference \
       >"$result_file" 2>"$error_file" &
   pids+=("$!")
 done < <(jq -cr '.[] | @base64' <<<"$RUNNER_HOST_GROUPS_MATRIX")
 
 miss_matrix='[]'
 hit_targets='[]'
+hit_references='{}'
 resolution_json='[]'
 hit_count=0
 miss_count=0
@@ -125,8 +126,6 @@ for index in "${!targets[@]}"; do
     reason=resolve-timeout
     producer_run_id=""
     candidate_inspections=0
-    runner_size=0
-    object_size=0
   elif [ "$status" -ne 0 ]; then
     echo "runner binary resolution failed for ${target}" >&2
     sed 's/^/  /' "$error_file" >&2
@@ -138,11 +137,7 @@ for index in "${!targets[@]}"; do
     reason=$(output_value resolve-reason "$result_file")
     producer_run_id=$(output_value resolve-producer-run-id "$result_file")
     candidate_inspections=$(output_value candidate-inspections "$result_file")
-    runner_size=$(output_value runner-size-bytes "$result_file")
-    object_size=$(output_value object-size-bytes "$result_file")
     candidate_inspections=${candidate_inspections:-0}
-    runner_size=${runner_size:-0}
-    object_size=${object_size:-0}
     if [ "$outcome" != "hit" ] && [ "$outcome" != "miss" ]; then
       echo "runner binary resolution returned an invalid outcome for ${target}: ${outcome}" >&2
       hard_failure=true
@@ -151,13 +146,15 @@ for index in "${!targets[@]}"; do
   fi
 
   if [ "$outcome" = "hit" ]; then
-    if [ ! -f "${RESOLVE_OUTPUT_DIR}/${target}/runner" ] ||
-      [ ! -f "${RESOLVE_OUTPUT_DIR}/${target}/metadata.json" ]; then
-      echo "runner binary hit transport is incomplete for ${target}" >&2
+    if [ ! -f "${RESOLVE_OUTPUT_DIR}/${target}/reference.json" ]; then
+      echo "runner binary cache reference is missing for ${target}" >&2
       hard_failure=true
       continue
     fi
     hit_targets=$(jq -c --arg target "$target" '. + [$target]' <<<"$hit_targets")
+    hit_references=$(jq -c --arg target "$target" \
+      --slurpfile reference "${RESOLVE_OUTPUT_DIR}/${target}/reference.json" \
+      '. + {($target): $reference[0]}' <<<"$hit_references")
     hit_count=$((hit_count + 1))
   else
     miss_matrix=$(jq -c --argjson entry "$entry" '. + [$entry]' <<<"$miss_matrix")
@@ -171,9 +168,7 @@ for index in "${!targets[@]}"; do
     --arg reason "$reason" \
     --arg producer_run_id "$producer_run_id" \
     --argjson duration "$duration" \
-    --argjson candidate_inspections "$candidate_inspections" \
-    --argjson runner_size "$runner_size" \
-    --argjson object_size "$object_size" '
+    --argjson candidate_inspections "$candidate_inspections" '
       . + [{
         target: $target,
         binaryInputDigest: $digest,
@@ -182,9 +177,7 @@ for index in "${!targets[@]}"; do
         reason: $reason,
         producerRunId: $producer_run_id,
         durationSeconds: $duration,
-        candidateInspections: $candidate_inspections,
-        runnerSizeBytes: $runner_size,
-        objectSizeBytes: $object_size
+        candidateInspections: $candidate_inspections
       }]
     ' <<<"$resolution_json")
 done
@@ -199,6 +192,7 @@ fi
 
 emit "compile-matrix" "$miss_matrix"
 emit "hit-targets" "$hit_targets"
+emit "hit-references" "$hit_references"
 emit "hit-count" "$hit_count"
 emit "miss-count" "$miss_count"
 printf 'resolution-json=%s\n' "$resolution_json"
@@ -207,9 +201,9 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
   {
     echo "### Runner binary cache plan"
     echo
-    echo "| Target | Outcome | Source | Reason | Producer run | Candidates | R2 bytes | Duration |"
-    echo "| --- | --- | --- | --- | --- | ---: | ---: | ---: |"
-    jq -r '.[] | "| `\(.target)` | `\(.outcome)` | `\(.source // "")` | `\(.reason)` | `\(.producerRunId // "")` | \(.candidateInspections) | \(.objectSizeBytes) | \(.durationSeconds)s |"' \
+    echo "| Target | Outcome | Source | Reason | Index run | Candidates | Duration |"
+    echo "| --- | --- | --- | --- | --- | ---: | ---: |"
+    jq -r '.[] | "| `\(.target)` | `\(.outcome)` | `\(.source // "")` | `\(.reason)` | `\(.producerRunId // "")` | \(.candidateInspections) | \(.durationSeconds)s |"' \
       <<<"$resolution_json"
   } >> "$GITHUB_STEP_SUMMARY"
 fi

--- a/.github/scripts/runner-binary-cache.sh
+++ b/.github/scripts/runner-binary-cache.sh
@@ -806,7 +806,6 @@ collect_trusted_candidates() {
   TRUSTED_CANDIDATES_FILE="$trusted_file"
   TRUSTED_CANDIDATE_COUNT="$trusted_count"
   TRUSTED_IDENTITY_COUNT="$identity_count"
-  TRUSTED_INSPECTION_COUNT="$inspected"
   if [ "$trusted_count" -eq 0 ]; then
     if [ "$limit_reached" = "true" ]; then
       CANDIDATE_DISCOVERY_REASON="candidate-limit-exhausted"
@@ -878,7 +877,7 @@ resolve_result() {
   emit "resolve-producer-run-id" "$run_id"
 }
 
-active_resolve() {
+validate_cache_request() {
   require_env EXPECTED_TARGET
   require_env EXPECTED_BINARY_INPUT_DIGEST
   require_env RESOLVE_OUTPUT_DIR
@@ -891,103 +890,160 @@ active_resolve() {
     echo "runner binary resolve output already exists or is unsafe: ${RESOLVE_OUTPUT_DIR}" >&2
     exit 2
   fi
-  validate_resolution_context
+}
 
+r2_available() {
+  [ -n "${R2_ACCOUNT_ID:-}" ] && [ -n "${R2_BUCKET_NAME:-}" ] &&
+    [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ] &&
+    command -v aws >/dev/null
+}
+
+cache_temp_directory() {
+  local output_parent
+  output_parent=$(dirname "$RESOLVE_OUTPUT_DIR")
+  mkdir -p "$output_parent"
+  RUNNER_CACHE_TEMP_ROOT=$(mktemp -d "${RUNNER_TEMP:-$output_parent}/runner-binary-cache.XXXXXX")
+  trap 'rm -rf "$RUNNER_CACHE_TEMP_ROOT"' EXIT
+}
+
+validate_cache_reference() {
+  jq -e \
+    --arg target "$EXPECTED_TARGET" \
+    --arg digest "$EXPECTED_BINARY_INPUT_DIGEST" \
+    --arg toolchain "$RUNNER_BINARY_TOOLCHAIN_IMAGE" \
+    --argjson guests "$(guest_keys_json)" '
+      .schemaVersion == 1 and
+      .target == $target and
+      .binaryInputDigest == $digest and
+      .toolchainImage == $toolchain and
+      (.objectKey | type == "string" and
+        test("^runner-binaries/" + $target + "/[0-9a-f]{64}\\.zst$")) and
+      (.guestSha256 | type == "object") and
+      ((.guestSha256 | keys | sort) == $guests) and
+      all(.guestSha256[]; type == "string" and test("^[0-9a-f]{64}$"))
+    ' <<<"$CACHE_REFERENCE" >/dev/null
+}
+
+resolve_reference() {
+  validate_cache_request
+  require_env REPO
   case "${RUNNER_BINARY_CACHE_FORCE_MISS:-false}" in
     true)
       resolve_result "miss" "" "force-miss"
       return 0
       ;;
     false|"") ;;
-    *)
-      echo "invalid RUNNER_BINARY_CACHE_FORCE_MISS: ${RUNNER_BINARY_CACHE_FORCE_MISS}" >&2
-      exit 2
-      ;;
+    *) echo "invalid RUNNER_BINARY_CACHE_FORCE_MISS" >&2; exit 2 ;;
   esac
-  if [ -z "${R2_ACCOUNT_ID:-}" ] || [ -z "${R2_BUCKET_NAME:-}" ] ||
-    [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+  if ! r2_available; then
     resolve_result "miss" "" "missing-r2-config"
     return 0
   fi
-  if ! command -v aws >/dev/null; then
-    resolve_result "miss" "" "aws-unavailable"
+
+  local name artifacts candidates run_id artifact_id inspected=0 reason=no-candidate
+  name=$(reusable_artifact_name "$EXPECTED_TARGET" "$EXPECTED_BINARY_INPUT_DIGEST")
+  if ! artifacts=$(gh api --paginate --slurp \
+    "repos/${REPO}/actions/artifacts?name=${name}&per_page=100" 2>/dev/null); then
+    resolve_result "miss" "" "artifact-api-unavailable"
     return 0
   fi
-  if ! command -v zstd >/dev/null; then
-    resolve_result "miss" "" "zstd-unavailable"
+  if ! candidates=$(jq -ce --arg name "$name" \
+    --argjson max_size "$RUNNER_BINARY_MAX_MANIFEST_ARTIFACT_BYTES" \
+    --argjson limit "$RUNNER_BINARY_MAX_CANDIDATE_INSPECTIONS" '
+      [ .[] | .artifacts[] |
+        select(.name == $name and .expired == false) |
+        select(.size_in_bytes > 0 and .size_in_bytes <= $max_size) |
+        select(.id | type == "number" and . > 0) |
+        select(.workflow_run.id | type == "number" and . > 0)
+      ] | sort_by(.created_at) | reverse | .[:$limit]
+    ' <<<"$artifacts" 2>/dev/null); then
+    resolve_result "miss" "" "artifact-api-malformed"
     return 0
   fi
 
-  local output_parent temp_root candidate_dir
-  output_parent=$(dirname "$RESOLVE_OUTPUT_DIR")
-  mkdir -p "$output_parent"
-  temp_root=$(mktemp -d "${RUNNER_TEMP:-${output_parent}}/runner-binary-resolve.XXXXXX")
-  candidate_dir="${temp_root}/candidates"
-  ACTIVE_RESOLVE_TEMP_ROOT="$temp_root"
-  trap 'rm -rf "$ACTIVE_RESOLVE_TEMP_ROOT"' EXIT
-
-  if ! collect_trusted_candidates \
-    "$EXPECTED_TARGET" "$EXPECTED_BINARY_INPUT_DIGEST" "$candidate_dir"; then
-    emit "candidate-inspections" "0"
-    resolve_result "miss" "" "$CANDIDATE_DISCOVERY_REASON"
+  cache_temp_directory
+  while IFS=$'\t' read -r run_id artifact_id; do
+    [ -n "$run_id" ] || continue
+    inspected=$((inspected + 1))
+    local candidate_dir="${RUNNER_CACHE_TEMP_ROOT}/${artifact_id}"
+    mkdir -p "$candidate_dir"
+    # GitHub is only the existing cache index; R2 does not need run/ancestry proof.
+    if ! gh run download "$run_id" -n "$name" -D "$candidate_dir" >/dev/null 2>&1; then
+      continue
+    fi
+    if ! CACHE_REFERENCE=$(jq -c '{
+      schemaVersion, binaryInputDigest, target, toolchainImage,
+      objectKey: .object.key, guestSha256: .guests
+    }' "${candidate_dir}/manifest.json" 2>/dev/null) ||
+      ! validate_cache_reference 2>/dev/null; then
+      continue
+    fi
+    local object_key
+    object_key=$(jq -r '.objectKey' <<<"$CACHE_REFERENCE")
+    if ! aws s3api head-object \
+      --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+      --bucket "$R2_BUCKET_NAME" --key "$object_key" \
+      --cli-connect-timeout 5 --cli-read-timeout 30 >/dev/null 2>&1; then
+      reason=r2-unavailable
+      continue
+    fi
+    mkdir -p "$RESOLVE_OUTPUT_DIR"
+    printf '%s\n' "$CACHE_REFERENCE" > "${RESOLVE_OUTPUT_DIR}/reference.json"
+    emit "candidate-inspections" "$inspected"
+    resolve_result "hit" "r2" "reference" "$run_id"
     return 0
-  fi
-  emit "candidate-inspections" "$TRUSTED_INSPECTION_COUNT"
-  if [ "$TRUSTED_IDENTITY_COUNT" -gt 1 ]; then
-    resolve_result "miss" "" "trusted-output-conflict"
-    return 0
-  fi
-  if [ "$TRUSTED_CANDIDATE_COUNT" -eq 0 ]; then
-    resolve_result "miss" "" "$CANDIDATE_DISCOVERY_REASON"
-    return 0
-  fi
-  first_trusted_candidate
+  done < <(jq -r '.[] | [.workflow_run.id, .id] | @tsv' <<<"$candidates")
+  emit "candidate-inspections" "$inspected"
+  resolve_result "miss" "" "$reason"
+}
 
-  local object_key object_size runner_sha runner_size
-  object_key=$(jq -r '.object.key' "$TRUSTED_MANIFEST_PATH")
-  object_size=$(jq -r '.object.sizeBytes' "$TRUSTED_MANIFEST_PATH")
-  runner_sha=$(jq -r '.runner.sha256' "$TRUSTED_MANIFEST_PATH")
-  runner_size=$(jq -r '.runner.sizeBytes' "$TRUSTED_MANIFEST_PATH")
-  local compressed decompressed
-  compressed="${temp_root}/runner.zst"
-  decompressed="${temp_root}/runner"
-  if ! fetch_verified_r2_runner \
-    "$object_key" "$object_size" "$runner_size" "$runner_sha" \
-    "$compressed" "$decompressed"; then
-    resolve_result "miss" "$TRUSTED_SOURCE" \
-      "r2-${R2_VERIFICATION_REASON}" "$TRUSTED_RUN_ID"
-    return 0
+download_reference() {
+  validate_cache_request
+  require_env CACHE_REFERENCE
+  require_env R2_ACCOUNT_ID
+  require_env R2_BUCKET_NAME
+  require_env AWS_ACCESS_KEY_ID
+  require_env AWS_SECRET_ACCESS_KEY
+  if ! validate_cache_reference; then
+    echo "invalid cached runner reference" >&2
+    exit 2
   fi
-
-  local transport_dir
-  transport_dir="${temp_root}/transport"
-  mkdir -p "$transport_dir"
-  install -m 755 "$decompressed" "${transport_dir}/runner"
-  jq '{
-    schemaVersion,
-    binaryInputDigest,
-    target,
-    toolchainImage,
-    runnerSha256: .runner.sha256,
-    runnerSizeBytes: .runner.sizeBytes,
-    guestSha256: .guests
-  }' "$TRUSTED_MANIFEST_PATH" > "${transport_dir}/metadata.json"
-  env GITHUB_OUTPUT= \
-    FRESH_METADATA_PATH="${transport_dir}/metadata.json" \
-    RUNNER_PATH="${transport_dir}/runner" \
-    EXPECTED_TARGET="$EXPECTED_TARGET" \
-    EXPECTED_BINARY_INPUT_DIGEST="$EXPECTED_BINARY_INPUT_DIGEST" \
-    "$0" fresh-validate >/dev/null
-  mv "$transport_dir" "$RESOLVE_OUTPUT_DIR"
-
+  cache_temp_directory
+  local object_key compressed runner transport runner_size runner_sha
+  object_key=$(jq -r '.objectKey' <<<"$CACHE_REFERENCE")
+  compressed="${RUNNER_CACHE_TEMP_ROOT}/runner.zst"
+  transport="${RUNNER_CACHE_TEMP_ROOT}/transport"
+  mkdir -p "$transport"
+  runner="${transport}/runner"
+  timeout --kill-after=5s 60s aws s3api get-object \
+    --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+    --bucket "$R2_BUCKET_NAME" --key "$object_key" \
+    --range "bytes=0-${RUNNER_BINARY_MAX_COMPRESSED_BYTES}" \
+    --cli-connect-timeout 5 --cli-read-timeout 30 \
+    "$compressed" >/dev/null
+  zstd -q -d -c "$compressed" |
+    head -c "$((RUNNER_BINARY_MAX_SIZE_BYTES + 1))" > "$runner"
+  runner_size=$(stat -c '%s' "$runner")
+  if [ "$runner_size" -eq 0 ] || [ "$runner_size" -gt "$RUNNER_BINARY_MAX_SIZE_BYTES" ]; then
+    echo "cached runner size is invalid: ${runner_size}" >&2
+    exit 1
+  fi
+  # Record local transport identity, without comparing trusted R2 bytes to GitHub.
+  runner_sha=$(sha256sum "$runner" | awk '{print $1}')
+  jq --arg sha "$runner_sha" --argjson size "$runner_size" '{
+    schemaVersion, binaryInputDigest, target, toolchainImage, guestSha256,
+    runnerSha256: $sha, runnerSizeBytes: $size
+  }' <<<"$CACHE_REFERENCE" > "${transport}/metadata.json"
+  chmod 755 "$runner"
+  mv "$transport" "$RESOLVE_OUTPUT_DIR"
   emit "runner-size-bytes" "$runner_size"
-  emit "object-size-bytes" "$object_size"
-  resolve_result "hit" "$TRUSTED_SOURCE" "validated" "$TRUSTED_RUN_ID"
+  emit "object-size-bytes" "$(stat -c '%s' "$compressed")"
+  resolve_result "hit" "r2" "downloaded"
 }
 
 usage() {
   cat <<'USAGE'
-Usage: runner-binary-cache.sh <fresh-validate|artifact-name|manifest-validate|publish|shadow-resolve|active-resolve>
+Usage: runner-binary-cache.sh <fresh-validate|artifact-name|manifest-validate|publish|shadow-resolve|resolve-reference|download-reference>
 USAGE
 }
 
@@ -997,7 +1053,8 @@ case "${1:-}" in
   manifest-validate) manifest_validate ;;
   publish) publish ;;
   shadow-resolve) shadow_resolve ;;
-  active-resolve) active_resolve ;;
+  resolve-reference) resolve_reference ;;
+  download-reference) download_reference ;;
   -h|--help|help) usage ;;
   *) usage >&2; exit 2 ;;
 esac

--- a/.github/scripts/tests/reconcile-and-start-runner-groups-test.sh
+++ b/.github/scripts/tests/reconcile-and-start-runner-groups-test.sh
@@ -33,11 +33,37 @@ if [ "$*" = "uname -m" ]; then
 fi
 if [ "$*" = "bash -s -- $BIN_DIR" ]; then
   cat >/dev/null
+  if [ "${MOCK_RECOVERY:-false}" = true ]; then
+    if [ -f "${MOCK_REMOTE_ROOT}/${host}/bin/runner" ]; then
+      sha256sum "${MOCK_REMOTE_ROOT}/${host}/bin/runner" | awk '{print $1}'
+    else
+      echo missing
+    fi
+    exit 0
+  fi
   jq -r --arg target "$target" '.[$target]' <<<"$RUNNER_SHA_MAP"
   exit 0
 fi
 if [ "$*" = "bash -s -- $RUNNER_DIR" ]; then
   bash -s -- "${MOCK_REMOTE_ROOT}/${host}"
+  exit 0
+fi
+if [[ "$*" == "bash -s -- ${BIN_DIR}/runner.recovery."* ]]; then
+  shift 3
+  mapped_args=()
+  for arg in "$@"; do
+    mapped_args+=("${arg//"$BIN_DIR"/"${MOCK_REMOTE_ROOT}/${host}/bin"}")
+  done
+  bash -s -- "${mapped_args[@]}"
+  exit 0
+fi
+if [ "$*" = "sudo mkdir -p -- $BIN_DIR" ]; then
+  mkdir -p "${MOCK_REMOTE_ROOT}/${host}/bin"
+  exit 0
+fi
+if [[ "$*" == "sudo install -m 755 /dev/stdin ${BIN_DIR}/runner.recovery."* ]]; then
+  destination=${*: -1}
+  install -m 755 /dev/stdin "${MOCK_REMOTE_ROOT}/${host}/bin/${destination##*/}"
   exit 0
 fi
 
@@ -84,6 +110,64 @@ exec "$@"
 SH
 chmod +x "${tmp_dir}/bin/sudo"
 
+cat >"${tmp_dir}/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = api ]; then
+  endpoint=${*: -1}
+  [[ "$endpoint" == *'/actions/artifacts?'* ]] || exit 2
+  name=${endpoint#*name=}
+  name=${name%%&*}
+  jq -cn --arg name "$name" '[{artifacts: [{
+    id: 120, name: $name, expired: false, size_in_bytes: 1000,
+    created_at: "2026-09-11T00:00:00Z", workflow_run: {id: 20}
+  }]}]'
+elif [ "$1" = run ] && [ "$2" = download ]; then
+  name="" output=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -n) name=$2; shift 2 ;;
+      -D) output=$2; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  cp "${MOCK_CACHE_ROOT}/${name}.json" "${output}/manifest.json"
+else
+  exit 2
+fi
+SH
+cat >"${tmp_dir}/bin/aws" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = s3api ] || exit 2
+case "$2" in
+  head-object) printf '{}\n' ;;
+  get-object) cp "${MOCK_CACHE_ROOT}/cached-runner.zst" "${*: -1}" ;;
+  *) exit 2 ;;
+esac
+SH
+chmod +x "${tmp_dir}/bin/gh" "${tmp_dir}/bin/aws"
+
+printf '#!/usr/bin/env bash\nprintf "cached runner fixture\\n"\n' >"${tmp_dir}/cached-runner"
+zstd -q -3 -o "${tmp_dir}/cached-runner.zst" "${tmp_dir}/cached-runner"
+cached_sha=$(sha256sum "${tmp_dir}/cached-runner" | awk '{print $1}')
+. "${repo_root}/.github/scripts/runner-guest-binaries.sh"
+. "${repo_root}/.github/scripts/runner-binary-build/contract.env"
+runner_guest_binaries_load
+guests=$(printf '%s\n' "${RUNNER_GUEST_BINARIES[@]}" |
+  jq -Rn --arg sha "$cached_sha" '[inputs | {key: ., value: $sha}] | from_entries')
+for target in aarch64-unknown-linux-musl x86_64-unknown-linux-musl; do
+  digest=$("${repo_root}/.github/scripts/runner-binary-build/digest.sh" "$target" |
+    sed -n 's/^binary-input-digest=//p')
+  jq -n --arg target "$target" --arg digest "$digest" \
+    --arg sha "$cached_sha" --arg toolchain "$RUNNER_BINARY_TOOLCHAIN_IMAGE" \
+    --argjson guests "$guests" '{
+      schemaVersion: 1, target: $target, binaryInputDigest: $digest,
+      toolchainImage: $toolchain, guests: $guests,
+      object: {key: ("runner-binaries/" + $target + "/" + $sha + ".zst")}
+    }' >"${tmp_dir}/runner-binary-asset-${target}-${digest}.json"
+done
+
 cat >"${tmp_dir}/run-deployment" <<'SH'
 #!/usr/bin/env bash
 export MOCK_DEPLOY_PID=$$
@@ -91,8 +175,12 @@ exec bash "$@"
 SH
 
 run_case() {
-  local case_name=$1 job_ref=$2 selected_host=$3 selected_index=$4 failure=$5
+  local case_name=$1 job_ref=$2 selected_host=$3 selected_index=$4 failure=$5 recovery=${6:-false}
   local case_dir="${tmp_dir}/${case_name}"
+  local runner_sha_map='{"aarch64-unknown-linux-musl":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","x86_64-unknown-linux-musl":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}'
+  if [ "$recovery" = true ]; then
+    runner_sha_map=$(jq -c --arg sha "$cached_sha" 'map_values($sha)' <<<"$runner_sha_map")
+  fi
   local service_ref=$job_ref current_event=pull_request
   if [[ "$job_ref" == staging-* ]]; then
     service_ref=staging
@@ -105,6 +193,10 @@ run_case() {
       mkdir -p "${case_dir}/${host}"
       printf 'existing-service\n' >"${case_dir}/${host}/${service_ref}-${host_index}"
       printf 'unrelated-service\n' >"${case_dir}/${host}/pr-999-${host_index}"
+      if [ "$recovery" = true ] && [ "$host" != x86-1 ]; then
+        mkdir -p "${case_dir}/${host}/bin"
+        cp "${tmp_dir}/cached-runner" "${case_dir}/${host}/bin/runner"
+      fi
     done
   fi
   : >"${case_dir}/service.log"
@@ -127,9 +219,15 @@ run_case() {
     RUNNER_DIR="/var/lib/vm0-runner/runners/${job_ref}" \
     RUNNER_GROUP="vm0/development-${service_ref}" \
     RUNNER_SERVICE_REF="$service_ref" \
-    RUNNER_SHA_MAP='{"aarch64-unknown-linux-musl":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","x86_64-unknown-linux-musl":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}' \
+    RUNNER_SHA_MAP="$runner_sha_map" \
     SNAPSHOT_HASH_MAP='{"arm-1":"snapshot-arm","x86-1":"snapshot-x86-1","x86-2":"snapshot-x86-2"}' \
     VERCEL_BYPASS=test-bypass \
+    AWS_ACCESS_KEY_ID=test-access \
+    AWS_SECRET_ACCESS_KEY=test-secret \
+    R2_ACCOUNT_ID=test-account \
+    R2_BUCKET_NAME=test-bucket \
+    MOCK_CACHE_ROOT="$tmp_dir" \
+    MOCK_RECOVERY="$recovery" \
     MOCK_REMOTE_ROOT="$case_dir" \
     MOCK_SERVICE_LOG="${case_dir}/service.log" \
     MOCK_FAILURE="$failure" \
@@ -157,6 +255,10 @@ run_case() {
       .host == $host and .service == $service and
       .runnerId == "550e8400-e29b-41d4-a716-446655440000" and .heartbeatGeneration == 7
     ' <<<"$receipt" >/dev/null || fail "${case_name}: invalid deployment receipt"
+    if [ "$recovery" = true ]; then
+      cmp "${tmp_dir}/cached-runner" "${case_dir}/x86-1/bin/runner" ||
+        fail "${case_name}: missing binary was not restored from the cache reference"
+    fi
   fi
 
   [ "$(awk '!/runner service stop / {print $1}' "${case_dir}/service.log" | sort -u)" = "$selected_host" ] ||
@@ -187,6 +289,7 @@ run_case() {
 run_case x86 pr-1 x86-1 2 none
 run_case x86 pr-1 x86-1 2 none
 run_case arm pr-2 arm-1 1 none
+run_case recovered-binary pr-1 x86-1 2 none true
 run_case failed-start pr-9 x86-2 3 readiness
 run_case invalid-identity pr-9 x86-2 3 identity
 run_case failed-retirement pr-1 x86-1 2 retire

--- a/.github/scripts/tests/reconcile-and-start-runner-groups-test.sh
+++ b/.github/scripts/tests/reconcile-and-start-runner-groups-test.sh
@@ -151,16 +151,15 @@ chmod +x "${tmp_dir}/bin/gh" "${tmp_dir}/bin/aws"
 printf '#!/usr/bin/env bash\nprintf "cached runner fixture\\n"\n' >"${tmp_dir}/cached-runner"
 zstd -q -3 -o "${tmp_dir}/cached-runner.zst" "${tmp_dir}/cached-runner"
 cached_sha=$(sha256sum "${tmp_dir}/cached-runner" | awk '{print $1}')
-. "${repo_root}/.github/scripts/runner-guest-binaries.sh"
-. "${repo_root}/.github/scripts/runner-binary-build/contract.env"
-runner_guest_binaries_load
-guests=$(printf '%s\n' "${RUNNER_GUEST_BINARIES[@]}" |
-  jq -Rn --arg sha "$cached_sha" '[inputs | {key: ., value: $sha}] | from_entries')
+guests=$(jq -c --arg sha "$cached_sha" \
+  'map({key: .binary, value: $sha}) | from_entries' \
+  "${repo_root}/crates/runner/guest-binaries.json")
 for target in aarch64-unknown-linux-musl x86_64-unknown-linux-musl; do
-  digest=$("${repo_root}/.github/scripts/runner-binary-build/digest.sh" "$target" |
-    sed -n 's/^binary-input-digest=//p')
+  digest_output=$("${repo_root}/.github/scripts/runner-binary-build/digest.sh" "$target")
+  digest=$(sed -n 's/^binary-input-digest=//p' <<<"$digest_output")
+  toolchain=$(sed -n 's/^toolchain-image=//p' <<<"$digest_output")
   jq -n --arg target "$target" --arg digest "$digest" \
-    --arg sha "$cached_sha" --arg toolchain "$RUNNER_BINARY_TOOLCHAIN_IMAGE" \
+    --arg sha "$cached_sha" --arg toolchain "$toolchain" \
     --argjson guests "$guests" '{
       schemaVersion: 1, target: $target, binaryInputDigest: $digest,
       toolchainImage: $toolchain, guests: $guests,

--- a/.github/scripts/tests/runner-binary-cache-plan-test.sh
+++ b/.github/scripts/tests/runner-binary-cache-plan-test.sh
@@ -63,29 +63,16 @@ create_fixture() {
     --arg digest "$digest" \
     --arg target "$target" \
     --arg toolchain "$RUNNER_BINARY_TOOLCHAIN_IMAGE" \
-    --arg runner_sha "$runner_sha" \
-    --argjson runner_size "$runner_size" \
     --argjson guests "$guest_json" \
     --arg object_key "runner-binaries/${target}/${runner_sha}.zst" \
-    --argjson object_size "$object_size" \
-    --arg head "$main_head" '
+    --argjson object_size "$object_size" '
       {
         schemaVersion: 1,
         binaryInputDigest: $digest,
         target: $target,
         toolchainImage: $toolchain,
-        runner: {sha256: $runner_sha, sizeBytes: $runner_size},
         guests: $guests,
         object: {key: $object_key, compression: "zstd", sizeBytes: $object_size},
-        producer: {
-          repository: "vm0-ai/vm0",
-          workflowPath: ".github/workflows/runner-image.yml",
-          runId: 20,
-          runAttempt: 1,
-          event: "push",
-          headSha: $head,
-          prNumber: null
-        },
         createdAt: "2026-07-22T00:00:00Z"
       }
     ' > "${TMPDIR}/fixtures/${name}.json"
@@ -93,10 +80,6 @@ create_fixture() {
 
 create_fixture "$arm_target" "$arm_digest" "$arm_artifact"
 create_fixture "$x86_target" "$x86_digest" "$x86_artifact"
-
-cat > "${TMPDIR}/fixtures/run-20.json" <<JSON
-{"id":20,"run_attempt":1,"event":"push","status":"completed","conclusion":"success","head_branch":"main","head_sha":"${main_head}","path":".github/workflows/runner-image.yml","repository":{"full_name":"vm0-ai/vm0"},"pull_requests":[]}
-JSON
 
 cat > "${TMPDIR}/bin/gh" <<'BASH'
 #!/usr/bin/env bash
@@ -116,8 +99,7 @@ if [ "$1" = "api" ]; then
     fi
     exit 0
   fi
-  cp "${FIXTURES}/run-20.json" /dev/stdout
-  exit 0
+  exit 2
 fi
 if [ "$1" = "run" ] && [ "$2" = "download" ]; then
   artifact_name=""
@@ -142,6 +124,7 @@ cat > "${TMPDIR}/bin/aws" <<'BASH'
 set -euo pipefail
 [ "$1" = "s3api" ] || exit 2
 operation=$2
+printf '%s\n' "$*" >> "$AWS_LOG"
 shift 2
 key=""
 destination=""
@@ -157,22 +140,22 @@ target=${key#runner-binaries/}
 target=${target%%/*}
 object="${OBJECTS}/${target}.zst"
 case "$operation" in
-  head-object) printf '{"ContentLength":%s}\n' "$(stat -c '%s' "$object")" ;;
-  get-object) cp "$object" "$destination"; printf '{}\n' ;;
+  head-object) test -f "$object"; printf '{"ContentLength":%s}\n' "$(stat -c '%s' "$object")" ;;
+  get-object)
+    [ "${AWS_MODE:-success}" != "get-fail" ] || exit 7
+    cp "$object" "$destination"
+    printf '{}\n'
+    ;;
   *) exit 2 ;;
 esac
 BASH
 chmod +x "${TMPDIR}/bin/aws"
 
 run_plan() {
-  local scenario=$1 output_dir=$2 event=${3:-pull_request}
-  local pr_number=123 pr_head_ref=feature
-  if [ "$event" = "push" ]; then
-    pr_number=""
-    pr_head_ref=""
-  fi
+  local scenario=$1 output_dir=$2
   PATH="${TMPDIR}/bin:${PATH}" \
   GH_LOG="${TMPDIR}/gh.log" \
+  AWS_LOG="${TMPDIR}/aws.log" \
   GH_SCENARIO="$scenario" \
   FIXTURES="${TMPDIR}/fixtures" \
   OBJECTS="${TMPDIR}/objects" \
@@ -185,11 +168,6 @@ run_plan() {
   R2_BUCKET_NAME=test-bucket \
   RUNNER_TEMP="${TMPDIR}/runner-temp" \
   REPO=vm0-ai/vm0 \
-  CURRENT_RUN_ID=99 \
-  CURRENT_EVENT="$event" \
-  CURRENT_PR_NUMBER="$pr_number" \
-  CURRENT_PR_HEAD_REF="$pr_head_ref" \
-  DEFAULT_BRANCH=main \
   RUNNER_HOST_GROUPS_MATRIX="$matrix" \
   RESOLVE_OUTPUT_DIR="$output_dir" \
     "$PLAN"
@@ -206,20 +184,23 @@ assert_contains "$all_hit" 'hit-count=2'
 assert_contains "$all_hit" 'miss-count=0'
 assert_contains "$all_hit" 'resolution-json=['
 plan_output_keys=$(cut -d= -f1 "$plan_output" | LC_ALL=C sort -u | paste -sd, -)
-[ "$plan_output_keys" = "compile-matrix,hit-count,hit-targets,miss-count" ] ||
+[ "$plan_output_keys" = "compile-matrix,hit-count,hit-references,hit-targets,miss-count" ] ||
   fail "unexpected plan output keys: ${plan_output_keys}"
 grep -qF '### Runner binary cache plan' "$plan_summary" || fail "expected plan summary"
 grep -qF "\`${arm_target}\`" "$plan_summary" || fail "expected arm target in plan summary"
 grep -qF "\`${x86_target}\`" "$plan_summary" || fail "expected x86 target in plan summary"
-cmp -s "$runner" "${TMPDIR}/all-hit/${arm_target}/runner" || fail "arm hit bytes were not staged"
-cmp -s "$runner" "${TMPDIR}/all-hit/${x86_target}/runner" || fail "x86 hit bytes were not staged"
+references=$(sed -n 's/^hit-references=//p' "$plan_output")
+jq -e --arg arm "$arm_target" --arg x86 "$x86_target" \
+  'keys == ([$arm, $x86] | sort) and .[$arm].target == $arm and .[$x86].target == $x86' \
+  <<<"$references" >/dev/null || fail "each target must receive its own cache reference"
+[ "$(wc -l < "${TMPDIR}/aws.log")" -eq 2 ] || fail "prepare should only inspect the two R2 objects"
 
 mixed=$(run_plan mixed "${TMPDIR}/mixed")
 assert_contains "$mixed" 'hit-count=1'
 assert_contains "$mixed" 'miss-count=1'
 mixed_matrix=$(sed -n 's/^compile-matrix=//p' <<<"$mixed")
 [ "$(jq -r '.[0].target' <<<"$mixed_matrix")" = "$x86_target" ] || fail "mixed plan must compile x86 only"
-[ -f "${TMPDIR}/mixed/${arm_target}/runner" ] || fail "mixed plan must stage the arm hit"
+[ -f "${TMPDIR}/mixed/${arm_target}/reference.json" ] || fail "mixed plan must resolve the arm hit"
 [ ! -e "${TMPDIR}/mixed/${x86_target}" ] || fail "mixed plan must not stage a missed target"
 
 all_miss=$(run_plan all-miss "${TMPDIR}/all-miss")
@@ -235,26 +216,56 @@ assert_contains "$forced" 'miss-count=2'
 assert_contains "$forced" '"reason":"force-miss"'
 [ ! -s "${TMPDIR}/gh.log" ] || fail "force-miss plan must not query GitHub"
 
-: > "${TMPDIR}/gh.log"
-main_all_hit=$(run_plan all-hit "${TMPDIR}/main-all-hit" push)
-assert_contains "$main_all_hit" 'compile-matrix=[]'
-assert_contains "$main_all_hit" 'hit-count=2'
-assert_contains "$main_all_hit" 'miss-count=0'
-assert_contains "$main_all_hit" '"source":"protected-main"'
+run_download() {
+  local target=$1 digest=$2 output_dir=$3 mode=${4:-success}
+  PATH="${TMPDIR}/bin:${PATH}" \
+  AWS_LOG="${TMPDIR}/aws.log" \
+  AWS_MODE="$mode" \
+  OBJECTS="${TMPDIR}/objects" \
+  AWS_ACCESS_KEY_ID=test-access \
+  AWS_SECRET_ACCESS_KEY=test-secret \
+  R2_ACCOUNT_ID=test-account \
+  R2_BUCKET_NAME=test-bucket \
+  RUNNER_TEMP="${TMPDIR}/runner-temp" \
+  EXPECTED_TARGET="$target" \
+  EXPECTED_BINARY_INPUT_DIGEST="$digest" \
+  CACHE_REFERENCE="$(jq -c --arg target "$target" '.[$target]' <<<"$references")" \
+  RESOLVE_OUTPUT_DIR="$output_dir" \
+    "${SCRIPT_DIR}/runner-binary-cache.sh" download-reference
+}
 
-main_mixed=$(run_plan mixed "${TMPDIR}/main-mixed" push)
-assert_contains "$main_mixed" 'hit-count=1'
-assert_contains "$main_mixed" 'miss-count=1'
-main_mixed_matrix=$(sed -n 's/^compile-matrix=//p' <<<"$main_mixed")
-[ "$(jq -r '.[0].target' <<<"$main_mixed_matrix")" = "$x86_target" ] ||
-  fail "mixed main plan must compile x86 only"
+: > "${TMPDIR}/aws.log"
+arm_download=$(run_download "$arm_target" "$arm_digest" "${TMPDIR}/download-arm")
+x86_download=$(run_download "$x86_target" "$x86_digest" "${TMPDIR}/download-x86")
+assert_contains "$arm_download" 'resolve-outcome=hit'
+assert_contains "$x86_download" 'resolve-outcome=hit'
+assert_contains "$arm_download" "runner-size-bytes=${runner_size}"
+cmp "$runner" "${TMPDIR}/download-arm/runner" || fail "arm build must receive cached bytes"
+cmp "$runner" "${TMPDIR}/download-x86/runner" || fail "x86 build must receive cached bytes"
+[ "$(wc -l < "${TMPDIR}/aws.log")" -eq 2 ] || fail "builds should perform one R2 download per target"
+[ "$(grep -c 's3api get-object' "${TMPDIR}/aws.log")" -eq 2 ] || fail "expected two target downloads"
+FRESH_METADATA_PATH="${TMPDIR}/download-arm/metadata.json" \
+RUNNER_PATH="${TMPDIR}/download-arm/runner" \
+EXPECTED_TARGET="$arm_target" \
+EXPECTED_BINARY_INPUT_DIGEST="$arm_digest" \
+  "${SCRIPT_DIR}/runner-binary-cache.sh" fresh-validate >/dev/null
 
-main_all_miss=$(run_plan all-miss "${TMPDIR}/main-all-miss" push)
-assert_contains "$main_all_miss" 'hit-count=0'
-assert_contains "$main_all_miss" 'miss-count=2'
-main_all_miss_matrix=$(sed -n 's/^compile-matrix=//p' <<<"$main_all_miss")
-[ "$(jq 'length' <<<"$main_all_miss_matrix")" -eq 2 ] ||
-  fail "all-miss main plan must compile both targets"
+mv "${TMPDIR}/objects/${arm_target}.zst" "${TMPDIR}/arm-unavailable.zst"
+unavailable=$(run_plan all-hit "${TMPDIR}/unavailable")
+assert_contains "$unavailable" 'hit-count=1'
+assert_contains "$unavailable" 'miss-count=1'
+unavailable_matrix=$(sed -n 's/^compile-matrix=//p' <<<"$unavailable")
+[ "$(jq -r '.[0].target' <<<"$unavailable_matrix")" = "$arm_target" ] || fail "missing arm object must select arm compilation"
+if run_download "$arm_target" "$arm_digest" "${TMPDIR}/late-missing" >/dev/null 2>&1; then
+  fail "a selected object that disappears must fail the download"
+fi
+[ ! -e "${TMPDIR}/late-missing" ] || fail "failed download must not expose partial transport"
+mv "${TMPDIR}/arm-unavailable.zst" "${TMPDIR}/objects/${arm_target}.zst"
+
+if run_download "$arm_target" "$arm_digest" "${TMPDIR}/download-failed" get-fail >/dev/null 2>&1; then
+  fail "a required cache download failure must propagate"
+fi
+[ ! -e "${TMPDIR}/download-failed" ] || fail "failed download must not expose partial transport"
 
 mkdir -p "${TMPDIR}/timeout-bin"
 cat > "${TMPDIR}/timeout-bin/timeout" <<'BASH'
@@ -267,11 +278,6 @@ timed_out=$(PATH="${TMPDIR}/timeout-bin:${TMPDIR}/bin:${PATH}" \
   RUNNER_HOST_GROUPS_MATRIX="$matrix" \
   RESOLVE_OUTPUT_DIR="${TMPDIR}/timed-out" \
   REPO=vm0-ai/vm0 \
-  CURRENT_RUN_ID=99 \
-  CURRENT_EVENT=pull_request \
-  CURRENT_PR_NUMBER=123 \
-  CURRENT_PR_HEAD_REF=feature \
-  DEFAULT_BRANCH=main \
   "$PLAN")
 assert_contains "$timed_out" 'hit-count=0'
 assert_contains "$timed_out" 'miss-count=2'
@@ -283,11 +289,6 @@ killed=$(TIMEOUT_STATUS=137 \
   RUNNER_HOST_GROUPS_MATRIX="$matrix" \
   RESOLVE_OUTPUT_DIR="${TMPDIR}/killed" \
   REPO=vm0-ai/vm0 \
-  CURRENT_RUN_ID=99 \
-  CURRENT_EVENT=pull_request \
-  CURRENT_PR_NUMBER=123 \
-  CURRENT_PR_HEAD_REF=feature \
-  DEFAULT_BRANCH=main \
   "$PLAN")
 assert_contains "$killed" 'hit-count=0'
 assert_contains "$killed" 'miss-count=2'

--- a/.github/scripts/tests/runner-binary-cache-test.sh
+++ b/.github/scripts/tests/runner-binary-cache-test.sh
@@ -357,7 +357,6 @@ main_manifest="${TMPDIR}/main-manifest.json"
 pr_manifest="${TMPDIR}/pr-manifest.json"
 failed_main_manifest="${TMPDIR}/failed-main-manifest.json"
 reachable_manifest="${TMPDIR}/reachable-manifest.json"
-reachable_pr_mismatch_manifest="${TMPDIR}/reachable-pr-mismatch-manifest.json"
 jq --arg head "$main_head" '
   .producer.runId = 20 |
   .producer.event = "push" |
@@ -377,7 +376,7 @@ jq --arg head "$reachable_head" '
   .producer.headSha = $head |
   .producer.prNumber = 456
 ' "${TMPDIR}/published/manifest.json" > "$reachable_manifest"
-jq '.producer.prNumber = 999' "$reachable_manifest" > "$reachable_pr_mismatch_manifest"
+
 jq '.producer.runId = 999' "$main_manifest" > "${TMPDIR}/untrusted-manifest.json"
 
 conflict_sha=$(printf 'e%.0s' {1..64})
@@ -385,10 +384,6 @@ jq --arg sha "$conflict_sha" '
   .runner.sha256 = $sha |
   .object.key = ("runner-binaries/" + .target + "/" + $sha + ".zst")
 ' "$main_manifest" > "${TMPDIR}/conflict-manifest.json"
-jq --arg sha "$conflict_sha" '
-  .runner.sha256 = $sha |
-  .object.key = ("runner-binaries/" + .target + "/" + $sha + ".zst")
-' "$main_manifest" > "${TMPDIR}/content-mismatch-manifest.json"
 guest_conflict_sha=$(printf 'f%.0s' {1..64})
 jq --arg guest "$first_guest" --arg sha "$guest_conflict_sha" \
   '.guests[$guest] = $sha' \
@@ -402,9 +397,6 @@ cat > "${TMPDIR}/run-21.json" <<JSON
 JSON
 cat > "${TMPDIR}/run-22.json" <<JSON
 {"id":22,"run_attempt":1,"event":"push","status":"completed","conclusion":"failure","head_branch":"main","head_sha":"${main_head}","path":".github/workflows/runner-image.yml","repository":{"full_name":"vm0-ai/vm0"},"pull_requests":[]}
-JSON
-cat > "${TMPDIR}/run-23.json" <<JSON
-{"id":23,"run_attempt":1,"event":"push","status":"in_progress","conclusion":null,"head_branch":"main","head_sha":"${main_head}","path":".github/workflows/runner-image.yml","repository":{"full_name":"vm0-ai/vm0"},"pull_requests":[]}
 JSON
 cat > "${TMPDIR}/run-24.json" <<JSON
 {"id":24,"run_attempt":1,"event":"merge_group","status":"completed","conclusion":"failure","head_branch":"gh-readonly-queue/main/pr-456-deadbeef","head_sha":"${reachable_head}","path":".github/workflows/runner-image.yml","repository":{"full_name":"vm0-ai/vm0"},"pull_requests":[]}
@@ -428,44 +420,16 @@ if [ "$1" = "api" ]; then
       failed-valid)
         printf '[{"artifacts":[{"id":122,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":22,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
         ;;
-      in-progress)
-        printf '[{"artifacts":[{"id":123,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":23,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
-        ;;
-      reachable|reachable-identical|compare-fail|compare-malformed|compare-mismatch|compare-behind|compare-diverged|pr-mismatch)
-        printf '[{"artifacts":[{"id":124,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":24,"head_branch":"gh-readonly-queue/main/pr-456-deadbeef","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$REACHABLE_HEAD"
-        ;;
       ranking-reachable)
         printf '[{"artifacts":[{"id":124,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T02:00:00Z","workflow_run":{"id":24,"head_branch":"gh-readonly-queue/main/pr-456-deadbeef","head_sha":"%s"}},{"id":121,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T01:00:00Z","workflow_run":{"id":21,"head_branch":"feature","head_sha":"%s"}}]}]\n' \
           "$EXPECTED_ARTIFACT_NAME" "$REACHABLE_HEAD" \
           "$EXPECTED_ARTIFACT_NAME" "$PR_HEAD"
-        ;;
-      invalid-head)
-        printf '[{"artifacts":[{"id":126,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":26,"head_branch":"other","head_sha":"not-a-sha"}}]}]\n' "$EXPECTED_ARTIFACT_NAME"
         ;;
       untrusted)
         printf '[{"artifacts":[{"id":120,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
         ;;
       empty)
         printf '[{"artifacts":[]}]\n'
-        ;;
-      expired)
-        printf '[{"artifacts":[{"id":120,"name":"%s","expired":true,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
-        ;;
-      oversized-artifact)
-        printf '[{"artifacts":[{"id":120,"name":"%s","expired":false,"size_in_bytes":1048577,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
-        ;;
-      content-mismatch)
-        printf '[{"artifacts":[{"id":120,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T00:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' "$EXPECTED_ARTIFACT_NAME" "$MAIN_HEAD"
-        ;;
-      many-invalid)
-        printf '[{"artifacts":['
-        separator=""
-        for run_id in $(seq 30 38); do
-          printf '%s{"id":%s,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T%02d:00:00Z","workflow_run":{"id":%s,"head_branch":"main","head_sha":"%s"}}' \
-            "$separator" "$((run_id + 100))" "$EXPECTED_ARTIFACT_NAME" "$((run_id - 30))" "$run_id" "$MAIN_HEAD"
-          separator=,
-        done
-        printf ']}]\n'
         ;;
       *)
         printf '[{"artifacts":[{"id":199,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T03:00:00Z","workflow_run":{"id":99,"head_branch":"feature","head_sha":"%s"}},{"id":130,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T02:30:00Z","workflow_run":{"id":30,"head_branch":"other","head_sha":"%s"}},{"id":121,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T02:00:00Z","workflow_run":{"id":21,"head_branch":"feature","head_sha":"%s"}}]},{"artifacts":[{"id":120,"name":"%s","expired":false,"size_in_bytes":1000,"created_at":"2026-07-21T01:00:00Z","workflow_run":{"id":20,"head_branch":"main","head_sha":"%s"}}]}]\n' \
@@ -479,21 +443,11 @@ if [ "$1" = "api" ]; then
   fi
   if [[ "$endpoint" == *'/compare/'* ]]; then
     case "${GH_SCENARIO:-rank}" in
-      compare-fail) exit 8 ;;
-      compare-malformed) printf '{}\n' ;;
-      compare-mismatch)
-        printf '{"status":"ahead","ahead_by":1,"behind_by":0,"base_commit":{"sha":"%s"},"merge_base_commit":{"sha":"%s"}}\n' "$UNREACHABLE_HEAD" "$UNREACHABLE_HEAD"
-        ;;
-      compare-behind)
-        printf '{"status":"behind","ahead_by":0,"behind_by":1,"base_commit":{"sha":"%s"},"merge_base_commit":{"sha":"%s"}}\n' "$REACHABLE_HEAD" "$UNREACHABLE_HEAD"
-        ;;
-      compare-diverged|rank)
+
+      rank)
         printf '{"status":"diverged","ahead_by":1,"behind_by":1,"base_commit":{"sha":"%s"},"merge_base_commit":{"sha":"%s"}}\n' "$UNREACHABLE_HEAD" "$MAIN_HEAD"
         ;;
-      reachable-identical)
-        printf '{"status":"identical","ahead_by":0,"behind_by":0,"base_commit":{"sha":"%s"},"merge_base_commit":{"sha":"%s"}}\n' "$REACHABLE_HEAD" "$REACHABLE_HEAD"
-        ;;
-      reachable|ranking-reachable|pr-mismatch)
+      ranking-reachable)
         printf '{"status":"ahead","ahead_by":3,"behind_by":0,"base_commit":{"sha":"%s"},"merge_base_commit":{"sha":"%s"}}\n' "$REACHABLE_HEAD" "$REACHABLE_HEAD"
         ;;
       *) exit 2 ;;
@@ -516,8 +470,6 @@ if [ "$1" = "run" ] && [ "$2" = "download" ]; then
   mkdir -p "$output_dir"
   if [ "$run_id" = "20" ] && [ "${GH_SCENARIO:-rank}" = "untrusted" ]; then
     cp "${GH_FIXTURES}/untrusted-manifest.json" "${output_dir}/manifest.json"
-  elif [ "$run_id" = "20" ] && [ "${GH_SCENARIO:-rank}" = "content-mismatch" ]; then
-    cp "${GH_FIXTURES}/content-mismatch-manifest.json" "${output_dir}/manifest.json"
   elif [ "$run_id" = "20" ] && [ "${GH_SCENARIO:-rank}" = "conflict" ]; then
     cp "${GH_FIXTURES}/conflict-manifest.json" "${output_dir}/manifest.json"
   elif [ "$run_id" = "20" ] && [ "${GH_SCENARIO:-rank}" = "guest-conflict" ]; then
@@ -528,8 +480,6 @@ if [ "$1" = "run" ] && [ "$2" = "download" ]; then
     cp "${GH_FIXTURES}/pr-manifest.json" "${output_dir}/manifest.json"
   elif [ "$run_id" = "22" ] && [ "${GH_SCENARIO:-rank}" = "failed-valid" ]; then
     cp "${GH_FIXTURES}/failed-main-manifest.json" "${output_dir}/manifest.json"
-  elif [ "$run_id" = "24" ] && [ "${GH_SCENARIO:-rank}" = "pr-mismatch" ]; then
-    cp "${GH_FIXTURES}/reachable-pr-mismatch-manifest.json" "${output_dir}/manifest.json"
   elif [ "$run_id" = "24" ]; then
     cp "${GH_FIXTURES}/reachable-manifest.json" "${output_dir}/manifest.json"
   else
@@ -639,149 +589,5 @@ if run_shadow pull_request guest-conflict "${TMPDIR}/shadow-guest-conflict" \
 fi
 grep -q 'equal runner binary input digest produced conflicting output identity' \
   "${TMPDIR}/guest-conflict.err" || fail "expected guest conflict diagnostic"
-
-run_active() {
-  local current_event=$1 scenario=$2 output_dir=$3 aws_mode=${4:-success}
-  local current_pr_number=123 current_pr_head_ref=feature
-  if [ "$current_event" = "push" ]; then
-    current_pr_number=""
-    current_pr_head_ref=""
-  fi
-  PATH="${TMPDIR}/bin:${PATH}" \
-  GH_LOG="${TMPDIR}/gh.log" \
-  GH_SCENARIO="$scenario" \
-  GH_FIXTURES="$TMPDIR" \
-  EXPECTED_ARTIFACT_NAME="$expected_artifact" \
-  MAIN_HEAD="$main_head" \
-  PR_HEAD="$pr_head" \
-  REACHABLE_HEAD="$reachable_head" \
-  UNREACHABLE_HEAD="$unreachable_head" \
-  AWS_LOG="${TMPDIR}/aws.log" \
-  AWS_MODE="$aws_mode" \
-  AWS_STORE="${TMPDIR}/store" \
-  AWS_ACCESS_KEY_ID=test-access \
-  AWS_SECRET_ACCESS_KEY=test-secret \
-  R2_ACCOUNT_ID=test-account \
-  R2_BUCKET_NAME=test-bucket \
-  RUNNER_TEMP="${TMPDIR}/runner-temp" \
-  EXPECTED_TARGET="$target" \
-  EXPECTED_BINARY_INPUT_DIGEST="$input_digest" \
-  RESOLVE_OUTPUT_DIR="$output_dir" \
-  REPO=vm0-ai/vm0 \
-  CURRENT_RUN_ID=99 \
-  CURRENT_EVENT="$current_event" \
-  CURRENT_PR_NUMBER="$current_pr_number" \
-  CURRENT_PR_HEAD_REF="$current_pr_head_ref" \
-  DEFAULT_BRANCH=main \
-    "$CACHE" active-resolve
-}
-
-zstd -q -3 -f -o "${TMPDIR}/store/object.zst" "$runner"
-: > "${TMPDIR}/gh.log"
-active_output="${TMPDIR}/active.output"
-active_hit=$(GITHUB_OUTPUT="$active_output" run_active pull_request rank "${TMPDIR}/active-hit")
-assert_contains "$active_hit" "resolve-outcome=hit"
-assert_contains "$active_hit" "resolve-source=protected-main"
-assert_contains "$active_hit" "resolve-producer-run-id=20"
-assert_output_keys "$active_output" \
-  "candidate-inspections,object-size-bytes,resolve-outcome,resolve-producer-run-id,resolve-reason,resolve-source,runner-size-bytes"
-cmp -s "$runner" "${TMPDIR}/active-hit/runner" || fail "active hit must materialize verified runner bytes"
-FRESH_METADATA_PATH="${TMPDIR}/active-hit/metadata.json" \
-RUNNER_PATH="${TMPDIR}/active-hit/runner" \
-EXPECTED_TARGET="$target" \
-EXPECTED_BINARY_INPUT_DIGEST="$input_digest" \
-  "$CACHE" fresh-validate >/dev/null
-
-: > "${TMPDIR}/gh.log"
-main_hit=$(run_active push rank "${TMPDIR}/active-main")
-assert_contains "$main_hit" "resolve-outcome=hit"
-assert_contains "$main_hit" "resolve-source=protected-main"
-assert_contains "$main_hit" "resolve-producer-run-id=20"
-
-reachable_hit=$(run_active push reachable "${TMPDIR}/active-reachable")
-assert_contains "$reachable_hit" "resolve-outcome=hit"
-assert_contains "$reachable_hit" "resolve-source=main-reachable"
-assert_contains "$reachable_hit" "resolve-producer-run-id=24"
-
-identical_hit=$(run_active push reachable-identical "${TMPDIR}/active-reachable-identical")
-assert_contains "$identical_hit" "resolve-outcome=hit"
-assert_contains "$identical_hit" "resolve-source=main-reachable"
-
-failed_valid_hit=$(run_active push failed-valid "${TMPDIR}/active-failed-valid")
-assert_contains "$failed_valid_hit" "resolve-outcome=hit"
-assert_contains "$failed_valid_hit" "resolve-source=protected-main"
-
-in_progress_miss=$(run_active push in-progress "${TMPDIR}/active-in-progress")
-assert_contains "$in_progress_miss" "resolve-outcome=miss"
-assert_contains "$in_progress_miss" "resolve-reason=no-trusted-candidate"
-
-for scenario in compare-fail compare-malformed compare-mismatch compare-behind compare-diverged pr-mismatch invalid-head; do
-  ancestry_miss=$(run_active push "$scenario" "${TMPDIR}/active-${scenario}")
-  assert_contains "$ancestry_miss" "resolve-outcome=miss"
-  assert_contains "$ancestry_miss" "resolve-reason=no-trusted-candidate"
-done
-
-: > "${TMPDIR}/gh.log"
-force_miss=$(RUNNER_BINARY_CACHE_FORCE_MISS=true \
-  run_active pull_request rank "${TMPDIR}/active-force")
-assert_contains "$force_miss" "resolve-reason=force-miss"
-[ ! -s "${TMPDIR}/gh.log" ] || fail "force miss must bypass candidate lookup"
-
-: > "${TMPDIR}/gh.log"
-if RUNNER_BINARY_CACHE_FORCE_MISS=true \
-  run_active unsupported rank "${TMPDIR}/active-invalid-context" \
-  > "${TMPDIR}/active-invalid-context.out" \
-  2> "${TMPDIR}/active-invalid-context.err"; then
-  fail "active force miss accepted an unsupported current event"
-fi
-grep -qF 'unsupported current event: unsupported' \
-  "${TMPDIR}/active-invalid-context.err" || fail "expected active context diagnostic"
-[ ! -s "${TMPDIR}/gh.log" ] || fail "invalid active context must fail before candidate lookup"
-
-api_miss=$(run_active pull_request api-fail "${TMPDIR}/active-api-fail")
-assert_contains "$api_miss" "resolve-outcome=miss"
-assert_contains "$api_miss" "resolve-reason=artifact-api-unavailable"
-
-expired_miss=$(run_active pull_request expired "${TMPDIR}/active-expired")
-assert_contains "$expired_miss" "resolve-reason=no-trusted-candidate"
-
-oversized_artifact_miss=$(run_active pull_request oversized-artifact "${TMPDIR}/active-oversized-artifact")
-assert_contains "$oversized_artifact_miss" "resolve-reason=no-trusted-candidate"
-
-conflict_miss=$(run_active pull_request conflict "${TMPDIR}/active-conflict")
-assert_contains "$conflict_miss" "resolve-outcome=miss"
-assert_contains "$conflict_miss" "resolve-reason=trusted-output-conflict"
-
-head_failure_miss=$(run_active pull_request rank "${TMPDIR}/active-head-failure" head-fail)
-assert_contains "$head_failure_miss" "resolve-reason=r2-head-failed"
-
-malformed_head_miss=$(run_active pull_request rank "${TMPDIR}/active-malformed-head" malformed-head)
-assert_contains "$malformed_head_miss" "resolve-reason=r2-head-malformed"
-
-oversized_head_miss=$(run_active pull_request rank "${TMPDIR}/active-oversized-head" oversized-head)
-assert_contains "$oversized_head_miss" "resolve-reason=r2-size-mismatch"
-
-size_mismatch_miss=$(run_active pull_request rank "${TMPDIR}/active-size-mismatch" size-mismatch)
-assert_contains "$size_mismatch_miss" "resolve-reason=r2-size-mismatch"
-
-get_failure_miss=$(run_active pull_request rank "${TMPDIR}/active-get-failure" get-fail)
-assert_contains "$get_failure_miss" "resolve-reason=r2-get-failed"
-
-content_mismatch_miss=$(run_active pull_request content-mismatch "${TMPDIR}/active-content-mismatch")
-assert_contains "$content_mismatch_miss" "resolve-reason=r2-content-mismatch"
-
-compressed_size=$(stat -c '%s' "${TMPDIR}/store/object.zst")
-dd if=/dev/zero of="${TMPDIR}/store/object.zst" bs="$compressed_size" count=1 status=none
-corrupt_miss=$(run_active pull_request rank "${TMPDIR}/active-corrupt")
-assert_contains "$corrupt_miss" "resolve-outcome=miss"
-assert_contains "$corrupt_miss" "resolve-reason=r2-decompression-invalid"
-zstd -q -3 -f -o "${TMPDIR}/store/object.zst" "$runner"
-
-: > "${TMPDIR}/gh.log"
-bounded_miss=$(run_active pull_request many-invalid "${TMPDIR}/active-bounded")
-assert_contains "$bounded_miss" "resolve-outcome=miss"
-assert_contains "$bounded_miss" "resolve-reason=candidate-limit-exhausted"
-run_queries=$(grep -c 'actions/runs/' "${TMPDIR}/gh.log")
-[ "$run_queries" -eq 8 ] || fail "active resolution must inspect at most eight candidate runs"
 
 echo "runner-binary-cache-test: ok"

--- a/.github/scripts/tests/runner-image-workflow-test.sh
+++ b/.github/scripts/tests/runner-image-workflow-test.sh
@@ -49,9 +49,9 @@ jq -e '
 jq -e '
   [.jobs | to_entries[] | .value.steps[]? |
     .with.name? // empty |
-    select(startswith("runner-binary-hits-") or startswith("runner-binary-compiled-"))
+    select(startswith("runner-binary-compiled-"))
   ] as $transport_names |
-  ($transport_names | length) == 5 and
+  ($transport_names | length) == 3 and
   all($transport_names[]; contains("${{ github.run_id }}")) and
   all($transport_names[]; contains("${{ github.run_attempt }}") | not)
 ' <<<"$workflow_json" >/dev/null || fail "runner binary transport identity must survive producer and consumer attempt mismatch"
@@ -61,22 +61,13 @@ jq -e '
   (.jobs.prepare | has("container") | not) and
   .jobs.prepare.permissions.actions == "read" and
   .jobs.prepare.outputs["runner-binary-compile-matrix"] == "${{ steps.binary-plan.outputs.compile-matrix }}" and
-  (.jobs.prepare.outputs | has("runner-binary-hit-count") | not) and
-  (.jobs.prepare.outputs | has("runner-binary-resolution-json") | not) and
+  .jobs.prepare.outputs["runner-binary-hit-references"] == "${{ steps.binary-plan.outputs.hit-references }}" and
   any(.jobs.prepare.steps[];
     .id == "binary-plan" and
     .run == ".github/scripts/runner-binary-cache-plan.sh" and
     .env.RUNNER_BINARY_CACHE_FORCE_MISS == "${{ vars.RUNNER_BINARY_CACHE_FORCE_MISS }}"
-  ) and
-  any(.jobs.prepare.steps[];
-    .uses == "actions/upload-artifact@v7" and
-    .with.name == "runner-binary-hits-${{ github.run_id }}" and
-    .with.overwrite == true and
-    .if == "steps.binary-plan.outputs.hit-count != '\''0'\''" and
-    .with["compression-level"] == 1 and
-    (. | has("continue-on-error") | not)
   )
-' <<<"$workflow_json" >/dev/null || fail "prepare must own bounded pre-container hit planning and required transport upload"
+' <<<"$workflow_json" >/dev/null || fail "prepare must publish cache references and the miss-only compile matrix"
 
 jq -e '
   .jobs.compile["runs-on"] == "ubuntu-latest-8-cores" and
@@ -115,14 +106,17 @@ jq -e '
 jq -e '
   .jobs.build.name == "Build runner image (${{ matrix.label }})" and
   .jobs.build["runs-on"] == "ubuntu-latest" and
+  .jobs.build["timeout-minutes"] == 20 and
   (.jobs.build | has("container") | not) and
   .jobs.build.strategy.matrix.include == "${{ fromJSON(needs.prepare.outputs.runner-host-groups-matrix) }}" and
   (.jobs.build.if | contains("needs.compile.result == '\''skipped'\''")) and
   (.jobs.build.if | contains("needs.compile.result == '\''success'\''")) and
   any(.jobs.build.steps[];
-    .name == "Download validated runner binary hit" and
+    .name == "Download cached runner binary from R2" and
     (.if | contains("runner-binary-hit-targets")) and
-    .with.name == "runner-binary-hits-${{ github.run_id }}"
+    .run == ".github/scripts/runner-binary-cache.sh download-reference" and
+    .env.CACHE_REFERENCE == "${{ toJSON(fromJSON(needs.prepare.outputs.runner-binary-hit-references)[matrix.target]) }}" and
+    .env.RESOLVE_OUTPUT_DIR == "runner-binary-transport/${{ matrix.target }}"
   ) and
   any(.jobs.build.steps[];
     .name == "Download compiled runner binary" and

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -74,6 +74,7 @@ jobs:
       runner-host-groups-configured: ${{ steps.host-group-presence.outputs.configured }}
       runner-binary-compile-matrix: ${{ steps.binary-plan.outputs.compile-matrix }}
       runner-binary-hit-targets: ${{ steps.binary-plan.outputs.hit-targets }}
+      runner-binary-hit-references: ${{ steps.binary-plan.outputs.hit-references }}
       runner-binary-miss-count: ${{ steps.binary-plan.outputs.miss-count }}
     steps:
       - uses: actions/checkout@v7.0.1
@@ -277,30 +278,14 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_DEFAULT_REGION: auto
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          CURRENT_EVENT: ${{ github.event_name }}
-          CURRENT_PR_HEAD_REF: ${{ steps.identity.outputs.pr-head-ref }}
-          CURRENT_PR_NUMBER: ${{ steps.identity.outputs.pr-number }}
-          CURRENT_RUN_ID: ${{ github.run_id }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
           R2_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
-          RESOLVE_OUTPUT_DIR: runner-binary-hits
+          RESOLVE_OUTPUT_DIR: runner-binary-references
           RUNNER_BINARY_CACHE_FORCE_MISS: ${{ vars.RUNNER_BINARY_CACHE_FORCE_MISS }}
           RUNNER_HOST_GROUPS_MATRIX: ${{ steps.host-groups.outputs.matrix }}
         run: .github/scripts/runner-binary-cache-plan.sh
-
-      - name: Upload validated runner binary hits
-        if: steps.binary-plan.outputs.hit-count != '0'
-        uses: actions/upload-artifact@v7
-        with:
-          name: runner-binary-hits-${{ github.run_id }}
-          overwrite: true
-          path: runner-binary-hits/
-          if-no-files-found: error
-          retention-days: 1
-          compression-level: 1
 
   compile:
     name: Compile runner binary (${{ matrix.label }})
@@ -428,12 +413,19 @@ jobs:
           TARGET_TRIPLE: ${{ matrix.target }}
         run: .github/scripts/runner-binary-build/digest.sh "$TARGET_TRIPLE"
 
-      - name: Download validated runner binary hit
+      - name: Download cached runner binary from R2
         if: contains(fromJSON(needs.prepare.outputs.runner-binary-hit-targets), matrix.target)
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: runner-binary-hits-${{ github.run_id }}
-          path: runner-binary-transport
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_DEFAULT_REGION: auto
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
+          R2_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
+          EXPECTED_TARGET: ${{ matrix.target }}
+          EXPECTED_BINARY_INPUT_DIGEST: ${{ steps.binary-input.outputs.binary-input-digest }}
+          CACHE_REFERENCE: ${{ toJSON(fromJSON(needs.prepare.outputs.runner-binary-hit-references)[matrix.target]) }}
+          RESOLVE_OUTPUT_DIR: runner-binary-transport/${{ matrix.target }}
+        run: .github/scripts/runner-binary-cache.sh download-reference
 
       - name: Download compiled runner binary
         if: ${{ !contains(fromJSON(needs.prepare.outputs.runner-binary-hit-targets), matrix.target) }}

--- a/docs/runner-multi-architecture.md
+++ b/docs/runner-multi-architecture.md
@@ -88,6 +88,18 @@ Jobs that need one representative host use the deterministic selector:
 Runner image production resolves architecture groups, builds one runner image per
 configured group, and validates the manifest under that group's target triple.
 
+Runner binary cache reuse is target-specific. Prepare resolves small references
+for the current build-input digest; each image-build job downloads its own
+binary directly from the trusted R2 cache. GitHub cache metadata is a lookup
+index, not a second source of provenance validation for R2 objects. Cached
+binaries are not re-uploaded as a combined GitHub artifact.
+
+Targets without an available cache reference use the normal compile job and
+compiled GitHub artifact. After prepare selects a cache hit, its download is
+required: an unavailable object or failed download fails the image-build job.
+Compilation stays in the existing compile job. Publishing freshly compiled
+binaries to R2 remains optional.
+
 Crates host-bound tests resolve the same sanitized matrix and run architecture
 specific checks, including NBD COW tests, on matching metal. Jobs that need an
 actual host resolve the host subset inside the job instead of reading hosts from


### PR DESCRIPTION
## Summary

- Replace prepare's full cached-binary download and combined GitHub artifact upload with compact per-target R2 references. Each image-build job downloads only its own binary directly from R2.
- Treat R2 as the trusted internal cache. Existing GitHub manifests only locate cache objects and provide target/build metadata; cache hits no longer require workflow-run, ancestry, or GitHub-backed content validation.
- Preserve the miss-only compile job, pinned Rust container, compiler caches, compiled artifacts, and optional asset publication. Keep build's existing responsibilities and 20-minute budget.
- Adapt the existing post-cleanup Runner binary restoration consumer to download resolved references before restoring files, and exercise that complete deployment path through real scripts with external command fixtures.

Closes #33478

## Failure policy and scope

If an object is unavailable during prepare, that target uses normal compilation. Once prepare selects a hit, its download is required: a failed download or unusable compressed payload fails build. As explicitly requested, there is no Docker execution or recovery compilation added to build.

Image-readiness polling (#33479), host selection/distribution, image lifecycle locks, fresh-binary delivery, and small manifests are unchanged. No new R2 objects or metadata store are introduced.

## Transfers

Bulk-binary GitHub artifact handoffs for the two supported targets, excluding small metadata artifacts:

| Case | Before: uploads / downloads | After: uploads / downloads |
| --- | --- | --- |
| Both targets hit | 1 / 2 | 0 / 0 |
| One hit, one compile | 2 / 3 | 1 / 2 |
| Both compile | 2 / 4 | 2 / 4 |

Controlled script tests verify prepare's reference-only resolution and one R2 download per hit target. The previous [all-hit run](https://github.com/vm0-ai/vm0/actions/runs/34569305214) relayed a 49,934,098-byte combined artifact through one upload and two downloads.

[PR all-hit run 34576159752](https://github.com/vm0-ai/vm0/actions/runs/34576159752), at production-code commit `05fc3dea85672b37272617e94c69d8b8a2fda8ec`, passed both architecture image builds and skipped the miss-only compile/asset jobs. The x86_64 build downloaded 21,362,909 compressed R2 bytes in a 6-second download step; arm64 downloaded 20,061,579 bytes in a 5-second step. Only two small image manifests were uploaded (1,019 and 1,015 bytes), with no bulk hit relay. These step timings are observations, not a claim of proportional end-to-end speedup. The later fix changes only test fixture metadata setup.

## Fallbacks

Preserved optional-cache selection in `runner-binary-cache.sh resolve-reference` and `runner-binary-cache-plan.sh`: unavailable cache configuration/index/objects or the existing resolution deadline select the ordinary compile matrix. This is an ongoing cache-availability contract, not a rollout compatibility window; it remains necessary while prepare-time caching is optional. No new recovery compilation fallback is introduced. After selection, download failures propagate.

## Validation

- The exact `Run workflow script tests` step from `security.yml` passed locally, including its full strict ShellCheck command, shell compatibility check, and all 87 script test entry points. This includes the new end-to-end post-cleanup binary recovery scenario.
- `bash -n` on all seven changed shell files.
- `shellcheck --severity=warning` on all seven changed shell files, plus the full CI-selected strict ShellCheck command. An initial CI failure exposed two SC1091 source imports in the added test fixture; the test now reads the committed guest inventory and production digest command output, without suppressions or lint-rule changes.
- `actionlint .github/workflows/runner-image.yml`.
- `.github/scripts/check-workflow-shell-compatibility.sh`.
- Prettier check for the changed YAML and Markdown; `git diff --check`; `scripts/check-file-size.sh` for all nine changed files.

Tests use real temporary files and production script entry points with external GitHub/AWS command fixtures. Live R2 and metal-host execution were not validated locally; the all-hit Runner Image CI evidence above covers both architectures on the production-code commit. Checks for the latest test-only commit are reported separately. No unrelated application test suite was run for these shell/YAML/documentation changes.

## Risks

Previously R2 downloads ran in prepare, so their failures could select normal compilation. With direct downloads in build, a failure after prepare confirms an object fails that job; the user chose this trade-off instead of adding recovery compilation to build. Existing cache objects remain readable without migration, and a code revert restores the prior hit relay. Local runner transport hashes are computed from downloaded bytes for the existing downstream contract, not compared with GitHub content claims.
