### PR TITLE
refactor(test): replace the remaining retired-brand agent fixtures

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
@@ -473,7 +473,7 @@ test("Authorize visible agents only for the first manual account", async () => {
   const researchId = "c0000000-0000-4000-a000-000000000002";
   mockConnectors(context, []);
   context.mocks.data.agents([
-    listAgent("c0000000-0000-4000-a000-000000000001", "Zero"),
+    listAgent("c0000000-0000-4000-a000-000000000001", "Nova"),
     listAgent(researchId, "Research Agent"),
   ]);
   mockPublicConnectorStatus(context, [
@@ -540,10 +540,10 @@ test("Authorize visible agents only for the first manual account", async () => {
   const access = await screen.findByRole("dialog", {
     name: "Manage Public Axiom access",
   });
-  click(getConnectorSwitch("Revoke Public Axiom access for Zero", access));
+  click(getConnectorSwitch("Revoke Public Axiom access for Nova", access));
   await waitFor(() => {
     expect(
-      getConnectorSwitch("Authorize Public Axiom access for Zero", access),
+      getConnectorSwitch("Authorize Public Axiom access for Nova", access),
     ).not.toBeChecked();
   });
   click(getConnectorAction("button", "Close", access));
@@ -572,7 +572,7 @@ test("Authorize visible agents only for the first manual account", async () => {
     name: "Manage Public Axiom access",
   });
   expect(
-    getConnectorSwitch("Authorize Public Axiom access for Zero", updatedAccess),
+    getConnectorSwitch("Authorize Public Axiom access for Nova", updatedAccess),
   ).not.toBeChecked();
   expect(
     getConnectorSwitch(
@@ -727,7 +727,7 @@ test("Enable a connector that needs no credentials", async () => {
   const researchId = "c0000000-0000-4000-a000-000000000002";
   mockConnectors(context, []);
   context.mocks.data.agents([
-    listAgent("c0000000-0000-4000-a000-000000000001", "Zero"),
+    listAgent("c0000000-0000-4000-a000-000000000001", "Nova"),
     listAgent(researchId, "Research Agent"),
   ]);
   mockPublicConnectorStatus(context, [
@@ -834,7 +834,7 @@ test("Complete OAuth only after the current attempt succeeds", async () => {
   const researchId = "c0000000-0000-4000-a000-000000000002";
   let listed = mockConnectors(context, []);
   context.mocks.data.agents([
-    listAgent("c0000000-0000-4000-a000-000000000001", "Zero"),
+    listAgent("c0000000-0000-4000-a000-000000000001", "Nova"),
     listAgent(researchId, "Research Agent"),
   ]);
   mockPublicConnectorStatus(context, [

--- a/turbo/apps/platform/src/views/okou-page/__tests__/telegram-settings.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/telegram-settings.test.tsx
@@ -54,7 +54,7 @@ test("An admin can set up a new Telegram bot", async () => {
         id: "bot_registered",
         username: "registered_bot",
         avatarUrl: null,
-        agent: { id: PRIMARY_AGENT_ID, name: "Zero" },
+        agent: { id: PRIMARY_AGENT_ID, name: "Nova" },
         isOwner: true,
         isConnected: false,
         connectedUser: null,


### PR DESCRIPTION
Closes #33503.

## What

The four fixture sites #33475 enumerated around but did not list:

| File | Change |
|---|---|
| `okou-page/__tests__/connectors-auth-methods.test.tsx` | 3× `listAgent(..., "Zero")` → `"Nova"` |
| `okou-page/__tests__/telegram-settings.test.tsx` | register-response `agent.name` → `"Nova"` |

`"Nova"` matches the neutral agent display name #33489 already established for this residue class.

## Assertions moved with the fixture

Only the first `connectors-auth-methods` site feeds an assertion. Its three connector-access switch labels are built from the agent display name (`connectors.access.accessFor` → `{action} {connector} access for {agent}`), so all three move to `Nova` and the test still proves the same authorize/revoke behavior. Nothing is relaxed, deleted, or inverted, and no "old name is absent" test is added. The other two `connectors-auth-methods` sites only assert `Used by 2 agents`, and the `telegram-settings` fixture is not asserted on.

## The trap from #33475

Checked before splitting. Neither value is a shared default:

- `listAgent` takes `displayName` as a required positional parameter — there is no default to collide with.
- The rendering fallback for a missing name is `connectors.access.unnamedAgent` = `"Unnamed"`, and the brand default is `ASSISTANT_NAME` = `"Okou"`. Neither is `"Zero"`, so no assertion was silently observing a default. `"Nova"` also collides with neither, nor with the `"Research Agent"` / `"Default"` / `"Support"` fixtures in these files.

No test failed on splitting, so no underlying coupling needed repair here.

## Out of scope, deliberately

The retained #26368 surfaces, `scripts/tunnel-access.sh`, `scripts/sync-env.sh`, the `it-IT` / `pt-BR` locale strings, and every `vm0*` identifier are untouched. No repository-wide substitution.

Declaring one observation rather than widening the diff: `"Zero"` still appears as a fixture value in the Teams/Feishu bot-name suites (`teams-bot.test.ts`, `teams-connect.test.ts`, `teams-oauth.test.ts`, `teams-browser-connect.test.ts`, `integrations-teams.test.ts`, `feishu-integration.test.ts`, `helpers/teams-connect.ts`) and in `cli/.../automation.test.ts`. Those are outside this issue's four-site enumeration, so they are left for a follow-up rather than folded in here.

## Verification

Test-only change; no release required.

- Prettier — clean on both files
- ESLint `--max-warnings 0` — clean
- `tsc -p tsconfig.tests.json --noEmit` — clean
- Vitest, the two affected suites — **2 files passed, 40 tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)