### PR TITLE
feat(pi): replace the pi base system prompt with an okou harness prompt

### DIFF
--- a/turbo/packages/pi-agent-runtime/src/okou-harness-prompt.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/okou-harness-prompt.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOkouHarnessSystemPrompt,
+  type OkouHarnessToolPrompt,
+} from "./okou-harness-prompt";
+
+const READ_TOOL: OkouHarnessToolPrompt = {
+  name: "read",
+  snippet: "Read file contents",
+  guidelines: ["Use read to examine files instead of cat or sed."],
+};
+
+const BASH_TOOL: OkouHarnessToolPrompt = {
+  name: "bash",
+  snippet: "Execute bash commands (ls, grep, find, etc.)",
+};
+
+describe("Okou Harness base system prompt", () => {
+  it("renders tools and guidelines in the order the session activates them", () => {
+    const prompt = buildOkouHarnessSystemPrompt([
+      READ_TOOL,
+      BASH_TOOL,
+      { name: "write", snippet: "Create or overwrite files" },
+    ]);
+
+    expect(prompt).toContain(
+      [
+        "Available tools:",
+        "- read: Read file contents",
+        "- bash: Execute bash commands (ls, grep, find, etc.)",
+        "- write: Create or overwrite files",
+      ].join("\n"),
+    );
+    expect(prompt).toContain(
+      [
+        "Guidelines:",
+        "- Use bash for file operations like ls, rg, find",
+        "- Use read to examine files instead of cat or sed.",
+        "- Show file paths clearly when working with files",
+      ].join("\n"),
+    );
+  });
+
+  it("drops the shell file-operation guideline when a search tool is active", () => {
+    const prompt = buildOkouHarnessSystemPrompt([
+      BASH_TOOL,
+      { name: "grep", snippet: "Search file contents for patterns" },
+    ]);
+
+    expect(prompt).not.toContain("Use bash for file operations");
+    expect(prompt).toContain("- Show file paths clearly when working with files");
+  });
+
+  it("keeps the shell file-operation guideline out when no shell is active", () => {
+    const prompt = buildOkouHarnessSystemPrompt([READ_TOOL]);
+
+    expect(prompt).not.toContain("Use bash for file operations");
+  });
+
+  it("omits a tool without a snippet from the available tools section", () => {
+    const prompt = buildOkouHarnessSystemPrompt([
+      READ_TOOL,
+      { name: "memories_search", guidelines: ["Search frozen memory first."] },
+    ]);
+
+    expect(prompt).not.toContain("- memories_search:");
+    expect(prompt).toContain("- Search frozen memory first.");
+  });
+
+  it("reports an empty tool list rather than an empty section", () => {
+    const prompt = buildOkouHarnessSystemPrompt([]);
+
+    expect(prompt).toContain("Available tools:\n(none)");
+  });
+
+  it("keeps one copy of a guideline two tools both contribute", () => {
+    const shared = "Prefer the smallest unique match.";
+    const prompt = buildOkouHarnessSystemPrompt([
+      { name: "edit", snippet: "Edit files", guidelines: [shared] },
+      { name: "write", snippet: "Write files", guidelines: [shared, "  "] },
+    ]);
+
+    expect(prompt.match(new RegExp(`- ${shared}`, "gu"))).toHaveLength(1);
+    expect(prompt).not.toContain("- \n");
+  });
+
+  it("names Okou Harness without naming the underlying harness package", () => {
+    const prompt = buildOkouHarnessSystemPrompt([READ_TOOL, BASH_TOOL]);
+
+    expect(prompt).toContain(
+      "You are an agent running on Okou Harness, Okou's agent runtime.",
+    );
+    expect(prompt).toContain("Refer to your runtime as Okou Harness.");
+    expect(prompt).toContain(
+      "Your work is not limited to software engineering.",
+    );
+    expect(prompt).not.toContain("coding agent harness");
+    expect(prompt).not.toContain("Pi documentation");
+    expect(prompt).not.toContain("Be concise in your responses");
+  });
+
+  it("leaves the working directory line to the official builder", () => {
+    const prompt = buildOkouHarnessSystemPrompt([READ_TOOL]);
+
+    expect(prompt).not.toContain("Current working directory:");
+  });
+});

