### PR TITLE
feat(api): trigger resend onboarding on user creation

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -185,6 +185,10 @@ export interface ApiTestMocks {
   };
   readonly resend: {
     readonly send: AsyncMock;
+    readonly eventsSend: AsyncMock;
+    readonly contactsCreate: AsyncMock;
+    readonly contactsGet: AsyncMock;
+    readonly contactsUpdate: AsyncMock;
   };
   readonly signalTimers: {
     readonly delay: SignalTimerDelayMock;
@@ -329,6 +333,14 @@ export interface ApiTestMocks {
 interface ResendClientMock {
   readonly emails: {
     readonly send: ApiTestMocks["resend"]["send"];
+  };
+  readonly events: {
+    readonly send: ApiTestMocks["resend"]["eventsSend"];
+  };
+  readonly contacts: {
+    readonly create: ApiTestMocks["resend"]["contactsCreate"];
+    readonly get: ApiTestMocks["resend"]["contactsGet"];
+    readonly update: ApiTestMocks["resend"]["contactsUpdate"];
   };
 }
 type SlackWebClientMock = Omit<ApiTestMocks["slack"], "fetchFile">;
@@ -569,6 +581,10 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
     },
     resend: {
       send: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      eventsSend: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      contactsCreate: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      contactsGet: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+      contactsUpdate: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     signalTimers: {
       delay:
@@ -964,6 +980,14 @@ vi.mock("resend", () => {
         const client: ResendClientMock = {
           emails: {
             send: apiTestMocks.resend.send,
+          },
+          events: {
+            send: apiTestMocks.resend.eventsSend,
+          },
+          contacts: {
+            create: apiTestMocks.resend.contactsCreate,
+            get: apiTestMocks.resend.contactsGet,
+            update: apiTestMocks.resend.contactsUpdate,
           },
         };
         return client;
@@ -1415,6 +1439,10 @@ export function resetApiTestMocks(): void {
   apiTestMocks.dns.lookupOverrides.clear();
   apiTestMocks.nodeRequest.pinnedAddresses.length = 0;
   apiTestMocks.resend.send.mockReset();
+  apiTestMocks.resend.eventsSend.mockReset();
+  apiTestMocks.resend.contactsCreate.mockReset();
+  apiTestMocks.resend.contactsGet.mockReset();
+  apiTestMocks.resend.contactsUpdate.mockReset();
   apiTestMocks.signalTimers.delay.mockReset();
   apiTestMocks.slack.assistant.threads.setStatus.mockReset();
   apiTestMocks.slack.chat.getPermalink.mockReset();

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-clerk-lifecycle.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-clerk-lifecycle.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getApiTestMocks } from "../../../__tests__/mocks";
+import type { TestContext } from "../../../__tests__/test-context";
+import { clearMockedEnv, mockEnv } from "../../../lib/env";
+import { flushWaitUntilForTest } from "../../context/wait-until";
+import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+
+describe("Clerk user.created lifecycle integration", () => {
+  const mocks = getApiTestMocks();
+  const context: TestContext = {
+    signal: new AbortController().signal,
+    mocks,
+    sessionHistoryBlobs: new Map(),
+  };
+  const webhooks = createWebhookCallbackApi(context);
+  const userCreatedData = {
+    id: "user_123",
+    created_at: 1_757_600_000_000,
+    first_name: "Scarlett",
+    last_name: "Xie",
+    primary_email_address_id: "idn_123",
+    email_addresses: [
+      {
+        id: "idn_123",
+        email_address: "scarlett@example.com",
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    clearMockedEnv();
+    mockEnv("ENV", "development");
+    mocks.resend.contactsCreate.mockReset();
+    mocks.resend.contactsGet.mockReset();
+    mocks.resend.contactsUpdate.mockReset();
+    mocks.resend.eventsSend.mockReset();
+  });
+
+  async function userCreatedWebhook(data: unknown): Promise<void> {
+    webhooks.configureClerkWebhookSecret();
+    webhooks.verifyNextClerkWebhook({ type: "user.created", data });
+    const response = await webhooks.requestClerkWebhook("{}", {}, [200]);
+    expect(response.body).toBe("OK");
+    await flushWaitUntilForTest();
+  }
+
+  it("does not emit a Resend event outside production", async () => {
+    await userCreatedWebhook(userCreatedData);
+
+    expect(mocks.resend.eventsSend).not.toHaveBeenCalled();
+  });
+
+  it("emits the Resend event after a production registration", async () => {
+    mockEnv("ENV", "production");
+    mocks.resend.contactsCreate.mockResolvedValue({
+      data: { id: "contact_123" },
+      error: null,
+    });
+    mocks.resend.eventsSend.mockResolvedValue({
+      data: { object: "event", event: "user.created" },
+      error: null,
+    });
+
+    await userCreatedWebhook(userCreatedData);
+
+    expect(mocks.resend.contactsCreate).toHaveBeenCalledExactlyOnceWith({
+      email: "scarlett@example.com",
+      firstName: "Scarlett",
+      lastName: "Xie",
+    });
+    expect(mocks.resend.eventsSend).toHaveBeenCalledExactlyOnceWith({
+      event: "user.created",
+      email: "scarlett@example.com",
+      payload: {
+        user_id: "user_123",
+        first_name: "Scarlett",
+        last_name: "Xie",
+        registered_at: "2025-09-11T14:13:20.000Z",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
@@ -22,6 +22,7 @@ import {
 } from "../services/webhooks-clerk-cleanup.service";
 import { handleUsagePackInvitationAccepted } from "../services/usage-pack-invitation-purchase.service";
 import { recordMorningBriefMembership } from "../services/morning-brief-enrollment-data.service";
+import { sendUserCreatedLifecycleEvent } from "../services/resend-lifecycle.service";
 import {
   ensureMorningBriefDefaultEnabled$,
   type EnsureMorningBriefDefaultEnabledResult,
@@ -527,6 +528,15 @@ const postClerkWebhook$ = command(
         return missingOrganizationDeletedIdResponse(event.data);
       }
       return await set(handleOrganizationDeletedWebhook$, orgId, signal);
+    }
+
+    if (event.type === "user.created") {
+      waitUntil(
+        tapError(sendUserCreatedLifecycleEvent(event.data), (error) => {
+          L.error("user.created lifecycle event failed", { error });
+        }),
+      );
+      return new Response("OK", { status: 200 });
     }
 
     if (event.type === "user.deleted") {

--- a/turbo/apps/api/src/signals/services/resend-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/resend-lifecycle.service.ts
@@ -1,0 +1,184 @@
+import { Resend } from "resend";
+
+import { env, optionalEnv } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { nowDate } from "../../lib/time";
+import { settle } from "../utils";
+
+const L = logger("ResendLifecycle");
+const USER_CREATED_EVENT = "user.created";
+
+function propertyOf(value: unknown, key: string): unknown {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  return Reflect.get(value, key);
+}
+
+function stringPropertyOf(value: unknown, key: string): string | undefined {
+  const property = propertyOf(value, key);
+  return typeof property === "string" && property.trim().length > 0
+    ? property.trim()
+    : undefined;
+}
+
+function numberPropertyOf(value: unknown, key: string): number | undefined {
+  const property = propertyOf(value, key);
+  return typeof property === "number" && Number.isFinite(property)
+    ? property
+    : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return stringPropertyOf(error, "message") ?? String(error);
+}
+
+interface UserCreatedIdentity {
+  readonly userId: string;
+  readonly email: string;
+  readonly firstName?: string;
+  readonly lastName?: string;
+  readonly registeredAt: string;
+}
+
+function userCreatedIdentity(data: unknown): UserCreatedIdentity | undefined {
+  const userId = stringPropertyOf(data, "id");
+  const emailAddresses = propertyOf(data, "email_addresses");
+  const camelEmailAddresses = propertyOf(data, "emailAddresses");
+  const addresses = Array.isArray(emailAddresses)
+    ? emailAddresses
+    : Array.isArray(camelEmailAddresses)
+      ? camelEmailAddresses
+      : [];
+  const primaryEmailAddressId =
+    stringPropertyOf(data, "primary_email_address_id") ??
+    stringPropertyOf(data, "primaryEmailAddressId");
+  const primaryAddress =
+    addresses.find((address) => {
+      return (
+        primaryEmailAddressId !== undefined &&
+        stringPropertyOf(address, "id") === primaryEmailAddressId
+      );
+    }) ?? addresses[0];
+  const email =
+    stringPropertyOf(primaryAddress, "email_address") ??
+    stringPropertyOf(primaryAddress, "emailAddress");
+
+  if (!userId || !email || !email.includes("@")) {
+    return undefined;
+  }
+
+  const createdAtMilliseconds =
+    numberPropertyOf(data, "created_at") ?? numberPropertyOf(data, "createdAt");
+  const createdAt =
+    createdAtMilliseconds === undefined
+      ? nowDate()
+      : new Date(createdAtMilliseconds);
+  const registeredAt = Number.isFinite(createdAt.getTime())
+    ? createdAt.toISOString()
+    : nowDate().toISOString();
+  const firstName =
+    stringPropertyOf(data, "first_name") ?? stringPropertyOf(data, "firstName");
+  const lastName =
+    stringPropertyOf(data, "last_name") ?? stringPropertyOf(data, "lastName");
+
+  return {
+    userId,
+    email,
+    ...(firstName ? { firstName } : {}),
+    ...(lastName ? { lastName } : {}),
+    registeredAt,
+  };
+}
+
+type ResendClient = Pick<Resend, "contacts" | "events">;
+
+async function upsertContact(
+  resend: ResendClient,
+  identity: UserCreatedIdentity,
+): Promise<void> {
+  const created = await resend.contacts.create({
+    email: identity.email,
+    firstName: identity.firstName,
+    lastName: identity.lastName,
+  });
+  if (!created.error) {
+    return;
+  }
+
+  // A new Clerk event can race with the daily audience sync. Treat an existing
+  // Resend contact as an upsert, while leaving its unsubscribe state untouched.
+  const existing = await resend.contacts.get({ email: identity.email });
+  if (existing.error) {
+    throw new Error(
+      `Could not create or find Resend contact: ${errorMessage(created.error)}; ${errorMessage(existing.error)}`,
+    );
+  }
+
+  const updated = await resend.contacts.update({
+    email: identity.email,
+    firstName: identity.firstName,
+    lastName: identity.lastName,
+  });
+  if (updated.error) {
+    throw new Error(
+      `Could not update existing Resend contact: ${errorMessage(updated.error)}`,
+    );
+  }
+}
+
+/**
+ * Starts the Resend onboarding Automation for a newly registered production
+ * user. The Automation itself remains the source of truth for the drip timing.
+ */
+export async function sendUserCreatedLifecycleEvent(
+  data: unknown,
+): Promise<void> {
+  if (env("ENV") !== "production") {
+    L.debug("skipping lifecycle event outside production");
+    return;
+  }
+
+  const apiKey = optionalEnv("RESEND_API_KEY");
+  if (!apiKey) {
+    L.error("cannot send lifecycle event without RESEND_API_KEY");
+    return;
+  }
+
+  const identity = userCreatedIdentity(data);
+  if (!identity) {
+    L.error("user.created event missing a valid user email or ID");
+    return;
+  }
+
+  const resend = new Resend(apiKey);
+  const contactSync = await settle(upsertContact(resend, identity));
+  if (!contactSync.ok) {
+    // Contact metadata is helpful for personalization, but it must not block
+    // the lifecycle event. Resend can create the contact when the event runs.
+    L.warn("could not synchronize Resend contact before lifecycle event", {
+      userId: identity.userId,
+      error: contactSync.error,
+    });
+  }
+
+  const result = await resend.events.send({
+    event: USER_CREATED_EVENT,
+    email: identity.email,
+    payload: {
+      user_id: identity.userId,
+      first_name: identity.firstName ?? "",
+      last_name: identity.lastName ?? "",
+      registered_at: identity.registeredAt,
+    },
+  });
+  if (result.error) {
+    throw new Error(
+      `Could not send Resend ${USER_CREATED_EVENT} event: ${errorMessage(result.error)}`,
+    );
+  }
+
+  L.debug("sent Resend user.created lifecycle event", {
+    userId: identity.userId,
+  });
+}


### PR DESCRIPTION
## Summary
- Trigger the Resend `user.created` custom event from verified Clerk `user.created` webhooks in production only.
- Upsert the Resend contact name before dispatching the event without changing unsubscribe state.
- Add external-behavior coverage for development/production routing.

## Resend configuration already prepared
- Custom event: `user.created`
- Disabled Automation: `Okou Lifecycle Onboarding | Signup Day 0-7`
- Published templates: Day 0, Day 1, Day 3, and Day 7

The Automation remains disabled until copy and launch approval.

## Verification
- `pnpm --filter api run check-types:gateways`
- `pnpm --filter api run check-types:core`
- `pnpm --filter api run check-types:tests`
- `pnpm --filter api run check-types:bootstrap`
- `pnpm --filter api run check-types:bootstrap-wiring`
- ESLint on changed files
- Targeted Clerk webhook lifecycle tests
