### PR TITLE
refactor(runner): rename the vm0-prefixed mitm addon options

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -162,7 +162,7 @@ def clear_cache() -> None:
 def configured_catalog_cache_path() -> str | None:
     """Return the runner-configured builtin catalog cache path."""
     options = getattr(ctx, "options", None)
-    cache_path = getattr(options, "vm0_builtin_firewall_catalog_cache_path", None)
+    cache_path = getattr(options, "okou_builtin_firewall_catalog_cache_path", None)
     if not isinstance(cache_path, str) or cache_path == "":
         return None
     return cache_path

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -187,16 +187,16 @@ def load(loader: Loader) -> None:
         runner_flush_lifecycle.handle_runner_usage_flush_signal,
     )
     loader.add_option(
-        name="vm0_api_url",
+        name="okou_api_url",
         typespec=str,
         default="https://api.okou.ai",
         help="Okou API URL for proxy endpoint",
     )
     loader.add_option(
-        name="vm0_proxy_registry_path",
+        name="okou_proxy_registry_path",
         typespec=str,
         # This default is a placeholder shown in `mitmdump --help`; the runner
-        # always passes `--set vm0_proxy_registry_path=<per-runner path>` (see
+        # always passes `--set okou_proxy_registry_path=<per-runner path>` (see
         # `proxy::process::spawn_mitmdump` in
         # `crates/runner/src/proxy/process.rs`), so the default is never used in
         # production. Computed via tempfile.gettempdir() so that standalone
@@ -205,37 +205,37 @@ def load(loader: Loader) -> None:
         help="Path to proxy registry file",
     )
     loader.add_option(
-        name="vm0_builtin_firewall_catalog_cache_path",
+        name="okou_builtin_firewall_catalog_cache_path",
         typespec=str,
         default=str(Path(tempfile.gettempdir()) / "builtin-firewall-catalog-cache.json"),
         help="Path to runner builtin firewall catalog cache file",
     )
     loader.add_option(
-        name="vm0_usage_state_id",
+        name="okou_usage_state_id",
         typespec=str,
         default="",
         help="Runner-generated usage-pending state id",
     )
     loader.add_option(
-        name="vm0_addon_ready_path",
+        name="okou_addon_ready_path",
         typespec=str,
         default="",
         help="Path for the runner's addon initialization marker",
     )
     loader.add_option(
-        name="vm0_client_session_id",
+        name="okou_client_session_id",
         typespec=str,
         default="",
         help="Runner-generated client session id for platform API requests",
     )
     loader.add_option(
-        name="vm0_client_version",
+        name="okou_client_version",
         typespec=str,
         default="",
         help="Runner package version for platform API request attribution",
     )
     loader.add_option(
-        name="vm0_usage_flush_interval_seconds",
+        name="okou_usage_flush_interval_seconds",
         typespec=float,
         default=usage.DEFAULT_FLUSH_INTERVAL_SECONDS,
         help="Usage-event buffer flush interval in seconds",
@@ -244,29 +244,29 @@ def load(loader: Loader) -> None:
 
 def configure(updated: set[str]) -> None:
     platform_api.configure_client_headers(
-        client_session_id=ctx.options.vm0_client_session_id,
-        client_version=ctx.options.vm0_client_version,
+        client_session_id=ctx.options.okou_client_session_id,
+        client_version=ctx.options.okou_client_version,
     )
     model_provider_failure.configure_reporting(
         api_url=get_api_url(),
         bearer_credential=os.environ.get(model_provider_failure.RUNNER_AUTH_ENV, ""),
     )
-    if "vm0_usage_flush_interval_seconds" in updated:
+    if "okou_usage_flush_interval_seconds" in updated:
         usage.configure_usage_buffer(
-            flush_interval_seconds=ctx.options.vm0_usage_flush_interval_seconds
+            flush_interval_seconds=ctx.options.okou_usage_flush_interval_seconds
         )
-    if "vm0_usage_state_id" in updated:
+    if "okou_usage_state_id" in updated:
         # Custom --set options are deferred until after load() registers them,
         # so initialize this file here where ctx.options has the runner value.
         usage.set_pending_path(
             str(Path(__file__).resolve().parent / "usage-pending"),
-            usage_state_id=ctx.options.vm0_usage_state_id or None,
+            usage_state_id=ctx.options.okou_usage_state_id or None,
         )
 
 
 def running() -> None:
-    ready_path = ctx.options.vm0_addon_ready_path
-    usage_state_id = ctx.options.vm0_usage_state_id
+    ready_path = ctx.options.okou_addon_ready_path
+    usage_state_id = ctx.options.okou_usage_state_id
     if ready_path and usage_state_id:
         runner_flush_lifecycle.start_runner_jsonl_flush_worker()
         Path(ready_path).write_text(usage_state_id, encoding="utf-8")
@@ -274,12 +274,12 @@ def running() -> None:
 
 def get_api_url() -> str:
     """Get API URL from options."""
-    return ctx.options.vm0_api_url
+    return ctx.options.okou_api_url
 
 
 def get_registry_path() -> str:
     """Get registry path from options."""
-    return ctx.options.vm0_proxy_registry_path
+    return ctx.options.okou_proxy_registry_path
 
 
 def _request_headers_probe_metadata_keys() -> tuple[str, ...]:

--- a/crates/runner/mitm-addon/src/platform_api.py
+++ b/crates/runner/mitm-addon/src/platform_api.py
@@ -115,7 +115,7 @@ def add_vercel_bypass_header(headers: http.Headers) -> None:
 
 def get_api_url() -> str:
     """Get API URL from mitmproxy options."""
-    return ctx.options.vm0_api_url
+    return ctx.options.okou_api_url
 
 
 def make_api_request(url: str, data: bytes, bearer_credential: str) -> urllib.request.Request:

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -351,12 +351,12 @@ class _StubOptions:
         client_version: str,
         ssl_insecure: bool,
     ) -> None:
