### PR TITLE
fix(pi-memory): publish full summaries with bounded prompt injection

### DIFF
--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -874,7 +874,7 @@ The App uses the exact attempt receipt, not account timestamps, account counts, 
 
 The receipt-capable writer from [#32880](https://github.com/vm0-ai/vm0/pull/32880) shipped in release `3d58eaa4609967a4f655f7cd61d0d7cd454ba2a1`: API `1.575.2` completed [production promotion](https://github.com/vm0-ai/vm0/actions/runs/34335229479/job/102417239410) on 2026-09-09 at 09:48:46 UTC, followed by App `0.873.0` at 09:50:38 UTC. Cleanup [#32870](https://github.com/vm0-ai/vm0/issues/32870) retires the optional response field and absent-ID branch after that release. The maintainer explicitly excludes old API rollback compatibility; no rollback restriction is added or changed. Pre-receipt APIs are outside this cleanup's supported boundary. Existing App requests remain accepted, and already-loaded pre-receipt App bundles are not retired by this change; no App version floor increase is included.
 
-## Pi memory summary reader preparation
+## Pi memory summary storage and injection budget
 
 A valid `memory_summary.md` may exceed 2500 exact o200k tokens on disk. The
 2500-token budget belongs to the summary excerpt injected into the model prompt,
@@ -882,7 +882,7 @@ including its truncation marker, not to the stored artifact. The 64 KiB UTF-8
 source ceiling, `sourceHash`/`sourceSize`/`tokenCount` full-source metadata, the
 frozen storage version identity and the immutable-path guards are unchanged.
 
-The reader slice of [#33351](https://github.com/vm0-ai/vm0/issues/33351) widens
+The reader slice of [#33351](https://github.com/vm0-ai/vm0/issues/33351) widened
 acceptance only:
 
 - `piMemoryRecallSelectionSchema` bounds the ready selection's full-source
@@ -893,20 +893,44 @@ acceptance only:
 - The API projection read path no longer treats an authentic larger source as a
   read-integrity mismatch, so it does not requeue that row.
 
-Producers stay capped in this slice. Phase 2 output validation still rejects a
-`summary_tokens` overflow, and projection materialization still classifies
-token-only excess as `over_limit`. Relaxing them is a later change that must not
-ship before compatible readers are actually deployed:
+That reader shipped in release
+[#33469](https://github.com/vm0-ai/vm0/pull/33469) /
+`9ce193854ab828baeec40579a6d36cdf2d4dbf73` (API `1.584.1`, `pi-agent-runtime`
+`1.25.1`, `api-contracts` `1.428.1`, CLI `9.323.12`). The producer slice then
+stopped capping sources by tokens:
 
-- old runner -> new backend: an old `pi-agent-runtime` rejects a larger source
-  with `token-overflow` and injects no memory. Do not emit larger projections
-  while runner versions without this reader remain eligible to consume them.
+- Phase 2 output validation rejects only genuine problems: invalid UTF-8, a
+  missing `v1` header, a source above 64 KiB, immutable-path violations and a
+  failed or incomplete atomic publication. A valid larger source publishes in
+  full together with its `MEMORY.md` and skills. `summary_tokens` remains a
+  parseable historical diagnostic; new runs no longer produce it.
+- Projection materialization classifies token-only excess as `ready` and stores
+  the complete source with its original `sourceHash`, `sourceSize` and exact
+  `tokenCount`. Archive, file-size, path, link, duplicate, hash and encoding
+  rejections are unchanged, and existing terminal `over_limit` rows are neither
+  mutated nor requeued by this change.
+- `phase2_write` and `phase2_edit` return content-free numeric feedback for the
+  resulting whole `memory_summary.md`: UTF-8 bytes, the 64 KiB ceiling, exact
+  o200k tokens and the 2500-token injection target. Above the byte ceiling the
+  token count is reported as `unmeasured` so feedback stays bounded, and output
+  validation still rejects that source.
+
+Rollout ordering is a correctness requirement, not a preference:
+
+- old runner -> new backend: a `pi-agent-runtime` without the widened reader
+  rejects a larger source and injects no memory. Producers must not emit larger
+  sources while such runner versions remain eligible to consume them; the
+  reader release above is the gate that made this safe.
 - new runner -> old backend: unchanged. An old backend keeps producing sources
   within the injection budget, which the new reader accepts and leaves intact.
 - Frozen selections are pinned per run, so a resumed or pinned run keeps the
-  epoch and reader decision it started with.
+  epoch and reader decision it started with. New launch contexts bind the
+  serving API's commit-addressed CLI package; a package tag alone does not
+  prove runtime availability.
 
-Rolling the backend back below this change restores the old read-side cap: an
-already stored larger projection is then read as a read-integrity mismatch and
-requeued, and materialization re-classifies it as `over_limit`. The stored
-source itself is never truncated or rewritten by either reader.
+Rolling the backend back below the reader change restores the old read-side cap:
+an already stored larger projection is then read as a read-integrity mismatch
+and requeued, and materialization re-classifies it as `over_limit`. Rolling back
+below the producer change only stops new larger sources; it does not rewrite
+what was already published. The stored source itself is never truncated or
+rewritten by any reader, producer or rollback.

--- a/turbo/apps/api/src/signals/routes/__tests__/memory-summary-projection.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/memory-summary-projection.test.ts
@@ -605,26 +605,6 @@ describe("memory summary projection", () => {
       status: "over_limit",
     },
     {
-      name: "oversized summary tokens",
-      files: () => {
-        return [
-          declaredFile(
-            "memory_summary.md",
-            Buffer.from("memory ".repeat(3000), "utf8"),
-          ),
-        ];
-      },
-      archive: () => {
-        return tarGz([
-          {
-            path: "memory_summary.md",
-            content: Buffer.from("memory ".repeat(3000), "utf8"),
-          },
-        ]);
-      },
-      status: "over_limit",
-    },
-    {
       name: "malformed manifest",
       files: () => {
         return [
@@ -791,6 +771,39 @@ describe("memory summary projection", () => {
       status: "pending",
       last_error_class: "read_integrity_mismatch",
       has_content: false,
+    });
+  });
+
+  it("materializes a full source above the prompt injection budget", async () => {
+    const summary = Buffer.from(
+      `v1\n## User Profile\n${" token".repeat(2936)}`,
+      "utf8",
+    );
+    const tokenCount = encode(summary.toString("utf8")).length;
+    expect(tokenCount).toBe(2943);
+    expect(summary.length).toBeLessThanOrEqual(64 * 1024);
+    const declared = declaredFile("memory_summary.md", summary);
+    const version = await publishVersion({
+      files: [declared],
+      archive: tarGz([{ path: "memory_summary.md", content: summary }]),
+    });
+
+    await expect(run(version)).resolves.toMatchObject({ ready: 1 });
+
+    // The stored projection describes the complete source; the runtime renderer
+    // is the only place that applies the 2500-token injection budget.
+    await expect(inspect(version)).resolves.toMatchObject({
+      status: "ready",
+      last_error_class: null,
+      source_hash: declared.hash,
+      source_size: summary.length,
+      token_count: tokenCount,
+    });
+    await expect(read(version)).resolves.toMatchObject({
+      content: summary.toString("utf8"),
+      source_hash: declared.hash,
+      source_size: summary.length,
+      token_count: tokenCount,
     });
   });
 

--- a/turbo/apps/api/src/signals/services/memory-summary-projection.service.ts
+++ b/turbo/apps/api/src/signals/services/memory-summary-projection.service.ts
@@ -1,10 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { gunzipSync } from "node:zlib";
 
-import {
-  PI_MEMORY_SUMMARY_MAX_BYTES,
-  PI_MEMORY_SUMMARY_MAX_TOKENS,
-} from "@okouai/api-contracts/contracts/runners";
+import { PI_MEMORY_SUMMARY_MAX_BYTES } from "@okouai/api-contracts/contracts/runners";
 import {
   MAX_FILE_SIZE_BYTES,
   STORAGE_MANIFEST_MAX_FILES,
@@ -621,9 +618,8 @@ const downloadProjectionArchive$ = command(
     if (!("ok" in tokenCount)) {
       return { status: "invalid" };
     }
-    if (tokenCount.ok > PI_MEMORY_SUMMARY_MAX_TOKENS) {
-      return { status: "over_limit" };
-    }
+    // `tokenCount` describes the full source. The prompt injection budget is
+    // applied by the runtime renderer, so token-only excess is not over limit.
     return {
       status: "ready",
       content: decoded.ok,

--- a/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
@@ -711,10 +711,15 @@ describe("sandbox Pi agent loop", () => {
   it.each(
     // Only the output-validation and mounted-apply fixtures are reproducible
     // by this scenario. Session-lifecycle fixtures are covered by the engine
-    // tests and the shared serializer boundary.
+    // tests and the shared serializer boundary. `summary_tokens` is a historical
+    // diagnostic: a valid source above the prompt injection budget now publishes
+    // in full, so the runtime cannot produce it. Its fixture stays for the
+    // parsers that must keep reading old terminal records.
     terminalFixtures.filter((fixture) => {
       return (
-        fixture.diagnostic && fixture.errorClass === "agent_output_invalid"
+        fixture.diagnostic &&
+        fixture.errorClass === "agent_output_invalid" &&
+        fixture.diagnostic.reason !== "summary_tokens"
       );
     }),
   )(
@@ -737,9 +742,7 @@ describe("sandbox Pi agent loop", () => {
       const isApply = fixture.diagnostic?.stage === "mounted_apply";
       const summary = isApply
         ? "v1\nValid summary"
-        : fixture.name === "summary_tokens"
-          ? `v1\n${" token".repeat(2605)}`
-          : "V1\nPRIVATE_SUMMARY_SENTINEL";
+        : "V1\nPRIVATE_SUMMARY_SENTINEL";
       await mkdir(memoryRoot);
       await writeFile(join(memoryRoot, "MEMORY.md"), memory);
       await writeFile(join(memoryRoot, "memory_summary.md"), summary);

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-filesystem.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-filesystem.test.ts
@@ -328,7 +328,6 @@ describe("Pi memory Phase 2 filesystem", () => {
 
   it.each([
     ["summary_header", "V1\nPRIVATE_SUMMARY_SENTINEL"],
-    ["summary_tokens", `v1\n${" token".repeat(2605)}`],
     ["summary_bytes", `v1\n${" ".repeat(PI_MEMORY_SUMMARY_MAX_BYTES - 2)}`],
   ])(
     "classifies %s without exposing generated content",
@@ -346,14 +345,6 @@ describe("Pi memory Phase 2 filesystem", () => {
             fileClass: "summary",
           },
         });
-        if (reason === "summary_tokens") {
-          expect(Buffer.byteLength(content)).toBeLessThan(
-            PI_MEMORY_SUMMARY_MAX_BYTES,
-          );
-          expect(error).toMatchObject({
-            diagnostic: { actual: encode(content).length, limit: 2500 },
-          });
-        }
         if (reason === "summary_bytes")
           expect(error).toMatchObject({
             diagnostic: { actual: 65537, limit: 65536 },
@@ -363,16 +354,53 @@ describe("Pi memory Phase 2 filesystem", () => {
     },
   );
 
-  it("keeps inclusive summary token and byte boundaries", async () => {
+  it("keeps the inclusive summary byte boundary", async () => {
     const workspace = await freshWorkspace(VALID_BASE);
-    const tokenBoundary = `v1\n${" token".repeat(2497)}`;
-    expect(encode(tokenBoundary).length).toBe(2500);
-    for (const content of [tokenBoundary, `v1\n${" ".repeat(65533)}`]) {
-      await put(workspace, "memory_summary.md", content);
-      await expect(
-        validatePiMemoryPhase2Output(workspace, "storage-phase2"),
-      ).resolves.toBeDefined();
-    }
+    await put(workspace, "memory_summary.md", `v1\n${" ".repeat(65533)}`);
+    await expect(
+      validatePiMemoryPhase2Output(workspace, "storage-phase2"),
+    ).resolves.toBeDefined();
+  });
+
+  it("publishes a summary above the prompt injection budget in full", async () => {
+    const workspace = await freshWorkspace(VALID_BASE);
+    // The production failures reported exactly 2943 source tokens; the prompt
+    // budget belongs to the injected excerpt, not to the stored artifact.
+    const summary = `v1\n${" token".repeat(2940)}`;
+    expect(encode(summary).length).toBe(2943);
+    expect(Buffer.byteLength(summary)).toBeLessThanOrEqual(
+      PI_MEMORY_SUMMARY_MAX_BYTES,
+    );
+    await put(workspace, "memory_summary.md", summary);
+    await put(workspace, "MEMORY.md", "# Task Group: larger consolidation\n");
+    const baseFiles = await snapshotMountedPiMemoryPhase2Base(
+      workspace.memoryRoot,
+    );
+
+    const prepared = await validatePiMemoryPhase2Output(
+      workspace,
+      "storage-phase2",
+    );
+    const published = prepared.files.find((file) => {
+      return file.path === "memory_summary.md";
+    });
+    expect(published?.size).toBe(Buffer.byteLength(summary));
+    expect(
+      Buffer.from(published?.contentBase64 ?? "", "base64").toString("utf8"),
+    ).toBe(summary);
+
+    await applyValidatedPiMemoryPhase2Result({
+      memoryRoot: workspace.memoryRoot,
+      memoryStorageId: "storage-phase2",
+      baseFiles,
+      ...prepared,
+    });
+    expect(
+      await readFile(join(workspace.memoryRoot, "memory_summary.md"), "utf8"),
+    ).toBe(summary);
+    expect(
+      await readFile(join(workspace.memoryRoot, "MEMORY.md"), "utf8"),
+    ).toBe("# Task Group: larger consolidation\n");
   });
 
   it("pins every frozen size and count boundary", () => {
@@ -768,15 +796,6 @@ describe("Pi memory Phase 2 filesystem", () => {
           "memory_summary.md",
           `v1\n${"s".repeat(PI_MEMORY_SUMMARY_MAX_BYTES)}`,
         );
-      },
-      async (workspace) => {
-        const tooManyTokens = `v1\n${" token".repeat(
-          PI_MEMORY_SUMMARY_MAX_TOKENS + 100,
-        )}`;
-        expect(encode(tooManyTokens).length).toBeGreaterThan(
-          PI_MEMORY_SUMMARY_MAX_TOKENS,
-        );
-        await put(workspace, "memory_summary.md", tooManyTokens);
       },
       async (workspace) => {
         await put(workspace, "skills/missing-manifest/reference.md", "x");

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-filesystem.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-filesystem.ts
@@ -2,16 +2,12 @@ import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { dirname, isAbsolute, join, posix } from "node:path";
 
-import {
-  PI_MEMORY_SUMMARY_MAX_BYTES,
-  PI_MEMORY_SUMMARY_MAX_TOKENS,
-} from "@okouai/api-contracts/contracts/runners";
+import { PI_MEMORY_SUMMARY_MAX_BYTES } from "@okouai/api-contracts/contracts/runners";
 import {
   MAX_FILE_SIZE_BYTES,
   STORAGE_MANIFEST_MAX_FILES,
   STORAGE_MANIFEST_MAX_PATH_BYTES,
 } from "@okouai/api-contracts/contracts/storages";
-import { encode } from "gpt-tokenizer/encoding/o200k_base";
 import { parse as parseYaml } from "yaml";
 
 import {
@@ -712,14 +708,9 @@ function summaryFailure(content: Buffer) {
       limit: PI_MEMORY_SUMMARY_MAX_BYTES,
     });
   }
-  const tokens = encode(decoded).length;
-  if (tokens > PI_MEMORY_SUMMARY_MAX_TOKENS) {
-    return new Phase2OutputInvalidError("summary_tokens", {
-      ...details,
-      actual: tokens,
-      limit: PI_MEMORY_SUMMARY_MAX_TOKENS,
-    });
-  }
+  // The exact o200k budget belongs to the summary excerpt injected into a
+  // prompt, not to the stored source. A valid source within the byte ceiling
+  // publishes in full and the shared recall renderer bounds what is injected.
   return undefined;
 }
 

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-prompt.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-prompt.test.ts
@@ -1,5 +1,9 @@
 import { createHash } from "node:crypto";
 
+import {
+  PI_MEMORY_SUMMARY_MAX_BYTES,
+  PI_MEMORY_SUMMARY_MAX_TOKENS,
+} from "@okouai/api-contracts/contracts/runners";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -62,5 +66,18 @@ describe("Pi memory Phase 2 prompt", () => {
     for (const block of requiredBlocks) {
       expect(prompt).toContain(block);
     }
+  });
+
+  it("states the injection target and the hard byte limit as separate numbers", () => {
+    const prompt = renderPiMemoryPhase2Prompt();
+    expect(prompt).toContain(
+      `at most ${PI_MEMORY_SUMMARY_MAX_TOKENS.toString()} exact o200k tokens`,
+    );
+    expect(prompt).toContain(
+      `within ${PI_MEMORY_SUMMARY_MAX_BYTES.toString()} UTF-8 bytes`,
+    );
+    expect(prompt).toContain(
+      "A file above the 2500-token target is still valid and is stored in full",
+    );
   });
 });

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-prompt.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-prompt.ts
@@ -96,8 +96,7 @@ Do not add generic advice, filler, secrets, or fabricated verification.
 2. \`memory_summary.md\`
 
 The first line must be exactly \`v1\`, with no prefix or frontmatter. The next
-heading must be \`## User Profile\`. Keep the whole file dense and within the
-engine's byte and token limits. Use this ordered structure:
+heading must be \`## User Profile\`. Use this ordered structure:
 
 - \`## User Profile\`: concise, grounded stable context.
 - \`## User preferences\`: compact actionable bullets likely to matter again.
@@ -108,6 +107,18 @@ engine's byte and token limits. Use this ordered structure:
 Every index topic must contain exact searchable keywords and a short routing
 description. Keep detailed runbooks and provenance in \`MEMORY.md\`, skills, or
 Pi evidence rather than duplicating them here.
+
+Two separate limits apply to this file:
+
+- Writing target: aim for at most 2500 exact o200k tokens. Later runs inject
+  only a bounded excerpt of this size, marker included, so the most important
+  routing content belongs near the beginning and the end.
+- Hard limit: the whole file must stay within 65536 UTF-8 bytes. Exceeding it
+  fails output validation.
+
+A file above the 2500-token target is still valid and is stored in full. Do not
+delete grounded content only to reach the target; move detail into
+\`MEMORY.md\`, skills, or Pi evidence instead, and do not pad this index.
 
 3. \`skills/<skill-name>/\` (optional)
 
@@ -133,7 +144,7 @@ WORKFLOW
 `;
 
 export const PI_MEMORY_PHASE2_ADAPTED_TEMPLATE_SHA256 =
-  "037a827b7144353283b57be564687f032380e21e3f945e31b69e445ea62acbd9";
+  "7f763f1bbdbaab290a565a1e831fdc66d6ae1f23c23cfee6c2eb90e2ba40ebfb";
 
 export function renderPiMemoryPhase2Prompt(): string {
   const digest = createHash("sha256")

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-tools.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-tools.test.ts
@@ -5,6 +5,7 @@ import {
   readFile,
   rename,
   rm,
+  stat,
   symlink,
   writeFile,
 } from "node:fs/promises";
@@ -226,8 +227,8 @@ describe("Pi memory Phase 2 maintenance tools", () => {
       `written summary_bytes=${Buffer.byteLength(oversized).toString()} summary_byte_limit=65536 summary_tokens=unmeasured summary_injection_target=2500`,
     );
     expect(
-      await readFile(join(fixture.memoryRoot, "memory_summary.md"), "utf8"),
-    ).toBe(oversized);
+      (await stat(join(fixture.memoryRoot, "memory_summary.md"))).size,
+    ).toBe(Buffer.byteLength(oversized));
   });
 
   it("rejects every path escape and mutation outside the exact allowlist", async () => {

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-tools.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-tools.test.ts
@@ -11,6 +11,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
+import { encode } from "gpt-tokenizer/encoding/o200k_base";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -163,6 +164,70 @@ describe("Pi memory Phase 2 maintenance tools", () => {
     expect(await readFile(join(fixture.memoryRoot, "legacy.md"), "utf8")).toBe(
       "legacy needle",
     );
+  });
+
+  it("reports bounded summary numbers and leaves other outputs unchanged", async () => {
+    const fixture = await roots();
+    const tools = createPiMemoryPhase2Tools(fixture);
+
+    expect(
+      await executeText(tools, "phase2_write", {
+        path: "memory/MEMORY.md",
+        content: "# Task Group: unchanged feedback\n",
+      }),
+    ).toBe("written");
+    expect(
+      await executeText(tools, "phase2_write", {
+        path: "memory/skills/reusable/SKILL.md",
+        content: "---\nname: reusable\ndescription: reusable\n---\n",
+      }),
+    ).toBe("written");
+
+    const summary = `v1\n## User Profile\n${" token".repeat(2936)}`;
+    expect(encode(summary).length).toBe(2943);
+    const written = await executeText(tools, "phase2_write", {
+      path: "memory/memory_summary.md",
+      content: summary,
+    });
+    expect(written).toBe(
+      `written summary_bytes=${Buffer.byteLength(summary).toString()} summary_byte_limit=65536 summary_tokens=2943 summary_injection_target=2500`,
+    );
+    expect(written).not.toContain("token token");
+
+    // The feedback describes the whole resulting file, not the edited fragment.
+    const edited = await executeText(tools, "phase2_edit", {
+      path: "memory/memory_summary.md",
+      old_text: "## User Profile",
+      new_text: "## User Profile\n- kept",
+    });
+    const updated = await readFile(
+      join(fixture.memoryRoot, "memory_summary.md"),
+      "utf8",
+    );
+    expect(edited).toBe(
+      `edited summary_bytes=${Buffer.byteLength(updated).toString()} summary_byte_limit=65536 summary_tokens=${encode(updated).length.toString()} summary_injection_target=2500`,
+    );
+    expect(encode(updated).length).toBeGreaterThan(2500);
+  });
+
+  it("keeps summary feedback bounded above the source byte ceiling", async () => {
+    const fixture = await roots();
+    const tools = createPiMemoryPhase2Tools(fixture);
+    // Tokenizing a multi-megabyte temporary source only to report that it
+    // exceeds the byte ceiling would be unbounded work; bytes decide it.
+    const oversized = `v1\n${"x".repeat(4 * 1024 * 1024)}`;
+
+    expect(
+      await executeText(tools, "phase2_write", {
+        path: "memory/memory_summary.md",
+        content: oversized,
+      }),
+    ).toBe(
+      `written summary_bytes=${Buffer.byteLength(oversized).toString()} summary_byte_limit=65536 summary_tokens=unmeasured summary_injection_target=2500`,
+    );
+    expect(
+      await readFile(join(fixture.memoryRoot, "memory_summary.md"), "utf8"),
+    ).toBe(oversized);
   });
 
   it("rejects every path escape and mutation outside the exact allowlist", async () => {

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-tools.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-tools.ts
@@ -4,6 +4,12 @@ import { isAbsolute, posix, resolve } from "node:path";
 
 import { Type } from "@earendil-works/pi-ai";
 import { defineTool } from "@earendil-works/pi-coding-agent";
+import {
+  PI_MEMORY_SUMMARY_MAX_BYTES,
+  PI_MEMORY_SUMMARY_MAX_TOKENS,
+} from "@okouai/api-contracts/contracts/runners";
+
+import { piMemorySummaryTokenCount } from "./memory-recall";
 
 export const PI_MEMORY_PHASE2_TOOL_NAMES = Object.freeze([
   "phase2_list",
@@ -32,6 +38,7 @@ const PRIVATE_INPUT_PATHS = new Set([
   "inputs/raw-memories.md",
   "inputs/workspace-diff.md",
 ]);
+const SUMMARY_LOGICAL_PATH = "memory/memory_summary.md";
 const textDecoder = new TextDecoder("utf-8", { fatal: true });
 
 interface Phase2MaintenanceToolRoots {
@@ -197,7 +204,7 @@ function mutableOutputPath(path: NormalizedToolPath): boolean {
   if (path.logicalPath === "memory/MEMORY.md") {
     return true;
   }
-  if (path.logicalPath === "memory/memory_summary.md") {
+  if (path.logicalPath === SUMMARY_LOGICAL_PATH) {
     return true;
   }
   if (!path.logicalPath.startsWith("memory/skills/")) {
@@ -303,6 +310,35 @@ async function writeMutableFile(
   } finally {
     await handle.close();
   }
+}
+
+/**
+ * Content-free numbers for the whole summary that a successful write or edit
+ * leaves on disk. The stored source is bounded by bytes, while the separate
+ * o200k budget only bounds the excerpt a later run injects into its prompt.
+ */
+function mutationOutcome(
+  outcome: "written" | "edited",
+  path: NormalizedToolPath,
+  content: string,
+): string {
+  if (path.logicalPath !== SUMMARY_LOGICAL_PATH) {
+    return outcome;
+  }
+  const bytes = byteLength(content);
+  // Tokenizing a source that already exceeds the byte ceiling would be
+  // unbounded work for feedback alone, and output validation rejects it anyway.
+  const tokens =
+    bytes > PI_MEMORY_SUMMARY_MAX_BYTES
+      ? "unmeasured"
+      : piMemorySummaryTokenCount(content).toString();
+  return [
+    outcome,
+    `summary_bytes=${bytes.toString()}`,
+    `summary_byte_limit=${PI_MEMORY_SUMMARY_MAX_BYTES.toString()}`,
+    `summary_tokens=${tokens}`,
+    `summary_injection_target=${PI_MEMORY_SUMMARY_MAX_TOKENS.toString()}`,
+  ].join(" ");
 }
 
 function boundedUtf8(
@@ -683,7 +719,12 @@ function createWriteTool(
         await args.testHooks?.afterPathValidation?.(path.logicalPath);
         await writeMutableFile(path, params.content);
         return {
-          content: [{ type: "text" as const, text: "written" }],
+          content: [
+            {
+              type: "text" as const,
+              text: mutationOutcome("written", path, params.content),
+            },
+          ],
           details: {},
         };
       });
@@ -730,7 +771,12 @@ function createEditTool(
         const updated = `${content.slice(0, first)}${params.new_text}${content.slice(first + params.old_text.length)}`;
         await writeMutableFile(path, updated);
         return {
-          content: [{ type: "text" as const, text: "edited" }],
+          content: [
+            {
+              type: "text" as const,
+              text: mutationOutcome("edited", path, updated),
+            },
+          ],
           details: {},
         };
       });

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
@@ -1094,7 +1094,6 @@ describe("Pi memory Phase 2 consolidation engine", () => {
     );
 
     expect(result.status).toBe("prepared");
-    if (result.status !== "prepared") return;
     const published = result.files.find((file) => {
       return file.path === "memory_summary.md";
     });

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
@@ -9,6 +9,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { encode } from "gpt-tokenizer/encoding/o200k_base";
 import { afterEach, describe, expect, it } from "vitest";
 
 import type { PiMemoryPhase2Diagnostic } from "./phase2-memory-diagnostics";
@@ -922,7 +923,7 @@ describe("Pi memory Phase 2 consolidation engine", () => {
     const input = args(provider.baseUrl, {
       baseFiles: [
         baseFile("MEMORY.md", "# Memory\n"),
-        baseFile("memory_summary.md", `v1\n${" token".repeat(2605)}`),
+        baseFile("memory_summary.md", `v1\n${" ".repeat(64 * 1024)}`),
       ],
       selected: [],
       onLifecycle(event) {
@@ -936,10 +937,10 @@ describe("Pi memory Phase 2 consolidation engine", () => {
       errorClass: "agent_output_invalid",
       diagnostic: {
         stage: "output_validation",
-        reason: "summary_tokens",
+        reason: "summary_bytes",
         fileClass: "summary",
-        actual: 2608,
-        limit: 2500,
+        actual: 65_539,
+        limit: 65_536,
       },
     });
   });
@@ -1061,6 +1062,51 @@ describe("Pi memory Phase 2 consolidation engine", () => {
     expect(files.get("MEMORY.md")).toBe("# Task Group: silent completion\n");
     expect(files.get("memory_summary.md")).toBe(
       "v1\n## User Profile\n- silent completion\n",
+    );
+  });
+
+  it("publishes a summary above the injection budget with its numeric feedback", async () => {
+    // The production failures reported exactly 2943 exact o200k source tokens.
+    const summary = `v1\n## User Profile\n${" token".repeat(2936)}`;
+    expect(encode(summary).length).toBe(2943);
+    const summaryBytes = Buffer.byteLength(summary);
+    expect(summaryBytes).toBeLessThanOrEqual(64 * 1024);
+    const provider = await startProvider([
+      {
+        type: "tool",
+        name: "phase2_write",
+        arguments: {
+          path: "memory/MEMORY.md",
+          content: "# Task Group: larger consolidation\n",
+        },
+      },
+      {
+        type: "tool",
+        name: "phase2_write",
+        arguments: { path: "memory/memory_summary.md", content: summary },
+      },
+      { type: "text", text: "done" },
+    ]);
+
+    const result = await runPiMemoryPhase2Consolidation(
+      args(provider.baseUrl),
+      new AbortController().signal,
+    );
+
+    expect(result.status).toBe("prepared");
+    if (result.status !== "prepared") return;
+    const published = result.files.find((file) => {
+      return file.path === "memory_summary.md";
+    });
+    expect(published?.size).toBe(summaryBytes);
+    expect(
+      Buffer.from(published?.contentBase64 ?? "", "base64").toString("utf8"),
+    ).toBe(summary);
+
+    // The write feedback the model actually observed describes the whole
+    // resulting summary, without ever repeating its content.
+    expect(JSON.stringify(provider.requests.at(-1)?.body ?? {})).toContain(
+      `written summary_bytes=${summaryBytes.toString()} summary_byte_limit=65536 summary_tokens=2943 summary_injection_target=2500`,
     );
   });
 


### PR DESCRIPTION
## Problem

Phase 2 output validation (`phase2-memory-filesystem.ts`) and API projection materialization (`memory-summary-projection.service.ts`) both rejected a valid `memory_summary.md` whose full source exceeded 2500 exact o200k tokens. Five production maintenance runs on 2026-09-10 failed with `summary_tokens` (2793–2943 actual), discarding a complete consolidated result — `MEMORY.md`, skills and summary — for a limit that belongs to the prompt excerpt, not to the stored artifact.

The reader side of #33351 already renders a deterministic <=2500-token excerpt from a larger authentic source and shipped in release #33469 / `9ce193854ab828baeec40579a6d36cdf2d4dbf73` (API `1.584.1`, `pi-agent-runtime` `1.25.1`, `api-contracts` `1.428.1`, CLI `9.323.12`), so the producers can now keep the full source.

## Changes

- **Phase 2 output validation**: remove only the source `summary_tokens` rejection. Strict UTF-8, the required `v1` first line, the 64 KiB full-source byte ceiling, inventory, immutable-path, `MEMORY.md`, skill, checkpoint and atomic-publication rules are unchanged. The same `summaryFailure` is used during preparation, so a valid larger source is no longer deleted or replaced before publication. `summary_tokens` remains in the diagnostics vocabulary so historical telemetry stays parseable.
- **Projection materialization**: stop returning `over_limit` solely because exact source tokens exceed 2500. Archive/file size ceilings, path/link/duplicate checks, bytes/hash authentication and UTF-8/non-empty handling keep their existing outcomes. The row stores the full source with its original `sourceHash`, `sourceSize` and exact `tokenCount`. No previously terminal row is requeued or mutated.
- **Phase 2 prompt**: state the two separate limits — a <=2500 exact-o200k *writing target* because later runs inject only a bounded excerpt, and the 64 KiB UTF-8 *hard limit* that fails validation. A source above the target stays valid; detail belongs in `MEMORY.md`, skills or Pi evidence rather than in this index. The adapted-template digest is updated accordingly.
- **`phase2_write` / `phase2_edit` feedback**: a successful mutation of `memory_summary.md` now returns content-free numbers for the whole resulting file — UTF-8 bytes, the 64 KiB ceiling, exact o200k tokens and the 2500 injection target — reusing the existing constants and `piMemorySummaryTokenCount`. An edit reports the whole updated summary, not the fragment. Above the byte ceiling the token count is reported as `unmeasured` so a multi-megabyte temporary source is never tokenized for feedback, and output validation still rejects it. Non-summary writes and edits return exactly `written` / `edited` as before. Feedback is emitted only after the write succeeds, so a rejected tool call cannot let an older valid summary disguise a failed new write.
- **Documentation**: `docs/deployment-compatibility.md` now describes stored source size and injected-summary budget as separate, records the reader release that gated this change, and states both rollback directions.

No change to the 64 KiB hard limit, the tokenizer, the shared truncator, the generic memory-tool output limit, atomic publication, lease/cancellation/timeout ownership, frozen or `no-content` epochs, or logging. No new model call, rejection counter, pending-breach state or corrective-generation loop. No DDL, backfill, requeue or production data mutation; bounded historical recovery remains slice C.

## Verification

Run locally:

- `vitest --run` in `@okouai/pi-agent-runtime` for `phase2-memory.test.ts`, `phase2-memory-filesystem.test.ts`, `phase2-memory-tools.test.ts`, `phase2-memory-prompt.test.ts`, `phase2-memory-diagnostics.test.ts`, `phase2-memory-scope.test.ts`, `memory-recall.test.ts`, `memory-tools-node.test.ts`, `session-memory.test.ts`, `stage1-memory.test.ts` — all pass.
- `pnpm -F @okouai/pi-agent-runtime run check-types` and `run lint` — pass.
- `apps/api` `pnpm run check-types` and `pnpm run lint` — pass.
- Prettier `--check` on every changed file — pass.

New behavioral coverage:

- A synthetic valid summary of exactly 2943 exact o200k tokens within 64 KiB passes final validation, is prepared with its full bytes/size, and applies atomically into the mounted tree together with its `MEMORY.md` change (`phase2-memory-filesystem.test.ts`).
- The same summary written through `phase2_write` reaches a `prepared` engine result with byte-identical content, and the numeric write feedback the model actually observed is asserted from the recorded provider request (`phase2-memory.test.ts`).
- Summary write/edit feedback, the whole-file semantics of an edit that leaves a >2500-token result, and bounded `unmeasured` feedback above the byte ceiling (`phase2-memory-tools.test.ts`).
- A >2500-token archive materializes to `ready` with full-source `content`, `sourceHash`, `sourceSize` and `tokenCount` (`memory-summary-projection.test.ts`). The obsolete `oversized summary tokens` → `over_limit` case is removed; `oversized summary bytes`, invalid UTF-8, hash mismatch, traversal, symlink, duplicate and malformed-manifest cases are retained unchanged.

Honest limitation: `apps/api` DB-backed tests cannot run in this environment — there is no local Postgres and no Docker, so `memory-summary-projection.test.ts` skips with `ECONNREFUSED 127.0.0.1:5432` locally. That file's result is established by PR CI. As instructed, no full local Vitest suite and no dev server were run.

## Compatibility

Reader compatibility is a prerequisite and is already satisfied in production; see the [rollout evidence](https://github.com/vm0-ai/vm0/issues/33351#issuecomment-5631745042). New launch contexts bind the serving API's commit-addressed CLI package, older queued payloads keep their original recall decision and package, and resumed or pinned runs keep their frozen storage/version selection. Rolling the backend below the reader change restores the old read-side cap for an already stored larger projection; rolling back below this producer change only stops new larger sources. The stored source is never truncated or rewritten in any direction.

Closes #33523
Refs #33351

🤖 Generated with [Claude Code](https://claude.com/claude-code)
