### PR TITLE
fix(api): absorb rate-limited activity summaries without a diagnostic

### DIFF
--- a/docs/chat-thread-activity-summary.md
+++ b/docs/chat-thread-activity-summary.md
@@ -97,43 +97,62 @@ transport's `info` threshold. The shared logger and unrelated debug filtering
 are unchanged. Axiom events retain `source: api`, the stable message, and the
 following nested `fields`:
 
-| Message                        | Context                | Level                                                                                     | Safe fields besides context                                                                                |
-| ------------------------------ | ---------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `Activity summary cache`       | `api:activity-summary` | info                                                                                      | `runId`, `outcome` (existing response status)                                                              |
-| `Activity summary attempt`     | `api:activity-summary` | info                                                                                      | `runId`                                                                                                    |
-| `Activity summary completion`  | `api:activity-summary` | info for success/timeout/cancelled; warn for provider_failure and invalid_or_unconfigured | `runId`, `outcome`, `durationMs`, `cooldownMs`; numeric `providerStatus` only for `OpenRouterRequestError` |
-| `Activity summary unavailable` | `api:activity-summary` | warn                                                                                      | `runId`, `outcome: storage_failed`                                                                         |
-| `Activity snapshot capture`    | `api:run-activity`     | info for written/unchanged and for an expected failure; warn otherwise                    | `runId`, `outcome`, `eventCount`; `stage` and `errorCode` on failure                                       |
-| `Activity snapshot cleanup`    | `api:run-activity`     | info on success; warn on failure                                                          | `outcome`, `removed`, `retentionMs`; `errorCode` on failure                                                |
+| Message                        | Context                | Level                                                                                                                                                             | Safe fields besides context                                                                                                            |
+| ------------------------------ | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `Activity summary cache`       | `api:activity-summary` | info                                                                                                                                                              | `runId`, `outcome` (existing response status)                                                                                          |
+| `Activity summary attempt`     | `api:activity-summary` | info                                                                                                                                                              | `runId`                                                                                                                                |
+| `Activity summary completion`  | `api:activity-summary` | info for success/timeout/cancelled; warn for invalid_or_unconfigured and for a reported provider_failure; no record at any level for an absorbed provider_failure | `runId`, `outcome`, `durationMs`, `cooldownMs`; numeric `providerStatus` and the enumerated `reason` only for `OpenRouterRequestError` |
+| `Activity summary unavailable` | `api:activity-summary` | warn                                                                                                                                                              | `runId`, `outcome: storage_failed`                                                                                                     |
+| `Activity snapshot capture`    | `api:run-activity`     | info for written/unchanged and for an expected failure; warn otherwise                                                                                            | `runId`, `outcome`, `eventCount`; `stage` and `errorCode` on failure                                                                   |
+| `Activity snapshot cleanup`    | `api:run-activity`     | info on success; warn on failure                                                                                                                                  | `outcome`, `removed`, `retentionMs`; `errorCode` on failure                                                                            |
 
 Completion outcomes are `success`, `timeout`, `cancelled`, `provider_failure`,
