### PR TITLE
fix(pi-memory): use the official terra context window for phase 2

### DIFF
--- a/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { encode } from "gpt-tokenizer/encoding/o200k_base";
 import { afterEach, describe, expect, it } from "vitest";
 
+import { resolvePiAgentModel } from "./model";
 import type { PiMemoryPhase2Diagnostic } from "./phase2-memory-diagnostics";
 import { renderPiMemoryPhase2Prompt } from "./phase2-memory-prompt";
 import { PI_MEMORY_PHASE2_TOOL_NAMES } from "./phase2-memory-tools";
@@ -140,12 +141,19 @@ type ProviderStep =
       readonly type: "tool";
       readonly name: string;
       readonly arguments: Record<string, unknown>;
+      /**
+       * Report a large prior context for the turn. The SDK anchors its context
+       * estimate on the last assistant usage, so this drives the next request's
+       * derived output ceiling without a real large provider request.
+       */
+      readonly usageTotalTokens?: number;
     }
   | {
       readonly type: "text";
       readonly text: string;
       /** Reproduce a provider that returns no response id for the turn. */
       readonly omitResponseId?: true;
+      readonly usageTotalTokens?: number;
     }
   | { readonly type: "incomplete"; readonly reason: string }
   | { readonly type: "http-error" }
@@ -162,13 +170,13 @@ function writeSse(response: ServerResponse, events: readonly unknown[]): void {
   );
 }
 
-function usage() {
+function usage(totalTokens?: number) {
   return {
     input_tokens: 11,
     output_tokens: 7,
     input_tokens_details: { cached_tokens: 2 },
     output_tokens_details: { reasoning_tokens: 2 },
-    total_tokens: 18,
+    total_tokens: totalTokens ?? 18,
   };
 }
 
@@ -228,7 +236,7 @@ function toolSse(
         object: "response",
         status: "completed",
         output: [item],
-        usage: usage(),
+        usage: usage(step.usageTotalTokens),
       },
     },
   ]);
@@ -282,7 +290,7 @@ function textSse(
         object: "response",
         status: "completed",
         output: [item],
-        usage: usage(),
+        usage: usage(step.usageTotalTokens),
       },
     },
   ]);
