### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/cli/src/commands/agent/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/delete.test.ts
@@ -62,10 +62,7 @@ describe("okou agent delete command", () => {
     });
   });
 
-  it.each([
-    [true, "cannot be deleted"],
-    [undefined, "Agent identity is unavailable"],
-  ])(
+  it.each([[true, "cannot be deleted"]])(
     "rejects deletion before confirmation for identity %s",
     async (identity, message) => {
       let deletes = 0;

--- a/turbo/apps/cli/src/commands/agent/__tests__/edit.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/edit.test.ts
@@ -308,32 +308,6 @@ describe("okou agent edit command", () => {
       },
     );
 
-    it("rejects protected edits when the API omits identity", async () => {
-      let writes = 0;
-      server.use(
-        http.get("http://localhost:3000/api/agents/my-agent", () => {
-          return HttpResponse.json({ ...mockAgent, isDefaultAgent: undefined });
-        }),
-        http.put("http://localhost:3000/api/agents/my-agent", () => {
-          writes++;
-          return HttpResponse.json(mockAgent);
-        }),
-      );
-      await expect(
-        editCommand.parseAsync([
-          "node",
-          "cli",
-          "my-agent",
-          "--visibility",
-          "private",
-        ]),
-      ).rejects.toThrow("process.exit called");
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Agent identity is unavailable"),
-      );
-      expect(writes).toBe(0);
-    });
-
     it("edits a default description and repeats canonical fields", async () => {
       const requests: unknown[] = [];
       server.use(

--- a/turbo/apps/platform/src/signals/okou-page/agent-types.ts
+++ b/turbo/apps/platform/src/signals/okou-page/agent-types.ts
@@ -1,6 +1,5 @@
 export interface AgentDetail {
-  // Mirrors the bounded AgentResponse compatibility in #33251.
-  isDefaultAgent?: boolean;
+  isDefaultAgent: boolean;
   agentId: string;
   ownerId: string;
   description: string | null;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
@@ -673,7 +673,7 @@ test("Keep the default agent’s canonical identity read-only", async () => {
   expect(saved).not.toHaveProperty("visibility");
 });
 
-test.each([true, undefined])(
+test.each([true])(
   "Reject queued protected actions for default identity %s",
   async (identity) => {
     const agent: AgentResponse = {
@@ -722,15 +722,11 @@ test.each([true, undefined])(
           { ...update, description: "Must not be saved" },
           context.signal,
         ),
-      ).rejects.toThrow(
-        identity === true ? "workspace default" : "identity is unavailable",
-      );
+      ).rejects.toThrow("workspace default");
     }
     await expect(
       context.store.set(deleteAgent$, context.signal),
-    ).rejects.toThrow(
-      identity === true ? "cannot be deleted" : "identity is unavailable",
-    );
+    ).rejects.toThrow("cannot be deleted");
   },
 );
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/workspace-agent-search.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/workspace-agent-search.test.tsx
@@ -38,6 +38,7 @@ function prepareAgents() {
     },
   ].map((agent) => {
     return {
+      isDefaultAgent: agent.agentId === DEFAULT_AGENT_ID,
       ownerId: "test-user-123",
       description: null,
       sound: null,

--- a/turbo/packages/api-contracts/src/contracts/agents.ts
+++ b/turbo/packages/api-contracts/src/contracts/agents.ts
@@ -33,9 +33,7 @@ export type AgentVisibility = z.infer<typeof agentVisibilitySchema>;
  */
 export const agentResponseSchema = z.object({
   agentId: z.string(),
-  // New App/CLI -> old API: unknown identity must not grant mutation access.
-  // Require this after older serving/rollback API targets retire (#33251).
-  isDefaultAgent: z.boolean().optional(),
+  isDefaultAgent: z.boolean(),
   ownerId: z.string(),
   description: z.string().nullable(),
   displayName: z.string().nullable(),

--- a/turbo/packages/core/src/agent-protection.ts
+++ b/turbo/packages/core/src/agent-protection.ts
@@ -7,17 +7,9 @@ interface AgentIdentityUpdate {
   readonly visibility?: "public" | "private";
 }
 
-// New App/CLI clients can reach older API targets during rollout/rollback.
-// Missing identity grants no protected action; retire old-response tolerance
-// after those API targets are gone (#33251).
-const identityUnavailableError = {
-  code: "AGENT_IDENTITY_UNAVAILABLE",
-  message: "Agent identity is unavailable. Refresh the agent and try again.",
-};
-
 /** Validate protected fields using authoritative identity, never a name. */
 export function agentIdentityUpdateError(
-  isDefaultAgent: boolean | undefined,
+  isDefaultAgent: boolean,
   update: AgentIdentityUpdate,
 ) {
   if (
@@ -26,9 +18,6 @@ export function agentIdentityUpdateError(
     update.visibility === undefined
   ) {
     return null;
-  }
-  if (typeof isDefaultAgent !== "boolean") {
-    return identityUnavailableError;
   }
   if (!isDefaultAgent) {
     return null;
@@ -60,10 +49,7 @@ export function agentIdentityUpdateError(
   return null;
 }
 
-export function agentDeletionError(isDefaultAgent: boolean | undefined) {
-  if (typeof isDefaultAgent !== "boolean") {
-    return identityUnavailableError;
-  }
+export function agentDeletionError(isDefaultAgent: boolean) {
   return isDefaultAgent
     ? {
         code: "DEFAULT_AGENT_DELETE_LOCKED",


### PR DESCRIPTION
Daily deployment-compatibility cleanup for 2026-09-12. One expired cohort, one branch, no schema changes. Windows follow `docs/deployment-compatibility.md`; timestamps are UTC.

## 1. Default-agent identity tolerance for older API targets (#33251)

- **Boundary**: `agentResponseSchema.isDefaultAgent` was optional so a new App/CLI could still parse a response from an API that predates #33266, and `@okouai/core/agent-protection` answered `AGENT_IDENTITY_UNAVAILABLE` ("Agent identity is unavailable. Refresh the agent and try again.") whenever the field was missing so a missing identity never granted a protected mutation. The field is now required, `agentIdentityUpdateError` / `agentDeletionError` take a `boolean`, and the tolerance branch, its Platform type mirror (`AgentDetail.isDefaultAgent?`), and the CLI/Platform tests that exercised the missing-identity path are removed. The API has computed the field from `defaultAgentId` since #33266 and never omitted it.
- **Rollout / floor**: producer `58e76a815b` (#33266) merged 2026-09-10 12:33. The production rollback resolver now requires every release/API target to contain `669d0befc9` (#33390, 2026-09-11 02:55, the `computer_use_hosts.client_product` drop), and `git merge-base --is-ancestor` confirms #33266 is an ancestor of that floor. Production `chore: release main` runs on 2026-09-11 at 06:17–06:39, 08:14–08:33, 11:18–11:37 and 15:02–15:21 all carry the floor, so no older API is serving and no permitted rollback target lacks the field. Consumer class: App/CLI → old API (old API rollout + 4 s; rollback closed by the floor). This is the removal gate written in #33251.
- **Axiom** (`vm0-request-log-prod`, 2026-09-10T21:20Z → 2026-09-11T21:20Z): the only App versions still receiving `426` are 0.806.1 (37 requests) and 0.855.1 (3 313) — both below the enforced 0.857.0 floor and unrelated to this cohort; Runner traffic is 0.189.7–0.190.6. Coverage note: the request log cannot show which client parsed a response without the field, so eligibility rests on the producer history and rollback floor above.
- **Persisted data**: none; the field is computed per response.

## Verification

- `check-types` for `@okouai/api-contracts`, `@okouai/core`, `api`, `@okouai/cli`, `@okouai/app`; `eslint --max-warnings 0` on every changed file; `pnpm knip` clean; reference searches for `AGENT_IDENTITY_UNAVAILABLE`, `identityUnavailableError` and the optional field return nothing.
- Local suites: `@okouai/core` (246 tests), CLI `agent edit` / `agent delete` (21), Platform `settings-tab` and `workspace-agent-search` (40).
- `job-detail-page.tsx` and `settings-tab.tsx` keep their `boolean | undefined` loading-placeholder props: that `undefined` models a page that has not resolved its agent yet, not the wire contract, and open PR #33335 modifies `job-detail-page.tsx`. Both typecheck against the required field.

## Deferred this run (exact blockers)

- **Billing status response optionals** (`status`, `canBuyConcurrency`, `concurrencyPurchaseReviewAvailable`, `canBuyCredits`, `autoRechargeAllowed`, `supportByok`, `restrictedVm0Models`, `videoGenerationAllowed`, `workflowWebhookAutomationAllowed`, `canRestorePlan`) plus the Platform `LEGACY_TIER_CAPABILITIES` fallback table: the producers (#28222 / #28452, 2026-08-19/20) are inside the rollback floor, so the cohort is expired, but the tightening was reverted from this branch: about fifteen typed Platform fixtures and args-spreading builders rely on the per-tier fallback, and the "Upgrade to invite members" scenario depends on `memberInvitationAllowed`, which #32575 owns. Needs a run with Platform test execution.
- Google Ads attribution aliases (#33059): Stripe metadata and analytics consumers still read the old keys.
- Usage-pack legacy columns (#32575), `chat_threads` provider pins (still read; 153 389 non-null rows), `pi_memory_phase2_jobs.legacy_lease_token`, browser compatibility structures, personal model-provider singleton expansion (MaskDB projection/join limits), `#29908` queue markers (writers live), `#31964`, `#31085` Slice 2, the `sourceId`-less secret path (`PersonalModelProviderAccounts` staff-only), and the `featureDisabled` / `noSessionId` reuse enum values (historical rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
