### PR TITLE
refactor(pi): canonicalize the internal execution route

### DIFF
--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1,7 +1,9 @@
 import { isCloudModelMappingValid } from "@okouai/api-contracts/contracts/cloud-model-mapping";
 import {
   assertPiNativeCredential,
-  materializePiAgentModelConfig,
+  materializePiExecutionRoute,
+  normalizePiExecutionRoute,
+  type PiExecutionRoute,
 } from "@okouai/pi-agent-runtime";
 import {
   PI_NATIVE_CREDENTIAL_PLACEHOLDER,
@@ -6692,15 +6694,22 @@ function assertNativeCredentialOverrides(
   }
 }
 
-function nativeCredentialEnvironment(
+function capturedPiExecutionRoute(
   provider: ResolvedModelProviderEnvironment | null,
+): PiExecutionRoute | undefined {
+  return provider?.piModelConfig
+    ? normalizePiExecutionRoute(provider.piModelConfig)
+    : undefined;
+}
+
+function nativeCredentialEnvironment(
+  route: PiExecutionRoute | undefined,
 ): Record<string, string> {
-  const nativeConfig = provider?.piModelConfig;
-  return nativeConfig &&
-    "schemaVersion" in nativeConfig &&
-    nativeConfig.schemaVersion === 4
+  return route &&
+    (route.dialect === "anthropic-messages" ||
+      route.dialect === "bedrock-converse-stream")
     ? Object.fromEntries(
-        nativeConfig.credentialBindings.map((binding) => {
+        route.credentialBindings.map((binding) => {
           return [binding.environment, PI_NATIVE_CREDENTIAL_PLACEHOLDER];
         }),
       )
@@ -6796,7 +6805,9 @@ async function buildStoredExecutionContextDraft(args: {
       connectorVars: args.connectorContext.vars,
     }),
   );
-  const nativeEnvironment = nativeCredentialEnvironment(args.modelProvider);
+  const nativeEnvironment = nativeCredentialEnvironment(
+    capturedPiExecutionRoute(args.modelProvider),
+  );
   const platformEnvironment = buildStoredPlatformEnvironment({
     platformEnvironment: { ...args.platformEnvironment, ...nativeEnvironment },
     canonicalOkouRuntime: args.includeOkouTokenSecret === true,
@@ -8930,8 +8941,9 @@ async function materializePreparedPiProvider(
     );
   }
   const secrets: Record<string, string> = {};
-  await materializePiAgentModelConfig({
-    config,
+  const route = normalizePiExecutionRoute(config);
+  await materializePiExecutionRoute({
+    route,
     target: "direct",
     resolveCredential(binding) {
       const value = provider.secrets[binding.secretName];
@@ -8955,11 +8967,7 @@ async function materializePreparedPiProvider(
   return {
     ...provider,
     piModelConfig: config,
-    environment: Object.fromEntries(
-      config.credentialBindings.map((binding) => {
-        return [binding.environment, PI_NATIVE_CREDENTIAL_PLACEHOLDER];
-      }),
-    ),
+    environment: nativeCredentialEnvironment(route),
     secrets,
     secretConnectorMap: undefined,
     secretConnectorMetadataMap: undefined,

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -18,7 +18,9 @@ import { activeInputDeliveries } from "@okouai/db/schema/active-input-delivery";
 import { agentRuns } from "@okouai/db/runtime/agent-run";
 import { blobs } from "@okouai/db/schema/blob";
 import {
-  materializePiAgentModelConfig,
+  materializePiExecutionRoute,
+  normalizePiExecutionRoute,
+  type PiExecutionRoute,
   type PiAgentCredentialReference,
   type PiAgentModelConfig,
 } from "@okouai/pi-agent-runtime";
@@ -690,6 +692,10 @@ interface ApiFirstTurnContext {
   readonly activation: PiApiFirstTurnActivation;
 }
 
+interface ApiFirstTurnModelContext extends ApiFirstTurnContext {
+  readonly route: PiExecutionRoute;
+}
+
 interface PreparedApiFirstTurn {
   readonly apiStartTime: number;
   readonly auth: SandboxAuth;
@@ -714,6 +720,8 @@ type ApiFirstTurnLaunchConfig =
 function piApiFirstTurnOutcomeTelemetry(
   executionContext: ApiFirstTurnExecutionContext,
 ) {
+  // Observe the original wire vocabulary for the reader drain in #31085.
+  // Execution uses the normalized route, including Gen1 public Responses.
   const config = executionContext.piModelConfig;
   const dialect =
     "schemaVersion" in config
@@ -979,15 +987,13 @@ function sameCredentialSource(
 function codexSubscriptionCredentialReferences(args: {
   readonly activation: PiApiFirstTurnActivation;
   readonly executionContext: ApiFirstTurnExecutionContext;
+  readonly route: PiExecutionRoute;
 }): {
   readonly accessToken: CodexSubscriptionCredentialReference;
   readonly accountId: CodexSubscriptionCredentialReference;
 } | null {
-  const config = args.executionContext.piModelConfig;
-  if (
-    !("schemaVersion" in config) ||
-    config.dialect !== "openai-codex-responses"
-  ) {
+  const config = args.route;
+  if (config.dialect !== "openai-codex-responses") {
     return null;
   }
   const reference = (
@@ -1132,14 +1138,15 @@ async function resolveCodexSubscriptionCredentials(
 }
 
 async function apiFirstTurnModelConfig(
-  args: ApiFirstTurnContext,
+  args: ApiFirstTurnModelContext,
   executionContext: ApiFirstTurnExecutionContext,
   signal: AbortSignal,
 ): Promise<PiAgentModelConfig> {
-  const modelConfig = executionContext.piModelConfig;
+  const modelConfig = args.route;
   const subscriptionReferences = codexSubscriptionCredentialReferences({
     activation: args.activation,
     executionContext,
+    route: modelConfig,
   });
   const subscriptionCredentials = subscriptionReferences
     ? await resolveCodexSubscriptionCredentials(
@@ -1164,8 +1171,8 @@ async function apiFirstTurnModelConfig(
     );
   }
   const secrets: Record<string, string> | null = decrypted.value;
-  return await materializePiAgentModelConfig({
-    config: modelConfig,
+  return await materializePiExecutionRoute({
+    route: modelConfig,
     target: "direct",
     async resolveCredential(binding: PiAgentCredentialReference) {
       let value = subscriptionCredentials?.get(binding.secretName);
@@ -1181,8 +1188,8 @@ async function apiFirstTurnModelConfig(
       const metadata =
         executionContext.secretConnectorMetadataMap?.[binding.secretName];
       if (
-        "schemaVersion" in modelConfig &&
-        modelConfig.schemaVersion === 4 &&
+        (modelConfig.dialect === "anthropic-messages" ||
+          modelConfig.dialect === "bedrock-converse-stream") &&
         providerKey === "claude-code-oauth-token"
       ) {
         throw piApiFirstTurnError(
@@ -1226,7 +1233,7 @@ async function apiFirstTurnModelConfig(
 }
 
 async function recordApiFirstTurnUsage(
-  context: ApiFirstTurnContext,
+  context: ApiFirstTurnModelContext,
   turn: PiApiFirstTurnResult,
 ): Promise<void> {
   const { activation } = context;
@@ -1236,23 +1243,22 @@ async function recordApiFirstTurnUsage(
     userId: activation.userId,
     billableFirewalls: activation.executionContext.billableFirewalls,
     modelUsageProvider: activation.executionContext.modelUsageProvider,
-    piProvider: activation.executionContext.piModelConfig.provider,
+    piProvider: context.route.provider,
+    // Adapt captured native meaning to the unchanged billing input contract.
+    // This object is not persisted or forwarded as a launch/claim payload.
     nativeModelConfig:
-      "schemaVersion" in activation.executionContext.piModelConfig &&
-      activation.executionContext.piModelConfig.schemaVersion === 4
-        ? activation.executionContext.piModelConfig
+      context.route.dialect === "anthropic-messages" ||
+      context.route.dialect === "bedrock-converse-stream"
+        ? { ...context.route, schemaVersion: 4 }
         : undefined,
-    requestedServiceTier:
-      "serviceTier" in activation.executionContext.piModelConfig
-        ? activation.executionContext.piModelConfig.serviceTier
-        : undefined,
+    requestedServiceTier: context.route.serviceTier,
     turn,
   });
 }
 
 async function observeDiscardedProviderResult(
   operation: Promise<PiApiFirstTurnResult>,
-  args: ApiFirstTurnContext,
+  args: ApiFirstTurnModelContext,
   ownership: PiApiFirstTurnOwnership,
   reason: "api_attempt_timed_out" | "aborted_execution",
 ): Promise<void> {
@@ -1271,7 +1277,7 @@ async function observeDiscardedProviderResult(
 
 async function discardCompletedProviderResult(
   turn: PiApiFirstTurnResult,
-  args: ApiFirstTurnContext,
+  args: ApiFirstTurnModelContext,
   ownership: PiApiFirstTurnOwnership,
 ): Promise<void> {
   L.info("Pi API first-turn outcome", {
@@ -1304,7 +1310,7 @@ function validateApiModelTurnOutcome(turn: PiApiFirstTurnResult): void {
 
 interface ExecuteApiModelTurnArgs {
   readonly activation: PiApiFirstTurnActivation;
-  readonly context: ApiFirstTurnContext;
+  readonly context: ApiFirstTurnModelContext;
   readonly commitIdentity: ApiFirstTurnCommitIdentity;
   readonly model: PiAgentModelConfig;
   readonly resourceSnapshot: PiResourceSnapshot;
@@ -1717,7 +1723,15 @@ const prepareApiFirstTurn$ = command(async function prepareApiFirstTurn(
     signal,
   );
   signal.throwIfAborted();
-  const model = await apiFirstTurnModelConfig(args, executionContext, signal);
+  const modelContext: ApiFirstTurnModelContext = {
+    ...args,
+    route: normalizePiExecutionRoute(executionContext.piModelConfig),
+  };
+  const model = await apiFirstTurnModelConfig(
+    modelContext,
+    executionContext,
+    signal,
+  );
   signal.throwIfAborted();
   const loadedSession = await set(
     loadResumeSessionJsonl$,
@@ -1740,7 +1754,7 @@ const prepareApiFirstTurn$ = command(async function prepareApiFirstTurn(
   const { startedAt, turn } = await executeApiModelTurn(
     {
       activation: args.activation,
-      context: args,
+      context: modelContext,
       commitIdentity,
       model,
       resourceSnapshot,

--- a/turbo/apps/api/src/signals/services/pi-memory-stage1-worker.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-stage1-worker.service.ts
@@ -706,6 +706,7 @@ function providerConfig(args: {
     apiKey: args.apiKey,
     model: args.route.upstreamModel,
     dialect: "openai-responses" as const,
+    transport: "sse" as const,
     thinkingLevel: "max" as const,
   };
 }

--- a/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
+++ b/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
@@ -339,6 +339,7 @@ function resolveCustomGatewayPiModelConfig(
     catalogModel: config.catalogModel,
     apiKey: "sandbox-secret",
     dialect: "openai-responses",
+    transport: "sse",
     ...runtimeContract,
   })
     ? config
@@ -507,6 +508,7 @@ function resolveResponsesPiModelConfig(
     model: config.model,
     apiKey: "sandbox-secret",
     dialect: "openai-responses",
+    transport: "sse",
     ...runtimeContract,
   })
     ? config

--- a/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
@@ -66,6 +66,7 @@ const CONFIG: PiSandboxAgentConfig = {
     baseUrl: "https://api.deepseek.com/",
     model: "deepseek-v4-flash",
     dialect: "openai-responses",
+    transport: "sse",
     apiKey: "test-api-key",
   },
 };
@@ -798,6 +799,7 @@ describe("sandbox Pi agent loop", () => {
               apiKey: "SYNTHETIC_KEY",
               model: "gpt-5.6-terra",
               dialect: "openai-responses",
+              transport: "sse",
             },
             launchPayload: {
               ...CONFIG.launchPayload,
@@ -1002,6 +1004,7 @@ describe("sandbox Pi agent loop", () => {
         baseUrl: "https://api.openai.com/v1",
         model: "gpt-5.6-terra",
         dialect: "openai-responses",
+        transport: "sse",
         thinkingLevel: "low",
         serviceTier: "priority",
         apiKey: "test-api-key",

--- a/turbo/packages/pi-agent-runtime/src/api-types.ts
+++ b/turbo/packages/pi-agent-runtime/src/api-types.ts
@@ -2,53 +2,15 @@ import type { PiAgentModelConfig } from "./types";
 import type { PiApiModelFailureDiagnostic } from "./api-failure";
 import type { PiApiFirstTurnOwnership } from "./provider-ownership";
 import type { PiMemoryCitation } from "@okouai/api-contracts/contracts/pi-memory-citations";
+import type { PiResourceSnapshot } from "@okouai/api-contracts/contracts/runners";
 
-export interface PiPreheatedAgentsFile {
-  readonly path: string;
-  readonly content: string;
-}
-
-export interface PiPreheatedSkill {
-  readonly name: string;
-  readonly description: string;
-  readonly filePath: string;
-  readonly baseDir: string;
-  readonly scope: "user" | "project" | "temporary";
-  readonly disableModelInvocation: boolean;
-}
-
-export type PiMemoryRecallSelection =
-  | {
-      readonly status: "no-content";
-      readonly memoryStorageId: string;
-      readonly storageVersionId: string;
-    }
-  | {
-      readonly status: "ready";
-      readonly memoryStorageId: string;
-      readonly storageVersionId: string;
-      readonly content: string;
-      readonly sourceHash: string;
-      readonly sourceSize: number;
-      readonly tokenCount: number;
-    };
-
-export interface PiPreheatedResourceSnapshotV1 {
-  readonly schemaVersion: 1;
-  readonly agentsFiles: readonly PiPreheatedAgentsFile[];
-  readonly skills: readonly PiPreheatedSkill[];
-}
-
-export interface PiPreheatedResourceSnapshotV2 {
-  readonly schemaVersion: 2;
-  readonly agentsFiles: readonly PiPreheatedAgentsFile[];
-  readonly skills: readonly PiPreheatedSkill[];
-  readonly memoryRecall: PiMemoryRecallSelection;
-}
-
-export type PiPreheatedResourceSnapshot =
-  | PiPreheatedResourceSnapshotV1
-  | PiPreheatedResourceSnapshotV2;
+export type PiMemoryRecallSelection = Extract<
+  PiResourceSnapshot,
+  { readonly schemaVersion: 2 }
+>["memoryRecall"];
+export type PiPreheatedAgentsFile = PiResourceSnapshot["agentsFiles"][number];
+export type PiPreheatedSkill = PiResourceSnapshot["skills"][number];
+export type PiPreheatedResourceSnapshot = PiResourceSnapshot;
 
 export type PiMemoryRecallOutcomeStatus = "hit" | "miss" | "invalid" | "stale";
 

--- a/turbo/packages/pi-agent-runtime/src/api.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/api.test.ts
@@ -241,6 +241,7 @@ describe("Pi API facade", () => {
           apiKey: "test-key",
           model: "gpt-5.6-terra",
           dialect: "openai-responses",
+          transport: "sse",
           thinkingLevel: "low",
         },
         resourceSnapshot: {
@@ -607,6 +608,7 @@ describe("Pi API facade", () => {
           apiKey: "test-key",
           model: "deepseek-v4-flash",
           dialect: "openai-responses",
+          transport: "sse",
         },
         resourceSnapshot: { schemaVersion: 1, agentsFiles: [], skills: [] },
         ownership: createPiApiFirstTurnOwnership(),
@@ -702,6 +704,7 @@ describe("Pi API facade", () => {
               apiKey: "test-key",
               model: "openai/gpt-5.6-terra",
               dialect: "openai-responses",
+              transport: "sse",
               thinkingLevel: "low",
               serviceTier: "priority",
             },
@@ -864,6 +867,7 @@ describe("Pi API facade", () => {
           apiKey: "test-key",
           model: "openai/gpt-5.6-terra",
           dialect: "openai-responses",
+          transport: "sse",
           thinkingLevel: "low",
         },
         resourceSnapshot: { schemaVersion: 1, agentsFiles: [], skills: [] },
@@ -940,6 +944,7 @@ describe("Pi API facade", () => {
       apiKey: "test-key",
       model: "gpt-5.6-terra",
       dialect: "openai-responses",
+      transport: "sse",
     });
     if (!resolvedModel) {
       throw new Error("Expected pinned Pi to catalog Terra");
@@ -986,6 +991,7 @@ describe("Pi API facade", () => {
       apiKey: "test-key",
       model: "gpt-5.6-terra",
       dialect: "openai-responses" as const,
+      transport: "sse" as const,
       thinkingLevel: "low" as const,
     };
 

--- a/turbo/packages/pi-agent-runtime/src/compaction-preflight.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/compaction-preflight.test.ts
@@ -20,6 +20,7 @@ function terraModel() {
     apiKey: "test-key",
     model: "gpt-5.6-terra",
     dialect: "openai-responses",
+    transport: "sse",
   });
   if (!model) {
     throw new Error("Expected pinned Pi to catalog Terra");

--- a/turbo/packages/pi-agent-runtime/src/credential.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/credential.test.ts
@@ -160,6 +160,7 @@ describe("Pi agent credential resolution", () => {
         model: "gpt-5.6-terra",
         dialect: "openai-responses",
         apiKey: "legacy-key",
+        transport: "sse",
       });
     },
   );

--- a/turbo/packages/pi-agent-runtime/src/credential.ts
+++ b/turbo/packages/pi-agent-runtime/src/credential.ts
@@ -1,8 +1,9 @@
-import {
-  PI_NATIVE_CREDENTIAL_PLACEHOLDER,
-  piModelConfigV4Schema,
-} from "@okouai/api-contracts/contracts/pi-native";
+import { PI_NATIVE_CREDENTIAL_PLACEHOLDER } from "@okouai/api-contracts/contracts/pi-native";
 import type { PiModelConfig } from "@okouai/api-contracts/contracts/runners";
+import {
+  normalizePiExecutionRoute,
+  type PiExecutionRoute,
+} from "./execution-route";
 
 import type {
   PiAgentCredentialHeaderTemplate,
@@ -75,32 +76,6 @@ export function resolvePiAgentCredential(args: {
   return { apiKey: UNUSED_OPENAI_API_KEY, requestHeaders };
 }
 
-function legacyCredentialBinding(
-  config: Exclude<PiModelConfig, { readonly schemaVersion: number }>,
-): PiAgentCredentialReference {
-  return {
-    kind: "api-key",
-    environment: config.apiKeyEnv,
-    secretName: config.credentialSecretName,
-    ...(config.credentialHeader === undefined
-      ? {}
-      : { credentialHeader: config.credentialHeader }),
-  };
-}
-
-function requiredBinding(
-  config: Extract<PiModelConfig, { readonly schemaVersion: number }>,
-  kind: PiAgentCredentialReference["kind"],
-): PiAgentCredentialReference {
-  const binding = config.credentialBindings.find((candidate) => {
-    return candidate.kind === kind;
-  });
-  if (!binding) {
-    throw new Error(`Pi model config is missing its ${kind} binding`);
-  }
-  return binding;
-}
-
 async function resolvedCredentialValue(args: {
   readonly binding: PiAgentCredentialReference;
   readonly resolveCredential: (
@@ -128,13 +103,16 @@ export function assertPiNativeCredential(value: string): void {
 }
 
 async function materializeNative(args: {
-  readonly config: Extract<PiModelConfig, { readonly schemaVersion: 4 }>;
+  readonly config: Extract<
+    PiExecutionRoute,
+    { readonly dialect: "anthropic-messages" | "bedrock-converse-stream" }
+  >;
   readonly target: PiAgentCredentialTarget;
   readonly resolveCredential: (
     binding: PiAgentCredentialReference,
   ) => string | Promise<string>;
 }): Promise<PiAgentModelConfig> {
-  const config = piModelConfigV4Schema.parse(args.config);
+  const config = args.config;
   const values = new Map<PiAgentCredentialReference["kind"], string>();
   for (const binding of config.credentialBindings) {
     const value = await resolvedCredentialValue({
@@ -162,8 +140,6 @@ async function materializeNative(args: {
     baseUrl: config.baseUrl,
     model: config.model,
     catalogModel: config.catalogModel,
-    dialect: config.dialect,
-    transport: config.transport,
     thinkingLevel: config.thinkingLevel,
   };
   if (config.dialect === "anthropic-messages") {
@@ -177,6 +153,9 @@ async function materializeNative(args: {
     });
     return {
       ...route,
+      provider: config.provider,
+      dialect: config.dialect,
+      transport: config.transport,
       ...credential,
       requestHeaders: {
         "x-api-key": null,
@@ -187,6 +166,9 @@ async function materializeNative(args: {
   }
   return {
     ...route,
+    provider: config.provider,
+    dialect: config.dialect,
+    transport: config.transport,
     // Explicit dummy prevents Pi's model registry from resolving ambient auth.
     apiKey: "unused",
     region: config.region,
@@ -216,28 +198,38 @@ export async function materializePiAgentModelConfig(args: {
     binding: PiAgentCredentialReference,
   ) => string | Promise<string>;
 }): Promise<PiAgentModelConfig> {
-  if ("schemaVersion" in args.config && args.config.schemaVersion === 4) {
-    return await materializeNative({ ...args, config: args.config });
+  return await materializePiExecutionRoute({
+    route: normalizePiExecutionRoute(args.config),
+    target: args.target,
+    resolveCredential: args.resolveCredential,
+  });
+}
+
+/** Materialize captured internal intent without reselecting its provider. */
+export async function materializePiExecutionRoute(args: {
+  readonly route: PiExecutionRoute;
+  readonly target: PiAgentCredentialTarget;
+  readonly resolveCredential: (
+    binding: PiAgentCredentialReference,
+  ) => string | Promise<string>;
+}): Promise<PiAgentModelConfig> {
+  const config = structuredClone(args.route);
+  if (
+    config.dialect === "anthropic-messages" ||
+    config.dialect === "bedrock-converse-stream"
+  ) {
+    return await materializeNative({ ...args, config });
   }
-  if (!("schemaVersion" in args.config)) {
-    // Old API/Runner payloads and stored contexts can still carry this alias
-    // through the rollback, queue, execution and finalization gates in #31085.
-    // Strip it before spreading the route; only dialect selects the adapter.
-    const {
-      api: _legacyApi,
-      apiKeyEnv: _apiKeyEnv,
-      credentialHeader: _credentialHeader,
-      credentialSecretName: _credentialSecretName,
-      ...route
-    } = args.config;
-    const binding = legacyCredentialBinding(args.config);
+
+  if (config.dialect === "openai-responses") {
+    const { credentialBindings, ...route } = config;
+    const binding = credentialBindings[0];
     const credential = await resolvedCredentialValue({
       binding,
       resolveCredential: args.resolveCredential,
     });
     return {
       ...route,
-      dialect: "openai-responses",
       ...resolvePiAgentCredential({
         credential,
         header: binding.credentialHeader,
@@ -246,33 +238,8 @@ export async function materializePiAgentModelConfig(args: {
     };
   }
 
-  const {
-    schemaVersion: _schemaVersion,
-    credentialBindings: _credentialBindings,
-    dialect,
-    transport,
-    ...route
-  } = args.config;
-  if (dialect === "openai-responses") {
-    const binding = requiredBinding(args.config, "api-key");
-    const credential = await resolvedCredentialValue({
-      binding,
-      resolveCredential: args.resolveCredential,
-    });
-    return {
-      ...route,
-      dialect,
-      transport,
-      ...resolvePiAgentCredential({
-        credential,
-        header: binding.credentialHeader,
-        target: args.target,
-      }),
-    };
-  }
-
-  const accessTokenBinding = requiredBinding(args.config, "access-token");
-  const accountIdBinding = requiredBinding(args.config, "account-id");
+  const { credentialBindings, ...route } = config;
+  const [accessTokenBinding, accountIdBinding] = credentialBindings;
   // Subscription credentials are one ordered bundle. The access token may be
   // refreshed at this boundary, so the matching account ID must only be read
   // after that refresh has settled.
@@ -286,8 +253,6 @@ export async function materializePiAgentModelConfig(args: {
   });
   return {
     ...route,
-    dialect,
-    transport,
     apiKey,
     accountId,
   };

--- a/turbo/packages/pi-agent-runtime/src/execution-route.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/execution-route.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import {
+  piModelConfigSchema,
+  type PiModelConfig,
+} from "@okouai/api-contracts/contracts/runners";
+import fixtures from "../../api-contracts/src/contracts/__tests__/fixtures/pi-native.json";
+
+import {
+  materializePiAgentModelConfig,
+  materializePiExecutionRoute,
+} from "./credential";
+import { normalizePiExecutionRoute } from "./execution-route";
+import type { PiAgentModelConfig, PiAgentStreamConfig } from "./types";
+import { piAgentStreamForConfig } from "./model";
+import { registeredModelConfig } from "./session-model";
+import { streamPiNative } from "./native-stream";
+
+describe("captured Pi execution intent", () => {
+  it("preserves dialect requirements through execution and registration helpers", () => {
+    type Codex = Extract<
+      PiAgentModelConfig,
+      { dialect: "openai-codex-responses" }
+    >;
+    type Public = Extract<PiAgentModelConfig, { dialect: "openai-responses" }>;
+    type Messages = Extract<
+      PiAgentModelConfig,
+      { dialect: "anthropic-messages" }
+    >;
+    type Bedrock = Extract<
+      PiAgentModelConfig,
+      { dialect: "bedrock-converse-stream" }
+    >;
+    expectTypeOf<
+      Omit<Codex, "accountId">
+    >().not.toMatchTypeOf<PiAgentModelConfig>();
+    expectTypeOf<
+      Omit<Codex, "accountId">
+    >().not.toMatchTypeOf<PiAgentStreamConfig>();
+    expectTypeOf<Omit<Codex, "accountId">>().not.toMatchTypeOf<
+      Parameters<typeof registeredModelConfig>[2]
+    >();
+    expectTypeOf<Omit<Codex, "transport">>().not.toMatchTypeOf<
+      Parameters<typeof piAgentStreamForConfig>[0]
+    >();
+    expectTypeOf<
+      Omit<Public, "serviceTier"> & { serviceTier: "fast" }
+    >().not.toMatchTypeOf<PiAgentModelConfig>();
+    expectTypeOf<
+      Omit<Codex, "serviceTier"> & { serviceTier: "priority" }
+    >().not.toMatchTypeOf<PiAgentModelConfig>();
+    expectTypeOf<
+      Omit<Messages, "catalogModel">
+    >().not.toMatchTypeOf<PiAgentModelConfig>();
+    expectTypeOf<
+      Omit<Messages, "requestHeaders">
+    >().not.toMatchTypeOf<PiAgentModelConfig>();
+    expectTypeOf<
+      Omit<Messages, "serviceTier"> & { serviceTier: "priority" }
+    >().not.toMatchTypeOf<PiAgentModelConfig>();
+    expectTypeOf<Omit<Bedrock, "region">>().not.toMatchTypeOf<
+      Parameters<typeof streamPiNative>[0]
+    >();
+    expectTypeOf<
+      Omit<Bedrock, "bedrockAuth">
+    >().not.toMatchTypeOf<PiAgentStreamConfig>();
+    expectTypeOf<
+      Omit<Bedrock, "transport"> & { transport: "sse" }
+    >().not.toMatchTypeOf<PiAgentModelConfig>();
+    expectTypeOf<{ kind: "sigv4"; accessKeyId: string }>().not.toMatchTypeOf<
+      Bedrock["bedrockAuth"]
+    >();
+    expectTypeOf<{ kind: "bearer" }>().not.toMatchTypeOf<
+      Bedrock["bedrockAuth"]
+    >();
+  });
+
+  it.each([1, 2, 3] as const)(
+    "owns generation %s header policy before credential resolution",
+    async (generation) => {
+      const header = {
+        name: "X-Selected-Key",
+        valueTemplate: "Key {{secret}}",
+      };
+      const config = {
+        provider: "openai",
+        baseUrl: "https://gateway.example.com/v1",
+        model: "company-production",
+        catalogModel: "gpt-5.6-terra",
+        ...(generation === 1
+          ? {
+              api: "openai-codex-responses",
+              apiKeyEnv: "OPENAI_API_KEY",
+              credentialSecretName: "OPENAI_API_KEY",
+              credentialHeader: header,
+            }
+          : {
+              schemaVersion: generation,
+              dialect: "openai-responses",
+              transport: "sse",
+              credentialBindings: [
+                {
+                  kind: "api-key",
+                  environment: "OPENAI_API_KEY",
+                  secretName: "OPENAI_API_KEY",
+                  credentialHeader: header,
+                },
+              ],
+            }),
+      } satisfies PiModelConfig;
+      const materializing = materializePiAgentModelConfig({
+        config,
+        target: "direct",
+        async resolveCredential() {
+          await Promise.resolve();
+          return "selected-secret";
+        },
+      });
+      header.name = "Authorization";
+      header.valueTemplate = "Changed {{secret}}";
+      expect(await materializing).toStrictEqual({
+        provider: "openai",
+        baseUrl: "https://gateway.example.com/v1",
+        model: "company-production",
+        catalogModel: "gpt-5.6-terra",
+        dialect: "openai-responses",
+        transport: "sse",
+        apiKey: "unused",
+        requestHeaders: {
+          authorization: null,
+          "X-Selected-Key": "Key selected-secret",
+        },
+      });
+    },
+  );
+
+  it.each(fixtures)(
+    "owns $name native references without rewriting the wire",
+    async ({ config }) => {
+      // JSON fixtures model the untrusted wire; normalization performs the same
+      // strict contract validation used by the actual launch reader.
+      const wire = piModelConfigSchema.parse(config);
+      const before = JSON.stringify(wire);
+      const route = normalizePiExecutionRoute(wire);
+      expect(route).not.toHaveProperty("schemaVersion");
+      expect(route).toMatchObject({
+        dialect: config.dialect,
+        model: config.model,
+        catalogModel: config.catalogModel,
+        billingOwner: config.billingOwner,
+        credentialOwner: config.credentialOwner,
+        requestPolicy: { maxAttempts: 1, cacheRetention: "short" },
+      });
+      const materializing = materializePiExecutionRoute({
+        route,
+        target: "direct",
+        async resolveCredential() {
+          await Promise.resolve();
+          return "selected-native-secret";
+        },
+      });
+      Object.defineProperty(route, "catalogModel", {
+        value: "unselected-catalog",
+      });
+      Object.defineProperty(route, "model", { value: "unselected-model" });
+      const materialized = await materializing;
+      expect(materialized.model).toBe(config.model);
+      expect(materialized.catalogModel).toBe(config.catalogModel);
+      expect(JSON.stringify(wire)).toBe(before);
+      expect(JSON.stringify(route)).not.toContain("selected-native-secret");
+    },
+  );
+});

--- a/turbo/packages/pi-agent-runtime/src/execution-route.ts
+++ b/turbo/packages/pi-agent-runtime/src/execution-route.ts
@@ -1,0 +1,124 @@
+import {
+  piModelConfigSchema,
+  type PiModelConfig,
+  type PiModelConfigLegacy,
+} from "@okouai/api-contracts/contracts/runners";
+import type { PiModelConfigV4 } from "@okouai/api-contracts/contracts/pi-native";
+
+import type { PiAgentCredentialReference } from "./types";
+
+type NativeRoute<T = PiModelConfigV4> = T extends PiModelConfigV4
+  ? Omit<T, "schemaVersion"> & { readonly serviceTier?: never }
+  : never;
+
+type ResponsesRoute = Omit<
+  PiModelConfigLegacy,
+  "api" | "apiKeyEnv" | "credentialSecretName" | "credentialHeader"
+>;
+
+type CredentialBinding<K extends PiAgentCredentialReference["kind"]> =
+  PiAgentCredentialReference & { readonly kind: K };
+
+/** In-process captured intent. Never persist this in place of the original wire. */
+export type PiExecutionRoute =
+  | (ResponsesRoute & {
+      readonly dialect: "openai-responses";
+      readonly transport: "sse";
+      readonly credentialBindings: readonly [CredentialBinding<"api-key">];
+    })
+  | (Pick<ResponsesRoute, "baseUrl" | "model" | "thinkingLevel"> & {
+      readonly provider: "openai-codex";
+      readonly dialect: "openai-codex-responses";
+      readonly transport: "sse";
+      readonly serviceTier?: "fast";
+      readonly credentialBindings: readonly [
+        CredentialBinding<"access-token">,
+        CredentialBinding<"account-id">,
+      ];
+    })
+  | NativeRoute;
+
+/**
+ * Normalize the supported readers, taking owned copies of nested policy before
+ * any asynchronous credential work. Validation remains at the wire boundary;
+ * the original generation is still authoritative for claims and observation.
+ */
+export function normalizePiExecutionRoute(
+  wire: PiModelConfig,
+): PiExecutionRoute {
+  const config = piModelConfigSchema.parse(wire);
+  if (!("schemaVersion" in config)) {
+    // Historical Gen1 api values all mean public Responses (#31085).
+    const {
+      api: _api,
+      apiKeyEnv,
+      credentialSecretName,
+      credentialHeader,
+      ...route
+    } = config;
+    return {
+      ...route,
+      dialect: "openai-responses",
+      transport: "sse",
+      credentialBindings: [
+        {
+          kind: "api-key",
+          environment: apiKeyEnv,
+          secretName: credentialSecretName,
+          ...(credentialHeader === undefined ? {} : { credentialHeader }),
+        },
+      ],
+    };
+  }
+  if (config.schemaVersion === 4) {
+    const { schemaVersion: _schemaVersion, ...route } = config;
+    return route;
+  }
+  const {
+    schemaVersion: _schemaVersion,
+    credentialBindings,
+    serviceTier,
+    ...route
+  } = config;
+  const required = <K extends "api-key" | "access-token" | "account-id">(
+    kind: K,
+  ): CredentialBinding<K> => {
+    const binding = credentialBindings.find((candidate) => {
+      return candidate.kind === kind;
+    });
+    if (!binding)
+      throw new Error(`Pi model config is missing its ${kind} binding`);
+    return { ...binding, kind };
+  };
+  if (route.dialect === "openai-responses") {
+    if (serviceTier !== undefined && serviceTier !== "priority") {
+      throw new Error("Pi public Responses requires a public service tier");
+    }
+    // V2's schema refinement supplies this invariant; keep it explicit here
+    // because its TypeScript type predates the dialect-discriminated V3 reader.
+    if (route.provider === "openai-codex") {
+      throw new Error("Pi public Responses cannot use the Codex catalog");
+    }
+    return {
+      ...route,
+      provider: route.provider,
+      dialect: "openai-responses",
+      ...(serviceTier === undefined ? {} : { serviceTier }),
+      credentialBindings: [required("api-key")],
+    };
+  }
+  if (
+    route.provider !== "openai-codex" ||
+    (serviceTier !== undefined && serviceTier !== "fast")
+  ) {
+    throw new Error("Pi Codex Responses requires its catalog and service tier");
+  }
+  const { catalogModel: _catalogModel, ...codex } = route;
+  return {
+    ...codex,
+    provider: "openai-codex",
+    dialect: "openai-codex-responses",
+    ...(serviceTier === undefined ? {} : { serviceTier }),
+    credentialBindings: [required("access-token"), required("account-id")],
+  };
+}

--- a/turbo/packages/pi-agent-runtime/src/index.ts
+++ b/turbo/packages/pi-agent-runtime/src/index.ts
@@ -8,8 +8,11 @@ export const isPiAgentModelSupported: (config: PiAgentModelConfig) => boolean =
 export {
   assertPiNativeCredential,
   materializePiAgentModelConfig,
+  materializePiExecutionRoute,
   resolvePiAgentCredential,
 } from "./credential";
+export { normalizePiExecutionRoute } from "./execution-route";
+export type { PiExecutionRoute } from "./execution-route";
 export { PI_AGENT_THINKING_LEVELS } from "./types";
 export type {
   PiAgentCredentialHeaderTemplate,

--- a/turbo/packages/pi-agent-runtime/src/model.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/model.test.ts
@@ -51,10 +51,15 @@ const OPENAI_TERRA = {
   apiKey: "test-key",
   model: "gpt-5.6-terra",
   dialect: "openai-responses",
+  transport: "sse",
 } as const;
 
 async function retryableCodexProvider() {
-  const requests: Array<{ headers: IncomingHttpHeaders; body: unknown }> = [];
+  const requests: Array<{
+    url: string | undefined;
+    headers: IncomingHttpHeaders;
+    body: unknown;
+  }> = [];
   const server = createServer((request, response) => {
     void (async () => {
       const chunks: Buffer[] = [];
@@ -63,6 +68,7 @@ async function retryableCodexProvider() {
       }
       const bytes = Buffer.concat(chunks);
       requests.push({
+        url: request.url,
         headers: request.headers,
         body: JSON.parse(
           (request.headers["content-encoding"] === "zstd"
@@ -100,6 +106,55 @@ async function retryableCodexProvider() {
 }
 
 describe("Pi agent model adapter", () => {
+  it.each([
+    undefined,
+    "openai-responses",
+    "openai-completions",
+    "openai-codex-responses",
+  ] as const)(
+    "sends legacy api %s only to public Responses with the selected credential",
+    async (api) => {
+      const provider = await retryableCodexProvider();
+      try {
+        const config = await materializePiAgentModelConfig({
+          config: {
+            provider: "openai",
+            baseUrl: provider.baseUrl,
+            model: "gpt-5.6-terra",
+            api,
+            apiKeyEnv: "OPENAI_API_KEY",
+            credentialSecretName: "OPENAI_API_KEY",
+          },
+          target: "direct",
+          resolveCredential: () => {
+            return "selected-public-key";
+          },
+        });
+        const model = resolvePiAgentModel(config);
+        if (!model) throw new Error("Expected a public model");
+        const result = await piAgentStreamForConfig(config)(
+          model,
+          {
+            messages: [{ role: "user", content: "hello", timestamp: 1 }],
+          },
+          { apiKey: config.apiKey },
+        ).result();
+        expect(result.stopReason).toBe("error");
+        expect(provider.requests).toHaveLength(1);
+        expect(provider.requests[0]).toMatchObject({
+          url: "/responses",
+          headers: { authorization: "Bearer selected-public-key" },
+          body: { model: "gpt-5.6-terra", stream: true, store: false },
+        });
+        expect(provider.requests[0]?.headers).not.toHaveProperty(
+          "chatgpt-account-id",
+        );
+      } finally {
+        await provider.close();
+      }
+    },
+  );
+
   it.each([
     undefined,
     "openai-completions",
@@ -213,6 +268,7 @@ describe("Pi agent model adapter", () => {
         apiKey: "test-key",
         model: "gpt-5.6-terra",
         dialect: "openai-responses",
+        transport: "sse",
       } as const,
     },
     {
@@ -276,6 +332,7 @@ describe("Pi agent model adapter", () => {
         apiKey: "test-key",
         model: "openai/gpt-5.6-sol",
         dialect: "openai-responses",
+        transport: "sse",
       }),
     ).toMatchObject({
       id: "openai/gpt-5.6-sol",
@@ -304,6 +361,7 @@ describe("Pi agent model adapter", () => {
           baseUrl: "https://gateway.example.com/v1",
           apiKey: "unused",
           dialect: "openai-responses",
+          transport: "sse",
         }),
       ).toMatchObject({
         id: config.model,
@@ -330,6 +388,7 @@ describe("Pi agent model adapter", () => {
         baseUrl: "https://example.invalid/v1",
         apiKey: "test-key",
         dialect: "openai-responses",
+        transport: "sse",
       }),
     ).toBeNull();
   });
@@ -351,14 +410,9 @@ describe("Pi agent model adapter", () => {
       baseUrl: "https://chatgpt.com/backend-api",
       api: "openai-codex-responses",
     });
-    expect(
-      resolvePiAgentModel({
-        ...OPENAI_TERRA,
-        dialect: "openai-codex-responses",
-        accountId: "account-id",
-        transport: "sse",
-      }),
-    ).toBeNull();
+    const invalid = { ...CODEX_ROUTE };
+    Object.defineProperty(invalid, "provider", { value: "openai" });
+    expect(resolvePiAgentModel(invalid)).toBeNull();
   });
 
   it.each([
@@ -367,19 +421,18 @@ describe("Pi agent model adapter", () => {
   ] as const)(
     "rejects $serviceTier on $dialect before a provider request",
     (policy) => {
-      const config = {
-        ...OPENAI_TERRA,
-        ...policy,
-        provider:
-          policy.dialect === "openai-codex-responses"
-            ? "openai-codex"
-            : "openai",
-        accountId: "exact-account-id",
-        transport: "sse" as const,
-      };
-      expect(resolvePiAgentModel(config)).toBeNull();
-      const model = resolvePiAgentModel({ ...config, serviceTier: undefined });
+      const config =
+        policy.dialect === "openai-codex-responses"
+          ? { ...CODEX_ROUTE }
+          : { ...OPENAI_TERRA };
+      const model = resolvePiAgentModel(config);
       if (!model) throw new Error("Expected a supported standard model");
+      // Untyped callers can still tamper with an otherwise valid config. The
+      // transport boundary must reject it independently of the internal types.
+      Object.defineProperty(config, "serviceTier", {
+        value: policy.serviceTier,
+      });
+      expect(resolvePiAgentModel(config)).toBeNull();
       expect(() => {
         return piAgentStreamForConfig(config)(model, {
           messages: [],

--- a/turbo/packages/pi-agent-runtime/src/model.ts
+++ b/turbo/packages/pi-agent-runtime/src/model.ts
@@ -19,7 +19,7 @@ import type {
 } from "@earendil-works/pi-ai";
 import { clampThinkingLevel } from "@earendil-works/pi-ai";
 
-import type { PiAgentModelConfig } from "./types";
+import type { PiAgentModelConfig, PiAgentStreamConfig } from "./types";
 import { preserveProviderErrorStatus } from "./provider-error-body";
 import {
   observePiResponseStatus,
@@ -282,17 +282,7 @@ export const piAgentRegisteredStream = (
 
 /** Apply API-owned per-request policy to both API-first and Sandbox turns. */
 export function piAgentStreamForConfig(
-  config: Pick<
-    PiAgentModelConfig,
-    | "accountId"
-    | "dialect"
-    | "requestHeaders"
-    | "serviceTier"
-    | "transport"
-    | "catalogModel"
-    | "region"
-    | "bedrockAuth"
-  >,
+  config: PiAgentStreamConfig,
 ): typeof piAgentRegisteredStream {
   return (model, context, options) => {
     const configuredHeaderNames = new Set(

--- a/turbo/packages/pi-agent-runtime/src/native-stream.ts
+++ b/turbo/packages/pi-agent-runtime/src/native-stream.ts
@@ -10,7 +10,7 @@ import { HttpProxyAgent } from "http-proxy-agent";
 import { HttpsProxyAgent } from "https-proxy-agent";
 
 import { assertPiNativeCredential } from "./credential";
-import type { PiAgentModelConfig } from "./types";
+import type { PiAgentStreamConfig } from "./types";
 import {
   observePiResponseStatus,
   type PiAgentStreamOptions,
@@ -26,9 +26,11 @@ function isBedrock(
   return model.api === "bedrock-converse-stream";
 }
 
-type NativeStreamConfig = Pick<
-  PiAgentModelConfig,
-  "catalogModel" | "dialect" | "region" | "bedrockAuth" | "transport"
+type NativeStreamConfig = Extract<
+  PiAgentStreamConfig,
+  {
+    readonly dialect: "anthropic-messages" | "bedrock-converse-stream";
+  }
 >;
 
 function assertNativeOptions(options: PiAgentStreamOptions): void {
@@ -103,6 +105,7 @@ export function streamPiNative(
   }
   if (
     !isBedrock(model) ||
+    config.dialect !== "bedrock-converse-stream" ||
     config.transport !== "aws-event-stream" ||
     !config.region ||
     !config.bedrockAuth

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-filesystem.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-filesystem.test.ts
@@ -115,6 +115,7 @@ function consolidationArgs(
       apiKey: "unused-test-key",
       model: "gpt-5.6-terra",
       dialect: "openai-responses",
+      transport: "sse",
     },
   };
 }

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-filesystem.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-filesystem.ts
@@ -321,25 +321,10 @@ function snapshotSelected(
 function snapshotModel(
   model: PiMemoryPhase2LocalConsolidationArgs["model"],
 ): Readonly<PiMemoryPhase2LocalConsolidationArgs["model"]> {
-  return Object.freeze({
-    provider: model.provider,
-    baseUrl: model.baseUrl,
-    apiKey: model.apiKey,
-    model: model.model,
-    dialect: model.dialect,
-    ...(model.catalogModel === undefined
-      ? {}
-      : { catalogModel: model.catalogModel }),
-    ...(model.requestHeaders === undefined
-      ? {}
-      : { requestHeaders: Object.freeze({ ...model.requestHeaders }) }),
-    ...(model.thinkingLevel === undefined
-      ? {}
-      : { thinkingLevel: model.thinkingLevel }),
-    ...(model.serviceTier === undefined
-      ? {}
-      : { serviceTier: model.serviceTier }),
-  });
+  const snapshot = structuredClone(model);
+  if (snapshot.requestHeaders) Object.freeze(snapshot.requestHeaders);
+  if (snapshot.bedrockAuth) Object.freeze(snapshot.bedrockAuth);
+  return Object.freeze(snapshot);
 }
 
 export function snapshotPiMemoryPhase2Input(

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
@@ -122,6 +122,7 @@ function args(
       model: "MODEL_ALIAS_SECRET_31243",
       catalogModel: "gpt-5.6-terra",
       dialect: "openai-responses",
+      transport: "sse",
       thinkingLevel: "max",
       requestHeaders: { "x-phase2-secret": "HEADER_SECRET_31243" },
     },
@@ -784,6 +785,7 @@ describe("Pi memory Phase 2 consolidation engine", () => {
         apiKey: "original-key",
         model: "gpt-5.6-terra",
         dialect: "openai-responses",
+        transport: "sse",
         requestHeaders: headers,
       },
     });

--- a/turbo/packages/pi-agent-runtime/src/session-model.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-model.ts
@@ -1,7 +1,7 @@
 import { registerSessionResourceCleanup } from "@earendil-works/pi-ai";
 
 import { piAgentStreamForConfig, resolvePiAgentModel } from "./model";
-import type { PiAgentModelConfig } from "./types";
+import type { PiAgentStreamConfig } from "./types";
 
 export function initializePiSessionResourceRegistry(): void {
   // Vite's SSR bundle otherwise keeps Pi's registry behind only the lazy
@@ -17,17 +17,7 @@ export function initializePiSessionResourceRegistry(): void {
 export function registeredModelConfig(
   model: NonNullable<ReturnType<typeof resolvePiAgentModel>>,
   apiKey: string,
-  config: Pick<
-    PiAgentModelConfig,
-    | "accountId"
-    | "dialect"
-    | "requestHeaders"
-    | "serviceTier"
-    | "transport"
-    | "catalogModel"
-    | "region"
-    | "bedrockAuth"
-  >,
+  config: PiAgentStreamConfig,
 ) {
   return {
     name: model.provider,

--- a/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
@@ -26,6 +26,7 @@ const TERRA_MODEL = {
   apiKey: "test-key",
   model: "gpt-5.6-terra",
   dialect: "openai-responses" as const,
+  transport: "sse" as const,
   thinkingLevel: "max" as const,
 };
 
@@ -1332,6 +1333,7 @@ describe("official Pi AgentSession runtime", () => {
             ? {}
             : { thinkingLevel: "max" as const }),
           dialect: "openai-responses",
+          transport: "sse",
           requestHeaders,
         },
         appendSystemPrompt: null,

--- a/turbo/packages/pi-agent-runtime/src/session-validation.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-validation.test.ts
@@ -276,6 +276,7 @@ describe("native Pi history structural boundaries", () => {
         provider: "openai",
         model: "gpt-5.6-terra",
         dialect: "openai-responses" as const,
+        transport: "sse" as const,
         apiKey: "synthetic-key",
         baseUrl: "http://127.0.0.1:1",
       },

--- a/turbo/packages/pi-agent-runtime/src/stage1-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/stage1-memory.test.ts
@@ -376,6 +376,7 @@ describe("Pi memory Stage 1 runtime", () => {
           apiKey: "test-key",
           model: "gpt-5.6-terra",
           dialect: "openai-responses",
+          transport: "sse",
         },
         projectedHistory: '{"role":"user","content":"work"}',
         requestId: "00000000-0000-4000-8000-000000000999",

--- a/turbo/packages/pi-agent-runtime/src/test/fixtures/pending-tool-rpc.ts
+++ b/turbo/packages/pi-agent-runtime/src/test/fixtures/pending-tool-rpc.ts
@@ -69,6 +69,7 @@ await runPiOfficialRpcMode({
     provider: "openai",
     model: "gpt-5.6-terra",
     dialect: "openai-responses",
+    transport: "sse",
     apiKey: "synthetic-key",
     baseUrl: "https://pending-tools.example/v1",
   },

--- a/turbo/packages/pi-agent-runtime/src/types.ts
+++ b/turbo/packages/pi-agent-runtime/src/types.ts
@@ -53,7 +53,7 @@ export type PiAgentBedrockAuth =
     };
 
 /** Model endpoint and credential resolved at a Pi execution edge. */
-export interface PiAgentModelConfig {
+interface PiAgentModelCommon {
   /** Native provider identity used for trusted catalog metadata. */
   readonly provider: string;
   readonly baseUrl: string;
@@ -64,19 +64,66 @@ export interface PiAgentModelConfig {
   readonly catalogModel?: string;
   /** Execution-edge headers that override provider defaults case-insensitively. */
   readonly requestHeaders?: PiAgentRequestHeaders;
-  /** Authoritative native adapter selected by the materialized route. */
-  readonly dialect: PiAgentDialect;
-  /** Explicit ChatGPT account identity required by the Codex dialect. */
-  readonly accountId?: string;
-  readonly region?: string;
-  readonly bedrockAuth?: PiAgentBedrockAuth;
-  /** Route-owned transport policy. Codex subscriptions are SSE-only. */
-  readonly transport?: PiAgentTransport;
   /** Omitted by legacy launch payloads, which retain Pi's medium default. */
   readonly thinkingLevel?: PiAgentThinkingLevel;
-  /**
-   * Omitted by legacy and standard launches. Applied to every request in this
-   * run.
-   */
-  readonly serviceTier?: PiAgentServiceTier;
 }
+
+/** Secret-bearing configuration exists only at the owning execution edge. */
+export type PiAgentModelConfig = PiAgentModelCommon &
+  (
+    | {
+        readonly dialect: "openai-responses";
+        readonly transport: "sse";
+        readonly serviceTier?: "priority";
+        readonly accountId?: never;
+        readonly region?: never;
+        readonly bedrockAuth?: never;
+      }
+    | {
+        readonly dialect: "openai-codex-responses";
+        readonly provider: "openai-codex";
+        readonly catalogModel?: never;
+        readonly transport: "sse";
+        readonly accountId: string;
+        readonly serviceTier?: "fast";
+        readonly region?: never;
+        readonly bedrockAuth?: never;
+      }
+    | {
+        readonly dialect: "anthropic-messages";
+        readonly provider: "anthropic";
+        readonly transport: "sse";
+        readonly catalogModel: string;
+        readonly requestHeaders: PiAgentRequestHeaders;
+        readonly serviceTier?: never;
+        readonly accountId?: never;
+        readonly region?: never;
+        readonly bedrockAuth?: never;
+      }
+    | {
+        readonly dialect: "bedrock-converse-stream";
+        readonly provider: "amazon-bedrock";
+        readonly transport: "aws-event-stream";
+        readonly catalogModel: string;
+        readonly region: string;
+        readonly bedrockAuth: PiAgentBedrockAuth;
+        readonly serviceTier?: never;
+        readonly accountId?: never;
+      }
+  );
+
+/** Distribute before picking so every helper retains dialect requirements. */
+export type PiAgentStreamConfig<T = PiAgentModelConfig> =
+  T extends PiAgentModelConfig
+    ? Pick<
+        T,
+        | "accountId"
+        | "dialect"
+        | "requestHeaders"
+        | "serviceTier"
+        | "transport"
+        | "catalogModel"
+        | "region"
+        | "bedrockAuth"
+      >
+    : never;


### PR DESCRIPTION
Closes #33556. Implements child B of #33519.

Pi already captures its execution route, but API-first and runtime consumers separately interpreted its wire generation and accepted an optional bag of dialect-specific credentials. Normalize that captured value into one non-secret, in-process route, then materialize a discriminated model configuration at the existing API or sandbox execution edge. Historical Gen1 `api` values, including `openai-completions` and `openai-codex-responses`, continue to send public Responses requests.

## Implementation and retained boundaries

- `execution-route.ts` is the single Gen1/V2/V3/V4 normalization path, derived from existing contracts. It owns nested credential/policy snapshots before asynchronous resolution. `materializePiAgentModelConfig` remains the CLI wire adapter; API-first captures the same normalized route for credential resolution and late usage attribution.
- Model, stream, native-stream, and A's session-registration helper preserve dialect correlations. Codex requires its account and SSE; public priority and Codex fast stay separate; native Messages requires catalog/header policy, and Bedrock requires catalog/region/event-stream plus a complete explicit auth bundle. Phase 2 retains A's local engine and snapshots the complete model variant.
- The two native opaque-environment projections now share one helper over captured intent. API direct secrets, custom-header dummy keys/Authorization suppression, sandbox opaque markers, exact-account source validation, and access-token refresh before account-ID lookup retain their existing owners and order.
- Resource, skill, agents-file, and recall declarations derive from `PiResourceSnapshot`, retaining the necessary public package names, readonly semantics, and V1/V2 readers.

Caller inventory covers API-first, CLI Pi launch, ordinary session/RPC, Stage 1, Phase 2, model/native-stream, and session registration. The following original-wire adapters remain deliberate:

- `pi-sandbox-config.ts`: initial provider/environment resolution and existing writer generation. Its three admission callers and completion telemetry policy are unchanged.
- `agent-run-create.service.ts`: launch persistence, generation-specific pinned CLI checks, native credential override/ambient-auth validation, and exact egress authority. Captured `piModelConfig` remains the only persisted plan.
- `pi-api-first-turn.service.ts`: original-wire drain telemetry for #31085; native captured metadata is adapted to the unchanged billing input type, never serialized as a new launch payload.
- `pi-model-config-claim-capability.ts`, contract schemas/fixtures, and Runner `env.rs`/`env/native.rs`: independent claim, validation, serialization, and egress trust boundaries.

No model/provider/channel admission, PiLoop/Fast/default/effort policy, retry/handoff/terminal ownership, billing writer, memory budget, storage CAS, wire generation, SDK version, or production release behavior changes. Official Claude Code subscription credentials remain excluded from Pi. #31085/#31964 readers remain. No new fallback is introduced.

## Validation

- Runtime: focused credential/model/native/session/Stage 1/Phase 2/API group **8 files, 260 passed**; adjacent compaction/session/Phase 2/normalization group **9 files, 101 passed**; final request/snapshot regression run **2 files, 44 passed** (overlapping invocations, not additive counts).
- API: `vitest run` on `chat-events.bdd.test.ts`, `run-lifecycle.bdd.test.ts`, and `pi-native-usage.bdd.test.ts`, filtered by `Pi|pi |native`: **159 selected cases passed** across the final runs. Used an isolated local PostgreSQL test database with UTC timezone. The first non-UTC setup produced queue-expiry 404s; after correcting only the local database setting, one dispatch-timing case exceeded its unchanged 5-second timeout under concurrent checks and passed in a single-worker rerun.
- Additional exact-account/Fast regression, separately selected because its name is outside that filter: `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t 'refreshes the captured subscription Fast account while another account becomes active' --maxWorkers=1`: **1 passed, 534 unselected/skipped**, exit 0. Its real Codex HTTP request uses the refreshed captured account's token and account ID after another account becomes active, with the existing Fast/SSE request policy and no extra active-account credential lookup.
- CLI: `pi-agent-loop.test.ts` **43 passed** in an isolated single-worker run; `pi-api-first-turn-handoff.test.ts` **39 passed**. Earlier local runs encountered RPC harness timeouts while other checks were running; the original assertions and timeouts were preserved. A clean `0bab4493a1237205175ce2d3df2dc66f9ba8034e` worktree also passed the focused unknown-slash case. No CLI behavioral test was weakened or removed.
- Contracts: `runners.test.ts` and `pi-native.test.ts`: **149 passed**, using the existing native wire fixtures.
- Runtime/API/CLI type checks, runtime public declaration boundaries, runtime lint, changed API/CLI-file lint (including applicable type-aware checks), affected-workspace Knip, Prettier, commitlint, and `git diff --check` passed.
- Rust verification boundary: the local `cargo test --manifest-path crates/Cargo.toml --locked --profile local -p runner --bin runner native_pi_context_ -j1` invocation did not finish compilation before the previous run ended; it is **not a local pass**. This PR's Rust coverage/build/behavior jobs are path-filtered **SKIPPED**, not test passes. Existing applicable evidence is [the successful Crates coverage job for #32835](https://github.com/vm0-ai/vm0/actions/runs/34314338210/job/102347366126), run head `00616bd5b5a58896e2c0fa44cfaca29c6060b9a9`: its log records both `native_pi_context_*` and all eleven `pi_execution_context_*` cases as `ok` under `cargo llvm-cov --all-targets --all-features --lcov --output-path lcov.info`. The three Rust validator/test files, `pi-native.ts`, and `fixtures/pi-native.json` are byte-identical between that head and this PR. This is retained fixture evidence, not a claim of a fresh Rust execution at this PR head.
- Exact PR head `4c8157d582f3596cea882caac1470e0f33d109e6`: all three required checks (`ci-gate-security`, `ci-gate-crates`, `ci-gate-turbo`) are **SUCCESS**; overall **80 successful / 22 skipped** checks. Skipped jobs are not counted as passed.

No full local Vitest suite or local development server was run. Required PR/merge-group CI and the current-head independent tracked review are owned by this implementation thread through protected merge. B9 controller acceptance and production release are separate.

## Qualified workload census

The issue's read-only MaskDB census uses **[2026-09-10T14:30:00Z, 2026-09-11T14:30:00Z)**: **3,096 unique run-created rows**, enumerated as 1,000 + 1,000 + 1,000 + 96, with zero missing launch snapshots. **270 Pi snapshots**, **250 thread-bound**, **1 organization / 8 users**, including internal/staff activity. Selected models: Luna 222, Sol 24, Terra 20, Sonnet 5 3, DeepSeek V4 Flash 1. Product providers: Codex subscription 246, Built-in 23, custom Responses 1.

This is a workload census, not an external-user metric, complete admission matrix, causal failure rate, or production acceptance. The 20 threadless rows do not authorize broader admission. **Zero database migrations, data rewrites, backfills, or replays.** The census was supplied by the issue and was not rerun for this refactor.

Fresh pre-implementation inventory covered 26 open PRs / 485 file entries. #33551's three admission-caller overlaps are inventory only; this PR neither implements that feature nor reserves merge order. #33552's release-generated runtime version is untouched.