@@ -1248,5 +1256,69 @@ describe("Pi memory Phase 2 consolidation engine", () => {
     await expect(stat(cleanupRoot ?? "missing")).rejects.toMatchObject({
       code: "ENOENT",
     });
+  });
+
+  async function maintenanceRequestBudget(
+    priorContextTokens: number,
+    modelOverrides: Partial<PiMemoryPhase2LocalConsolidationArgs["model"]> = {},
+  ): Promise<number> {
+    const provider = await startProvider([
+      {
+        type: "tool",
+        name: "phase2_write",
+        arguments: {
+          path: "memory/MEMORY.md",
+          content: "# Task Group: maintenance budget\n",
+        },
+        usageTotalTokens: priorContextTokens,
+      },
+      { type: "text", text: "consolidated" },
+    ]);
+    const input = args(provider.baseUrl);
+    const result = await runPiMemoryPhase2LocalConsolidation(
+      { ...input, model: { ...input.model, ...modelOverrides } },
+      new AbortController().signal,
+    );
+    expect(result.status).toBe("prepared");
+    const next = provider.requests[1];
+    if (!next) {
+      throw new Error("Missing the Phase 2 request after the reported context");
+    }
+    expect(next.body).toMatchObject({ reasoning: { effort: "max" } });
+    const budget = next.body.max_output_tokens;
+    if (typeof budget !== "number") {
+      throw new Error("Phase 2 request did not serialize an output ceiling");
+    }
+    return budget;
+  }
+
+  it("serializes the official output ceiling past the legacy context threshold", async () => {
+    // The legacy catalog window collapses both of these to the Responses
+    // adapter's 16-token floor, which ends the turn as `length`.
+    expect(await maintenanceRequestBudget(270_000)).toBe(128_000);
+    expect(await maintenanceRequestBudget(330_000)).toBe(128_000);
+  });
+
+  it("keeps the real context clamp active near the official window", async () => {
+    const lower = await maintenanceRequestBudget(950_000);
+    const higher = await maintenanceRequestBudget(950_001);
+    expect(lower).toBeGreaterThan(16);
+    expect(lower).toBeLessThan(128_000);
+    expect(lower - higher).toBe(1);
+  });
+
+  it("scopes the correction to the one legacy catalog case", async () => {
+    const config = args("http://127.0.0.1:1/v1").model;
+    // Ordinary resolution keeps the catalog value before and after maintenance.
+    expect(resolvePiAgentModel(config)?.contextWindow).toBe(272_000);
+    // A different catalog model on the same provider and dialect is untouched,
+    // so it still derives the legacy floor. This pins the correction's scope;
+    // it is not a statement that the other model should stay uncorrected.
+    expect(
+      await maintenanceRequestBudget(270_000, { catalogModel: "gpt-5.6-sol" }),
+    ).toBe(16);
+    const after = resolvePiAgentModel(config);
+    expect(after?.contextWindow).toBe(272_000);
+    expect(after?.maxTokens).toBe(128_000);
   });
 });

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
@@ -1311,12 +1311,21 @@ describe("Pi memory Phase 2 consolidation engine", () => {
     const config = args("http://127.0.0.1:1/v1").model;
     // Ordinary resolution keeps the catalog value before and after maintenance.
     expect(resolvePiAgentModel(config)?.contextWindow).toBe(272_000);
-    // A different catalog model on the same provider and dialect is untouched,
-    // so it still derives the legacy floor. This pins the correction's scope;
-    // it is not a statement that the other model should stay uncorrected.
+    // Precondition: the sibling model still carries the same stale catalog
+    // window. If the catalog is corrected upstream this fails deliberately, so
+    // the scope of the local correction is re-decided rather than drifting.
     expect(
-      await maintenanceRequestBudget(270_000, { catalogModel: "gpt-5.6-sol" }),
-    ).toBe(16);
+      resolvePiAgentModel({ ...config, catalogModel: "gpt-5.6-sol" })
+        ?.contextWindow,
+    ).toBe(272_000);
+    // The correction cannot lift a different catalog model on the same provider
+    // and dialect, so its derived ceiling stays below the corrected one.
+    const corrected = await maintenanceRequestBudget(270_000);
+    const untouched = await maintenanceRequestBudget(270_000, {
+      catalogModel: "gpt-5.6-sol",
+    });
+    expect(corrected).toBe(128_000);
+    expect(untouched).toBeLessThan(corrected);
     const after = resolvePiAgentModel(config);
     expect(after?.contextWindow).toBe(272_000);
     expect(after?.maxTokens).toBe(128_000);

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
@@ -104,6 +104,8 @@ function selected(
 function args(
   baseUrl: string,
   overrides: Partial<PiMemoryPhase2LocalConsolidationArgs> = {},
+  /** Written into the literal below so the dialect arm stays discriminated. */
+  catalogModel = "gpt-5.6-terra",
 ): PiMemoryPhase2LocalConsolidationArgs {
   return {
     memoryStorageId: "storage-phase2",
@@ -121,7 +123,7 @@ function args(
       baseUrl,
       apiKey: "PROVIDER_KEY_SECRET_31243",
       model: "MODEL_ALIAS_SECRET_31243",
-      catalogModel: "gpt-5.6-terra",
+      catalogModel,
       dialect: "openai-responses",
       transport: "sse",
       thinkingLevel: "max",
@@ -1262,7 +1264,7 @@ describe("Pi memory Phase 2 consolidation engine", () => {
 
   async function maintenanceRequestBudget(
     priorContextTokens: number,
-    modelOverrides: Partial<PiMemoryPhase2LocalConsolidationArgs["model"]> = {},
+    catalogModel?: string,
   ): Promise<number> {
     const provider = await startProvider([
       {
@@ -1276,9 +1278,8 @@ describe("Pi memory Phase 2 consolidation engine", () => {
       },
       { type: "text", text: "consolidated" },
     ]);
-    const input = args(provider.baseUrl);
     const result = await runPiMemoryPhase2LocalConsolidation(
-      { ...input, model: { ...input.model, ...modelOverrides } },
+      args(provider.baseUrl, {}, catalogModel),
       new AbortController().signal,
     );
     expect(result.status).toBe("prepared");
@@ -1317,15 +1318,14 @@ describe("Pi memory Phase 2 consolidation engine", () => {
     // window. If the catalog is corrected upstream this fails deliberately, so
     // the scope of the local correction is re-decided rather than drifting.
     expect(
-      resolvePiAgentModel({ ...config, catalogModel: "gpt-5.6-sol" })
-        ?.contextWindow,
+      resolvePiAgentModel(
+        args("http://127.0.0.1:1/v1", {}, "gpt-5.6-sol").model,
+      )?.contextWindow,
     ).toBe(272_000);
     // The correction cannot lift a different catalog model on the same provider
     // and dialect, so its derived ceiling stays below the corrected one.
     const corrected = await maintenanceRequestBudget(270_000);
-    const untouched = await maintenanceRequestBudget(270_000, {
-      catalogModel: "gpt-5.6-sol",
-    });
+    const untouched = await maintenanceRequestBudget(270_000, "gpt-5.6-sol");
     expect(corrected).toBe(128_000);
     expect(untouched).toBeLessThan(corrected);
     const after = resolvePiAgentModel(config);

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory.ts
@@ -413,6 +413,57 @@ function providerResult(
   return { responseId: final.responseId ?? null, usage: Object.freeze(usage) };
 }
 
+type ResolvedPiAgentModel = NonNullable<ReturnType<typeof resolvePiAgentModel>>;
+
+/**
+ * The legacy catalog case this narrow maintenance correction adapts.
+ *
+ * The pinned catalog publishes `openai` / `gpt-5.6-terra` / `openai-responses`
+ * with a 272000 context window. 272000 is that model's long-context pricing
+ * threshold, above which the stated multipliers apply to the full request; the
+ * official specification states 1050000 context tokens and 128000 maximum
+ * output tokens: https://developers.openai.com/api/docs/models/gpt-5.6-terra
+ */
+const PI_MEMORY_PHASE2_LEGACY_CONTEXT_PROVIDER = "openai";
+const PI_MEMORY_PHASE2_LEGACY_CONTEXT_API = "openai-responses";
+const PI_MEMORY_PHASE2_LEGACY_CONTEXT_CATALOG_MODEL = "gpt-5.6-terra";
+const PI_MEMORY_PHASE2_LEGACY_CONTEXT_WINDOW = 272_000;
+const PI_MEMORY_PHASE2_OFFICIAL_CONTEXT_WINDOW = 1_050_000;
+
+/**
+ * Return the maintenance model with the stale catalog context window corrected.
+ *
+ * `buildBaseOptions` derives each request's output ceiling by subtracting the
+ * estimated context from `contextWindow`, so the pricing threshold above caps a
+ * long consolidation turn at the Responses adapter's minimum output budget. The
+ * turn then ends as `length`, which Phase 2 correctly refuses to publish.
+ *
+ * This adapts only that one legacy case, only for maintenance, and only as an
+ * immutable copy: the shared catalog object is never mutated, ordinary
+ * resolution is untouched, and a value that is already corrected or otherwise
+ * different is returned unchanged so newer metadata is never capped. Model
+ * identity, provider, route, credentials, headers, tier, transport, reasoning
+ * policy, `maxTokens` and pricing all stay exactly as resolved.
+ */
+function maintenanceModelWithOfficialContextWindow(
+  model: ResolvedPiAgentModel,
+  config: SnapshotPhase2Input["model"],
+): ResolvedPiAgentModel {
+  if (
+    model.provider !== PI_MEMORY_PHASE2_LEGACY_CONTEXT_PROVIDER ||
+    model.api !== PI_MEMORY_PHASE2_LEGACY_CONTEXT_API ||
+    (config.catalogModel ?? config.model) !==
+      PI_MEMORY_PHASE2_LEGACY_CONTEXT_CATALOG_MODEL ||
+    model.contextWindow !== PI_MEMORY_PHASE2_LEGACY_CONTEXT_WINDOW
+  ) {
+    return model;
+  }
+  return {
+    ...model,
+    contextWindow: PI_MEMORY_PHASE2_OFFICIAL_CONTEXT_WINDOW,
+  };
+}
+
 async function createMaintenanceSession(args: {
   readonly input: SnapshotPhase2Input;
   readonly workspace: Phase2PrivateWorkspace;
@@ -420,10 +471,16 @@ async function createMaintenanceSession(args: {
   readonly testHooks: PiMemoryPhase2EngineTestHooks | undefined;
 }): Promise<AgentSession> {
   initializePiSessionResourceRegistry();
-  const model = resolvePiAgentModel(args.input.model);
-  if (!model) {
+  const resolved = resolvePiAgentModel(args.input.model);
+  if (!resolved) {
     throw new Phase2InputInvalidError();
   }
+  // One corrected model object reaches both provider registration and the real
+  // session, so the adapter cannot receive the stale window.
+  const model = maintenanceModelWithOfficialContextWindow(
+    resolved,
+    args.input.model,
+  );
   const modelRuntime = await ModelRuntime.create({
     allowModelNetwork: false,
     credentials: new InMemoryCredentialStore(),

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory.ts
@@ -444,6 +444,11 @@ const PI_MEMORY_PHASE2_OFFICIAL_CONTEXT_WINDOW = 1_050_000;
  * different is returned unchanged so newer metadata is never capped. Model
  * identity, provider, route, credentials, headers, tier, transport, reasoning
  * policy, `maxTokens` and pricing all stay exactly as resolved.
+ *
+ * Remove this correction once the pinned catalog publishes the official window:
+ * the guard then stops matching, so it is inert rather than wrong. The catalog
+ * identity is matched here instead of the caller's product model id because the
+ * stale value belongs to that catalog entry, not to Okou's model selection.
  */
 function maintenanceModelWithOfficialContextWindow(
   model: ResolvedPiAgentModel,


### PR DESCRIPTION
## Problem

Phase 2 memory maintenance fails with `stage=final_response / reason=final_stop_length`: the maintenance session's last assistant message returns `stopReason="length"`, and `providerResult` correctly refuses to publish an incomplete turn, so consolidated memory is never updated.

The cause is a stale catalog context window, not model output volume.

The pinned pi-ai catalog publishes `openai` / `gpt-5.6-terra` / `openai-responses` with `contextWindow: 272000`. Per the [official GPT-5.6 Terra specification](https://developers.openai.com/api/docs/models/gpt-5.6-terra) that model has **1,050,000 context tokens** and **128,000 maximum output tokens**; **272K is a pricing threshold**, above which the stated multipliers apply to the **full request**, not only the excess. The repository's own `MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS` records the same 272,001 boundary as a billing tier.

`buildBaseOptions` derives each request's output ceiling as `min(model.maxTokens, max(1, contextWindow - estimatedContext - 4096))`, and the Responses adapter floors the serialized parameter at 16. With the stale window, a consolidation turn whose estimated context passes roughly 268,000 serializes `max_output_tokens=16`, the provider returns `incomplete / max_output_tokens`, and pi-ai maps that to `length`.

The repository's local `pi-ai` patch touches no catalog, `contextWindow` or clamp code, so the stale value comes from the pinned upstream package and is present in the installed patched build (verified locally: `contextWindow=272000`, `maxTokens=128000`, clamp present, `CONTEXT_SAFETY_TOKENS=4096`).

## Change

One narrow correction inside Phase 2 maintenance session construction only. It matches exactly the legacy case — resolved provider `openai`, API `openai-responses`, catalog identity `gpt-5.6-terra`, existing context window `272000` — and returns an **immutable copy** with the official `1050000`.

The corrected object is assigned to the single `model` variable that reaches **both** `registeredModelConfig(...)` and `createAgentSessionFromServices({ model })`, so the real adapter cannot receive the stale window.

Preserved exactly as resolved: model ID/alias, provider, base URL, headers, credentials, tier, transport, reasoning policy (`effort: max`), `maxTokens=128000` and pricing fields. The shared catalog object is never mutated, ordinary `resolvePiAgentModel` is untouched, and a value that is already corrected or otherwise different is returned unchanged, so newer metadata is never capped at a stale local value.

## Not in this change

No global model-metadata override or override registry, no dependency patch/bump, no new API/DB/wire field, no budget framework. No change to `openai-codex`, OpenRouter, other models or dialects, API-first turns, user conversations, Stage 1, or their compaction thresholds. Selection set and 20 MiB ceiling, tool and read chunk sizes, system prompt, compaction/retry settings, lease/heartbeat, cancellation precedence, the final non-`stop` rejection, the 64 KiB summary source ceiling and the 2500 exact-o200k injected excerpt are all unchanged. No evidence is deleted or deferred, and no log level, diagnostic vocabulary or Sentry behavior changes.

## Verification

Focused local runs against the real adapter boundary (the fixture asserts the actually serialized request body, not a helper return value):

- `phase2-memory.test.ts` — 22 passed, including three new cases.
- Related suites `phase2-memory-filesystem` / `-tools` / `-diagnostics` / `-selection` / `-scope`, `model`, `memory-recall` — 8 files, 115 passed.
- Types (`tsc --noEmit`), ESLint and Prettier clean on the changed files.

New coverage:

- **Request construction past the legacy threshold** — scripted prior assistant usage of 270,000 and 330,000 tokens plus the trailing tool message; the next real maintenance request serializes `max_output_tokens=128000` with `reasoning.effort=max` preserved.
- **The real clamp still works near the official window** — scripted contexts of 950,000 and 950,001 serialize positive ceilings below 128,000 that differ by exactly 1, so the genuine subtraction boundary is intact rather than removed.
- **Scope** — ordinary `resolvePiAgentModel` still reports `contextWindow=272000` and `maxTokens=128000` before and after a maintenance session, proving no catalog mutation; a different catalog model on the same provider and dialect (`gpt-5.6-sol`) still derives the legacy floor of 16, pinning the correction to the single matched case.

Mutation check: restoring the legacy `272000` constant makes the two budget tests fail with `expected 16 to be 128000` and `expected 16 to be greater than 16`, confirming they bind the actual defect. The fix was restored and re-verified green.

Existing regression tests continue to cover the unchanged boundaries — coherent full-bundle preparation with retained selected evidence and legacy immutable files, final `length` / error / abort producing no prepared result, marker or checkpoint and leaving the mounted base byte-identical, cancellation precedence, and the source/excerpt policy.

Per the repository guidance I did not run full local Vitest or a dev server; the complete suite runs in PR CI.

## Limits

This restores the official capacity for the maintenance path. It does not prefill the window, does not reserve or charge 128,000 output tokens, and does not guarantee that any particular historical or arbitrarily large evidence set completes. Because more input and generated tokens are now possible, a longer successful attempt can cost more, and requests above 272K input are billed at the model's stated long-context multipliers for the full request. Legitimate incomplete results still fail, preserve the previously published bundle and remain observable. The original count of 16 output tokens does not by itself prove a serialized cap or route, and the two unattributed failures in the observed cohort are not claimed to share this cause. Production acceptance requires a finite naturally occurring cohort on the actual corrected artifact with nonzero maintenance execution and coherent successful publication; a missing failure string alone is not recovery.

A broader catalog correction and a general maintenance context-management policy remain separate decisions. Parent #33351 stays open for its remaining historical slice.

Closes #33560

🤖 Generated with [Claude Code](https://claude.com/claude-code)
