### PR TITLE
fix(api): raise morning brief provisioning outcome logs to info

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -299,6 +299,51 @@ export default [
     },
   },
   {
+    files: ["src/signals/services/morning-brief-enrollment-worker.service.ts"],
+    rules: {
+      // Only a first attempt, a changed error, or an actual install reaches
+      // this record, so it is bounded by enrollment progress rather than by
+      // cron ticks. Axiom's default transport drops debug events, and the
+      // skipped reasons are the only evidence that enrollment ran and chose
+      // not to install.
+      "api/no-logger-info": [
+        "error",
+        { allowedMessages: ["Morning Brief enrollment changed"] },
+      ],
+    },
+  },
+  {
+    files: ["src/signals/routes/webhooks-clerk.ts"],
+    rules: {
+      // One record per organization-membership creation. Failures already
+      // reach Axiom at warn; the succeeded and skipped outcomes must survive
+      // the info default too, or a silent dataset is indistinguishable from a
+      // working one.
+      "api/no-logger-info": [
+        "error",
+        { allowedMessages: ["Morning Brief membership provisioning outcome"] },
+      ],
+    },
+  },
+  {
+    files: ["src/signals/routes/user-preferences.ts"],
+    rules: {
+      // Both records fire on the timezone initialize call, which an
+      // authenticated session invokes once. They share their details object
+      // with the warn branch beside them, so retaining them at info adds no
+      // field that Axiom does not already receive on failure.
+      "api/no-logger-info": [
+        "error",
+        {
+          allowedMessages: [
+            "Morning Brief timezone provisioning outcome",
+            "Morning Brief initialization outcome",
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ["src/signals/routes/webhooks-built-in-generations.ts"],
     rules: {
       "api/no-logger-info": [

--- a/turbo/apps/api/src/signals/routes/user-preferences.ts
+++ b/turbo/apps/api/src/signals/routes/user-preferences.ts
@@ -38,7 +38,7 @@ async function observeMorningBriefProvisioning(
     L.warn("Morning Brief timezone provisioning outcome", details);
     return;
   }
-  L.debug("Morning Brief timezone provisioning outcome", details);
+  L.info("Morning Brief timezone provisioning outcome", details);
 }
 
 function enqueueMorningBriefProvisioning(
@@ -167,7 +167,7 @@ const initializeUserPreferencesInner$ = command(
     if (!enrollment.ok || enrollment.value.outcome === "failed") {
       L.warn("Morning Brief initialization deferred", details);
     } else {
-      L.debug("Morning Brief initialization outcome", details);
+      L.info("Morning Brief initialization outcome", details);
     }
     await publishMorningBriefChangedSafely({
       orgId: auth.orgId,

--- a/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
@@ -168,7 +168,7 @@ async function observeNewMembershipMorningBriefProvisioning(
     L.warn("Morning Brief membership provisioning outcome", details);
     return;
   }
-  L.debug("Morning Brief membership provisioning outcome", details);
+  L.info("Morning Brief membership provisioning outcome", details);
 }
 
 function enqueueMorningBriefMembershipProvisioning(args: {

--- a/turbo/apps/api/src/signals/services/morning-brief-enrollment-worker.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-enrollment-worker.service.ts
@@ -108,7 +108,7 @@ const executeMorningBriefEnrollmentScope$ = command(
         if (lastError) {
           log.warn("Morning Brief enrollment will retry", details);
         } else {
-          log.debug("Morning Brief enrollment changed", details);
+          log.info("Morning Brief enrollment changed", details);
         }
         await publishMorningBriefChangedSafely(identity);
         signal.throwIfAborted();


### PR DESCRIPTION
Closes #33538

## Problem

Morning Brief auto-enrollment shipped in #33434 and works, but its **success and skip outcomes are invisible in production**.

The Axiom transport is constructed with an explicit threshold at `turbo/apps/api/src/lib/log.ts:162` (`logLevel: "info"`), and the comment above it states the rule: *"A signal that must be observable in production has to be emitted at info or above."* Records below that threshold never reach the dataset.

Every Morning Brief provisioning path logs failures at `warn`/`error` but logs the successful and skipped outcome at `debug`. So production can show that enrollments **failed**, but not how many succeeded, nor why any were skipped — and the skip reasons (`missing-data-source`, `missing-timezone`, `missing-default-agent`) are exactly the product signal we need.

## Change

Raise the four success/skip call sites from `debug` to `info`:

| File | Message |
| --- | --- |
| `signals/services/morning-brief-enrollment-worker.service.ts` | `"Morning Brief enrollment changed"` |
| `signals/routes/webhooks-clerk.ts` | `"Morning Brief membership provisioning outcome"` |
| `signals/routes/user-preferences.ts` | `"Morning Brief timezone provisioning outcome"` |
| `signals/routes/user-preferences.ts` | `"Morning Brief initialization outcome"` |

`signals/services/onboarding.service.ts:268` already emits `L.info` for this same family of events and is the precedent followed here; it is untouched.

## Why this shape

- `info` is the documented minimum for a production-observable signal in this codebase.
- Each site already builds a single `details` object shared by its failure branch and its success branch, so raising the level exposes **no new fields** and no new personal data beyond what the `warn` branch already emits. The source diff is four level tokens and nothing else.
- The `api/no-logger-info` lint rule bans `logger().info` in API source unless the file declares the exact static message in `allowedMessages`. That allowlist is why `onboarding.service.ts` can already emit this family at info, so `turbo/apps/api/eslint.config.mjs` gains one purely additive entry per file with the exact message strings. The rule stays `"error"` everywhere; every other `logger().info` in these three files is still rejected.
- Volume is bounded by user actions, not polling: the worker only logs on first attempt, on a changed error, or on an actual install — not every cron tick; the Clerk webhook fires once per organization-membership creation; the two `user-preferences.ts` sites fire on the timezone `initialize` call, invoked once per authenticated session.

Rejected alternative: lowering the Axiom threshold in `lib/log.ts`. That would admit every `debug` record in the entire API to the dataset — an unbounded volume and cost change far outside this problem — and would erase a deliberate, documented boundary.

## Not in scope

No change to the Axiom threshold, to any `warn`/`error` call site, to message text, `details` payload shape, or field names, to enrollment behavior/state machine/eligibility rules, to feature switch values, and no new metrics, dashboards, monitors, or alerting.

## Verification

- `grep -rn 'debug("Morning Brief' turbo/apps/api/src` returns no matches; no `debug`-level Morning Brief provisioning outcome call site remains.
- Message strings and `details` field names are byte-identical to `main`, so existing downstream queries keep matching.
- No test asserts these log levels (searched the four message strings repo-wide), so no test update was required.
- `info` and `debug` share the same `LogMethod` signature in `lib/log.ts`, so the change is type-identical at the call site. Remaining checks rely on PR CI.

## Follow-up

Unblocks the `morning-brief-install-report` automation scheduled for 2026-09-14 10:00 Asia/Shanghai, which currently cannot report the success/skip distribution at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

