### PR TITLE
feat(platform): add the get started quest entry to the home corner

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1679,6 +1679,51 @@
       "title": "Aktion nicht verfügbar"
     },
     "agentPage": {
+      "getStarted": {
+        "checkin": {
+          "description": "Einmal am Tag, jeden Tag",
+          "name": "Täglich einchecken",
+          "unit": "pro Tag"
+        },
+        "connector": {
+          "description": "Gmail, Notion und 100+ weitere",
+          "name": "Connector verbinden",
+          "unit": "pro Connector"
+        },
+        "inReview": "In Prüfung",
+        "inReviewDescription": "Eingereicht, wartet auf Prüfung",
+        "invite": {
+          "description": "Jede Person, die du hinzufügst, zählt",
+          "name": "Team einladen",
+          "unit": "pro Mitglied"
+        },
+        "personalBalanceNote": "Credits gehen auf dein persönliches Guthaben.",
+        "progressLabel": "Fortschritt beim Einstieg",
+        "reward": "+{{amount}}",
+        "share": {
+          "description": "Poste es und füge den Link hier ein",
+          "name": "{{assistantName}} auf X teilen"
+        },
+        "shareDialog": {
+          "description": "Poste etwas, das du gebaut hast, und füge den Link ein. Du hast eine Einreichung.",
+          "helper": "Der Post muss öffentlich sein und {{assistantName}} erwähnen.",
+          "inputLabel": "Post-Link",
+          "placeholder": "https://x.com/...",
+          "submit": "Einreichen",
+          "title": "{{assistantName}} auf X teilen"
+        },
+        "slack": {
+          "description": "Da, wo dein Team schon arbeitet",
+          "name": "{{assistantName}} zu Slack hinzufügen"
+        },
+        "stepCount": "{{completed}}/{{total}}",
+        "subtitle": "Schließe einen Schritt ab, die Credits bleiben dir.",
+        "title": "Einstieg",
+        "workflow": {
+          "description": "Mach aus einer wiederkehrenden Aufgabe eine Automatisierung",
+          "name": "Workflow bauen"
+        }
+      },
       "growth": {
         "addInSlack": "{{assistantName}} in Slack hinzufügen",
         "connect": "Verbinden",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1679,6 +1679,51 @@
       "title": "Action unavailable"
     },
     "agentPage": {
+      "getStarted": {
+        "checkin": {
+          "description": "Once a day, every day",
+          "name": "Check in daily",
+          "unit": "a day"
+        },
+        "connector": {
+          "description": "Gmail, Notion, and 100+ more",
+          "name": "Connect a connector",
+          "unit": "per connector"
+        },
+        "inReview": "In review",
+        "inReviewDescription": "Submitted, waiting on review",
+        "invite": {
+          "description": "Everyone you add counts",
+          "name": "Invite your team",
+          "unit": "per member"
+        },
+        "personalBalanceNote": "Credits go to your personal balance.",
+        "progressLabel": "Get started progress",
+        "reward": "+{{amount}}",
+        "share": {
+          "description": "Post it, then paste the link",
+          "name": "Share {{assistantName}} on X"
+        },
+        "shareDialog": {
+          "description": "Post about something you built, then paste the link. You get one submission.",
+          "helper": "The post has to be public and mention {{assistantName}}.",
+          "inputLabel": "Post link",
+          "placeholder": "https://x.com/...",
+          "submit": "Submit",
+          "title": "Share {{assistantName}} on X"
+        },
+        "slack": {
+          "description": "Where your team already works",
+          "name": "Add {{assistantName}} to Slack"
+        },
+        "stepCount": "{{completed}}/{{total}}",
+        "subtitle": "Finish a step, keep the credits.",
+        "title": "Get started",
+        "workflow": {
+          "description": "Turn a repeat task into an automation",
+          "name": "Build a workflow"
+        }
+      },
       "growth": {
         "addInSlack": "Add {{assistantName}} in Slack",
         "connect": "Connect",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1703,6 +1703,51 @@
       "title": "Acción no disponible"
     },
     "agentPage": {
+      "getStarted": {
+        "checkin": {
+          "description": "Una vez al día, todos los días",
+          "name": "Entrar cada día",
+          "unit": "al día"
+        },
+        "connector": {
+          "description": "Gmail, Notion y más de 100",
+          "name": "Conectar un conector",
+          "unit": "por conector"
+        },
+        "inReview": "En revisión",
+        "inReviewDescription": "Enviado, pendiente de revisión",
+        "invite": {
+          "description": "Cada persona que añadas cuenta",
+          "name": "Invita a tu equipo",
+          "unit": "por miembro"
+        },
+        "personalBalanceNote": "Los créditos van a tu saldo personal.",
+        "progressLabel": "Progreso de los primeros pasos",
+        "reward": "+{{amount}}",
+        "share": {
+          "description": "Publícalo y pega el enlace",
+          "name": "Comparte {{assistantName}} en X"
+        },
+        "shareDialog": {
+          "description": "Publica algo que hayas creado y pega el enlace. Tienes un solo envío.",
+          "helper": "La publicación tiene que ser pública y mencionar a {{assistantName}}.",
+          "inputLabel": "Enlace de la publicación",
+          "placeholder": "https://x.com/...",
+          "submit": "Enviar",
+          "title": "Comparte {{assistantName}} en X"
+        },
+        "slack": {
+          "description": "Donde tu equipo ya trabaja",
+          "name": "Añadir {{assistantName}} a Slack"
+        },
+        "stepCount": "{{completed}}/{{total}}",
+        "subtitle": "Completa un paso y quédate con los créditos.",
+        "title": "Primeros pasos",
+        "workflow": {
+          "description": "Convierte una tarea repetida en una automatización",
+          "name": "Crea un workflow"
+        }
+      },
       "growth": {
         "addInSlack": "Añadir {{assistantName}} en Slack",
         "connect": "Conectar",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1703,6 +1703,51 @@
       "title": "Action indisponible"
     },
     "agentPage": {
+      "getStarted": {
+        "checkin": {
+          "description": "Une fois par jour, chaque jour",
+          "name": "Se connecter chaque jour",
+          "unit": "par jour"
+        },
+        "connector": {
+          "description": "Gmail, Notion et plus de 100 autres",
+          "name": "Connecter un connecteur",
+          "unit": "par connecteur"
+        },
+        "inReview": "En cours d'examen",
+        "inReviewDescription": "Envoyé, en attente d'examen",
+        "invite": {
+          "description": "Chaque personne ajoutée compte",
+          "name": "Invitez votre équipe",
+          "unit": "par membre"
+        },
+        "personalBalanceNote": "Les crédits vont sur votre solde personnel.",
+        "progressLabel": "Progression du démarrage",
+        "reward": "+{{amount}}",
+        "share": {
+          "description": "Publiez, puis collez le lien",
+          "name": "Partager {{assistantName}} sur X"
+        },
+        "shareDialog": {
+          "description": "Publiez ce que vous avez créé, puis collez le lien. Vous avez un seul envoi.",
+          "helper": "La publication doit être publique et mentionner {{assistantName}}.",
+          "inputLabel": "Lien de la publication",
+          "placeholder": "https://x.com/...",
+          "submit": "Envoyer",
+          "title": "Partager {{assistantName}} sur X"
+        },
+        "slack": {
+          "description": "Là où votre équipe travaille déjà",
+          "name": "Ajouter {{assistantName}} à Slack"
+        },
+        "stepCount": "{{completed}}/{{total}}",
+        "subtitle": "Terminez une étape, les crédits sont à vous.",
+        "title": "Démarrer",
+        "workflow": {
+          "description": "Transformez une tâche répétitive en automatisation",
+          "name": "Créer un workflow"
+        }
+      },
       "growth": {
         "addInSlack": "Ajouter {{assistantName}} dans Slack",
         "connect": "Connecter",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1679,6 +1679,51 @@
       "title": "कार्रवाई उपलब्ध नहीं है"
     },
     "agentPage": {
+      "getStarted": {
+        "checkin": {
+          "description": "दिन में एक बार, हर दिन",
+          "name": "रोज़ चेक इन करें",
+          "unit": "प्रति दिन"
+        },
+        "connector": {
+          "description": "Gmail, Notion और 100+ अन्य",
+          "name": "कनेक्टर जोड़ें",
+          "unit": "प्रति कनेक्टर"
+        },
+        "inReview": "समीक्षा में",
+        "inReviewDescription": "भेजा गया, समीक्षा बाकी है",
+        "invite": {
+          "description": "आप जिसे भी जोड़ेंगे वह गिना जाएगा",
+          "name": "अपनी टीम को बुलाएँ",
+          "unit": "प्रति सदस्य"
+        },
+        "personalBalanceNote": "क्रेडिट आपके निजी बैलेंस में जाते हैं।",
+        "progressLabel": "शुरुआत की प्रगति",
+        "reward": "+{{amount}}",
+        "share": {
+          "description": "पोस्ट करें, फिर लिंक यहाँ चिपकाएँ",
+          "name": "{{assistantName}} को X पर शेयर करें"
+        },
+        "shareDialog": {
+          "description": "आपने जो बनाया है उसके बारे में पोस्ट करें, फिर लिंक चिपकाएँ। आपको एक ही मौका मिलेगा।",
+          "helper": "पोस्ट सार्वजनिक होनी चाहिए और उसमें {{assistantName}} का ज़िक्र होना चाहिए।",
+          "inputLabel": "पोस्ट का लिंक",
+          "placeholder": "https://x.com/...",
+          "submit": "भेजें",
+          "title": "{{assistantName}} को X पर शेयर करें"
+        },
+        "slack": {
+          "description": "जहाँ आपकी टीम पहले से काम करती है",
+          "name": "{{assistantName}} को Slack में जोड़ें"
+        },
+        "stepCount": "{{completed}}/{{total}}",
+        "subtitle": "एक कदम पूरा करें, क्रेडिट आपके।",
+        "title": "शुरू करें",
+        "workflow": {
+          "description": "बार-बार होने वाले काम को ऑटोमेशन बनाएँ",
+          "name": "वर्कफ़्लो बनाएँ"
+        }
+      },
       "growth": {
         "addInSlack": "Slack में {{assistantName}} जोड़ें",
         "connect": "कनेक्ट करें",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1678,6 +1678,51 @@
       "title": "Tindakan tidak tersedia"
     },
     "agentPage": {
+      "getStarted": {
+        "checkin": {
+          "description": "Sekali sehari, setiap hari",
+          "name": "Check in setiap hari",
+          "unit": "per hari"
+        },
+        "connector": {
+          "description": "Gmail, Notion, dan 100+ lainnya",
+          "name": "Hubungkan konektor",
+          "unit": "per konektor"
+        },
+        "inReview": "Sedang ditinjau",
+        "inReviewDescription": "Terkirim, menunggu ditinjau",
+        "invite": {
+          "description": "Setiap orang yang kamu tambahkan dihitung",
+          "name": "Undang tim kamu",
+          "unit": "per anggota"
+        },
+        "personalBalanceNote": "Kredit masuk ke saldo pribadi kamu.",
+        "progressLabel": "Progres memulai",
+        "reward": "+{{amount}}",
+        "share": {
+          "description": "Posting, lalu tempel tautannya",
+          "name": "Bagikan {{assistantName}} di X"
+        },
+        "shareDialog": {
+          "description": "Posting sesuatu yang kamu buat, lalu tempel tautannya. Kamu dapat satu kali kirim.",
+          "helper": "Postingan harus publik dan menyebut {{assistantName}}.",
+          "inputLabel": "Tautan postingan",
+          "placeholder": "https://x.com/...",
+          "submit": "Kirim",
+          "title": "Bagikan {{assistantName}} di X"
+        },
+        "slack": {
+          "description": "Tempat tim kamu sudah bekerja",
+          "name": "Tambahkan {{assistantName}} ke Slack"
+        },
+        "stepCount": "{{completed}}/{{total}}",
+        "subtitle": "Selesaikan satu langkah, kreditnya jadi milikmu.",
+        "title": "Mulai",
+        "workflow": {
+          "description": "Ubah tugas berulang jadi otomatisasi",
+          "name": "Buat workflow"
+        }
+      },
       "growth": {
         "addInSlack": "Tambahkan {{assistantName}} di Slack",
         "connect": "Hubungkan",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1703,6 +1703,51 @@
       "title": "Azione non disponibile"
     },
     "agentPage": {
+      "getStarted": {
+        "checkin": {
+          "description": "Una volta al giorno, ogni giorno",
+          "name": "Accedi ogni giorno",
+          "unit": "al giorno"
+        },
+        "connector": {
+          "description": "Gmail, Notion e altri 100+",
+          "name": "Collega un connettore",
+          "unit": "per connettore"
+        },
+        "inReview": "In revisione",
+        "inReviewDescription": "Inviato, in attesa di revisione",
+        "invite": {
+          "description": "Ogni persona che aggiungi conta",
+          "name": "Invita il tuo team",
+          "unit": "per membro"
+        },
+        "personalBalanceNote": "I crediti vanno sul tuo saldo personale.",
+        "progressLabel": "Avanzamento dei primi passi",
+        "reward": "+{{amount}}",
+        "share": {
+          "description": "Pubblica, poi incolla il link",
+          "name": "Condividi {{assistantName}} su X"
+        },
+        "shareDialog": {
+          "description": "Pubblica qualcosa che hai creato, poi incolla il link. Hai un solo invio.",
+          "helper": "Il post deve essere pubblico e menzionare {{assistantName}}.",
+          "inputLabel": "Link del post",
+          "placeholder": "https://x.com/...",
+          "submit": "Invia",
+          "title": "Condividi {{assistantName}} su X"
+        },
+        "slack": {
+          "description": "Dove il tuo team lavora già",
+          "name": "Aggiungi {{assistantName}} a Slack"
+        },
+        "stepCount": "{{completed}}/{{total}}",
+        "subtitle": "Completa un passo, i crediti restano tuoi.",
+        "title": "Inizia",
+        "workflow": {
+          "description": "Trasforma un'attività ricorrente in un'automazione",
+          "name": "Crea un workflow"
+        }
+      },
       "growth": {
         "addInSlack": "Aggiungi {{assistantName}} su Slack",
         "connect": "Connetti",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1678,6 +1678,51 @@
       "title": "アクションを利用できません"
     },
     "agentPage": {
+      "getStarted": {
+        "checkin": {
+          "description": "1日1回、毎日",
+          "name": "毎日チェックイン",
+          "unit": "1日あたり"
+        },
+        "connector": {
+          "description": "Gmail、Notion など100以上",
+          "name": "コネクタを接続",
+          "unit": "コネクタごと"
+        },
+        "inReview": "確認中",
+        "inReviewDescription": "送信済み、確認待ち",
+        "invite": {
+          "description": "追加した人数だけ加算されます",
+          "name": "チームを招待",
+          "unit": "メンバーごと"
+        },
+        "personalBalanceNote": "クレジットはあなた個人の残高に入ります。",
+        "progressLabel": "セットアップの進捗",
+        "reward": "+{{amount}}",
+        "share": {
+          "description": "投稿して、リンクを貼り付け",
+          "name": "{{assistantName}} を X でシェア"
+        },
+        "shareDialog": {
+          "description": "作ったものについて投稿し、リンクを貼り付けてください。提出は1回だけです。",
+          "helper": "投稿は公開で、{{assistantName}} に触れている必要があります。",
+          "inputLabel": "投稿のリンク",
+          "placeholder": "https://x.com/...",
+          "submit": "送信",
+          "title": "{{assistantName}} を X でシェア"
+        },
+        "slack": {
+          "description": "チームがすでに使っている場所へ",
+          "name": "{{assistantName}} を Slack に追加"
+        },
+        "stepCount": "{{completed}}/{{total}}",
+        "subtitle": "ステップを終えると、クレジットがもらえます。",
+        "title": "はじめる",
+        "workflow": {
+          "description": "繰り返しの作業を自動化に変える",
+          "name": "ワークフローを作る"
+        }
+      },
       "growth": {
         "addInSlack": "Slack に {{assistantName}} を追加",
         "connect": "接続",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1678,6 +1678,51 @@
       "title": "작업을 사용할 수 없음"
     },
     "agentPage": {
+      "getStarted": {
+        "checkin": {
+          "description": "하루에 한 번, 매일",
+          "name": "매일 출석하기",
+          "unit": "하루당"
+        },
+        "connector": {
+          "description": "Gmail, Notion 등 100개 이상",
+          "name": "커넥터 연결하기",
+          "unit": "커넥터당"
+        },
+        "inReview": "검토 중",
+        "inReviewDescription": "제출됨, 검토 대기 중",
+        "invite": {
+          "description": "추가하는 사람마다 적립됩니다",
+          "name": "팀 초대하기",
+          "unit": "멤버당"
+        },
+        "personalBalanceNote": "크레딧은 개인 잔액으로 들어갑니다.",
+        "progressLabel": "시작하기 진행 상황",
+        "reward": "+{{amount}}",
+        "share": {
+          "description": "게시한 뒤 링크를 붙여넣기",
+          "name": "X에 {{assistantName}} 공유하기"
+        },
+        "shareDialog": {
+          "description": "만든 것을 게시하고 링크를 붙여넣으세요. 제출은 한 번만 가능합니다.",
+          "helper": "게시물은 공개 상태여야 하고 {{assistantName}}을(를) 언급해야 합니다.",
+          "inputLabel": "게시물 링크",
+          "placeholder": "https://x.com/...",
+          "submit": "제출",
+          "title": "X에 {{assistantName}} 공유하기"
+        },
+        "slack": {
+          "description": "팀이 이미 일하고 있는 곳으로",
+          "name": "Slack에 {{assistantName}} 추가하기"
+        },
+        "stepCount": "{{completed}}/{{total}}",
+        "subtitle": "한 단계를 끝내면 크레딧은 그대로 내 것.",
+        "title": "시작하기",
+        "workflow": {
+          "description": "반복 작업을 자동화로 바꾸기",
+          "name": "워크플로 만들기"
+        }
+      },
       "growth": {
         "addInSlack": "Slack에 {{assistantName}} 추가",
         "connect": "연결",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1703,6 +1703,51 @@
       "title": "Ação indisponível"
     },
     "agentPage": {
+      "getStarted": {
+        "checkin": {
+          "description": "Uma vez por dia, todo dia",
+          "name": "Entrar todo dia",
+          "unit": "por dia"
+        },
+        "connector": {
+          "description": "Gmail, Notion e mais de 100",
+          "name": "Conectar um conector",
+          "unit": "por conector"
+        },
+        "inReview": "Em análise",
+        "inReviewDescription": "Enviado, aguardando análise",
+        "invite": {
+          "description": "Cada pessoa que você adiciona conta",
+          "name": "Convide seu time",
+          "unit": "por membro"
+        },
+        "personalBalanceNote": "Os créditos vão para o seu saldo pessoal.",
+        "progressLabel": "Progresso dos primeiros passos",
+        "reward": "+{{amount}}",
+        "share": {
+          "description": "Publique e cole o link aqui",
+          "name": "Compartilhe o {{assistantName}} no X"
+        },
+        "shareDialog": {
+          "description": "Publique algo que você criou e cole o link. Você tem um envio.",
+          "helper": "A publicação precisa ser pública e mencionar o {{assistantName}}.",
+          "inputLabel": "Link da publicação",
+          "placeholder": "https://x.com/...",
+          "submit": "Enviar",
+          "title": "Compartilhe o {{assistantName}} no X"
+        },
+        "slack": {
+          "description": "Onde seu time já trabalha",
+          "name": "Adicionar o {{assistantName}} ao Slack"
+        },
+        "stepCount": "{{completed}}/{{total}}",
+        "subtitle": "Conclua uma etapa e fique com os créditos.",
+        "title": "Primeiros passos",
+        "workflow": {
+          "description": "Transforme uma tarefa repetida em automação",
+          "name": "Criar um workflow"
+        }
+      },
       "growth": {
         "addInSlack": "Adicionar {{assistantName}} no Slack",
         "connect": "Conectar",

--- a/turbo/apps/platform/src/signals/okou-page/get-started.ts
+++ b/turbo/apps/platform/src/signals/okou-page/get-started.ts
@@ -1,0 +1,136 @@
+import { command, computed, state } from "ccstate";
+import { isOrgAdmin$ } from "../org.ts";
+
+/** The onboarding quests, named the way the panel lists them. */
+export type GetStartedQuestKey =
+  | "connector"
+  | "slack"
+  | "workflow"
+  | "invite"
+  | "share"
+  | "checkin";
+
+/**
+ * `inReview` belongs to the X post alone: it is the only quest a person claims
+ * by submitting something, so it has a state between untouched and earned.
+ */
+export type GetStartedQuestStatus = "todo" | "inReview" | "done";
+
+export interface GetStartedQuest {
+  readonly key: GetStartedQuestKey;
+  readonly status: GetStartedQuestStatus;
+  /** Credits this person has already earned from this quest. */
+  readonly earnedCredits: number;
+}
+
+/**
+ * Installing Slack and inviting members are org-level actions, so a member is
+ * offered only the quests they can finish on their own. Both the count and the
+ * ring are computed from whichever set applies, never from the admin set, so a
+ * member is never shown a step they cannot take or a total they cannot reach.
+ */
+const ADMIN_QUEST_KEYS = [
+  "connector",
+  "slack",
+  "workflow",
+  "invite",
+  "share",
+  "checkin",
+] as const satisfies readonly GetStartedQuestKey[];
+
+const MEMBER_QUEST_KEYS = [
+  "connector",
+  "workflow",
+  "share",
+  "checkin",
+] as const satisfies readonly GetStartedQuestKey[];
+
+/**
+ * Placeholder progress.
+ *
+ * Credits are earned per person rather than per org, so this stands in for a
+ * per-user endpoint that does not exist yet. Nothing here reads or writes a
+ * real balance, which is why the whole entry stays behind its feature switch.
+ */
+const mockQuestProgress$ = state<
+  Readonly<Record<GetStartedQuestKey, GetStartedQuest>>
+>({
+  connector: { key: "connector", status: "done", earnedCredits: 300 },
+  slack: { key: "slack", status: "done", earnedCredits: 2000 },
+  workflow: { key: "workflow", status: "todo", earnedCredits: 0 },
+  invite: { key: "invite", status: "todo", earnedCredits: 0 },
+  share: { key: "share", status: "todo", earnedCredits: 0 },
+  checkin: { key: "checkin", status: "todo", earnedCredits: 0 },
+});
+
+export const getStartedQuests$ = computed(
+  async (get): Promise<readonly GetStartedQuest[]> => {
+    const isAdmin = await get(isOrgAdmin$);
+    const progress = get(mockQuestProgress$);
+    const keys = isAdmin ? ADMIN_QUEST_KEYS : MEMBER_QUEST_KEYS;
+    return keys.map((key) => {
+      return progress[key];
+    });
+  },
+);
+
+export interface GetStartedSummary {
+  readonly completed: number;
+  readonly total: number;
+  /** Credits this person has earned, not the org balance. */
+  readonly earnedCredits: number;
+}
+
+export const getStartedSummary$ = computed(
+  async (get): Promise<GetStartedSummary> => {
+    const quests = await get(getStartedQuests$);
+    return {
+      completed: quests.filter((quest) => {
+        return quest.status === "done";
+      }).length,
+      total: quests.length,
+      earnedCredits: quests.reduce((sum, quest) => {
+        return sum + quest.earnedCredits;
+      }, 0),
+    };
+  },
+);
+
+const internalShareDialogOpen$ = state(false);
+const internalSharePostDraft$ = state("");
+
+export const shareDialogOpen$ = computed((get) => {
+  return get(internalShareDialogOpen$);
+});
+
+export const sharePostDraft$ = computed((get) => {
+  return get(internalSharePostDraft$);
+});
+
+/** Closing always clears the field, so reopening never shows a stale link. */
+export const setShareDialogOpen$ = command(({ set }, open: boolean) => {
+  set(internalShareDialogOpen$, open);
+  if (!open) {
+    set(internalSharePostDraft$, "");
+  }
+});
+
+export const setSharePostDraft$ = command(({ set }, draft: string) => {
+  set(internalSharePostDraft$, draft);
+});
+
+/**
+ * Spend the single X submission.
+ *
+ * The post URL is deliberately not carried anywhere yet: no endpoint accepts
+ * it, and keeping it in the client would only pretend it had been stored. The
+ * real command takes the URL and returns the review outcome.
+ */
+export const submitSharePost$ = command(({ set }) => {
+  set(mockQuestProgress$, (progress) => {
+    const share: GetStartedQuest = { ...progress.share, status: "inReview" };
+    return { ...progress, share };
+  });
+  set(internalShareDialogOpen$, false);
+  set(internalSharePostDraft$, "");
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/get-started-entry.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/get-started-entry.test.tsx
@@ -1,0 +1,207 @@
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import {
+  integrationsSlackContract,
+  type SlackOrgStatus,
+} from "@okouai/api-contracts/contracts/integrations-slack";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { expect, test } from "vitest";
+
+import {
+  click,
+  queryAllByRoleFast,
+  setupPage,
+} from "../../../__tests__/page-helper.ts";
+import { pathname } from "../../../signals/location.ts";
+import {
+  testContext,
+  type TestContext,
+} from "../../../signals/__tests__/test-helpers.ts";
+
+const QUEST_AGENT_ID = "c0000000-0000-4000-a000-000000000002";
+const context = testContext();
+
+function normalizedText(element: Element): string {
+  return element.textContent?.replace(/\s+/gu, " ").trim() ?? "";
+}
+
+function slackInstalled(): SlackOrgStatus {
+  return {
+    isConnected: true,
+    isInstalled: true,
+    isAdmin: true,
+    workspaceName: "Quest Workspace",
+    installUrl: null,
+    connectUrl: null,
+    environment: {
+      requiredSecrets: [],
+      requiredVars: [],
+      missingSecrets: [],
+      missingVars: [],
+    },
+  };
+}
+
+function configureQuestPage(
+  context: TestContext,
+  role: "admin" | "member",
+): void {
+  context.mocks.data.org({
+    id: "org_default",
+    name: "Quest Workspace",
+    role,
+  });
+  context.mocks.data.agents([
+    {
+      agentId: QUEST_AGENT_ID,
+      ownerId: "test-user-123",
+      displayName: null,
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      modelProviderId: null,
+      selectedModel: null,
+      preferPersonalProvider: false,
+      visibility: "private",
+    },
+  ]);
+  context.mocks.api(integrationsSlackContract.getStatus, ({ respond }) => {
+    return respond(200, slackInstalled());
+  });
+}
+
+function questChatPath(): string {
+  return `/agents/${QUEST_AGENT_ID}/chat`;
+}
+
+async function openQuestPanel(): Promise<HTMLElement> {
+  const entry = await waitFor(() => {
+    return screen.getByTestId("get-started-entry");
+  });
+  click(entry);
+  return await screen.findByRole("menu");
+}
+
+test("An admin sees every step and what each one pays", async () => {
+  configureQuestPage(context, "admin");
+  await setupPage({
+    context,
+    path: questChatPath(),
+    featureSwitches: { [FeatureSwitchKey.GetStartedQuests]: true },
+  });
+
+  const entry = await waitFor(() => {
+    return screen.getByTestId("get-started-entry");
+  });
+  expect(normalizedText(entry)).toBe("Get started2/6");
+
+  const panel = await openQuestPanel();
+  expect(
+    within(panel).getByText("Credits go to your personal balance."),
+  ).toBeVisible();
+  const workflow = within(screen.getByTestId("get-started-quest-workflow"));
+  expect(workflow.getByText("Build a workflow")).toBeVisible();
+  expect(
+    workflow.getByText("Turn a repeat task into an automation"),
+  ).toBeVisible();
+  expect(workflow.getByText("+1,000")).toBeVisible();
+
+  // A reward that keeps paying names its unit next to the amount.
+  const invite = within(screen.getByTestId("get-started-quest-invite"));
+  expect(invite.getByText("Invite your team")).toBeVisible();
+  expect(invite.getByText("per member")).toBeVisible();
+
+  // Connecting and installing Slack are already done, so they carry no reward.
+  expect(within(panel).getByText("2,300")).toBeVisible();
+  expect(
+    screen.queryByTestId("get-started-quest-connector"),
+  ).not.toBeInTheDocument();
+});
+
+test("A member is only offered the steps they can finish themselves", async () => {
+  configureQuestPage(context, "member");
+  await setupPage({
+    context,
+    path: questChatPath(),
+    featureSwitches: { [FeatureSwitchKey.GetStartedQuests]: true },
+  });
+
+  const entry = await waitFor(() => {
+    return screen.getByTestId("get-started-entry");
+  });
+  expect(normalizedText(entry)).toBe("Get started1/4");
+
+  const panel = await openQuestPanel();
+  expect(screen.getByTestId("get-started-quest-workflow")).toBeVisible();
+  expect(screen.getByTestId("get-started-quest-share")).toBeVisible();
+  expect(within(panel).queryByText("Invite your team")).not.toBeInTheDocument();
+  expect(
+    within(panel).queryByText("Add Okou to Slack"),
+  ).not.toBeInTheDocument();
+  // The earned total counts only the quests this role was offered.
+  expect(within(panel).getByText("300")).toBeVisible();
+});
+
+test("Building a workflow opens the workflows page", async () => {
+  configureQuestPage(context, "admin");
+  await setupPage({
+    context,
+    path: questChatPath(),
+    featureSwitches: { [FeatureSwitchKey.GetStartedQuests]: true },
+  });
+
+  await openQuestPanel();
+  click(screen.getByTestId("get-started-quest-workflow"));
+
+  await waitFor(() => {
+    expect(pathname()).toBe("/workflows");
+  });
+});
+
+test("Sharing on X spends the one submission", async () => {
+  configureQuestPage(context, "admin");
+  await setupPage({
+    context,
+    path: questChatPath(),
+    featureSwitches: { [FeatureSwitchKey.GetStartedQuests]: true },
+  });
+
+  await openQuestPanel();
+  click(screen.getByTestId("get-started-quest-share"));
+
+  const dialog = await screen.findByRole("dialog", {
+    name: "Share Okou on X",
+  });
+  const submit = within(dialog).getByRole("button", { name: "Submit" });
+  // Nothing can be claimed without a link.
+  expect(submit).toBeDisabled();
+
+  fireEvent.change(within(dialog).getByRole("textbox", { name: "Post link" }), {
+    target: { value: "https://x.com/molly/status/1873" },
+  });
+  expect(submit).toBeEnabled();
+  click(submit);
+
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  const panel = await openQuestPanel();
+  expect(within(panel).getByText("In review")).toBeVisible();
+  expect(within(panel).queryByText("Share Okou on X")).toBeInTheDocument();
+  // The row no longer offers the reward, and it is no longer a menu item.
+  expect(
+    queryAllByRoleFast("menuitem", panel).find((candidate) => {
+      return normalizedText(candidate).includes("Share Okou on X");
+    }),
+  ).toBeUndefined();
+});
+
+test("The entry stays hidden while the switch is off", async () => {
+  configureQuestPage(context, "admin");
+  await setupPage({ context, path: questChatPath() });
+
+  await expect(
+    screen.findByRole("textbox", { name: "Message" }),
+  ).resolves.toBeVisible();
+  expect(screen.queryByTestId("get-started-entry")).not.toBeInTheDocument();
+});

--- a/turbo/apps/platform/src/views/okou-page/components/slack-mark.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/slack-mark.tsx
@@ -1,0 +1,26 @@
+import { settingsIconAssetUrl } from "./settings/settings-icon-assets.ts";
+
+const slackIconImg = settingsIconAssetUrl("slack");
+
+/**
+ * The Slack mark, drawn the way the nav rail draws it: the artwork carries its
+ * own padding, so it is scaled up inside a box the size we actually want.
+ *
+ * 16px everywhere, because Button and DropdownMenuItem both enforce
+ * `[&_svg]:size-4` on their descendants and the marks have to agree with it.
+ */
+export function SlackMark({ size }: { size: number }) {
+  return (
+    <span
+      className="grid shrink-0 place-items-center"
+      style={{ width: size, height: size }}
+    >
+      <img
+        src={slackIconImg}
+        alt=""
+        className="scale-[2.2]"
+        style={{ width: size, height: size }}
+      />
+    </span>
+  );
+}

--- a/turbo/apps/platform/src/views/okou-page/get-started-entry.tsx
+++ b/turbo/apps/platform/src/views/okou-page/get-started-entry.tsx
@@ -1,0 +1,564 @@
+import type { ReactNode } from "react";
+import { useGet, useLastLoadable, useSet } from "ccstate-react";
+import { useTranslation } from "react-i18next";
+import {
+  CalendarCheck,
+  Check,
+  Coins,
+  Link2,
+  UserPlus,
+  Workflow,
+} from "lucide-react";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Input,
+} from "@okouai/ui";
+import { assistantName$ } from "../../signals/branding.ts";
+import { detachedNavigateTo$ } from "../../signals/route.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { openSettingsDialogAt$ } from "../../signals/okou-page/settings/settings-dialog.ts";
+import {
+  getStartedQuests$,
+  getStartedSummary$,
+  setShareDialogOpen$,
+  setSharePostDraft$,
+  shareDialogOpen$,
+  sharePostDraft$,
+  submitSharePost$,
+  type GetStartedQuest,
+  type GetStartedQuestKey,
+  type GetStartedSummary,
+} from "../../signals/okou-page/get-started.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import { formatLocalizedNumber } from "../../i18n/format.ts";
+import { DropdownMenuModalItem } from "../components/dropdown-menu-modal-item.tsx";
+import { SlackMark } from "./components/slack-mark.tsx";
+
+/** What each quest pays. Rewards are per person, not per org. */
+const QUEST_REWARDS = {
+  connector: 100,
+  slack: 2000,
+  workflow: 1000,
+  invite: 100,
+  share: 2000,
+  checkin: 100,
+} as const satisfies Record<GetStartedQuestKey, number>;
+
+// The ring is drawn at 16px so it agrees with the `[&_svg]:size-4` that Button
+// enforces on its descendants, and its geometry is fixed at that size.
+const RING_RADIUS = 7;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
+function QuestRing({ completed, total }: { completed: number; total: number }) {
+  const fraction = total === 0 ? 0 : completed / total;
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      className="size-4 shrink-0"
+      fill="none"
+      strokeWidth={2}
+      aria-hidden="true"
+    >
+      <circle
+        cx={8}
+        cy={8}
+        r={RING_RADIUS}
+        className="stroke-[hsl(var(--gray-300))]"
+      />
+      {fraction > 0 && (
+        <circle
+          cx={8}
+          cy={8}
+          r={RING_RADIUS}
+          className="stroke-[hsl(var(--primary))]"
+          strokeLinecap="round"
+          strokeDasharray={RING_CIRCUMFERENCE}
+          strokeDashoffset={RING_CIRCUMFERENCE * (1 - fraction)}
+          transform="rotate(-90 8 8)"
+        />
+      )}
+    </svg>
+  );
+}
+
+/** X publishes no icon font and lucide dropped brand marks, so it is inlined. */
+function XMark() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="size-4 shrink-0"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M17.53 3H21l-7.19 8.21L22.24 21h-6.63l-5.2-6.79L4.46 21H1l7.69-8.79L1.27 3h6.8l4.7 6.22L17.53 3Zm-1.16 16h1.83L7.75 4.9H5.79L16.37 19Z" />
+    </svg>
+  );
+}
+
+const QUEST_ICONS = Object.freeze<Record<GetStartedQuestKey, ReactNode>>({
+  connector: <Link2 className="text-muted-foreground" />,
+  slack: <SlackMark size={16} />,
+  workflow: <Workflow className="text-muted-foreground" />,
+  invite: <UserPlus className="text-muted-foreground" />,
+  share: <XMark />,
+  checkin: <CalendarCheck className="text-muted-foreground" />,
+});
+
+interface QuestCopy {
+  readonly name: string;
+  readonly description: string;
+  /** The trailing unit on a reward that is paid more than once, if any. */
+  readonly unit: string | null;
+}
+
+function useQuestCopy(): Record<GetStartedQuestKey, QuestCopy> {
+  const { t } = useTranslation();
+  const assistantName = useGet(assistantName$);
+  return {
+    connector: {
+      name: t(($) => {
+        return $.chat.agentPage.getStarted.connector.name;
+      }),
+      description: t(($) => {
+        return $.chat.agentPage.getStarted.connector.description;
+      }),
+      unit: t(($) => {
+        return $.chat.agentPage.getStarted.connector.unit;
+      }),
+    },
+    slack: {
+      name: t(
+        ($) => {
+          return $.chat.agentPage.getStarted.slack.name;
+        },
+        { assistantName },
+      ),
+      description: t(($) => {
+        return $.chat.agentPage.getStarted.slack.description;
+      }),
+      unit: null,
+    },
+    workflow: {
+      name: t(($) => {
+        return $.chat.agentPage.getStarted.workflow.name;
+      }),
+      description: t(($) => {
+        return $.chat.agentPage.getStarted.workflow.description;
+      }),
+      unit: null,
+    },
+    invite: {
+      name: t(($) => {
+        return $.chat.agentPage.getStarted.invite.name;
+      }),
+      description: t(($) => {
+        return $.chat.agentPage.getStarted.invite.description;
+      }),
+      unit: t(($) => {
+        return $.chat.agentPage.getStarted.invite.unit;
+      }),
+    },
+    share: {
+      name: t(
+        ($) => {
+          return $.chat.agentPage.getStarted.share.name;
+        },
+        { assistantName },
+      ),
+      description: t(($) => {
+        return $.chat.agentPage.getStarted.share.description;
+      }),
+      unit: null,
+    },
+    checkin: {
+      name: t(($) => {
+        return $.chat.agentPage.getStarted.checkin.name;
+      }),
+      description: t(($) => {
+        return $.chat.agentPage.getStarted.checkin.description;
+      }),
+      unit: t(($) => {
+        return $.chat.agentPage.getStarted.checkin.unit;
+      }),
+    },
+  };
+}
+
+function QuestReward({
+  questKey,
+  unit,
+}: {
+  questKey: GetStartedQuestKey;
+  unit: string | null;
+}) {
+  const { t } = useTranslation();
+  return (
+    <span className="shrink-0 text-xs font-semibold tabular-nums text-brand-text">
+      {t(
+        ($) => {
+          return $.chat.agentPage.getStarted.reward;
+        },
+        { amount: formatLocalizedNumber(QUEST_REWARDS[questKey]) },
+      )}
+      {unit !== null && (
+        <span className="font-normal text-muted-foreground"> {unit}</span>
+      )}
+    </span>
+  );
+}
+
+const QUEST_ROW_CLASS = "gap-3 px-3 py-2.5";
+
+function QuestRowBody({
+  quest,
+  copy,
+}: {
+  quest: GetStartedQuest;
+  copy: QuestCopy;
+}) {
+  const { t } = useTranslation();
+  const done = quest.status === "done";
+  const description =
+    quest.status === "inReview"
+      ? t(($) => {
+          return $.chat.agentPage.getStarted.inReviewDescription;
+        })
+      : copy.description;
+  return (
+    <>
+      {QUEST_ICONS[quest.key]}
+      <span className="min-w-0 flex-1">
+        <span
+          className={`block truncate ${done ? "text-muted-foreground" : ""}`}
+        >
+          {copy.name}
+        </span>
+        <span className="block truncate text-xs text-muted-foreground">
+          {description}
+        </span>
+      </span>
+      {done && <Check className="shrink-0 text-[#2EB67D]" />}
+      {quest.status === "inReview" && (
+        <span className="shrink-0 rounded-full bg-gray-50 px-2 py-0.5 text-xs text-muted-foreground">
+          {t(($) => {
+            return $.chat.agentPage.getStarted.inReview;
+          })}
+        </span>
+      )}
+      {quest.status === "todo" && (
+        <QuestReward questKey={quest.key} unit={copy.unit} />
+      )}
+    </>
+  );
+}
+
+function QuestRow({
+  quest,
+  copy,
+  onSelect,
+}: {
+  quest: GetStartedQuest;
+  copy: QuestCopy;
+  onSelect: (() => void) | null;
+}) {
+  const body = <QuestRowBody quest={quest} copy={copy} />;
+  const testId = `get-started-quest-${quest.key}`;
+
+  // A quest with nothing left to open is a status line, not a control, so it
+  // renders without a hover state rather than as a menu item that does nothing.
+  if (onSelect === null) {
+    return <div className={`flex items-center ${QUEST_ROW_CLASS}`}>{body}</div>;
+  }
+
+  // The X quest is the only row that opens a dialog, so it hands the menu a
+  // select handler rather than a click: the menu has to finish closing before
+  // the dialog takes focus.
+  if (quest.key === "share") {
+    return (
+      <DropdownMenuModalItem
+        className={QUEST_ROW_CLASS}
+        onModalSelect={onSelect}
+        data-testid={testId}
+      >
+        {body}
+      </DropdownMenuModalItem>
+    );
+  }
+
+  return (
+    <DropdownMenuItem
+      className={QUEST_ROW_CLASS}
+      onClick={onSelect}
+      data-testid={testId}
+    >
+      {body}
+    </DropdownMenuItem>
+  );
+}
+
+function ShareOnXDialog() {
+  const { t } = useTranslation();
+  const assistantName = useGet(assistantName$);
+  const open = useGet(shareDialogOpen$);
+  const postUrl = useGet(sharePostDraft$);
+  const setOpen = useSet(setShareDialogOpen$);
+  const setDraft = useSet(setSharePostDraft$);
+  const submitShare = useSet(submitSharePost$);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent smMaxWidth="sm" maxWidth={420} contentClassName="okou-app">
+        <DialogHeader>
+          <DialogTitle>
+            {t(
+              ($) => {
+                return $.chat.agentPage.getStarted.shareDialog.title;
+              },
+              { assistantName },
+            )}
+          </DialogTitle>
+          <DialogDescription>
+            {t(($) => {
+              return $.chat.agentPage.getStarted.shareDialog.description;
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <div>
+          <Input
+            type="url"
+            value={postUrl}
+            aria-label={t(($) => {
+              return $.chat.agentPage.getStarted.shareDialog.inputLabel;
+            })}
+            placeholder={t(($) => {
+              return $.chat.agentPage.getStarted.shareDialog.placeholder;
+            })}
+            onChange={(event) => {
+              setDraft(event.target.value);
+            }}
+          />
+          <p className="mt-2 text-xs text-muted-foreground">
+            {t(
+              ($) => {
+                return $.chat.agentPage.getStarted.shareDialog.helper;
+              },
+              { assistantName },
+            )}
+          </p>
+        </div>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              setOpen(false);
+            }}
+          >
+            {t(($) => {
+              return $.chat.actions.cancel;
+            })}
+          </Button>
+          <Button
+            type="button"
+            disabled={postUrl.trim() === ""}
+            onClick={() => {
+              submitShare();
+            }}
+          >
+            {t(($) => {
+              return $.chat.agentPage.getStarted.shareDialog.submit;
+            })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function useQuestActions(): Record<GetStartedQuestKey, (() => void) | null> {
+  const pageSignal = useGet(pageSignal$);
+  const openSettings = useSet(openSettingsDialogAt$);
+  const navigate = useSet(detachedNavigateTo$);
+  const setShareDialogOpen = useSet(setShareDialogOpen$);
+  return {
+    connector: () => {
+      navigate("/connectors");
+    },
+    slack: () => {
+      navigate("/works");
+    },
+    workflow: () => {
+      navigate("/workflows");
+    },
+    invite: () => {
+      detach(openSettings("people", pageSignal), Reason.DomCallback);
+    },
+    share: () => {
+      setShareDialogOpen(true);
+    },
+    // Opening the app is the check-in, so there is nothing to navigate to.
+    checkin: null,
+  };
+}
+
+function GetStartedPanel({
+  quests,
+  summary,
+}: {
+  quests: readonly GetStartedQuest[];
+  summary: GetStartedSummary;
+}) {
+  const { t } = useTranslation();
+  const copy = useQuestCopy();
+  const actions = useQuestActions();
+  const percent =
+    summary.total === 0 ? 0 : (summary.completed / summary.total) * 100;
+  // Checking in is the one quest that never finishes, so it sits below a
+  // divider instead of competing with the steps that can be completed.
+  const oneTimeQuests = quests.filter((quest) => {
+    return quest.key !== "checkin";
+  });
+  const recurringQuests = quests.filter((quest) => {
+    return quest.key === "checkin";
+  });
+  const selectHandler = (quest: GetStartedQuest): (() => void) | null => {
+    return quest.status === "todo" ? actions[quest.key] : null;
+  };
+
+  return (
+    <DropdownMenuContent align="end" className="w-[356px]">
+      <div className="flex items-start gap-2.5 px-3 pb-2 pt-2.5">
+        <div className="min-w-0 flex-1">
+          <p className="text-[13px] font-semibold">
+            {t(($) => {
+              return $.chat.agentPage.getStarted.title;
+            })}
+          </p>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {t(($) => {
+              return $.chat.agentPage.getStarted.subtitle;
+            })}
+          </p>
+        </div>
+        <span className="flex h-[22px] shrink-0 items-center gap-1.5 rounded-full bg-brand-subtle px-2 text-xs font-semibold tabular-nums text-brand-text">
+          <Coins />
+          {formatLocalizedNumber(summary.earnedCredits)}
+        </span>
+      </div>
+      <div className="px-3 pb-2.5">
+        <span
+          role="progressbar"
+          aria-label={t(($) => {
+            return $.chat.agentPage.getStarted.progressLabel;
+          })}
+          aria-valuemin={0}
+          aria-valuemax={summary.total}
+          aria-valuenow={summary.completed}
+          className="block h-1 overflow-hidden rounded-full bg-[hsl(var(--gray-200))]"
+        >
+          <span
+            className="block h-full rounded-full bg-primary"
+            style={{ width: `${percent}%` }}
+          />
+        </span>
+      </div>
+      <DropdownMenuSeparator />
+      {oneTimeQuests.map((quest) => {
+        return (
+          <QuestRow
+            key={quest.key}
+            quest={quest}
+            copy={copy[quest.key]}
+            onSelect={selectHandler(quest)}
+          />
+        );
+      })}
+      {recurringQuests.length > 0 && <DropdownMenuSeparator />}
+      {recurringQuests.map((quest) => {
+        return (
+          <QuestRow
+            key={quest.key}
+            quest={quest}
+            copy={copy[quest.key]}
+            onSelect={selectHandler(quest)}
+          />
+        );
+      })}
+      <DropdownMenuSeparator />
+      <p className="px-3 pb-1 pt-1.5 text-xs text-muted-foreground">
+        {t(($) => {
+          return $.chat.agentPage.getStarted.personalBalanceNote;
+        })}
+      </p>
+    </DropdownMenuContent>
+  );
+}
+
+/**
+ * The home corner's onboarding entry.
+ *
+ * It takes the same shape as the growth control beside it — 32px tall, the same
+ * 12px radius, hairline and card shadow — so the two read as one row rather
+ * than as a control and a banner. The ring is the only mark the corner gains.
+ */
+export function GetStartedEntry() {
+  const { t } = useTranslation();
+  const questsLoadable = useLastLoadable(getStartedQuests$);
+  const summaryLoadable = useLastLoadable(getStartedSummary$);
+
+  if (
+    questsLoadable.state !== "hasData" ||
+    summaryLoadable.state !== "hasData"
+  ) {
+    return null;
+  }
+  const summary = summaryLoadable.data;
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="quiet"
+            size="sm"
+            className="h-8 gap-2 rounded-[12px] border border-[hsl(var(--gray-400))] bg-card px-[11px] text-foreground shadow-[var(--okou-card-shadow)] data-popup-open:bg-state-hover"
+            data-testid="get-started-entry"
+          >
+            <QuestRing completed={summary.completed} total={summary.total} />
+            <span className="text-[13px] font-medium">
+              {t(($) => {
+                return $.chat.agentPage.getStarted.title;
+              })}
+            </span>
+            <span
+              aria-hidden="true"
+              className="h-4 w-px shrink-0 bg-[hsl(var(--gray-300))]"
+            />
+            <span className="text-xs font-semibold tabular-nums text-muted-foreground">
+              {t(
+                ($) => {
+                  return $.chat.agentPage.getStarted.stepCount;
+                },
+                { completed: summary.completed, total: summary.total },
+              )}
+            </span>
+          </Button>
+        </DropdownMenuTrigger>
+        <GetStartedPanel quests={questsLoadable.data} summary={summary} />
+      </DropdownMenu>
+      <ShareOnXDialog />
+    </>
+  );
+}

--- a/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
+++ b/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
@@ -1,7 +1,13 @@
-import { useGet, useLastLoadable, useSet } from "ccstate-react";
+import {
+  useGet,
+  useLastLoadable,
+  useLastResolved,
+  useSet,
+} from "ccstate-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { Check, ChevronDown, Coins, PlusCircle } from "lucide-react";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   Button,
   DropdownMenu,
@@ -21,33 +27,14 @@ import {
   billingStatusAsync$,
   usagePackCreditsAsync$,
 } from "../../signals/okou-page/billing.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { formatLocalizedNumber } from "../../i18n/format.ts";
 import { DropdownMenuModalItem } from "../components/dropdown-menu-modal-item.tsx";
 import { settingsIconAssetUrl } from "./components/settings/settings-icon-assets.ts";
+import { SlackMark } from "./components/slack-mark.tsx";
+import { GetStartedEntry } from "./get-started-entry.tsx";
 
-const slackIconImg = settingsIconAssetUrl("slack");
 const telegramIconImg = settingsIconAssetUrl("telegram");
-
-// The nav rail draws this asset the same way: the artwork carries its own
-// padding, so it is scaled up inside a box the size we actually want.
-//
-// 16px everywhere, because Button and DropdownMenuItem both enforce
-// `[&_svg]:size-4` on their descendants and the marks have to agree with it.
-function SlackMark({ size }: { size: number }) {
-  return (
-    <span
-      className="grid shrink-0 place-items-center"
-      style={{ width: size, height: size }}
-    >
-      <img
-        src={slackIconImg}
-        alt=""
-        className="scale-[2.2]"
-        style={{ width: size, height: size }}
-      />
-    </span>
-  );
-}
 
 /** Whether the org-scoped Slack app is installed. */
 function useSlackInstalled(): boolean | null {
@@ -266,28 +253,34 @@ function CornerHeader({ children }: { children: ReactNode }) {
   );
 }
 
-function AdminGrowthEntryHeader() {
+function AdminGrowthEntry() {
   const slackInstalled = useSlackInstalled();
   if (slackInstalled === null) {
     return null;
   }
-  return (
-    <CornerHeader>
-      <GrowthEntry slackInstalled={slackInstalled} />
-    </CornerHeader>
-  );
+  return <GrowthEntry slackInstalled={slackInstalled} />;
 }
 
 export function GrowthEntryHeader() {
   const isAdminLoadable = useLastLoadable(isOrgAdmin$);
   const isAdmin = isAdminLoadable.state === "hasData" && isAdminLoadable.data;
+  const features = useLastResolved(featureSwitch$);
+  const questsEnabled = features?.[FeatureSwitchKey.GetStartedQuests] ?? false;
   return (
     <>
       {/* Match the former in-flow header's 16px + 32px + 8px height. The
           slot exists from the first render so async role and entry resolution
-          cannot move the home content. The admin controls stay absolute. */}
+          cannot move the home content. The corner controls stay absolute. */}
       <div aria-hidden className="hidden h-14 shrink-0 md:block" />
-      {isAdmin ? <AdminGrowthEntryHeader /> : null}
+      {/* Getting started is offered to every role — a member can connect,
+          build, share and check in on their own — while the workspace controls
+          beside it stay admin-only. */}
+      {questsEnabled || isAdmin ? (
+        <CornerHeader>
+          {questsEnabled ? <GetStartedEntry /> : null}
+          {isAdmin ? <AdminGrowthEntry /> : null}
+        </CornerHeader>
+      ) : null}
     </>
   );
 }

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -83,4 +83,5 @@ export enum FeatureSwitchKey {
   ConnectorDirectory = "connectorDirectory",
   ChatThreadHeaderActions = "chatThreadHeaderActions",
   ComposerTemplateChipCover = "composerTemplateChipCover",
+  GetStartedQuests = "getStartedQuests",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -515,6 +515,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.GetStartedQuests]: {
+    maintainer: "ming@okou.ai",
+    description:
+      "Show the home corner's Get started quest list. Progress is placeholder data; no credits are awarded yet.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ComposerTemplateChipCover]: {
     maintainer: "tongx@okou.ai",
     description:


### PR DESCRIPTION
## What

Adds the **Get started** control to the home corner, left of the existing growth entry. Frontend only: progress is placeholder client state, and the whole entry is behind the new `getStartedQuests` feature switch (off, staff orgs only).

Design was chosen from an 11-frame before/after + variants exploration; this implements the picked direction.

| Quest | Reward |
|---|---|
| Connect a connector | +100 per connector |
| Add Okou to Slack | +2,000 |
| Build a workflow | +1,000 |
| Invite your team | +100 per member |
| Share Okou on X | +2,000 |
| Check in daily | +100 a day |

## Decisions worth reviewing

**Role-aware quest set.** Installing Slack and inviting members are org-level actions, so a member is offered only the four steps they can finish alone. The ring and the count are computed from whichever set applies (`1/4`, not `1/6`) — a member is never shown a step they cannot take or a total they cannot reach. This is why `CornerHeader` now renders for members too; the workspace controls inside it stay admin-only.

**Credits are per person.** The panel chip shows the viewer's own earned total, not the org balance. The invite menu immediately beside it already shows an org `Credits` row, so the two numbers would otherwise be read as the same thing — hence the `Credits go to your personal balance.` footer line.

**Share on X spends one submission.** The row opens a `Dialog` (so it uses `DropdownMenuModalItem` — the menu has to close before the dialog takes focus), and after submitting it reads `In review` and is no longer a menu item.

**Check in daily is a status line, not a control.** Opening the app *is* the check-in, so the row renders without a hover state rather than as a menu item that does nothing.

## Reuse

No new exported primitive. The pill mirrors the growth entry's shell classes, the panel is a plain `DropdownMenuContent` with the growth menu's `gap-3 px-3 py-2.5` rows, the dialog input is the `Input` primitive verbatim, and the modal confirm keeps the brand primary while page primaries stay neutral-dark. `SlackMark` moved out of `growth-entry.tsx` into `components/slack-mark.tsx` so both entries share it.

## Not in this PR

- **No credit is awarded anywhere.** There is no endpoint, no ledger, no per-day or per-person de-duplication. `get-started.ts` is a mock store.
- Note that `feature-switch.ts` states it is *not* an authorization boundary — when the awarding endpoints land they need a hard identity check, not this switch.
- Two product rules are still open: whether a rejected X submission may be resubmitted (currently one shot, full stop), and whether `Build a workflow` should require a successful run rather than a saved draft (this PR's copy assumes a run).

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/get-started-entry.test.tsx` — 5 passed
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/growth-entry.test.tsx` — 6 passed, unchanged
- `pnpm -F @okouai/core exec vitest run` — 245 passed
- `pnpm -F @okouai/app check-types`, `pnpm -F @okouai/app lint`, `pnpm -F @okouai/core check-types`, `pnpm -F @okouai/core lint`, `pnpm knip`, `pnpm format` — clean
- All 10 locales translated; `i18n:check` reports 100%

No local dev server was started, per the repo's standing instruction to rely on the PR pipeline and preview. **The UI has not been exercised in a real browser** — worth a look at the preview before this graduates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)