### PR TITLE
feat(core): enable the welcome thread switch for the staff org

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -82,6 +82,20 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Lab, {})).toBe(false);
   });
 
+  it("should enable the Welcome Thread switch for the staff org only", () => {
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.WelcomeThread, {
+        orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+      }),
+    ).toBe(true);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.WelcomeThread, {
+        orgId: "org_nonexistent",
+      }),
+    ).toBe(false);
+    expect(isFeatureEnabled(FeatureSwitchKey.WelcomeThread, {})).toBe(false);
+  });
+
   it("should apply user overrides to the staff-default Official Workflows switch", () => {
     const staffOrgId = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
     expect(
@@ -339,6 +353,7 @@ describe("getFeatureSwitchMetadata", () => {
     );
     expect(metadata[FeatureSwitchKey.Banking].rolloutStage).toBe("beta");
     expect(metadata[FeatureSwitchKey.IntroVideo].rolloutStage).toBe("beta");
+    expect(metadata[FeatureSwitchKey.WelcomeThread].rolloutStage).toBe("beta");
     expect(metadata[FeatureSwitchKey.AhrefsConnector].rolloutStage).toBe(
       "alpha",
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -54,6 +54,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "lancy@okou.ai",
     description: "Manually create a welcome conversation with fixed examples",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ThreadActivitySummary]: {
     maintainer: "lancy@okou.ai",


### PR DESCRIPTION
## Summary

Enables `FeatureSwitchKey.WelcomeThread` for the staff organization by default so staff can reach the Settings → Debug `Welcome thread` card in production without setting a personal override.

The switch stays globally disabled (`enabled: false`). This is a staff-only default rollout, not a general release. It mirrors the shape already used by the neighbouring `OkouDebug` entry, which gates the surrounding Debug section, so staff gain a working end-to-end path from this single registry change.

`STAFF_ORG_ID_HASHES` contains one org hash, so the blast radius is that single workspace. `STAFF_ORG_ID_HASHES` itself is unchanged.

Both gates already resolve effective switch state correctly, so no service, route, or component change is needed:

- Server: `welcome-chat-thread.service.ts` returns `403` unless `isFeatureEnabled(FeatureSwitchKey.WelcomeThread, switches)` passes.
- Client: `debug-section.tsx` renders `<WelcomeThreadCard />` only when `featureSwitch$` reports the switch on.

## Rollout stage moves from `alpha` to `beta`

`getFeatureSwitchRolloutStage` returns `beta` for a disabled switch whose `enabledOrgIdHashes` intersects `STAFF_ORG_ID_HASHES`. That is the intended classification and is what the Lab page displays. The existing rollout-audience test is extended with a `WelcomeThread` → `beta` assertion alongside the pinned `Banking`, `IntroVideo`, and `AhrefsConnector` cases, which is the regression guard keeping a future edit from silently dropping the staff audience. A second test pins staff-only `isFeatureEnabled` behaviour with no override applied.

## Accepted risk, deliberately not repaired here

#33327 removed the retry `clientThreadId` reuse and the in-flight guard from the client command. Each click sends a fresh `clientThreadId`, so a lost response followed by another click can create a second welcome thread. For a staff-only, manually triggered Debug action this is acceptable — the operator can see and delete a duplicate. It must be reconsidered before any wider audience or automatic trigger. Recorded, not fixed in this PR.

## Non-goals

No `enabled: true`, no user/email hashes, no audience beyond `STAFF_ORG_ID_HASHES`, no automatic welcome delivery on registration or onboarding, no welcome content/copy/example-asset changes, and no other switch entry touched.

## Verification

Focused runs only, per repository convention; no full local suite and no dev server.

- `turbo/packages/core` — `vitest --run src/__tests__/feature-switch.test.ts`: **1 file passed, 30 tests passed**.
- `turbo/apps/api` — `vitest --run src/signals/routes/__tests__/welcome-chat-threads.test.ts` against a local migrated Postgres: **1 file passed, 22 tests passed**, unmodified.
- `turbo/apps/platform` — `vitest --run` over `welcome-thread.test.tsx`, `welcome-thread-sync.test.tsx`, `welcome-thread-sync-overlap.test.tsx`: **3 files passed, 16 tests passed**, unmodified.
- `prettier --check`, `eslint`, `oxlint` (including `--type-aware`), and `tsc --noEmit` on the changed files: all clean.

```
$ git diff --stat
 turbo/packages/core/src/__tests__/feature-switch.test.ts | 15 +++++++++++++++
 turbo/packages/core/src/feature-switch.ts                |  1 +
 2 files changed, 16 insertions(+)
```

Closes #33495. Parent epic #33205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
