### PR TITLE
refactor(api): make pi api-first transitions explicit

### DIFF
--- a/crates/guest-agent/src/cli/pi_rpc.rs
+++ b/crates/guest-agent/src/cli/pi_rpc.rs
@@ -1164,6 +1164,63 @@ mod tests {
 
     use super::*;
 
+    #[test]
+    fn projection_matches_shared_public_event_fixtures() {
+        let fixture: Value =
+            serde_json::from_str(include_str!("../../../../fixtures/pi-public-events.json"))
+                .expect("shared public event fixture must parse");
+        for case in fixture["cases"].as_array().expect("fixture cases") {
+            let name = case["name"].as_str().expect("case name");
+            let (responses, _rx) = response_channel();
+            let mut projection = PiRpcProjection::new(
+                fixture["runId"].as_str().expect("run id"),
+                fixture["sessionId"].as_str().expect("session id"),
+            );
+            let projected = projection
+                .project(
+                    json!({ "type": "message_end", "message": case["guestMessage"] }),
+                    &responses,
+                    0,
+                )
+                .expect("official assistant should project");
+            let events: Vec<Value> = projected
+                .into_iter()
+                .flat_map(|event| {
+                    super::super::provider_event_normalization::normalize_for_sequencing(
+                        crate::env::Framework::Pi,
+                        event,
+                    )
+                })
+                .collect();
+            let messages: Vec<&Value> = events.iter().map(|event| &event["message"]).collect();
+            assert_eq!(json!(messages), case["expectedMessages"], "{name}");
+            // Guest sequencing belongs to the installed startup boundary and
+            // ingestor. Projection does not invent the API's zero-based index.
+            for event in events {
+                assert_eq!(event["type"], "assistant", "{name}");
+                assert!(event.get("sequenceNumber").is_none(), "{name}");
+                assert!(event.get("duration_ms").is_none(), "{name}");
+            }
+            assert!(
+                projection
+                    .project(json!({ "type": "agent_end" }), &responses, 0)
+                    .expect("agent_end is not terminal")
+                    .is_none(),
+                "{name}"
+            );
+            let terminal = projection
+                .project(json!({ "type": "agent_settled" }), &responses, 0)
+                .expect("agent_settled should project")
+                .expect("only agent_settled owns the terminal result");
+            assert_eq!(terminal["type"], "result", "{name}");
+            assert_eq!(terminal["subtype"], "success", "{name}");
+            assert_eq!(terminal["is_error"], false, "{name}");
+            assert_eq!(terminal["result"], case["guestResult"], "{name}");
+            assert_eq!(terminal["session_id"], fixture["sessionId"], "{name}");
+            assert!(terminal["duration_ms"].as_u64().is_some(), "{name}");
+        }
+    }
+
     async fn next_command(reader: &mut BufReader<tokio::process::ChildStdout>) -> Value {
         let mut line = String::new();
         reader

--- a/fixtures/pi-public-events.json
+++ b/fixtures/pi-public-events.json
@@ -1,0 +1,552 @@
+{
+  "runId": "run-fixture",
+  "sessionId": "session-fixture",
+  "apiStartedAt": 100,
+  "apiObservedAt": 125,
+  "apiDurationMs": 25,
+  "cases": [
+    {
+      "name": "trim text and omit empty and thinking blocks",
+      "guestMessage": {
+        "role": "assistant",
+        "api": "openai-responses",
+        "provider": "openai",
+        "model": "fixture-model",
+        "timestamp": 42,
+        "usage": {
+          "input": 11,
+          "output": 7,
+          "cacheRead": 5,
+          "cacheWrite": 3,
+          "totalTokens": 26,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0,
+            "total": 0
+          }
+        },
+        "stopReason": "stop",
+        "responseId": "response-fixture",
+        "content": [
+          {
+            "type": "text",
+            "text": " \n hello \t"
+          },
+          {
+            "type": "text",
+            "text": "\n\t "
+          },
+          {
+            "type": "thinking",
+            "thinking": "private reasoning"
+          },
+          {
+            "type": "text",
+            "text": " world \n"
+          }
+        ]
+      },
+      "apiAssistant": {
+        "model": "fixture-model",
+        "timestamp": 42,
+        "usage": {
+          "input": 11,
+          "output": 7,
+          "cacheRead": 5,
+          "cacheWrite": 3
+        },
+        "stopReason": "stop",
+        "responseId": "response-fixture",
+        "content": [
+          {
+            "type": "text",
+            "text": " \n hello \t"
+          },
+          {
+            "type": "text",
+            "text": "\n\t "
+          },
+          {
+            "type": "text",
+            "text": " world \n"
+          }
+        ]
+      },
+      "expectedMessages": [
+        {
+          "id": "response-fixture",
+          "role": "assistant",
+          "model": "fixture-model",
+          "usage": {
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "cache_read_input_tokens": 5,
+            "cache_creation_input_tokens": 3
+          },
+          "content": [
+            {
+              "type": "text",
+              "text": "hello"
+            }
+          ]
+        },
+        {
+          "id": "response-fixture",
+          "role": "assistant",
+          "model": "fixture-model",
+          "usage": {
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "cache_read_input_tokens": 5,
+            "cache_creation_input_tokens": 3
+          },
+          "content": [
+            {
+              "type": "text",
+              "text": "world"
+            }
+          ]
+        }
+      ],
+      "apiResult": "hello\n\nworld",
+      "guestResult": "hello\n\nworld"
+    },
+    {
+      "name": "ordered tool blocks and fallback identity",
+      "guestMessage": {
+        "role": "assistant",
+        "api": "openai-responses",
+        "provider": "openai",
+        "model": "fixture-model",
+        "timestamp": 42,
+        "usage": {
+          "input": 11,
+          "output": 7,
+          "cacheRead": 5,
+          "cacheWrite": 3,
+          "totalTokens": 26,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0,
+            "total": 0
+          }
+        },
+        "stopReason": "toolUse",
+        "content": [
+          {
+            "type": "text",
+            "text": " before "
+          },
+          {
+            "type": "toolCall",
+            "id": "call-read",
+            "name": "read",
+            "arguments": {
+              "path": "notes.txt"
+            }
+          },
+          {
+            "type": "text",
+            "text": "  "
+          },
+          {
+            "type": "toolCall",
+            "id": "call-bash",
+            "name": "bash",
+            "arguments": {
+              "command": "printf done"
+            }
+          }
+        ]
+      },
+      "apiAssistant": {
+        "model": "fixture-model",
+        "timestamp": 42,
+        "usage": {
+          "input": 11,
+          "output": 7,
+          "cacheRead": 5,
+          "cacheWrite": 3
+        },
+        "stopReason": "toolUse",
+        "content": [
+          {
+            "type": "text",
+            "text": " before "
+          },
+          {
+            "type": "toolCall",
+            "id": "call-read",
+            "name": "read",
+            "arguments": {
+              "path": "notes.txt"
+            }
+          },
+          {
+            "type": "text",
+            "text": "  "
+          },
+          {
+            "type": "toolCall",
+            "id": "call-bash",
+            "name": "bash",
+            "arguments": {
+              "command": "printf done"
+            }
+          }
+        ]
+      },
+      "expectedMessages": [
+        {
+          "id": "run-fixture:42:fixture-model",
+          "role": "assistant",
+          "model": "fixture-model",
+          "usage": {
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "cache_read_input_tokens": 5,
+            "cache_creation_input_tokens": 3
+          },
+          "content": [
+            {
+              "type": "text",
+              "text": "before"
+            }
+          ]
+        },
+        {
+          "id": "run-fixture:42:fixture-model",
+          "role": "assistant",
+          "model": "fixture-model",
+          "usage": {
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "cache_read_input_tokens": 5,
+            "cache_creation_input_tokens": 3
+          },
+          "content": [
+            {
+              "type": "tool_use",
+              "id": "call-read",
+              "name": "read",
+              "input": {
+                "path": "notes.txt"
+              }
+            }
+          ]
+        },
+        {
+          "id": "run-fixture:42:fixture-model",
+          "role": "assistant",
+          "model": "fixture-model",
+          "usage": {
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "cache_read_input_tokens": 5,
+            "cache_creation_input_tokens": 3
+          },
+          "content": [
+            {
+              "type": "tool_use",
+              "id": "call-bash",
+              "name": "bash",
+              "input": {
+                "command": "printf done"
+              }
+            }
+          ]
+        }
+      ],
+      "apiResult": "before",
+      "guestResult": "before"
+    },
+    {
+      "name": "empty assistant retains adapter terminal defaults",
+      "guestMessage": {
+        "role": "assistant",
+        "api": "openai-responses",
+        "provider": "openai",
+        "model": "fixture-model",
+        "timestamp": 42,
+        "usage": {
+          "input": 11,
+          "output": 7,
+          "cacheRead": 5,
+          "cacheWrite": 3,
+          "totalTokens": 26,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0,
+            "total": 0
+          }
+        },
+        "stopReason": "stop",
+        "content": []
+      },
+      "apiAssistant": {
+        "model": "fixture-model",
+        "timestamp": 42,
+        "usage": {
+          "input": 11,
+          "output": 7,
+          "cacheRead": 5,
+          "cacheWrite": 3
+        },
+        "stopReason": "stop",
+        "content": []
+      },
+      "expectedMessages": [],
+      "apiResult": "",
+      "guestResult": "Pi model turn stop"
+    },
+    {
+      "name": "citation only retains empty content provenance",
+      "guestMessage": {
+        "role": "assistant",
+        "api": "openai-responses",
+        "provider": "openai",
+        "model": "fixture-model",
+        "timestamp": 42,
+        "usage": {
+          "input": 11,
+          "output": 7,
+          "cacheRead": 5,
+          "cacheWrite": 3,
+          "totalTokens": 26,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0,
+            "total": 0
+          }
+        },
+        "stopReason": "stop",
+        "responseId": "response-fixture",
+        "content": [
+          {
+            "type": "text",
+            "text": "<oai-mem-citation><citation_entries>memory.md:2-4|note=[used]</citation_entries><rollout_ids>019c6e27-e55b-73d1-87d8-4e01f1f75043</rollout_ids></oai-mem-citation>"
+          }
+        ]
+      },
+      "apiAssistant": {
+        "model": "fixture-model",
+        "timestamp": 42,
+        "usage": {
+          "input": 11,
+          "output": 7,
+          "cacheRead": 5,
+          "cacheWrite": 3
+        },
+        "stopReason": "stop",
+        "responseId": "response-fixture",
+        "content": [
+          {
+            "type": "text",
+            "text": ""
+          }
+        ],
+        "memoryCitation": {
+          "entries": [
+            {
+              "path": "memory.md",
+              "lineStart": 2,
+              "lineEnd": 4,
+              "note": "used"
+            }
+          ],
+          "rolloutIds": ["019c6e27-e55b-73d1-87d8-4e01f1f75043"]
+        }
+      },
+      "expectedMessages": [
+        {
+          "id": "response-fixture",
+          "role": "assistant",
+          "model": "fixture-model",
+          "usage": {
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "cache_read_input_tokens": 5,
+            "cache_creation_input_tokens": 3
+          },
+          "content": [],
+          "memoryCitation": {
+            "entries": [
+              {
+                "path": "memory.md",
+                "lineStart": 2,
+                "lineEnd": 4,
+                "note": "used"
+              }
+            ],
+            "rolloutIds": ["019c6e27-e55b-73d1-87d8-4e01f1f75043"]
+          }
+        }
+      ],
+      "apiResult": "",
+      "guestResult": ""
+    },
+    {
+      "name": "split citation provenance belongs only to the final block",
+      "guestMessage": {
+        "role": "assistant",
+        "api": "openai-responses",
+        "provider": "openai",
+        "model": "fixture-model",
+        "timestamp": 42,
+        "usage": {
+          "input": 11,
+          "output": 7,
+          "cacheRead": 5,
+          "cacheWrite": 3,
+          "totalTokens": 26,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0,
+            "total": 0
+          }
+        },
+        "stopReason": "stop",
+        "responseId": "response-fixture",
+        "content": [
+          {
+            "type": "text",
+            "text": " before<oai-mem-cit"
+          },
+          {
+            "type": "toolCall",
+            "id": "call-read",
+            "name": "read",
+            "arguments": {
+              "path": "notes.txt"
+            }
+          },
+          {
+            "type": "text",
+            "text": "ation><citation_entries>memory.md:2-4|note=[used]</citation_entries><rollout_ids>019c6e27-e55b-73d1-87d8-4e01f1f75043</rollout_ids></oai-mem-citation>after "
+          }
+        ]
+      },
+      "apiAssistant": {
+        "model": "fixture-model",
+        "timestamp": 42,
+        "usage": {
+          "input": 11,
+          "output": 7,
+          "cacheRead": 5,
+          "cacheWrite": 3
+        },
+        "stopReason": "stop",
+        "responseId": "response-fixture",
+        "content": [
+          {
+            "type": "text",
+            "text": " before"
+          },
+          {
+            "type": "toolCall",
+            "id": "call-read",
+            "name": "read",
+            "arguments": {
+              "path": "notes.txt"
+            }
+          },
+          {
+            "type": "text",
+            "text": "after "
+          }
+        ],
+        "memoryCitation": {
+          "entries": [
+            {
+              "path": "memory.md",
+              "lineStart": 2,
+              "lineEnd": 4,
+              "note": "used"
+            }
+          ],
+          "rolloutIds": ["019c6e27-e55b-73d1-87d8-4e01f1f75043"]
+        }
+      },
+      "expectedMessages": [
+        {
+          "id": "response-fixture",
+          "role": "assistant",
+          "model": "fixture-model",
+          "usage": {
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "cache_read_input_tokens": 5,
+            "cache_creation_input_tokens": 3
+          },
+          "content": [
+            {
+              "type": "text",
+              "text": "before"
+            }
+          ]
+        },
+        {
+          "id": "response-fixture",
+          "role": "assistant",
+          "model": "fixture-model",
+          "usage": {
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "cache_read_input_tokens": 5,
+            "cache_creation_input_tokens": 3
+          },
+          "content": [
+            {
+              "type": "tool_use",
+              "id": "call-read",
+              "name": "read",
+              "input": {
+                "path": "notes.txt"
+              }
+            }
+          ]
+        },
+        {
+          "id": "response-fixture",
+          "role": "assistant",
+          "model": "fixture-model",
+          "usage": {
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "cache_read_input_tokens": 5,
+            "cache_creation_input_tokens": 3
+          },
+          "content": [
+            {
+              "type": "text",
+              "text": "after"
+            }
+          ],
+          "memoryCitation": {
+            "entries": [
+              {
+                "path": "memory.md",
+                "lineStart": 2,
+                "lineEnd": 4,
+                "note": "used"
+              }
+            ],
+            "rolloutIds": ["019c6e27-e55b-73d1-87d8-4e01f1f75043"]
+          }
+        }
+      ],
+      "apiResult": "before\n\nafter",
+      "guestResult": "before\n\nafter"
+    }
+  ]
+}

