### PR TITLE
fix(api): treat empty recommended followups as an expected omission

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1638,66 +1638,72 @@ describe("CHAT-02: completed chat callback", () => {
     },
   );
 
-  it("reports a genuine recommended follow-up failure exactly once at error level", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
-    const privateProviderDetail = "private-openrouter-credential-detail";
-    chatCallbacks.mockOpenRouterCompletions((body) => {
-      const system = body.messages[0]?.content ?? "";
-      if (
-        system.includes(
-          "You generate recommended follow-up messages for a chat.",
-        )
-      ) {
-        return new HttpResponse(privateProviderDetail, { status: 401 });
-      }
-      return "Generated summary";
-    });
+  it.each([
+    { name: "rejected credentials", status: 401, reason: "auth" },
+    { name: "a rejected request", status: 400, reason: "invalid_request" },
+  ])(
+    "reports $name for recommended follow-ups exactly once at error level",
+    async ({ status, reason }) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
+      const privateProviderDetail = "private-openrouter-credential-detail";
+      chatCallbacks.mockOpenRouterCompletions((body) => {
+        const system = body.messages[0]?.content ?? "";
+        if (
+          system.includes(
+            "You generate recommended follow-up messages for a chat.",
+          )
+        ) {
+          return new HttpResponse(privateProviderDetail, { status });
+        }
+        return "Generated summary";
+      });
 
-    const run = await startChatRun(actor, {
-      agentId,
-      prompt: "Keep the main answer",
-    });
-    await flushWaitUntilForTest();
-    await chatCallbacks.registerPushSubscription(actor);
-    chatCallbacks.enableVapid();
-    const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
-    chatCallbacks.mockChatOutputEvents([
-      assistantEvent(0, "The main answer survives"),
-    ]);
-    await completeChatRunOk(run.runId, sandboxHeaders, {
-      lastEventSequence: 0,
-    });
-    await flushWaitUntilForTest();
+      const run = await startChatRun(actor, {
+        agentId,
+        prompt: "Keep the main answer",
+      });
+      await flushWaitUntilForTest();
+      await chatCallbacks.registerPushSubscription(actor);
+      chatCallbacks.enableVapid();
+      const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
+      chatCallbacks.mockChatOutputEvents([
+        assistantEvent(0, "The main answer survives"),
+      ]);
+      await completeChatRunOk(run.runId, sandboxHeaders, {
+        lastEventSequence: 0,
+      });
+      await flushWaitUntilForTest();
 
-    const events = await chat.listThreadEvents(actor, run.threadId);
-    expect(events.events).toContainEqual(
-      expect.objectContaining({ content: "The main answer survives" }),
-    );
-    expect(
-      events.events.some((event) => {
-        return event.eventType === "output.followups";
-      }),
-    ).toBeFalsy();
-    expect(auxiliaryResults(context, "recommended_followups")).toStrictEqual([
-      expect.objectContaining({ outcome: "error", reason: "auth" }),
-    ]);
-    expect(
-      auxiliaryDiagnostics(context, "recommended_followups"),
-    ).toStrictEqual([
-      expect.objectContaining({
-        level: "error",
-        reason: "auth",
-        errorKind: "openrouter_request",
-        status: 401,
-      }),
-    ]);
-    // A real failure must not also reappear on the shared warning channel.
-    expect(auxiliaryWarnings(context)).toStrictEqual([]);
-    expect(JSON.stringify(auxiliaryDiagnostics(context))).not.toContain(
-      privateProviderDetail,
-    );
-  });
+      const events = await chat.listThreadEvents(actor, run.threadId);
+      expect(events.events).toContainEqual(
+        expect.objectContaining({ content: "The main answer survives" }),
+      );
+      expect(
+        events.events.some((event) => {
+          return event.eventType === "output.followups";
+        }),
+      ).toBeFalsy();
+      expect(auxiliaryResults(context, "recommended_followups")).toStrictEqual([
+        expect.objectContaining({ outcome: "error", reason }),
+      ]);
+      expect(
+        auxiliaryDiagnostics(context, "recommended_followups"),
+      ).toStrictEqual([
+        expect.objectContaining({
+          level: "error",
+          reason,
+          errorKind: "openrouter_request",
+          status,
+        }),
+      ]);
+      // A real failure must not also reappear on the shared warning channel.
+      expect(auxiliaryWarnings(context)).toStrictEqual([]);
+      expect(JSON.stringify(auxiliaryDiagnostics(context))).not.toContain(
+        privateProviderDetail,
+      );
+    },
+  );
 
   it.each([
     {
@@ -2154,9 +2160,11 @@ describe("CHAT-02: completed chat callback", () => {
         reason: "output_truncated",
       }),
     );
-    // Truncation keeps classifying ahead of this caller's expected-empty
-    // policy, and this caller can now report at error, so silence has to be
-    // proved across every level rather than on the warning channel alone.
+    // This caller rejects a truncated array, so the outcome comes from the
+    // recorded truncation reason rather than from the returned value. Either
+    // way it stays a counted degradation, and since this caller can now report
+    // at error, silence has to be proved across every level rather than on the
+    // warning channel alone.
     expect(auxiliaryDiagnostics(context)).toStrictEqual([]);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1550,27 +1550,51 @@ describe("CHAT-02: completed chat callback", () => {
   });
 
   it.each([
-    { name: "an empty suggestion array", text: "[]" },
+    // The provider reports usage even when the generated text interprets to
+    // nothing, and an expected omission keeps that detail on its counted
+    // event.
+    {
+      name: "an empty suggestion array",
+      response: () => {
+        return HttpResponse.json({
+          choices: [{ finish_reason: "stop", message: { content: "[]" } }],
+          usage: {
+            completion_tokens: 63,
+            completion_tokens_details: { reasoning_tokens: 0 },
+          },
+        });
+      },
+      tokens: { completion_tokens: 63, reasoning_tokens: 0 },
+    },
     {
       name: "generated text that is not JSON",
-      text: "I have no useful follow-ups for this conversation.",
+      response: () => {
+        return "I have no useful follow-ups for this conversation.";
+      },
+      tokens: {},
     },
     {
       name: "generated JSON that is not an array",
-      text: JSON.stringify({
-        followups: [{ prompt: "Run the failing case again", kind: "talk" }],
-      }),
+      response: () => {
+        return JSON.stringify({
+          followups: [{ prompt: "Run the failing case again", kind: "talk" }],
+        });
+      },
+      tokens: {},
     },
     {
       name: "an array whose every item fails validation",
-      text: JSON.stringify([
-        { prompt: "Run the failing case again", kind: "chat" },
-        { text: "Try the other branch", kind: "talk" },
-      ]),
+      response: () => {
+        return JSON.stringify([
+          { prompt: "Run the failing case again", kind: "chat" },
+          { text: "Try the other branch", kind: "talk" },
+        ]);
+      },
+      tokens: {},
     },
   ])(
     "omits recommended follow-ups with no diagnostic at any level for $name",
-    async ({ text }) => {
+    async ({ response, tokens }) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
       mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
       chatCallbacks.mockOpenRouterCompletions((body) => {
@@ -1580,7 +1604,7 @@ describe("CHAT-02: completed chat callback", () => {
             "You generate recommended follow-up messages for a chat.",
           )
         ) {
-          return text;
+          return response();
         }
         // A sibling whose interpreted output is empty in the same run proves
         // the silence is scoped to this caller rather than shared.
@@ -1620,6 +1644,7 @@ describe("CHAT-02: completed chat callback", () => {
         expect.objectContaining({
           outcome: "degraded",
           reason: "unusable_output",
+          ...tokens,
         }),
       ]);
       expect(
@@ -1707,70 +1732,105 @@ describe("CHAT-02: completed chat callback", () => {
 
   it.each([
     {
-      name: "a completion that produced no content",
-      // Stopping with nothing to interpret is another way to get no
-      // suggestions, not a defect this caller can act on.
+      // The generated text is well formed for the provider; it is the response
+      // envelope around it that breaks its contract.
+      name: "a response body that is not JSON",
       response: () => {
-        return HttpResponse.json({
-          choices: [{ finish_reason: "stop", message: { content: "" } }],
+        return new HttpResponse("<html>gateway</html>", {
+          headers: { "content-type": "application/json" },
         });
       },
       reason: "invalid_output",
     },
     {
-      name: "a provider failure nothing classified",
-      // The reason the classifier's status table misses, which in practice is
-      // provider-side unavailability rather than a defect of ours.
+      name: "a response carrying no choices",
       response: () => {
-        return new HttpResponse("Internal Server Error", { status: 500 });
+        return HttpResponse.json({ id: "gen-1" });
+      },
+      reason: "invalid_output",
+    },
+    {
+      name: "a choice whose content is not a string",
+      response: () => {
+        return HttpResponse.json({
+          choices: [{ finish_reason: "stop", message: { content: 42 } }],
+        });
+      },
+      reason: "invalid_output",
+    },
+    {
+      // Nothing annotates this, so the reason stays literally unknown rather
+      // than being presented as a specific cause.
+      name: "a response body that fails while streaming",
+      response: () => {
+        return new HttpResponse(
+          new ReadableStream({
+            start(controller) {
+              controller.error(new TypeError("terminated"));
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        );
       },
       reason: "unknown",
     },
-  ])("does not raise the severity of $name", async ({ response, reason }) => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
-    chatCallbacks.mockOpenRouterCompletions((body) => {
-      const system = body.messages[0]?.content ?? "";
-      if (
-        system.includes(
-          "You generate recommended follow-up messages for a chat.",
-        )
-      ) {
-        return response();
-      }
-      return "Generated summary";
-    });
+  ])(
+    "reports $name for recommended follow-ups exactly once at error level",
+    async ({ response, reason }) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
+      chatCallbacks.mockOpenRouterCompletions((body) => {
+        const system = body.messages[0]?.content ?? "";
+        if (
+          system.includes(
+            "You generate recommended follow-up messages for a chat.",
+          )
+        ) {
+          return response();
+        }
+        return "Generated summary";
+      });
 
-    const run = await startChatRun(actor, {
-      agentId,
-      prompt: "Keep the main answer",
-    });
-    await flushWaitUntilForTest();
-    await chatCallbacks.registerPushSubscription(actor);
-    chatCallbacks.enableVapid();
-    const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
-    chatCallbacks.mockChatOutputEvents([
-      assistantEvent(0, "The main answer survives"),
-    ]);
-    await completeChatRunOk(run.runId, sandboxHeaders, {
-      lastEventSequence: 0,
-    });
-    await flushWaitUntilForTest();
+      const run = await startChatRun(actor, {
+        agentId,
+        prompt: "Keep the main answer",
+      });
+      await flushWaitUntilForTest();
+      await chatCallbacks.registerPushSubscription(actor);
+      chatCallbacks.enableVapid();
+      const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
+      chatCallbacks.mockChatOutputEvents([
+        assistantEvent(0, "The main answer survives"),
+      ]);
+      await completeChatRunOk(run.runId, sandboxHeaders, {
+        lastEventSequence: 0,
+      });
+      await flushWaitUntilForTest();
 
-    const events = await chat.listThreadEvents(actor, run.threadId);
-    expect(events.events).toContainEqual(
-      expect.objectContaining({ content: "The main answer survives" }),
-    );
-    expect(auxiliaryResults(context, "recommended_followups")).toStrictEqual([
-      expect.objectContaining({ outcome: "error", reason }),
-    ]);
-    // The caller's raised severity covers only the reasons that name a defect,
-    // so these keep the shared level instead of being escalated.
-    expect(
-      auxiliaryDiagnostics(context, "recommended_followups"),
-    ).toStrictEqual([expect.objectContaining({ level: "warn", reason })]);
-    expect(context.mocks.axiomLogging.error.mock.calls).toStrictEqual([]);
-  });
+      const events = await chat.listThreadEvents(actor, run.threadId);
+      expect(events.events).toContainEqual(
+        expect.objectContaining({ content: "The main answer survives" }),
+      );
+      expect(
+        events.events.some((event) => {
+          return event.eventType === "output.followups";
+        }),
+      ).toBeFalsy();
+      expect(auxiliaryResults(context, "recommended_followups")).toStrictEqual([
+        expect.objectContaining({ outcome: "error", reason }),
+      ]);
+      // A response that broke its contract, and an exception nothing
+      // classified, are failures rather than omissions: one error record, and
+      // no warning copy of it.
+      expect(
+        auxiliaryDiagnostics(context, "recommended_followups"),
+      ).toStrictEqual([expect.objectContaining({ level: "error", reason })]);
+      expect(auxiliaryWarnings(context)).toStrictEqual([]);
+      expect(JSON.stringify(auxiliaryDiagnostics(context))).not.toContain(
+        "gateway",
+      );
+    },
+  );
 
   it("keeps title and summary storage failures observable after successful generation", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1700,6 +1700,58 @@ describe("CHAT-02: completed chat callback", () => {
     );
   });
 
+  it("does not raise the severity of a follow-up completion that produced no content", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
+    chatCallbacks.mockOpenRouterCompletions((body) => {
+      const system = body.messages[0]?.content ?? "";
+      if (
+        system.includes(
+          "You generate recommended follow-up messages for a chat.",
+        )
+      ) {
+        // A completion that stops with nothing to interpret is another way to
+        // get no suggestions, not a defect this caller can act on.
+        return HttpResponse.json({
+          choices: [{ finish_reason: "stop", message: { content: "" } }],
+        });
+      }
+      return "Generated summary";
+    });
+
+    const run = await startChatRun(actor, {
+      agentId,
+      prompt: "Keep the main answer",
+    });
+    await flushWaitUntilForTest();
+    await chatCallbacks.registerPushSubscription(actor);
+    chatCallbacks.enableVapid();
+    const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "The main answer survives"),
+    ]);
+    await completeChatRunOk(run.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+    await flushWaitUntilForTest();
+
+    const events = await chat.listThreadEvents(actor, run.threadId);
+    expect(events.events).toContainEqual(
+      expect.objectContaining({ content: "The main answer survives" }),
+    );
+    expect(auxiliaryResults(context, "recommended_followups")).toStrictEqual([
+      expect.objectContaining({ outcome: "error", reason: "invalid_output" }),
+    ]);
+    // The caller's raised severity covers the reasons that name a defect, so
+    // this one keeps the shared level instead of being escalated.
+    expect(
+      auxiliaryDiagnostics(context, "recommended_followups"),
+    ).toStrictEqual([
+      expect.objectContaining({ level: "warn", reason: "invalid_output" }),
+    ]);
+    expect(context.mocks.axiomLogging.error.mock.calls).toStrictEqual([]);
+  });
+
   it("keeps title and summary storage failures observable after successful generation", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
@@ -2088,7 +2140,10 @@ describe("CHAT-02: completed chat callback", () => {
         reason: "output_truncated",
       }),
     );
-    expect(auxiliaryWarnings(context)).toStrictEqual([]);
+    // Truncation keeps classifying ahead of this caller's expected-empty
+    // policy, and this caller can now report at error, so silence has to be
+    // proved across every level rather than on the warning channel alone.
+    expect(auxiliaryDiagnostics(context)).toStrictEqual([]);
   });
 
   it("auto-sends the queued message before completed-run LLM side effects finish", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -8,6 +8,7 @@ import {
 
 import { HttpResponse } from "msw";
 import {
+  auxiliaryDiagnostics,
   auxiliaryResults,
   auxiliaryWarnings,
 } from "./helpers/auxiliary-generation";
@@ -1546,6 +1547,157 @@ describe("CHAT-02: completed chat callback", () => {
     ]);
     expect(context.mocks.axiomLogging.warn.mock.calls).toStrictEqual([]);
     expect(context.mocks.axiomLogging.error.mock.calls).toStrictEqual([]);
+  });
+
+  it.each([
+    { name: "an empty suggestion array", text: "[]" },
+    {
+      name: "generated text that is not JSON",
+      text: "I have no useful follow-ups for this conversation.",
+    },
+    {
+      name: "generated JSON that is not an array",
+      text: JSON.stringify({
+        followups: [{ prompt: "Run the failing case again", kind: "talk" }],
+      }),
+    },
+    {
+      name: "an array whose every item fails validation",
+      text: JSON.stringify([
+        { prompt: "Run the failing case again", kind: "chat" },
+        { text: "Try the other branch", kind: "talk" },
+      ]),
+    },
+  ])(
+    "omits recommended follow-ups with no diagnostic at any level for $name",
+    async ({ text }) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
+      chatCallbacks.mockOpenRouterCompletions((body) => {
+        const system = body.messages[0]?.content ?? "";
+        if (
+          system.includes(
+            "You generate recommended follow-up messages for a chat.",
+          )
+        ) {
+          return text;
+        }
+        // A sibling whose interpreted output is empty in the same run proves
+        // the silence is scoped to this caller rather than shared.
+        if (system.includes("one short notification sentence")) {
+          return "---";
+        }
+        return "Generated summary";
+      });
+
+      const run = await startChatRun(actor, {
+        agentId,
+        prompt: "Keep the main answer",
+      });
+      await flushWaitUntilForTest();
+      await chatCallbacks.registerPushSubscription(actor);
+      chatCallbacks.enableVapid();
+      const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
+      chatCallbacks.mockChatOutputEvents([
+        assistantEvent(0, "The main answer survives"),
+      ]);
+      await completeChatRunOk(run.runId, sandboxHeaders, {
+        lastEventSequence: 0,
+      });
+      await flushWaitUntilForTest();
+
+      const events = await chat.listThreadEvents(actor, run.threadId);
+      expect(events.events).toContainEqual(
+        expect.objectContaining({ content: "The main answer survives" }),
+      );
+      expect(
+        events.events.some((event) => {
+          return event.eventType === "output.followups";
+        }),
+      ).toBeFalsy();
+      // The omission stays counted, with its reason and token detail intact.
+      expect(auxiliaryResults(context, "recommended_followups")).toStrictEqual([
+        expect.objectContaining({
+          outcome: "degraded",
+          reason: "unusable_output",
+        }),
+      ]);
+      expect(
+        auxiliaryDiagnostics(context, "recommended_followups"),
+      ).toStrictEqual([]);
+      expect(
+        auxiliaryDiagnostics(context, "notification_summary"),
+      ).toStrictEqual([
+        expect.objectContaining({ level: "warn", reason: "unusable_output" }),
+      ]);
+      expect(
+        context.mocks.webpush.sendNotification.mock.calls.map(pushPayload),
+      ).toContainEqual(
+        expect.objectContaining({ body: "Your task is complete" }),
+      );
+      expect(JSON.stringify(auxiliaryDiagnostics(context))).not.toContain(text);
+    },
+  );
+
+  it("reports a genuine recommended follow-up failure exactly once at error level", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
+    const privateProviderDetail = "private-openrouter-credential-detail";
+    chatCallbacks.mockOpenRouterCompletions((body) => {
+      const system = body.messages[0]?.content ?? "";
+      if (
+        system.includes(
+          "You generate recommended follow-up messages for a chat.",
+        )
+      ) {
+        return new HttpResponse(privateProviderDetail, { status: 401 });
+      }
+      return "Generated summary";
+    });
+
+    const run = await startChatRun(actor, {
+      agentId,
+      prompt: "Keep the main answer",
+    });
+    await flushWaitUntilForTest();
+    await chatCallbacks.registerPushSubscription(actor);
+    chatCallbacks.enableVapid();
+    const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "The main answer survives"),
+    ]);
+    await completeChatRunOk(run.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+    await flushWaitUntilForTest();
+
+    const events = await chat.listThreadEvents(actor, run.threadId);
+    expect(events.events).toContainEqual(
+      expect.objectContaining({ content: "The main answer survives" }),
+    );
+    expect(
+      events.events.some((event) => {
+        return event.eventType === "output.followups";
+      }),
+    ).toBeFalsy();
+    expect(auxiliaryResults(context, "recommended_followups")).toStrictEqual([
+      expect.objectContaining({ outcome: "error", reason: "auth" }),
+    ]);
+    expect(
+      auxiliaryDiagnostics(context, "recommended_followups"),
+    ).toStrictEqual([
+      expect.objectContaining({
+        level: "error",
+        reason: "auth",
+        errorKind: "openrouter_request",
+        status: 401,
+      }),
+    ]);
+    // A real failure must not also reappear on the shared warning channel.
+    expect(auxiliaryWarnings(context)).toStrictEqual([]);
+    expect(JSON.stringify(auxiliaryDiagnostics(context))).not.toContain(
+      privateProviderDetail,
+    );
   });
 
   it("keeps title and summary storage failures observable after successful generation", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1635,7 +1635,6 @@ describe("CHAT-02: completed chat callback", () => {
       ).toContainEqual(
         expect.objectContaining({ body: "Your task is complete" }),
       );
-      expect(JSON.stringify(auxiliaryDiagnostics(context))).not.toContain(text);
     },
   );
 
@@ -1700,7 +1699,28 @@ describe("CHAT-02: completed chat callback", () => {
     );
   });
 
