### PR TITLE
perf(guest-init): reduce dynamic cgroup placement latency

### DIFF
--- a/.github/scripts/runner-behavior-process-containment-remote.sh
+++ b/.github/scripts/runner-behavior-process-containment-remote.sh
@@ -62,6 +62,10 @@ rm -rf "$marker"
 mkdir -p "$marker"
 touch "$marker/sandbox-reuse-marker"
 
+# Observe the policy installed by guest-init in the restored snapshot.
+awk '$2 == "/sys/fs/cgroup" && $3 == "cgroup2" && $4 ~ /(^|,)favordynmods(,|$)/ { found = 1 } END { exit !found }' /proc/mounts \
+  || { echo "guest cgroup2 mount is missing favordynmods" >&2; exit 1; }
+
 expected_path="/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:$HOME/go/bin:$HOME/.cargo/bin"
 if [ "$PATH" != "$expected_path" ]; then
   echo "Guest Agent CLI child PATH changed: expected=$expected_path actual=$PATH" >&2
@@ -287,6 +291,8 @@ set -eu
 marker=/tmp/vm0-process-containment
 base=/sys/fs/cgroup/vm0-exec
 test -f "$marker/sandbox-reuse-marker"
+awk '$2 == "/sys/fs/cgroup" && $3 == "cgroup2" && $4 ~ /(^|,)favordynmods(,|$)/ { found = 1 } END { exit !found }' /proc/mounts \
+  || { echo "reused guest cgroup2 mount is missing favordynmods" >&2; exit 1; }
 if [ -e "$marker/profile-executed" ]; then
   echo "sandbox login profile executed before Guest Agent" >&2
   exit 1

--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -166,12 +166,14 @@ impl std::error::Error for InitError {}
 /// operation.
 fn initialize_process_containment() -> Result<(), InitError> {
     create_dir_all(Path::new(CGROUP_V2_MOUNT_PATH))?;
+    // CLI children and managed tools migrate before exec. Favor these dynamic
+    // placements over fork/exit throughput; this policy applies only to the guest.
     mount(
         Some("cgroup2"),
         CGROUP_V2_MOUNT_PATH,
         Some("cgroup2"),
         MsFlags::MS_NODEV | MsFlags::MS_NOEXEC | MsFlags::MS_NOSUID,
-        None::<&str>,
+        Some("favordynmods"),
     )
     .map_err(|source| InitError::Mount {
         target: CGROUP_V2_MOUNT_PATH.into(),

--- a/docs/runner-guest-process-lifecycle.md
+++ b/docs/runner-guest-process-lifecycle.md
@@ -76,6 +76,20 @@ Guest Agent places the CLI in `runtime` immediately before exec. Each managed
 tool authenticates separately and receives a fresh `tool-N` descriptor.
 Controlled processes deny process inspection across the boundary.
 
+Guest-init mounts cgroup v2 with `favordynmods` before creating the containment
+hierarchy. This guest-only policy reduces dynamic placement latency for CLI
+children and managed tools. Linux documents a trade-off: fork/exit hot paths
+can become more expensive. It does not change credentials, controller limits,
+placement capabilities, or the CLI's before-exec migration boundary. See the
+[kernel mount policy documentation](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html#mounting).
+
+The option is installed at boot, not toggled for individual runs or on the host.
+Guest-init binary content participates in the rootfs hash and the derived
+snapshot hash, so new artifacts build snapshots with this policy; draining old
+sandboxes retain their existing mount. Mount failure remains fatal before guest
+readiness. Reverting the policy requires a new image and sandbox lifetime, not
+an inverse remount of a running guest.
+
 ## Ownership and Reuse
 
 ### Direct cgroup creation
@@ -142,7 +156,7 @@ committed guest kernel is 6.18.44. Fixed process-group-only helpers and explicit
 local TestNoop backends still use standard process creation. Guest Agent's
 internal CLI launcher and the managed tool's migrate-self/exec boundary are
 unchanged. There is no persistent cgroup pool, resident launcher or cgroup
-mount-policy change.
+mount-policy change on the host; the guest mount policy is described above.
 
 ### Operation lifetime
 


### PR DESCRIPTION
## Summary

- Enable guest cgroup2 `favordynmods` at initial boot to reduce managed CLI/tool migration latency.
- Preserve existing direct `clone3(CLONE_INTO_CGROUP)` launches, non-root placement, authentication, resource limits and child ownership. No new privileged helper, fallback, kernel/Firecracker change or host remount.
- Verify the real mount policy in the existing snapshot-restored and reused process-containment scenarios; document the guest-wide fork/exit trade-off and content-addressed image rollout.

Closes #32719. Parent context: #24203 (not closed).

The owner's selected performance objective explicitly replaces the issue's former mandatory inner-CLI direct-birth requirement. With favored mounts, adding a CLI helper showed no stable extra spawn benefit. This does not claim improved initial resource accounting or production `api_to_spawn`.

## Validation

- `cargo test --locked --profile local -p guest-init -j 2`: 25 passed, one existing process-isolated child ignored.
- `cargo clippy --locked --profile local -p guest-init --all-targets --all-features -j 2 -- -D warnings`
- `cargo doc --locked --profile local -p guest-init --no-deps -j 2`
- `cargo fmt --all -- --check`; `bash -n` and `shellcheck` on the native worker; Prettier on the lifecycle documentation.
- Locked release cross-build for x86_64-musl; built a separate rootfs and snapshot on dev-11 with the exact guest-init candidate using the retained fixture Runner's `build --guest-init` override. First boot, snapshot restore and reuse passed without remounting. Full current-head CI remains separate from this controlled fixture.
- Complete native process-containment worker passed: identity/placement, mixed root/user cleanup, CPU responsiveness, tool OOM isolation, PID-pressure cleanup and reuse. Fresh/workspace-cache/exact-reuse startup diagnostics each recorded three successful samples.
- Three fresh snapshot restores: 345 measured actual managed tools + 33 warmups passed. Spaced-call P50 2.33–2.46 ms, P95 3.01–4.51 ms. Native fork/exec controls and fork-heavy/parallel tools also completed. This validates the initial-mount candidate, not a new causal before/after or universal no-regression claim.

Guest-init SHA256: `50d1ce938c6bc2a492ff4970b9671b1e1786e31555fa1ba50f11f1076c6a5fc8`.
Rootfs: `4b39150e167e623d4a5b3bacfe24cb63b647a4b1fe01eab069b8c10d11475593`.
Snapshot: `6204c5d183d19bd4e2b38228e82c2f06676e81219d971ea81ba5bd7a930acb44`.

The fixture uses official Firecracker 1.16.2, guest kernel 6.18.44+, 2 vCPU / 4096 MiB. Prior research text saying 2048 MiB is corrected: original and candidate configs/snapshot memory sizes both prove 4096 MiB. All prior samples and unfavorable tails are retained in #32719 research.

Both task services are stopped; no active task sandboxes remain. Temporary upload files and native worker-owned ephemeral state were removed; logs and candidate artifacts are retained. No other service or host mount policy changed.

## Risks

`favordynmods` trades guest-wide fork/exit cost for dynamic modification latency. Earlier controlled experiments include unfavorable burst/fork cells and inconsistent first-initialize tails; no full-provider, large-session or all-guest CPU guarantee is made. The native CI assertions add no timing thresholds. New guest-init bytes generate new rootfs/snapshot identities; draining old sandboxes retain their own policy.
