### PR TITLE
fix(api): report unabsorbed activity-summary provider failures as errors

### DIFF
--- a/docs/chat-thread-activity-summary.md
+++ b/docs/chat-thread-activity-summary.md
@@ -97,14 +97,14 @@ transport's `info` threshold. The shared logger and unrelated debug filtering
 are unchanged. Axiom events retain `source: api`, the stable message, and the
 following nested `fields`:
 
-| Message                        | Context                | Level                                                                                                                                                             | Safe fields besides context                                                                                                            |
-| ------------------------------ | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `Activity summary cache`       | `api:activity-summary` | info                                                                                                                                                              | `runId`, `outcome` (existing response status)                                                                                          |
-| `Activity summary attempt`     | `api:activity-summary` | info                                                                                                                                                              | `runId`                                                                                                                                |
-| `Activity summary completion`  | `api:activity-summary` | info for success/timeout/cancelled; warn for invalid_or_unconfigured and for a reported provider_failure; no record at any level for an absorbed provider_failure | `runId`, `outcome`, `durationMs`, `cooldownMs`; numeric `providerStatus` and the enumerated `reason` only for `OpenRouterRequestError` |
-| `Activity summary unavailable` | `api:activity-summary` | warn                                                                                                                                                              | `runId`, `outcome: storage_failed`                                                                                                     |
-| `Activity snapshot capture`    | `api:run-activity`     | info for written/unchanged and for an expected failure; warn otherwise                                                                                            | `runId`, `outcome`, `eventCount`; `stage` and `errorCode` on failure                                                                   |
-| `Activity snapshot cleanup`    | `api:run-activity`     | info on success; warn on failure                                                                                                                                  | `outcome`, `removed`, `retentionMs`; `errorCode` on failure                                                                            |
+| Message                        | Context                | Level                                                                                                                                                                | Safe fields besides context                                                                                                            |
+| ------------------------------ | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `Activity summary cache`       | `api:activity-summary` | info                                                                                                                                                                 | `runId`, `outcome` (existing response status)                                                                                          |
+| `Activity summary attempt`     | `api:activity-summary` | info                                                                                                                                                                 | `runId`                                                                                                                                |
+| `Activity summary completion`  | `api:activity-summary` | info for success/timeout/cancelled; warn for invalid_or_unconfigured; error for a reported provider_failure; no record at any level for an absorbed provider_failure | `runId`, `outcome`, `durationMs`, `cooldownMs`; numeric `providerStatus` and the enumerated `reason` only for `OpenRouterRequestError` |
+| `Activity summary unavailable` | `api:activity-summary` | warn                                                                                                                                                                 | `runId`, `outcome: storage_failed`                                                                                                     |
+| `Activity snapshot capture`    | `api:run-activity`     | info for written/unchanged and for an expected failure; warn otherwise                                                                                               | `runId`, `outcome`, `eventCount`; `stage` and `errorCode` on failure                                                                   |
+| `Activity snapshot cleanup`    | `api:run-activity`     | info on success; warn on failure                                                                                                                                     | `outcome`, `removed`, `retentionMs`; `errorCode` on failure                                                                            |
 
 Completion outcomes are `success`, `timeout`, `cancelled`, `provider_failure`,
 and `invalid_or_unconfigured`. A `provider_failure` also carries `reason`, the
@@ -124,12 +124,24 @@ recovery at the shared cooldown; `cancelled` means the request's own lifetime
 ended before the provider answered. Neither has an operator action, so a
 per-event `warn` only trains operators to ignore the record.
 
