### PR TITLE
feat: add deepseek v4.1 flash

### DIFF
--- a/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
@@ -8,6 +8,7 @@ load '../../helpers/runner-api'
 
 BATS_TEST_TIMEOUT=600
 REAL_CLAUDE_MODEL="claude-sonnet-5"
+REAL_PI_MODEL="deepseek-v4-pro"
 
 setup_file() {
     local credentials="/tmp/e2e-api-credentials-runner-real-claude.json"
@@ -16,7 +17,37 @@ setup_file() {
     E2E_API_URL="$(jq -er '.apiUrl | select(type == "string" and length > 0)' "$credentials")"
     runner_e2e_require_environment
 
-    local feature_switches
+    local policies policy_payload feature_switches
+    policies="$(runner_api_curl "/api/model-policies")"
+    policy_payload="$(jq -c --arg model "$REAL_PI_MODEL" '
+        {
+            policies: (
+                [.policies[] |
+                    select(.model != $model) |
+                    {
+                        model,
+                        isDefault,
+                        defaultProviderType,
+                        credentialScope,
+                        modelProviderId
+                    }
+                ] + [
+                    {
+                        model: $model,
+                        isDefault: false,
+                        defaultProviderType: "built-in",
+                        credentialScope: "org",
+                        modelProviderId: null
+                    }
+                ]
+            )
+        }
+    ' <<<"$policies")"
+    runner_api_curl "/api/model-policies" \
+        -X PUT \
+        -d "$policy_payload" \
+        >/dev/null
+
     feature_switches="$(runner_api_curl "/api/feature-switches" \
         -X POST \
         -d '{"switches":{"_realAgentInPreview":true,"piLoop":true}}')"
@@ -155,9 +186,9 @@ run_real_claude_steer() {
 @test "built-in real pi loop returns a successful answer" {
     run runner_api_curl "/api/model-policies"
     assert_success
-    run jq -e '
+    run jq -e --arg model "$REAL_PI_MODEL" '
         any(.policies[]?;
-            .model == "deepseek-v4-pro" and
+            .model == $model and
             .defaultProviderType == "built-in" and
             .credentialScope == "org" and
             .modelProviderId == null
@@ -168,7 +199,7 @@ run_real_claude_steer() {
     run run_real_chat \
         "123+456. Reply only RESULT=<answer>." \
         "RESULT=579" \
-        "deepseek-v4-pro"
+        "$REAL_PI_MODEL"
 
     assert_success
     assert_output --partial '"status":"completed"'
@@ -182,10 +213,10 @@ run_real_claude_steer() {
 
     run runner_api_curl "/api/runs/${run_id}/context"
     assert_success
-    run jq -e '
+    run jq -e --arg model "$REAL_PI_MODEL" '
         .cliAgentType == "pi" and
         .environment.OPENAI_BASE_URL == "https://api.deepseek.com/" and
-        .environment.OPENAI_MODEL == "deepseek-v4-pro" and
+        .environment.OPENAI_MODEL == $model and
         any(
             .firewalls[];
             .kind == "builtin" and

--- a/turbo/apps/api/src/scripts/dev-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-seed.ts
@@ -35,7 +35,7 @@ function writeLine(message: string): void {
  * Populate the development database with pricing, model keys, and skills.
  *
  * Pricing convention: 1 USD = 1000 credits.
- * Prices are per 1M tokens, stored as integer credits per 1M tokens.
+ * Token prices use integer credits with a per-row token unit size.
  *
  * API keys are read from environment variables per vendor:
  *   DEV_MODEL_{VENDOR_UPPER}_KEY (e.g., DEV_MODEL_ANTHROPIC_KEY, DEV_MODEL_OPENAI_KEY)
@@ -413,6 +413,12 @@ const USAGE_PRICING: readonly (typeof usagePricing.$inferInsert)[] = [
     ["tokens.output", usd(50), 1_000_000],
     ["tokens.cache_read", usd(1), 1_000_000],
     ["tokens.cache_creation", usd(12.5), 1_000_000],
+  ]),
+  ...usageGroup("model", "deepseek-v4.1-flash", [
+    ["tokens.input", usd(37.5), 100_000_000],
+    ["tokens.output", usd(150), 100_000_000],
+    ["tokens.cache_read", usd(3.75), 100_000_000],
+    ["tokens.cache_creation", 0, 100_000_000],
   ]),
   // Canonical Okou customer credit pricing for managed DeepSeek V4 Flash.
   // Keep this product rate independent of the selected upstream route.

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -49,6 +49,7 @@ import {
 import {
   getModelProviderFirewall,
   getProviderRuntimeModel,
+  LIMITED_FREE1_DEFAULT_RUN_MODEL,
   type UpsertModelProviderRequest,
   MODEL_PROVIDER_ENV_PLACEHOLDERS,
   type ModelProviderType,
@@ -7960,7 +7961,7 @@ describe("CHAT-02: model-first provider policies", () => {
       supportByok: false,
       restrictedVm0Models: false,
     });
-    await seedBuiltInModelKey("deepseek-v4-pro");
+    await seedBuiltInModelKey(LIMITED_FREE1_DEFAULT_RUN_MODEL);
     const byokDisabled = await chat.requestSendEvent(
       actor,
       {
@@ -7979,7 +7980,7 @@ describe("CHAT-02: model-first provider policies", () => {
     const byokDisabledPolicies = await misc.listModelPolicies(actor);
     expect(byokDisabledPolicies.policies).toContainEqual(
       expect.objectContaining({
-        model: "deepseek-v4-pro",
+        model: LIMITED_FREE1_DEFAULT_RUN_MODEL,
         isDefault: true,
         defaultProviderType: "built-in",
         modelProviderId: null,
@@ -8028,7 +8029,7 @@ describe("CHAT-02: model-first provider policies", () => {
     const restrictedPolicies = await misc.listModelPolicies(actor);
     expect(restrictedPolicies.policies).toContainEqual(
       expect.objectContaining({
-        model: "deepseek-v4-pro",
+        model: LIMITED_FREE1_DEFAULT_RUN_MODEL,
         isDefault: true,
         defaultProviderType: "built-in",
         modelProviderId: null,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -4763,7 +4763,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       integrations.modelPickerSubmission({
         workspaceId: teamId,
         slackUserId,
-        selectedValue: "deepseek-v4-pro",
+        selectedValue: "deepseek-v4.1-flash",
         channelId: "C_BDD_PICK",
       }),
     );
@@ -4772,13 +4772,13 @@ describe("INT-01: Slack app deep webhook flows", () => {
       expect.objectContaining({
         channel: "C_BDD_PICK",
         user: slackUserId,
-        text: "Switched to *DeepSeek V4 Pro* for new Slack threads.",
+        text: "Switched to *DeepSeek V4.1 Flash* for new Slack threads.",
       }),
     );
     await expect(
       integrations.readUserModelPreference(actor),
     ).resolves.toMatchObject({
-      selectedModel: "deepseek-v4-pro",
+      selectedModel: "deepseek-v4.1-flash",
     });
 
     const replaceModel = await integrations.postSlackInteractive(

--- a/turbo/apps/api/src/signals/routes/__tests__/model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-policies.test.ts
@@ -1513,7 +1513,12 @@ describe("GET/PUT /api/model-policies", () => {
       client.list({ headers: authHeaders() }),
       [200],
     );
-    const updates = toUpdate(listResponse.body).map((policy) => {
+    const updates = [
+      ...toUpdate(listResponse.body).filter((policy) => {
+        return policy.model !== "deepseek-v4-pro";
+      }),
+      makeBuiltInPolicy("deepseek-v4-pro"),
+    ].map((policy) => {
       if (policy.model !== "deepseek-v4-pro") {
         return policy;
       }

--- a/turbo/apps/api/src/signals/routes/__tests__/model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-policies.test.ts
@@ -383,7 +383,7 @@ describe("GET/PUT /api/model-policies", () => {
     ).toBe(LIMITED_FREE1_DEFAULT_RUN_MODEL);
   });
 
-  it.each(["deepseek-v4-flash", "gpt-5.6-luna"] as const)(
+  it.each(["deepseek-v4-pro", "deepseek-v4-flash", "gpt-5.6-luna"] as const)(
     "keeps an existing %s default for limited-free-1 workspaces",
     async (previousDefaultModel) => {
       const fixture = seedFixture();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -4,6 +4,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { CLIENT_VERSION_HEADER } from "@okouai/api-contracts/contracts/client-headers";
 import {
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+  getBuiltInApiModel,
   getModelProviderFirewall,
   getProviderRuntimeModel,
   getBuiltInConcreteProviderType,
@@ -8514,7 +8515,7 @@ describe("RUN-02: model provider selection and built-in admission", () => {
     expect(queue.body.concurrency.active).toBe(0);
   });
 
-  it("defaults limited-free runs to DeepSeek V4 Pro and rejects paid models", async () => {
+  it("defaults limited-free runs to DeepSeek V4.1 Flash and rejects paid models", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
     const chat = createChatFilesBddApi(context);
@@ -8565,7 +8566,20 @@ describe("RUN-02: model provider selection and built-in admission", () => {
       await api.heartbeatRunner(runnerGroup);
       const claim = await api.claimRunnerJob(sent.body.runId);
       expect(claim.cliAgentType).toBe("codex");
-      expect(claim.environment).toMatchObject({ OPENAI_MODEL: model });
+      expect(claim.environment).toMatchObject({
+        OPENAI_MODEL: getBuiltInApiModel(model),
+      });
+      if (model === "deepseek-v4.1-flash") {
+        expect(claim.codexRuntimeConfig?.providerId).toBe("openrouter-codex");
+        expect(claim.codexRuntimeConfig?.modelCatalog?.models).toStrictEqual([
+          expect.objectContaining({
+            slug: "deepseek/deepseek-v4.1-flash",
+            context_window: 1_048_576,
+            input_modalities: ["text", "image"],
+            apply_patch_tool_type: null,
+          }),
+        ]);
+      }
       expect(claim.modelUsageProvider).toBe(model);
       await api.requestCancelRun(actor, sent.body.runId, [200]);
     }
@@ -8851,6 +8865,68 @@ describe("RUN-02: model provider selection and built-in admission", () => {
       await api.requestCancelRun(actor, sent.body.runId, [200]);
     },
   );
+
+  it("projects DeepSeek V4.1 Flash metadata for an OpenRouter workspace key", async () => {
+    const api = createRunsApi(context);
+    const chat = createChatFilesBddApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const { providerId } = await api.createOrgModelProvider(actor, {
+      type: "openrouter-codex",
+      secret: "openrouter-deepseek-v4-1-flash-key",
+    });
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "deepseek-v4.1-flash",
+        isDefault: true,
+        defaultProviderType: "openrouter-codex",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+    ]);
+
+    const sent = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        prompt: "use DeepSeek V4.1 Flash through OpenRouter",
+        model: "deepseek-v4.1-flash",
+      },
+      [201],
+    );
+    if (sent.status !== 201 || sent.body.runId === null) {
+      throw new Error("Expected DeepSeek V4.1 Flash to create a run");
+    }
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(sent.body.runId);
+
+    expect(claim.cliAgentType).toBe("codex");
+    expect(claim.environment).toMatchObject({
+      OPENAI_API_KEY: modelProviderPlaceholder(
+        "openrouter-codex",
+        "OPENROUTER_API_KEY",
+      ),
+      OPENAI_BASE_URL: "https://openrouter.ai/api/v1",
+      OPENAI_MODEL: "deepseek/deepseek-v4.1-flash",
+    });
+    expect(claim.codexRuntimeConfig).toMatchObject({
+      providerId: "openrouter-codex",
+      baseUrl: "https://openrouter.ai/api/v1",
+      wireApi: "responses",
+      modelCatalog: {
+        models: [
+          expect.objectContaining({
+            slug: "deepseek/deepseek-v4.1-flash",
+            context_window: 1_048_576,
+            input_modalities: ["text", "image"],
+            apply_patch_tool_type: null,
+          }),
+        ],
+      },
+    });
+    expect(claim.modelUsageProvider).toBe("deepseek-v4.1-flash");
+
+    await api.requestCancelRun(actor, sent.body.runId, [200]);
+  });
 
   it("offers image recognition only for image-unsupported models", async () => {
     const api = createRunsApi(context);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -2189,6 +2189,40 @@ function modelProviderFirewallAuthMaps(
   return { secretConnectorMap, secretConnectorMetadataMap };
 }
 
+function resolveModelProviderCodexRuntimeConfig(args: {
+  readonly type: ModelProviderType;
+  readonly logicalModel: string | null;
+  readonly runtimeModel: string;
+  readonly environment: Readonly<Record<string, string>>;
+}): ModelProviderCodexRuntimeConfig | undefined {
+  const providerConfig = getModelProviderCodexRuntimeConfig(args.type);
+  if (providerConfig || !args.logicalModel || !args.runtimeModel) {
+    return providerConfig;
+  }
+  const modelCatalog = getModelProviderCodexCatalogForModel(
+    args.logicalModel,
+    args.runtimeModel,
+    args.type,
+  );
+  if (!modelCatalog) {
+    return undefined;
+  }
+  const baseUrl = args.environment.OPENAI_BASE_URL;
+  if (!baseUrl) {
+    throw new Error(`Missing OPENAI_BASE_URL for Codex provider ${args.type}`);
+  }
+  return {
+    providerId: args.type,
+    name: MODEL_PROVIDER_TYPES[args.type].label,
+    baseUrl,
+    envKey: "OPENAI_API_KEY",
+    requiresOpenaiAuth: false,
+    wireApi: "responses",
+    supportsWebsockets: false,
+    modelCatalog,
+  };
+}
+
 function modelProviderEnvironment(args: {
   readonly id: string | null;
   readonly type: ModelProviderType;
@@ -2228,7 +2262,12 @@ function modelProviderEnvironment(args: {
       .replaceAll("$secret", environmentSecret)
       .replaceAll("$model", runtimeModel);
   }
-  const codexRuntimeConfig = getModelProviderCodexRuntimeConfig(args.type);
+  const codexRuntimeConfig = resolveModelProviderCodexRuntimeConfig({
+    type: args.type,
+    logicalModel: model,
+    runtimeModel,
+    environment,
+  });
 
   return {
     id: args.id,
@@ -2559,34 +2598,12 @@ async function builtInModelProviderEnvironment(
     key.apiKey,
     route.upstreamModel,
   );
-  let codexRuntimeConfig = getModelProviderCodexRuntimeConfig(
-    route.providerType,
-  );
-  if (!codexRuntimeConfig) {
-    const modelCatalog = getModelProviderCodexCatalogForModel(
-      selectedModel,
-      route.upstreamModel,
-      route.providerType,
-    );
-    if (modelCatalog) {
-      const baseUrl = environment.OPENAI_BASE_URL;
-      if (!baseUrl) {
-        throw new Error(
-          `Missing OPENAI_BASE_URL for built-in Codex provider ${route.providerType}`,
-        );
-      }
-      codexRuntimeConfig = {
-        providerId: route.providerType,
-        name: MODEL_PROVIDER_TYPES[route.providerType].label,
-        baseUrl,
-        envKey: "OPENAI_API_KEY",
-        requiresOpenaiAuth: false,
-        wireApi: "responses",
-        supportsWebsockets: false,
-        modelCatalog,
-      };
-    }
-  }
+  const codexRuntimeConfig = resolveModelProviderCodexRuntimeConfig({
+    type: route.providerType,
+    logicalModel: selectedModel,
+    runtimeModel: route.upstreamModel,
+    environment,
+  });
 
   return {
     id: null,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-core-behavior.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-core-behavior.test.tsx
@@ -108,7 +108,7 @@ test("A new message keeps its attachment, text, and selected model together", as
     readonly userMessage?: UserMessageDocument;
   }[] = [];
   context.mocks.data.userModelPreference({
-    selectedModel: "deepseek-v4-pro",
+    selectedModel: "deepseek-v4.1-flash",
     serviceTier: null,
     selectedImageModel: null,
     selectedVideoModel: null,
@@ -139,7 +139,7 @@ test("A new message keeps its attachment, text, and selected model together", as
   await waitFor(() => {
     expect(buttonsNamed("Attach").length).toBeGreaterThan(0);
   });
-  await screen.findByText("DeepSeek V4 Pro");
+  await screen.findByText("DeepSeek V4.1 Flash");
   const fileInput = document.querySelector('input[type="file"]');
   if (!(fileInput instanceof HTMLInputElement)) {
     throw new Error("Composer file input is not mounted");
@@ -172,7 +172,7 @@ test("A new message keeps its attachment, text, and selected model together", as
           contentType: "text/plain",
         },
         { type: "text", text: "Review the launch brief." },
-        { type: "model", selectedModel: "deepseek-v4-pro" },
+        { type: "model", selectedModel: "deepseek-v4.1-flash" },
       ],
     },
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-composer.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-composer.test.tsx
@@ -13,6 +13,7 @@ import {
   mockPushBrowserSupport,
   setupPage,
 } from "./chat-lifecycle-test-helpers.ts";
+import { buildModelPolicy } from "./chat-composer-test-helpers.ts";
 import {
   assistantEvent,
   context,
@@ -217,10 +218,21 @@ test("Send a large image with a fallback-enabled text model", async () => {
       }
     | undefined;
   installRunChat({
+    selectedModel: "deepseek-v4-pro",
     onRunCreate(body) {
       sentMessage = { model: body.model, userMessage: body.userMessage };
     },
   });
+  context.mocks.data.orgModelPolicies([
+    buildModelPolicy({
+      model: "deepseek-v4-pro",
+      modelLabel: "DeepSeek V4 Pro",
+      isDefault: true,
+      defaultProviderType: "built-in",
+      credentialScope: "org",
+      modelProviderId: null,
+    }),
+  ]);
   context.mocks.upload.success({
     id: "large-image-upload",
     filename: "launch-board.png",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx
@@ -1015,6 +1015,25 @@ test("Add a GPT 6 Astra Codex subscription model route", async () => {
   expect(within(codexRow).getByText("ChatGPT (Codex)")).toBeInTheDocument();
 });
 
+test("Add DeepSeek V4.1 Flash as a built-in model", async () => {
+  mockAdminOrg();
+  context.mocks.data.orgModelProviders([]);
+  context.mocks.data.orgModelPolicies([]);
+  await openProvidersTab();
+
+  click(buttonByText("Add model"));
+  const dialog = screen.getByRole("dialog", { name: "Add model" });
+  await selectDialogModel("DeepSeek V4.1 Flash");
+  expect(radioByName(/Built-in/u, dialog)).toBeChecked();
+  click(buttonByText("Add model", dialog));
+
+  const modelRow = await screen.findByTestId(
+    "org-model-policy-row-deepseek-v4.1-flash",
+  );
+  expect(within(modelRow).getByText("DeepSeek V4.1 Flash")).toBeInTheDocument();
+  expect(within(modelRow).getByText("Built-in")).toBeInTheDocument();
+});
+
 test("Offer an upgrade for restricted Pro models", async () => {
   mockAdminOrg();
   mockBillingCapabilities({ supportByok: false, restrictedVm0Models: true });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/prompt-link.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/prompt-link.test.tsx
@@ -220,10 +220,10 @@ test("A prompt link starts a presentation chat with its selected template", asyn
       },
     },
   });
-  expect(capture.createdThreads[0]?.model).toBe("deepseek-v4-pro");
+  expect(capture.createdThreads[0]?.model).toBe("deepseek-v4.1-flash");
   expect(userMessageParts(send)).toContainEqual({
     type: "model",
-    selectedModel: "deepseek-v4-pro",
+    selectedModel: "deepseek-v4.1-flash",
   });
 });
 

--- a/turbo/apps/platform/src/views/okou-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/provider-ui-config.ts
@@ -102,6 +102,7 @@ const MODEL_BRAND_ICON: Readonly<Record<SupportedRunModel, ModelProviderType>> =
     "claude-opus-4-8": "anthropic-api-key",
     "claude-sonnet-5": "anthropic-api-key",
     "claude-sonnet-4-6": "anthropic-api-key",
+    "deepseek-v4.1-flash": "deepseek",
     "deepseek-v4-flash": "deepseek",
     "deepseek-v4-pro": "deepseek",
     "gpt-6-astra": "openai-api-key",

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -114,6 +114,7 @@ describe("model-first canonical catalog", () => {
       "gpt-5.6-terra",
       "gpt-5.6-luna",
       "gpt-5.5",
+      "deepseek-v4.1-flash",
       "deepseek-v4-pro",
       "deepseek-v4-flash",
     ]);
@@ -144,6 +145,9 @@ describe("model-first canonical catalog", () => {
     expect(supportedRunModelSchema.safeParse("claude-opus-5").success).toBe(
       true,
     );
+    expect(
+      supportedRunModelSchema.safeParse("deepseek-v4.1-flash").success,
+    ).toBe(true);
     expect(supportedRunModelSchema.safeParse("deepseek-v4-flash").success).toBe(
       true,
     );
@@ -186,6 +190,10 @@ describe("model-first canonical catalog", () => {
     expect(isLimitedFree1RestrictedRunModel("openai/gpt-5.6-terra")).toBe(true);
     expect(isLimitedFree1RestrictedRunModel("gpt-5.6-luna")).toBe(false);
     expect(isLimitedFree1RestrictedRunModel("openai/gpt-5.6-luna")).toBe(false);
+    expect(isLimitedFree1RestrictedRunModel("deepseek-v4.1-flash")).toBe(false);
+    expect(
+      isLimitedFree1RestrictedRunModel("deepseek/deepseek-v4.1-flash"),
+    ).toBe(false);
     expect(isLimitedFree1RestrictedRunModel("deepseek-v4-flash")).toBe(false);
     expect(isLimitedFree1RestrictedRunModel("deepseek/deepseek-v4-flash")).toBe(
       false,
@@ -246,6 +254,9 @@ describe("model-first canonical catalog", () => {
     expect(getCanonicalModelDisplayName("gpt-5.6-terra")).toBe("GPT 5.6 Terra");
     expect(getCanonicalModelDisplayName("gpt-5.6-luna")).toBe("GPT 5.6 Luna");
     expect(getCanonicalModelDisplayName("gpt-5.5")).toBe("GPT 5.5");
+    expect(getCanonicalModelDisplayName("deepseek-v4.1-flash")).toBe(
+      "DeepSeek V4.1 Flash",
+    );
     expect(getCanonicalModelDisplayName("deepseek-v4-pro")).toBe(
       "DeepSeek V4 Pro",
     );
@@ -265,6 +276,9 @@ describe("model-first canonical catalog", () => {
     expect(normalizeRunModelId("anthropic/claude-opus-5")).toBe(
       "claude-opus-5",
     );
+    expect(normalizeRunModelId("deepseek/deepseek-v4.1-flash")).toBe(
+      "deepseek-v4.1-flash",
+    );
     expect(normalizeRunModelId("custom/model")).toBe("custom/model");
     expect(isSupportedRunModel("claude-fable-5-1")).toBe(true);
     expect(isSupportedRunModel("claude-fable-5")).toBe(true);
@@ -272,6 +286,7 @@ describe("model-first canonical catalog", () => {
     expect(isSupportedRunModel("gpt-6-astra")).toBe(true);
     expect(isSupportedRunModel("gpt-5.6-sol")).toBe(true);
     expect(isSupportedRunModel("openai/gpt-5.6-sol")).toBe(false);
+    expect(isSupportedRunModel("deepseek-v4.1-flash")).toBe(true);
     expect(isSupportedRunModel("deepseek-v4-flash")).toBe(true);
     expect(isSupportedRunModel("deepseek-v4-pro")).toBe(true);
   });
@@ -289,6 +304,7 @@ describe("model-first canonical catalog", () => {
       "gpt-5.6-terra",
       "gpt-5.6-luna",
       "gpt-5.5",
+      "deepseek-v4.1-flash",
       "deepseek-v4-pro",
       "deepseek-v4-flash",
     ]);
@@ -386,6 +402,10 @@ describe("model-first canonical catalog", () => {
       "vercel-ai-gateway-codex",
     ]);
     expect(getProvidersForModel("openai/gpt-5.6-sol")).toEqual([]);
+    expect(getProvidersForModel("deepseek-v4.1-flash")).toEqual([
+      "built-in",
+      "openrouter-codex",
+    ]);
     expect(getProvidersForModel("deepseek-v4-flash")).toEqual([
       "built-in",
       "deepseek",
@@ -435,6 +455,12 @@ describe("model-first canonical catalog", () => {
     ).toBe(true);
     expect(isModelSupportedByProvider("gpt-5.5", "openai-api-key")).toBe(true);
     expect(isModelSupportedByProvider("gpt-5.5", "anthropic-api-key")).toBe(
+      false,
+    );
+    expect(
+      isModelSupportedByProvider("deepseek-v4.1-flash", "openrouter-codex"),
+    ).toBe(true);
+    expect(isModelSupportedByProvider("deepseek-v4.1-flash", "deepseek")).toBe(
       false,
     );
     expect(isModelSupportedByProvider("deepseek-v4-pro", "deepseek")).toBe(
@@ -529,6 +555,12 @@ describe("model-first canonical catalog", () => {
       "openai-api-key",
     );
     expect(getBuiltInVendor("gpt-5.6-sol")).toBe("openai");
+    expect(
+      getProviderRuntimeModel("openrouter-codex", "deepseek-v4.1-flash"),
+    ).toBe("deepseek/deepseek-v4.1-flash");
+    expect(getProviderRuntimeModel("built-in", "deepseek-v4.1-flash")).toBe(
+      "deepseek/deepseek-v4.1-flash",
+    );
     expect(getProviderRuntimeModel("openrouter-api-key", "custom/model")).toBe(
       "custom/model",
     );
@@ -549,6 +581,21 @@ describe("model-first canonical catalog", () => {
         vendor: "openrouter",
       },
     ]);
+  });
+
+  it("routes DeepSeek V4.1 Flash through OpenRouter", () => {
+    expect(getBuiltInModelRouteCandidates("deepseek-v4.1-flash")).toEqual([
+      {
+        selectedModel: "deepseek-v4.1-flash",
+        providerType: "openrouter-codex",
+        upstreamModel: "deepseek/deepseek-v4.1-flash",
+        vendor: "openrouter",
+      },
+    ]);
+    expect(getBuiltInConcreteProviderType("deepseek-v4.1-flash")).toBe(
+      "openrouter-codex",
+    );
+    expect(getBuiltInVendor("deepseek-v4.1-flash")).toBe("openrouter");
   });
 
   it.each(["deepseek-v4-flash", "deepseek-v4-pro"] as const)(
@@ -577,13 +624,14 @@ describe("model-first canonical catalog", () => {
     },
   );
 
-  it("defines two statically compilable built-in model routes for every active model", () => {
+  it("defines statically compilable built-in routes for every active model", () => {
     expect(Object.keys(BUILT_IN_MODEL_TO_PROVIDER)).toEqual([
       "claude-fable-5-1",
       "claude-opus-5",
       "claude-opus-4-8",
       "claude-sonnet-5",
       "claude-sonnet-4-6",
+      "deepseek-v4.1-flash",
       "deepseek-v4-flash",
       "deepseek-v4-pro",
       "gpt-6-astra",
@@ -601,7 +649,7 @@ describe("model-first canonical catalog", () => {
 
     for (const model of ACTIVE_RUN_MODELS) {
       const candidates = getBuiltInModelRouteCandidates(model);
-      expect(candidates).toHaveLength(2);
+      expect(candidates).toHaveLength(model === "deepseek-v4.1-flash" ? 1 : 2);
       expect(candidates[0]?.providerType).toBe(
         getBuiltInConcreteProviderType(model),
       );
@@ -631,10 +679,11 @@ describe("model-first canonical catalog", () => {
   });
 
   it.each([
+    ["deepseek-v4.1-flash", "deepseek/deepseek-v4.1-flash"],
     ["deepseek-v4-flash", "deepseek/deepseek-v4-flash"],
     ["deepseek-v4-pro", "deepseek/deepseek-v4-pro"],
   ] as const)(
-    "projects provider-owned Codex metadata for OpenRouter %s",
+    "projects Codex metadata for OpenRouter %s",
     (model, upstreamModel) => {
       const catalog = getModelProviderCodexCatalogForModel(
         model,
@@ -654,10 +703,10 @@ describe("model-first canonical catalog", () => {
     expect(DEFAULT_ORG_MODEL_POLICY_MODELS).toEqual([
       "gpt-6-astra",
       "gpt-5.6-luna",
-      "deepseek-v4-pro",
+      "deepseek-v4.1-flash",
     ]);
-    expect(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL).toBe("deepseek-v4-pro");
-    expect(LIMITED_FREE1_DEFAULT_RUN_MODEL).toBe("deepseek-v4-pro");
+    expect(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL).toBe("deepseek-v4.1-flash");
+    expect(LIMITED_FREE1_DEFAULT_RUN_MODEL).toBe("deepseek-v4.1-flash");
     expect(getDefaultModel("built-in")).toBe(
       DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
     );
@@ -693,6 +742,7 @@ describe("model-first canonical catalog", () => {
         "gpt-5.6-luna": "$",
         "claude-opus-4-8": "$$$",
         "claude-sonnet-5": "$$",
+        "deepseek-v4.1-flash": "$",
         "deepseek-v4-flash": "$",
         "deepseek-v4-pro": "$",
       }),
@@ -706,6 +756,7 @@ describe("model-first canonical catalog", () => {
     expect(getBuiltInModelPriceTier("gpt-5.6-luna")).toBe("$");
     expect(getBuiltInModelPriceTier("claude-opus-4-8")).toBe("$$$");
     expect(getBuiltInModelPriceTier("claude-sonnet-5")).toBe("$$");
+    expect(getBuiltInModelPriceTier("deepseek-v4.1-flash")).toBe("$");
     expect(getBuiltInModelPriceTier("deepseek-v4-flash")).toBe("$");
     expect(getBuiltInModelPriceTier("deepseek-v4-pro")).toBe("$");
     expect(getBuiltInModelPriceTier("claude-opus-4-7")).toBeUndefined();
@@ -834,6 +885,8 @@ describe("model image input support", () => {
   it.each([
     "gpt-6-astra",
     "openai/gpt-6-astra",
+    "deepseek-v4.1-flash",
+    "deepseek/deepseek-v4.1-flash",
     "claude-fable-5-1",
     "anthropic/claude-fable-5.1",
     "claude-opus-5",
@@ -1344,6 +1397,7 @@ describe("codex-framework gateway providers (openrouter-codex, vercel-ai-gateway
         expect(getModels(type)).toEqual(
           expect.arrayContaining([
             "openai/gpt-6-astra",
+            "deepseek/deepseek-v4.1-flash",
             "deepseek/deepseek-v4-flash",
             "deepseek/deepseek-v4-pro",
           ]),
@@ -1362,13 +1416,16 @@ describe("codex-framework gateway providers (openrouter-codex, vercel-ai-gateway
     expect(selectable).toContain("vercel-ai-gateway-codex");
   });
 
-  it("translate canonical GPT models to vendor-prefixed runtime IDs", () => {
+  it("translates canonical models to vendor-prefixed runtime IDs", () => {
     expect(getProviderRuntimeModel("openrouter-codex", "gpt-6-astra")).toBe(
       "openai/gpt-6-astra",
     );
     expect(getProviderRuntimeModel("openrouter-codex", "gpt-5.5")).toBe(
       "openai/gpt-5.5",
     );
+    expect(
+      getProviderRuntimeModel("openrouter-codex", "deepseek-v4.1-flash"),
+    ).toBe("deepseek/deepseek-v4.1-flash");
   });
 
   it("share the secretName with their claude-code twin gateway", () => {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-reasoning-effort.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-reasoning-effort.test.ts
@@ -45,6 +45,7 @@ describe("chat reasoning effort capabilities", () => {
     expect(compatibleReasoningEffort("claude-sonnet-5", "extra")).toBe("extra");
     expect(compatibleReasoningEffort("gpt-6-astra", "xhigh")).toBe("xhigh");
     expect(compatibleReasoningEffort("claude-sonnet-5", "high")).toBe("high");
+    expect(compatibleReasoningEffort("deepseek-v4.1-flash", "high")).toBeNull();
     expect(compatibleReasoningEffort("deepseek-v4-flash", "high")).toBeNull();
   });
 

--- a/turbo/packages/api-contracts/src/contracts/model-price-tiers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-price-tiers.ts
@@ -20,6 +20,7 @@ export const SUPPORTED_RUN_MODELS = [
   "gpt-5.6-terra",
   "gpt-5.6-luna",
   "gpt-5.5",
+  "deepseek-v4.1-flash",
   "deepseek-v4-pro",
   "deepseek-v4-flash",
 ] as const;
@@ -47,6 +48,7 @@ export const BUILT_IN_MODEL_PRICE_TIER = Object.freeze<
   "claude-opus-4-8": "$$$",
   "claude-sonnet-5": "$$",
   "claude-sonnet-4-6": "$$",
+  "deepseek-v4.1-flash": "$",
   "deepseek-v4-flash": "$",
   // Display tier only. Runtime token pricing is seeded separately.
   "deepseek-v4-pro": "$",

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -39,6 +39,18 @@ if (!deepseekV4FlashCatalogModel) {
   throw new Error("DeepSeek V4 Flash model catalog entry is required");
 }
 
+const deepseekV41FlashCatalogModel = {
+  ...deepseekV4FlashCatalogModel,
+  slug: "deepseek-v4.1-flash",
+  display_name: "DeepSeek-V4.1-Flash",
+  input_modalities: ["text", "image"],
+};
+
+const DEEPSEEK_V4_1_FLASH_MODEL_CATALOG = {
+  ...DEEPSEEK_V4_FLASH_MODEL_CATALOG,
+  models: [deepseekV41FlashCatalogModel],
+};
+
 const DEEPSEEK_MODEL_CATALOG = {
   ...DEEPSEEK_V4_FLASH_MODEL_CATALOG,
   models: [
@@ -132,14 +144,14 @@ const MODEL_PROVIDER_CODEX_RUNTIME_CONFIGS: Partial<
 export const DEFAULT_ORG_MODEL_POLICY_MODELS = [
   "gpt-6-astra",
   "gpt-5.6-luna",
-  "deepseek-v4-pro",
+  "deepseek-v4.1-flash",
 ] as const satisfies readonly SupportedRunModel[];
 
 export const DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL =
-  "deepseek-v4-pro" as const satisfies SupportedRunModel;
+  "deepseek-v4.1-flash" as const satisfies SupportedRunModel;
 
 export const LIMITED_FREE1_DEFAULT_RUN_MODEL =
-  "deepseek-v4-pro" as const satisfies SupportedRunModel;
+  "deepseek-v4.1-flash" as const satisfies SupportedRunModel;
 
 export const supportedRunModelSchema = z.enum(SUPPORTED_RUN_MODELS);
 
@@ -164,6 +176,7 @@ const SUPPORTED_RUN_MODEL_LABELS: Record<SupportedRunModel, string> = {
   "claude-opus-4-8": "Claude Opus 4.8",
   "claude-sonnet-5": "Claude Sonnet 5",
   "claude-sonnet-4-6": "Claude Sonnet 4.6",
+  "deepseek-v4.1-flash": "DeepSeek V4.1 Flash",
   "deepseek-v4-flash": "DeepSeek V4 Flash",
   "deepseek-v4-pro": "DeepSeek V4 Pro",
   "gpt-6-astra": "GPT 6 Astra",
@@ -336,6 +349,14 @@ export const BUILT_IN_MODEL_TO_PROVIDER = {
       },
     ],
   },
+  "deepseek-v4.1-flash": {
+    candidates: [
+      {
+        concreteType: "openrouter-codex",
+        apiModel: "deepseek/deepseek-v4.1-flash",
+      },
+    ],
+  },
   "deepseek-v4-flash": {
     candidates: [
       { concreteType: "deepseek" },
@@ -464,6 +485,7 @@ const BUILT_IN_MODEL_ALIAS_LOOKUP: Readonly<Record<string, string>> =
 
 const LIMITED_FREE1_ALLOWED_RUN_MODELS: ReadonlySet<string> = new Set([
   "gpt-5.6-luna",
+  "deepseek-v4.1-flash",
   "deepseek-v4-flash",
   "deepseek-v4-pro",
 ]);
@@ -498,6 +520,8 @@ export type ModelImageInputSupport = "supported" | "unsupported" | "unknown";
 const IMAGE_INPUT_SUPPORTED_MODELS = new Set([
   "gpt-6-astra",
   "openai/gpt-6-astra",
+  "deepseek-v4.1-flash",
+  "deepseek/deepseek-v4.1-flash",
   "claude-fable-5-1",
   "claude-opus-5",
   "claude-opus-4-8",
@@ -707,6 +731,7 @@ export const MODEL_PROVIDER_TYPES = {
       "openai/gpt-5.6-terra",
       "openai/gpt-5.6-luna",
       "openai/gpt-5.5",
+      "deepseek/deepseek-v4.1-flash",
       "deepseek/deepseek-v4-flash",
       "deepseek/deepseek-v4-pro",
     ] as string[],
@@ -1033,6 +1058,7 @@ const MODEL_FIRST_PROVIDER_COMPATIBILITY = {
     "openrouter-codex",
     "vercel-ai-gateway-codex",
   ],
+  "deepseek-v4.1-flash": ["built-in", "openrouter-codex"],
   "deepseek-v4-flash": ["built-in", "deepseek", "openrouter-codex"],
   "deepseek-v4-pro": ["built-in", "deepseek", "openrouter-codex"],
 } as const satisfies Record<ActiveRunModel, readonly ModelProviderType[]>;
@@ -1055,6 +1081,7 @@ const PROVIDER_RUNTIME_MODEL_ALIASES: Partial<
     "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
   },
   "openrouter-codex": {
+    "deepseek-v4.1-flash": "deepseek/deepseek-v4.1-flash",
     "deepseek-v4-flash": "deepseek/deepseek-v4-flash",
     "deepseek-v4-pro": "deepseek/deepseek-v4-pro",
     "gpt-6-astra": "openai/gpt-6-astra",
@@ -1073,6 +1100,7 @@ const PROVIDER_RUNTIME_MODEL_ALIASES: Partial<
 
 const CANONICAL_RUN_MODEL_ALIASES: Readonly<Record<string, SupportedRunModel>> =
   {
+    "deepseek/deepseek-v4.1-flash": "deepseek-v4.1-flash",
     "deepseek/deepseek-v4-flash": "deepseek-v4-flash",
     "deepseek/deepseek-v4-pro": "deepseek-v4-pro",
     "anthropic/claude-fable-5.1": "claude-fable-5-1",
@@ -1285,10 +1313,16 @@ export function getModelProviderCodexRuntimeConfig(
   return MODEL_PROVIDER_CODEX_RUNTIME_CONFIGS[type];
 }
 
+const CODEX_MODEL_CATALOG_OVERRIDES: Readonly<
+  Partial<Record<ActiveRunModel, Record<string, unknown>>>
+> = {
+  "deepseek-v4.1-flash": DEEPSEEK_V4_1_FLASH_MODEL_CATALOG,
+};
+
 /**
- * Project a provider-owned Codex catalog record onto the model ID and provider
- * used at runtime. Returns undefined when no provider has authoritative
- * metadata for the logical model.
+ * Project a Codex catalog record onto the model ID and provider used at
+ * runtime. Returns undefined when no authoritative metadata is available for
+ * the logical model.
  */
 export function getModelProviderCodexCatalogForModel(
   logicalModel: string,
@@ -1297,12 +1331,22 @@ export function getModelProviderCodexCatalogForModel(
 ): Record<string, unknown> | undefined {
   const disableApplyPatch =
     runtimeProviderType === "openrouter-codex" &&
-    (logicalModel === "deepseek-v4-flash" ||
+    (logicalModel === "deepseek-v4.1-flash" ||
+      logicalModel === "deepseek-v4-flash" ||
       logicalModel === "deepseek-v4-pro");
-  for (const type of getProvidersForModel(logicalModel)) {
-    const sourceCatalog =
-      MODEL_PROVIDER_CODEX_RUNTIME_CONFIGS[type]?.modelCatalog;
-    const sourceModels = sourceCatalog?.models;
+  const canonicalModel = normalizeRunModelId(logicalModel);
+  const overrideCatalog = isActiveRunModel(canonicalModel)
+    ? CODEX_MODEL_CATALOG_OVERRIDES[canonicalModel]
+    : undefined;
+  const sourceCatalogs = overrideCatalog
+    ? [overrideCatalog]
+    : getProvidersForModel(logicalModel).flatMap((type) => {
+        const sourceCatalog =
+          MODEL_PROVIDER_CODEX_RUNTIME_CONFIGS[type]?.modelCatalog;
+        return sourceCatalog ? [sourceCatalog] : [];
+      });
+  for (const sourceCatalog of sourceCatalogs) {
+    const sourceModels = sourceCatalog.models;
     const sourceModel = Array.isArray(sourceModels)
       ? sourceModels.find(
           (model: unknown): model is Record<string, unknown> => {
@@ -1311,7 +1355,7 @@ export function getModelProviderCodexCatalogForModel(
               model !== null &&
               !Array.isArray(model) &&
               "slug" in model &&
-              model.slug === logicalModel
+              model.slug === canonicalModel
             );
           },
         )

--- a/turbo/packages/core/src/__tests__/model-display-name.test.ts
+++ b/turbo/packages/core/src/__tests__/model-display-name.test.ts
@@ -32,6 +32,9 @@ describe("getModelDisplayName", () => {
   });
 
   it("uses friendly labels for DeepSeek V4 models", () => {
+    expect(getModelDisplayName("deepseek-v4.1-flash")).toBe(
+      "DeepSeek V4.1 Flash",
+    );
     expect(getModelDisplayName("deepseek-v4-flash")).toBe("DeepSeek V4 Flash");
     expect(getModelDisplayName("deepseek-v4-pro")).toBe("DeepSeek V4 Pro");
   });

--- a/turbo/packages/core/src/model-display-name.ts
+++ b/turbo/packages/core/src/model-display-name.ts
@@ -26,6 +26,7 @@ const MODEL_DISPLAY_NAMES = Object.freeze<Record<string, string>>({
   "anthropic/claude-opus-4.5": "Claude Opus 4.5",
   "anthropic/claude-haiku-4.5": "Claude Haiku 4.5",
   // Canonical DeepSeek model IDs
+  "deepseek-v4.1-flash": "DeepSeek V4.1 Flash",
   "deepseek-v4-flash": "DeepSeek V4 Flash",
   "deepseek-v4-pro": "DeepSeek V4 Pro",
   // MiniMax via shared gateways


### PR DESCRIPTION
## Summary

- add DeepSeek V4.1 Flash to the active model catalog and route built-in and OpenRouter workspace-key runs to `deepseek/deepseek-v4.1-flash`
- seed new workspaces with DeepSeek V4.1 Flash, GPT 5.6 Luna, and GPT 6 Astra, with DeepSeek V4.1 Flash as the default
- preserve existing workspace policies while adding Codex runtime metadata, image-input support, labels, and UI coverage for the new model

## Testing

- `pnpm --filter @okouai/api-contracts check-types`
- `pnpm --filter @okouai/core check-types`
- `pnpm --filter @okouai/app check-types`
- `pnpm --filter api check-types`
- focused oxlint, type-aware oxlint, and ESLint checks for all changed files
- `pnpm exec vitest run packages/api-contracts/src/contracts/__tests__/model-providers.test.ts packages/api-contracts/src/contracts/__tests__/model-reasoning-effort.test.ts packages/core/src/__tests__/model-display-name.test.ts apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx` (197 tests)

The targeted API BDD tests were added and type-checked, but could not run locally because PostgreSQL was unavailable on `localhost:5432`; CI will execute them.