-and `invalid_or_unconfigured`. A provider HTTP 429 is distinguishable by
-`fields.providerStatus: 429`; no error object or provider body is attached.
+and `invalid_or_unconfigured`. A `provider_failure` also carries `reason`, the
+shared `openRouterFailureReason` classification of that request, alongside the
+numeric `providerStatus`. No error object or provider body is attached.
+
+`reason` is what decides whether the failure is reported, because the transport
+status cannot. OpenRouter delivers a native rate limit inside an HTTP 200 error
+envelope that this client wraps as a synthetic `502`, while a raw `429` whose
+native evidence is `auth` or `invalid_request` is a real failure. Both cases are
+classified by the shared reason, never by `providerStatus`.
 
 `timeout` and `cancelled` are accepted degradations of an optional output, not
 failed operations, so they record at `info`. Missing the deadline leaves the
 response truthful (`cooldown` with the caller's last usable phrase) and bounds
 recovery at the shared cooldown; `cancelled` means the request's own lifetime
 ended before the provider answered. Neither has an operator action, so a
-per-event `warn` only trains operators to ignore the record. Persistent
-provider failure and contract or configuration defects keep their `warn`,
-including a repeated 429.
+per-event `warn` only trains operators to ignore the record.
 
-Deadline pressure is a rate, not an event. Detect it from the same records
-instead of a per-event level:
+A `provider_failure` with `reason: rate_limited` is absorbed the same way and
+emits no record at any level. The shared account is momentarily over its limit,
+the caller keeps its last usable phrase or the generic label, and the cooldown
+that record would have reported already bounds the retry, so there is nothing
+for an operator to do. Contract and configuration defects, and the provider
+failures that are not an absorbed rate limit, still reach an operator.
+
+Deadline pressure is a rate, not an event. Read it from the attempt records,
+which count every generation, against the completions that are still emitted:
 
 ```
 ['vm0-web-logs-prod']
-| where ['fields.context'] == 'api:activity-summary' and message == 'Activity summary completion'
-| summarize total=count(),
+| where ['fields.context'] == 'api:activity-summary'
+| summarize attempts=countif(message == 'Activity summary attempt'),
             timeouts=countif(['fields.outcome'] == 'timeout'),
             provider=countif(['fields.outcome'] == 'provider_failure'),
             invalid=countif(['fields.outcome'] == 'invalid_or_unconfigured')
         by bin(_time, 30m)
-| extend timeoutRate = todouble(timeouts) / total
+| extend timeoutRate = todouble(timeouts) / attempts
 ```
 
 Alerting on that rate is an operator decision and is not configured here.
+
+Absorbed rate limits are deliberately not counted anywhere. `attempts` minus the
+emitted completions is not that count: an attempt and its completion are written
+separately, so an instance that stops between them leaves the same residual. No
+replacement record or telemetry channel is added to recover the number, and the
+rate-limit counters of other auxiliary generations describe their own features,
+not this one.
 
 A failed capture is classified into a finite set instead of one opaque
 `write_failed`. `contended` (`55P03`) and `run_missing` (`23503`) are expected
@@ -149,8 +168,9 @@ validated before it is published, and omitted when the driver reports no
 SQLSTATE. Driver messages, statement text, constraint details and bound
 parameters are never attached.
 
-Granularity is unchanged: one cache record for a request resolved without a
-claim, one attempt/completion pair per generation attempt, one unavailable
+Granularity is otherwise unchanged: one cache record for a request resolved
+without a claim, one attempt record per generation attempt and one completion
+record for each attempt that is not absorbed, one unavailable
 record for an optional summary storage failure, one capture record per relevant
 batch (including unchanged duplicates), and one cleanup record per maintenance
 operation (including zero removals). Disabled, irrelevant, and ineligible

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
@@ -1153,20 +1153,36 @@ describe("thread activity summary", () => {
   it("bounds the absorbed cooldown between the floor and the ceiling", async () => {
     const f = await fixture();
     const diagnostics = captureDiagnostics();
-    const headers: (Record<string, string> | undefined)[] = [
-      undefined,
-      { "Retry-After": "not-a-number" },
-      { "Retry-After": "30" },
-      { "Retry-After": "120" },
-      { "Retry-After": "600" },
-      { "Retry-After": new Date(now() + 120_000).toUTCString() },
+    // Resolved per response, because the parser reads a date header against the
+    // same process clock. Building it up front would spend the encoded delay on
+    // this test's own runtime instead of measuring the header.
+    const retryAfter: (() => string | undefined)[] = [
+      () => {
+        return undefined;
+      },
+      () => {
+        return "not-a-number";
+      },
+      () => {
+        return "30";
+      },
+      () => {
+        return "120";
+      },
+      () => {
+        return "600";
+      },
+      () => {
+        return new Date(now() + 120_000).toUTCString();
+      },
     ];
     const inputs = provider((_input, index) => {
+      const value = retryAfter[index - 1]?.();
       return HttpResponse.json(
         { error: { code: 429, message: "PRIVATE_PROVIDER_BODY" } },
         {
           status: 429,
-          ...(headers[index - 1] ? { headers: headers[index - 1] } : {}),
+          ...(value === undefined ? {} : { headers: { "Retry-After": value } }),
         },
       );
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
@@ -11,6 +11,7 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
+import { now } from "../../../lib/time";
 import {
   flushLogs,
   logger,
@@ -262,6 +263,32 @@ function captureDiagnostics() {
       );
     });
   };
+}
+
+type DiagnosticEvent = {
+  readonly level: string;
+  readonly message: string;
+  readonly fields: Record<string, unknown>;
+};
+
+function completionRecords(logs: readonly DiagnosticEvent[]) {
+  return logs.filter((event) => {
+    return event.message === "Activity summary completion";
+  });
+}
+
+/** Provider-request completions at every level, including any absorbed one. */
+function providerFailureRecords(logs: readonly DiagnosticEvent[]) {
+  return completionRecords(logs).filter((event) => {
+    return event.fields.outcome === "provider_failure";
+  });
+}
+
+/** Anything this service asked an operator to look at. */
+function operatorRecords(logs: readonly DiagnosticEvent[]) {
+  return logs.filter((event) => {
+    return event.level === "warn" || event.level === "error";
+  });
 }
 
 describe("thread activity summary", () => {
@@ -952,7 +979,7 @@ describe("thread activity summary", () => {
     ).toContain("Public commentary during the Axiom outage");
   });
 
-  it("honors bounded Retry-After and keeps the last known summary", async () => {
+  it("honors bounded Retry-After and keeps the last known summary without a record", async () => {
     const f = await fixture();
     const diagnostics = captureDiagnostics();
     const inputs = provider((_input, index) => {
@@ -968,26 +995,34 @@ describe("thread activity summary", () => {
     await advanceRunActivityClockFixture(f.run.runId, 16_000);
     const failed = await summarize(f.actor, f.run);
     expect(failed.messages).toStrictEqual(first.messages);
+    expect(failed.status).toBe("cooldown");
     expect(failed.summaryRevision).toBe(first.summaryRevision);
+    // The skipped diagnostic is not a skipped cooldown: the provider's bounded
+    // Retry-After is still persisted and reported back to the caller.
     expect(failed.retryAfterMs).toBeGreaterThan(110_000);
     expect(failed.retryAfterMs).toBeLessThanOrEqual(120_000);
     await summarize(f.actor, f.run);
     expect(inputs).toHaveLength(2);
     const logs = await diagnostics();
+    // The seeding generation is still reported; only the absorbed attempt is not.
     expect(logs).toContainEqual(
       expect.objectContaining({
-        level: "warn",
+        level: "info",
         message: "Activity summary completion",
         fields: {
           context: "api:activity-summary",
           runId: f.run.runId,
-          outcome: "provider_failure",
-          providerStatus: 429,
+          outcome: "success",
           durationMs: expect.any(Number),
-          cooldownMs: 120_000,
+          cooldownMs: 0,
         },
       }),
     );
+    // Two attempts, one completion: the absorbed attempt left no record at
+    // debug, info, warn or error.
+    expect(providerFailureRecords(logs)).toStrictEqual([]);
+    expect(completionRecords(logs)).toHaveLength(1);
+    expect(operatorRecords(logs)).toStrictEqual([]);
     expect(
       logs.filter((event) => {
         return event.message === "Activity summary attempt";
@@ -1004,6 +1039,169 @@ describe("thread activity summary", () => {
         },
       }),
     );
+    expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
+  });
+
+  it("absorbs a rate limit before any summary exists and recovers after the cooldown", async () => {
+    const f = await fixture();
+    const diagnostics = captureDiagnostics();
+    const inputs = provider((_input, index) => {
+      return index === 1
+        ? HttpResponse.json(
+            { error: { code: 429, message: "PRIVATE_PROVIDER_BODY" } },
+            { status: 429 },
+          )
+        : "Checking the current launch materials";
+    });
+    const empty = await summarize(f.actor, f.run);
+    // Nothing was ever generated for this run, so the viewer keeps the generic
+    // label its own fallback renders for an empty batch.
+    expect(empty.messages).toStrictEqual([]);
+    expect(empty.status).toBe("cooldown");
+    expect(empty.summaryRevision).toBeNull();
+    expect(empty.retryAfterMs).toBeGreaterThan(50_000);
+    expect(empty.retryAfterMs).toBeLessThanOrEqual(60_000);
+    // The shared cooldown still bounds the provider, not just the diagnostic.
+    await summarize(f.actor, f.run);
+    expect(inputs).toHaveLength(1);
+    await advanceRunActivityClockFixture(f.run.runId, 61_000);
+    const recovered = await summarize(f.actor, f.run);
+    expect(recovered.messages[0]?.text).toBe(
+      "Checking the current launch materials",
+    );
+    expect(recovered.status).toBe("fresh");
+    expect(inputs).toHaveLength(2);
+    const logs = await diagnostics();
+    expect(
+      logs.filter((event) => {
+        return event.message === "Activity summary attempt";
+      }),
+    ).toHaveLength(2);
+    // Only the recovery generation is reported.
+    expect(providerFailureRecords(logs)).toStrictEqual([]);
+    expect(completionRecords(logs)).toHaveLength(1);
+    expect(operatorRecords(logs)).toStrictEqual([]);
+    expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
+  });
+
+  it("classifies provider rate limits by native reason, not by transport status", async () => {
+    const f = await fixture();
+    const diagnostics = captureDiagnostics();
+    const inputs = provider((_input, index) => {
+      if (index === 1) {
+        // OpenRouter reports an upstream rate limit inside a successful
+        // envelope; the client wraps it as a synthetic 502.
+        return HttpResponse.json({
+          error: {
+            code: 429,
+            message: "PRIVATE_PROVIDER_BODY",
+            metadata: {
+              raw: JSON.stringify({
+                error: {
+                  status: "RESOURCE_EXHAUSTED",
+                  message: "PRIVATE_PROVIDER_BODY",
+                },
+              }),
+            },
+          },
+        });
+      }
+      return HttpResponse.json(
+        {
+          error: {
+            code: index === 2 ? "invalid_request_error" : 401,
+            message: "PRIVATE_PROVIDER_BODY",
+          },
+        },
+        { status: 429 },
+      );
+    });
+    const wrapped = await summarize(f.actor, f.run);
+    expect(wrapped.status).toBe("cooldown");
+    expect(wrapped.retryAfterMs).toBeGreaterThan(50_000);
+    await advanceRunActivityClockFixture(f.run.runId, 61_000);
+    await summarize(f.actor, f.run);
+    await advanceRunActivityClockFixture(f.run.runId, 61_000);
+    await summarize(f.actor, f.run);
+    expect(inputs).toHaveLength(3);
+    const logs = await diagnostics();
+    // A native rate limit is absorbed even though its status is 502.
+    expect(
+      providerFailureRecords(logs).filter((event) => {
+        return event.fields.reason === "rate_limited";
+      }),
+    ).toStrictEqual([]);
+    expect(providerFailureRecords(logs)).toHaveLength(2);
+    // A 429 whose native evidence is a real defect still reaches an operator.
+    // The level is the adjacent severity decision and is asserted elsewhere.
+    for (const reason of ["invalid_request", "auth"]) {
+      expect(logs).toContainEqual(
+        expect.objectContaining({
+          message: "Activity summary completion",
+          fields: expect.objectContaining({
+            runId: f.run.runId,
+            outcome: "provider_failure",
+            reason,
+            providerStatus: 429,
+          }),
+        }),
+      );
+    }
+    expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
+  });
+
+  it("bounds the absorbed cooldown between the floor and the ceiling", async () => {
+    const f = await fixture();
+    const diagnostics = captureDiagnostics();
+    const headers: (Record<string, string> | undefined)[] = [
+      undefined,
+      { "Retry-After": "not-a-number" },
+      { "Retry-After": "30" },
+      { "Retry-After": "120" },
+      { "Retry-After": "600" },
+      { "Retry-After": new Date(now() + 120_000).toUTCString() },
+    ];
+    const inputs = provider((_input, index) => {
+      return HttpResponse.json(
+        { error: { code: 429, message: "PRIVATE_PROVIDER_BODY" } },
+        {
+          status: 429,
+          ...(headers[index - 1] ? { headers: headers[index - 1] } : {}),
+        },
+      );
+    });
+    // Floor for missing, unparseable and short delays; the provider's own value
+    // in between; the five-minute ceiling above it. A date header resolves
+    // against the same clock as a delta.
+    const expected = [
+      [50_000, 60_000],
+      [50_000, 60_000],
+      [50_000, 60_000],
+      [110_000, 120_000],
+      [290_000, 300_000],
+      [110_000, 120_000],
+    ] as const;
+    let elapsed = 0;
+    for (const [lower, upper] of expected) {
+      if (elapsed > 0) {
+        await advanceRunActivityClockFixture(f.run.runId, elapsed + 1000);
+      }
+      const limited = await summarize(f.actor, f.run);
+      expect(limited.status).toBe("cooldown");
+      expect(limited.retryAfterMs).toBeGreaterThan(lower);
+      expect(limited.retryAfterMs).toBeLessThanOrEqual(upper);
+      elapsed = upper;
+    }
+    expect(inputs).toHaveLength(expected.length);
+    const logs = await diagnostics();
+    expect(
+      logs.filter((event) => {
+        return event.message === "Activity summary attempt";
+      }),
+    ).toHaveLength(expected.length);
+    expect(providerFailureRecords(logs)).toStrictEqual([]);
+    expect(completionRecords(logs)).toStrictEqual([]);
+    expect(operatorRecords(logs)).toStrictEqual([]);
     expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
   });
 

--- a/turbo/apps/api/src/signals/services/chat-activity-summary.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-activity-summary.service.ts
@@ -30,6 +30,10 @@ import {
   generateText,
   OpenRouterRequestError,
 } from "../external/openrouter";
+import {
+  openRouterFailureReason,
+  type OpenRouterFailureReason,
+} from "../external/openrouter-failure";
 import { settleIncludingAbort } from "../utils";
 import {
   canonicalChatEventContent,
@@ -321,8 +325,7 @@ async function claimSummary(db: Db, identity: ActivityRunIdentity) {
 /**
  * Completion outcomes an operator cannot act on. The response stays truthful,
  * the caller keeps its last usable phrase, and the shared cooldown or the
- * attempt interval bounds recovery. Persistent provider failures and
- * contract/configuration defects stay at warn.
+ * attempt interval bounds recovery.
  */
 function expectedOutcome(outcome: string): boolean {
   return (
@@ -330,11 +333,38 @@ function expectedOutcome(outcome: string): boolean {
   );
 }
 
+interface CompletionRecord {
+  readonly outcome: string;
+  readonly durationMs: number;
+  readonly cooldownMs: number;
+  /** Present only for an `OpenRouterRequestError`; never a provider body. */
+  readonly providerStatus?: number;
+  /** The shared semantic classification of a provider request failure. */
+  readonly reason?: OpenRouterFailureReason;
+}
+
+/**
+ * Provider failures this optional generation already absorbs, recognized by the
+ * shared semantic reason rather than by a transport status. A shared rate limit
+ * resolves without anyone here acting: the caller keeps its last usable phrase
+ * or the existing generic label, and the same cooldown this record would report
+ * bounds the retry. Emitting it at any level would only teach operators to
+ * ignore the record. The outer status cannot decide this — a native rate limit
+ * arrives inside a synthetic 502 envelope, and a raw 429 whose native evidence
+ * is auth or invalid_request is a real failure that must keep reaching someone.
+ */
+function absorbedCompletion(completion: CompletionRecord): boolean {
+  return (
+    completion.outcome === "provider_failure" &&
+    completion.reason === "rate_limited"
+  );
+}
+
 /**
  * The content-free record of one generation attempt. The caller reads `outcome`
- * to pick a level and `cooldownMs` to write the next attempt, so the diagnostic
- * and the stored backoff can never disagree. No prompt, phrase, provider body
- * or driver message is ever attached.
+ * and `reason` to pick a level and `cooldownMs` to write the next attempt, so
+ * the diagnostic and the stored backoff can never disagree. No prompt, phrase,
+ * provider body or driver message is ever attached.
  */
 function completionRecord(
   started: number,
@@ -342,7 +372,7 @@ function completionRecord(
   abandoned: boolean,
   deadlineReached: boolean,
   failure: unknown,
-) {
+): CompletionRecord {
   const request =
     failure instanceof OpenRouterRequestError ? failure : undefined;
   const cooldown = Math.min(
@@ -361,7 +391,12 @@ function completionRecord(
             : "invalid_or_unconfigured",
     durationMs: Math.round(performance.now() - started),
     cooldownMs: phrase || abandoned ? 0 : cooldown,
-    ...(request ? { providerStatus: request.status } : {}),
+    ...(request
+      ? {
+          providerStatus: request.status,
+          reason: openRouterFailureReason(failure),
+        }
+      : {}),
   };
 }
 
@@ -421,10 +456,15 @@ async function generateSummary(
       result.ok ? null : result.error,
     ),
   };
-  if (expectedOutcome(completion.outcome)) {
-    log.info("Activity summary completion", completion);
-  } else {
-    log.warn("Activity summary completion", completion);
+  // Only the diagnostic is skipped. The cooldown this attempt charged, the
+  // stored summary and the final reread below all still run, so an absorbed
+  // failure degrades exactly like a reported one.
+  if (!absorbedCompletion(completion)) {
+    if (expectedOutcome(completion.outcome)) {
+      log.info("Activity summary completion", completion);
+    } else {
+      log.warn("Activity summary completion", completion);
+    }
   }
   // An abandoned attempt must not spend the shared cooldown on the next
   // viewer's behalf. Its lease expires like any owner that stopped reporting,


### PR DESCRIPTION
Closes #33354

## Problem

An optional activity summary that loses its generation to a shared provider rate
limit reaches operators as `warn`:

https://github.com/vm0-ai/vm0/blob/b4762ad9fc399a1a9dbde812f63b0eb7252dd05b/turbo/apps/api/src/signals/services/chat-activity-summary.service.ts#L424-L428

Nothing here can act on it. The snapshot keeps its previous `summary`, so the
response stays a truthful `cooldown` carrying the caller's last usable phrase;
with no phrase ever stored the viewer keeps the generic label its own fallback
renders for an empty batch. The shared cooldown that this very record reports
already bounds the retry.

The service flattened every `OpenRouterRequestError` into a single
`provider_failure` and never consulted `openRouterFailureReason`, the classifier
`auxiliary-generation.service.ts` already shares across the other fast-path
generations, where the same upstream condition is classified `degraded` and
produces no log.

## Change

- A provider-request completion carries the enumerated `reason` beside
  `providerStatus`. `outcome` stays `provider_failure`.
- A completion whose `reason` is `rate_limited` emits **no record at any level**.
- The reason decides this, never the transport status. OpenRouter delivers a
  native rate limit inside an HTTP 200 error envelope that this client wraps as a
  synthetic `502`, and a raw `429` whose native evidence is `auth` or
  `invalid_request` is a real failure that must keep reaching an operator.

Only the diagnostic is skipped. Success, caller cancellation and deadline keep
their priority ahead of request-error classification; the charged cooldown, the
stored summary and the final reread all still run. `min(300000, max(60000,
retryAfterMs ?? 0))`, Retry-After parsing, claim ownership, the fallback and the
content-free boundary are unchanged. No retry is added.

`reason` is the finite `OpenRouterFailureReason` enum, so an unclassified error
stays an explicit `unknown` rather than a claimed cause.

### Observability

Removing the record intentionally changes operator event counts. The documented
rate query now divides by the attempt records instead of the completions, and the
docs state plainly that absorbed rate limits are counted nowhere: an attempt and
its completion are written separately, so the residual between them is not that
count. No replacement record or telemetry channel is added to recover it.

## Scope

Per the issue's dispatch contract this PR owns semantic `rate_limited` only.
Non-rate provider severity and `unknown` belong to #33361; the residual bucket and
timeout/cancelled noise belong to #33362. The new real-failure assertions
deliberately do **not** pin a level, so neither owner has to unwind a WARN
expectation entrenched here.

## Tests

Four endpoint tests in `chat-activity-summary.test.ts`, all driving the real
route, the real MSW provider and the production logger/Axiom transport through
the existing `captureDiagnostics` harness. Each asserts the cooldown through
persisted/response behaviour under the fixture clock, because an absorbed branch
has no event to inspect.

- **Cached fallback.** A seeded phrase is retained with `status: cooldown` and a
  `Retry-After: 120` deadline; two attempts produce one completion record, no
  `provider_failure` record at any level, and nothing at `warn`/`error`.
- **Empty fallback and recovery.** The first attempt on a run is rate-limited:
  empty messages, `status: cooldown`, floor cooldown, a second request makes no
  further provider call, and the run recovers to `fresh` once the cooldown
  expires.
- **Semantic classification.** A native `RESOURCE_EXHAUSTED` inside a 200
  envelope (synthetic `502`) is absorbed, while `429` responses whose native
  evidence is `invalid_request_error` and `401` still produce a record with the
  matching `reason`.
- **Cooldown bounds.** Missing, unparseable, `30`, `120`, `600` and HTTP-date
  `Retry-After` values resolve to the 60s floor, the provider's own value, and the
  300s ceiling.

All four fail if the skip is removed, and the semantic test fails if the decision
is made on `providerStatus === 429` instead of the reason. Every test asserts the
provider body never reaches a diagnostic.

Verified locally against a real Postgres: 31/31 in the file, plus API package
lint, `check-types:core` and `check-types:tests`, and Prettier. No full Vitest
suite and no dev server were run; the remaining environment verification is the
PR pipeline's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
