### PR TITLE
test: split voice accounting and trim slow test fixtures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/codex-reset-credit-expiry.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/codex-reset-credit-expiry.test.ts
@@ -840,6 +840,16 @@ describe("Codex expiry metadata resilience", () => {
     });
     const providers = app(personalModelProvidersMainContract);
     const switches = app(featureSwitchesContract);
+    // Fresh users in this non-staff organization already use legacy bindings.
+    // Verify that public context once instead of writing the same disabled
+    // override for all 129 independent owners.
+    const defaults = await accept(
+      switches.get({ headers: { authorization: `Bearer ${userIds[0]}` } }),
+      [200],
+    );
+    expect(defaults.body.effectiveSwitches).toMatchObject({
+      [FeatureSwitchKey.PersonalModelProviderAccounts]: false,
+    });
     // Each API-created owner occupies a connect binding and a legacy binding.
     // More than 256 bindings must evict the oldest, without time manipulation.
     // Token-scoped Clerk responses let independent owners prepare concurrently
@@ -848,17 +858,6 @@ describe("Codex expiry metadata resilience", () => {
       await Promise.all(
         userIds.slice(index, index + 8).map(async (userId) => {
           const ownerHeaders = { authorization: `Bearer ${userId}` };
-          await accept(
-            switches.update({
-              headers: ownerHeaders,
-              body: {
-                switches: {
-                  [FeatureSwitchKey.PersonalModelProviderAccounts]: false,
-                },
-              },
-            }),
-            [200],
-          );
           await accept(
             providers.upsert({
               headers: ownerHeaders,

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
@@ -1311,7 +1311,10 @@ describe("POST /api/voice-io/transcribe/segment", () => {
     expect(response.body.error.code).toBe("VOICE_TRANSCRIPTION_FAILED");
   });
 
-  it("counts one free-tier recording only after finalization, including a failed final attempt", async () => {
+  it.each([
+    "unfinished segments",
+    "a failed final attempt followed by a successful retry",
+  ])("counts free-tier recordings correctly for %s", async (phase) => {
     mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
     const actor = await enabledActor();
     if (!actor.orgId) {
@@ -1362,24 +1365,30 @@ describe("POST /api/voice-io/transcribe/segment", () => {
         });
       }),
     );
-    await accept(
-      client().segment({
-        headers,
-        body: segmentForm([audioFile(1, 60)], "", false, 60),
-      }),
-      [200],
-    );
-    await accept(
-      client().segment({
-        headers,
-        body: segmentForm([audioFile(2, 60)], "First part.", false, 120),
-      }),
-      [200],
-    );
-    await expect(readQuota()).resolves.toMatchObject({
-      allowed: true,
-      count: 0,
-    });
+    if (phase === "unfinished segments") {
+      await accept(
+        client().segment({
+          headers,
+          body: segmentForm([audioFile(1, 60)], "", false, 60),
+        }),
+        [200],
+      );
+      await accept(
+        client().segment({
+          headers,
+          body: segmentForm([audioFile(2, 60)], "First part.", false, 120),
+        }),
+        [200],
+      );
+      await expect(readQuota()).resolves.toMatchObject({
+        allowed: true,
+        count: 0,
+      });
+      return;
+    }
+
+    // Finalization receives the accumulated transcript from the client; it
+    // does not depend on server-owned state from the earlier segment requests.
     await accept(
       client().segment({
         headers,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-mail-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-mail-feedback.test.tsx
@@ -109,7 +109,9 @@ async function sendMailFeedback(
 ): Promise<CapturedChatSend> {
   await selectPassage("launch review to Monday morning");
   const editor = await quoteSelectedPassage();
-  await userEvent.setup({ delay: null }).type(editor, comment);
+  const user = userEvent.setup({ delay: null });
+  await user.click(editor);
+  await user.paste(comment);
   const composer = editor.closest<HTMLElement>("[data-chat-composer]");
   if (!composer) {
     throw new Error("Owning mail feedback composer was not available");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-position-restoration.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-position-restoration.test.tsx
@@ -503,17 +503,18 @@ test("Restore the reading position during keyboard thread navigation", async () 
 });
 
 test("Restore the reading position after switching threads from the sidebar", async () => {
-  const user = userEvent.setup();
+  // The current thread needs a middle anchor; the neighboring thread only
+  // needs enough content to prove that sidebar navigation completed.
   mockThreadStories(SIDEBAR_CURRENT_THREAD_ID, [
     {
       id: SIDEBAR_OTHER_THREAD_ID,
       title: "Planning notes",
-      events: conversationEvents("sidebar-other", "Planning"),
+      events: conversationEvents("sidebar-other", "Planning", 1),
     },
     {
       id: SIDEBAR_CURRENT_THREAD_ID,
       title: "Research notes",
-      events: conversationEvents("sidebar-current", "Research"),
+      events: conversationEvents("sidebar-current", "Research", 3),
     },
   ]);
 
@@ -523,7 +524,7 @@ test("Restore the reading position after switching threads from the sidebar", as
     path: `/chats/${SIDEBAR_CURRENT_THREAD_ID}`,
   });
 
-  const targetText = "Research message 3";
+  const targetText = "Research message 2";
   await waitForThreadMessage(SIDEBAR_CURRENT_THREAD_ID, targetText);
   const initialGeometry = installChatScrollGeometry(
     threadContainer(SIDEBAR_CURRENT_THREAD_ID),
@@ -547,11 +548,11 @@ test("Restore the reading position after switching threads from the sidebar", as
     "href",
     `/chats/${SIDEBAR_OTHER_THREAD_ID}`,
   );
-  await user.click(planningLink);
+  click(planningLink);
   await waitForInteractiveThread(
     SIDEBAR_OTHER_THREAD_ID,
     "Planning notes",
-    "Planning message 6",
+    "Planning message 1",
   );
 
   const researchLink = sidebarThreadLink(
@@ -562,7 +563,7 @@ test("Restore the reading position after switching threads from the sidebar", as
     "href",
     `/chats/${SIDEBAR_CURRENT_THREAD_ID}`,
   );
-  await user.click(researchLink);
+  click(researchLink);
   await waitForInteractiveThread(
     SIDEBAR_CURRENT_THREAD_ID,
     "Research notes",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/presentation-preview.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/presentation-preview.test.tsx
@@ -200,7 +200,12 @@ test("Selecting a slide preserves its authored layout", async () => {
   });
 
   const firstFrame = await openPresentationDetail();
-  await hydratePreviewFrame(firstFrame, objectUrls);
+  // Selection depends on the iframe load event, not on reading the first
+  // slide's document. Render and inspect the selected slide below.
+  fireEvent.load(firstFrame);
+  await waitFor(() => {
+    expect(firstFrame).toHaveAttribute("data-loaded", "true");
+  });
   const firstFrameUrl = firstFrame.getAttribute("src");
   click(await waitForNamedButton("Preview slide 2"));
   await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
@@ -112,22 +112,25 @@ function resizeWindow(): void {
 }
 
 test("entering the scrolled list keeps the visible threads available for navigation", async () => {
-  mockThreads(120);
+  // Thirty rows exceed this five-row viewport plus its overscan. Row 21
+  // starts outside the top window while keeping the rendered fixture small.
+  mockThreads(30);
   mockViewportHeight(() => {
-    return 612;
-  });
-  await setupPage({ context, path: `/chats/${threadId(80)}` });
+    return 5 * ROW_HEIGHT;
+  }, 30);
+  await setupPage({ context, path: `/chats/${threadId(20)}` });
   const sidebar = screen.getByTestId("chat-list-column");
-  await within(sidebar).findByText("History 81");
+  await within(sidebar).findByText("History 21");
   const viewport = within(sidebar).getByTestId("sidebar-scroll-area");
   await waitFor(() => {
-    expect(viewport.scrollTop).toBe(80 * ROW_HEIGHT);
+    expect(viewport.scrollTop).toBe(20 * ROW_HEIGHT);
   });
   viewport.scrollTop = 0;
   fireEvent.scroll(viewport);
   const title = await within(sidebar).findByText("History 1");
+  expect(within(sidebar).queryByText("History 21")).not.toBeInTheDocument();
   const link = title.closest("a");
-  const user = userEvent.setup();
+  const user = userEvent.setup({ delay: null });
   act(() => {
     viewport.focus();
   });


### PR DESCRIPTION
Tests identified in #33319 still approach Vitest's unchanged 5-second timeout. Split free-tier voice accounting into independent unfinished-segment and failed-finalization/retry cases, and reduce unnecessary fixture or interaction work in five other original scenarios.

| Original scenario | Preserved behavior |
| --- | --- |
| T158: voice recording quota | Both unfinished segments leave the count at zero; failed finalization also leaves zero, then a successful retry counts exactly once. Keep the Google Cloud provider path introduced in #33462. |
| T027: bounded expiry cache | Keep all 129 owners and both bindings per owner to exceed the real 256-entry capacity, then re-read the oldest identity. Assert the fresh public switch context instead of writing 129 identical disabled overrides. |
| T115: sidebar reading restoration | Keep a middle reading anchor, navigate to another thread, return, and assert the original reading offset. Trim unrelated conversation history and use ordinary click helpers. |
| T097: virtualized keyboard navigation | Keep actual overflow and offscreen row removal, Tab focus, zero scroll position, and Enter navigation with a smaller viewport and thread fixture. |
| T085: authored slide layout | Load the initial iframe and fully render/inspect the selected second slide, retaining every authored-layout assertion. |
| T160: email feedback source | Paste into the empty feedback note while retaining the quote, note, source IDs, captured request and displayed-message checks for both draft and sent email. |

Relates to #33319. This is one consolidated continuation after #33500. The [76-finding reconciliation](https://github.com/vm0-ai/vm0/issues/33319#issuecomment-5632424389) records all current mappings and precise blockers. One original is split into two cases; five originals receive fixture/interaction improvements. The other 70 identities and the separate browser-validation gap remain unresolved, so this PR does not close the tracking issue. Production code, timeout settings and test retry/skip behavior are unchanged.

Validation: eight targeted cases across the six changed files pass with the default timeout and at most two workers. The voice cases measure approximately 1.51s and 3.14s versus the original 4.17s; the bounded cache measures 3.25s versus a 5.06s timeout; the five Platform cases measure 1.73–3.88s on the corrected revision. Earlier failed measurements remain in the issue evidence; local speed does not remove an unchanged CI-confirmed finding.

Formatting, affected-file Oxlint (including type-aware rules) and ESLint, affected-workspace Knip, and API/Platform type checks are recorded with the implementation evidence. Full-suite validation is delegated to the PR pipeline.
