### PR TITLE
test: split compound scenarios behind september ci timeout risks

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -318,200 +318,224 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     );
   });
 
-  it("dispatches linked iMessage DMs, refreshes typing, and replies with plain-text completions", async () => {
-    mockEnv("APP_URL", "https://app.okou.ai");
-    const webhooks = createWebhookCallbackApi(context);
-    const ap = createAgentPhoneBddApi(context);
-    const chat = createChatFilesBddApi(context);
-    const integrations = createBddIntegrationApi(context);
-    const { actor, phone, runnerGroup, sends } = await entitledLinkedActor();
-    await integrations.enableAuditLinkSwitch(actor);
-    const conversationId = uniqueConversationId();
+  it.each(["dispatch context", "typing and plain-text completion"] as const)(
+    "linked iMessage DMs preserve %s",
+    async (scenario) => {
+      mockEnv("APP_URL", "https://app.okou.ai");
+      const webhooks = createWebhookCallbackApi(context);
+      const ap = createAgentPhoneBddApi(context);
+      const chat = createChatFilesBddApi(context);
+      const integrations = createBddIntegrationApi(context);
+      const { actor, phone, runnerGroup, sends } = await entitledLinkedActor();
+      await integrations.enableAuditLinkSwitch(actor);
+      const conversationId = uniqueConversationId();
 
-    // Linked DM creates a run and sends a typing indicator.
-    const messageId1 = await ap.postAgentPhoneInboundMessage({
-      channel: "imessage",
-      from: phone,
-      body: "summarize my inbox",
-      conversationId,
-      isGroup: false,
-    });
-    await waitForTyping(sends, [conversationId]);
+      // Linked DM creates a run and sends a typing indicator.
+      const messageId1 = await ap.postAgentPhoneInboundMessage({
+        channel: "imessage",
+        from: phone,
+        body: "summarize my inbox",
+        conversationId,
+        isGroup: false,
+      });
+      await waitForTyping(sends, [conversationId]);
 
-    const admitted = await findAgentphoneChatEventByPromptFixture({
-      userId: actor.userId,
-      prompt: "summarize my inbox",
-    });
-    expect(admitted).toMatchObject({ eventId: expect.any(String) });
-    if (!admitted) {
-      throw new Error("Expected admitted AgentPhone input event");
-    }
-    const launchContext = await readChatEventContextFixture(admitted.eventId);
-    expect(launchContext).toMatchObject({
-      contextType: "agentphone",
-      contextId: expect.any(String),
-      agentphoneChatThreadId: expect.any(String),
-      agentphoneMessageText: "summarize my inbox",
-      agentphoneThreadContext: "",
-      agentphoneMessageId: messageId1,
-      agentphoneRootMessageId: "dm",
-      agentphoneConversationId: conversationId,
-      agentphoneChannel: "imessage",
-      agentphoneIsGroup: false,
-      agentphonePhoneHandle: phone,
-      agentphoneFromNumber: phone,
-      agentphoneToNumber: AGENTPHONE_BDD_PHONE_NUMBER,
-      agentphoneUserLinkId: expect.any(String),
-      agentphoneAgentId: AGENTPHONE_BDD_AGENT_ID,
-    });
-    const launchThreadId = launchContext?.agentphoneChatThreadId;
-    if (!launchThreadId) {
-      throw new Error("Expected AgentPhone launch context to own a thread");
-    }
-    const admittedEvents = await chat.listThreadEvents(actor, launchThreadId);
-    const admittedInput = admittedEvents.events.find((event) => {
-      return (
-        event.id === admitted.eventId && event.eventType === "input.prompt"
+      if (scenario === "dispatch context") {
+        const admitted = await findAgentphoneChatEventByPromptFixture({
+          userId: actor.userId,
+          prompt: "summarize my inbox",
+        });
+        expect(admitted).toMatchObject({ eventId: expect.any(String) });
+        if (!admitted) {
+          throw new Error("Expected admitted AgentPhone input event");
+        }
+        const launchContext = await readChatEventContextFixture(
+          admitted.eventId,
+        );
+        expect(launchContext).toMatchObject({
+          contextType: "agentphone",
+          contextId: expect.any(String),
+          agentphoneChatThreadId: expect.any(String),
+          agentphoneMessageText: "summarize my inbox",
+          agentphoneThreadContext: "",
+          agentphoneMessageId: messageId1,
+          agentphoneRootMessageId: "dm",
+          agentphoneConversationId: conversationId,
+          agentphoneChannel: "imessage",
+          agentphoneIsGroup: false,
+          agentphonePhoneHandle: phone,
+          agentphoneFromNumber: phone,
+          agentphoneToNumber: AGENTPHONE_BDD_PHONE_NUMBER,
+          agentphoneUserLinkId: expect.any(String),
+          agentphoneAgentId: AGENTPHONE_BDD_AGENT_ID,
+        });
+        const launchThreadId = launchContext?.agentphoneChatThreadId;
+        if (!launchThreadId) {
+          throw new Error("Expected AgentPhone launch context to own a thread");
+        }
+        const admittedEvents = await chat.listThreadEvents(
+          actor,
+          launchThreadId,
+        );
+        const admittedInput = admittedEvents.events.find((event) => {
+          return (
+            event.id === admitted.eventId && event.eventType === "input.prompt"
+          );
+        });
+        expect(
+          admittedInput?.eventType === "input.prompt"
+            ? admittedInput.userMessage.parts.find((part) => {
+                return part.type === "source";
+              })
+            : undefined,
+        ).toStrictEqual({ type: "source", kind: "agentphone" });
+      }
+
+      const run1 = await claimDispatchedRun(runnerGroup);
+      expect(run1.prompt).toBe("summarize my inbox");
+      if (scenario === "dispatch context") {
+        expectIntegrationImmediatelyBeforeRestrictedContent(
+          run1.appendSystemPrompt,
+          [
+            "# Current Integration",
+            "You are currently running inside: AgentPhone",
+            `Shared AgentPhone number: ${AGENTPHONE_BDD_PHONE_NUMBER}`,
+            `User phone handle: ${phone}`,
+            `AgentPhone Agent ID: ${AGENTPHONE_BDD_AGENT_ID}`,
+            "Channel: imessage",
+            "Conversation type: dm",
+            `Conversation ID: ${conversationId}`,
+            `Message ID: ${messageId1}`,
+          ].join("\n"),
+        );
+
+        await completeSandboxRun(run1.sandboxToken, run1.runId, 0);
+        return;
+      }
+
+      // Agent event dispatch refreshes the iMessage indicator while the run's
+      // AgentPhone callback is still pending.
+      const typingBody = {
+        runId: run1.runId,
+        events: [{ type: "assistant", sequenceNumber: 1 }],
+      };
+      const typingScheduled = await webhooks.requestAgentEvents(
+        typingBody,
+        { authorization: `Bearer ${run1.sandboxToken}` },
+        [200],
       );
-    });
-    expect(
-      admittedInput?.eventType === "input.prompt"
-        ? admittedInput.userMessage.parts.find((part) => {
-            return part.type === "source";
-          })
-        : undefined,
-    ).toStrictEqual({ type: "source", kind: "agentphone" });
+      expect(typingScheduled.body).toStrictEqual({
+        received: 1,
+        firstSequence: 1,
+        lastSequence: 1,
+      });
+      await waitForTyping(sends, [conversationId, conversationId]);
 
-    const run1 = await claimDispatchedRun(runnerGroup);
-    expect(run1.prompt).toBe("summarize my inbox");
-    expectIntegrationImmediatelyBeforeRestrictedContent(
-      run1.appendSystemPrompt,
-      [
-        "# Current Integration",
-        "You are currently running inside: AgentPhone",
-        `Shared AgentPhone number: ${AGENTPHONE_BDD_PHONE_NUMBER}`,
-        `User phone handle: ${phone}`,
-        `AgentPhone Agent ID: ${AGENTPHONE_BDD_AGENT_ID}`,
-        "Channel: imessage",
-        "Conversation type: dm",
-        `Conversation ID: ${conversationId}`,
-        `Message ID: ${messageId1}`,
-      ].join("\n"),
-    );
+      // Sandbox progress refreshes the typing indicator through the callback.
+      await webhooks.requestAgentHeartbeat(
+        { runId: run1.runId },
+        { authorization: `Bearer ${run1.sandboxToken}` },
+        [200],
+      );
+      await waitForTyping(sends, [
+        conversationId,
+        conversationId,
+        conversationId,
+      ]);
 
-    // Agent event dispatch refreshes the iMessage indicator while the run's
-    // AgentPhone callback is still pending.
-    const typingBody = {
-      runId: run1.runId,
-      events: [{ type: "assistant", sequenceNumber: 1 }],
-    };
-    const typingScheduled = await webhooks.requestAgentEvents(
-      typingBody,
-      { authorization: `Bearer ${run1.sandboxToken}` },
-      [200],
-    );
-    expect(typingScheduled.body).toStrictEqual({
-      received: 1,
-      firstSequence: 1,
-      lastSequence: 1,
-    });
-    await waitForTyping(sends, [conversationId, conversationId]);
+      // Completion converts markdown output to iMessage plain text and binds
+      // the delayed audit link to the configured Okou app origin.
+      const beforeCompletion = sends.messages.length;
+      await completeSandboxRun(run1.sandboxToken, run1.runId, 0, {
+        resultText: MARKDOWN_RUN_OUTPUT,
+      });
+      await waitForSendCount(sends, beforeCompletion + 1);
+      const completionReply = lastSend(sends);
+      expect(completionReply.toNumber).toBe(phone);
+      expect(completionReply.conversationId).toBeUndefined();
+      expect(completionReply.body).toContain(EXPECTED_PLAIN_RUN_OUTPUT);
+      expect(completionReply.body).toContain(
+        `Audit: https://app.okou.ai/activities/${run1.runId}`,
+      );
+      expect(completionReply.body).not.toContain("Responded by");
+    },
+  );
 
-    // Sandbox progress refreshes the typing indicator through the callback.
-    await webhooks.requestAgentHeartbeat(
-      { runId: run1.runId },
-      { authorization: `Bearer ${run1.sandboxToken}` },
-      [200],
-    );
-    await waitForTyping(sends, [
-      conversationId,
-      conversationId,
-      conversationId,
-    ]);
+  it.each(["reuse", "reset"] as const)(
+    "linked iMessage sessions support %s",
+    async (scenario) => {
+      const ap = createAgentPhoneBddApi(context);
+      const { actor, phone, runnerGroup, sends } = await entitledLinkedActor();
+      const conversationId = uniqueConversationId();
 
-    // Completion converts markdown output to iMessage plain text and binds
-    // the delayed audit link to the configured Okou app origin.
-    const beforeCompletion = sends.messages.length;
-    await completeSandboxRun(run1.sandboxToken, run1.runId, 0, {
-      resultText: MARKDOWN_RUN_OUTPUT,
-    });
-    await waitForSendCount(sends, beforeCompletion + 1);
-    const completionReply = lastSend(sends);
-    expect(completionReply.toNumber).toBe(phone);
-    expect(completionReply.conversationId).toBeUndefined();
-    expect(completionReply.body).toContain(EXPECTED_PLAIN_RUN_OUTPUT);
-    expect(completionReply.body).toContain(
-      `Audit: https://app.okou.ai/activities/${run1.runId}`,
-    );
-    expect(completionReply.body).not.toContain("Responded by");
-  });
+      const beforeFirstCompletion = sends.messages.length;
+      const messageId1 = await ap.postAgentPhoneInboundMessage({
+        channel: "imessage",
+        from: phone,
+        body: "start session",
+        conversationId,
+        isGroup: false,
+      });
+      const run1 = await claimDispatchedRun(runnerGroup);
+      await completeSandboxRun(run1.sandboxToken, run1.runId, 0);
+      await waitForSendCount(sends, beforeFirstCompletion + 1);
+      expect(lastSend(sends).body).toBe("Task completed successfully.");
+      // Session persistence happens in background callback processing, so
+      // wait for the session id to be saved before reading it.
+      const session1 = await waitForRunSessionIdPresent(actor, run1.runId);
 
-  it("reuses and resets linked iMessage sessions", async () => {
-    const ap = createAgentPhoneBddApi(context);
-    const { actor, phone, runnerGroup, sends } = await entitledLinkedActor();
-    const conversationId = uniqueConversationId();
+      if (scenario === "reuse") {
+        // The follow-up DM reuses the saved session and carries stored context.
+        await ap.postAgentPhoneInboundMessage({
+          channel: "imessage",
+          from: phone,
+          body: "follow up",
+          conversationId,
+          isGroup: false,
+        });
+        const run2 = await claimDispatchedRun(runnerGroup);
+        expect(run2.appendSystemPrompt).toContain(
+          "# AgentPhone Message Context",
+        );
+        expect(run2.appendSystemPrompt).toContain("RELATIVE_INDEX");
+        expect(run2.appendSystemPrompt).toContain(`MSG_ID: ${messageId1}`);
+        expect(run2.appendSystemPrompt).toContain("SENDER: {id: BOT}");
 
-    const beforeFirstCompletion = sends.messages.length;
-    const messageId1 = await ap.postAgentPhoneInboundMessage({
-      channel: "imessage",
-      from: phone,
-      body: "start session",
-      conversationId,
-      isGroup: false,
-    });
-    const run1 = await claimDispatchedRun(runnerGroup);
-    await completeSandboxRun(run1.sandboxToken, run1.runId, 0);
-    await waitForSendCount(sends, beforeFirstCompletion + 1);
-    expect(lastSend(sends).body).toBe("Task completed successfully.");
-    // Session persistence happens in background callback processing, so
-    // wait for the session id to be saved before reading it.
-    const session1 = await waitForRunSessionIdPresent(actor, run1.runId);
+        const beforeRun2Completion = sends.messages.length;
+        await completeSandboxRun(run2.sandboxToken, run2.runId, 0);
+        await waitForSendCount(sends, beforeRun2Completion + 1);
+        expect(lastSend(sends).body).toBe("Task completed successfully.");
+        await waitForRunSessionId(actor, run2.runId, session1);
 
-    // The follow-up DM reuses the saved session and carries stored context.
-    await ap.postAgentPhoneInboundMessage({
-      channel: "imessage",
-      from: phone,
-      body: "follow up",
-      conversationId,
-      isGroup: false,
-    });
-    const run2 = await claimDispatchedRun(runnerGroup);
-    expect(run2.appendSystemPrompt).toContain("# AgentPhone Message Context");
-    expect(run2.appendSystemPrompt).toContain("RELATIVE_INDEX");
-    expect(run2.appendSystemPrompt).toContain(`MSG_ID: ${messageId1}`);
-    expect(run2.appendSystemPrompt).toContain("SENDER: {id: BOT}");
+        return;
+      }
 
-    const beforeRun2Completion = sends.messages.length;
-    await completeSandboxRun(run2.sandboxToken, run2.runId, 0);
-    await waitForSendCount(sends, beforeRun2Completion + 1);
-    expect(lastSend(sends).body).toBe("Task completed successfully.");
-    await waitForRunSessionId(actor, run2.runId, session1);
+      // /new_session over iMessage replies without the SMS reliability warning.
+      const beforeNewSession = sends.messages.length;
+      await ap.postAgentPhoneInboundMessage({
+        channel: "imessage",
+        from: phone,
+        body: "/new_session",
+        conversationId,
+        isGroup: false,
+      });
+      await waitForSendCount(sends, beforeNewSession + 1);
+      expect(lastSend(sends).body).toBe("New session started.");
 
-    // /new_session over iMessage replies without the SMS reliability warning.
-    const beforeNewSession = sends.messages.length;
-    await ap.postAgentPhoneInboundMessage({
-      channel: "imessage",
-      from: phone,
-      body: "/new_session",
-      conversationId,
-      isGroup: false,
-    });
-    await waitForSendCount(sends, beforeNewSession + 1);
-    expect(lastSend(sends).body).toBe("New session started.");
-
-    // The next DM starts a fresh session.
-    await ap.postAgentPhoneInboundMessage({
-      channel: "imessage",
-      from: phone,
-      body: "fresh start",
-      conversationId,
-      isGroup: false,
-    });
-    const run3 = await claimDispatchedRun(runnerGroup);
-    await completeSandboxRun(run3.sandboxToken, run3.runId, 0);
-    const session3 = await waitForRunSessionIdPresent(actor, run3.runId);
-    expect(session3).not.toBe(session1);
-  });
+      // The next DM starts a fresh session.
+      await ap.postAgentPhoneInboundMessage({
+        channel: "imessage",
+        from: phone,
+        body: "fresh start",
+        conversationId,
+        isGroup: false,
+      });
+      const run3 = await claimDispatchedRun(runnerGroup);
+      await completeSandboxRun(run3.sandboxToken, run3.runId, 0);
+      const session3 = await waitForRunSessionIdPresent(actor, run3.runId);
+      expect(session3).not.toBe(session1);
+    },
+  );
 
   it("replies to failed linked iMessage runs", async () => {
     const ap = createAgentPhoneBddApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -2195,95 +2195,113 @@ describe("CHAT-02: thread connector account selection", () => {
     );
   });
 
-  it("uses the current default connector account without persisting an override", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    if (!actor.orgId) {
-      throw new Error("Expected an organization-scoped chat actor");
-    }
-    const connection = await connectors.connectManualGrant(
-      actor,
-      "openai",
-      "api-token",
-      { apiKey: "thread-selected-openai-key" },
-      agentId,
-    );
-
-    context.mocks.ably.publish.mockClear();
-    const run = await sendChatRun(actor, {
-      agentId,
-      prompt: "Use my OpenAI connector account",
-    });
-    const { claim, sandboxHeaders } = await claimChatRun(
-      runnerGroup,
-      run.runId,
-    );
-    expect(claim.secretConnectorMetadataMap?.OPENAI_TOKEN).toMatchObject({
-      sourceId: connection.id,
-    });
-
-    const selections = await accept(
-      chatThreadConnectorSelectionsClient().get({
-        headers: sessionHeaders(actor),
-        params: { id: run.threadId },
-      }),
-      [200],
-    );
-    expect(selections.body.selections).toStrictEqual([]);
-    expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
-      `chatThreadDetailChanged:${run.threadId}`,
-      null,
-    );
-
-    await completeChatRunOk(run.runId, sandboxHeaders);
-    await flushWaitUntilForTest();
-    await api.enableAgentConnectors(actor, agentId, []);
-    const unauthorizedResponse = await chat.requestSendEvent(
-      actor,
-      {
+  it.each(["revocation", "reauthorization"] as const)(
+    "uses the default connector account across %s without an override",
+    async (transition) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      if (!actor.orgId) {
+        throw new Error("Expected an organization-scoped chat actor");
+      }
+      const connection = await connectors.connectManualGrant(
+        actor,
+        "openai",
+        "api-token",
+        { apiKey: "thread-selected-openai-key" },
         agentId,
-        threadId: run.threadId,
-        prompt: "Continue while OpenAI is unauthorized",
-      },
-      [201],
-    );
-    if (unauthorizedResponse.status !== 201) {
-      throw new Error("Expected the unauthorized-connector send to succeed");
-    }
-    if (!unauthorizedResponse.body.runId) {
-      throw new Error("Expected the unauthorized-connector run to start");
-    }
-    const unauthorized = {
-      runId: unauthorizedResponse.body.runId,
-      threadId: unauthorizedResponse.body.threadId,
-    };
-    const unauthorizedClaim = await claimChatRun(
-      runnerGroup,
-      unauthorized.runId,
-    );
-    expect(
-      unauthorizedClaim.claim.secretConnectorMetadataMap?.OPENAI_TOKEN,
-    ).toBeUndefined();
-    await completeChatRunOk(
-      unauthorized.runId,
-      unauthorizedClaim.sandboxHeaders,
-    );
-    await flushWaitUntilForTest();
+      );
 
-    await api.enableAgentConnectors(actor, agentId, ["openai"]);
-    const reauthorized = await sendChatRun(actor, {
-      agentId,
-      threadId: run.threadId,
-      prompt: "Continue after OpenAI is authorized again",
-    });
-    const reauthorizedClaim = await claimChatRun(
-      runnerGroup,
-      reauthorized.runId,
-    );
-    expect(
-      reauthorizedClaim.claim.secretConnectorMetadataMap?.OPENAI_TOKEN,
-    ).toMatchObject({ sourceId: connection.id });
-    await cancelChatRun(actor, reauthorized.runId);
-  });
+      let threadId: string;
+      if (transition === "revocation") {
+        context.mocks.ably.publish.mockClear();
+        const authorized = await sendChatRun(actor, {
+          agentId,
+          prompt: "Use my OpenAI connector account",
+        });
+        const { claim, sandboxHeaders } = await claimChatRun(
+          runnerGroup,
+          authorized.runId,
+        );
+        expect(claim.secretConnectorMetadataMap?.OPENAI_TOKEN).toMatchObject({
+          sourceId: connection.id,
+        });
+
+        const selections = await accept(
+          chatThreadConnectorSelectionsClient().get({
+            headers: sessionHeaders(actor),
+            params: { id: authorized.threadId },
+          }),
+          [200],
+        );
+        expect(selections.body.selections).toStrictEqual([]);
+        expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
+          `chatThreadDetailChanged:${authorized.threadId}`,
+          null,
+        );
+
+        await completeChatRunOk(authorized.runId, sandboxHeaders);
+        await flushWaitUntilForTest();
+        threadId = authorized.threadId;
+      } else {
+        const thread = await chat.createThread(actor, {
+          agentId,
+          title: "Connector reauthorization",
+        });
+        threadId = thread.id;
+      }
+
+      await api.enableAgentConnectors(actor, agentId, []);
+      const unauthorizedResponse = await chat.requestSendEvent(
+        actor,
+        {
+          agentId,
+          threadId,
+          prompt: "Continue while OpenAI is unauthorized",
+        },
+        [201],
+      );
+      if (unauthorizedResponse.status !== 201) {
+        throw new Error("Expected the unauthorized-connector send to succeed");
+      }
+      if (!unauthorizedResponse.body.runId) {
+        throw new Error("Expected the unauthorized-connector run to start");
+      }
+      const unauthorized = {
+        runId: unauthorizedResponse.body.runId,
+        threadId: unauthorizedResponse.body.threadId,
+      };
+      const unauthorizedClaim = await claimChatRun(
+        runnerGroup,
+        unauthorized.runId,
+      );
+      expect(
+        unauthorizedClaim.claim.secretConnectorMetadataMap?.OPENAI_TOKEN,
+      ).toBeUndefined();
+      await completeChatRunOk(
+        unauthorized.runId,
+        unauthorizedClaim.sandboxHeaders,
+      );
+      await flushWaitUntilForTest();
+
+      if (transition === "revocation") {
+        return;
+      }
+
+      await api.enableAgentConnectors(actor, agentId, ["openai"]);
+      const reauthorized = await sendChatRun(actor, {
+        agentId,
+        threadId,
+        prompt: "Continue after OpenAI is authorized again",
+      });
+      const reauthorizedClaim = await claimChatRun(
+        runnerGroup,
+        reauthorized.runId,
+      );
+      expect(
+        reauthorizedClaim.claim.secretConnectorMetadataMap?.OPENAI_TOKEN,
+      ).toMatchObject({ sourceId: connection.id });
+      await cancelChatRun(actor, reauthorized.runId);
+    },
+  );
 
   it("does not persist connector overrides during concurrent first sends", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -100,6 +100,32 @@ function customConnectorValuesClient() {
   return setupApp({ context, routes })(customConnectorValuesContract);
 }
 
+async function deleteBuiltinAccountPage(
+  connectorSlug: "openai" | "github",
+  connections: readonly { readonly id: string }[],
+): Promise<void> {
+  const accountsApi = accountClient();
+  for (let offset = 0; offset < connections.length; offset += 4) {
+    const deleted = await Promise.allSettled(
+      connections.slice(offset, offset + 4).map(async (account) => {
+        await accept(
+          accountsApi.delete({
+            headers: authHeaders(),
+            params: { connectionId: account.id },
+            body: { target: { kind: "builtin", connectorSlug } },
+          }),
+          [200, 404],
+        );
+      }),
+    );
+    for (const result of deleted) {
+      if (result.status === "rejected") {
+        throw result.reason;
+      }
+    }
+  }
+}
+
 async function cleanupFixture(fixture: Fixture): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId);
   const accountsApi = accountClient();
