### PR TITLE
fix(api): report built-in capacity failures as errors

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -19698,6 +19698,169 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       },
     );
 
+    it.each([
+      {
+        name: "a built-in Codex run",
+        modelProvider: "built-in",
+        failureReason: "provider_overloaded",
+      },
+      // The reason token carries no framework, so a Claude run stored against
+      // the built-in provider reaches the same terminal record.
+      {
+        name: "a built-in Claude run",
+        modelProvider: "anthropic-api-key",
+        persistedModelProvider: "built-in",
+        failureReason: "provider_overloaded",
+      },
+    ] satisfies readonly (FailureCase & { readonly name: string })[])(
+      "reports capacity exhaustion on $name as an error",
+      async (failure) => {
+        const control = await completeFailure(failure);
+        const errors = matchingLogCalls(
+          context.mocks.axiomLogging.error,
+          "Run failed",
+          control.runId,
+        );
+        expect(errors).toHaveLength(1);
+        expect(errors[0]?.[1]).toStrictEqual(
+          expect.objectContaining({
+            runId: control.runId,
+            exitCode: 1,
+            error: control.error,
+            failureReason: "provider_overloaded",
+            context: "webhook:complete",
+          }),
+        );
+        expect(genericFailureLogCalls(control.runId)).toHaveLength(1);
+      },
+    );
+
+    it.each([
+      { name: "a null provider", persistedModelProvider: null },
+      {
+        name: "a legacy provider",
+        persistedModelProvider: "legacy-unknown-provider",
+      },
+    ] satisfies readonly (FailureCase & { readonly name: string })[])(
+      "keeps capacity exhaustion on $name at warning severity",
+      async (provider) => {
+        const control = await completeFailure({
+          ...provider,
+          failureReason: "provider_overloaded",
+        });
+        expect(
+          matchingLogCalls(
+            context.mocks.axiomLogging.warn,
+            "Run failed",
+            control.runId,
+          ),
+        ).toHaveLength(1);
+        expect(genericFailureLogCalls(control.runId)).toHaveLength(1);
+      },
+    );
+
+    it("keeps built-in credit exhaustion on its own debug record", async () => {
+      const control = await completeFailure({
+        modelProvider: "built-in",
+        failureReason: "insufficient_credits",
+      });
+      expect(
+        matchingLogCalls(
+          context.mocks.axiomLogging.debug,
+          "Run stopped: insufficient credits",
+          control.runId,
+        ),
+      ).toHaveLength(1);
+      expect(genericFailureLogCalls(control.runId)).toHaveLength(0);
+    });
+
+    it("keeps one error when a duplicate repeats the capacity failure", async () => {
+      const api = createRunsApi(context);
+      const webhooks = createWebhookCallbackApi(context);
+      const first = await completeFailure({
+        modelProvider: "built-in",
+        failureReason: "provider_overloaded",
+      });
+      expect(genericFailureLogCalls(first.runId)).toHaveLength(1);
+
+      await webhooks.requestAgentComplete(
+        {
+          runId: first.runId,
+          exitCode: 1,
+          error: "late built-in capacity report",
+          failureReason: "provider_overloaded",
+        },
+        {
+          authorization: `Bearer ${api.sandboxTokenForRun(
+            first.actor,
+            first.runId,
+          )}`,
+        },
+        [200],
+      );
+
+      expect(genericFailureLogCalls(first.runId)).toHaveLength(1);
+      await expect(
+        api.readRun(first.actor, first.runId),
+      ).resolves.toMatchObject({ status: "failed", error: first.error });
+      await expect(
+        readRunFailureReasonFixture(context, first.runId),
+      ).resolves.toBe("provider_overloaded");
+    });
+
+    it("records one error when completions race the capacity failure", async () => {
+      const api = createRunsApi(context);
+      const webhooks = createWebhookCallbackApi(context);
+      await seedBuiltInDefaultModelKey();
+      const { actor, agentId } = await entitledRunActor();
+      const run = await api.createRun(actor, {
+        agentId,
+        prompt: "race a built-in capacity completion",
+        modelProvider: "built-in",
+      });
+      const error = `racing capacity failure for ${run.runId}`;
+      const body = {
+        runId: run.runId,
+        exitCode: 1,
+        error,
+        failureReason: "provider_overloaded",
+      } as const;
+      const headers = {
+        authorization: `Bearer ${api.sandboxTokenForRun(actor, run.runId)}`,
+      };
+      const lifecycleGate = await holdAgentRunRowLockFixture({
+        runId: run.runId,
+        signal: context.signal,
+      });
+      const completions = Promise.all([
+        webhooks.requestAgentComplete(body, headers, [200]),
+        webhooks.requestAgentComplete(body, headers, [200]),
+      ]);
+      onTestFinished(async () => {
+        lifecycleGate.release();
+        await Promise.allSettled([completions, lifecycleGate.done]);
+      });
+      await expect.poll(lifecycleGate.waiterCount).toBe(2);
+      lifecycleGate.release();
+      await Promise.all([lifecycleGate.done, completions]);
+
+      expect(genericFailureLogCalls(run.runId)).toHaveLength(1);
+      expect(
+        matchingLogCalls(
+          context.mocks.axiomLogging.error,
+          "Run failed",
+          run.runId,
+        ),
+      ).toHaveLength(1);
+      await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+        status: "failed",
+        error,
+      });
+      await expect(
+        readRunFailureReasonFixture(context, run.runId),
+      ).resolves.toBe("provider_overloaded");
+    });
+
     it("keeps the missing-checkpoint warning visible for a suppressible reason", async () => {
       const api = createRunsApi(context);
       const webhooks = createWebhookCallbackApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -19698,42 +19698,31 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       },
     );
 
