### PR TITLE
feat(voice): enable google cloud routing by default for staff

### DIFF
--- a/docs/google-llm-voice.md
+++ b/docs/google-llm-voice.md
@@ -11,14 +11,16 @@ OpenRouter/fal provider, and generic chat/image/LLM consumers retain their routi
 
 ## Configuration
 
-The public `voiceGoogleCloud` switch is **off by default**, including for
-staff. Enable it for a user in **Lab → Alpha** using the existing
-per-user feature-switch override. The existing `voiceInputV2` access switch must
-also be enabled. Both voice API routes resolve the authenticated user's override
-on every request; no browser/API contract or additional environment variable is
-needed. Off preserves the existing OpenRouter Gemini path and does not require
-Google credentials. On selects Google for all Gemini voice steps, including
-independent text polish. Failures never change the selected provider.
+The public `voiceGoogleCloud` switch is **on by default in staff organizations**
+and off by default elsewhere. Manage it in **Lab → Beta** using the existing
+per-user feature-switch override. An explicit off override still disables it
+for staff; resetting the override restores the organization default. The existing
+`voiceInputV2` access switch must also be enabled. Both voice API routes resolve
+the authenticated user's override on every request; no browser/API contract or
+additional environment variable is needed. Off preserves the existing OpenRouter
+Gemini path and does not require Google credentials. On selects Google for all
+Gemini voice steps, including independent text polish. Failures never change the
+selected provider.
 
 The active billed project is `vm0-ai-488909` (number `662642595011`). The separate
 project `vm0-ai` is deprecated. These values are GitHub Actions **Variables**:
@@ -146,10 +148,10 @@ recovery and caller cancellation do not produce terminal-error warnings.
 Follow [issue #33138](https://github.com/vm0-ai/vm0/issues/33138) for the verification
 record. Provisioned IAM and configured Variables establish prerequisites, not
 successful runtime authentication or model access. HTTP fixtures establish code
-behavior, not Google's live project capacity or audio limits.
+behavior, not Google's live project capacity or audio limits. Enabling the staff
+default does not establish these live acceptance criteria.
 
-Before production rollout, enable `voiceGoogleCloud` only for the preview test
-user and use the PR preview to verify the actual dev runtime
+Before expanding beyond staff, use the PR preview to verify the actual dev runtime
 identity and each model/location with non-sensitive audio, all three structured
 output schemas, plain-text polish, normal 75s browser PCM, and the existing valid
 WAV boundary up to 25 MiB including base64 expansion. Bound functional generation

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-polish.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-polish.test.ts
@@ -9,7 +9,10 @@ import { mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { createUniqueStaffOrgIdFixture } from "../../../test-fixtures/staff-org";
 import { createBddApi } from "./helpers/api-bdd";
-import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
+import {
+  deleteFeatureSwitchesForUser,
+  updateFeatureSwitchesForUser,
+} from "./helpers/feature-switches";
 import { createRouteMocks } from "./helpers/route-test";
 import {
   mockGoogleVoice,
@@ -119,6 +122,50 @@ describe("POST /api/voice-io/polish", () => {
     );
     expect(response.body.error.code).toBe("PROVIDER_UNAVAILABLE");
     expect(calls).toBe(1);
+  });
+
+  it("defaults staff to Google and honors disabling and resetting the override", async () => {
+    const actor = {
+      ...createBddApi(context).user(),
+      orgId: createUniqueStaffOrgIdFixture(),
+      orgRole: "org:member" as const,
+    };
+    mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    server.use(
+      http.post(VERTEX_VOICE_URL, () => {
+        return vertexVoiceResponse("Google staff default.");
+      }),
+      http.post("https://openrouter.ai/api/v1/chat/completions", () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: { content: "OpenRouter override." },
+            },
+          ],
+        });
+      }),
+    );
+    const polish = () => {
+      return client().post({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { text: "Synthetic dictation." },
+      });
+    };
+
+    const staffDefault = await accept(polish(), [200]);
+    expect(staffDefault.body.text).toBe("Google staff default.");
+
+    await updateFeatureSwitchesForUser(context, actor, {
+      [FeatureSwitchKey.VoiceGoogleCloud]: false,
+    });
+    const disabled = await accept(polish(), [200]);
+    expect(disabled.body.text).toBe("OpenRouter override.");
+
+    await deleteFeatureSwitchesForUser(context, actor);
+    const reset = await accept(polish(), [200]);
+    expect(reset.body.text).toBe("Google staff default.");
   });
 
   it("preserves OpenRouter polishing by default without Google credentials", async () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -373,6 +373,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Route Gemini voice transcription and polishing through Google Cloud instead of OpenRouter.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "yuma@okou.ai",


### PR DESCRIPTION
## Summary

- Enable `voiceGoogleCloud` by default for the existing staff organization audience through `STAFF_ORG_ID_HASHES`; keep the global default disabled.
- Preserve per-user overrides, including explicit staff opt-out and reset to the organization default. The existing Lab classification moves this switch from Alpha to Beta.
- Add a public-route regression test covering staff default Google routing, explicit OpenRouter opt-out, and reset back to Google. Update the routing/rollout documentation.

## Scope and risk

No voice UI, provider implementation, model/location, retry, API contract, database or cloud-configuration changes. Non-staff defaults stay off, and non-staff users retain their existing explicit opt-in behavior. Staff members who saved an off override remain off.

Staff default-on requests depend on the existing Google configuration, workload identity and model access; failures do not automatically switch providers. This change is not evidence of live capacity or input-limit validation. Related verification record: #33138 (not closed by this PR). No live inference probes or production mutations were performed.

## Validation

- Regression demonstrated before the registry change: the new staff-default route test received the OpenRouter fixture instead of the Google fixture.
- Four focused API route suites (voice auth, transcription, polish and feature switches): **125 passed**.
- Core feature-switch suite: **30 passed**.
- `pnpm -F @okouai/core lint` and `pnpm -F api lint` passed.
- Changed-file Prettier and `git diff --check` passed.
- Normal commit hooks passed, including style policy, Knip, workspace type checks (14/14 tasks), file-size and commitlint.
