### PR TITLE
refactor: make activity summary polling thread-owned

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2332,6 +2332,7 @@ function createEventChangeEffects(
     projections,
     scroll,
     syncVisibleEventTrees$,
+    reconcileThreadSummaryDemand$,
   }: {
     readonly threadId: string;
     readonly chatEvents: ChatEventSignals;
@@ -2344,6 +2345,7 @@ function createEventChangeEffects(
       Promise<void>,
       [boolean, AbortSignal]
     >;
+    readonly reconcileThreadSummaryDemand$: Command<void, [AbortSignal]>;
   },
   ownerSignal: AbortSignal,
 ) {
@@ -2416,6 +2418,7 @@ function createEventChangeEffects(
           get(chatEvents.chatEvents$).slice(-10),
         ),
       });
+      set(reconcileThreadSummaryDemand$, ownerSignal);
       await Promise.all([
         set(updateEventPresentation$, scrollPosition, signal),
         set(markThreadReadIfNeeded$, signal),
@@ -2523,18 +2526,22 @@ function createBrowserLifecycleOptimisticEvents(
   };
 }
 
+interface ChatThreadMessagePipelineOptions {
+  chatActionContext: ChatActionContext;
+  chatEvents: ChatEventSignals;
+  previewImageUrlsByUrl$: Computed<Promise<ReadonlyMap<string, string>>>;
+  connector: ComposerConnectorSignals;
+  reconcileThreadSummaryDemand$: Command<void, [AbortSignal]>;
+}
+
 function createChatThreadMessagePipeline(
   {
     chatActionContext,
     chatEvents,
     previewImageUrlsByUrl$,
     connector,
-  }: {
-    chatActionContext: ChatActionContext;
-    chatEvents: ChatEventSignals;
-    previewImageUrlsByUrl$: Computed<Promise<ReadonlyMap<string, string>>>;
-    connector: ComposerConnectorSignals;
-  },
+    reconcileThreadSummaryDemand$,
+  }: ChatThreadMessagePipelineOptions,
   ownerSignal: AbortSignal,
 ) {
   const { threadId } = chatActionContext;
@@ -2605,6 +2612,7 @@ function createChatThreadMessagePipeline(
       projections,
       scroll,
       syncVisibleEventTrees$,
+      reconcileThreadSummaryDemand$,
     },
     ownerSignal,
   );
@@ -4019,6 +4027,7 @@ function createChatPanelSignalsWithDraft(
         artifact.artifacts$,
       ),
       connector: composer.connector,
+      reconcileThreadSummaryDemand$: activity.reconcileThreadSummaryDemand$,
     },
     signal,
   );

--- a/turbo/apps/platform/src/signals/chat-page/thread-activity-summary.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-activity-summary.ts
@@ -44,6 +44,7 @@ function createThreadSummaryDemand(
   const internalReloadThreadSummaries$ = state(0);
   const summaryLoopRunId$ = state<string | null>(null);
   const resetSummaryDemand$ = resetSignal();
+  let latestSummaryLoop = Promise.resolve();
   const threadSummaries$ = computed(async (get) => {
     const runId = get(currentActiveRunId$);
     if (runId === null) {
@@ -106,7 +107,7 @@ function createThreadSummaryDemand(
       const loopSignal = set(resetSummaryDemand$, demandOwnerSignal);
       set(summaryLoopRunId$, runId);
       if (runId !== null) {
-        set(startSummaryLoop$, loopSignal);
+        latestSummaryLoop = set(startSummaryLoop$, loopSignal);
       }
     },
   );
@@ -126,9 +127,10 @@ function createThreadSummaryDemand(
         set(reconcileHydratedThreadSummaryDemand$, signal),
         subscriptionEnd.promise,
       ]),
-      () => {
+      async () => {
         set(summaryLoopRunId$, null);
         set(resetSummaryDemand$);
+        await latestSummaryLoop;
       },
     );
   });

--- a/turbo/apps/platform/src/signals/chat-page/thread-activity-summary.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-activity-summary.ts
@@ -20,7 +20,6 @@ import {
   setLoop,
   withCleanup,
 } from "../utils.ts";
-import { registerChatEventChangeHandler$ } from "./chat-event-change-registry.ts";
 import { liveRunIdsFromChatEvents } from "./chat-event-state.ts";
 import type { ChatEvent } from "./chat-event-types.ts";
 import type { ThreadMeta } from "./chat-thread-event-sourcing.ts";
@@ -38,21 +37,21 @@ export interface ThinkingSummaries extends Pick<
   readonly messages: readonly ThinkingMessage[];
 }
 
