### PR TITLE
test: isolate recovery scenarios and trim timeout-risk fixtures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
@@ -523,7 +523,8 @@ beforeEach(() => {
 describe("Stripe automation event webhook", () => {
   it("keeps the existing billing webhook operational without the automation secret", async () => {
     mockOptionalEnv("STRIPE_AUTOMATION_WEBHOOK_SECRET", undefined);
-    const billing = await workflows.setupWorkflowOrg();
+    const actor = workflows.user();
+    const billing = { actor, ...(await runs.grantProEntitlement(actor)) };
     expect(billing).toMatchObject({
       actor: { orgId: expect.any(String) },
       customerId: expect.any(String),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-input.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-input.test.tsx
@@ -10,6 +10,7 @@ import { expect, test, vi } from "vitest";
 import { click, fill, setupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { currentLeftThread$ } from "../../../signals/chat-page/chat-thread-panes.ts";
+import { createChildAbortController } from "../../../signals/utils.ts";
 import { AGENT_ID } from "./chat-lifecycle-test-helpers.ts";
 import {
   assistantEvent,
@@ -26,6 +27,14 @@ import {
 } from "./chat-run-test-fixtures.ts";
 
 const refreshedContext = testContext();
+
+function unloadVoicePage(page: AbortController): void {
+  page.abort(new DOMException("Page reloaded", "AbortError"));
+  cleanup();
+  vi.mocked(window.history.pushState).mockRestore();
+  vi.mocked(window.history.replaceState).mockRestore();
+  vi.mocked(window.history.back).mockRestore();
+}
 
 interface CapturedVoiceSend {
   readonly prompt: string;
@@ -749,12 +758,16 @@ test.each(
 });
 
 test.each([
-  { path: RUN_PATH, failed: false },
-  { path: RUN_PATH, failed: true },
-  { path: NEW_CHAT_PATH, failed: true },
+  { path: RUN_PATH, failed: false, recovery: "navigation" },
+  { path: RUN_PATH, failed: false, recovery: "reload" },
+  { path: RUN_PATH, failed: true, recovery: "navigation" },
+  { path: RUN_PATH, failed: true, recovery: "reload" },
+  { path: NEW_CHAT_PATH, failed: true, recovery: "navigation" },
+  { path: NEW_CHAT_PATH, failed: true, recovery: "reload" },
 ])(
-  "Restore a retryable recording at $path after reload (failed: $failed)",
-  async ({ path, failed }) => {
+  "Restore a retryable recording at $path after $recovery (failed: $failed)",
+  async ({ path, failed, recovery }) => {
+    const initialPage = createChildAbortController(context.signal);
     const firstRequest = context.mocks.deferred<void>();
     const firstResponse = context.mocks.deferred<void>();
     const recordings: ArrayBuffer[] = [];
@@ -793,7 +806,7 @@ test.each([
     );
     installRunChat();
     await setupPage({
-      context,
+      context: { ...context, signal: initialPage.signal },
       path,
       featureSwitches: { [FeatureSwitchKey.VoiceInputV2]: true },
     });
@@ -805,17 +818,25 @@ test.each([
       : screen.findByText("Transcribing");
     await expect(pendingRecording).resolves.toBeVisible();
 
-    click(await findLink("Agents"));
-    await screen.findByRole("heading", { name: "Agents" });
+    if (recovery === "navigation") {
+      click(await findLink("Agents"));
+      await screen.findByRole("heading", { name: "Agents" });
+    } else {
+      // A browser reload ends the old page's daemons as well as its React tree.
+      unloadVoicePage(initialPage);
+    }
     if (!failed) {
       firstResponse.resolve(undefined);
     }
-    cleanup();
-    await setupPage({
-      context: refreshedContext,
-      path,
-      featureSwitches: { [FeatureSwitchKey.VoiceInputV2]: true },
-    });
+    if (recovery === "navigation") {
+      window.history.back();
+    } else {
+      await setupPage({
+        context: refreshedContext,
+        path,
+        featureSwitches: { [FeatureSwitchKey.VoiceInputV2]: true },
+      });
+    }
 
     await screen.findByRole("textbox", { name: "Message" });
     click(await findButton("Retry"));
@@ -866,6 +887,7 @@ test("Keep a saved voice recording isolated from another signed-in user", async 
 });
 
 test("Discard a failed recording without removing typed notes", async () => {
+  const initialPage = createChildAbortController(context.signal);
   context.mocks.browser.voiceInput({ rms: 0.12 });
   installAvailableVoiceQuota();
   context.mocks.http.post("*/api/voice-io/transcribe/segment", () => {
@@ -881,7 +903,7 @@ test("Discard a failed recording without removing typed notes", async () => {
   });
   installRunChat();
   await setupPage({
-    context,
+    context: { ...context, signal: initialPage.signal },
     path: RUN_PATH,
     featureSwitches: { [FeatureSwitchKey.VoiceInputV2]: true },
   });
@@ -900,7 +922,7 @@ test("Discard a failed recording without removing typed notes", async () => {
 
   click(await findLink("Agents"));
   await screen.findByRole("heading", { name: "Agents" });
-  cleanup();
+  unloadVoicePage(initialPage);
   await setupPage({
     context: refreshedContext,
     path: RUN_PATH,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-position-restoration.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-position-restoration.test.tsx
@@ -31,7 +31,6 @@ const LINUX_CHROME_USER_AGENT =
 
 const KEYBOARD_PREVIOUS_THREAD_ID = "b0000000-0000-4000-a000-000000000801";
 const KEYBOARD_CURRENT_THREAD_ID = "b0000000-0000-4000-a000-000000000802";
-const KEYBOARD_NEXT_THREAD_ID = "b0000000-0000-4000-a000-000000000803";
 const SIDEBAR_OTHER_THREAD_ID = "b0000000-0000-4000-a000-000000000804";
 const SIDEBAR_CURRENT_THREAD_ID = "b0000000-0000-4000-a000-000000000805";
 const DEEP_LINK_THREAD_ID = "b0000000-0000-4000-a000-000000000806";
@@ -435,9 +434,10 @@ async function expectAtLatestActivity(
 test("Restore the reading position during keyboard thread navigation", async () => {
   context.mocks.browser.userAgent(LINUX_CHROME_USER_AGENT);
   const user = userEvent.setup({ delay: null });
-  // Three exchanges keep the reading anchor between the top and tail. The
-  // neighboring threads only need content that proves navigation completed.
-  const currentEvents = conversationEvents("keyboard-current", "Current", 3);
+  // Four message anchors in a shorter viewport keep message 2 away from both
+  // scroll boundaries without rendering an unrelated third exchange.
+  const viewportHeight = 240;
+  const currentEvents = conversationEvents("keyboard-current", "Current", 2);
   mockThreadStories(KEYBOARD_CURRENT_THREAD_ID, [
     {
       id: KEYBOARD_PREVIOUS_THREAD_ID,
@@ -448,11 +448,6 @@ test("Restore the reading position during keyboard thread navigation", async () 
       id: KEYBOARD_CURRENT_THREAD_ID,
       title: "Current keyboard thread",
       events: currentEvents,
-    },
-    {
-      id: KEYBOARD_NEXT_THREAD_ID,
-      title: "Next keyboard thread",
-      events: conversationEvents("keyboard-next", "Next", 1),
     },
   ]);
 
@@ -471,11 +466,13 @@ test("Restore the reading position during keyboard thread navigation", async () 
   const initialGeometry = installChatScrollGeometry(
     threadContainer(KEYBOARD_CURRENT_THREAD_ID),
   );
+  initialGeometry.setViewportHeight(viewportHeight);
   fireEvent.resize(window);
   await waitFor(() => {
     expect(initialGeometry.atBottom()).toBeTruthy();
   });
   await chooseReadingPosition(initialGeometry, targetText);
+  expect(initialGeometry.atBottom()).toBeFalsy();
 
   await user.click(threadSection(KEYBOARD_CURRENT_THREAD_ID));
   expect(threadSection(KEYBOARD_CURRENT_THREAD_ID)).toHaveFocus();
@@ -497,9 +494,11 @@ test("Restore the reading position during keyboard thread navigation", async () 
   const returnedGeometry = installChatScrollGeometry(
     threadContainer(KEYBOARD_CURRENT_THREAD_ID),
   );
+  returnedGeometry.setViewportHeight(viewportHeight);
   fireEvent.resize(window);
 
   await expectReadingPosition(returnedGeometry, targetText);
+  expect(returnedGeometry.atBottom()).toBeFalsy();
 });
 
 test("Restore the reading position after switching threads from the sidebar", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-general-tab.test.tsx
@@ -45,7 +45,7 @@ async function reopenSettings(): Promise<void> {
 }
 
 async function openGeneralTab(): Promise<void> {
-  await setupPage({ context, path: "/?settings=general" });
+  await setupPage({ context, path: "/agents?settings=general" });
   await waitFor(() => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(
@@ -362,7 +362,7 @@ test.each(["closing Settings", "navigating back"])(
   "Require fresh workspace confirmation after %s",
   async (exit) => {
     context.mocks.data.org({ id: "org_1", name: "Acme", role: "admin" });
-    await setupPage({ context, path: "/" });
+    await setupPage({ context, path: "/agents" });
     await reopenSettings();
 
     const dialog = await openDeleteDialog();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-members-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-members-tab.test.tsx
@@ -405,14 +405,14 @@ test("Show a scheduled package change on a pending invitation", async () => {
 });
 
 test("Configure a member’s package from People", async () => {
-  mockMembersStory();
+  mockMembersStory(undefined, "admin", "owner");
   mockMemberInviteEntitlement(true);
   mockUsagePackManagement();
   mockUsagePackCatalog();
 
   await setupPage({
     context,
-    path: "/?settings=people",
+    path: "/agents?settings=people",
   });
   await expect(screen.findByText("Usage pack")).resolves.toBeInTheDocument();
 
@@ -598,7 +598,7 @@ test.each([
 ] as const)(
   "Invite a member after selecting No package on $tier (subscription: $hasSubscription)",
   async ({ tier, hasSubscription }) => {
-    mockMembersStory();
+    mockMembersStory(undefined, "admin", "owner");
     mockMemberInviteEntitlement(
       true,
       { tier, status: "active" },
@@ -622,7 +622,7 @@ test.each([
     }
     mockUsagePackCatalog(true);
 
-    await setupPage({ context, path: "/?settings=people" });
+    await setupPage({ context, path: "/agents?settings=people" });
     await screen.findByRole("heading", { name: "People" });
     click(buttonByText("Add member"));
     const inviteDialog = await screen.findByRole("dialog", {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx
@@ -358,7 +358,7 @@ async function openExistingGateway(displayName: string, routed = false) {
 async function openProvidersTab(): Promise<void> {
   await setupPage({
     context,
-    path: "/?settings=model",
+    path: "/agents?settings=model",
   });
   await waitFor(() => {
     expect(
@@ -371,7 +371,7 @@ async function openProvidersTab(): Promise<void> {
 async function openModelSettings(): Promise<void> {
   await setupPage({
     context,
-    path: "/?settings=model",
+    path: "/agents?settings=model",
   });
   await waitFor(() => {
     expect(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
@@ -1215,6 +1215,17 @@ test.each(["Cancel", "Close", "Escape", "backdrop"])(
 test.each([false, true])(
   "Retry unfinished rescues without duplicating completed workflows (reopen: %s)",
   async (reopen) => {
+    async function chooseBothWorkflowCopies(dialog: HTMLElement) {
+      for (const title of ["Daily research", "Weekly research"]) {
+        click(
+          within(dialog).getByRole("combobox", {
+            name: `Handle workflow ${title}`,
+          }),
+        );
+        click(await screen.findByRole("option", { name: "Copy to Nova" }));
+      }
+    }
+
     prepareAgentProfile();
     const first = prepareDeleteWorkflow();
     const second: WorkflowSummary = {
@@ -1283,8 +1294,7 @@ test.each([false, true])(
     click(screen.getByText("Delete agent"));
     let dialog = await screen.findByRole("dialog");
     await within(dialog).findByText("Weekly research");
-    await chooseWorkflowCopy(dialog);
-    await chooseWorkflowCopy(dialog, "Weekly research");
+    await chooseBothWorkflowCopies(dialog);
     click(within(dialog).getByText("Delete agent"));
     await expect(within(dialog).findByRole("alert")).resolves.toHaveTextContent(
       "Second copy failed",
@@ -1302,9 +1312,8 @@ test.each([false, true])(
     }
 
     if (reopen) {
-      const user = userEvent.setup({ delay: null });
-      await user.click(within(dialog).getByText("Cancel"));
-      await user.click(screen.getByText("Delete agent"));
+      click(within(dialog).getByText("Cancel"));
+      click(screen.getByText("Delete agent"));
       dialog = await screen.findByRole("dialog");
     }
     for (const select of within(dialog).getAllByRole("combobox")) {
@@ -1313,8 +1322,7 @@ test.each([false, true])(
     expect(
       within(dialog).getByText("Daily research copied to Nova"),
     ).toBeInTheDocument();
-    await chooseWorkflowCopy(dialog);
-    await chooseWorkflowCopy(dialog, "Weekly research");
+    await chooseBothWorkflowCopies(dialog);
     allowSecondCopy = true;
     click(within(dialog).getByText("Delete agent"));
     await screen.findByText("Agent deleted");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -2356,7 +2356,12 @@ test.each(["agent", "thread"] as const)(
   "Refresh the %s unread indicator",
   async (indicator) => {
     mockMobileLayout();
-    prepareAgents();
+    // Both consumers observe Nova and its thread; unrelated agents add no coverage.
+    context.mocks.data.agents(
+      prepareAgents().filter((agent) => {
+        return agent.agentId === AGENT_ID;
+      }),
+    );
     mockSidebarThreadStory([
       createThread(EXISTING_THREAD_ID, "Remote unread conversation"),
     ]);
@@ -2399,7 +2404,7 @@ test.each(["agent", "thread"] as const)(
 
     await setupSidebarPage({
       context,
-      path: `/agents/${AGENT_ID}/chat`,
+      path: "/agents",
       sharedWorkerTestTransport: "message-port",
     });
 


### PR DESCRIPTION
## Summary

Split the three voice-recording recovery scenarios into six independent navigation/reload cases, preserving real PCM capture, failed or pending transcription, retry bytes and recovered drafts. Reloads now terminate the initial page lifetime before remounting.

Reduce unrelated work in the remaining timeout-risk tests: use smaller but still scrollable keyboard fixtures, only the observed sidebar agent and People roster, an Agents background for settings dialogs, ordinary clicks within workflow-rescue retry tests, and the existing direct billing-entitlement fixture. All original assertions, recovery ordering and timeout settings remain.

Relates to #33319. The [complete 70-finding reconciliation](https://github.com/vm0-ai/vm0/issues/33319#issuecomment-5637572218) accounts for 18 historical identities changed here (two split identities plus 16 fixture/interaction improvements), the additional pending-recording companion, and 52 precise unresolved split constraints. Keep the audit issue open; this does not claim to resolve those constraints or the separate browser prerequisites.

## Validation

- Targeted Vitest: 75 distinct affected cases and helper consumers have passing final-source results, with two workers and one process at a time. All model/general-settings helper consumers and pointer-specific rescue consumers were included.
- Affected-file Prettier, Oxlint, type-aware Oxlint and ESLint passed; API/Platform type checks and workspace Knip passed.
- Earlier failures remain in the ledger. In particular, the new pending-recording navigation companion timed out once at 5159.780ms; its later 2921.6ms pass does not erase that observation or certify the flake as fixed. Submitted-head CI is now green: all eight Platform and eight API shards passed. All 74 Platform cases printed timings of 759–2801ms (at least 2199ms headroom); the billing file passed all 26 tests but did not print this case's exact duration. The pending-navigation companion measured 1472ms in CI; that does not erase the retained local failure.
- Test-only changes in eight files. No full local Vitest suite, dev server, timeout increase, retry, skip or production change.


CI run: https://github.com/vm0-ai/vm0/actions/runs/34623205938. Its verified checkout is `89e6f60d701d1739de86947680b5501e6f967b40`, the PR merge ref containing reviewed source `bcd3c2775d6a666f2dc8a54882987bf58852b187`.

