### PR TITLE
test: split slack recovery and webhook queue scenarios

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -3078,228 +3078,250 @@ describe("INT-01: Slack app deep webhook flows", () => {
     90_000,
   );
 
-  it("keeps canonical Slack status stable across failed delivery and cancellation", async () => {
-    const actor = bdd.user();
-    runs.acceptStorageDownloads();
-    runs.acceptTelemetryIngest();
-    const runnerGroup = runs.configureRunnerGroup();
-    integrations.configureSlackAppMocks();
-    await runs.grantProEntitlement(actor);
-    await runs.ensureOrgModelProvider(actor);
-    if (!actor.orgId) {
-      throw new Error("Expected canonical Slack actor to belong to an org");
-    }
-    const orgId = actor.orgId;
-    const slackUserId = uniqueSlackUserId();
-    const { teamId, botUserId } = await integrations.installSlackWorkspace(
-      actor,
-      {
-        installerSlackUserId: slackUserId,
-      },
-    );
-    const channelId = "C_BDD_CANONICAL_STATUS";
-    const threadTs = "2902.000100";
-    const event = {
-      type: "app_mention",
-      user: slackUserId,
-      text: "<@" + botUserId + "> establish the canonical status route",
-      ts: threadTs,
-      channel: channelId,
-      channel_type: "channel",
-    };
-    const eventBody = JSON.stringify({
-      type: "event_callback",
-      team_id: teamId,
-      event_id: `EvBDD${randomUUID().replace(/-/g, "")}`,
-      event,
-    });
-    await integrations.requestSlackEvent(
-      eventBody,
-      integrations.signedSlackIngressHeaders(eventBody),
-      [200],
-    );
-    await flushWaitUntilForTest();
-
-    const state = await integrations.readSlackTestState(teamId);
-    const canonicalChatThreadId = state.chat_thread_routes[0]?.chatThreadId;
-    if (!canonicalChatThreadId) {
-      throw new Error("Expected canonical Slack status route to own a thread");
-    }
-    const run1Id = await pollSlackRun(runnerGroup);
-    const claim1 = await runs.claimRunnerJob(run1Id);
-    const queuedEventBody = JSON.stringify({
-      type: "event_callback",
-      team_id: teamId,
-      event_id: `EvBDD${randomUUID().replace(/-/g, "")}`,
-      event: {
-        ...event,
-        text: "fail this canonical Slack delivery",
-        ts: "2902.000200",
-        thread_ts: threadTs,
-      },
-    });
-    await integrations.requestSlackEvent(
-      queuedEventBody,
-      integrations.signedSlackIngressHeaders(queuedEventBody),
-      [200],
-    );
-    await flushWaitUntilForTest();
-    await completeSlackTriggeredRun({
-      runId: run1Id,
-      sandboxToken: claim1.sandboxToken,
-      cliAgentType: claim1.cliAgentType,
-      assistantText: "Canonical Slack seed answer",
-    });
-    await flushWaitUntilForTest();
-    const run1 = await runs.readRun(actor, run1Id);
-    const slackSessionId = run1.result?.agentSessionId;
-    if (!slackSessionId) {
-      throw new Error(
-        "Expected the canonical Slack seed run to save a session",
+  it.each(["queued session", "overlapping status"] as const)(
+    "preserves canonical Slack %s after failed delivery",
+    async (scenario) => {
+      const actor = bdd.user();
+      runs.acceptStorageDownloads();
+      runs.acceptTelemetryIngest();
+      const runnerGroup = runs.configureRunnerGroup();
+      integrations.configureSlackAppMocks();
+      await runs.grantProEntitlement(actor);
+      await runs.ensureOrgModelProvider(actor);
+      if (!actor.orgId) {
+        throw new Error("Expected canonical Slack actor to belong to an org");
+      }
+      const orgId = actor.orgId;
+      const slackUserId = uniqueSlackUserId();
+      const { teamId, botUserId } = await integrations.installSlackWorkspace(
+        actor,
+        {
+          installerSlackUserId: slackUserId,
+        },
       );
-    }
-
-    const run2Id = await pollSlackRun(runnerGroup);
-    const claim2 = await runs.claimRunnerJob(run2Id);
-    expect(claim2.resumeSession?.sessionId).toBe(`bdd-slack-cli-${run1Id}`);
-    context.mocks.slack.chat.postMessage.mockClear();
-    context.mocks.slack.chat.postMessage.mockRejectedValueOnce(
-      new DOMException("Slack delivery aborted", "AbortError"),
-    );
-    const terminalStatusClearStarted = createDeferredPromise<void>(
-      context.signal,
-    );
-    const releaseTerminalStatusClear = createDeferredPromise<void>(
-      context.signal,
-    );
-    const overlappingThinkingStatusSet = createDeferredPromise<void>(
-      context.signal,
-    );
-    context.mocks.slack.assistant.threads.setStatus
-      .mockImplementationOnce(async () => {
-        terminalStatusClearStarted.resolve(undefined);
-        await releaseTerminalStatusClear.promise;
-        return { ok: true };
-      })
-      .mockImplementationOnce(() => {
-        overlappingThinkingStatusSet.resolve(undefined);
-        return Promise.resolve({ ok: true });
+      const channelId = "C_BDD_CANONICAL_STATUS";
+      const threadTs = "2902.000100";
+      const event = {
+        type: "app_mention",
+        user: slackUserId,
+        text: "<@" + botUserId + "> establish the canonical status route",
+        ts: threadTs,
+        channel: channelId,
+        channel_type: "channel",
+      };
+      const eventBody = JSON.stringify({
+        type: "event_callback",
+        team_id: teamId,
+        event_id: `EvBDD${randomUUID().replace(/-/g, "")}`,
+        event,
       });
-    await completeSlackTriggeredRun({
-      runId: run2Id,
-      sandboxToken: claim2.sandboxToken,
-      cliAgentType: claim2.cliAgentType,
-      assistantText: "Canonical Slack answer two",
-    });
-    await terminalStatusClearStarted.promise;
-    await expect
-      .poll(async () => {
-        const callbacks = await callbackStore.set(
+      await integrations.requestSlackEvent(
+        eventBody,
+        integrations.signedSlackIngressHeaders(eventBody),
+        [200],
+      );
+      await flushWaitUntilForTest();
+
+      const state = await integrations.readSlackTestState(teamId);
+      const canonicalChatThreadId = state.chat_thread_routes[0]?.chatThreadId;
+      if (!canonicalChatThreadId) {
+        throw new Error(
+          "Expected canonical Slack status route to own a thread",
+        );
+      }
+      const run1Id = await pollSlackRun(runnerGroup);
+      const claim1 = await runs.claimRunnerJob(run1Id);
+      let deliveryRunId = run1Id;
+      let deliveryClaim = claim1;
+      let slackSessionId: string | undefined;
+      if (scenario === "queued session") {
+        const queuedEventBody = JSON.stringify({
+          type: "event_callback",
+          team_id: teamId,
+          event_id: `EvBDD${randomUUID().replace(/-/g, "")}`,
+          event: {
+            ...event,
+            text: "fail this canonical Slack delivery",
+            ts: "2902.000200",
+            thread_ts: threadTs,
+          },
+        });
+        await integrations.requestSlackEvent(
+          queuedEventBody,
+          integrations.signedSlackIngressHeaders(queuedEventBody),
+          [200],
+        );
+        await flushWaitUntilForTest();
+        await completeSlackTriggeredRun({
+          runId: run1Id,
+          sandboxToken: claim1.sandboxToken,
+          cliAgentType: claim1.cliAgentType,
+          assistantText: "Canonical Slack seed answer",
+        });
+        await flushWaitUntilForTest();
+        const run1 = await runs.readRun(actor, run1Id);
+        slackSessionId = run1.result?.agentSessionId;
+        if (!slackSessionId) {
+          throw new Error(
+            "Expected the canonical Slack seed run to save a session",
+          );
+        }
+
+        deliveryRunId = await pollSlackRun(runnerGroup);
+        deliveryClaim = await runs.claimRunnerJob(deliveryRunId);
+        expect(deliveryClaim.resumeSession?.sessionId).toBe(
+          `bdd-slack-cli-${run1Id}`,
+        );
+      }
+      context.mocks.slack.chat.postMessage.mockClear();
+      context.mocks.slack.chat.postMessage.mockRejectedValueOnce(
+        new DOMException("Slack delivery aborted", "AbortError"),
+      );
+      const terminalStatusClearStarted = createDeferredPromise<void>(
+        context.signal,
+      );
+      const releaseTerminalStatusClear = createDeferredPromise<void>(
+        context.signal,
+      );
+      const overlappingThinkingStatusSet = createDeferredPromise<void>(
+        context.signal,
+      );
+      if (scenario === "overlapping status") {
+        context.mocks.slack.assistant.threads.setStatus
+          .mockImplementationOnce(async () => {
+            terminalStatusClearStarted.resolve(undefined);
+            await releaseTerminalStatusClear.promise;
+            return { ok: true };
+          })
+          .mockImplementationOnce(() => {
+            overlappingThinkingStatusSet.resolve(undefined);
+            return Promise.resolve({ ok: true });
+          });
+      }
+      await completeSlackTriggeredRun({
+        runId: deliveryRunId,
+        sandboxToken: deliveryClaim.sandboxToken,
+        cliAgentType: deliveryClaim.cliAgentType,
+        assistantText: "Canonical Slack answer two",
+      });
+      if (scenario === "overlapping status") {
+        await terminalStatusClearStarted.promise;
+      } else {
+        await flushWaitUntilForTest();
+      }
+      await expect
+        .poll(async () => {
+          const callbacks = await callbackStore.set(
+            readAgentRunCallbacks$,
+            {
+              orgId,
+              userId: actor.userId,
+              runId: deliveryRunId,
+            },
+            context.signal,
+          );
+          const delivery = callbacks.find((callback) => {
+            return callback.internalKind === "slack:chat";
+          });
+          return delivery?.status;
+        })
+        .toBe("failed");
+      const failedDelivery = (
+        await callbackStore.set(
           readAgentRunCallbacks$,
           {
             orgId,
             userId: actor.userId,
-            runId: run2Id,
+            runId: deliveryRunId,
           },
           context.signal,
-        );
-        const delivery = callbacks.find((callback) => {
-          return callback.internalKind === "slack:chat";
+        )
+      ).find((callback) => {
+        return callback.internalKind === "slack:chat";
+      });
+      expect(failedDelivery).toMatchObject({
+        attempts: 1,
+        lastError: "Slack delivery aborted",
+      });
+      expect(context.mocks.slack.chat.postMessage).toHaveBeenCalledOnce();
+      if (scenario === "overlapping status") {
+        const cancelledEventId = `EvBDD${randomUUID().replace(/-/g, "")}`;
+        const cancelledBody = JSON.stringify({
+          type: "event_callback",
+          team_id: teamId,
+          event_id: cancelledEventId,
+          event: {
+            ...event,
+            text: "cancel this canonical Slack run",
+            ts: "2900.000300",
+            thread_ts: threadTs,
+          },
         });
-        return delivery?.status;
-      })
-      .toBe("failed");
-    const run2Delivery = (
-      await callbackStore.set(
-        readAgentRunCallbacks$,
-        {
-          orgId,
-          userId: actor.userId,
-          runId: run2Id,
-        },
-        context.signal,
-      )
-    ).find((callback) => {
-      return callback.internalKind === "slack:chat";
-    });
-    expect(run2Delivery).toMatchObject({
-      attempts: 1,
-      lastError: "Slack delivery aborted",
-    });
-    expect(context.mocks.slack.chat.postMessage).toHaveBeenCalledOnce();
-    const cancelledEventId = `EvBDD${randomUUID().replace(/-/g, "")}`;
-    const cancelledBody = JSON.stringify({
-      type: "event_callback",
-      team_id: teamId,
-      event_id: cancelledEventId,
-      event: {
-        ...event,
-        text: "cancel this canonical Slack run",
-        ts: "2900.000300",
-        thread_ts: threadTs,
-      },
-    });
-    await integrations.requestSlackEvent(
-      cancelledBody,
-      integrations.signedSlackIngressHeaders(cancelledBody),
-      [200],
-    );
-    await overlappingThinkingStatusSet.promise;
-    expect(
-      context.mocks.slack.assistant.threads.setStatus.mock.calls.map(
-        ([input]) => {
-          if (!isRecord(input)) {
-            throw new Error("Expected Slack thread status request");
-          }
-          return readStringField(input, "status");
-        },
-      ),
-    ).toStrictEqual(["is thinking...", "is thinking...", "", "is thinking..."]);
-    releaseTerminalStatusClear.resolve(undefined);
-    await flushWaitUntilForTest();
-    expect(firstAssistantEventsForRun(run2Id)).toHaveLength(1);
-    expect(
-      context.mocks.slack.assistant.threads.setStatus,
-    ).toHaveBeenCalledTimes(5);
-    expect(
-      context.mocks.slack.assistant.threads.setStatus,
-    ).toHaveBeenLastCalledWith({
-      channel_id: channelId,
-      thread_ts: threadTs,
-      status: "is thinking...",
-    });
-    const cancelledRunId = await pollSlackRun(runnerGroup);
-    await runs.requestCancelRun(actor, cancelledRunId, [200]);
-    await expect
-      .poll(async () => {
-        return (await runs.readRun(actor, cancelledRunId)).status;
-      })
-      .toBe("cancelled");
-    await flushWaitUntilForTest();
-    expect(
-      context.mocks.slack.assistant.threads.setStatus,
-    ).toHaveBeenCalledTimes(6);
-    expect(
-      context.mocks.slack.assistant.threads.setStatus,
-    ).toHaveBeenLastCalledWith({
-      channel_id: channelId,
-      thread_ts: threadTs,
-      status: "",
-    });
+        await integrations.requestSlackEvent(
+          cancelledBody,
+          integrations.signedSlackIngressHeaders(cancelledBody),
+          [200],
+        );
+        await overlappingThinkingStatusSet.promise;
+        expect(
+          context.mocks.slack.assistant.threads.setStatus.mock.calls.map(
+            ([input]) => {
+              if (!isRecord(input)) {
+                throw new Error("Expected Slack thread status request");
+              }
+              return readStringField(input, "status");
+            },
+          ),
+        ).toStrictEqual(["is thinking...", "", "is thinking..."]);
+        releaseTerminalStatusClear.resolve(undefined);
+        await flushWaitUntilForTest();
+        expect(
+          context.mocks.slack.assistant.threads.setStatus,
+        ).toHaveBeenCalledTimes(4);
+        expect(
+          context.mocks.slack.assistant.threads.setStatus,
+        ).toHaveBeenLastCalledWith({
+          channel_id: channelId,
+          thread_ts: threadTs,
+          status: "is thinking...",
+        });
+        const cancelledRunId = await pollSlackRun(runnerGroup);
+        await runs.requestCancelRun(actor, cancelledRunId, [200]);
+        await expect
+          .poll(async () => {
+            return (await runs.readRun(actor, cancelledRunId)).status;
+          })
+          .toBe("cancelled");
+        await flushWaitUntilForTest();
+        expect(
+          context.mocks.slack.assistant.threads.setStatus,
+        ).toHaveBeenCalledTimes(5);
+        expect(
+          context.mocks.slack.assistant.threads.setStatus,
+        ).toHaveBeenLastCalledWith({
+          channel_id: channelId,
+          thread_ts: threadTs,
+          status: "",
+        });
+      }
 
-    expect(
-      (await chat.listThreadEvents(actor, canonicalChatThreadId)).events,
-    ).toStrictEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          eventType: "output.message",
-          content: "Canonical Slack answer two",
-        }),
-      ]),
-    );
-    const run2 = await runs.readRun(actor, run2Id);
-    expect(run2.result?.agentSessionId).toBe(slackSessionId);
-  });
+      expect(firstAssistantEventsForRun(deliveryRunId)).toHaveLength(1);
+      expect(
+        (await chat.listThreadEvents(actor, canonicalChatThreadId)).events,
+      ).toStrictEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            eventType: "output.message",
+            content: "Canonical Slack answer two",
+          }),
+        ]),
+      );
+      if (scenario === "queued session") {
+        const deliveredRun = await runs.readRun(actor, deliveryRunId);
+        expect(deliveredRun.result?.agentSessionId).toBe(slackSessionId);
+      }
+    },
+  );
 
   it("keeps Slack DM sessions scoped to the selected agent", async () => {
     const actor = bdd.user();

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
@@ -1037,7 +1037,7 @@ describe("workflow queue", () => {
     ).toBeTruthy();
   });
 
-  it("queues webhook events behind the active run and drains one per completion", async () => {
+  it("queues webhook events without extra keys and drains one per completion", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
     const kms = useSecretKmsProbe();
@@ -1070,10 +1070,29 @@ describe("workflow queue", () => {
     await completeRunThroughSandbox(scenario, firstRunId);
     const afterFirst = await workflowRunIds(automation.threadId);
     expect(afterFirst).toHaveLength(2);
-    const secondClaim = await completeRunThroughSandbox(
-      scenario,
-      afterFirst[1]!,
+    await expect(
+      pendingAutomationEvents(automation.threadId),
+    ).resolves.toHaveLength(1);
+  });
+
+  it("starts a promoted webhook run's API clock at dequeue time", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const firstRunId = await expectAcceptedRunId(
+      await postWorkflowWebhook(automation, "first"),
+      automation.threadId,
     );
+    const enqueuedAt = now() + 60_000;
+    mockNow(enqueuedAt);
+    expectAcceptedWithoutRun(await postWorkflowWebhook(automation, "second"));
+
+    const dequeuedAt = enqueuedAt + 10_000;
+    mockNow(dequeuedAt);
+    await completeRunThroughSandbox(scenario, firstRunId);
+    const runIds = await workflowRunIds(automation.threadId);
+    expect(runIds).toHaveLength(2);
+    await runsApi.heartbeatRunner(scenario.runnerGroup);
+    const secondClaim = await runsApi.claimRunnerJob(runIds[1]!);
     expect(secondClaim.apiStartTime).toBe(dequeuedAt);
   });
 


### PR DESCRIPTION
Two CI-flagged tests combine independent recovery and queue contracts: canonical Slack delivery reached 4740ms, and webhook queue drain timed out at 5012ms under the 5000ms limit. Split them into four independently timed cases across two API test files:

- Slack queued-session persistence and failed-delivery status overlap/cancellation each use two real runs instead of three.
- Webhook queue accounting/single-successor drain is separate from the promoted run's API start time. Timestamp verification claims the successor without completing it merely to return the claim.

All original assertion groups and required ordering remain, with an additional pending-queue count assertion. Timeout settings are unchanged.

Local targeted results: Slack baseline 2695ms → 1182ms / 677ms; queue baseline 1180ms → 1066ms / 545ms. All replacements passed on their first run. Affected-file Prettier, Oxlint, type-aware Oxlint, ESLint, API Knip and type checking passed. The full local Vitest suite and dev server were not run; broad verification remains with the PR pipeline.

Relates to #33319. This PR covers T077 and T029; the complete remaining inventory and previous failures remain tracked on the issue.
