### PR TITLE
refactor(platform): simplify activity summary polling

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-event-change-registry.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-change-registry.ts
@@ -1,21 +1,30 @@
 import { command, state, type Command, type Computed } from "ccstate";
 import type { ChatEvent } from "./chat-event-types.ts";
 
-type ChatEventChangeHandler = Command<Promise<void>, [AbortSignal]>;
+type ChatEventsSignal = Computed<ChatEvent[]>;
+
+export interface ChatEventChangeHandler {
+  readonly command$: Command<
+    Promise<void>,
+    [ChatEventChangeHandler, AbortSignal]
+  >;
+}
 
 interface ChatEventChangeRegistration {
   readonly id: string;
-  readonly handler$: ChatEventChangeHandler;
+  readonly handler: ChatEventChangeHandler;
 }
-
-type ChatEventsSignal = Computed<ChatEvent[]>;
 
 const registrationsByEvents$ = state(
   new Map<ChatEventsSignal, readonly ChatEventChangeRegistration[]>(),
 );
+const ownerSignalsByRegistrationId$ = state(new Map<string, AbortSignal>());
 
 const unregisterChatEventChangeHandler$ = command(
   ({ get, set }, events$: ChatEventsSignal, id: string): void => {
+    const ownerSignals = new Map(get(ownerSignalsByRegistrationId$));
+    ownerSignals.delete(id);
+    set(ownerSignalsByRegistrationId$, ownerSignals);
     const current = get(registrationsByEvents$);
     const registrations = current.get(events$);
     if (registrations === undefined) {
@@ -34,19 +43,40 @@ const unregisterChatEventChangeHandler$ = command(
   },
 );
 
+const invokeChatEventChangeHandler$ = command(
+  async (
+    { set },
+    handler: ChatEventChangeHandler,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const [completion] = await Promise.allSettled([
+      set(handler.command$, handler, signal),
+    ]);
+    if (signal.aborted) {
+      return;
+    }
+    if (completion.status === "rejected") {
+      throw completion.reason;
+    }
+  },
+);
+
 export const registerChatEventChangeHandler$ = command(
   (
     { get, set },
     events$: ChatEventsSignal,
-    handler$: ChatEventChangeHandler,
+    handler: ChatEventChangeHandler,
     signal: AbortSignal,
   ): void => {
     signal.throwIfAborted();
     const id = crypto.randomUUID();
     const current = get(registrationsByEvents$);
     const next = new Map(current);
-    next.set(events$, [...(current.get(events$) ?? []), { id, handler$ }]);
+    next.set(events$, [...(current.get(events$) ?? []), { id, handler }]);
     set(registrationsByEvents$, next);
+    const ownerSignals = new Map(get(ownerSignalsByRegistrationId$));
+    ownerSignals.set(id, signal);
+    set(ownerSignalsByRegistrationId$, ownerSignals);
     signal.addEventListener(
       "abort",
       () => {
@@ -63,10 +93,22 @@ export const notifyChatEventsChanged$ = command(
     events$: ChatEventsSignal,
     signal: AbortSignal,
   ): Promise<void> => {
+    const ownerSignals = get(ownerSignalsByRegistrationId$);
     await Promise.all(
-      (get(registrationsByEvents$).get(events$) ?? []).map((registration) => {
-        return set(registration.handler$, signal);
-      }),
+      (get(registrationsByEvents$).get(events$) ?? []).flatMap(
+        (registration) => {
+          const ownerSignal = ownerSignals.get(registration.id);
+          return ownerSignal === undefined
+            ? []
+            : [
+                set(
+                  invokeChatEventChangeHandler$,
+                  registration.handler,
+                  AbortSignal.any([ownerSignal, signal]),
+                ),
+              ];
+        },
+      ),
     );
     signal.throwIfAborted();
   },

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -237,7 +237,10 @@ import type {
   SendChatEventResult,
   SendInputChatEvent,
 } from "./chat-event-signals.ts";
-import { registerChatEventChangeHandler$ } from "./chat-event-change-registry.ts";
+import {
+  registerChatEventChangeHandler$,
+  type ChatEventChangeHandler,
+} from "./chat-event-change-registry.ts";
 import {
   canonicalUserMessageFileUrl,
   userMessageFileAttachments,
@@ -2394,7 +2397,12 @@ function createEventChangeEffects(
     },
   );
   const afterEventsChange$ = command(
-    async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    async (
+      { get, set },
+      _handler: ChatEventChangeHandler,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      signal.throwIfAborted();
       const hasOptimisticUserMessage = get(
         chatEvents.hasOptimisticUserMessage$,
       );
@@ -2423,18 +2431,21 @@ function createEventChangeEffects(
       signal.throwIfAborted();
     },
   );
-  return { sidebar, afterEventsChange$ };
+  const eventChangeHandler: ChatEventChangeHandler = Object.freeze({
+    command$: afterEventsChange$,
+  });
+  return { sidebar, eventChangeHandler };
 }
 
 function createChatEventPresentationLifecycle({
   chatEvents,
-  afterEventsChange$,
+  eventChangeHandler,
   syncVisibleEventTrees$,
   enableSidebarEntryAnimations$,
   initialEventsReady$,
 }: {
   readonly chatEvents: ChatEventSignals;
-  readonly afterEventsChange$: Command<Promise<void>, [AbortSignal]>;
+  readonly eventChangeHandler: ChatEventChangeHandler;
   readonly syncVisibleEventTrees$: Command<
     Promise<void>,
     [boolean, AbortSignal]
@@ -2454,7 +2465,7 @@ function createChatEventPresentationLifecycle({
       set(
         registerChatEventChangeHandler$,
         chatEvents.chatEvents$,
-        afterEventsChange$,
+        eventChangeHandler,
         signal,
       );
       await set(syncVisibleEventTrees$, false, signal);
@@ -2610,7 +2621,7 @@ function createChatThreadMessagePipeline(
   );
   const lifecycle = createChatEventPresentationLifecycle({
     chatEvents,
-    afterEventsChange$: effects.afterEventsChange$,
+    eventChangeHandler: effects.eventChangeHandler,
     syncVisibleEventTrees$,
     enableSidebarEntryAnimations$: effects.sidebar.enableEntryAnimations$,
     initialEventsReady$,
@@ -2686,6 +2697,10 @@ function createEventRunIndicatorState(chatEvents$: Computed<ChatEvent[]>) {
 // Factory: createRunTracking
 // ---------------------------------------------------------------------------
 
+type ThreadActivitySummarySignals = ReturnType<
+  typeof createThreadActivitySummarySignals
+>;
+
 interface RunTrackingDeps {
   threadId: string;
   setupChatEvents$: Command<Promise<void>, [AbortSignal]>;
@@ -2693,7 +2708,8 @@ interface RunTrackingDeps {
   syncHydratedEventTrees$: Command<Promise<void>, [AbortSignal]>;
   reloadArtifacts$: Command<void, []>;
   subscribeBrowserSessions$: Command<Promise<void>, [AbortSignal]>;
-  subscribeThinkingSummaries$: Command<Promise<void>, [AbortSignal]>;
+  subscribeThinkingSummaries$: ThreadActivitySummarySignals["subscribe$"];
+  thinkingSummarySubscription: ThreadActivitySummarySignals["subscription"];
   automationSignals: Pick<ChatPanelSignals, "headerAutomations">;
   cancellationRecovery: ReturnType<typeof createCancellationRecoverySignals>;
   reloadConnectorAccounts$: Command<void, []>;
@@ -3056,6 +3072,7 @@ function createRunTracking({
   reloadArtifacts$,
   subscribeBrowserSessions$,
   subscribeThinkingSummaries$,
+  thinkingSummarySubscription,
   automationSignals,
   cancellationRecovery,
   reloadConnectorAccounts$,
@@ -3098,7 +3115,7 @@ function createRunTracking({
     await Promise.all([
       set(syncHydratedEventTrees$, signal),
       set(subscribeBrowserSessions$, signal),
-      set(subscribeThinkingSummaries$, signal),
+      set(subscribeThinkingSummaries$, thinkingSummarySubscription, signal),
       set(
         subscribeChatThreadRealtime$,
         {
@@ -4047,6 +4064,7 @@ function createChatPanelSignalsWithDraft(
     reloadArtifacts$: messages.reloadArtifacts$,
     subscribeBrowserSessions$: messages.subscribeBrowserSessions$,
     subscribeThinkingSummaries$: activity.subscribe$,
+    thinkingSummarySubscription: activity.subscription,
     automationSignals: threadOwned,
     cancellationRecovery,
     reloadConnectorAccounts$: composer.connector.accounts.reload$,

--- a/turbo/apps/platform/src/signals/chat-page/thread-activity-summary.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-activity-summary.ts
@@ -1,4 +1,4 @@
-import { command, computed, state, type Computed } from "ccstate";
+import { command, computed, state, type Computed, type State } from "ccstate";
 import {
   activitySummaryResponseSchema,
   chatThreadActivitySummaryContract,
@@ -10,17 +10,12 @@ import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { accept } from "../../lib/accept.ts";
 import { currentChatThreadId$ } from "../agent-chat.ts";
 import { apiClient$ } from "../api-client.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import { setLoop } from "../utils.ts";
 import {
-  featureSwitch$,
-  initialFeatureSwitchHydration$,
-} from "../external/feature-switch.ts";
-import {
-  createDeferredPromise,
-  resetSignal,
-  setLoop,
-  withCleanup,
-} from "../utils.ts";
-import { registerChatEventChangeHandler$ } from "./chat-event-change-registry.ts";
+  registerChatEventChangeHandler$,
+  type ChatEventChangeHandler,
+} from "./chat-event-change-registry.ts";
 import { liveRunIdsFromChatEvents } from "./chat-event-state.ts";
 import type { ChatEvent } from "./chat-event-types.ts";
 import type { ThreadMeta } from "./chat-thread-event-sourcing.ts";
@@ -38,19 +33,116 @@ export interface ThinkingSummaries extends Pick<
   readonly messages: readonly ThinkingMessage[];
 }
 
+interface ThreadActivitySummarySubscription extends ChatEventChangeHandler {
+  readonly chatEvents$: Computed<ChatEvent[]>;
+  readonly currentActiveRunId$: Computed<string | null>;
+  readonly reloadVersion$: State<number>;
+  readonly runId$: State<string | null>;
+  readonly readyRunId$: State<string | null>;
+}
+
+function isThreadActivitySummarySubscription(
+  handler: ChatEventChangeHandler,
+): handler is ThreadActivitySummarySubscription {
+  return handler.command$ === afterThreadActivitySummaryEventsChange$;
+}
+
+const reconcileThreadActivitySummaryDemand$ = command(
+  (
+    { get, set },
+    subscription: ThreadActivitySummarySubscription,
+    signal: AbortSignal,
+  ): boolean => {
+    signal.throwIfAborted();
+    const runId = get(subscription.currentActiveRunId$);
+    if (
+      runId === get(subscription.runId$) &&
+      (runId === null || get(subscription.readyRunId$) === runId)
+    ) {
+      return false;
+    }
+    set(subscription.readyRunId$, null);
+    set(subscription.runId$, runId);
+    return runId !== null;
+  },
+);
+
+const reloadThreadActivitySummaryDemand$ = command(
+  ({ get, set }, subscription: ThreadActivitySummarySubscription): void => {
+    const runId = get(subscription.runId$);
+    if (runId === null || get(subscription.currentActiveRunId$) !== runId) {
+      return;
+    }
+    set(subscription.reloadVersion$, (version) => {
+      return version + 1;
+    });
+    set(subscription.readyRunId$, runId);
+  },
+);
+
+const afterThreadActivitySummaryEventsChange$ = command(
+  (
+    { set },
+    handler: ChatEventChangeHandler,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    signal.throwIfAborted();
+    if (!isThreadActivitySummarySubscription(handler)) {
+      throw new Error("Invalid thread activity summary event handler");
+    }
+    if (set(reconcileThreadActivitySummaryDemand$, handler, signal)) {
+      set(reloadThreadActivitySummaryDemand$, handler);
+    }
+    return Promise.resolve();
+  },
+);
+
+const subscribeThreadActivitySummaries$ = command(
+  async (
+    { set },
+    subscription: ThreadActivitySummarySubscription,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    signal.throwIfAborted();
+    set(
+      registerChatEventChangeHandler$,
+      subscription.chatEvents$,
+      subscription,
+      signal,
+    );
+    set(reconcileThreadActivitySummaryDemand$, subscription, signal);
+    await setLoop(
+      () => {
+        set(reloadThreadActivitySummaryDemand$, subscription);
+        return false;
+      },
+      REQUEST_INTERVAL_MS,
+      signal,
+      { testIntervalMs: 100 },
+    );
+  },
+);
+
 function createThinkingSummaryDemand(
   threadId: string,
   currentActiveRunId$: Computed<string | null>,
   chatEvents$: Computed<ChatEvent[]>,
 ) {
-  const internalReloadDemandSummary$ = state(0);
-  const summaryDemandRunId$ = state<string | null>(null);
-  const summaryDemandReadyRunId$ = state<string | null>(null);
-  const resetSummaryDemand$ = resetSignal();
+  const reloadVersion$ = state(0);
+  const runId$ = state<string | null>(null);
+  const readyRunId$ = state<string | null>(null);
+  const subscription: ThreadActivitySummarySubscription = Object.freeze({
+    command$: afterThreadActivitySummaryEventsChange$,
+    chatEvents$,
+    currentActiveRunId$,
+    reloadVersion$,
+    runId$,
+    readyRunId$,
+  });
   const demandSummaries$ = computed(async (get) => {
-    get(internalReloadDemandSummary$);
-    const runId = get(summaryDemandRunId$);
-    if (!runId || get(summaryDemandReadyRunId$) !== runId) {
+    get(reloadVersion$);
+    const runId = get(runId$);
+    if (!runId || get(readyRunId$) !== runId) {
       return null;
     }
     const response = await accept(
@@ -74,92 +166,8 @@ function createThinkingSummaryDemand(
     }
     return data;
   });
-  const startSummaryDemand$ = command(
-    async ({ set }, signal: AbortSignal): Promise<void> => {
-      const [completion] = await Promise.allSettled([
-        setLoop(
-          () => {
-            set(internalReloadDemandSummary$, (version) => {
-              return version + 1;
-            });
-            return false;
-          },
-          REQUEST_INTERVAL_MS,
-          signal,
-          { testIntervalMs: 100 },
-        ),
-      ]);
-      if (signal.aborted) {
-        return;
-      }
-      if (completion.status === "rejected") {
-        throw completion.reason;
-      }
-    },
-  );
-  const subscribe$ = command(async ({ set }, signal: AbortSignal) => {
-    signal.throwIfAborted();
-    let activeDemand = Promise.resolve();
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const ensureSummaryDemand$ = command(
-      async ({ get, set }, demandOwnerSignal: AbortSignal) => {
-        demandOwnerSignal.throwIfAborted();
-        const runId = get(currentActiveRunId$);
-        if (
-          runId === get(summaryDemandRunId$) &&
-          (runId === null || get(summaryDemandReadyRunId$) === runId)
-        ) {
-          return;
-        }
-        set(summaryDemandReadyRunId$, null);
-        const previousDemand = activeDemand;
-        const demandSignal = set(resetSummaryDemand$, demandOwnerSignal);
-        set(summaryDemandRunId$, runId);
-        await previousDemand;
-        demandOwnerSignal.throwIfAborted();
-        if (runId !== get(summaryDemandRunId$)) {
-          return;
-        }
-        if (runId) {
-          activeDemand = set(startSummaryDemand$, demandSignal);
-          set(summaryDemandReadyRunId$, runId);
-        }
-      },
-    );
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const afterEventsChange$ = command(({ set }) => {
-      return set(ensureSummaryDemand$, signal);
-    });
-    set(
-      registerChatEventChangeHandler$,
-      chatEvents$,
-      afterEventsChange$,
-      signal,
-    );
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const ensureHydratedSummaryDemand$ = command(
-      async ({ get, set }, signal: AbortSignal) => {
-        await get(initialFeatureSwitchHydration$);
-        signal.throwIfAborted();
-        await set(ensureSummaryDemand$, signal);
-      },
-    );
-    const subscriptionEnd = createDeferredPromise<void>(signal);
-    await withCleanup(
-      Promise.all([
-        set(ensureSummaryDemand$, signal),
-        set(ensureHydratedSummaryDemand$, signal),
-        subscriptionEnd.promise,
-      ]),
-      async () => {
-        set(summaryDemandReadyRunId$, null);
-        set(resetSummaryDemand$);
-        await activeDemand;
-      },
-    );
-  });
 
-  return { demandSummaries$, subscribe$, summaryDemandRunId$ };
+  return { demandSummaries$, runId$, subscription };
 }
 
 export function createThreadActivitySummarySignals(
@@ -195,9 +203,10 @@ export function createThreadActivitySummarySignals(
   );
 
   return {
-    subscribe$: demand.subscribe$,
+    subscribe$: subscribeThreadActivitySummaries$,
+    subscription: demand.subscription,
     enabled$,
     thinkingSummaries$: demand.demandSummaries$,
-    thinkingRunId$: demand.summaryDemandRunId$,
+    thinkingRunId$: demand.runId$,
   };
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-activity-summary.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-activity-summary.test.tsx
@@ -191,28 +191,54 @@ test("The pending summary fallback follows a saved language change", async () =>
   expect(screen.queryByText("Thinking...")).not.toBeInTheDocument();
 });
 
-test("Authoritative switch hydration starts demand in the mounted thread", async () => {
-  installActiveRun();
+test("Authoritative switch hydration waits for a chat event before starting demand", async () => {
+  const events = installActiveRun();
   const featureResponse = createDeferredPromise<void>(context.signal);
+  const featureResponseReturned = createDeferredPromise<void>(context.signal);
   context.mocks.api(featureSwitchesContract.get, async ({ respond }) => {
     await featureResponse.promise;
-    return respond(200, {
+    const response = respond(200, {
       switches: featureSwitches,
       effectiveSwitches: featureSwitches,
     });
+    featureResponseReturned.resolve(undefined);
+    return response;
   });
+  let eventPublished = false;
+  let requestedBeforeEvent = false;
   context.mocks.api(
     chatThreadActivitySummaryContract.summarize,
     ({ respond }) => {
-      return respond(200, summary({ status: "pending", messages: [] }));
+      if (!eventPublished) {
+        requestedBeforeEvent = true;
+      }
+      return respond(200, summary());
     },
   );
 
   await setupPage({ context, path: RUN_PATH });
   await expect(screen.findByText(LEGACY_FALLBACK)).resolves.toBeVisible();
 
-  featureResponse.resolve(undefined);
+  await act(async () => {
+    featureResponse.resolve(undefined);
+    await featureResponseReturned.promise;
+  });
   await expect(screen.findByText("Thinking...")).resolves.toBeVisible();
+  expect(requestedBeforeEvent).toBeFalsy();
+  expect(screen.queryByText(PREPARATION)).not.toBeInTheDocument();
+
+  eventPublished = true;
+  events.push(
+    thinkingEvent({
+      id: "hydrated-thinking",
+      runId: RUN_ID,
+      seqId: 2,
+      text: "Preparing the original response",
+    }),
+  );
+  publishRunUpdate();
+
+  await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
   expect(screen.queryByText(LEGACY_FALLBACK)).not.toBeInTheDocument();
 });
 


### PR DESCRIPTION
## Summary
- replace per-run activity-summary tasks and explicit promise cleanup with one subscription-owned polling loop
- reconcile active runs only at subscription start and on chat-event changes, so late feature-switch hydration no longer starts demand by itself
- bind each chat-event handler registration to its owner signal while preserving notification cancellation, allowing the summary commands to live in the stable command graph
- remove the nested-command suppressions and cover the hydration trade-off in the activity-summary tests

## Verification
- `pnpm --filter @okouai/app lint` (pnpm 10.33.4)
- `corepack pnpm --filter @okouai/app check-types`
- `corepack pnpm exec knip --workspace @okouai/app --no-progress`
- `corepack pnpm exec vitest run src/views/okou-page/__tests__/chat-activity-summary.test.tsx --maxWorkers=1` (19 tests)