-A `provider_failure` with `reason: rate_limited` is absorbed the same way and
-emits no record at any level. The shared account is momentarily over its limit,
-the caller keeps its last usable phrase or the generic label, and the cooldown
-that record would have reported already bounds the retry, so there is nothing
-for an operator to do. Contract and configuration defects, and the provider
-failures that are not an absorbed rate limit, still reach an operator.
+A `provider_failure` is absorbed the same way, and emits no record at any level,
+whenever its `reason` is one the shared classifier calls transient:
+`rate_limited`, `upstream_timeout` or `provider_unavailable`. The provider is
+momentarily over its limit or unreachable, the caller keeps its last usable
+phrase or the generic label, and the cooldown that record would have reported
+already bounds the retry, so there is nothing for an operator to do. The set is
+the classifier's own, so a reason that stops counting as transient there stops
+being absorbed here. (`network` is in that set but cannot occur on this branch:
+a transport rejection is not an `OpenRouterRequestError`, so it becomes
+`invalid_or_unconfigured` instead.)
+
+Every other `provider_failure` reason is a real failure and records at `error`:
+`auth` and `invalid_request` are credential and request-contract defects, and a
+request error the classifier could not place records as `reason: unknown`.
+`unknown` stays unknown — it names no cause and implies nothing about the main
+run — but it is still reported, because nothing here shows it recovers on its
+own. `invalid_or_unconfigured` is a separate bucket and keeps its `warn`; its
+classification is resolved separately and that level is not a final policy.
 
 Deadline pressure is a rate, not an event. Read it from the attempt records,
 which count every generation, against the completions that are still emitted:
@@ -147,12 +159,13 @@ which count every generation, against the completions that are still emitted:
 
 Alerting on that rate is an operator decision and is not configured here.
 
-Absorbed rate limits are deliberately not counted anywhere. `attempts` minus the
-emitted completions is not that count: an attempt and its completion are written
-separately, so an instance that stops between them leaves the same residual. No
-replacement record or telemetry channel is added to recover the number, and the
-rate-limit counters of other auxiliary generations describe their own features,
-not this one.
+Absorbed provider failures are deliberately not counted anywhere. `attempts`
+minus the emitted completions is not that count: an attempt and its completion
+are written separately, so an instance that stops between them leaves the same
+residual. No replacement record or telemetry channel is added to recover the
+number, and the rate-limit counters of other auxiliary generations describe
+their own features, not this one. `provider` above therefore counts only the
+reported failures, which are exactly the ones at `error`.
 
 A failed capture is classified into a finite set instead of one opaque
 `write_failed`. `contended` (`55P03`) and `run_missing` (`23503`) are expected

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
@@ -1221,6 +1221,143 @@ describe("thread activity summary", () => {
     expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
   });
 
