### PR TITLE
fix(runner): bound proxy flush filesystem waits

### DIFF
--- a/crates/runner/src/proxy/flush.rs
+++ b/crates/runner/src/proxy/flush.rs
@@ -1,4 +1,14 @@
 //! Addon flush request/ack protocols.
+//!
+//! Marker publication has a separate five-second budget. Its blocking worker
+//! retains serialization, temporary-file cleanup, and proxy directory ownership
+//! after caller cancellation until its filesystem work finishes. Acknowledgement
+//! deadlines include state-file I/O. JSONL has five seconds each for lock
+//! admission, publication, and acknowledgement; usage publication and
+//! acknowledgement have five- and 30-second budgets respectively. These bound
+//! callers, not kernel I/O or Tokio runtime teardown.
+
+mod publication;
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -7,13 +17,17 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{future::Future as _, task::Poll};
 
 use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex as AsyncMutex;
 #[cfg(test)]
 use tokio::sync::mpsc;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+use tokio::time::Instant;
 use tracing::{error, warn};
 use uuid::Uuid;
 
 use crate::error::{RunnerError, RunnerResult};
+
+use super::runtime::MitmdumpRuntime;
+use publication::MarkerPublication;
 
 /// Maximum time to wait for buffered work and pending reports before stopping.
 ///
@@ -30,6 +44,9 @@ pub const JSONL_FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
 /// Maximum time to wait to serialize a mitmproxy JSONL flush request.
 const JSONL_FLUSH_LOCK_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Marker publication budget, including usage lock admission and queued I/O.
+const FLUSH_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Poll interval when waiting for usage flush.
 const USAGE_FLUSH_POLL: Duration = Duration::from_millis(200);
 
