### PR TITLE
fix(runner): keep local cancellation scans responsive

### DIFF
--- a/crates/runner/src/provider/local/cancel.rs
+++ b/crates/runner/src/provider/local/cancel.rs
@@ -1,6 +1,10 @@
 use std::collections::{HashMap, HashSet};
+use std::future::poll_fn;
 use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
 
+use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream::FuturesUnordered};
+use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -21,6 +25,8 @@ pub(super) struct LocalCancelScanner {
     queue: LocalQueue,
     cancel_tokens: RunCancellationRegistry,
     owned_claims: Arc<tokio::sync::Mutex<HashSet<RunId>>>,
+    deliveries: Arc<Mutex<PendingCancelDeliveries>>,
+    delivery_queued: Arc<Notify>,
     #[cfg(test)]
     scan_observer: ScanObserver,
 }
@@ -28,6 +34,80 @@ pub(super) struct LocalCancelScanner {
 pub(super) struct LocalCancelWatcher {
     shutdown: CancellationToken,
     handle: Mutex<Option<JoinHandle<()>>>,
+    scanner: LocalCancelScanner,
+}
+
+type CancelDelivery = BoxFuture<'static, (RunId, RunCancellationHandle)>;
+
+#[derive(Default)]
+struct PendingCancelDeliveries {
+    futures: FuturesUnordered<CancelDelivery>,
+    registrations: HashMap<RunId, Vec<RunCancellationHandle>>,
+    stopped: bool,
+}
+
+impl PendingCancelDeliveries {
+    /// Poll once to preserve immediate claim-time cancellation, retaining the
+    /// exact future (and its gate queue position) only when it has to wait.
+    fn enqueue(&mut self, run_id: RunId, handle: &RunCancellationHandle) -> bool {
+        if self.stopped
+            || handle.is_hard_cancelled()
+            || self.registrations.get(&run_id).is_some_and(|handles| {
+                handles
+                    .iter()
+                    .any(|pending| pending.same_registration(handle))
+            })
+        {
+            return false;
+        }
+
+        let delivery_handle = handle.clone();
+        let mut delivery = async move {
+            if delivery_handle.request_hard_cancellation().await {
+                info!(run_id = %run_id, "local: cancel file detected, cancelling job");
+            }
+            (run_id, delivery_handle)
+        }
+        .boxed();
+        if delivery.as_mut().now_or_never().is_some() {
+            return false;
+        }
+
+        self.registrations
+            .entry(run_id)
+            .or_default()
+            .push(handle.clone());
+        self.futures.push(delivery);
+        true
+    }
+
+    fn poll_completed(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        let mut completed = false;
+        while let Poll::Ready(Some((run_id, handle))) = self.futures.poll_next_unpin(cx) {
+            completed = true;
+            if let std::collections::hash_map::Entry::Occupied(mut entry) =
+                self.registrations.entry(run_id)
+            {
+                entry
+                    .get_mut()
+                    .retain(|pending| !pending.same_registration(&handle));
+                if entry.get().is_empty() {
+                    entry.remove();
+                }
+            }
+        }
+        if completed {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn stop(&mut self) {
+        self.stopped = true;
+        self.futures.clear();
+        self.registrations.clear();
+    }
 }
 
 impl LocalCancelScanner {
@@ -40,6 +120,8 @@ impl LocalCancelScanner {
             queue,
             cancel_tokens,
             owned_claims,
+            deliveries: Arc::new(Mutex::new(PendingCancelDeliveries::default())),
+            delivery_queued: Arc::new(Notify::new()),
             #[cfg(test)]
             scan_observer: ScanObserver::default(),
         }
@@ -51,7 +133,8 @@ impl LocalCancelScanner {
     /// can exist before `claim()` succeeds, so ownership is tracked separately
     /// to avoid stealing another runner's cancel marker. Markers without a
     /// token are kept while a claim/job may still exist, and are deleted only
-    /// after they no longer have a pending target.
+    /// after they no longer have a pending target. Gate-blocked deliveries stay
+    /// owned by the provider and are polled by the watcher, not awaited here.
     pub(super) async fn scan_cancel_files(&self) {
         #[cfg(test)]
         let _scan_observation = self.scan_observer.observe();
@@ -80,11 +163,19 @@ impl LocalCancelScanner {
         for marker in cancel_markers {
             let run_id = marker.run_id;
             if let Some(handle) = tokens.get(&run_id) {
-                if handle.request_hard_cancellation().await {
-                    info!(run_id = %run_id, "local: cancel file detected, cancelling job");
+                let queued = self
+                    .deliveries
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .enqueue(run_id, handle);
+                if queued {
+                    // Claim can scan while the watcher is asleep with no
+                    // pending deliveries, so insertion needs its own wakeup.
+                    self.delivery_queued.notify_one();
                 }
-                let should_delete = owned_claims.contains(&run_id)
-                    || marker.target_state == CancelTargetState::NotPending;
+                let should_delete = handle.is_hard_cancelled()
+                    && (owned_claims.contains(&run_id)
+                        || marker.target_state == CancelTargetState::NotPending);
                 if should_delete {
                     delete_cancel_ids.push(run_id);
                 }
@@ -103,6 +194,25 @@ impl LocalCancelScanner {
                 warn!(error = %e, "local: blocking cancel marker cleanup failed");
             }
         }
+    }
+
+    async fn next_cancel_completion(&self) {
+        // Release the shared lock after every poll, including Pending, so
+        // scans and teardown never wait for a delivery's transfer gate.
+        poll_fn(|cx| {
+            self.deliveries
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .poll_completed(cx)
+        })
+        .await;
+    }
+
+    fn stop_cancel_deliveries(&self) {
+        self.deliveries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .stop();
     }
 
     async fn snapshot_cancel_tokens(
@@ -179,8 +289,13 @@ impl LocalCancelWatcher {
                 {
                     warn!(error = %error, "local: cancel watcher unavailable, using reconciliation");
                 }
+                let task_scanner = scanner.clone();
                 Some(handle.spawn(async move {
+                    let scanner = task_scanner;
                     loop {
+                        if task_shutdown.is_cancelled() {
+                            break;
+                        }
                         if let Err(error) =
                             ensure_watcher(&mut watcher, &watch_paths, QueueFileKind::Cancel)
                         {
@@ -189,7 +304,10 @@ impl LocalCancelWatcher {
                         scanner.prune_owned_claims_without_tokens().await;
                         scanner.scan_cancel_files().await;
                         tokio::select! {
+                            biased;
                             () = task_shutdown.cancelled() => break,
+                            () = scanner.next_cancel_completion() => {}
+                            () = scanner.delivery_queued.notified() => {}
                             () = tokio::time::sleep(RECONCILE_INTERVAL) => {}
                             result = next_change_or_pending(&mut watcher) => {
                                 if let Err(error) = result {
@@ -210,19 +328,22 @@ impl LocalCancelWatcher {
         Self {
             shutdown,
             handle: Mutex::new(handle),
+            scanner,
         }
     }
 
-    pub(super) fn disabled() -> Self {
+    pub(super) fn disabled(scanner: LocalCancelScanner) -> Self {
         let shutdown = CancellationToken::new();
         shutdown.cancel();
         Self {
             shutdown,
             handle: Mutex::new(None),
+            scanner,
         }
     }
 
     pub(super) async fn shutdown(&self) {
+        self.scanner.stop_cancel_deliveries();
         self.shutdown.cancel();
         let handle = self
             .handle
@@ -240,6 +361,7 @@ impl LocalCancelWatcher {
 
 impl Drop for LocalCancelWatcher {
     fn drop(&mut self) {
+        self.scanner.stop_cancel_deliveries();
         self.shutdown.cancel();
         let handle = self
             .handle
@@ -302,6 +424,167 @@ mod tests {
         std::fs::create_dir_all(result_path.parent().unwrap()).unwrap();
         std::fs::write(&result_path, content).unwrap();
         result_path
+    }
+
+    async fn wait_for_marker_cleanup(scanner: &LocalCancelScanner, path: &std::path::Path) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let scans = scanner.scan_count();
+                if !path.exists() {
+                    return;
+                }
+                scanner.wait_for_scan_count(scans + 1).await;
+            }
+        })
+        .await
+        .expect("completed cancellation should reconcile marker cleanup");
+    }
+
+    #[tokio::test]
+    async fn blocked_delivery_does_not_delay_same_scan_or_repeat_requests() {
+        let dir = tempfile::tempdir().unwrap();
+        let tokens = empty_cancel_tokens();
+        let scanner = scanner(dir.path(), tokens.clone());
+        let blocked_id = RunId::new_v4();
+        let ready_id = RunId::new_v4();
+        let blocked = insert_cancel_registration(&tokens, blocked_id).await;
+        let ready = insert_cancel_registration(&tokens, ready_id).await;
+        let guard = blocked.handle().transfer_guard().await;
+        write_job(dir.path(), blocked_id);
+        write_job(dir.path(), ready_id);
+        let blocked_marker = write_cancel(dir.path(), blocked_id);
+        let ready_marker = write_cancel(dir.path(), ready_id);
+        scanner.mark_owned_claim(blocked_id).await;
+        scanner.mark_owned_claim(ready_id).await;
+
+        // Scan completion proves progress regardless of directory entry order.
+        for _ in 0..3 {
+            tokio::time::timeout(Duration::from_secs(2), scanner.scan_cancel_files())
+                .await
+                .expect("a held gate must not delay reconciliation");
+        }
+        assert!(ready.handle().is_hard_cancelled());
+        assert!(!ready_marker.exists());
+        assert!(!blocked.is_cancelled());
+        assert!(blocked_marker.exists());
+        assert_eq!(scanner.deliveries.lock().unwrap().futures.len(), 1);
+
+        let watcher = LocalCancelWatcher::start(scanner.clone());
+        drop(guard);
+        tokio::time::timeout(Duration::from_secs(2), blocked.token().cancelled())
+            .await
+            .expect("pending cancellation should complete after gate release");
+        wait_for_marker_cleanup(&scanner, &blocked_marker).await;
+        watcher.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn blocked_delivery_allows_later_markers_and_shutdown() {
+        let dir = tempfile::tempdir().unwrap();
+        let tokens = empty_cancel_tokens();
+        let scanner = scanner(dir.path(), tokens.clone());
+        let blocked_id = RunId::new_v4();
+        let blocked = insert_cancel_registration(&tokens, blocked_id).await;
+        let guard = blocked.handle().transfer_guard().await;
+        write_job(dir.path(), blocked_id);
+        let blocked_marker = write_cancel(dir.path(), blocked_id);
+        scanner.mark_owned_claim(blocked_id).await;
+        let watcher = LocalCancelWatcher::start(scanner.clone());
+        tokio::time::timeout(Duration::from_secs(2), scanner.wait_for_scan_count(1))
+            .await
+            .expect("watcher should finish discovering the blocked marker");
+
+        let later_id = RunId::new_v4();
+        let later = insert_cancel_registration(&tokens, later_id).await;
+        write_job(dir.path(), later_id);
+        write_cancel(dir.path(), later_id);
+        tokio::time::timeout(Duration::from_secs(2), later.token().cancelled())
+            .await
+            .expect("later marker should progress while the earlier gate is held");
+        assert!(!blocked.is_cancelled());
+        assert!(blocked_marker.exists());
+
+        tokio::time::timeout(Duration::from_secs(2), watcher.shutdown())
+            .await
+            .expect("shutdown must not wait for a transfer gate");
+        // A scan racing after shutdown must not recreate pending deliveries.
+        scanner.scan_cancel_files().await;
+        drop(guard);
+        let _guard =
+            tokio::time::timeout(Duration::from_secs(2), blocked.handle().transfer_guard())
+                .await
+                .expect("shutdown should release the pending gate waiter");
+        assert!(!blocked.is_cancelled());
+        assert!(blocked_marker.exists());
+    }
+
+    #[tokio::test]
+    async fn dropping_watcher_releases_pending_delivery_without_cancelling() {
+        let dir = tempfile::tempdir().unwrap();
+        let tokens = empty_cancel_tokens();
+        let scanner = scanner(dir.path(), tokens.clone());
+        let run_id = RunId::new_v4();
+        let registration = insert_cancel_registration(&tokens, run_id).await;
+        let guard = registration.handle().transfer_guard().await;
+        write_job(dir.path(), run_id);
+        let marker = write_cancel(dir.path(), run_id);
+        scanner.mark_owned_claim(run_id).await;
+        let watcher = LocalCancelWatcher::start(scanner.clone());
+        tokio::time::timeout(Duration::from_secs(2), scanner.wait_for_scan_count(1))
+            .await
+            .expect("watcher should discover the blocked marker");
+
+        drop(watcher);
+        drop(guard);
+        let _guard = tokio::time::timeout(
+            Duration::from_secs(2),
+            registration.handle().transfer_guard(),
+        )
+        .await
+        .expect("dropping the watcher should release its queued gate waiter");
+        assert!(!registration.is_cancelled());
+        assert!(marker.exists());
+    }
+
+    #[tokio::test]
+    async fn deferred_cancellation_keeps_registration_identity_and_preclaim_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let tokens = empty_cancel_tokens();
+        let scanner = scanner(dir.path(), tokens.clone());
+        let run_id = RunId::new_v4();
+        let original = insert_cancel_registration(&tokens, run_id).await;
+        let original_guard = original.handle().transfer_guard().await;
+        write_job(dir.path(), run_id);
+        let marker = write_cancel(dir.path(), run_id);
+        scanner.scan_cancel_files().await;
+
+        assert!(original.unregister().await);
+        let replacement = insert_cancel_registration(&tokens, run_id).await;
+        let replacement_guard = replacement.handle().transfer_guard().await;
+        scanner.scan_cancel_files().await;
+        assert_eq!(scanner.deliveries.lock().unwrap().futures.len(), 2);
+        let watcher = LocalCancelWatcher::start(scanner.clone());
+
+        drop(original_guard);
+        tokio::time::timeout(Duration::from_secs(2), original.token().cancelled())
+            .await
+            .expect("the deferred request must still cancel its original registration");
+        assert!(!replacement.is_cancelled());
+        assert!(marker.exists());
+
+        drop(replacement_guard);
+        tokio::time::timeout(Duration::from_secs(2), replacement.token().cancelled())
+            .await
+            .expect("the replacement's separate delivery should also complete");
+        scanner.scan_cancel_files().await;
+        assert!(
+            marker.exists(),
+            "pre-claim cancellation must retain the marker"
+        );
+        scanner.mark_owned_claim(run_id).await;
+        scanner.scan_cancel_files().await;
+        assert!(!marker.exists());
+        watcher.shutdown().await;
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/local/mod.rs
+++ b/crates/runner/src/provider/local/mod.rs
@@ -124,7 +124,7 @@ impl LocalProvider {
         let cancel_watcher = if start_cancel_watcher {
             LocalCancelWatcher::start(cancel_scanner.clone())
         } else {
-            LocalCancelWatcher::disabled()
+            LocalCancelWatcher::disabled(cancel_scanner.clone())
         };
         Arc::new(Self {
             queue,

--- a/crates/runner/src/provider/local/tests/cancellation.rs
+++ b/crates/runner/src/provider/local/tests/cancellation.rs
@@ -1,6 +1,63 @@
 use super::support::*;
 
 #[tokio::test]
+async fn claim_reconciles_without_waiting_for_unrelated_gate_and_wakes_watcher() {
+    let dir = tempfile::tempdir().unwrap();
+    let tokens = empty_cancel_tokens();
+    let blocked_id = RunId::new_v4();
+    let claimed_id = RunId::new_v4();
+    write_job(dir.path(), blocked_id, "activating");
+    write_job(dir.path(), claimed_id, "claim me");
+    std::fs::create_dir_all(local_queue::cancels_dir(dir.path())).unwrap();
+    let blocked_marker = local_queue::cancel_path(dir.path(), blocked_id);
+    let claimed_marker = local_queue::cancel_path(dir.path(), claimed_id);
+    std::fs::write(&blocked_marker, b"").unwrap();
+    std::fs::write(&claimed_marker, b"").unwrap();
+    let provider = LocalProvider::new(
+        dir.path().to_path_buf(),
+        default_profiles(),
+        CancellationToken::new(),
+        tokens.clone(),
+    );
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        provider.wait_for_cancel_scan_count(1),
+    )
+    .await
+    .expect("initial scan should retain markers without registered handles");
+    let blocked = insert_cancel_registration(&tokens, blocked_id).await;
+    let guard = blocked.handle().transfer_guard().await;
+    let claimed = insert_cancel_registration(&tokens, claimed_id).await;
+    let candidate = JobCandidate::local(
+        claimed_id,
+        crate::profile::DEFAULT_PROFILE.to_owned(),
+        local_queue::job_path(dir.path(), crate::profile::DEFAULT_PROFILE, claimed_id).unwrap(),
+    );
+
+    let job = tokio::time::timeout(Duration::from_secs(2), provider.claim(candidate))
+        .await
+        .expect("claim must not wait for an unrelated cancellation gate")
+        .expect("claim should succeed");
+    assert_eq!(job.context().run_id, claimed_id);
+    assert!(claimed.handle().is_hard_cancelled());
+    assert!(!claimed_marker.exists());
+    assert!(!blocked.is_cancelled());
+    assert!(blocked_marker.exists());
+
+    // No cancel file was published after the watcher's initial scan. The
+    // claim's enqueue notification must wake it before the five-second timer.
+    drop(guard);
+    tokio::time::timeout(Duration::from_secs(2), blocked.token().cancelled())
+        .await
+        .expect("claim-time delivery should wake the idle watcher");
+    assert!(
+        blocked_marker.exists(),
+        "the unrelated run is still pre-claim"
+    );
+    provider.shutdown().await;
+}
+
+#[tokio::test]
 async fn claimed_cancelled_submit_survives_non_owner_scan() {
     let dir = tempfile::tempdir().unwrap();
     let owner_tokens = empty_cancel_tokens();

--- a/crates/runner/src/run_cancellation.rs
+++ b/crates/runner/src/run_cancellation.rs
@@ -360,7 +360,8 @@ impl RunCancellationHandle {
         self.inner.transfer_gate.clone().try_lock_owned().ok()
     }
 
-    fn same_registration(&self, other: &Self) -> bool {
+    /// Compare registration identity, even when a run ID has been reused.
+    pub(crate) fn same_registration(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.inner, &other.inner)
     }
 }


### PR DESCRIPTION
When a local run holds its cancellation transfer gate, other cancel markers and successful claims currently wait behind it, and provider shutdown joins the blocked scan. Keep blocked cancellation futures owned by the local provider so ready requests, later markers, claims, and shutdown can progress independently.

Bind each delivery to the scanned registration, deduplicate pending requests, and retain live markers until cancellation has actually been delivered. Shutdown and Drop clear pending futures and release their gate waiters. Adds five controlled-gate regressions covering scanner progress, registration replacement, lifecycle cleanup, and claim-time wakeup.

Closes #33446

### Validation

- `cargo fmt --manifest-path crates/runner/Cargo.toml -- --check` and `git diff --check`: passed.
- `cargo clippy --locked --manifest-path crates/Cargo.toml --profile local -p runner --bin runner --all-features -- -D warnings`: passed.
- `cargo doc --locked --manifest-path crates/Cargo.toml --profile local -p runner --all-features --no-deps`: passed.
- An isolated local verification crate loaded the actual scanner, cancellation registry, queue, and inotify modules: **81 tests passed**, including all four new scanner regressions and existing pre-claim/multi-runner marker cases. It used real files and cancellation gates; no VM or mocked queue.
- The native runner test binary exceeded local memory during compilation. All-target Clippy was also stopped by a 2.6 GB process memory ceiling. Full runner tests and the new provider claim regression require PR CI; the isolated checks do not cover the entire provider integration.

Scope is `runner start --local`; Ably behavior, transfer ordering, and queue formats are unchanged. No new compatibility fallback.