-function createThinkingSummaryDemand(
+function createThreadSummaryDemand(
   threadId: string,
   currentActiveRunId$: Computed<string | null>,
-  chatEvents$: Computed<ChatEvent[]>,
 ) {
-  const internalReloadDemandSummary$ = state(0);
-  const summaryDemandRunId$ = state<string | null>(null);
-  const summaryDemandReadyRunId$ = state<string | null>(null);
+  const internalReloadThreadSummaries$ = state(0);
+  const summaryLoopRunId$ = state<string | null>(null);
   const resetSummaryDemand$ = resetSignal();
-  const demandSummaries$ = computed(async (get) => {
-    get(internalReloadDemandSummary$);
-    const runId = get(summaryDemandRunId$);
-    if (!runId || get(summaryDemandReadyRunId$) !== runId) {
+  const threadSummaries$ = computed(async (get) => {
+    const runId = get(currentActiveRunId$);
+    if (runId === null) {
       return null;
     }
+    // Run changes invalidate this computed directly. The reload dependency only
+    // drives interval refreshes while this thread has summary demand.
+    get(internalReloadThreadSummaries$);
     const response = await accept(
       get(apiClient$)(chatThreadActivitySummaryContract).summarize({
         params: { id: threadId },
@@ -74,12 +73,12 @@ function createThinkingSummaryDemand(
     }
     return data;
   });
-  const startSummaryDemand$ = command(
+  const startSummaryLoop$ = command(
     async ({ set }, signal: AbortSignal): Promise<void> => {
       const [completion] = await Promise.allSettled([
         setLoop(
           () => {
-            set(internalReloadDemandSummary$, (version) => {
+            set(internalReloadThreadSummaries$, (version) => {
               return version + 1;
             });
             return false;
@@ -97,69 +96,44 @@ function createThinkingSummaryDemand(
       }
     },
   );
+  const reconcileThreadSummaryDemand$ = command(
+    ({ get, set }, demandOwnerSignal: AbortSignal): void => {
+      demandOwnerSignal.throwIfAborted();
+      const runId = get(currentActiveRunId$);
+      if (runId === get(summaryLoopRunId$)) {
+        return;
+      }
+      const loopSignal = set(resetSummaryDemand$, demandOwnerSignal);
+      set(summaryLoopRunId$, runId);
+      if (runId !== null) {
+        set(startSummaryLoop$, loopSignal);
+      }
+    },
+  );
+  const reconcileHydratedThreadSummaryDemand$ = command(
+    async ({ get, set }, signal: AbortSignal): Promise<void> => {
+      await get(initialFeatureSwitchHydration$);
+      signal.throwIfAborted();
+      set(reconcileThreadSummaryDemand$, signal);
+    },
+  );
   const subscribe$ = command(async ({ set }, signal: AbortSignal) => {
     signal.throwIfAborted();
-    let activeDemand = Promise.resolve();
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const ensureSummaryDemand$ = command(
-      async ({ get, set }, demandOwnerSignal: AbortSignal) => {
-        demandOwnerSignal.throwIfAborted();
-        const runId = get(currentActiveRunId$);
-        if (
-          runId === get(summaryDemandRunId$) &&
-          (runId === null || get(summaryDemandReadyRunId$) === runId)
-        ) {
-          return;
-        }
-        set(summaryDemandReadyRunId$, null);
-        const previousDemand = activeDemand;
-        const demandSignal = set(resetSummaryDemand$, demandOwnerSignal);
-        set(summaryDemandRunId$, runId);
-        await previousDemand;
-        demandOwnerSignal.throwIfAborted();
-        if (runId !== get(summaryDemandRunId$)) {
-          return;
-        }
-        if (runId) {
-          activeDemand = set(startSummaryDemand$, demandSignal);
-          set(summaryDemandReadyRunId$, runId);
-        }
-      },
-    );
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const afterEventsChange$ = command(({ set }) => {
-      return set(ensureSummaryDemand$, signal);
-    });
-    set(
-      registerChatEventChangeHandler$,
-      chatEvents$,
-      afterEventsChange$,
-      signal,
-    );
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const ensureHydratedSummaryDemand$ = command(
-      async ({ get, set }, signal: AbortSignal) => {
-        await get(initialFeatureSwitchHydration$);
-        signal.throwIfAborted();
-        await set(ensureSummaryDemand$, signal);
-      },
-    );
+    set(reconcileThreadSummaryDemand$, signal);
     const subscriptionEnd = createDeferredPromise<void>(signal);
     await withCleanup(
       Promise.all([
-        set(ensureSummaryDemand$, signal),
-        set(ensureHydratedSummaryDemand$, signal),
+        set(reconcileHydratedThreadSummaryDemand$, signal),
         subscriptionEnd.promise,
       ]),
-      async () => {
-        set(summaryDemandReadyRunId$, null);
+      () => {
+        set(summaryLoopRunId$, null);
         set(resetSummaryDemand$);
-        await activeDemand;
       },
     );
   });
 
-  return { demandSummaries$, subscribe$, summaryDemandRunId$ };
+  return { threadSummaries$, reconcileThreadSummaryDemand$, subscribe$ };
 }
 
 export function createThreadActivitySummarySignals(
@@ -188,16 +162,13 @@ export function createThreadActivitySummarySignals(
         .at(-1) ?? null
     );
   });
-  const demand = createThinkingSummaryDemand(
-    threadId,
-    currentActiveRunId$,
-    chatEvents$,
-  );
+  const demand = createThreadSummaryDemand(threadId, currentActiveRunId$);
 
   return {
     subscribe$: demand.subscribe$,
+    reconcileThreadSummaryDemand$: demand.reconcileThreadSummaryDemand$,
     enabled$,
-    thinkingSummaries$: demand.demandSummaries$,
-    thinkingRunId$: demand.summaryDemandRunId$,
+    thinkingSummaries$: demand.threadSummaries$,
+    thinkingRunId$: currentActiveRunId$,
   };
 }


### PR DESCRIPTION
## Summary
- make each thread's activity summary computed read the authoritative active run before subscribing to interval reloads
- reconcile at most one polling loop per thread, replacing or stopping it only when the active run ID changes
- compose the stable demand reconciler into the existing thread event-change command and preserve initial and feature-hydration reconciliation under the thread owner signal
- remove the three nested-command suppressions and the obsolete ready-run handoff state

## Verification
- `git diff --check`
- Source-level review against the existing `chat-activity-summary.test.tsx` coverage for event startup, feature hydration, interval refresh, run replacement/termination, hidden-page polling, and navigation cancellation
- Local Prettier, ESLint, TypeScript, and Vitest commands could not start because this checkout has no installed `node_modules`; the PR pipeline will run those checks
