### PR TITLE
refactor(platform): stabilize oauth and prohibit child abort controllers

### DIFF
--- a/.claude/skills/ccstate/references/lifecycle.md
+++ b/.claude/skills/ccstate/references/lifecycle.md
@@ -15,6 +15,10 @@ rootSignal$ (app lifecycle)
           └── resetSignal() (per-operation, e.g. send/polling)
 ```
 
+Do not use `createChildAbortController()` to create an imperative owner outside
+this hierarchy. Existing calls are tracked with targeted
+`ccstate/no-create-child-abort-controller` suppressions while they migrate.
+
 ### Two usage patterns of `resetSignal()`
 
 `resetSignal()` creates an independent `AbortController` and aborts the previous one on each call. It has two normal usage patterns:

--- a/docs/platform-lint.md
+++ b/docs/platform-lint.md
@@ -26,9 +26,10 @@ adaptation uses `createDeferredPromise`; it does not justify a file exemption.
 
 Within ESLint's application scope, `new AbortController` is reserved for
 `signals/utils.ts`, the browser polyfill, and the shared test context that owns
-the root test lifetime. Individual tests use `context.signal`, `resetSignal`,
-or `createChildAbortController`. Child cancellation removes its parent listener
-immediately.
+the root test lifetime. Individual tests inherit `context.signal` or use a
+stable `resetSignal()` command. `createChildAbortController()` is prohibited;
+existing calls carry targeted `ccstate/no-create-child-abort-controller`
+suppressions until they migrate to the signal hierarchy.
 
 Polling and timed retries use `setLoop`. Do not implement a loop containing
 `sleep`, `delay`, or a timer, including through an import alias. Tests
@@ -38,9 +39,10 @@ iteration, and a loop waiting for an explicit event are not timed polling.
 
 The existing global ESLint exclusions for `src/__tests__` and `src/mocks` also
 exclude those files from these rules. They still follow the polling policy;
-their current loops iterate data or dispatch events. Startup cancellation tests
-also use child signals. Raw primitives remain in the Web Animations, MSW, and
-Ably adapters that model external browser/protocol lifetimes. These broad
+their current loops iterate data or dispatch events. Existing startup
+cancellation tests with child signals carry the same targeted debt marker. Raw
+primitives remain in the Web Animations, MSW, and Ably adapters that model
+external browser/protocol lifetimes. These broad
 exclusions are separate from the explicit primitive exceptions above.
 
 The multipart upload retry uses `setLoop` with its existing bounded attempt

--- a/docs/platform-lint.md
+++ b/docs/platform-lint.md
@@ -37,13 +37,14 @@ should await an event or operation completion instead. Testing Library's
 observable UI waits remain supported. Paging, stream reads, synchronous
 iteration, and a loop waiting for an explicit event are not timed polling.
 
-The existing global ESLint exclusions for `src/__tests__` and `src/mocks` also
-exclude those files from these rules. They still follow the polling policy;
-their current loops iterate data or dispatch events. Existing startup
-cancellation tests with child signals carry the same targeted debt marker. Raw
-primitives remain in the Web Animations, MSW, and Ably adapters that model
-external browser/protocol lifetimes. These broad
-exclusions are separate from the explicit primitive exceptions above.
+The existing global ESLint exclusions for `src/mocks` and most top-level
+`src/__tests__` files also exclude those files from these rules. They still
+follow the polling policy; their current loops iterate data or dispatch events.
+`src/__tests__/authentication-startup.test.tsx` remains in scope so its child
+signals carry validated `ccstate/no-create-child-abort-controller` debt markers.
+Raw primitives remain in the Web Animations, MSW, and Ably adapters that model
+external browser/protocol lifetimes. These broad exclusions are separate from
+the explicit primitive exceptions above.
 
 The multipart upload retry uses `setLoop` with its existing bounded attempt
 count and exponential delay. Its terminal error must propagate, so the helper's

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -373,6 +373,7 @@ export default [
       "vitest.config.ts",
       "src/mocks/**",
       "src/__tests__/**/*",
+      // Keep startup child-signal debt visible to the lifecycle rules.
       "!src/__tests__/authentication-startup.test.tsx",
       // Asset files — not JS/TS, would cause parse errors when matched by
       // broad file globs in .oxlintrc.json overrides (e.g. src/views/**/*.*)

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -96,6 +96,7 @@ export default [
       "ccstate/setup-page-render": "off",
       "ccstate/no-side-effect-in-render": "error",
       "ccstate/no-new-abort-controller": "error",
+      "ccstate/no-create-child-abort-controller": "error",
       "ccstate/no-new-promise": "error",
       "ccstate/no-direct-local-storage": "error",
       "ccstate/no-direct-session-storage": "error",

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -372,7 +372,8 @@ export default [
       "vite.config.ts",
       "vitest.config.ts",
       "src/mocks/**",
-      "src/__tests__/**",
+      "src/__tests__/**/*",
+      "!src/__tests__/authentication-startup.test.tsx",
       // Asset files — not JS/TS, would cause parse errors when matched by
       // broad file globs in .oxlintrc.json overrides (e.g. src/views/**/*.*)
       "**/*.svg",

--- a/turbo/apps/platform/src/__tests__/authentication-startup.test.tsx
+++ b/turbo/apps/platform/src/__tests__/authentication-startup.test.tsx
@@ -108,6 +108,7 @@ test.each(["setupPage", "startPage"])(
   "%s does not report cancelled authentication startup as ready",
   async (entryPoint) => {
     const clerkLoad = context.mocks.clerk().runtimePending();
+    // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
     const controller = createChildAbortController(context.signal);
     const options = {
       context: {
@@ -142,6 +143,7 @@ test("Cancelled locale startup does not adopt a replacement lifetime", async () 
     await localeResponse.promise;
     return HttpResponse.json(frFRCommon);
   });
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const controller = createChildAbortController(context.signal);
   let currentSignal = controller.signal;
   const startup = startPage({

--- a/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
@@ -148,6 +148,7 @@ function startViewportKeyboardState(): ControlledViewportClock {
   let settledController: AbortController | null = null;
   setupVisualViewportKeyboardState(context.signal, () => {
     settledController?.abort();
+    // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
     settledController = createChildAbortController(context.signal);
     return settledController.signal;
   });

--- a/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
@@ -207,7 +207,9 @@ function connectProtocolTransport(
 
 test("share one Worker realtime subscription until tabs disconnect", async () => {
   initializeWorker();
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const firstOwner = createChildAbortController(context.signal);
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const secondOwner = createChildAbortController(context.signal);
   const first = connectProtocolTransport(firstOwner.signal);
   const second = connectProtocolTransport(secondOwner.signal);
@@ -286,6 +288,7 @@ test("share one Worker realtime subscription until tabs disconnect", async () =>
 
 test("route workspace realtime subscriptions through the organization channel", async () => {
   initializeWorker();
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const owner = createChildAbortController(context.signal);
   const { bridge } = connectProtocolTransport(owner.signal);
   const messages: unknown[] = [];
@@ -397,6 +400,7 @@ test.each([401, 426])(
 
 test("Keep concurrent shared chat loads independent", async () => {
   initializeWorker();
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const owner = createChildAbortController(context.signal);
   const { bridge } = connectProtocolTransport(owner.signal);
   await bridge.registerTab(owner.signal);
@@ -455,7 +459,9 @@ test("Keep concurrent shared chat loads independent", async () => {
 
 test("Authenticate worker requests through the tab with the latest heartbeat", async () => {
   initializeWorker();
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const firstOwner = createChildAbortController(context.signal);
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const secondOwner = createChildAbortController(context.signal);
   const first = connectProtocolTransport(firstOwner.signal, () => {
     return Promise.resolve("first-tab-token");
@@ -526,6 +532,7 @@ test("Authenticate worker requests through the tab with the latest heartbeat", a
 
 test("Cancel one shared chat load without cancelling worker progress", async () => {
   initializeWorker();
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const owner = createChildAbortController(context.signal);
   const { bridge, workerPort } = connectProtocolTransport(owner.signal);
   await bridge.registerTab(owner.signal);
@@ -554,6 +561,7 @@ test("Cancel one shared chat load without cancelling worker progress", async () 
     },
   );
 
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const caller = createChildAbortController(owner.signal);
   const pending = bridge.query(
     { dataKey: key, afterSeqId: null, consistency: "catch-up" },
@@ -577,7 +585,9 @@ test("Cancel one shared chat load without cancelling worker progress", async () 
 
 test("Disconnect one tab without interrupting another tab", async () => {
   initializeWorker();
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const firstOwner = createChildAbortController(context.signal);
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const secondOwner = createChildAbortController(context.signal);
   const first = connectProtocolTransport(firstOwner.signal);
   const second = connectProtocolTransport(secondOwner.signal);
@@ -616,6 +626,7 @@ test("Send a heartbeat immediately after tab registration", async () => {
 
 test("Keep sending heartbeats while the tab bridge is active", async () => {
   const [platformPort] = messagePortPair();
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const owner = createChildAbortController(context.signal);
   const bridge = new MessagePortSharedDatabaseBridge(
     platformPort,
@@ -659,6 +670,7 @@ test("Reject shared-data access before the tab is registered", async () => {
 
 test("Validate shared chat results received from the worker", async () => {
   const [platformPort, workerPort] = messagePortPair();
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const owner = createChildAbortController(context.signal);
   const bridge = new MessagePortSharedDatabaseBridge(
     platformPort,
@@ -702,6 +714,7 @@ test("Validate shared chat results received from the worker", async () => {
 
 test("Stop pending requests when the bridge lifecycle ends", async () => {
   const [platformPort, workerPort] = messagePortPair();
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const owner = createChildAbortController(context.signal);
   const bridge = new MessagePortSharedDatabaseBridge(
     platformPort,
@@ -732,6 +745,7 @@ test("Stop pending requests when the bridge lifecycle ends", async () => {
   workerPort.start();
   await bridge.registerTab(owner.signal);
 
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const caller = createChildAbortController(context.signal);
   const pendingQuery = bridge.query(
     {
@@ -938,6 +952,7 @@ test("Keep indicators readable when chat warming fails", async () => {
 test("Cancel waiting indicator reads when their Worker lifecycle ends", async () => {
   mockNow(30_000, context.signal);
   const threadId = crypto.randomUUID();
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const worker = createChildAbortController(context.signal);
   const refreshLoaded = context.mocks.deferred<void>();
   let refreshing = false;

--- a/turbo/apps/platform/src/shared-database/__tests__/platform-direct-bridge.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/platform-direct-bridge.test.ts
@@ -223,6 +223,7 @@ test("Show cached chat data before catching up live", async () => {
     expect(prewarmedThreadIds).toContain(unreadThreadId);
   });
 
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const owner = createChildAbortController(context.signal);
   const signals = createChatEventSignals(threadId);
   await context.store.set(signals.setup$, owner.signal);
@@ -336,6 +337,7 @@ test("Cache incoming chat messages before the conversation is opened", async () 
     expect(batchedThreadIds).toContain(unopenedThreadId);
   });
 
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const owner = createChildAbortController(context.signal);
   const signals = createChatEventSignals(unopenedThreadId);
   await context.store.set(signals.setup$, owner.signal);
@@ -420,6 +422,7 @@ test("Preserve every message during a burst of realtime notifications", async ()
   await vi.waitFor(() => {
     expect(prewarmedThreadIds).toContain(unopenedThreadId);
   });
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const owner = createChildAbortController(context.signal);
   const signals = createChatEventSignals(threadId);
   await context.store.set(signals.setup$, owner.signal);

--- a/turbo/apps/platform/src/shared-database/__tests__/single-connection-client.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/single-connection-client.test.ts
@@ -125,6 +125,7 @@ async function createRegisteredBridge(): Promise<{
     },
     events: createEvents(),
   });
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const owner = createChildAbortController(context.signal);
   await bridge.registerTab(owner.signal);
   return { bridge, bridges, owner };

--- a/turbo/apps/platform/src/shared-database/message-port-server.ts
+++ b/turbo/apps/platform/src/shared-database/message-port-server.ts
@@ -78,6 +78,7 @@ export class SharedDatabaseMessagePortServer {
     workerSignal: AbortSignal,
   ) {
     workerSignal.throwIfAborted();
+    // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
     this.connectionController = createChildAbortController(workerSignal);
     this.connectionSignal = this.connectionController.signal;
     L.debug("connection.connect", { connectionId: this.connectionId });

--- a/turbo/apps/platform/src/shared-database/test-bridge.ts
+++ b/turbo/apps/platform/src/shared-database/test-bridge.ts
@@ -135,6 +135,7 @@ function waitForWorkerOperation<T>(
   signal: AbortSignal,
 ): Promise<T> {
   signal.throwIfAborted();
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const waitController = createChildAbortController(signal);
   const aborted = createDeferredPromise<never>(waitController.signal);
   return withCleanup(Promise.race([operation, aborted.promise]), () => {
@@ -246,6 +247,7 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
     if (this.connectionSignal) {
       throw new Error("Shared database tab is already registered");
     }
+    // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
     const connectionController = createChildAbortController(signal);
     const connectionSignal = connectionController.signal;
     this.connectionSignal = this.workerStore.set(

--- a/turbo/apps/platform/src/shared-database/worker-realtime-subscriptions.ts
+++ b/turbo/apps/platform/src/shared-database/worker-realtime-subscriptions.ts
@@ -303,6 +303,7 @@ export const startWorkerRealtimeSubscription$ = command(
       return null;
     }
 
+    // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
     const controller = createChildAbortController(get(rootSignal$));
     const subscription: WorkerRealtimeSubscription = {
       controller,

--- a/turbo/apps/platform/src/signals/__tests__/command-scheduling.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/command-scheduling.test.ts
@@ -65,6 +65,7 @@ test("A cancelled debounce can be reused without running the discarded command",
     return value;
   });
   const debounced$ = debounceCommand(read$, 20);
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const caller = createChildAbortController(context.signal);
   const reason = new DOMException("Search closed", "AbortError");
   const pending = context.store.set(debounced$, "discarded", caller.signal);

--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -111,6 +111,7 @@ async function setupAuthAndRealtime(): Promise<void> {
 }
 
 function testSubscriber(): AbortController {
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   return createChildAbortController(context.signal);
 }
 

--- a/turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-up-flow.ts
@@ -849,6 +849,7 @@ function createScheduleExpiryCommand(
         set(atoms.verificationExpired$, true);
         return;
       }
+      // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
       const controller = createChildAbortController(signal);
       set(runtime.expiryController$, controller);
       controller.signal.addEventListener(

--- a/turbo/apps/platform/src/signals/chat-page/chat-layout.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-layout.ts
@@ -53,6 +53,7 @@ export const chatLayoutTransitionOnRef$ = onRef(
         properties.add(event.propertyName);
         transitions.set(event.target, properties);
         if (!frames) {
+          // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
           frames = createChildAbortController(signal);
           startFrames(frames.signal);
         }

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
@@ -402,6 +402,7 @@ function waitForSharedWork<T>(
   signal: AbortSignal,
 ): Promise<T> {
   signal.throwIfAborted();
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const waitController = createChildAbortController(signal);
   const aborted = createDeferredPromise<never>(waitController.signal);
   return withCleanup(Promise.race([work, aborted.promise]), () => {
@@ -462,6 +463,7 @@ const resolveColdThreadMeta$ = command(
     canonicalSync: Promise<void>,
     signal: AbortSignal,
   ): Promise<ColdThreadMetaResolution> => {
+    // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
     const controller = createChildAbortController(signal);
     const metadata = set(attemptRemoteThreadMeta$, threadId, controller.signal);
     const eventStream = set(

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -231,6 +231,7 @@ const refreshFeatureSwitchState$ = command(
       return;
     }
 
+    // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
     const requestController = createChildAbortController(signal);
     const abortIfIdentityChanged = () => {
       if (

--- a/turbo/apps/platform/src/signals/okou-page/composer-voice-input.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-voice-input.ts
@@ -444,6 +444,7 @@ function createVoiceActionBindings(
   const mount$ = onRef(
     command(async ({ set }, element: HTMLElement, signal: AbortSignal) => {
       set(element$, element);
+      // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
       set(internalOwner$, createChildAbortController(signal));
       signal.addEventListener(
         "abort",

--- a/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
@@ -45,6 +45,7 @@ import {
   type ApiClientFactory,
 } from "../../api-client.ts";
 import {
+  createChildAbortController,
   resetSignal,
   setLoop,
   settle,
@@ -2197,7 +2198,114 @@ async function waitForOAuthAuthCodePopupClosed(
   return "popupClosed";
 }
 
-const resetOAuthAuthCodeWaitSignal$ = resetSignal();
+type ActiveConnectorOAuthAuthCodeWaitState = {
+  readonly flowId: string;
+  readonly connectorSlug: ConnectorSlug;
+  readonly account: PlatformConnectorAccountMutationIntent;
+  readonly oauthAttemptId: string;
+};
+
+type ConnectorOAuthAuthCodeWaitState =
+  | (ActiveConnectorOAuthAuthCodeWaitState & {
+      readonly status: "waiting";
+    })
+  | (ActiveConnectorOAuthAuthCodeWaitState & {
+      readonly status: "completed";
+      readonly connectionId: string;
+    });
+
+const internalConnectorOAuthAuthCodeWaitState$ =
+  state<ConnectorOAuthAuthCodeWaitState | null>(null);
+
+function connectorOAuthAuthCodeWaitIsCurrent(
+  waitState: ConnectorOAuthAuthCodeWaitState | null,
+  flowId: string,
+  oauthAttemptId: string,
+): waitState is ConnectorOAuthAuthCodeWaitState {
+  return (
+    waitState?.flowId === flowId && waitState.oauthAttemptId === oauthAttemptId
+  );
+}
+
+const refreshConnectorOAuthAuthCodeCompletion$ = command(
+  async (
+    { get, set },
+    flowId: string,
+    oauthAttemptId: string,
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    const current = get(internalConnectorOAuthAuthCodeWaitState$);
+    if (!connectorOAuthAuthCodeWaitIsCurrent(current, flowId, oauthAttemptId)) {
+      return false;
+    }
+    if (current.status === "completed") {
+      return true;
+    }
+
+    const connectionId = await readConnectorOAuthCompletion(
+      get(apiClient$),
+      { kind: "builtin", connectorSlug: current.connectorSlug },
+      current.account,
+      current.oauthAttemptId,
+      signal,
+    );
+    signal.throwIfAborted();
+
+    const latest = get(internalConnectorOAuthAuthCodeWaitState$);
+    if (!connectorOAuthAuthCodeWaitIsCurrent(latest, flowId, oauthAttemptId)) {
+      return false;
+    }
+    if (latest.status === "completed") {
+      return true;
+    }
+    if (connectionId === null) {
+      return false;
+    }
+
+    set(internalConnectorOAuthAuthCodeWaitState$, {
+      ...latest,
+      status: "completed",
+      connectionId,
+    });
+    return true;
+  },
+);
+
+const refreshActiveConnectorOAuthAuthCodeCompletion$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
+    const current = get(internalConnectorOAuthAuthCodeWaitState$);
+    return current
+      ? await set(
+          refreshConnectorOAuthAuthCodeCompletion$,
+          current.flowId,
+          current.oauthAttemptId,
+          signal,
+        )
+      : false;
+  },
+);
+
+const onActiveConnectorChanged$ = command(
+  async (
+    { get, set },
+    payload: unknown,
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    const current = get(internalConnectorOAuthAuthCodeWaitState$);
+    if (
+      !current ||
+      !isConnectorChangedPayloadFor(payload, current.connectorSlug)
+    ) {
+      return false;
+    }
+    return await set(
+      refreshConnectorOAuthAuthCodeCompletion$,
+      current.flowId,
+      current.oauthAttemptId,
+      signal,
+    );
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Connect command
@@ -2358,8 +2466,9 @@ const openConnectorOAuthAuthCodeWindow$ = command(
 
 const completeConnectorOAuthAuthCodeFlow$ = command(
   async (
-    { set },
+    { get, set },
     args: {
+      readonly flowId: string;
       readonly connectorSlug: ConnectorSlug;
       readonly method: PublicConnectorCatalogAuthMethodDetail;
       readonly options: PostConnectOptions;
@@ -2371,37 +2480,25 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
     },
     signal: AbortSignal,
   ): Promise<ConnectorConnectionResult | false> => {
-    const { connectorSlug, method, options, account, oauthStart } = args;
-    let completedConnectionId: string | null = null;
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const completionAvailable$ = command(async ({ get }, sig: AbortSignal) => {
-      const connectionId = await readConnectorOAuthCompletion(
-        get(apiClient$),
-        { kind: "builtin", connectorSlug },
-        account,
-        oauthStart.oauthAttemptId,
-        sig,
-      );
-      sig.throwIfAborted();
-      completedConnectionId = connectionId;
-      return completedConnectionId !== null;
+    const { flowId, connectorSlug, method, options, account, oauthStart } =
+      args;
+    set(internalConnectorOAuthAuthCodeWaitState$, {
+      status: "waiting",
+      flowId,
+      connectorSlug,
+      account,
+      oauthAttemptId: oauthStart.oauthAttemptId,
     });
-    const waitSignal = set(resetOAuthAuthCodeWaitSignal$, signal);
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const onMatchingConnectorChanged$ = command(
-      async ({ set }, payload: unknown, sig: AbortSignal): Promise<boolean> => {
-        return isConnectorChangedPayloadFor(payload, connectorSlug)
-          ? await set(completionAvailable$, sig)
-          : false;
-      },
-    );
+
+    const waitController = createChildAbortController(signal);
+    const waitSignal = waitController.signal;
     const changedPromise = (async () => {
       await set(
         setAblyPayloadLoop$,
         {
           topic: "connector:changed",
-          loopCommand$: onMatchingConnectorChanged$,
-          initializeCommand$: completionAvailable$,
+          loopCommand$: onActiveConnectorChanged$,
+          initializeCommand$: refreshActiveConnectorOAuthAuthCodeCompletion$,
         },
         waitSignal,
       );
@@ -2415,18 +2512,32 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
             waitForOAuthAuthCodePopupClosed(oauthStart.authWindow, waitSignal),
           ]),
       () => {
-        set(resetOAuthAuthCodeWaitSignal$, signal);
+        waitController.abort();
       },
     );
     signal.throwIfAborted();
 
     if (waitResult === "popupClosed") {
-      await set(completionAvailable$, signal);
+      await set(
+        refreshConnectorOAuthAuthCodeCompletion$,
+        flowId,
+        oauthStart.oauthAttemptId,
+        signal,
+      );
       signal.throwIfAborted();
     }
-    if (completedConnectionId === null) {
+    const completed = get(internalConnectorOAuthAuthCodeWaitState$);
+    if (
+      !connectorOAuthAuthCodeWaitIsCurrent(
+        completed,
+        flowId,
+        oauthStart.oauthAttemptId,
+      ) ||
+      completed.status !== "completed"
+    ) {
       return false;
     }
+    const completedConnectionId = completed.connectionId;
 
     set(reloadConnectorConnectionState$);
     const isConnected =
@@ -2507,6 +2618,7 @@ const connectConnectorOAuthAuthCodeCommand$ = command(
         return await set(
           completeConnectorOAuthAuthCodeFlow$,
           {
+            flowId: flow.id,
             connectorSlug,
             method,
             options: oauthStart.options,
@@ -2519,6 +2631,9 @@ const connectConnectorOAuthAuthCodeCommand$ = command(
       () => {
         set(internalPollingOAuthAuthCodeConnectorSlug$, (current) => {
           return current === connectorSlug ? null : current;
+        });
+        set(internalConnectorOAuthAuthCodeWaitState$, (current) => {
+          return current?.flowId === flow.id ? null : current;
         });
         set(internalConnectFlowState$, (current) => {
           return current?.id === flow.id ? null : current;

--- a/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
@@ -45,7 +45,6 @@ import {
   type ApiClientFactory,
 } from "../../api-client.ts";
 import {
-  createChildAbortController,
   resetSignal,
   setLoop,
   settle,
@@ -2198,6 +2197,8 @@ async function waitForOAuthAuthCodePopupClosed(
   return "popupClosed";
 }
 
+const resetOAuthAuthCodeWaitSignal$ = resetSignal();
+
 type ActiveConnectorOAuthAuthCodeWaitState = {
   readonly flowId: string;
   readonly connectorSlug: ConnectorSlug;
@@ -2490,8 +2491,7 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
       oauthAttemptId: oauthStart.oauthAttemptId,
     });
 
-    const waitController = createChildAbortController(signal);
-    const waitSignal = waitController.signal;
+    const waitSignal = set(resetOAuthAuthCodeWaitSignal$, signal);
     const changedPromise = (async () => {
       await set(
         setAblyPayloadLoop$,
@@ -2512,7 +2512,7 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
             waitForOAuthAuthCodePopupClosed(oauthStart.authWindow, waitSignal),
           ]),
       () => {
-        waitController.abort();
+        set(resetOAuthAuthCodeWaitSignal$, signal);
       },
     );
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -402,6 +402,8 @@ export function resetSignal(): Command<AbortSignal, AbortSignal[]> {
 /**
  * Create a local cancellation owner that always cascades its parent signal.
  * Aborting the child also removes its listener from the parent immediately.
+ *
+ * @deprecated Inherit an existing owner or use a stable resetSignal() command.
  */
 export function createChildAbortController(
   parentSignal: AbortSignal,

--- a/turbo/apps/platform/src/signals/voice-io/voice-draft-capture.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-draft-capture.ts
@@ -52,6 +52,7 @@ export function createVoiceDraftCaptureSignals() {
       if (get(acquisition$)) {
         return false;
       }
+      // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
       const controller = createChildAbortController(parentSignal);
       const signal = controller.signal;
       set(acquisition$, controller);

--- a/turbo/apps/platform/src/signals/voice-io/voice-draft-pcm.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-draft-pcm.ts
@@ -245,6 +245,7 @@ async function waitForSafariCaptureStart(
 ): Promise<void> {
   // Safari can initially supply only zeros after capture has started.
   // Bound the extra wait so a quiet room still becomes ready.
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const startupController = createChildAbortController(signal);
   timeout(
     () => {

--- a/turbo/apps/platform/src/signals/voice-io/voice-draft-transcription.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-draft-transcription.ts
@@ -125,6 +125,7 @@ function createInitialization(
       key,
       recordingId: recording.id,
       context: recording.progress?.context,
+      // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
       controller: createChildAbortController(signal),
     };
     const restored: VoiceDraftTranscriptionSegment[] = [];

--- a/turbo/apps/platform/src/signals/workflows-page/google-calendar-recovery.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/google-calendar-recovery.ts
@@ -80,6 +80,7 @@ export const closeGoogleCalendarReconnect$ = command(
 const confirmRecovery$ = command(
   async ({ get, set }, target: CalendarRecoveryTarget, signal: AbortSignal) => {
     const deadline = now() + 30_000;
+    // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
     const controller = createChildAbortController(signal);
     timeout(
       () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-draft-confirmation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-draft-confirmation.test.tsx
@@ -57,7 +57,9 @@ test.each([false, true])(
   "Finish voice without waiting for conversation creation confirmation (reload: %s)",
   async (reloadBeforeRetry) => {
     const auth = chatListAuth(49);
+    // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
     const initialPage = createChildAbortController(context.signal);
+    // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
     const refreshedPage = createChildAbortController(refreshedContext.signal);
     await seedPersistentChatListCache(49, auth, []);
     let createdThreadId: string | undefined;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-draft-save.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-draft-save.test.tsx
@@ -35,6 +35,7 @@ test.each([
 ])(
   "Finish voice independently of a failed text draft save at $path after $recovery",
   async ({ path, recovery }) => {
+    // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
     const initialPage = createChildAbortController(context.signal);
     context.mocks.browser.voiceInput({ rms: 0.12 });
     installRunChat();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-forwarding.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-forwarding.test.tsx
@@ -125,6 +125,7 @@ test.each(targets)(
 test.each(targets)(
   "Reuse an unfinished $target recording in the forward dialog without replacing it",
   async ({ name, path }) => {
+    // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
     const initialPage = createChildAbortController(context.signal);
     installVoiceBoundaries();
     context.mocks.browser.voiceInput({ rms: 0.12 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-incremental.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-incremental.test.tsx
@@ -101,6 +101,7 @@ test("Keep recording after an incremental segment fails and finish in order", as
 });
 
 test("Resume a completed segment after reload without retranscribing its audio", async () => {
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const page = createChildAbortController(context.signal);
   const capture = context.mocks.deferred<(samples: Float32Array) => void>();
   const started = context.mocks.deferred<void>();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-input.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-input.test.tsx
@@ -767,6 +767,7 @@ test.each([
 ])(
   "Restore a retryable recording at $path after $recovery (failed: $failed)",
   async ({ path, failed, recovery }) => {
+    // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
     const initialPage = createChildAbortController(context.signal);
     const firstRequest = context.mocks.deferred<void>();
     const firstResponse = context.mocks.deferred<void>();
@@ -887,6 +888,7 @@ test("Keep a saved voice recording isolated from another signed-in user", async 
 });
 
 test("Discard a failed recording without removing typed notes", async () => {
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const initialPage = createChildAbortController(context.signal);
   context.mocks.browser.voiceInput({ rms: 0.12 });
   installAvailableVoiceQuota();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-isolation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-isolation.test.tsx
@@ -54,6 +54,7 @@ test.each(["user", "org", "target"] as const)(
   "Keep local recordings isolated when the composer changes %s",
   async (part) => {
     installVoiceBoundaries();
+    // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
     const firstPage = createChildAbortController(context.signal);
     context.mocks.http.post("*/api/voice-io/transcribe/segment", () => {
       return HttpResponse.json({ error: "Temporary outage" }, { status: 503 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-recording.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-recording.test.tsx
@@ -92,6 +92,7 @@ test.each([
 ])(
   "Recover committed PCM across a reload ($reloadAt) at $path",
   async ({ path, reloadAt }) => {
+    // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
     const firstPage = createChildAbortController(context.signal);
     const capture = context.mocks.deferred<(samples: Float32Array) => void>();
     context.mocks.browser.voiceInput({
@@ -232,6 +233,7 @@ test.each([
 ])(
   "Do not restore a completed silent recording at $path (empty: $empty)",
   async ({ path, empty }) => {
+    // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
     const firstPage = createChildAbortController(context.signal);
     context.mocks.browser.voiceInput({
       rms: 0,
@@ -319,6 +321,7 @@ test("Stop capture and expose a failed chunk write without discarding the saved 
 });
 
 test("Restore audio when voice input v2 enables after the composer mounts", async () => {
+  // eslint-disable-next-line ccstate/no-create-child-abort-controller -- migrate this lifetime to the ccstate signal hierarchy
   const firstPage = createChildAbortController(context.signal);
   context.mocks.browser.voiceInput({ rms: 0.12 });
   installVoiceBoundaries();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
@@ -37,11 +37,20 @@ import {
 
 const context = testContext();
 
-function createAuthWindow(): Window {
+function createAuthWindow(onNavigate?: (href: string) => void): Window {
   const authWindow = context.mocks.browser.authWindow();
+  let href = "";
   Object.defineProperty(authWindow, "location", {
     configurable: true,
-    value: { href: "" },
+    value: {
+      get href() {
+        return href;
+      },
+      set href(value: string) {
+        href = value;
+        onNavigate?.(value);
+      },
+    },
   });
   return authWindow;
 }
@@ -371,7 +380,15 @@ test("Add an account through OpenID", async () => {
       ],
     }),
   ]);
-  const authWindow = createAuthWindow();
+  const authorizationUrl = "https://openid.test/partner-steam/authorize";
+  const authWindow = createAuthWindow((href) => {
+    if (href !== authorizationUrl) {
+      return;
+    }
+    const connected = storeConnectedConnector(slug, "partner-openid");
+    completedAttempts.set(oauthAttemptId, connected.id);
+    context.mocks.ably.trigger("connector:changed", { connectorSlug: slug });
+  });
   context.mocks.browser.open(authWindow);
   context.mocks.api(connectorOpenIdStartContract.start, ({ body, respond }) => {
     expect(body).toMatchObject({
@@ -379,7 +396,7 @@ test("Add an account through OpenID", async () => {
       authMethod: "partner-openid",
     });
     return respond(200, {
-      authorizationUrl: "https://openid.test/partner-steam/authorize",
+      authorizationUrl,
       oauthAttemptId,
     });
   });
@@ -396,13 +413,12 @@ test("Add an account through OpenID", async () => {
   click(getConnectorAction("button", "Connect Partner Steam"));
 
   await waitFor(() => {
-    expect(authWindow.location.href).toBe(
-      "https://openid.test/partner-steam/authorize",
-    );
+    expect(authWindow.location.href).toBe(authorizationUrl);
   });
-  const connected = storeConnectedConnector(slug, "partner-openid");
-  completedAttempts.set(oauthAttemptId, connected.id);
-  context.mocks.ably.trigger("connector:changed", { connectorSlug: slug });
+  const naming = await screen.findByRole("dialog", {
+    name: "Name your Partner Steam account",
+  });
+  click(getConnectorAction("button", "Skip", naming));
   await waitFor(() => {
     expect(
       getConnectorAction("button", "Manage Partner Steam access"),
@@ -874,7 +890,9 @@ test("Complete OAuth only after the current attempt succeeds", async () => {
     );
   });
 
-  context.mocks.ably.trigger("connector:changed", null);
+  context.mocks.ably.trigger("connector:changed", {
+    connectorSlug: "stripe",
+  });
   authWindow.close();
 
   await waitFor(() => {

--- a/turbo/packages/eslint-rules/src/ccstate/__tests__/no-create-child-abort-controller.test.ts
+++ b/turbo/packages/eslint-rules/src/ccstate/__tests__/no-create-child-abort-controller.test.ts
@@ -1,0 +1,75 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "vitest";
+import rule from "../rules/no-create-child-abort-controller.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-create-child-abort-controller", rule, {
+  valid: [
+    {
+      code: `
+        import { resetSignal } from "../utils.ts";
+
+        const resetOperationSignal$ = resetSignal();
+      `,
+    },
+    {
+      code: `
+        import { createOwner as createChildAbortController } from "another-package";
+
+        createChildAbortController();
+      `,
+    },
+    {
+      code: `
+        const utils = { createChildAbortController: () => undefined };
+
+        utils.createChildAbortController();
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { createChildAbortController } from "../utils.ts";
+
+        createChildAbortController(signal);
+      `,
+      errors: [{ messageId: "childAbortController" }],
+    },
+    {
+      code: `
+        import { createChildAbortController as createOwner } from "../utils.ts";
+
+        createOwner(signal);
+      `,
+      errors: [{ messageId: "childAbortController" }],
+    },
+    {
+      code: `
+        import * as utils from "../utils.ts";
+
+        utils.createChildAbortController(signal);
+        utils["createChildAbortController"](signal);
+      `,
+      errors: [
+        { messageId: "childAbortController" },
+        { messageId: "childAbortController" },
+      ],
+    },
+    {
+      code: `
+        function createChildAbortController() {
+          return undefined;
+        }
+
+        createChildAbortController();
+      `,
+      errors: [{ messageId: "childAbortController" }],
+    },
+  ],
+});

--- a/turbo/packages/eslint-rules/src/ccstate/index.ts
+++ b/turbo/packages/eslint-rules/src/ccstate/index.ts
@@ -19,6 +19,7 @@
  * - no-getter-setter-params: Functions must not accept ccstate Getter/Setter — use command()
  * - no-accessor-escape: ccstate get/set accessors must only be called directly
  * - no-new-abort-controller: Disallow new AbortController() — use signal hierarchy
+ * - no-create-child-abort-controller: Disallow createChildAbortController() lifecycle escape hatches
  * - no-direct-local-storage: Disallow direct localStorage access — use localStorageSignals()
  * - no-direct-session-storage: Disallow direct sessionStorage access — use sessionStorageSignals()
  * - no-detach-in-signals: Disallow detach() in signals/ — use await or signal chain
@@ -51,6 +52,7 @@ import noCommandInCommand from "./rules/no-command-in-command.ts";
 import noGetterSetterParams from "./rules/no-getter-setter-params.ts";
 import noAccessorEscape from "./rules/no-accessor-escape.ts";
 import noNewAbortController from "./rules/no-new-abort-controller.ts";
+import noCreateChildAbortController from "./rules/no-create-child-abort-controller.ts";
 import noNewPromise from "./rules/no-new-promise.ts";
 import noDirectLocalStorage from "./rules/no-direct-local-storage.ts";
 import noDirectSessionStorage from "./rules/no-direct-session-storage.ts";
@@ -96,6 +98,7 @@ const plugin = {
     "no-getter-setter-params": noGetterSetterParams,
     "no-accessor-escape": noAccessorEscape,
     "no-new-abort-controller": noNewAbortController,
+    "no-create-child-abort-controller": noCreateChildAbortController,
     "no-new-promise": noNewPromise,
     "no-direct-local-storage": noDirectLocalStorage,
     "no-direct-session-storage": noDirectSessionStorage,

--- a/turbo/packages/eslint-rules/src/ccstate/rules/no-create-child-abort-controller.ts
+++ b/turbo/packages/eslint-rules/src/ccstate/rules/no-create-child-abort-controller.ts
@@ -1,0 +1,108 @@
+/**
+ * ESLint rule: no-create-child-abort-controller
+ *
+ * createChildAbortController() creates imperative cancellation ownership outside
+ * the ccstate signal hierarchy. Operations should inherit an existing owner or
+ * use a stable resetSignal() command for local cancellation and mutual exclusion.
+ */
+
+import {
+  AST_NODE_TYPES,
+  ASTUtils,
+  type TSESTree,
+} from "@typescript-eslint/utils";
+import { createRule } from "../utils.ts";
+
+const TARGET_NAME = "createChildAbortController";
+
+interface ImportReference {
+  readonly importedName: string;
+}
+
+function memberName(node: TSESTree.MemberExpression): string | null {
+  if (!node.computed && node.property.type === AST_NODE_TYPES.Identifier) {
+    return node.property.name;
+  }
+  if (
+    node.computed &&
+    node.property.type === AST_NODE_TYPES.Literal &&
+    typeof node.property.value === "string"
+  ) {
+    return node.property.value;
+  }
+  return null;
+}
+
+export default createRule({
+  name: "no-create-child-abort-controller",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow createChildAbortController() — use the ccstate signal hierarchy",
+      recommended: true,
+      requiresTypeChecking: false,
+    },
+    schema: [],
+    messages: {
+      childAbortController:
+        "Do not call createChildAbortController(). Inherit pageSignal$/rootSignal$ or use a stable resetSignal() command for operation ownership.",
+    },
+  },
+  create(context) {
+    function importReference(
+      node: TSESTree.Identifier,
+    ): ImportReference | null {
+      const variable = ASTUtils.findVariable(
+        context.sourceCode.getScope(node),
+        node,
+      );
+      const definition = variable?.defs.find((candidate) => {
+        return candidate.type === "ImportBinding";
+      });
+      const specifier = definition?.node;
+      if (
+        specifier === undefined ||
+        (specifier.type !== AST_NODE_TYPES.ImportNamespaceSpecifier &&
+          specifier.type !== AST_NODE_TYPES.ImportSpecifier)
+      ) {
+        return null;
+      }
+      return {
+        importedName:
+          specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier
+            ? "*"
+            : specifier.imported.type === AST_NODE_TYPES.Identifier
+              ? specifier.imported.name
+              : String(specifier.imported.value),
+      };
+    }
+
+    function isTargetCall(node: TSESTree.CallExpression): boolean {
+      const callee = node.callee;
+      if (callee.type === AST_NODE_TYPES.Identifier) {
+        const reference = importReference(callee);
+        return reference
+          ? reference.importedName === TARGET_NAME
+          : callee.name === TARGET_NAME;
+      }
+      if (
+        callee.type !== AST_NODE_TYPES.MemberExpression ||
+        callee.object.type !== AST_NODE_TYPES.Identifier ||
+        memberName(callee) !== TARGET_NAME
+      ) {
+        return false;
+      }
+      return importReference(callee.object)?.importedName === "*";
+    }
+
+    return {
+      CallExpression(node: TSESTree.CallExpression): void {
+        if (isTargetCall(node)) {
+          context.report({ node, messageId: "childAbortController" });
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
## Summary

- replace runtime-created OAuth completion and Realtime commands with stable module-level ccstate commands
- keep per-attempt completion data in private state and guard asynchronous reads with both `flowId` and `oauthAttemptId`
- preserve subscription-baseline, matching-event, and popup-close completion paths with a stable `resetSignal()` owner
- add and enable `ccstate/no-create-child-abort-controller`, including direct, aliased-import, and namespace-import coverage
- mark all 49 baseline call sites with targeted migration suppressions without adding a new suppressed call
- deprecate the helper and align the ccstate lifecycle and Platform lint guidance

## Verification

- `pnpm -F @okouai/eslint-rules test` (58 files, 792 tests passed)
- `pnpm -F @okouai/eslint-rules lint`
- `pnpm -F @okouai/eslint-rules check-types`
- full Platform ESLint with zero warnings
- unused-disable audit for all linted suppression files
- changed-file Oxlint and type-aware Oxlint
- `pnpm -F @okouai/app check-types`
- Connector auth-method tests (39 passed)
- mechanical audit: 49 calls, 49 suppressions, 0 missing
- `git diff --check`