-        self.vm0_proxy_registry_path = registry_path
-        self.vm0_api_url = api_url
-        self.vm0_builtin_firewall_catalog_cache_path = builtin_firewall_catalog_cache_path
-        self.vm0_client_session_id = client_session_id
-        self.vm0_client_version = client_version
-        self.vm0_usage_flush_interval_seconds = usage.DEFAULT_FLUSH_INTERVAL_SECONDS
+        self.okou_proxy_registry_path = registry_path
+        self.okou_api_url = api_url
+        self.okou_builtin_firewall_catalog_cache_path = builtin_firewall_catalog_cache_path
+        self.okou_client_session_id = client_session_id
+        self.okou_client_version = client_version
+        self.okou_usage_flush_interval_seconds = usage.DEFAULT_FLUSH_INTERVAL_SECONDS
         self.ssl_insecure = ssl_insecure
 
 

--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -69,12 +69,12 @@ class _Options:
         client_version: str = "runner-version-test",
         api_url: str = "https://api.okou.ai",
     ) -> None:
-        self.vm0_usage_state_id = usage_state_id
-        self.vm0_addon_ready_path = addon_ready_path
-        self.vm0_usage_flush_interval_seconds = flush_interval_seconds
-        self.vm0_client_session_id = client_session_id
-        self.vm0_client_version = client_version
-        self.vm0_api_url = api_url
+        self.okou_usage_state_id = usage_state_id
+        self.okou_addon_ready_path = addon_ready_path
+        self.okou_usage_flush_interval_seconds = flush_interval_seconds
+        self.okou_client_session_id = client_session_id
+        self.okou_client_version = client_version
+        self.okou_api_url = api_url
 
 
 def _addon_file_path(tmp_path: Path) -> str:
@@ -118,11 +118,11 @@ class TestAddonConfiguration:
             mitm_addon.load(loader)
 
         option_names = [option.name for option in master.options.added]
-        assert "vm0_usage_state_id" in option_names
-        assert "vm0_addon_ready_path" in option_names
-        assert "vm0_client_session_id" in option_names
-        assert "vm0_client_version" in option_names
-        assert "vm0_usage_flush_interval_seconds" in option_names
+        assert "okou_usage_state_id" in option_names
+        assert "okou_addon_ready_path" in option_names
+        assert "okou_client_session_id" in option_names
+        assert "okou_client_version" in option_names
+        assert "okou_usage_flush_interval_seconds" in option_names
         assert not pending_path.exists()
         signal_handler.assert_called_once_with(
             runner_flush_lifecycle.RUNNER_USAGE_FLUSH_SIGNAL,
@@ -160,7 +160,7 @@ class TestAddonConfiguration:
             patch.object(mitm_addon, "__file__", _addon_file_path(tmp_path)),
             patch.object(mitm_addon.ctx, "options", _Options(), create=True),
         ):
-            mitm_addon.configure({"vm0_usage_state_id"})
+            mitm_addon.configure({"okou_usage_state_id"})
 
         state = assert_pending(pending_path, flows=0, buffered=0, reports=0)
         assert state["usageStateId"] == "runner-usage-state-id"
@@ -190,7 +190,7 @@ class TestAddonConfiguration:
             ),
             patch.object(logging_utils, "flush_log_path", return_value=True) as flush_log_path,
         ):
-            mitm_addon.configure({"vm0_addon_ready_path", "vm0_usage_state_id"})
+            mitm_addon.configure({"okou_addon_ready_path", "okou_usage_state_id"})
             assert not ready_path.exists()
             mitm_addon.running()
             runner_flush_lifecycle.stop_runner_jsonl_flush_worker_for_tests()
