### PR TITLE
test: split remaining ci timeout scenarios

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -2952,384 +2952,433 @@ describe("Feishu integration", () => {
     expect(loginReplies).toHaveLength(1);
   });
 
-  it("uses Okou branding without renaming the provider bot", async () => {
-    mockEnv("APP_URL", "https://app.okou.ai");
-    server.use(
-      http.get("https://open.feishu.cn/open-apis/bot/v3/info", () => {
-        return HttpResponse.json({
-          code: 0,
-          bot: {
-            open_id: BOT_OPEN_ID,
-            app_name: "Owner Managed Bot",
-            avatar_url: "https://example.com/owner-managed-bot.png",
-          },
+  it.each([
+    "installation status",
+    "unconnected commands",
+    "connected commands",
+  ] as const)(
+    "uses Okou branding for %s without renaming the provider bot",
+    async (phase) => {
+      mockEnv("APP_URL", "https://app.okou.ai");
+      server.use(
+        http.get("https://open.feishu.cn/open-apis/bot/v3/info", () => {
+          return HttpResponse.json({
+            code: 0,
+            bot: {
+              open_id: BOT_OPEN_ID,
+              app_name: "Owner Managed Bot",
+              avatar_url: "https://example.com/owner-managed-bot.png",
+            },
+          });
+        }),
+      );
+      const fixture = await setupFeishuRunFixture();
+      mocks.clerk.session(
+        fixture.actor.userId,
+        fixture.actor.orgId,
+        fixture.actor.orgRole,
+      );
+      const client = setupApp({ context, routes: feishuConnectRoutes })(
+        feishuConnectContract,
+      );
+
+      if (phase === "installation status") {
+        const status = await accept(
+          client.getStatus({
+            headers: { authorization: "Bearer clerk-session" },
+            extraHeaders: { origin: "https://app.okou.ai" },
+          }),
+          [200],
+        );
+        expect(status.body.publicBrand).toBe("okou");
+        expect(status.body.installations?.[0]).toMatchObject({
+          publicBrand: "okou",
+          botName: "Owner Managed Bot",
+          callbackUrl: fixture.callbackUrl,
         });
-      }),
-    );
-    const fixture = await setupFeishuRunFixture();
-    mocks.clerk.session(
-      fixture.actor.userId,
-      fixture.actor.orgId,
-      fixture.actor.orgRole,
-    );
-    const client = setupApp({ context, routes: feishuConnectRoutes })(
-      feishuConnectContract,
-    );
-    const status = await accept(
-      client.getStatus({
-        headers: { authorization: "Bearer clerk-session" },
-        extraHeaders: { origin: "https://app.okou.ai" },
-      }),
-      [200],
-    );
-    expect(status.body.publicBrand).toBe("okou");
-    expect(status.body.installations?.[0]).toMatchObject({
-      publicBrand: "okou",
-      botName: "Owner Managed Bot",
-      callbackUrl: fixture.callbackUrl,
-    });
+      } else if (phase === "unconnected commands") {
+        await postEvent(
+          fixture.callbackUrl,
+          directMessage(fixture.appId, "/help", "ou_feishu_unconnected"),
+          { encrypted: true },
+        );
+        await postEvent(
+          fixture.callbackUrl,
+          directMessage(fixture.appId, "hello", "ou_feishu_unconnected"),
+          { encrypted: true },
+        );
+        await flushWaitUntilForTest();
+        const unconnectedContent = outboundMessages
+          .map(messageContent)
+          .join("\n");
+        expect(unconnectedContent).toContain("Owner Managed Bot commands");
+        expect(unconnectedContent).toContain("To use Okou in Feishu");
+        const connectUrl = requireValue(
+          unconnectedContent.match(/https:\/\/[^"\\]+/u)?.[0],
+          "Expected branded Feishu connect URL",
+        );
+        expect(new URL(connectUrl).hostname).toBe("app.okou.ai");
+      } else {
+        outboundMessages = [];
+        await connectFixtureUser(fixture);
+        await postEvent(
+          fixture.callbackUrl,
+          directMessage(fixture.appId, "/help"),
+          { encrypted: true },
+        );
+        await postEvent(
+          fixture.callbackUrl,
+          directMessage(fixture.appId, "/connect"),
+          { encrypted: true },
+        );
+        await flushWaitUntilForTest();
+        const connectedContent = outboundMessages
+          .map(messageContent)
+          .join("\n");
+        expect(connectedContent).toContain("Owner Managed Bot commands");
+        expect(connectedContent).toContain(
+          "Your Feishu account is already connected to Okou",
+        );
+      }
+      mocks.clerk.session(
+        fixture.actor.userId,
+        fixture.actor.orgId,
+        fixture.actor.orgRole,
+      );
+      await accept(
+        client.removeInstallation({
+          headers: { authorization: "Bearer clerk-session" },
+          params: { installationId: fixture.installationId },
+        }),
+        [200],
+      );
+    },
+  );
 
-    await postEvent(
-      fixture.callbackUrl,
-      directMessage(fixture.appId, "/help", "ou_feishu_unconnected"),
-      { encrypted: true },
-    );
-    await postEvent(
-      fixture.callbackUrl,
-      directMessage(fixture.appId, "hello", "ou_feishu_unconnected"),
-      { encrypted: true },
-    );
-    await flushWaitUntilForTest();
-    const unconnectedContent = outboundMessages.map(messageContent).join("\n");
-    expect(unconnectedContent).toContain("Owner Managed Bot commands");
-    expect(unconnectedContent).toContain("To use Okou in Feishu");
-    const connectUrl = requireValue(
-      unconnectedContent.match(/https:\/\/[^"\\]+/u)?.[0],
-      "Expected branded Feishu connect URL",
-    );
-    expect(new URL(connectUrl).hostname).toBe("app.okou.ai");
+  it.each(["input context", "asynchronous delivery"] as const)(
+    "uses Okou for Feishu %s",
+    async (phase) => {
+      const fixture = await setupFeishuRunFixture({
+        useSystemDefaultIdentity: true,
+      });
+      await connectFixtureUser(fixture);
+      const prompt = "run with the Okou default identity";
 
-    outboundMessages = [];
-    await connectFixtureUser(fixture);
-    await postEvent(
-      fixture.callbackUrl,
-      directMessage(fixture.appId, "/help"),
-      { encrypted: true },
-    );
-    await postEvent(
-      fixture.callbackUrl,
-      directMessage(fixture.appId, "/connect"),
-      { encrypted: true },
-    );
-    await flushWaitUntilForTest();
-    const connectedContent = outboundMessages.map(messageContent).join("\n");
-    expect(connectedContent).toContain("Owner Managed Bot commands");
-    expect(connectedContent).toContain(
-      "Your Feishu account is already connected to Okou",
-    );
+      await postEvent(
+        fixture.callbackUrl,
+        directMessage(fixture.appId, prompt),
+        {
+          encrypted: true,
+        },
+      );
+      await flushWaitUntilForTest();
 
-    mocks.clerk.session(
-      fixture.actor.userId,
-      fixture.actor.orgId,
-      fixture.actor.orgRole,
-    );
-    await accept(
-      client.removeInstallation({
-        headers: { authorization: "Bearer clerk-session" },
-        params: { installationId: fixture.installationId },
-      }),
-      [200],
-    );
-  });
+      const run = await findRun(fixture.actor, prompt);
 
-  it("uses Okou throughout the run and asynchronous delivery", async () => {
-    const fixture = await setupFeishuRunFixture({
-      useSystemDefaultIdentity: true,
-    });
-    await connectFixtureUser(fixture);
-    const prompt = "run with the Okou default identity";
+      if (phase === "input context") {
+        const inputEvent = requireValue(
+          await findFeishuChatEventByPromptFixture({
+            userId: fixture.actor.userId,
+            prompt,
+          }),
+          "Expected the Host-branded Feishu input event",
+        );
+        await expect(
+          readChatEventContextFixture(inputEvent.eventId),
+        ).resolves.toMatchObject({ feishuPublicBrand: "okou" });
 
-    await postEvent(fixture.callbackUrl, directMessage(fixture.appId, prompt), {
-      encrypted: true,
-    });
-    await flushWaitUntilForTest();
+        await runsApi.requestCancelRun(fixture.actor, run.id, [200]);
+      } else {
+        await runsApi.heartbeatRunner(fixture.runnerGroup);
+        const claim = await runsApi.claimRunnerJob(run.id);
+        expect(claim.appendSystemPrompt).toContain("Your name is Okou.");
+        outboundMessages = [];
+        await completeRunSession({
+          runId: run.id,
+          sandboxToken: claim.sandboxToken,
+          sessionId: `bdd-feishu-host-brand-${run.id}`,
+          history: `bdd Feishu host brand history ${run.id}`,
+          assistantText: "Host-branded Feishu response",
+        });
+        await flushWaitUntilForTest();
+        const delivered = requireValue(
+          outboundMessages.find((message) => {
+            return messageContent(message).includes(
+              "Host-branded Feishu response",
+            );
+          }),
+          "Expected the asynchronous Feishu response",
+        );
+        expect(messageContent(delivered)).toContain('"content":"Okou"');
+      }
+    },
+  );
 
-    const run = await findRun(fixture.actor, prompt);
-    const inputEvent = requireValue(
-      await findFeishuChatEventByPromptFixture({
-        userId: fixture.actor.userId,
+  it.each(["input context", "claimed run"] as const)(
+    "restores the legacy Feishu brand in %s",
+    async (phase) => {
+      const fixture = await setupFeishuRunFixture({
+        useSystemDefaultIdentity: true,
+      });
+      await connectFixtureUser(fixture);
+      const eventId = `evt_legacy_brand_${randomUUID()}`;
+      const messageId = `om_legacy_brand_${randomUUID()}`;
+      const prompt = `legacy Okou ingress ${randomUUID()}`;
+      const providerEvent = directMessage(
+        fixture.appId,
         prompt,
-      }),
-      "Expected the Host-branded Feishu input event",
-    );
-    await expect(
-      readChatEventContextFixture(inputEvent.eventId),
-    ).resolves.toMatchObject({ feishuPublicBrand: "okou" });
-    await runsApi.heartbeatRunner(fixture.runnerGroup);
-    const claim = await runsApi.claimRunnerJob(run.id);
-    expect(claim.appendSystemPrompt).toContain("Your name is Okou.");
-    outboundMessages = [];
-    await completeRunSession({
-      runId: run.id,
-      sandboxToken: claim.sandboxToken,
-      sessionId: `bdd-feishu-host-brand-${run.id}`,
-      history: `bdd Feishu host brand history ${run.id}`,
-      assistantText: "Host-branded Feishu response",
-    });
-    await flushWaitUntilForTest();
-    const delivered = requireValue(
-      outboundMessages.find((message) => {
-        return messageContent(message).includes("Host-branded Feishu response");
-      }),
-      "Expected the asynchronous Feishu response",
-    );
-    expect(messageContent(delivered)).toContain('"content":"Okou"');
-  });
-
-  it("reads a legacy null ingress brand from the existing installation during rollout", async () => {
-    const fixture = await setupFeishuRunFixture({
-      useSystemDefaultIdentity: true,
-    });
-    await connectFixtureUser(fixture);
-    const eventId = `evt_legacy_brand_${randomUUID()}`;
-    const messageId = `om_legacy_brand_${randomUUID()}`;
-    const prompt = `legacy Okou ingress ${randomUUID()}`;
-    const providerEvent = directMessage(
-      fixture.appId,
-      prompt,
-      "ou_feishu_user",
-      { eventId, messageId },
-    );
-    await seedLegacyFeishuIngressFixture({
-      installationId: fixture.installationId,
-      eventId,
-      payload: JSON.stringify({
+        "ou_feishu_user",
+        { eventId, messageId },
+      );
+      await seedLegacyFeishuIngressFixture({
         installationId: fixture.installationId,
         eventId,
-        tenantKey: TENANT_KEY,
-        appId: fixture.appId,
-        messageId,
-        chatId: "oc_feishu_dm",
-        chatType: "p2p",
-        rootId: null,
-        parentId: null,
-        threadId: null,
-        openId: "ou_feishu_user",
-        text: prompt,
-        promptText: prompt,
-        file: null,
-      }),
-    });
-
-    const retried = await postEvent(fixture.callbackUrl, providerEvent, {
-      encrypted: true,
-    });
-    expect(retried.status).toBe(200);
-    await flushWaitUntilForTest();
-    const inputEvent = requireValue(
-      await findFeishuChatEventByPromptFixture({
-        userId: fixture.actor.userId,
-        prompt,
-      }),
-      "Expected the legacy Feishu ingress to become a canonical event",
-    );
-    await expect(
-      readChatEventContextFixture(inputEvent.eventId),
-    ).resolves.toMatchObject({ feishuPublicBrand: "okou" });
-    const run = await findRun(fixture.actor, prompt);
-    await runsApi.heartbeatRunner(fixture.runnerGroup);
-    const claim = await runsApi.claimRunnerJob(run.id);
-    expect(claim.appendSystemPrompt).toContain("Your name is Okou.");
-    await runsApi.requestCancelRun(fixture.actor, run.id, [200]);
-  });
-
-  it("preserves the custom app identity and connection when callback credentials rotate", async () => {
-    const fixture = await setupFeishuRunFixture();
-    await connectFixtureUser(fixture);
-    const orgId = requireValue(fixture.actor.orgId, "Expected an organization");
-    const connectionBefore = await readFeishuMemberConnectorState(context, {
-      orgId,
-      userId: fixture.actor.userId,
-      installationId: fixture.installationId,
-    });
-    const rotatedVerificationToken = `rotated-${randomUUID()}`;
-    mocks.clerk.session(
-      fixture.actor.userId,
-      fixture.actor.orgId,
-      fixture.actor.orgRole,
-    );
-    const client = setupApp({ context, routes: feishuConnectRoutes })(
-      feishuConnectContract,
-    );
-    const customConnectorClient = setupApp({
-      context,
-      routes: customConnectorsRoutes,
-    })(customConnectorsContract);
-    const before = await accept(
-      customConnectorClient.list({
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-    const connectorBefore = requireValue(
-      before.body.connectors[0],
-      "Expected the managed Feishu connector",
-    );
-
-    const retried = await accept(
-      client.setup({
-        headers: { authorization: "Bearer clerk-session" },
-        extraHeaders: { origin: "https://app.okou.ai" },
-        body: {
+        payload: JSON.stringify({
           installationId: fixture.installationId,
+          eventId,
+          tenantKey: TENANT_KEY,
           appId: fixture.appId,
-          appSecret: APP_SECRET,
-          verificationToken: rotatedVerificationToken,
-          encryptKey: ENCRYPT_KEY,
-          defaultAgentId: fixture.defaultAgentId,
-        },
-      }),
-      [200],
-    );
-    expect(retried.body.publicBrand).toBe("okou");
-    expect(retried.body.installations?.[0]).toMatchObject({
-      id: fixture.installationId,
-      publicBrand: "okou",
-      botName: "Okou Feishu",
-      callbackUrl: fixture.callbackUrl,
-      callbackVerified: false,
-      setupCompleted: true,
-      isConnected: true,
-    });
+          messageId,
+          chatId: "oc_feishu_dm",
+          chatType: "p2p",
+          rootId: null,
+          parentId: null,
+          threadId: null,
+          openId: "ou_feishu_user",
+          text: prompt,
+          promptText: prompt,
+          file: null,
+        }),
+      });
 
-    const after = await accept(
-      customConnectorClient.list({
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-    expect(after.body.connectors).toStrictEqual([
-      expect.objectContaining({
-        id: connectorBefore.id,
-        storageVersion: connectorBefore.storageVersion,
-        oauthConfig: expect.objectContaining({ clientId: fixture.appId }),
-      }),
-    ]);
-    await expect(
-      readFeishuMemberConnectorState(context, {
+      const retried = await postEvent(fixture.callbackUrl, providerEvent, {
+        encrypted: true,
+      });
+      expect(retried.status).toBe(200);
+      await flushWaitUntilForTest();
+
+      const run = await findRun(fixture.actor, prompt);
+
+      if (phase === "input context") {
+        const inputEvent = requireValue(
+          await findFeishuChatEventByPromptFixture({
+            userId: fixture.actor.userId,
+            prompt,
+          }),
+          "Expected the legacy Feishu ingress to become a canonical event",
+        );
+        await expect(
+          readChatEventContextFixture(inputEvent.eventId),
+        ).resolves.toMatchObject({ feishuPublicBrand: "okou" });
+      } else {
+        await runsApi.heartbeatRunner(fixture.runnerGroup);
+        const claim = await runsApi.claimRunnerJob(run.id);
+        expect(claim.appendSystemPrompt).toContain("Your name is Okou.");
+      }
+      await runsApi.requestCancelRun(fixture.actor, run.id, [200]);
+    },
+  );
+
+  it.each(["connection identity", "rotated callback"] as const)(
+    "preserves the custom Feishu app's %s when credentials rotate",
+    async (phase) => {
+      const fixture = await setupFeishuRunFixture();
+      await connectFixtureUser(fixture);
+      const orgId = requireValue(
+        fixture.actor.orgId,
+        "Expected an organization",
+      );
+      const connectionBefore = await readFeishuMemberConnectorState(context, {
         orgId,
         userId: fixture.actor.userId,
         installationId: fixture.installationId,
-      }),
-    ).resolves.toStrictEqual(connectionBefore);
+      });
+      const rotatedVerificationToken = `rotated-${randomUUID()}`;
+      mocks.clerk.session(
+        fixture.actor.userId,
+        fixture.actor.orgId,
+        fixture.actor.orgRole,
+      );
+      const client = setupApp({ context, routes: feishuConnectRoutes })(
+        feishuConnectContract,
+      );
+      const customConnectorClient = setupApp({
+        context,
+        routes: customConnectorsRoutes,
+      })(customConnectorsContract);
+      const before = await accept(
+        customConnectorClient.list({
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      );
+      const connectorBefore = requireValue(
+        before.body.connectors[0],
+        "Expected the managed Feishu connector",
+      );
 
-    const prompt = `use the existing Feishu connection ${randomUUID()}`;
-    const eventResponse = await postEvent(
-      fixture.callbackUrl,
-      directMessage(fixture.appId, prompt, "ou_feishu_user", {
-        verificationToken: rotatedVerificationToken,
-      }),
-      { encrypted: true },
-    );
-    expect(eventResponse.status).toBe(200);
-    await flushWaitUntilForTest();
-    const run = await findRun(fixture.actor, prompt);
-    await runsApi.requestCancelRun(fixture.actor, run.id, [200]);
-    await accept(
-      client.removeInstallation({
-        headers: { authorization: "Bearer clerk-session" },
-        params: { installationId: fixture.installationId },
-      }),
-      [200],
-    );
-  });
+      const retried = await accept(
+        client.setup({
+          headers: { authorization: "Bearer clerk-session" },
+          extraHeaders: { origin: "https://app.okou.ai" },
+          body: {
+            installationId: fixture.installationId,
+            appId: fixture.appId,
+            appSecret: APP_SECRET,
+            verificationToken: rotatedVerificationToken,
+            encryptKey: ENCRYPT_KEY,
+            defaultAgentId: fixture.defaultAgentId,
+          },
+        }),
+        [200],
+      );
+      expect(retried.body.publicBrand).toBe("okou");
+      expect(retried.body.installations?.[0]).toMatchObject({
+        id: fixture.installationId,
+        publicBrand: "okou",
+        botName: "Okou Feishu",
+        callbackUrl: fixture.callbackUrl,
+        callbackVerified: false,
+        setupCompleted: true,
+        isConnected: true,
+      });
 
-  it("rejects replacing an existing custom app through setup", async () => {
-    const fixture = await setupFeishuRunFixture();
-    await connectFixtureUser(fixture);
-    mocks.clerk.session(
-      fixture.actor.userId,
-      fixture.actor.orgId,
-      fixture.actor.orgRole,
-    );
-    const client = feishuConnectClient();
-    const customConnectorClient = setupApp({
-      context,
-      routes: customConnectorsRoutes,
-    })(customConnectorsContract);
-    const connectorsBefore = await accept(
-      customConnectorClient.list({
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
+      if (phase === "connection identity") {
+        const after = await accept(
+          customConnectorClient.list({
+            headers: { authorization: "Bearer clerk-session" },
+          }),
+          [200],
+        );
+        expect(after.body.connectors).toStrictEqual([
+          expect.objectContaining({
+            id: connectorBefore.id,
+            storageVersion: connectorBefore.storageVersion,
+            oauthConfig: expect.objectContaining({ clientId: fixture.appId }),
+          }),
+        ]);
+        await expect(
+          readFeishuMemberConnectorState(context, {
+            orgId,
+            userId: fixture.actor.userId,
+            installationId: fixture.installationId,
+          }),
+        ).resolves.toStrictEqual(connectionBefore);
+      } else {
+        const prompt = `use the existing Feishu connection ${randomUUID()}`;
+        const eventResponse = await postEvent(
+          fixture.callbackUrl,
+          directMessage(fixture.appId, prompt, "ou_feishu_user", {
+            verificationToken: rotatedVerificationToken,
+          }),
+          { encrypted: true },
+        );
+        expect(eventResponse.status).toBe(200);
+        await flushWaitUntilForTest();
+        const run = await findRun(fixture.actor, prompt);
+        await runsApi.requestCancelRun(fixture.actor, run.id, [200]);
+      }
+      await accept(
+        client.removeInstallation({
+          headers: { authorization: "Bearer clerk-session" },
+          params: { installationId: fixture.installationId },
+        }),
+        [200],
+      );
+    },
+  );
 
-    const rejected = await accept(
-      client.setup({
-        headers: { authorization: "Bearer clerk-session" },
-        extraHeaders: { origin: "https://app.okou.ai" },
-        body: {
-          installationId: fixture.installationId,
-          appId: `cli_replacement_${randomUUID()}`,
-          appSecret: "replacement-app-secret",
-          verificationToken: "replacement-verification-token",
-          encryptKey: "replacement-encrypt-key",
-          defaultAgentId: fixture.alternateAgentId,
-        },
-      }),
-      [409],
-    );
-    expect(rejected.body.error.message).toContain(
-      "cannot be changed to a different App ID",
-    );
+  it.each(["installation state", "original callback"] as const)(
+    "preserves the %s after rejecting a replacement Feishu app",
+    async (phase) => {
+      const fixture = await setupFeishuRunFixture();
+      await connectFixtureUser(fixture);
+      mocks.clerk.session(
+        fixture.actor.userId,
+        fixture.actor.orgId,
+        fixture.actor.orgRole,
+      );
+      const client = feishuConnectClient();
+      const customConnectorClient = setupApp({
+        context,
+        routes: customConnectorsRoutes,
+      })(customConnectorsContract);
+      const connectorsBefore = await accept(
+        customConnectorClient.list({
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      );
 
-    const status = await accept(
-      client.getStatus({
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-    expect(status.body.installations?.[0]).toMatchObject({
-      id: fixture.installationId,
-      appId: fixture.appId,
-      botName: "Okou Feishu",
-      botAvatarUrl: "https://example.com/okou-feishu.png",
-      callbackUrl: fixture.callbackUrl,
-      callbackVerified: true,
-      setupCompleted: true,
-      isConnected: true,
-      tenantKey: TENANT_KEY,
-      defaultAgentId: fixture.defaultAgentId,
-    });
-    const connectorsAfter = await accept(
-      customConnectorClient.list({
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-    expect(connectorsAfter.body.connectors).toStrictEqual(
-      connectorsBefore.body.connectors,
-    );
+      const rejected = await accept(
+        client.setup({
+          headers: { authorization: "Bearer clerk-session" },
+          extraHeaders: { origin: "https://app.okou.ai" },
+          body: {
+            installationId: fixture.installationId,
+            appId: `cli_replacement_${randomUUID()}`,
+            appSecret: "replacement-app-secret",
+            verificationToken: "replacement-verification-token",
+            encryptKey: "replacement-encrypt-key",
+            defaultAgentId: fixture.alternateAgentId,
+          },
+        }),
+        [409],
+      );
+      expect(rejected.body.error.message).toContain(
+        "cannot be changed to a different App ID",
+      );
 
-    outboundMessages = [];
-    const oldProviderEvent = await postEvent(
-      fixture.callbackUrl,
-      directMessage(fixture.appId, "/help"),
-      { encrypted: true },
-    );
-    expect(oldProviderEvent.status).toBe(200);
-    await flushWaitUntilForTest();
-    expect(outboundMessages.map(messageContent).join("\n")).toContain(
-      "Okou Feishu commands",
-    );
-    await accept(
-      client.removeInstallation({
-        headers: { authorization: "Bearer clerk-session" },
-        params: { installationId: fixture.installationId },
-      }),
-      [200],
-    );
-  });
+      if (phase === "installation state") {
+        const status = await accept(
+          client.getStatus({
+            headers: { authorization: "Bearer clerk-session" },
+          }),
+          [200],
+        );
+        expect(status.body.installations?.[0]).toMatchObject({
+          id: fixture.installationId,
+          appId: fixture.appId,
+          botName: "Okou Feishu",
+          botAvatarUrl: "https://example.com/okou-feishu.png",
+          callbackUrl: fixture.callbackUrl,
+          callbackVerified: true,
+          setupCompleted: true,
+          isConnected: true,
+          tenantKey: TENANT_KEY,
+          defaultAgentId: fixture.defaultAgentId,
+        });
+        const connectorsAfter = await accept(
+          customConnectorClient.list({
+            headers: { authorization: "Bearer clerk-session" },
+          }),
+          [200],
+        );
+        expect(connectorsAfter.body.connectors).toStrictEqual(
+          connectorsBefore.body.connectors,
+        );
+      } else {
+        outboundMessages = [];
+        const oldProviderEvent = await postEvent(
+          fixture.callbackUrl,
+          directMessage(fixture.appId, "/help"),
+          { encrypted: true },
+        );
+        expect(oldProviderEvent.status).toBe(200);
+        await flushWaitUntilForTest();
+        expect(outboundMessages.map(messageContent).join("\n")).toContain(
+          "Okou Feishu commands",
+        );
+      }
+      await accept(
+        client.removeInstallation({
+          headers: { authorization: "Bearer clerk-session" },
+          params: { installationId: fixture.installationId },
+        }),
+        [200],
+      );
+    },
+  );
 
   it("rejects an in-place setup update that resolves to a different provider bot", async () => {
     const fixture = await setupFeishuRunFixture();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/projection-observations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/projection-observations.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from "node:crypto";
+import { expect } from "vitest";
+import type { TestContext } from "../../../../__tests__/test-context";
+import { mockEnv } from "../../../../lib/env";
+import {
+  API_TEST_CONNECTOR_FIREWALL_CONFIGS,
+  installApiTestConnectorCatalog,
+} from "../../../../test-fixtures/connector-catalog";
+import { createBddApi } from "./api-bdd";
+import { createFirewallApi } from "./api-bdd-firewall";
+import { createRunsApi } from "./api-bdd-runs";
+
+// Setup and every real dispatch remain inside the caller's test budget.
+export async function createProjectionObservationFixture(context: TestContext) {
+  const bdd = createBddApi(context);
+  const api = createRunsApi(context);
+  const actor = bdd.user();
+  const catalogVersion = `projection-observations-${randomUUID()}`;
+  mockEnv("R2_USER_STORAGES_BUCKET_NAME", `test-${randomUUID()}`);
+  await installApiTestConnectorCatalog({
+    catalogVersion,
+    runtimeProjection: true,
+  });
+  bdd.acceptAgentStorageWrites();
+  api.acceptStorageDownloads();
+  api.acceptTelemetryIngest();
+  api.configureRunnerGroup();
+  await api.grantProEntitlement(actor);
+  await api.ensureOrgModelProvider(actor);
+  const agent = await bdd.createAgent(actor, {
+    displayName: "Projection observation agent",
+    description: "Exercises process-local projection reuse observations.",
+    visibility: "private",
+  });
+  const accessToken = `projection-access-${randomUUID()}`;
+  await createFirewallApi(context).seedTestConnector(actor, {
+    connectorSlug: "x",
+    authMethod: "oauth",
+    accessToken,
+    refreshToken: "projection-refresh-token",
+  });
+  const otherConnectorSlugs = API_TEST_CONNECTOR_FIREWALL_CONFIGS.map(
+    (firewall) => {
+      return firewall.name;
+    },
+  )
+    .filter((slug) => {
+      return slug !== "x" && slug !== "nintendo-store";
+    })
+    .slice(0, 16);
+  expect(otherConnectorSlugs).toHaveLength(16);
+
+  const createObservedRun = async (
+    scope: number,
+    observation: string,
+    outcome = "miss",
+    normalize = false,
+  ) => {
+    const connectorSlugs =
+      scope === 0
+        ? ["x"]
+        : ["x", ...otherConnectorSlugs.slice(scope - 1, scope)];
+    await api.enableAgentConnectors(
+      actor,
+      agent.agentId,
+      normalize
+        ? [...connectorSlugs].reverse().concat(connectorSlugs)
+        : connectorSlugs,
+    );
+    const run = await api.createRun(actor, {
+      agentId: agent.agentId,
+      prompt: "Observe scoped projection reuse",
+      modelProvider: "anthropic-api-key",
+    });
+    const events = context.mocks.axiom.sdkIngest.mock.calls.flatMap(
+      ([dataset, entries]) => {
+        return dataset === "vm0-sandbox-op-log-dev" && Array.isArray(entries)
+          ? entries.filter(
+              (entry: unknown): entry is Record<string, unknown> => {
+                return (
+                  typeof entry === "object" &&
+                  entry !== null &&
+                  "run_id" in entry &&
+                  entry.run_id === run.runId
+                );
+              },
+            )
+          : [];
+      },
+    );
+    const loads = events.filter((event) => {
+      return (
+        event.op_type === "api_dispatch_connector_catalog_load_runtime_snapshot"
+      );
+    });
+    expect(loads).toHaveLength(1);
+    expect(loads[0]).toStrictEqual(
+      expect.objectContaining({
+        connector_catalog_projection_cache_outcome: outcome,
+        connector_catalog_runtime_selection_source: "projection",
+        connector_catalog_projection_cache_observation: observation,
+      }),
+    );
+    expect(
+      events.filter((event) => {
+        return (
+          event.op_type ===
+          "api_dispatch_connector_catalog_query_projection_identity"
+        );
+      }),
+    ).toHaveLength(1);
+    if (outcome === "hit") {
+      expect(
+        events.filter((event) => {
+          return (
+            event.op_type ===
+            "api_dispatch_connector_catalog_query_projection_rows"
+          );
+        }),
+      ).toHaveLength(0);
+    }
+    const serialized = JSON.stringify(loads);
+    for (const connectorSlug of connectorSlugs) {
+      expect(serialized).not.toContain(JSON.stringify(connectorSlug));
+    }
+    for (const privateValue of [
+      catalogVersion,
+      accessToken,
+      "projection-refresh-token",
+    ]) {
+      expect(serialized).not.toContain(privateValue);
+    }
+    await api.requestCancelRun(actor, run.runId, [200]);
+  };
+
+  return createObservedRun;
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -635,97 +635,110 @@ afterEach(async () => {
 });
 
 describe("Teams chat callbacks", () => {
-  it("claims Teams launch material from context", async () => {
-    const teams = await setupConnectedTeamsActor();
-    teamsApiMocks({ fixture: teams.fixture });
-    const firstActivityId = teamsFixtureExternalId(
-      teams.fixture,
-      "activity-queue-params-first",
-    );
-    const queuedActivityId = teamsFixtureExternalId(
-      teams.fixture,
-      "activity-queue-params-second",
-    );
-    const firstRunId = await dispatchTeamsPersonalRun({
-      fixture: teams.fixture,
-      activityId: firstActivityId,
-      text: "hold the Teams queue",
-    });
-    const firstClaim = await claimTeamsRun({
-      runnerGroup: teams.runnerGroup,
-      runId: firstRunId,
-    });
+  it.each(["stored context", "claimed launch material"] as const)(
+    "preserves queued Teams %s",
+    async (phase) => {
+      const teams = await setupConnectedTeamsActor();
+      teamsApiMocks({ fixture: teams.fixture });
+      const firstActivityId = teamsFixtureExternalId(
+        teams.fixture,
+        "activity-queue-params-first",
+      );
+      const queuedActivityId = teamsFixtureExternalId(
+        teams.fixture,
+        "activity-queue-params-second",
+      );
+      const firstRunId = await dispatchTeamsPersonalRun({
+        fixture: teams.fixture,
+        activityId: firstActivityId,
+        text: "hold the Teams queue",
+      });
+      const firstClaim = await claimTeamsRun({
+        runnerGroup: teams.runnerGroup,
+        runId: firstRunId,
+      });
 
-    const queuedPrompt = `claim Teams launch context ${teams.fixture.teamsTenantId}`;
-    await postTeamsPersonalMessage({
-      fixture: teams.fixture,
-      activityId: queuedActivityId,
-      text: queuedPrompt,
-    });
-    const queuedParams = await findPendingChatEventByPromptFixture({
-      userId: teams.actor.userId,
-      prompt: queuedPrompt,
-    });
-    expect(queuedParams).toMatchObject({
-      eventId: expect.any(String),
-    });
-    if (!queuedParams) {
-      throw new Error("Expected queued Teams event");
-    }
-    await expect(
-      readChatEventContextFixture(queuedParams.eventId),
-    ).resolves.toMatchObject({
-      contextType: "teams",
-      teamsTenantId: teams.fixture.teamsTenantId,
-      teamsTeamId: null,
-      teamsChannelId: null,
-      teamsConversationId: `a:personal-${teams.fixture.teamsUserId}`,
-      teamsConversationType: "personal",
-      teamsActivityId: queuedActivityId,
-      teamsThreadContext: "",
-      teamsMessageText: queuedPrompt,
-      teamsMessageFiles: [],
-      teamsTenantName: teams.fixture.teamsTenantName,
-      teamsTeamName: null,
-      teamsThreadId: `direct-message:${teams.defaultAgentId}:claude-sonnet-5`,
-      teamsServiceUrl: teams.fixture.serviceUrl,
-      teamsAppId: teams.fixture.teamsAppId,
-      teamsPublicBrand: "okou",
-      teamsSenderUserId: teams.fixture.teamsUserId,
-      teamsSenderDisplayName: "Ada Lovelace",
-      teamsSenderPrincipalName: teams.fixture.teamsUserPrincipalName,
-      teamsConnectionId: expect.any(String),
-    });
-    await completeSandboxRun({
-      runId: firstRunId,
-      sandboxToken: firstClaim.sandboxToken,
-      exitCode: 0,
-    });
-    const queuedRunId = await runIdForPrompt(teams.actor, queuedPrompt);
-    const queuedClaim = await claimTeamsRun({
-      runnerGroup: teams.runnerGroup,
-      runId: queuedRunId,
-    });
-    const queuedRun = (
-      await runsApi.listAgentRuns(teams.actor, { limit: 20 })
-    ).runs.find((run) => {
-      return run.id === queuedRunId;
-    });
-    expect(queuedClaim.prompt).toBe(queuedRun?.prompt);
-    expect(queuedClaim.appendSystemPrompt).toBe(queuedRun?.appendSystemPrompt);
-    expect(queuedClaim.appendSystemPrompt).toContain(
-      "You are currently running inside: Microsoft Teams",
-    );
-    expect(queuedClaim.appendSystemPrompt).toContain(
-      `Thread ID: ${queuedActivityId}`,
-    );
+      const queuedPrompt = `claim Teams launch context ${teams.fixture.teamsTenantId}`;
+      await postTeamsPersonalMessage({
+        fixture: teams.fixture,
+        activityId: queuedActivityId,
+        text: queuedPrompt,
+      });
+      const queuedParams = await findPendingChatEventByPromptFixture({
+        userId: teams.actor.userId,
+        prompt: queuedPrompt,
+      });
+      expect(queuedParams).toMatchObject({
+        eventId: expect.any(String),
+      });
+      if (!queuedParams) {
+        throw new Error("Expected queued Teams event");
+      }
 
-    await completeSandboxRun({
-      runId: queuedRunId,
-      sandboxToken: queuedClaim.sandboxToken,
-      exitCode: 0,
-    });
-  });
+      if (phase === "stored context") {
+        await expect(
+          readChatEventContextFixture(queuedParams.eventId),
+        ).resolves.toMatchObject({
+          contextType: "teams",
+          teamsTenantId: teams.fixture.teamsTenantId,
+          teamsTeamId: null,
+          teamsChannelId: null,
+          teamsConversationId: `a:personal-${teams.fixture.teamsUserId}`,
+          teamsConversationType: "personal",
+          teamsActivityId: queuedActivityId,
+          teamsThreadContext: "",
+          teamsMessageText: queuedPrompt,
+          teamsMessageFiles: [],
+          teamsTenantName: teams.fixture.teamsTenantName,
+          teamsTeamName: null,
+          teamsThreadId: `direct-message:${teams.defaultAgentId}:claude-sonnet-5`,
+          teamsServiceUrl: teams.fixture.serviceUrl,
+          teamsAppId: teams.fixture.teamsAppId,
+          teamsPublicBrand: "okou",
+          teamsSenderUserId: teams.fixture.teamsUserId,
+          teamsSenderDisplayName: "Ada Lovelace",
+          teamsSenderPrincipalName: teams.fixture.teamsUserPrincipalName,
+          teamsConnectionId: expect.any(String),
+        });
+      }
+      await completeSandboxRun({
+        runId: firstRunId,
+        sandboxToken: firstClaim.sandboxToken,
+        exitCode: 0,
+      });
+      const queuedRunId = await runIdForPrompt(teams.actor, queuedPrompt);
+
+      if (phase === "claimed launch material") {
+        const queuedClaim = await claimTeamsRun({
+          runnerGroup: teams.runnerGroup,
+          runId: queuedRunId,
+        });
+        const queuedRun = (
+          await runsApi.listAgentRuns(teams.actor, { limit: 20 })
+        ).runs.find((run) => {
+          return run.id === queuedRunId;
+        });
+        expect(queuedClaim.prompt).toBe(queuedRun?.prompt);
+        expect(queuedClaim.appendSystemPrompt).toBe(
+          queuedRun?.appendSystemPrompt,
+        );
+        expect(queuedClaim.appendSystemPrompt).toContain(
+          "You are currently running inside: Microsoft Teams",
+        );
+        expect(queuedClaim.appendSystemPrompt).toContain(
+          `Thread ID: ${queuedActivityId}`,
+        );
+
+        await completeSandboxRun({
+          runId: queuedRunId,
+          sandboxToken: queuedClaim.sandboxToken,
+          exitCode: 0,
+        });
+      } else {
+        await runsApi.requestCancelRun(teams.actor, queuedRunId, [200]);
+      }
+    },
+  );
 
   it("delivers queued Teams admission failures with launch material", async () => {
     const teams = await setupConnectedTeamsActor();
@@ -1016,7 +1029,12 @@ describe("Teams chat callbacks", () => {
     expect(returnToMainClaim.resumeSession?.sessionId).toBe(mainSessionId);
   });
 
-  it("posts completed run replies and persists canonical Teams thread sessions", async () => {
+  it.each([
+    "canonical input",
+    "completed delivery",
+    "participant reply",
+    "participant session",
+  ] as const)("preserves Teams %s", async (phase) => {
     setupTeamsConnectTestEnv("https://app.okou.ai");
     const teams = await setupConnectedTeamsActor({
       okouDebug: true,
@@ -1035,190 +1053,220 @@ describe("Teams chat callbacks", () => {
       threadId,
       text: "finish the task",
     });
-    mocks.clerk.session(teams.fixture.userId, teams.fixture.orgId, "org:admin");
-    const threadEvents = await accept(
-      setupApp({ context, routes: chatThreadRoutes })(
-        chatThreadsContract,
-      ).events({
-        headers: { authorization: "Bearer clerk-session" },
-        query: {},
-      }),
-      [200],
-    );
-    const createdThread = threadEvents.body.events.find((event) => {
-      return event.kind === "created";
-    });
-    if (!createdThread) {
-      throw new Error("Expected the canonical Teams chat thread");
-    }
-    const threadMessages = await readProjectedChatEvents(context, {
-      threadId: createdThread.chatThreadId,
-      headers: { authorization: "Bearer clerk-session" },
-    });
-    expect(threadMessages).toContainEqual(
-      expect.objectContaining({
-        eventType: "input.prompt",
-        content: null,
-        userMessage: {
-          version: 1,
-          parts: [
-            { type: "text", text: "@Zero finish the task" },
-            {
-              type: "source",
-              kind: "teams",
-              href:
-                "https://teams.microsoft.com/l/message/" +
-                `${encodeURIComponent(teams.fixture.teamsChannelId)}/${activityId}` +
-                `?tenantId=${encodeURIComponent(teams.fixture.teamsTenantId)}`,
-            },
-          ],
-        },
-      }),
-    );
-    const claim = await claimTeamsRun({
-      runnerGroup: teams.runnerGroup,
-      runId,
-    });
-    clearTeamsApiCalls(teamsApi);
 
-    await webhooksApi.requestAgentHeartbeat(
-      { runId },
-      { authorization: `Bearer ${claim.sandboxToken}` },
-      [200],
-    );
-    await flushWaitUntilForTest();
-    expect(teamsApi.tokenRequests).toHaveLength(0);
-    expect(teamsApi.postedActivities).toHaveLength(0);
-    expect(teamsApi.reactionRequests).toHaveLength(0);
-    clearTeamsApiCalls(teamsApi);
-
-    const cliAgentSessionId = await completeSandboxRun({
-      runId,
-      sandboxToken: claim.sandboxToken,
-      exitCode: 0,
-    });
-
-    expect(teamsApi.tokenRequests).toHaveLength(2);
-    expect(teamsApi.tokenRequests[0]?.get("client_id")).toBe(BOT_APP_ID);
-    expect(teamsApi.tokenRequests[0]?.get("client_secret")).toBe(
-      BOT_APP_PASSWORD,
-    );
-    expect(teamsApi.postedActivities).toHaveLength(1);
-    expect(teamsApi.postedActivities[0]).toMatchObject({
-      type: "message",
-      textFormat: "markdown",
-      replyToId: activityId,
-      channelData: {
-        tenant: { id: teams.fixture.teamsTenantId },
-      },
-    });
-    expect(teamsApi.postedActivities[0]?.text).toContain(
-      "Task completed successfully.",
-    );
-    expect(teamsApi.postedActivities[0]?.text).toContain(
-      `[Audit](https://app.okou.ai/activities/${runId})`,
-    );
-    expect(teamsApi.postedActivities[0]?.text).not.toContain("Reply to");
-    expect(teamsApi.reactionRequests).toStrictEqual([
-      {
-        method: "DELETE",
-        conversationId: teams.fixture.teamsConversationId,
-        activityId,
-        reactionType: "1f4ad_thoughtballoon",
-      },
-    ]);
-    const completedThreadMessages = await readProjectedChatEvents(context, {
-      threadId: createdThread.chatThreadId,
-      headers: { authorization: "Bearer clerk-session" },
-    });
-    expect(completedThreadMessages).toContainEqual(
-      expect.objectContaining({
-        eventType: "output.message",
-        content: "Task completed successfully.",
-      }),
-    );
-    const summaryRequestValue = summaryRequests.find((request) => {
-      const serialized = JSON.stringify(request);
-      return serialized.includes("finish the task");
-    });
-    const summaryRequest = recordFromUnknown(
-      summaryRequestValue,
-      "Expected Teams run summary request",
-    );
-    expect(JSON.stringify(summaryRequest.messages)).toContain(
-      "finish the task",
-    );
-    const firstRunOpenRouterRequestCount = summaryRequests.length;
-
-    const secondFixture = await trackTeamsFixture(
-      Promise.resolve(
-        teamsConnectFixture({
-          orgId: teams.fixture.orgId,
-          teamsTenantId: teams.fixture.teamsTenantId,
-          teamsTenantName: teams.fixture.teamsTenantName,
-          teamsTeamId: teams.fixture.teamsTeamId,
-          teamsTeamAadGroupId: teams.fixture.teamsTeamAadGroupId,
-          teamsTeamName: teams.fixture.teamsTeamName,
-          teamsChannelId: teams.fixture.teamsChannelId,
-          teamsConversationId: teams.fixture.teamsConversationId,
-          teamsThreadId: threadId,
-          teamsAppId: teams.fixture.teamsAppId,
-          teamsBotId: teams.fixture.teamsBotId,
-          serviceUrl: teams.fixture.serviceUrl,
+    if (phase === "canonical input" || phase === "completed delivery") {
+      mocks.clerk.session(
+        teams.fixture.userId,
+        teams.fixture.orgId,
+        "org:admin",
+      );
+      const threadEvents = await accept(
+        setupApp({ context, routes: chatThreadRoutes })(
+          chatThreadsContract,
+        ).events({
+          headers: { authorization: "Bearer clerk-session" },
+          query: {},
         }),
-      ),
-    );
-    authOrgApi.user({
-      userId: secondFixture.userId,
-      orgId: secondFixture.orgId,
-      orgRole: "org:admin",
-    });
-    const tokenRequestCountBeforeConnect = teamsApi.tokenRequests.length;
-    const postedActivityCountBeforeConnect = teamsApi.postedActivities.length;
-    const secondPrincipalName = secondFixture.teamsUserPrincipalName;
-    await connectTeamsFixture(secondFixture, {
-      displayName: "Grace Hopper",
-      principalName: secondPrincipalName,
-    });
-    await flushWaitUntilForTest();
-    teamsApi.tokenRequests.splice(tokenRequestCountBeforeConnect);
-    teamsApi.postedActivities.splice(postedActivityCountBeforeConnect);
-    const secondRunId = await dispatchTeamsRun({
-      fixture: secondFixture,
-      activityId: teamsFixtureExternalId(secondFixture, "activity-completed-2"),
-      threadId,
-      text: "finish the follow-up",
-      senderName: "Grace Hopper",
-      senderPrincipalName: secondPrincipalName,
-    });
-    const secondClaim = await claimTeamsRun({
-      runnerGroup: teams.runnerGroup,
-      runId: secondRunId,
-    });
-    dropLastTeamsIndicatorRequest(teamsApi);
-    await completeSandboxRun({
-      runId: secondRunId,
-      sandboxToken: secondClaim.sandboxToken,
-      exitCode: 0,
-    });
-    expect(teamsApi.postedActivities).toHaveLength(2);
-    expect(teamsApi.postedActivities[1]?.text).toContain(
-      "Reply to Grace Hopper",
-    );
-    expect(summaryRequests.length).toBeGreaterThan(
-      firstRunOpenRouterRequestCount,
-    );
+        [200],
+      );
+      const createdThread = threadEvents.body.events.find((event) => {
+        return event.kind === "created";
+      });
+      if (!createdThread) {
+        throw new Error("Expected the canonical Teams chat thread");
+      }
+      const threadMessages = await readProjectedChatEvents(context, {
+        threadId: createdThread.chatThreadId,
+        headers: { authorization: "Bearer clerk-session" },
+      });
+      expect(threadMessages).toContainEqual(
+        expect.objectContaining({
+          eventType: "input.prompt",
+          content: null,
+          userMessage: {
+            version: 1,
+            parts: [
+              { type: "text", text: "@Zero finish the task" },
+              {
+                type: "source",
+                kind: "teams",
+                href:
+                  "https://teams.microsoft.com/l/message/" +
+                  `${encodeURIComponent(teams.fixture.teamsChannelId)}/${activityId}` +
+                  `?tenantId=${encodeURIComponent(teams.fixture.teamsTenantId)}`,
+              },
+            ],
+          },
+        }),
+      );
 
-    const followUpClaim = await claimFollowUpInThread({
-      fixture: teams.fixture,
-      runnerGroup: teams.runnerGroup,
-      threadId,
-      activityId: teamsFixtureExternalId(
-        teams.fixture,
-        "activity-completed-follow-up",
-      ),
-    });
-    expect(followUpClaim.resumeSession?.sessionId).toBe(cliAgentSessionId);
+      if (phase === "canonical input") {
+        await runsApi.requestCancelRun(teams.actor, runId, [200]);
+      } else {
+        const claim = await claimTeamsRun({
+          runnerGroup: teams.runnerGroup,
+          runId,
+        });
+        clearTeamsApiCalls(teamsApi);
+
+        await webhooksApi.requestAgentHeartbeat(
+          { runId },
+          { authorization: `Bearer ${claim.sandboxToken}` },
+          [200],
+        );
+        await flushWaitUntilForTest();
+        expect(teamsApi.tokenRequests).toHaveLength(0);
+        expect(teamsApi.postedActivities).toHaveLength(0);
+        expect(teamsApi.reactionRequests).toHaveLength(0);
+        clearTeamsApiCalls(teamsApi);
+
+        await completeSandboxRun({
+          runId,
+          sandboxToken: claim.sandboxToken,
+          exitCode: 0,
+        });
+
+        expect(teamsApi.tokenRequests).toHaveLength(2);
+        expect(teamsApi.tokenRequests[0]?.get("client_id")).toBe(BOT_APP_ID);
+        expect(teamsApi.tokenRequests[0]?.get("client_secret")).toBe(
+          BOT_APP_PASSWORD,
+        );
+        expect(teamsApi.postedActivities).toHaveLength(1);
+        expect(teamsApi.postedActivities[0]).toMatchObject({
+          type: "message",
+          textFormat: "markdown",
+          replyToId: activityId,
+          channelData: {
+            tenant: { id: teams.fixture.teamsTenantId },
+          },
+        });
+        expect(teamsApi.postedActivities[0]?.text).toContain(
+          "Task completed successfully.",
+        );
+        expect(teamsApi.postedActivities[0]?.text).toContain(
+          `[Audit](https://app.okou.ai/activities/${runId})`,
+        );
+        expect(teamsApi.postedActivities[0]?.text).not.toContain("Reply to");
+        expect(teamsApi.reactionRequests).toStrictEqual([
+          {
+            method: "DELETE",
+            conversationId: teams.fixture.teamsConversationId,
+            activityId,
+            reactionType: "1f4ad_thoughtballoon",
+          },
+        ]);
+        const completedThreadMessages = await readProjectedChatEvents(context, {
+          threadId: createdThread.chatThreadId,
+          headers: { authorization: "Bearer clerk-session" },
+        });
+        expect(completedThreadMessages).toContainEqual(
+          expect.objectContaining({
+            eventType: "output.message",
+            content: "Task completed successfully.",
+          }),
+        );
+        const summaryRequestValue = summaryRequests.find((request) => {
+          const serialized = JSON.stringify(request);
+          return serialized.includes("finish the task");
+        });
+        const summaryRequest = recordFromUnknown(
+          summaryRequestValue,
+          "Expected Teams run summary request",
+        );
+        expect(JSON.stringify(summaryRequest.messages)).toContain(
+          "finish the task",
+        );
+      }
+    } else {
+      const claim = await claimTeamsRun({
+        runnerGroup: teams.runnerGroup,
+        runId,
+      });
+      clearTeamsApiCalls(teamsApi);
+
+      const cliAgentSessionId = await completeSandboxRun({
+        runId,
+        sandboxToken: claim.sandboxToken,
+        exitCode: 0,
+      });
+
+      const firstRunOpenRouterRequestCount = summaryRequests.length;
+
+      const secondFixture = await trackTeamsFixture(
+        Promise.resolve(
+          teamsConnectFixture({
+            orgId: teams.fixture.orgId,
+            teamsTenantId: teams.fixture.teamsTenantId,
+            teamsTenantName: teams.fixture.teamsTenantName,
+            teamsTeamId: teams.fixture.teamsTeamId,
+            teamsTeamAadGroupId: teams.fixture.teamsTeamAadGroupId,
+            teamsTeamName: teams.fixture.teamsTeamName,
+            teamsChannelId: teams.fixture.teamsChannelId,
+            teamsConversationId: teams.fixture.teamsConversationId,
+            teamsThreadId: threadId,
+            teamsAppId: teams.fixture.teamsAppId,
+            teamsBotId: teams.fixture.teamsBotId,
+            serviceUrl: teams.fixture.serviceUrl,
+          }),
+        ),
+      );
+      authOrgApi.user({
+        userId: secondFixture.userId,
+        orgId: secondFixture.orgId,
+        orgRole: "org:admin",
+      });
+      const tokenRequestCountBeforeConnect = teamsApi.tokenRequests.length;
+      const postedActivityCountBeforeConnect = teamsApi.postedActivities.length;
+      const secondPrincipalName = secondFixture.teamsUserPrincipalName;
+      await connectTeamsFixture(secondFixture, {
+        displayName: "Grace Hopper",
+        principalName: secondPrincipalName,
+      });
+      await flushWaitUntilForTest();
+      teamsApi.tokenRequests.splice(tokenRequestCountBeforeConnect);
+      teamsApi.postedActivities.splice(postedActivityCountBeforeConnect);
+      const secondRunId = await dispatchTeamsRun({
+        fixture: secondFixture,
+        activityId: teamsFixtureExternalId(
+          secondFixture,
+          "activity-completed-2",
+        ),
+        threadId,
+        text: "finish the follow-up",
+        senderName: "Grace Hopper",
+        senderPrincipalName: secondPrincipalName,
+      });
+      const secondClaim = await claimTeamsRun({
+        runnerGroup: teams.runnerGroup,
+        runId: secondRunId,
+      });
+      dropLastTeamsIndicatorRequest(teamsApi);
+      await completeSandboxRun({
+        runId: secondRunId,
+        sandboxToken: secondClaim.sandboxToken,
+        exitCode: 0,
+      });
+      expect(teamsApi.postedActivities).toHaveLength(2);
+      expect(teamsApi.postedActivities[1]?.text).toContain(
+        "Reply to Grace Hopper",
+      );
+      expect(summaryRequests.length).toBeGreaterThan(
+        firstRunOpenRouterRequestCount,
+      );
+
+      if (phase === "participant session") {
+        const followUpClaim = await claimFollowUpInThread({
+          fixture: teams.fixture,
+          runnerGroup: teams.runnerGroup,
+          threadId,
+          activityId: teamsFixtureExternalId(
+            teams.fixture,
+            "activity-completed-follow-up",
+          ),
+        });
+        expect(followUpClaim.resumeSession?.sessionId).toBe(cliAgentSessionId);
+      }
+    }
   });
 
   it("posts readable failed run replies without persisting a thread session", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -4342,7 +4342,12 @@ describe.sequential("Official Workflow installations", () => {
     ).resolves.toStrictEqual(beforeRunFamily);
   });
 
-  it("rejects installation release races without churning unchanged reconfiguration Blueprints", async () => {
+  it.each([
+    "installation release",
+    "instruction release",
+    "concurrent pause",
+    "persisted reconciliation",
+  ] as const)("preserves workflow identity during %s races", async (phase) => {
     installCatalogStorageFixture();
     const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
     const definitionName = `api-test-race-${suffix}`;
@@ -4426,281 +4431,313 @@ describe.sequential("Official Workflow installations", () => {
       ],
     };
 
-    const installing = accept(
-      officialClient().install({
-        headers,
-        params: { definitionName },
-        body: installBody,
-      }),
-      [409],
-    );
-    await watchStarted.promise;
-    const installingWorkspaceAutomations = await accept(
-      automationClient().listWorkspace({ headers }),
-      [200],
-    );
-    expect(
-      installingWorkspaceAutomations.body.some((entry) => {
-        return entry.workflow.name === definitionName;
-      }),
-    ).toBeFalsy();
-    await syncCatalog(
-      catalog([
-        activeDefinition(
-          definitionName,
-          [blueprint],
-          "Accepted Definition revision two.",
-        ),
-      ]),
-    );
-    releaseWatch.resolve(undefined);
-    const installConflict = await installing;
-    expect(installConflict.body.error.message).toBe(
-      "Official Workflow changed during installation; retry",
-    );
-    const afterInstallConflict = await accept(
-      workflowCollectionClient().list({
-        headers,
-        query: { agentId },
-      }),
-      [200],
-    );
-    expect(
-      afterInstallConflict.body.some((workflow) => {
-        return workflow.name === definitionName;
-      }),
-    ).toBeFalsy();
-    expect(stopCalls).toBeGreaterThan(0);
+    if (phase === "installation release") {
+      const installing = accept(
+        officialClient().install({
+          headers,
+          params: { definitionName },
+          body: installBody,
+        }),
+        [409],
+      );
+      await watchStarted.promise;
+      const installingWorkspaceAutomations = await accept(
+        automationClient().listWorkspace({ headers }),
+        [200],
+      );
+      expect(
+        installingWorkspaceAutomations.body.some((entry) => {
+          return entry.workflow.name === definitionName;
+        }),
+      ).toBeFalsy();
+      await syncCatalog(
+        catalog([
+          activeDefinition(
+            definitionName,
+            [blueprint],
+            "Accepted Definition revision two.",
+          ),
+        ]),
+      );
+      releaseWatch.resolve(undefined);
+      const installConflict = await installing;
+      expect(installConflict.body.error.message).toBe(
+        "Official Workflow changed during installation; retry",
+      );
+      const afterInstallConflict = await accept(
+        workflowCollectionClient().list({
+          headers,
+          query: { agentId },
+        }),
+        [200],
+      );
+      expect(
+        afterInstallConflict.body.some((workflow) => {
+          return workflow.name === definitionName;
+        }),
+      ).toBeFalsy();
+      expect(stopCalls).toBeGreaterThan(0);
+    } else {
+      blockNextWatch = false;
+      const installed = await accept(
+        officialClient().install({
+          headers,
+          params: { definitionName },
+          body:
+            phase === "concurrent pause"
+              ? {
+                  ...installBody,
+                  blueprints: [
+                    {
+                      blueprintKey: "gmail-label-trigger",
+                      bindings: [{ key: "label-name", value: "Follow Up" }],
+                    },
+                  ],
+                }
+              : installBody,
+        }),
+        [201],
+      );
+      const installedAutomation = installed.body.workflow.automations[0];
+      if (!installedAutomation) {
+        throw new Error("Expected Official Gmail automation");
+      }
 
-    const installed = await accept(
-      officialClient().install({
-        headers,
-        params: { definitionName },
-        body: installBody,
-      }),
-      [201],
-    );
-    const installedAutomation = installed.body.workflow.automations[0];
-    if (!installedAutomation) {
-      throw new Error("Expected Official Gmail automation");
-    }
-
-    blockNextLabelLookup = true;
-    const reconfiguring = accept(
-      installationClient().reconfigure({
-        headers,
-        params: { workflowId: installed.body.workflow.id },
-        body: {
-          blueprints: [
-            {
-              blueprintKey: "gmail-label-trigger",
-              bindings: [{ key: "label-name", value: "Follow Up" }],
+      if (phase === "instruction release") {
+        blockNextLabelLookup = true;
+        const reconfiguring = accept(
+          installationClient().reconfigure({
+            headers,
+            params: { workflowId: installed.body.workflow.id },
+            body: {
+              blueprints: [
+                {
+                  blueprintKey: "gmail-label-trigger",
+                  bindings: [{ key: "label-name", value: "Follow Up" }],
+                },
+              ],
             },
-          ],
-        },
-      }),
-      [200],
-    );
-    await labelLookupStarted.promise;
-    await syncCatalog(
-      catalog([
-        activeDefinition(
-          definitionName,
-          [blueprint],
-          "Accepted Definition revision three.",
-        ),
-      ]),
-    );
-    releaseLabelLookup.resolve(undefined);
-    const reconfiguredAcrossInstructionRelease = await reconfiguring;
-    expect(
-      reconfiguredAcrossInstructionRelease.body.workflow.automations[0],
-    ).toMatchObject({
-      id: installedAutomation.id,
-      official: {
-        reconciliationStatus: "current",
-        parameterBindings: [{ key: "label-name", value: "Follow Up" }],
-      },
-    });
-    const unchanged = await accept(
-      installationClient().get({
-        headers,
-        params: { workflowId: installed.body.workflow.id },
-      }),
-      [200],
-    );
-    expect(unchanged.body.workflow.instruction).toBe(
-      "Accepted Definition revision three.",
-    );
-    expect(unchanged.body.workflow.automations[0]?.official).toMatchObject({
-      reconciliationStatus: "current",
-      parameterBindings: [{ key: "label-name", value: "Follow Up" }],
-    });
-
-    const reconfigured = await accept(
-      installationClient().reconfigure({
-        headers,
-        params: { workflowId: installed.body.workflow.id },
-        body: {
-          blueprints: [
-            {
-              blueprintKey: "gmail-label-trigger",
-              bindings: [{ key: "label-name", value: "Follow Up" }],
-            },
-          ],
-        },
-      }),
-      [200],
-    );
-    expect(reconfigured.body.workflow.automations[0]).toMatchObject({
-      id: installedAutomation.id,
-      chatThreadId: installedAutomation.chatThreadId,
-      official: {
-        reconciliationStatus: "current",
-        parameterBindings: [{ key: "label-name", value: "Follow Up" }],
-      },
-    });
-
-    const concurrentLookupStarted = createDeferredPromise<void>(context.signal);
-    const releaseConcurrentLookup = createDeferredPromise<void>(context.signal);
-    let blockConcurrentLookup = true;
-    server.use(
-      http.get(
-        "https://gmail.googleapis.com/gmail/v1/users/me/labels",
-        async () => {
-          if (blockConcurrentLookup) {
-            blockConcurrentLookup = false;
-            concurrentLookupStarted.resolve(undefined);
-            await releaseConcurrentLookup.promise;
-          }
-          return HttpResponse.json({
-            labels: [
-              { id: "Label_important", name: "Important" },
-              { id: "Label_follow_up", name: "Follow Up" },
-            ],
-          });
-        },
-      ),
-    );
-    const concurrentReconfiguration = accept(
-      installationClient().reconfigure({
-        headers,
-        params: { workflowId: installed.body.workflow.id },
-        body: {
-          blueprints: [
-            {
-              blueprintKey: "gmail-label-trigger",
-              bindings: [{ key: "label-name", value: "Important" }],
-            },
-          ],
-        },
-      }),
-      [200],
-    );
-    await concurrentLookupStarted.promise;
-    await accept(
-      automationClient().disable({
-        headers,
-        params: { id: installedAutomation.id },
-      }),
-      [200],
-    );
-    releaseConcurrentLookup.resolve(undefined);
-    const reconfiguredAfterPause = await concurrentReconfiguration;
-    expect(reconfiguredAfterPause.body.workflow.automations[0]).toMatchObject({
-      id: installedAutomation.id,
-      enabled: false,
-      official: {
-        intendedEnabled: false,
-        reconciliationStatus: "current",
-        parameterBindings: [{ key: "label-name", value: "Important" }],
-      },
-    });
-
-    let expiringWatchCalls = 0;
-    server.use(
-      http.post("https://gmail.googleapis.com/gmail/v1/users/me/watch", () => {
-        expiringWatchCalls++;
-        return HttpResponse.json({
-          historyId: "101",
-          expiration: String(now() + 60_000),
+          }),
+          [200],
+        );
+        await labelLookupStarted.promise;
+        await syncCatalog(
+          catalog([
+            activeDefinition(
+              definitionName,
+              [blueprint],
+              "Accepted Definition revision three.",
+            ),
+          ]),
+        );
+        releaseLabelLookup.resolve(undefined);
+        const reconfiguredAcrossInstructionRelease = await reconfiguring;
+        expect(
+          reconfiguredAcrossInstructionRelease.body.workflow.automations[0],
+        ).toMatchObject({
+          id: installedAutomation.id,
+          official: {
+            reconciliationStatus: "current",
+            parameterBindings: [{ key: "label-name", value: "Follow Up" }],
+          },
         });
-      }),
-    );
-    await accept(
-      automationClient().enable({
-        headers,
-        params: { id: installedAutomation.id },
-      }),
-      [200],
-    );
-    expect(expiringWatchCalls).toBe(1);
+        const unchanged = await accept(
+          installationClient().get({
+            headers,
+            params: { workflowId: installed.body.workflow.id },
+          }),
+          [200],
+        );
+        expect(unchanged.body.workflow.instruction).toBe(
+          "Accepted Definition revision three.",
+        );
+        expect(unchanged.body.workflow.automations[0]?.official).toMatchObject({
+          reconciliationStatus: "current",
+          parameterBindings: [{ key: "label-name", value: "Follow Up" }],
+        });
 
-    const reconciliationWatchStarted = createDeferredPromise<void>(
-      context.signal,
-    );
-    const releaseReconciliationWatch = createDeferredPromise<void>(
-      context.signal,
-    );
-    server.use(
-      http.post(
-        "https://gmail.googleapis.com/gmail/v1/users/me/watch",
-        async () => {
-          reconciliationWatchStarted.resolve(undefined);
-          await releaseReconciliationWatch.promise;
-          return HttpResponse.json({
-            historyId: "102",
-            expiration: "4102444800000",
-          });
-        },
-      ),
-    );
-    const persistedReconfiguration = accept(
-      installationClient().reconfigure({
-        headers,
-        params: { workflowId: installed.body.workflow.id },
-        body: {
-          blueprints: [
-            {
-              blueprintKey: "gmail-label-trigger",
-              bindings: [{ key: "label-name", value: "Follow Up" }],
+        const reconfigured = await accept(
+          installationClient().reconfigure({
+            headers,
+            params: { workflowId: installed.body.workflow.id },
+            body: {
+              blueprints: [
+                {
+                  blueprintKey: "gmail-label-trigger",
+                  bindings: [{ key: "label-name", value: "Follow Up" }],
+                },
+              ],
             },
-          ],
-        },
-      }),
-      [200],
-    );
-    await reconciliationWatchStarted.promise;
-    const disableDuringReconciliation = await accept(
-      automationClient().disable({
-        headers,
-        params: { id: installedAutomation.id },
-      }),
-      [409],
-    );
-    expect(disableDuringReconciliation.body.error.message).toBe(
-      "Official Workflow reconfiguration is in progress; retry shortly",
-    );
-    releaseReconciliationWatch.resolve(undefined);
-    const reconfiguredAfterConflict = await persistedReconfiguration;
-    expect(
-      reconfiguredAfterConflict.body.workflow.automations[0],
-    ).toMatchObject({
-      id: installedAutomation.id,
-      enabled: true,
-      official: {
-        intendedEnabled: true,
-        reconciliationStatus: "current",
-        parameterBindings: [{ key: "label-name", value: "Follow Up" }],
-      },
-    });
-    await accept(
-      installationClient().uninstall({
-        headers,
-        params: { workflowId: installed.body.workflow.id },
-      }),
-      [204],
-    );
+          }),
+          [200],
+        );
+        expect(reconfigured.body.workflow.automations[0]).toMatchObject({
+          id: installedAutomation.id,
+          chatThreadId: installedAutomation.chatThreadId,
+          official: {
+            reconciliationStatus: "current",
+            parameterBindings: [{ key: "label-name", value: "Follow Up" }],
+          },
+        });
+      } else if (phase === "concurrent pause") {
+        const concurrentLookupStarted = createDeferredPromise<void>(
+          context.signal,
+        );
+        const releaseConcurrentLookup = createDeferredPromise<void>(
+          context.signal,
+        );
+        let blockConcurrentLookup = true;
+        server.use(
+          http.get(
+            "https://gmail.googleapis.com/gmail/v1/users/me/labels",
+            async () => {
+              if (blockConcurrentLookup) {
+                blockConcurrentLookup = false;
+                concurrentLookupStarted.resolve(undefined);
+                await releaseConcurrentLookup.promise;
+              }
+              return HttpResponse.json({
+                labels: [
+                  { id: "Label_important", name: "Important" },
+                  { id: "Label_follow_up", name: "Follow Up" },
+                ],
+              });
+            },
+          ),
+        );
+        const concurrentReconfiguration = accept(
+          installationClient().reconfigure({
+            headers,
+            params: { workflowId: installed.body.workflow.id },
+            body: {
+              blueprints: [
+                {
+                  blueprintKey: "gmail-label-trigger",
+                  bindings: [{ key: "label-name", value: "Important" }],
+                },
+              ],
+            },
+          }),
+          [200],
+        );
+        await concurrentLookupStarted.promise;
+        await accept(
+          automationClient().disable({
+            headers,
+            params: { id: installedAutomation.id },
+          }),
+          [200],
+        );
+        releaseConcurrentLookup.resolve(undefined);
+        const reconfiguredAfterPause = await concurrentReconfiguration;
+        expect(
+          reconfiguredAfterPause.body.workflow.automations[0],
+        ).toMatchObject({
+          id: installedAutomation.id,
+          enabled: false,
+          official: {
+            intendedEnabled: false,
+            reconciliationStatus: "current",
+            parameterBindings: [{ key: "label-name", value: "Important" }],
+          },
+        });
+      } else {
+        await accept(
+          automationClient().disable({
+            headers,
+            params: { id: installedAutomation.id },
+          }),
+          [200],
+        );
+        let expiringWatchCalls = 0;
+        server.use(
+          http.post(
+            "https://gmail.googleapis.com/gmail/v1/users/me/watch",
+            () => {
+              expiringWatchCalls++;
+              return HttpResponse.json({
+                historyId: "101",
+                expiration: String(now() + 60_000),
+              });
+            },
+          ),
+        );
+        await accept(
+          automationClient().enable({
+            headers,
+            params: { id: installedAutomation.id },
+          }),
+          [200],
+        );
+        expect(expiringWatchCalls).toBe(1);
+
+        const reconciliationWatchStarted = createDeferredPromise<void>(
+          context.signal,
+        );
+        const releaseReconciliationWatch = createDeferredPromise<void>(
+          context.signal,
+        );
+        server.use(
+          http.post(
+            "https://gmail.googleapis.com/gmail/v1/users/me/watch",
+            async () => {
+              reconciliationWatchStarted.resolve(undefined);
+              await releaseReconciliationWatch.promise;
+              return HttpResponse.json({
+                historyId: "102",
+                expiration: "4102444800000",
+              });
+            },
+          ),
+        );
+        const persistedReconfiguration = accept(
+          installationClient().reconfigure({
+            headers,
+            params: { workflowId: installed.body.workflow.id },
+            body: {
+              blueprints: [
+                {
+                  blueprintKey: "gmail-label-trigger",
+                  bindings: [{ key: "label-name", value: "Follow Up" }],
+                },
+              ],
+            },
+          }),
+          [200],
+        );
+        await reconciliationWatchStarted.promise;
+        const disableDuringReconciliation = await accept(
+          automationClient().disable({
+            headers,
+            params: { id: installedAutomation.id },
+          }),
+          [409],
+        );
+        expect(disableDuringReconciliation.body.error.message).toBe(
+          "Official Workflow reconfiguration is in progress; retry shortly",
+        );
+        releaseReconciliationWatch.resolve(undefined);
+        const reconfiguredAfterConflict = await persistedReconfiguration;
+        expect(
+          reconfiguredAfterConflict.body.workflow.automations[0],
+        ).toMatchObject({
+          id: installedAutomation.id,
+          enabled: true,
+          official: {
+            intendedEnabled: true,
+            reconciliationStatus: "current",
+            parameterBindings: [{ key: "label-name", value: "Follow Up" }],
+          },
+        });
+      }
+      await accept(
+        installationClient().uninstall({
+          headers,
+          params: { workflowId: installed.body.workflow.id },
+        }),
+        [204],
+      );
+    }
   });
 
   it("compensates a later provider-watch failure and retries without a visible partial installation", async () => {
@@ -5745,336 +5782,358 @@ describe.sequential("Official Workflow installations", () => {
     ).resolves.toMatchObject({ autonomyBudget: 8, enabled: true });
   });
 
-  it("repairs a committed dormant materialization gap after lease expiry without duplicating identity, watch, or history", async () => {
-    installCatalogStorageFixture();
-    const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
-    const definitionName = `api-test-materialize-${suffix}`;
-    await syncCatalog(
-      catalog([activeDefinition(definitionName, [gmailBlueprint()])]),
-    );
-    const setup = await workflowBdd.setupWorkflowOrg();
-    const { actor } = setup;
-    const { agentId } = await workflowBdd.createAgent(actor);
-    onTestFinished(async () => {
+  it.each([
+    "dormant materialization",
+    "current lifecycle gap",
+    "discarded materialization",
+  ] as const)(
+    "repairs %s without duplicating identity, watch, or history",
+    async (phase) => {
       installCatalogStorageFixture();
-      const createdRuns = await runs.listAgentRuns(actor, {
-        agent: agentId,
-        limit: 100,
-      });
-      for (const run of createdRuns.runs) {
-        await runs.requestCancelRun(actor, run.id, [200, 400]);
-      }
-      await flushWaitUntilForTest();
-      await bdd.deleteAgent(actor, agentId);
-      await cleanupCatalog();
-    });
-    mockGmailConnectorOAuth({ email: `materialize-${suffix}@example.test` });
-    await workflowBdd.connectConnector(actor, "gmail");
-    mockOptionalEnv("GMAIL_PUBSUB_TOPIC_NAME", GMAIL_TOPIC_NAME);
-    let watchCalls = 0;
-    let stopCalls = 0;
-    server.use(
-      http.post("https://gmail.googleapis.com/gmail/v1/users/me/watch", () => {
-        watchCalls++;
-        return HttpResponse.json({
-          historyId: String(100 + watchCalls),
-          expiration: "4102444800000",
+      const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
+      const definitionName = `api-test-materialize-${suffix}`;
+      await syncCatalog(
+        catalog([activeDefinition(definitionName, [gmailBlueprint()])]),
+      );
+      const setup = await workflowBdd.setupWorkflowOrg();
+      const { actor } = setup;
+      const { agentId } = await workflowBdd.createAgent(actor);
+      onTestFinished(async () => {
+        installCatalogStorageFixture();
+        const createdRuns = await runs.listAgentRuns(actor, {
+          agent: agentId,
+          limit: 100,
         });
-      }),
-      http.post("https://gmail.googleapis.com/gmail/v1/users/me/stop", () => {
-        stopCalls++;
-        return new HttpResponse(null, { status: 204 });
-      }),
-    );
-    await setOfficialWorkflowsEnabled(actor, true);
-    const headers = authHeaders(actor);
-    const installed = await accept(
-      officialClient().install({
-        headers,
-        params: { definitionName },
-        body: {
-          agentId,
-          blueprints: [{ blueprintKey: "gmail-trigger", bindings: [] }],
+        for (const run of createdRuns.runs) {
+          await runs.requestCancelRun(actor, run.id, [200, 400]);
+        }
+        await flushWaitUntilForTest();
+        await bdd.deleteAgent(actor, agentId);
+        await cleanupCatalog();
+      });
+      mockGmailConnectorOAuth({ email: `materialize-${suffix}@example.test` });
+      await workflowBdd.connectConnector(actor, "gmail");
+      mockOptionalEnv("GMAIL_PUBSUB_TOPIC_NAME", GMAIL_TOPIC_NAME);
+      let watchCalls = 0;
+      let stopCalls = 0;
+      server.use(
+        http.post(
+          "https://gmail.googleapis.com/gmail/v1/users/me/watch",
+          () => {
+            watchCalls++;
+            return HttpResponse.json({
+              historyId: String(100 + watchCalls),
+              expiration: "4102444800000",
+            });
+          },
+        ),
+        http.post("https://gmail.googleapis.com/gmail/v1/users/me/stop", () => {
+          stopCalls++;
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+      await setOfficialWorkflowsEnabled(actor, true);
+      const headers = authHeaders(actor);
+      const installed = await accept(
+        officialClient().install({
+          headers,
+          params: { definitionName },
+          body: {
+            agentId,
+            blueprints: [{ blueprintKey: "gmail-trigger", bindings: [] }],
+          },
+        }),
+        [201],
+      );
+      const workflowId = installed.body.workflow.id;
+      const automation = installed.body.workflow.automations[0];
+      if (!automation) {
+        throw new Error("Expected Official Gmail Automation");
+      }
+      expect(automation).toMatchObject({
+        enabled: true,
+        official: {
+          intendedEnabled: true,
+          reconciliationStatus: "current",
         },
-      }),
-      [201],
-    );
-    const workflowId = installed.body.workflow.id;
-    const automation = installed.body.workflow.automations[0];
-    if (!automation) {
-      throw new Error("Expected Official Gmail Automation");
-    }
-    expect(automation).toMatchObject({
-      enabled: true,
-      official: {
-        intendedEnabled: true,
-        reconciliationStatus: "current",
-      },
-    });
+      });
 
-    runs.configureRunnerGroup();
-    runs.acceptStorageDownloads();
-    const historical = await accept(
-      automationClient().run({
-        headers,
-        params: { id: automation.id },
-      }),
-      [201],
-    );
-    if (!historical.body.runId) {
-      throw new Error("Expected historical Official Automation Run");
-    }
-    await runs.requestCancelRun(actor, historical.body.runId, [200, 400]);
+      runs.configureRunnerGroup();
+      runs.acceptStorageDownloads();
+      const historical = await accept(
+        automationClient().run({
+          headers,
+          params: { id: automation.id },
+        }),
+        [201],
+      );
+      if (!historical.body.runId) {
+        throw new Error("Expected historical Official Automation Run");
+      }
+      await runs.requestCancelRun(actor, historical.body.runId, [200, 400]);
 
-    await syncCatalog(catalog([activeDefinition(definitionName, [])]));
-    await runOfficialWorkflowReconciliationWorker();
-    const removedIdentity = await readOfficialWorkflowReconciliationState({
-      workflowId,
-    });
-    expect(removedIdentity.body.identities).toStrictEqual([
-      expect.objectContaining({
+      await syncCatalog(catalog([activeDefinition(definitionName, [])]));
+      await runOfficialWorkflowReconciliationWorker();
+      const removedIdentity = await readOfficialWorkflowReconciliationState({
+        workflowId,
+      });
+      expect(removedIdentity.body.identities).toStrictEqual([
+        expect.objectContaining({
+          id: automation.id,
+          automationId: null,
+          blueprintKey: "gmail-trigger",
+          state: "removed",
+          retainedIntendedEnabled: true,
+        }),
+      ]);
+
+      await syncCatalog(
+        catalog([activeDefinition(definitionName, [gmailBlueprint()])]),
+      );
+      await runOfficialWorkflowReconciliationWorker();
+      const restored = await accept(
+        installationClient().get({ headers, params: { workflowId } }),
+        [200],
+      );
+      expect(restored.body.workflow.automations).toHaveLength(1);
+      expect(restored.body.workflow.automations[0]).toMatchObject({
         id: automation.id,
-        automationId: null,
-        blueprintKey: "gmail-trigger",
-        state: "removed",
-        retainedIntendedEnabled: true,
-      }),
-    ]);
+        chatThreadId: automation.chatThreadId,
+        enabled: true,
+        official: {
+          intendedEnabled: true,
+          reconciliationStatus: "current",
+        },
+      });
+      const historyCounts = await readAgentRunFamilyCountsFixture(
+        context,
+        agentId,
+      );
 
-    await syncCatalog(
-      catalog([activeDefinition(definitionName, [gmailBlueprint()])]),
-    );
-    await runOfficialWorkflowReconciliationWorker();
-    const restored = await accept(
-      installationClient().get({ headers, params: { workflowId } }),
-      [200],
-    );
-    expect(restored.body.workflow.automations).toHaveLength(1);
-    expect(restored.body.workflow.automations[0]).toMatchObject({
-      id: automation.id,
-      chatThreadId: automation.chatThreadId,
-      enabled: true,
-      official: {
-        intendedEnabled: true,
-        reconciliationStatus: "current",
-      },
-    });
-    const historyCounts = await readAgentRunFamilyCountsFixture(
-      context,
-      agentId,
-    );
+      if (phase === "dormant materialization") {
+        await simulateDormantMaterializationCrash({
+          definitionName,
+          automationId: automation.id,
+        });
+        watchCalls = 0;
+        const crashed = await accept(
+          installationClient().get({ headers, params: { workflowId } }),
+          [200],
+        );
+        expect(crashed.body.workflow.automations).toHaveLength(1);
+        expect(crashed.body.workflow.automations[0]).toMatchObject({
+          id: automation.id,
+          enabled: false,
+          official: {
+            intendedEnabled: true,
+            reconciliationStatus: "reconciling",
+          },
+        });
+        const crashedWork = await readOfficialWorkflowReconciliationState({
+          workflowId,
+        });
+        expect(crashedWork.body.reconciliationWork).toMatchObject([
+          {
+            definitionName,
+            state: "running",
+            leaseId: expect.any(String),
+            attemptCount: 0,
+          },
+        ]);
+        expect(crashedWork.body.identities).toStrictEqual([
+          expect.objectContaining({
+            id: automation.id,
+            automationId: null,
+            blueprintKey: "gmail-trigger",
+            state: "reconciling",
+            retainedIntendedEnabled: true,
+            retainedAppliedFingerprint: expect.any(String),
+          }),
+        ]);
 
-    await simulateDormantMaterializationCrash({
-      definitionName,
-      automationId: automation.id,
-    });
-    watchCalls = 0;
-    const crashed = await accept(
-      installationClient().get({ headers, params: { workflowId } }),
-      [200],
-    );
-    expect(crashed.body.workflow.automations).toHaveLength(1);
-    expect(crashed.body.workflow.automations[0]).toMatchObject({
-      id: automation.id,
-      enabled: false,
-      official: {
-        intendedEnabled: true,
-        reconciliationStatus: "reconciling",
-      },
-    });
-    const crashedWork = await readOfficialWorkflowReconciliationState({
-      workflowId,
-    });
-    expect(crashedWork.body.reconciliationWork).toMatchObject([
-      {
-        definitionName,
-        state: "running",
-        leaseId: expect.any(String),
-        attemptCount: 0,
-      },
-    ]);
-    expect(crashedWork.body.identities).toStrictEqual([
-      expect.objectContaining({
-        id: automation.id,
-        automationId: null,
-        blueprintKey: "gmail-trigger",
-        state: "reconciling",
-        retainedIntendedEnabled: true,
-        retainedAppliedFingerprint: expect.any(String),
-      }),
-    ]);
+        const retried = await Promise.all([
+          runOfficialWorkflowReconciliationWorker(),
+          runOfficialWorkflowReconciliationWorker(),
+        ]);
+        expect(
+          retried.reduce((sum, result) => {
+            return sum + result.claimed;
+          }, 0),
+        ).toBe(1);
+        expect(
+          retried.reduce((sum, result) => {
+            return sum + result.completed;
+          }, 0),
+        ).toBe(1);
+        expect(
+          retried.reduce((sum, result) => {
+            return sum + result.installations;
+          }, 0),
+        ).toBe(1);
 
-    const retried = await Promise.all([
-      runOfficialWorkflowReconciliationWorker(),
-      runOfficialWorkflowReconciliationWorker(),
-    ]);
-    expect(
-      retried.reduce((sum, result) => {
-        return sum + result.claimed;
-      }, 0),
-    ).toBe(1);
-    expect(
-      retried.reduce((sum, result) => {
-        return sum + result.completed;
-      }, 0),
-    ).toBe(1);
-    expect(
-      retried.reduce((sum, result) => {
-        return sum + result.installations;
-      }, 0),
-    ).toBe(1);
-
-    const recovered = await accept(
-      installationClient().get({ headers, params: { workflowId } }),
-      [200],
-    );
-    expect(recovered.body.workflow.automations).toHaveLength(1);
-    expect(recovered.body.workflow.automations[0]).toMatchObject({
-      id: automation.id,
-      chatThreadId: automation.chatThreadId,
-      enabled: true,
-      official: {
-        intendedEnabled: true,
-        reconciliationStatus: "current",
-      },
-    });
-    const recoveredIdentity = await readOfficialWorkflowReconciliationState({
-      workflowId,
-    });
-    expect(recoveredIdentity.body.identities).toStrictEqual([
-      expect.objectContaining({
-        id: automation.id,
-        automationId: automation.id,
-        blueprintKey: "gmail-trigger",
-        state: "active",
-      }),
-    ]);
-    expect(watchCalls).toBe(1);
-    await expect(
-      readAgentRunFamilyCountsFixture(context, agentId),
-    ).resolves.toStrictEqual(historyCounts);
-    await expect(
-      readOfficialWorkflowRunStateFixture(context, historical.body.runId),
-    ).resolves.toMatchObject({
-      provenance: {
-        definitions: [expect.objectContaining({ name: definitionName })],
-      },
-    });
-
-    await simulateCurrentLifecycleGap({
-      definitionName,
-      automationId: automation.id,
-    });
-    watchCalls = 0;
-    const currentGap = await accept(
-      installationClient().get({ headers, params: { workflowId } }),
-      [200],
-    );
-    expect(currentGap.body.workflow.automations).toHaveLength(1);
-    expect(currentGap.body.workflow.automations[0]).toMatchObject({
-      id: automation.id,
-      enabled: false,
-      official: {
-        intendedEnabled: true,
-        reconciliationStatus: "current",
-      },
-    });
-    await expect(
-      runOfficialWorkflowReconciliationWorker(),
-    ).resolves.toStrictEqual(
-      expect.objectContaining({ claimed: 1, completed: 1, installations: 1 }),
-    );
-    const currentGapRecovered = await accept(
-      installationClient().get({ headers, params: { workflowId } }),
-      [200],
-    );
-    expect(currentGapRecovered.body.workflow.automations).toHaveLength(1);
-    expect(currentGapRecovered.body.workflow.automations[0]).toMatchObject({
-      id: automation.id,
-      enabled: true,
-      official: {
-        intendedEnabled: true,
-        reconciliationStatus: "current",
-      },
-    });
-    expect(watchCalls).toBe(1);
-    await expect(
-      readAgentRunFamilyCountsFixture(context, agentId),
-    ).resolves.toStrictEqual(historyCounts);
-
-    watchCalls = 0;
-    stopCalls = 0;
-    await simulateDormantMaterializationDiscardCrash({
-      definitionName,
-      automationId: automation.id,
-    });
-    const discardGap = await accept(
-      installationClient().get({ headers, params: { workflowId } }),
-      [200],
-    );
-    expect(discardGap.body.workflow.automations).toHaveLength(1);
-    expect(discardGap.body.workflow.automations[0]).toMatchObject({
-      id: automation.id,
-      enabled: false,
-      official: {
-        intendedEnabled: true,
-        reconciliationStatus: "failed",
-      },
-    });
-    await runOfficialWorkflowReconciliationWorker();
-    const compensated = await accept(
-      installationClient().get({ headers, params: { workflowId } }),
-      [200],
-    );
-    expect(compensated.body.workflow.automations).toHaveLength(0);
-    expect(stopCalls).toBe(1);
-    expect(watchCalls).toBe(0);
-    const compensatedState = await readOfficialWorkflowReconciliationState({
-      workflowId,
-    });
-    expect(compensatedState.body.identities).toStrictEqual([
-      expect.objectContaining({
-        id: automation.id,
-        automationId: null,
-        blueprintKey: "gmail-trigger",
-        state: "failed",
-        retainedIntendedEnabled: true,
-      }),
-    ]);
-    await makeOfficialWorkflowReconciliationWorkDue(definitionName);
-    await expect(
-      runOfficialWorkflowReconciliationWorker(),
-    ).resolves.toStrictEqual(
-      expect.objectContaining({ claimed: 1, completed: 1, installations: 1 }),
-    );
-    const discardRecovered = await accept(
-      installationClient().get({ headers, params: { workflowId } }),
-      [200],
-    );
-    expect(discardRecovered.body.workflow.automations).toHaveLength(1);
-    expect(discardRecovered.body.workflow.automations[0]).toMatchObject({
-      id: automation.id,
-      enabled: true,
-      official: {
-        intendedEnabled: true,
-        reconciliationStatus: "current",
-      },
-    });
-    expect(watchCalls).toBe(1);
-    await expect(
-      readAgentRunFamilyCountsFixture(context, agentId),
-    ).resolves.toStrictEqual(historyCounts);
-    await expect(
-      runOfficialWorkflowReconciliationWorker(),
-    ).resolves.toStrictEqual({
-      claimed: 0,
-      completed: 0,
-      advanced: 0,
-      retried: 0,
-      installations: 0,
-    });
-    expect(watchCalls).toBe(1);
-  });
+        const recovered = await accept(
+          installationClient().get({ headers, params: { workflowId } }),
+          [200],
+        );
+        expect(recovered.body.workflow.automations).toHaveLength(1);
+        expect(recovered.body.workflow.automations[0]).toMatchObject({
+          id: automation.id,
+          chatThreadId: automation.chatThreadId,
+          enabled: true,
+          official: {
+            intendedEnabled: true,
+            reconciliationStatus: "current",
+          },
+        });
+        const recoveredIdentity = await readOfficialWorkflowReconciliationState(
+          {
+            workflowId,
+          },
+        );
+        expect(recoveredIdentity.body.identities).toStrictEqual([
+          expect.objectContaining({
+            id: automation.id,
+            automationId: automation.id,
+            blueprintKey: "gmail-trigger",
+            state: "active",
+          }),
+        ]);
+        expect(watchCalls).toBe(1);
+        await expect(
+          readAgentRunFamilyCountsFixture(context, agentId),
+        ).resolves.toStrictEqual(historyCounts);
+        await expect(
+          readOfficialWorkflowRunStateFixture(context, historical.body.runId),
+        ).resolves.toMatchObject({
+          provenance: {
+            definitions: [expect.objectContaining({ name: definitionName })],
+          },
+        });
+      } else if (phase === "current lifecycle gap") {
+        await simulateCurrentLifecycleGap({
+          definitionName,
+          automationId: automation.id,
+        });
+        watchCalls = 0;
+        const currentGap = await accept(
+          installationClient().get({ headers, params: { workflowId } }),
+          [200],
+        );
+        expect(currentGap.body.workflow.automations).toHaveLength(1);
+        expect(currentGap.body.workflow.automations[0]).toMatchObject({
+          id: automation.id,
+          enabled: false,
+          official: {
+            intendedEnabled: true,
+            reconciliationStatus: "current",
+          },
+        });
+        await expect(
+          runOfficialWorkflowReconciliationWorker(),
+        ).resolves.toStrictEqual(
+          expect.objectContaining({
+            claimed: 1,
+            completed: 1,
+            installations: 1,
+          }),
+        );
+        const currentGapRecovered = await accept(
+          installationClient().get({ headers, params: { workflowId } }),
+          [200],
+        );
+        expect(currentGapRecovered.body.workflow.automations).toHaveLength(1);
+        expect(currentGapRecovered.body.workflow.automations[0]).toMatchObject({
+          id: automation.id,
+          enabled: true,
+          official: {
+            intendedEnabled: true,
+            reconciliationStatus: "current",
+          },
+        });
+        expect(watchCalls).toBe(1);
+        await expect(
+          readAgentRunFamilyCountsFixture(context, agentId),
+        ).resolves.toStrictEqual(historyCounts);
+      } else {
+        watchCalls = 0;
+        stopCalls = 0;
+        await simulateDormantMaterializationDiscardCrash({
+          definitionName,
+          automationId: automation.id,
+        });
+        const discardGap = await accept(
+          installationClient().get({ headers, params: { workflowId } }),
+          [200],
+        );
+        expect(discardGap.body.workflow.automations).toHaveLength(1);
+        expect(discardGap.body.workflow.automations[0]).toMatchObject({
+          id: automation.id,
+          enabled: false,
+          official: {
+            intendedEnabled: true,
+            reconciliationStatus: "failed",
+          },
+        });
+        await runOfficialWorkflowReconciliationWorker();
+        const compensated = await accept(
+          installationClient().get({ headers, params: { workflowId } }),
+          [200],
+        );
+        expect(compensated.body.workflow.automations).toHaveLength(0);
+        expect(stopCalls).toBe(1);
+        expect(watchCalls).toBe(0);
+        const compensatedState = await readOfficialWorkflowReconciliationState({
+          workflowId,
+        });
+        expect(compensatedState.body.identities).toStrictEqual([
+          expect.objectContaining({
+            id: automation.id,
+            automationId: null,
+            blueprintKey: "gmail-trigger",
+            state: "failed",
+            retainedIntendedEnabled: true,
+          }),
+        ]);
+        await makeOfficialWorkflowReconciliationWorkDue(definitionName);
+        await expect(
+          runOfficialWorkflowReconciliationWorker(),
+        ).resolves.toStrictEqual(
+          expect.objectContaining({
+            claimed: 1,
+            completed: 1,
+            installations: 1,
+          }),
+        );
+        const discardRecovered = await accept(
+          installationClient().get({ headers, params: { workflowId } }),
+          [200],
+        );
+        expect(discardRecovered.body.workflow.automations).toHaveLength(1);
+        expect(discardRecovered.body.workflow.automations[0]).toMatchObject({
+          id: automation.id,
+          enabled: true,
+          official: {
+            intendedEnabled: true,
+            reconciliationStatus: "current",
+          },
+        });
+        expect(watchCalls).toBe(1);
+        await expect(
+          readAgentRunFamilyCountsFixture(context, agentId),
+        ).resolves.toStrictEqual(historyCounts);
+        await expect(
+          runOfficialWorkflowReconciliationWorker(),
+        ).resolves.toStrictEqual({
+          claimed: 0,
+          completed: 0,
+          advanced: 0,
+          retried: 0,
+          installations: 0,
+        });
+        expect(watchCalls).toBe(1);
+      }
+    },
+  );
 
   it("discards paused stale dormant materialization before promotion and preserves newer catalog intent", async () => {
     installCatalogStorageFixture();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-projection-cache-reuse-eviction.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-projection-cache-reuse-eviction.bdd.test.ts
@@ -6,9 +6,16 @@ const context = testContext();
 
 // This isolated module owns one process-local observation history.
 // Independent scenarios use separate modules, without a shared cache reset.
-test("observes normalized warm selection without changing the run selection cache", async () => {
+test("observes projection eviction beyond sixteen selections without changing the run selection cache", async () => {
   expect.hasAssertions();
   const createObservedRun = await createProjectionObservationFixture(context);
   await createObservedRun(0, "first_observation");
-  await createObservedRun(0, "reuse_1", "hit", true);
+  for (let scope = 1; scope < 16; scope++) {
+    await createObservedRun(scope, "not_in_recent_history");
+  }
+  // Refresh the oldest entry so eviction must follow recency, not insertion.
+  await createObservedRun(0, "reuse_9_16");
+  await createObservedRun(16, "not_in_recent_history");
+  await createObservedRun(1, "not_in_recent_history");
+  await createObservedRun(1, "reuse_1", "hit");
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-projection-cache-reuse-four.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-projection-cache-reuse-four.bdd.test.ts
@@ -6,9 +6,12 @@ const context = testContext();
 
 // This isolated module owns one process-local observation history.
 // Independent scenarios use separate modules, without a shared cache reset.
-test("observes normalized warm selection without changing the run selection cache", async () => {
+test("observes projection reuse at distance four without changing the run selection cache", async () => {
   expect.hasAssertions();
   const createObservedRun = await createProjectionObservationFixture(context);
   await createObservedRun(0, "first_observation");
-  await createObservedRun(0, "reuse_1", "hit", true);
+  for (let scope = 1; scope < 4; scope++) {
+    await createObservedRun(scope, "not_in_recent_history");
+  }
+  await createObservedRun(0, "reuse_3_4");
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-projection-cache-reuse-six.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-projection-cache-reuse-six.bdd.test.ts
@@ -6,9 +6,12 @@ const context = testContext();
 
 // This isolated module owns one process-local observation history.
 // Independent scenarios use separate modules, without a shared cache reset.
-test("observes normalized warm selection without changing the run selection cache", async () => {
+test("observes projection reuse at distance six without changing the run selection cache", async () => {
   expect.hasAssertions();
   const createObservedRun = await createProjectionObservationFixture(context);
   await createObservedRun(0, "first_observation");
-  await createObservedRun(0, "reuse_1", "hit", true);
+  for (let scope = 1; scope < 6; scope++) {
+    await createObservedRun(scope, "not_in_recent_history");
+  }
+  await createObservedRun(0, "reuse_5_8");
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-projection-cache-reuse-sixteen.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-projection-cache-reuse-sixteen.bdd.test.ts
@@ -6,9 +6,12 @@ const context = testContext();
 
 // This isolated module owns one process-local observation history.
 // Independent scenarios use separate modules, without a shared cache reset.
-test("observes normalized warm selection without changing the run selection cache", async () => {
+test("observes projection reuse at distance sixteen without changing the run selection cache", async () => {
   expect.hasAssertions();
   const createObservedRun = await createProjectionObservationFixture(context);
   await createObservedRun(0, "first_observation");
-  await createObservedRun(0, "reuse_1", "hit", true);
+  for (let scope = 1; scope < 16; scope++) {
+    await createObservedRun(scope, "not_in_recent_history");
+  }
+  await createObservedRun(0, "reuse_9_16");
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-projection-cache-reuse-two.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-projection-cache-reuse-two.bdd.test.ts
@@ -6,9 +6,12 @@ const context = testContext();
 
 // This isolated module owns one process-local observation history.
 // Independent scenarios use separate modules, without a shared cache reset.
-test("observes normalized warm selection without changing the run selection cache", async () => {
+test("observes projection reuse at distance two without changing the run selection cache", async () => {
   expect.hasAssertions();
   const createObservedRun = await createProjectionObservationFixture(context);
   await createObservedRun(0, "first_observation");
-  await createObservedRun(0, "reuse_1", "hit", true);
+  for (let scope = 1; scope < 2; scope++) {
+    await createObservedRun(scope, "not_in_recent_history");
+  }
+  await createObservedRun(0, "reuse_2");
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-computer-use.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-computer-use.test.tsx
@@ -138,7 +138,7 @@ async function openComputerDownloadDialog(title: string): Promise<HTMLElement> {
   return await screen.findByRole("dialog", { name: title });
 }
 
-test("Choose cloud browsing or a local computer for a new chat", async () => {
+async function prepareCloudBrowserDefaults() {
   const sends: CapturedComputerSend[] = [];
   installNewComputerChat(sends, [
     computerHost({
@@ -147,10 +147,13 @@ test("Choose cloud browsing or a local computer for a new chat", async () => {
       status: "online",
     }),
   ]);
-
   await setupPage({ context, path: NEW_CHAT_PATH });
-
   await readyChat();
+  return { sends };
+}
+
+test("Show cloud browser and local computer defaults in a new chat", async () => {
+  await prepareCloudBrowserDefaults();
   await openComputerMenu();
   expect(screen.getByText("Cloud browser")).toBeVisible();
   expect(
@@ -159,9 +162,11 @@ test("Choose cloud browsing or a local computer for a new chat", async () => {
   expect(
     screen.getByRole("switch", { name: "Connect Studio Mac" }),
   ).not.toBeChecked();
+});
 
+test("Send a new chat with the default cloud browser", async () => {
+  const { sends } = await prepareCloudBrowserDefaults();
   await sendText("Research the launch market");
-
   const sent = await waitForComputerSend(sends, 1);
   expect(sent).toMatchObject({
     prompt: "Research the launch market",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connectors.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connectors.test.tsx
@@ -157,7 +157,7 @@ async function clearConnectorFilter(
   act(notifyResize);
 }
 
-test("Keep searchable connector menu above while filtering on desktop", async () => {
+async function prepareScrollableDesktopConnectorMenu() {
   const user = userEvent.setup({ delay: null });
   const layout = mockConnectorPopoverLayout({
     viewport: { width: 1000, height: 520 },
@@ -167,12 +167,10 @@ test("Keep searchable connector menu above while filtering on desktop", async ()
     catalog: searchableConnectorCatalog(),
     builtinAuthorizations: { [SCOUT_AGENT_ID]: [GITHUB_SLUG] },
   });
-
   await setupPage({
     context,
     path: `/agents/${SCOUT_AGENT_ID}/chat`,
   });
-
   await loadComposer();
   const trigger = await findFastControl("button", "Connectors");
   await openConnectors(user);
@@ -189,7 +187,27 @@ test("Keep searchable connector menu above while filtering on desktop", async ()
   expect(connectorList.scrollHeight).toBeGreaterThan(
     connectorList.clientHeight,
   );
+  return {
+    user,
+    searchInput,
+    layout,
+    popover,
+    trigger,
+    connectorList,
+    expandedListHeight,
+  };
+}
 
+test("Keep the desktop connector menu above while filtering", async () => {
+  const {
+    user,
+    searchInput,
+    layout,
+    popover,
+    trigger,
+    connectorList,
+    expandedListHeight,
+  } = await prepareScrollableDesktopConnectorMenu();
   await filterConnectorMenu(user, searchInput, layout.notifyResize);
   await waitFor(() => {
     expect(popoverSide(popover, trigger)).toBe("top");
@@ -197,7 +215,15 @@ test("Keep searchable connector menu above while filtering on desktop", async ()
     expect(connectorList.scrollHeight).toBe(connectorList.clientHeight);
     expect(screen.getByText("Add connectors")).toBeInTheDocument();
   });
+});
 
+test("Keep the desktop connector menu above after clearing its filter", async () => {
+  const { user, searchInput, layout, popover, trigger, connectorList } =
+    await prepareScrollableDesktopConnectorMenu();
+  await filterConnectorMenu(user, searchInput, layout.notifyResize);
+  await waitFor(() => {
+    expect(connectorList.scrollHeight).toBe(connectorList.clientHeight);
+  });
   await clearConnectorFilter(user, layout.notifyResize);
   await waitFor(() => {
     expect(popoverSide(popover, trigger)).toBe("top");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
@@ -566,15 +566,16 @@ test("Multiple templates keep a generic toolbar label and all references survive
       }
     },
   });
-  const editor = await setupComposer();
+  await setupComposer();
   const user = userEvent.setup({ delay: null });
   const [first, second] = PRESENTATION_TEMPLATE_PICKER_ITEMS;
   if (!first || !second) {
     throw new Error("Expected two presentation templates");
   }
-  await selectTemplate(user, first);
-  await selectTemplate(user, second);
-  await user.click(editor);
+  await selectTemplate(first);
+  await selectTemplate(second);
+  // Page bootstrap can remount the editor while the template dialogs are open.
+  await user.click(await findComposerEditor());
   await user.paste(" /create presentation");
   const menu = await screen.findByTestId("slash-workflow-menu");
   click(button("Create presentation", menu));
@@ -605,7 +606,7 @@ test("Presentation adds another template when the draft already has one", async 
   if (!first || !second) {
     throw new Error("Expected two presentation templates");
   }
-  await selectTemplate(user, first);
+  await selectTemplate(first);
   await user.click(editor);
   await user.paste(" /create presentation");
   const menu = await screen.findByTestId("slash-workflow-menu");
@@ -671,7 +672,7 @@ test("Canceling and switching Create preserve slash text and template references
   if (!template) {
     throw new Error("Expected a presentation template");
   }
-  await selectTemplate(user, template);
+  await selectTemplate(template);
   await user.click(editor);
   await user.paste("Our launch /create");
   const menu = await screen.findByTestId("slash-workflow-menu");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-test-helpers.ts
@@ -1,5 +1,4 @@
 import { screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import type { PresentationTemplateItem } from "@okouai/core";
 import {
   chatThreadByIdContract,
@@ -520,7 +519,6 @@ export async function expectInlineTemplateInComposer(
 }
 
 export async function selectTemplate(
-  user: ReturnType<typeof userEvent.setup>,
   template: PresentationTemplateItem,
 ): Promise<void> {
   click(
@@ -532,7 +530,7 @@ export async function selectTemplate(
     expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
 
-  await user.click(screen.getByLabelText(`Select template ${template.title}`));
+  click(screen.getByLabelText(`Select template ${template.title}`));
 
   await waitFor(() => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-workflows.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-workflows.test.tsx
@@ -270,8 +270,8 @@ test.each(["insert", "send"])(
     await expect(screen.findByLabelText("Template")).resolves.toBeVisible();
 
     if (action === "insert") {
-      await selectTemplate(user, first);
-      await selectTemplate(user, second);
+      await selectTemplate(first);
+      await selectTemplate(second);
     }
     await waitFor(() => {
       return expect(composerInlineTemplates()).toHaveLength(2);
@@ -314,8 +314,8 @@ test("Replace an inline template after sending a message", async () => {
 
   await setupPage({ context, path: `/chats/${THREAD_ID}` });
 
-  const user = userEvent.setup();
-  await selectTemplate(user, first);
+  const user = userEvent.setup({ delay: null });
+  await selectTemplate(first);
   await user.click(await findComposerEditor());
   await user.keyboard("{Enter}");
   await waitFor(() => {
@@ -324,7 +324,7 @@ test("Replace an inline template after sending a message", async () => {
     expect(composerInlineTemplates()).toHaveLength(0);
   });
 
-  await selectTemplate(user, first);
+  await selectTemplate(first);
   const inlineTemplate = composerInlineTemplates()[0];
   if (!inlineTemplate) {
     throw new Error("Expected an inline template to replace");
@@ -809,12 +809,11 @@ test("Send a template while the current run is active", async () => {
 
   await setupPage({ context, path: `/chats/${THREAD_ID}` });
 
-  const user = userEvent.setup();
   await findComposerEditor();
   await expect(
     screen.findByText("Start an active deck run"),
   ).resolves.toBeVisible();
-  await selectTemplate(user, template);
+  await selectTemplate(template);
   await waitFor(() => {
     expect(namedButton("Send")).toBeEnabled();
   });
@@ -952,9 +951,8 @@ test("Wait for a template attachment before sending", async () => {
   });
   await setupPage({ context, path: `/chats/${THREAD_ID}` });
 
-  const user = userEvent.setup();
   await findComposerEditor();
-  await selectTemplate(user, template);
+  await selectTemplate(template);
   const file = new File(["launch brief"], "brief.txt", {
     type: "text/plain",
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-history.test.tsx
@@ -133,7 +133,7 @@ function queuedMessage(container: ParentNode): HTMLElement | undefined {
   );
 }
 
-test("Load a long chat history without losing grouped-run context", async () => {
+async function prepareLongGroupedConversation() {
   const thread = continuityThread(20, 1, "Long grouped history");
   const rows: ChatEventRow[] = [];
   let sequence = 1;
@@ -156,7 +156,6 @@ test("Load a long chat history without losing grouped-run context", async () => 
     rows.push(promptEvent, responseEvent);
     return { prompt: promptEvent, response: responseEvent };
   };
-
   const earliest = addPair(
     "Earliest retained request",
     "Earliest retained answer",
@@ -209,21 +208,32 @@ test("Load a long chat history without losing grouped-run context", async () => 
     "history-run-after-group",
   );
   addPair("Most recent follow-up", "Most recent answer", "history-run-recent");
-
   const workspace = installContinuityWorkspace(context, {
     caseId: 20,
     threads: [thread],
     chatEventRows: rows,
   });
-
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
     ...workspace.pageOptions,
   });
-
   const composer = await screen.findByRole("textbox", { name: "Message" });
   const container = threadContainer(thread.id);
+  return {
+    thread,
+    composer,
+    container,
+    latestGrouped,
+    earliest,
+    beforeGroup,
+    afterGroup,
+  };
+}
+
+test("Render a long conversation with intact grouped messages", async () => {
+  const { composer, container, latestGrouped } =
+    await prepareLongGroupedConversation();
   await waitFor(() => {
     expect(container).toHaveTextContent("Final launch brief is ready");
     expect(container).toHaveTextContent(
@@ -238,14 +248,20 @@ test("Load a long chat history without losing grouped-run context", async () => 
   expect(container).toHaveTextContent("First launch brief result");
   expect(container).toHaveTextContent("Second launch brief result");
   expect(container).not.toHaveTextContent("Earliest retained request");
-
   expect(eventAnchorCount(container, latestGrouped.response.id)).toBe(1);
+});
 
+test("Page older conversation history without losing grouped-run anchors", async () => {
+  const { thread, container, earliest, beforeGroup, afterGroup } =
+    await prepareLongGroupedConversation();
+  await waitFor(() => {
+    expect(container).toHaveTextContent("Final launch brief is ready");
+  });
+  expect(container).not.toHaveTextContent("Earliest retained request");
   const scroller = scrollContainer(thread.id);
   setScrollableGeometry(scroller, 2400, 600);
   scroller.scrollTop = 50;
   fireEvent.scroll(scroller);
-
   await waitFor(() => {
     expect(container).toHaveTextContent("Earliest retained request");
     expect(container).toHaveTextContent("Earliest retained answer");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-position-restoration.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-position-restoration.test.tsx
@@ -434,7 +434,7 @@ async function expectAtLatestActivity(
 
 test("Restore the reading position during keyboard thread navigation", async () => {
   context.mocks.browser.userAgent(LINUX_CHROME_USER_AGENT);
-  const user = userEvent.setup();
+  const user = userEvent.setup({ delay: null });
   // Three exchanges keep the reading anchor between the top and tail. The
   // neighboring threads only need content that proves navigation completed.
   const currentEvents = conversationEvents("keyboard-current", "Current", 3);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/markdown-parser-isolation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/markdown-parser-isolation.test.tsx
@@ -83,7 +83,7 @@ async function openInstructionsThenChat(): Promise<void> {
   await screen.findByRole("textbox", { name: "Message" });
 }
 
-test("Opening Instructions preserves literal plus signs in streamed chat Markdown", async () => {
+async function prepareLiteralPlusMarkdownChat() {
   const chat = createMarkdownChatFixture(context);
   const rows = [chat.outputMessage("++Plain message++", { seqId: 1 })];
   chat.install({
@@ -91,11 +91,17 @@ test("Opening Instructions preserves literal plus signs in streamed chat Markdow
       return rows;
     },
   });
-
   await openInstructionsThenChat();
+  return { chat, rows };
+}
 
+test("Opening Instructions preserves literal plus signs in the initial message", async () => {
+  await prepareLiteralPlusMarkdownChat();
   await expect(screen.findByText("++Plain message++")).resolves.toBeVisible();
+});
 
+test("Opening Instructions preserves literal plus signs through streamed revisions", async () => {
+  const { chat, rows } = await prepareLiteralPlusMarkdownChat();
   rows.push(
     chat.outputMessage("**Streaming:** ++Reply", {
       id: "streamed-markdown",
@@ -104,11 +110,9 @@ test("Opening Instructions preserves literal plus signs in streamed chat Markdow
     }),
   );
   context.mocks.ably.trigger(chat.realtimeTopic);
-
   const streaming = await screen.findByText("Streaming:");
   expect(streaming.tagName).toBe("STRONG");
   expect(markdownFrameFor(streaming)).toHaveTextContent("++Reply");
-
   rows[1] = chat.outputMessage("**Streaming:** ++Reply+", {
     id: "streamed-markdown",
     runEventId: "streamed-markdown",
@@ -116,13 +120,11 @@ test("Opening Instructions preserves literal plus signs in streamed chat Markdow
     sequenceNumber: 2,
   });
   context.mocks.ably.trigger(chat.realtimeTopic);
-
   await waitFor(() => {
     expect(markdownFrameFor(screen.getByText("Streaming:"))).toHaveTextContent(
       "++Reply+",
     );
   });
-
   rows[1] = chat.outputMessage(
     [
       "**Streaming:** ++Reply++",
@@ -145,7 +147,6 @@ test("Opening Instructions preserves literal plus signs in streamed chat Markdow
   );
   rows.push(chat.runCompleted({ seqId: 5, sequenceNumber: 3 }));
   context.mocks.ably.trigger(chat.realtimeTopic);
-
   await screen.findByText("Checked task");
   const frame = markdownFrameFor(screen.getByText("Streaming:"));
   expect(frame).toHaveTextContent("++Reply++");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-members-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-members-tab.test.tsx
@@ -53,6 +53,7 @@ function mockMembersStory(
     readonly role: string;
   }) => void,
   role: "admin" | "member" = "admin",
+  initialRoster: "all" | "owner" = "all",
 ): {
   readonly addPendingInvitation: (
     invitation: NonNullable<OrgMembersResponse["pendingInvitations"]>[number],
@@ -120,6 +121,15 @@ function mockMembersStory(
       },
     ],
   };
+
+  if (initialRoster === "owner") {
+    response = {
+      ...response,
+      members: response.members.slice(0, 1),
+      pendingInvitations: [],
+      membershipRequests: [],
+    };
+  }
 
   context.mocks.data.org({
     id: "org_1",
@@ -743,91 +753,120 @@ test("Use the default $20 package when inviting a member", async () => {
   expect(within(confirmation).getByText(/5,100 credits/u)).toBeVisible();
 });
 
-test.each([
+const PAID_INVITATION_SCENARIOS = [
   { tier: "pro", supportsFreeMembers: true },
   { tier: "team", supportsFreeMembers: true },
   { tier: "pro", supportsFreeMembers: false },
   { tier: "team", supportsFreeMembers: false },
-] as const)(
-  "Buy an invitation package on $tier (no package: $supportsFreeMembers)",
-  async ({ tier, supportsFreeMembers }) => {
-    const story = mockMembersStory();
-    mockMemberInviteEntitlement(true, { tier, status: "active" });
-    mockUsagePackManagement({ tier });
-    mockUsagePackCatalog(supportsFreeMembers ? true : undefined);
-    const purchaseId = "67d0ac76-170e-4a99-a5b6-ecc74c1179df";
-    context.mocks.api(
-      orgInviteContract.previewPurchase,
-      ({ body, respond }) => {
-        expect(body).toMatchObject({
-          email: "paid.invitee@example.com",
-          role: "member",
-          usagePackUsd: 50,
-          supportsInAppPreview: true,
-        });
-        return respond(200, {
-          purchaseId,
-          usagePackUsd: 50,
-          immediateAmountCents: 1250,
-          currency: "usd",
-          purchasedCredits: 12_500,
-          bonusCredits: 650,
-          totalCredits: 13_150,
-          currentPeriodEnd: "2026-09-01T00:00:00.000Z",
-          expiresAt: "2026-08-10T00:00:00.000Z",
-          paymentMethodPreviewToken: "invite-payment-preview",
-        });
-      },
-    );
-    context.mocks.api(
-      orgInviteContract.confirmPurchase,
-      ({ body, params, respond }) => {
-        expect(params.purchaseId).toBe(purchaseId);
-        expect(body).toStrictEqual({
-          paymentMethodPreviewToken: "invite-payment-preview",
-        });
-        story.addPendingInvitation({
-          id: "inv-paid",
-          email: "paid.invitee@example.com",
-          role: "member",
-          createdAt: "2026-08-01T00:00:00.000Z",
-          usagePackUsd: 50,
-        });
-        return respond(200, { message: "Invitation sent" });
-      },
-    );
+] as const;
+async function preparePaidInvitation(
+  tier: "pro" | "team",
+  supportsFreeMembers: boolean,
+) {
+  const story = mockMembersStory(undefined, "admin", "owner");
+  mockMemberInviteEntitlement(true, { tier, status: "active" });
+  mockUsagePackManagement({ tier });
+  mockUsagePackCatalog(supportsFreeMembers ? true : undefined);
+  const purchaseId = "67d0ac76-170e-4a99-a5b6-ecc74c1179df";
+  context.mocks.api(orgInviteContract.previewPurchase, ({ body, respond }) => {
+    expect(body).toMatchObject({
+      email: "paid.invitee@example.com",
+      role: "member",
+      usagePackUsd: 50,
+      supportsInAppPreview: true,
+    });
+    return respond(200, {
+      purchaseId,
+      usagePackUsd: 50,
+      immediateAmountCents: 1250,
+      currency: "usd",
+      purchasedCredits: 12_500,
+      bonusCredits: 650,
+      totalCredits: 13_150,
+      currentPeriodEnd: "2026-09-01T00:00:00.000Z",
+      expiresAt: "2026-08-10T00:00:00.000Z",
+      paymentMethodPreviewToken: "invite-payment-preview",
+    });
+  });
+  context.mocks.api(
+    orgInviteContract.confirmPurchase,
+    ({ body, params, respond }) => {
+      expect(params.purchaseId).toBe(purchaseId);
+      expect(body).toStrictEqual({
+        paymentMethodPreviewToken: "invite-payment-preview",
+      });
+      story.addPendingInvitation({
+        id: "inv-paid",
+        email: "paid.invitee@example.com",
+        role: "member",
+        createdAt: "2026-08-01T00:00:00.000Z",
+        usagePackUsd: 50,
+      });
+      return respond(200, { message: "Invitation sent" });
+    },
+  );
+  await setupPage({ context, path: "/?settings=people" });
+  await screen.findByRole("heading", { name: "People" });
+  click(buttonByText("Add member"));
+  const inviteDialog = await screen.findByRole("dialog", {
+    name: "Invite member",
+  });
+  const packages = await within(inviteDialog).findByRole("combobox", {
+    name: "Member packages",
+  });
+  expect(packages).toHaveTextContent("20,400 credits");
+  await fill(
+    within(inviteDialog).getByPlaceholderText("email@example.com"),
+    "paid.invitee@example.com",
+  );
+  click(packages);
+  expect(
+    queryAllByRoleFast("option").some((option) => {
+      return option.textContent?.trim() === "No package";
+    }),
+  ).toBe(supportsFreeMembers);
+  click(
+    await waitFor(() => {
+      const option = queryAllByRoleFast("option").find((candidate) => {
+        return candidate.textContent?.includes("52,600 credits");
+      });
+      if (!option) {
+        throw new Error("Expected the 52,600-credit member package");
+      }
+      return option;
+    }),
+  );
+  await waitFor(() => {
+    expect(buttonByText("Continue", inviteDialog)).toBeEnabled();
+  });
+  click(buttonByText("Continue", inviteDialog));
+  const confirmation = await screen.findByRole("dialog", {
+    name: "Review invitation",
+  });
+  return { confirmation };
+}
 
-    await setupPage({ context, path: "/?settings=people" });
-    await screen.findByRole("heading", { name: "People" });
-    click(buttonByText("Add member"));
-    const inviteDialog = await screen.findByRole("dialog", {
-      name: "Invite member",
-    });
-    const packages = await within(inviteDialog).findByRole("combobox", {
-      name: "Member packages",
-    });
-    expect(packages).toHaveTextContent("20,400 credits");
-    await fill(
-      within(inviteDialog).getByPlaceholderText("email@example.com"),
-      "paid.invitee@example.com",
-    );
-    click(packages);
-    expect(screen.queryByRole("option", { name: "No package" }) !== null).toBe(
+test.each(PAID_INVITATION_SCENARIOS)(
+  "Review a paid invitation on $tier (no package: $supportsFreeMembers)",
+  async ({ tier, supportsFreeMembers }) => {
+    const { confirmation } = await preparePaidInvitation(
+      tier,
       supportsFreeMembers,
     );
-    click(await screen.findByRole("option", { name: /52,600 credits/u }));
-    await waitFor(() => {
-      expect(buttonByText("Continue", inviteDialog)).toBeEnabled();
-    });
-    click(buttonByText("Continue", inviteDialog));
-
-    const confirmation = await screen.findByRole("dialog", {
-      name: "Review invitation",
-    });
     expect(within(confirmation).getByText("$12.50")).toBeVisible();
     expect(
       within(confirmation).getByText("paid.invitee@example.com"),
     ).toBeVisible();
+  },
+);
+
+test.each(PAID_INVITATION_SCENARIOS)(
+  "Purchase an invitation and reset its package on $tier (no package: $supportsFreeMembers)",
+  async ({ tier, supportsFreeMembers }) => {
+    const { confirmation } = await preparePaidInvitation(
+      tier,
+      supportsFreeMembers,
+    );
     click(buttonByText("Pay and invite", confirmation));
     await waitFor(() => {
       expect(rowByEmail("paid.invitee@example.com")).toBeVisible();
@@ -835,7 +874,6 @@ test.each([
     expect(
       within(rowByEmail("paid.invitee@example.com")).getByText("$50/month"),
     ).toBeVisible();
-
     click(buttonByText("Add member"));
     const nextInvite = await screen.findByRole("dialog", {
       name: "Invite member",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx
@@ -863,7 +863,7 @@ test("Connect a workspace API key to a model route", async () => {
   expect(within(row).getByText("Anthropic")).toBeInTheDocument();
 });
 
-test("Rotate a workspace model API key", async () => {
+test("Reject an empty workspace model API key without replacing its provider", async () => {
   mockApiKeyModelRouteStory();
   await openProvidersTab();
 
@@ -883,6 +883,24 @@ test("Rotate a workspace model API key", async () => {
   click(buttonByText("Save changes"));
   expect(screen.getByText("API key is required")).toBeInTheDocument();
   expect(within(row).getByText("Anthropic")).toBeInTheDocument();
+});
+
+test("Rotate a workspace model API key without exposing the new secret", async () => {
+  mockApiKeyModelRouteStory();
+  await openProvidersTab();
+
+  const row = await screen.findByTestId("org-model-policy-row-claude-opus-4-8");
+  expect(within(row).getByText("Claude Opus 4.8")).toBeInTheDocument();
+  expect(within(row).getByText("Anthropic")).toBeInTheDocument();
+
+  click(within(row).getByLabelText("Actions for Claude Opus 4.8"));
+  click(menuItemByText("Edit model"));
+
+  await waitFor(() => {
+    expect(
+      screen.getByRole("dialog", { name: "Edit model" }),
+    ).toBeInTheDocument();
+  });
   await fill(
     screen.getByPlaceholderText("Enter your API key"),
     "  sk-ant-rotated  ",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
@@ -214,33 +214,27 @@ test("Keep rendering a legacy custom SVG avatar", async () => {
   ]);
 });
 
+async function prepareLegacyAvatarPreview(avatarUrl: string) {
+  const profile = prepareAgentProfile(avatarUrl);
+  await setupPage({
+    context,
+    path: `/agents/${AGENT_ID}?tab=profile`,
+  });
+  const legacyLayerSrcs = renderedAvatarSvgLayerSrcs(await findAvatarRow());
+  expect(legacyLayerSrcs).toHaveLength(3);
+  click(await findCustomizeAvatarButton());
+  const dialog = await screen.findByRole("dialog", { name: "Edit avatar" });
+  expect(within(dialog).getByText("Face")).toBeVisible();
+  expect(profile.lastSavedProfile()).toBeNull();
+  return { profile, legacyLayerSrcs, dialog };
+}
+
 test.each(["preset:0", "svg:r3s2h4c1f5h"])(
-  "Replace legacy avatar %s with a composer avatar only after confirmation",
+  "Cancel avatar composition without converting legacy avatar %s",
   async (avatarUrl) => {
-    const profile = prepareAgentProfile(avatarUrl);
-    await setupPage({
-      context,
-      path: `/agents/${AGENT_ID}?tab=profile`,
-    });
-
-    const legacyLayerSrcs = renderedAvatarSvgLayerSrcs(await findAvatarRow());
-    expect(legacyLayerSrcs).toHaveLength(3);
-    click(await findCustomizeAvatarButton());
-
-    const dialog = await screen.findByRole("dialog", { name: "Edit avatar" });
-    expect(within(dialog).getByText("Face")).toBeVisible();
-    expect(renderedAvatarSvgLayerSrcs(dialog).slice(0, 6)).toStrictEqual([
-      expect.stringContaining("/avatar-svg-v2/"),
-      expect.stringContaining("/avatar-svg-v2/"),
-      expect.stringContaining("/avatar-svg-v2/"),
-      expect.stringContaining("/avatar-svg-v2/"),
-      expect.stringContaining("/avatar-svg-v2/"),
-      expect.stringContaining("/avatar-svg-v2/"),
-    ]);
-    expect(profile.lastSavedProfile()).toBeNull();
-
+    const { profile, legacyLayerSrcs, dialog } =
+      await prepareLegacyAvatarPreview(avatarUrl);
     click(within(dialog).getByText("Cancel"));
-
     await waitFor(() => {
       expect(dialog).not.toBeInTheDocument();
     });
@@ -250,7 +244,6 @@ test.each(["preset:0", "svg:r3s2h4c1f5h"])(
     expect(profile.lastSavedProfile()).toBeNull();
     await fill(await findAgentNameInput(), "Research Lead");
     click(screen.getByText("Save"));
-
     await waitFor(() => {
       expect(screen.getByText("Profile saved")).toBeInTheDocument();
       expect(profile.lastSavedProfile()).toMatchObject({
@@ -258,12 +251,24 @@ test.each(["preset:0", "svg:r3s2h4c1f5h"])(
         avatarUrl,
       });
     });
-    click(await findCustomizeAvatarButton());
+  },
+);
 
-    const reopened = await screen.findByRole("dialog", { name: "Edit avatar" });
-    click(within(reopened).getByLabelText("Randomize avatar"));
-    await waitForAvatarFeedback(reopened);
-    const composerLayerSrcs = renderedAvatarSvgLayerSrcs(reopened).slice(0, 6);
+test.each(["preset:0", "svg:r3s2h4c1f5h"])(
+  "Confirm conversion of legacy avatar %s to a composed avatar",
+  async (avatarUrl) => {
+    const { profile, dialog } = await prepareLegacyAvatarPreview(avatarUrl);
+    expect(renderedAvatarSvgLayerSrcs(dialog).slice(0, 6)).toStrictEqual([
+      expect.stringContaining("/avatar-svg-v2/"),
+      expect.stringContaining("/avatar-svg-v2/"),
+      expect.stringContaining("/avatar-svg-v2/"),
+      expect.stringContaining("/avatar-svg-v2/"),
+      expect.stringContaining("/avatar-svg-v2/"),
+      expect.stringContaining("/avatar-svg-v2/"),
+    ]);
+    click(within(dialog).getByLabelText("Randomize avatar"));
+    await waitForAvatarFeedback(dialog);
+    const composerLayerSrcs = renderedAvatarSvgLayerSrcs(dialog).slice(0, 6);
     expect(composerLayerSrcs).toStrictEqual([
       expect.stringContaining("/avatar-svg-v2/"),
       expect.stringContaining("/avatar-svg-v2/"),
@@ -272,10 +277,9 @@ test.each(["preset:0", "svg:r3s2h4c1f5h"])(
       expect.stringContaining("/avatar-svg-v2/"),
       expect.stringContaining("/avatar-svg-v2/"),
     ]);
-    click(within(reopened).getByText("Use this avatar"));
-
+    click(within(dialog).getByText("Use this avatar"));
     await waitFor(() => {
-      expect(reopened).not.toBeInTheDocument();
+      expect(dialog).not.toBeInTheDocument();
     });
     expect(profile.lastSavedProfile()?.avatarUrl).toContain("/avatar-svg-v2/");
     expect(renderedAvatarSvgLayerSrcs(await findAvatarRow())).toStrictEqual(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -2352,80 +2352,83 @@ test("Recognize and pin sidebar conversation states", async () => {
   expect(menuItemByText("Delete chat")).toBeInTheDocument();
 });
 
-test("Refresh agent and thread unread indicators", async () => {
-  mockMobileLayout();
-  prepareAgents();
-  mockSidebarThreadStory([
-    createThread(EXISTING_THREAD_ID, "Remote unread conversation"),
-  ]);
-  let hasUnread = false;
-  let unreadIndicatorsLoaded = false;
-  const unreadCatchUpReturned = context.mocks.deferred<void>();
-  context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
-    unreadIndicatorsLoaded = hasUnread;
-    return respond(200, {
-      agents: hasUnread ? { [AGENT_ID]: "unread" } : {},
-      threads: hasUnread ? { [EXISTING_THREAD_ID]: "unread" } : {},
+test.each(["agent", "thread"] as const)(
+  "Refresh the %s unread indicator",
+  async (indicator) => {
+    mockMobileLayout();
+    prepareAgents();
+    mockSidebarThreadStory([
+      createThread(EXISTING_THREAD_ID, "Remote unread conversation"),
+    ]);
+    let hasUnread = false;
+    let unreadIndicatorsLoaded = false;
+    const unreadCatchUpReturned = context.mocks.deferred<void>();
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      unreadIndicatorsLoaded = hasUnread;
+      return respond(200, {
+        agents: hasUnread ? { [AGENT_ID]: "unread" } : {},
+        threads: hasUnread ? { [EXISTING_THREAD_ID]: "unread" } : {},
+      });
     });
-  });
-  context.mocks.api(chatThreadEventsContract.catchUp, ({ body, respond }) => {
-    const response = respond(200, {
-      events: Object.fromEntries(
-        body.map(([threadId]) => {
-          return [threadId, []];
-        }),
-      ),
-      notFoundThreads: [],
+    context.mocks.api(chatThreadEventsContract.catchUp, ({ body, respond }) => {
+      const response = respond(200, {
+        events: Object.fromEntries(
+          body.map(([threadId]) => {
+            return [threadId, []];
+          }),
+        ),
+        notFoundThreads: [],
+      });
+      if (unreadIndicatorsLoaded && !unreadCatchUpReturned.settled()) {
+        unreadCatchUpReturned.resolve(undefined);
+      }
+      return response;
     });
-    if (unreadIndicatorsLoaded && !unreadCatchUpReturned.settled()) {
-      unreadCatchUpReturned.resolve(undefined);
-    }
-    return response;
-  });
-  context.mocks.api(chatThreadsContract.unreads, ({ respond }) => {
-    return respond(200, {
-      unreads: hasUnread
-        ? [
-            {
-              threadId: EXISTING_THREAD_ID,
-              unreadAt: "2026-03-10T00:05:00Z",
-            },
-          ]
-        : [],
+    context.mocks.api(chatThreadsContract.unreads, ({ respond }) => {
+      return respond(200, {
+        unreads: hasUnread
+          ? [
+              {
+                threadId: EXISTING_THREAD_ID,
+                unreadAt: "2026-03-10T00:05:00Z",
+              },
+            ]
+          : [],
+      });
     });
-  });
 
-  await setupSidebarPage({
-    context,
-    path: `/agents/${AGENT_ID}/chat`,
-    sharedWorkerTestTransport: "message-port",
-  });
+    await setupSidebarPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      sharedWorkerTestTransport: "message-port",
+    });
 
-  const nav = await waitFor(() => {
-    const current = mobileSidebar();
-    expect(within(current).getByText("Nova")).toBeInTheDocument();
-    return current;
-  });
-  const agentRow = agentRowByName(nav, "Nova");
-  const threadRow = await waitFor(() => {
-    return threadRowByTitle("Remote unread conversation", nav);
-  });
-  await waitFor(() => {
-    expect(within(agentRow).queryByLabelText("Unread")).toBeNull();
-    expect(within(threadRow).queryByLabelText("Unread")).toBeNull();
-  });
+    const nav = await waitFor(() => {
+      const current = mobileSidebar();
+      expect(within(current).getByText("Nova")).toBeInTheDocument();
+      return current;
+    });
+    const row =
+      indicator === "agent"
+        ? agentRowByName(nav, "Nova")
+        : await waitFor(() => {
+            return threadRowByTitle("Remote unread conversation", nav);
+          });
+    await waitFor(() => {
+      expect(within(row).queryByLabelText("Unread")).toBeNull();
+    });
 
-  hasUnread = true;
-  changeChatThreadList();
+    hasUnread = true;
+    changeChatThreadList();
 
-  // Indicator delivery follows the throttled batch, which may start after a
-  // trailing bootstrap request. Observe that response before checking the UI.
-  await unreadCatchUpReturned.promise;
-  await waitFor(() => {
-    expect(within(agentRow).getByLabelText("Unread")).toBeInTheDocument();
-    expect(within(threadRow).getByLabelText("Unread")).toBeInTheDocument();
-  });
-});
+    // Indicator delivery follows the throttled batch, which may start after a
+    // trailing bootstrap request. Observe that response before checking the UI.
+    await unreadCatchUpReturned.promise;
+    await waitFor(() => {
+      expect(within(row).getByLabelText("Unread")).toBeInTheDocument();
+    });
+  },
+);
 
 test("Rename a conversation from the sidebar", async () => {
   prepareDefaultAgent();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -2403,19 +2403,23 @@ test.each(["agent", "thread"] as const)(
       sharedWorkerTestTransport: "message-port",
     });
 
-    const nav = await waitFor(() => {
+    await waitFor(() => {
       const current = mobileSidebar();
       expect(within(current).getByText("Nova")).toBeInTheDocument();
-      return current;
     });
-    const row =
-      indicator === "agent"
-        ? agentRowByName(nav, "Nova")
-        : await waitFor(() => {
-            return threadRowByTitle("Remote unread conversation", nav);
-          });
+    // Both indicator consumers must finish loading before the external refresh.
     await waitFor(() => {
-      expect(within(row).queryByLabelText("Unread")).toBeNull();
+      expect(
+        threadRowByTitle("Remote unread conversation", mobileSidebar()),
+      ).toBeInTheDocument();
+    });
+    const indicatorRow = () => {
+      return indicator === "agent"
+        ? agentRowByName(mobileSidebar(), "Nova")
+        : threadRowByTitle("Remote unread conversation", mobileSidebar());
+    };
+    await waitFor(() => {
+      expect(within(indicatorRow()).queryByLabelText("Unread")).toBeNull();
     });
 
     hasUnread = true;
@@ -2425,7 +2429,9 @@ test.each(["agent", "thread"] as const)(
     // trailing bootstrap request. Observe that response before checking the UI.
     await unreadCatchUpReturned.promise;
     await waitFor(() => {
-      expect(within(row).getByLabelText("Unread")).toBeInTheDocument();
+      expect(
+        within(indicatorRow()).getByLabelText("Unread"),
+      ).toBeInTheDocument();
     });
   },
 );


### PR DESCRIPTION
September 10 CI recorded TypeScript test timeouts or at most one second of headroom in compound scenarios. Split 22 historical scenario identities (18 declarations) into 54 independently timed cases and repair interaction overhead in two additional audited scenarios.

The API cases separate Feishu state/callbacks/branding/delivery, Teams context/completion/participant sessions, workflow release/reconciliation races, and projection reuse distances/eviction. Platform cases separate provider validation/rotation, unread indicators, connector filtering/clearing, initial/streamed Markdown, history rendering/paging, avatar cancellation/confirmation, invitation review/purchase and computer defaults/submission. Each case establishes its own required state inside its test budget. Projection cases retain real dispatches and the sixteen-entry LRU boundary in isolated modules. Unread refresh cases wait for both sidebar consumers to load and query the current row after the external refresh.

Relates to #33319. This is the consolidated continuation after merged #33427 and #33449. The [complete reconciliation](https://github.com/vm0-ai/vm0/issues/33319#issuecomment-5631305073) retains all 161 identities: 63 prior dispositions, 24 identities changed here and 74 precise source-level constraints that remain unresolved. A fast local duration never excludes an unchanged CI-flagged test. All changes are tests/helpers; product code, timeout values, retries, skips and CI configuration are unchanged.

Validation:

- All 63 current target cases/helper consumers have passing local evidence: 30 API cases at 443–3794 ms and 33 Platform cases at 662–4002 ms. Unchanged cases reuse source-matched reports; the six cases affected by rebasing onto current main were rerun with two workers. The agent unread case's 4001.203 ms sample is still classified as near-limit.
- Prior two-worker Platform timeouts at 5139/7697/5270 ms and the initial-head CI unread-refresh failure remain in the evidence. They are not erased by faster isolated runs. The readiness defect was fixed and reverified; current-head CI remains mandatory.
- Passed API/Platform type checks, basic/type-aware lint, ESLint, affected-workspace Knip and formatting. Rebase conflict resolution preserved main's Nova fixture names; its semantic delta is only those names, and both affected files passed targeted tests, lint and formatting again.
- Only targeted Vitest selections were run locally. The PR pipeline provides full verification; submitted-head and merge-group timings are recorded in the audit before terminal reconciliation.

Current-head CI: all three required gates passed. Of 63 target cases, 61 have exact logged durations: 60 are at most 3048 ms; T067 (keyboard reading-position restoration) is still near-limit at 4090 ms. Two Feishu branding cases have passing file coverage without a printed individual duration. T067's required leave-and-return sequence cannot be split without losing restoration coverage, so it remains unresolved alongside T041's 4001.203 ms local sample and the existing constraints. See the [current CI reconciliation](https://github.com/vm0-ai/vm0/issues/33319#issuecomment-5631472153).

