### PR TITLE
refactor(ci): remove unused runner recovery provenance context

### DIFF
--- a/.github/scripts/reconcile-and-start-runner-groups.sh
+++ b/.github/scripts/reconcile-and-start-runner-groups.sh
@@ -19,9 +19,6 @@ output_value() {
 required_env=(
   AWS_METAL_RUNNER_HOSTS
   BIN_DIR
-  CURRENT_EVENT
-  CURRENT_RUN_ID
-  DEFAULT_BRANCH
   JOB_REF
   METAL_HOSTS
   METAL_USER
@@ -63,25 +60,8 @@ if [ "$recovery_needed" != "true" ] && [ "$recovery_needed" != "false" ]; then
 fi
 
 if [ "$recovery_needed" = "true" ]; then
-  current_pr_number=""
-  case "$CURRENT_EVENT" in
-    pull_request|merge_group)
-      if [[ ! "$JOB_REF" =~ ^pr-([1-9][0-9]*)$ ]]; then
-        echo "::error::Cannot resolve the runner owner PR from ${JOB_REF}" >&2
-        exit 2
-      fi
-      current_pr_number=${BASH_REMATCH[1]}
-      ;;
-    push) ;;
-    *)
-      echo "::error::Unsupported runner recovery event: ${CURRENT_EVENT}" >&2
-      exit 2
-      ;;
-  esac
-
   recovery_dir="${work_dir}/recovery"
   plan_output="${work_dir}/plan.out"
-  export CURRENT_PR_NUMBER=$current_pr_number
   GITHUB_OUTPUT="$plan_output" \
     RESOLVE_OUTPUT_DIR="${work_dir}/references" \
     RUNNER_HOST_GROUPS_MATRIX="$runner_host_groups_matrix" \

--- a/.github/scripts/tests/reconcile-and-start-runner-groups-test.sh
+++ b/.github/scripts/tests/reconcile-and-start-runner-groups-test.sh
@@ -180,10 +180,9 @@ run_case() {
   if [ "$recovery" = true ]; then
     runner_sha_map=$(jq -c --arg sha "$cached_sha" 'map_values($sha)' <<<"$runner_sha_map")
   fi
-  local service_ref=$job_ref current_event=pull_request
+  local service_ref=$job_ref
   if [[ "$job_ref" == staging-* ]]; then
     service_ref=staging
-    current_event=push
   fi
   local host host_index=0
   if [ ! -d "$case_dir" ]; then
@@ -205,9 +204,6 @@ run_case() {
     PATH="${tmp_dir}/bin:$PATH" \
     AWS_METAL_RUNNER_HOSTS=arm-1,x86-1,x86-2 \
     BIN_DIR="/var/lib/vm0-runner/bin/${job_ref}" \
-    CURRENT_EVENT="$current_event" \
-    CURRENT_RUN_ID=123 \
-    DEFAULT_BRANCH=main \
     JOB_REF="$job_ref" \
     METAL_HOSTS=arm-1,x86-1,x86-2 \
     METAL_USER=ci \

--- a/.github/scripts/tests/runner-lifecycle-ownership-workflow-test.sh
+++ b/.github/scripts/tests/runner-lifecycle-ownership-workflow-test.sh
@@ -204,7 +204,6 @@ raise "missing locked runner reconciliation and start" unless locked_start
 unless locked_start.dig("env", "AWS_METAL_RUNNER_HOSTS") ==
       "${{ secrets.AWS_METAL_RUNNER_HOSTS }}" &&
     locked_start.dig("env", "BIN_DIR") == "${{ needs.deploy-runner-prepare.outputs.bin-dir }}" &&
-    locked_start.dig("env", "CURRENT_EVENT") == "${{ github.event_name }}" &&
     locked_start.dig("env", "JOB_REF") == "${{ needs.prepare.outputs.runner-image-job-ref }}" &&
     locked_start.dig("env", "METAL_HOSTS") == "${{ secrets.AWS_METAL_RUNNER_HOSTS }}" &&
     locked_start.dig("env", "RUNNER_SHA_MAP") ==

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2518,10 +2518,6 @@ jobs:
           AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
-          CURRENT_EVENT: ${{ github.event_name }}
-          CURRENT_PR_HEAD_REF: ${{ github.head_ref || '' }}
-          CURRENT_RUN_ID: ${{ github.run_id }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ github.token }}
           JOB_REF: ${{ needs.prepare.outputs.runner-image-job-ref }}
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}


### PR DESCRIPTION
## Summary

Follow-up to #33499, which is already merged. That PR changed cache recovery to resolve trusted R2 references without workflow-run or ancestry provenance checks, but its deployment caller still required and constructed the retired resolver's context.

- Remove unused `CURRENT_EVENT`, `CURRENT_RUN_ID`, and `DEFAULT_BRANCH` requirements and PR-number derivation from Runner recovery.
- Remove the corresponding Turbo workflow arguments, including unused `CURRENT_PR_HEAD_REF`.
- Update existing integration fixtures and workflow assertions together with the retired inputs. Preserve deployment and restored-binary assertions; add no tombstone tests.

This PR contains only the cleanup identified during self-review: four files, one insertion and 30 deletions. It does not repeat the cache transport implementation from #33499 or close another issue.

## Behavior and risks

Namespace validation remains in the lifecycle-lock and binary-reconciliation helpers. Architecture/build-input selection, required R2 downloads, restoration SHA checks, atomic installation, host selection, service readiness, and cleanup behavior are unchanged. No new fallback, retry, Docker execution, or compilation path is introduced.

The removed values no longer have a consumer in the recovery call chain. Callers providing the previous extra environment variables continue to work; the workflow and script otherwise ship from the same checkout.

## Validation

On this branch based on current `main` (`b4762ad9fc399a1a9dbde812f63b0eb7252dd05b`):

- Shell syntax and strict ShellCheck for all three changed shell files.
- `actionlint .github/workflows/turbo.yml` and Prettier check.
- `.github/scripts/check-workflow-shell-compatibility.sh`.
- Five production-entry/workflow script tests: `reconcile-and-start-runner-groups`, `reconcile-runner-binary-groups`, `runner-binary-cache-plan`, `runner-lifecycle-ownership-workflow`, and `turbo-playwright-runner-workflow`.
- Staged diff whitespace and file-size checks.
- Local `pnpm -F @okouai/db db:migrate` after syncing the base.

The identical cleanup previously passed the full 87-script CI test step on the original branch; relevant tests were rerun after moving it onto current main. No unrelated application test suite was run for this shell/workflow-only change. Latest-head CI and live-host execution remain separate evidence.