@@ -118,18 +144,7 @@ async function cleanupFixture(fixture: Fixture): Promise<void> {
       if (accounts.status !== 200) {
         break;
       }
-      for (const account of accounts.body.connections) {
-        await accept(
-          accountsApi.delete({
-            headers: authHeaders(),
-            params: { connectionId: account.id },
-            body: {
-              target: { kind: "builtin", connectorSlug },
-            },
-          }),
-          [200, 404],
-        );
-      }
+      await deleteBuiltinAccountPage(connectorSlug, accounts.body.connections);
     }
   }
   const customConnectors = await accept(
@@ -823,7 +838,7 @@ describe("connector account lifecycle routes", () => {
     return createdAccountIds;
   }
 
-  it("paginates and summarizes more than one hundred accounts", async () => {
+  it("paginates more than one hundred accounts", async () => {
     await createBulkAccounts();
     const ids = new Set<string>();
     let cursor: string | undefined;
@@ -846,6 +861,10 @@ describe("connector account lifecycle routes", () => {
       cursor = page.body.nextCursor ?? undefined;
     } while (cursor);
     expect(ids.size).toBe(101);
+  });
+
+  it("summarizes more than one hundred accounts", async () => {
+    await createBulkAccounts();
     const summary = await accept(
       accountClient().summaries({ headers: authHeaders() }),
       [200],
@@ -927,7 +946,7 @@ describe("connector account lifecycle routes", () => {
     );
   });
 
-  it("returns no matches and rejects blank searches with more than one hundred accounts", async () => {
+  it("returns no matches for absent searches with more than one hundred accounts", async () => {
     await createBulkAccounts();
     const noMatch = await accept(
       accountClient().connections({
@@ -945,8 +964,11 @@ describe("connector account lifecycle routes", () => {
       connections: [],
       nextCursor: null,
     });
+  });
 
-    await accept(
+  it("rejects blank searches with more than one hundred accounts", async () => {
+    await createBulkAccounts();
+    const response = await accept(
       accountClient().connections({
         headers: authHeaders(),
         query: {
@@ -958,6 +980,7 @@ describe("connector account lifecycle routes", () => {
       }),
       [400],
     );
+    expect(response.status).toBe(400);
   });
 
   it("does not enumerate or mutate another member account", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -1593,7 +1593,7 @@ describe("CONN-02: OAuth device authorization", () => {
     await connectorsApi.deleteFeatureSwitches(actor);
   });
 
-  it("serializes concurrent polls and restores claims after races and provider failures", async () => {
+  it("serializes concurrent device polls when a session is superseded", async () => {
     const bdd = createBddApi(context);
     const actor = bdd.user();
     await connectorsApi.updateFeatureSwitches(actor, {
@@ -1601,7 +1601,7 @@ describe("CONN-02: OAuth device authorization", () => {
     });
 
     mockTestOAuthDeviceConnectorProvider();
-    const deferred = mockDeferredTestOAuthTokenEndpoint();
+    const deferred = mockDeferredTestOAuthTokenEndpoint(context.signal);
 
     const first = await connectorsApi.startDeviceAuth(
       actor,
@@ -1614,34 +1614,62 @@ describe("CONN-02: OAuth device authorization", () => {
       first.sessionId,
       first.sessionToken,
     );
-    await deferred.started;
+    const pollResults = await Promise.allSettled([
+      (async () => {
+        await deferred.started;
 
-    const concurrentPoll = await connectorsApi.pollDeviceAuth(
-      actor,
-      "test-oauth-device",
-      first.sessionId,
-      first.sessionToken,
-    );
-    expect(concurrentPoll).toStrictEqual({ status: "pending", interval: 0 });
-    expect(deferred.calls()).toBe(1);
+        const concurrentPoll = await connectorsApi.pollDeviceAuth(
+          actor,
+          "test-oauth-device",
+          first.sessionId,
+          first.sessionToken,
+        );
+        expect(concurrentPoll).toStrictEqual({
+          status: "pending",
+          interval: 0,
+        });
+        expect(deferred.calls()).toBe(1);
 
-    await connectorsApi.startDeviceAuth(actor, "test-oauth-device", "oauth");
-    deferred.release();
-    const racedPoll = await racedPollPromise;
-    expect(racedPoll).toStrictEqual({
-      status: "error",
-      errorCode: "session_superseded",
-      errorMessage: "OAuth device authorization session was superseded",
+        await connectorsApi.startDeviceAuth(
+          actor,
+          "test-oauth-device",
+          "oauth",
+        );
+        deferred.release();
+        const racedPoll = await racedPollPromise;
+        expect(racedPoll).toStrictEqual({
+          status: "error",
+          errorCode: "session_superseded",
+          errorMessage: "OAuth device authorization session was superseded",
+        });
+        expect(deferred.calls()).toBe(1);
+
+        const nothingPersisted = await connectorsApi.requestReadConnectorBySlug(
+          actor,
+          "test-oauth-device",
+          [404],
+        );
+        expectApiError(nothingPersisted.body);
+        expect(nothingPersisted.body.error.code).toBe("NOT_FOUND");
+      })().finally(() => {
+        deferred.release();
+      }),
+      racedPollPromise,
+    ]);
+    for (const result of pollResults) {
+      if (result.status === "rejected") {
+        throw result.reason;
+      }
+    }
+    await connectorsApi.deleteFeatureSwitches(actor);
+  });
+
+  it("restores a device poll claim after a provider failure", async () => {
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.TestOauthConnector]: true,
     });
-    expect(deferred.calls()).toBe(1);
-
-    const nothingPersisted = await connectorsApi.requestReadConnectorBySlug(
-      actor,
-      "test-oauth-device",
-      [404],
-    );
-    expectApiError(nothingPersisted.body);
-    expect(nothingPersisted.body.error.code).toBe("NOT_FOUND");
 
     mockTestOAuthDeviceConnectorProvider({
       deviceCode: "pending",
@@ -1675,7 +1703,18 @@ describe("CONN-02: OAuth device authorization", () => {
     expect(restoredPoll).toStrictEqual({ status: "pending", interval: 0 });
     expect(restoredProvider.tokenBodies).toHaveLength(1);
 
-    const staleDeferred = mockDeferredTestOAuthTokenEndpoint();
+    await connectorsApi.deleteFeatureSwitches(actor);
+  });
+
+  it("reclaims a stale device poll while its original request is pending", async () => {
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.TestOauthConnector]: true,
+    });
+
+    mockTestOAuthDeviceConnectorProvider({ deviceCode: "pending" });
+    const staleDeferred = mockDeferredTestOAuthTokenEndpoint(context.signal);
     const stale = await connectorsApi.startDeviceAuth(
       actor,
       "test-oauth-device",
@@ -1687,22 +1726,33 @@ describe("CONN-02: OAuth device authorization", () => {
       stale.sessionId,
       stale.sessionToken,
     );
-    await staleDeferred.started;
-    mockNow(now() + 31_000);
+    const pollResults = await Promise.allSettled([
+      (async () => {
+        await staleDeferred.started;
+        mockNow(now() + 31_000);
 
-    const reclaimedPoll = await connectorsApi.pollDeviceAuth(
-      actor,
-      "test-oauth-device",
-      stale.sessionId,
-      stale.sessionToken,
-    );
-    expect(reclaimedPoll).toStrictEqual({ status: "pending", interval: 0 });
-    expect(staleDeferred.calls()).toBe(2);
-    staleDeferred.release();
-    const stalePoll = await stalePollPromise;
-    expect(stalePoll).toStrictEqual({ status: "pending", interval: 0 });
-    clearMockNow();
-
+        const reclaimedPoll = await connectorsApi.pollDeviceAuth(
+          actor,
+          "test-oauth-device",
+          stale.sessionId,
+          stale.sessionToken,
+        );
+        expect(reclaimedPoll).toStrictEqual({ status: "pending", interval: 0 });
+        expect(staleDeferred.calls()).toBe(2);
+        staleDeferred.release();
+        const stalePoll = await stalePollPromise;
+        expect(stalePoll).toStrictEqual({ status: "pending", interval: 0 });
+      })().finally(() => {
+        staleDeferred.release();
+        clearMockNow();
+      }),
+      stalePollPromise,
+    ]);
+    for (const result of pollResults) {
+      if (result.status === "rejected") {
+        throw result.reason;
+      }
+    }
     await connectorsApi.deleteFeatureSwitches(actor);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -1326,13 +1326,15 @@ interface DeferredTestOAuthTokenEndpoint {
  * Shadows the test-oauth device token endpoint with a handler whose first
  * call blocks until {@link DeferredTestOAuthTokenEndpoint.release} is called
  * and then completes; later calls return authorization_pending immediately.
- * The gate auto-releases when the test finishes (even on assertion failure)
- * so a hung handler can never leak past the test; callers must still release
- * explicitly and await all in-flight polls before the test ends.
+ * The owner signal cancels both synchronization promises before detached-work
+ * teardown. Callers must still release explicitly and await all in-flight
+ * polls before the test ends; the finish hook also releases a pending gate.
  */
-export function mockDeferredTestOAuthTokenEndpoint(): DeferredTestOAuthTokenEndpoint {
+export function mockDeferredTestOAuthTokenEndpoint(
+  signal: AbortSignal,
+): DeferredTestOAuthTokenEndpoint {
   let callCount = 0;
-  const gate = createDeferredPromise<void>(AbortSignal.any([]));
+  const gate = createDeferredPromise<void>(signal);
   const releaseGate = (): void => {
     if (!gate.settled()) {
       gate.resolve(undefined);
@@ -1341,7 +1343,7 @@ export function mockDeferredTestOAuthTokenEndpoint(): DeferredTestOAuthTokenEndp
   onTestFinished(() => {
     releaseGate();
   });
-  const started = createDeferredPromise<void>(AbortSignal.any([]));
+  const started = createDeferredPromise<void>(signal);
   const markStarted = (): void => {
     if (!started.settled()) {
       started.resolve(undefined);

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -4688,176 +4688,206 @@ describe.sequential("Official Workflow installations", () => {
     }
   });
 
-  it("compensates a later provider-watch failure and retries without a visible partial installation", async () => {
-    installCatalogStorageFixture();
-    const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
-    const definitionName = `api-test-watch-${suffix}`;
-    await syncCatalog(
-      catalog([
-        activeDefinition(definitionName, [
-          scheduledBlueprint(),
-          gmailBlueprint(),
+  it.each(["installation retry", "resume retry", "agent deletion"] as const)(
+    "preserves official workflow state through %s",
+    async (scenario) => {
+      installCatalogStorageFixture();
+      const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
+      const definitionName = `api-test-watch-${suffix}`;
+      await syncCatalog(
+        catalog([
+          activeDefinition(definitionName, [
+            scheduledBlueprint(),
+            gmailBlueprint(),
+          ]),
         ]),
-      ]),
-    );
+      );
 
-    const setup = await workflowBdd.setupWorkflowOrg({
-      timezone: "Asia/Shanghai",
-    });
-    const actor = setup.actor;
-    const { agentId } = await workflowBdd.createAgent(actor);
-    let agentDeleted = false;
-    onTestFinished(async () => {
-      if (!agentDeleted) {
-        installCatalogStorageFixture();
-        await bdd.deleteAgent(actor, agentId);
-      }
-      await cleanupCatalog();
-    });
-    mockGmailConnectorOAuth({ email: `official-${suffix}@example.test` });
-    await workflowBdd.connectConnector(actor, "gmail");
-    mockOptionalEnv("GMAIL_PUBSUB_TOPIC_NAME", GMAIL_TOPIC_NAME);
-    let stopCalls = 0;
-    server.use(
-      http.post("https://gmail.googleapis.com/gmail/v1/users/me/watch", () => {
-        return HttpResponse.json({ error: "watch failed" }, { status: 500 });
-      }),
-      http.post("https://gmail.googleapis.com/gmail/v1/users/me/stop", () => {
-        stopCalls++;
-        return new HttpResponse(null, { status: 204 });
-      }),
-    );
-    await setOfficialWorkflowsEnabled(actor, true);
-    const headers = authHeaders(actor);
-    const body = {
-      agentId,
-      blueprints: [
-        {
-          blueprintKey: "daily",
-          bindings: [{ key: "cron-expression", value: "0 6 * * *" }],
-        },
-        { blueprintKey: "gmail-trigger", bindings: [] },
-      ],
-    };
+      const setup = await workflowBdd.setupWorkflowOrg({
+        timezone: "Asia/Shanghai",
+      });
+      const actor = setup.actor;
+      const { agentId } = await workflowBdd.createAgent(actor);
+      let agentDeleted = false;
+      onTestFinished(async () => {
+        if (!agentDeleted) {
+          installCatalogStorageFixture();
+          await bdd.deleteAgent(actor, agentId);
+        }
+        await cleanupCatalog();
+      });
+      mockGmailConnectorOAuth({ email: `official-${suffix}@example.test` });
+      await workflowBdd.connectConnector(actor, "gmail");
+      mockOptionalEnv("GMAIL_PUBSUB_TOPIC_NAME", GMAIL_TOPIC_NAME);
+      let stopCalls = 0;
+      server.use(
+        http.post(
+          "https://gmail.googleapis.com/gmail/v1/users/me/watch",
+          () => {
+            return scenario === "installation retry"
+              ? HttpResponse.json({ error: "watch failed" }, { status: 500 })
+              : HttpResponse.json({
+                  historyId: "100",
+                  expiration: "4102444800000",
+                });
+          },
+        ),
+        http.post("https://gmail.googleapis.com/gmail/v1/users/me/stop", () => {
+          stopCalls++;
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+      await setOfficialWorkflowsEnabled(actor, true);
+      const headers = authHeaders(actor);
+      const body = {
+        agentId,
+        blueprints: [
+          {
+            blueprintKey: "daily",
+            bindings: [{ key: "cron-expression", value: "0 6 * * *" }],
+          },
+          { blueprintKey: "gmail-trigger", bindings: [] },
+        ],
+      };
 
-    await accept(
-      officialClient().install({
-        headers,
-        params: { definitionName },
-        body,
-      }),
-      [400],
-    );
-    const listedAfterFailure = await accept(
-      workflowCollectionClient().list({
-        headers,
-        query: { agentId },
-      }),
-      [200],
-    );
-    expect(
-      listedAfterFailure.body.some((workflow) => {
-        return workflow.name === definitionName;
-      }),
-    ).toBeFalsy();
-
-    server.use(
-      http.post("https://gmail.googleapis.com/gmail/v1/users/me/watch", () => {
-        return HttpResponse.json({
-          historyId: "100",
-          expiration: "4102444800000",
-        });
-      }),
-    );
-    const retried = await accept(
-      officialClient().install({
-        headers,
-        params: { definitionName },
-        body,
-      }),
-      [201],
-    );
-    expect(retried.body.workflow.automations).toHaveLength(2);
-    expect(
-      retried.body.workflow.automations.every((automation) => {
-        return automation.enabled;
-      }),
-    ).toBeTruthy();
-    const gmailAutomation = retried.body.workflow.automations.find(
-      (automation) => {
-        return automation.official?.blueprintKey === "gmail-trigger";
-      },
-    );
-    if (!gmailAutomation) {
-      throw new Error("Expected retried Official Gmail automation");
-    }
-    await accept(
-      automationClient().disable({
-        headers,
-        params: { id: gmailAutomation.id },
-      }),
-      [200],
-    );
-    server.use(
-      http.post("https://gmail.googleapis.com/gmail/v1/users/me/watch", () => {
-        return HttpResponse.json(
-          { error: "resume watch failed" },
-          { status: 500 },
+      if (scenario === "installation retry") {
+        await accept(
+          officialClient().install({
+            headers,
+            params: { definitionName },
+            body,
+          }),
+          [400],
         );
-      }),
-    );
-    await accept(
-      automationClient().enable({
-        headers,
-        params: { id: gmailAutomation.id },
-      }),
-      [400],
-    );
-    const afterFailedResume = await accept(
-      installationClient().get({
-        headers,
-        params: { workflowId: retried.body.workflow.id },
-      }),
-      [200],
-    );
-    expect(
-      afterFailedResume.body.workflow.automations.find((automation) => {
-        return automation.id === gmailAutomation.id;
-      }),
-    ).toMatchObject({
-      enabled: false,
-      official: {
-        intendedEnabled: false,
-        reconciliationStatus: "current",
-      },
-    });
-    server.use(
-      http.post("https://gmail.googleapis.com/gmail/v1/users/me/watch", () => {
-        return HttpResponse.json({
-          historyId: "101",
-          expiration: "4102444800000",
+        const listedAfterFailure = await accept(
+          workflowCollectionClient().list({
+            headers,
+            query: { agentId },
+          }),
+          [200],
+        );
+        expect(
+          listedAfterFailure.body.some((workflow) => {
+            return workflow.name === definitionName;
+          }),
+        ).toBeFalsy();
+      }
+
+      server.use(
+        http.post(
+          "https://gmail.googleapis.com/gmail/v1/users/me/watch",
+          () => {
+            return HttpResponse.json({
+              historyId: "100",
+              expiration: "4102444800000",
+            });
+          },
+        ),
+      );
+      const retried = await accept(
+        officialClient().install({
+          headers,
+          params: { definitionName },
+          body,
+        }),
+        [201],
+      );
+      expect(retried.body.workflow.automations).toHaveLength(2);
+      expect(
+        retried.body.workflow.automations.every((automation) => {
+          return automation.enabled;
+        }),
+      ).toBeTruthy();
+      if (scenario === "installation retry") {
+        return;
+      }
+
+      if (scenario === "resume retry") {
+        const gmailAutomation = retried.body.workflow.automations.find(
+          (automation) => {
+            return automation.official?.blueprintKey === "gmail-trigger";
+          },
+        );
+        if (!gmailAutomation) {
+          throw new Error("Expected retried Official Gmail automation");
+        }
+        await accept(
+          automationClient().disable({
+            headers,
+            params: { id: gmailAutomation.id },
+          }),
+          [200],
+        );
+        server.use(
+          http.post(
+            "https://gmail.googleapis.com/gmail/v1/users/me/watch",
+            () => {
+              return HttpResponse.json(
+                { error: "resume watch failed" },
+                { status: 500 },
+              );
+            },
+          ),
+        );
+        await accept(
+          automationClient().enable({
+            headers,
+            params: { id: gmailAutomation.id },
+          }),
+          [400],
+        );
+        const afterFailedResume = await accept(
+          installationClient().get({
+            headers,
+            params: { workflowId: retried.body.workflow.id },
+          }),
+          [200],
+        );
+        expect(
+          afterFailedResume.body.workflow.automations.find((automation) => {
+            return automation.id === gmailAutomation.id;
+          }),
+        ).toMatchObject({
+          enabled: false,
+          official: {
+            intendedEnabled: false,
+            reconciliationStatus: "current",
+          },
         });
-      }),
-    );
-    await accept(
-      automationClient().enable({
-        headers,
-        params: { id: gmailAutomation.id },
-      }),
-      [200],
-    );
-    const stopCallsBeforeAgentDeletion = stopCalls;
-    await bdd.deleteAgent(actor, agentId);
-    agentDeleted = true;
-    await accept(
-      installationClient().get({
-        headers,
-        params: { workflowId: retried.body.workflow.id },
-      }),
-      [404],
-    );
-    expect(stopCalls).toBeGreaterThan(stopCallsBeforeAgentDeletion);
-  });
+        server.use(
+          http.post(
+            "https://gmail.googleapis.com/gmail/v1/users/me/watch",
+            () => {
+              return HttpResponse.json({
+                historyId: "101",
+                expiration: "4102444800000",
+              });
+            },
+          ),
+        );
+        await accept(
+          automationClient().enable({
+            headers,
+            params: { id: gmailAutomation.id },
+          }),
+          [200],
+        );
+        return;
+      }
+
+      const stopCallsBeforeAgentDeletion = stopCalls;
+      await bdd.deleteAgent(actor, agentId);
+      agentDeleted = true;
+      await accept(
+        installationClient().get({
+          headers,
+          params: { workflowId: retried.body.workflow.id },
+        }),
+        [404],
+      );
+      expect(stopCalls).toBeGreaterThan(stopCallsBeforeAgentDeletion);
+    },
+  );
 
   it("preserves the Google Forms account projection across same-target reconfiguration", async () => {
     installCatalogStorageFixture();

--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
@@ -599,84 +599,97 @@ describe("Stripe automation event webhook", () => {
     );
   });
 
-  it("fans out a normalized Live snapshot exactly once and reports health", async () => {
-    const receivedAt = Date.parse("2026-08-07T08:00:00.000Z");
-    mockNow(receivedAt);
-    const scenario = await setupScenario({
-      billingReasons: ["subscription_cycle"],
-    });
-    expect((await readStripeAutomation(scenario)).health).toStrictEqual({
-      lastMatchingEventReceivedAt: null,
-      lastDeliveryStatus: null,
-      lastDeliveryStatusAt: null,
-      warning: null,
-    });
-    const event = invoicePaidEvent({
-      eventId: "evt_workflow_once",
-      invoiceId: "in_workflow_once",
-    });
+  it.each(["normalized input", "delivery health"] as const)(
+    "deduplicates a Live Stripe snapshot while projecting %s",
+    async (projection) => {
+      const receivedAt = Date.parse("2026-08-07T08:00:00.000Z");
+      mockNow(receivedAt);
+      const scenario = await setupScenario({
+        billingReasons: ["subscription_cycle"],
+      });
+      if (projection === "delivery health") {
+        expect((await readStripeAutomation(scenario)).health).toStrictEqual({
+          lastMatchingEventReceivedAt: null,
+          lastDeliveryStatus: null,
+          lastDeliveryStatusAt: null,
+          warning: null,
+        });
+      }
 
-    await Promise.all([
-      postStripeAutomationEvent(event),
-      postStripeAutomationEvent(event),
-    ]);
+      const event = invoicePaidEvent({
+        eventId: "evt_workflow_once",
+        invoiceId: "in_workflow_once",
+      });
 
-    expect((await readStripeAutomation(scenario)).health).toStrictEqual({
-      lastMatchingEventReceivedAt: "2026-08-07T08:00:00.000Z",
-      lastDeliveryStatus: "pending",
-      lastDeliveryStatusAt: "2026-08-07T08:00:00.000Z",
-      warning: null,
-    });
-    const executionResults = await Promise.all([
-      executeAutomation(scenario),
-      executeAutomation(scenario),
-    ]);
-    expect(
-      executionResults
-        .map((result) => {
-          return result.body;
-        })
-        .sort((left, right) => {
-          return left.executed - right.executed;
-        }),
-    ).toStrictEqual([NO_EXECUTION, EXECUTED_EXECUTION]);
-    expect((await readStripeAutomation(scenario)).health).toMatchObject({
-      lastDeliveryStatus: "delivered",
-      warning: null,
-    });
-    mocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
-    const threadAutomations = await accept(
-      automationsClient().listForChatThread({
-        headers: authHeaders(),
-        params: { threadId: scenario.chatThreadId },
-      }),
-      [200],
-    );
-    expect(threadAutomations.body).toContainEqual(
-      expect.objectContaining({
-        id: scenario.automationId,
-        health: expect.objectContaining({
+      await Promise.all([
+        postStripeAutomationEvent(event),
+        postStripeAutomationEvent(event),
+      ]);
+
+      if (projection === "delivery health") {
+        expect((await readStripeAutomation(scenario)).health).toStrictEqual({
+          lastMatchingEventReceivedAt: "2026-08-07T08:00:00.000Z",
+          lastDeliveryStatus: "pending",
+          lastDeliveryStatusAt: "2026-08-07T08:00:00.000Z",
+          warning: null,
+        });
+      }
+
+      const executionResults = await Promise.all([
+        executeAutomation(scenario),
+        executeAutomation(scenario),
+      ]);
+      expect(
+        executionResults
+          .map((result) => {
+            return result.body;
+          })
+          .sort((left, right) => {
+            return left.executed - right.executed;
+          }),
+      ).toStrictEqual([NO_EXECUTION, EXECUTED_EXECUTION]);
+      if (projection === "delivery health") {
+        expect((await readStripeAutomation(scenario)).health).toMatchObject({
           lastDeliveryStatus: "delivered",
           warning: null,
-        }),
-      }),
-    );
+        });
+        mocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
+        const threadAutomations = await accept(
+          automationsClient().listForChatThread({
+            headers: authHeaders(),
+            params: { threadId: scenario.chatThreadId },
+          }),
+          [200],
+        );
+        expect(threadAutomations.body).toContainEqual(
+          expect.objectContaining({
+            id: scenario.automationId,
+            health: expect.objectContaining({
+              lastDeliveryStatus: "delivered",
+              warning: null,
+            }),
+          }),
+        );
 
-    mocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
-    const events = await workflows.readThreadEvents(scenario.chatThreadId);
-    const inputs = events.filter((eventRow) => {
-      return eventRow.eventType === "input.automation";
-    });
-    expect(inputs).toHaveLength(1);
-    const input = inputs[0];
-    if (!input) {
-      throw new Error("Expected one Stripe automation input event");
-    }
-    expect(chatEventDisplayText(input)).toBe(
-      'Stripe invoice "in_workflow_once" was paid.',
-    );
-    expect(context.mocks.stripe.invoices.list).not.toHaveBeenCalled();
-  });
+        return;
+      }
+
+      mocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
+      const events = await workflows.readThreadEvents(scenario.chatThreadId);
+      const inputs = events.filter((eventRow) => {
+        return eventRow.eventType === "input.automation";
+      });
+      expect(inputs).toHaveLength(1);
+      const input = inputs[0];
+      if (!input) {
+        throw new Error("Expected one Stripe automation input event");
+      }
+      expect(chatEventDisplayText(input)).toBe(
+        'Stripe invoice "in_workflow_once" was paid.',
+      );
+      expect(context.mocks.stripe.invoices.list).not.toHaveBeenCalled();
+    },
+  );
 
   it("uses the exact Stripe source without persisting a thread override", async () => {
     const scenario = await setupScenario();

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
@@ -2230,176 +2230,193 @@ describe("POST /api/webhooks/teams/bot", () => {
     );
   });
 
-  it("applies agent and model switches to existing Teams chat threads", async () => {
-    const { fixture, actor, runnerGroup } = await setupConnectedTeamsBotActor();
-    const threadId = teamsFixtureExternalId(
-      fixture,
-      "activity-existing-switch-root",
-    );
-    const activityIds = {
-      initial: teamsFixtureExternalId(
+  it.each(["agent", "model"] as const)(
+    "applies a Teams %s switch to an existing chat thread",
+    async (selection) => {
+      const { fixture, actor, runnerGroup } =
+        await setupConnectedTeamsBotActor();
+      const threadId = teamsFixtureExternalId(
         fixture,
-        "activity-existing-switch-initial",
-      ),
-      switchAgent: teamsFixtureExternalId(
-        fixture,
-        "activity-existing-switch-agent",
-      ),
-      switchedAgentRun: teamsFixtureExternalId(
-        fixture,
-        "activity-existing-switch-agent-run",
-      ),
-      switchModel: teamsFixtureExternalId(
-        fixture,
-        "activity-existing-switch-model",
-      ),
-      switchedModelRun: teamsFixtureExternalId(
-        fixture,
-        "activity-existing-switch-model-run",
-      ),
-    };
-    const supportAgent = await authOrgApi.createAgent(actor, {
-      displayName: "Teams switched agent",
-      visibility: "public",
-    });
-    const anthropic = await runsApi.createOrgModelProvider(actor, {
-      type: "anthropic-api-key",
-      secret: "teams-switch-anthropic-key",
-    });
-    const openai = await runsApi.createOrgModelProvider(actor, {
-      type: "openai-api-key",
-      secret: "teams-switch-openai-key",
-    });
-    await runsApi.updateOrgModelPolicies(actor, [
-      {
-        model: "claude-sonnet-5",
-        isDefault: true,
-        defaultProviderType: "anthropic-api-key",
-        credentialScope: "org",
-        modelProviderId: anthropic.providerId,
-      },
-      {
-        model: "gpt-5.6-sol",
-        isDefault: false,
-        defaultProviderType: "openai-api-key",
-        credentialScope: "org",
-        modelProviderId: openai.providerId,
-      },
-    ]);
-    teamsGraphHistoryHandlers({
-      fixture,
-      chatMessages: [],
-      channelMessages: [],
-      threadRoots: {},
-      threadReplies: {},
-    });
-
-    const initialResponse = await postTeamsActivity({
-      activity: teamsPersonalThreadMessageActivity({
-        fixture,
-        id: activityIds.initial,
-        threadId,
-        text: "run before switching",
-      }),
-      token: teamsToken(),
-    });
-    expect(initialResponse.status).toBe(200);
-    await readTeamsBotResponseAndFlush(initialResponse);
-    const initialRunId = await runIdForPrompt(actor, "run before switching");
-    await runsApi.heartbeatRunner(runnerGroup);
-    const initialClaim = await runsApi.claimRunnerJob(initialRunId);
-    await runsApi.requestCancelRun(actor, initialRunId, [200]);
-    await completeCancelledRun(initialRunId, initialClaim.sandboxToken);
-
-    const switchAgentResponse = await postTeamsActivity({
-      activity: teamsPersonalMessageActivity({
-        fixture,
-        id: activityIds.switchAgent,
-        text: "",
-        value: {
-          okouTeamsAction: "switch_agent",
-          selectedAgentId: supportAgent.agentId,
+        "activity-existing-switch-root",
+      );
+      const activityIds = {
+        initial: teamsFixtureExternalId(
+          fixture,
+          "activity-existing-switch-initial",
+        ),
+        switchAgent: teamsFixtureExternalId(
+          fixture,
+          "activity-existing-switch-agent",
+        ),
+        switchedAgentRun: teamsFixtureExternalId(
+          fixture,
+          "activity-existing-switch-agent-run",
+        ),
+        switchModel: teamsFixtureExternalId(
+          fixture,
+          "activity-existing-switch-model",
+        ),
+        switchedModelRun: teamsFixtureExternalId(
+          fixture,
+          "activity-existing-switch-model-run",
+        ),
+      };
+      const supportAgent = await authOrgApi.createAgent(actor, {
+        displayName: "Teams switched agent",
+        visibility: "public",
+      });
+      const anthropic = await runsApi.createOrgModelProvider(actor, {
+        type: "anthropic-api-key",
+        secret: "teams-switch-anthropic-key",
+      });
+      const openai = await runsApi.createOrgModelProvider(actor, {
+        type: "openai-api-key",
+        secret: "teams-switch-openai-key",
+      });
+      await runsApi.updateOrgModelPolicies(actor, [
+        {
+          model: "claude-sonnet-5",
+          isDefault: true,
+          defaultProviderType: "anthropic-api-key",
+          credentialScope: "org",
+          modelProviderId: anthropic.providerId,
         },
-      }),
-      token: teamsToken(),
-    });
-    expect(switchAgentResponse.status).toBe(200);
-    await readTeamsBotResponseAndFlush(switchAgentResponse);
-
-    const switchedAgentResponse = await postTeamsActivity({
-      activity: teamsPersonalThreadMessageActivity({
-        fixture,
-        id: activityIds.switchedAgentRun,
-        threadId,
-        text: "run after agent switch",
-      }),
-      token: teamsToken(),
-    });
-    expect(switchedAgentResponse.status).toBe(200);
-    await readTeamsBotResponseAndFlush(switchedAgentResponse);
-    const switchedAgentRunId = await runIdForPrompt(
-      actor,
-      "run after agent switch",
-    );
-    await runsApi.heartbeatRunner(runnerGroup);
-    const switchedAgentClaim = await runsApi.claimRunnerJob(switchedAgentRunId);
-    expect(switchedAgentClaim.appendSystemPrompt).toContain(
-      "Your name is Teams switched agent.",
-    );
-    await runsApi.requestCancelRun(actor, switchedAgentRunId, [200]);
-    await completeCancelledRun(
-      switchedAgentRunId,
-      switchedAgentClaim.sandboxToken,
-    );
-
-    const switchModelResponse = await postTeamsActivity({
-      activity: teamsPersonalMessageActivity({
-        fixture,
-        id: activityIds.switchModel,
-        text: "",
-        value: {
-          okouTeamsAction: "switch_model",
-          selectedModel: "gpt-5.6-sol",
+        {
+          model: "gpt-5.6-sol",
+          isDefault: false,
+          defaultProviderType: "openai-api-key",
+          credentialScope: "org",
+          modelProviderId: openai.providerId,
         },
-      }),
-      token: teamsToken(),
-    });
-    expect(switchModelResponse.status).toBe(200);
-    await readTeamsBotResponseAndFlush(switchModelResponse);
-
-    const switchedModelResponse = await postTeamsActivity({
-      activity: teamsPersonalThreadMessageActivity({
+      ]);
+      teamsGraphHistoryHandlers({
         fixture,
-        id: activityIds.switchedModelRun,
-        threadId,
-        text: "run after model switch",
-      }),
-      token: teamsToken(),
-    });
-    expect(switchedModelResponse.status).toBe(200);
-    await readTeamsBotResponseAndFlush(switchedModelResponse);
-    const switchedModelRunId = await runIdForPrompt(
-      actor,
-      "run after model switch",
-    );
-    await runsApi.heartbeatRunner(runnerGroup);
-    const switchedModelClaim = await runsApi.claimRunnerJob(switchedModelRunId);
-    expect(switchedModelClaim.appendSystemPrompt).toContain(
-      "Your name is Teams switched agent.",
-    );
-    expect(switchedModelClaim.appendSystemPrompt).toContain(
-      "# Microsoft Teams Run Context",
-    );
-    expect(switchedModelClaim.appendSystemPrompt).toContain(
-      `- AGENT_SESSION_COMMAND: okou search "${switchedAgentRunId}" --source agent-session`,
-    );
-    expect(switchedModelClaim.appendSystemPrompt).toContain(
-      "Use the AGENT_SESSION_COMMAND for a run",
-    );
-    expect(switchedModelClaim.appendSystemPrompt).not.toContain("LOG_COMMAND");
-    expect(switchedModelClaim.modelUsageProvider).toBe("gpt-5.6-sol");
-    await runsApi.requestCancelRun(actor, switchedModelRunId, [200]);
-  });
+        chatMessages: [],
+        channelMessages: [],
+        threadRoots: {},
+        threadReplies: {},
+      });
+
+      if (selection === "agent") {
+        const initialResponse = await postTeamsActivity({
+          activity: teamsPersonalThreadMessageActivity({
+            fixture,
+            id: activityIds.initial,
+            threadId,
+            text: "run before switching",
+          }),
+          token: teamsToken(),
+        });
+        expect(initialResponse.status).toBe(200);
+        await readTeamsBotResponseAndFlush(initialResponse);
+        const initialRunId = await runIdForPrompt(
+          actor,
+          "run before switching",
+        );
+        await runsApi.heartbeatRunner(runnerGroup);
+        const initialClaim = await runsApi.claimRunnerJob(initialRunId);
+        await runsApi.requestCancelRun(actor, initialRunId, [200]);
+        await completeCancelledRun(initialRunId, initialClaim.sandboxToken);
+      }
+
+      const switchAgentResponse = await postTeamsActivity({
+        activity: teamsPersonalMessageActivity({
+          fixture,
+          id: activityIds.switchAgent,
+          text: "",
+          value: {
+            okouTeamsAction: "switch_agent",
+            selectedAgentId: supportAgent.agentId,
+          },
+        }),
+        token: teamsToken(),
+      });
+      expect(switchAgentResponse.status).toBe(200);
+      await readTeamsBotResponseAndFlush(switchAgentResponse);
+
+      const switchedAgentResponse = await postTeamsActivity({
+        activity: teamsPersonalThreadMessageActivity({
+          fixture,
+          id: activityIds.switchedAgentRun,
+          threadId,
+          text: "run after agent switch",
+        }),
+        token: teamsToken(),
+      });
+      expect(switchedAgentResponse.status).toBe(200);
+      await readTeamsBotResponseAndFlush(switchedAgentResponse);
+      const switchedAgentRunId = await runIdForPrompt(
+        actor,
+        "run after agent switch",
+      );
+      await runsApi.heartbeatRunner(runnerGroup);
+      const switchedAgentClaim =
+        await runsApi.claimRunnerJob(switchedAgentRunId);
+      expect(switchedAgentClaim.appendSystemPrompt).toContain(
+        "Your name is Teams switched agent.",
+      );
+      await runsApi.requestCancelRun(actor, switchedAgentRunId, [200]);
+      await completeCancelledRun(
+        switchedAgentRunId,
+        switchedAgentClaim.sandboxToken,
+      );
+
+      if (selection === "agent") {
+        return;
+      }
+
+      const switchModelResponse = await postTeamsActivity({
+        activity: teamsPersonalMessageActivity({
+          fixture,
+          id: activityIds.switchModel,
+          text: "",
+          value: {
+            okouTeamsAction: "switch_model",
+            selectedModel: "gpt-5.6-sol",
+          },
+        }),
+        token: teamsToken(),
+      });
+      expect(switchModelResponse.status).toBe(200);
+      await readTeamsBotResponseAndFlush(switchModelResponse);
+
+      const switchedModelResponse = await postTeamsActivity({
+        activity: teamsPersonalThreadMessageActivity({
+          fixture,
+          id: activityIds.switchedModelRun,
+          threadId,
+          text: "run after model switch",
+        }),
+        token: teamsToken(),
+      });
+      expect(switchedModelResponse.status).toBe(200);
+      await readTeamsBotResponseAndFlush(switchedModelResponse);
+      const switchedModelRunId = await runIdForPrompt(
+        actor,
+        "run after model switch",
+      );
+      await runsApi.heartbeatRunner(runnerGroup);
+      const switchedModelClaim =
+        await runsApi.claimRunnerJob(switchedModelRunId);
+      expect(switchedModelClaim.appendSystemPrompt).toContain(
+        "Your name is Teams switched agent.",
+      );
+      expect(switchedModelClaim.appendSystemPrompt).toContain(
+        "# Microsoft Teams Run Context",
+      );
+      expect(switchedModelClaim.appendSystemPrompt).toContain(
+        `- AGENT_SESSION_COMMAND: okou search "${switchedAgentRunId}" --source agent-session`,
+      );
+      expect(switchedModelClaim.appendSystemPrompt).toContain(
+        "Use the AGENT_SESSION_COMMAND for a run",
+      );
+      expect(switchedModelClaim.appendSystemPrompt).not.toContain(
+        "LOG_COMMAND",
+      );
+      expect(switchedModelClaim.modelUsageProvider).toBe("gpt-5.6-sol");
+      await runsApi.requestCancelRun(actor, switchedModelRunId, [200]);
+    },
+  );
 
   it("replies when a connected Teams run is queued", async () => {
     const { fixture, actor, outboundRequests } =
@@ -2705,391 +2722,411 @@ describe("POST /api/webhooks/teams/bot", () => {
     await runsApi.requestCancelRun(actor, run.id, [200]);
   });
 
-  it("dispatches connected Teams messages to the org default agent", async () => {
-    const fixture = await trackTeamsFixture(
-      Promise.resolve(teamsConnectFixture()),
-    );
-    const rootDispatchId = teamsFixtureExternalId(fixture, "root-dispatch");
-    const contextActivityId = teamsFixtureExternalId(
-      fixture,
-      "activity-context",
-    );
-    const contextFileActivityId = teamsFixtureExternalId(
-      fixture,
-      "activity-context-file-only",
-    );
-    const dispatchActivityId = teamsFixtureExternalId(
-      fixture,
-      "activity-dispatch",
-    );
-    const channelContextActivityId = teamsFixtureExternalId(
-      fixture,
-      "activity-channel-context",
-    );
-    const priorChannelMessageId = teamsFixtureExternalId(
-      fixture,
-      "channel-prior",
-    );
-    const futureChannelMessageId = teamsFixtureExternalId(
-      fixture,
-      "channel-future",
-    );
-    const mentionedUserId = teamsFixtureExternalId(fixture, "29:user-grace");
-    const planAttachmentId = teamsFixtureExternalId(fixture, "teams-file-plan");
-    const checklistAttachmentId = teamsFixtureExternalId(
-      fixture,
-      "teams-file-checklist",
-    );
-    const currentAttachmentId = teamsFixtureExternalId(
-      fixture,
-      "teams-file-current",
-    );
-    const actor = authOrgApi.user({
-      userId: fixture.userId,
-      orgId: fixture.orgId,
-      orgRole: "org:admin",
-    });
-    const runnerGroup = runsApi.configureRunnerGroup();
-    context.mocks.ably.publish.mockResolvedValue(undefined);
-    authOrgApi.acceptAgentStorageWrites();
-    runsApi.acceptStorageDownloads();
-    runsApi.acceptTelemetryIngest();
-    const defaultAgent = await authOrgApi.bootstrapLimitedFreeOnboarding(
-      actor,
-      {
-        displayName: "Teams default agent",
-      },
-    );
-    await authOrgApi.updateAgentMetadata(actor, defaultAgent.body.agentId, {
-      visibility: "public",
-    });
-    await runsApi.grantProEntitlement(actor);
-    await runsApi.ensureOrgModelProvider(actor);
-    botFrameworkHandlers();
-    const outboundRequests = teamsOutboundHandlers(fixture.serviceUrl);
-
-    const installResponse = await postTeamsActivity({
-      activity: teamsMessageActivity(fixture),
-      token: teamsToken(),
-    });
-    expect(installResponse.status).toBe(200);
-    await installResponse.json();
-    await flushWaitUntilForTest();
-    await connectTeamsFixture(fixture);
-    outboundRequests.splice(0, outboundRequests.length);
-    outboundRequests.reactions.splice(0, outboundRequests.reactions.length);
-
-    const channelMessages: TeamsGraphMessageFixture[] = [];
-    const threadRoots: Record<string, TeamsGraphMessageFixture> = {
-      [rootDispatchId]: {
-        id: rootDispatchId,
-        text: "remember the deployment target",
-        createdDateTime: "2026-06-30T09:10:00.000Z",
-        senderId: fixture.teamsUserId,
-        graphUserPrincipalName: fixture.teamsUserPrincipalName,
-      },
-    };
-    const threadReplies: Record<string, TeamsGraphMessageFixture[]> = {
-      [rootDispatchId]: [
+  it.each(["channel", "thread"] as const)(
+    "dispatches a connected Teams %s message with its context",
+    async (surface) => {
+      const fixture = await trackTeamsFixture(
+        Promise.resolve(teamsConnectFixture()),
+      );
+      const rootDispatchId = teamsFixtureExternalId(fixture, "root-dispatch");
+      const contextActivityId = teamsFixtureExternalId(
+        fixture,
+        "activity-context",
+      );
+      const contextFileActivityId = teamsFixtureExternalId(
+        fixture,
+        "activity-context-file-only",
+      );
+      const dispatchActivityId = teamsFixtureExternalId(
+        fixture,
+        "activity-dispatch",
+      );
+      const channelContextActivityId = teamsFixtureExternalId(
+        fixture,
+        "activity-channel-context",
+      );
+      const priorChannelMessageId = teamsFixtureExternalId(
+        fixture,
+        "channel-prior",
+      );
+      const futureChannelMessageId = teamsFixtureExternalId(
+        fixture,
+        "channel-future",
+      );
+      const mentionedUserId = teamsFixtureExternalId(fixture, "29:user-grace");
+      const planAttachmentId = teamsFixtureExternalId(
+        fixture,
+        "teams-file-plan",
+      );
+      const checklistAttachmentId = teamsFixtureExternalId(
+        fixture,
+        "teams-file-checklist",
+      );
+      const currentAttachmentId = teamsFixtureExternalId(
+        fixture,
+        "teams-file-current",
+      );
+      const actor = authOrgApi.user({
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        orgRole: "org:admin",
+      });
+      const runnerGroup = runsApi.configureRunnerGroup();
+      context.mocks.ably.publish.mockResolvedValue(undefined);
+      authOrgApi.acceptAgentStorageWrites();
+      runsApi.acceptStorageDownloads();
+      runsApi.acceptTelemetryIngest();
+      const defaultAgent = await authOrgApi.bootstrapLimitedFreeOnboarding(
+        actor,
         {
-          id: contextActivityId,
-          text: 'confirm with <at id="0">Grace Hopper</at> that the target is staging',
-          createdDateTime: "2026-06-30T09:11:00.000Z",
+          displayName: "Teams default agent",
+        },
+      );
+      await authOrgApi.updateAgentMetadata(actor, defaultAgent.body.agentId, {
+        visibility: "public",
+      });
+      await runsApi.grantProEntitlement(actor);
+      await runsApi.ensureOrgModelProvider(actor);
+      botFrameworkHandlers();
+      const outboundRequests = teamsOutboundHandlers(fixture.serviceUrl);
+
+      const installResponse = await postTeamsActivity({
+        activity: teamsMessageActivity(fixture),
+        token: teamsToken(),
+      });
+      expect(installResponse.status).toBe(200);
+      await installResponse.json();
+      await flushWaitUntilForTest();
+      await connectTeamsFixture(fixture);
+      outboundRequests.splice(0, outboundRequests.length);
+      outboundRequests.reactions.splice(0, outboundRequests.reactions.length);
+
+      const channelMessages: TeamsGraphMessageFixture[] = [];
+      const threadRoots: Record<string, TeamsGraphMessageFixture> = {
+        [rootDispatchId]: {
+          id: rootDispatchId,
+          text: "remember the deployment target",
+          createdDateTime: "2026-06-30T09:10:00.000Z",
           senderId: fixture.teamsUserId,
-          mentions: [
-            {
-              id: 0,
-              mentionText: '<at id="0">Grace Hopper</at>',
-              mentioned: {
-                user: {
-                  id: mentionedUserId,
-                  displayName: "Grace Hopper",
+          graphUserPrincipalName: fixture.teamsUserPrincipalName,
+        },
+      };
+      const threadReplies: Record<string, TeamsGraphMessageFixture[]> = {
+        [rootDispatchId]: [
+          {
+            id: contextActivityId,
+            text: 'confirm with <at id="0">Grace Hopper</at> that the target is staging',
+            createdDateTime: "2026-06-30T09:11:00.000Z",
+            senderId: fixture.teamsUserId,
+            mentions: [
+              {
+                id: 0,
+                mentionText: '<at id="0">Grace Hopper</at>',
+                mentioned: {
+                  user: {
+                    id: mentionedUserId,
+                    displayName: "Grace Hopper",
+                  },
                 },
               },
-            },
-          ],
-          attachments: [
-            {
-              id: planAttachmentId,
-              name: "deployment-plan.pdf",
-              contentType: "application/vnd.microsoft.teams.file.download.info",
-              content: {
-                downloadUrl: "https://files.example.test/deployment-plan.pdf",
-                fileType: "pdf",
+            ],
+            attachments: [
+              {
+                id: planAttachmentId,
+                name: "deployment-plan.pdf",
+                contentType:
+                  "application/vnd.microsoft.teams.file.download.info",
+                content: {
+                  downloadUrl: "https://files.example.test/deployment-plan.pdf",
+                  fileType: "pdf",
+                },
               },
-            },
-          ],
+            ],
+          },
+          {
+            id: contextFileActivityId,
+            text: "",
+            createdDateTime: "2026-06-30T09:11:30.000Z",
+            senderId: fixture.teamsUserId,
+            attachments: [
+              {
+                id: checklistAttachmentId,
+                name: "release-checklist.txt",
+                contentType:
+                  "application/vnd.microsoft.teams.file.download.info",
+                content: {
+                  downloadUrl:
+                    "https://files.example.test/release-checklist.txt",
+                  fileType: "txt",
+                },
+              },
+            ],
+          },
+          {
+            id: dispatchActivityId,
+            text: "ship the Teams dispatch",
+            createdDateTime: "2026-06-30T09:12:00.000Z",
+            senderId: fixture.teamsUserId,
+          },
+        ],
+      };
+      const graphRequests = teamsGraphHistoryHandlers({
+        fixture,
+        channelMessages,
+        threadRoots,
+        threadReplies,
+      });
+
+      if (surface === "channel") {
+        channelMessages.push(
+          {
+            id: channelContextActivityId,
+            text: "start another topic",
+            createdDateTime: "2026-06-30T09:12:00.000Z",
+            senderId: fixture.teamsUserId,
+          },
+          {
+            id: priorChannelMessageId,
+            text: "api channel planning",
+            createdDateTime: "2026-06-30T09:09:00.000Z",
+            senderId: fixture.teamsUserId,
+          },
+          {
+            id: futureChannelMessageId,
+            text: "future channel topic",
+            createdDateTime: "2026-06-30T09:13:00.000Z",
+            senderId: fixture.teamsUserId,
+          },
+        );
+
+        const channelContextResponse = await postTeamsActivity({
+          activity: teamsMessageActivity(fixture, {
+            id: channelContextActivityId,
+            replyToId: null,
+            text: "<at>Zero</at>",
+          }),
+          token: teamsToken(),
+        });
+        expect(channelContextResponse.status).toBe(200);
+        const channelContextBody = await readTeamsBotResponseAndFlush(
+          channelContextResponse,
+        );
+        expect(channelContextBody).not.toHaveProperty("dispatch");
+        expect(outboundRequests).toHaveLength(0);
+        expect(outboundRequests.reactions).toStrictEqual([
+          {
+            method: "PUT",
+            conversationId: fixture.teamsConversationId,
+            activityId: channelContextActivityId,
+            reactionType: "1f4ad_thoughtballoon",
+          },
+        ]);
+        const channelContextRunId = await runIdForPrompt(actor, "@Zero");
+        await runsApi.heartbeatRunner(runnerGroup);
+        const channelContextClaim =
+          await runsApi.claimRunnerJob(channelContextRunId);
+        const channelContextAppendSystemPrompt =
+          channelContextClaim.appendSystemPrompt ?? "";
+        const recentChannelContext = promptSection(
+          channelContextAppendSystemPrompt,
+          "# Recent Channel Messages",
+        );
+        expect(channelContextClaim.prompt).toBe("@Zero");
+        expect(graphRequests).toContain("channel-messages");
+        expect(recentChannelContext).toContain("api channel planning");
+        expect(recentChannelContext).not.toContain("start another topic");
+        expect(channelContextAppendSystemPrompt).not.toContain(
+          "# Microsoft Teams Thread Context",
+        );
+
+        await runsApi.requestCancelRun(actor, channelContextRunId, [200]);
+        await completeCancelledRun(
+          channelContextRunId,
+          channelContextClaim.sandboxToken,
+        );
+        return;
+      }
+
+      channelMessages.splice(
+        0,
+        channelMessages.length,
+        {
+          id: rootDispatchId,
+          text: "remember the deployment target",
+          createdDateTime: "2026-06-30T09:10:00.000Z",
+          senderId: fixture.teamsUserId,
         },
         {
-          id: contextFileActivityId,
-          text: "",
-          createdDateTime: "2026-06-30T09:11:30.000Z",
+          id: priorChannelMessageId,
+          text: "api channel planning",
+          createdDateTime: "2026-06-30T09:09:00.000Z",
           senderId: fixture.teamsUserId,
+        },
+      );
+
+      const response = await postTeamsActivity({
+        activity: teamsMessageActivity(fixture, {
+          id: dispatchActivityId,
+          replyToId: rootDispatchId,
+          text: "<at>Zero</at> ship the Teams dispatch",
           attachments: [
             {
-              id: checklistAttachmentId,
-              name: "release-checklist.txt",
+              id: currentAttachmentId,
+              name: "current-task.txt",
               contentType: "application/vnd.microsoft.teams.file.download.info",
               content: {
-                downloadUrl: "https://files.example.test/release-checklist.txt",
+                downloadUrl: "https://files.example.test/current-task.txt",
                 fileType: "txt",
               },
             },
           ],
-        },
+        }),
+        token: teamsToken(),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await readTeamsBotResponseAndFlush(response);
+      expect(body).not.toHaveProperty("dispatch");
+      expect(outboundRequests).toHaveLength(0);
+      expect(outboundRequests.reactions).toStrictEqual([
         {
-          id: dispatchActivityId,
-          text: "ship the Teams dispatch",
-          createdDateTime: "2026-06-30T09:12:00.000Z",
-          senderId: fixture.teamsUserId,
+          method: "PUT",
+          conversationId: fixture.teamsConversationId,
+          activityId: dispatchActivityId,
+          reactionType: "1f4ad_thoughtballoon",
         },
-      ],
-    };
-    const graphRequests = teamsGraphHistoryHandlers({
-      fixture,
-      channelMessages,
-      threadRoots,
-      threadReplies,
-    });
+      ]);
 
-    channelMessages.push(
-      {
-        id: channelContextActivityId,
-        text: "start another topic",
-        createdDateTime: "2026-06-30T09:12:00.000Z",
-        senderId: fixture.teamsUserId,
-      },
-      {
-        id: priorChannelMessageId,
-        text: "api channel planning",
-        createdDateTime: "2026-06-30T09:09:00.000Z",
-        senderId: fixture.teamsUserId,
-      },
-      {
-        id: futureChannelMessageId,
-        text: "future channel topic",
-        createdDateTime: "2026-06-30T09:13:00.000Z",
-        senderId: fixture.teamsUserId,
-      },
-    );
-
-    const channelContextResponse = await postTeamsActivity({
-      activity: teamsMessageActivity(fixture, {
-        id: channelContextActivityId,
-        replyToId: null,
-        text: "<at>Zero</at>",
-      }),
-      token: teamsToken(),
-    });
-    expect(channelContextResponse.status).toBe(200);
-    const channelContextBody = await readTeamsBotResponseAndFlush(
-      channelContextResponse,
-    );
-    expect(channelContextBody).not.toHaveProperty("dispatch");
-    expect(outboundRequests).toHaveLength(0);
-    expect(outboundRequests.reactions).toStrictEqual([
-      {
-        method: "PUT",
-        conversationId: fixture.teamsConversationId,
-        activityId: channelContextActivityId,
-        reactionType: "1f4ad_thoughtballoon",
-      },
-    ]);
-    const channelContextRunId = await runIdForPrompt(actor, "@Zero");
-    await runsApi.heartbeatRunner(runnerGroup);
-    const channelContextClaim =
-      await runsApi.claimRunnerJob(channelContextRunId);
-    const channelContextAppendSystemPrompt =
-      channelContextClaim.appendSystemPrompt ?? "";
-    const recentChannelContext = promptSection(
-      channelContextAppendSystemPrompt,
-      "# Recent Channel Messages",
-    );
-    expect(channelContextClaim.prompt).toBe("@Zero");
-    expect(graphRequests).toContain("channel-messages");
-    expect(recentChannelContext).toContain("api channel planning");
-    expect(recentChannelContext).not.toContain("start another topic");
-    expect(channelContextAppendSystemPrompt).not.toContain(
-      "# Microsoft Teams Thread Context",
-    );
-
-    channelMessages.splice(
-      0,
-      channelMessages.length,
-      {
-        id: rootDispatchId,
-        text: "remember the deployment target",
-        createdDateTime: "2026-06-30T09:10:00.000Z",
-        senderId: fixture.teamsUserId,
-      },
-      {
-        id: priorChannelMessageId,
-        text: "api channel planning",
-        createdDateTime: "2026-06-30T09:09:00.000Z",
-        senderId: fixture.teamsUserId,
-      },
-    );
-
-    const response = await postTeamsActivity({
-      activity: teamsMessageActivity(fixture, {
-        id: dispatchActivityId,
-        replyToId: rootDispatchId,
-        text: "<at>Zero</at> ship the Teams dispatch",
-        attachments: [
+      const dispatchRuns = await runsApi.listAgentRuns(actor, { limit: 20 });
+      const dispatchRun = dispatchRuns.runs.find((run) => {
+        return run.prompt.includes("ship the Teams dispatch");
+      });
+      if (!dispatchRun) {
+        throw new Error("Expected Teams dispatch run");
+      }
+      const runId = dispatchRun.id;
+      await runsApi.heartbeatRunner(runnerGroup);
+      const claim = await runsApi.claimRunnerJob(runId);
+      const appendSystemPrompt = claim.appendSystemPrompt ?? "";
+      const currentUserPrompt = promptSection(
+        appendSystemPrompt,
+        "# Current User Info",
+        "# Current Integration",
+      );
+      const currentIntegrationPrompt = promptSection(
+        appendSystemPrompt,
+        "# Current Integration",
+        "# Recent Channel Messages",
+      );
+      const replyRecentChannelContext = promptSection(
+        appendSystemPrompt,
+        "# Recent Channel Messages",
+        "# Microsoft Teams Thread Context",
+      );
+      const teamsThreadContext = promptSection(
+        appendSystemPrompt,
+        "# Microsoft Teams Thread Context",
+      );
+      expect(claim.prompt).toContain("ship the Teams dispatch");
+      expect(claim.prompt).toContain(
+        "[Web file] current-task.txt (text/plain)",
+      );
+      expect(claim.prompt).not.toContain("deployment-plan.pdf");
+      expect(claim.prompt).not.toContain("release-checklist.txt");
+      await expect(
+        callbackStore.set(
+          readAgentRunCallbacks$,
           {
-            id: currentAttachmentId,
-            name: "current-task.txt",
-            contentType: "application/vnd.microsoft.teams.file.download.info",
-            content: {
-              downloadUrl: "https://files.example.test/current-task.txt",
-              fileType: "txt",
-            },
+            orgId: fixture.orgId,
+            userId: fixture.userId,
+            runId,
           },
-        ],
-      }),
-      token: teamsToken(),
-    });
-
-    expect(response.status).toBe(200);
-    const body = await readTeamsBotResponseAndFlush(response);
-    expect(body).not.toHaveProperty("dispatch");
-    expect(outboundRequests).toHaveLength(0);
-    expect(outboundRequests.reactions).toStrictEqual([
-      {
-        method: "PUT",
-        conversationId: fixture.teamsConversationId,
-        activityId: channelContextActivityId,
-        reactionType: "1f4ad_thoughtballoon",
-      },
-      {
-        method: "PUT",
-        conversationId: fixture.teamsConversationId,
-        activityId: dispatchActivityId,
-        reactionType: "1f4ad_thoughtballoon",
-      },
-    ]);
-
-    const dispatchRuns = await runsApi.listAgentRuns(actor, { limit: 20 });
-    const dispatchRun = dispatchRuns.runs.find((run) => {
-      return run.prompt.includes("ship the Teams dispatch");
-    });
-    if (!dispatchRun) {
-      throw new Error("Expected Teams dispatch run");
-    }
-    const runId = dispatchRun.id;
-    await runsApi.heartbeatRunner(runnerGroup);
-    const claim = await runsApi.claimRunnerJob(runId);
-    const appendSystemPrompt = claim.appendSystemPrompt ?? "";
-    const currentUserPrompt = promptSection(
-      appendSystemPrompt,
-      "# Current User Info",
-      "# Current Integration",
-    );
-    const currentIntegrationPrompt = promptSection(
-      appendSystemPrompt,
-      "# Current Integration",
-      "# Recent Channel Messages",
-    );
-    const replyRecentChannelContext = promptSection(
-      appendSystemPrompt,
-      "# Recent Channel Messages",
-      "# Microsoft Teams Thread Context",
-    );
-    const teamsThreadContext = promptSection(
-      appendSystemPrompt,
-      "# Microsoft Teams Thread Context",
-    );
-    expect(claim.prompt).toContain("ship the Teams dispatch");
-    expect(claim.prompt).toContain("[Web file] current-task.txt (text/plain)");
-    expect(claim.prompt).not.toContain("deployment-plan.pdf");
-    expect(claim.prompt).not.toContain("release-checklist.txt");
-    await expect(
-      callbackStore.set(
-        readAgentRunCallbacks$,
-        {
-          orgId: fixture.orgId,
-          userId: fixture.userId,
-          runId,
-        },
-        context.signal,
-      ),
-    ).resolves.toStrictEqual([
-      expect.objectContaining({
-        payload: expect.objectContaining({
-          teamsDelivery: expect.objectContaining({
-            publicBrand: "okou",
-            files: expect.arrayContaining([
-              expect.objectContaining({ name: "current-task.txt" }),
-              expect.objectContaining({ name: "deployment-plan.pdf" }),
-              expect.objectContaining({ name: "release-checklist.txt" }),
-            ]),
+          context.signal,
+        ),
+      ).resolves.toStrictEqual([
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            teamsDelivery: expect.objectContaining({
+              publicBrand: "okou",
+              files: expect.arrayContaining([
+                expect.objectContaining({ name: "current-task.txt" }),
+                expect.objectContaining({ name: "deployment-plan.pdf" }),
+                expect.objectContaining({ name: "release-checklist.txt" }),
+              ]),
+            }),
           }),
         }),
-      }),
-    ]);
-    expect(currentIntegrationPrompt).toContain(
-      "You are currently running inside: Microsoft Teams",
-    );
-    expect(appendSystemPrompt).toContain("Microsoft Teams messaging and files");
-    expect(appendSystemPrompt).toContain("okou teams --help");
-    expect(appendSystemPrompt).toContain("okou teams message send -h");
-    expect(appendSystemPrompt).toContain("okou teams download-file -h");
-    expect(appendSystemPrompt).toContain("okou teams upload-file -h");
-    expect(currentIntegrationPrompt).toContain(
-      `Tenant ID: ${fixture.teamsTenantId}`,
-    );
-    expect(currentIntegrationPrompt).toContain(
-      `Team ID: ${fixture.teamsTeamId}`,
-    );
-    expect(currentIntegrationPrompt).toContain(
-      `Conversation ID: ${fixture.teamsConversationId}`,
-    );
-    expect(currentIntegrationPrompt).toContain(`Thread ID: ${rootDispatchId}`);
-    expect(currentIntegrationPrompt).not.toContain("Teams user ID:");
-    expect(currentIntegrationPrompt).not.toContain("Teams display name:");
-    expect(currentIntegrationPrompt).not.toContain(
-      "Teams user principal name:",
-    );
-    expect(replyRecentChannelContext).toContain("api channel planning");
-    expect(replyRecentChannelContext).not.toContain(
-      "remember the deployment target",
-    );
-    expect(replyRecentChannelContext).not.toContain("future channel topic");
-    expect(currentUserPrompt).toContain(
-      `Teams user ID: ${fixture.teamsUserId}`,
-    );
-    expect(currentUserPrompt).toContain(
-      `Teams user principal name: ${fixture.teamsUserPrincipalName}`,
-    );
-    expect(currentUserPrompt).toContain("Teams display name: Ada Lovelace");
-    expect(teamsThreadContext).toContain(
-      "The messages below are from a Microsoft Teams conversation",
-    );
-    expect(teamsThreadContext).toContain("- RELATIVE_INDEX: -1");
-    expect(teamsThreadContext).toContain(
-      `- SENDER: {id: ${fixture.teamsUserId}, name: Ada Lovelace, email: ${fixture.teamsUserPrincipalName}}`,
-    );
-    expect(teamsThreadContext).toContain("remember the deployment target");
-    expect(teamsThreadContext).toContain(
-      `confirm with @Grace Hopper (${mentionedUserId}) that the target is staging`,
-    );
-    expect(teamsThreadContext).toContain(
-      "[Teams file] deployment-plan.pdf (application/pdf)",
-    );
-    expect(teamsThreadContext).toContain(
-      `[Teams attachment ID] ${planAttachmentId}`,
-    );
-    expect(teamsThreadContext).toContain(
-      "[Teams file] release-checklist.txt (text/plain)",
-    );
-    expect(teamsThreadContext).toContain(
-      `[Teams attachment ID] ${checklistAttachmentId}`,
-    );
-    expect(teamsThreadContext).not.toContain("ship the Teams dispatch");
-    expect(graphRequests).toContain(`thread-root:${rootDispatchId}`);
-    expect(graphRequests).toContain(`thread-replies:${rootDispatchId}`);
-    expect(graphRequests).toContain(`user:${fixture.teamsUserId}`);
-  });
+      ]);
+      expect(currentIntegrationPrompt).toContain(
+        "You are currently running inside: Microsoft Teams",
+      );
+      expect(appendSystemPrompt).toContain(
+        "Microsoft Teams messaging and files",
+      );
+      expect(appendSystemPrompt).toContain("okou teams --help");
+      expect(appendSystemPrompt).toContain("okou teams message send -h");
+      expect(appendSystemPrompt).toContain("okou teams download-file -h");
+      expect(appendSystemPrompt).toContain("okou teams upload-file -h");
+      expect(currentIntegrationPrompt).toContain(
+        `Tenant ID: ${fixture.teamsTenantId}`,
+      );
+      expect(currentIntegrationPrompt).toContain(
+        `Team ID: ${fixture.teamsTeamId}`,
+      );
+      expect(currentIntegrationPrompt).toContain(
+        `Conversation ID: ${fixture.teamsConversationId}`,
+      );
+      expect(currentIntegrationPrompt).toContain(
+        `Thread ID: ${rootDispatchId}`,
+      );
+      expect(currentIntegrationPrompt).not.toContain("Teams user ID:");
+      expect(currentIntegrationPrompt).not.toContain("Teams display name:");
+      expect(currentIntegrationPrompt).not.toContain(
+        "Teams user principal name:",
+      );
+      expect(replyRecentChannelContext).toContain("api channel planning");
+      expect(replyRecentChannelContext).not.toContain(
+        "remember the deployment target",
+      );
+      expect(replyRecentChannelContext).not.toContain("future channel topic");
+      expect(currentUserPrompt).toContain(
+        `Teams user ID: ${fixture.teamsUserId}`,
+      );
+      expect(currentUserPrompt).toContain(
+        `Teams user principal name: ${fixture.teamsUserPrincipalName}`,
+      );
+      expect(currentUserPrompt).toContain("Teams display name: Ada Lovelace");
+      expect(teamsThreadContext).toContain(
+        "The messages below are from a Microsoft Teams conversation",
+      );
+      expect(teamsThreadContext).toContain("- RELATIVE_INDEX: -1");
+      expect(teamsThreadContext).toContain(
+        `- SENDER: {id: ${fixture.teamsUserId}, name: Ada Lovelace, email: ${fixture.teamsUserPrincipalName}}`,
+      );
+      expect(teamsThreadContext).toContain("remember the deployment target");
+      expect(teamsThreadContext).toContain(
+        `confirm with @Grace Hopper (${mentionedUserId}) that the target is staging`,
+      );
+      expect(teamsThreadContext).toContain(
+        "[Teams file] deployment-plan.pdf (application/pdf)",
+      );
+      expect(teamsThreadContext).toContain(
+        `[Teams attachment ID] ${planAttachmentId}`,
+      );
+      expect(teamsThreadContext).toContain(
+        "[Teams file] release-checklist.txt (text/plain)",
+      );
+      expect(teamsThreadContext).toContain(
+        `[Teams attachment ID] ${checklistAttachmentId}`,
+      );
+      expect(teamsThreadContext).not.toContain("ship the Teams dispatch");
+      expect(graphRequests).toContain(`thread-root:${rootDispatchId}`);
+      expect(graphRequests).toContain(`thread-replies:${rootDispatchId}`);
+      expect(graphRequests).toContain(`user:${fixture.teamsUserId}`);
+      await runsApi.requestCancelRun(actor, runId, [200]);
+      await completeCancelledRun(runId, claim.sandboxToken);
+    },
+  );
 
   it("includes recent Teams personal messages in the run context", async () => {
     const { fixture, actor, runnerGroup, outboundRequests } =

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-pack-subscription-lifecycle.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-pack-subscription-lifecycle.test.ts
@@ -432,111 +432,120 @@ describe("usage pack subscription Stripe lifecycle", () => {
     );
   });
 
-  it("waits for invoice.paid, grants member buckets once, and renews while the switch is off", async () => {
-    const userId = `user_${randomUUID()}`;
-    const invitationId = `inv_${randomUUID()}`;
-    const fixture = await seedUsagePackLifecycle([
-      { userId, usagePackUsd: 20 },
-      { invitationId, usagePackUsd: 20 },
-    ]);
-    const quantities = new Map([[TEST_PRICE_PACK_20, 2]]);
-    let paidPeriod = period(0);
-    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
-      stripeSubscription(fixture, paidPeriod, quantities),
-    );
-
-    await postStripeEvent(
-      stripeEvent("checkout.session.completed", {
-        id: fixture.checkoutSessionId,
-        customer: fixture.customerId,
-        subscription: fixture.subscriptionId,
-        metadata: usagePackMetadata(fixture),
-      }),
-      200,
-    );
-    await postStripeEvent(
-      stripeEvent(
-        "customer.subscription.created",
+  it.each(["initial payment", "renewal"] as const)(
+    "grants usage pack buckets once for %s while the switch is off",
+    async (phase) => {
+      const userId = `user_${randomUUID()}`;
+      const invitationId = `inv_${randomUUID()}`;
+      const fixture = await seedUsagePackLifecycle([
+        { userId, usagePackUsd: 20 },
+        { invitationId, usagePackUsd: 20 },
+      ]);
+      const quantities = new Map([[TEST_PRICE_PACK_20, 2]]);
+      let paidPeriod = period(0);
+      context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
         stripeSubscription(fixture, paidPeriod, quantities),
-      ),
-      200,
-    );
+      );
 
-    await expect(grantRows(fixture)).resolves.toHaveLength(0);
-    const beforePayment = (await readUsagePackState(fixture)).org;
-    expect(beforePayment).toStrictEqual(
-      expect.objectContaining({
-        tier: "limited-free-1",
-        stripeSubscriptionId: fixture.subscriptionId,
-      }),
-    );
-
-    const firstInvoiceId = `in_${randomUUID()}`;
-    const firstInvoice = paidInvoice(fixture, {
-      invoiceId: firstInvoiceId,
-      paidPeriod,
-      quantities,
-    });
-    await postStripeEvent(stripeEvent("invoice.paid", firstInvoice), 200);
-    await postStripeEvent(stripeEvent("invoice.paid", firstInvoice), 200);
-
-    await expect(grantRows(fixture)).resolves.toStrictEqual([
-      {
-        userId,
-        grantType: "bonus",
-        originalAmount: 400,
-        expiresAt: new Date(paidPeriod.end * 1000).toISOString(),
-      },
-      {
-        userId,
-        grantType: "purchased",
-        originalAmount: 20_000,
-        expiresAt: new Date(paidPeriod.end * 1000).toISOString(),
-      },
-    ]);
-    const allocationRows = (await readUsagePackState(fixture)).allocations;
-    expect(allocationRows).toStrictEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          userId,
-          invitationId: null,
-          status: "active",
+      await postStripeEvent(
+        stripeEvent("checkout.session.completed", {
+          id: fixture.checkoutSessionId,
+          customer: fixture.customerId,
+          subscription: fixture.subscriptionId,
+          metadata: usagePackMetadata(fixture),
         }),
-        expect.objectContaining({
-          userId: null,
-          invitationId,
-          status: "pending_invitation",
-        }),
-      ]),
-    );
-    const activatedOrg = (await readUsagePackState(fixture)).org;
-    expect(activatedOrg).toStrictEqual(
-      expect.objectContaining({ tier: "pro", credits: 0 }),
-    );
+        200,
+      );
+      await postStripeEvent(
+        stripeEvent(
+          "customer.subscription.created",
+          stripeSubscription(fixture, paidPeriod, quantities),
+        ),
+        200,
+      );
 
-    paidPeriod = period(30);
-    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
-      stripeSubscription(fixture, paidPeriod, quantities),
-    );
-    const renewalInvoice = paidInvoice(fixture, {
-      invoiceId: `in_${randomUUID()}`,
-      paidPeriod,
-      quantities,
-    });
-    await postStripeEvent(stripeEvent("invoice.paid", renewalInvoice), 200);
-    await expect(grantRows(fixture)).resolves.toHaveLength(4);
-    const renewalGrantRows = await grantRows(fixture);
-    expect(
-      renewalGrantRows.filter((grant) => {
-        return (
-          grant.expiresAt === new Date(paidPeriod.end * 1000).toISOString()
+      if (phase === "initial payment") {
+        await expect(grantRows(fixture)).resolves.toHaveLength(0);
+        const beforePayment = (await readUsagePackState(fixture)).org;
+        expect(beforePayment).toStrictEqual(
+          expect.objectContaining({
+            tier: "limited-free-1",
+            stripeSubscriptionId: fixture.subscriptionId,
+          }),
         );
-      }),
-    ).toHaveLength(2);
-    expect(
-      (await readUsagePackState(fixture)).fulfillmentInvoiceIds,
-    ).toHaveLength(2);
-  });
+      }
+
+      const firstInvoiceId = `in_${randomUUID()}`;
+      const firstInvoice = paidInvoice(fixture, {
+        invoiceId: firstInvoiceId,
+        paidPeriod,
+        quantities,
+      });
+      await postStripeEvent(stripeEvent("invoice.paid", firstInvoice), 200);
+      if (phase === "initial payment") {
+        await postStripeEvent(stripeEvent("invoice.paid", firstInvoice), 200);
+
+        await expect(grantRows(fixture)).resolves.toStrictEqual([
+          {
+            userId,
+            grantType: "bonus",
+            originalAmount: 400,
+            expiresAt: new Date(paidPeriod.end * 1000).toISOString(),
+          },
+          {
+            userId,
+            grantType: "purchased",
+            originalAmount: 20_000,
+            expiresAt: new Date(paidPeriod.end * 1000).toISOString(),
+          },
+        ]);
+        const allocationRows = (await readUsagePackState(fixture)).allocations;
+        expect(allocationRows).toStrictEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              userId,
+              invitationId: null,
+              status: "active",
+            }),
+            expect.objectContaining({
+              userId: null,
+              invitationId,
+              status: "pending_invitation",
+            }),
+          ]),
+        );
+        const activatedOrg = (await readUsagePackState(fixture)).org;
+        expect(activatedOrg).toStrictEqual(
+          expect.objectContaining({ tier: "pro", credits: 0 }),
+        );
+
+        return;
+      }
+
+      paidPeriod = period(30);
+      context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+        stripeSubscription(fixture, paidPeriod, quantities),
+      );
+      const renewalInvoice = paidInvoice(fixture, {
+        invoiceId: `in_${randomUUID()}`,
+        paidPeriod,
+        quantities,
+      });
+      await postStripeEvent(stripeEvent("invoice.paid", renewalInvoice), 200);
+      await expect(grantRows(fixture)).resolves.toHaveLength(4);
+      const renewalGrantRows = await grantRows(fixture);
+      expect(
+        renewalGrantRows.filter((grant) => {
+          return (
+            grant.expiresAt === new Date(paidPeriod.end * 1000).toISOString()
+          );
+        }),
+      ).toHaveLength(2);
+      expect(
+        (await readUsagePackState(fixture)).fulfillmentInvoiceIds,
+      ).toHaveLength(2);
+    },
+  );
 
   it("floors prorated purchased and bonus grants independently", async () => {
     const userId = `user_${randomUUID()}`;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/artifact-image-viewer.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/artifact-image-viewer.test.tsx
@@ -85,7 +85,7 @@ async function finishLightboxImageDecode(
   });
 }
 
-test("The image viewer navigates across one assistant response", async () => {
+test("The image viewer supports initial preview and download focus within one assistant response", async () => {
   const firstImageUrl =
     "https://cdn.vm7.io/artifacts/test/body-image-split-navigation/first.png";
   const secondImageUrl =
@@ -163,14 +163,11 @@ test("The image viewer navigates across one assistant response", async () => {
       },
     ],
   });
-
   await setupPage({ context, path: `/chats/${THREAD_ID}` });
-
   const expandHistory = await waitFor(() => {
     return getButtonByName("Expand work history");
   });
   click(expandHistory);
-
   const firstImage = await screen.findByAltText("first.png");
   const previewButton = firstImage.closest<HTMLElement>("button");
   if (!previewButton) {
@@ -208,13 +205,126 @@ test("The image viewer navigates across one assistant response", async () => {
   await waitFor(() => {
     expect(downloadButton).toHaveFocus();
   });
+});
+
+test("The image viewer supports next image within one assistant response", async () => {
+  const firstImageUrl =
+    "https://cdn.vm7.io/artifacts/test/body-image-split-navigation/first.png";
+  const secondImageUrl =
+    "https://cdn.vm7.io/artifacts/test/body-image-split-navigation/second.png";
+  const firstDecode = context.mocks.deferred<void>();
+  const secondDecode = context.mocks.deferred<void>();
+  vi.spyOn(HTMLImageElement.prototype, "decode").mockImplementation(function (
+    this: HTMLImageElement,
+  ) {
+    if (this.src === firstImageUrl) {
+      return firstDecode.promise;
+    }
+    if (this.src === secondImageUrl) {
+      return secondDecode.promise;
+    }
+    return Promise.resolve();
+  });
+  const runId = "run-body-image-split-navigation";
+  context.mocks.api(chatThreadArtifactsContract.list, ({ respond }) => {
+    return respond(200, {
+      runs: [
+        {
+          runId,
+          files: [
+            artifactFile(firstImageUrl, {
+              id: "artifact-body-split-first-image",
+              filename: "first.png",
+            }),
+            artifactFile(secondImageUrl, {
+              id: "artifact-body-split-second-image",
+              filename: "second.png",
+            }),
+          ],
+        },
+      ],
+    });
+  });
+  context.mocks.api(browserContract.get, ({ respond }) => {
+    return respond(404, {
+      error: {
+        code: "BROWSER_NOT_FOUND",
+        message: "Managed browser not found",
+      },
+    });
+  });
+  mockChatLifecycle(context, {
+    threadId: THREAD_ID,
+    chatEvents: [
+      {
+        id: "msg-body-image-split-label",
+        role: "assistant",
+        content: "Generated images:",
+        runId,
+        runEventId: "event:0",
+        sequenceNumber: 0,
+        createdAt: "2026-03-10T00:00:00Z",
+      },
+      {
+        id: "msg-body-image-split-first",
+        role: "assistant",
+        content: `1. ![first.png](${firstImageUrl})`,
+        runId,
+        runEventId: "event:1",
+        sequenceNumber: 1,
+        createdAt: "2026-03-10T00:00:01Z",
+      },
+      {
+        id: "msg-body-image-split-second",
+        role: "assistant",
+        content: `2. ![second.png](${secondImageUrl})`,
+        runId,
+        runEventId: "event:2",
+        sequenceNumber: 2,
+        createdAt: "2026-03-10T00:00:02Z",
+      },
+    ],
+  });
+  await setupPage({ context, path: `/chats/${THREAD_ID}` });
+  const expandHistory = await waitFor(() => {
+    return getButtonByName("Expand work history");
+  });
+  click(expandHistory);
+  const firstImage = await screen.findByAltText("first.png");
+  const previewButton = firstImage.closest<HTMLElement>("button");
+  if (!previewButton) {
+    throw new Error("Expected the first generated image to open a preview");
+  }
+  fireEvent.load(firstImage);
+  click(previewButton);
+  await waitFor(() => {
+    const image = getLightboxImage();
+    expect(image).toHaveAttribute("alt", "first.png");
+    expect(image).toHaveAttribute("src", firstImageUrl);
+  });
+  const dialog = screen.getByRole("dialog", { name: "first.png preview" });
+  await waitFor(() => {
+    expect(dialog).toHaveFocus();
+  });
+  const firstLightboxImage = getLightboxImage();
+  expect(firstLightboxImage).not.toBeVisible();
+  expect(
+    screen.getByRole("status", { name: "Loading artifacts" }),
+  ).toBeVisible();
+  setImageDimensions(firstLightboxImage, 1600, 900);
+  expect(firstLightboxImage).not.toBeVisible();
+  await finishLightboxImageDecode(firstLightboxImage, () => {
+    return firstDecode.resolve();
+  });
+  expect(firstLightboxImage).toHaveStyle({ width: "1600px" });
+  expect(
+    screen.queryByRole("status", { name: "Loading artifacts" }),
+  ).toBeNull();
   expect(queryButtonByName("Previous image artifact")).toBeUndefined();
   const nextImage = await waitFor(() => {
     return getButtonByName("Next image artifact");
   });
-
   click(nextImage);
-
   await waitFor(() => {
     const image = getLightboxImage();
     expect(image).toHaveAttribute("alt", "second.png");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-run-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-run-history.test.tsx
@@ -145,7 +145,7 @@ function completedWorkflowRun(args: {
   ];
 }
 
-test("Project all workflow run outputs through one run-group history", async () => {
+test("Project workflow history expansion through the existing run group", async () => {
   const events = [
     ...completedWorkflowRun({
       number: 1,
@@ -179,12 +179,10 @@ test("Project all workflow run outputs through one run-group history", async () 
     },
   ] satisfies MockChatEventInput[];
   installRunChat({ chatEvents: events, activeRunIds: [WORKFLOW_RUN_IDS[2]] });
-
   await setupPage({
     context,
     path: RUN_PATH,
   });
-
   await readyChat();
   expect(screen.queryByText("Earlier workflow evidence 1")).toBeNull();
   expect(screen.queryByText("Earlier workflow result 1")).toBeNull();
@@ -208,7 +206,6 @@ test("Project all workflow run outputs through one run-group history", async () 
       return link.getAttribute("aria-label") === "View agent profile";
     }),
   ).toHaveLength(1);
-
   click(await findWorkHistoryToggle("collapsed"));
   const firstEarlierEvidence = await screen.findByText(
     "Earlier workflow evidence 1",
@@ -221,10 +218,71 @@ test("Project all workflow run outputs through one run-group history", async () 
     assistantGroup,
   );
   expect(screen.queryByText("Nightly launch review")).toBeNull();
-
   click(await findWorkHistoryToggle("expanded"));
   await expect(findWorkHistoryToggle("collapsed")).resolves.toBeVisible();
+});
 
+test("Project workflow current run output through the existing run group", async () => {
+  const events = [
+    ...completedWorkflowRun({
+      number: 1,
+      runId: WORKFLOW_RUN_IDS[0],
+      seqId: 1,
+      minute: 0,
+    }),
+    ...completedWorkflowRun({
+      number: 2,
+      runId: WORKFLOW_RUN_IDS[1],
+      seqId: 5,
+      minute: 2,
+    }),
+    workflowInput({
+      id: "workflow-history-current-input",
+      runId: WORKFLOW_RUN_IDS[2],
+      runGroupId: WORKFLOW_GROUP_ID,
+      seqId: 9,
+      minute: 4,
+    }),
+    {
+      id: "workflow-history-current-thinking",
+      role: "assistant" as const,
+      eventType: "output.thinking" as const,
+      content: null,
+      thinking: "Checking the latest workflow run",
+      runId: WORKFLOW_RUN_IDS[2],
+      runGroupId: WORKFLOW_GROUP_ID,
+      seqId: 10,
+      createdAt: timestamp(4, 10),
+    },
+  ] satisfies MockChatEventInput[];
+  installRunChat({ chatEvents: events, activeRunIds: [WORKFLOW_RUN_IDS[2]] });
+  await setupPage({
+    context,
+    path: RUN_PATH,
+  });
+  await readyChat();
+  expect(screen.queryByText("Earlier workflow evidence 1")).toBeNull();
+  expect(screen.queryByText("Earlier workflow result 1")).toBeNull();
+  expect(screen.queryByText("Earlier workflow evidence 2")).toBeNull();
+  const main = screen.getByText("Earlier workflow result 2");
+  expect(main).toBeVisible();
+  expect(queryWorkHistoryToggle("collapsed")).toBeVisible();
+  const currentProgress = await screen.findByLabelText(
+    "Checking the latest workflow run",
+  );
+  expect(currentProgress).toBeVisible();
+  const assistantGroup = main.closest<HTMLElement>('[data-role="assistant"]');
+  if (!assistantGroup) {
+    throw new Error(
+      "Expected the workflow result inside an assistant response",
+    );
+  }
+  expect(assistantGroup).toContainElement(currentProgress);
+  expect(
+    queryAllByRoleFast("link").filter((link) => {
+      return link.getAttribute("aria-label") === "View agent profile";
+    }),
+  ).toHaveLength(1);
   events.push(
     assistantOutput({
       id: "workflow-history-current-result",
@@ -237,7 +295,6 @@ test("Project all workflow run outputs through one run-group history", async () 
     }),
   );
   publishRunUpdate();
-
   const currentMain = await screen.findByText("Current workflow result");
   expect(currentMain).toBeVisible();
   expect(screen.queryByText("Earlier workflow result 2")).toBeNull();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-presentation-gallery.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-presentation-gallery.test.tsx
@@ -53,7 +53,7 @@ async function openPresentationThemePreview() {
   const capture = mockTemplateChat();
   const template = builtInTemplate();
   mockTemplateObjectUrls();
-  mockPresentationHtml(template.embedUrl, ["Opening", "Evidence", "Close"]);
+  mockPresentationHtml(template.embedUrl, ["Opening"]);
   installImmediateAnimationFrames();
   const user = userEvent.setup();
 
@@ -122,7 +122,7 @@ test("Use a presentation template's default theme", async () => {
   });
 
   await openTemplatePicker(user, "Presentation");
-  await user.click(screen.getByLabelText(`Select template ${template.title}`));
+  click(screen.getByLabelText(`Select template ${template.title}`));
   await expectInlineTemplate(template.title);
   await sendComposerMessage(user, "Create a presentation with this template");
   await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-media.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-media.test.tsx
@@ -153,15 +153,19 @@ async function filterProfessionalAvatars(
   return filters;
 }
 
-test("Filter and preview avatar templates before restoring the full catalog", async () => {
+test("Preview avatar templates within the selected style", async () => {
   const { user, dialog, media } = await openAvatarCatalog();
-  const filters = await filterProfessionalAvatars(user, dialog);
+  await filterProfessionalAvatars(user, dialog);
   await user.hover(
     within(dialog).getByLabelText("Select template Motion Maya"),
   );
   expect(media.play).toHaveBeenCalledWith();
   expect(within(dialog).getByAltText("Still Sara")).toBeVisible();
+});
 
+test("Clearing an avatar style restores the full catalog", async () => {
+  const { user, dialog } = await openAvatarCatalog();
+  const filters = await filterProfessionalAvatars(user, dialog);
   await user.click(buttonNamed("Clear", filters));
   await expect(
     within(dialog).findByLabelText("Select template Social Sam"),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-uploaded-presentation-templates.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-uploaded-presentation-templates.test.tsx
@@ -396,7 +396,7 @@ test("Keep uploaded-template browsing stable during changes", async () => {
   expectTextBefore(remaining.title, firstBuiltInTitle());
 });
 
-test("Keep workspace template availability current", async () => {
+test("Keep workspace templates current through publication after changing chats", async () => {
   mockNow(UPLOADED_TEMPLATE_NOW_MS, context.signal);
   const capture = mockTemplateChat();
   const existing = createUploadedTemplate({
@@ -428,13 +428,11 @@ test("Keep workspace template availability current", async () => {
   ]);
   trackTemplatePreviewImagePreloads();
   const user = userEvent.setup();
-
   await setupPage({
     context,
     path: `/chats/${THREAD_ID}`,
     host: "app.okou.ai",
   });
-
   await openTemplatePicker(user, "Presentation");
   await waitFor(() => {
     expect(screen.getByText(existing.title)).toBeVisible();
@@ -447,7 +445,6 @@ test("Keep workspace template availability current", async () => {
   await waitFor(() => {
     expect(secondChat).toHaveAttribute("aria-current", "page");
   });
-
   library.replace([existing, published]);
   context.mocks.ably.triggerOnChannel(
     "org:org_default",
@@ -461,12 +458,66 @@ test("Keep workspace template availability current", async () => {
       screen.getByLabelText(`Select template ${published.title}`),
     ).toBeEnabled();
   });
+});
+
+test("Keep workspace templates current through withdrawal after preview", async () => {
+  mockNow(UPLOADED_TEMPLATE_NOW_MS, context.signal);
+  const capture = mockTemplateChat();
+  const existing = createUploadedTemplate({
+    id: UPLOADED_TEMPLATE_ID,
+    title: "Existing Workspace Deck",
+    canManage: false,
+  });
+  const published = createUploadedTemplate({
+    id: UPDATED_TEMPLATE_ID,
+    title: "New Workspace Deck",
+    canManage: false,
+  });
+  const library = mockPresentationTemplateLibrary([existing]);
+  capture.lifecycle.setThreadList([
+    {
+      id: THREAD_ID,
+      title: "First workspace chat",
+      agent: { id: AGENT_ID, avatarUrl: null },
+      createdAt: "2026-08-01T00:00:00.000Z",
+      updatedAt: "2026-08-01T00:01:00.000Z",
+    },
+    {
+      id: OTHER_THREAD_ID,
+      title: "Second workspace chat",
+      agent: { id: AGENT_ID, avatarUrl: null },
+      createdAt: "2026-08-01T00:02:00.000Z",
+      updatedAt: "2026-08-01T00:03:00.000Z",
+    },
+  ]);
+  trackTemplatePreviewImagePreloads();
+  const user = userEvent.setup();
+  await setupPage({
+    context,
+    path: `/chats/${THREAD_ID}`,
+    host: "app.okou.ai",
+  });
+  await openTemplatePicker(user, "Presentation");
+  await waitFor(() => {
+    expect(screen.getByText(existing.title)).toBeVisible();
+  });
+  library.replace([existing, published]);
+  context.mocks.ably.triggerOnChannel(
+    "org:org_default",
+    "presentationTemplatesChanged",
+    published.id,
+  );
+  await waitFor(() => {
+    expect(screen.getByText(published.title)).toBeVisible();
+    expect(
+      screen.getByLabelText(`Select template ${published.title}`),
+    ).toBeEnabled();
+  });
   click(buttonNamed(`Preview ${published.title} at current slide`));
   await screen.findByRole("group", {
     name: `${published.title} slide preview`,
   });
   click(buttonContainingText("Template", screen.getByRole("dialog")));
-
   library.replace([existing]);
   context.mocks.ably.triggerOnChannel(
     "org:org_default",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-drafts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-drafts.test.tsx
@@ -268,7 +268,7 @@ async function typePersistentDraft() {
   });
 
   const composer = await messageComposer();
-  await userEvent.type(composer, "Unsent launch checklist");
+  await fill(composer, "Unsent launch checklist");
   await waitFor(() => {
     expect(
       workspace.draftPatches.some((patch) => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connector-page-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connector-page-test-helpers.ts
@@ -330,10 +330,22 @@ function publicOAuthConfig(
   return publicConfig;
 }
 
-export function mockCustomConnectorStory(context: TestContext): void {
+export function mockCustomConnectorStory(
+  context: TestContext,
+  initial: readonly {
+    readonly connector: CustomConnectorHttpResponse;
+    readonly account?: ConnectorAccountConnection;
+  }[] = [],
+): void {
   context.mocks.data.org({ id: "org_1", name: "Test Org", role: "admin" });
-  let connectors: CustomConnectorHttpResponse[] = [];
-  const accounts = new Map<string, ConnectorAccountConnection>();
+  let connectors = initial.map(({ connector }) => {
+    return connector;
+  });
+  const accounts = new Map<string, ConnectorAccountConnection>(
+    initial.flatMap(({ connector, account }) => {
+      return account ? [[connector.id, account] as const] : [];
+    }),
+  );
   context.mocks.api(customConnectorsContract.list, ({ respond }) => {
     return respond(200, { connectors });
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-custom.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-custom.test.tsx
@@ -759,7 +759,7 @@ test("Complete a custom connector’s declared fields", async () => {
   });
 });
 
-test("Manage a custom HTTP connector through its lifecycle", async () => {
+test("Manage a custom HTTP connector through creation and connection", async () => {
   mockCustomConnectorStory(context);
   context.mocks.data.agents([
     listAgent(RESEARCH_ID, "Research"),
@@ -779,7 +779,6 @@ test("Manage a custom HTTP connector through its lifecycle", async () => {
       "No custom connectors yet. Create one to register an API for every member to use.",
     ),
   ).resolves.toBeInTheDocument();
-
   click(getConnectorAction("button", "New connector"));
   const create = await screen.findByRole("dialog", {
     name: "New custom connector",
@@ -805,7 +804,6 @@ test("Manage a custom HTTP connector through its lifecycle", async () => {
   expect(card).toHaveTextContent("HTTP API");
   expect(card).toHaveTextContent("https://api.acme.test/v1/");
   expect(card).toHaveTextContent("No accounts");
-
   click(getConnectorAction("button", "Connect Acme API", card));
   const connect = await screen.findByRole("dialog", {
     name: "Connect Acme API",
@@ -826,7 +824,38 @@ test("Manage a custom HTTP connector through its lifecycle", async () => {
       ),
     ).toHaveTextContent("Used by 2 agents");
   });
+});
 
+test("Manage a custom HTTP connector through rename and deletion", async () => {
+  const existing = customConnector({
+    displayName: "Acme API",
+    connected: true,
+    connectedAccountId: "66666666-6666-4666-8666-666666666666",
+    missingRequiredFields: [],
+    configuredFieldKeys: ["secret"],
+  });
+  mockCustomConnectorStory(context, [
+    {
+      connector: existing,
+      account: customAccount(
+        existing.id,
+        "66666666-6666-4666-8666-666666666666",
+      ),
+    },
+  ]);
+  context.mocks.data.agents([
+    listAgent(RESEARCH_ID, "Research"),
+    listAgent(SUPPORT_ID, "Support"),
+  ]);
+  await setupPage({
+    context,
+    path: "/connectors",
+  });
+  click(
+    await waitFor(() => {
+      return getConnectorAction("tab", "Custom");
+    }),
+  );
   click(
     await waitFor(() => {
       return getConnectorAction("button", "More options");
@@ -851,7 +880,6 @@ test("Manage a custom HTTP connector through its lifecycle", async () => {
   expect(getConnectorCard("Acme Billing API")).toHaveTextContent(
     "https://api.acme.test/v1/",
   );
-
   click(
     await waitFor(() => {
       return getConnectorAction("button", "More options");
@@ -865,7 +893,6 @@ test("Manage a custom HTTP connector through its lifecycle", async () => {
   const deletion = await screen.findByRole("dialog");
   expect(deletion).toHaveTextContent("Delete Acme Billing API?");
   click(getConnectorAction("button", "Delete", deletion));
-
   await expect(
     screen.findByText(
       "No custom connectors yet. Create one to register an API for every member to use.",
@@ -873,7 +900,7 @@ test("Manage a custom HTTP connector through its lifecycle", async () => {
   ).resolves.toBeInTheDocument();
 });
 
-test("Configure and maintain OAuth for a custom HTTP connector", async () => {
+test("Manage custom HTTP OAuth through creation", async () => {
   const completedAttempts = mockOAuthCompletions(context);
   const oauthAttemptId = crypto.randomUUID();
   let connector: CustomConnectorHttpResponse | null = null;
@@ -930,7 +957,11 @@ test("Configure and maintain OAuth for a custom HTTP connector", async () => {
       if (!connector) {
         throw new Error("Expected OAuth connector");
       }
-      connector = { ...connector, connected: true, missingRequiredFields: [] };
+      connector = {
+        ...connector,
+        connected: true,
+        missingRequiredFields: [],
+      };
       const connectedAccountId =
         connector.connectedAccountId ?? crypto.randomUUID();
       connector = { ...connector, connectedAccountId };
@@ -1009,9 +1040,7 @@ test("Configure and maintain OAuth for a custom HTTP connector", async () => {
     ]);
   });
   expect(getConnectorAction("button", "Create", create)).toBeEnabled();
-
   click(getConnectorAction("button", "Create", create));
-
   const card = await waitFor(() => {
     return getConnectorCard("Acme API");
   });
@@ -1033,7 +1062,107 @@ test("Configure and maintain OAuth for a custom HTTP connector", async () => {
     },
   });
   expect(card).not.toHaveTextContent("connector-oauth-client-secret");
+});
 
+test("Manage custom HTTP OAuth through configuration update and connection", async () => {
+  const completedAttempts = mockOAuthCompletions(context);
+  const oauthAttemptId = crypto.randomUUID();
+  let connector: CustomConnectorHttpResponse | null = customConnector({
+    displayName: "Acme API",
+    fields: [],
+    headerInjections: [],
+    queryInjections: [],
+    authMode: "oauth",
+    missingRequiredFields: ["oauth"],
+    oauthConfig: {
+      providerAdapter: "standard",
+      authorizationUrl: "https://oauth.acme.test/authorize",
+      tokenUrl: "https://oauth.acme.test/token",
+      clientId: "connector-oauth-client-id",
+      tokenEndpointAuthMethod: "client_secret_post",
+      scopes: ["search.read", "search.write"],
+      pkceMethod: "S256",
+      authorizationParams: {
+        resource: "https://api.acme.test",
+        audience: "acme-api",
+        access_type: "offline",
+        prompt: "consent",
+      },
+    },
+  });
+  const created: CreateCustomConnectorBody[] = [];
+  const updated: UpdateCustomConnectorBody[] = [];
+  const authWindow = createAuthWindow();
+  context.mocks.browser.open(authWindow);
+  context.mocks.data.agents([listAgent(RESEARCH_ID, "Research")]);
+  context.mocks.api(customConnectorsContract.list, ({ respond }) => {
+    return respond(200, { connectors: connector ? [connector] : [] });
+  });
+  context.mocks.api(customConnectorsContract.create, ({ body, respond }) => {
+    if (!body.oauthConfig || body.kind === "mcp") {
+      throw new Error("Expected OAuth HTTP connector");
+    }
+    created.push(body);
+    connector = customConnector({
+      displayName: body.displayName,
+      prefixTemplates: body.prefixTemplates ?? [],
+      fields: body.fields ?? [],
+      headerInjections: body.headerInjections ?? [],
+      queryInjections: body.queryInjections ?? [],
+      authMode: "oauth",
+      oauthConfig: publicOAuthConfig(body.oauthConfig),
+      missingRequiredFields: ["oauth"],
+    });
+    return respond(201, connector);
+  });
+  context.mocks.api(customConnectorByIdContract.update, ({ body, respond }) => {
+    if (!connector || body.kind === "mcp" || !body.oauthConfig) {
+      throw new Error("Expected OAuth HTTP connector update");
+    }
+    updated.push(body);
+    const updatedConnector = customConnectorHttpResponseSchema.parse({
+      ...connector,
+      displayName: body.displayName,
+      prefixTemplates: body.prefixTemplates,
+      fields: body.fields,
+      headerInjections: body.headerInjections,
+      queryInjections: body.queryInjections,
+      storageVersion: body.storageVersion ?? connector.storageVersion,
+      oauthConfig: publicOAuthConfig(body.oauthConfig),
+      connected: false,
+      missingRequiredFields: ["oauth"],
+    });
+    connector = updatedConnector;
+    return respond(200, updatedConnector);
+  });
+  context.mocks.api(
+    customConnectorOAuth2Contract.start,
+    ({ body, respond }) => {
+      expect(body.account).toStrictEqual({ intent: "add" });
+      if (!connector) {
+        throw new Error("Expected OAuth connector");
+      }
+      connector = {
+        ...connector,
+        connected: true,
+        missingRequiredFields: [],
+      };
+      const connectedAccountId =
+        connector.connectedAccountId ?? crypto.randomUUID();
+      connector = { ...connector, connectedAccountId };
+      completedAttempts.set(oauthAttemptId, connectedAccountId);
+      authWindow.close();
+      return respond(200, {
+        result: "authorization",
+        oauthAttemptId,
+        authorizationUrl: "https://oauth.acme.test/authorize?state=ui-test",
+      });
+    },
+  );
+  mockCustomAccountSummary(() => {
+    return connector;
+  });
+  await setupCustomPage();
   click(
     await waitFor(() => {
       return getConnectorAction("button", "More options");
@@ -1064,9 +1193,7 @@ test("Configure and maintain OAuth for a custom HTTP connector", async () => {
   expect(confirmation).toHaveTextContent(
     /disconnect every member currently connected with OAuth/u,
   );
-
   click(getConnectorAction("button", "Save and disconnect", confirmation));
-
   await waitFor(() => {
     return expect(updated).toHaveLength(1);
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-billing-tab.test.tsx
@@ -380,14 +380,16 @@ function mockInitialUsagePackPurchase(supportsFreeMembers?: boolean): void {
   });
 }
 
-async function openUsagePackPlanSelection(): Promise<{
+async function openUsagePackPlanSelection(
+  path = "/?settings=billing",
+): Promise<{
   choosePlanHeading: HTMLElement;
   proPlan: HTMLElement;
   teamPlan: HTMLElement;
 }> {
   await setupPage({
     context,
-    path: "/?settings=billing",
+    path,
     auth: {
       user: {
         id: "user_1",
@@ -528,7 +530,7 @@ test("Compare usage-pack plans before choosing one", async () => {
 });
 
 test.each(["pro", "team"] as const)(
-  "Default a new %s plan to the $20 member package",
+  "Default new '%s' member packages through 'checkout preview'",
   async (tier) => {
     mockInitialUsagePackPurchase(true);
     context.mocks.api(
@@ -555,12 +557,13 @@ test.each(["pro", "team"] as const)(
         });
       },
     );
-    const { proPlan, teamPlan } = await openUsagePackPlanSelection();
+    const { proPlan, teamPlan } = await openUsagePackPlanSelection(
+      "/agents?settings=billing",
+    );
     const plan = tier === "pro" ? proPlan : teamPlan;
     click(
       buttonByText(tier === "pro" ? "Start with Pro" : "Start with Team", plan),
     );
-
     const memberUsage = await screen.findByRole("group", {
       name: "Member usage",
     });
@@ -576,7 +579,6 @@ test.each(["pro", "team"] as const)(
       ).toHaveTextContent("21,234 credits · 6% off");
     }
     expect(buttonByText(upgradeLabel, orderSummary)).toBeEnabled();
-
     click(buttonByText(upgradeLabel, orderSummary));
     const confirmation = await screen.findByRole("dialog", {
       name: "Order summary",
@@ -587,7 +589,59 @@ test.each(["pro", "team"] as const)(
         screen.queryByRole("dialog", { name: "Order summary" }),
       ).not.toBeInTheDocument();
     });
+  },
+);
 
+test.each(["pro", "team"] as const)(
+  "Default new '%s' member packages through 'empty selection recovery'",
+  async (tier) => {
+    mockInitialUsagePackPurchase(true);
+    context.mocks.api(
+      billingUsagePackCheckoutContract.create,
+      ({ body, respond }) => {
+        expect(body).toMatchObject({
+          tier,
+          supportsInAppPreview: true,
+          memberUsagePacks: [
+            { memberId: "user_1", usagePackUsd: 20 },
+            { memberId: "user_2", usagePackUsd: 20 },
+            { memberId: "invitation_1", usagePackUsd: 20 },
+          ],
+        });
+        return respond(200, {
+          status: "preview",
+          purchaseType: "usage_pack",
+          tier,
+          immediateAmountCents: tier === "pro" ? 6000 : 22_000,
+          nextRecurringAmountCents: tier === "pro" ? 6000 : 22_000,
+          currency: "usd",
+          expiresAt: "2026-03-16T00:15:00Z",
+          previewToken: `usage-pack-${tier}-preview`,
+        });
+      },
+    );
+    const { proPlan, teamPlan } = await openUsagePackPlanSelection(
+      "/agents?settings=billing",
+    );
+    const plan = tier === "pro" ? proPlan : teamPlan;
+    click(
+      buttonByText(tier === "pro" ? "Start with Pro" : "Start with Team", plan),
+    );
+    const memberUsage = await screen.findByRole("group", {
+      name: "Member usage",
+    });
+    const orderSummary = screen.getByRole("region", {
+      name: "Order summary",
+    });
+    const upgradeLabel = tier === "pro" ? "Upgrade to Pro" : "Upgrade to Team";
+    for (const memberName of ["Alex Chen", "Sam Lee", "pending@example.com"]) {
+      expect(
+        within(memberUsage).getByRole("combobox", {
+          name: `Usage for ${memberName}`,
+        }),
+      ).toHaveTextContent("21,234 credits · 6% off");
+    }
+    expect(buttonByText(upgradeLabel, orderSummary)).toBeEnabled();
     for (const memberName of ["Alex Chen", "Sam Lee", "pending@example.com"]) {
       await selectMemberUsagePack(memberUsage, memberName, "No package");
     }
@@ -597,7 +651,6 @@ test.each(["pro", "team"] as const)(
         "Select a paid package for at least one member to continue.",
       ),
     ).toBeVisible();
-
     await selectMemberUsagePack(
       memberUsage,
       "Alex Chen",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/personal-providers-tab.test.tsx
@@ -249,7 +249,7 @@ function mockBrowserTimeZone(timeZone: string): void {
   });
 }
 
-test("Review and explicitly switch personal subscription accounts", async () => {
+test("Review personal subscriptions through account identity", async () => {
   const user = userEvent.setup();
   mockBrowserTimeZone("America/New_York");
   mockNow(new Date("2030-01-01T00:48:00.000Z"), context.signal);
@@ -287,11 +287,9 @@ test("Review and explicitly switch personal subscription accounts", async () => 
     subscriptionResetCredits: null,
   };
   context.mocks.data.personalModelProviders([accountA, accountB, accountC]);
-
   await openModelSettings("Models", {
     [FeatureSwitchKey.PersonalModelProviderAccounts]: true,
   });
-
   const rowA = await screen.findByTestId(`oauth-account-${accountA.id}`);
   const rowB = await screen.findByTestId(`oauth-account-${accountB.id}`);
   const rowC = await screen.findByTestId(`oauth-account-${accountC.id}`);
@@ -318,18 +316,91 @@ test("Review and explicitly switch personal subscription accounts", async () => 
       return button.textContent?.trim() === "Add account";
     }),
   ).toHaveLength(2);
-
   const accountIdentity = within(rowA).getByText("account-a@example.com");
   await user.hover(accountIdentity);
   await expect(
     screen.findAllByText("Account A Organization"),
   ).resolves.not.toHaveLength(0);
+  click(within(rowA).getByLabelText("More options"));
+  expect(
+    queryAllByRoleFast("menuitem").some((item) => {
+      return item.textContent?.trim() === "Remove";
+    }),
+  ).toBeFalsy();
+  click(within(rowA).getByLabelText("More options"));
+});
 
+test("Review personal subscriptions through usage details", async () => {
+  const user = userEvent.setup();
+  mockBrowserTimeZone("America/New_York");
+  mockNow(new Date("2030-01-01T00:48:00.000Z"), context.signal);
+  context.mocks.data.org({
+    id: "org_1",
+    name: "Test Org",
+    role: "member",
+  });
+  const accountA = {
+    ...connectedPersonalCodexAccount({
+      id: "00000000-0000-4000-a000-000000000311",
+      email: "account-a@example.com",
+      isActive: true,
+      createdAt: "2026-03-01T00:00:00Z",
+    }),
+    workspaceName: "Account A Organization",
+    subscriptionResetCreditsNextExpiresAt: "2030-01-04T00:48:00.000Z",
+  };
+  const accountB = {
+    ...connectedPersonalCodexAccount({
+      id: "00000000-0000-4000-a000-000000000312",
+      email: "account-b@example.com",
+      isActive: false,
+      createdAt: "2026-03-02T00:00:00Z",
+    }),
+    subscriptionResetCredits: 0,
+  };
+  const accountC = {
+    ...connectedPersonalCodexAccount({
+      id: "00000000-0000-4000-a000-000000000313",
+      email: "account-c@example.com",
+      isActive: false,
+      createdAt: "2026-03-03T00:00:00Z",
+    }),
+    subscriptionResetCredits: null,
+  };
+  context.mocks.data.personalModelProviders([accountA, accountB, accountC]);
+  await openModelSettings("Models", {
+    [FeatureSwitchKey.PersonalModelProviderAccounts]: true,
+  });
+  const rowA = await screen.findByTestId(`oauth-account-${accountA.id}`);
+  const rowB = await screen.findByTestId(`oauth-account-${accountB.id}`);
+  const rowC = await screen.findByTestId(`oauth-account-${accountC.id}`);
+  expect(within(rowA).getByText("account-a@example.com")).toBeInTheDocument();
+  expect(within(rowB).getByText("account-b@example.com")).toBeInTheDocument();
+  expect(within(rowA).getByText("2 resets left")).toBeVisible();
+  expect(within(rowB).getByText("0 resets left")).toBeVisible();
+  expect(within(rowC).getByText("Resets —")).toBeVisible();
+  expect(
+    within(rowC).getByLabelText("Resets left unavailable"),
+  ).toBeInTheDocument();
+  expect(within(rowA).queryByText("Active")).not.toBeInTheDocument();
+  expect(within(rowB).queryByText("Active")).not.toBeInTheDocument();
+  expect(within(rowB).queryByText("Use")).not.toBeInTheDocument();
+  expect(radioByName("Active", rowA)).toHaveAttribute("aria-checked", "true");
+  expect(radioByName("Use", rowB)).toHaveAttribute("aria-checked", "false");
+  const usageRings = within(rowA).getAllByRole("progressbar");
+  expect(usageRings).toHaveLength(2);
+  expect(usageRings[0]).toHaveAttribute("aria-valuenow", "82");
+  expect(usageRings[1]).toHaveAttribute("aria-valuenow", "55");
+  expect(within(rowA).queryByText("82% left")).not.toBeInTheDocument();
+  expect(
+    queryAllByRoleFast("button").filter((button) => {
+      return button.textContent?.trim() === "Add account";
+    }),
+  ).toHaveLength(2);
   await user.hover(within(rowA).getByLabelText("2 resets left"));
   await expect(
     screen.findAllByText("2 resets left · expires in 3d"),
   ).resolves.not.toHaveLength(0);
-
   usageRings[0].focus();
   await expect(screen.findAllByText("82% left")).resolves.not.toHaveLength(0);
   expect(
@@ -349,15 +420,74 @@ test("Review and explicitly switch personal subscription accounts", async () => 
       ).replace(/^resets /u, ""),
     ),
   ).resolves.not.toHaveLength(0);
+});
 
-  click(within(rowA).getByLabelText("More options"));
-  expect(
-    queryAllByRoleFast("menuitem").some((item) => {
-      return item.textContent?.trim() === "Remove";
+test("Review personal subscriptions through account switching", async () => {
+  mockBrowserTimeZone("America/New_York");
+  mockNow(new Date("2030-01-01T00:48:00.000Z"), context.signal);
+  context.mocks.data.org({
+    id: "org_1",
+    name: "Test Org",
+    role: "member",
+  });
+  const accountA = {
+    ...connectedPersonalCodexAccount({
+      id: "00000000-0000-4000-a000-000000000311",
+      email: "account-a@example.com",
+      isActive: true,
+      createdAt: "2026-03-01T00:00:00Z",
     }),
-  ).toBeFalsy();
-  click(within(rowA).getByLabelText("More options"));
-
+    workspaceName: "Account A Organization",
+    subscriptionResetCreditsNextExpiresAt: "2030-01-04T00:48:00.000Z",
+  };
+  const accountB = {
+    ...connectedPersonalCodexAccount({
+      id: "00000000-0000-4000-a000-000000000312",
+      email: "account-b@example.com",
+      isActive: false,
+      createdAt: "2026-03-02T00:00:00Z",
+    }),
+    subscriptionResetCredits: 0,
+  };
+  const accountC = {
+    ...connectedPersonalCodexAccount({
+      id: "00000000-0000-4000-a000-000000000313",
+      email: "account-c@example.com",
+      isActive: false,
+      createdAt: "2026-03-03T00:00:00Z",
+    }),
+    subscriptionResetCredits: null,
+  };
+  context.mocks.data.personalModelProviders([accountA, accountB, accountC]);
+  await openModelSettings("Models", {
+    [FeatureSwitchKey.PersonalModelProviderAccounts]: true,
+  });
+  const rowA = await screen.findByTestId(`oauth-account-${accountA.id}`);
+  const rowB = await screen.findByTestId(`oauth-account-${accountB.id}`);
+  const rowC = await screen.findByTestId(`oauth-account-${accountC.id}`);
+  expect(within(rowA).getByText("account-a@example.com")).toBeInTheDocument();
+  expect(within(rowB).getByText("account-b@example.com")).toBeInTheDocument();
+  expect(within(rowA).getByText("2 resets left")).toBeVisible();
+  expect(within(rowB).getByText("0 resets left")).toBeVisible();
+  expect(within(rowC).getByText("Resets —")).toBeVisible();
+  expect(
+    within(rowC).getByLabelText("Resets left unavailable"),
+  ).toBeInTheDocument();
+  expect(within(rowA).queryByText("Active")).not.toBeInTheDocument();
+  expect(within(rowB).queryByText("Active")).not.toBeInTheDocument();
+  expect(within(rowB).queryByText("Use")).not.toBeInTheDocument();
+  expect(radioByName("Active", rowA)).toHaveAttribute("aria-checked", "true");
+  expect(radioByName("Use", rowB)).toHaveAttribute("aria-checked", "false");
+  const usageRings = within(rowA).getAllByRole("progressbar");
+  expect(usageRings).toHaveLength(2);
+  expect(usageRings[0]).toHaveAttribute("aria-valuenow", "82");
+  expect(usageRings[1]).toHaveAttribute("aria-valuenow", "55");
+  expect(within(rowA).queryByText("82% left")).not.toBeInTheDocument();
+  expect(
+    queryAllByRoleFast("button").filter((button) => {
+      return button.textContent?.trim() === "Add account";
+    }),
+  ).toHaveLength(2);
   click(radioByName("Use", rowB));
   await waitFor(() => {
     expect(radioByName("Active", rowB)).toHaveAttribute("aria-checked", "true");


### PR DESCRIPTION
## Problem and behavior

The September 11 Beijing CI audit found compound TypeScript scenarios running within one second of their effective timeout, including actual test and teardown timeouts. Split **20 original scenarios into 43 independently runnable cases** across API and Platform tests, covering iMessage sessions, connector authorization and searches, workflow recovery, Teams context, Stripe lifecycle, artifact navigation, template pickers, account settings, and billing.

Preserve the original assertions, real API/page entry points, failure-to-recovery transitions, selected-account/session identity, and cleanup. Separately reduce fixture overhead for **6 existing scenarios** with bounded and fully awaited account cleanup, one-slide theme fixtures, and ordinary complete-value text entry. Billing cases open the same settings flow from Agents. Bind deferred OAuth provider fixtures to their test owner so teardown can cancel a held request before draining detached work. Timeout settings are unchanged.

Relates to #33572. This daily tracker deliberately remains open for the documented causal contracts, removed-but-unverified coverage, and unavailable CI logs. Its reconciliation tables account for all 123 Vitest candidates, including **31 historical repairs verified locally**. The browser overlay defect is tracked separately in #33578. This PR does not close the previous-day tracker #33319.

## Validation

- Bounded targeted Vitest runs with at most two workers and sequential heavy checks: **39 API cases and 25 Platform cases passed**. Final API maximum: **3396.086ms**. After the additional billing fixture change, all four billing replacements passed at **650.928–1679.146ms**; all three owned OAuth poll replacements passed at **46.726–221.207ms**.
- Retained initial failures and measurements in the audit evidence. A parallel account-creation experiment exposed a 101-versus-96 pagination result and was removed; account creation remains sequential. An intermediate billing case took 4096.302ms before the final fixture change. Neither observation is discarded or treated as a passing retry.
- Formatting, affected-file Oxlint, type-aware lint, ESLint, API/Platform test type checks, and scoped Knip passed. Full suites are delegated to PR CI.
- Assertion conservation inspection found only the intentional local variable rename for the connector thread and the per-scenario division of the Teams reaction list; all original expectations remain represented.

The issue's before/after mapping and evidence archive carry each original scenario, all replacements, historical fixing commits, commands, measurements, and precise unresolved dispositions. CI timings and protected merge status will be recorded against the submitted head.