--- a/turbo/packages/pi-agent-runtime/src/okou-harness-prompt.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/okou-harness-prompt.test.ts
@@ -49,7 +49,9 @@ describe("Okou Harness base system prompt", () => {
     ]);
 
     expect(prompt).not.toContain("Use bash for file operations");
-    expect(prompt).toContain("- Show file paths clearly when working with files");
+    expect(prompt).toContain(
+      "- Show file paths clearly when working with files",
+    );
   });
 
   it("keeps the shell file-operation guideline out when no shell is active", () => {

--- a/turbo/packages/pi-agent-runtime/src/okou-harness-prompt.ts
+++ b/turbo/packages/pi-agent-runtime/src/okou-harness-prompt.ts
@@ -1,0 +1,110 @@
+/**
+ * Okou Harness base system prompt for the Pi loop.
+ *
+ * The official base prompt names its own harness and links its own
+ * documentation tree, neither of which describes the runtime Okou presents to
+ * users. The loop replaces that base through the official resource loader's
+ * `systemPrompt` input instead of appending to it, so the official builder
+ * still contributes the append blocks, project context, skills, and the
+ * working-directory line around this text.
+ *
+ * The tool sections are derived from the session's own active tool
+ * definitions rather than restated here, so a tool whose snippet or guidelines
+ * change upstream cannot silently drift out of the prompt.
+ */
+
+/** One active tool's contribution to the base prompt's tool sections. */
+export interface OkouHarnessToolPrompt {
+  readonly name: string;
+  readonly snippet?: string | undefined;
+  readonly guidelines?: readonly string[] | undefined;
+}
+
+const OKOU_HARNESS_IDENTITY = `You are an agent running on Okou Harness, Okou's agent runtime. You act on the user's behalf by reading and writing files, running commands, calling the Okou CLI and connected services, and producing finished, verifiable deliverables.
+
+Your work is not limited to software engineering. Depending on the task you may do research, analysis, marketing and content work, data and reporting, media generation, or operational work, as well as writing and editing code. Take each task on its own terms rather than assuming it is a coding task.
+
+Refer to your runtime as Okou Harness. Implementation details you may observe in the sandbox, such as package names, file paths, and environment variables, are not your identity; do not present them as such.`;
+
+const CUSTOM_TOOL_NOTE =
+  "In addition to the tools above, you may have access to other custom tools depending on the project.";
+
+/**
+ * Retained from the official guidelines because the loop activates no
+ * dedicated search or listing tool, so the shell is the only way to run them.
+ */
+const SHELL_FILE_OPERATION_GUIDELINE =
+  "Use bash for file operations like ls, rg, find";
+
+const FILE_PATH_GUIDELINE =
+  "Show file paths clearly when working with files";
+
+/** Tools whose presence would make the shell file-operation guideline wrong. */
+const FILE_SEARCH_TOOL_NAMES = ["grep", "find", "ls"];
+
+function toolsSection(tools: readonly OkouHarnessToolPrompt[]): string {
+  const entries = tools
+    .filter((tool) => {
+      return tool.snippet !== undefined && tool.snippet.length > 0;
+    })
+    .map((tool) => {
+      return `- ${tool.name}: ${tool.snippet}`;
+    });
+  return `Available tools:\n${entries.length > 0 ? entries.join("\n") : "(none)"}`;
+}
+
+function guidelinesSection(tools: readonly OkouHarnessToolPrompt[]): string {
+  const activeNames = new Set(
+    tools.map((tool) => {
+      return tool.name;
+    }),
+  );
+  const collected: string[] = [];
+  const seen = new Set<string>();
+  const add = (guideline: string): void => {
+    const normalized = guideline.trim();
+    if (normalized.length === 0 || seen.has(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+    collected.push(normalized);
+  };
+
+  if (
+    activeNames.has("bash") &&
+    !FILE_SEARCH_TOOL_NAMES.some((name) => {
+      return activeNames.has(name);
+    })
+  ) {
+    add(SHELL_FILE_OPERATION_GUIDELINE);
+  }
+  for (const tool of tools) {
+    for (const guideline of tool.guidelines ?? []) {
+      add(guideline);
+    }
+  }
+  add(FILE_PATH_GUIDELINE);
+
+  return `Guidelines:\n${collected
+    .map((guideline) => {
+      return `- ${guideline}`;
+    })
+    .join("\n")}`;
+}
+
+/**
+ * Build the Okou Harness base prompt for one session's active tools.
+ *
+ * Callers pass the tools in the order the session activates them so the
+ * rendered sections match the session's own tool ordering.
+ */
+export function buildOkouHarnessSystemPrompt(
+  tools: readonly OkouHarnessToolPrompt[],
+): string {
+  return [
+    OKOU_HARNESS_IDENTITY,
+    toolsSection(tools),
+    CUSTOM_TOOL_NOTE,
+    guidelinesSection(tools),
+  ].join("\n\n");
+}

--- a/turbo/packages/pi-agent-runtime/src/okou-harness-prompt.ts
+++ b/turbo/packages/pi-agent-runtime/src/okou-harness-prompt.ts
@@ -36,8 +36,7 @@ const CUSTOM_TOOL_NOTE =
 const SHELL_FILE_OPERATION_GUIDELINE =
   "Use bash for file operations like ls, rg, find";
 
-const FILE_PATH_GUIDELINE =
-  "Show file paths clearly when working with files";
+const FILE_PATH_GUIDELINE = "Show file paths clearly when working with files";
 
 /** Tools whose presence would make the shell file-operation guideline wrong. */
 const FILE_SEARCH_TOOL_NAMES = ["grep", "find", "ls"];

--- a/turbo/packages/pi-agent-runtime/src/resources.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/resources.test.ts
@@ -47,6 +47,7 @@ describe("preheated Pi resources", () => {
       agentDir,
       ...piPreheatedResourceLoaderOptions({
         appendSystemPrompt: ["Appended by the run"],
+        systemPrompt: "Okou Harness base prompt for the preheated route.",
         snapshot: {
           schemaVersion: 1,
           agentsFiles: [
@@ -106,6 +107,9 @@ describe("preheated Pi resources", () => {
     ).toStrictEqual(["release-check", "manual-only"]);
     expect(session.systemPrompt).not.toContain("Stale automatic Goal guidance");
     expect(session.systemPrompt).toContain("Appended by the run");
+    expect(session.systemPrompt).toContain(
+      "Okou Harness base prompt for the preheated route.",
+    );
     expect(session.sessionManager.getSessionFile()).toBeUndefined();
     session.dispose();
 

--- a/turbo/packages/pi-agent-runtime/src/resources.ts
+++ b/turbo/packages/pi-agent-runtime/src/resources.ts
@@ -31,6 +31,7 @@ function officialSkill(skill: PiPreheatedSkill): Skill {
 export function piPreheatedResourceLoaderOptions(args: {
   readonly snapshot: PiPreheatedResourceSnapshot;
   readonly appendSystemPrompt: readonly string[];
+  readonly systemPrompt: string;
 }) {
   return {
     noExtensions: true,
@@ -38,6 +39,7 @@ export function piPreheatedResourceLoaderOptions(args: {
     noPromptTemplates: true,
     noThemes: true,
     noContextFiles: true,
+    systemPrompt: args.systemPrompt,
     appendSystemPrompt: [...args.appendSystemPrompt],
     agentsFilesOverride() {
       return {

--- a/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
@@ -1609,10 +1609,11 @@ describe("Okou Harness base system prompt", () => {
     });
 
     try {
-      // The shell tool only advertises the session environment when it
-      // actually exports it, so an absent guideline proves the child shell
-      // inherits no PI_SESSION_ID, PI_SESSION_FILE, PI_PROVIDER, PI_MODEL,
-      // or PI_REASONING_LEVEL.
+      // The shell tool gates its session-environment guideline and its
+      // PI_SESSION_ID, PI_SESSION_FILE, PI_PROVIDER, PI_MODEL, and
+      // PI_REASONING_LEVEL exports on the same option, so an absent guideline
+      // observes that the option is off. Asserting the child environment
+      // directly would need the sandbox shell, which CI does not provide.
       expect(created.session.systemPrompt).not.toContain("PI_");
     } finally {
       created.session.dispose();

--- a/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
@@ -1532,3 +1532,90 @@ describe("official Pi AgentSession runtime", () => {
     }
   });
 });
+
+describe("Okou Harness base system prompt", () => {
+  it.each([
+    { mode: "sandbox" as const, snapshot: undefined },
+    { mode: "api-first" as const, snapshot: EMPTY_RESOURCE_SNAPSHOT },
+  ])("replaces the upstream base prompt for $mode", async ({ snapshot }) => {
+    const root = await mkdtemp(join(tmpdir(), "pi-harness-prompt-"));
+    onTestFinished(async () => {
+      await rm(root, { force: true, recursive: true });
+    });
+    const cwd = join(root, "workspace");
+    const created = await createPiAgentSessionForRuntime({
+      cwd,
+      agentDir: root,
+      sessionManager: SessionManager.inMemory(cwd, { id: randomUUID() }),
+      model: TERRA_MODEL,
+      appendSystemPrompt: "Caller instructions stay appended.",
+      ...(snapshot === undefined ? {} : { resourceSnapshot: snapshot }),
+    });
+
+    try {
+      const { systemPrompt } = created.session;
+      expect(systemPrompt).toContain(
+        "You are an agent running on Okou Harness, Okou's agent runtime.",
+      );
+      expect(systemPrompt).toContain("Refer to your runtime as Okou Harness.");
+
+      // The upstream base prompt names its own harness, links its own
+      // documentation tree, and points at its session environment variables.
+      expect(systemPrompt).not.toContain("coding agent harness");
+      expect(systemPrompt).not.toContain("Pi documentation");
+      expect(systemPrompt).not.toContain("PI_* environment variables");
+      expect(systemPrompt).not.toContain("Be concise in your responses");
+
+      // Tool sections are derived from the session's own tool definitions.
+      expect(systemPrompt).toContain("- read: Read file contents");
+      expect(systemPrompt).toContain(
+        "- bash: Execute bash commands (ls, grep, find, etc.)",
+      );
+      expect(systemPrompt).toContain("- edit: Make precise file edits");
+      expect(systemPrompt).toContain("- write: Create or overwrite files");
+      expect(systemPrompt).toContain(
+        "- Use read to examine files instead of cat or sed.",
+      );
+      expect(systemPrompt).toContain(
+        "- Show file paths clearly when working with files",
+      );
+
+      // Everything the official builder contributes around a custom base
+      // prompt still surrounds it.
+      expect(systemPrompt).toContain(INTERMEDIATE_COMMENTARY_PROMPT);
+      expect(systemPrompt).toContain("Caller instructions stay appended.");
+      expect(systemPrompt).toContain(`Current working directory: ${cwd}`);
+      expect(systemPrompt.indexOf("Okou Harness")).toBeLessThan(
+        systemPrompt.indexOf(INTERMEDIATE_COMMENTARY_PROMPT),
+      );
+    } finally {
+      created.session.dispose();
+    }
+  });
+
+  it("keeps no PI_* session variables in the shell tool environment", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pi-harness-env-"));
+    onTestFinished(async () => {
+      await rm(root, { force: true, recursive: true });
+    });
+    const cwd = join(root, "workspace");
+    const created = await createPiAgentSessionForRuntime({
+      cwd,
+      agentDir: root,
+      sessionManager: SessionManager.inMemory(cwd, { id: randomUUID() }),
+      model: TERRA_MODEL,
+      appendSystemPrompt: null,
+      resourceSnapshot: EMPTY_RESOURCE_SNAPSHOT,
+    });
+
+    try {
+      // The shell tool only advertises the session environment when it
+      // actually exports it, so an absent guideline proves the child shell
+      // inherits no PI_SESSION_ID, PI_SESSION_FILE, PI_PROVIDER, PI_MODEL,
+      // or PI_REASONING_LEVEL.
+      expect(created.session.systemPrompt).not.toContain("PI_");
+    } finally {
+      created.session.dispose();
+    }
+  });
+});

--- a/turbo/packages/pi-agent-runtime/src/session-runtime.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-runtime.ts
@@ -7,6 +7,10 @@ import {
   createAgentSessionFromServices,
   createAgentSessionServices,
   createBashTool,
+  createBashToolDefinition,
+  createEditToolDefinition,
+  createReadToolDefinition,
+  createWriteToolDefinition,
   ModelRuntime,
   SettingsManager,
   type CreateAgentSessionFromServicesOptions,
@@ -25,6 +29,10 @@ import {
 } from "./memory-recall-node";
 import { createPiMemoryTools } from "./memory-tools-node";
 import { piAgentStreamForConfig, resolvePiAgentModel } from "./model";
+import {
+  buildOkouHarnessSystemPrompt,
+  type OkouHarnessToolPrompt,
+} from "./okou-harness-prompt";
 import { piPreheatedResourceLoaderOptions } from "./resources";
 import type { PiAgentModelConfig } from "./types";
 
@@ -35,6 +43,37 @@ As you work, provide brief intermediate text messages to the user. These message
 If the user's request requires calling tools, start with a brief intermediate message before the first tool call. During longer work, provide additional updates at meaningful points.
 
 Do not put a final response, such as a blocking or clarifying question, in an intermediate message. Intermediate messages are only for partial updates, partial results, or non-blocking context that can provide value while you continue working. An intermediate update does not end the task; continue working when more work remains. The final answer must always be fully self-contained.`;
+
+/**
+ * Shell options for the loop's Bash tool.
+ *
+ * `exposeSessionEnvironment` stays off so the child shell inherits no `PI_*`
+ * session variables and the tool contributes no guideline pointing at them.
+ * The guest injects its own run identifiers separately.
+ */
+const PI_BASH_TOOL_OPTIONS = {
+  shellPath: "/usr/local/bin/guest-tool-exec",
+  exposeSessionEnvironment: false,
+} as const;
+
+/**
+ * Tools the official session activates by default. Custom tools stay out of
+ * the base prompt's tool sections because they carry no prompt snippet.
+ */
+function okouHarnessToolPrompts(cwd: string): OkouHarnessToolPrompt[] {
+  return [
+    createReadToolDefinition(cwd),
+    createBashToolDefinition(cwd, PI_BASH_TOOL_OPTIONS),
+    createEditToolDefinition(cwd),
+    createWriteToolDefinition(cwd),
+  ].map((definition) => {
+    return {
+      name: definition.name,
+      snippet: definition.promptSnippet,
+      guidelines: definition.promptGuidelines,
+    };
+  });
+}
 
 function initializePiSessionResourceRegistry(): void {
   // Vite's SSR bundle otherwise keeps Pi's registry behind only the lazy
@@ -157,14 +196,18 @@ export async function createPiAgentSessionForRuntime(args: {
     ...(args.appendSystemPrompt === null ? [] : [args.appendSystemPrompt]),
     ...(memoryRecall.block === null ? [] : [memoryRecall.block]),
   ];
+  const systemPrompt = buildOkouHarnessSystemPrompt(
+    okouHarnessToolPrompts(args.cwd),
+  );
   const sandboxResourceLoaderOptions =
     args.appendSystemPrompt === null && memoryRecall.block === null
       ? {
+          systemPrompt,
           appendSystemPromptOverride(base: string[]) {
             return [PI_INTERMEDIATE_COMMENTARY_PROMPT, ...base];
           },
         }
-      : { appendSystemPrompt };
+      : { systemPrompt, appendSystemPrompt };
   const model = resolvePiAgentModel(args.model);
   if (!model) {
     throw new Error(
@@ -203,6 +246,7 @@ export async function createPiAgentSessionForRuntime(args: {
       ? piPreheatedResourceLoaderOptions({
           snapshot: args.resourceSnapshot,
           appendSystemPrompt,
+          systemPrompt,
         })
       : sandboxResourceLoaderOptions,
   });
@@ -216,9 +260,7 @@ export async function createPiAgentSessionForRuntime(args: {
       args.model.thinkingLevel,
     ),
     customTools: [
-      createBashTool(args.cwd, {
-        shellPath: "/usr/local/bin/guest-tool-exec",
-      }),
+      createBashTool(args.cwd, PI_BASH_TOOL_OPTIONS),
       ...memoryTools,
     ],
   });


### PR DESCRIPTION
## Problem

The Pi loop's base system prompt comes from the upstream package, and Okou never
replaced it. Rendered for this loop's active tools it currently opens with:

> You are an expert coding assistant operating inside pi, a coding agent harness.

and then appends a seven-line documentation block linking three absolute paths
into the upstream package tree, plus a Guidelines entry telling the model to
read `PI_*` environment variables for its model and session details. Those
variables are genuinely exported to the child shell, so the guideline is
actionable.

Two further mismatches in the same base prompt:

- `expert coding assistant` under-describes the loop, which runs research,
  marketing, reporting, and generation work as often as it edits code.
- `Be concise in your responses` pulls against the `## Intermediate commentary`
  block the loop already appends, which asks for proactive progress updates.

## Change

Replace the base prompt through the official resource loader's `systemPrompt`
input rather than appending to it. The official builder still contributes the
append blocks, project context, skills, and the trailing working-directory line
around the custom base, so only the base text changes. Phase 2 memory already
drives the same input; it is untouched.

Both loop routes are covered — the sandbox loader options in
`createPiAgentSessionForRuntime` and the preheated options in
`piPreheatedResourceLoaderOptions` — so the sandbox and API-first turns render
the same base.

The Available tools and Guidelines sections are **derived from the session's own
tool definitions**, not restated. `okouHarnessToolPrompts` builds the same four
definitions the session activates by default and reads their `promptSnippet` and
`promptGuidelines`, so an upstream snippet or guideline change cannot silently
drift out of the prompt. The per-tool guidelines that earn their place are kept
verbatim, including the four `edit` rules about `edits[].oldText` matching.

`exposeSessionEnvironment` is now off for the loop's Bash tool. The child shell
inherits no `PI_SESSION_ID`, `PI_SESSION_FILE`, `PI_PROVIDER`, `PI_MODEL`, or
`PI_REASONING_LEVEL`. Because the upstream shell tool only contributes its
session-environment guideline when it actually exports those variables, this
removes the guideline and the variables together. No first-party code reads
them; the guest injects `OKOU_PI_SESSION_ID` through its own contract and is
unaffected.

## Kept vs dropped

| Base prompt block | Outcome |
| --- | --- |
| Identity sentence | Rewritten: names Okou Harness, widens the role beyond coding |
| Available tools | Kept, now derived from the session's tool definitions |
| "you may have access to other custom tools" | Kept — the loop has many tools outside that list |
| `Use bash for file operations like ls, rg, find` | Kept — no search or listing tool is active |
| `read` / `edit` / `write` guidelines | Kept verbatim |
| `inspect PI_* environment variables` | Dropped with the variables themselves |
| `Be concise in your responses` | Dropped — conflicts with intermediate commentary |
| `Show file paths clearly when working with files` | Kept |
| Pi documentation block | Dropped entirely |

## Not in this PR

**No new feature switch.** Gating this would need a new generation of the
`.strict()` `piLaunchConfigSchema` cross-version contract plus runner capability
negotiation, which is a larger and riskier change than the prompt swap it would
gate. Prompt content is also outside the categories the feature-switch guide
requires a switch for. The change is pure text with no schema, migration, or
contract impact, and reverts cleanly.

**`OKOU_PI_SESSION_ID` is unchanged.** It still carries `PI` in its name and
stays visible to `env` in the sandbox. Renaming it touches the `guest-contracts`
cross-language contract and the runner, so it belongs in its own PR.

## Verification

Unit coverage for the builder's derivation rules in
`okou-harness-prompt.test.ts`, and entry-point coverage through
`createPiAgentSessionForRuntime` for both routes in `session-runtime.test.ts`,
asserting the rendered `session.systemPrompt` names Okou Harness, carries the
derived tool sections, retains the append blocks and working-directory line, and
contains no `PI_`, `coding agent harness`, `Pi documentation`, or
`Be concise in your responses`. Relying on the PR pipeline for lint, types, and
the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
