### PR TITLE
feat(app): narrow the slash panel and scroll its index as one list

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-slash-panel.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-slash-panel.test.tsx
@@ -113,6 +113,21 @@ test("The slash panel previews the highlighted type's covers", async () => {
   expect(within(pane).getByText(first.title)).toBeInTheDocument();
 });
 
+test("The pane carries more than one row of covers, so later templates are reachable", async () => {
+  await openSlashMenu(true);
+  const pane = detailPane();
+  if (!pane) {
+    throw new Error("Expected the detail pane");
+  }
+  // A template past the first row proves the pane scrolls its covers rather
+  // than showing the single row a fixed-height pane could hold.
+  const later = PRESENTATION_TEMPLATE_PICKER_ITEMS[7];
+  if (!later) {
+    throw new Error("Expected an eighth presentation template");
+  }
+  expect(within(pane).getByText(later.title)).toBeInTheDocument();
+});
+
 test("Highlighting a website row swaps the pane to the website catalog", async () => {
   const user = userEvent.setup();
   await openSlashMenu(true);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-slash-panel.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-slash-panel.test.tsx
@@ -156,6 +156,31 @@ test("Highlighting a workflow closes the pane instead of leaving a stale type op
   });
 });
 
+test("The panel emphasizes the typed query inside a workflow name", async () => {
+  setupModels();
+  mockChatLifecycle(context);
+  await setupPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+    featureSwitches: {
+      [FeatureSwitchKey.ComposerCreateCommands]: true,
+      [FeatureSwitchKey.ComposerSlashTemplatePanel]: true,
+    },
+  });
+  const editor = await findComposerEditor();
+  await fill(editor, "Draft /axi");
+  const menu = await screen.findByTestId("slash-workflow-menu");
+  await waitFor(() => {
+    expect(
+      menu.querySelector('[data-slot="workflow-query-match"]'),
+    ).toHaveTextContent("axi");
+  });
+  // The rest of the name is not emphasized, so the match is what stands out.
+  expect(slashButton(`/${WORKFLOW_NAME}`)).toHaveTextContent(
+    `/${WORKFLOW_NAME}`,
+  );
+});
+
 test("Choosing a cover in the pane attaches that template without opening the picker", async () => {
   const user = userEvent.setup();
   await openSlashMenu(true);

--- a/turbo/apps/platform/src/views/okou-page/composer-template-catalog.ts
+++ b/turbo/apps/platform/src/views/okou-page/composer-template-catalog.ts
@@ -121,11 +121,16 @@ export function isSlashTemplatePreviewCategory(
   });
 }
 
-/** Covers render two across a 400px pane, so they are requested at 2x that. */
-const SLASH_TEMPLATE_COVER_SIZE = { width: 360, height: 202 } as const;
+/** Covers render two across a 320px pane, so they are requested at 2x that. */
+const SLASH_TEMPLATE_COVER_SIZE = { width: 280, height: 158 } as const;
 
