### PR TITLE
docs(python): correct buffered pending-state counter semantics

### DIFF
--- a/crates/runner/mitm-addon/tests/pending_helpers.py
+++ b/crates/runner/mitm-addon/tests/pending_helpers.py
@@ -23,11 +23,21 @@ def assert_pending(
 
     ``flows``, ``buffered``, and ``reports`` map directly to the JSON fields
     with the same names.  ``flows`` is the number of admitted in-flight usage
-    flows, including billable model-provider and connector flows. ``buffered``
-    is the number
-    of unadmitted addon work units, including usage source events and retained
-    diagnostic reports, and ``reports`` is the number of pending webhook
-    report deliveries.
+    flows, including billable model-provider and connector flows.
+
+    ``buffered`` counts original usage source records in live stores, pending
+    or retry flushes, and delivering flushes, plus retained unadmitted
+    diagnostic reports. Usage is counted in source records, not webhook batches
+    or aggregated payload events. Admission alone does not remove usage:
+    delivering flushes remain counted while admitted callbacks are unresolved.
+    Successful or permanent outcomes leave the buffer when delivery ownership
+    ends. Retryable or unadmitted batches return to pending unless the retry
+    budget drops them. See ``usage.buffer.state`` for the ownership contract.
+
+    Diagnostic reports stop contributing to ``buffered`` at admission or
+    terminal discard, eviction, or reset, as defined by
+    ``usage.counters.BufferedReportLease``. ``reports`` is the number of pending
+    webhook report deliveries.
 
     When ``flush_request_id`` is provided, the snapshot must include a matching
     ``flushRequestId`` field.  When it is omitted, ``flushRequestId`` must be


### PR DESCRIPTION
The pending-snapshot assertion helper describes all `buffered` work as unadmitted, even though usage source records remain counted during delivery. Document live, pending/retry, and delivering usage ownership, source-record counting rather than aggregated payload or batch counts, and the shorter lifetime of retained diagnostic-report leases. Reference the existing ownership contracts for details.

Only the helper docstring changes; runtime counters and regression expectations are preserved.

Validation in the locked addon environment (uv 0.11.32, Python 3.14.0):

- `uv lock --check` and `uv sync --locked`
- `uv run --no-sync ruff format --check tests/pending_helpers.py`
- `uv run --no-sync ruff check tests/pending_helpers.py`
- `uv run --no-sync python -m pytest tests/test_usage_buffer_flush_failures.py::test_delivery_in_progress_does_not_block_live_usage_snapshot` — 1 passed
- `git diff --check` and the repository file-size check

Closes #33524