+  it("absorbs upstream unavailability and keeps the last known summary", async () => {
+    const f = await fixture();
+    const diagnostics = captureDiagnostics();
+    const inputs = provider((_input, index) => {
+      return index === 1
+        ? "Preparing the launch checklist"
+        : HttpResponse.json(
+            { error: { code: 503, message: "PRIVATE_PROVIDER_BODY" } },
+            { status: 503 },
+          );
+    });
+    const first = await summarize(f.actor, f.run);
+    await deliver(f, [tool(0)]);
+    await advanceRunActivityClockFixture(f.run.runId, 16_000);
+    const failed = await summarize(f.actor, f.run);
+    expect(failed.messages).toStrictEqual(first.messages);
+    expect(failed.summaryRevision).toBe(first.summaryRevision);
+    expect(failed.retryAfterMs).toBeGreaterThan(55_000);
+    expect(failed.retryAfterMs).toBeLessThanOrEqual(60_000);
+    // The charged cooldown still bounds the next provider call.
+    await summarize(f.actor, f.run);
+    expect(inputs).toHaveLength(2);
+    const logs = await diagnostics();
+    expect(providerFailureRecords(logs)).toStrictEqual([]);
+    expect(operatorRecords(logs)).toStrictEqual([]);
+    // The attempt is still counted; only the absorbed outcome is silent.
+    expect(
+      logs.filter((event) => {
+        return event.message === "Activity summary attempt";
+      }),
+    ).toHaveLength(2);
+    expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
+  });
+
+  it("absorbs an envelope unavailability and an upstream timeout", async () => {
+    const f = await fixture();
+    const diagnostics = captureDiagnostics();
+    const inputs = provider((_input, index) => {
+      // A native unavailability arrives inside a successful envelope, which
+      // this client wraps as a synthetic 502; the reason decides, not the status.
+      return index === 1
+        ? HttpResponse.json({
+            choices: [
+              {
+                finish_reason: "error",
+                error: {
+                  code: "UNAVAILABLE",
+                  message: "PRIVATE_PROVIDER_BODY",
+                },
+              },
+            ],
+          })
+        : HttpResponse.json(
+            { error: { code: 504, message: "PRIVATE_PROVIDER_BODY" } },
+            { status: 504 },
+          );
+    });
+    const unavailable = await summarize(f.actor, f.run);
+    expect(unavailable.status).toBe("cooldown");
+    expect(unavailable.retryAfterMs).toBeGreaterThan(55_000);
+    expect(unavailable.retryAfterMs).toBeLessThanOrEqual(60_000);
+    await advanceRunActivityClockFixture(f.run.runId, 61_000);
+    const timedOut = await summarize(f.actor, f.run);
+    expect(timedOut.status).toBe("cooldown");
+    expect(inputs).toHaveLength(2);
+    const logs = await diagnostics();
+    expect(completionRecords(logs)).toStrictEqual([]);
+    expect(operatorRecords(logs)).toStrictEqual([]);
+    expect(
+      logs.filter((event) => {
+        return event.message === "Activity summary attempt";
+      }),
+    ).toHaveLength(2);
+    expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
+  });
+
+  it("reports credential, contract and unplaced provider failures as errors", async () => {
+    const f = await fixture();
+    const diagnostics = captureDiagnostics();
+    const inputs = provider((_input, index) => {
+      if (index === 1) {
+        // A native credential defect inside a rate-limited wrapper: the native
+        // code decides the class, so this is not absorbed with the 429s.
+        return HttpResponse.json(
+          { error: { code: 401, message: "PRIVATE_PROVIDER_BODY" } },
+          { status: 429, headers: { "Retry-After": "120" } },
+        );
+      }
+      if (index === 2) {
+        return HttpResponse.json({
+          error: {
+            code: "INVALID_ARGUMENT",
+            message: "PRIVATE_PROVIDER_BODY",
+          },
+        });
+      }
+      return HttpResponse.json(
+        { error: { code: 500, message: "PRIVATE_PROVIDER_BODY" } },
+        { status: 500 },
+      );
+    });
+    const auth = await summarize(f.actor, f.run);
+    expect(auth.retryAfterMs).toBeGreaterThan(110_000);
+    expect(auth.retryAfterMs).toBeLessThanOrEqual(120_000);
+    await advanceRunActivityClockFixture(f.run.runId, 121_000);
+    await summarize(f.actor, f.run);
+    await advanceRunActivityClockFixture(f.run.runId, 61_000);
+    await summarize(f.actor, f.run);
+    expect(inputs).toHaveLength(3);
+    const logs = await diagnostics();
+    const expected = [
+      { reason: "auth", providerStatus: 429, cooldownMs: 120_000 },
+      { reason: "invalid_request", providerStatus: 502, cooldownMs: 60_000 },
+      // Not every 5xx is absorbed: an error the shared classifier cannot place
+      // stays reported as `unknown` and claims no cause.
+      { reason: "unknown", providerStatus: 500, cooldownMs: 60_000 },
+    ] as const;
+    for (const fields of expected) {
+      expect(logs).toContainEqual(
+        expect.objectContaining({
+          level: "error",
+          message: "Activity summary completion",
+          fields: {
+            context: "api:activity-summary",
+            runId: f.run.runId,
+            outcome: "provider_failure",
+            durationMs: expect.any(Number),
+            ...fields,
+          },
+        }),
+      );
+    }
+    expect(providerFailureRecords(logs)).toHaveLength(expected.length);
+    expect(operatorRecords(logs)).toHaveLength(expected.length);
+    expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
+  });
+
   it("records a missed deadline as an accepted degradation, not a failure", async () => {
     const f = await fixture();
     const entered = createDeferredPromise<void>(context.signal);

--- a/turbo/apps/api/src/signals/services/chat-activity-summary.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-activity-summary.service.ts
@@ -31,6 +31,7 @@ import {
   OpenRouterRequestError,
 } from "../external/openrouter";
 import {
+  isTransientProviderFailure,
   openRouterFailureReason,
   type OpenRouterFailureReason,
 } from "../external/openrouter-failure";
@@ -345,18 +346,41 @@ interface CompletionRecord {
 
 /**
  * Provider failures this optional generation already absorbs, recognized by the
- * shared semantic reason rather than by a transport status. A shared rate limit
- * resolves without anyone here acting: the caller keeps its last usable phrase
- * or the existing generic label, and the same cooldown this record would report
- * bounds the retry. Emitting it at any level would only teach operators to
+ * shared semantic reason rather than by a transport status. None of them
+ * resolves by anyone here acting: the caller keeps its last usable phrase or
+ * the existing generic label, and the same cooldown this record would report
+ * bounds the retry. Emitting them at any level would only teach operators to
  * ignore the record. The outer status cannot decide this — a native rate limit
- * arrives inside a synthetic 502 envelope, and a raw 429 whose native evidence
- * is auth or invalid_request is a real failure that must keep reaching someone.
+ * or an upstream timeout/unavailability arrives inside a synthetic 502
+ * envelope, and a raw 429 whose native evidence is auth or invalid_request is a
+ * real failure that must keep reaching someone.
+ *
+ * The set is the shared classifier's own, so a reason that stops counting as
+ * transient there stops being absorbed here. `network` belongs to it but is
+ * unreachable on this branch: a transport rejection is not an
+ * `OpenRouterRequestError`, so it lands in the residual bucket instead.
  */
 function absorbedCompletion(completion: CompletionRecord): boolean {
   return (
     completion.outcome === "provider_failure" &&
-    completion.reason === "rate_limited"
+    completion.reason !== undefined &&
+    isTransientProviderFailure(completion.reason)
+  );
+}
+
+/**
+ * A provider-request failure the shared classifier does not absorb: a
+ * credential defect, a request-contract defect, or a request error it could not
+ * place. Each needs an owner, so each is a real failure rather than a
+ * degradation. `unknown` stays unknown — it names no cause and implies nothing
+ * about the main run — but it is still reported, because nothing here shows it
+ * recovers on its own.
+ */
+function realProviderFailure(completion: CompletionRecord): boolean {
+  return (
+    completion.outcome === "provider_failure" &&
+    completion.reason !== undefined &&
+    !isTransientProviderFailure(completion.reason)
   );
 }
 
@@ -460,7 +484,9 @@ async function generateSummary(
   // stored summary and the final reread below all still run, so an absorbed
   // failure degrades exactly like a reported one.
   if (!absorbedCompletion(completion)) {
-    if (expectedOutcome(completion.outcome)) {
+    if (realProviderFailure(completion)) {
+      log.error("Activity summary completion", completion);
+    } else if (expectedOutcome(completion.outcome)) {
       log.info("Activity summary completion", completion);
     } else {
       log.warn("Activity summary completion", completion);


### PR DESCRIPTION
Closes #33361

## Problem

`chat-activity-summary.service.ts` already classifies a provider-request failure
by the shared `openRouterFailureReason` (added for `rate_limited` in #33522),
but it acts on only one reason. `absorbedCompletion` recognizes `rate_limited`
alone, so the remaining transient reasons the same classifier owns —
`upstream_timeout` and `provider_unavailable` — still reach operators even
though the caller keeps its last usable phrase and the charged cooldown already
bounds the retry.

At the same time, everything that is not absorbed lands on one `warn`: a real
credential or request-contract defect is reported at exactly the level of an
unusable model result. #33522 deliberately left that severity unasserted — its
test says "the level is the adjacent severity decision and is asserted
elsewhere". This is that decision.

`providerStatus` cannot make either call: OpenRouter delivers a native error
inside an HTTP 200 envelope that this client wraps as a synthetic `502`, so the
same number can mean unavailability, a contract defect or an auth failure.

## Change

Route the rest of the `provider_failure` branch by the same shared reason.

- **Absorb every reason `isTransientProviderFailure` accepts.** An upstream
  timeout or unavailability becomes as silent as the already-merged rate limit —
  no record at any level, and no replacement diagnostic. The predicate is the
  shared classifier's own, so a reason that stops counting as transient there
  stops being absorbed here. `network` is in that set but is unreachable on this
  branch, because a transport rejection is not an `OpenRouterRequestError`.
- **Report everything else at `error`.** `auth` and `invalid_request` are real
  credential and contract defects. A request error the classifier could not
  place stays `reason: unknown`: it names no cause and implies nothing about the
  main run, but nothing here shows it recovers, so it is still reported.

Precedence is unchanged, so a raw `429` carrying a native `401` is an `auth`
error rather than an absorbed rate limit, and a native unavailability inside a
synthetic `502` is absorbed.

Only the level and the absorbed set change. Success, caller cancellation and
deadline keep their priority ahead of request-error classification; the charged
cooldown, bounded `Retry-After`, the retained summary, claim ownership and
lease, the final reread and the content-free boundary are untouched. The
residual `invalid_or_unconfigured` bucket keeps its `warn` for its own owner
(#33362), and #33522's absorbed `rate_limited` diagnostic is not restored.

## Validation

`turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts` —
34/34 pass against a local PostgreSQL 18 (UTC), through the real route, the MSW
provider transport and the production logger with the real Axiom SDK/transport.
Three new cases, reusing this suite's existing `completionRecords`,
`providerFailureRecords` and `operatorRecords` helpers:

- HTTP `503` → absorbed: no `provider_failure` record and no operator record at
  any level, while the previous summary and its revision are retained,
  `retryAfterMs` stays inside the 60 s bound, the stored cooldown still
  suppresses the next provider call, and both attempts are still counted.
- A 200 envelope carrying native `UNAVAILABLE` (the synthetic-502 path) and HTTP
  `504` → both absorbed: no completion record at all, attempts still counted.
- HTTP `429` carrying native `401`, an `INVALID_ARGUMENT` envelope, and HTTP
  `500` → exactly three `error` records with `reason` `auth` / `invalid_request`
  / `unknown`, `providerStatus` `429` / `502` / `500`, and `cooldownMs`
  `120000` / `60000` / `60000`, proving native precedence over the wrapper
  status, that a synthetic 502 is not assumed transient, and that not every 5xx
  is absorbed.

Every case asserts the provider body never reaches a record.

The three new cases were confirmed non-vacuous: reverting `absorbedCompletion`
to `rate_limited` only and removing the `error` routing fails all three, and
they pass again once restored.

Also run locally: `tsc` on the `core` and `tests` projects, `oxlint` including
the type-aware pass, `eslint --max-warnings 0`, and `prettier`.

### Limitations

No full local Vitest suite and no dev server, per the task constraints; the PR
pipeline owns full-suite and environment verification. This change does not make
an absorbed failure individually attributable after the fact — it removes that
record by design; `reason` improves the diagnostics that are still emitted. The
historical production `502` records that motivated the issue were logged without
their origin or native code, so they cannot be attributed retroactively and no
claim is made about a specific historical provider fault.

## Documentation

`docs/chat-thread-activity-summary.md` records the widened absorbed set, the new
`error` level, the explicit `unknown` semantics, and that `invalid_or_unconfigured`
keeps its `warn` under separate ownership. It also states that the reported
`provider` count now covers only the emitted failures and that absorbed ones
remain counted nowhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
