### PR TITLE
fix(voice): classify google failures and retain safe diagnostics

### DIFF
--- a/docs/google-llm-voice.md
+++ b/docs/google-llm-voice.md
@@ -124,10 +124,22 @@ capacity recovery from #33403 within the same attempt/time budget. Native Google
 responses use Google's own response contract; OpenRouter error shapes are not
 interpreted as successful Google output.
 
-Capacity exhaustion and transient auth unavailability use public 503; invalid
-output or denied auth use 502. App quota 402/429, no-speech 204, and successful
-usage accounting retain their existing route contracts. Logs contain sanitized
-model/location/operation/status metadata, never tokens, audio, or transcripts.
+Capacity exhaustion, transient auth unavailability, and recognized Google
+fetch/body network or timeout failures use public 503 / `PROVIDER_UNAVAILABLE`.
+Transport failures do not add automatic replay: an interrupted response may
+follow a billable generation. Unknown errors, invalid output, and denied auth
+still use 502. A received non-2xx status remains authoritative even if its body
+is unreadable. Caller cancellation retains its original outcome.
+
+App quota 402/429, no-speech 204, and successful usage accounting retain their
+existing route contracts. Terminal native errors log sanitized
+model/location/operation/status and a fixed reason, including truncation,
+blocking, empty output, invalid response/schema, and oversized responses. Auth
+diagnostics include the failing stage and fixed reason. Neither diagnostics nor
+public errors include tokens, audio, transcripts, raw provider responses, or
+unbounded provider-supplied reason strings. Auth, native validation/transport,
+and exhausted HTTP recovery retain separate diagnostic owners; successful
+recovery and caller cancellation do not produce terminal-error warnings.
 
 ## Verification and rollout gates
 

--- a/turbo/apps/api/src/signals/external/gcp-llm-auth.ts
+++ b/turbo/apps/api/src/signals/external/gcp-llm-auth.ts
@@ -6,11 +6,16 @@ import { logger } from "../../lib/log";
 import { now } from "../../lib/time";
 import { singleton } from "../../lib/singleton";
 import {
+  gcpLlmTransportReason,
+  type GcpLlmTransportReason,
+} from "./gcp-llm-transport";
+import {
   awaitWithSignal,
   onRejection,
   readBoundedResponseText,
   safeJsonParse,
   safeSync,
+  startUntrackedBestEffortCleanup,
 } from "../utils";
 
 const L = logger("GcpLlmAuth");
