### PR TITLE
fix(platform): let each chat thread list catch-up own its lifetime

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
@@ -16,7 +16,7 @@ import {
 import { activeRoute$ } from "../active-route.ts";
 import { apiClient$ } from "../api-client.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
-import { rootSignal$, rootVersion$ } from "../root-signal.ts";
+import { rootSignal$ } from "../root-signal.ts";
 import { pathParams$ } from "../route.ts";
 import {
   createChildAbortController,
@@ -161,17 +161,6 @@ const initialLocalChatThreadEventsLoaded$ = computed((get) => {
   return get(initialLocalChatThreadEventsLoadedDeferred$).promise;
 });
 
-interface ChatThreadEventSyncBarrier {
-  work: Promise<void> | null;
-}
-
-const chatThreadEventSyncBarrier$ = computed(
-  (get): ChatThreadEventSyncBarrier => {
-    get(rootVersion$);
-    return { work: null };
-  },
-);
-
 const optimisticChatThreadCreateIds$ = computed((get): ReadonlySet<string> => {
   return new Set(
     get(optimisticChatThreadEventsState$).flatMap((event) => {
@@ -243,54 +232,41 @@ const applySharedChatThreadEventResult$ = command(
   },
 );
 
+// Each caller runs its own catch-up: a mutation can commit after an older sync
+// has already read its result, so sharing one in-flight refresh would serve a
+// stale answer. Failure remains a rejection, never authoritative not-found.
 const syncSharedEventDrivenChatThreads$ = command(
-  ({ get, set }, signal: AbortSignal): Promise<void> => {
-    const barrier = get(chatThreadEventSyncBarrier$);
-    // Keep explicit refreshes independent: a mutation can commit after an
-    // older sync has already read its result. Readers await the latest work.
-    const work = withCleanup(
-      (async () => {
-        const dataKey = await get(sharedChatThreadEventDataKey$);
-        signal.throwIfAborted();
-        const currentSeqId = get(chatThreadEventState$).latestSeqId;
-        const cached = await set(
-          queryChatThreadEventSharedDatabase$,
-          {
-            dataKey,
-            afterSeqId: currentSeqId,
-            consistency: "cache-only",
-          },
-          signal,
-        );
-        signal.throwIfAborted();
-        const cachedLastSeqId =
-          cached.events.at(-1)?.seqId ?? cached.snapshot?.latestSeqId ?? null;
-        const result =
-          cachedLastSeqId !== null &&
-          (currentSeqId === null || cachedLastSeqId > currentSeqId)
-            ? cached
-            : await set(
-                queryChatThreadEventSharedDatabase$,
-                {
-                  dataKey,
-                  afterSeqId: currentSeqId,
-                  consistency: "catch-up",
-                },
-                signal,
-              );
-        signal.throwIfAborted();
-        set(applySharedChatThreadEventResult$, result, "remote", signal);
-      })(),
-      () => {
-        // Failure remains a rejection, never authoritative not-found. An
-        // older completion must not release a newer caller's ownership.
-        if (barrier.work === work) {
-          barrier.work = null;
-        }
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const dataKey = await get(sharedChatThreadEventDataKey$);
+    signal.throwIfAborted();
+    const currentSeqId = get(chatThreadEventState$).latestSeqId;
+    const cached = await set(
+      queryChatThreadEventSharedDatabase$,
+      {
+        dataKey,
+        afterSeqId: currentSeqId,
+        consistency: "cache-only",
       },
+      signal,
     );
-    barrier.work = work;
-    return work;
+    signal.throwIfAborted();
+    const cachedLastSeqId =
+      cached.events.at(-1)?.seqId ?? cached.snapshot?.latestSeqId ?? null;
+    const result =
+      cachedLastSeqId !== null &&
+      (currentSeqId === null || cachedLastSeqId > currentSeqId)
+        ? cached
+        : await set(
+            queryChatThreadEventSharedDatabase$,
+            {
+              dataKey,
+              afterSeqId: currentSeqId,
+              consistency: "catch-up",
+            },
+            signal,
+          );
+    signal.throwIfAborted();
+    set(applySharedChatThreadEventResult$, result, "remote", signal);
   },
 );
 
@@ -528,13 +504,12 @@ export const resolveThreadMeta$ = command(
 
     const remoteStartedAt = performance.now();
     const initialRemoteSync = get(initialRemoteChatThreadEventsSyncedDeferred$);
-    const syncBarrier = get(chatThreadEventSyncBarrier$);
     // Refresh missing threads against current server state after initial sync.
-    const canonicalSync =
-      syncBarrier.work ??
-      (initialRemoteSync.settled()
-        ? set(syncSharedEventDrivenChatThreads$, get(rootSignal$))
-        : initialRemoteSync.promise);
+    // This reader owns its own refresh, so another caller's cancellation can
+    // never finish it.
+    const canonicalSync = initialRemoteSync.settled()
+      ? set(syncSharedEventDrivenChatThreads$, get(rootSignal$))
+      : initialRemoteSync.promise;
     const syncVersion = get(chatThreadEventSyncVersion$);
     const resolution = await set(
       resolveColdThreadMeta$,


### PR DESCRIPTION
## Problem

`resolveThreadMeta$` borrowed the in-flight list synchronization from a global
`chatThreadEventSyncBarrier$` entry to save one incremental request. The
borrowed promise carried the `AbortSignal` of whichever caller started it.

When the welcome thread action started a list catch-up and the user dismissed
Settings before it finished, the action signal aborted. A cold reader that had
already borrowed that promise finished with the other owner's `AbortError`, the
metadata 404 fallback could not reach the canonical event stream, and the pane
stayed without its history. Whether the reader observed the cancelled entry or
a cleared one depended on microtask ordering, so it surfaced as a flaky test
rather than a hard failure — most recently in
`welcome-thread-sync-overlap.test.tsx`, "An older list refresh cannot finish a
newer welcome reader".

## Change

Remove the barrier. Every caller runs its own catch-up under its own signal, so
a caller can no longer inherit a cancellation it did not request. The shared
mutable promise holder and its `withCleanup` ownership-release go away with it.

The lost deduplication is cheap: each synchronization reads `cache-only` first
and only falls back to a network `catch-up` when the cache is behind the current
cursor, and the Worker does not coalesce concurrent chat-thread-event catch-ups
either. The worst case is one extra incremental `sinceSeqId` tail request inside
a narrow overlap window.

## Verification

- `welcome-thread-sync-overlap`, `welcome-thread-sync`, `welcome-thread`: 16 tests pass.
- `chat-list-cache`, `chat-metadata`, `chat-offline-cache`, `sidebar`,
  `settings-dialog`, `platform-direct-bridge`, `shared-database-browser`: 91 tests pass.
- `tsconfig.production.json` type check, ESLint, oxlint, and Prettier pass.

No new test is added: the existing overlap suite already pins both contracts —
an older refresh must not finish a newer reader, and leaving one reader must not
cancel synchronization for the next one. The local reproduction of the flake
remained order-dependent, so this fix is argued structurally: after the change
there is no code path by which a reader can await work owned by another
caller's signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)