@@ -232,7 +232,7 @@ class TestAddonConfiguration:
                 create=True,
             ),
         ):
-            mitm_addon.configure({"vm0_addon_ready_path", "vm0_usage_state_id"})
+            mitm_addon.configure({"okou_addon_ready_path", "okou_usage_state_id"})
             assert not ready_path.exists()
             with (
                 patch.object(
@@ -274,7 +274,7 @@ class TestAddonConfiguration:
                 create=True,
             ),
         ):
-            mitm_addon.configure({"vm0_usage_state_id"})
+            mitm_addon.configure({"okou_usage_state_id"})
 
         state = assert_pending(pending_path, flows=0, buffered=0, reports=0)
         uuid.UUID(state["usageStateId"])
@@ -286,7 +286,7 @@ class TestAddonConfiguration:
             patch.object(mitm_addon, "__file__", _addon_file_path(tmp_path)),
             patch.object(mitm_addon.ctx, "options", _Options(), create=True),
         ):
-            mitm_addon.configure({"vm0_api_url"})
+            mitm_addon.configure({"okou_api_url"})
 
         assert not pending_path.exists()
 
@@ -300,7 +300,7 @@ class TestAddonConfiguration:
             ),
             create=True,
         ):
-            mitm_addon.configure({"vm0_client_session_id", "vm0_client_version"})
+            mitm_addon.configure({"okou_client_session_id", "okou_client_version"})
 
         req = platform_api.make_api_request("https://api.okou.ai/webhook", b"{}", "tok")
         normalized_headers = {name.lower(): value for name, value in req.header_items()}
@@ -318,7 +318,7 @@ class TestAddonConfiguration:
             _Options(flush_interval_seconds=flush_interval_seconds),
             create=True,
         ):