--- a/turbo/apps/api/src/lib/__tests__/pi-api-first-turn-events.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/pi-api-first-turn-events.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+
+import type { PiApiAssistantMessage } from "@okouai/pi-agent-runtime/api";
+import { describe, expect, it } from "vitest";
+
+import {
+  piApiFirstTurnAssistantEvents,
+  piApiFirstTurnResultEvent,
+} from "../pi-api-first-turn-events";
+
+const fixture = JSON.parse(
+  readFileSync(
+    new URL(
+      "../../../../../../fixtures/pi-public-events.json",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+) as {
+  readonly runId: string;
+  readonly apiStartedAt: number;
+  readonly apiObservedAt: number;
+  readonly apiDurationMs: number;
+  readonly cases: readonly {
+    readonly name: string;
+    readonly apiAssistant: PiApiAssistantMessage;
+    readonly expectedMessages: readonly unknown[];
+    readonly apiResult: string;
+  }[];
+};
+
+// The route suites prove lifecycle and billing. This cross-language contract
+// enters the actual producer before transport consumes its private envelope;
+// neither raw sequence numbers nor private provenance are public route output.
+describe("Pi API public projection fixtures", () => {
+  it.each(fixture.cases)("projects $name", (example) => {
+    const events = piApiFirstTurnAssistantEvents(
+      fixture.runId,
+      example.apiAssistant,
+    );
+    expect(events).toStrictEqual(
+      example.expectedMessages.map((message, sequenceNumber) => {
+        return { type: "assistant", sequenceNumber, message };
+      }),
+    );
+    expect(
+      piApiFirstTurnResultEvent(
+        example.apiAssistant,
+        fixture.apiStartedAt,
+        events.length,
+        fixture.apiObservedAt,
+      ),
+    ).toStrictEqual({
+      type: "result",
+      sequenceNumber: example.expectedMessages.length,
+      subtype: "success",
+      is_error: false,
+      result: example.apiResult,
+      duration_ms: fixture.apiDurationMs,
+    });
+  });
+});

--- a/turbo/apps/api/src/lib/__tests__/pi-api-first-turn-policy.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/pi-api-first-turn-policy.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decideApiFirstTurnCommit,
+  decideApiFirstTurnHistory,
+  decideApiFirstTurnRecovery,
+  decideApiFirstTurnTerminal,
+  normalizedApiFirstTurnFailure,
+  piApiFirstTurnError,
+  PiApiFirstTurnModelFailureError,
+} from "../pi-api-first-turn-policy";
+
+// These conflicting snapshots specify precedence without simulating IO. Real
+// lock races, effects and usage remain covered through chat-events BDD.
+describe("Pi API-first transition precedence", () => {
+  it.each([
+    {
+      rawSize: 16 * 1024 * 1024,
+      encodedSize: 16 * 1024 * 1024,
+      expected: "api",
+    },
+    { rawSize: 16 * 1024 * 1024 + 1, encodedSize: 1, expected: "sandbox" },
+    { rawSize: 1, encodedSize: 16 * 1024 * 1024 + 1, expected: "sandbox" },
+  ])(
+    "selects history from raw=$rawSize encoded=$encodedSize",
+    ({ rawSize, encodedSize, expected }) => {
+      expect(decideApiFirstTurnHistory({ rawSize, encodedSize })).toBe(
+        expected,
+      );
+    },
+  );
+  it.each([
+    {
+      pendingTools: false,
+      activeInput: false,
+      expected: { outcome: "complete" },
+    },
+    {
+      pendingTools: true,
+      activeInput: false,
+      expected: {
+        outcome: "transfer",
+        mode: "pending-tool-continuation",
+        reason: "pending_tool_continuation",
+      },
+    },
+    {
+      pendingTools: true,
+      activeInput: true,
+      expected: {
+        outcome: "transfer",
+        mode: "pending-tool-continuation",
+        reason: "active_input_pending_tool",
+      },
+    },
+    {
+      pendingTools: false,
+      activeInput: true,
+      expected: {
+        outcome: "transfer",
+        mode: "settled-session-continuation",
+        reason: "active_input_settled_session",
+      },
+    },
+  ])(
+    "commits pendingTools=$pendingTools activeInput=$activeInput",
+    ({ pendingTools, activeInput, expected }) => {
+      expect(
+        decideApiFirstTurnCommit({ pendingTools, activeInput }),
+      ).toStrictEqual(expected);
+    },
+  );
+
+  const attempt = {
+    activeInputBeforeProvider: false,
+    ownershipStage: "pre-provider" as const,
+    commitStarted: false,
+    coordinationAborted: false,
+    coordinationDeadlineAt: 55_000,
+    observedAt: 45_000,
+  };
+
+  it("keeps a raw failure distinct from the private abort used to close its attempt", () => {
+    const controller = new AbortController();
+    const raw = new Error("invalid consumed usage");
+    const failure = normalizedApiFirstTurnFailure(
+      raw,
+      controller.signal.aborted,
+    );
+    controller.abort(raw);
+    expect(failure.code).toBe("PI_API_MODEL_FAILED");
+    expect(decideApiFirstTurnRecovery({ ...attempt, failure })).toMatchObject({
+      outcome: "arbitrate-terminal",
+      suppressCompletionFailureLog: false,
+    });
+  });
+
+  it.each([
+    "PI_API_NATIVE_INPUT_REQUIRED",
+    "PI_API_PREHEAT_FAILED",
+    "PI_API_COMPACTION_PREFLIGHT_REQUIRED",
+    "PI_API_RESOURCE_PREPARATION_FAILED",
+  ] as const)(
+    "recovers %s only before provider ownership and commit",
+    (code) => {
+      const failure = piApiFirstTurnError(code, "preparation failed");
+      expect(decideApiFirstTurnRecovery({ ...attempt, failure })).toMatchObject(
+        { outcome: "sandbox-first", reason: code },
+      );
+      for (const boundary of [
+        { ownershipStage: "provider-may-have-started" as const },
+        { commitStarted: true },
+        { coordinationAborted: true },
+      ]) {
+        expect(
+          decideApiFirstTurnRecovery({ ...attempt, ...boundary, failure })
+            .outcome,
+        ).toBe("arbitrate-terminal");
+      }
+    },
+  );
+
+  it.each([
+    "PI_API_MODEL_CREDENTIAL_INVALID",
+    "PI_API_RESOURCE_INVALID",
+    "PI_H0_HASH_MISMATCH",
+    "PI_H0_JSONL_INVALID",
+    "PI_API_MODEL_OUTPUT_INCOMPLETE",
+  ] as const)("does not grant H0 recovery for %s", (code) => {
+    expect(
+      decideApiFirstTurnRecovery({
+        ...attempt,
+        failure: piApiFirstTurnError(code, "invalid"),
+      }).outcome,
+    ).toBe("arbitrate-terminal");
+  });
+
+  it("retains active-input precedence while requiring the guarded transfer to validate delivery", () => {
+    expect(
+      decideApiFirstTurnRecovery({
+        ...attempt,
+        activeInputBeforeProvider: true,
+        failure: piApiFirstTurnError(
+          "PI_API_FIRST_TURN_DEADLINE_EXCEEDED",
+          "deadline",
+        ),
+      }),
+    ).toMatchObject({
+      outcome: "sandbox-first",
+      reason: "active_input",
+      logAttemptTimeout: true,
+    });
+  });
+
+  it.each(["pre-provider", "provider-may-have-started"] as const)(
+    "recovers an API deadline at %s only before commit and the coordination cap",
+    (ownershipStage) => {
+      const facts = {
+        ...attempt,
+        ownershipStage,
+        failure: piApiFirstTurnError(
+          "PI_API_FIRST_TURN_DEADLINE_EXCEEDED",
+          "deadline",
+        ),
+      };
+      expect(decideApiFirstTurnRecovery(facts)).toMatchObject({
+        outcome: "sandbox-first",
+        reason: "api_attempt_timed_out",
+        suppressCompletionFailureLog: true,
+      });
+      for (const boundary of [
+        { commitStarted: true },
+        { coordinationAborted: true },
+        { observedAt: 55_000 },
+      ]) {
+        expect(
+          decideApiFirstTurnRecovery({ ...facts, ...boundary }).outcome,
+        ).toBe("arbitrate-terminal");
+      }
+    },
+  );
+
+  it.each([
+    { status: 401, failureReason: undefined, outcome: "arbitrate-terminal" },
+    { status: 403, failureReason: undefined, outcome: "arbitrate-terminal" },
+    { status: 525, failureReason: undefined, outcome: "sandbox-first" },
+    {
+      status: 525,
+      failureReason: "reconnect_required" as const,
+      outcome: "arbitrate-terminal",
+    },
+    {
+      status: 525,
+      failureReason: "usage_limit" as const,
+      outcome: "arbitrate-terminal",
+    },
+  ])(
+    "arbitrates model status=$status reason=$failureReason",
+    ({ status, failureReason, outcome }) => {
+      const failure = new PiApiFirstTurnModelFailureError(
+        { category: "http_error", httpStatus: status },
+        failureReason,
+      );
+      expect(decideApiFirstTurnRecovery({ ...attempt, failure }).outcome).toBe(
+        outcome,
+      );
+      for (const boundary of [
+        { commitStarted: true },
+        { coordinationAborted: true },
+        { observedAt: 55_000 },
+      ]) {
+        expect(
+          decideApiFirstTurnRecovery({ ...attempt, ...boundary, failure })
+            .outcome,
+        ).toBe("arbitrate-terminal");
+      }
+    },
+  );
+
+  it.each([
+    { status: "cancelled", expected: "cancelled" },
+    { status: "completed", expected: "already-terminal" },
+    { status: "failed", expected: "already-terminal" },
+    { status: undefined, expected: "already-terminal" },
+    { status: "pending", expected: "fail" },
+    { status: "running", expected: "fail" },
+  ])(
+    "preserves the durable terminal owner at $status",
+    ({ status, expected }) => {
+      expect(decideApiFirstTurnTerminal(status)).toBe(expected);
+    },
+  );
+});

--- a/turbo/apps/api/src/lib/pi-api-first-turn-events.ts
+++ b/turbo/apps/api/src/lib/pi-api-first-turn-events.ts
@@ -1,0 +1,86 @@
+import type { PiApiFirstTurnResult } from "@okouai/pi-agent-runtime/api";
+
+import type { AgentEvent } from "./event-consumer/verify";
+
+function projectedAssistantBlocks(
+  assistant: PiApiFirstTurnResult["assistantMessage"],
+): unknown[] {
+  return assistant.content.flatMap((block): unknown[] => {
+    if (block.type === "text") {
+      const text = block.text.trim();
+      return text ? [{ type: "text", text }] : [];
+    }
+    if (block.type === "toolCall") {
+      return [
+        {
+          type: "tool_use",
+          id: block.id,
+          name: block.name,
+          input: block.arguments,
+        },
+      ];
+    }
+    return [];
+  });
+}
+
+function assistantText(
+  assistant: PiApiFirstTurnResult["assistantMessage"],
+): string {
+  return assistant.content
+    .flatMap((block) => {
+      return block.type === "text" && block.text.trim()
+        ? [block.text.trim()]
+        : [];
+    })
+    .join("\n\n");
+}
+
+export function piApiFirstTurnAssistantEvents(
+  runId: string,
+  assistant: PiApiFirstTurnResult["assistantMessage"],
+): AgentEvent[] {
+  const blocks = projectedAssistantBlocks(assistant);
+  const eventBlocks =
+    blocks.length === 0 && assistant.memoryCitation ? [null] : blocks;
+  return eventBlocks.map((block, sequenceNumber) => {
+    return {
+      type: "assistant",
+      sequenceNumber,
+      message: {
+        id:
+          assistant.responseId ??
+          `${runId}:${assistant.timestamp}:${assistant.model}`,
+        role: "assistant",
+        content: block === null ? [] : [block],
+        ...(sequenceNumber === eventBlocks.length - 1 &&
+        assistant.memoryCitation
+          ? { memoryCitation: assistant.memoryCitation }
+          : {}),
+        model: assistant.model,
+        usage: {
+          input_tokens: assistant.usage.input,
+          output_tokens: assistant.usage.output,
+          cache_read_input_tokens: assistant.usage.cacheRead,
+          cache_creation_input_tokens: assistant.usage.cacheWrite,
+        },
+      },
+    };
+  });
+}
+
+export function piApiFirstTurnResultEvent(
+  assistant: PiApiFirstTurnResult["assistantMessage"],
+  startedAt: number,
+  sequenceNumber: number,
+  observedAt: number,
+): AgentEvent {
+  return {
+    type: "result",
+    sequenceNumber,
+    subtype: "success",
+    is_error: false,
+    result: assistantText(assistant),
+    duration_ms: Math.max(0, observedAt - startedAt),
+  };
+}

--- a/turbo/apps/api/src/lib/pi-api-first-turn-policy.ts
+++ b/turbo/apps/api/src/lib/pi-api-first-turn-policy.ts
@@ -1,0 +1,302 @@
+import type { RunFailureReasonToken } from "@okouai/api-contracts/contracts/run-failure-reasons";
+import { PI_API_FIRST_TURN_SESSION_MAX_BYTES } from "@okouai/api-contracts/contracts/runners";
+import type {
+  PiApiFirstTurnOwnershipStage,
+  PiApiModelFailureDiagnostic,
+} from "@okouai/pi-agent-runtime/api";
+
+type PiApiFirstTurnErrorCode =
+  | "PI_API_COMMIT_FAILED"
+  | "PI_API_COMPACTION_PREFLIGHT_REQUIRED"
+  | "PI_API_FIRST_TURN_DEADLINE_EXCEEDED"
+  | "PI_API_FIRST_TURN_NOT_COMMITTABLE"
+  | "PI_API_MODEL_FAILED"
+  | "PI_API_MODEL_OUTPUT_INCOMPLETE"
+  | "PI_API_MODEL_CREDENTIAL_INVALID"
+  | "PI_API_NATIVE_INPUT_REQUIRED"
+  | "PI_API_PREHEAT_FAILED"
+  | "PI_API_RESOURCE_INVALID"
+  | "PI_API_RESOURCE_PREPARATION_FAILED"
+  | "PI_API_RESOURCE_UNSUPPORTED"
+  | "PI_API_SANDBOX_FALLBACK_FAILED"
+  | "PI_H0_DECOMPRESSION_FAILED"
+  | "PI_H0_DOWNLOAD_FAILED"
+  | "PI_H0_ENCODING_UNSUPPORTED"
+  | "PI_H0_HASH_MISMATCH"
+  | "PI_H0_JSONL_INVALID"
+  | "PI_H0_METADATA_INVALID"
+  | "PI_H0_SESSION_MISMATCH"
+  | "PI_H0_SESSION_UNSUPPORTED"
+  | "PI_H0_TOO_LARGE"
+  | "PI_H1_INVALID"
+  | "PI_H1_TOO_LARGE"
+  | "PI_LAUNCH_CONFIG_INVALID";
+
+export class PiApiFirstTurnError extends Error {
+  readonly code: PiApiFirstTurnErrorCode;
+  readonly failureReason: RunFailureReasonToken | undefined;
+
+  constructor(
+    code: PiApiFirstTurnErrorCode,
+    message: string,
+    options?: {
+      readonly cause?: unknown;
+      readonly failureReason?: RunFailureReasonToken;
+    },
+  ) {
+    super(
+      `[${code}] ${message}`,
+      options && "cause" in options ? { cause: options.cause } : undefined,
+    );
+    this.name = "PiApiFirstTurnError";
+    this.code = code;
+    this.failureReason = options?.failureReason;
+  }
+}
+
+export class PiApiFirstTurnCodexReconnectRequiredError extends PiApiFirstTurnError {
+  constructor() {
+    super(
+      "PI_API_MODEL_CREDENTIAL_INVALID",
+      "Pi API first-turn subscription access token is unavailable",
+      { failureReason: "reconnect_required" },
+    );
+  }
+}
+
+export class PiApiFirstTurnModelFailureError extends PiApiFirstTurnError {
+  constructor(
+    readonly diagnostic: PiApiModelFailureDiagnostic,
+    failureReason?: RunFailureReasonToken,
+  ) {
+    super("PI_API_MODEL_FAILED", "Pi API first-turn model request failed", {
+      failureReason,
+    });
+  }
+}
+
+export class PiApiFirstTurnActiveInputBeforeProviderError extends Error {
+  constructor() {
+    super("Active input committed before Pi provider ownership");
+    this.name = "PiApiFirstTurnActiveInputBeforeProviderError";
+  }
+}
+
+export class PiApiFirstTurnCanonicalCancellationError extends Error {
+  constructor() {
+    super("Canonical Run cancellation owns the Pi API first turn");
+    this.name = "PiApiFirstTurnCanonicalCancellationError";
+  }
+}
+
+export function piApiFirstTurnError(
+  code: PiApiFirstTurnErrorCode,
+  message: string,
+  cause?: unknown,
+  failureReason?: RunFailureReasonToken,
+): PiApiFirstTurnError {
+  return new PiApiFirstTurnError(
+    code,
+    message,
+    cause === undefined && failureReason === undefined
+      ? undefined
+      : { cause, failureReason },
+  );
+}
+
+export type PiSandboxFallbackReason =
+  | "PI_API_COMPACTION_PREFLIGHT_REQUIRED"
+  | "PI_API_NATIVE_INPUT_REQUIRED"
+  | "PI_API_PREHEAT_FAILED"
+  | "PI_API_RESOURCE_PREPARATION_FAILED";
+
+export type PiSandboxFirstReason =
+  | PiSandboxFallbackReason
+  | "active_input"
+  | "api_model_failed"
+  | "api_attempt_timed_out";
+
+export function normalizedApiFirstTurnFailure(
+  error: unknown,
+  aborted: boolean,
+): PiApiFirstTurnError {
+  if (error instanceof PiApiFirstTurnError) {
+    return error;
+  }
+  return piApiFirstTurnError(
+    aborted ? "PI_API_FIRST_TURN_DEADLINE_EXCEEDED" : "PI_API_MODEL_FAILED",
+    aborted ? "Pi API first-turn deadline elapsed" : "Pi API first turn failed",
+    error,
+  );
+}
+
+export function normalizedSandboxFallbackFailure(
+  error: unknown,
+  aborted: boolean,
+): PiApiFirstTurnError {
+  if (error instanceof PiApiFirstTurnError) {
+    return error;
+  }
+  return piApiFirstTurnError(
+    aborted
+      ? "PI_API_FIRST_TURN_DEADLINE_EXCEEDED"
+      : "PI_API_SANDBOX_FALLBACK_FAILED",
+    aborted
+      ? "Pi API first-turn deadline elapsed during sandbox fallback"
+      : "Pi sandbox fallback publication failed",
+    error,
+  );
+}
+
+/** Metadata has already passed the native raw/encoded bounds and encoding checks. */
+export function decideApiFirstTurnHistory(metadata: {
+  readonly rawSize: number;
+  readonly encodedSize: number;
+}): "api" | "sandbox" {
+  return metadata.rawSize <= PI_API_FIRST_TURN_SESSION_MAX_BYTES &&
+    metadata.encodedSize <= PI_API_FIRST_TURN_SESSION_MAX_BYTES
+    ? "api"
+    : "sandbox";
+}
+
+type ApiFirstTurnCommitDecision =
+  | { readonly outcome: "complete" }
+  | {
+      readonly outcome: "transfer";
+      readonly mode:
+        | "pending-tool-continuation"
+        | "settled-session-continuation";
+      readonly reason:
+        | "pending_tool_continuation"
+        | "active_input_pending_tool"
+        | "active_input_settled_session";
+    };
+
+/** Apply only after the guarded H1 effect has reread lifecycle and identity. */
+export function decideApiFirstTurnCommit(facts: {
+  readonly pendingTools: boolean;
+  readonly activeInput: boolean;
+}): ApiFirstTurnCommitDecision {
+  if (facts.pendingTools) {
+    return {
+      outcome: "transfer",
+      mode: "pending-tool-continuation",
+      reason: facts.activeInput
+        ? "active_input_pending_tool"
+        : "pending_tool_continuation",
+    };
+  }
+  if (facts.activeInput) {
+    return {
+      outcome: "transfer",
+      mode: "settled-session-continuation",
+      reason: "active_input_settled_session",
+    };
+  }
+  return { outcome: "complete" };
+}
+
+interface ApiFirstTurnRecoveryFacts {
+  readonly failure: PiApiFirstTurnError;
+  readonly activeInputBeforeProvider: boolean;
+  readonly ownershipStage: PiApiFirstTurnOwnershipStage;
+  readonly commitStarted: boolean;
+  readonly coordinationAborted: boolean;
+  readonly coordinationDeadlineAt: number;
+  readonly observedAt: number;
+}
+
+type ApiFirstTurnRecoveryDecision = {
+  readonly modelFailure: PiApiModelFailureDiagnostic | undefined;
+  readonly resourceFallbackReason: PiSandboxFallbackReason | null;
+  readonly logAttemptTimeout: boolean;
+  readonly suppressCompletionFailureLog: boolean;
+} & (
+  | { readonly outcome: "sandbox-first"; readonly reason: PiSandboxFirstReason }
+  | { readonly outcome: "arbitrate-terminal" }
+);
+
+function resourceFallbackReason(
+  facts: ApiFirstTurnRecoveryFacts,
+): PiSandboxFallbackReason | null {
+  if (
+    facts.activeInputBeforeProvider ||
+    facts.coordinationAborted ||
+    facts.ownershipStage !== "pre-provider"
+  ) {
+    return null;
+  }
+  switch (facts.failure.code) {
+    case "PI_API_NATIVE_INPUT_REQUIRED":
+    case "PI_API_PREHEAT_FAILED":
+    case "PI_API_COMPACTION_PREFLIGHT_REQUIRED":
+    case "PI_API_RESOURCE_PREPARATION_FAILED": {
+      return facts.failure.code;
+    }
+    default: {
+      return null;
+    }
+  }
+}
+
+/**
+ * One observed attempt, not another lifecycle. Classify before private abort;
+ * every selected effect must still acquire the canonical lifecycle lock.
+ * #32751 permits same-route H0 recovery only at the named pre-commit boundaries.
+ */
+export function decideApiFirstTurnRecovery(
+  facts: ApiFirstTurnRecoveryFacts,
+): ApiFirstTurnRecoveryDecision {
+  const { failure } = facts;
+  const modelFailure =
+    failure instanceof PiApiFirstTurnModelFailureError
+      ? failure.diagnostic
+      : undefined;
+  const resourceReason = resourceFallbackReason(facts);
+  const apiOwnershipExpired =
+    failure.code === "PI_API_FIRST_TURN_DEADLINE_EXCEEDED" &&
+    !facts.commitStarted &&
+    !facts.coordinationAborted;
+  const coordinationRemains = facts.observedAt < facts.coordinationDeadlineAt;
+  const apiModelFailed =
+    failure instanceof PiApiFirstTurnModelFailureError &&
+    !failure.failureReason &&
+    failure.diagnostic.httpStatus !== 401 &&
+    failure.diagnostic.httpStatus !== 403 &&
+    !facts.commitStarted &&
+    !facts.coordinationAborted &&
+    coordinationRemains;
+  const diagnostics = {
+    modelFailure,
+    resourceFallbackReason: resourceReason,
+    logAttemptTimeout: apiOwnershipExpired && coordinationRemains,
+    suppressCompletionFailureLog: apiOwnershipExpired || apiModelFailed,
+  };
+  // Publication may have succeeded even when its response was lost. Only the
+  // guarded terminal effect can arbitrate failure after this irreversible edge.
+  if (facts.commitStarted) {
+    return { ...diagnostics, outcome: "arbitrate-terminal" };
+  }
+  const reason = facts.activeInputBeforeProvider
+    ? "active_input"
+    : apiOwnershipExpired && coordinationRemains
+      ? "api_attempt_timed_out"
+      : apiModelFailed
+        ? "api_model_failed"
+        : resourceReason;
+  return reason
+    ? { ...diagnostics, outcome: "sandbox-first", reason }
+    : { ...diagnostics, outcome: "arbitrate-terminal" };
+}
+
+/** Called with fresh durable status under the existing database lifecycle lock. */
+export function decideApiFirstTurnTerminal(
+  status: string | undefined,
+): "cancelled" | "already-terminal" | "fail" {
+  if (status === "cancelled") {
+    return "cancelled";
+  }
+  return status === "pending" || status === "running"
+    ? "fail"
+    : "already-terminal";
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -7122,14 +7122,14 @@ async function expectPiApiFirstTurnTerminalWithoutOutput(
   actor: ApiTestUser,
   run: { readonly runId: string; readonly threadId: string },
   status: "failed" | "cancelled",
+  failureMessage = "[PI_API_MODEL_OUTPUT_INCOMPLETE] Pi API first-turn model output is incomplete",
 ): Promise<void> {
   const terminal = await api.readRun(actor, run.runId);
   expect(terminal).toMatchObject({
     status,
     ...(status === "failed"
       ? {
-          error:
-            "[PI_API_MODEL_OUTPUT_INCOMPLETE] Pi API first-turn model output is incomplete",
+          error: failureMessage,
         }
       : {}),
   });
@@ -7160,6 +7160,9 @@ function uploadedPiS3Object(objectKey: string): Buffer | undefined {
       candidate.constructor?.name === "PutObjectCommand" &&
       piS3ObjectKey(candidate) === objectKey
     ) {
+      if (typeof candidate.input?.Body === "string") {
+        return Buffer.from(candidate.input.Body, "utf8");
+      }
       if (!(candidate.input?.Body instanceof Uint8Array)) {
         throw new Error(
           `Expected uploaded Pi S3 object bytes for ${objectKey}`,
@@ -15016,6 +15019,57 @@ describe("CHAT-02: model-first provider policies", () => {
     });
   }, 90_000);
 
+  it("keeps a raw API usage failure terminal before aborting its private attempt", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    mockPiResourceArchiveDownloads();
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.openai.com/v1/responses", () => {
+        modelCalls += 1;
+        return nativeCodexSseResponse(
+          piResponsesTextSse(
+            "invalid usage must not authorize H0 replay",
+            modelCalls,
+            {
+              input_tokens: 1.5,
+              output_tokens: 3,
+              total_tokens: 4.5,
+            },
+          ),
+        );
+      }),
+    );
+    const objects = mockPiCheckpointObjectStore();
+    const { anchor, anchorClaim, run, usagePricingResolution } =
+      await queueCapabilityProvenPiRun({
+        actor,
+        agentId,
+        runnerGroup,
+        prompt: "reject invalid provider usage without retrying the prompt",
+      });
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+      usagePricingResolution,
+    });
+    await waitForRunStatus(actor, run.runId, "failed");
+    await flushWaitUntilForTest();
+    expect(modelCalls).toBe(1);
+    expectNoPiApiFirstTurnArtifacts(run.runId, objects);
+    await expectPiApiFirstTurnTerminalWithoutOutput(
+      actor,
+      run,
+      "failed",
+      "[PI_API_MODEL_FAILED] Pi API first turn failed",
+    );
+    await expectNoBuiltInModelUsage(run.runId);
+    expect(context.mocks.axiomLogging.info).not.toHaveBeenCalledWith(
+      "Pi API first-turn outcome",
+      expect.objectContaining({
+        runId: run.runId,
+        outcome: "sandbox_retry_started",
+      }),
+    );
+  }, 90_000);
+
   it.each(["H1 commit", "H1 deadline", "handoff publication"] as const)(
     "keeps a genuine %s failure terminal without replaying H0",
     async (stage) => {
@@ -15284,9 +15338,14 @@ describe("CHAT-02: model-first provider policies", () => {
     90_000,
   );
 
-  it.each(["identity", "gzip", "zstd"] as const)(
-    "saves large Pi %s history and transfers the next turn without API history or resource IO",
-    async (encoding) => {
+  it.each([
+    { encoding: "identity", responseLost: false },
+    { encoding: "gzip", responseLost: false },
+    { encoding: "zstd", responseLost: false },
+    { encoding: "identity", responseLost: true },
+  ] as const)(
+    "saves large Pi $encoding history without API history or resource IO (publication response lost: $responseLost)",
+    async ({ encoding, responseLost }) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
       const checkpointObjects = mockPiCheckpointObjectStore();
       let modelCalls = 0;
@@ -15449,6 +15508,44 @@ describe("CHAT-02: model-first provider policies", () => {
       await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
         status: "completed",
       });
+      if (responseLost) {
+        const deadline = new AbortController();
+        onTestFinished(() => {
+          deadline.abort();
+        });
+        // An object-store response can be lost after the manifest is visible.
+        // Expire the real attempt signal exactly at that external boundary.
+        context.mocks.abortSignal.timeout.mockImplementation((milliseconds) => {
+          return milliseconds > API_FIRST_TURN_OWNERSHIP_BUDGET_MS - 1000 &&
+            milliseconds <= API_FIRST_TURN_OWNERSHIP_BUDGET_MS
+            ? deadline.signal
+            : undefined;
+        });
+        const send = context.mocks.s3.send.getMockImplementation();
+        if (!send) {
+          throw new Error("Expected the checkpoint object store");
+        }
+        context.mocks.s3.send.mockImplementation(async (command: unknown) => {
+          const candidate = command as PiCheckpointS3Command;
+          const stored = await send(command);
+          if (
+            candidate.constructor?.name === "PutObjectCommand" &&
+            piS3ObjectKey(candidate)?.endsWith("/manifest.json")
+          ) {
+            expect(
+              checkpointObjects.has(piS3ObjectKey(candidate) ?? ""),
+            ).toBeTruthy();
+            deadline.abort(
+              new DOMException(
+                "Manifest response lost at ownership deadline",
+                "TimeoutError",
+              ),
+            );
+            throw deadline.signal.reason;
+          }
+          return stored;
+        });
+      }
       const callsBeforeResume = context.mocks.s3.send.mock.calls.length;
       const resumed = await sendChatRun(
         actor,
@@ -15462,10 +15559,14 @@ describe("CHAT-02: model-first provider policies", () => {
       );
       await flushWaitUntilForTest();
       const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${resumed.runId}/manifest.json`;
+      // Terminal cleanup removes the failed run's object. The captured write
+      // still proves that ownership publication happened before its response
+      // was lost; the normal transfer retains its currently readable object.
+      const publishedManifest = responseLost
+        ? uploadedPiS3Object(manifestKey)
+        : checkpointObjects.get(manifestKey);
       const manifest = piApiFirstTurnManifestSchema.parse(
-        JSON.parse(
-          checkpointObjects.get(manifestKey)?.toString("utf8") ?? "{}",
-        ),
+        JSON.parse(publishedManifest?.toString("utf8") ?? "{}"),
       );
       expect(manifest).toMatchObject({
         schemaVersion: 4,
@@ -15504,6 +15605,28 @@ describe("CHAT-02: model-first provider policies", () => {
           `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${resumed.runId}/session.jsonl`,
         ),
       ).toBeFalsy();
+      if (responseLost) {
+        await waitForRunStatus(actor, resumed.runId, "failed");
+        await expectPiApiFirstTurnTerminalWithoutOutput(
+          actor,
+          resumed,
+          "failed",
+          "[PI_API_FIRST_TURN_DEADLINE_EXCEEDED] Pi API first-turn deadline elapsed",
+        );
+        expect(
+          context.mocks.s3.send.mock.calls
+            .slice(callsBeforeResume)
+            .filter(([command]) => {
+              const candidate = command as PiCheckpointS3Command;
+              return (
+                candidate.constructor?.name === "PutObjectCommand" &&
+                piS3ObjectKey(candidate) === manifestKey
+              );
+            }),
+        ).toHaveLength(1);
+        await api.requestClaimRunnerJob(true, resumed.runId, [404]);
+        return;
+      }
       const resumedClaim = await claimChatRun(runnerGroup, resumed.runId);
       expect(resumedClaim.claim.resumeSession).toMatchObject({
         sessionId: run.threadId,

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.md
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.md
@@ -1,0 +1,80 @@
+# API-first transition boundary
+
+This is the local module contract for #33570. The wider Pi SDK and memory
+architecture remains owned by #33519's later SDK boundary work.
+
+## Responsibilities and dependency direction
+
+- `pi-api-first-turn-registration.service.ts` owns cancellation registration,
+  release in `finally`, and completion side-effect dispatch. The configured
+  dispatcher and public `runPiApiFirstTurn$` entry retain their source fencing.
+- `pi-api-first-turn.service.ts` owns preparation, the provider attempt, and
+  guarded effects. Its module-scope commands share history validation and
+  immutable launch identity locally; no command accessors escape into helpers.
+  `runPiApiFirstTurnCore$` interprets explicit completed/transferred results,
+  then a recovery decision, then canonical terminal arbitration.
+- `../../lib/pi-api-first-turn-policy.ts` owns pure history, H1, recovery and
+  terminal decisions, with the existing typed errors. It receives observed
+  facts and time values and imports no service, database, signal or clock.
+- `../../lib/pi-api-first-turn-events.ts` is the actual API public-event
+  producer. It receives the runtime's already-normalized assistant, preserves
+  ordered blocks and final-block provenance, and has no accounting effects.
+- `pi-api-first-turn-lifecycle.service.ts` retains the advisory transaction lock
+  shared with active-input reservation and cancellation. Usage remains in
+  `pi-api-first-turn-usage.service.ts`; Runner/proxy billing is independent.
+
+The service depends on the pure modules, not the reverse. Preparation and guarded
+effects remain adjacent because they share authenticated H0 and launch identity;
+splitting those helpers into an IO interface would add indirection without
+removing a responsibility. Registration and provider runtime remain separate.
+
+## Authority and precedence
+
+The runtime's `ownership.stage` is the irreversible provider-request fact.
+`commitProgress.started` is a separate irreversible publication fact. Both keep
+their existing owners; decisions are immutable snapshots, not a second lifecycle.
+
+1. Validated blob metadata selects large-history transfer before API resource
+   loading or history materialization. Raw and encoded bounds remain independent.
+2. Before transport, the lifecycle lock validates run status, immutable identity
+   and active delivery. Active input transfers H0 without an API request.
+3. Before the first H1 side effect, the lock revalidates eligibility and marks
+   commit started. Pending tools take precedence over active input; settled
+   active input transfers H1 as a new prompt; otherwise the API completes once.
+4. On error, classification and recovery selection happen **before** private
+   attempt abort. A raw model/usage error cannot acquire deadline recovery merely
+   because cleanup aborted the attempt. #32751's specified preparation failures,
+   pre-commit API deadline and eligible model failures retain same-route recovery.
+   Reconnect/failureReason, 401/403, corrupt credentials/history and incomplete
+   output retain their existing terminal handling.
+5. Commit start prevents H0 replay even if publication's response was lost. The
+   large-history manifest marks this fact immediately before publication too.
+6. Every selected handoff still validates status, identity, deadline and durable
+   delivery under the same lock. Network calls and H0 readback/hash checks stay
+   inside their existing critical section. The API-attempt deadline and the
+   later coordination cap are not interchangeable.
+7. Failed handoff or ineligible recovery first checks canonical cancellation;
+   failure then rereads under the lock. Cancellation or another terminal owner
+   wins without another completion. Existing prepared-sandbox cleanup remains.
+
+Late provider results belong to the original API attempt. Owned `waitUntil`
+observers may record actual usage with the original response/category
+idempotency, but never output, checkpoint or another terminal event. The captured
+`PiExecutionRoute`, exact account and one edge materializer remain authoritative.
+
+## Fixed cross-language examples
+
+`fixtures/pi-public-events.json` has hand-authored raw Guest input, normalized API
+input and expected common messages. Runtime `api.test.ts` checks the real input
+normalizer; API `pi-api-first-turn-events.test.ts` checks the service's producer;
+Guest `pi_rpc.rs` checks `PiRpcProjection` followed by
+`provider_event_normalization`. Expected values are fixture data.
+
+Common assertions cover content order, response/fallback ID, model, four public
+token counters and citation provenance. API events start at zero and the API
+owns its guarded result. Guest sequencing starts at the installed handoff
+boundary; only `agent_settled` emits its result with Guest session/elapsed time.
+The empty-message terminal default differs intentionally. Existing shared
+`pi-memory-citations.json` parser cases and route lifecycle/late-usage tests retain
+their separate boundaries. No persisted/wire format, reader, billing writer,
+deadline, byte limit, provider policy or release authority changes here.

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -12,7 +12,6 @@ import {
   type SecretConnectorMetadata,
   type StoredExecutionContext,
 } from "@okouai/api-contracts/contracts/runners";
-import type { RunFailureReasonToken } from "@okouai/api-contracts/contracts/run-failure-reasons";
 import { modelProviderTypeSchema } from "@okouai/api-contracts/contracts/model-providers";
 import { activeInputDeliveries } from "@okouai/db/schema/active-input-delivery";
 import { agentRuns } from "@okouai/db/runtime/agent-run";
@@ -41,6 +40,26 @@ import { command } from "ccstate";
 import { and, eq } from "drizzle-orm";
 
 import { env } from "../../lib/env";
+import {
+  decideApiFirstTurnCommit,
+  decideApiFirstTurnHistory,
+  decideApiFirstTurnRecovery,
+  decideApiFirstTurnTerminal,
+  normalizedApiFirstTurnFailure,
+  normalizedSandboxFallbackFailure,
+  PiApiFirstTurnActiveInputBeforeProviderError,
+  PiApiFirstTurnCanonicalCancellationError,
+  PiApiFirstTurnCodexReconnectRequiredError,
+  PiApiFirstTurnError,
+  piApiFirstTurnError,
+  PiApiFirstTurnModelFailureError,
+  type PiSandboxFallbackReason,
+  type PiSandboxFirstReason,
+} from "../../lib/pi-api-first-turn-policy";
+import {
+  piApiFirstTurnAssistantEvents,
+  piApiFirstTurnResultEvent,
+} from "../../lib/pi-api-first-turn-events";
 import type { Tx } from "../../lib/db-types";
 import type { AgentEvent } from "../../lib/event-consumer/verify";
 import { logger } from "../../lib/log";
@@ -107,105 +126,6 @@ import {
 const MODEL_COMMIT_BUDGET_MS = 2000;
 const FAILURE_COMMIT_TIMEOUT_MS = 10_000;
 const L = logger("pi-api-first-turn");
-
-type PiApiFirstTurnErrorCode =
-  | "PI_API_COMMIT_FAILED"
-  | "PI_API_COMPACTION_PREFLIGHT_REQUIRED"
-  | "PI_API_FIRST_TURN_DEADLINE_EXCEEDED"
-  | "PI_API_FIRST_TURN_NOT_COMMITTABLE"
-  | "PI_API_MODEL_FAILED"
-  | "PI_API_MODEL_OUTPUT_INCOMPLETE"
-  | "PI_API_MODEL_CREDENTIAL_INVALID"
-  | "PI_API_NATIVE_INPUT_REQUIRED"
-  | "PI_API_PREHEAT_FAILED"
-  | "PI_API_RESOURCE_INVALID"
-  | "PI_API_RESOURCE_PREPARATION_FAILED"
-  | "PI_API_RESOURCE_UNSUPPORTED"
-  | "PI_API_SANDBOX_FALLBACK_FAILED"
-  | "PI_H0_DECOMPRESSION_FAILED"
-  | "PI_H0_DOWNLOAD_FAILED"
-  | "PI_H0_ENCODING_UNSUPPORTED"
-  | "PI_H0_HASH_MISMATCH"
-  | "PI_H0_JSONL_INVALID"
-  | "PI_H0_METADATA_INVALID"
-  | "PI_H0_SESSION_MISMATCH"
-  | "PI_H0_SESSION_UNSUPPORTED"
-  | "PI_H0_TOO_LARGE"
-  | "PI_H1_INVALID"
-  | "PI_H1_TOO_LARGE"
-  | "PI_LAUNCH_CONFIG_INVALID";
-
-class PiApiFirstTurnError extends Error {
-  readonly code: PiApiFirstTurnErrorCode;
-  readonly failureReason: RunFailureReasonToken | undefined;
-
-  constructor(
-    code: PiApiFirstTurnErrorCode,
-    message: string,
-    options?: {
-      readonly cause?: unknown;
-      readonly failureReason?: RunFailureReasonToken;
-    },
-  ) {
-    super(
-      `[${code}] ${message}`,
-      options && "cause" in options ? { cause: options.cause } : undefined,
-    );
-    this.name = "PiApiFirstTurnError";
-    this.code = code;
-    this.failureReason = options?.failureReason;
-  }
-}
-
-class PiApiFirstTurnCodexReconnectRequiredError extends PiApiFirstTurnError {
-  constructor() {
-    super(
-      "PI_API_MODEL_CREDENTIAL_INVALID",
-      "Pi API first-turn subscription access token is unavailable",
-      { failureReason: "reconnect_required" },
-    );
-  }
-}
-
-class PiApiFirstTurnModelFailureError extends PiApiFirstTurnError {
-  constructor(
-    readonly diagnostic: PiApiModelFailureDiagnostic,
-    failureReason?: RunFailureReasonToken,
-  ) {
-    super("PI_API_MODEL_FAILED", "Pi API first-turn model request failed", {
-      failureReason,
-    });
-  }
-}
-
-class PiApiFirstTurnActiveInputBeforeProviderError extends Error {
-  constructor() {
-    super("Active input committed before Pi provider ownership");
-    this.name = "PiApiFirstTurnActiveInputBeforeProviderError";
-  }
-}
-
-class PiApiFirstTurnCanonicalCancellationError extends Error {
-  constructor() {
-    super("Canonical Run cancellation owns the Pi API first turn");
-    this.name = "PiApiFirstTurnCanonicalCancellationError";
-  }
-}
-
-function piApiFirstTurnError(
-  code: PiApiFirstTurnErrorCode,
-  message: string,
-  cause?: unknown,
-  failureReason?: RunFailureReasonToken,
-): PiApiFirstTurnError {
-  return new PiApiFirstTurnError(
-    code,
-    message,
-    cause === undefined && failureReason === undefined
-      ? undefined
-      : { cause, failureReason },
-  );
-}
 
 function sha256(buffer: Buffer): string {
   return createHash("sha256").update(buffer).digest("hex");
@@ -500,88 +420,6 @@ async function readApiFirstTurnLifecycleState(
     : null;
 }
 
-function projectedAssistantBlocks(
-  assistant: PiApiFirstTurnResult["assistantMessage"],
-): unknown[] {
-  return assistant.content.flatMap((block): unknown[] => {
-    if (block.type === "text") {
-      const text = block.text.trim();
-      return text ? [{ type: "text", text }] : [];
-    }
-    if (block.type === "toolCall") {
-      return [
-        {
-          type: "tool_use",
-          id: block.id,
-          name: block.name,
-          input: block.arguments,
-        },
-      ];
-    }
-    return [];
-  });
-}
-
-function assistantText(
-  assistant: PiApiFirstTurnResult["assistantMessage"],
-): string {
-  return assistant.content
-    .flatMap((block) => {
-      return block.type === "text" && block.text.trim()
-        ? [block.text.trim()]
-        : [];
-    })
-    .join("\n\n");
-}
-
-function assistantEvents(
-  runId: string,
-  assistant: PiApiFirstTurnResult["assistantMessage"],
-): AgentEvent[] {
-  const blocks = projectedAssistantBlocks(assistant);
-  const eventBlocks =
-    blocks.length === 0 && assistant.memoryCitation ? [null] : blocks;
-  return eventBlocks.map((block, sequenceNumber) => {
-    return {
-      type: "assistant",
-      sequenceNumber,
-      message: {
-        id:
-          assistant.responseId ??
-          `${runId}:${assistant.timestamp}:${assistant.model}`,
-        role: "assistant",
-        content: block === null ? [] : [block],
-        ...(sequenceNumber === eventBlocks.length - 1 &&
-        assistant.memoryCitation
-          ? { memoryCitation: assistant.memoryCitation }
-          : {}),
-        model: assistant.model,
-        usage: {
-          input_tokens: assistant.usage.input,
-          output_tokens: assistant.usage.output,
-          cache_read_input_tokens: assistant.usage.cacheRead,
-          cache_creation_input_tokens: assistant.usage.cacheWrite,
-        },
-      },
-    };
-  });
-}
-
-function resultEvent(
-  assistant: PiApiFirstTurnResult["assistantMessage"],
-  startedAt: number,
-  sequenceNumber: number,
-): AgentEvent {
-  return {
-    type: "result",
-    sequenceNumber,
-    subtype: "success",
-    is_error: false,
-    result: assistantText(assistant),
-    duration_ms: Math.max(0, now() - startedAt),
-  };
-}
-
 const publishEvents$ = command(async function publishEvents(
   { set },
   args: {
@@ -707,6 +545,13 @@ interface PreparedApiFirstTurn {
   readonly startedAt: number;
   readonly turn: PiApiFirstTurnResult;
 }
+
+type ApiFirstTurnExecutionResult =
+  | {
+      readonly outcome: "completed";
+      readonly sideEffects: CompleteSideEffectsInput | undefined;
+    }
+  | { readonly outcome: "transferred" };
 
 interface ApiFirstTurnCommitProgress {
   started: boolean;
@@ -1510,41 +1355,6 @@ function ownershipTransferManifest(args: {
   };
 }
 
-type PiSandboxFallbackReason =
-  | "PI_API_COMPACTION_PREFLIGHT_REQUIRED"
-  | "PI_API_NATIVE_INPUT_REQUIRED"
-  | "PI_API_PREHEAT_FAILED"
-  | "PI_API_RESOURCE_PREPARATION_FAILED";
-
-type PiSandboxFirstReason =
-  | PiSandboxFallbackReason
-  | "active_input"
-  | "api_model_failed"
-  | "api_attempt_timed_out";
-
-function eligibleSandboxFallbackReason(
-  args: {
-    readonly failure: PiApiFirstTurnError;
-    readonly ownership: PiApiFirstTurnOwnership;
-  },
-  signal: AbortSignal,
-): PiSandboxFallbackReason | null {
-  if (signal.aborted || args.ownership.stage !== "pre-provider") {
-    return null;
-  }
-  switch (args.failure.code) {
-    case "PI_API_NATIVE_INPUT_REQUIRED":
-    case "PI_API_PREHEAT_FAILED":
-    case "PI_API_COMPACTION_PREFLIGHT_REQUIRED":
-    case "PI_API_RESOURCE_PREPARATION_FAILED": {
-      return args.failure.code;
-    }
-    default: {
-      return null;
-    }
-  }
-}
-
 function validateSandboxFallbackSession(
   sessionJsonl: string,
   sessionId: string,
@@ -1874,7 +1684,7 @@ const commitApiFirstTurn$ = command(async function commitApiFirstTurn(
   prepared: PreparedApiFirstTurn,
   commitProgress: ApiFirstTurnCommitProgress,
   signal: AbortSignal,
-): Promise<CompleteSideEffectsInput | undefined> {
+): Promise<ApiFirstTurnExecutionResult> {
   return await withApiFirstTurnLifecycle(args, async (tx) => {
     signal.throwIfAborted();
     const state = validateApiFirstTurnApiCommit(
@@ -1886,13 +1696,10 @@ const commitApiFirstTurn$ = command(async function commitApiFirstTurn(
     // Once any H1 commit side effect can begin, a later timeout must fail
     // terminally instead of replaying H0 over potentially published state.
     commitProgress.started = true;
-    const hasActiveInput = state.activeDeliveryId !== null;
-    const transferMode: PiApiFirstTurnOwnershipTransferMode | null = prepared
-      .turn.handoffRequired
-      ? "pending-tool-continuation"
-      : hasActiveInput
-        ? "settled-session-continuation"
-        : null;
+    const transition = decideApiFirstTurnCommit({
+      pendingTools: prepared.turn.handoffRequired,
+      activeInput: state.activeDeliveryId !== null,
+    });
 
     await get(
       putS3Object(
@@ -1905,13 +1712,13 @@ const commitApiFirstTurn$ = command(async function commitApiFirstTurn(
     );
     signal.throwIfAborted();
 
-    const blockEvents = assistantEvents(
+    const blockEvents = piApiFirstTurnAssistantEvents(
       args.activation.runId,
       prepared.turn.assistantMessage,
     );
     const nextSequenceNumber = blockEvents.length;
     if (
-      transferMode &&
+      transition.outcome === "transfer" &&
       nextSequenceNumber < prepared.commitIdentity.sandboxEventSequenceStart
     ) {
       throw piApiFirstTurnError(
@@ -1919,20 +1726,22 @@ const commitApiFirstTurn$ = command(async function commitApiFirstTurn(
         "Pi API first-turn event boundary precedes the immutable Sandbox boundary",
       );
     }
-    const events = transferMode
-      ? blockEvents
-      : [
-          ...blockEvents,
-          resultEvent(
-            prepared.turn.assistantMessage,
-            prepared.startedAt,
-            nextSequenceNumber,
-          ),
-        ];
+    const events =
+      transition.outcome === "transfer"
+        ? blockEvents
+        : [
+            ...blockEvents,
+            piApiFirstTurnResultEvent(
+              prepared.turn.assistantMessage,
+              prepared.startedAt,
+              nextSequenceNumber,
+              now(),
+            ),
+          ];
     await set(publishEvents$, { auth: prepared.auth, events }, signal);
-    if (transferMode) {
+    if (transition.outcome === "transfer") {
       const manifest = ownershipTransferManifest({
-        mode: transferMode,
+        mode: transition.mode,
         baseSession: prepared.baseSession,
         session: {
           sessionId: prepared.sessionId,
@@ -1951,14 +1760,10 @@ const commitApiFirstTurn$ = command(async function commitApiFirstTurn(
         ...piApiFirstTurnOutcomeTelemetry(args.activation.executionContext),
         handoffOwner: "sandbox",
         outcome: "ownership_transfer",
-        reason: hasActiveInput
-          ? transferMode === "settled-session-continuation"
-            ? "active_input_settled_session"
-            : "active_input_pending_tool"
-          : "pending_tool_continuation",
+        reason: transition.reason,
         ownershipStage: "provider-may-have-started",
       });
-      return undefined;
+      return { outcome: "transferred" };
     }
 
     await set(persistCompleteTurnCheckpoint$, args, prepared, signal);
@@ -1977,7 +1782,7 @@ const commitApiFirstTurn$ = command(async function commitApiFirstTurn(
       reason: "settled_session",
       ownershipStage: "provider-may-have-started",
     });
-    return sideEffects;
+    return { outcome: "completed", sideEffects };
   });
 });
 
@@ -2001,10 +1806,7 @@ const publishLargeHistoryTransfer$ = command(
       resumeSession.historyRef,
       signal,
     );
-    if (
-      metadata.rawSize <= PI_API_FIRST_TURN_SESSION_MAX_BYTES &&
-      metadata.encodedSize <= PI_API_FIRST_TURN_SESSION_MAX_BYTES
-    ) {
+    if (decideApiFirstTurnHistory(metadata) === "api") {
       return false;
     }
     const hash = resumeSession.historyRef.hash;
@@ -2086,9 +1888,9 @@ const executeApiFirstTurn$ = command(async function executeApiFirstTurn(
   ownership: PiApiFirstTurnOwnership,
   commitProgress: ApiFirstTurnCommitProgress,
   signal: AbortSignal,
-): Promise<CompleteSideEffectsInput | undefined> {
+): Promise<ApiFirstTurnExecutionResult> {
   if (await set(publishLargeHistoryTransfer$, args, commitProgress, signal)) {
-    return undefined;
+    return { outcome: "transferred" };
   }
   const prepared = await set(prepareApiFirstTurn$, args, ownership, signal);
   const committed = await settle(
@@ -2110,42 +1912,6 @@ const executeApiFirstTurn$ = command(async function executeApiFirstTurn(
   }
   return committed.value;
 });
-
-function normalizedApiFirstTurnFailure(
-  error: unknown,
-  signal: AbortSignal,
-): PiApiFirstTurnError {
-  if (error instanceof PiApiFirstTurnError) {
-    return error;
-  }
-  return piApiFirstTurnError(
-    signal.aborted
-      ? "PI_API_FIRST_TURN_DEADLINE_EXCEEDED"
-      : "PI_API_MODEL_FAILED",
-    signal.aborted
-      ? "Pi API first-turn deadline elapsed"
-      : "Pi API first turn failed",
-    error,
-  );
-}
-
-function normalizedSandboxFallbackFailure(
-  error: unknown,
-  signal: AbortSignal,
-): PiApiFirstTurnError {
-  if (error instanceof PiApiFirstTurnError) {
-    return error;
-  }
-  return piApiFirstTurnError(
-    signal.aborted
-      ? "PI_API_FIRST_TURN_DEADLINE_EXCEEDED"
-      : "PI_API_SANDBOX_FALLBACK_FAILED",
-    signal.aborted
-      ? "Pi API first-turn deadline elapsed during sandbox fallback"
-      : "Pi sandbox fallback publication failed",
-    error,
-  );
-}
 
 async function settleApiFirstTurnExecution<T>(
   execution: Promise<T>,
@@ -2302,23 +2068,6 @@ function modelFailureTelemetry(
     : {};
 }
 
-function eligibleApiModelFailure(
-  failure: PiApiFirstTurnError,
-  commitStarted: boolean,
-  coordinationDeadlineAt: number,
-  signal: AbortSignal,
-): boolean {
-  return (
-    failure instanceof PiApiFirstTurnModelFailureError &&
-    !failure.failureReason &&
-    failure.diagnostic.httpStatus !== 401 &&
-    failure.diagnostic.httpStatus !== 403 &&
-    !commitStarted &&
-    !signal.aborted &&
-    now() < coordinationDeadlineAt
-  );
-}
-
 function logApiFirstTurnTerminalFailure(args: {
   readonly activation: PiApiFirstTurnActivation;
   readonly ownership: PiApiFirstTurnOwnership;
@@ -2362,11 +2111,12 @@ const failApiFirstTurn$ = command(async function failApiFirstTurn(
       tx,
       args.activation.runId,
     );
-    if (state?.status === "cancelled") {
+    const transition = decideApiFirstTurnTerminal(state?.status);
+    if (transition === "cancelled") {
       logCanonicalApiFirstTurnCancellation(args, ownership);
       return undefined;
     }
-    if (!state || (state.status !== "pending" && state.status !== "running")) {
+    if (transition === "already-terminal") {
       return undefined;
     }
     const completion = await set(
@@ -2434,70 +2184,39 @@ const runPiApiFirstTurnCore$ = command(
       signal,
     );
     if (executed.ok) {
-      return executed.value
+      const outcome = executed.value;
+      return outcome.outcome === "completed" && outcome.sideEffects
         ? {
-            ...executed.value,
+            ...outcome.sideEffects,
             apiStartTime: activation.executionContext.apiStartTime,
           }
         : undefined;
     }
-    const activeInputBeforeProvider =
-      executed.error instanceof PiApiFirstTurnActiveInputBeforeProviderError;
+    // Classify the original error before aborting the private attempt. Closing
+    // it first would turn raw model failures into deadlines and permit H0 replay.
     let failure = normalizedApiFirstTurnFailure(
       executed.error,
-      apiAttemptSignal,
+      apiAttemptSignal.aborted,
     );
-    // Classify the failure before closing any residual attempt work. Aborting
-    // the private controller first would misclassify every raw API failure as
-    // an ownership deadline and incorrectly replay it in Sandbox.
-    const modelFailure =
-      failure instanceof PiApiFirstTurnModelFailureError
-        ? failure.diagnostic
-        : undefined;
-    const resourceFallbackReason = activeInputBeforeProvider
-      ? null
-      : eligibleSandboxFallbackReason(
-          {
-            failure,
-            ownership,
-          },
-          signal,
-        );
-    const coordinationDeadlineAt =
-      activation.executionContext.piLaunchConfig.apiFirstTurn.deadlineAt;
-    const apiOwnershipExpired =
-      failure.code === "PI_API_FIRST_TURN_DEADLINE_EXCEEDED" &&
-      !commitProgress.started &&
-      !signal.aborted;
-    const apiAttemptTimedOut =
-      apiOwnershipExpired && now() < coordinationDeadlineAt;
-    const apiModelFailed = eligibleApiModelFailure(
+    const decision = decideApiFirstTurnRecovery({
       failure,
-      commitProgress.started,
-      coordinationDeadlineAt,
-      signal,
-    );
-    const sandboxFirstReason: PiSandboxFirstReason | null =
-      activeInputBeforeProvider
-        ? "active_input"
-        : apiAttemptTimedOut
-          ? "api_attempt_timed_out"
-          : apiModelFailed
-            ? "api_model_failed"
-            : resourceFallbackReason;
+      activeInputBeforeProvider:
+        executed.error instanceof PiApiFirstTurnActiveInputBeforeProviderError,
+      ownershipStage: ownership.stage,
+      commitStarted: commitProgress.started,
+      coordinationAborted: signal.aborted,
+      coordinationDeadlineAt:
+        activation.executionContext.piLaunchConfig.apiFirstTurn.deadlineAt,
+      observedAt: now(),
+    });
     apiAttemptController.abort(executed.error);
-    if (sandboxFirstReason) {
-      if (apiAttemptTimedOut) {
+    if (decision.outcome === "sandbox-first") {
+      if (decision.logAttemptTimeout) {
         logApiFirstTurnAttemptTimedOut(activation, ownership, failure);
       }
       const handoffSignal = piApiFirstTurnHandoffSignal(activation, signal);
       const fallback = await settleApiFirstTurnExecution(
-        set(
-          publishSandboxFallback$,
-          context,
-          sandboxFirstReason,
-          handoffSignal,
-        ),
+        set(publishSandboxFallback$, context, decision.reason, handoffSignal),
         handoffSignal,
         signal,
       );
@@ -2505,12 +2224,15 @@ const runPiApiFirstTurnCore$ = command(
         logSandboxFirstPublication(
           activation,
           ownership,
-          sandboxFirstReason,
-          modelFailure,
+          decision.reason,
+          decision.modelFailure,
         );
         return undefined;
       }
-      failure = normalizedSandboxFallbackFailure(fallback.error, handoffSignal);
+      failure = normalizedSandboxFallbackFailure(
+        fallback.error,
+        handoffSignal.aborted,
+      );
     }
     if (await canonicalApiFirstTurnCancellationWon(context)) {
       logCanonicalApiFirstTurnCancellation(context, ownership, executed.error);
@@ -2520,16 +2242,17 @@ const runPiApiFirstTurnCore$ = command(
       activation,
       ownership,
       failure,
-      modelFailure,
-      resourceFallbackReason,
-      sandboxFirstReason,
+      modelFailure: decision.modelFailure,
+      resourceFallbackReason: decision.resourceFallbackReason,
+      sandboxFirstReason:
+        decision.outcome === "sandbox-first" ? decision.reason : null,
     });
     return set(
       failApiFirstTurn$,
       context,
       failure,
       ownership,
-      apiOwnershipExpired || apiModelFailed,
+      decision.suppressCompletionFailureLog,
     );
   },
 );

--- a/turbo/packages/pi-agent-runtime/src/api.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/api.test.ts
@@ -1,4 +1,5 @@
 import { zstdDecompressSync } from "node:zlib";
+import { readFileSync } from "node:fs";
 import { createServer, type ServerResponse } from "node:http";
 
 import { piModelConfigSchema } from "@okouai/api-contracts/contracts/runners";
@@ -26,6 +27,31 @@ import {
 import { projectPiApiAssistantMessage } from "./api-turn";
 import { resolvePiAgentModel } from "./model";
 import { MemoryPiSession } from "./session-memory";
+import type { PiApiAssistantMessage } from "./api-types";
+
+const publicEventFixture = JSON.parse(
+  readFileSync(
+    new URL("../../../../fixtures/pi-public-events.json", import.meta.url),
+    "utf8",
+  ),
+) as {
+  readonly cases: readonly {
+    readonly name: string;
+    readonly guestMessage: AssistantMessage;
+    readonly apiAssistant: PiApiAssistantMessage;
+  }[];
+};
+
+describe("Pi API input normalization fixtures", () => {
+  it.each(publicEventFixture.cases)(
+    "normalizes $name before API event projection",
+    (example) => {
+      expect(projectPiApiAssistantMessage(example.guestMessage)).toEqual(
+        example.apiAssistant,
+      );
+    },
+  );
+});
 
 const SESSION_ID = "00000000-0000-4000-8000-000000000123";
 const SESSION_TIMESTAMP = "2026-08-31T12:34:56.000Z";


### PR DESCRIPTION
## Summary

API-first already had prepare/execute/commit functions, but recovery precedence and terminal arbitration remained mixed with IO. This change introduces pure, typed history, commit, recovery and terminal decisions, and makes the coordinator interpret explicit completed/transferred outcomes. Preparation and guarded effects keep their existing module-scope commands, lifecycle locks, identity revalidation, commit-start barriers and signal owners.

The API service now uses an extracted public-event producer. A fixed repository fixture exercises that producer, the runtime's real input normalization, and Guest `PiRpcProjection` plus block normalization. It covers text/empty content, ordered tools, response/fallback identity, all four token counters and citation provenance while preserving each adapter's sequence/session/duration and terminal boundary.

Two real route regressions cover raw usage failure before private abort and a large-history manifest whose write succeeds but whose response is lost at the API deadline. The local module note documents responsibility, dependency direction and retained ownership facts for child D.

## Compatibility and scope

Existing #32751 same-route recovery, captured `PiExecutionRoute`, exact credentials, native provider preparation, API/coordination deadlines, metadata-first large-history transfer and late API usage attribution remain in place. API and Runner/proxy billing retain separate writers. Persisted and wire contracts, protected readers, provider/admission policy and release behavior are unchanged.

## Validation

- Pure policy/public projection: 36 cases; runtime API/failure/session/route suites: 153 cases.
- Real API route sweeps cover completion, pending tools, active input, deadlines, cancellation, partial publication, late usage, incomplete output and exact-account Fast routing; native-usage BDD covers separate categories/idempotency. Targeted failures in the new test assertions were corrected and the final policy/race run passed all 38 selected cases.
- Guest projection, block normalization and citation suites: 27 cases. The first bounded Rust build and shared-fixture test finished in 4m 43s.
- CLI handoff/loop: 79 cases passed initially; the three RPC cases that hit their existing 10-second deadline passed a focused rerun without concurrent static checks. No timeout or assertion was relaxed.
- The initial local database needed UTC to match the test/CI timestamp convention. One existing CLI isolation helper spawned a child Vitest from a single top-level invocation; that execution deviation is recorded. Its cyclic-history case subsequently passed directly in one process with the helper's existing isolation environment variable. No full local Vitest suite or dev server was run.
- ESLint, ordinary/type-aware Oxlint, runtime lint, whole-workspace Knip and all 14 type-check tasks passed. Native API type checking exhausted the 4 GiB environment with two checkers; a local hook configuration differing only in `TSC_CHECKERS=1` passed the same checks in 3m 26s. No check, type rule, assertion or timeout was disabled, and repository/CI hook definitions were not modified.
- After integrating main `9e03a65070e78e71cf477967eb6ff9b309c8763e`, all 13 selected model-recovery, subscription H0, API/Runner independent-billing and new regression cases passed. All 14 type-check tasks passed again in 2m 26s. Earlier scoped test results above predate that main integration; required CI must validate the pushed head.
- The first owner run timed out during Runner Clippy without producing a commit. The resumed normal hooks passed completely in 10m 41s, including workspace Clippy (7m 24s), Rust documentation, formatting, file-size and commitlint. A temporary local 2 GiB swap file and one Cargo build job allowed that check to finish in this 4 GiB environment; no repository rule changed.

Exact-head review and required CI remain the merge gates. This PR carries no production release authorization.

Closes #33570.