-  it("does not raise the severity of a follow-up completion that produced no content", async () => {
+  it.each([
+    {
+      name: "a completion that produced no content",
+      // Stopping with nothing to interpret is another way to get no
+      // suggestions, not a defect this caller can act on.
+      response: () => {
+        return HttpResponse.json({
+          choices: [{ finish_reason: "stop", message: { content: "" } }],
+        });
+      },
+      reason: "invalid_output",
+    },
+    {
+      name: "a provider failure nothing classified",
+      // The reason the classifier's status table misses, which in practice is
+      // provider-side unavailability rather than a defect of ours.
+      response: () => {
+        return new HttpResponse("Internal Server Error", { status: 500 });
+      },
+      reason: "unknown",
+    },
+  ])("does not raise the severity of $name", async ({ response, reason }) => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
     chatCallbacks.mockOpenRouterCompletions((body) => {
@@ -1710,11 +1730,7 @@ describe("CHAT-02: completed chat callback", () => {
           "You generate recommended follow-up messages for a chat.",
         )
       ) {
-        // A completion that stops with nothing to interpret is another way to
-        // get no suggestions, not a defect this caller can act on.
-        return HttpResponse.json({
-          choices: [{ finish_reason: "stop", message: { content: "" } }],
-        });
+        return response();
       }
       return "Generated summary";
     });
@@ -1740,15 +1756,13 @@ describe("CHAT-02: completed chat callback", () => {
       expect.objectContaining({ content: "The main answer survives" }),
     );
     expect(auxiliaryResults(context, "recommended_followups")).toStrictEqual([
-      expect.objectContaining({ outcome: "error", reason: "invalid_output" }),
+      expect.objectContaining({ outcome: "error", reason }),
     ]);
-    // The caller's raised severity covers the reasons that name a defect, so
-    // this one keeps the shared level instead of being escalated.
+    // The caller's raised severity covers only the reasons that name a defect,
+    // so these keep the shared level instead of being escalated.
     expect(
       auxiliaryDiagnostics(context, "recommended_followups"),
-    ).toStrictEqual([
-      expect.objectContaining({ level: "warn", reason: "invalid_output" }),
-    ]);
+    ).toStrictEqual([expect.objectContaining({ level: "warn", reason })]);
     expect(context.mocks.axiomLogging.error.mock.calls).toStrictEqual([]);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/auxiliary-generation.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/auxiliary-generation.ts
@@ -96,3 +96,37 @@ export function auxiliaryWarnings(context: TestContext) {
     return message === "Auxiliary generation failed";
   });
 }
+
+const diagnosticLevels = ["debug", "info", "warn", "error"] as const;
+
+const diagnosticSchema = z.object({
+  feature: z.string(),
+  reason: z.string(),
+  errorKind: z.string(),
+  threadId: z.string().optional(),
+  runId: z.string().optional(),
+  status: z.number().optional(),
+});
+
+/**
+ * Every diagnostic level, so a caller that stops reporting an expected outcome
+ * is proved silent rather than merely quieter: a reappearance at info or debug
+ * fails the same assertion as a reappearance at warn.
+ */
+export function auxiliaryDiagnostics(
+  context: TestContext,
+  feature?: AuxiliaryFeature,
+) {
+  return diagnosticLevels.flatMap((level) => {
+    return context.mocks.axiomLogging[level].mock.calls
+      .filter(([message]) => {
+        return message === "Auxiliary generation failed";
+      })
+      .map(([, fields]) => {
+        return { level, ...diagnosticSchema.parse(fields) };
+      })
+      .filter((diagnostic) => {
+        return feature === undefined || diagnostic.feature === feature;
+      });
+  });
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/auxiliary-generation.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/auxiliary-generation.ts
@@ -122,14 +122,20 @@ export function auxiliaryDiagnostics(
       .filter(([message]) => {
         return message === "Auxiliary generation failed";
       })
+      .filter(([, fields]) => {
+        return (
+          feature === undefined ||
+          (typeof fields === "object" &&
+            fields !== null &&
+            "feature" in fields &&
+            fields.feature === feature)
+        );
+      })
       .map(([, fields]) => {
         // `fields` is kept verbatim beside the parsed projection: the schema
         // strips unknown keys, which are exactly the provider-derived ones a
         // leak assertion has to be able to see.
         return { level, ...diagnosticSchema.parse(fields), fields };
-      })
-      .filter((diagnostic) => {
-        return feature === undefined || diagnostic.feature === feature;
       });
   });
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/auxiliary-generation.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/auxiliary-generation.ts
@@ -123,7 +123,10 @@ export function auxiliaryDiagnostics(
         return message === "Auxiliary generation failed";
       })
       .map(([, fields]) => {
-        return { level, ...diagnosticSchema.parse(fields) };
+        // `fields` is kept verbatim beside the parsed projection: the schema
+        // strips unknown keys, which are exactly the provider-derived ones a
+        // leak assertion has to be able to see.
+        return { level, ...diagnosticSchema.parse(fields), fields };
       })
       .filter((diagnostic) => {
         return feature === undefined || diagnostic.feature === feature;

--- a/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
@@ -32,6 +32,22 @@ type Reason =
   | "unusable_output";
 
 /**
+ * How a caller wants a returned-but-unusable result reported. `expected` is for
+ * a caller whose empty result is an omission it already handles, so the outcome
+ * stays counted in `auxiliary_generation_result` and produces no diagnostic at
+ * any level. It describes the interpreted return value only, never a thrown
+ * provider error. `failure` keeps the shared default.
+ */
+type UnusableOutputPolicy = "expected" | "failure";
+
+/**
+ * Severity a caller's genuine failures deserve. Only a caller that has
+ * characterized its own outcomes can raise this, so the shared default stays
+ * `warn` for features whose failure classification is not established.
+ */
+type AuxiliaryFailureLevel = "warn" | "error";
+
+/**
  * Provider-outcome detail the generation closure observes and the boundary
  * cannot infer from the returned value. Token counts are integers, so they
  * carry no payload risk while showing how much of the shared thinking-plus-
@@ -143,8 +159,9 @@ function diagnose(
   reason: Reason,
   error: unknown,
   context: Readonly<{ runId?: string; threadId?: string }> | undefined,
+  level: AuxiliaryFailureLevel,
 ): void {
-  log.warn("Auxiliary generation failed", {
+  const fields = {
     feature,
     reason,
     ...context,
@@ -165,7 +182,12 @@ function diagnose(
           retryAfterMs: error.retryAfterMs,
         }
       : {}),
-  });
+  };
+  if (level === "error") {
+    log.error("Auxiliary generation failed", fields);
+    return;
+  }
+  log.warn("Auxiliary generation failed", fields);
 }
 
 /** Only generation and feature output interpretation belong inside this boundary. */
@@ -174,6 +196,8 @@ export async function generateAuxiliary<T>(
     readonly feature: AuxiliaryFeature;
     readonly generate: (record: RecordAuxiliaryGenerationDetail) => Promise<T>;
     readonly usable: (value: T) => boolean;
+    readonly unusableOutput?: UnusableOutputPolicy;
+    readonly failureLevel?: AuxiliaryFailureLevel;
     readonly diagnosticContext?: Readonly<{
       runId?: string;
       threadId?: string;
@@ -182,6 +206,7 @@ export async function generateAuxiliary<T>(
   signal?: AbortSignal,
 ): Promise<T | undefined> {
   const startedAt = now();
+  const failureLevel = args.failureLevel ?? "warn";
   const runId = args.diagnosticContext?.runId;
   let detail: AuxiliaryGenerationDetail | undefined;
   const result = await settle(
@@ -208,13 +233,24 @@ export async function generateAuxiliary<T>(
         // be unusable: the token ceiling is the known, non-actionable cause, and
         // reporting it as a defect would restore the noise this replaces.
         const truncated = detail?.truncated === true;
-        const outcome = truncated ? "degraded" : usable ? "success" : "error";
+        // A caller that declares its empty result expected keeps the reason and
+        // the counted event; only the diagnostic goes away. Truncation still
+        // classifies ahead of it, so a usable shortened sibling output stays
+        // `output_truncated` rather than being reported as a plain success.
+        const outcome = truncated
+          ? "degraded"
+          : usable
+            ? "success"
+            : args.unusableOutput === "expected"
+              ? "degraded"
+              : "error";
         if (outcome === "error") {
           diagnose(
             args.feature,
             "unusable_output",
             undefined,
             args.diagnosticContext,
+            failureLevel,
           );
         }
         recordResult({
@@ -244,7 +280,13 @@ export async function generateAuxiliary<T>(
             ? "degraded"
             : "error";
         if (outcome === "error") {
-          diagnose(args.feature, reason, error, args.diagnosticContext);
+          diagnose(
+            args.feature,
+            reason,
+            error,
+            args.diagnosticContext,
+            failureLevel,
+          );
         }
         const retryAfterMs = retryAfterMilliseconds(error);
         recordResult({

--- a/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
@@ -39,31 +39,6 @@ type Reason =
 type AuxiliaryFailureLevel = "warn" | "error";
 
 /**
- * Reasons that name a defect somebody can act on: the provider rejected the
- * request on its credentials or on its shape. Both are ours to fix.
- *
- * Two absences are deliberate, because each is a bucket rather than a cause:
- *
- * - `invalid_output` folds a genuine envelope contract violation together with
- *   a completion that returned no content and one stopped by a content filter.
- *   The last two are omissions of the same kind as an empty interpreted
- *   result.
- * - `unknown` is what the classifier returns for everything its status and
- *   envelope tables miss, which is dominated by provider-side unavailability
- *   such as a plain HTTP 500 or an unrecognized timeout. Its enumerated
- *   siblings are already treated as degraded and reported to nobody.
- *
- * Raising either would reintroduce, at a higher severity, exactly the
- * unactionable report this boundary removes. Both stay visible as a counted
- * `auxiliary_generation_result` reason, which is where a classifier gap shows
- * up without an error log. Narrowing those buckets belongs to the provider
- * classification, not to a caller's severity choice.
- */
-function isActionableFailure(reason: Reason): boolean {
-  return reason === "auth" || reason === "invalid_request";
-}
-
-/**
  * Provider-outcome detail the generation closure observes and the boundary
  * cannot infer from the returned value. Token counts are integers, so they
  * carry no payload risk while showing how much of the shared thinking-plus-
@@ -228,14 +203,11 @@ export async function generateAuxiliary<T>(
   signal?: AbortSignal,
 ): Promise<T | undefined> {
   const startedAt = now();
-  // A caller only raises the severity of the failures that name a defect.
-  // Everything else keeps the shared level, so a caller cannot escalate an
-  // outcome the boundary itself treats as unactionable.
-  const levelFor = (reason: Reason): AuxiliaryFailureLevel => {
-    return args.failureLevel !== undefined && isActionableFailure(reason)
-      ? args.failureLevel
-      : "warn";
-  };
+  // The caller's level applies to whatever this boundary already classifies as
+  // an error. It cannot reach an outcome that is counted silently: transient
+  // provider failures, truncation, an unexpected tool call, a cancellation and
+  // a caller's expected empty result never get here.
+  const failureLevel = args.failureLevel ?? "warn";
   const runId = args.diagnosticContext?.runId;
   let detail: AuxiliaryGenerationDetail | undefined;
   const result = await settle(
@@ -279,10 +251,7 @@ export async function generateAuxiliary<T>(
             "unusable_output",
             undefined,
             args.diagnosticContext,
-            // Reached only by a caller that has not declared this outcome
-            // expected, and an output the feature cannot interpret names no
-            // defect, so it stays at the shared level for every caller.
-            "warn",
+            failureLevel,
           );
         }
         recordResult({
@@ -317,7 +286,7 @@ export async function generateAuxiliary<T>(
             reason,
             error,
             args.diagnosticContext,
-            levelFor(reason),
+            failureLevel,
           );
         }
         const retryAfterMs = retryAfterMilliseconds(error);

--- a/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
@@ -32,20 +32,29 @@ type Reason =
   | "unusable_output";
 
 /**
- * How a caller wants a returned-but-unusable result reported. `expected` is for
- * a caller whose empty result is an omission it already handles, so the outcome
- * stays counted in `auxiliary_generation_result` and produces no diagnostic at
- * any level. It describes the interpreted return value only, never a thrown
- * provider error. `failure` keeps the shared default.
- */
-type UnusableOutputPolicy = "expected" | "failure";
-
-/**
- * Severity a caller's genuine failures deserve. Only a caller that has
+ * Severity a caller's actionable failures deserve. Only a caller that has
  * characterized its own outcomes can raise this, so the shared default stays
  * `warn` for features whose failure classification is not established.
  */
 type AuxiliaryFailureLevel = "warn" | "error";
+
+/**
+ * Reasons that name a defect somebody can act on: the request was rejected on
+ * its credentials or its shape, or nothing classified the failure at all.
+ *
+ * `invalid_output` is deliberately absent. It currently folds a genuine
+ * envelope contract violation together with a completion that returned no
+ * content or was stopped by a content filter, and those two are omissions of
+ * the same kind as an empty interpreted result rather than defects. Raising
+ * them would reintroduce, at a higher severity, exactly the unactionable
+ * report this boundary is removing. Separating that reason belongs to the
+ * provider classification, not to a caller's severity choice.
+ */
+function isActionableFailure(reason: Reason): boolean {
+  return (
+    reason === "auth" || reason === "invalid_request" || reason === "unknown"
+  );
+}
 
 /**
  * Provider-outcome detail the generation closure observes and the boundary
@@ -196,7 +205,13 @@ export async function generateAuxiliary<T>(
     readonly feature: AuxiliaryFeature;
     readonly generate: (record: RecordAuxiliaryGenerationDetail) => Promise<T>;
     readonly usable: (value: T) => boolean;
-    readonly unusableOutput?: UnusableOutputPolicy;
+    /**
+     * Set by a caller whose empty interpreted result is an omission it already
+     * handles: the outcome stays counted in `auxiliary_generation_result` and
+     * produces no diagnostic at any level. It describes the interpreted return
+     * value only, never a thrown provider error.
+     */
+    readonly unusableOutput?: "expected";
     readonly failureLevel?: AuxiliaryFailureLevel;
     readonly diagnosticContext?: Readonly<{
       runId?: string;
@@ -206,7 +221,14 @@ export async function generateAuxiliary<T>(
   signal?: AbortSignal,
 ): Promise<T | undefined> {
   const startedAt = now();
-  const failureLevel = args.failureLevel ?? "warn";
+  // A caller only raises the severity of the failures that name a defect.
+  // Everything else keeps the shared level, so a caller cannot escalate an
+  // outcome the boundary itself treats as unactionable.
+  const levelFor = (reason: Reason): AuxiliaryFailureLevel => {
+    return args.failureLevel !== undefined && isActionableFailure(reason)
+      ? args.failureLevel
+      : "warn";
+  };
   const runId = args.diagnosticContext?.runId;
   let detail: AuxiliaryGenerationDetail | undefined;
   const result = await settle(
@@ -250,7 +272,7 @@ export async function generateAuxiliary<T>(
             "unusable_output",
             undefined,
             args.diagnosticContext,
-            failureLevel,
+            levelFor("unusable_output"),
           );
         }
         recordResult({
@@ -285,7 +307,7 @@ export async function generateAuxiliary<T>(
             reason,
             error,
             args.diagnosticContext,
-            failureLevel,
+            levelFor(reason),
           );
         }
         const retryAfterMs = retryAfterMilliseconds(error);

--- a/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
@@ -39,21 +39,28 @@ type Reason =
 type AuxiliaryFailureLevel = "warn" | "error";
 
 /**
- * Reasons that name a defect somebody can act on: the request was rejected on
- * its credentials or its shape, or nothing classified the failure at all.
+ * Reasons that name a defect somebody can act on: the provider rejected the
+ * request on its credentials or on its shape. Both are ours to fix.
  *
- * `invalid_output` is deliberately absent. It currently folds a genuine
- * envelope contract violation together with a completion that returned no
- * content or was stopped by a content filter, and those two are omissions of
- * the same kind as an empty interpreted result rather than defects. Raising
- * them would reintroduce, at a higher severity, exactly the unactionable
- * report this boundary is removing. Separating that reason belongs to the
- * provider classification, not to a caller's severity choice.
+ * Two absences are deliberate, because each is a bucket rather than a cause:
+ *
+ * - `invalid_output` folds a genuine envelope contract violation together with
+ *   a completion that returned no content and one stopped by a content filter.
+ *   The last two are omissions of the same kind as an empty interpreted
+ *   result.
+ * - `unknown` is what the classifier returns for everything its status and
+ *   envelope tables miss, which is dominated by provider-side unavailability
+ *   such as a plain HTTP 500 or an unrecognized timeout. Its enumerated
+ *   siblings are already treated as degraded and reported to nobody.
+ *
+ * Raising either would reintroduce, at a higher severity, exactly the
+ * unactionable report this boundary removes. Both stay visible as a counted
+ * `auxiliary_generation_result` reason, which is where a classifier gap shows
+ * up without an error log. Narrowing those buckets belongs to the provider
+ * classification, not to a caller's severity choice.
  */
 function isActionableFailure(reason: Reason): boolean {
-  return (
-    reason === "auth" || reason === "invalid_request" || reason === "unknown"
-  );
+  return reason === "auth" || reason === "invalid_request";
 }
 
 /**
@@ -272,7 +279,10 @@ export async function generateAuxiliary<T>(
             "unusable_output",
             undefined,
             args.diagnosticContext,
-            levelFor("unusable_output"),
+            // Reached only by a caller that has not declared this outcome
+            // expected, and an output the feature cannot interpret names no
+            // defect, so it stays at the shared level for every caller.
+            "warn",
           );
         }
         recordResult({

--- a/turbo/apps/api/src/signals/services/chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-title.service.ts
@@ -619,14 +619,14 @@ export async function generateChatThreadRecommendedFollowupsFromContext(
         // result untouched. Count it and say nothing. The generated text is
         // never inspected here, so the empty result cannot name a defect.
         unusableOutput: "expected",
-        // Rejected credentials, a rejected request shape, or a failure nothing
-        // classified are defects rather than omissions, so this caller reports
-        // those at error. The boundary keeps every other reason at the shared
-        // level, which matters here: a completion that returned no content or
-        // was stopped by a content filter is another way to get no
-        // suggestions, not something to escalate. Scoped to this caller; the
-        // shared default is unchanged for features whose own outcomes have not
-        // been characterized.
+        // Rejected credentials and a rejected request shape are defects rather
+        // than omissions, so this caller reports those at error. The boundary
+        // holds every other reason at the shared level, which matters here: a
+        // completion that returned no content, one stopped by a content
+        // filter, and an unclassified provider failure are all further ways to
+        // end up with no suggestions rather than things to escalate. Scoped to
+        // this caller; the shared default is unchanged for features whose own
+        // outcomes have not been characterized.
         failureLevel: "error",
         diagnosticContext: args.threadId
           ? { threadId: args.threadId }

--- a/turbo/apps/api/src/signals/services/chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-title.service.ts
@@ -619,10 +619,13 @@ export async function generateChatThreadRecommendedFollowupsFromContext(
         // result untouched. Count it and say nothing. The generated text is
         // never inspected here, so the empty result cannot name a defect.
         unusableOutput: "expected",
-        // Everything else that reaches the diagnostic for this feature is a
-        // provider, credential or response-contract failure, which is a real
-        // defect rather than an expected omission. Scoped to this caller: the
-        // shared default stays `warn` for features whose own outcomes have not
+        // Rejected credentials, a rejected request shape, or a failure nothing
+        // classified are defects rather than omissions, so this caller reports
+        // those at error. The boundary keeps every other reason at the shared
+        // level, which matters here: a completion that returned no content or
+        // was stopped by a content filter is another way to get no
+        // suggestions, not something to escalate. Scoped to this caller; the
+        // shared default is unchanged for features whose own outcomes have not
         // been characterized.
         failureLevel: "error",
         diagnosticContext: args.threadId

--- a/turbo/apps/api/src/signals/services/chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-title.service.ts
@@ -619,14 +619,14 @@ export async function generateChatThreadRecommendedFollowupsFromContext(
         // result untouched. Count it and say nothing. The generated text is
         // never inspected here, so the empty result cannot name a defect.
         unusableOutput: "expected",
-        // Rejected credentials and a rejected request shape are defects rather
-        // than omissions, so this caller reports those at error. The boundary
-        // holds every other reason at the shared level, which matters here: a
-        // completion that returned no content, one stopped by a content
-        // filter, and an unclassified provider failure are all further ways to
-        // end up with no suggestions rather than things to escalate. Scoped to
-        // this caller; the shared default is unchanged for features whose own
-        // outcomes have not been characterized.
+        // Whatever still reaches the diagnostic after that is a failure rather
+        // than an omission: rejected credentials, a rejected request, a
+        // response that broke its contract, or an exception nothing
+        // classified. Those are reported at error. The reason stays whatever
+        // the provider classification decided, including `unknown`, which is
+        // left unknown rather than presented as a specific cause. Scoped to
+        // this caller through the option; the shared default is unchanged for
+        // features whose own outcomes have not been characterized.
         failureLevel: "error",
         diagnosticContext: args.threadId
           ? { threadId: args.threadId }

--- a/turbo/apps/api/src/signals/services/chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-title.service.ts
@@ -613,6 +613,18 @@ export async function generateChatThreadRecommendedFollowupsFromContext(
         usable: (value) => {
           return value.length > 0;
         },
+        // Zero normalized suggestions is an omission this caller already
+        // handles: the completed-run callback inserts no follow-up event and
+        // the thread simply shows no quick replies, leaving the run's own
+        // result untouched. Count it and say nothing. The generated text is
+        // never inspected here, so the empty result cannot name a defect.
+        unusableOutput: "expected",
+        // Everything else that reaches the diagnostic for this feature is a
+        // provider, credential or response-contract failure, which is a real
+        // defect rather than an expected omission. Scoped to this caller: the
+        // shared default stays `warn` for features whose own outcomes have not
+        // been characterized.
+        failureLevel: "error",
         diagnosticContext: args.threadId
           ? { threadId: args.threadId }
           : undefined,


### PR DESCRIPTION
Closes #33377. Implements the [authorized scope](https://github.com/vm0-ai/vm0/issues/33377) and the [accepted research](https://github.com/vm0-ai/vm0/issues/33377#issuecomment-5615159810) with its controller corrections.

## Problem

`generateAuxiliary` classified every unusable result as `error` and reported it through `diagnose`. For `recommended_followups`, "unusable" only means the normalizer produced zero optional suggestions:

- `chat-title.service.ts` returns `[]`, the completed-run callback maps that to `undefined` and inserts no `output.followups` event, and the thread simply renders no quick replies.
- The run's own completed result, the push notification and the other auxiliary generations are untouched; the follow-up step is one branch of a `Promise.allSettled`.

The warning could not name a defect either. That call site passes `undefined` as the error, so `errorKind` was always the constant `unknown`, and the generated text is never inspected. In production this produced `Auxiliary generation failed` records that no operator could act on.

## Change

**One explicit caller policy, defaulting to today's behavior.** `generateAuxiliary` accepts `unusableOutput` and `failureLevel`. Both default to the current shared behavior, so the five sibling features are untouched by construction.

`recommended_followups` is the only caller that opts in:

- `unusableOutput: "expected"` — a zero-length normalized result becomes `degraded`/`unusable_output`. It stays counted in `auxiliary_generation_result` with its existing token detail, and emits no `Auxiliary generation failed` record at **any** level. No info/debug replacement was added.
- `failureLevel: "error"` — raises the severity of the failures that name a defect.

**`failureLevel: "error"` applies to whatever the boundary already classifies as an error.** It cannot reach an outcome that is counted silently — transient provider failures, truncation, an unexpected tool call, a cancellation, and this caller's expected empty result never reach the diagnostic at all.

| Outcome for this caller | Record |
| --- | --- |
| Empty normalized result | **none, at any level**; counted as `degraded`/`unusable_output` with its token detail |
| `rate_limited`, `upstream_timeout`, `network`, `provider_unavailable` | none; already `degraded` |
| `output_truncated`, `unexpected_tool_calls` | none; already `degraded` |
| `caller_cancelled` | none; already `cancelled` |
| `auth`, `invalid_request` | exactly one **error** |
| `invalid_output` — non-JSON body, no choices, non-string content | exactly one **error** |
| `unknown` — an exception nothing classified | exactly one **error**, reason left literally unknown |

An earlier revision gated this behind an allowlist of `auth` and `invalid_request`, which pushed response-contract failures back to `warn`. That is corrected here: the authorized scope requires genuine provider, credential and response-contract failures for this feature to emit exactly one safe ERROR. `invalid_output` does currently conflate an envelope contract violation with an empty or content-filtered completion, and `unknown` is a catch-all; narrowing either belongs to the shared provider classification, not to this change, and neither is a reason to withhold the error this contract requires.

**Decision precedence is preserved** and stated in the code:

```ts
const outcome = truncated
  ? "degraded"
  : usable
    ? "success"
    : args.unusableOutput === "expected"
      ? "degraded"
      : "error";
```

Truncation still classifies first, so a usable shortened sibling output remains `degraded`/`output_truncated` rather than becoming a plain success.

The policy describes the interpreted return value only. Thrown provider errors keep the existing semantic classification, transient/cancellation handling, `Retry-After` bounds and token detail. The parser, normalizer, event insertion and return values are unchanged — no parser relaxation, no output-shape telemetry, no generated-content capture.

## Verification

Local, on the current tree:

| Check | Result |
| --- | --- |
| `pnpm --filter api check-types` | pass |
| `pnpm --filter api lint` | pass |
| `prettier --check` on changed files | pass |
| `vitest run src/signals/routes/__tests__/auxiliary-generation.test.ts` | **44 passed** |

That suite drives the shared boundary through a sibling (`chat_title`) and is the executed evidence that sibling policy is unchanged: its full reason table asserts `axiomLogging.error` stays empty for `auth`, `invalid_request`, `unknown` and `invalid_output`, so any global `warn → error` change would fail it. It also pins truncation at `degraded`/`output_truncated` with no record.

New tests in `chat-callbacks.bdd.test.ts` cover this feature at the real completion/event boundary, and deliberately separate the two cases that are easy to conflate:

- **Generated text that cannot be used** — an empty array, text that is not JSON, JSON that is not an array, and an array whose every item fails validation. Each asserts the main answer survives, no `output.followups` event exists, the result is `degraded`/`unusable_output`, and `auxiliaryDiagnostics` is empty across debug/info/warn/error. The empty-array row carries provider usage so the retained `completion_tokens`/`reasoning_tokens` are actually asserted rather than vacuously absent.
- **Provider envelope that broke its contract** — a response body that is not JSON, a response carrying no choices, a choice whose content is not a string, and a body that fails mid-stream with an exception nothing classified. Each asserts exactly one **error**-level record with the right reason (`invalid_output`, and `unknown` for the unclassified one), zero warnings, and no provider payload in any diagnostic.
- **Credential and request rejections** — HTTP 401 and HTTP 400 on the follow-up request only, asserting one **error** record with `reason: "auth"` / `"invalid_request"` and no warning copy.
- **Scoping control** — each expected-empty case also drives `notification_summary` to an unusable output in the same completion and asserts it still produces a `warn`, proving the silence is caller-scoped rather than shared.
- The pre-existing truncation test proves silence with the all-level helper instead of the warning channel alone.

The test helper gained `auxiliaryDiagnostics`, which reads all four levels so a removed record cannot reappear as quieter noise, and retains each record's raw fields so the leak assertions can see keys the schema would otherwise strip.

### Limitation, stated honestly

`chat-callbacks.bdd.test.ts` could not be executed in the authoring environment. Postgres was provisioned and migrated locally, but the runner-claim step (`claimChatRunJob`) returns 404 there, so those tests time out. **This reproduces identically on unmodified `origin/main`** — verified by stashing this change and re-running a pre-existing test from the same file — so it is an environment limitation, not a regression. Those tests are type-checked and run in the PR pipeline; the pipeline is the actual verification for them.

Monitor and downstream dependencies on `outcome`/`level` were not inspected. This change intentionally alters operator-event counts and levels for this one feature: its empty normalized result moves from `outcome: "error"` with a warning to `degraded` with no record at all, while its remaining failure records move from `warn` to `error`. The `auxiliary_generation_result` event itself is still emitted for every outcome, including the silenced one.

## Review history

Independent full-HEAD reviews were run on each revision. Two of them argued for withholding `invalid_output` and `unknown` from the error level; that direction was followed and then corrected, because it contradicted this issue's authorized scope, which requires genuine provider, credential and response-contract failures for this feature to emit exactly one safe ERROR. The severity table above is what ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
