### PR TITLE
refactor(api): accept x-okou signature headers alongside the legacy names

### DIFF
--- a/turbo/apps/api/src/lib/callback-route/__tests__/callback-route.test.ts
+++ b/turbo/apps/api/src/lib/callback-route/__tests__/callback-route.test.ts
@@ -37,6 +37,8 @@ interface SignedHeaderOptions {
   readonly skipSignature?: boolean;
   readonly skipTimestamp?: boolean;
   readonly staleTimestamp?: boolean;
+  /** Sign under the pre-rename header names a draining sender still emits. */
+  readonly legacyHeaderNames?: boolean;
 }
 
 interface SeedCallbackOptions {
@@ -53,16 +55,38 @@ function signedHeaders(
   const ts = options.staleTimestamp
     ? Math.floor(now() / 1000) - 1000
     : Math.floor(now() / 1000);
+  const signatureHeader = options.legacyHeaderNames
+    ? "X-VM0-Signature"
+    : "X-Okou-Signature";
+  const timestampHeader = options.legacyHeaderNames
+    ? "X-VM0-Timestamp"
+    : "X-Okou-Timestamp";
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
   if (!options.skipSignature) {
-    headers["X-VM0-Signature"] = computeHmacSignature(rawBody, secret, ts);
+    headers[signatureHeader] = computeHmacSignature(rawBody, secret, ts);
   }
   if (!options.skipTimestamp) {
-    headers["X-VM0-Timestamp"] = String(ts);
+    headers[timestampHeader] = String(ts);
   }
   return headers;
+}
+
+function legacySignatureHeaderSurfaces(): unknown[] {
+  return context.mocks.axiomLogging.warn.mock.calls.flatMap((call) => {
+    const fields = call[1];
+    if (
+      typeof fields !== "object" ||
+      fields === null ||
+      !("type" in fields) ||
+      fields.type !== "legacy_signature_header_use" ||
+      !("surface" in fields)
+    ) {
+      return [];
+    }
+    return [fields.surface];
+  });
 }
 
 async function seedCallback(options: SeedCallbackOptions = {}): Promise<{
@@ -258,7 +282,7 @@ describe("callbackRoute$ primitive", () => {
     });
   });
 