-            mitm_addon.configure({"vm0_usage_flush_interval_seconds"})
+            mitm_addon.configure({"okou_usage_flush_interval_seconds"})
 
         usage.buffer_usage_events(
             "https://api.test/api/webhooks/agent/usage-event",

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_authority_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_authority_framing.py
@@ -73,8 +73,8 @@ async def test_over_budget_http1_host_is_rejected_in_both_hooks_without_string_a
         fake_firewall_headers(headers={"Authorization": "Bearer managed-secret"}) as get_headers,
     ):
         addon_context.options.update(
-            vm0_api_url="https://api.okou.ai",
-            vm0_proxy_registry_path=str(registry_path),
+            okou_api_url="https://api.okou.ai",
+            okou_proxy_registry_path=str(registry_path),
         )
         client, http_layer = start_http_layer(
             addon_context,
@@ -176,8 +176,8 @@ async def test_http2_duplicate_host_is_rejected_before_auth_or_http1_downgrade(
         fake_firewall_headers(headers={"Authorization": "Bearer managed-secret"}) as get_headers,
     ):
         addon_context.options.update(
-            vm0_api_url="https://api.okou.ai",
-            vm0_proxy_registry_path=str(registry_path),
+            okou_api_url="https://api.okou.ai",
+            okou_proxy_registry_path=str(registry_path),
         )
         http_layer, request_headers_hook = start_http2_request(
             addon_context,
@@ -269,8 +269,8 @@ async def test_http1_absolute_form_authority_is_rejected_before_auth_or_forwardi
         fake_firewall_headers(headers={"Authorization": "Bearer managed-secret"}) as get_headers,
     ):
         addon_context.options.update(
-            vm0_api_url="https://api.okou.ai",
-            vm0_proxy_registry_path=str(registry_path),
+            okou_api_url="https://api.okou.ai",
+            okou_proxy_registry_path=str(registry_path),
         )
         http_layer, request_headers_hook = _start_transparent_http1_absolute_request(
             addon_context,
@@ -333,8 +333,8 @@ async def test_matching_http1_absolute_form_authority_is_forwardable_with_auth(
         fake_firewall_headers(headers={"Authorization": "Bearer managed-secret"}),
     ):
         addon_context.options.update(
-            vm0_api_url="https://api.okou.ai",
-            vm0_proxy_registry_path=str(registry_path),
+            okou_api_url="https://api.okou.ai",
+            okou_proxy_registry_path=str(registry_path),
         )
         http_layer, request_headers_hook = _start_transparent_http1_absolute_request(
             addon_context,

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_bodyless_response_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_bodyless_response_framing.py
@@ -105,8 +105,8 @@ async def test_head_firewall_block_emits_no_response_data(
         taddons.context(Proxyserver(), mitm_addon) as addon_context,
     ):
         addon_context.options.update(
-            vm0_api_url="https://api.okou.ai",
-            vm0_proxy_registry_path=str(registry_path),
+            okou_api_url="https://api.okou.ai",
+            okou_proxy_registry_path=str(registry_path),
         )
         client, http2, http_layer, request_headers_hook = _start_head_firewall_request(
             addon_context,
@@ -189,11 +189,11 @@ async def test_head_connector_diagnostic_emits_no_response_data(
         taddons.context(Proxyserver(), mitm_addon) as addon_context,
     ):
         addon_context.options.update(
-            vm0_api_url="https://api.okou.ai",
-            vm0_builtin_firewall_catalog_cache_path=str(
+            okou_api_url="https://api.okou.ai",
+            okou_builtin_firewall_catalog_cache_path=str(
                 tmp_path / "builtin-firewall-catalog-cache.json"
             ),
-            vm0_proxy_registry_path=str(registry_path),
+            okou_proxy_registry_path=str(registry_path),
         )
         record_connector_diagnostic_requestheaders_context(flow)
         _, http_layer = start_http_layer(

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_codex_catalog_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_codex_catalog_framing.py
@@ -161,8 +161,8 @@ async def test_http2_fresh_catalog_hit_completes_without_provider_connection(
         patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
     ):
         addon_context.options.update(
-            vm0_api_url="https://api.okou.ai",
-            vm0_proxy_registry_path=str(registry_path),
+            okou_api_url="https://api.okou.ai",
+            okou_proxy_registry_path=str(registry_path),
         )
         client, http2, http_layer, request_headers_hook = _start_http2_request_with_client(
             addon_context,

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_request_body_admission_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_request_body_admission_framing.py
@@ -122,8 +122,8 @@ async def test_http2_open_sigv4_request_without_length_is_rejected_before_body(
         patch.object(auth, "get_firewall_headers", get_headers),
     ):
         addon_context.options.update(
-            vm0_api_url="https://api.okou.ai",
-            vm0_proxy_registry_path=str(registry_path),
+            okou_api_url="https://api.okou.ai",
+            okou_proxy_registry_path=str(registry_path),
         )
         http_layer, request_headers_hook = start_http2_request(
             addon_context,
@@ -170,8 +170,8 @@ async def test_http2_headers_only_sigv4_request_uses_zero_byte_admission(
         patch.object(auth, "get_firewall_headers", get_headers),
     ):
         addon_context.options.update(
-            vm0_api_url="https://api.okou.ai",
-            vm0_proxy_registry_path=str(registry_path),
+            okou_api_url="https://api.okou.ai",
+            okou_proxy_registry_path=str(registry_path),
         )
         http_layer, request_headers_hook = start_http2_request(
             addon_context,
@@ -214,8 +214,8 @@ async def test_http2_open_auth_base_request_without_length_is_rejected_before_bo
         patch.object(auth, "get_firewall_headers", get_headers),
     ):
         addon_context.options.update(
-            vm0_api_url="https://api.okou.ai",
-            vm0_proxy_registry_path=str(registry_path),
+            okou_api_url="https://api.okou.ai",
+            okou_proxy_registry_path=str(registry_path),
         )
         http_layer, request_headers_hook = start_http2_request(
             addon_context,
@@ -273,8 +273,8 @@ async def test_headers_only_auth_base_request_without_length_is_forwarded(
         fake_forwarder_upstream(status=200, body=b"ok"),
     ):
         addon_context.options.update(
-            vm0_api_url="https://api.okou.ai",
-            vm0_proxy_registry_path=str(registry_path),
+            okou_api_url="https://api.okou.ai",
+            okou_proxy_registry_path=str(registry_path),
         )
         if http_version == "HTTP/2":
             http_layer, request_headers_hook = start_http2_request(

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_request_exception_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_request_exception_framing.py
@@ -41,8 +41,8 @@ async def test_post_auth_request_exception_fails_closed_after_dispatch(
         fake_firewall_headers(headers={"Authorization": resolved_token}),
     ):
         addon_context.options.update(
-            vm0_api_url="https://api.okou.ai",
-            vm0_proxy_registry_path=str(registry_path),
+            okou_api_url="https://api.okou.ai",
+            okou_proxy_registry_path=str(registry_path),
         )
         client, http_layer = start_http_layer(
             addon_context,

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_websocket_header_budget.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_websocket_header_budget.py
@@ -90,7 +90,7 @@ async def test_http1_handshake_classification_bounds_raw_value_conversion(
         fake_firewall_headers(headers={"Authorization": "Bearer managed-secret"}),
     ):
         addon_context.options.update(
-            vm0_api_url="https://api.okou.ai", vm0_proxy_registry_path=str(registry_path)
+            okou_api_url="https://api.okou.ai", okou_proxy_registry_path=str(registry_path)
         )
         client, http_layer = start_http_layer(
             addon_context, alpn=b"http/1.1", host="api.openai.com"

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
@@ -24,7 +24,7 @@ _TEST_BUILTIN_FIREWALLS: dict[str, dict] = {}
 
 class _RegistryOptions:
     def __init__(self) -> None:
-        self.vm0_builtin_firewall_catalog_cache_path = ""
+        self.okou_builtin_firewall_catalog_cache_path = ""
 
 
 @pytest.fixture(autouse=True)
@@ -111,7 +111,7 @@ def write_builtin_firewall_registry(
     firewall = cache_firewall or _TEST_BUILTIN_FIREWALLS.get(name) or _builtin_firewall(name)
     cache_path = _cache_path_for_registry(path)
     _write_catalog_cache(cache_path, {firewall["name"]: firewall})
-    builtin_firewall_cache.ctx.options.vm0_builtin_firewall_catalog_cache_path = str(cache_path)
+    builtin_firewall_cache.ctx.options.okou_builtin_firewall_catalog_cache_path = str(cache_path)
 
 
 class TestRegistryBuiltinBaseUrlVars:
@@ -1035,7 +1035,9 @@ class TestRegistryBuiltinBaseUrlVars:
         )
         cache_path = _cache_path_for_registry(path)
         _write_catalog_cache(cache_path, {"zendesk": _builtin_firewall("zendesk")})
-        builtin_firewall_cache.ctx.options.vm0_builtin_firewall_catalog_cache_path = str(cache_path)
+        builtin_firewall_cache.ctx.options.okou_builtin_firewall_catalog_cache_path = str(
+            cache_path
+        )
 
         invalid_sandbox = assert_invalid_builtin_sandbox(path)
         assert "ZENDESK_SUBDOMAIN" in invalid_sandbox.message

--- a/crates/runner/mitm-addon/tests/test_request_handler_api_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_api_admission.py
@@ -397,8 +397,8 @@ async def test_malformed_platform_api_url_is_cached_as_non_match(
         assert parsed_api_urls == [malformed_platform_api_url]
 
         updated_api_url = "ftp://api.okou.ai"
-        mitm_addon.ctx.options.vm0_api_url = updated_api_url
-        mitm_addon.configure({"vm0_api_url"})
+        mitm_addon.ctx.options.okou_api_url = updated_api_url
+        mitm_addon.configure({"okou_api_url"})
         updated_flow = real_flow(with_response=False, host="api.okou.ai")
         flows.append(updated_flow)
         await mitm_addon.request(updated_flow)

--- a/crates/runner/mitm-addon/tests/test_request_headers_api_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_api_admission.py
@@ -80,8 +80,8 @@ async def test_api_destination_derivation_reuses_and_refreshes_effective_option(
         assert parsed_api_hosts == ["api.okou.ai"]
 
         updated_api_url = "http://API.PREVIEW.OKOU.AI:8080"
-        mitm_addon.ctx.options.vm0_api_url = updated_api_url
-        mitm_addon.configure({"vm0_api_url"})
+        mitm_addon.ctx.options.okou_api_url = updated_api_url
+        mitm_addon.configure({"okou_api_url"})
         updated_flow = api_flow(
             host="jobs.api.preview.okou.ai",
             scheme="http",
@@ -100,8 +100,8 @@ async def test_api_destination_derivation_reuses_and_refreshes_effective_option(
         assert parsed_api_hosts == ["api.okou.ai", "api.preview.okou.ai"]
 
         invalid_api_url = "ftp://api.invalid.okou.ai"
-        mitm_addon.ctx.options.vm0_api_url = invalid_api_url
-        mitm_addon.configure({"vm0_api_url"})
+        mitm_addon.ctx.options.okou_api_url = invalid_api_url
+        mitm_addon.configure({"okou_api_url"})
         invalid_flows = [
             api_flow(host="api.invalid.okou.ai"),
             api_flow(host="jobs.api.invalid.okou.ai"),

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -20,12 +20,12 @@ pub(crate) fn is_firecracker_cmdline(argv: &[String]) -> bool {
 
 /// Parse a mitmdump argv for the listen port.
 ///
-/// Identifies our mitmdump by `vm0_proxy_registry_path=` and extracts
+/// Identifies our mitmdump by `okou_proxy_registry_path=` and extracts
 /// the `--listen-port` value.
 fn parse_mitmdump_cmdline(argv: &[String]) -> Option<u16> {
     if !argv
         .iter()
-        .any(|t| t.starts_with("vm0_proxy_registry_path="))
+        .any(|t| t.starts_with("okou_proxy_registry_path="))
     {
         return None;
     }
@@ -380,7 +380,7 @@ mod tests {
             "--listen-port",
             "8080",
             "--set",
-            "vm0_proxy_registry_path=/data/runner-01/proxy-registry.json",
+            "okou_proxy_registry_path=/data/runner-01/proxy-registry.json",
         ]);
         assert_eq!(parse_mitmdump_cmdline(&a), Some(8080));
     }
@@ -393,7 +393,7 @@ mod tests {
             "--listen-port",
             "8080",
             "--set",
-            "vm0_proxy_registry_path=/data/my runner/proxy-registry.json",
+            "okou_proxy_registry_path=/data/my runner/proxy-registry.json",
         ]);
         assert_eq!(parse_mitmdump_cmdline(&a), Some(8080));
     }
@@ -409,7 +409,7 @@ mod tests {
         let a = argv(&[
             "mitmdump",
             "--set",
-            "vm0_proxy_registry_path=/data/proxy-registry.json",
+            "okou_proxy_registry_path=/data/proxy-registry.json",
         ]);
         assert!(parse_mitmdump_cmdline(&a).is_none());
     }

--- a/crates/runner/src/proxy/mod.rs
+++ b/crates/runner/src/proxy/mod.rs
@@ -8,12 +8,12 @@
 //!
 //! The Rust/Python boundary is intentionally file- and option-based:
 //!
-//! - `vm0_proxy_registry_path` points the addon at the registry JSON written
+//! - `okou_proxy_registry_path` points the addon at the registry JSON written
 //!   by [`ProxyRegistryHandle`].
-//! - `vm0_usage_state_id` identifies the currently running mitmdump/addon
+//! - `okou_usage_state_id` identifies the currently running mitmdump/addon
 //!   process. Restart rotates this value so stale addon state from an older
 //!   child is rejected.
-//! - `vm0_addon_ready_path` points to a marker the addon writes only after its
+//! - `okou_addon_ready_path` points to a marker the addon writes only after its
 //!   hooks and runner options initialize successfully. Rust requires the
 //!   marker to contain the active usage state before accepting the TCP
 //!   listener as ready.

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -732,28 +732,28 @@ async fn spawn_mitmdump(
         .arg("upstream_cert=false")
         .arg("--set")
         .arg(format!(
-            "vm0_proxy_registry_path={}",
+            "okou_proxy_registry_path={}",
             config.registry_path.display()
         ))
         .arg("--set")
-        .arg(format!("vm0_usage_state_id={usage_state_id}"))
+        .arg(format!("okou_usage_state_id={usage_state_id}"))
         .arg("--set")
         .arg(format!(
-            "vm0_addon_ready_path={}",
+            "okou_addon_ready_path={}",
             addon_ready_path.display()
         ))
         .arg("--set")
         .arg(format!(
-            "vm0_builtin_firewall_catalog_cache_path={}",
+            "okou_builtin_firewall_catalog_cache_path={}",
             config.builtin_firewall_catalog_cache_path.display()
         ))
         .arg("--set")
         .arg(format!(
-            "vm0_client_session_id={}",
+            "okou_client_session_id={}",
             config.client_session_id
         ))
         .arg("--set")
-        .arg(format!("vm0_client_version={RUNNER_CLIENT_VERSION}"))
+        .arg(format!("okou_client_version={RUNNER_CLIENT_VERSION}"))
         .arg("--scripts")
         .arg(config.addon_dir.join("mitm_addon.py"))
         .arg("--set")
@@ -766,7 +766,7 @@ async fn spawn_mitmdump(
             crate::deps::SYSTEM_CA_BUNDLE
         ));
     if let Some(url) = &config.api_url {
-        cmd.arg("--set").arg(format!("vm0_api_url={url}"));
+        cmd.arg("--set").arg(format!("okou_api_url={url}"));
     }
     if let Some(token) = &config.runner_token {
         cmd.env(RUNNER_TOKEN_ENV, token);
@@ -1177,8 +1177,8 @@ for arg in "$@"; do
     port="$arg"
   fi
   case "$arg" in
-    vm0_addon_ready_path=*) ready_path="${arg#vm0_addon_ready_path=}" ;;
-    vm0_usage_state_id=*) usage_state_id="${arg#vm0_usage_state_id=}" ;;
+    okou_addon_ready_path=*) ready_path="${arg#okou_addon_ready_path=}" ;;
+    okou_usage_state_id=*) usage_state_id="${arg#okou_usage_state_id=}" ;;
   esac
   prev="$arg"
 done
@@ -1234,8 +1234,8 @@ ready_path=""
 usage_state_id=""
 for arg in "$@"; do
   case "$arg" in
-    vm0_addon_ready_path=*) ready_path="${arg#vm0_addon_ready_path=}" ;;
-    vm0_usage_state_id=*) usage_state_id="${arg#vm0_usage_state_id=}" ;;
+    okou_addon_ready_path=*) ready_path="${arg#okou_addon_ready_path=}" ;;
+    okou_usage_state_id=*) usage_state_id="${arg#okou_usage_state_id=}" ;;
   esac
 done
 python3 - "$ready_path" "$usage_state_id" "$0.descendant" <<'PY' &
@@ -1285,10 +1285,10 @@ previous = None
 for argument in sys.argv[1:]:
     if previous == "--listen-port":
         port = int(argument)
-    if argument.startswith("vm0_addon_ready_path="):
-        ready_path = Path(argument.removeprefix("vm0_addon_ready_path="))
-    if argument.startswith("vm0_usage_state_id="):
-        usage_state_id = argument.removeprefix("vm0_usage_state_id=")
+    if argument.startswith("okou_addon_ready_path="):
+        ready_path = Path(argument.removeprefix("okou_addon_ready_path="))
+    if argument.startswith("okou_usage_state_id="):
+        usage_state_id = argument.removeprefix("okou_usage_state_id=")
     previous = argument
 
 descendant_pid = os.fork()
@@ -1980,36 +1980,36 @@ exit 42
         );
         assert!(
             args.lines()
-                .any(|arg| arg == "vm0_usage_state_id=usage-state-test"),
-            "mitmdump args should include vm0_usage_state_id option; got:\n{args}",
+                .any(|arg| arg == "okou_usage_state_id=usage-state-test"),
+            "mitmdump args should include okou_usage_state_id option; got:\n{args}",
         );
         assert!(
             args.lines().any(|arg| {
                 arg == format!(
-                    "vm0_addon_ready_path={}",
+                    "okou_addon_ready_path={}",
                     config.addon_dir.join(ADDON_READY_FILENAME).display()
                 )
             }),
-            "mitmdump args should include vm0_addon_ready_path option; got:\n{args}",
+            "mitmdump args should include okou_addon_ready_path option; got:\n{args}",
         );
         assert!(
             args.lines().any(|arg| {
                 arg == format!(
-                    "vm0_builtin_firewall_catalog_cache_path={}",
+                    "okou_builtin_firewall_catalog_cache_path={}",
                     builtin_firewall_catalog_cache_path.display()
                 )
             }),
-            "mitmdump args should include vm0_builtin_firewall_catalog_cache_path option; got:\n{args}",
+            "mitmdump args should include okou_builtin_firewall_catalog_cache_path option; got:\n{args}",
         );
         assert!(
             args.lines()
-                .any(|arg| arg == "vm0_client_session_id=runner-session-test"),
-            "mitmdump args should include vm0_client_session_id option; got:\n{args}",
+                .any(|arg| arg == "okou_client_session_id=runner-session-test"),
+            "mitmdump args should include okou_client_session_id option; got:\n{args}",
         );
         assert!(
             args.lines()
-                .any(|arg| arg == format!("vm0_client_version={RUNNER_CLIENT_VERSION}")),
-            "mitmdump args should include vm0_client_version option; got:\n{args}",
+                .any(|arg| arg == format!("okou_client_version={RUNNER_CLIENT_VERSION}")),
+            "mitmdump args should include okou_client_version option; got:\n{args}",
         );
         assert!(!args.contains("runner-token"));
         assert!(


### PR DESCRIPTION
Closes #33492

Renames all eight mitmproxy addon options from the retired `vm0_` prefix to `okou_`, preserving each suffix exactly.

## Option mapping

| Old | New | Rust sites | Python sites |
|---|---|---|---|
| `vm0_api_url` | `okou_api_url` | 1 | 12 |
| `vm0_proxy_registry_path` | `okou_proxy_registry_path` | 3 | 8 |
| `vm0_builtin_firewall_catalog_cache_path` | `okou_builtin_firewall_catalog_cache_path` | 1 | 5 |
| `vm0_usage_state_id` | `okou_usage_state_id` | 2 | 2 |
| `vm0_addon_ready_path` | `okou_addon_ready_path` | 2 | 2 |
| `vm0_client_session_id` | `okou_client_session_id` | 1 | 3 |
| `vm0_client_version` | `okou_client_version` | 1 | 3 |
| `vm0_usage_flush_interval_seconds` | `okou_usage_flush_interval_seconds` | 0 | 3 |

17 files changed, +115/−113. Post-rename file counts match this table exactly.

## Why this is an atomic rename, despite crossing a process boundary

`generate_addon_files()` at `crates/runner/build.rs:190` recursively scans `mitm-addon/src/**` and embeds every file into the Rust binary through `include_str!()`. At runtime `crates/runner/src/proxy/process.rs:272` extracts them to `config.addon_dir` before launching mitmdump.

So the Rust code that writes `--set okou_api_url=…` and the Python code that declares `name="okou_api_url"` are **compiled from the same commit into the same Runner artifact**. There is no independent release cadence and no version skew — a single commit changes both sides, and no deployed component ever observes a mismatched pair.

An earlier issue (#32939) fenced `vm0_api_url` out of scope and described it as a cross-version Rust/Python contract. That characterisation was wrong; #33492 supersedes it. Accordingly this PR adds **no compatibility alias, dual-name acceptance, or deprecation shim** — such a layer would be dead code on arrival.

## The three traps

**1. `configure()` update sets use string literals.** mitmproxy passes a set of changed option names to `configure(updated)`, so membership tests like `if "vm0_api_url" in updated:` are bare strings that a symbol rename would miss. Renamed at `mitm_addon.py:254,258` and at every test call site, including `test_addon_configuration.py:289`. Verified by a bare-string grep for each of the eight old names across the whole tracked tree.

**2. Test doubles mirror the options object.** Renamed the fake `ctx.options` attributes in `tests/conftest.py:354-359` and `tests/test_addon_configuration.py:72-77`. The identifier sweep also caught **a third mirror the issue did not name**: `tests/test_registry_builtin_base_url_vars.py:27`. Had any of these been missed, the fake would have silently stopped matching production while the tests still passed.

Two further test doubles of the same class live on the Rust side: the embedded fake-mitmdump argument parsers in `proxy/process.rs` (one bash `case` block at ~L1180/L1237, one Python `startswith`/`removeprefix` block at ~L1288) parse `okou_addon_ready_path=` and `okou_usage_state_id=` out of the spawned argv. Both are renamed in step with the `--set` formatters.

**3. `vm0_usage_flush_interval_seconds` has no Rust setter.** It is declared and read only in Python and relies on its default. It is renamed, and **no `--set` was added** — confirmed by grep: zero occurrences in `crates/runner/src`.

## Note on `discovery.rs`

`parse_mitmdump_cmdline` identifies "our" mitmdump by the `okou_proxy_registry_path=` argv prefix. Its only consumer is `cmd/doctor.rs`, which uses the result for **diagnostic warnings only** (`NoMitmproxy` / `StaleMitmproxy`) and never kills or reaps a process.

So on a host where a mitmdump spawned by a pre-rename Runner binary is still alive, `okou runner doctor` would briefly not classify it. That is a transient reporting-coverage gap that clears as soon as that mitmdump is replaced — not a correctness or safety issue. #33492 counts this among the three Rust sites for the option, so it is renamed as specified.

## Behavior is unchanged

Mechanically verified: mapping every added line's new name back to its old name reproduces the removed line exactly, with no residue other than one `ruff format` line-wrap (`test_registry_builtin_base_url_vars.py`, which crossed the 100-char limit from the one extra character). Option types, defaults, help text, validation, firewall decisions, usage accounting, and the mitmdump launch sequence are untouched.

Out of scope and confirmed byte-identical by grep over the full diff: all `X-VM0-*` headers (including `x-vm0-connector-intent` and `x-vm0-test-endpoint-bypass`), the `vm0_official_` token prefix, `vm0.ai` / `vm0.io` hosts, repository names, systemd units. `build.rs` and the addon extraction path are not restructured.

The single surviving tree-wide hit for an old name is `turbo/apps/cli/CHANGELOG.md:17374` — a historical release note about an *environment variable* from #110, not this addon option. Release changelogs are explicitly out of scope per EPIC #32157.

## Verification

Run locally and green:

| Check | Result |
|---|---|
| addon `ruff check` | passed |
| addon `ruff format --check` | 377 files clean |
| addon `basedpyright` | 0 errors, 0 warnings, 0 notes |
| addon flow-metadata linter | passed |
| addon `pytest` | **7688 passed** |
| `cargo fmt -p runner` | no changes needed |

**Not completed locally — relying on PR CI:** `cargo clippy -p runner --all-targets` and the Rust proxy tests. The cold debug build exceeded the sandbox time limit; this sandbox has a known memory problem building vm0's Rust debug profile (it was OOM-killed twice during #32937, which was likewise verified by PR CI). `ci-gate-crates` runs clippy and the proxy tests on this PR, and **that is the Rust verification for this change**. Stating this plainly rather than implying local coverage I do not have.

## Overlap

Re-checked against the 41 currently open PRs: only #33533 touches `crates/runner/mitm-addon`, and solely `tests/pending_helpers.py`, which is not among the 17 files here. No conflict. Per repository precedence this is inventory information only — whichever merges first defines the new `main` and the other rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
