### PR TITLE
test(platform): await unread sidebar agent readiness

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -1672,11 +1672,14 @@ test("Mark all of an agent’s chats read", async () => {
   const nav = await waitFor(() => {
     const current = mobileSidebar();
     expect(within(current).getByText("Research Agent")).toBeInTheDocument();
-    expect(within(current).getByText("Support Agent")).toBeInTheDocument();
     return current;
   });
   const researchSidebarRow = agentRowByName(nav, "Research Agent");
-  const supportSidebarRow = agentRowByName(nav, "Support Agent");
+  // Unpinned agents appear after the Worker finishes loading unread indicators,
+  // independently of the pinned-agent list above.
+  const supportSidebarRow = await waitFor(() => {
+    return agentRowByName(nav, "Support Agent");
+  });
   await waitFor(() => {
     expect(
       within(researchSidebarRow).getByLabelText("Unread"),


### PR DESCRIPTION
Fix the intermittent [`test-app (2)` failure](https://github.com/vm0-ai/vm0/actions/runs/34580034517/job/103201293677) in **Mark all of an agent’s chats read**. The test used one `waitFor` for pinned `Research Agent` and unpinned `Support Agent`, although Support appears only after the Worker's unread indicators resolve, including IndexedDB work and throttled chat-event catch-up. A delayed indicator load could exhaust the shared assertion window before any action ran.

Wait for the pinned list first, then independently await the unread-only agent, matching the adjacent sidebar story. Retain all assertions that marking Research read clears only its badge, leaves Support unread, and removes the completed menu action. This is a test-only change with unchanged timeouts, cleanup, and application behavior.

The [preceding main run passed](https://github.com/vm0-ai/vm0/actions/runs/34579124813/job/103199893360) with identical test/application code; the failing merge group only deleted a screenshot. The same missing-Support failure was reproduced locally with temporary timing instrumentation, which has been removed. The CI realtime HTTP 500 warnings came from other passing tests.

Validation from `turbo/`:

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx -t 'Mark all of an agent' --silent=false` — 5 consecutive passes.
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx` — all 42 tests passed.
- Scoped Prettier, ESLint, Oxlint (including type-aware rules), Platform test TypeScript (`tsc -p tsconfig.tests.json --noEmit --checkers 2`), and Knip (`knip --workspace apps/platform`) passed.
- `git diff --check` passed.