@@ -52,6 +57,12 @@ export class GcpLlmAuthError extends Error {
     readonly stage: "oidc" | "sts" | "impersonation" | "deadline",
     readonly status: number,
     readonly temporary = false,
+    readonly reason:
+      | GcpLlmTransportReason
+      | "http"
+      | "invalid_response"
+      | "missing_identity"
+      | "deadline" = "invalid_response",
   ) {
     super("Google Cloud LLM authentication failed");
     this.name = "GcpLlmAuthError";
@@ -93,19 +104,35 @@ const impersonationResponseSchema = z.object({
 });
 
 async function tokenResponse(
-  response: Response,
+  pending: Promise<Response>,
   stage: "sts" | "impersonation",
   signal: AbortSignal,
 ): Promise<unknown> {
-  const body = await readBoundedResponseText(response, MAX_RESPONSE_BYTES);
+  const rejectTransport = (error: unknown) => {
+    signal.throwIfAborted();
+    const reason = gcpLlmTransportReason(error);
+    if (reason) {
+      throw new GcpLlmAuthError(stage, 503, true, reason);
+    }
+  };
+  const response = await onRejection(pending, rejectTransport);
   signal.throwIfAborted();
   if (!response.ok) {
+    if (response.body) {
+      startUntrackedBestEffortCleanup(response.body.cancel());
+    }
     throw new GcpLlmAuthError(
       stage,
       response.status,
       response.status === 429 || response.status >= 500,
+      "http",
     );
   }
+  const body = await onRejection(
+    readBoundedResponseText(response, MAX_RESPONSE_BYTES),
+    rejectTransport,
+  );
+  signal.throwIfAborted();
   if (body.kind !== "text") {
     throw new GcpLlmAuthError(stage, 502);
   }
@@ -120,9 +147,9 @@ async function exchange(
   // Read the current request context without the SDK's local CLI refresh path.
   const subjectToken = safeSync(getVercelOidcTokenSync);
   if (!("ok" in subjectToken) || !subjectToken.ok) {
-    throw new GcpLlmAuthError("oidc", 401);
+    throw new GcpLlmAuthError("oidc", 401, false, "missing_identity");
   }
-  const stsResponse = await fetch(STS_URL, {
+  const stsResponse = fetch(STS_URL, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({
@@ -141,7 +168,7 @@ async function exchange(
   if (!sts.success) {
     throw new GcpLlmAuthError("sts", 502);
   }
-  const response = await fetch(
+  const response = fetch(
     `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${configuration.serviceAccount}:generateAccessToken`,
     {
       method: "POST",
@@ -190,12 +217,18 @@ async function completeRefresh(
     (error) => {
       ownerSignal.throwIfAborted();
       if (deadline.aborted) {
-        throw new GcpLlmAuthError("deadline", 503, true);
+        L.warn("Google Cloud LLM authentication rejected", {
+          stage: "deadline",
+          status: 503,
+          reason: "deadline",
+        });
+        throw new GcpLlmAuthError("deadline", 503, true, "deadline");
       }
       if (error instanceof GcpLlmAuthError) {
         L.warn("Google Cloud LLM authentication rejected", {
           stage: error.stage,
           status: error.status,
+          reason: error.reason,
         });
       }
     },

--- a/turbo/apps/api/src/signals/external/gcp-llm-transport.ts
+++ b/turbo/apps/api/src/signals/external/gcp-llm-transport.ts
@@ -1,0 +1,45 @@
+export type GcpLlmTransportReason = "network" | "upstream_timeout";
+
+function property(value: unknown, key: string): unknown {
+  return typeof value === "object" && value !== null && key in value
+    ? value[key as keyof typeof value]
+    : undefined;
+}
+
+/** Classify only errors caught at fetch/body I/O, never output interpretation. */
+export function gcpLlmTransportReason(
+  error: unknown,
+): GcpLlmTransportReason | undefined {
+  if (error instanceof Error && error.name === "AbortError") {
+    return undefined;
+  }
+  const code =
+    property(property(error, "cause"), "code") ?? property(error, "code");
+  if (
+    typeof code === "string" &&
+    [
+      "ETIMEDOUT",
+      "UND_ERR_CONNECT_TIMEOUT",
+      "UND_ERR_HEADERS_TIMEOUT",
+      "UND_ERR_BODY_TIMEOUT",
+    ].includes(code)
+  ) {
+    return "upstream_timeout";
+  }
+  if (
+    (typeof code === "string" &&
+      [
+        "ECONNRESET",
+        "ECONNREFUSED",
+        "EAI_AGAIN",
+        "ENETUNREACH",
+        "UND_ERR_SOCKET",
+      ].includes(code)) ||
+    (code === undefined &&
+      error instanceof TypeError &&
+      (error.message === "fetch failed" || error.message === "Failed to fetch"))
+  ) {
+    return "network";
+  }
+  return undefined;
+}

--- a/turbo/apps/api/src/signals/external/vertex-voice.ts
+++ b/turbo/apps/api/src/signals/external/vertex-voice.ts
@@ -2,8 +2,18 @@ import type { MultimodalVoiceInputModelId } from "@okouai/api-contracts/contract
 import { z } from "zod";
 
 import { logger } from "../../lib/log";
-import { readBoundedResponseText, safeJsonParse } from "../utils";
+import {
+  onRejection,
+  readBoundedResponseText,
+  safeJsonParse,
+  safeSync,
+  startUntrackedBestEffortCleanup,
+} from "../utils";
 import { gcpLlmAccessToken, gcpLlmConfiguration } from "./gcp-llm-auth";
+import {
+  gcpLlmTransportReason,
+  type GcpLlmTransportReason,
+} from "./gcp-llm-transport";
 import type { VoiceCompletionRequest } from "./voice-completion-types";
 import { requestVoiceProvider } from "./voice-provider-request";
 
@@ -60,11 +70,42 @@ export function isVertexVoiceModel(
   return Object.hasOwn(MODELS, model);
 }
 
-class VertexVoiceError extends Error {
-  constructor(readonly status: number) {
+type VertexVoiceFailureReason =
+  | GcpLlmTransportReason
+  | "http"
+  | "response_too_large"
+  | "invalid_response"
+  | "blocked"
+  | "output_truncated"
+  | "non_stop"
+  | "empty_output"
+  | "invalid_output";
+
+export class VertexVoiceError extends Error {
+  constructor(
+    readonly status: number,
+    readonly reason: VertexVoiceFailureReason,
+  ) {
     super("Google voice request failed");
     this.name = "VertexVoiceError";
   }
+
+  get temporary(): boolean {
+    return this.reason === "network" || this.reason === "upstream_timeout";
+  }
+}
+
+async function vertexIo<T>(
+  pending: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  return await onRejection(pending, (error) => {
+    signal.throwIfAborted();
+    const reason = gcpLlmTransportReason(error);
+    if (reason) {
+      throw new VertexVoiceError(503, reason);
+    }
+  });
 }
 
 const responseSchema = z.object({
@@ -72,16 +113,70 @@ const responseSchema = z.object({
   candidates: z
     .array(
       z.object({
-        finishReason: z.literal("STOP"),
-        content: z.object({
-          parts: z.array(
-            z.object({ text: z.string(), thought: z.boolean().optional() }),
-          ),
-        }),
+        finishReason: z.string(),
+        content: z
+          .object({
+            parts: z.array(
+              z.object({ text: z.string(), thought: z.boolean().optional() }),
+            ),
+          })
+          .optional(),
       }),
     )
-    .length(1),
+    .optional(),
 });
+
+function parseVertexResponse<T>(
+  body: string,
+  parseResponse: (content: string) => T,
+): T {
+  const parsed = responseSchema.safeParse(safeJsonParse(body));
+  if (!parsed.success) {
+    throw new VertexVoiceError(502, "invalid_response");
+  }
+  if (parsed.data.promptFeedback?.blockReason) {
+    throw new VertexVoiceError(502, "blocked");
+  }
+  const candidate = parsed.data.candidates?.[0];
+  if (!candidate || parsed.data.candidates?.length !== 1) {
+    throw new VertexVoiceError(502, "invalid_response");
+  }
+  if (candidate.finishReason !== "STOP") {
+    const reason =
+      candidate.finishReason === "MAX_TOKENS"
+        ? "output_truncated"
+        : [
+              "SAFETY",
+              "RECITATION",
+              "BLOCKLIST",
+              "PROHIBITED_CONTENT",
+              "SPII",
+              "IMAGE_SAFETY",
+            ].includes(candidate.finishReason)
+          ? "blocked"
+          : "non_stop";
+    throw new VertexVoiceError(502, reason);
+  }
+  const text = candidate.content?.parts
+    .filter((part) => {
+      return !part.thought;
+    })
+    .map((part) => {
+      return part.text;
+    })
+    .join("")
+    .trim();
+  if (!text) {
+    throw new VertexVoiceError(502, "empty_output");
+  }
+  const result = safeSync(() => {
+    return parseResponse(text);
+  });
+  if (!("ok" in result)) {
+    throw new VertexVoiceError(502, "invalid_output");
+  }
+  return result.ok;
+}
 
 /** Voice-only native transport; other Google consumers keep their own routing. */
 export async function generateVertexVoice<T>(
@@ -125,64 +220,66 @@ export async function generateVertexVoice<T>(
       }),
     },
   });
-  return await requestVoiceProvider(
-    async (requestSignal) => {
-      const token = await gcpLlmAccessToken(configuration, requestSignal);
-      requestSignal.throwIfAborted();
-      return await fetch(
-        `https://${model.host}/v1/projects/${configuration.project}/locations/${model.location}/publishers/google/models/${model.model}:generateContent`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
-          body,
-          signal: requestSignal,
-        },
-      );
-    },
-    async (response) => {
-      const body = await readBoundedResponseText(
-        response,
-        args.jsonSchema ? 1024 * 1024 : 2 * 1024 * 1024,
-      );
+  return await onRejection(
+    requestVoiceProvider(
+      async (requestSignal) => {
+        const token = await gcpLlmAccessToken(configuration, requestSignal);
+        requestSignal.throwIfAborted();
+        return await vertexIo(
+          fetch(
+            `https://${model.host}/v1/projects/${configuration.project}/locations/${model.location}/publishers/google/models/${model.model}:generateContent`,
+            {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json",
+              },
+              body,
+              signal: requestSignal,
+            },
+          ),
+          requestSignal,
+        );
+      },
+      async (response) => {
+        signal.throwIfAborted();
+        if (!response.ok) {
+          if (response.body) {
+            startUntrackedBestEffortCleanup(response.body.cancel());
+          }
+          throw new VertexVoiceError(response.status, "http");
+        }
+        const body = await vertexIo(
+          readBoundedResponseText(
+            response,
+            args.jsonSchema ? 1024 * 1024 : 2 * 1024 * 1024,
+          ),
+          signal,
+        );
+        signal.throwIfAborted();
+        if (body.kind !== "text") {
+          throw new VertexVoiceError(502, "response_too_large");
+        }
+        return parseVertexResponse(body.text, parseResponse);
+      },
+      {
+        provider: "vertex",
+        model: args.model,
+        responseSchema: args.jsonSchema?.name,
+      },
+      signal,
+    ),
+    (error) => {
       signal.throwIfAborted();
-      if (!response.ok) {
+      if (error instanceof VertexVoiceError) {
         L.warn("Google voice request rejected", {
           model: args.model,
           location: model.location,
           operation: args.jsonSchema?.name ?? "plain_text_polish",
-          status: response.status,
+          status: error.status,
+          reason: error.reason,
         });
-        throw new VertexVoiceError(response.status);
       }
-      const parsed = responseSchema.safeParse(
-        body.kind === "text" ? safeJsonParse(body.text) : undefined,
-      );
-      if (!parsed.success || parsed.data.promptFeedback?.blockReason) {
-        throw new VertexVoiceError(502);
-      }
-      const candidate = parsed.data.candidates[0];
-      const text = candidate?.content.parts
-        .filter((part) => {
-          return !part.thought;
-        })
-        .map((part) => {
-          return part.text;
-        })
-        .join("")
-        .trim();
-      if (!text) {
-        throw new VertexVoiceError(502);
-      }
-      return parseResponse(text);
     },
-    {
-      provider: "vertex",
-      model: args.model,
-      responseSchema: args.jsonSchema?.name,
-    },
-    signal,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-google-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-google-auth.test.ts
@@ -76,6 +76,86 @@ afterEach(() => {
 });
 
 describe("Google voice workload identity through the public API", () => {
+  it.each([
+    { url: GOOGLE_STS_URL, stage: "sts", bodyFailure: false },
+    {
+      url: GOOGLE_IMPERSONATION_URL,
+      stage: "impersonation",
+      bodyFailure: false,
+    },
+    { url: GOOGLE_STS_URL, stage: "sts", bodyFailure: true },
+    {
+      url: GOOGLE_IMPERSONATION_URL,
+      stage: "impersonation",
+      bodyFailure: true,
+    },
+  ])(
+    "reports temporary $stage I/O failure (body=$bodyFailure) without replay",
+    async ({ url, stage, bodyFailure }) => {
+      let calls = 0;
+      server.use(
+        http.post(url, () => {
+          calls += 1;
+          return bodyFailure
+            ? new HttpResponse(
+                new ReadableStream({
+                  start(controller) {
+                    controller.error(
+                      new Error("private credential response", {
+                        cause: { code: "UND_ERR_BODY_TIMEOUT" },
+                      }),
+                    );
+                  },
+                }),
+              )
+            : HttpResponse.error();
+        }),
+      );
+      const response = await accept(polish(), [503]);
+      expect(response.body.error.code).toBe("PROVIDER_UNAVAILABLE");
+      expect(calls).toBe(1);
+      expect(context.mocks.axiomLogging.warn).toHaveBeenCalledExactlyOnceWith(
+        "Google Cloud LLM authentication rejected",
+        expect.objectContaining({
+          stage,
+          status: 503,
+          reason: bodyFailure ? "upstream_timeout" : "network",
+        }),
+      );
+      expect(
+        JSON.stringify(context.mocks.axiomLogging.warn.mock.calls),
+      ).not.toContain("private credential response");
+    },
+  );
+
+  it.each([GOOGLE_STS_URL, GOOGLE_IMPERSONATION_URL])(
+    "preserves denied auth even when its body fails at %s",
+    async (url) => {
+      server.use(
+        http.post(url, () => {
+          return new HttpResponse(
+            new ReadableStream({
+              start(controller) {
+                controller.error(
+                  new Error("private denied response", {
+                    cause: { code: "ECONNRESET" },
+                  }),
+                );
+              },
+            }),
+            { status: 403 },
+          );
+        }),
+      );
+      const response = await accept(polish(), [502]);
+      expect(response.body.error.code).toBe("VOICE_POLISH_FAILED");
+      expect(context.mocks.axiomLogging.warn).toHaveBeenCalledExactlyOnceWith(
+        "Google Cloud LLM authentication rejected",
+        expect.objectContaining({ status: 403, reason: "http" }),
+      );
+    },
+  );
+
   it("bounds an in-flight auth request by its own deadline and permits a later refresh", async () => {
     const deadline = new AbortController();
     context.mocks.abortSignal.timeout.mockImplementation((milliseconds) => {
@@ -102,6 +182,14 @@ describe("Google voice workload identity through the public API", () => {
     deadline.abort(new DOMException("Auth deadline", "TimeoutError"));
     await accept(pending, [503]);
     await aborted.promise;
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledExactlyOnceWith(
+      "Google Cloud LLM authentication rejected",
+      expect.objectContaining({
+        stage: "deadline",
+        reason: "deadline",
+        status: 503,
+      }),
+    );
     context.mocks.abortSignal.timeout.mockReset();
     server.use(
       http.post(GOOGLE_STS_URL, () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-polish.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-polish.test.ts
@@ -52,6 +52,75 @@ async function enableVoicePolish(useGoogleCloud = true) {
 }
 
 describe("POST /api/voice-io/polish", () => {
+  it.each([
+    { code: "ECONNRESET", status: 503, reason: "network" },
+    { code: "UND_ERR_BODY_TIMEOUT", status: 503, reason: "upstream_timeout" },
+    { code: "CERT_HAS_EXPIRED", status: 502 },
+  ])(
+    "classifies a Google body I/O failure with $code",
+    async ({ code, status, reason }) => {
+      await enableVoicePolish();
+      let calls = 0;
+      server.use(
+        http.post(VERTEX_VOICE_URL, () => {
+          calls += 1;
+          return new HttpResponse(
+            new ReadableStream({
+              start(controller) {
+                controller.error(
+                  new TypeError("fetch failed", { cause: { code } }),
+                );
+              },
+            }),
+          );
+        }),
+      );
+      const response = await client().post({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { text: "Synthetic dictation." },
+      });
+      expect(response.status).toBe(status);
+      expect(response.body).toMatchObject({
+        error: {
+          code: status === 503 ? "PROVIDER_UNAVAILABLE" : "VOICE_POLISH_FAILED",
+        },
+      });
+      expect(calls).toBe(1);
+      if (reason) {
+        expect(context.mocks.axiomLogging.warn).toHaveBeenCalledExactlyOnceWith(
+          "Google voice request rejected",
+          expect.objectContaining({
+            model: "google/gemini-3.8-flash",
+            location: "us",
+            operation: "plain_text_polish",
+            status,
+            reason,
+          }),
+        );
+      }
+    },
+  );
+
+  it("classifies a Google connection failure without replaying generation", async () => {
+    await enableVoicePolish();
+    let calls = 0;
+    server.use(
+      http.post(VERTEX_VOICE_URL, () => {
+        calls += 1;
+        return HttpResponse.error();
+      }),
+    );
+    const response = await accept(
+      client().post({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { text: "Synthetic dictation." },
+      }),
+      [503],
+    );
+    expect(response.body.error.code).toBe("PROVIDER_UNAVAILABLE");
+    expect(calls).toBe(1);
+  });
+
   it("preserves OpenRouter polishing by default without Google credentials", async () => {
     await enableVoicePolish(false);
     mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
@@ -162,6 +231,75 @@ describe("POST /api/voice-io/polish", () => {
     expect(urls[0]).toContain(
       "/locations/us/publishers/google/models/gemini-3.8-flash:generateContent",
     );
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      reason: "output_truncated",
+      body: {
+        candidates: [
+          {
+            finishReason: "MAX_TOKENS",
+            content: { parts: [{ text: "private partial transcript" }] },
+          },
+        ],
+      },
+    },
+    {
+      reason: "blocked",
+      body: {
+        promptFeedback: { blockReason: "private upstream block reason" },
+      },
+    },
+    { reason: "blocked", body: { candidates: [{ finishReason: "SAFETY" }] } },
+    {
+      reason: "non_stop",
+      body: { candidates: [{ finishReason: "private unknown finish reason" }] },
+    },
+    {
+      reason: "empty_output",
+      body: {
+        candidates: [
+          {
+            finishReason: "STOP",
+            content: {
+              parts: [{ text: "private thought text", thought: true }],
+            },
+          },
+        ],
+      },
+    },
+    { reason: "invalid_response", body: { candidates: [{ finishReason: 7 }] } },
+  ])("records only safe metadata for $reason", async ({ reason, body }) => {
+    await enableVoicePolish();
+    server.use(
+      http.post(VERTEX_VOICE_URL, () => {
+        return HttpResponse.json(body);
+      }),
+    );
+    const response = await accept(
+      client().post({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { text: "private user dictation" },
+      }),
+      [502],
+    );
+    expect(response.body.error.code).toBe("VOICE_POLISH_FAILED");
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledExactlyOnceWith(
+      "Google voice request rejected",
+      expect.objectContaining({
+        model: "google/gemini-3.8-flash",
+        location: "us",
+        operation: "plain_text_polish",
+        status: 502,
+        reason,
+      }),
+    );
+    expect(
+      JSON.stringify(context.mocks.axiomLogging.warn.mock.calls),
+    ).not.toContain("private");
   });
 
   it("preserves public provider errors, respects long Retry-After, and rejects incomplete polish", async () => {
@@ -301,6 +439,8 @@ describe("POST /api/voice-io/polish", () => {
     controller.abort();
     await expect(result).rejects.toMatchObject({ name: "AbortError" });
     await aborted.promise;
+    expect(context.mocks.axiomLogging.warn).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
   });
 
   it("turns raw dictation into send-ready text without charging usage", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
@@ -12,6 +12,8 @@ import { voiceIoQuotaRoutes } from "../voice-io-quota";
 import { HttpResponse, http } from "msw";
 import {
   mockGoogleVoice,
+  GOOGLE_STS_URL,
+  GOOGLE_IMPERSONATION_URL,
   VERTEX_VOICE_URL,
   vertexVoiceResponse,
   type VertexVoiceRequest,
@@ -1840,6 +1842,61 @@ describe("voice provider capacity recovery", () => {
   beforeEach(() => {
     mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
     context.mocks.signalTimers.delay.mockResolvedValue(undefined);
+  });
+
+  it.each([GOOGLE_STS_URL, GOOGLE_IMPERSONATION_URL, VERTEX_VOICE_URL])(
+    "returns provider-unavailability for a connection failure at %s",
+    async (url) => {
+      await enabledActor();
+      let calls = 0;
+      server.use(
+        http.post(url, () => {
+          calls += 1;
+          return HttpResponse.error();
+        }),
+      );
+      const response = await accept(
+        client().segment({
+          headers: { authorization: "Bearer clerk-session" },
+          body: form([audioFile(1)]),
+        }),
+        [503],
+      );
+      expect(response.body.error.code).toBe("PROVIDER_UNAVAILABLE");
+      expect(calls).toBe(1);
+    },
+  );
+
+  it("reports invalid structured Google output without logging its transcript", async () => {
+    await enabledActor();
+    server.use(
+      http.post(VERTEX_VOICE_URL, () => {
+        return vertexVoiceResponse(
+          JSON.stringify({
+            transcript: "private transcript without required fields",
+          }),
+        );
+      }),
+    );
+    const response = await accept(
+      client().segment({
+        headers: { authorization: "Bearer clerk-session" },
+        body: form([audioFile(1)]),
+      }),
+      [502],
+    );
+    expect(response.body.error.code).toBe("VOICE_TRANSCRIPTION_FAILED");
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledExactlyOnceWith(
+      "Google voice request rejected",
+      expect.objectContaining({
+        reason: "invalid_output",
+        operation: "voice_transcript_and_polish",
+        status: 502,
+      }),
+    );
+    expect(
+      JSON.stringify(context.mocks.axiomLogging.warn.mock.calls),
+    ).not.toContain("private transcript");
   });
 
   it.each([

--- a/turbo/apps/api/src/signals/services/voice-io-polish.service.ts
+++ b/turbo/apps/api/src/signals/services/voice-io-polish.service.ts
@@ -8,7 +8,10 @@ import { command } from "ccstate";
 import { notConfigured } from "../../lib/error";
 import { requestSignal$ } from "../context/hono";
 import { gcpLlmConfiguration, GcpLlmAuthError } from "../external/gcp-llm-auth";
-import { generateVertexVoice } from "../external/vertex-voice";
+import {
+  generateVertexVoice,
+  VertexVoiceError,
+} from "../external/vertex-voice";
 import {
   FAST_PATH_MODEL,
   generateText,
@@ -43,6 +46,7 @@ function providerError(error: unknown) {
   if (
     error instanceof VoiceProviderUnavailableError ||
     (error instanceof GcpLlmAuthError && error.temporary) ||
+    (error instanceof VertexVoiceError && error.temporary) ||
     (error instanceof OpenRouterRequestError &&
       (error.status === 429 || error.status >= 500))
   ) {

--- a/turbo/apps/api/src/signals/services/voice-io-transcribe.service.ts
+++ b/turbo/apps/api/src/signals/services/voice-io-transcribe.service.ts
@@ -27,7 +27,7 @@ import {
 } from "../external/voice-input-transcription";
 import { settle } from "../utils";
 import { GcpLlmAuthError, gcpLlmConfiguration } from "../external/gcp-llm-auth";
-import { isVertexVoiceModel } from "../external/vertex-voice";
+import { isVertexVoiceModel, VertexVoiceError } from "../external/vertex-voice";
 import type { VoiceAudio } from "../external/voice-completion-types";
 import { VoiceProviderUnavailableError } from "../external/voice-provider-request";
 
@@ -77,7 +77,10 @@ function providerError(error: unknown) {
       "Speech recognition is temporarily busy. Please retry in a moment.",
     );
   }
-  if (error instanceof GcpLlmAuthError && error.temporary) {
+  if (
+    (error instanceof GcpLlmAuthError || error instanceof VertexVoiceError) &&
+    error.temporary
+  ) {
     return transcriptionError(
       503,
       "PROVIDER_UNAVAILABLE",


### PR DESCRIPTION
## Summary

- Classify recognized Google fetch/body network and timeout failures as `503 / PROVIDER_UNAVAILABLE` in both voice endpoints, including STS, service-account impersonation and native Gemini inference.
- Retain finite, sanitized terminal failure reasons for auth and native Google responses: truncation, blocking, empty output, invalid response/schema and response-size limits. Keep one diagnostic owner per failure path and suppress terminal warnings on successful recovery/caller cancellation.
- Keep received HTTP failures authoritative without reading their discarded bodies, so an interrupted 401/403 body cannot turn denied auth into temporary unavailability.

Closes #33563. Related rollout context: #33138; this PR does not close its live identity/model/input/capacity gates.

## Scope and safety

No feature-switch, provider/model/location, UI, public API schema, quota/checkpoint, database or cloud-configuration changes. No provider/configuration/compatibility fallback or new automatic replay: a lost inference response may follow an already billable operation. Authentication remains non-retrying and existing bounded HTTP capacity recovery is unchanged. Unknown/certificate failures stay ordinary 502; cancellation retains its original outcome. Diagnostics never include credentials, audio, transcripts or raw upstream reason strings/bodies.

## Validation

- Three focused voice route suites: **141 passed** (20 added cases), single worker. Uses the real API routes and external HTTP fixtures.
- `pnpm -F api lint`
- `TSC_CHECKERS=2 pnpm -F api check-types`
- Changed-file Prettier and `git diff --check`
- Normal commit hooks passed: style policy, Knip, workspace type checks (14 tasks), file-size and commitlint.

Coverage includes STS/IAM/native network errors, failed response streams, permanent certificate errors, auth denial with unreadable bodies, structured-output rejection, sanitized terminal metadata, successful capacity recovery and cancellation. No production requests or paid model probes were run.
