### PR TITLE
fix(guest-agent): bound pi and codex event delivery

### DIFF
--- a/crates/codex-mock/src/app_server/messages.rs
+++ b/crates/codex-mock/src/app_server/messages.rs
@@ -540,6 +540,18 @@ pub(super) fn write_oversized_delivery_notifications<W: Write>(
             }
         }),
     )?;
+    if let Some(path) = std::env::var_os("MOCK_CODEX_DELIVERY_ITEMS_PATH") {
+        let items: Vec<Value> = serde_json::from_slice(&std::fs::read(path)?)?;
+        for item in items {
+            write_json_line(
+                output,
+                &json!({
+                    "method": "item/completed",
+                    "params": {"threadId": thread_id, "turnId": turn_id, "completedAtMs": 9, "item": item}
+                }),
+            )?;
+        }
+    }
     write_json_line(output, &warning_notification(thread_id, 999))
 }
 

--- a/crates/guest-agent/src/cli/bounded_event_delivery.rs
+++ b/crates/guest-agent/src/cli/bounded_event_delivery.rs
@@ -1,0 +1,454 @@
+//! Bounded webhook representation for normalized Pi and Codex events.
+//!
+//! Source records reach the best-effort local log before this module sees
+//! the webhook copy. Official history is owned by the CLI. Normal events retain
+//! their existing serialization. Only events that cannot fit in one delivery
+//! request receive visibly marked content reduction.
+
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+
+use super::{codex_event_delivery, pi_event_delivery};
+
+use crate::error::AgentError;
+
+#[derive(Clone, Copy)]
+pub(super) enum Framework {
+    Pi,
+    Codex,
+}
+
+pub(super) const DELIVERY_NOTICE: &str = "[event content truncated for delivery]";
+const MAX_REDUCTION_CANDIDATES: usize = 256;
+// Numeric arrays and long keys must not create input-sized traversal state.
+const MAX_VISITED_VALUES: usize = 4096;
+const MAX_PATH_DEPTH: usize = 64;
+const MAX_PATH_KEY_BYTES: usize = 256;
+const MAX_REDUCED_FIELDS: usize = 16;
+const RETAINED_CONTENT_ADJUSTMENT_ATTEMPTS: usize = 4;
+
+pub(super) struct PreparedEvent {
+    pub(super) serialized: Vec<u8>,
+    pub(super) reduction: Option<EventReduction>,
+}
+
+pub(super) struct EventReduction {
+    pub(super) event_type: &'static str,
+    pub(super) item_type: &'static str,
+    pub(super) original_bytes: usize,
+    pub(super) delivered_bytes: usize,
+    pub(super) fields: Vec<&'static str>,
+    pub(super) fallback: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum PathSegment {
+    Key(String),
+    Index(usize),
+}
+
+#[derive(Clone, Debug)]
+struct ContentCandidate {
+    path: Vec<PathSegment>,
+    path_key: String,
+    image_text_type: Option<&'static str>,
+    category: &'static str,
+    reducible_bytes: usize,
+}
+
+struct SelectedContent {
+    path: Vec<PathSegment>,
+    original: String,
+}
+
+pub(super) fn prepare_for_delivery(
+    mut event: Value,
+    max_serialized_event_bytes: usize,
+    framework: Framework,
+) -> Result<PreparedEvent, AgentError> {
+    let serialized = serde_json::to_vec(&event)?;
+    if serialized.len() <= max_serialized_event_bytes {
+        return Ok(PreparedEvent {
+            serialized,
+            reduction: None,
+        });
+    }
+
+    let original_bytes = serialized.len();
+    drop(serialized);
+    let (event_type, item_type) = match framework {
+        Framework::Pi => pi_event_delivery::labels(&event),
+        Framework::Codex => codex_event_delivery::labels(&event),
+    };
+    let mut candidates = collect_content_candidates(&event, framework)?;
+    candidates.sort_by(|left, right| {
+        right
+            .reducible_bytes
+            .cmp(&left.reducible_bytes)
+            .then_with(|| left.path_key.cmp(&right.path_key))
+    });
+
+    let mut reduced_categories = BTreeSet::new();
+    let mut selected = Vec::new();
+    let mut reducible_bytes = 0usize;
+    for candidate in candidates
+        .iter()
+        .filter(|candidate| candidate.reducible_bytes > 0)
+        .take(MAX_REDUCED_FIELDS)
+    {
+        reduced_categories.insert(candidate.category);
+        reducible_bytes = reducible_bytes.saturating_add(candidate.reducible_bytes);
+        if let Some(text_type) = candidate.image_text_type {
+            *value_at_path_mut(&mut event, &candidate.path)? = image_notice(text_type);
+        } else {
+            let Value::String(original) =
+                std::mem::take(value_at_path_mut(&mut event, &candidate.path)?)
+            else {
+                return Err(AgentError::Execution("delivery content is not text".into()));
+            };
+            *value_at_path_mut(&mut event, &candidate.path)? =
+                Value::String(truncated_text(&original, 0));
+            selected.push(SelectedContent {
+                path: candidate.path.clone(),
+                original,
+            });
+        }
+
+        let minimum_bytes = original_bytes.saturating_sub(reducible_bytes);
+        if minimum_bytes > max_serialized_event_bytes {
+            continue;
+        }
+
+        apply_retained_budget(&mut event, &selected, 0, 1)?;
+        let minimum = serde_json::to_vec(&event)?;
+        if minimum.len() > max_serialized_event_bytes {
+            continue;
+        }
+        let total_original_bytes = selected
+            .iter()
+            .map(|content| content.original.len())
+            .sum::<usize>();
+        let available_bytes = max_serialized_event_bytes - minimum.len();
+        let mut retained_bytes = available_bytes.min(total_original_bytes);
+
+        for _ in 0..RETAINED_CONTENT_ADJUSTMENT_ATTEMPTS {
+            apply_retained_budget(
+                &mut event,
+                &selected,
+                retained_bytes,
+                total_original_bytes.max(1),
+            )?;
+            let serialized = serde_json::to_vec(&event)?;
+            if serialized.len() <= max_serialized_event_bytes {
+                return Ok(reduced_event(
+                    serialized,
+                    event_type,
+                    item_type,
+                    original_bytes,
+                    reduced_categories,
+                    false,
+                ));
+            }
+
+            let added_bytes = serialized.len().saturating_sub(minimum.len()).max(1);
+            // Leave bounded room for UTF-8 edges, JSON escapes and changing
+            // marker digit counts instead of spending all four attempts on rounding.
+            retained_bytes = (retained_bytes.saturating_mul(available_bytes) / added_bytes)
+                .saturating_sub(selected.len().saturating_mul(32));
+        }
+
+        return Ok(reduced_event(
+            minimum,
+            event_type,
+            item_type,
+            original_bytes,
+            reduced_categories,
+            false,
+        ));
+    }
+
+    let mut fallback_categories = candidates
+        .iter()
+        .map(|candidate| candidate.category)
+        .collect::<BTreeSet<_>>();
+    fallback_categories.insert("event_structure");
+    let fallback = match framework {
+        Framework::Pi => {
+            pi_event_delivery::minimum_event(event, reduced_categories.contains("image"))?
+        }
+        Framework::Codex => {
+            codex_event_delivery::minimum_event(event, reduced_categories.contains("image"))?
+        }
+    };
+    let serialized = serde_json::to_vec(&fallback)?;
+    if serialized.len() > max_serialized_event_bytes {
+        return Err(AgentError::Execution(format!(
+            "CLI event delivery minimum is {} bytes, exceeding the {max_serialized_event_bytes}-byte serialized event budget",
+            serialized.len()
+        )));
+    }
+
+    Ok(reduced_event(
+        serialized,
+        event_type,
+        item_type,
+        original_bytes,
+        fallback_categories,
+        true,
+    ))
+}
+
+fn reduced_event(
+    serialized: Vec<u8>,
+    event_type: &'static str,
+    item_type: &'static str,
+    original_bytes: usize,
+    fields: BTreeSet<&'static str>,
+    fallback: bool,
+) -> PreparedEvent {
+    let delivered_bytes = serialized.len();
+    PreparedEvent {
+        serialized,
+        reduction: Some(EventReduction {
+            event_type,
+            item_type,
+            original_bytes,
+            delivered_bytes,
+            fields: fields.into_iter().collect(),
+            fallback,
+        }),
+    }
+}
+
+pub(super) enum ContentPolicy {
+    Preserve,
+    Descend,
+    Text(&'static str),
+    Image(&'static str),
+}
+
+fn collect_content_candidates(
+    event: &Value,
+    framework: Framework,
+) -> Result<Vec<ContentCandidate>, AgentError> {
+    let mut candidates = Vec::new();
+    collect_value(
+        event,
+        framework,
+        event.pointer("/item/type").and_then(Value::as_str),
+        &mut Vec::new(),
+        &mut candidates,
+        &mut 0,
+    )?;
+    Ok(candidates)
+}
+
+fn collect_value(
+    value: &Value,
+    framework: Framework,
+    item_type: Option<&str>,
+    path: &mut Vec<PathSegment>,
+    candidates: &mut Vec<ContentCandidate>,
+    visited: &mut usize,
+) -> Result<(), AgentError> {
+    if candidates.len() >= MAX_REDUCTION_CANDIDATES
+        || *visited >= MAX_VISITED_VALUES
+        || path.len() >= MAX_PATH_DEPTH
+    {
+        return Ok(());
+    }
+    *visited += 1;
+    let policy = match framework {
+        Framework::Pi => pi_event_delivery::content_policy(value, path),
+        Framework::Codex => codex_event_delivery::content_policy(value, path, item_type),
+    };
+    match policy {
+        ContentPolicy::Preserve => return Ok(()),
+        ContentPolicy::Text(category) => {
+            if let Some(text) = value.as_str() {
+                candidates.push(ContentCandidate {
+                    path: path.clone(),
+                    path_key: path_key(path),
+                    category,
+                    image_text_type: None,
+                    reducible_bytes: json_string_bytes(text)
+                        .saturating_sub(json_string_bytes(&truncated_text(text, 0))),
+                });
+            }
+            return Ok(());
+        }
+        ContentPolicy::Image(text_type) => {
+            candidates.push(ContentCandidate {
+                path: path.clone(),
+                path_key: path_key(path),
+                category: "image",
+                image_text_type: Some(text_type),
+                reducible_bytes: serialized_bytes(value)?
+                    .saturating_sub(serialized_bytes(&image_notice(text_type))?),
+            });
+            return Ok(());
+        }
+        ContentPolicy::Descend => {}
+    }
+    match value {
+        Value::Array(values) => {
+            for (index, value) in values.iter().enumerate() {
+                path.push(PathSegment::Index(index));
+                collect_value(value, framework, item_type, path, candidates, visited)?;
+                path.pop();
+                if candidates.len() >= MAX_REDUCTION_CANDIDATES || *visited >= MAX_VISITED_VALUES {
+                    break;
+                }
+            }
+        }
+        Value::Object(fields) => {
+            for (key, value) in fields {
+                if key.len() > MAX_PATH_KEY_BYTES {
+                    continue;
+                }
+                path.push(PathSegment::Key(key.clone()));
+                collect_value(value, framework, item_type, path, candidates, visited)?;
+                path.pop();
+                if candidates.len() >= MAX_REDUCTION_CANDIDATES || *visited >= MAX_VISITED_VALUES {
+                    break;
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+// Count without allocating another image-sized serialization.
+fn serialized_bytes(value: &Value) -> Result<usize, AgentError> {
+    struct Counter(usize);
+    impl std::io::Write for Counter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0 = self.0.saturating_add(bytes.len());
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    let mut counter = Counter(0);
+    serde_json::to_writer(&mut counter, value)?;
+    Ok(counter.0)
+}
+
+pub(super) fn image_notice(text_type: &str) -> Value {
+    serde_json::json!({"type": text_type, "text": "[image omitted for delivery]"})
+}
+
+fn json_string_bytes(value: &str) -> usize {
+    value.chars().fold(2usize, |bytes, character| {
+        bytes
+            + match character {
+                '"' | '\\' | '\u{0008}' | '\t' | '\n' | '\u{000c}' | '\r' => 2,
+                '\u{0000}'..='\u{001f}' => 6,
+                _ => character.len_utf8(),
+            }
+    })
+}
+
+fn apply_retained_budget(
+    event: &mut Value,
+    selected: &[SelectedContent],
+    retained_bytes: usize,
+    total_original_bytes: usize,
+) -> Result<(), AgentError> {
+    let retained_bytes = retained_bytes.min(total_original_bytes);
+    let mut allocations = selected
+        .iter()
+        .map(|content| {
+            ((retained_bytes as u128 * content.original.len() as u128)
+                / total_original_bytes as u128) as usize
+        })
+        .collect::<Vec<_>>();
+    let allocated = allocations.iter().sum::<usize>();
+    let mut remainder = retained_bytes.saturating_sub(allocated);
+    while remainder > 0 {
+        for (allocation, content) in allocations.iter_mut().zip(selected) {
+            if *allocation < content.original.len() {
+                *allocation += 1;
+                remainder -= 1;
+                if remainder == 0 {
+                    break;
+                }
+            }
+        }
+    }
+
+    for (content, allocation) in selected.iter().zip(allocations) {
+        *value_at_path_mut(event, &content.path)? =
+            Value::String(truncated_text(&content.original, allocation));
+    }
+    Ok(())
+}
+
+fn path_key(path: &[PathSegment]) -> String {
+    let mut output = String::new();
+    for segment in path {
+        match segment {
+            PathSegment::Key(key) => {
+                output.push('/');
+                output.push_str(key);
+            }
+            PathSegment::Index(index) => {
+                output.push('/');
+                output.push_str(&index.to_string());
+            }
+        }
+    }
+    output
+}
+
+fn value_at_path_mut<'a>(
+    value: &'a mut Value,
+    path: &[PathSegment],
+) -> Result<&'a mut Value, AgentError> {
+    let mut current = value;
+    for segment in path {
+        current = match segment {
+            PathSegment::Key(key) => current.get_mut(key),
+            PathSegment::Index(index) => current.get_mut(*index),
+        }
+        .ok_or_else(|| AgentError::Execution("event reduction path disappeared".into()))?;
+    }
+    Ok(current)
+}
+
+fn truncated_text(original: &str, retained_bytes: usize) -> String {
+    if retained_bytes >= original.len() {
+        return original.to_string();
+    }
+
+    let head_target = retained_bytes.div_ceil(2);
+    let tail_target = retained_bytes / 2;
+    let head_end = floor_char_boundary(original, head_target);
+    let tail_start = ceil_char_boundary(original, original.len().saturating_sub(tail_target));
+    let preserved = head_end + original.len().saturating_sub(tail_start);
+    let omitted = original.len().saturating_sub(preserved);
+    format!(
+        "{}\n[{omitted} bytes truncated for delivery]\n{}",
+        &original[..head_end],
+        &original[tail_start..]
+    )
+}
+
+fn floor_char_boundary(value: &str, mut index: usize) -> usize {
+    index = index.min(value.len());
+    while !value.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+fn ceil_char_boundary(value: &str, mut index: usize) -> usize {
+    index = index.min(value.len());
+    while !value.is_char_boundary(index) {
+        index += 1;
+    }
+    index
+}

--- a/crates/guest-agent/src/cli/codex_event_delivery.rs
+++ b/crates/guest-agent/src/cli/codex_event_delivery.rs
@@ -1,291 +1,54 @@
-//! Bounded webhook representation for normalized Codex events.
-//!
-//! The app-server backend writes the complete normalized event to the local
-//! agent log before this module sees the webhook copy. Normal events retain
-//! their existing serialization. Only events that cannot fit in one delivery
-//! request receive visibly marked content reduction.
-
-use std::collections::BTreeSet;
-
-use serde_json::{Map, Value, json};
-
+//! Codex content policy for the shared delivery budget engine.
+use super::bounded_event_delivery::{ContentPolicy, DELIVERY_NOTICE, PathSegment};
 use crate::error::AgentError;
+use serde_json::{Value, json};
 
-const DELIVERY_NOTICE: &str = "[event content truncated for delivery]";
-const MAX_REDUCTION_CANDIDATES: usize = 256;
-const MAX_REDUCED_FIELDS: usize = 16;
-const RETAINED_CONTENT_ADJUSTMENT_ATTEMPTS: usize = 4;
-
-pub(super) struct PreparedCodexEvent {
-    pub(super) serialized: Vec<u8>,
-    pub(super) reduction: Option<CodexEventReduction>,
+pub(super) fn labels(event: &Value) -> (&'static str, &'static str) {
+    (event_type_label(event), item_type_label(event))
 }
 
-pub(super) struct CodexEventReduction {
-    pub(super) event_type: &'static str,
-    pub(super) item_type: &'static str,
-    pub(super) original_bytes: usize,
-    pub(super) delivered_bytes: usize,
-    pub(super) fields: Vec<&'static str>,
-    pub(super) fallback: bool,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-enum PathSegment {
-    Key(String),
-    Index(usize),
-}
-
-#[derive(Clone, Debug)]
-struct ContentCandidate {
-    path: Vec<PathSegment>,
-    path_key: String,
-    category: &'static str,
-    reducible_bytes: usize,
-}
-
-struct SelectedContent {
-    path: Vec<PathSegment>,
-    original: String,
-}
-
-pub(super) fn prepare_for_delivery(
-    mut event: Value,
-    max_serialized_event_bytes: usize,
-) -> Result<PreparedCodexEvent, AgentError> {
-    let serialized = serde_json::to_vec(&event)?;
-    if serialized.len() <= max_serialized_event_bytes {
-        return Ok(PreparedCodexEvent {
-            serialized,
-            reduction: None,
-        });
-    }
-
-    let original_bytes = serialized.len();
-    drop(serialized);
-    let event_type = event_type_label(&event);
-    let item_type = item_type_label(&event);
-    let mut candidates = collect_content_candidates(&event);
-    candidates.sort_by(|left, right| {
-        right
-            .reducible_bytes
-            .cmp(&left.reducible_bytes)
-            .then_with(|| left.path_key.cmp(&right.path_key))
-    });
-
-    let mut reduced_categories = BTreeSet::new();
-    let mut selected = Vec::new();
-    let mut reducible_bytes = 0usize;
-    for candidate in candidates.iter().take(MAX_REDUCED_FIELDS) {
-        let Some(original) = string_at_path(&event, &candidate.path).map(str::to_owned) else {
-            continue;
-        };
-        reduced_categories.insert(candidate.category);
-        reducible_bytes = reducible_bytes.saturating_add(candidate.reducible_bytes);
-        selected.push(SelectedContent {
-            path: candidate.path.clone(),
-            original,
-        });
-
-        let minimum_bytes = original_bytes.saturating_sub(reducible_bytes);
-        if minimum_bytes > max_serialized_event_bytes {
-            continue;
-        }
-
-        apply_retained_budget(&mut event, &selected, 0, 1)?;
-        let minimum = serde_json::to_vec(&event)?;
-        if minimum.len() > max_serialized_event_bytes {
-            continue;
-        }
-        let total_original_bytes = selected
-            .iter()
-            .map(|content| content.original.len())
-            .sum::<usize>();
-        let available_bytes = max_serialized_event_bytes - minimum.len();
-        let mut retained_bytes = available_bytes.min(total_original_bytes);
-
-        for _ in 0..RETAINED_CONTENT_ADJUSTMENT_ATTEMPTS {
-            apply_retained_budget(&mut event, &selected, retained_bytes, total_original_bytes)?;
-            let serialized = serde_json::to_vec(&event)?;
-            if serialized.len() <= max_serialized_event_bytes {
-                return Ok(reduced_event(
-                    serialized,
-                    event_type,
-                    item_type,
-                    original_bytes,
-                    reduced_categories,
-                    false,
-                ));
-            }
-
-            let added_bytes = serialized.len().saturating_sub(minimum.len()).max(1);
-            retained_bytes = retained_bytes.saturating_mul(available_bytes) / added_bytes;
-        }
-
-        return Ok(reduced_event(
-            minimum,
-            event_type,
-            item_type,
-            original_bytes,
-            reduced_categories,
-            false,
-        ));
-    }
-
-    let mut fallback_categories = candidates
-        .iter()
-        .map(|candidate| candidate.category)
-        .collect::<BTreeSet<_>>();
-    fallback_categories.insert("event_structure");
-    let fallback = fallback_event(&event)?;
-    let serialized = serde_json::to_vec(&fallback)?;
-    if serialized.len() > max_serialized_event_bytes {
-        return Err(AgentError::Execution(format!(
-            "Codex event delivery fallback is {} bytes, exceeding the {max_serialized_event_bytes}-byte serialized event budget",
-            serialized.len()
-        )));
-    }
-
-    Ok(reduced_event(
-        serialized,
-        event_type,
-        item_type,
-        original_bytes,
-        fallback_categories,
-        true,
-    ))
-}
-
-fn reduced_event(
-    serialized: Vec<u8>,
-    event_type: &'static str,
-    item_type: &'static str,
-    original_bytes: usize,
-    fields: BTreeSet<&'static str>,
-    fallback: bool,
-) -> PreparedCodexEvent {
-    let delivered_bytes = serialized.len();
-    PreparedCodexEvent {
-        serialized,
-        reduction: Some(CodexEventReduction {
-            event_type,
-            item_type,
-            original_bytes,
-            delivered_bytes,
-            fields: fields.into_iter().collect(),
-            fallback,
-        }),
-    }
-}
-
-fn collect_content_candidates(event: &Value) -> Vec<ContentCandidate> {
-    let item_type = event.pointer("/item/type").and_then(Value::as_str);
-    let mut candidates = Vec::new();
-    collect_value(event, item_type, &mut Vec::new(), &mut candidates);
-    candidates
-}
-
-fn collect_value(
+pub(super) fn content_policy(
     value: &Value,
+    path: &[PathSegment],
     item_type: Option<&str>,
-    path: &mut Vec<PathSegment>,
-    candidates: &mut Vec<ContentCandidate>,
-) {
-    if candidates.len() >= MAX_REDUCTION_CANDIDATES {
-        return;
+) -> ContentPolicy {
+    if matches!(path, [PathSegment::Key(item), PathSegment::Key(output), PathSegment::Index(_)] if item == "item" && output == "output")
+        && item_type == Some("function_call_output")
+        && value.get("type").and_then(Value::as_str) == Some("input_image")
+    {
+        return ContentPolicy::Image("input_text");
     }
-
-    match value {
-        Value::String(text) if !protected_string(path) => {
-            candidates.push(ContentCandidate {
-                path: path.clone(),
-                path_key: path_key(path),
-                category: field_category(path, item_type),
-                reducible_bytes: json_string_bytes(text)
-                    .saturating_sub(json_string_bytes(&truncated_text(text, 0))),
-            });
-        }
-        Value::Array(values) => {
-            for (index, value) in values.iter().enumerate() {
-                path.push(PathSegment::Index(index));
-                collect_value(value, item_type, path, candidates);
-                path.pop();
-                if candidates.len() >= MAX_REDUCTION_CANDIDATES {
-                    break;
-                }
-            }
-        }
-        Value::Object(fields) => {
-            for (key, value) in fields {
-                path.push(PathSegment::Key(key.clone()));
-                collect_value(value, item_type, path, candidates);
-                path.pop();
-                if candidates.len() >= MAX_REDUCTION_CANDIDATES {
-                    break;
-                }
-            }
-        }
-        _ => {}
+    if let Some(PathSegment::Key(key)) = path.last()
+        && matches!(
+            key.as_str(),
+            "id" | "type"
+                | "status"
+                | "kind"
+                | "thread_id"
+                | "turn_id"
+                | "name"
+                | "namespace"
+                | "call_id"
+                | "tool"
+                | "server"
+                | "model"
+                | "usage"
+                | "sender_thread_id"
+                | "receiver_thread_ids"
+                | "agents_states"
+                | "error_code"
+                | "codex_error_info"
+                | "http_status_code"
+                | "memoryCitation"
+        )
+    {
+        return ContentPolicy::Preserve;
     }
-}
-
-fn json_string_bytes(value: &str) -> usize {
-    value.chars().fold(2usize, |bytes, character| {
-        bytes
-            + match character {
-                '"' | '\\' | '\u{0008}' | '\t' | '\n' | '\u{000c}' | '\r' => 2,
-                '\u{0000}'..='\u{001f}' => 6,
-                _ => character.len_utf8(),
-            }
-    })
-}
-
-fn apply_retained_budget(
-    event: &mut Value,
-    selected: &[SelectedContent],
-    retained_bytes: usize,
-    total_original_bytes: usize,
-) -> Result<(), AgentError> {
-    let retained_bytes = retained_bytes.min(total_original_bytes);
-    let mut allocations = selected
-        .iter()
-        .map(|content| {
-            ((retained_bytes as u128 * content.original.len() as u128)
-                / total_original_bytes as u128) as usize
-        })
-        .collect::<Vec<_>>();
-    let allocated = allocations.iter().sum::<usize>();
-    let mut remainder = retained_bytes.saturating_sub(allocated);
-    while remainder > 0 {
-        for (allocation, content) in allocations.iter_mut().zip(selected) {
-            if *allocation < content.original.len() {
-                *allocation += 1;
-                remainder -= 1;
-                if remainder == 0 {
-                    break;
-                }
-            }
-        }
+    if value.is_string() {
+        ContentPolicy::Text(field_category(path, item_type))
+    } else {
+        ContentPolicy::Descend
     }
-
-    for (content, allocation) in selected.iter().zip(allocations) {
-        set_string_at_path(
-            event,
-            &content.path,
-            truncated_text(&content.original, allocation),
-        )?;
-    }
-    Ok(())
-}
-
-fn protected_string(path: &[PathSegment]) -> bool {
-    let Some(PathSegment::Key(key)) = path.last() else {
-        return false;
-    };
-    matches!(
-        key.as_str(),
-        "id" | "type" | "status" | "kind" | "thread_id" | "turn_id"
-    )
 }
 
 fn field_category(path: &[PathSegment], item_type: Option<&str>) -> &'static str {
@@ -315,207 +78,82 @@ fn field_category(path: &[PathSegment], item_type: Option<&str>) -> &'static str
     }
 }
 
-fn path_key(path: &[PathSegment]) -> String {
-    let mut output = String::new();
-    for segment in path {
-        match segment {
-            PathSegment::Key(key) => {
-                output.push('/');
-                output.push_str(key);
-            }
-            PathSegment::Index(index) => {
-                output.push('/');
-                output.push_str(&index.to_string());
-            }
+pub(super) fn minimum_event(mut event: Value, omitted_image: bool) -> Result<Value, AgentError> {
+    for path in [
+        "/message",
+        "/error/message",
+        "/turn/error/message",
+        "/item/error/message",
+    ] {
+        if let Some(text) = event.pointer_mut(path).filter(|text| text.is_string()) {
+            *text = json!(DELIVERY_NOTICE);
         }
     }
-    output
-}
-
-fn string_at_path<'a>(value: &'a Value, path: &[PathSegment]) -> Option<&'a str> {
-    let mut current = value;
-    for segment in path {
-        current = match segment {
-            PathSegment::Key(key) => current.get(key)?,
-            PathSegment::Index(index) => current.get(*index)?,
+    let fields = event
+        .as_object_mut()
+        .ok_or_else(|| AgentError::Execution("normalized Codex event is not an object".into()))?;
+    if fields.get("type").and_then(Value::as_str) == Some("turn.plan.updated") {
+        let plan = fields
+            .get("plan")
+            .and_then(Value::as_array)
+            .ok_or_else(|| AgentError::Execution("Codex delivery plan is not an array".into()))?;
+        let status = if plan
+            .iter()
+            .all(|step| step.get("status").and_then(Value::as_str) == Some("completed"))
+        {
+            "completed"
+        } else if plan
+            .iter()
+            .any(|step| step.get("status").and_then(Value::as_str) == Some("in_progress"))
+        {
+            "in_progress"
+        } else {
+            "pending"
         };
-    }
-    current.as_str()
-}
-
-fn set_string_at_path(
-    value: &mut Value,
-    path: &[PathSegment],
-    replacement: String,
-) -> Result<(), AgentError> {
-    let mut current = value;
-    for segment in path {
-        current = match segment {
-            PathSegment::Key(key) => current.get_mut(key),
-            PathSegment::Index(index) => current.get_mut(*index),
-        }
-        .ok_or_else(|| {
-            AgentError::Execution("Codex event reduction path disappeared".to_string())
-        })?;
-    }
-    *current = Value::String(replacement);
-    Ok(())
-}
-
-fn truncated_text(original: &str, retained_bytes: usize) -> String {
-    if retained_bytes >= original.len() {
-        return original.to_string();
-    }
-
-    let head_target = retained_bytes.div_ceil(2);
-    let tail_target = retained_bytes / 2;
-    let head_end = floor_char_boundary(original, head_target);
-    let tail_start = ceil_char_boundary(original, original.len().saturating_sub(tail_target));
-    let preserved = head_end + original.len().saturating_sub(tail_start);
-    let omitted = original.len().saturating_sub(preserved);
-    format!(
-        "{}\n[{omitted} bytes truncated for delivery]\n{}",
-        &original[..head_end],
-        &original[tail_start..]
-    )
-}
-
-fn floor_char_boundary(value: &str, mut index: usize) -> usize {
-    index = index.min(value.len());
-    while !value.is_char_boundary(index) {
-        index -= 1;
-    }
-    index
-}
-
-fn ceil_char_boundary(value: &str, mut index: usize) -> usize {
-    index = index.min(value.len());
-    while !value.is_char_boundary(index) {
-        index += 1;
-    }
-    index
-}
-
-fn fallback_event(source: &Value) -> Result<Value, AgentError> {
-    let source = source.as_object().ok_or_else(|| {
-        AgentError::Execution("normalized Codex event is not an object".to_string())
-    })?;
-    let mut output = Map::new();
-    copy_fields(
-        source,
-        &mut output,
-        &[
-            "type",
-            "thread_id",
-            "turn_id",
-            "sequenceNumber",
-            "started_at_ms",
-            "completed_at_ms",
-            "will_retry",
-        ],
-    );
-
-    if let Some(turn) = source.get("turn").and_then(Value::as_object) {
-        let mut retained_turn = Map::new();
-        copy_fields(
-            turn,
-            &mut retained_turn,
-            &[
-                "id",
-                "type",
-                "status",
-                "started_at",
-                "completed_at",
-                "duration_ms",
-            ],
+        fields.insert(
+            "plan".into(),
+            json!([{"step": DELIVERY_NOTICE, "status": status}]),
         );
-        if turn.get("error").is_some_and(|error| !error.is_null()) {
-            retained_turn.insert("error".to_string(), fallback_error());
-        }
-        output.insert("turn".to_string(), Value::Object(retained_turn));
+        fields.insert("explanation".into(), json!(DELIVERY_NOTICE));
     }
-
-    if let Some(item) = source.get("item").and_then(Value::as_object) {
-        output.insert("item".to_string(), fallback_item(item));
-    }
-
-    match source.get("type").and_then(Value::as_str) {
-        Some("turn.plan.updated") => {
-            output.insert(
-                "plan".to_string(),
-                json!([{ "step": DELIVERY_NOTICE, "status": "pending" }]),
-            );
-            output.insert(
-                "explanation".to_string(),
-                Value::String(DELIVERY_NOTICE.to_string()),
-            );
-        }
-        Some("warning" | "error") => {
-            output.insert(
-                "message".to_string(),
-                Value::String(DELIVERY_NOTICE.to_string()),
-            );
-            if source.contains_key("error") {
-                output.insert("error".to_string(), fallback_error());
+    if let Some(item) = fields.get_mut("item").and_then(Value::as_object_mut) {
+        match item.get("type").and_then(Value::as_str) {
+            Some("agent_message" | "reasoning" | "plan") => {
+                item.insert("text".into(), json!(DELIVERY_NOTICE));
             }
-        }
-        _ => {}
-    }
-
-    Ok(Value::Object(output))
-}
-
-fn fallback_item(item: &Map<String, Value>) -> Value {
-    let mut output = Map::new();
-    copy_fields(
-        item,
-        &mut output,
-        &["id", "type", "status", "exit_code", "duration_ms"],
-    );
-    if item.get("error").is_some_and(|error| !error.is_null()) {
-        output.insert("error".to_string(), fallback_error());
-    }
-    match item.get("type").and_then(Value::as_str) {
-        Some("agent_message" | "reasoning" | "plan") => {
-            output.insert(
-                "text".to_string(),
-                Value::String(DELIVERY_NOTICE.to_string()),
-            );
-        }
-        Some("command_execution") => {
-            output.insert(
-                "command".to_string(),
-                Value::String(DELIVERY_NOTICE.to_string()),
-            );
-            output.insert(
-                "aggregated_output".to_string(),
-                Value::String(DELIVERY_NOTICE.to_string()),
-            );
-        }
-        Some("file_change") => {
-            output.insert(
-                "changes".to_string(),
-                json!([{
-                    "path": DELIVERY_NOTICE,
-                    "diff": DELIVERY_NOTICE,
-                }]),
-            );
-        }
-        _ => {}
-    }
-    Value::Object(output)
-}
-
-fn fallback_error() -> Value {
-    json!({ "message": DELIVERY_NOTICE })
-}
-
-fn copy_fields(source: &Map<String, Value>, output: &mut Map<String, Value>, fields: &[&str]) {
-    for field in fields {
-        if let Some(value) = source.get(*field) {
-            output.insert((*field).to_string(), value.clone());
+            Some("command_execution") => {
+                item.insert("command".into(), json!(DELIVERY_NOTICE));
+                item.insert("aggregated_output".into(), json!(DELIVERY_NOTICE));
+            }
+            Some("function_call_output") => {
+                let output = if let Some(output) = item.get("output").and_then(Value::as_array) {
+                    let images = output.iter().any(|block| {
+                        block.get("type").and_then(Value::as_str) == Some("input_image")
+                    });
+                    let mut blocks = vec![json!({"type": "input_text", "text": DELIVERY_NOTICE})];
+                    if omitted_image || images {
+                        blocks.push(super::bounded_event_delivery::image_notice("input_text"));
+                    }
+                    Value::Array(blocks)
+                } else {
+                    json!(DELIVERY_NOTICE)
+                };
+                item.insert("output".into(), output);
+            }
+            Some("file_change") => {
+                // Each canonical file-change event already has one change.
+                if let Some(changes) = item.get_mut("changes").and_then(Value::as_array_mut) {
+                    for change in changes {
+                        if let Some(change) = change.as_object_mut() {
+                            change.insert("diff".into(), json!(DELIVERY_NOTICE));
+                        }
+                    }
+                }
+            }
+            _ => {}
         }
     }
+    Ok(event)
 }
 
 fn event_type_label(event: &Value) -> &'static str {
@@ -539,6 +177,7 @@ fn item_type_label(event: &Value) -> &'static str {
         Some("reasoning") => "reasoning",
         Some("command_execution") => "command_execution",
         Some("file_change") => "file_change",
+        Some("function_call_output") => "function_call_output",
         Some(_) => "other",
         None => "none",
     }

--- a/crates/guest-agent/src/cli/event_delivery.rs
+++ b/crates/guest-agent/src/cli/event_delivery.rs
@@ -63,16 +63,48 @@ impl EventDeliverySender {
         self.try_send_prepared(sequence, serialized_event, private_citation)
     }
 
-    pub(super) fn max_serialized_event_bytes(&self) -> usize {
-        EVENT_DELIVERY_MAX_REQUEST_BYTES.saturating_sub(self.payload_envelope.singleton_bytes(0, 0))
-    }
-
-    pub(super) fn try_send_serialized(
+    pub(super) fn try_send_for_framework(
         &self,
         sequence: u32,
-        serialized_event: Vec<u8>,
+        mut event: serde_json::Value,
+        framework: crate::env::Framework,
     ) -> Result<(), AgentError> {
-        self.try_send_prepared(sequence, serialized_event, None)
+        let framework = match framework {
+            crate::env::Framework::ClaudeCode => return self.try_send(sequence, event),
+            crate::env::Framework::Pi => super::bounded_event_delivery::Framework::Pi,
+            crate::env::Framework::Codex => super::bounded_event_delivery::Framework::Codex,
+        };
+        let private_citation = self
+            .payload_envelope
+            .take_private_citation(sequence, &mut event)?;
+        let envelope_bytes = self
+            .payload_envelope
+            .singleton_bytes(0, private_citation.as_ref().map_or(0, Bytes::len));
+        let budget = EVENT_DELIVERY_MAX_REQUEST_BYTES.saturating_sub(envelope_bytes);
+        let prepared =
+            super::bounded_event_delivery::prepare_for_delivery(event, budget, framework)?;
+        self.try_send_prepared(sequence, prepared.serialized, private_citation)?;
+        if let Some(reduction) = prepared.reduction {
+            let framework = match framework {
+                super::bounded_event_delivery::Framework::Pi => "Pi",
+                super::bounded_event_delivery::Framework::Codex => "Codex",
+            };
+            log_info!(
+                LOG_TAG,
+                "{} event reduced for delivery: seq={} event_type={} item_type={} original_event_bytes={} delivered_event_bytes={} original_request_bytes={} delivered_request_bytes={} fields={} fallback={}",
+                framework,
+                sequence,
+                reduction.event_type,
+                reduction.item_type,
+                reduction.original_bytes,
+                reduction.delivered_bytes,
+                envelope_bytes.saturating_add(reduction.original_bytes),
+                envelope_bytes.saturating_add(reduction.delivered_bytes),
+                reduction.fields.join(","),
+                reduction.fallback,
+            );
+        }
+        Ok(())
     }
 
     fn try_send_prepared(

--- a/crates/guest-agent/src/cli/event_delivery_budget_tests.rs
+++ b/crates/guest-agent/src/cli/event_delivery_budget_tests.rs
@@ -1,0 +1,196 @@
+//! Exercise exact final requests and failure controls through the real sender.
+use super::event_delivery::*;
+use crate::env::Framework;
+use crate::events;
+use crate::http::HttpClient;
+use crate::masker::SecretMasker;
+use httpmock::prelude::*;
+use serde_json::{Value, json};
+use std::time::Duration;
+
+const LIMIT: usize = 4 * 1024 * 1024;
+const RUN_ID: &str = "delivery-\"\\-你好";
+
+fn body(event: &Value, transport: bool) -> Result<String, String> {
+    let mut public = event.clone();
+    let citation = public
+        .as_object_mut()
+        .ok_or("event is not an object")?
+        .remove("memoryCitation");
+    let suffix = if transport {
+        let citations = citation
+            .map(|citation| json!({"sequenceNumber":19,"citation":citation}))
+            .into_iter()
+            .collect::<Vec<_>>();
+        format!(
+            ",\"piMemoryCitationTransport\":{{\"schemaVersion\":1,\"citations\":{}}}",
+            json!(citations)
+        )
+    } else {
+        public = event.clone();
+        String::new()
+    };
+    Ok(format!(
+        "{{\"runId\":{},\"events\":[{}]{suffix}}}",
+        json!(RUN_ID),
+        public
+    ))
+}
+
+fn text_event(framework: Framework, text: &str) -> Value {
+    let mut event = match framework {
+        Framework::Pi => {
+            json!({"type":"assistant","message":{"id":"message","role":"assistant","model":"test","usage":{"input_tokens":2},"content":[{"type":"text","text":text}]}})
+        }
+        _ => {
+            json!({"type":"item.completed","thread_id":"thread","turn_id":"turn","item":{"id":"item","type":"agent_message","text":text}})
+        }
+    };
+    if let Some(event) = event.as_object_mut() {
+        event.insert("memoryCitation".into(), json!({"entries":[{"path":"memory.md","lineStart":1,"lineEnd":2,"note":"citation-你好\"\\\n"}],"rolloutIds":[]}));
+    }
+    events::prepare_event_for_delivery(event, 19, &SecretMasker::from_raw(""))
+}
+
+#[tokio::test]
+async fn sender_preserves_normal_bytes_and_accounts_for_exact_citation_envelopes() {
+    for framework in [Framework::Pi, Framework::Codex] {
+        for transport in [false, true] {
+            for overflow in [None, Some(0), Some(1)] {
+                let empty = text_event(framework, "");
+                let retained = overflow.map_or(5, |extra| {
+                    LIMIT - body(&empty, transport).unwrap().len() + extra
+                });
+                let event = text_event(framework, &"x".repeat(retained));
+                let expected = body(&event, transport).unwrap();
+                if let Some(extra) = overflow {
+                    assert_eq!(expected.len(), LIMIT + extra);
+                }
+                let expected_json: Value = serde_json::from_str(&expected).unwrap();
+                let server = MockServer::start_async().await;
+                let request = server.mock(|when, then| {
+                    when.method(POST)
+                        .path("/api/webhooks/agent/events")
+                        .is_true(move |request| {
+                            if overflow != Some(1) {
+                                return request.body_ref() == expected.as_bytes();
+                            }
+                            let payload: Value =
+                                serde_json::from_slice(request.body_ref()).unwrap();
+                            request.body_ref().len() <= LIMIT
+                                && request
+                                    .body_string()
+                                    .contains("bytes truncated for delivery")
+                                && payload["piMemoryCitationTransport"]
+                                    == expected_json["piMemoryCitationTransport"]
+                                && payload["events"][0]["memoryCitation"]
+                                    == expected_json["events"][0]["memoryCitation"]
+                                && payload["events"][0]["sequenceNumber"] == 19
+                        });
+                    then.status(200);
+                });
+                let http = HttpClient::with_api_config(
+                    server.base_url(),
+                    "test-token",
+                    "",
+                    "test-session",
+                    Duration::ZERO,
+                )
+                .unwrap();
+                let runtime = EventDeliveryRuntime::start(http, RUN_ID, 19, transport).unwrap();
+                runtime
+                    .sender()
+                    .try_send_for_framework(19, event, framework)
+                    .unwrap();
+                let report = runtime.finish().await.unwrap();
+                assert_eq!(report.last_acknowledged_sequence, Some(19));
+                assert!(report.diagnostic.is_none());
+                request.assert_calls_async(1).await;
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn impossible_citation_and_protected_core_fail_before_http() {
+    let server = MockServer::start_async().await;
+    let request = server.mock(|when, then| {
+        when.method(POST);
+        then.status(200);
+    });
+    for (framework, mut event) in [
+        (Framework::Pi, text_event(Framework::Pi, "text")),
+        (Framework::Pi, text_event(Framework::Pi, "text")),
+        (Framework::Codex, text_event(Framework::Codex, "text")),
+    ]
+    .into_iter()
+    .enumerate()
+    .map(|(i, (framework, mut event))| {
+        match i {
+            0 => event["memoryCitation"]["entries"][0]["note"] = json!("x".repeat(LIMIT)),
+            1 => event["message"]["id"] = json!("x".repeat(LIMIT)),
+            _ => event["item"]["id"] = json!("x".repeat(LIMIT)),
+        }
+        (framework, event)
+    }) {
+        let http = HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-session",
+            Duration::ZERO,
+        )
+        .unwrap();
+        let runtime = EventDeliveryRuntime::start(http, RUN_ID, 19, true).unwrap();
+        let error = runtime
+            .sender()
+            .try_send_for_framework(19, event.take(), framework)
+            .unwrap_err();
+        assert!(error.to_string().contains("serialized event budget"));
+        assert!(runtime.finish().await.unwrap().last_acknowledged_sequence == Some(18));
+    }
+    request.assert_calls_async(0).await;
+}
+
+#[tokio::test]
+async fn reduced_http_failure_still_breaks_acknowledgement_and_retries_identical_bytes() {
+    let server = MockServer::start_async().await;
+    let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::<Vec<u8>>::new()));
+    let captured = seen.clone();
+    let request = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .is_true(move |request| {
+                captured.lock().unwrap().push(request.body_vec());
+                request.body_ref().len() <= LIMIT
+                    && request
+                        .body_string()
+                        .contains("bytes truncated for delivery")
+            });
+        then.status(500);
+    });
+    let http = HttpClient::with_api_config(
+        server.base_url(),
+        "test-token",
+        "",
+        "test-session",
+        Duration::ZERO,
+    )
+    .unwrap();
+    let runtime = EventDeliveryRuntime::start(http, RUN_ID, 19, true).unwrap();
+    runtime
+        .sender()
+        .try_send_for_framework(
+            19,
+            text_event(Framework::Pi, &"x".repeat(LIMIT)),
+            Framework::Pi,
+        )
+        .unwrap();
+    let report = runtime.finish().await.unwrap();
+    assert_eq!(report.last_acknowledged_sequence, Some(18));
+    assert!(report.diagnostic.is_some());
+    assert!(request.calls_async().await > 1);
+    let requests = seen.lock().unwrap();
+    assert!(requests.len() > 1);
+    assert!(requests.iter().all(|body| body == &requests[0]));
+}

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -19,6 +19,7 @@
 //! lifecycle. Each path retains ownership of its process, event delivery,
 //! heartbeat races, and child reaping until completion.
 
+mod bounded_event_delivery;
 mod child_env;
 mod child_exit_notifier;
 mod claude;
@@ -35,9 +36,12 @@ mod codex_startup;
 mod command;
 mod diagnostics;
 mod event_delivery;
+#[cfg(test)]
+mod event_delivery_budget_tests;
 mod exec_boundary;
 mod jsonl_result;
 mod line_reader;
+mod pi_event_delivery;
 mod pi_memory_citation;
 mod pi_rpc;
 mod process_group;
@@ -811,28 +815,7 @@ impl<'a> CliEventIngestor<'a> {
             })?;
             if should_send_events {
                 let event = events::prepare_event_for_delivery(event, sequence, masker);
-                if self.framework == env::Framework::Codex {
-                    let prepared = codex_event_delivery::prepare_for_delivery(
-                        event,
-                        event_tx.max_serialized_event_bytes(),
-                    )?;
-                    if let Some(reduction) = prepared.reduction {
-                        log_warn!(
-                            LOG_TAG,
-                            "Codex event reduced for delivery: seq={} event_type={} item_type={} original_bytes={} delivered_bytes={} fields={} fallback={}",
-                            sequence,
-                            reduction.event_type,
-                            reduction.item_type,
-                            reduction.original_bytes,
-                            reduction.delivered_bytes,
-                            reduction.fields.join(","),
-                            reduction.fallback
-                        );
-                    }
-                    event_tx.try_send_serialized(sequence, prepared.serialized)?;
-                } else {
-                    event_tx.try_send(sequence, event)?;
-                }
+                event_tx.try_send_for_framework(sequence, event, self.framework)?;
             }
         }
         Ok(())

--- a/crates/guest-agent/src/cli/pi_event_delivery.rs
+++ b/crates/guest-agent/src/cli/pi_event_delivery.rs
@@ -1,0 +1,136 @@
+//! Pi's projected message shapes remain intact when only delivery content shrinks.
+
+use serde_json::{Value, json};
+
+use super::bounded_event_delivery::{ContentPolicy, DELIVERY_NOTICE, PathSegment};
+use crate::error::AgentError;
+
+pub(super) fn labels(event: &Value) -> (&'static str, &'static str) {
+    let event_type = match event.get("type").and_then(Value::as_str) {
+        Some("assistant") => "assistant",
+        Some("user") => "user",
+        Some("result") => "result",
+        Some("system") => "system",
+        _ => "other",
+    };
+    let content_type = match event
+        .pointer("/message/content/0/type")
+        .and_then(Value::as_str)
+    {
+        Some("text") => "text",
+        Some("tool_use") => "tool_use",
+        Some("tool_result") => "tool_result",
+        _ => "none",
+    };
+    (event_type, content_type)
+}
+
+pub(super) fn content_policy(value: &Value, path: &[PathSegment]) -> ContentPolicy {
+    use PathSegment::{Index, Key};
+    match path {
+        [] => ContentPolicy::Descend,
+        [Key(message)] if message == "message" => ContentPolicy::Descend,
+        [Key(result)] if result == "result" => ContentPolicy::Text("result_text"),
+        [Key(message), Key(content)] if message == "message" && content == "content" => {
+            ContentPolicy::Descend
+        }
+        [Key(message), Key(content), Index(_)] if message == "message" && content == "content" => {
+            ContentPolicy::Descend
+        }
+        [Key(message), Key(content), Index(_), Key(field), rest @ ..]
+            if message == "message" && content == "content" =>
+        {
+            match field.as_str() {
+                "text" if rest.is_empty() => ContentPolicy::Text("message_text"),
+                "input" => {
+                    if value.is_string() {
+                        ContentPolicy::Text("tool_input")
+                    } else {
+                        ContentPolicy::Descend
+                    }
+                }
+                "content" => {
+                    if value.get("type").and_then(Value::as_str) == Some("image") {
+                        ContentPolicy::Image("text")
+                    } else if value.is_string()
+                        && matches!(rest.last(), Some(Key(key)) if key == "text")
+                    {
+                        ContentPolicy::Text("tool_output")
+                    } else if value.is_array() || value.is_object() {
+                        ContentPolicy::Descend
+                    } else {
+                        ContentPolicy::Preserve
+                    }
+                }
+                _ => ContentPolicy::Preserve,
+            }
+        }
+        _ => ContentPolicy::Preserve,
+    }
+}
+
+pub(super) fn minimum_event(mut event: Value, omitted_image: bool) -> Result<Value, AgentError> {
+    let fields = event
+        .as_object_mut()
+        .ok_or_else(|| AgentError::Execution("normalized Pi event is not an object".into()))?;
+    match fields.get("type").and_then(Value::as_str) {
+        Some("assistant" | "user") => {
+            let blocks = fields
+                .get_mut("message")
+                .and_then(|message| message.get_mut("content"))
+                .and_then(Value::as_array_mut)
+                .ok_or_else(|| {
+                    AgentError::Execution("Pi delivery minimum requires message content".into())
+                })?;
+            // Normalization owns expansion before sequence allocation; never split here.
+            let [block] = blocks.as_mut_slice() else {
+                return Err(AgentError::Execution(
+                    "Pi delivery minimum requires one canonical content block".into(),
+                ));
+            };
+            let block = block.as_object_mut().ok_or_else(|| {
+                AgentError::Execution("Pi delivery content is not an object".into())
+            })?;
+            match block.get("type").and_then(Value::as_str) {
+                Some("text") => {
+                    block.insert("text".into(), json!(DELIVERY_NOTICE));
+                }
+                Some("tool_use") if block.get("input").is_some_and(Value::is_object) => {
+                    block.insert("input".into(), json!({"_delivery_notice": DELIVERY_NOTICE}));
+                }
+                Some("tool_result") => {
+                    let images =
+                        block
+                            .get("content")
+                            .and_then(Value::as_array)
+                            .is_some_and(|blocks| {
+                                blocks.iter().any(|block| {
+                                    block.get("type").and_then(Value::as_str) == Some("image")
+                                })
+                            });
+                    let mut content = vec![json!({"type": "text", "text": DELIVERY_NOTICE})];
+                    if omitted_image || images {
+                        content.push(super::bounded_event_delivery::image_notice("text"));
+                    }
+                    block.insert("content".into(), Value::Array(content));
+                }
+                _ => {
+                    return Err(AgentError::Execution(
+                        "unsupported Pi delivery minimum content".into(),
+                    ));
+                }
+            }
+        }
+        Some("result") => {
+            fields.insert("result".into(), json!(DELIVERY_NOTICE));
+        }
+        _ => {
+            return Err(AgentError::Execution(
+                "unsupported Pi delivery minimum event".into(),
+            ));
+        }
+    }
+    // All outer fields, tool identities, usage, outcomes and unknown data remain.
+    // The final admission guard rejects any irreducibly oversized protected core.
+    Ok(event)
+}

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -165,16 +165,18 @@ impl EventPayloadEnvelope {
         event_bytes: usize,
         private_citation_bytes: usize,
     ) -> usize {
-        self.prefix.len()
-            + event_bytes
-            + EVENT_PAYLOAD_EVENTS_SUFFIX.len()
-            + if self.pi_memory_citation_transport {
-                PI_MEMORY_CITATION_TRANSPORT_PREFIX.len()
-                    + private_citation_bytes
-                    + PI_MEMORY_CITATION_TRANSPORT_SUFFIX.len()
+        self.prefix
+            .len()
+            .saturating_add(event_bytes)
+            .saturating_add(EVENT_PAYLOAD_EVENTS_SUFFIX.len())
+            .saturating_add(if self.pi_memory_citation_transport {
+                PI_MEMORY_CITATION_TRANSPORT_PREFIX
+                    .len()
+                    .saturating_add(private_citation_bytes)
+                    .saturating_add(PI_MEMORY_CITATION_TRANSPORT_SUFFIX.len())
             } else {
                 EVENT_PAYLOAD_PUBLIC_SUFFIX.len()
-            }
+            })
     }
 
     pub(crate) fn payload(&self, events: &[Bytes], private_citations: &[Bytes]) -> Bytes {

--- a/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
@@ -2,8 +2,7 @@
 //! representation without changing the complete local normalized event.
 
 mod common;
-#[path = "common/delivery_image.rs"]
-mod delivery_image;
+use common::delivery_image;
 
 use base64::Engine as _;
 use guest_agent::masker::SecretMasker;

--- a/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
@@ -2,6 +2,8 @@
 //! representation without changing the complete local normalized event.
 
 mod common;
+#[path = "common/delivery_image.rs"]
+mod delivery_image;
 
 use base64::Engine as _;
 use guest_agent::masker::SecretMasker;
@@ -46,6 +48,32 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
         RUN_ID,
         Duration::ZERO,
     )?;
+    let small_image = format!(
+        "data:image/png;base64,{}",
+        delivery_image::png_base64(1, 1)?
+    );
+    let half_image = format!(
+        "data:image/png;base64,{}",
+        delivery_image::png_base64(1024, 512)?
+    );
+    let large_image = format!(
+        "data:image/png;base64,{}",
+        delivery_image::png_base64(1024, 1024)?
+    );
+    let image = |url: &str| serde_json::json!({"type":"input_image","image_url":url});
+    let image_items = serde_json::json!([
+        {"type":"functionCallOutput","id":"small-image","name":"read","output":[image(&small_image)]},
+        {"type":"functionCallOutput","id":"large-image","name":"read","namespace":"tools","output":[image(&large_image)]},
+        {"type":"functionCallOutput","id":"aggregate-images","name":"read","output":[image(&half_image),image(&half_image),image(&small_image)]},
+        {"type":"functionCallOutput","id":"structure-output","name":"read","namespace":"tools","output":std::iter::once(image(&half_image)).chain(std::iter::repeat_n(serde_json::json!({"type":"input_text","text":"bounded-content"}),100_000)).collect::<Vec<_>>()},
+        {"type":"commandExecution","id":"failed-command","command":"false","status":"failed","exitCode":7,"durationMs":42,"aggregatedOutput":format!("failed-output-head-{}-failed-output-tail", "x".repeat(MAX_REQUEST_BYTES))}
+    ]);
+    let items_path = tmp.path().join("delivery-items.json");
+    std::fs::write(&items_path, serde_json::to_vec(&image_items)?)?;
+    runtime.config.user_env.insert(
+        "MOCK_CODEX_DELIVERY_ITEMS_PATH".into(),
+        items_path.to_string_lossy().into_owned(),
+    );
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
     let _system_log = common::SystemLogOverrideGuard::set(runtime.paths.system_log_file());
     let encoded_secret = base64::engine::general_purpose::STANDARD.encode(SECRET);
@@ -60,7 +88,7 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
 
     assert_eq!(result.exit_code, common::CLEAN_EXIT);
     assert!(result.control_error.is_none());
-    assert_eq!(result.last_event_sequence, Some(11));
+    assert_eq!(result.last_event_sequence, Some(16));
 
     server
         .wait_for_quiet(Duration::from_millis(50), Duration::from_secs(5))
@@ -90,13 +118,13 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
                 .unwrap_or_default()
         })
         .collect::<Vec<_>>();
-    assert_eq!(delivered.len(), 12);
+    assert_eq!(delivered.len(), 17);
     assert_eq!(
         delivered
             .iter()
             .map(|event| event["sequenceNumber"].as_u64())
             .collect::<Vec<_>>(),
-        (0..12).map(Some).collect::<Vec<_>>()
+        (0..17).map(Some).collect::<Vec<_>>()
     );
 
     for item_id in [
@@ -226,6 +254,57 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
         .ok_or("normal warning was not delivered")?;
     assert_eq!(warning["message"], "codex-mock warning 999");
 
+    let failed = delivered_item(&delivered, "failed-command")?;
+    assert_eq!(failed["item"]["status"], "failed");
+    assert_eq!(failed["item"]["exit_code"], 7);
+    assert_eq!(failed["item"]["duration_ms"], 42);
+    assert_eq!(failed["item"]["command"], "false");
+    assert!(
+        failed["item"]["aggregated_output"]
+            .as_str()
+            .is_some_and(|text| text.starts_with("failed-output-head-")
+                && text.ends_with("-failed-output-tail")
+                && text.contains(DELIVERY_MARKER))
+    );
+
+    let small = delivered_item(&delivered, "small-image")?;
+    assert_eq!(
+        small["item"]["output"],
+        serde_json::json!([image(&small_image)])
+    );
+    let large = delivered_item(&delivered, "large-image")?;
+    assert_eq!(large["item"]["name"], "read");
+    assert_eq!(large["item"]["namespace"], "tools");
+    assert_eq!(
+        large["item"]["output"],
+        serde_json::json!([{"type":"input_text","text":"[image omitted for delivery]"}])
+    );
+    let aggregate = delivered_item(&delivered, "aggregate-images")?;
+    assert_eq!(
+        aggregate["item"]["output"],
+        serde_json::json!([
+            {"type":"input_text","text":"[image omitted for delivery]"},image(&half_image),image(&small_image)
+        ])
+    );
+    let structure = delivered_item(&delivered, "structure-output")?;
+    assert_eq!(structure["item"]["name"], "read");
+    assert_eq!(structure["item"]["namespace"], "tools");
+    assert_eq!(
+        structure["item"]["output"],
+        serde_json::json!([{"type":"input_text","text":FALLBACK_MARKER},{"type":"input_text","text":"[image omitted for delivery]"}])
+    );
+    assert_eq!(
+        std::fs::read(&items_path)?,
+        serde_json::to_vec(&image_items)?
+    );
+    let history = common::read_codex_session_history_events_for_runtime(&runtime)?;
+    let inputs = history
+        .iter()
+        .filter(|event| event["type"] == "mock.app_server.input")
+        .collect::<Vec<_>>();
+    assert_eq!(inputs.len(), 1);
+    assert_eq!(inputs[0]["text"], runtime.config.prompt);
+    assert!(!serde_json::to_string(&history)?.contains("for delivery"));
     let local_events = read_jsonl(runtime.paths.agent_log_file())?;
     let local_agent = delivered_item(&local_events, "oversized-agent-message")?;
     let local_text = local_agent["item"]["text"]
@@ -257,12 +336,22 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
             }))
     );
 
+    assert_eq!(
+        delivered_item(&local_events, "large-image")?["item"]["output"],
+        serde_json::json!([image(&large_image)])
+    );
     let system_log = std::fs::read_to_string(runtime.paths.system_log_file())?;
     assert_eq!(
         system_log
             .matches("Codex event reduced for delivery")
             .count(),
-        8
+        12
+    );
+    assert!(
+        system_log
+            .lines()
+            .filter(|line| line.contains("Codex event reduced for delivery"))
+            .all(|line| line.contains("[INFO]"))
     );
     assert!(system_log.contains("event_type=turn.plan.updated"));
     assert!(system_log.contains("fallback=true"));

--- a/crates/guest-agent/tests/common/delivery_image.rs
+++ b/crates/guest-agent/tests/common/delivery_image.rs
@@ -1,0 +1,31 @@
+//! Valid RGB PNGs with uncompressed pixel data exercise Base64 transport size.
+use base64::Engine as _;
+use std::io::Write;
+
+pub fn png_base64(width: u32, height: u32) -> std::io::Result<String> {
+    fn chunk(png: &mut Vec<u8>, kind: &[u8; 4], data: &[u8]) {
+        png.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        png.extend_from_slice(kind);
+        png.extend_from_slice(data);
+        let mut crc = flate2::Crc::new();
+        crc.update(kind);
+        crc.update(data);
+        png.extend_from_slice(&crc.sum().to_be_bytes());
+    }
+    let mut png = b"\x89PNG\r\n\x1a\n".to_vec();
+    let mut header = Vec::new();
+    header.extend_from_slice(&width.to_be_bytes());
+    header.extend_from_slice(&height.to_be_bytes());
+    header.extend_from_slice(&[8, 2, 0, 0, 0]);
+    chunk(&mut png, b"IHDR", &header);
+    let mut pixels = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::none());
+    for row in 0..height {
+        pixels.write_all(&[0])?;
+        for column in 0..width {
+            pixels.write_all(&[(row % 256) as u8, (column % 256) as u8, 128])?;
+        }
+    }
+    chunk(&mut png, b"IDAT", &pixels.finish()?);
+    chunk(&mut png, b"IEND", &[]);
+    Ok(base64::engine::general_purpose::STANDARD.encode(png))
+}

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -17,6 +17,7 @@
 
 #![allow(dead_code)] // consumed across multiple test binaries
 
+pub(crate) mod delivery_image;
 pub(crate) mod process_session;
 mod system_log;
 

--- a/crates/guest-agent/tests/fixtures/pi_rpc_delivery.py
+++ b/crates/guest-agent/tests/fixtures/pi_rpc_delivery.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python3
+"""Official RPC peer paced by captured webhook responses, not elapsed time."""
+import json
+import os
+import socket
+import sys
+
+
+def emit(record):
+    print(json.dumps(record, ensure_ascii=False, separators=(",", ":")), flush=True)
+
+
+def command(expected):
+    line = sys.stdin.readline()
+    with open(os.environ["PI_COMMANDS_PATH"], "a", encoding="utf-8") as output:
+        output.write(line)
+    record = json.loads(line)
+    assert record["type"] == expected
+    return record
+
+
+emit({"type": "vm0_pi_api_first_turn_boundary", "schemaVersion": 2,
+      "sandboxEventSequenceStart": 1, "ownershipTransferMode": "pending-tool-continuation"})
+state = command("get_state")
+emit({"id": state["id"], "type": "response", "command": "get_state", "success": True,
+      "data": {"sessionId": os.environ["PI_SESSION_ID"], "sessionFile": os.environ["PI_SESSION_PATH"]}})
+prompt = command("prompt")
+emit({"id": prompt["id"], "type": "response", "command": "prompt", "success": True})
+with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as gate:
+    gate.connect(os.environ["PI_DELIVERY_GATE"])
+    with open(os.environ["PI_EVENTS_PATH"], encoding="utf-8") as source:
+        for line in source:
+            print(line, end="", flush=True)
+            assert gate.recv(1) == b"x"
+emit({"type": "agent_settled"})
+assert sys.stdin.readline() == ""

--- a/crates/guest-agent/tests/pi_cli_oversized_event_delivery.rs
+++ b/crates/guest-agent/tests/pi_cli_oversized_event_delivery.rs
@@ -1,8 +1,7 @@
 //! Real RPC stdout -> projection -> canonical sequencing/masking -> private
 //! citation -> bounded sender/HTTP. The fixture's official session is immutable.
 mod common;
-#[path = "common/delivery_image.rs"]
-mod delivery_image;
+use common::delivery_image;
 
 use base64::Engine as _;
 use guest_agent::env::{GuestConfig, GuestConfigRaw};

--- a/crates/guest-agent/tests/pi_cli_oversized_event_delivery.rs
+++ b/crates/guest-agent/tests/pi_cli_oversized_event_delivery.rs
@@ -1,0 +1,437 @@
+//! Real RPC stdout -> projection -> canonical sequencing/masking -> private
+//! citation -> bounded sender/HTTP. The fixture's official session is immutable.
+mod common;
+#[path = "common/delivery_image.rs"]
+mod delivery_image;
+
+use base64::Engine as _;
+use guest_agent::env::{GuestConfig, GuestConfigRaw};
+use guest_agent::masker::SecretMasker;
+use guest_agent::paths::GuestPaths;
+use guest_agent::run_context::GuestRuntime;
+use serde_json::{Value, json};
+use std::os::unix::fs::PermissionsExt;
+use std::time::Duration;
+
+const LIMIT: usize = 4 * 1024 * 1024;
+const SECRET: &str = "delivery-secret-value";
+const NOTICE: &str = "[event content truncated for delivery]";
+const CITATION: &str = "<oai-mem-citation>\n<citation_entries>\nprivate-memory.md:1-2|note=[private-note]\n</citation_entries>\n<rollout_ids>\n11111111-1111-4111-8111-111111111111\n</rollout_ids>\n</oai-mem-citation>";
+
+fn assistant(id: &str, content: Value, failed: bool) -> Value {
+    let mut message = json!({
+        "role":"assistant", "responseId":id, "content":content,
+        "model":"test-model", "usage":{"input":11,"output":7,"cacheRead":3,"cacheWrite":2},
+        "stopReason":if failed {"error"} else {"stop"}, "timestamp":1
+    });
+    if failed && let Some(message) = message.as_object_mut() {
+        message.insert("errorMessage".into(), json!("API Error: Overloaded"));
+    }
+    json!({"type":"message_end", "message":message})
+}
+
+fn tool_result(id: &str, content: Value, failed: bool) -> Value {
+    json!({"type":"message_end", "message":{
+        "role":"toolResult", "toolCallId":id, "toolName":"read", "isError":failed,
+        "content":content, "timestamp":2
+    }})
+}
+fn image(data: &str) -> Value {
+    json!({"type":"image", "mimeType":"image/png", "data":data})
+}
+
+#[tokio::test]
+async fn pi_rpc_bounds_delivery_and_preserves_truth_and_originals()
+-> Result<(), Box<dyn std::error::Error>> {
+    let small_image = delivery_image::png_base64(1, 1)?;
+    let half_image = delivery_image::png_base64(1024, 512)?;
+    let large_image = delivery_image::png_base64(1024, 1024)?;
+    assert!(large_image.len() > LIMIT);
+    assert!(half_image.len() < LIMIT && half_image.len() * 2 > LIMIT);
+    let text = format!(
+        "text-head-{SECRET}-{}-text-tail",
+        "你好\"\\\n".repeat(450_000)
+    );
+    let input = format!("input-head-{SECRET}-{}-input-tail", "x".repeat(LIMIT));
+    let messages = vec![
+        assistant(
+            "small",
+            json!([{"type":"text","text":"unchanged small event"}]),
+            false,
+        ),
+        assistant(
+            "large",
+            json!([{"type":"text","text":format!("{text}{CITATION}")}]),
+            false,
+        ),
+        assistant(
+            "split-citation",
+            json!([
+                {"type":"text","text":"first block"}, {"type":"text","text":format!("last block{CITATION}")}
+            ]),
+            false,
+        ),
+        assistant(
+            "tool-input",
+            json!([{"type":"toolCall","id":"tool-input-id","name":"read","arguments":{"path":input}}]),
+            false,
+        ),
+        assistant(
+            "aggregate",
+            json!([{"type":"toolCall","id":"aggregate-id","name":"read","arguments":
+            (0..32).map(|i| (format!("field-{i:02}"), json!("a".repeat(140_000)))).collect::<serde_json::Map<_,_>>() }]),
+            false,
+        ),
+        assistant(
+            "structure",
+            json!([{"type":"toolCall","id":"structure-id","name":"read","arguments":{"values":vec![0;2_200_000]}}]),
+            false,
+        ),
+        tool_result("tool-input-id", json!([{"type":"text","text":text}]), true),
+        tool_result("small-image", json!([image(&small_image)]), false),
+        tool_result("large-image", json!([image(&large_image)]), true),
+        tool_result(
+            "aggregate-images",
+            json!([image(&half_image), image(&half_image), image(&small_image)]),
+            false,
+        ),
+        assistant("terminal", json!([{"type":"text","text":input}]), false),
+    ];
+    let failed = [assistant(
+        "failed",
+        json!([{"type":"text","text":input}]),
+        true,
+    )];
+    let mut failed_terminal = assistant(
+        "failed-terminal",
+        json!([{"type":"text","text":input}]),
+        true,
+    );
+    failed_terminal["message"]
+        .as_object_mut()
+        .unwrap()
+        .remove("errorMessage");
+    let failed_terminal = [failed_terminal];
+    for (messages, failed) in [
+        (messages.as_slice(), false),
+        (failed.as_slice(), true),
+        (failed_terminal.as_slice(), true),
+    ] {
+        let tmp = tempfile::tempdir()?;
+        let mut server = common::ControlledHttpServer::start().await?;
+        let gate_path = tmp.path().join("delivery.sock");
+        let gate = tokio::net::UnixListener::bind(&gate_path)?;
+        let bin = tmp.path().join("bin");
+        std::fs::create_dir_all(&bin)?;
+        let events_path = tmp.path().join("rpc-events.jsonl");
+        let session_id = uuid::Uuid::new_v4().to_string();
+        let session_dir =
+            api_contracts::generated::constants::runners::paths::CANONICAL_PI_SESSION_DIR;
+        std::fs::create_dir_all(session_dir)?;
+        let session_file = tempfile::Builder::new()
+            .prefix("delivery-")
+            .suffix(&format!("_{session_id}.jsonl"))
+            .tempfile_in(session_dir)?;
+        let session_path = session_file.path();
+        let original = messages
+            .iter()
+            .map(|event| format!("{event}\n"))
+            .collect::<String>();
+        assert!(
+            original.lines().all(|line| line.len()
+                < guest_contracts::stdout_framing::ORDINARY_CLI_STDOUT_MAX_LINE_BYTES)
+        );
+        std::fs::write(&events_path, &original)?;
+        let mut session = format!(
+            "{}\n",
+            json!({"type":"session","version":3,"id":session_id,"timestamp":"2026-09-11T00:00:00Z","cwd":"/home/user/workspace"})
+        );
+        for (index, event) in messages.iter().enumerate() {
+            session.push_str(&format!("{}\n",json!({"type":"message","id":format!("message-{index}"),"parentId":if index == 0 {None} else {Some(format!("message-{}",index-1))},"timestamp":"2026-09-11T00:00:00Z","message":event["message"]})));
+        }
+        std::fs::write(session_path, &session)?;
+        let commands_path = tmp.path().join("commands.jsonl");
+        let npx = bin.join("npx");
+        std::fs::write(&npx, include_str!("fixtures/pi_rpc_delivery.py"))?;
+        std::fs::set_permissions(&npx, std::fs::Permissions::from_mode(0o700))?;
+        let run_id = "00000000-0000-4000-8000-000000000124";
+        let paths = GuestPaths::from_home(tmp.path(), run_id)?;
+        let payload_path = common::write_run_payload_file_for_test(
+            paths.runtime_dir(),
+            &guest_contracts::env::RunPayload {
+                prompt: "test bounded Pi delivery".into(),
+                pi_launch_config:
+                    r#"{"schemaVersion":2,"apiFirstTurn":{"sandboxEventSequenceStart":1}}"#.into(),
+                pi_model_config: "{}".into(),
+                pi_session_id: session_id.clone(),
+                ..Default::default()
+            },
+        )?;
+        let mut config = GuestConfig::from_raw(GuestConfigRaw {
+            run_id: run_id.into(),
+            api_url: server.base_url.clone(),
+            api_token: "test-token".into(),
+            cli_agent_type: "pi".into(),
+            home: Some(tmp.path().to_string_lossy().into_owned()),
+            run_payload_file: payload_path.to_string_lossy().into_owned(),
+            guest_runtime_dir: Some(paths.runtime_dir().into()),
+            ..Default::default()
+        })?;
+        config.user_env.extend([
+            ("PATH".into(), format!("{}:/usr/bin:/bin", bin.display())),
+            (
+                "CLI_PKG_URL".into(),
+                "https://example.invalid/cli.tgz".into(),
+            ),
+            (
+                "PI_EVENTS_PATH".into(),
+                events_path.to_string_lossy().into_owned(),
+            ),
+            ("PI_SESSION_ID".into(), session_id),
+            (
+                "PI_DELIVERY_GATE".into(),
+                gate_path.to_string_lossy().into_owned(),
+            ),
+            (
+                "PI_SESSION_PATH".into(),
+                session_path.to_string_lossy().into_owned(),
+            ),
+            (
+                "PI_COMMANDS_PATH".into(),
+                commands_path.to_string_lossy().into_owned(),
+            ),
+        ]);
+        let runtime = GuestRuntime {
+            http: guest_agent::http::HttpClient::with_api_config(
+                &server.base_url,
+                "test-token",
+                "",
+                run_id,
+                Duration::ZERO,
+            )?,
+            config,
+            paths,
+            workload_containment: None,
+            process_control_endpoint: None,
+        };
+        let _system_log = common::SystemLogOverrideGuard::set(runtime.paths.system_log_file());
+        common::ensure_canonical_workspace_for_test()?;
+        let masker =
+            SecretMasker::from_raw(&base64::engine::general_purpose::STANDARD.encode(SECRET));
+        let mut sequence = 1u32;
+        let ends = messages
+            .iter()
+            .map(|event| {
+                sequence += if event["message"]["role"] == "assistant" {
+                    event["message"]["content"].as_array().map_or(0, Vec::len) as u32
+                } else {
+                    1
+                };
+                sequence
+            })
+            .collect::<Vec<_>>();
+        let serving = async {
+            use tokio::io::AsyncWriteExt;
+            let (mut gate, _) = gate.accept().await?;
+            let mut next = 0;
+            loop {
+                let request = server.next_request(Duration::from_secs(10)).await?;
+                let last = common::event_request_sequences(&request.request)?
+                    .into_iter()
+                    .max()
+                    .ok_or("empty event request")?;
+                request.respond(200)?;
+                if ends.get(next).is_some_and(|end| last >= *end) {
+                    gate.write_all(b"x").await?;
+                    next += 1;
+                }
+                if last == sequence + 1 {
+                    break;
+                }
+            }
+            Ok::<_, Box<dyn std::error::Error>>(())
+        };
+        let execution = common::execute_cli_for_runtime(&runtime, &masker, None);
+        tokio::pin!(execution);
+        let result = tokio::time::timeout(Duration::from_secs(30), async {
+            tokio::select! {
+                result = &mut execution => Ok::<_,Box<dyn std::error::Error>>(result?),
+                served = serving => { served?; Ok(execution.await?) }
+            }
+        })
+        .await??;
+        assert!(result.control_error.is_none(), "{:?}", result.control_error);
+        assert_eq!(result.exit_code, if failed { 1 } else { 0 });
+        let requests = server.requests()?;
+        assert!(!requests.is_empty());
+        let mut delivered = Vec::new();
+        let mut citations = Vec::new();
+        for request in &requests {
+            assert!(request.body.len() <= LIMIT);
+            let payload: Value = serde_json::from_str(&request.body)?;
+            delivered.extend(
+                payload["events"]
+                    .as_array()
+                    .ok_or("missing events")?
+                    .iter()
+                    .cloned(),
+            );
+            citations.extend(
+                payload["piMemoryCitationTransport"]["citations"]
+                    .as_array()
+                    .ok_or("missing private transport")?
+                    .iter()
+                    .cloned(),
+            );
+        }
+        assert_eq!(
+            delivered
+                .iter()
+                .map(|e| e["sequenceNumber"].as_u64())
+                .collect::<Vec<_>>(),
+            (1..=delivered.len() as u64).map(Some).collect::<Vec<_>>()
+        );
+        assert_eq!(result.last_event_sequence, Some(delivered.len() as u32));
+        let terminal = delivered.last().ok_or("missing terminal")?;
+        assert_eq!(terminal["type"], "result");
+        assert_eq!(terminal["is_error"], failed);
+        let public = serde_json::to_string(&delivered)?;
+        assert!(!public.contains(SECRET));
+        assert!(
+            !public.contains("private-memory")
+                && !public.contains("private-note")
+                && !public.contains("memoryCitation")
+        );
+        let log = std::fs::read_to_string(runtime.paths.system_log_file())?;
+        let reductions = log
+            .lines()
+            .filter(|line| line.contains("Pi event reduced for delivery"))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            reductions.len(),
+            delivered
+                .iter()
+                .filter(|e| e.to_string().contains("for delivery"))
+                .count()
+        );
+        assert!(reductions.iter().all(|line| line.contains("[INFO]")
+            && !line.contains("[WARN]")
+            && !line.contains("[ERROR]")));
+        for sentinel in [
+            SECRET,
+            "private-memory",
+            "private-note",
+            "text-head",
+            "input-head",
+            "base64",
+            "image/png",
+        ] {
+            assert!(reductions.iter().all(|line| !line.contains(sentinel)));
+        }
+        assert_eq!(std::fs::read_to_string(&events_path)?, original);
+        assert_eq!(std::fs::read_to_string(session_path)?, session);
+        let local = std::fs::read_to_string(runtime.paths.agent_log_file())?;
+        for event in messages {
+            let expected = event.to_string();
+            assert!(local.lines().any(|line| line == expected));
+        }
+        assert!(!local.contains("for delivery"));
+        let commands = std::fs::read_to_string(commands_path)?;
+        assert_eq!(commands.lines().count(), 2);
+        assert!(!commands.contains("for delivery"));
+        if failed {
+            assert!(log.contains("[WARN]") && log.contains("Pi JSONL failure result"));
+            let failure = guest_agent::failure_diagnostics::cli_nonzero_failure_for_config(
+                &runtime.config,
+                None,
+                &result,
+            );
+            assert_eq!(
+                failure.diagnostic.failure_detail_source,
+                Some(guest_contracts::diagnostics::FailureDetailSource::PiResult)
+            );
+            if messages[0]["message"].get("errorMessage").is_some() {
+                assert_eq!(terminal["result"], "API Error: Overloaded");
+            } else {
+                assert!(
+                    terminal["result"]
+                        .as_str()
+                        .is_some_and(|text| text.contains("bytes truncated for delivery"))
+                );
+            }
+            continue;
+        }
+        assert_eq!(citations.len(), 2);
+        for citation in &citations {
+            assert_eq!(
+                citation["citation"],
+                json!({"entries":[{"path":"private-memory.md","lineStart":1,"lineEnd":2,"note":"private-note"}],"rolloutIds":["11111111-1111-4111-8111-111111111111"]})
+            );
+        }
+        let find_message = |id: &str| {
+            delivered
+                .iter()
+                .find(|e| e["message"]["id"] == id)
+                .expect("message delivered")
+        };
+        let small = find_message("small");
+        assert_eq!(
+            small["message"],
+            json!({"id":"small","role":"assistant","model":"test-model","usage":{"input_tokens":11,"output_tokens":7,"cache_read_input_tokens":3,"cache_creation_input_tokens":2},"content":[{"type":"text","text":"unchanged small event"}]})
+        );
+        let large = find_message("large");
+        assert_eq!(large["message"]["usage"], small["message"]["usage"]);
+        let large_text = large["message"]["content"][0]["text"]
+            .as_str()
+            .ok_or("missing text")?;
+        assert!(
+            large_text.starts_with("text-head-***-")
+                && large_text.ends_with("-text-tail")
+                && large_text.contains("bytes truncated for delivery")
+        );
+        let split = delivered
+            .iter()
+            .filter(|e| e["message"]["id"] == "split-citation")
+            .collect::<Vec<_>>();
+        assert_eq!(split.len(), 2);
+        assert_eq!(citations[1]["sequenceNumber"], split[1]["sequenceNumber"]);
+        let structure = &find_message("structure")["message"]["content"][0];
+        assert_eq!(structure["id"], "structure-id");
+        assert_eq!(structure["name"], "read");
+        assert_eq!(structure["input"], json!({"_delivery_notice":NOTICE}));
+        let tool = |id: &str| {
+            &delivered
+                .iter()
+                .find(|e| e["message"]["content"][0]["tool_use_id"] == id)
+                .expect("tool delivered")["message"]["content"][0]
+        };
+        assert_eq!(tool("tool-input-id")["is_error"], true);
+        assert_eq!(
+            tool("small-image")["content"][0]["source"]["data"],
+            small_image
+        );
+        assert_eq!(tool("large-image")["is_error"], true);
+        assert_eq!(
+            tool("large-image")["content"],
+            json!([{"type":"text","text":"[image omitted for delivery]"}])
+        );
+        assert_eq!(
+            tool("aggregate-images")["content"][0],
+            json!({"type":"text","text":"[image omitted for delivery]"})
+        );
+        assert_eq!(
+            tool("aggregate-images")["content"][1]["source"]["data"],
+            half_image
+        );
+        assert_eq!(
+            tool("aggregate-images")["content"][2]["source"]["data"],
+            small_image
+        );
+        assert!(
+            terminal["result"]
+                .as_str()
+                .is_some_and(|s| s.contains("bytes truncated for delivery"))
+        );
+    }
+    Ok(())
+}

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-log.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-log.test.tsx
@@ -702,3 +702,77 @@ test("Activity logs show useful reasoning without progress noise", async () => {
   expect(screen.queryByText("thinking_tokens")).not.toBeInTheDocument();
   expect(screen.queryByText("777777")).not.toBeInTheDocument();
 });
+
+test("Pi bounded tool content stays associated with a failed tool and run", async () => {
+  const notice = "[event content truncated for delivery]";
+  const imageNotice = "[image omitted for delivery]";
+  mockActivity(
+    [
+      event(1, "assistant", {
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "bounded-pi-call",
+              name: "read",
+              input: { _delivery_notice: notice },
+            },
+          ],
+        },
+      }),
+      event(2, "user", {
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "bounded-pi-call",
+              is_error: true,
+              content: [
+                { type: "text", text: notice },
+                { type: "text", text: imageNotice },
+              ],
+            },
+          ],
+        },
+      }),
+    ],
+    { framework: "pi", status: "failed" },
+  );
+  await openActivity();
+  const search = await screen.findByPlaceholderText("Search steps");
+  await fill(search, imageNotice);
+  await expect(screen.findByText("(1/1 matched)")).resolves.toBeInTheDocument();
+  expect(screen.getByText(imageNotice)).toBeVisible();
+  expect(screen.getAllByText("Failed").length).toBeGreaterThan(0);
+});
+
+test("Codex bounded structured output remains a readable completed item", async () => {
+  mockActivity(
+    [
+      event(1, "item.completed", {
+        type: "item.completed",
+        thread_id: "thread",
+        turn_id: "turn",
+        item: {
+          type: "function_call_output",
+          id: "bounded-codex-call",
+          name: "read",
+          namespace: "tools",
+          output: [
+            {
+              type: "input_text",
+              text: "[event content truncated for delivery]",
+            },
+            { type: "input_text", text: "[image omitted for delivery]" },
+          ],
+        },
+      }),
+    ],
+    { framework: "codex" },
+  );
+  await openActivity();
+  await expect(
+    screen.findByText(/bounded-codex-call/u),
+  ).resolves.toBeInTheDocument();
+  expect(screen.getByText(/function_call_output/u)).toBeVisible();
+});

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -848,3 +848,67 @@ describe("webhook telemetry contract", () => {
     expect(result.success).toBe(false);
   });
 });
+
+it("accepts existing Pi and Codex shapes used by bounded delivery", () => {
+  const notice = "[event content truncated for delivery]";
+  const imageNotice = "[image omitted for delivery]";
+  const events = [
+    {
+      type: "assistant",
+      sequenceNumber: 1,
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "pi-call",
+            name: "read",
+            input: { _delivery_notice: notice },
+          },
+        ],
+      },
+    },
+    {
+      type: "user",
+      sequenceNumber: 2,
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "pi-call",
+            is_error: true,
+            content: [
+              { type: "text", text: notice },
+              { type: "text", text: imageNotice },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      type: "item.completed",
+      sequenceNumber: 3,
+      thread_id: "thread",
+      turn_id: "turn",
+      item: {
+        type: "function_call_output",
+        id: "codex-call",
+        name: "read",
+        namespace: "tools",
+        output: [
+          { type: "input_text", text: notice },
+          { type: "input_text", text: imageNotice },
+        ],
+      },
+    },
+  ];
+  for (const transport of [undefined, { schemaVersion: 1, citations: [] }]) {
+    const payload = {
+      runId: "bounded-delivery",
+      events,
+      piMemoryCitationTransport: transport,
+    };
+    expect(webhookEventsContract.send.body.parse(payload)).toStrictEqual(
+      payload,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #33069. Pi currently terminates a valid run when a projected event exceeds the 4 MiB webhook request limit. Reduce only the delivery copy after normalization, canonical sequencing and masking, while preserving original local-log inputs and official history.

- Share the bounded byte accounting, UTF-8 head/tail marker and selection engine; keep Pi and Codex content/identity policies separate. Retain the 256-candidate, 16-field and four-adjustment bounds, and cap new traversal state at 4,096 visited values / 64 levels / 256-byte path keys. A bounded rounding allowance preserves useful escaped UTF-8 text within the existing four attempts.
- Extract private citation once before budgeting and carry its exact bytes through final admission. The complete event envelope, public event and private sidecar must fit the unchanged 4,194,304-byte guard. There is no post-sequence split.
- Preserve known images whole or replace their whole block with an explicit text notice in the existing Pi/Codex shape. Preserve tool identity, required input/output containers, usage and truthful outcome fields. Log one bounded INFO only after a reduction is admitted; ordinary events and genuine failure handling retain their existing behavior.

## Fallbacks

These are continuing, intentionally lossy **display/transport representations** of reachable supported events, authorized by #33069 and justified by `docs/fallback.md` §6.4. They are not rollout compatibility readers or defaults for corrupt persisted state.

| File / symbol | Reachable condition and representation | Surface, gate and removal |
| --- | --- | --- |
| `crates/guest-agent/src/cli/bounded_event_delivery.rs::prepare_for_delivery` | An otherwise supported singleton exceeds the real request budget: retain UTF-8 head/tail text with the existing byte marker; bounded adjustment exhaustion retains the explicit zero-content marker. | Guest delivery to existing API readers. No cross-version removal gate; retain while the bounded transport needs lossy display content. #33069 records the approved policy. |
| `bounded_event_delivery.rs::image_notice`, Pi/Codex `content_policy` | An oversized event needs image space: replace the whole known image block with `[image omitted for delivery]`, keeping retained images byte-identical. | Existing Pi `text` / Codex `input_text` blocks, no new protocol. Same continuing presentation policy; no temporary compatibility follow-up applies. |
| `pi_event_delivery.rs::minimum_event`, `codex_event_delivery.rs::minimum_event` | Aggregate fields/arrays still exceed the budget: replace only supported content with the explicit generic notice, retaining identities, outcomes, input-object/output-array shape and any image-omitted notice. Irreducibly large protected data still fails before HTTP. | Guest delivery to current consumers. Remove only if the transport no longer requires a bounded minimum representation; no rollout drain gate or retired-protocol reader is introduced. |

## Verification

All heavy checks were run sequentially. No full local Vitest suite or development server was started.

Rust commands use `--manifest-path crates/Cargo.toml --profile local`:

- `cargo run ... -p xtask -- check-rust-path-attributes`
- `cargo clippy ... -p guest-agent -p codex-mock --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc ... -p guest-agent -p codex-mock --all-features --no-deps`
- `cargo test ... -p guest-agent -p codex-mock --lib delivery`: seven sender/ACK tests.
- `cargo test ... -p guest-agent --lib <filter>` for `events::tests`, `cli::pi_rpc`, `cli::provider_event_normalization`, and `cli::codex_app_server_events`.
- The two real oversized producer regressions below, plus 19 existing integration files (20 cases): `event_delivery_{oversized,batching,batch_failure,byte_overload,count_overload,singleton,nonretryable_failure,transport_classification,drain_timeout,failure_recovery}`, `codex_app_server_event_delivery{,_byte_overload,_overload}`, `pi_cli_{malformed_tool_event,settlement_errors}`, `codex_app_server_agent_log_persistence_failure`, and `cli_agent_log_{open_failure,persistence_failure,buffering}`.

Consumer checks from `turbo/`, using repository pnpm 10.33.4:

- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/webhooks.test.ts`: 27 passed.
- `pnpm -F api exec vitest run src/lib/__tests__/run-activity.test.ts`: seven passed after creating and migrating a temporary local PostgreSQL database; that database was then stopped.
- `pnpm -F @okouai/app exec vitest run src/views/activity-page/__tests__/activity-log.test.tsx`: 14 passed, including real page consumption of Pi and Codex reduced shapes.
- Affected-workspace type checks, scoped ESLint/Oxlint including type-aware checks, scoped Knip, Prettier and Rust formatting.

The PNG helper's actual 1×1, 1024×512 and 1024×1024 outputs were also independently decoded with Python's Base64/zlib/struct libraries: dimensions, RGB pixels, chunk CRCs and complete PNG structure passed.

### Compiled old-behavior controls

For each command, temporarily restore the relevant old behavior, run the unchanged behavioral regression, restore the fix, and rerun the same command:

```sh
cargo test --manifest-path crates/Cargo.toml --profile local -p guest-agent -p codex-mock --test pi_cli_oversized_event_delivery
cargo test --manifest-path crates/Cargo.toml --profile local -p guest-agent -p codex-mock --test codex_app_server_oversized_event_delivery
```

The old Pi route compiled successfully and failed behaviorally at sequence 3: a 5,400,571-byte request was rejected by the unchanged 4,194,304-byte guard, triggering controlled CLI termination. The old Codex image-as-generic-string policy compiled successfully and failed the whole-image assertion. Both commands pass with the fix restored. Temporary mutations/control scripts are not committed; no tombstone tests, weakened assertions, increased timeouts or disabled checks are included.

## Acceptance evidence

| #33069 criterion | Evidence |
| --- | --- |
| 1 | Shared engine and thin adapters; real sender compares complete normal/exact-fit request bytes for both frameworks with citation transport on/off. Existing Claude oversized rejection passes. |
| 2 | `pi_cli_oversized_event_delivery`: real RPC subprocess, projection, normalization, masking, canonical sequences, private sidecars and captured HTTP; success continues through 14 events/ACK 14. Covers huge assistant/tool input/tool output/terminal text, aggregate strings and numeric-array minimum. |
| 3 | Both real producer tests use valid PNGs for small, oversized and aggregate-image cases. Retained Base64/data URLs are identical; omitted blocks are explicit text. Codex also covers image omission followed by structural minimum. |
| 4 | `event_delivery_budget_tests`: full envelope exact fit and +1 byte, escaped run ID, nonempty sidecars, both transport modes, impossible sidecar/protected-core failure before HTTP. Pi integration verifies citation once on the final expanded block. |
| 5 | Real producer assertions retain tool IDs/names, input object shape, usage and outcomes; Pi failing tool/run and Codex failed command remain failed after reduction. Raw local-log input and Pi official-session fixture bytes stay unchanged; Codex history records exactly one original prompt, with no extra model/tool command. Contract and bootstrapped page tests exercise current consumers. |
| 6 | UTF-8/JSON escaping, aggregate fields/arrays and protected-core failure controls; existing queue/byte pressure, batching, retry, HTTP failure, cancellation/drain and ACK tests pass. The bound concerns delivery work/requests, not whole-process RSS. |
| 7 | One safe INFO per actual canonical reduction, zero ordinary reduction logs, no content/citation/secret diagnostic leakage. Real Pi failure still yields WARN, exit 1 and `PiResult` failure diagnostics. |
| 8 | Compiled red/green controls above, focused Rust and consumer checks. Required PR CI covers broad suites. |
| 9 | One PR; implementation owner will immediately execute same-thread `/pr-auto` for independent full-HEAD review, required PR/merge-group checks and the protected queue. Final merge evidence belongs in the owner handback. |

## Compatibility and rollout boundary

No request/stdout/queue/retry/timeout limits, provider execution/routing, billing, storage, database, persisted event format or production UI code change. New Guests send existing supported event shapes to current API/readers; old Guests continue using their existing paths. Local logging remains best-effort and has no new I/O durability guarantee.

Deployment requires a **Runner/Guest artifact containing the fixed guest-agent**; API-only promotion is insufficient. An old active Guest can still fail on oversized Pi content. Rolling back the Runner restores the prior Pi failure and Codex image behavior, without a destructive data migration. This PR does not attribute the two historical incidents to images or OOM.

No production release, approval, promotion, fault injection or production write is authorized or performed. Production artifact identity, fleet rollout/drain and traffic-bearing observation remain unverified pending separately authorized controller work. Criterion 10 and completion-watcher cleanup remain exclusively with the controller.