-    it.each([
-      {
-        name: "a built-in Codex run",
+    // The predicate reads only the terminal reason and the stored provider, so
+    // every built-in route reaches this record with the same two inputs no
+    // matter which framework produced the reason token.
+    it("reports capacity exhaustion on a built-in run as an error", async () => {
+      const control = await completeFailure({
         modelProvider: "built-in",
         failureReason: "provider_overloaded",
-      },
-      // The reason token carries no framework, so a Claude run stored against
-      // the built-in provider reaches the same terminal record.
-      {
-        name: "a built-in Claude run",
-        modelProvider: "anthropic-api-key",
-        persistedModelProvider: "built-in",
-        failureReason: "provider_overloaded",
-      },
-    ] satisfies readonly (FailureCase & { readonly name: string })[])(
-      "reports capacity exhaustion on $name as an error",
-      async (failure) => {
-        const control = await completeFailure(failure);
-        const errors = matchingLogCalls(
-          context.mocks.axiomLogging.error,
-          "Run failed",
-          control.runId,
-        );
-        expect(errors).toHaveLength(1);
-        expect(errors[0]?.[1]).toStrictEqual(
-          expect.objectContaining({
-            runId: control.runId,
-            exitCode: 1,
-            error: control.error,
-            failureReason: "provider_overloaded",
-            context: "webhook:complete",
-          }),
-        );
-        expect(genericFailureLogCalls(control.runId)).toHaveLength(1);
-      },
-    );
+      });
+      const errors = matchingLogCalls(
+        context.mocks.axiomLogging.error,
+        "Run failed",
+        control.runId,
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.[1]).toStrictEqual(
+        expect.objectContaining({
+          runId: control.runId,
+          exitCode: 1,
+          error: control.error,
+          failureReason: "provider_overloaded",
+          context: "webhook:complete",
+        }),
+      );
+      expect(genericFailureLogCalls(control.runId)).toHaveLength(1);
+    });
 
     it.each([
       { name: "a null provider", persistedModelProvider: null },
@@ -19800,6 +19789,13 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       );
 
       expect(genericFailureLogCalls(first.runId)).toHaveLength(1);
+      expect(
+        matchingLogCalls(
+          context.mocks.axiomLogging.error,
+          "Run failed",
+          first.runId,
+        ),
+      ).toHaveLength(1);
       await expect(
         api.readRun(first.actor, first.runId),
       ).resolves.toMatchObject({ status: "failed", error: first.error });

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -282,13 +282,32 @@ function shouldSuppressFailureLog(
   return shouldSuppressKnownFailureLog(run, knownFailureReason.data);
 }
 
+/**
+ * A capacity rejection on a built-in route fails the user's run against a
+ * credential the platform owns, so it stays a genuine operator-actionable
+ * failure rather than a caller-side condition. The reason token is
+ * framework-independent, so a built-in Claude overload that reaches this same
+ * boundary is included. Routing recovery is a separate decision; this only
+ * classifies the severity of the single terminal record.
+ */
+function isBuiltInCapacityFailure(commit: CompletionCommit): boolean {
+  return (
+    commit.transitionFailureReason === "provider_overloaded" &&
+    isBuiltInModelProviderType(commit.run.modelProvider)
+  );
+}
+
 function logRunFailure(
   input: CompleteAgentRunInput,
   commit: CompletionCommit,
 ): void {
   const isCreditError =
     commit.transitionFailureReason === "insufficient_credits";
-  const logFailure = isCreditError ? L.debug : L.warn;
+  const logFailure = isCreditError
+    ? L.debug
+    : isBuiltInCapacityFailure(commit)
+      ? L.error
+      : L.warn;
   logFailure(
     isCreditError ? "Run stopped: insufficient credits" : "Run failed",
     {


### PR DESCRIPTION
## Problem

Fixes #33360.

A run that terminates with `provider_overloaded` on a **built-in** route is a genuine failed main task: the user's turn is lost, and the rejected credential is one the platform owns. The API terminal boundary already declines to suppress that record — `shouldSuppressKnownFailureLog` suppresses the provider reasons only for non-built-in providers — but `logRunFailure` then selected `WARN` for everything except the insufficient-credit case.

The reviewed production incident (2026-09-10, built-in `gpt-5.6-sol`, web-triggered, failed after ~6.9s) produced exactly one Axiom record for the run, at `warn`. The Runner classifies this condition at `info`, and Runner `info` is not shipped, so this API record is the only production signal for the failure.

## Change

`turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts`

- Add `isBuiltInCapacityFailure`: the normalized terminal reason is `provider_overloaded` **and** the server-stored `modelProvider` is built-in. It reads `commit.run.modelProvider`, the same stored value the suppression decision already uses, so the two cannot disagree.
- Extend the existing level selection in `logRunFailure` to pick `L.error` for that combination.

Nothing else moves. The insufficient-credit `DEBUG` record, every other reason, BYOK/legacy/null providers, the suppression matrix, the message text, the logged fields, the failed run state and the user-facing copy are unchanged, and no additional terminal record is emitted. The reason token carries no framework, so a built-in Claude overload arriving at this same boundary is covered.

## Scope

This is the severity fix only. It does **not** repair upstream capacity, and it does **not** claim the reporter gap is closed.

Explicitly out of scope and still pending product/design discussion, per the issue's authorized scope:

- reporting from API terminal completion into the shared candidate cooldown,
- automatically re-routing or retrying the failed user task,
- WebSocket parsing changes,
- accepting a new reporter trust/provenance path, freshness semantics, or durable/deduplicated dual-source delivery.

Those change shared routing for other users and their trust and delivery questions are not resolved by a severity change.

## Tests

All in the existing `RUN-03 > completion failure logs` matrix, driven through the real completion webhook and the real logger mocks.

- `reports capacity exhaustion on a built-in run as an error` — a genuine built-in run created through the production run-create endpoint. It asserts exactly one `ERROR "Run failed"` with the unchanged fields, and `genericFailureLogCalls` (which scans `debug`/`info`/`warn`/`error`) of length 1, so there is no WARN duplicate and no extra terminal record. The predicate reads only the terminal reason and the stored provider, which are identical for every built-in route, so the framework-independence claim stays a documented code comment rather than a second case that would restate the same two inputs.
- `keeps capacity exhaustion on ... at warning severity` — null provider and legacy provider stay at `WARN`. Only a stored built-in provider escalates.
- `keeps built-in credit exhaustion on its own debug record` — built-in `insufficient_credits` still logs `Run stopped: insufficient credits` at `DEBUG` and produces no `Run failed` record at any level, so the credit branch still wins.
- `keeps one error when a duplicate repeats the capacity failure` — a duplicate completion adds no second record and leaves the run status, error text and persisted failure reason unchanged.
- `records one error when completions race the capacity failure` — two completions are held behind `holdAgentRunRowLockFixture` and released together; exactly one `ERROR` is produced and the terminal state is unchanged.

Existing controls are unchanged and still pass: BYOK `provider_overloaded` stays fully suppressed, built-in `provider_rate_limited` stays at `WARN`, and the globally suppressed reasons stay silent for built-in.

## Verification

Run locally against a local PostgreSQL 18 instance with the repository migrations applied:

- `vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "completion failure logs"` — **38 passed**, 220 skipped on final source HEAD `edad62c6e69e90c26e30c68f647d3bc203765df6` (implementation-owner report; not rerun locally by the controller).
- Negative control was performed on the preceding HEAD: reverting the production change made the capacity cases fail (`expected [] to have a length of 1`). It was not rerun on final source HEAD `edad62c6e69e90c26e30c68f647d3bc203765df6`; the separate-context review verified binding at that HEAD, and the final merge-group CI provides the merged-code execution evidence.
- `check-types:gateways`, `check-types:core`, `check-types:tests` — clean.
- `eslint` and `oxlint --deny-warnings` on both changed files — clean.
- `prettier --check` on both changed files — clean.

Limitations, honestly reported:

- No full local Vitest suite and no dev server were run.
- `chat-callbacks.bdd.test.ts -t "CHAT-02: failed chat callbacks"` fails 4 tests in this sandbox with `Matcher did not succeed in time` inside `claimChatRunJob`. The identical 4 failures reproduce on unmodified `main` in the same environment, so they are a pre-existing local runner-claim timing limitation, not a regression from this change. CI covers that suite.
- No Rust, addon, or frontend surface is touched.

## Review

The first tracked review on this PR was a self-review by the PR author and did not satisfy the issue's independent-review requirement. An independent reviewer then reviewed `692f5f88` and returned `Changes Requested` with one P1: the second escalation case rewrote `agent_runs.model_provider` to `built-in` on a BYOK run through an internal test-only write, producing a hybrid row production cannot create. `edad62c6` resolves it by dropping that case, and a fresh independent review of `edad62c6` returned `LGTM` with no P0/P1 findings.

## Deployment compatibility

API-only log-severity change. No contract, Runner protocol, persisted shape, migration, backfill, provider model or production configuration change. Operator error/warn event counts for this one combination intentionally shift from `warn` to `error`; no in-repo documentation references that record. External monitors were not independently inspected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