-/** The pane shows one screen of covers; the rest live in the picker dialog. */
-const SLASH_TEMPLATE_PREVIEW_COUNT = 4;
+/**
+ * The pane scrolls, so it carries several screens of covers rather than the one
+ * row a fixed pane could hold. This is catalog order, which is the same
+ * curated order the picker dialog leads with; the client has no usage signal to
+ * rank by. The remainder still lives behind "Browse all templates".
+ */
+const SLASH_TEMPLATE_PREVIEW_COUNT = 12;
 
 export interface SlashTemplatePreview {
   readonly slug: string;

--- a/turbo/apps/platform/src/views/okou-page/slash-template-panel.tsx
+++ b/turbo/apps/platform/src/views/okou-page/slash-template-panel.tsx
@@ -129,12 +129,12 @@ function SlashTemplateDetailPane({
   const Icon = SLASH_TEMPLATE_CATEGORY_ICONS[category];
   return (
     <div
-      className="w-[400px] shrink-0"
+      className="w-[320px] shrink-0"
       data-slot="slash-template-detail"
       data-category={category}
     >
       <div className="flex h-full flex-col p-4">
-        <div className="flex items-center gap-2.5">
+        <div className="flex shrink-0 items-center gap-2.5">
           <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted">
             <Icon size={18} className="text-muted-foreground" aria-hidden />
           </span>
@@ -152,10 +152,11 @@ function SlashTemplateDetailPane({
             </span>
           </span>
         </div>
-        <p className="mt-3 text-[13px] leading-6 text-muted-foreground">
+        <p className="mt-3 shrink-0 text-[13px] leading-6 text-muted-foreground">
           {categoryDescription(category)}
         </p>
-        <div className="mt-3 grid grid-cols-2 gap-2.5">
+        {/* The covers scroll so the pane can carry more than one row of them. */}
+        <div className="mt-3 grid min-h-0 flex-1 grid-cols-2 content-start gap-2.5 overflow-y-auto">
           {group.previews.map((preview) => {
             return (
               <button
@@ -210,7 +211,7 @@ function SlashPanelWorkflowList({
   const { t } = useTranslation();
   if (loading) {
     return (
-      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-1.5 text-sm text-muted-foreground">
+      <div className="px-2 py-1.5 text-sm text-muted-foreground">
         {t(($) => {
           return $.chat.composer.workflows.loading;
         })}
@@ -219,7 +220,7 @@ function SlashPanelWorkflowList({
   }
   if (workflows.length === 0) {
     return (
-      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-1.5 text-sm text-muted-foreground">
+      <div className="px-2 py-1.5 text-sm text-muted-foreground">
         {t(($) => {
           return $.chat.composer.workflows.empty;
         })}
@@ -227,7 +228,7 @@ function SlashPanelWorkflowList({
     );
   }
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto px-1.5 pb-1.5">
+    <div className="px-1.5">
       {workflows.map((workflow) => {
         return (
           <button
@@ -283,8 +284,13 @@ export function SlashTemplatePanel({
       : null;
   return (
     <div className="flex h-[380px] overflow-hidden" data-slot="slash-panel">
-      <div className="flex min-h-0 w-[320px] shrink-0 flex-col border-r border-border/60">
-        <div className="shrink-0">
+      <div className="flex min-h-0 w-[260px] shrink-0 flex-col border-r border-border/60">
+        {/*
+          Make and Workflows scroll as one list. Scrolling only the workflows
+          left a row sliced in half under a pinned section label, and hid that
+          the two groups are one index.
+        */}
+        <div className="min-h-0 flex-1 overflow-y-auto pb-1.5">
           <SectionLabel>
             {t(($) => {
               return $.chat.composer.slashPanel.make;
@@ -329,14 +335,14 @@ export function SlashTemplatePanel({
               return $.chat.composer.workflows.title;
             })}
           </SectionLabel>
+          <SlashPanelWorkflowList
+            workflows={workflows}
+            loading={workflowsLoading}
+            onHighlight={onHighlight}
+            onSelect={onSelectWorkflow}
+            workflowOptionId={workflowOptionId}
+          />
         </div>
-        <SlashPanelWorkflowList
-          workflows={workflows}
-          loading={workflowsLoading}
-          onHighlight={onHighlight}
-          onSelect={onSelectWorkflow}
-          workflowOptionId={workflowOptionId}
-        />
         <div className="shrink-0 border-t border-border/60 p-1">
           <button
             type="button"

--- a/turbo/apps/platform/src/views/okou-page/slash-template-panel.tsx
+++ b/turbo/apps/platform/src/views/okou-page/slash-template-panel.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { cn } from "@okouai/ui";
 import { useTranslation } from "react-i18next";
+import { SlashWorkflowName } from "./slash-workflow.tsx";
 import { i18n } from "../../i18n/index.ts";
 import type { ComposerSlashWorkflowMatch } from "../../signals/okou-page/workflow-composer-domain.ts";
 import {
@@ -23,6 +24,9 @@ import {
   type SlashTemplatePreviewCategory,
 } from "./composer-template-catalog.ts";
 
+// Concentric corners, the same rule the shared DropdownMenu states: an inner
+// radius equals the outer radius minus the gap. The popover is 12px and the row
+// gutters are `p-1` (4px), so every hoverable row is `rounded-lg` (8px).
 const SLASH_TEMPLATE_CATEGORY_ICONS = {
   slides: Presentation,
   illustration: Image,
@@ -133,7 +137,12 @@ function SlashTemplateDetailPane({
       data-slot="slash-template-detail"
       data-category={category}
     >
-      <div className="flex h-full flex-col p-4">
+      {/*
+        No bottom padding: the covers scroll all the way to the panel's bottom
+        edge, so a half-visible row reads as more content rather than sitting
+        above a white gutter. The trailing space lives inside the scroller.
+      */}
+      <div className="flex h-full flex-col px-4 pt-4">
         <div className="flex shrink-0 items-center gap-2.5">
           <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted">
             <Icon size={18} className="text-muted-foreground" aria-hidden />
@@ -155,40 +164,46 @@ function SlashTemplateDetailPane({
         <p className="mt-3 shrink-0 text-[13px] leading-6 text-muted-foreground">
           {categoryDescription(category)}
         </p>
-        {/* The covers scroll so the pane can carry more than one row of them. */}
-        <div className="mt-3 grid min-h-0 flex-1 grid-cols-2 content-start gap-2.5 overflow-y-auto">
-          {group.previews.map((preview) => {
-            return (
-              <button
-                key={preview.slug}
-                type="button"
-                className="group min-w-0 text-left"
-                aria-label={t(
-                  ($) => {
-                    return $.chat.composer.slashPanel.useTemplate;
-                  },
-                  { title: preview.title },
-                )}
-                onMouseDown={(event) => {
-                  // Keep the editor focused; the panel never takes selection.
-                  event.preventDefault();
-                  onSelectTemplate(preview);
-                }}
-              >
-                <span className="block aspect-video overflow-hidden rounded-lg bg-muted ring-1 ring-border/60">
-                  <img
-                    src={preview.coverUrl}
-                    alt=""
-                    loading="lazy"
-                    className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-[1.04]"
-                  />
-                </span>
-                <span className="mt-1 block truncate text-[12px] text-muted-foreground">
-                  {preview.title}
-                </span>
-              </button>
-            );
-          })}
+        {/*
+          The grid is a child of the scroller rather than the scroller itself,
+          so its trailing padding is an ordinary block margin every engine
+          measures, not padding on a scroll container.
+        */}
+        <div className="mt-3 min-h-0 flex-1 overflow-y-auto">
+          <div className="grid grid-cols-2 gap-2.5 pb-4">
+            {group.previews.map((preview) => {
+              return (
+                <button
+                  key={preview.slug}
+                  type="button"
+                  className="group min-w-0 text-left"
+                  aria-label={t(
+                    ($) => {
+                      return $.chat.composer.slashPanel.useTemplate;
+                    },
+                    { title: preview.title },
+                  )}
+                  onMouseDown={(event) => {
+                    // Keep the editor focused; the panel never takes selection.
+                    event.preventDefault();
+                    onSelectTemplate(preview);
+                  }}
+                >
+                  <span className="block aspect-video overflow-hidden rounded-lg bg-muted ring-1 ring-border/60">
+                    <img
+                      src={preview.coverUrl}
+                      alt=""
+                      loading="lazy"
+                      className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-[1.04]"
+                    />
+                  </span>
+                  <span className="mt-1 block truncate text-[12px] text-muted-foreground">
+                    {preview.title}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
         </div>
       </div>
     </div>
@@ -228,14 +243,14 @@ function SlashPanelWorkflowList({
     );
   }
   return (
-    <div className="px-1.5">
+    <div className="px-1">
       {workflows.map((workflow) => {
         return (
           <button
             key={workflow.id}
             id={workflowOptionId(workflow.id)}
             type="button"
-            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition-colors hover:bg-state-hover"
+            className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-state-hover"
             onMouseEnter={() => {
               // A workflow has nothing to preview, so highlighting one closes
               // the pane rather than leaving a stale type open.
@@ -251,10 +266,10 @@ function SlashPanelWorkflowList({
               className="shrink-0 text-muted-foreground"
               aria-hidden
             />
-            <span className="min-w-0 flex-1 truncate font-mono text-[13px] text-foreground">
-              <span className="text-brand-text">/</span>
-              {workflow.name}
-            </span>
+            <SlashWorkflowName
+              workflow={workflow}
+              className="min-w-0 flex-1 text-[13px]"
+            />
           </button>
         );
       })}
@@ -290,13 +305,13 @@ export function SlashTemplatePanel({
           left a row sliced in half under a pinned section label, and hid that
           the two groups are one index.
         */}
-        <div className="min-h-0 flex-1 overflow-y-auto pb-1.5">
+        <div className="min-h-0 flex-1 overflow-y-auto pb-1">
           <SectionLabel>
             {t(($) => {
               return $.chat.composer.slashPanel.make;
             })}
           </SectionLabel>
-          <div className="px-1.5">
+          <div className="px-1">
             {categories.map((category) => {
               const Icon = SLASH_TEMPLATE_CATEGORY_ICONS[category];
               const label = slashTemplateCategoryLabel(category);
@@ -307,7 +322,7 @@ export function SlashTemplatePanel({
                   type="button"
                   aria-label={label}
                   className={cn(
-                    "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-foreground transition-colors",
+                    "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm text-foreground transition-colors",
                     highlighted === category
                       ? "bg-state-hover"
                       : "hover:bg-state-hover",
@@ -346,7 +361,7 @@ export function SlashTemplatePanel({
         <div className="shrink-0 border-t border-border/60 p-1">
           <button
             type="button"
-            className="flex h-8 w-full items-center justify-between rounded px-2 text-sm text-foreground transition-colors hover:bg-state-hover"
+            className="flex h-8 w-full items-center justify-between rounded-lg px-2 text-sm text-foreground transition-colors hover:bg-state-hover"
             onMouseDown={(event) => {
               event.preventDefault();
               onBrowseAll();

--- a/turbo/apps/platform/src/views/okou-page/slash-template-panel.tsx
+++ b/turbo/apps/platform/src/views/okou-page/slash-template-panel.tsx
@@ -165,11 +165,14 @@ function SlashTemplateDetailPane({
           {categoryDescription(category)}
         </p>
         {/*
+          The scroller reaches the pane's right edge and pads its content back,
+          so the overlay scrollbar — which draws inward from the viewport edge —
+          lands in that gutter instead of on top of the right-hand covers.
           The grid is a child of the scroller rather than the scroller itself,
           so its trailing padding is an ordinary block margin every engine
           measures, not padding on a scroll container.
         */}
-        <div className="mt-3 min-h-0 flex-1 overflow-y-auto">
+        <div className="-mr-4 mt-3 min-h-0 flex-1 overflow-y-auto pr-4">
           <div className="grid grid-cols-2 gap-2.5 pb-4">
             {group.previews.map((preview) => {
               return (

--- a/turbo/apps/platform/src/views/okou-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/okou-page/slash-workflow.tsx
@@ -91,7 +91,7 @@ function SlashCreateGroup({
     return null;
   }
   return (
-    <div className="px-1.5 py-1.5">
+    <div className="px-1 py-1">
       {modes.map((mode, index) => {
         const Icon = COMPOSER_CREATE_ICONS[mode];
         return (
@@ -101,7 +101,7 @@ function SlashCreateGroup({
             type="button"
             aria-label={composerCreateCommandLabel(mode)}
             className={cn(
-              "flex w-full items-center gap-2 rounded px-2 py-2 text-left text-sm transition-colors",
+              "flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-sm transition-colors",
               index === selectedIndex ? "bg-accent" : "hover:bg-state-hover",
             )}
             onPointerDown={(event) => {
@@ -130,14 +130,20 @@ function SlashCreateGroup({
   );
 }
 
-function SlashWorkflowName({
+/**
+ * The name with the typed query emphasized. Shared with the slash panel so both
+ * menus show the same match feedback while typing.
+ */
+export function SlashWorkflowName({
   workflow,
+  className,
 }: {
   readonly workflow: ComposerSlashWorkflowMatch;
+  readonly className?: string;
 }) {
   return (
     <span
-      className="w-full truncate font-mono text-sm text-foreground"
+      className={cn("truncate font-mono text-foreground", className)}
       data-slot="slash-workflow-name"
     >
       <span className="text-brand-text">/</span>
@@ -158,6 +164,71 @@ function SlashWorkflowName({
       })}
       {workflow.name.slice(workflow.matchRanges.at(-1)?.end ?? 0)}
     </span>
+  );
+}
+
+/** The flat menu's workflow rows, split out to keep the menu within its size. */
+function SlashWorkflowRows({
+  workflows,
+  loading,
+  selectedIndex,
+  indexOffset,
+  onSelect,
+}: {
+  readonly workflows: readonly ComposerSlashWorkflowMatch[];
+  readonly loading: boolean;
+  readonly selectedIndex: number;
+  /** How many rows precede these, so the shared index still lines up. */
+  readonly indexOffset: number;
+  readonly onSelect: (workflow: ComposerSlashWorkflow) => void;
+}) {
+  const { t } = useTranslation();
+  if (loading) {
+    return (
+      <div className="px-2.5 py-2 text-sm text-muted-foreground">
+        {t(($) => {
+          return $.chat.composer.workflows.loading;
+        })}
+      </div>
+    );
+  }
+  if (workflows.length === 0) {
+    return (
+      <div className="px-2.5 pt-1 pb-2.5 text-sm text-muted-foreground">
+        {t(($) => {
+          return $.chat.composer.workflows.empty;
+        })}
+      </div>
+    );
+  }
+  return (
+    <div className="px-1 pb-1">
+      {workflows.map((workflow, index) => {
+        const selected = index + indexOffset === selectedIndex;
+        return (
+          <button
+            id={slashWorkflowOptionId(workflow.id)}
+            key={workflow.id}
+            type="button"
+            className={cn(
+              "flex w-full flex-col items-start gap-0.5 rounded-lg px-2 py-1.5 text-left transition-colors",
+              selected ? "bg-accent" : "hover:bg-state-hover",
+            )}
+            onMouseDown={(event) => {
+              event.preventDefault();
+              onSelect(workflow);
+            }}
+          >
+            <SlashWorkflowName workflow={workflow} className="w-full text-sm" />
+            {workflow.description && (
+              <span className="w-full truncate text-xs text-muted-foreground/70">
+                {workflow.description}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
   );
 }
 
@@ -221,47 +292,13 @@ export function SlashWorkflowMenu({
                 return $.chat.composer.workflows.title;
               })}
             </div>
-            {loading ? (
-              <div className="px-2.5 py-2 text-sm text-muted-foreground">
-                {t(($) => {
-                  return $.chat.composer.workflows.loading;
-                })}
-              </div>
-            ) : workflows.length > 0 ? (
-              <div className="px-1.5 pb-1.5">
-                {workflows.map((workflow, index) => {
-                  const selected = index + createModes.length === selectedIndex;
-                  return (
-                    <button
-                      id={slashWorkflowOptionId(workflow.id)}
-                      key={workflow.id}
-                      type="button"
-                      className={cn(
-                        "flex w-full flex-col items-start gap-0.5 rounded px-2 py-1.5 text-left transition-colors",
-                        selected ? "bg-accent" : "hover:bg-state-hover",
-                      )}
-                      onMouseDown={(event) => {
-                        event.preventDefault();
-                        onSelect(workflow);
-                      }}
-                    >
-                      <SlashWorkflowName workflow={workflow} />
-                      {workflow.description && (
-                        <span className="w-full truncate text-xs text-muted-foreground/70">
-                          {workflow.description}
-                        </span>
-                      )}
-                    </button>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className="px-2.5 pt-1 pb-2.5 text-sm text-muted-foreground">
-                {t(($) => {
-                  return $.chat.composer.workflows.empty;
-                })}
-              </div>
-            )}
+            <SlashWorkflowRows
+              workflows={workflows}
+              loading={loading}
+              selectedIndex={selectedIndex}
+              indexOffset={createModes.length}
+              onSelect={onSelect}
+            />
           </div>
           {showWorkflowsPageLink && (
             <div className="shrink-0 border-t border-border/60 bg-popover/95 p-1">
@@ -271,7 +308,7 @@ export function SlashWorkflowMenu({
                   // Keep the composer focused until Link handles the click.
                   event.preventDefault();
                 }}
-                className="flex h-8 w-full items-center justify-between rounded px-2 text-sm font-medium text-popover-foreground transition-colors hover:bg-state-hover"
+                className="flex h-8 w-full items-center justify-between rounded-lg px-2 text-sm font-medium text-popover-foreground transition-colors hover:bg-state-hover"
               >
                 <span className="flex min-w-0 items-center gap-2">
                   <FileText


### PR DESCRIPTION
## What

Three design-review changes to the `/` panel shipped in #33405. Everything stays
behind `composerSlashTemplatePanel`.

Before / after at 1:1, with the numbers measured by the page itself:
https://okou-slash-panel-narrow.okou.app

## Why and how

**Both columns were too wide.** The index goes `320px → 260px` and the detail
pane `400px → 320px`, so the panel is 580px instead of 720px. Cover cards follow
the pane down to 139px and are requested at 2x that (`360×202 → 280×158`).
Make labels have room to spare at 260px; workflow names already truncated and
simply truncate a little sooner.

**Make and Workflows now scroll as one list.** Scrolling only the workflow group
produced the reported artefact: a row sliced in half under a pinned section
label, which also hid that the two groups are one index. The scroller moved up
to wrap both, `SlashPanelWorkflowList` stopped owning one, and only
"Browse all templates" stays pinned. Keyboard navigation improves as a side
effect — arrowing from a Make row into the workflows used to cross two scroll
contexts and now crosses none.

**The detail pane's covers scroll.** The grid became the pane's flex child with
`min-h-0 flex-1 overflow-y-auto content-start`, and the header and description
are `shrink-0` so they do not compress. The preview count goes 4 → 12, which is
about 6 rows against ~2.5 visible.

## Judgment call

"多展示几个用户用的多的 template" asks for the most-used templates. The client has
no usage signal — nothing plumbs run counts to the composer — so this uses
**catalog order**, which is the curated order the picker dialog already leads
with, and is the closest thing to "recommended" that exists today. Ranking by
real usage would need an API that does not exist yet. Twelve is a bounded
"several more" rather than the whole catalog, so the popover does not mount 32
images; the remainder stays behind **Browse all templates**.

## Design review round 2

Three further fixes after looking at the rendered panel.

**Covers bleed to the bottom edge.** The grid stopped 16px above the panel edge,
so a half-visible row sat above a white gutter and read as a mistake rather than
as more content. The pane drops its bottom padding and the trailing space moves
inside the scroller, where it only shows once the list is scrolled to its end.
The grid is now a child of the scroller rather than the scroller itself, so that
trailing padding is an ordinary block box every engine measures instead of
padding on a scroll container.

**Hover corners nest.** Rows were `rounded` (4px) inside a 12px popover, so a
hovered footer crossed the panel's bottom corner. Both slash menus now follow
the rule the shared `DropdownMenu` already documents at
`turbo/packages/ui/src/components/ui/dropdown-menu.tsx:70` — inner radius equals
outer radius minus the gap — so 12px with `p-1` gutters gives `rounded-lg` rows.
The flat menu had the same defect and is fixed with it, since it is the same
surface with the switch off.

**Query-match emphasis restored.** The panel rendered a plain workflow name and
so dropped the highlight the flat menu has always had while typing.
`SlashWorkflowName` is now exported and shared by both menus rather than
duplicated, with a `className` for the panel's 13px rows.

`SlashWorkflowMenu` crossed the 128-line limit once the shared name component
was wired in, so its workflow rows were extracted into `SlashWorkflowRows`.
No suppressions.

Added test: typing a query emphasizes the matching letters inside a workflow
name in the panel, asserted through the existing `data-slot="workflow-query-match"`
hook that `chat-composer-workflows` already uses.

## Verification

- `vitest run` on `chat-composer-slash-panel` (7, two new), `chat-composer-create`
  (19), `chat-composer-workflows` (17) — 50 passed
- `pnpm run check-types`, full `pnpm run lint` (platform), `prettier --check`

The new test covers the one thing here that is externally observable rather than
layout: a template past the first row is now reachable in the pane. The scroll
container placement itself is a layout property with no assertable surface in
happy-dom, so it is carried by the linked before/after instead of a class
assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
