### PR TITLE
refactor(platform): route chat realtime invalidations directly

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -69,6 +69,8 @@ const keepAliveLoop$ = command((_ctx, _signal: AbortSignal) => {
   return Promise.resolve(false);
 });
 
+const noopInvalidation$ = command((): void => {});
+
 const keepAlivePayloadLoop$ = command(
   (_ctx, _payload: unknown, _signal: AbortSignal) => {
     return Promise.resolve(false);
@@ -775,6 +777,89 @@ test("A persistent refresh error pauses until a new update", async () => {
   expect(runs).toBe(5);
 });
 
+test("Chat thread notifications invalidate their matching resources", async () => {
+  mockSignedInUser();
+  const threadId = "test-thread-invalidations";
+  const subscriber = testSubscriber();
+  const invalidated: string[] = [];
+  const recordInvalidation = (name: string) => {
+    return command((): void => {
+      invalidated.push(name);
+    });
+  };
+
+  await context.store.set(setupRealtime$, context.signal);
+  detach(
+    context.store.set(
+      subscribeChatThreadRealtime$,
+      {
+        threadId,
+        invalidations: {
+          threadDetail: [
+            recordInvalidation("thread-detail"),
+            recordInvalidation("connector-preference"),
+          ],
+          automations: [recordInvalidation("automations")],
+          artifacts: [recordInvalidation("artifacts")],
+        },
+        handlers: { onWorkflowsChanged$: keepAliveLoop$ },
+      },
+      subscriber.signal,
+    ),
+    Reason.Daemon,
+    "test chat thread realtime invalidations",
+  );
+
+  await waitFor(() => {
+    for (const topic of [
+      "chatThreadDetailChanged",
+      "chatThreadAutomationsChanged",
+      "chatThreadArtifactsChanged",
+      "chatThreadWorkflowsChanged",
+    ]) {
+      expect(
+        context.mocks.ably.hasSubscription(`${topic}:${threadId}`),
+      ).toBeTruthy();
+    }
+  });
+
+  const notifications = [
+    {
+      topic: `chatThreadDetailChanged:${threadId}`,
+      expected: ["thread-detail", "connector-preference"],
+    },
+    {
+      topic: `chatThreadAutomationsChanged:${threadId}`,
+      expected: ["thread-detail", "connector-preference", "automations"],
+    },
+    {
+      topic: `chatThreadArtifactsChanged:${threadId}`,
+      expected: [
+        "thread-detail",
+        "connector-preference",
+        "automations",
+        "artifacts",
+      ],
+    },
+    {
+      topic: `chatThreadArtifactsChanged:${threadId}`,
+      expected: [
+        "thread-detail",
+        "connector-preference",
+        "automations",
+        "artifacts",
+        "artifacts",
+      ],
+    },
+  ] as const;
+  for (const notification of notifications) {
+    context.mocks.ably.trigger(notification.topic);
+    await waitFor(() => {
+      expect(invalidated).toStrictEqual(notification.expected);
+    });
+  }
+});
+
 test("An initial refresh failure does not destroy live subscriptions", async () => {
   mockSignedInUser();
   const threadId = "test-thread-initialization-failure";
@@ -785,10 +870,12 @@ test("An initial refresh failure does not destroy live subscriptions", async () 
       subscribeChatThreadRealtime$,
       {
         threadId,
+        invalidations: {
+          threadDetail: [noopInvalidation$],
+          automations: [noopInvalidation$],
+          artifacts: [noopInvalidation$],
+        },
         handlers: {
-          onThreadDetailChanged$: keepAliveLoop$,
-          onAutomationsChanged$: keepAliveLoop$,
-          onArtifactsChanged$: keepAliveLoop$,
           onWorkflowsChanged$: keepAliveLoop$,
           onSubscribed$: failSubscriptionInitialization$,
         },

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-remote-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-remote-signals.ts
@@ -17,7 +17,11 @@ import { nowDate } from "../../lib/time.ts";
 import { apiClient$ } from "../api-client.ts";
 import { chatReasoningEffortEnabled$ } from "../external/feature-switch.ts";
 import { threadCodexServiceTierFromSelection } from "./model-selection-request.ts";
-import { setAblyLoop$ } from "../realtime.ts";
+import {
+  setAblyInvalidationLoop$,
+  setAblyLoop$,
+  type RealtimeInvalidationCommands,
+} from "../realtime.ts";
 import { createDeferredPromise } from "../utils.ts";
 import { reloadSidebarDraftThreads$ } from "./sidebar-draft-threads.ts";
 import {
@@ -27,19 +31,13 @@ import {
 } from "./chat-thread-event-sourcing.ts";
 import type { ModelProviderSelection } from "../../views/okou-page/components/model-provider-picker.tsx";
 
+interface ChatThreadRealtimeInvalidations {
+  readonly threadDetail: RealtimeInvalidationCommands;
+  readonly automations: RealtimeInvalidationCommands;
+  readonly artifacts: RealtimeInvalidationCommands;
+}
+
 interface ChatThreadRealtimeHandlers {
-  readonly onThreadDetailChanged$: Command<
-    Promise<boolean> | boolean,
-    [AbortSignal]
-  >;
-  readonly onAutomationsChanged$: Command<
-    Promise<boolean> | boolean,
-    [AbortSignal]
-  >;
-  readonly onArtifactsChanged$: Command<
-    Promise<boolean> | boolean,
-    [AbortSignal]
-  >;
   readonly onWorkflowsChanged$: Command<
     Promise<boolean> | boolean,
     [AbortSignal]
@@ -76,13 +74,21 @@ interface PatchImageModelArgs {
 
 interface SubscribeRealtimeArgs {
   readonly threadId: string;
+  readonly invalidations: ChatThreadRealtimeInvalidations;
   readonly handlers: ChatThreadRealtimeHandlers;
 }
 
-type ChatRealtimeSubscription = {
-  readonly topic: string;
-  readonly loopCommand$: Command<Promise<boolean> | boolean, [AbortSignal]>;
-};
+type ChatRealtimeSubscription =
+  | {
+      readonly kind: "invalidate";
+      readonly topic: string;
+      readonly invalidations: RealtimeInvalidationCommands;
+    }
+  | {
+      readonly kind: "command";
+      readonly topic: string;
+      readonly loopCommand$: Command<Promise<boolean> | boolean, [AbortSignal]>;
+    };
 
 export const patchChatThreadDraft$ = command(
   async (
@@ -256,24 +262,28 @@ export const patchChatThreadImageModel$ = command(
 export const subscribeChatThreadRealtime$ = command(
   async (
     { set },
-    { threadId, handlers }: SubscribeRealtimeArgs,
+    { threadId, invalidations, handlers }: SubscribeRealtimeArgs,
     signal: AbortSignal,
   ) => {
     const ready = createDeferredPromise<void>(signal);
     const subscriptions: ChatRealtimeSubscription[] = [
       {
+        kind: "invalidate",
         topic: `chatThreadDetailChanged:${threadId}`,
-        loopCommand$: handlers.onThreadDetailChanged$,
+        invalidations: invalidations.threadDetail,
       },
       {
+        kind: "invalidate",
         topic: `chatThreadAutomationsChanged:${threadId}`,
-        loopCommand$: handlers.onAutomationsChanged$,
+        invalidations: invalidations.automations,
       },
       {
+        kind: "invalidate",
         topic: `chatThreadArtifactsChanged:${threadId}`,
-        loopCommand$: handlers.onArtifactsChanged$,
+        invalidations: invalidations.artifacts,
       },
       {
+        kind: "command",
         topic: `chatThreadWorkflowsChanged:${threadId}`,
         loopCommand$: handlers.onWorkflowsChanged$,
       },
@@ -289,6 +299,17 @@ export const subscribeChatThreadRealtime$ = command(
     const options = { onSubscribed: markSubscribed };
     const subscription = Promise.all(
       subscriptions.map((subscription) => {
+        if (subscription.kind === "invalidate") {
+          return set(
+            setAblyInvalidationLoop$,
+            {
+              topic: subscription.topic,
+              invalidations: subscription.invalidations,
+              options,
+            },
+            signal,
+          );
+        }
         return set(
           setAblyLoop$,
           {

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -3093,27 +3093,6 @@ function createRunTracking({
     await set(setupChatEvents$, signal);
     signal.throwIfAborted();
 
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const onThreadDetailChanged$ = command(({ set }) => {
-      L.debug("onThreadDetailChanged$ fired", { threadId });
-      set(cancellationRecovery.reload$);
-      set(reloadConnectorAccountPreference$);
-      return false;
-    });
-
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const onAutomationsChanged$ = command(({ set }) => {
-      set(automationSignals.headerAutomations.reload$);
-      return false;
-    });
-
-    // eslint-disable-next-line ccstate/no-command-in-command -- migrate this runtime callback to the static command graph
-    const onArtifactsChanged$ = command(({ set }) => {
-      L.debug("onArtifactsChanged$ fired", { threadId });
-      set(reloadArtifacts$);
-      return false;
-    });
-
     await Promise.all([
       set(syncHydratedEventTrees$, signal),
       set(subscribeBrowserSessions$, signal),
@@ -3122,10 +3101,15 @@ function createRunTracking({
         subscribeChatThreadRealtime$,
         {
           threadId,
+          invalidations: {
+            threadDetail: [
+              cancellationRecovery.reload$,
+              reloadConnectorAccountPreference$,
+            ],
+            automations: [automationSignals.headerAutomations.reload$],
+            artifacts: [reloadArtifacts$],
+          },
           handlers: {
-            onThreadDetailChanged$,
-            onAutomationsChanged$,
-            onArtifactsChanged$,
             onWorkflowsChanged$,
             onSubscribed$,
           },

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -207,10 +207,25 @@ interface RealtimeSubscribeOptions {
   readonly runOnSubscribe?: boolean;
 }
 
+export type RealtimeInvalidationCommands = readonly [
+  Command<void, []>,
+  ...Command<void, []>[],
+];
+
+type RealtimeLoopAction =
+  | {
+      readonly kind: "command";
+      readonly command$: Command<Promise<boolean> | boolean, [AbortSignal]>;
+    }
+  | {
+      readonly kind: "invalidate";
+      readonly invalidations: RealtimeInvalidationCommands;
+    };
+
 interface RealtimeLoopArgs {
   readonly channel: RealtimeSubscriptionChannel;
   readonly topic: string;
-  readonly loopCommand$: Command<Promise<boolean> | boolean, [AbortSignal]>;
+  readonly action: RealtimeLoopAction;
   readonly options?: RealtimeSubscribeOptions;
 }
 
@@ -233,6 +248,13 @@ interface SetAblyLoopArgs {
   readonly scope?: RealtimeChannelScope;
   readonly topic: string;
   readonly loopCommand$: Command<Promise<boolean> | boolean, [AbortSignal]>;
+  readonly options?: RealtimeSubscribeOptions;
+}
+
+interface SetAblyInvalidationLoopArgs {
+  readonly scope?: RealtimeChannelScope;
+  readonly topic: string;
+  readonly invalidations: RealtimeInvalidationCommands;
   readonly options?: RealtimeSubscribeOptions;
 }
 
@@ -334,7 +356,7 @@ async function subscribeChannel(
 const runWithChannel$ = command(
   async (
     { set },
-    { channel, topic, loopCommand$, options }: RealtimeLoopArgs,
+    { channel, topic, action, options }: RealtimeLoopArgs,
     signal: AbortSignal,
   ): Promise<void> => {
     // No implicit prime on subscribe by default. Callers whose loop body sets
@@ -390,7 +412,14 @@ const runWithChannel$ = command(
               poked = false;
               // eslint-disable-next-line no-restricted-syntax -- polling loop requires try/catch for transient error retry with backoff
               try {
-                const done = await set(loopCommand$, loopSignal);
+                let done = false;
+                if (action.kind === "command") {
+                  done = await set(action.command$, loopSignal);
+                } else {
+                  for (const invalidation$ of action.invalidations) {
+                    set(invalidation$);
+                  }
+                }
                 loopSignal.throwIfAborted();
                 transientRetryCount = 0;
                 if (done) {
@@ -1126,7 +1155,40 @@ export const setAblyLoop$ = command(
     signal.throwIfAborted();
     await set(
       runWithChannel$,
-      { channel, topic, loopCommand$, options },
+      {
+        channel,
+        topic,
+        action: { kind: "command", command$: loopCommand$ },
+        options,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+  },
+);
+
+/** Run existing synchronous invalidation commands for every notification. */
+export const setAblyInvalidationLoop$ = command(
+  async (
+    { set },
+    {
+      scope = "user",
+      topic,
+      invalidations,
+      options,
+    }: SetAblyInvalidationLoopArgs,
+    signal: AbortSignal,
+  ) => {
+    const channel = await set(realtimeChannel$, scope, topic, signal);
+    signal.throwIfAborted();
+    await set(
+      runWithChannel$,
+      {
+        channel,
+        topic,
+        action: { kind: "invalidate", invalidations },
+        options,
+      },
       signal,
     );
     signal.throwIfAborted();


### PR DESCRIPTION
## Summary

- add a typed realtime invalidation loop that runs a non-empty list of existing synchronous commands for each notification
- route chat thread detail, automation, and artifact topics through their thread-owned invalidation commands
- remove three runtime `command()` wrappers and their `ccstate/no-command-in-command` suppressions while preserving the asynchronous workflow handler
- cover topic isolation, multi-command invalidation, repeated notifications, and subscription initialization behavior

## Scope

This keeps the existing chat panel graph ownership unchanged. The realtime subscription still owns readiness, continuity-gap recovery, transient retries, and cancellation through the pane lifecycle signal.

## Verification

- `pnpm --filter @okouai/app exec vitest run src/signals/__tests__/realtime.test.ts` — 19 tests passed
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-navigation-browser.test.tsx -t "Automatically show a browser that starts in the background"` — 1 test passed
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-workflows.test.tsx -t "A newly available workflow highlights the existing draft without changing its text"` — 1 test passed
- `pnpm --filter @okouai/app check-types`
- `pnpm --filter @okouai/app lint`
- `pnpm exec knip --workspace @okouai/app`
- `pnpm exec prettier --check apps/platform/src/signals/realtime.ts apps/platform/src/signals/chat-page/chat-thread-remote-signals.ts apps/platform/src/signals/chat-page/create-chat-thread.ts apps/platform/src/signals/__tests__/realtime.test.ts`
- `git diff --check`
