### PR TITLE
ci: pin snapshot inspection compute readback

### DIFF
--- a/.github/scripts/kms-recovery-snapshot-inspect.py
+++ b/.github/scripts/kms-recovery-snapshot-inspect.py
@@ -408,9 +408,19 @@ def main():
         validate_preview(
             api(f"/branches/{preview_id}")["branch"], name, snapshot_id, existing_ids
         )
-        endpoints = [
-            e for e in listing("endpoints") if e.get("branch_id") == preview_id
-        ]
+        # Discover only this preview's computes. The project-wide listing is not
+        # an acknowledgement of a just-created endpoint; pin its returned ID.
+        endpoints = api(f"/branches/{preview_id}/endpoints")["endpoints"]
+        require(
+            isinstance(endpoints, list)
+            and all(
+                isinstance(e, dict) and e.get("branch_id") == preview_id
+                for e in endpoints
+            ),
+            "preview_endpoint_listing_mismatch",
+        )
+        report["previewEndpointCountBeforeCreate"] = len(endpoints)
+        checkpoint()
         if not endpoints:
             created = api(
                 "/endpoints",
@@ -429,15 +439,22 @@ def main():
                 created["endpoint"].get("branch_id") == preview_id,
                 "created_endpoint_branch_mismatch",
             )
+            endpoint_id = identifier(created["endpoint"].get("id"), "ep-")
+            require(
+                endpoint_id not in {e["id"] for e in before_endpoints},
+                "created_endpoint_is_existing",
+            )
+            report["createdPreviewEndpointId"] = endpoint_id
+            checkpoint()
             wait_operations(created)
-            endpoints = [
-                e for e in listing("endpoints") if e.get("branch_id") == preview_id
-            ]
+            endpoints = [created["endpoint"]]
         require(len(endpoints) == 1, "preview_endpoint_not_unique")
-        endpoint = endpoints[0]
-        identifier(endpoint.get("id"), "ep-")
+        endpoint_id = identifier(endpoints[0].get("id"), "ep-")
+        endpoint = api(f"/endpoints/{endpoint_id}")["endpoint"]
         require(
-            isinstance(endpoint.get("host"), str)
+            endpoint.get("id") == endpoint_id
+            and endpoint.get("branch_id") == preview_id
+            and isinstance(endpoint.get("host"), str)
             and endpoint["host"].startswith(endpoint["id"] + ".")
             and endpoint["host"].endswith(".neon.tech")
             and endpoint["id"] not in {e["id"] for e in before_endpoints},

--- a/.github/scripts/tests/fixtures/kms-recovery-snapshot-tools.py
+++ b/.github/scripts/tests/fixtures/kms-recovery-snapshot-tools.py
@@ -128,9 +128,26 @@ if path == "/endpoints" and method == "GET":
             "type": "read_write",
         }
     ]
-    if state.get("endpointCreated") and not state.get("deleted"):
+    if (
+        state.get("endpointCreated")
+        and not state.get("deleted")
+        and scenario != "endpoint-absent-from-project-list"
+    ):
         endpoints.append(endpoint)
     respond({"endpoints": endpoints})
+if path == "/branches/br-preview/endpoints" and method == "GET":
+    endpoints = [endpoint] if state.get("endpointCreated") else []
+    if scenario == "ambiguous-preview-endpoints":
+        endpoints = [endpoint, {**endpoint, "id": "ep-second"}]
+    respond({"endpoints": endpoints})
+if path == "/endpoints/ep-preview" and method == "GET":
+    assert state.get("endpointCreated")
+    current = (
+        {**endpoint, "branch_id": "br-production"}
+        if scenario == "endpoint-readback-production"
+        else endpoint
+    )
+    respond({"endpoint": current})
 if path == "/snapshots/snapshot-manual/restore" and method == "POST":
     assert body == {"name": name, "finalize_restore": False}
     state["restored"] = True

--- a/.github/scripts/tests/kms-recovery-snapshot-inspect-test.py
+++ b/.github/scripts/tests/kms-recovery-snapshot-inspect-test.py
@@ -99,6 +99,30 @@ class SnapshotInspectionTest(unittest.TestCase):
         self.assertEqual(report["failure"], "snapshot_identity_mismatch")
         self.assertTrue(all(c["method"] == "GET" for c in state["calls"]))
 
+    def test_created_endpoint_is_read_back_without_project_list_visibility(self):
+        result, report, state = self.invoke("endpoint-absent-from-project-list")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(report["collectionComplete"])
+        self.assertTrue(report["cleanupComplete"])
+        self.assertEqual(report["previewEndpointCountBeforeCreate"], 0)
+        self.assertEqual(report["createdPreviewEndpointId"], "ep-preview")
+        self.assertEqual(state["sqlCalls"], 1)
+
+    def test_endpoint_readback_cannot_retarget_production(self):
+        result, report, state = self.invoke("endpoint-readback-production")
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(report["failure"], "preview_endpoint_identity_mismatch")
+        self.assertTrue(report["cleanupComplete"])
+        self.assertNotIn("sqlCalls", state)
+
+    def test_multiple_preview_endpoints_report_count_without_connecting(self):
+        result, report, state = self.invoke("ambiguous-preview-endpoints")
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(report["failure"], "preview_endpoint_not_unique")
+        self.assertEqual(report["previewEndpointCountBeforeCreate"], 2)
+        self.assertTrue(report["cleanupComplete"])
+        self.assertNotIn("sqlCalls", state)
+
     def test_production_returned_as_preview_never_connects_or_deletes(self):
         result, report, state = self.invoke("production-returned")
         self.assertEqual(result.returncode, 1)


### PR DESCRIPTION
The first isolated snapshot inspection stopped at `preview_endpoint_not_unique` before opening a database connection ([run 34577277712](https://github.com/vm0-ai/vm0/actions/runs/34577277712)). Preview cleanup and preservation of production endpoints and original snapshots all passed; the report did not distinguish an absent endpoint from multiple endpoints.

Discover computes through the preview branch's endpoint API, record the observed count, and read a newly created compute back by the exact returned ID after its operations finish. This removes the dependency on immediate visibility in the project-wide listing while preserving the unique-preview, branch, host and pre-existing-endpoint guards. The actual provider condition behind the first run remains unconfirmed; a mismatch now retains enough bounded metadata to diagnose it.

Validation: 12 external-boundary CLI cases and the real isolated PostgreSQL aggregate test pass, including missing project-list visibility, a readback pointing to production, ambiguous preview endpoints and cleanup. Ruff check/format and `git diff --check` pass. No KMS, credential, deployment or original-backup change.

Refs #32264.