-  it("returns 401 on missing X-VM0-Signature header", async () => {
+  it("returns 401 on missing X-Okou-Signature header", async () => {
     const { runId } = await seedCallback();
     const app = createAppWithRoutes({
       signal: context.signal,
@@ -276,11 +300,11 @@ describe("callbackRoute$ primitive", () => {
 
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toStrictEqual({
-      error: "Missing X-VM0-Signature header",
+      error: "Missing X-Okou-Signature header",
     });
   });
 
-  it("returns 401 on missing X-VM0-Timestamp header", async () => {
+  it("returns 401 on missing X-Okou-Timestamp header", async () => {
     const { runId } = await seedCallback();
     const app = createAppWithRoutes({
       signal: context.signal,
@@ -298,7 +322,7 @@ describe("callbackRoute$ primitive", () => {
 
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toStrictEqual({
-      error: "Missing X-VM0-Timestamp header",
+      error: "Missing X-Okou-Timestamp header",
     });
   });
 
@@ -345,5 +369,32 @@ describe("callbackRoute$ primitive", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toStrictEqual({ ok: true, runId });
+    expect(legacySignatureHeaderSurfaces()).toStrictEqual([]);
+  });
+
+  it("accepts a callback signed under the legacy header names", async () => {
+    const { runId, callbackId } = await seedCallback();
+    const app = createAppWithRoutes({
+      signal: context.signal,
+      routes: [probeRoute],
+    });
+    const rawBody = JSON.stringify({
+      callbackId,
+      runId,
+      status: "completed",
+      payload: { hello: "world" },
+    });
+
+    const response = await app.request(PATH, {
+      method: "POST",
+      headers: signedHeaders(rawBody, TEST_CALLBACK_SECRET, {
+        legacyHeaderNames: true,
+      }),
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ ok: true, runId });
+    expect(legacySignatureHeaderSurfaces()).toStrictEqual(["callback-route"]);
   });
 });

--- a/turbo/apps/api/src/lib/callback-route/callback-route.ts
+++ b/turbo/apps/api/src/lib/callback-route/callback-route.ts
@@ -9,6 +9,10 @@ import { db$ } from "../../signals/external/db";
 import { decryptPersistentSecretValue } from "../../signals/services/crypto.utils";
 import { userFeatureSwitchContext } from "../../signals/services/feature-switches.service";
 import { safeJsonParse } from "../../signals/utils";
+import {
+  readSignatureHeaders,
+  reportLegacySignatureHeaderUse,
+} from "../event-consumer/signature-headers";
 import { verifyCallbackRequest } from "../event-consumer/verify-signature";
 
 /**
@@ -67,8 +71,8 @@ function isCommand<T>(
  * Reads the raw request body (single-shot stream consumption), parses the
  * JSON envelope, looks up the `agent_run_callbacks` row by `callbackId` (PK,
  * preferred) or `runId` (fallback), decrypts the per-callback secret, verifies
- * `X-VM0-Signature` / `X-VM0-Timestamp`, and exposes the verified envelope via
- * `callbackPayload$`.
+ * `X-Okou-Signature` / `X-Okou-Timestamp` (or their legacy `X-VM0-*` names),
+ * and exposes the verified envelope via `callbackPayload$`.
  */
 export function callbackRoute<T>(
   handler$: SignalRouteHandler<T>,
@@ -134,17 +138,23 @@ export function callbackRoute<T>(
       );
       signal.throwIfAborted();
 
+      const signatureHeaders = readSignatureHeaders((name) => {
+        return req.header(name) ?? null;
+      });
       const verification = verifyCallbackRequest(
         rawBody,
         secret,
-        req.header("X-VM0-Signature") ?? null,
-        req.header("X-VM0-Timestamp") ?? null,
+        signatureHeaders.signature,
+        signatureHeaders.timestamp,
       );
       if (!verification.valid) {
         return {
           status: 401,
           body: { error: verification.error ?? "Invalid signature" },
         };
+      }
+      if (signatureHeaders.legacy) {
+        reportLegacySignatureHeaderUse("callback-route");
       }
 
       set(callbackPayloadState$, {

--- a/turbo/apps/api/src/lib/event-consumer/signature-headers.ts
+++ b/turbo/apps/api/src/lib/event-consumer/signature-headers.ts
@@ -1,0 +1,74 @@
+import { logger } from "../log";
+
+const L = logger("api:legacy-signature-header");
+
+/** Header names a caller should send. */
+const SIGNATURE_HEADER = "X-Okou-Signature";
+const TIMESTAMP_HEADER = "X-Okou-Timestamp";
+
+/** Pre-rename header names, still emitted by every sender in this release. */
+const LEGACY_SIGNATURE_HEADER = "X-VM0-Signature";
+const LEGACY_TIMESTAMP_HEADER = "X-VM0-Timestamp";
+
+/** Verification site that accepted a request, recorded on the legacy signal. */
+type SignatureHeaderSurface = "callback-route" | "workflow-webhook";
+
+interface SignatureHeaders {
+  readonly signature: string | null;
+  readonly timestamp: string | null;
+  /** True when a value was taken from a legacy header name. */
+  readonly legacy: boolean;
+}
+
+type ReadHeader = (name: string) => string | null | undefined;
+
+/**
+ * Read the HMAC signature headers, preferring `X-Okou-*` and falling back per
+ * header to the legacy `X-VM0-*` name.
+ *
+ * Fallback surface: an API instance draining across a deploy window still
+ * signs the legacy names, and the published curl snippets still document them.
+ * Gate for removal: every sender emits `X-Okou-*` (#33497) in production and
+ * {@link reportLegacySignatureHeaderUse} has gone silent over an observation
+ * window. Removed together with that signal by #33498.
+ *
+ * `readHeader` is case-insensitive at both call sites — Hono's `req.header`
+ * and `Headers.get`.
+ */
+export function readSignatureHeaders(readHeader: ReadHeader): SignatureHeaders {
+  const signature = readHeader(SIGNATURE_HEADER) ?? null;
+  const timestamp = readHeader(TIMESTAMP_HEADER) ?? null;
+  const legacySignature =
+    signature === null ? (readHeader(LEGACY_SIGNATURE_HEADER) ?? null) : null;
+  const legacyTimestamp =
+    timestamp === null ? (readHeader(LEGACY_TIMESTAMP_HEADER) ?? null) : null;
+  return {
+    signature: signature ?? legacySignature,
+    timestamp: timestamp ?? legacyTimestamp,
+    legacy: legacySignature !== null || legacyTimestamp !== null,
+  };
+}
+
+/**
+ * Record that a request whose signature verified arrived under a legacy header
+ * name, so #33498 can gate the removal of the fallback above on observed
+ * silence instead of elapsed time.
+ *
+ * Emitted at warn under a fixed logger context, so the gate is a single
+ * queryable filter: the Axiom transport drops debug records, and a caller that
+ * still signs the legacy name is the actionable finding release 3 acts on.
+ * Every sender emits the legacy name until #33497 ships, so this is expected
+ * to be loud for releases 1 and 2 and silent afterwards.
+ *
+ * Restricting it to requests that verified keeps an unauthenticated caller
+ * from driving log volume through the public webhook endpoint, and keeps the
+ * signal to callers holding a valid secret — the ones release 3 would reject.
+ */
+export function reportLegacySignatureHeaderUse(
+  surface: SignatureHeaderSurface,
+): void {
+  L.warn("Verified a request signed with a legacy signature header name", {
+    type: "legacy_signature_header_use",
+    surface,
+  });
+}

--- a/turbo/apps/api/src/lib/event-consumer/verify-signature.ts
+++ b/turbo/apps/api/src/lib/event-consumer/verify-signature.ts
@@ -15,10 +15,10 @@ export function verifyCallbackRequest(
   timestamp: string | null,
 ): VerifyResult {
   if (!signature) {
-    return { valid: false, error: "Missing X-VM0-Signature header" };
+    return { valid: false, error: "Missing X-Okou-Signature header" };
   }
   if (!timestamp) {
-    return { valid: false, error: "Missing X-VM0-Timestamp header" };
+    return { valid: false, error: "Missing X-Okou-Timestamp header" };
   }
 
   const timestampNum = Number.parseInt(timestamp, 10);

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-workflow-automations.test.ts
@@ -311,19 +311,16 @@ describe("POST /api/webhooks/workflow-automations/:token", () => {
     const { workflowId } = await setupFixture();
     const webhook = await createWebhookAutomation(workflowId);
 
+    // Each delivery only has to be accepted rather than rejected as
+    // unauthorized. The second one queues behind the first on the workflow's
+    // automation thread, so its response carries no runId.
     const renamed = await postWorkflowWebhook({
       token: webhook.token,
       rawBody: JSON.stringify({ event: "renamed-signature-headers" }),
       secret: webhook.secret,
     });
-    expect(renamed).toStrictEqual({
-      status: 200,
-      body: {
-        success: true,
-        duplicate: false,
-        runId: expect.any(String),
-      },
-    });
+    expect(renamed.status).toBe(200);
+    expect(renamed.body).toMatchObject({ success: true, duplicate: false });
     expect(legacySignatureHeaderSurfaces()).toStrictEqual([]);
 
     const legacy = await postWorkflowWebhook({
@@ -332,14 +329,8 @@ describe("POST /api/webhooks/workflow-automations/:token", () => {
       secret: webhook.secret,
       legacyHeaderNames: true,
     });
-    expect(legacy).toStrictEqual({
-      status: 200,
-      body: {
-        success: true,
-        duplicate: false,
-        runId: expect.any(String),
-      },
-    });
+    expect(legacy.status).toBe(200);
+    expect(legacy.body).toMatchObject({ success: true, duplicate: false });
     expect(legacySignatureHeaderSurfaces()).toStrictEqual(["workflow-webhook"]);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-workflow-automations.test.ts
@@ -138,6 +138,8 @@ async function postWorkflowWebhook(args: {
   readonly secret: string;
   readonly timestamp?: number;
   readonly signature?: string;
+  /** Sign under the pre-rename header names a stored curl snippet emits. */
+  readonly legacyHeaderNames?: boolean;
 }): Promise<{ readonly status: number; readonly body: unknown }> {
   const timestamp = args.timestamp ?? Math.floor(now() / 1000);
   const response = await createApp({
@@ -147,8 +149,9 @@ async function postWorkflowWebhook(args: {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-VM0-Timestamp": String(timestamp),
-      "X-VM0-Signature":
+      [args.legacyHeaderNames ? "X-VM0-Timestamp" : "X-Okou-Timestamp"]:
+        String(timestamp),
+      [args.legacyHeaderNames ? "X-VM0-Signature" : "X-Okou-Signature"]:
         args.signature ??
         computeHmacSignature(args.rawBody, args.secret, timestamp),
     },
@@ -158,6 +161,20 @@ async function postWorkflowWebhook(args: {
     status: response.status,
     body: await response.json(),
   };
+}
+
+function legacySignatureHeaderSurfaces(): unknown[] {
+  return context.mocks.axiomLogging.warn.mock.calls.flatMap((call) => {
+    const fields = call[1];
+    if (
+      !isRecord(fields) ||
+      fields.type !== "legacy_signature_header_use" ||
+      !("surface" in fields)
+    ) {
+      return [];
+    }
+    return [fields.surface];
+  });
 }
 
 describe("POST /api/webhooks/workflow-automations/:token", () => {
@@ -288,6 +305,42 @@ describe("POST /api/webhooks/workflow-automations/:token", () => {
       ]),
     );
     expect(concurrent).toHaveLength(2);
+  });
+
+  it("accepts either signature header name and signals only the legacy one", async () => {
+    const { workflowId } = await setupFixture();
+    const webhook = await createWebhookAutomation(workflowId);
+
+    const renamed = await postWorkflowWebhook({
+      token: webhook.token,
+      rawBody: JSON.stringify({ event: "renamed-signature-headers" }),
+      secret: webhook.secret,
+    });
+    expect(renamed).toStrictEqual({
+      status: 200,
+      body: {
+        success: true,
+        duplicate: false,
+        runId: expect.any(String),
+      },
+    });
+    expect(legacySignatureHeaderSurfaces()).toStrictEqual([]);
+
+    const legacy = await postWorkflowWebhook({
+      token: webhook.token,
+      rawBody: JSON.stringify({ event: "legacy-signature-headers" }),
+      secret: webhook.secret,
+      legacyHeaderNames: true,
+    });
+    expect(legacy).toStrictEqual({
+      status: 200,
+      body: {
+        success: true,
+        duplicate: false,
+        runId: expect.any(String),
+      },
+    });
+    expect(legacySignatureHeaderSurfaces()).toStrictEqual(["workflow-webhook"]);
   });
 
   it("deletes a failed delivery so an identical request can retry", async () => {

--- a/turbo/apps/api/src/signals/routes/webhooks-workflow-automations.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-workflow-automations.ts
@@ -5,6 +5,10 @@ import { command } from "ccstate";
 
 import { request$ } from "../context/hono";
 import { pathParamsOf } from "../context/request";
+import {
+  readSignatureHeaders,
+  reportLegacySignatureHeaderUse,
+} from "../../lib/event-consumer/signature-headers";
 import { now } from "../../lib/time";
 import type { RouteEntry } from "../route-entry";
 import {
@@ -42,19 +46,33 @@ const postWorkflowAutomationWebhook$ = command(
       return jsonError("Payload too large", 413);
     }
 
+    const signatureHeaders = readSignatureHeaders((name) => {
+      return request.raw.headers.get(name);
+    });
     const result = await set(
       dispatchWorkflowWebhook$,
       {
         token: params.token,
         rawBody,
         headers: Object.fromEntries(request.raw.headers.entries()),
-        signature: request.raw.headers.get("X-VM0-Signature"),
-        timestamp: request.raw.headers.get("X-VM0-Timestamp"),
+        signature: signatureHeaders.signature,
+        timestamp: signatureHeaders.timestamp,
         apiStartTime: now(),
       },
       signal,
     );
     signal.throwIfAborted();
+    // The dispatcher decides `not_found` before it checks the signature and
+    // `unauthorized` is that check failing, so any other outcome means the
+    // signature — and the header name it arrived under — was accepted.
+    if (
+      signatureHeaders.legacy &&
+      result.kind !== "not_found" &&
+      result.kind !== "unauthorized" &&
+      result.kind !== "payload_too_large"
+    ) {
+      reportLegacySignatureHeaderUse("workflow-webhook");
+    }
 
     switch (result.kind) {
       case "ok": {

--- a/turbo/apps/api/src/signals/services/workflow-webhook-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-webhook-automation.service.ts
@@ -245,6 +245,8 @@ function sanitizedHeaders(
     if (
       lower === "authorization" ||
       lower === "cookie" ||
+      lower === "x-okou-signature" ||
+      lower === "x-okou-timestamp" ||
       lower === "x-vm0-signature" ||
       lower === "x-vm0-timestamp" ||
       lower.includes("secret") ||


### PR DESCRIPTION
Closes #33496.

Step 1 of 3 in renaming the HMAC signature headers `X-VM0-Signature` / `X-VM0-Timestamp` to `X-Okou-*`. Purely additive: both verification sites now accept the new names **and** the old ones, and no sender or published snippet changes in this release.

Delivery of a run callback is single-attempt (`markCallbackAttemptStarted` sets `attempts: 1`, there is no timed retry, and a terminal run has no further status transition to re-dispatch on), so a callback rejected during a deploy window is lost rather than retried. Accepting both names first is what makes the sender switch in #33497 safe in both directions of a mixed fleet.

## Changes

- `lib/event-consumer/signature-headers.ts` (new) — `readSignatureHeaders()` prefers `X-Okou-*` and falls back per header to the legacy name; `reportLegacySignatureHeaderUse()` records an acceptance under a legacy name.
- `lib/callback-route/callback-route.ts` — reads the headers through the helper; signals after the signature verifies, with surface `callback-route`.
- `signals/routes/webhooks-workflow-automations.ts` — same through `request.raw.headers.get`, with surface `workflow-webhook`. The dispatcher decides `not_found` before it checks the signature and `unauthorized` is that check failing, so every other outcome means the header name was accepted.
- `signals/services/workflow-webhook-automation.service.ts` — `sanitizedHeaders()` also strips `x-okou-signature` / `x-okou-timestamp`. Without this, the newly accepted header would leak into the headers exposed to the webhook run while its legacy twin stayed stripped. No sender or dispatch behavior changes.
- `lib/event-consumer/verify-signature.ts` — the two missing-header error strings name the new headers, since that is what a caller should send. Signature and validation logic unchanged.

### Legacy-use signal

`logger("api:legacy-signature-header")` emits one record per accepted legacy request with `type: "legacy_signature_header_use"` and `surface`. Two deliberate choices:

- **warn, not info.** `api/no-logger-info` forbids `logger.info()` in API source, and the Axiom transport drops `debug` records before the dataset (`lib/log.ts`), so `warn` is the only level at which the gate for #33498 is observable. Since every sender still emits the legacy name until #33497 ships, **this signal is expected to be loud through releases 1 and 2 and silent afterwards** — that silence is exactly what #33498 queries.
- **Only for requests that verified.** `/api/webhooks/workflow-automations/:token` is unauthenticated, so signalling on header read would let any caller drive log volume. Restricting it to verified requests keeps the signal to callers holding a valid secret — the ones release 3 would start rejecting. No database write; nothing blocks the response.

## Fallbacks

- `lib/event-consumer/signature-headers.ts:readSignatureHeaders` — accepts the legacy `X-VM0-Signature` / `X-VM0-Timestamp` names when the `X-Okou-*` name is absent. Protects an API instance draining across a deploy window (and the stored curl snippets) that still signs the old names against a promoted verifier, in a surface where delivery is single-attempt. Surface: old API sender -> new API verifier; gate: every sender emits `X-Okou-*` (#33497) in production **and** the legacy-use signal has been silent over an observation window. Removed together with the signal by #33498.

## Out of scope (unchanged, verified by `git diff`)

`agent-run-callback.service.ts`, `agent-run-callbacks.service.ts`, `workflow-detail-page.tsx`, and `display.ts` all keep emitting `X-VM0-*` — moving them here would create the skew this staging prevents (#33497). `X-VM0-*` acceptance is not removed (#33498). No change to the HMAC scheme, signed payload, `computeHmacSignature`, `isTimestampValid`, the timestamp window, or any status code. `X-VM0-Connector-Intent`, `x-vm0-test-endpoint-bypass`, `x-vm0-idempotency-key`, and `vm0_official_` are untouched, and there is no repository-wide substitution.

## Tests

- `callback-route.test.ts` — the shared signer now uses the new names, so the existing success/invalid/expired/missing cases cover `X-Okou-*`; a new case signs under the legacy names, expects 200, and asserts the signal carries `callback-route`. The new-name success case asserts no signal.
- `webhooks-workflow-automations.test.ts` — a new case posts under each name: the new name returns 200 with no signal, the legacy name returns 200 and signals `workflow-webhook`.
- `chat-events.bdd.test.ts`, `official-workflows.test.ts`, and `workflow-queue.test.ts` still sign with the legacy names. They stand in for senders that legitimately still emit them in this release, so they now exercise the fallback; #33497 moves them with the senders.

## Verification

`prettier --check`, `pnpm -F api lint`, `pnpm -F api check-types`, and `pnpm knip` pass on the affected scope. The API test suites need a local Postgres, which is not available in this environment, so the two affected suites run in the PR pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