@@ -43,10 +60,27 @@ const JSONL_FLUSH_POLL: Duration = Duration::from_millis(50);
 /// Tolerated wall-clock skew when validating addon timestamps.
 const USAGE_PENDING_CLOCK_SKEW: Duration = Duration::from_secs(300);
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct UsageFlushTarget {
     pub(super) expected_usage_state_id: String,
     pub(super) usage_state_started_at_ms: u64,
+    usage_request_lock: Arc<AsyncMutex<()>>,
+    runtime: Option<Arc<MitmdumpRuntime>>,
+}
+
+impl UsageFlushTarget {
+    pub(super) fn new(
+        expected_usage_state_id: String,
+        usage_state_started_at_ms: u64,
+        runtime: Option<Arc<MitmdumpRuntime>>,
+    ) -> Self {
+        Self {
+            expected_usage_state_id,
+            usage_state_started_at_ms,
+            usage_request_lock: Arc::new(AsyncMutex::new(())),
+            runtime,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -250,7 +284,7 @@ impl JsonlFlushRequest {
 
 impl MitmJsonlFlushHandle {
     pub async fn flush_path(&self, path: &Path) -> bool {
-        let Some(_request_guard) = self.acquire_request_lock().await else {
+        let Some(request_guard) = self.acquire_request_lock().await else {
             warn!(
                 phase = "request_lock",
                 timeout_secs = JSONL_FLUSH_LOCK_TIMEOUT.as_secs(),
@@ -260,8 +294,15 @@ impl MitmJsonlFlushHandle {
             return false;
         };
         let target = usage_flush_state_guard(&self.usage_state).clone();
-        let request = match write_jsonl_flush_request(&self.addon_dir, &target, path).await {
-            Ok(request) => request,
+        let (request, _request_guard) = match write_jsonl_flush_request(
+            &self.addon_dir,
+            &target,
+            path,
+            request_guard,
+        )
+        .await
+        {
+            Ok(result) => result,
             Err(e) => {
                 warn!(error = %e, path = %path.display(), "failed to create JSONL flush request");
                 return false;
@@ -276,10 +317,10 @@ impl MitmJsonlFlushHandle {
         wait_jsonl_flush(&self.addon_dir, JSONL_FLUSH_TIMEOUT, &request).await
     }
 
-    async fn acquire_request_lock(&self) -> Option<tokio::sync::MutexGuard<'_, ()>> {
+    async fn acquire_request_lock(&self) -> Option<OwnedMutexGuard<()>> {
         #[cfg(test)]
         if let Some(request_lock_poll_tx) = &self.request_lock_poll_tx {
-            let request_lock = self.request_lock.lock();
+            let request_lock = Arc::clone(&self.request_lock).lock_owned();
             tokio::pin!(request_lock);
             let mut first_poll_tx = Some(request_lock_poll_tx);
             let mut first_poll_was_pending = false;
@@ -315,9 +356,12 @@ impl MitmJsonlFlushHandle {
             return request_guard;
         }
 
-        tokio::time::timeout(JSONL_FLUSH_LOCK_TIMEOUT, self.request_lock.lock())
-            .await
-            .ok()
+        tokio::time::timeout(
+            JSONL_FLUSH_LOCK_TIMEOUT,
+            Arc::clone(&self.request_lock).lock_owned(),
+        )
+        .await
+        .ok()
     }
 }
 
@@ -325,17 +369,27 @@ pub async fn write_usage_flush_request(
     addon_dir: &Path,
     target: &UsageFlushTarget,
 ) -> RunnerResult<UsageFlushRequest> {
+    let deadline = Instant::now() + FLUSH_REQUEST_TIMEOUT;
+    let request_guard = tokio::time::timeout_at(
+        deadline,
+        Arc::clone(&target.usage_request_lock).lock_owned(),
+    )
+    .await
+    .map_err(|_| RunnerError::Internal("usage flush publication lock timed out".to_string()))?;
     let request = UsageFlushRequest::new(target);
     let marker = UsageFlushRequestMarker {
         usage_state_id: &request.core.expected_usage_state_id,
         flush_request_id: &request.core.flush_request_id,
         requested_at_ms: request.core.requested_at_ms,
     };
-    write_flush_request_marker(
+    let _request_guard = write_flush_request_marker(
         addon_dir,
         "usage-flush-request",
         &marker,
         "usage flush request",
+        request_guard,
+        target.runtime.clone(),
+        deadline,
     )
     .await?;
     Ok(request)
@@ -345,7 +399,9 @@ async fn write_jsonl_flush_request(
     addon_dir: &Path,
     target: &UsageFlushTarget,
     log_path: &Path,
-) -> RunnerResult<JsonlFlushRequest> {
+    request_guard: OwnedMutexGuard<()>,
+) -> RunnerResult<(JsonlFlushRequest, OwnedMutexGuard<()>)> {
+    let deadline = Instant::now() + FLUSH_REQUEST_TIMEOUT;
     let request = JsonlFlushRequest::new(target, log_path);
     let marker = JsonlFlushRequestMarker {
         usage_state_id: &request.core.expected_usage_state_id,
@@ -353,14 +409,17 @@ async fn write_jsonl_flush_request(
         requested_at_ms: request.core.requested_at_ms,
         path: &request.path,
     };
-    write_flush_request_marker(
+    let request_guard = write_flush_request_marker(
         addon_dir,
         "jsonl-flush-request",
         &marker,
         "JSONL flush request",
+        request_guard,
+        target.runtime.clone(),
+        deadline,
     )
     .await?;
-    Ok(request)
+    Ok((request, request_guard))
 }
 
 async fn write_flush_request_marker<T: Serialize>(
@@ -368,11 +427,24 @@ async fn write_flush_request_marker<T: Serialize>(
     file_name: &str,
     marker: &T,
     description: &str,
-) -> RunnerResult<()> {
+    request_guard: OwnedMutexGuard<()>,
+    runtime: Option<Arc<MitmdumpRuntime>>,
+    deadline: Instant,
+) -> RunnerResult<OwnedMutexGuard<()>> {
     let path = addon_dir.join(file_name);
     let content = serde_json::to_vec(marker)
         .map_err(|e| RunnerError::Internal(format!("serialize {description}: {e}")))?;
-    crate::state_file::write_private_atomic(&path, &content).await
+    MarkerPublication {
+        path,
+        content,
+        deadline,
+        request_guard,
+        runtime,
+        #[cfg(test)]
+        staged_gate: None,
+    }
+    .publish()
+    .await
 }
 
 fn parse_usage_pending_state(content: &str) -> Result<UsagePendingState, String> {
@@ -605,8 +677,26 @@ where
     let mut next_flush_request_at = repeat_request
         .as_ref()
         .map(|(repeat_request_interval, _)| started_at + *repeat_request_interval);
+    let read_timed_out = || FlushWaitFailure::TimedOut {
+        phase: "state_read",
+        not_ready: format!(
+            "read {} did not finish before the flush deadline",
+            path.display()
+        ),
+        snapshot: None,
+    };
+    let mut last_failure = read_timed_out();
     loop {
-        let (phase, not_ready, snapshot) = match read_addon_state_file(&path).await {
+        if Instant::now() >= deadline {
+            return Err(last_failure);
+        }
+        let state = tokio::time::timeout_at(deadline, read_addon_state_file(&path))
+            .await
+            .map_err(|_| read_timed_out())?;
+        if Instant::now() >= deadline {
+            return Err(read_timed_out());
+        }
+        let (phase, not_ready, snapshot) = match state {
             Ok(Some(content)) => match evaluate_state(&content) {
                 FlushReadiness::Ready => return Ok(()),
                 FlushReadiness::NotReady {
@@ -643,6 +733,11 @@ where
                 snapshot,
             });
         }
+        last_failure = FlushWaitFailure::TimedOut {
+            phase,
+            not_ready,
+            snapshot,
+        };
         tokio::time::sleep(std::cmp::min(poll_interval, deadline - now)).await;
     }
 }
@@ -757,6 +852,207 @@ mod tests {
     use tracing_subscriber::prelude::*;
     use tracing_test_support::{CapturedEvent, CapturedEvents};
 
+    struct BlockingPoolGate {
+        release: std::sync::mpsc::Sender<()>,
+        worker: tokio::task::JoinHandle<()>,
+    }
+
+    impl BlockingPoolGate {
+        async fn occupy() -> Self {
+            let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+            let (release, release_rx) = std::sync::mpsc::channel();
+            let worker = tokio::task::spawn_blocking(move || {
+                let _ = ready_tx.send(());
+                // Dropping the sender also releases the worker on test failure.
+                let _ = release_rx.recv_timeout(Duration::from_secs(10));
+            });
+            ready_rx.await.unwrap();
+            Self { release, worker }
+        }
+
+        async fn release(self) {
+            let _ = self.release.send(());
+            self.worker.await.unwrap();
+        }
+    }
+
+    fn filesystem_test_runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .max_blocking_threads(1)
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn usage_publication_serialization_survives_proxy_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut proxy, _crash_rx) = MitmProxy::noop();
+        let handle = proxy.jsonl_flush_handle();
+        let previous = usage_flush_state_guard(&handle.usage_state).clone();
+        let previous_guard = Arc::clone(&previous.usage_request_lock).lock_owned().await;
+        let _restart = proxy.begin_restart();
+        let current = usage_flush_state_guard(&handle.usage_state).clone();
+        assert_ne!(
+            previous.expected_usage_state_id,
+            current.expected_usage_state_id
+        );
+
+        tokio::time::pause();
+        assert!(
+            write_usage_flush_request(dir.path(), &current)
+                .await
+                .is_err()
+        );
+        tokio::time::resume();
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+
+        drop(previous_guard);
+        let request = write_usage_flush_request(dir.path(), &current)
+            .await
+            .unwrap();
+        let marker: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(dir.path().join("usage-flush-request")).unwrap())
+                .unwrap();
+        assert_eq!(marker["usageStateId"], current.expected_usage_state_id);
+        assert_eq!(marker["flushRequestId"], request.core.flush_request_id);
+    }
+
+    #[test]
+    fn usage_flush_read_deadline_includes_blocking_pool_queueing() {
+        filesystem_test_runtime().block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let request = usage_request();
+            let gate = BlockingPoolGate::occupy().await;
+            tokio::time::pause();
+            let wait =
+                wait_usage_flush_requesting(dir.path(), USAGE_FLUSH_TIMEOUT, &request, || true);
+            tokio::pin!(wait);
+            assert!(futures_util::poll!(&mut wait).is_pending());
+            tokio::time::advance(USAGE_FLUSH_TIMEOUT + Duration::from_secs(1)).await;
+            let at_deadline = futures_util::poll!(&mut wait);
+            tokio::time::resume();
+            gate.release().await;
+            if at_deadline.is_pending() {
+                let _ = wait.await;
+            }
+            assert_eq!(at_deadline, Poll::Ready(false));
+        });
+    }
+
+    #[test]
+    fn jsonl_flush_read_deadline_includes_blocking_pool_queueing() {
+        filesystem_test_runtime().block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("network.jsonl");
+            let request = jsonl_request(&path);
+            let gate = BlockingPoolGate::occupy().await;
+            tokio::time::pause();
+            let wait = wait_jsonl_flush(dir.path(), JSONL_FLUSH_TIMEOUT, &request);
+            tokio::pin!(wait);
+            assert!(futures_util::poll!(&mut wait).is_pending());
+            tokio::time::advance(JSONL_FLUSH_TIMEOUT + Duration::from_secs(1)).await;
+            let at_deadline = futures_util::poll!(&mut wait);
+            tokio::time::resume();
+            gate.release().await;
+            if at_deadline.is_pending() {
+                let _ = wait.await;
+            }
+            assert_eq!(at_deadline, Poll::Ready(false));
+        });
+    }
+
+    #[test]
+    fn usage_marker_deadline_includes_blocking_pool_queueing() {
+        filesystem_test_runtime().block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let target = usage_target();
+            let gate = BlockingPoolGate::occupy().await;
+            tokio::time::pause();
+            let write = write_usage_flush_request(dir.path(), &target);
+            tokio::pin!(write);
+            assert!(futures_util::poll!(&mut write).is_pending());
+            tokio::time::advance(Duration::from_secs(6)).await;
+            let at_deadline = futures_util::poll!(&mut write);
+            let timed_out = matches!(&at_deadline, Poll::Ready(Err(_)));
+            tokio::time::resume();
+            gate.release().await;
+            if at_deadline.is_pending() {
+                let _ = write.await;
+            }
+            // With one blocking worker, this also drains previously queued I/O.
+            tokio::task::spawn_blocking(|| ()).await.unwrap();
+            assert!(
+                timed_out,
+                "usage marker write exceeded its publication budget"
+            );
+            assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+
+            let next = write_usage_flush_request(dir.path(), &target)
+                .await
+                .unwrap();
+            let marker: serde_json::Value = serde_json::from_slice(
+                &std::fs::read(dir.path().join("usage-flush-request")).unwrap(),
+            )
+            .unwrap();
+            assert_eq!(marker["flushRequestId"], next.core.flush_request_id);
+            assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
+        });
+    }
+
+    #[test]
+    fn jsonl_marker_deadline_includes_blocking_pool_queueing() {
+        filesystem_test_runtime().block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("network.jsonl");
+            let mut handle = MitmJsonlFlushHandle {
+                addon_dir: dir.path().to_path_buf(),
+                usage_state: Arc::new(Mutex::new(usage_target())),
+                request_lock: Arc::new(AsyncMutex::new(())),
+                request_lock_poll_tx: None,
+                request_published_tx: None,
+            };
+            let gate = BlockingPoolGate::occupy().await;
+            tokio::time::pause();
+            {
+                let flush = handle.flush_path(&path);
+                tokio::pin!(flush);
+                assert!(futures_util::poll!(&mut flush).is_pending());
+                tokio::time::advance(Duration::from_secs(6)).await;
+                let at_deadline = futures_util::poll!(&mut flush);
+                tokio::time::resume();
+                gate.release().await;
+                if at_deadline.is_pending() {
+                    let _ = flush.await;
+                }
+                assert_eq!(at_deadline, Poll::Ready(false));
+            }
+            {
+                let _guard = handle.request_lock.lock().await;
+                assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+            }
+            let mut published_rx = observe_request_publication(&mut handle);
+            let next_path = path.clone();
+            let next = tokio::spawn(async move { handle.flush_path(&next_path).await });
+            let marker = assert_request_published(dir.path(), &path, &mut published_rx).await;
+            std::fs::write(
+                dir.path().join("jsonl-flush-state"),
+                serde_json::json!({
+                    "pid": 1234,
+                    "usageStateId": marker["usageStateId"],
+                    "updatedAtMs": now_millis(),
+                    "flushRequestId": marker["flushRequestId"],
+                    "path": marker["path"],
+                    "pending": 0,
+                })
+                .to_string(),
+            )
+            .unwrap();
+            assert!(next.await.unwrap());
+            assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 2);
+        });
+    }
+
     async fn capture_async_log_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)
     where
         F: std::future::Future,
@@ -798,10 +1094,7 @@ mod tests {
     }
 
     fn usage_target() -> UsageFlushTarget {
-        UsageFlushTarget {
-            expected_usage_state_id: "state-test".to_string(),
-            usage_state_started_at_ms: 1_770_000_000_000,
-        }
+        UsageFlushTarget::new("state-test".to_string(), 1_770_000_000_000, None)
     }
 
     fn observe_request_publication(
@@ -978,9 +1271,11 @@ mod tests {
         let target = usage_target();
         let log_path = dir.path().join("network.jsonl");
 
-        let request = write_jsonl_flush_request(dir.path(), &target, &log_path)
-            .await
-            .unwrap();
+        let request_guard = Arc::new(AsyncMutex::new(())).lock_owned().await;
+        let (request, _guard) =
+            write_jsonl_flush_request(dir.path(), &target, &log_path, request_guard)
+                .await
+                .unwrap();
 
         let marker: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(dir.path().join("jsonl-flush-request")).unwrap(),
@@ -999,7 +1294,8 @@ mod tests {
         let log_path = dir.path().join("network.jsonl");
         std::fs::create_dir(dir.path().join("jsonl-flush-request")).unwrap();
 
-        let result = write_jsonl_flush_request(dir.path(), &target, &log_path).await;
+        let request_guard = Arc::new(AsyncMutex::new(())).lock_owned().await;
+        let result = write_jsonl_flush_request(dir.path(), &target, &log_path, request_guard).await;
 
         assert!(result.is_err());
         let leaked_tmp = std::fs::read_dir(dir.path())
@@ -1038,7 +1334,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn wait_jsonl_flush_returns_true_when_ready_at_immediate_deadline() {
+    async fn wait_jsonl_flush_expires_without_starting_io_at_zero_deadline() {
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("network.jsonl");
         let request = jsonl_request(&log_path);
@@ -1048,7 +1344,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(wait_jsonl_flush(dir.path(), Duration::ZERO, &request).await);
+        assert!(!wait_jsonl_flush(dir.path(), Duration::ZERO, &request).await);
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/runner/src/proxy/flush/publication.rs
+++ b/crates/runner/src/proxy/flush/publication.rs
@@ -1,0 +1,210 @@
+//! Deadline-bounded callers with ownership of uncancellable marker I/O.
+
+use std::io::{self, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::OwnedMutexGuard;
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::AbortOnDropHandle;
+
+use super::super::runtime::MitmdumpRuntime;
+use crate::error::{RunnerError, RunnerResult};
+
+pub(super) struct MarkerPublication {
+    pub path: PathBuf,
+    pub content: Vec<u8>,
+    pub deadline: Instant,
+    pub request_guard: OwnedMutexGuard<()>,
+    // Keep the shared addon directory exclusively owned even if the proxy and
+    // the waiting caller are dropped while a filesystem syscall is running.
+    pub runtime: Option<Arc<MitmdumpRuntime>>,
+    #[cfg(test)]
+    pub staged_gate: Option<(
+        tokio::sync::oneshot::Sender<()>,
+        std::sync::mpsc::Receiver<()>,
+    )>,
+}
+
+impl MarkerPublication {
+    pub async fn publish(self) -> RunnerResult<OwnedMutexGuard<()>> {
+        let path = self.path.clone();
+        let deadline = self.deadline;
+        let cancelled = CancellationToken::new();
+        let worker_cancelled = cancelled.clone();
+        let mut worker = AbortOnDropHandle::new(tokio::task::spawn_blocking(move || {
+            self.write(worker_cancelled)
+        }));
+        // Cancel before dropping/aborting the handle. Aborting alone only stops
+        // queued work; a running worker must keep its guard until cleanup ends.
+        let _cancel_on_drop = cancelled.drop_guard();
+        tokio::time::timeout_at(deadline, &mut worker)
+            .await
+            .map_err(|_| {
+                RunnerError::Internal(format!(
+                    "publish flush request {} timed out",
+                    path.display()
+                ))
+            })?
+            .map_err(|error| {
+                RunnerError::Internal(format!(
+                    "flush request publisher {} failed: {error}",
+                    path.display()
+                ))
+            })?
+            .map_err(|error| {
+                RunnerError::Internal(format!("publish flush request {}: {error}", path.display()))
+            })
+    }
+
+    fn write(self, cancelled: CancellationToken) -> io::Result<OwnedMutexGuard<()>> {
+        let _runtime = self.runtime;
+        let ensure_active = || {
+            if cancelled.is_cancelled() || Instant::now() >= self.deadline {
+                Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "flush request publication expired or was cancelled",
+                ))
+            } else {
+                Ok(())
+            }
+        };
+        ensure_active()?;
+        let parent = self.path.parent().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "flush request has no parent")
+        })?;
+        let name = self.path.file_name().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "flush request has no file name",
+            )
+        })?;
+        let mut staging = tempfile::Builder::new()
+            .prefix(&format!(".{}.", name.to_string_lossy()))
+            .suffix(".tmp")
+            .tempfile_in(parent)?;
+        staging
+            .as_file()
+            .set_permissions(std::fs::Permissions::from_mode(
+                crate::host_file::PRIVATE_FILE_MODE,
+            ))?;
+        staging.write_all(&self.content)?;
+        staging.flush()?;
+        #[cfg(test)]
+        if let Some((ready, release)) = self.staged_gate {
+            let _ = ready.send(());
+            let _ = release.recv_timeout(std::time::Duration::from_secs(10));
+        }
+        ensure_active()?;
+        // NamedTempFile owns cleanup on errors and unwind. A rename that has
+        // already started can finish after cancellation, but the request guard
+        // prevents a newer publication from overtaking it.
+        staging.persist(&self.path).map_err(|error| error.error)?;
+        Ok(self.request_guard)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::sync::Mutex;
+
+    async fn staged_publication_retains_ownership(until_timeout: bool) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("usage-flush-request");
+        std::fs::write(&path, b"previous request").unwrap();
+        let runtime_root = dir.path().join("runtime");
+        let runtime_lock_path = dir.path().join("runtime.lock");
+        let runtime = MitmdumpRuntime::acquire(runtime_root.clone(), runtime_lock_path.clone())
+            .await
+            .unwrap();
+        let request_lock = Arc::new(Mutex::new(()));
+        let (staged_tx, staged_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let operation = MarkerPublication {
+            path: path.clone(),
+            content: b"expired request".to_vec(),
+            deadline: Instant::now() + Duration::from_secs(5),
+            request_guard: Arc::clone(&request_lock).lock_owned().await,
+            runtime: Some(runtime),
+            staged_gate: Some((staged_tx, release_rx)),
+        };
+        let mut publication = Box::pin(operation.publish());
+        assert!(futures_util::poll!(&mut publication).is_pending());
+        tokio::time::timeout(Duration::from_secs(2), staged_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        if until_timeout {
+            tokio::time::pause();
+            tokio::time::advance(Duration::from_secs(6)).await;
+            assert!(matches!(
+                futures_util::poll!(&mut publication),
+                std::task::Poll::Ready(Err(_))
+            ));
+            tokio::time::resume();
+        }
+        drop(publication);
+
+        assert!(request_lock.try_lock().is_err());
+        let runtime_error =
+            match MitmdumpRuntime::acquire(runtime_root.clone(), runtime_lock_path.clone()).await {
+                Ok(_) => panic!("active publisher released the proxy runtime ownership"),
+                Err(error) => error,
+            };
+        assert!(runtime_error.to_string().contains("lock is already held"));
+        assert_eq!(std::fs::read(&path).unwrap(), b"previous request");
+        assert_eq!(staging_file_count(dir.path()), 1);
+
+        release_tx.send(()).unwrap();
+        let request_guard = tokio::time::timeout(
+            Duration::from_secs(2),
+            Arc::clone(&request_lock).lock_owned(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(staging_file_count(dir.path()), 0);
+        assert_eq!(std::fs::read(&path).unwrap(), b"previous request");
+        let runtime = MitmdumpRuntime::acquire(runtime_root, runtime_lock_path)
+            .await
+            .unwrap();
+        let _guard = MarkerPublication {
+            path: path.clone(),
+            content: b"new request".to_vec(),
+            deadline: Instant::now() + Duration::from_secs(5),
+            request_guard,
+            runtime: Some(runtime),
+            staged_gate: None,
+        }
+        .publish()
+        .await
+        .unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"new request");
+        assert_eq!(staging_file_count(dir.path()), 0);
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    fn staging_file_count(dir: &std::path::Path) -> usize {
+        std::fs::read_dir(dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .filter(|name| name.to_string_lossy().ends_with(".tmp"))
+            .count()
+    }
+
+    #[tokio::test]
+    async fn timed_out_staged_publication_cleans_up_before_releasing_ownership() {
+        staged_publication_retains_ownership(true).await;
+    }
+
+    #[tokio::test]
+    async fn dropped_staged_publication_cleans_up_before_releasing_ownership() {
+        staged_publication_retains_ownership(false).await;
+    }
+}

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -234,8 +234,6 @@ pub struct MitmProxy {
     stopping: Arc<AtomicBool>,
     /// Per-mitmdump-process token written by the addon to `usage-pending`.
     usage_state_id: String,
-    /// Host timestamp from when `usage_state_id` was minted.
-    usage_state_started_at_ms: u64,
     usage_flush_state: Arc<Mutex<UsageFlushTarget>>,
     jsonl_flush_request_lock: Arc<AsyncMutex<()>>,
 }
@@ -292,10 +290,11 @@ impl MitmProxy {
 
         let (crash_tx, crash_rx) = mpsc::channel(1);
         let (usage_state_id, usage_state_started_at_ms) = new_usage_state_id();
-        let usage_flush_state = Arc::new(Mutex::new(UsageFlushTarget {
-            expected_usage_state_id: usage_state_id.clone(),
+        let usage_flush_state = Arc::new(Mutex::new(UsageFlushTarget::new(
+            usage_state_id.clone(),
             usage_state_started_at_ms,
-        }));
+            Some(Arc::clone(&runtime)),
+        )));
         let jsonl_flush_request_lock = Arc::new(AsyncMutex::new(()));
 
         Ok((
@@ -307,7 +306,6 @@ impl MitmProxy {
                 crash_tx,
                 stopping: Arc::new(AtomicBool::new(false)),
                 usage_state_id,
-                usage_state_started_at_ms,
                 usage_flush_state,
                 jsonl_flush_request_lock,
             },
@@ -440,10 +438,7 @@ impl MitmProxy {
         }
 
         let _child_pid = self.child.as_ref().and_then(|child| child.id())?;
-        Some(UsageFlushTarget {
-            expected_usage_state_id: self.usage_state_id.clone(),
-            usage_state_started_at_ms: self.usage_state_started_at_ms,
-        })
+        Some(usage_flush_state_guard(&self.usage_flush_state).clone())
     }
 
     /// Ask the running addon to flush buffered webhook work before shutdown.
@@ -524,11 +519,12 @@ impl MitmProxy {
         self.stopping = Arc::clone(&new_stopping);
         let (usage_state_id, usage_state_started_at_ms) = new_usage_state_id();
         self.usage_state_id = usage_state_id.clone();
-        self.usage_state_started_at_ms = usage_state_started_at_ms;
-        *usage_flush_state_guard(&self.usage_flush_state) = UsageFlushTarget {
-            expected_usage_state_id: usage_state_id.clone(),
-            usage_state_started_at_ms,
-        };
+        {
+            // Preserve publication ownership across addon identity changes.
+            let mut target = usage_flush_state_guard(&self.usage_flush_state);
+            target.expected_usage_state_id = usage_state_id.clone();
+            target.usage_state_started_at_ms = usage_state_started_at_ms;
+        }
         MitmRestartParams {
             old_child,
             config: self.config.clone(),
@@ -596,11 +592,11 @@ impl MitmProxy {
                 crash_tx,
                 stopping: Arc::new(AtomicBool::new(false)),
                 usage_state_id: "test-usage-state-id".to_string(),
-                usage_state_started_at_ms: super::flush::now_millis(),
-                usage_flush_state: Arc::new(Mutex::new(UsageFlushTarget {
-                    expected_usage_state_id: "test-usage-state-id".to_string(),
-                    usage_state_started_at_ms: super::flush::now_millis(),
-                })),
+                usage_flush_state: Arc::new(Mutex::new(UsageFlushTarget::new(
+                    "test-usage-state-id".to_string(),
+                    super::flush::now_millis(),
+                    None,
+                ))),
                 jsonl_flush_request_lock: Arc::new(AsyncMutex::new(())),
             },
             crash_rx,


### PR DESCRIPTION
## Summary

Proxy shutdown and deferred network-log upload could wait indefinitely when state-file I/O stalled. Bound acknowledgement reads by their absolute deadline and give marker publication a separate five-second budget, including blocking-pool queueing.

Publication runs in an owned blocking worker that retains the request lock, proxy runtime ownership, and private staging-file cleanup after timeout or cancellation. Cancelled queued/staged writes cannot overtake a newer request; JSONL keeps its lock through acknowledgement, and usage publication serialization survives proxy restart. The addon marker schema and acknowledgement validation remain unchanged.

Closes #33426

## Validation

- 49 focused tests passed in an isolated harness containing the actual flush, publication, hardened filesystem, process inspection, and proxy runtime-lock implementations. This includes both read and write blocking-pool regressions, staged cancellation/timeout cleanup, request validation, and concurrent JSONL requests.
- Rust formatting and `git diff --check` passed.
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p runner --bin runner -j 1` passed.
- `cargo doc --manifest-path crates/Cargo.toml --profile local -p runner --no-deps -j 1` passed.
- Full Runner test compilation and all-target Clippy exceeded this environment's memory capacity. The full Runner lifecycle tests, including the added restart regression, require PR CI. The isolated harness excludes two tests requiring the complete `MitmProxy` fixture and does not replace full Runner validation.

## Limits

The budgets bound the awaiting flush caller. An already-running kernel filesystem operation remains uncancellable and retains ownership until it finishes; this does not establish a hard process-exit deadline or crash-durable publication. No new fallback or protocol migration is introduced.
